### PR TITLE
fix: add repo/bug tracker links to packages

### DIFF
--- a/.changeset/clever-houses-heal.md
+++ b/.changeset/clever-houses-heal.md
@@ -1,0 +1,6 @@
+---
+"agents-sdk": patch
+"hono-agents": patch
+---
+
+fix: add repo/bug tracker links to packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -6010,7 +6010,7 @@
     "packages/agents": {
       "name": "agents-sdk",
       "version": "0.0.19",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "cron-schedule": "^5.0.4",
         "nanoid": "^5.1.0",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -39,8 +39,16 @@
     }
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/agents.git",
+    "directory": "packages/agents"
+  },
+  "bugs": {
+    "url": "https://github.com/cloudflare/agents/issues"
+  },
+  "author": "Cloudflare Inc.",
+  "license": "MIT",
   "description": "A home for your AI agents",
   "dependencies": {
     "cron-schedule": "^5.0.4",

--- a/packages/hono-agents/package.json
+++ b/packages/hono-agents/package.json
@@ -23,6 +23,14 @@
     "agents",
     "hono"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/agents.git",
+    "directory": "packages/hono-agents"
+  },
+  "bugs": {
+    "url": "https://github.com/cloudflare/agents/issues"
+  },
   "author": "Cloudflare Inc.",
   "license": "MIT",
   "description": "Add Cloudflare Agents to your Hono app",


### PR DESCRIPTION
This improves a few minor things in the `package.json` of the packages, so https://www.npmjs.com/package/agents-sdk?activeTab=readme etc. link to the repo/folder, as well as the issue tracker.

I also updated the author/license for the `agents` package which seems correct with the rest of the repo, but pls yell if incorrect!