### PR TITLE
adds JSDoc to public symbols.

### DIFF
--- a/.changeset/healthy-bananas-roll.md
+++ b/.changeset/healthy-bananas-roll.md
@@ -1,0 +1,5 @@
+---
+"agents-sdk": patch
+---
+
+adds JSDoc to public symbols.

--- a/packages/agents/src/ai-chat-agent.ts
+++ b/packages/agents/src/ai-chat-agent.ts
@@ -4,7 +4,12 @@ import { appendResponseMessages } from "ai";
 import type { OutgoingMessage, IncomingMessage } from "./ai-types";
 const decoder = new TextDecoder();
 
+/**
+ * Extension of Agent with built-in chat capabilities
+ * @template Env Environment type containing bindings
+ */
 export class AIChatAgent<Env = unknown> extends Agent<Env> {
+  /** Array of chat messages for the current conversation */
   messages: ChatMessage[];
   constructor(ctx: AgentContext, env: Env) {
     super(ctx, env);
@@ -111,10 +116,10 @@ export class AIChatAgent<Env = unknown> extends Agent<Env> {
     return super.onRequest(request);
   }
 
-  /*
-   * override this to handle incoming messages
-   * @param onFinish - a callback that is called when the response is finished
-   * @returns a Response to send to the client
+  /**
+   * Handle incoming chat messages and generate a response
+   * @param onFinish Callback to be called when the response is finished
+   * @returns Response to send to the client or undefined
    */
   async onChatMessage(
     onFinish: StreamTextOnFinishCallback<any>
@@ -124,8 +129,9 @@ export class AIChatAgent<Env = unknown> extends Agent<Env> {
     );
   }
 
-  /*
-   * You can save messages on the server side
+  /**
+   * Save messages on the server side and trigger AI response
+   * @param messages Chat messages to save
    */
   async saveMessages(messages: ChatMessage[]) {
     await this.persistMessages(messages);

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -3,8 +3,13 @@ import type { Message } from "ai";
 import { useAgent } from "./react";
 import { useEffect, use } from "react";
 import type { OutgoingMessage } from "./ai-types";
+
+/**
+ * Options for the useAgentChat hook
+ */
 type UseAgentChatOptions = Omit<
   Parameters<typeof useChat>[0] & {
+    /** Agent connection from useAgent */
     agent: ReturnType<typeof useAgent>;
   },
   "fetch"
@@ -13,6 +18,11 @@ type UseAgentChatOptions = Omit<
 // TODO: clear cache when the agent is unmounted?
 const requestCache = new Map<string, Promise<any>>();
 
+/**
+ * React hook for building AI chat interfaces using an Agent
+ * @param options Chat options including the agent connection
+ * @returns Chat interface controls and state with added clearHistory method
+ */
 export function useAgentChat(options: UseAgentChatOptions) {
   const { agent, ...rest } = options;
   const url =
@@ -149,6 +159,10 @@ export function useAgentChat(options: UseAgentChatOptions) {
 
   return {
     ...useChatHelpers,
+    /**
+     * Set the chat messages and synchronize with the Agent
+     * @param messages New messages to set
+     */
     setMessages: (messages: Message[]) => {
       useChatHelpers.setMessages(messages);
       agent.send(
@@ -158,6 +172,9 @@ export function useAgentChat(options: UseAgentChatOptions) {
         })
       );
     },
+    /**
+     * Clear chat history on both client and Agent
+     */
     clearHistory: () => {
       useChatHelpers.setMessages([]);
       agent.send(

--- a/packages/agents/src/ai-types.ts
+++ b/packages/agents/src/ai-types.ts
@@ -1,32 +1,52 @@
 import type { Message as ChatMessage } from "ai";
 
+/**
+ * Types of messages sent from the Agent to clients
+ */
 export type OutgoingMessage =
   | {
+      /** Indicates this message contains updated chat messages */
       type: "cf_agent_chat_messages";
+      /** Array of chat messages */
       messages: ChatMessage[];
     }
   | {
+      /** Indicates this message is a response to a chat request */
       type: "cf_agent_use_chat_response";
+      /** Unique ID of the request this response corresponds to */
       id: string;
+      /** Content body of the response */
       body: string;
+      /** Whether this is the final chunk of the response */
       done: boolean;
     }
   | {
+      /** Indicates this message contains updated chat messages */
       type: "cf_agent_chat_messages";
+      /** Array of chat messages */
       messages: ChatMessage[];
     }
   | {
+      /** Indicates this message is a command to clear chat history */
       type: "cf_agent_chat_clear";
     };
 
+/**
+ * Types of messages sent from clients to the Agent
+ */
 export type IncomingMessage =
   | {
+      /** Indicates this message is initializing a chat connection */
       type: "cf_agent_chat_init";
+      /** Initial messages to load, if any */
       messages: ChatMessage[];
     }
   | {
+      /** Indicates this message is a request to the chat API */
       type: "cf_agent_use_chat_request";
+      /** Unique ID for this request */
       id: string;
+      /** Request initialization options */
       init: Pick<
         RequestInit,
         | "method"
@@ -43,9 +63,12 @@ export type IncomingMessage =
       >;
     }
   | {
+      /** Indicates this message is a command to clear chat history */
       type: "cf_agent_chat_clear";
     }
   | {
+      /** Indicates this message contains updated chat messages */
       type: "cf_agent_chat_messages";
+      /** Array of chat messages */
       messages: ChatMessage[];
     };

--- a/packages/agents/src/client.ts
+++ b/packages/agents/src/client.ts
@@ -4,19 +4,32 @@ import {
   type PartyFetchOptions,
 } from "partysocket";
 
+/**
+ * Options for creating an AgentClient
+ */
 export type AgentClientOptions = Omit<PartySocketOptions, "party" | "room"> & {
+  /** Name of the agent to connect to */
   agent: string;
+  /** Name of the specific Agent instance */
   name?: string;
 };
 
+/**
+ * Options for the agentFetch function
+ */
 export type AgentClientFetchOptions = Omit<
   PartyFetchOptions,
   "party" | "room"
 > & {
+  /** Name of the agent to connect to */
   agent: string;
+  /** Name of the specific Agent instance */
   name?: string;
 };
 
+/**
+ * WebSocket client for connecting to an Agent
+ */
 export class AgentClient extends PartySocket {
   static fetch(opts: PartyFetchOptions): Promise<Response> {
     throw new Error(
@@ -33,6 +46,12 @@ export class AgentClient extends PartySocket {
   }
 }
 
+/**
+ * Make an HTTP request to an Agent
+ * @param opts Connection options
+ * @param init Request initialization options
+ * @returns Promise resolving to a Response
+ */
 export function agentFetch(opts: AgentClientFetchOptions, init?: RequestInit) {
   return PartySocket.fetch(
     {

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -1,15 +1,28 @@
 import type { PartySocket } from "partysocket";
 import { usePartySocket } from "partysocket/react";
 
+/**
+ * Options for the useAgent hook
+ * @template State Type of the Agent's state
+ */
 export type UseAgentOptions<State = unknown> = Omit<
   Parameters<typeof usePartySocket>[0],
   "party" | "room"
 > & {
+  /** Name of the agent to connect to */
   agent: string;
+  /** Name of the specific Agent instance */
   name?: string;
+  /** Called when the Agent's state is updated */
   onStateUpdate?: (state: State, source: "server" | "client") => void;
 };
 
+/**
+ * React hook for connecting to an Agent
+ * @template State Type of the Agent's state
+ * @param options Connection options
+ * @returns WebSocket connection with setState method
+ */
 export function useAgent<State = unknown>(
   options: UseAgentOptions<State>
 ): PartySocket & { setState: (state: State) => void } {


### PR DESCRIPTION
Used Claude 3.7 with the following prompt:

  Generate valid JSDoc comments for the public types in the `agents` package.
  Comments should be generated for all public types, including classes,
  interfaces, and functions. Comments should include a description of the type,
  its parameters, and its return value. Be concise, and do not include any
  unnecessary details.

  Return the entirety of each file separately, and include all other code, even
  if there are no JSDOc comments for those symbols.