### PR TITLE
Fix agents prefix in example

### DIFF
--- a/.changeset/slow-suits-agree.md
+++ b/.changeset/slow-suits-agree.md
@@ -1,0 +1,5 @@
+---
+"hono-agents": patch
+---
+
+Fix agents prefix in example

--- a/packages/hono-agents/README.md
+++ b/packages/hono-agents/README.md
@@ -56,7 +56,7 @@ app.use(
   "*",
   agentsMiddleware({
     options: {
-      prefix: "/agents", // Handles /agents/* routes only
+      prefix: "agents", // Handles /agents/* routes only
     },
   })
 );


### PR DESCRIPTION
From what I could tell from grepping the codebase and what worked for me, the leading slash is not supposed to be there.