### PR TITLE
fix onMessage not getting called

### DIFF
--- a/.changeset/stale-toys-protect.md
+++ b/.changeset/stale-toys-protect.md
@@ -1,0 +1,5 @@
+---
+"agents-sdk": patch
+---
+
+fix onMessage not getting called

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -36,8 +36,8 @@ export function useAgent<State = unknown>(
         const parsedMessage = JSON.parse(message.data);
         if (parsedMessage.type === "cf_agent_state") {
           options.onStateUpdate?.(parsedMessage.state, "server");
+          return;
         }
-        return;
       }
       options.onMessage?.(message);
     },


### PR DESCRIPTION
The commit updating the `cf_agent_state` logic added a bug where the user's `onMessage` would never get called for string messages.

https://github.com/cloudflare/agents/commit/b244068c7266f048493b3796393cfa74bbbd9ec1#diff-93607242176a99b6eb20508d9bb1707085a97ec316e8835d194d97fa6b44a04cL35-R40