### PR TITLE
fix: prevent data race with useAgentHook on slow websocket connection

### DIFF
--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -130,6 +130,10 @@ export function useAgentChat(options: UseAgentChatOptions) {
   });
 
   useEffect(() => {
+    if (agent.readyState !== agent.OPEN) {
+      return;
+    }
+
     agent.send(
       JSON.stringify({
         type: "cf_agent_chat_init",
@@ -167,6 +171,8 @@ export function useAgentChat(options: UseAgentChatOptions) {
     agent.addEventListener,
     agent.removeEventListener,
     agent.send,
+    agent.readyState,
+    agent.OPEN,
     useChatHelpers.setMessages,
   ]);
 


### PR DESCRIPTION
In the event the WebSocket connection to the agent is slow the `useAgentChat` hook will try to send `cf_agent_chat_init` before the connection has opened, dropping the message and breaking streaming since `isChatConnection` is never set.