### PR TITLE
Add RPC support with `unstable_callable` decorator for method exposure.

### DIFF
--- a/.changeset/deep-pumas-peel.md
+++ b/.changeset/deep-pumas-peel.md
@@ -1,0 +1,13 @@
+---
+"agents-sdk": patch
+---
+
+Add RPC support with `unstable_callable` decorator for method exposure. This feature enables:
+
+- Remote procedure calls from clients to agents
+- Method decoration with `@unstable_callable` to expose agent methods
+- Support for both regular and streaming RPC calls
+- Type-safe RPC calls with automatic response handling
+- Real-time streaming responses for long-running operations
+
+Note: The `callable` decorator has been renamed to `unstable_callable` to indicate its experimental status.

--- a/examples/playground/src/agents/rpc.ts
+++ b/examples/playground/src/agents/rpc.ts
@@ -1,0 +1,23 @@
+import { unstable_callable, Agent, type StreamingResponse } from "agents-sdk";
+import type { Env } from "../server";
+
+export class Rpc extends Agent<Env> {
+  @unstable_callable({
+    description: "rpc test",
+  })
+  async test() {
+    return "Hello, world!";
+  }
+
+  @unstable_callable({
+    description: "rpc test streaming",
+    streaming: true,
+  })
+  async testStreaming(stream: StreamingResponse) {
+    for (let i = 0; i < 10; i++) {
+      stream.send(`Hello, world! ${i}`);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    stream.end("Done");
+  }
+}

--- a/examples/playground/src/client.tsx
+++ b/examples/playground/src/client.tsx
@@ -5,6 +5,7 @@ import { Scheduler } from "./components/Scheduler";
 import { Stateful } from "./components/Stateful";
 import Email from "./components/Email";
 import Chat from "./components/Chat";
+import RPC from "./components/RPC";
 
 interface Toast {
   id: string;
@@ -79,6 +80,10 @@ function App() {
         <div className="col-span-1">
           <h2 className="text-xl font-bold mb-4">Chat</h2>
           <Chat />
+        </div>
+        <div className="col-span-1">
+          <h2 className="text-xl font-bold mb-4">RPC Demo</h2>
+          <RPC addToast={addToast} />
         </div>
       </div>
     </div>

--- a/examples/playground/src/components/RPC.css
+++ b/examples/playground/src/components/RPC.css
@@ -1,0 +1,176 @@
+.rpc-container {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  padding: 24px;
+  border: 1px solid #e5e7eb;
+}
+
+.rpc-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.button-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (min-width: 640px) {
+  .button-container {
+    flex-direction: row;
+  }
+}
+
+.rpc-button {
+  flex: 1;
+  padding: 12px 24px;
+  font-weight: 500;
+  border-radius: 8px;
+  transition: all 0.2s ease-in-out;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rpc-button:focus {
+  outline: none;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.rpc-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button-regular {
+  background-color: #3b82f6;
+  color: white;
+}
+
+.button-regular:hover:not(:disabled) {
+  background-color: #2563eb;
+}
+
+.button-regular:focus {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
+}
+
+.button-streaming {
+  background-color: #10b981;
+  color: white;
+}
+
+.button-streaming:hover:not(:disabled) {
+  background-color: #059669;
+}
+
+.button-streaming:focus {
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.5);
+}
+
+.loading-spinner {
+  animation: spin 1s linear infinite;
+  margin: 0 8px;
+  height: 20px;
+  width: 20px;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.messages-container {
+  margin-top: 24px;
+  background-color: #f9fafb;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  overflow: hidden;
+}
+
+.messages-header {
+  padding: 12px 16px;
+  background-color: #f3f4f6;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.messages-header h3 {
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0;
+}
+
+.messages-list {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.message-item {
+  padding: 16px;
+  transition: background-color 0.15s ease-in-out;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.message-item:hover {
+  background-color: #f9fafb;
+}
+
+.message-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.message-icon-container {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #d1fae5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.message-icon {
+  width: 16px;
+  height: 16px;
+  color: #059669;
+}
+
+.message-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.message-text p {
+  margin: 0;
+}
+
+.message-main {
+  font-size: 14px;
+  color: #111827;
+}
+
+.message-number {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.button-text {
+  display: inline-flex;
+  align-items: center;
+}

--- a/examples/playground/src/components/RPC.tsx
+++ b/examples/playground/src/components/RPC.tsx
@@ -1,0 +1,172 @@
+import { useAgent } from "agents-sdk/react";
+import { useState } from "react";
+import "./RPC.css";
+
+interface StreamOptions {
+  onMessage?: (message: unknown) => void;
+}
+
+export default function RPC({
+  addToast,
+}: {
+  addToast: (message: string, type: "success" | "error" | "info") => void;
+}) {
+  const { call } = useAgent({ agent: "rpc" });
+  const [messages, setMessages] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleRegularCall = async () => {
+    try {
+      setLoading(true);
+      const result = await call("test");
+      addToast(`Regular RPC result: ${result}`, "success");
+    } catch (error) {
+      addToast(`Error: ${error}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStreamingCall = async () => {
+    try {
+      setLoading(true);
+      setMessages([]);
+      await call("testStreaming", [], {
+        onChunk: (chunk: unknown) => {
+          setMessages((prev) => [...prev, chunk as string]);
+        },
+      });
+    } catch (error) {
+      addToast(`Error: ${error}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="rpc-container">
+      <div className="rpc-content">
+        <div className="button-container">
+          <button
+            type="button"
+            onClick={handleRegularCall}
+            disabled={loading}
+            className="rpc-button button-regular"
+          >
+            {loading ? (
+              <span className="button-text">
+                <svg
+                  className="loading-spinner"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  role="img"
+                  aria-label="Loading spinner"
+                >
+                  <title>Loading spinner</title>
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Processing...
+              </span>
+            ) : (
+              "Regular RPC Call"
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleStreamingCall}
+            disabled={loading}
+            className="rpc-button button-streaming"
+          >
+            {loading ? (
+              <span className="button-text">
+                <svg
+                  className="loading-spinner"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  role="img"
+                  aria-label="Loading spinner"
+                >
+                  <title>Loading spinner</title>
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Streaming...
+              </span>
+            ) : (
+              "Start Streaming"
+            )}
+          </button>
+        </div>
+
+        {messages.length > 0 && (
+          <div className="messages-container">
+            <div className="messages-header">
+              <h3>Streaming Messages</h3>
+            </div>
+            <div className="messages-list">
+              {messages.map((message, messageId) => (
+                <div
+                  key={`message-${
+                    // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                    messageId
+                  }`}
+                  className="message-item"
+                >
+                  <div className="message-content">
+                    <div className="message-icon-container">
+                      <svg
+                        className="message-icon"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        role="img"
+                        aria-label="Message icon"
+                      >
+                        <title>Message icon</title>
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M13 10V3L4 14h7v7l9-11h-7z"
+                        />
+                      </svg>
+                    </div>
+                    <div className="message-text">
+                      <p className="message-main">{message}</p>
+                      <p className="message-number">Message #{messageId + 1}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/playground/src/server.ts
+++ b/examples/playground/src/server.ts
@@ -5,6 +5,7 @@ import { Stateful } from "./agents/stateful";
 import { EmailAgent } from "./agents/email";
 import { MockEmailService } from "./agents/mock-email";
 import { Chat } from "./agents/chat";
+import { Rpc } from "./agents/rpc";
 // import { emailHandler } from "./agents/email";
 
 export type Env = {
@@ -15,7 +16,7 @@ export type Env = {
   OPENAI_API_KEY: string;
 };
 
-export { Scheduler, Stateful, EmailAgent, MockEmailService, Chat };
+export { Scheduler, Stateful, EmailAgent, MockEmailService, Chat, Rpc };
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {

--- a/examples/playground/wrangler.jsonc
+++ b/examples/playground/wrangler.jsonc
@@ -31,6 +31,10 @@
         "name": "Chat",
         "class_name": "Chat",
       },
+      {
+        "name": "Rpc",
+        "class_name": "Rpc",
+      },
     ],
   },
 
@@ -43,6 +47,7 @@
         "EmailAgent",
         "MockEmailService",
         "Chat",
+        "Rpc",
       ],
     },
   ],

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -1,5 +1,8 @@
 import type { PartySocket } from "partysocket";
 import { usePartySocket } from "partysocket/react";
+import { useCallback, useRef } from "react";
+import type { RPCRequest, RPCResponse } from "./";
+import type { StreamOptions } from "./client";
 
 /**
  * Options for the useAgent hook
@@ -21,7 +24,7 @@ export type UseAgentOptions<State = unknown> = Omit<
  * React hook for connecting to an Agent
  * @template State Type of the Agent's state
  * @param options Connection options
- * @returns WebSocket connection with setState method
+ * @returns WebSocket connection with setState and call methods
  */
 export function useAgent<State = unknown>(
   options: UseAgentOptions<State>
@@ -29,7 +32,52 @@ export function useAgent<State = unknown>(
   agent: string;
   name: string;
   setState: (state: State) => void;
+  call: <T = unknown>(
+    method: string,
+    args?: unknown[],
+    streamOptions?: StreamOptions
+  ) => Promise<T>;
 } {
+  // Keep track of pending RPC calls
+  const pendingCallsRef = useRef(
+    new Map<
+      string,
+      {
+        resolve: (value: unknown) => void;
+        reject: (error: Error) => void;
+        stream?: StreamOptions;
+      }
+    >()
+  );
+
+  // Create the call method
+  const call = useCallback(
+    <T = unknown,>(
+      method: string,
+      args: unknown[] = [],
+      streamOptions?: StreamOptions
+    ): Promise<T> => {
+      return new Promise((resolve, reject) => {
+        const id = Math.random().toString(36).slice(2);
+        pendingCallsRef.current.set(id, {
+          resolve: resolve as (value: unknown) => void,
+          reject,
+          stream: streamOptions,
+        });
+
+        const request: RPCRequest = {
+          type: "rpc",
+          id,
+          method,
+          args,
+        };
+
+        agent.send(JSON.stringify(request));
+      });
+    },
+    []
+  );
+
   const agent = usePartySocket({
     prefix: "agents",
     party: options.agent,
@@ -42,6 +90,34 @@ export function useAgent<State = unknown>(
           options.onStateUpdate?.(parsedMessage.state, "server");
           return;
         }
+        if (parsedMessage.type === "rpc") {
+          const response = parsedMessage as RPCResponse;
+          const pending = pendingCallsRef.current.get(response.id);
+          if (!pending) return;
+
+          if (!response.success) {
+            pending.reject(new Error(response.error));
+            pendingCallsRef.current.delete(response.id);
+            pending.stream?.onError?.(response.error);
+            return;
+          }
+
+          // Handle streaming responses
+          if ("done" in response) {
+            if (response.done) {
+              pending.resolve(response.result);
+              pendingCallsRef.current.delete(response.id);
+              pending.stream?.onDone?.(response.result);
+            } else {
+              pending.stream?.onChunk?.(response.result);
+            }
+          } else {
+            // Non-streaming response
+            pending.resolve(response.result);
+            pendingCallsRef.current.delete(response.id);
+          }
+          return;
+        }
       }
       options.onMessage?.(message);
     },
@@ -49,6 +125,11 @@ export function useAgent<State = unknown>(
     agent: string;
     name: string;
     setState: (state: State) => void;
+    call: <T = unknown>(
+      method: string,
+      args?: unknown[],
+      streamOptions?: StreamOptions
+    ) => Promise<T>;
   };
 
   agent.setState = (state: State) => {
@@ -56,6 +137,7 @@ export function useAgent<State = unknown>(
     options.onStateUpdate?.(state, "client");
   };
 
+  agent.call = call;
   agent.agent = options.agent;
   agent.name = options.name || "default";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
       "ESNext",
       "DOM"


### PR DESCRIPTION
- Remote procedure calls from clients to agents
- Method decoration with `@unstable_callable` to expose agent methods
- Support for both regular and streaming RPC calls
- Type-safe RPC calls with automatic response handling
- Real-time streaming responses for long-running operations

Note: The `callable` decorator has been renamed to `unstable_callable` to indicate its experimental status.