### PR TITLE
Pass state generic through `useAgentChat`

### DIFF
--- a/.changeset/thin-foxes-hang.md
+++ b/.changeset/thin-foxes-hang.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Pass state generic through `useAgentChat`

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -13,10 +13,10 @@ type GetInitialMessagesOptions = {
 /**
  * Options for the useAgentChat hook
  */
-type UseAgentChatOptions = Omit<
+type UseAgentChatOptions<State> = Omit<
   Parameters<typeof useChat>[0] & {
     /** Agent connection from useAgent */
-    agent: ReturnType<typeof useAgent>;
+    agent: ReturnType<typeof useAgent<State>>;
     getInitialMessages?:
       | undefined
       | null
@@ -34,7 +34,7 @@ const requestCache = new Map<string, Promise<Message[]>>();
  * @param options Chat options including the agent connection
  * @returns Chat interface controls and state with added clearHistory method
  */
-export function useAgentChat(options: UseAgentChatOptions) {
+export function useAgentChat<State>(options: UseAgentChatOptions<State>) {
   const { agent, getInitialMessages, ...rest } = options;
   const url = `${agent._pkurl
     .replace("ws://", "http://")

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -34,7 +34,9 @@ const requestCache = new Map<string, Promise<Message[]>>();
  * @param options Chat options including the agent connection
  * @returns Chat interface controls and state with added clearHistory method
  */
-export function useAgentChat<State>(options: UseAgentChatOptions<State>) {
+export function useAgentChat<State = unknown>(
+  options: UseAgentChatOptions<State>
+) {
   const { agent, getInitialMessages, ...rest } = options;
   const url = `${agent._pkurl
     .replace("ws://", "http://")


### PR DESCRIPTION
In current version I get an error 

`
Types of parameters state and state are incompatible.
`

When trying to type the `useAgent` hook with my state object. 

E.g.

```ts
// No errors here
const agent = useAgent<{ currentRecipe: Recipe | null }>({
  host: 'http://localhost:8787',
  agent: 'chat',
  onStateUpdate: (state) => {
    setCurrentRecipe(state.currentRecipe);
  },
});

const {
  messages: agentMessages,
  input: agentInput,
  handleInputChange: handleAgentInputChange,
  handleSubmit: handleAgentSubmit,
  addToolResult,
  clearHistory,
} = useAgentChat({
  // Error here, my `currentRecipe` shape does not match `unknown` since the generic isn't being passed through
  agent,
  maxSteps: 5,
});
```

