### PR TITLE
WIP: Implement chat agent stop generation

### DIFF
--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -225,8 +225,6 @@ export function useAgentChat<State = unknown>(
     useChatHelpers.setMessages,
   ]);
 
-  const stop = useCallback(, [agent, useChatHelpers.stop])
-
   return {
     ...useChatHelpers,
     /**

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -1,7 +1,7 @@
 import { useChat } from "@ai-sdk/react";
 import type { Message } from "ai";
 import type { useAgent } from "./react";
-import { useEffect, use } from "react";
+import { useEffect, use, useCallback } from "react";
 import type { OutgoingMessage } from "./ai-types";
 
 type GetInitialMessagesOptions = {
@@ -225,6 +225,8 @@ export function useAgentChat<State = unknown>(
     useChatHelpers.setMessages,
   ]);
 
+  const stop = useCallback(, [agent, useChatHelpers.stop])
+
   return {
     ...useChatHelpers,
     /**
@@ -250,6 +252,20 @@ export function useAgentChat<State = unknown>(
           type: "cf_agent_chat_clear",
         })
       );
+    },
+    /**
+     * Stop any responses to a user's message
+     * @NOTE - This is confusing. `id` needs to be the user message id that kicked off the chat message response
+     *         I'm starting to think maybe the `stop` should just stop all pending generations?
+     *
+     * @param id The user message id 
+     */
+    stop: (id: string) => {
+      agent.send(JSON.stringify({
+        type: "cf_agent_chat_request_cancel",
+        id,
+      }))
+      useChatHelpers.stop();
     },
   };
 }

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -110,16 +110,16 @@ export function useAgentChat<State = unknown>(
     const abortController = new AbortController();
 
     signal?.addEventListener("abort", () => {
-      console.log("Getting the abort signal inside aiFetch signal prop...")
-      // Propagate request cancellation
+      // Propagate request cancellation to the Agent
+      // We need to communciate cancellation as a websocket message, instead of a request signal
       agent.send(JSON.stringify({
         type: "cf_agent_chat_request_cancel",
         id,
       }));
 
       // NOTE - If we wanted to, we could preserve the "interrupted" message here, with the code below
-      //        However, I think it might be on the user to implement that behavior manually?
-      //        This code could be subject to collisions, as it "force saves" the messages we have locally
+      //        However, I think it might be the responsibility of the library user to implement that behavior manually?
+      //        Reasoning: This code could be subject to collisions, as it "force saves" the messages we have locally
       //  
       // agent.send(JSON.stringify({
       //   type: "cf_agent_chat_messages",
@@ -267,19 +267,5 @@ export function useAgentChat<State = unknown>(
         })
       );
     },
-    /**
-     * Stop any responses to a user's message
-     * @NOTE - This is confusing. `id` needs to be the user message id that kicked off the chat message response
-     *         I'm starting to think maybe the `stop` should just stop all pending generations?
-     *
-     * @param id The user message id 
-     */
-    // stop: (id: string) => {
-    //   agent.send(JSON.stringify({
-    //     type: "cf_agent_chat_request_cancel",
-    //     id,
-    //   }))
-    //   useChatHelpers.stop();
-    // },
   };
 }

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -110,6 +110,22 @@ export function useAgentChat<State = unknown>(
     const abortController = new AbortController();
 
     signal?.addEventListener("abort", () => {
+      console.log("Getting the abort signal inside aiFetch signal prop...")
+      // Propagate request cancellation
+      agent.send(JSON.stringify({
+        type: "cf_agent_chat_request_cancel",
+        id,
+      }));
+
+      // NOTE - If we wanted to, we could preserve the "interrupted" message here, with the code below
+      //        However, I think it might be on the user to implement that behavior manually?
+      //        This code could be subject to collisions, as it "force saves" the messages we have locally
+      //  
+      // agent.send(JSON.stringify({
+      //   type: "cf_agent_chat_messages",
+      //   messages: ... /* some way of getting current messages ref? */
+      // }))
+     
       abortController.abort();
     });
 
@@ -258,12 +274,12 @@ export function useAgentChat<State = unknown>(
      *
      * @param id The user message id 
      */
-    stop: (id: string) => {
-      agent.send(JSON.stringify({
-        type: "cf_agent_chat_request_cancel",
-        id,
-      }))
-      useChatHelpers.stop();
-    },
+    // stop: (id: string) => {
+    //   agent.send(JSON.stringify({
+    //     type: "cf_agent_chat_request_cancel",
+    //     id,
+    //   }))
+    //   useChatHelpers.stop();
+    // },
   };
 }

--- a/packages/agents/src/ai-types.ts
+++ b/packages/agents/src/ai-types.ts
@@ -65,4 +65,9 @@ export type IncomingMessage =
       type: "cf_agent_chat_messages";
       /** Array of chat messages */
       messages: ChatMessage[];
+    }
+  | {
+      /** Indicates the user wants to stop generation of this message */
+      type: "cf_agent_chat_request_cancel";
+      id: string;
     };


### PR DESCRIPTION
Fixes #68 (kind of)

***

Will write a bit more of a stable description when I get better internet 

However, broad strokes:

- the ChatAgent keeps a map of request ids to AbortControllers
- the ChatAgent passes an abortSignal that can be used by implementers of `onChatMessage`
- when you call `stop` on the client, it emits a new type of message (`"cf_agent_chat_request_cancel"`)
- the ChatAgent handles this new message by looking up if it has an assocaited abortSignal that it can invoke