### PR TITLE
fix: Pass Env param thru to DurableObject definition

### DIFF
--- a/.changeset/lovely-tips-joke.md
+++ b/.changeset/lovely-tips-joke.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+fix: Pass Env param thru to DurableObject definition

--- a/packages/agents/src/mcp.ts
+++ b/packages/agents/src/mcp.ts
@@ -36,7 +36,7 @@ export abstract class McpAgent<
   Env = unknown,
   State = unknown,
   Props extends Record<string, unknown> = Record<string, unknown>,
-> extends DurableObject {
+> extends DurableObject<Env> {
   /**
    * Since McpAgent's _aren't_ yet real "Agents" (they route differently, don't support
    * websockets, don't support hibernation), let's only expose a couple of the methods


### PR DESCRIPTION
Fixes an issue where classes extending `McpAgent` cannot access typesafe `this.env`, since the DurableObject type is declared as `DurableObject<Env = unknown>`