### PR TITLE
`import {context} from 'agents';`

### DIFF
--- a/.changeset/grumpy-buckets-lead.md
+++ b/.changeset/grumpy-buckets-lead.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+`import {context} from 'agents';`
+
+Export the current agent, request, and connection from a shared context. Particularly useful for tool calls that might not have access to the current agent in their module scope.

--- a/examples/playground/src/agents/email.ts
+++ b/examples/playground/src/agents/email.ts
@@ -98,7 +98,7 @@ export class EmailAgent extends AIChatAgent<Env> {
     return super.onRequest(request);
   }
 
-  onEmail(email: ForwardableEmailMessage) {
+  async onEmail(email: ForwardableEmailMessage) {
     //
   }
   // biome-ignore lint/complexity/noBannedTypes: vibes

--- a/guides/human-in-the-loop/src/app.tsx
+++ b/guides/human-in-the-loop/src/app.tsx
@@ -1,6 +1,6 @@
 import type { Message } from "@ai-sdk/react";
-import { APPROVAL, getToolsRequiringConfirmation } from "./utils";
-import { tools } from "./tools";
+import { APPROVAL } from "./utils";
+import type { tools } from "./tools";
 import "./styles.css";
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useAgent } from "agents/react";
@@ -51,14 +51,19 @@ export default function Chat() {
     messages.length > 0 && scrollToBottom();
   }, [messages, scrollToBottom]);
 
-  const toolsRequiringConfirmation = getToolsRequiringConfirmation(tools);
+  // List of tools that require human confirmation
+  const toolsRequiringConfirmation: (keyof typeof tools)[] = [
+    "getWeatherInformation",
+  ];
 
   const pendingToolCallConfirmation = messages.some((m: Message) =>
     m.parts?.some(
       (part) =>
         part.type === "tool-invocation" &&
         part.toolInvocation.state === "call" &&
-        toolsRequiringConfirmation.includes(part.toolInvocation.toolName)
+        toolsRequiringConfirmation.includes(
+          part.toolInvocation.toolName as keyof typeof tools
+        )
     )
   );
 
@@ -100,7 +105,7 @@ export default function Chat() {
                     // render confirmation tool (client-side tool with user interaction)
                     if (
                       toolsRequiringConfirmation.includes(
-                        toolInvocation.toolName
+                        toolInvocation.toolName as keyof typeof tools
                       ) &&
                       toolInvocation.state === "call"
                     ) {


### PR DESCRIPTION
Export the current agent, request, and connection from a shared context. Particularly useful for tool calls that might not have access to the current agent in their module scope.