### PR TITLE
Fixed the build error that was stripping `.js` files from NPM

### DIFF
--- a/.changeset/curvy-months-matter.md
+++ b/.changeset/curvy-months-matter.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fixed internal build issue that caused incomplete package to be published

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -67,12 +67,10 @@
   "license": "MIT",
   "description": "A home for your AI agents",
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.8.0",
     "cron-schedule": "^5.0.4",
     "nanoid": "^5.1.5",
     "partyserver": "^0.0.66",
     "partysocket": "1.1.3"
-  },
-  "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.8.0"
   }
 }

--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -7,7 +7,14 @@ async function main() {
     splitting: true,
     sourcemap: true,
     clean: true,
-    external: ["cloudflare:workers", "@ai-sdk/react", "ai", "react", "zod"],
+    external: [
+      "cloudflare:workers",
+      "@ai-sdk/react",
+      "ai",
+      "react",
+      "zod",
+      "@modelcontextprotocol/sdk",
+    ],
     format: "esm",
     dts: true,
   });
@@ -18,4 +25,8 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  // Build failures should fail
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Made @modelcontextprotocol/sdk an external dependency, and made build failures actually fail