### PR TITLE
Automatically change "/" path to "/*" in MCP server mount() method

### DIFF
--- a/.changeset/puny-cows-drop.md
+++ b/.changeset/puny-cows-drop.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Automatically change "/" path to "/\*" in MCP server mount() method

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -321,7 +321,9 @@ export abstract class McpAgent<
     } = {}
   ) {
     let pathname = path;
-    if (path === "/") { pathname = "/*" }
+    if (path === "/") {
+      pathname = "/*";
+    }
     const basePattern = new URLPattern({ pathname });
     const messagePattern = new URLPattern({ pathname: `${pathname}/message` });
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -320,8 +320,10 @@ export abstract class McpAgent<
       corsOptions?: CORSOptions;
     } = {}
   ) {
-    const basePattern = new URLPattern({ pathname: path });
-    const messagePattern = new URLPattern({ pathname: `${path}/message` });
+    let pathname = path;
+    if (path === "/") { pathname = "/*" }
+    const basePattern = new URLPattern({ pathname });
+    const messagePattern = new URLPattern({ pathname: `${pathname}/message` });
 
     return {
       fetch: async (
@@ -350,7 +352,7 @@ export abstract class McpAgent<
           const encoder = new TextEncoder();
 
           // Send the endpoint event
-          const endpointMessage = `event: endpoint\ndata: ${encodeURI(`${path}/message`)}?sessionId=${sessionId}\n\n`;
+          const endpointMessage = `event: endpoint\ndata: ${encodeURI(`${pathname}/message`)}?sessionId=${sessionId}\n\n`;
           writer.write(encoder.encode(endpointMessage));
 
           // Get the Durable Object
@@ -450,7 +452,7 @@ export abstract class McpAgent<
           const sessionId = url.searchParams.get("sessionId");
           if (!sessionId) {
             return new Response(
-              `Missing sessionId. Expected POST to ${path} to initiate new one`,
+              `Missing sessionId. Expected POST to ${pathname} to initiate new one`,
               { status: 400 }
             );
           }


### PR DESCRIPTION
Fixes https://github.com/cloudflare/agents/issues/148

Could instead throw an error here and ask people to set this themselves. But having hard time seeing problematic case if we just made it work as people might expect, who aren't thinking about the `path` argument as something that gets fed into `URLPattern`?