### PR TITLE
Fix the state issues

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -194,11 +194,8 @@ export class Agent<Env, State = unknown> extends Server<Env> {
    * Current state of the Agent
    */
   get state(): State {
-    console.log("state()");
-
     if (this.#state !== DEFAULT_STATE) {
       // state was previously set, and populated internal state
-      console.log("state was previously set, and populated internal state");
       return this.#state;
     }
     // looks like this is the first time the state is being accessed
@@ -206,8 +203,6 @@ export class Agent<Env, State = unknown> extends Server<Env> {
     const wasChanged = this.sql<{ state: "true" | undefined }>`
         SELECT state FROM cf_agents_state WHERE id = ${STATE_WAS_CHANGED}
       `;
-
-    console.log("wasChanged", wasChanged);
 
     // ok, let's pick up the actual state from the db
     const result = this.sql<{ state: State | undefined }>`
@@ -224,24 +219,18 @@ export class Agent<Env, State = unknown> extends Server<Env> {
       this.#state = JSON.parse(state);
       return this.#state;
     }
-    console.log("here");
 
     // ok, this is the first time the state is being accessed
     // and the state was not set in a previous life
     // so we need to set the initial state (if provided)
     if (this.initialState === DEFAULT_STATE) {
-      console.log("no initial state provided, so we return undefined");
       // no initial state provided, so we return undefined
       return undefined as State;
     }
 
-    console.log("this.initialState", this.initialState);
     // initial state provided, so we set the state,
     // update db and return the initial state
     this.setState(this.initialState);
-    console.log(
-      "initial state provided, so we set the state, update db and return the initial state"
-    );
     return this.initialState;
   }
 
@@ -442,7 +431,6 @@ export class Agent<Env, State = unknown> extends Server<Env> {
    * @param state New state to set
    */
   setState(state: State) {
-    console.log("setState", state);
     this.#setStateInternal(state, "server");
   }
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -227,7 +227,6 @@ export class Agent<Env, State = unknown> extends Server<Env> {
       // no initial state provided, so we return undefined
       return undefined as State;
     }
-
     // initial state provided, so we set the state,
     // update db and return the initial state
     this.setState(this.initialState);

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -194,8 +194,11 @@ export class Agent<Env, State = unknown> extends Server<Env> {
    * Current state of the Agent
    */
   get state(): State {
+    console.log("state()");
+
     if (this.#state !== DEFAULT_STATE) {
       // state was previously set, and populated internal state
+      console.log("state was previously set, and populated internal state");
       return this.#state;
     }
     // looks like this is the first time the state is being accessed
@@ -203,6 +206,8 @@ export class Agent<Env, State = unknown> extends Server<Env> {
     const wasChanged = this.sql<{ state: "true" | undefined }>`
         SELECT state FROM cf_agents_state WHERE id = ${STATE_WAS_CHANGED}
       `;
+
+    console.log("wasChanged", wasChanged);
 
     // ok, let's pick up the actual state from the db
     const result = this.sql<{ state: State | undefined }>`
@@ -219,17 +224,24 @@ export class Agent<Env, State = unknown> extends Server<Env> {
       this.#state = JSON.parse(state);
       return this.#state;
     }
+    console.log("here");
 
     // ok, this is the first time the state is being accessed
     // and the state was not set in a previous life
     // so we need to set the initial state (if provided)
     if (this.initialState === DEFAULT_STATE) {
+      console.log("no initial state provided, so we return undefined");
       // no initial state provided, so we return undefined
       return undefined as State;
     }
+
+    console.log("this.initialState", this.initialState);
     // initial state provided, so we set the state,
     // update db and return the initial state
     this.setState(this.initialState);
+    console.log(
+      "initial state provided, so we set the state, update db and return the initial state"
+    );
     return this.initialState;
   }
 
@@ -430,6 +442,7 @@ export class Agent<Env, State = unknown> extends Server<Env> {
    * @param state New state to set
    */
   setState(state: State) {
+    console.log("setState", state);
     this.#setStateInternal(state, "server");
   }
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -114,10 +114,6 @@ export abstract class McpAgent<
     })(this.ctx, this.env);
   }
 
-  logAgent() {
-    console.log("agent.state", this.#agent.state);
-  }
-
   /**
    * Agents API allowlist
    */
@@ -279,7 +275,6 @@ export abstract class McpAgent<
         throw error;
       }
 
-      console.log("onmessage", parsedMessage);
       this.#transport?.onmessage?.(parsedMessage);
       return new Response("Accepted", { status: 202 });
     } catch (error) {
@@ -421,7 +416,6 @@ export abstract class McpAgent<
               // validate that the message is a valid JSONRPC message
               // https://www.jsonrpc.org/specification#response_object
               if (!(typeof message.id === "number" || message.id === null)) {
-                console.log("invalid message id", message);
                 throw new Error("Invalid jsonrpc message id");
               }
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -99,11 +99,7 @@ export abstract class McpAgent<
     super(ctx, env);
     const self = this;
 
-    // Since McpAgent's _aren't_ yet real "Agents" (they route differently, they don't support
-    // scheduling etc, let's only expose a couple of the methods
-    // to the outer class for now.
     this.#agent = new (class extends Agent<Env, State> {
-      initialState: State = self.initialState;
       static options = {
         hibernate: true,
       };
@@ -111,7 +107,7 @@ export abstract class McpAgent<
       onStateUpdate(state: State | undefined, source: Connection | "server") {
         return self.onStateUpdate(state, source);
       }
-    })(this.ctx, this.env);
+    })(ctx, env);
   }
 
   /**
@@ -137,9 +133,6 @@ export abstract class McpAgent<
   async onStart() {
     const self = this;
 
-    // Since McpAgent's _aren't_ yet real "Agents" (they route differently, they don't support
-    // scheduling etc, let's only expose a couple of the methods
-    // to the outer class for now.
     this.#agent = new (class extends Agent<Env, State> {
       initialState: State = self.initialState;
       static options = {


### PR DESCRIPTION
Addresses https://github.com/cloudflare/agents/issues/157

There were a couple of issues here:

- We were managing the connections explicitly, but then deferring to PartyKit's Server class for a lot of things. This led to the `Cannot read properties of null (reading '__pk')` error. We resolve this by deferring to the Agent class' `fetch` implementation so it can manage the websocket connection for us.

- We were not passing the `initialState` to the `#agent`, and `initialState` is not available during the constructor. We can resolve this by re-creating the `#agent` in `onStart`

- As a side effect of letting PartyKit manage the connections, we get some more messages broadcast back to the original worker that are not JSONRPC messages. I've re-worked the code there so that it filters those out.