### PR TITLE
1/ Refactoring to prepare to support streamable transport

### DIFF
--- a/.changeset/purple-falcons-work.md
+++ b/.changeset/purple-falcons-work.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Rename McpAgent.mount to McpAgent.serveSSE with McpAgent.mount serving as an alias for backward compatibility

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -213,14 +213,14 @@ export abstract class McpAgent<
     const url = new URL(request.url);
     const path = url.pathname;
 
-    // This session is going to communicate via the SSE protocol
     switch (path) {
+      // This session is going to communicate via the SSE protocol
       case "/sse": {
         // For SSE connections, we can only have one open connection per session
         // If we get an upgrade while already connected, we should error
         const websockets = this.ctx.getWebSockets();
         if (websockets.length > 0) {
-          return new Response("WebSocket already connected", { status: 400 });
+          return new Response("Websocket already connected", { status: 400 });
         }
 
         // This connection must use the SSE protocol

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -80,7 +80,7 @@ class McpSSETransport implements Transport {
   }
 }
 
-type Protocol = "sse" | "streamable" | "unset";
+type TransportType = "sse" | "streamable" | "unset";
 
 export abstract class McpAgent<
   Env = unknown,
@@ -89,7 +89,7 @@ export abstract class McpAgent<
 > extends DurableObject<Env> {
   #status: "zero" | "starting" | "started" = "zero";
   #transport?: Transport;
-  #protocol: Protocol = "unset";
+  #protocol: TransportType = "unset";
 
   /**
    * Since McpAgent's _aren't_ yet real "Agents", let's only expose a couple of the methods
@@ -158,7 +158,7 @@ export abstract class McpAgent<
     })(this.ctx, this.env);
 
     this.props = (await this.ctx.storage.get("props")) as Props;
-    this.#protocol = (await this.ctx.storage.get("protocol")) as Protocol;
+    this.#protocol = (await this.ctx.storage.get("protocol")) as TransportType;
     this.init?.();
 
     // Connect to the MCP server


### PR DESCRIPTION
In preparation for supporting the streaming protocol, I've moved some things around to help the code "slot in" without disturbing the existing functionality.

- Rename `McpAgent.mount` to `McpAgent.serveSSE` with `McpAgent.mount` serving as an alias for backward compatibility.
- The DO will now store which protocol has been initiated. A session must always use the same protocol once it's been initialized. This is enforced by baking the protocol into the DO address: ``namespace.idFromName(`sse:${sessionId}`);`` however this is also enforced within the DO logic as well.
- When initializing the websocket connection between the worker and the DO, it used to pass the URL request through. Now we enforce that any request for an SSE transport has an `/sse` path. This will allow us to initialize the correct transport. This gives us space to accommodate an '/mcp' path for the streamable protocol. This change is entirely internal and not exposed to users.
- Better leverage the underlying `Agent` class to manage websocket connections. With the SSE transport, there is only one websocket connection, but this will become more important with the Streamable transport as there may be many more connections.
