### PR TITLE
2/ Add support for HTTP Streamable MCP Transport

### DIFF
--- a/.changeset/purple-falcons-work.md
+++ b/.changeset/purple-falcons-work.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Rename McpAgent.mount to McpAgent.serveSSE with McpAgent.mount serving as an alias for backward compatibility

--- a/package-lock.json
+++ b/package-lock.json
@@ -12384,11 +12384,32 @@
       "version": "0.0.60",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.9.0",
+        "@modelcontextprotocol/sdk": "^1.10.0",
         "cron-schedule": "^5.0.4",
         "nanoid": "^5.1.5",
         "partyserver": "^0.0.66",
         "partysocket": "1.1.3"
+      }
+    },
+    "packages/agents/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.0.tgz",
+      "integrity": "sha512-wijOavYZfSOADbVM0LA7mrQ17N4IKNdFcfezknCCsZ1Y1KstVWlkDZ5ebcxuQJmqTTxsNjBHLc7it1SV0TBiPg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/agents/node_modules/nanoid": {
@@ -12407,6 +12428,15 @@
       },
       "engines": {
         "node": "^18 || >=20"
+      }
+    },
+    "packages/agents/node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "packages/hono-agents": {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -72,7 +72,7 @@
   "license": "MIT",
   "description": "A home for your AI agents",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.10.0",
     "cron-schedule": "^5.0.4",
     "nanoid": "^5.1.5",
     "partyserver": "^0.0.66",

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -213,14 +213,14 @@ export abstract class McpAgent<
     const url = new URL(request.url);
     const path = url.pathname;
 
-    // This session is going to communicate via the SSE protocol
     switch (path) {
+      // This session is going to communicate via the SSE protocol
       case "/sse": {
         // For SSE connections, we can only have one open connection per session
         // If we get an upgrade while already connected, we should error
         const websockets = this.ctx.getWebSockets();
         if (websockets.length > 0) {
-          return new Response("WebSocket already connected", { status: 400 });
+          return new Response("Websocket already connected", { status: 400 });
         }
 
         // This connection must use the SSE protocol

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -3,11 +3,24 @@ import { Agent } from "../";
 import type { WSMessage } from "../";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Connection } from "../";
-import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
-import { JSONRPCMessageSchema } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  JSONRPCError,
+  JSONRPCMessage,
+  JSONRPCNotification,
+  JSONRPCRequest,
+  JSONRPCResponse,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  InitializeRequestSchema,
+  JSONRPCErrorSchema,
+  JSONRPCMessageSchema,
+  JSONRPCNotificationSchema,
+  JSONRPCRequestSchema,
+  JSONRPCResponseSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 
-const MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024; // 4MB
+const MAXIMUM_MESSAGE_SIZE_BYTES = 4 * 1024 * 1024; // 4MB
 
 // CORS helper function
 function handleCORS(
@@ -35,6 +48,67 @@ interface CORSOptions {
   methods?: string;
   headers?: string;
   maxAge?: number;
+}
+
+type ParseMessageResult =
+  | {
+      type: "request";
+      message: JSONRPCRequest;
+      isInitializationRequest: boolean;
+    }
+  | {
+      type: "notification";
+      message: JSONRPCNotification;
+    }
+  | {
+      type: "response";
+      message: JSONRPCResponse;
+    }
+  | {
+      type: "error";
+      message: JSONRPCError;
+    };
+
+// TODO: Swap to https://github.com/modelcontextprotocol/typescript-sdk/pull/281
+// when it gets released
+function parseMessage(message: JSONRPCMessage): ParseMessageResult {
+  const requestResult = JSONRPCRequestSchema.safeParse(message);
+  if (requestResult.success) {
+    return {
+      type: "request",
+      message: requestResult.data,
+      isInitializationRequest:
+        InitializeRequestSchema.safeParse(message).success,
+    };
+  }
+
+  const notificationResult = JSONRPCNotificationSchema.safeParse(message);
+  if (notificationResult.success) {
+    return {
+      type: "notification",
+      message: notificationResult.data,
+    };
+  }
+
+  const responseResult = JSONRPCResponseSchema.safeParse(message);
+  if (responseResult.success) {
+    return {
+      type: "response",
+      message: responseResult.data,
+    };
+  }
+
+  const errorResult = JSONRPCErrorSchema.safeParse(message);
+  if (errorResult.success) {
+    return {
+      type: "error",
+      message: errorResult.data,
+    };
+  }
+
+  // JSONRPCMessage is a union of these 4 types, so if we have a valid
+  // JSONRPCMessage, we should not get this error
+  throw new Error("Invalid message");
 }
 
 class McpSSETransport implements Transport {
@@ -80,7 +154,93 @@ class McpSSETransport implements Transport {
   }
 }
 
-type Protocol = "sse" | "streamable" | "unset";
+class McpStreamableHttpTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+  sessionId?: string;
+
+  // TODO: If there is an open connection to send server-initiated messages
+  // back, we should use that connection
+  #getWebSocketForGetRequest: () => WebSocket | null;
+
+  // Get the appropriate websocket connection for a given message id
+  #getWebSocketForMessageID: (id: string) => WebSocket | null;
+
+  // Notify the server that a response has been sent for a given message id
+  // so that it may clean up it's mapping of message ids to connections
+  // once they are no longer needed
+  #notifyResponseIdSent: (id: string) => void;
+
+  #started = false;
+  constructor(
+    getWebSocketForMessageID: (id: string) => WebSocket | null,
+    notifyResponseIdSent: (id: string | number) => void
+  ) {
+    this.#getWebSocketForMessageID = getWebSocketForMessageID;
+    this.#notifyResponseIdSent = notifyResponseIdSent;
+    // TODO
+    this.#getWebSocketForGetRequest = () => null;
+  }
+
+  async start() {
+    // The transport does not manage the WebSocket connection since it's terminated
+    // by the Durable Object in order to allow hibernation. There's nothing to initialize.
+    if (this.#started) {
+      throw new Error("Transport already started");
+    }
+    this.#started = true;
+  }
+
+  async send(message: JSONRPCMessage) {
+    if (!this.#started) {
+      throw new Error("Transport not started");
+    }
+
+    let websocket: WebSocket | null = null;
+    const parsedMessage = parseMessage(message);
+    switch (parsedMessage.type) {
+      // These types have an id
+      case "response":
+      case "error":
+        websocket = this.#getWebSocketForMessageID(
+          parsedMessage.message.id.toString()
+        );
+        if (!websocket) {
+          throw new Error(
+            `Could not find WebSocket for message id: ${parsedMessage.message.id}`
+          );
+        }
+        break;
+      // requests have an ID but are originated by the server so do not correspond to
+      // any active connection
+      case "request":
+        websocket = this.#getWebSocketForGetRequest();
+        break;
+      // Notifications do not have an id
+      case "notification":
+        websocket = this.#getWebSocketForGetRequest();
+        break;
+    }
+
+    try {
+      websocket?.send(JSON.stringify(message));
+      if (parsedMessage.type === "response") {
+        this.#notifyResponseIdSent(parsedMessage.message.id.toString());
+      }
+    } catch (error) {
+      this.onerror?.(error as Error);
+      throw error;
+    }
+  }
+
+  async close() {
+    // Similar to start, the only thing to do is to pass the event on to the server
+    this.onclose?.();
+  }
+}
+
+type Protocol = "sse" | "streamable-http" | "unset";
 
 export abstract class McpAgent<
   Env = unknown,
@@ -90,6 +250,7 @@ export abstract class McpAgent<
   #status: "zero" | "starting" | "started" = "zero";
   #transport?: Transport;
   #protocol: Protocol = "unset";
+  #requestIdToConnectionId: Map<string | number, string> = new Map();
 
   /**
    * Since McpAgent's _aren't_ yet real "Agents", let's only expose a couple of the methods
@@ -165,6 +326,12 @@ export abstract class McpAgent<
     if (this.#protocol === "sse") {
       this.#transport = new McpSSETransport(() => this.getWebSocket());
       await this.server.connect(this.#transport);
+    } else if (this.#protocol === "streamable-http") {
+      this.#transport = new McpStreamableHttpTransport(
+        (id) => this.getWebSocketForResponseID(id),
+        (id) => this.#requestIdToConnectionId.delete(id)
+      );
+      await this.server.connect(this.#transport);
     }
   }
 
@@ -185,6 +352,10 @@ export abstract class McpAgent<
       this.initRun = true;
       await this.init();
     }
+  }
+
+  isInitialized() {
+    return this.initRun;
   }
 
   async #initialize(): Promise<void> {
@@ -223,11 +394,10 @@ export abstract class McpAgent<
           return new Response("Websocket already connected", { status: 400 });
         }
 
-        // This connection must use the SSE protocol
+        // This session must use the SSE protocol
         await this.ctx.storage.put("protocol", "sse");
         this.#protocol = "sse";
 
-        // Connect to the MCP server
         if (!this.#transport) {
           this.#transport = new McpSSETransport(() => this.getWebSocket());
           await this.server.connect(this.#transport);
@@ -236,10 +406,28 @@ export abstract class McpAgent<
         // Defer to the Agent's fetch method to handle the WebSocket connection
         return this.#agent.fetch(request);
       }
+      case "/streamable-http": {
+        if (!this.#transport) {
+          this.#transport = new McpStreamableHttpTransport(
+            (id) => this.getWebSocketForResponseID(id),
+            (id) => this.#requestIdToConnectionId.delete(id)
+          );
+          await this.server.connect(this.#transport);
+        }
+
+        // This session must use the streamable-http protocol
+        await this.ctx.storage.put("protocol", "streamable-http");
+        this.#protocol = "streamable-http";
+
+        return this.#agent.fetch(request);
+      }
       default:
-        return new Response("Internal Server Error: Expected /sse path", {
-          status: 500,
-        });
+        return new Response(
+          "Internal Server Error: Expected /sse or /streamable-http path",
+          {
+            status: 500,
+          }
+        );
     }
   }
 
@@ -251,8 +439,26 @@ export abstract class McpAgent<
     return websockets[0];
   }
 
+  getWebSocketForResponseID(id: string): WebSocket | null {
+    const connectionId = this.#requestIdToConnectionId.get(id);
+    if (connectionId === undefined) {
+      return null;
+    }
+    return this.#agent.getConnection(connectionId) ?? null;
+  }
+
   // All messages received here. This is currently never called
   async onMessage(connection: Connection, event: WSMessage) {
+    // Since we address the DO via both the protocol and the session id,
+    // this should never happen, but let's enforce it just in case
+    if (this.#protocol !== "streamable-http") {
+      const err = new Error(
+        "Internal Server Error: Expected streamable-http protocol"
+      );
+      this.#transport?.onerror?.(err);
+      return;
+    }
+
     let message: JSONRPCMessage;
     try {
       // Ensure event is a string
@@ -262,6 +468,22 @@ export abstract class McpAgent<
     } catch (error) {
       this.#transport?.onerror?.(error as Error);
       return;
+    }
+
+    // We need to map every incoming message to the connection that it came in on
+    // so that we can send relevant responses and notifications back on the same connection
+    const parsedMessage = parseMessage(message);
+    switch (parsedMessage.type) {
+      case "request":
+        this.#requestIdToConnectionId.set(
+          parsedMessage.message.id.toString(),
+          connection.id
+        );
+        break;
+      case "response":
+      case "notification":
+      case "error":
+        break;
     }
 
     this.#transport?.onmessage?.(message);
@@ -507,7 +729,7 @@ export abstract class McpAgent<
             request.headers.get("content-length") || "0",
             10
           );
-          if (contentLength > MAXIMUM_MESSAGE_SIZE) {
+          if (contentLength > MAXIMUM_MESSAGE_SIZE_BYTES) {
             return new Response(
               `Request body too large: ${contentLength} bytes`,
               {
@@ -547,6 +769,337 @@ export abstract class McpAgent<
         }
 
         return new Response("Not Found", { status: 404 });
+      },
+    };
+  }
+
+  static serve(
+    path: string,
+    {
+      binding = "MCP_OBJECT",
+      corsOptions,
+    }: { binding?: string; corsOptions?: CORSOptions } = {}
+  ) {
+    let pathname = path;
+    if (path === "/") {
+      pathname = "/*";
+    }
+    const basePattern = new URLPattern({ pathname });
+
+    return {
+      fetch: async (
+        request: Request,
+        env: Record<string, DurableObjectNamespace<McpAgent>>,
+        ctx: ExecutionContext
+      ) => {
+        // Handle CORS preflight
+        const corsResponse = handleCORS(request, corsOptions);
+        if (corsResponse) {
+          return corsResponse;
+        }
+
+        const url = new URL(request.url);
+        const namespace = env[binding];
+
+        if (request.method === "POST" && basePattern.test(url)) {
+          // validate the Accept header
+          const acceptHeader = request.headers.get("accept");
+          // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
+          if (
+            !acceptHeader?.includes("application/json") ||
+            !acceptHeader.includes("text/event-stream")
+          ) {
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message:
+                  "Not Acceptable: Client must accept application/json and text/event-stream",
+              },
+              id: null,
+            });
+            return new Response(body, { status: 406 });
+          }
+
+          const ct = request.headers.get("content-type");
+          if (!ct || !ct.includes("application/json")) {
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message:
+                  "Unsupported Media Type: Content-Type must be application/json",
+              },
+              id: null,
+            });
+            return new Response(body, { status: 415 });
+          }
+
+          // Check content length against maximum allowed size
+          const contentLength = Number.parseInt(
+            request.headers.get("content-length") ?? "0",
+            10
+          );
+          if (contentLength > MAXIMUM_MESSAGE_SIZE_BYTES) {
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message: `Request body too large. Maximum size is ${MAXIMUM_MESSAGE_SIZE_BYTES} bytes`,
+              },
+              id: null,
+            });
+            return new Response(body, { status: 413 });
+          }
+
+          let sessionId = request.headers.get("mcp-session-id");
+
+          const rawMessage = await request.json();
+          let messages: JSONRPCMessage[] = [];
+          let parsedMessages: ParseMessageResult[] = [];
+
+          // handle batch and single messages
+          if (Array.isArray(rawMessage)) {
+            messages = rawMessage.map((msg) => JSONRPCMessageSchema.parse(msg));
+          } else {
+            messages = [JSONRPCMessageSchema.parse(rawMessage)];
+          }
+          parsedMessages = messages.map(parseMessage);
+
+          // Before we pass the messages to the agent, there's another error condition we need to enforce
+          // Check if this is an initialization request
+          // https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle/
+          const isInitializationRequest = parsedMessages.some(
+            (msg) => msg.type === "request" && msg.isInitializationRequest
+          );
+
+          if (isInitializationRequest && sessionId) {
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32600,
+                message:
+                  "Invalid Request: Initialization requests must not include a sessionId",
+              },
+              id: null,
+            });
+            return new Response(body, { status: 400 });
+          }
+
+          // The initialization request must be the only request in the batch
+          if (isInitializationRequest && messages.length > 1) {
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32600,
+                message:
+                  "Invalid Request: Only one initialization request is allowed",
+              },
+              id: null,
+            });
+            return new Response(body, { status: 400 });
+          }
+
+          // If an Mcp-Session-Id is returned by the server during initialization,
+          // clients using the Streamable HTTP transport MUST include it
+          // in the Mcp-Session-Id header on all of their subsequent HTTP requests.
+          if (!isInitializationRequest && !sessionId) {
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32600,
+                message: "Bad Request: Mcp-Session-Id header is required",
+              },
+              id: null,
+            });
+            return new Response(body, { status: 400 });
+          }
+
+          // If we don't have a sessionId, we are serving an initialization request
+          // and need to generate a new sessionId
+          sessionId = sessionId ?? namespace.newUniqueId().toString();
+
+          // fetch the agent DO
+          const id = namespace.idFromName(`streamable-http:${sessionId}`);
+          const doStub = namespace.get(id);
+
+          if (isInitializationRequest) {
+            await doStub._init(ctx.props);
+          } else if (!doStub.isInitialized()) {
+            // if we have gotten here, then a session id that was never initialized
+            // was provided
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32001,
+                message: "Session not found",
+              },
+              id: null,
+            });
+            return new Response(body, { status: 400 });
+          }
+
+          // We've evaluated all the error conditions! Now it's time to establish
+          // all the streams
+
+          // Create a Transform Stream for SSE
+          const { readable, writable } = new TransformStream();
+          const writer = writable.getWriter();
+          const encoder = new TextEncoder();
+
+          // Connect to the Durable Object via WebSocket
+          const upgradeUrl = new URL(request.url);
+          upgradeUrl.pathname = "/streamable-http";
+          const response = await doStub.fetch(
+            new Request(upgradeUrl, {
+              headers: {
+                Upgrade: "websocket",
+                // Required by PartyServer
+                "x-partykit-room": sessionId,
+              },
+            })
+          );
+
+          // Get the WebSocket
+          const ws = response.webSocket;
+          if (!ws) {
+            console.error("Failed to establish WebSocket connection");
+
+            await writer.close();
+            const body = JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32001,
+                message: "Failed to establish WebSocket connection",
+              },
+              id: null,
+            });
+            return new Response(body, { status: 500 });
+          }
+
+          // Keep track of the request ids that we have sent to the server
+          // so that we can close the connection once we have received
+          // all the responses
+          const requestIds: Set<string | number> = new Set();
+
+          // Accept the WebSocket
+          ws.accept();
+
+          // Handle messages from the Durable Object
+          ws.addEventListener("message", async (event) => {
+            try {
+              const data =
+                typeof event.data === "string"
+                  ? event.data
+                  : new TextDecoder().decode(event.data);
+              const message = JSON.parse(data);
+
+              // validate that the message is a valid JSONRPC message
+              const result = JSONRPCMessageSchema.safeParse(message);
+              if (!result.success) {
+                // The message was not a valid JSONRPC message, so we will drop it
+                // PartyKit will broadcast state change messages to all connected clients
+                // and we need to filter those out so they are not passed to MCP clients
+                return;
+              }
+
+              // If the message is a response, add the id to the set of request ids
+              const parsedMessage = parseMessage(result.data);
+              switch (parsedMessage.type) {
+                case "response":
+                case "error":
+                  requestIds.add(parsedMessage.message.id);
+                  break;
+                case "notification":
+                case "request":
+                  break;
+              }
+
+              // Send the message as an SSE event
+              const messageText = `event: message\ndata: ${JSON.stringify(result.data)}\n\n`;
+              await writer.write(encoder.encode(messageText));
+
+              // If we have received all the responses, close the connection
+              if (requestIds.size === messages.length) {
+                ws.close();
+              }
+            } catch (error) {
+              console.error("Error forwarding message to SSE:", error);
+            }
+          });
+
+          // Handle WebSocket errors
+          ws.addEventListener("error", async (error) => {
+            try {
+              await writer.close();
+            } catch (e) {
+              // Ignore errors when closing
+            }
+          });
+
+          // Handle WebSocket closure
+          ws.addEventListener("close", async () => {
+            try {
+              await writer.close();
+            } catch (error) {
+              console.error("Error closing SSE connection:", error);
+            }
+          });
+
+          // If there are no requests, we send the messages to the agent and acknowledge the request with a 202
+          // since we don't expect any responses back through this connection
+          const hasOnlyNotificationsOrResponses = parsedMessages.every(
+            (msg) => msg.type === "notification" || msg.type === "response"
+          );
+          if (hasOnlyNotificationsOrResponses) {
+            for (const message of messages) {
+              ws.send(JSON.stringify(message));
+            }
+
+            // closing the websocket will also close the SSE connection
+            ws.close();
+
+            return new Response(null, { status: 202 });
+          }
+
+          for (const message of messages) {
+            const parsedMessage = parseMessage(message);
+            switch (parsedMessage.type) {
+              case "request":
+                requestIds.add(parsedMessage.message.id);
+                break;
+              case "notification":
+              case "response":
+              case "error":
+                break;
+            }
+            ws.send(JSON.stringify(message));
+          }
+
+          // Return the SSE response. We handle closing the stream in the ws "message"
+          // handler
+          return new Response(readable, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "mcp-session-id": sessionId,
+              "Access-Control-Allow-Origin": corsOptions?.origin || "*",
+            },
+            status: 200,
+          });
+        }
+
+        // We don't yet support GET or DELETE requests
+        const body = JSON.stringify({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Method not allowed",
+          },
+          id: null,
+        });
+        return new Response(body, { status: 405 });
       },
     };
   }


### PR DESCRIPTION
Note: Stacked on top of #185 *

This adds support for the new Streamable HTTP transport alongside the existing SSE transport. No code changes on the client should be necessary, and you can serve both at once with the same codebase.

This only supports `POST` requests for now. Resumability et al will come later, which we should also not require any further changes.

Setting up a worker to serve these transports on different endpoints would look like this:

```ts
export default {
	fetch(request: Request, env: Env, ctx: ExecutionContext) {
		let url = new URL(request.url);
		let path = url.pathname;
		if (path.startsWith('/sse')) {
			return MyMcpAgent.serveSSE('/sse').fetch(request, env, ctx);
		}
		if (path.startsWith('/mcp')) {
			return MyMcpAgent.serve('/mcp').fetch(request, env, ctx);
		}
	},
};
```

Marking as draft for now since I still have a few things I want to clean up and more validation to do. Initial testing with [the unreleased MCP Inspector branch](https://github.com/modelcontextprotocol/inspector/pull/294) seems to work well!

* Not sure if you can set up a stacked diff on github when both branches are remote so that you can only see the second set of changes here? Please let me know the secret it is