### PR TITLE
Fix streamable hibernation issues

### DIFF
--- a/.changeset/nasty-ties-jog.md
+++ b/.changeset/nasty-ties-jog.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Jmorrell/fix streamable hibernation issue

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -300,11 +300,6 @@ export abstract class McpAgent<
   }
 
   async isInitialized() {
-    if (this.#status !== "started") {
-      // This means the server "woke up" after hibernation
-      // so we need to hydrate it again
-      await this.#initialize();
-    }
     return (await this.ctx.storage.get("initialized")) === true;
   }
 

--- a/packages/agents/src/tests/mcp-streamable-http.test.ts
+++ b/packages/agents/src/tests/mcp-streamable-http.test.ts
@@ -269,7 +269,6 @@ describe("McpAgent Streamable HTTP Transport", () => {
 
   it("should reject invalid session ID", async () => {
     const ctx = createExecutionContext();
-    const sessionId = await initializeServer(ctx);
 
     // Now try with invalid session ID
     const response = await sendPostRequest(


### PR DESCRIPTION
Fixes an error introduced in https://github.com/cloudflare/agents/pull/186

The first the the Streamable worker does on an incoming request with a `sessionId` is ask the DO if it's been initialized. If it has not, then the DO has never received an initialize message, and we should reject it.

In the current version once a DO hibernates, this always returns `false`.

However, we're conflating two different types of "initialization" here:

- We call "init" on the `McpAgent` class to allow the user to define the `McpServer`
- There is an "initialization" message that is the first message the Streamable server receives

This fixes the issue by having an explicit `setInitialized()` method, and tracking the second kind of authentication in DO storage.

There was also an additional error with the `this.init?.()` call where it was not `await`'d. Once you await you get errors because it is being run twice and trying to define the same tool twice. These were being silently ignored.