### PR TITLE
Agent::mcp, McpClientManager::unstable_getAITools

### DIFF
--- a/.changeset/ninety-lizards-doubt.md
+++ b/.changeset/ninety-lizards-doubt.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Add .mcp to the Agent class, and add a helper to McpClientManager to convert tools to work with AI SDK

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -12,6 +12,7 @@ import { parseCronExpression } from "cron-schedule";
 import { nanoid } from "nanoid";
 
 import { AsyncLocalStorage } from "node:async_hooks";
+import { MCPClientManager } from "./mcp/client";
 
 export type { Connection, WSMessage, ConnectionContext } from "partyserver";
 
@@ -176,6 +177,11 @@ export const unstable_context = new AsyncLocalStorage<{
  */
 export class Agent<Env, State = unknown> extends Server<Env> {
   #state = DEFAULT_STATE as State;
+
+  #ParentClass: typeof Agent<Env, State> =
+    Object.getPrototypeOf(this).constructor;
+
+  mcp: MCPClientManager = new MCPClientManager(this.#ParentClass.name, "0.0.1");
 
   /**
    * Initial state for the Agent

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -196,6 +196,10 @@ export abstract class McpAgent<
    */
   #agent: Agent<Env, State>;
 
+  get mcp() {
+    return this.#agent.mcp;
+  }
+
   protected constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     const self = this;


### PR DESCRIPTION
- Every Agent now has a default McpClientManager (this.mcp)
- This means you can now connect to an MCP server from inside an MCP server (!!!)
- You can convert McpClientManager tools to be compatible with AI SDK