### PR TITLE
throw an error if an mcp client is already connected to a server

### DIFF
--- a/.changeset/moody-spies-talk.md
+++ b/.changeset/moody-spies-talk.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+throw an error if an mcp client is already connected to a server

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -60,6 +60,18 @@ export class MCPClientManager {
       capabilities?: ClientCapabilities;
     } = {}
   ): Promise<{ id: string; authUrl: string | undefined }> {
+    const { host, pathname } = new URL(url);
+    for (const connection of Object.values(this.mcpConnections)) {
+      if (
+        connection.url.host === host &&
+        connection.url.pathname === pathname
+      ) {
+        throw new Error(
+          `Connection with host: ${host} and pathname: ${pathname} already exists`
+        );
+      }
+    }
+
     const id = options.reconnect?.id ?? crypto.randomUUID();
 
     if (!options.transport?.authProvider) {


### PR DESCRIPTION
@cmsparks I posit that we shouldn't connect to the same server multiple times in the same client manager. is that correct? is this the right approach? should we instead return a previous existing connection? is comparing host/pathname the correct strategy here? how do different "sessions" affect this? should I move this logic outside to my own app layer?

context: going to add a natural language input to the AIChatAgent to dynamically add remote mcp servers, and trying to handle edge cases. 