### PR TITLE
Fix type error for McpAgent.fetch

### DIFF
--- a/.changeset/fuzzy-ads-matter.md
+++ b/.changeset/fuzzy-ads-matter.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix type error for McpAgent.serve and McpAgent.serveSSE

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -532,17 +532,22 @@ export abstract class McpAgent<
     const messagePattern = new URLPattern({ pathname: `${pathname}/message` });
 
     return {
-      fetch: async (
+      async fetch<Env>(
         request: Request,
-        env: Record<string, DurableObjectNamespace<McpAgent>>,
+        env: Env,
         ctx: ExecutionContext
-      ): Promise<Response> => {
+      ): Promise<Response> {
         // Handle CORS preflight
         const corsResponse = handleCORS(request, corsOptions);
         if (corsResponse) return corsResponse;
 
         const url = new URL(request.url);
-        const namespace = env[binding];
+
+        // Ensure we have an MCP agent as a binding
+        // TODO: How can we address this in a type-safe way??
+        const namespace = env[
+          binding
+        ] as unknown as DurableObjectNamespace<McpAgent>;
 
         // Handle initial SSE connection
         if (request.method === "GET" && basePattern.test(url)) {

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -546,6 +546,9 @@ export abstract class McpAgent<
 
         // Ensure we have a binding of some sort
         if (bindingValue == null || typeof bindingValue !== "object") {
+          console.error(
+            `Could not find McpAgent binding for ${binding}. Did you update your wrangler configuration?`
+          );
           return new Response("Invalid binding", { status: 500 });
         }
 
@@ -765,6 +768,9 @@ export abstract class McpAgent<
 
         // Ensure we have a binding of some sort
         if (bindingValue == null || typeof bindingValue !== "object") {
+          console.error(
+            `Could not find McpAgent binding for ${binding}. Did you update your wrangler configuration?`
+          );
           return new Response("Invalid binding", { status: 500 });
         }
 


### PR DESCRIPTION
An attempt at fixing https://github.com/cloudflare/agents/issues/210

No more red squiggles or `@ts-ignore` in our demo code!

<img width="631" alt="Monosnap index ts — remote-mcp-authless 2025-04-25 08-45-25" src="https://github.com/user-attachments/assets/1fd3e5d8-e2e2-4fe2-98d9-bac3523de3fa" />
