### PR TITLE
Support server as promises in McpAgent

### DIFF
--- a/.changeset/moody-nails-melt.md
+++ b/.changeset/moody-nails-melt.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Support server as promises in McpAgent


### PR DESCRIPTION
Generalizes `McpServer.server` to also support promises.

In `playwright-mcp`, [mcp server is created asynchronously](https://github.com/cloudflare/playwright-mcp/blob/b51e41a0c5c71fc48eb2018a0ccdd48b2d6f4d60/src/index.ts#L79) and it's not possible to pass it to McpAgent, so these changes are to provide support for asynchronously created servers.