### PR TITLE
feat(obs): basic agent instrumentation

### DIFF
--- a/.changeset/chilly-owls-wonder.md
+++ b/.changeset/chilly-owls-wonder.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Basic observability instrumentation

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -58,6 +58,11 @@
       "import": "./dist/mcp/do-oauth-client-provider.js",
       "require": "./dist/mcp/do-oauth-client-provider.js"
     },
+    "./observability": {
+      "import": "./dist/observability/index.js",
+      "require": "./dist/observability/index.js",
+      "types": "./dist/observability/index.d.ts"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "import": "./dist/react.js",

--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -11,6 +11,7 @@ async function main() {
       "src/mcp/index.ts",
       "src/mcp/client.ts",
       "src/mcp/do-oauth-client-provider.ts",
+      "src/observability/index.ts",
     ],
     external: [
       "cloudflare:workers",

--- a/packages/agents/src/observability/index.ts
+++ b/packages/agents/src/observability/index.ts
@@ -1,0 +1,106 @@
+import type { Message } from "ai";
+import type { Schedule } from "../index";
+import { getCurrentAgent } from "../index";
+
+type BaseEvent<
+  T extends string,
+  Payload extends Record<string, unknown> = {},
+> = {
+  type: T;
+  /**
+   * The unique identifier for the event
+   */
+  id: string;
+  /**
+   * The message to display in the logs for this event, should the implementation choose to display
+   * a human-readable message.
+   */
+  displayMessage: string;
+  /**
+   * The payload of the event
+   */
+  payload: Payload;
+  /**
+   * The timestamp of the event in milliseconds since epoch
+   */
+  timestamp: number;
+};
+
+/**
+ * The type of events that can be emitted by an Agent
+ */
+export type ObservabilityEvent =
+  | BaseEvent<
+      "state:update",
+      {
+        state: unknown;
+        previousState: unknown;
+      }
+    >
+  | BaseEvent<
+      "rpc",
+      {
+        method: string;
+        args: unknown[];
+        streaming?: boolean;
+        success: boolean;
+      }
+    >
+  | BaseEvent<
+      "message:request" | "message:response",
+      {
+        message: Message[];
+      }
+    >
+  | BaseEvent<"message:clear">
+  | BaseEvent<
+      "schedule:create" | "schedule:execute" | "schedule:cancel",
+      Schedule<unknown>
+    >
+  | BaseEvent<"destroy">
+  | BaseEvent<
+      "connect",
+      {
+        connectionId: string;
+      }
+    >;
+
+export interface Observability {
+  /**
+   * Emit an event for the Agent's observability implementation to handle.
+   * @param event - The event to emit
+   * @param ctx - The execution context of the invocation
+   */
+  emit(event: ObservabilityEvent, ctx: DurableObjectState): void;
+}
+
+/**
+ * A generic observability implementation that logs events to the console.
+ */
+export const genericObservability: Observability = {
+  emit(event) {
+    // In local mode, we display a pretty-print version of the event for easier debugging.
+    if (isLocalMode()) {
+      console.log(event.displayMessage);
+      return;
+    }
+
+    console.log(event);
+  },
+};
+
+let localMode = false;
+
+function isLocalMode() {
+  if (localMode) {
+    return true;
+  }
+  const { request } = getCurrentAgent();
+  if (!request) {
+    return false;
+  }
+
+  const url = new URL(request.url);
+  localMode = url.hostname === "localhost";
+  return localMode;
+}


### PR DESCRIPTION
Adds a new `observability` property to Agents that receives events during the Agent's exeuction that can be used for configurable observability. The default observability implementation prints the events to console, but in the future this could be hooked up to a UI or some other observability tooling.