### PR TITLE
fix(types): explicitly annotate this with void to avoid unbound method warning

### DIFF
--- a/.changeset/strong-cougars-change.md
+++ b/.changeset/strong-cougars-change.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+fix(types): explicitly annotate this with void to avoid unbound method warning

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -542,6 +542,7 @@ export abstract class McpAgent<
 
     return {
       async fetch<Env>(
+        this: void,
         request: Request,
         env: Env,
         ctx: ExecutionContext
@@ -767,6 +768,7 @@ export abstract class McpAgent<
 
     return {
       async fetch<Env>(
+        this: void,
         request: Request,
         env: Env,
         ctx: ExecutionContext


### PR DESCRIPTION
Implementing [this Hono example](https://blog.cloudflare.com/streamable-http-mcp-servers-python/#streamable-http-a-simpler-way-for-ai-agents-to-communicate-with-services-via-mcp) will result in a [typescript-eslint's unbound-method](https://typescript-eslint.io/rules/unbound-method/) warning.

Since the `fetch` function returned by `MCPAgent.serve` and `MCPAgent.serveSSE` does not access `this`,
explicitly annotating `this` with `void` makes the implementation type-safer and will not cause warnings.
