### PR TITLE
Pass props to do streamable

### DIFF
--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -949,6 +949,7 @@ export abstract class McpAgent<
           const isInitialized = await doStub.isInitialized();
 
           if (isInitializationRequest) {
+            await doStub._init(ctx.props);
             await doStub.setInitialized();
           } else if (!isInitialized) {
             // if we have gotten here, then a session id that was never initialized


### PR DESCRIPTION
Thanks to @BrandonNoad for pointing this out here: https://github.com/cloudflare/agents/pull/203#discussion_r2071566725

In refactoring to prevent issues with hibernation, I removed the logic where we pass on the `ctx.props` to the `McpAgent`. `init` still runs so this doesn't break if the user never tries to read the props, but if they, say, need to read the user id from an auth flow, it won't be available.

Luckily it's a one-line change to fix. Most of this PR is adding tests to make sure `props` is available to the Agent for both SSE and Streamable