### PR TITLE
chore: add top level default types to package.json

### DIFF
--- a/.changeset/chatty-schools-speak.md
+++ b/.changeset/chatty-schools-speak.md
@@ -1,0 +1,6 @@
+---
+"agents": patch
+"hono-agents": patch
+---
+
+chore: add top level default types to package.json

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -2,6 +2,7 @@
   "name": "agents",
   "version": "0.0.76",
   "main": "src/index.ts",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "check:test": "npm run check:test:workers && npm run check:test:react",

--- a/packages/hono-agents/package.json
+++ b/packages/hono-agents/package.json
@@ -2,6 +2,7 @@
   "name": "hono-agents",
   "version": "0.0.66",
   "main": "src/index.ts",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
- Add top level default types to package.json for both modules
- Works in conjunction with explicit exports object
- This lets the NPM registry know that this project indeed does support TS.

Don't bother with changeset, when it happens it happens. 