### PR TITLE
Ensure isLoading is false after you `stop` an ongoing chat agent request

### DIFF
--- a/.changeset/gorgeous-bears-beam.md
+++ b/.changeset/gorgeous-bears-beam.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Ensure isLoading is false after you `stop` an ongoing chat agent request

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -155,6 +155,8 @@ export function useAgentChat<State = unknown>(
       // }))
 
       abortController.abort();
+      // Make sure to also close the stream (cf. https://github.com/cloudflare/agents-starter/issues/69)
+      controller.close();
     });
 
     agent.addEventListener(


### PR DESCRIPTION
Fixes  cloudflare/agents-starter#69 (tested locally) - big thank you to @Gyurmatag

***

So in https://github.com/cloudflare/agents/pull/105, I forgot to also close the controller after sending an abort signal. This meant the `isLoading` from the chat agent hook didn't turn back to false.