### PR TITLE
fix: allow overriding fetch and request headers in SSEEdgeClientTransport

### DIFF
--- a/.changeset/forty-eagles-worry.md
+++ b/.changeset/forty-eagles-worry.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+fix: allow overriding fetch and request headers in SSEEdgeClientTransport

--- a/packages/agents/src/mcp/sse-edge.ts
+++ b/packages/agents/src/mcp/sse-edge.ts
@@ -31,12 +31,11 @@ export class SSEEdgeClientTransport extends SSEClientTransport {
 
       // Call the original fetch with fixed options
       return (
-        options.eventSourceInit?.fetch?.(
+        (options.eventSourceInit?.fetch?.(
           fetchUrl as URL | string,
           // @ts-expect-error Expects FetchLikeInit from EventSource but is compatible with RequestInit
           workerOptions
-        ) as Promise<Response> ||
-        fetch(fetchUrl, workerOptions)
+        ) as Promise<Response>) || fetch(fetchUrl, workerOptions)
       );
     };
 

--- a/packages/agents/src/mcp/sse-edge.ts
+++ b/packages/agents/src/mcp/sse-edge.ts
@@ -19,6 +19,7 @@ export class SSEEdgeClientTransport extends SSEClientTransport {
       const workerOptions = {
         ...fetchInit,
         headers: {
+          ...options.requestInit?.headers,
           ...fetchInit?.headers,
           ...headers,
         },
@@ -29,12 +30,20 @@ export class SSEEdgeClientTransport extends SSEClientTransport {
       delete workerOptions.mode;
 
       // Call the original fetch with fixed options
-      return fetch(fetchUrl, workerOptions);
+      return (
+        options.eventSourceInit?.fetch?.(
+          fetchUrl as URL | string,
+          // @ts-expect-error Expects FetchLikeInit from EventSource but is compatible with RequestInit
+          workerOptions
+        ) as Promise<Response> ||
+        fetch(fetchUrl, workerOptions)
+      );
     };
 
     super(url, {
       ...options,
       eventSourceInit: {
+        ...options.eventSourceInit,
         fetch: fetchOverride,
       },
     });


### PR DESCRIPTION
This PR enhances SSEEdgeClientTransport to support custom fetch options and merges custom request headers with workerOptions headers.

In my use case, I was trying to pass along CF access id and secrets as headers to a remote mcp server but those headers were not sent because SSEEdgeClientTransport is overriding the fetch function and doesn't call user-provided fetch function when it exists.

# How to test
1. Connect to an mcp server behind Cloudflare access using a clone of this branch.
```ts
manager.connect("https://mcp.example.com/sse", {
      transport: {
        eventSourceInit: {
          fetch: (url, init) => fetch(url, {
            ...init,
            headers: {
              ...init?.headers,
              'CF-Access-Client-Id': env.CF_ACCESS_CLIENT_ID,
              'CF-Access-Client-Secret': env.CF_ACCESS_CLIENT_SECRET
            }
          })
        },
        //requestInit: {
          //headers: {
            //'CF-Access-Client-Id': env.CF_ACCESS_CLIENT_ID,
            //'CF-Access-Client-Secret': env.CF_ACCESS_CLIENT_SECRET,
          //}
        //}
      }
    })
```
2. Assert that you do not get a 403 error