### PR TITLE
Update Agent.alarm to readonly, linking to schedule-task docs

### DIFF
--- a/.changeset/gorgeous-poems-care.md
+++ b/.changeset/gorgeous-poems-care.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Update Agent.alarm to readonly, linking to schedule-task docs

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -713,10 +713,14 @@ export class Agent<Env, State = unknown> extends Server<Env> {
   }
 
   /**
-   * Method called when an alarm fires
-   * Executes any scheduled tasks that are due
+   * Method called when an alarm fires.
+   * Executes any scheduled tasks that are due.
+   *
+   * @remarks
+   * To schedule a task, please use the `this.schedule` method instead.
+   * See {@link https://developers.cloudflare.com/agents/api-reference/schedule-tasks/}
    */
-  async alarm() {
+  public readonly alarm = async () => {
     const now = Math.floor(Date.now() / 1000);
 
     // Get all schedules that should be executed now

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -767,7 +767,7 @@ export class Agent<Env, State = unknown> extends Server<Env> {
 
     // Schedule the next alarm
     await this.#scheduleNextAlarm();
-  }
+  };
 
   /**
    * Destroy the Agent, removing all state and scheduled tasks


### PR DESCRIPTION
Since the Agent class has a custom implementation for scheduled tasks via `this.schedule`, if the `alarm` class is implemented on a subclass, it doesn't perform as expected. While a quick trip to the docs would point you in this direction, it would be nice to have a ts error and js doc explaining that instead of implementing alarm, use the schedule method instead. Was able to find a solution to provide a type warning in one case, but not sure if there is a better way to do this to catch all cases?

- Updates alarm function on Agent class to be readonly, to produce a ts error on subclasses trying to override this method as an instance member function
- Adds js doc to alarm function with link to schedule-task docs, in the hopes that this steers them in the right direction

#### Test happy path

- In the `AIChatAgent` class, add a dummy alarm method
```
async alarm() {
  console.log('hello');
}
```
- Produces the following type error
```
Class 'Agent<Env, State>' defines instance member property 'alarm', but extended class 'AIChatAgent<Env, State>' defines it as instance member function.ts(2425)
```
- If the code is executed, the alarm function on `AIChatAgent` shouldn't be called, only the one on `Agent`

#### Possible subversion
If the user reads the error they could actually just get around this by instead adding to `AIChatAgent`
```
alarm = async () => {
  console.log('hello');
}
```
So it's not a fool proof solution, but the hope is that it would guard the majority that just follow the [cloudflare docs on how to implement alarms](https://developers.cloudflare.com/durable-objects/api/alarms/#example).