### PR TITLE
Add type support to react useAgent().call

### DIFF
--- a/.changeset/popular-dingos-perform.md
+++ b/.changeset/popular-dingos-perform.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/agents-mcp-example": patch
+"@cloudflare/agents-playground": patch
+"agents": patch
+"@cloudflare/agents-human-in-the-loop": patch
+---
+
+Add type support to react useAgent().call

--- a/.changeset/popular-dingos-perform.md
+++ b/.changeset/popular-dingos-perform.md
@@ -1,8 +1,5 @@
 ---
-"@cloudflare/agents-mcp-example": patch
-"@cloudflare/agents-playground": patch
 "agents": patch
-"@cloudflare/agents-human-in-the-loop": patch
 ---
 
 Add type support to react useAgent().call

--- a/biome.json
+++ b/biome.json
@@ -25,6 +25,9 @@
       },
       "a11y": {
         "useKeyWithClickEvents": "off"
+      },
+      "complexity": {
+        "noBannedTypes": "off"
       }
     }
   }

--- a/examples/mcp/src/server.ts
+++ b/examples/mcp/src/server.ts
@@ -8,7 +8,6 @@ type Env = {
 
 type State = { counter: number };
 
-// biome-ignore lint/complexity/noBannedTypes: <explanation>
 export class MyMCP extends McpAgent<Env, State, {}> {
   server = new McpServer({
     name: "Demo",

--- a/examples/playground/src/agents/chat.ts
+++ b/examples/playground/src/agents/chat.ts
@@ -5,7 +5,6 @@ import type { Env } from "../server";
 import { model } from "../model";
 
 export class Chat extends AIChatAgent<Env> {
-  // biome-ignore lint/complexity/noBannedTypes: <explanation>
   async onChatMessage(onFinish: StreamTextOnFinishCallback<{}>) {
     const dataStreamResponse = createDataStreamResponse({
       execute: async (dataStream) => {

--- a/examples/playground/src/agents/email.ts
+++ b/examples/playground/src/agents/email.ts
@@ -101,7 +101,7 @@ export class EmailAgent extends AIChatAgent<Env> {
   async onEmail(email: ForwardableEmailMessage) {
     //
   }
-  // biome-ignore lint/complexity/noBannedTypes: vibes
+
   async onChatMessage(onFinish: StreamTextOnFinishCallback<{}>) {
     const dataStreamResponse = createDataStreamResponse({
       execute: async (dataStream) => {

--- a/guides/human-in-the-loop/src/server.ts
+++ b/guides/human-in-the-loop/src/server.ts
@@ -14,7 +14,6 @@ type Env = {
 };
 
 export class HumanInTheLoop extends AIChatAgent<Env> {
-  // biome-ignore lint/complexity/noBannedTypes: vibes
   async onChatMessage(onFinish: StreamTextOnFinishCallback<{}>) {
     const dataStreamResponse = createDataStreamResponse({
       execute: async (dataStream) => {

--- a/guides/human-in-the-loop/src/utils.ts
+++ b/guides/human-in-the-loop/src/utils.ts
@@ -33,7 +33,6 @@ function isValidToolName<K extends PropertyKey, T extends object>(
 export async function processToolCalls<
   Tools extends ToolSet,
   ExecutableTools extends {
-    // biome-ignore lint/complexity/noBannedTypes: <explanation>
     [Tool in keyof Tools as Tools[Tool] extends { execute: Function }
       ? never
       : Tool]: Tools[Tool];

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -8,8 +8,9 @@
     "check:test": "npm run check:test:workers && npm run check:test:react",
     "check:test:workers": "vitest -r src/tests --watch false",
     "check:test:react": "vitest -r src/react-tests --watch false",
-    "test": "vitest -r src/tests",
+    "test": "vitest -r src/tests && npm run test:types",
     "test:react": "vitest -r src/react-tests",
+    "test:types": "tsc",
     "evals": "(cd evals; evalite)",
     "build": "tsx ./scripts/build.ts"
   },

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -112,7 +112,6 @@ export type CallableMetadata = {
   streaming?: boolean;
 };
 
-// biome-ignore lint/complexity/noBannedTypes: <explanation>
 const callableMetadata = new Map<Function, CallableMetadata>();
 
 /**
@@ -448,7 +447,6 @@ export class Agent<Env, State = unknown> extends Server<Env> {
                 throw new Error(`Method ${method} is not callable`);
               }
 
-              // biome-ignore lint/complexity/noBannedTypes: <explanation>
               const metadata = callableMetadata.get(methodFn as Function);
 
               // For streaming methods, pass a StreamingResponse object
@@ -914,8 +912,11 @@ export class Agent<Env, State = unknown> extends Server<Env> {
     await this.ctx.storage.deleteAll();
   }
 
+  /**
+   * Get all methods marked as callable on this Agent
+   * @returns A map of method names to their metadata
+   */
   private _isCallable(method: string): boolean {
-    // biome-ignore lint/complexity/noBannedTypes: <explanation>
     return callableMetadata.has(this[method as keyof this] as Function);
   }
 

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -77,9 +77,9 @@ type AgentPromiseReturnType<T extends AgentMethods<any>, K extends keyof T> =
  * @param options Connection options
  * @returns WebSocket connection with setState and call methods
  */
-export function useAgent<State, AgentT extends {
+export function useAgent<AgentT extends {
   get state(): State;
-}>(
+}, State>(
   options: UseAgentOptions<State>
 ): PartySocket & {
   agent: string;

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -88,6 +88,18 @@ type AgentPromiseReturnType<T extends AgentMethods<any>, K extends keyof T> =
  * @param options Connection options
  * @returns WebSocket connection with setState and call methods
  */
+export function useAgent<State = unknown>(
+  options: UseAgentOptions<State>
+): PartySocket & {
+  agent: string;
+  name: string;
+  setState: (state: State) => void;
+  call: <T = unknown>(
+    method: string,
+    args?: unknown[],
+    streamOptions?: StreamOptions
+  ) => Promise<T>;
+};
 export function useAgent<
   AgentT extends {
     get state(): State;
@@ -109,18 +121,6 @@ export function useAgent<
       args: Parameters<RequiredAgentMethods<AgentT>[T]>,
       streamOptions?: StreamOptions
     ) => AgentPromiseReturnType<AgentT, T>);
-};
-export function useAgent<State = unknown>(
-  options: UseAgentOptions<State>
-): PartySocket & {
-  agent: string;
-  name: string;
-  setState: (state: State) => void;
-  call: <T = unknown>(
-    method: string,
-    args?: unknown[],
-    streamOptions?: StreamOptions
-  ) => Promise<T>;
 };
 export function useAgent<State>(
   options: UseAgentOptions<unknown>

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -1,9 +1,8 @@
 import type { PartySocket } from "partysocket";
 import { usePartySocket } from "partysocket/react";
 import { useCallback, useRef } from "react";
-import type { MCPServersState, RPCRequest, RPCResponse } from "./";
+import type { MCPServersState, RPCRequest, RPCResponse, Agent } from "./";
 import type { StreamOptions } from "./client";
-import type { Agent } from "../dist";
 
 /**
  * Convert a camelCase string to a kebab-case string

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -52,7 +52,7 @@ type OptionalParametersMethod<T> = T extends (
   arg?: infer R,
   // biome-ignore lint: suppressions/parse
   ...rest: any
-// biome-ignore lint: suppressions/parse
+  // biome-ignore lint: suppressions/parse
 ) => any
   ? R extends undefined
     ? never

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -47,7 +47,10 @@ type Methods<T> = {
   [K in keyof T as T[K] extends (...args: any) => any ? K : never]: T[K];
 };
 
-type OptionalParametersMethod<T> = T extends (arg?: infer R, ...rest: any) => any
+type OptionalParametersMethod<T> = T extends (
+  arg?: infer R,
+  ...rest: any
+) => any
   ? R extends undefined
     ? never
     : T
@@ -59,11 +62,13 @@ type AgentMethods<T> = Omit<Methods<T>, keyof Agent<any, any>>;
 type OptionalAgentMethods<T> = {
   [K in keyof AgentMethods<T> as T[K] extends OptionalParametersMethod<T[K]>
     ? K
-    : never
-  ]: OptionalParametersMethod<T[K]>;
+    : never]: OptionalParametersMethod<T[K]>;
 };
 
-type RequiredAgentMethods<T> = Omit<AgentMethods<T>, keyof OptionalAgentMethods<T>>;
+type RequiredAgentMethods<T> = Omit<
+  AgentMethods<T>,
+  keyof OptionalAgentMethods<T>
+>;
 
 type AgentPromiseReturnType<T extends AgentMethods<any>, K extends keyof T> =
   ReturnType<T[K]> extends Promise<any>
@@ -77,25 +82,27 @@ type AgentPromiseReturnType<T extends AgentMethods<any>, K extends keyof T> =
  * @param options Connection options
  * @returns WebSocket connection with setState and call methods
  */
-export function useAgent<AgentT extends {
-  get state(): State;
-}, State>(
+export function useAgent<
+  AgentT extends {
+    get state(): State;
+  },
+  State,
+>(
   options: UseAgentOptions<State>
 ): PartySocket & {
   agent: string;
   name: string;
   setState: (state: State) => void;
-  call: 
-    & (<T extends keyof OptionalAgentMethods<AgentT>>(
-        method: T,
-        args?: Parameters<OptionalAgentMethods<AgentT>[T]>,
-        streamOptions?: StreamOptions
-      ) => AgentPromiseReturnType<AgentT, T>)
-    & (<T extends keyof RequiredAgentMethods<AgentT>>(
-        method: T,
-        args: Parameters<RequiredAgentMethods<AgentT>[T]>,
-        streamOptions?: StreamOptions
-      ) => AgentPromiseReturnType<AgentT, T>);
+  call: (<T extends keyof OptionalAgentMethods<AgentT>>(
+    method: T,
+    args?: Parameters<OptionalAgentMethods<AgentT>[T]>,
+    streamOptions?: StreamOptions
+  ) => AgentPromiseReturnType<AgentT, T>) &
+    (<T extends keyof RequiredAgentMethods<AgentT>>(
+      method: T,
+      args: Parameters<RequiredAgentMethods<AgentT>[T]>,
+      streamOptions?: StreamOptions
+    ) => AgentPromiseReturnType<AgentT, T>);
 };
 export function useAgent<State = unknown>(
   options: UseAgentOptions<State>

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -44,12 +44,15 @@ export type UseAgentOptions<State = unknown> = Omit<
 };
 
 type Methods<T> = {
+  // biome-ignore lint: suppressions/parse
   [K in keyof T as T[K] extends (...args: any) => any ? K : never]: T[K];
 };
 
 type OptionalParametersMethod<T> = T extends (
   arg?: infer R,
+  // biome-ignore lint: suppressions/parse
   ...rest: any
+// biome-ignore lint: suppressions/parse
 ) => any
   ? R extends undefined
     ? never
@@ -57,6 +60,7 @@ type OptionalParametersMethod<T> = T extends (
   : never;
 
 // all methods of the Agent, excluding the ones that are declared in the base Agent class
+// biome-ignore lint: suppressions/parse
 type AgentMethods<T> = Omit<Methods<T>, keyof Agent<any, any>>;
 
 type OptionalAgentMethods<T> = {
@@ -70,7 +74,9 @@ type RequiredAgentMethods<T> = Omit<
   keyof OptionalAgentMethods<T>
 >;
 
+// biome-ignore lint: suppressions/parse
 type AgentPromiseReturnType<T extends AgentMethods<any>, K extends keyof T> =
+  // biome-ignore lint: suppressions/parse
   ReturnType<T[K]> extends Promise<any>
     ? ReturnType<T[K]>
     : Promise<ReturnType<T[K]>>;

--- a/packages/agents/src/tests-d/example.test-d.ts
+++ b/packages/agents/src/tests-d/example.test-d.ts
@@ -1,0 +1,41 @@
+import { Agent } from '../../dist';
+import { env } from "cloudflare:workers";
+import { unstable_callable as callable } from '../index.ts';
+import { useAgent } from '../react.tsx';
+
+class MyAgent extends Agent<typeof env, {}> {
+  @callable()
+  sayHello(name?: string): string {
+    return `Hello, ${name ?? 'World'}!`;
+  }
+  
+  @callable()
+  async perform(task: string, p1?: number): Promise<void> {
+    // do something
+  }
+
+  // not decorated with @callable()
+  nonRpc(): void {
+  }
+}
+
+const agent = useAgent<{}, MyAgent>({ agent: 'my-agent' });
+// return type is promisified
+agent.call('sayHello') satisfies Promise<string>;
+
+// @ts-expect-error first argument is not a string
+await agent.call('sayHello', [1]);
+
+await agent.call('perform', ['some task', 1]);
+await agent.call('perform', ['another task']);
+// @ts-expect-error requires parameters
+await agent.call('perform');
+
+// we cannot exclude it because typescript doesn't have a way
+// to exclude based on decorators
+await agent.call('nonRpc');
+
+const agent2 = useAgent<{}, Omit<MyAgent, 'nonRpc'>>({ agent: 'my-agent' });
+agent2.call('sayHello');
+// @ts-expect-error nonRpc excluded from useAgent
+agent2.call('nonRpc');

--- a/packages/agents/src/tests-d/example.test-d.ts
+++ b/packages/agents/src/tests-d/example.test-d.ts
@@ -1,40 +1,39 @@
-import { env } from "cloudflare:workers";
-import { unstable_callable as callable, Agent } from '../index.ts';
-import { useAgent } from '../react.tsx';
+import type { env } from "cloudflare:workers";
+import { unstable_callable as callable, Agent } from "../index.ts";
+import { useAgent } from "../react.tsx";
 
 class MyAgent extends Agent<typeof env, {}> {
   @callable()
   sayHello(name?: string): string {
-    return `Hello, ${name ?? 'World'}!`;
+    return `Hello, ${name ?? "World"}!`;
   }
-  
+
   @callable()
   async perform(task: string, p1?: number): Promise<void> {
     // do something
   }
 
   // not decorated with @callable()
-  nonRpc(): void {
-  }
+  nonRpc(): void {}
 }
 
-const agent = useAgent<MyAgent, {}>({ agent: 'my-agent' });
+const agent = useAgent<MyAgent, {}>({ agent: "my-agent" });
 // return type is promisified
-agent.call('sayHello') satisfies Promise<string>;
+agent.call("sayHello") satisfies Promise<string>;
 
 // @ts-expect-error first argument is not a string
-await agent.call('sayHello', [1]);
+await agent.call("sayHello", [1]);
 
-await agent.call('perform', ['some task', 1]);
-await agent.call('perform', ['another task']);
+await agent.call("perform", ["some task", 1]);
+await agent.call("perform", ["another task"]);
 // @ts-expect-error requires parameters
-await agent.call('perform');
+await agent.call("perform");
 
 // we cannot exclude it because typescript doesn't have a way
 // to exclude based on decorators
-await agent.call('nonRpc');
+await agent.call("nonRpc");
 
-const agent2 = useAgent<Omit<MyAgent, 'nonRpc'>, {}>({ agent: 'my-agent' });
-agent2.call('sayHello');
+const agent2 = useAgent<Omit<MyAgent, "nonRpc">, {}>({ agent: "my-agent" });
+agent2.call("sayHello");
 // @ts-expect-error nonRpc excluded from useAgent
-agent2.call('nonRpc');
+agent2.call("nonRpc");

--- a/packages/agents/src/tests-d/example.test-d.ts
+++ b/packages/agents/src/tests-d/example.test-d.ts
@@ -1,6 +1,5 @@
-import { Agent } from '../../dist';
 import { env } from "cloudflare:workers";
-import { unstable_callable as callable } from '../index.ts';
+import { unstable_callable as callable, Agent } from '../index.ts';
 import { useAgent } from '../react.tsx';
 
 class MyAgent extends Agent<typeof env, {}> {

--- a/packages/agents/src/tests-d/example.test-d.ts
+++ b/packages/agents/src/tests-d/example.test-d.ts
@@ -18,7 +18,7 @@ class MyAgent extends Agent<typeof env, {}> {
   }
 }
 
-const agent = useAgent<{}, MyAgent>({ agent: 'my-agent' });
+const agent = useAgent<MyAgent, {}>({ agent: 'my-agent' });
 // return type is promisified
 agent.call('sayHello') satisfies Promise<string>;
 
@@ -34,7 +34,7 @@ await agent.call('perform');
 // to exclude based on decorators
 await agent.call('nonRpc');
 
-const agent2 = useAgent<{}, Omit<MyAgent, 'nonRpc'>>({ agent: 'my-agent' });
+const agent2 = useAgent<Omit<MyAgent, 'nonRpc'>, {}>({ agent: 'my-agent' });
 agent2.call('sayHello');
 // @ts-expect-error nonRpc excluded from useAgent
 agent2.call('nonRpc');

--- a/packages/agents/src/tests-d/typed-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/typed-use-agent.test-d.ts
@@ -1,5 +1,5 @@
 import type { Agent } from "../..";
-import { env } from "cloudflare:workers";
+import type { env } from "cloudflare:workers";
 import { useAgent } from "../react";
 
 declare class A extends Agent<typeof env, {}> {
@@ -13,37 +13,37 @@ declare class A extends Agent<typeof env, {}> {
 }
 
 // @ts-expect-error state doesn't match type A state
-const a2 = useAgent<A, { foo: 'bar' }>({
-  agent: 'test',
+const a2 = useAgent<A, { foo: "bar" }>({
+  agent: "test",
 });
 
 const a1 = useAgent<A, {}>({
-  agent: 'test',
+  agent: "test",
 });
 
-a1.call('f1') satisfies Promise<number>;
+a1.call("f1") satisfies Promise<number>;
 // @ts-expect-error
-a1.call('f1', [1]) satisfies Promise<number>;
+a1.call("f1", [1]) satisfies Promise<number>;
 
-a1.call('f2', ['test']) satisfies Promise<void>;
+a1.call("f2", ["test"]) satisfies Promise<void>;
 // @ts-expect-error should receive a [string]
-a1.call('f2');
+a1.call("f2");
 // @ts-expect-error
-a1.call('f2', [1]);
+a1.call("f2", [1]);
 
-a1.call('f3', [1, 'test']) satisfies Promise<string>;
+a1.call("f3", [1, "test"]) satisfies Promise<string>;
 // @ts-expect-error should receive a [number, string]
-a1.call('f3') satisfies Promise<string>;
+a1.call("f3") satisfies Promise<string>;
 // @ts-expect-error
-a1.call('f3', [1]) satisfies Promise<string>;
+a1.call("f3", [1]) satisfies Promise<string>;
 
-a1.call('f4') satisfies Promise<void>;
-a1.call('f4', []) satisfies Promise<void>;
-a1.call('f4', [undefined]) satisfies Promise<void>;
+a1.call("f4") satisfies Promise<void>;
+a1.call("f4", []) satisfies Promise<void>;
+a1.call("f4", [undefined]) satisfies Promise<void>;
 
-a1.call('f5') satisfies Promise<void>;
+a1.call("f5") satisfies Promise<void>;
 // @ts-expect-error should receive a [string | undefined]
-a1.call('f5', []) satisfies Promise<void>;
-a1.call('f5', [undefined]) satisfies Promise<void>;
+a1.call("f5", []) satisfies Promise<void>;
+a1.call("f5", [undefined]) satisfies Promise<void>;
 
-a1.call('f6') satisfies Promise<void>;
+a1.call("f6") satisfies Promise<void>;

--- a/packages/agents/src/tests-d/typed-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/typed-use-agent.test-d.ts
@@ -13,11 +13,11 @@ declare class A extends Agent<typeof env, {}> {
 }
 
 // @ts-expect-error state doesn't match type A state
-const a2 = useAgent<{ foo: 'bar' }, A>({
+const a2 = useAgent<A, { foo: 'bar' }>({
   agent: 'test',
 });
 
-const a1 = useAgent<{}, A>({
+const a1 = useAgent<A, {}>({
   agent: 'test',
 });
 

--- a/packages/agents/src/tests-d/typed-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/typed-use-agent.test-d.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "../../dist";
+import type { Agent } from "../..";
 import { env } from "cloudflare:workers";
 import { useAgent } from "../react";
 

--- a/packages/agents/src/tests-d/typed-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/typed-use-agent.test-d.ts
@@ -1,0 +1,49 @@
+import type { Agent } from "../../dist";
+import { env } from "cloudflare:workers";
+import { useAgent } from "../react";
+
+declare class A extends Agent<typeof env, {}> {
+  prop: string;
+  f1: () => number;
+  f2: (a: string) => void;
+  f3: (a: number, b: string) => Promise<string>;
+  f4: (a?: string) => void;
+  f5: (a: string | undefined) => void;
+  f6: () => Promise<void>;
+}
+
+// @ts-expect-error state doesn't match type A state
+const a2 = useAgent<{ foo: 'bar' }, A>({
+  agent: 'test',
+});
+
+const a1 = useAgent<{}, A>({
+  agent: 'test',
+});
+
+a1.call('f1') satisfies Promise<number>;
+// @ts-expect-error
+a1.call('f1', [1]) satisfies Promise<number>;
+
+a1.call('f2', ['test']) satisfies Promise<void>;
+// @ts-expect-error should receive a [string]
+a1.call('f2');
+// @ts-expect-error
+a1.call('f2', [1]);
+
+a1.call('f3', [1, 'test']) satisfies Promise<string>;
+// @ts-expect-error should receive a [number, string]
+a1.call('f3') satisfies Promise<string>;
+// @ts-expect-error
+a1.call('f3', [1]) satisfies Promise<string>;
+
+a1.call('f4') satisfies Promise<void>;
+a1.call('f4', []) satisfies Promise<void>;
+a1.call('f4', [undefined]) satisfies Promise<void>;
+
+a1.call('f5') satisfies Promise<void>;
+// @ts-expect-error should receive a [string | undefined]
+a1.call('f5', []) satisfies Promise<void>;
+a1.call('f5', [undefined]) satisfies Promise<void>;
+
+a1.call('f6') satisfies Promise<void>;

--- a/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
@@ -1,5 +1,5 @@
 import type { Agent } from "../../dist";
-import { env } from "cloudflare:workers";
+import type { env } from "cloudflare:workers";
 import { useAgent } from "../react";
 
 declare class A extends Agent<typeof env, {}> {
@@ -8,10 +8,10 @@ declare class A extends Agent<typeof env, {}> {
 }
 
 const a1 = useAgent<{}>({
-  agent: 'test',
+  agent: "test",
 });
 
 // ensure retro-compatibility with useAgent<State> API
-a1.call('fn');
-a1.call('fn', [1]);
-a1.call('fn', [1], { onDone: () => {} });
+a1.call("fn");
+a1.call("fn", [1]);
+a1.call("fn", [1], { onDone: () => {} });

--- a/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
@@ -1,0 +1,17 @@
+import type { Agent } from "../../dist";
+import { env } from "cloudflare:workers";
+import { useAgent } from "../react";
+
+declare class A extends Agent<typeof env, {}> {
+  prop: string;
+  fn: () => number;
+}
+
+const a1 = useAgent<{}>({
+  agent: 'test',
+});
+
+// ensure retro-compatibility with useAgent<State> API
+a1.call('fn');
+a1.call('fn', [1]);
+a1.call('fn', [1], { onDone: () => {} });

--- a/packages/agents/src/tests/wrangler.toml
+++ b/packages/agents/src/tests/wrangler.toml
@@ -1,4 +1,4 @@
-main = "/worker.ts"
+main = "worker.ts"
 compatibility_date = "2025-04-17"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
Proposal to add type support to react useAgent() RPC calls. It can infer argument tyoes and ensure we pass all required values.

Usage example:

```ts
// server.ts
class MyAgent extends Agent<typeof env, {}> {
  @callable()
  sayHello(name?: string): string {
    return `Hello, ${name ?? 'World'}!`;
  }
  
  @callable()
  async perform(task: string, p1?: number): Promise<void> {
    // do something
  }

  // not annotated with @callable()
  nonRpc(): void {
  }
}

// index.tsx
import type { MyAgent } from './server.ts';

// ...

const agent = useAgent<{}, MyAgent>({ agent: 'my-agent' });
// return type is promisified
agent.call('sayHello') satisfies Promise<string>;

// @ts-expect-error first argument is not a string
await agent.call('sayHello', [1]);

await agent.call('perform', ['some task', 1]);
await agent.call('perform', ['another task']);
// @ts-expect-error requires parameters
await agent.call('perform');

// we cannot exclude it because typescript doesn't have a way
// to exclude based on decorators
await agent.call('nonRpc');
```

Intellisense in vscode:

![image](https://github.com/user-attachments/assets/1844cee4-4c14-41b2-9ef8-cb8c396270bc)

Unfortunately, I didn't find a way to restrict calls to methods decorated with `@callable()`, so it will also suggest non-RPC methods.
Nevertheless, I excluded the ones declared in the base `Agent` class to ensure intellisense is as clean as possible.

If there are public methods to exclude, it's always possible to exclude the non-RPC ones with `Omit<MyAgent, 'noRpc'>`:

![image](https://github.com/user-attachments/assets/6f532a17-0712-4ba0-b2ba-b18518715be5)