### PR TITLE
Stub for Agent RPC

### DIFF
--- a/.changeset/ninety-lizards-pay.md
+++ b/.changeset/ninety-lizards-pay.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Stub for Agent RPC

--- a/packages/agents/src/tests-d/example-stub.test-d.ts
+++ b/packages/agents/src/tests-d/example-stub.test-d.ts
@@ -1,0 +1,41 @@
+import type { env } from "cloudflare:workers";
+import { unstable_callable as callable, Agent } from "../index.ts";
+import { useAgent } from "../react.tsx";
+
+class MyAgent extends Agent<typeof env, {}> {
+  @callable()
+  sayHello(name?: string): string {
+    return `Hello, ${name ?? "World"}!`;
+  }
+
+  @callable()
+  async perform(task: string, p1?: number): Promise<void> {
+    // do something
+  }
+
+  // not decorated with @callable()
+  nonRpc(): void {}
+}
+
+const { stub } = useAgent<MyAgent, {}>({ agent: "my-agent" });
+// return type is promisified
+stub.sayHello() satisfies Promise<string>;
+
+// @ts-expect-error first argument is not a string
+await stub.sayHello(1);
+
+await stub.perform("some task", 1);
+await stub.perform("another task");
+// @ts-expect-error requires parameters
+await stub.perform();
+
+// we cannot exclude it because typescript doesn't have a way
+// to exclude based on decorators
+await stub.nonRpc();
+
+const { stub: stub2 } = useAgent<Omit<MyAgent, "nonRpc">, {}>({
+  agent: "my-agent",
+});
+stub2.sayHello();
+// @ts-expect-error nonRpc excluded from useAgent
+stub2.nonRpc();

--- a/packages/agents/src/tests-d/use-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/use-agent-stub.test-d.ts
@@ -1,0 +1,43 @@
+import type { Agent } from "../..";
+import type { env } from "cloudflare:workers";
+import { useAgent } from "../react";
+
+declare class A extends Agent<typeof env, {}> {
+  prop: string;
+  f1: () => number;
+  f2: (a: string) => void;
+  f3: (a: number, b: string) => Promise<string>;
+  f4: (a?: string) => void;
+  f5: (a: string | undefined) => void;
+  f6: () => Promise<void>;
+}
+
+const { stub } = useAgent<A, {}>({
+  agent: "test",
+});
+
+stub.f1() satisfies Promise<number>;
+// @ts-expect-error
+stub.f1(1) satisfies Promise<number>;
+
+stub.f2("test") satisfies Promise<void>;
+// @ts-expect-error should receive a [string]
+stub.f2();
+// @ts-expect-error
+stub.f2(1);
+
+stub.f3(1, "test") satisfies Promise<string>;
+// @ts-expect-error should receive a [number, string]
+stub.f3() satisfies Promise<string>;
+// @ts-expect-error
+stub.f3(1) satisfies Promise<string>;
+
+stub.f4() satisfies Promise<void>;
+stub.f4() satisfies Promise<void>;
+stub.f4(undefined) satisfies Promise<void>;
+
+// @ts-expect-error should receive a [string | undefined]
+stub.f5() satisfies Promise<void>;
+stub.f5(undefined) satisfies Promise<void>;
+
+stub.f6() satisfies Promise<void>;


### PR DESCRIPTION
A proposal for a stub object for Agent RPC that better mimics method calls.

Usage example:

```ts
const { stub } = useAgent<MyAgent, {}>({ agent: "my-agent" });

// return type is promisified
stub.sayHello() satisfies Promise<string>;

// @ts-expect-error first argument is not a string
await stub.sayHello(1);

await stub.perform("some task", 1);
await stub.perform("another task");
// @ts-expect-error requires parameters
await stub.perform();
```
