### PR TITLE
Improve Agent stub

### DIFF
--- a/.changeset/seven-shirts-decide.md
+++ b/.changeset/seven-shirts-decide.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Improve Agent stub

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -77,20 +77,16 @@ type RequiredAgentMethods<T> = Omit<
   keyof OptionalAgentMethods<T>
 >;
 
-// biome-ignore lint: suppressions/parse
-type AgentPromiseReturnType<T extends AgentMethods<any>, K extends keyof T> =
+type AgentPromiseReturnType<T extends AgentMethods<T>, K extends keyof T> =
   // biome-ignore lint: suppressions/parse
   ReturnType<T[K]> extends Promise<any>
     ? ReturnType<T[K]>
     : Promise<ReturnType<T[K]>>;
 
-// biome-ignore lint: suppressions/parse
-type AgentStub<T extends AgentMethods<any> | unknown> = {
-  // biome-ignore lint: suppressions/parse
-  [K in keyof T]: T extends AgentMethods<any>
-    ? (...args: Parameters<T[K]>) => AgentPromiseReturnType<T, K>
-    : // biome-ignore lint: suppressions/parse
-      any;
+type AgentStub<T extends AgentMethods<T>> = {
+  [K in keyof AgentMethods<T>]: (
+    ...args: Parameters<T[K]>
+  ) => AgentPromiseReturnType<AgentMethods<T>, K>;
 };
 
 /**
@@ -111,6 +107,7 @@ export function useAgent<State = unknown>(
     args?: unknown[],
     streamOptions?: StreamOptions
   ) => Promise<T>;
+  stub: Record<string, Method>;
 };
 export function useAgent<
   AgentT extends {
@@ -146,7 +143,7 @@ export function useAgent<State>(
     args?: unknown[],
     streamOptions?: StreamOptions
   ) => Promise<T>;
-  stub: AgentStub<unknown>;
+  stub: Record<string, Method>;
 } {
   const agentNamespace = camelCaseToKebabCase(options.agent);
   // Keep track of pending RPC calls
@@ -227,7 +224,7 @@ export function useAgent<State>(
       args?: unknown[],
       streamOptions?: StreamOptions
     ) => Promise<T>;
-    stub: AgentStub<unknown>;
+    stub: Record<string, Method>;
   };
   // Create the call method
   const call = useCallback(
@@ -275,7 +272,7 @@ export function useAgent<State>(
         };
       },
     }
-  ) as AgentStub<unknown>;
+  );
 
   // warn if agent isn't in lowercase
   if (agent.agent !== agent.agent.toLowerCase()) {

--- a/packages/agents/src/tests-d/untyped-use-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/untyped-use-agent-stub.test-d.ts
@@ -1,0 +1,20 @@
+import type { Agent } from "../../dist";
+import type { env } from "cloudflare:workers";
+import { useAgent } from "../react";
+
+declare class A extends Agent<typeof env, {}> {
+  prop: string;
+  fn: () => number;
+}
+
+const { stub } = useAgent<{}>({
+  agent: "test",
+});
+
+// ensure retro-compatibility with useAgent<State> API
+stub.fn();
+stub.fn(1);
+stub.fn(1);
+
+// no type checking on the stub
+stub.foo(1, "bar");

--- a/packages/agents/src/tests-d/use-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/use-agent-stub.test-d.ts
@@ -41,3 +41,6 @@ stub.f5() satisfies Promise<void>;
 stub.f5(undefined) satisfies Promise<void>;
 
 stub.f6() satisfies Promise<void>;
+
+// @ts-expect-error should not have base Agent methods
+stub.setState({ prop: "test" });


### PR DESCRIPTION
Stub intellisense was including base Agent methods:

![image](https://github.com/user-attachments/assets/6e2849ea-6204-4d19-9a1e-811397915432)

I improved and simplified AgentStub type to fix it, and add a few more type tests.
