### PR TITLE
Improve agent types

### DIFF
--- a/.changeset/public-spoons-return.md
+++ b/.changeset/public-spoons-return.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Improve agent types

--- a/packages/agents/src/tests-d/example-stub.test-d.ts
+++ b/packages/agents/src/tests-d/example-stub.test-d.ts
@@ -1,5 +1,5 @@
 import type { env } from "cloudflare:workers";
-import { unstable_callable as callable, Agent } from "../index.ts";
+import { unstable_callable as callable, Agent } from "..";
 import { useAgent } from "../react.tsx";
 
 class MyAgent extends Agent<typeof env, {}> {

--- a/packages/agents/src/tests-d/example.test-d.ts
+++ b/packages/agents/src/tests-d/example.test-d.ts
@@ -1,5 +1,5 @@
 import type { env } from "cloudflare:workers";
-import { unstable_callable as callable, Agent } from "../index.ts";
+import { unstable_callable as callable, Agent } from "..";
 import { useAgent } from "../react.tsx";
 
 class MyAgent extends Agent<typeof env, {}> {

--- a/packages/agents/src/tests-d/typed-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/typed-use-agent.test-d.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "../..";
+import { Agent } from "..";
 import type { env } from "cloudflare:workers";
 import { useAgent } from "../react";
 

--- a/packages/agents/src/tests-d/untyped-use-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/untyped-use-agent-stub.test-d.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "../../dist";
+import { Agent } from "..";
 import type { env } from "cloudflare:workers";
 import { useAgent } from "../react";
 

--- a/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "../../dist";
+import { Agent } from "..";
 import type { env } from "cloudflare:workers";
 import { useAgent } from "../react";
 

--- a/packages/agents/src/tests-d/use-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/use-agent-stub.test-d.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "../..";
+import { Agent } from "..";
 import type { env } from "cloudflare:workers";
 import { useAgent } from "../react";
 


### PR DESCRIPTION
I think this is the final version! Even if the previous version was passing the tests, I was not happy with those types because I couldn't understand why they were not behaving the way I expected them to.

For instance, `Methods<T>` should return a object type with only `Method`  values, something similar to `Record<string, Method>` but if I tried to use `Parameters<Method<T>[K]>` it would fail, which was odd.

It turns out I was missing a condition in the `Method<T>` value, even if its keys were already using the same condition.

After fixing that one and `OptionalAgentMethods`, which had the same problem, I was able to simplify the remaining types, like `AgentStub<T>` which no longer needs to be a `type AgentStub<T extends AgentMethods<T>>`.