### PR TITLE
Type-safe serializable RPC methods

### DIFF
--- a/.changeset/gorgeous-donkeys-bake.md
+++ b/.changeset/gorgeous-donkeys-bake.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Type-safe serializable RPC methods

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -8,9 +8,8 @@
     "check:test": "npm run check:test:workers && npm run check:test:react",
     "check:test:workers": "vitest -r src/tests --watch false",
     "check:test:react": "vitest -r src/react-tests --watch false",
-    "test": "vitest -r src/tests && npm run test:types",
+    "test": "vitest -r src/tests",
     "test:react": "vitest -r src/react-tests",
-    "test:types": "tsc",
     "evals": "(cd evals; evalite)",
     "build": "tsx ./scripts/build.ts"
   },

--- a/packages/agents/src/client.ts
+++ b/packages/agents/src/client.ts
@@ -4,6 +4,10 @@ import {
   type PartyFetchOptions,
 } from "partysocket";
 import type { RPCRequest, RPCResponse } from "./";
+import type {
+  SerializableReturnValue,
+  SerializableValue,
+} from "./serializable";
 
 /**
  * Options for creating an AgentClient
@@ -160,7 +164,17 @@ export class AgentClient<State = unknown> extends PartySocket {
    * @param streamOptions Options for handling streaming responses
    * @returns Promise that resolves with the method's return value
    */
-  async call<T = unknown>(
+  call<T extends SerializableReturnValue>(
+    method: string,
+    args?: SerializableValue[],
+    streamOptions?: StreamOptions
+  ): Promise<T>;
+  call<T = unknown>(
+    method: string,
+    args?: unknown[],
+    streamOptions?: StreamOptions
+  ): Promise<T>;
+  async call<T>(
     method: string,
     args: unknown[] = [],
     streamOptions?: StreamOptions

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -28,6 +28,10 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
 
 import { camelCaseToKebabCase } from "./client";
+import type {
+  SerializableReturnValue,
+  SerializableValue,
+} from "./serializable";
 
 export type { Connection, WSMessage, ConnectionContext } from "partyserver";
 
@@ -120,7 +124,11 @@ const callableMetadata = new Map<Function, CallableMetadata>();
  * @param metadata Optional metadata about the callable method
  */
 export function unstable_callable(metadata: CallableMetadata = {}) {
-  return function callableDecorator<This, Args extends unknown[], Return>(
+  return function callableDecorator<
+    This,
+    Args extends SerializableValue[],
+    Return extends SerializableReturnValue,
+  >(
     target: (this: This, ...args: Args) => Return,
     context: ClassMethodDecoratorContext
   ) {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -28,10 +28,6 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
 
 import { camelCaseToKebabCase } from "./client";
-import type {
-  SerializableReturnValue,
-  SerializableValue,
-} from "./serializable";
 
 export type { Connection, WSMessage, ConnectionContext } from "partyserver";
 
@@ -124,11 +120,7 @@ const callableMetadata = new Map<Function, CallableMetadata>();
  * @param metadata Optional metadata about the callable method
  */
 export function unstable_callable(metadata: CallableMetadata = {}) {
-  return function callableDecorator<
-    This,
-    Args extends SerializableValue[],
-    Return extends SerializableReturnValue,
-  >(
+  return function callableDecorator<This, Args extends unknown[], Return>(
     target: (this: This, ...args: Args) => Return,
     context: ClassMethodDecoratorContext
   ) {

--- a/packages/agents/src/serializable.ts
+++ b/packages/agents/src/serializable.ts
@@ -1,0 +1,33 @@
+export type SerializableValue =
+  | undefined
+  | null
+  | string
+  | number
+  | boolean
+  | { [key: string]: SerializableValue }
+  | SerializableValue[];
+
+export type SerializableReturnValue =
+  | SerializableValue
+  | void
+  | Promise<SerializableValue>
+  | Promise<void>;
+
+type AllSerializableValues<A> = A extends [infer First, ...infer Rest]
+  ? First extends SerializableValue
+    ? AllSerializableValues<Rest>
+    : false
+  : true; // no params means serializable by default
+
+// biome-ignore lint: suspicious/noExplicitAny
+export type Method = (...args: any[]) => any;
+
+export type RPCMethod<T = Method> = T extends Method
+  ? T extends (...arg: infer A) => infer R
+    ? AllSerializableValues<A> extends true
+      ? R extends SerializableReturnValue
+        ? T
+        : never
+      : never
+    : never
+  : never;

--- a/packages/agents/src/tests-d/example-stub.test-d.ts
+++ b/packages/agents/src/tests-d/example-stub.test-d.ts
@@ -14,7 +14,16 @@ class MyAgent extends Agent<typeof env, {}> {
   }
 
   // not decorated with @callable()
-  nonRpc(): void {}
+  nonRpc(): void {
+    // do something
+  }
+
+  // @ts-expect-error Date is not serializable, therefore nonSerializable
+  // cannot be decorated with @callable()
+  @callable()
+  nonSerializable(c: string, d: Date): void {
+    // do something
+  }
 }
 
 const { stub } = useAgent<MyAgent, {}>({ agent: "my-agent" });
@@ -32,6 +41,9 @@ await stub.perform();
 // we cannot exclude it because typescript doesn't have a way
 // to exclude based on decorators
 await stub.nonRpc();
+
+// @ts-expect-error nonSerializable is not serializable
+await stub.nonSerializable("hello", new Date());
 
 const { stub: stub2 } = useAgent<Omit<MyAgent, "nonRpc">, {}>({
   agent: "my-agent",

--- a/packages/agents/src/tests-d/example-stub.test-d.ts
+++ b/packages/agents/src/tests-d/example-stub.test-d.ts
@@ -17,13 +17,6 @@ class MyAgent extends Agent<typeof env, {}> {
   nonRpc(): void {
     // do something
   }
-
-  // @ts-expect-error Date is not serializable, therefore nonSerializable
-  // cannot be decorated with @callable()
-  @callable()
-  nonSerializable(c: string, d: Date): void {
-    // do something
-  }
 }
 
 const { stub } = useAgent<MyAgent, {}>({ agent: "my-agent" });

--- a/packages/agents/src/tests-d/example.test-d.ts
+++ b/packages/agents/src/tests-d/example.test-d.ts
@@ -14,7 +14,16 @@ class MyAgent extends Agent<typeof env, {}> {
   }
 
   // not decorated with @callable()
-  nonRpc(): void {}
+  nonRpc(): void {
+    // do something
+  }
+
+  // @ts-expect-error Date is not serializable, therefore nonSerializable
+  // cannot be decorated with @callable()
+  @callable()
+  nonSerializable(c: string, d: Date): void {
+    // do something
+  }
 }
 
 const agent = useAgent<MyAgent, {}>({ agent: "my-agent" });
@@ -32,6 +41,9 @@ await agent.call("perform");
 // we cannot exclude it because typescript doesn't have a way
 // to exclude based on decorators
 await agent.call("nonRpc");
+
+// @ts-expect-error nonSerializable is not serializable
+await agent.call("nonSerializable", ["hello", new Date()]);
 
 const agent2 = useAgent<Omit<MyAgent, "nonRpc">, {}>({ agent: "my-agent" });
 agent2.call("sayHello");

--- a/packages/agents/src/tests-d/example.test-d.ts
+++ b/packages/agents/src/tests-d/example.test-d.ts
@@ -17,13 +17,6 @@ class MyAgent extends Agent<typeof env, {}> {
   nonRpc(): void {
     // do something
   }
-
-  // @ts-expect-error Date is not serializable, therefore nonSerializable
-  // cannot be decorated with @callable()
-  @callable()
-  nonSerializable(c: string, d: Date): void {
-    // do something
-  }
 }
 
 const agent = useAgent<MyAgent, {}>({ agent: "my-agent" });

--- a/packages/agents/src/tests-d/typed-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/typed-use-agent.test-d.ts
@@ -12,6 +12,8 @@ declare class A extends Agent<typeof env, {}> {
   f6: () => Promise<void>;
   f7: (a: string | undefined, b: number) => Promise<void>;
   f8: (a: string | undefined, b?: number) => Promise<void>;
+  nonSerializableParams: (a: string, b: { c: Date }) => void;
+  nonSerializableReturn: (a: string) => Date;
 }
 
 // @ts-expect-error state doesn't match type A state
@@ -56,3 +58,8 @@ a1.call("f7", [undefined, 1]) satisfies Promise<void>;
 
 a1.call("f8") satisfies Promise<void>;
 a1.call("f8", [undefined, undefined]) satisfies Promise<void>;
+
+// @ts-expect-error Date parameter not serializable
+a1.call("nonSerializableParams", ["test", { c: new Date() }]);
+// @ts-expect-error Date return not serializable
+a1.call("nonSerializableReturn", ["test"]);

--- a/packages/agents/src/tests-d/untyped-use-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/untyped-use-agent-stub.test-d.ts
@@ -5,6 +5,8 @@ import { useAgent } from "../react";
 declare class A extends Agent<typeof env, {}> {
   prop: string;
   fn: () => number;
+  nonSerializableParams: (a: string, b: { c: Date }) => void;
+  nonSerializableReturn: (a: string) => Date;
 }
 
 const { stub } = useAgent<{}>({
@@ -14,7 +16,6 @@ const { stub } = useAgent<{}>({
 // ensure retro-compatibility with useAgent<State> API
 stub.fn();
 stub.fn(1);
-stub.fn(1);
-
-// no type checking on the stub
 stub.foo(1, "bar");
+stub.nonSerializableParams("test", { c: new Date(), unexistent: "property" });
+stub.nonSerializableReturn("test");

--- a/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/untyped-use-agent.test-d.ts
@@ -5,6 +5,8 @@ import { useAgent } from "../react";
 declare class A extends Agent<typeof env, {}> {
   prop: string;
   fn: () => number;
+  nonSerializableParams: (a: string, b: { c: Date }) => void;
+  nonSerializableReturn: (a: string) => Date;
 }
 
 const a1 = useAgent<{}>({
@@ -15,3 +17,8 @@ const a1 = useAgent<{}>({
 a1.call("fn");
 a1.call("fn", [1]);
 a1.call("fn", [1], { onDone: () => {} });
+a1.call("nonSerializableParams", [
+  "test",
+  { c: new Date(), unexistent: "property" },
+]);
+a1.call("nonSerializableReturn", []);

--- a/packages/agents/src/tests-d/use-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/use-agent-stub.test-d.ts
@@ -10,6 +10,8 @@ declare class A extends Agent<typeof env, {}> {
   f4: (a?: string) => void;
   f5: (a: string | undefined) => void;
   f6: () => Promise<void>;
+  nonSerializableParams: (a: string, b: { c: Date }) => void;
+  nonSerializableReturn: (a: string) => Date;
 }
 
 const { stub } = useAgent<A, {}>({
@@ -44,3 +46,8 @@ stub.f6() satisfies Promise<void>;
 
 // @ts-expect-error should not have base Agent methods
 stub.setState({ prop: "test" });
+
+// @ts-expect-error Date parameter not serializable
+stub.nonSerializableParams("test", { c: new Date() });
+// @ts-expect-error Date return not serializable
+stub.nonSerializableReturn("test");


### PR DESCRIPTION
Last one (I guess...)!

In "typed" mode, onlly serializable parameters and return values or their promises are supported, so this is not retro-compatible with my previous changes.

However, I kept retro-compatibility with type-unsafe agent proxies.

Another breaking change is on `unstable_callable`, which enforces decorated method to be serializable.
I can revert those breaking changes, it's just a couple of lines.