### PR TITLE
docs(readme): fix incorrect usage of npm create for template

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This project is actively evolving. Current focus areas:
 
 ```bash
 # Create a new project
-npm create cloudflare@latest -- --template cloudflare/agents-starter
+npm create cloudflare@latest --template cloudflare/agents-starter
 
 # Or add to existing project
 npm install agents


### PR DESCRIPTION
The README previously included an incorrect double-dash (`--`) in the  `npm create cloudflare@latest` command, which breaks execution when  copied directly. This commit removes the extra `--` to ensure the  Cloudflare agents-starter template initializes correctly.