### PR TITLE
Fix issue where stray MCP connection state is left after closing connection

### DIFF
--- a/.changeset/rude-glasses-know.md
+++ b/.changeset/rude-glasses-know.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix issue where stray MCP connection state is left after closing connection

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -232,6 +232,7 @@ export class MCPClientManager {
       throw new Error(`Connection with id "${id}" does not exist.`);
     }
     await this.mcpConnections[id].client.close();
+    delete this.mcpConnections[id];
   }
 
   /**


### PR DESCRIPTION
Resolves #284 

Simple one line fix to remove the orphaned MCP state after deleting a connection.