### PR TITLE
Add type guard for DurableObjectNamespace

### DIFF
--- a/.changeset/modern-crabs-smash.md
+++ b/.changeset/modern-crabs-smash.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+duck typing DurableObjectNamespace type

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -575,7 +575,8 @@ export abstract class McpAgent<
           return new Response("Invalid binding", { status: 500 });
         }
 
-        const namespace = bindingValue satisfies DurableObjectNamespace<McpAgent>;
+        const namespace =
+          bindingValue satisfies DurableObjectNamespace<McpAgent>;
 
         // Handle initial SSE connection
         if (request.method === "GET" && basePattern.test(url)) {
@@ -803,7 +804,8 @@ export abstract class McpAgent<
           return new Response("Invalid binding", { status: 500 });
         }
 
-        const namespace = bindingValue satisfies DurableObjectNamespace<McpAgent>;
+        const namespace =
+          bindingValue satisfies DurableObjectNamespace<McpAgent>;
 
         if (request.method === "POST" && basePattern.test(url)) {
           // validate the Accept header

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -30,6 +30,19 @@ function corsHeaders(request: Request, corsOptions: CORSOptions = {}) {
   };
 }
 
+function isDurableObjectNamespace(
+  namespace: unknown
+): namespace is DurableObjectNamespace<McpAgent> {
+  return (
+    typeof namespace === "object" &&
+    namespace !== null &&
+    "newUniqueId" in namespace &&
+    typeof namespace.newUniqueId === "function" &&
+    "idFromName" in namespace &&
+    typeof namespace.idFromName === "function"
+  );
+}
+
 function handleCORS(
   request: Request,
   corsOptions?: CORSOptions
@@ -557,12 +570,12 @@ export abstract class McpAgent<
           return new Response("Invalid binding", { status: 500 });
         }
 
-        // Ensure that the biding is to a DurableObject
-        if (bindingValue.toString() !== "[object DurableObjectNamespace]") {
+        // Ensure that the binding is to a DurableObject
+        if (!isDurableObjectNamespace(bindingValue)) {
           return new Response("Invalid binding", { status: 500 });
         }
 
-        const namespace = bindingValue as DurableObjectNamespace<McpAgent>;
+        const namespace = bindingValue satisfies DurableObjectNamespace<McpAgent>;
 
         // Handle initial SSE connection
         if (request.method === "GET" && basePattern.test(url)) {
@@ -785,12 +798,12 @@ export abstract class McpAgent<
           return new Response("Invalid binding", { status: 500 });
         }
 
-        // Ensure that the biding is to a DurableObject
-        if (bindingValue.toString() !== "[object DurableObjectNamespace]") {
+        // Ensure that the binding is to a DurableObject
+        if (!isDurableObjectNamespace(bindingValue)) {
           return new Response("Invalid binding", { status: 500 });
         }
 
-        const namespace = bindingValue as DurableObjectNamespace<McpAgent>;
+        const namespace = bindingValue satisfies DurableObjectNamespace<McpAgent>;
 
         if (request.method === "POST" && basePattern.test(url)) {
           // validate the Accept header


### PR DESCRIPTION
Introduced a type guard function `isDurableObjectNamespace` to validate objects as DurableObjectNamespace. Updated relevant checks in McpAgent to use this type guard for improved type safety and clarity.

Fixes #294