### PR TITLE
FIX: Only attempt server connections with servers not actively in oauth flow

### DIFF
--- a/.changeset/bumpy-doors-tap.md
+++ b/.changeset/bumpy-doors-tap.md
@@ -1,0 +1,5 @@
+---
+"agents": minor
+---
+
+Prevent auth url from being regenerated during oauth flow

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -1,14 +1,22 @@
-# Mcp Client demo using Agents
+# MCP Client Demo Using Agents
 
-A minimal example showing an `Agent` as an MCP Client.
+A minimal example showing an `Agent` as an MCP client.
 
 ## Instructions
 
-First, start an MCP server. A simple example can be found in `examples/mcp`, which already has valid binding setup.
+First, start an MCP server. A simple example can be found in `examples/mcp`, which already has a valid binding setup.
 
-```sh
-npm install
-npm start
-```
+Then, follow the steps below to setup the client:
 
-Tap "O + enter" to open the front end. It should list out all the tools, prompts, and resources available.
+1. This example uses a pre-built version of the agents package. Run `npm run build` in the root of this repo to build it.
+2. Copy the `.dev.vars.example` file in this directory to a new file called `.dev.vars`.
+3. Run `npm install` from this directory.
+4. Run `npm start` from this directory.
+
+Tap "O + enter" to open the front end. It should list out all the tools, prompts, and resources available for each server added.
+
+## Troubleshooting
+
+### TypeError: Cannot read properties of undefined (reading 'connectionState')
+
+Clear the Local Storage cookies in your browser, then restart the client.

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -1,22 +1,22 @@
 import { MCPClientConnection } from "./client-connection";
 
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
   CallToolRequest,
   CallToolResultSchema,
   CompatibilityCallToolResultSchema,
-  ReadResourceRequest,
   GetPromptRequest,
-  Tool,
-  Resource,
   Prompt,
+  ReadResourceRequest,
+  Resource,
   ResourceTemplate,
+  Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type { AgentsOAuthProvider } from "./do-oauth-client-provider";
 import { jsonSchema, type ToolSet } from "ai";
 import { nanoid } from "nanoid";
+import type { AgentsOAuthProvider } from "./do-oauth-client-provider";
 
 /**
  * Utility class that aggregates multiple MCP clients into one
@@ -45,8 +45,9 @@ export class MCPClientManager {
   async connect(
     url: string,
     options: {
-      // Allows you to reconnect to a server (in the case of a auth reconnect)
+      // Allows you to reconnect to a server (in the case of an auth reconnect)
       reconnect?: {
+        // server id
         id: string;
         oauthClientId?: string;
         oauthCode?: string;
@@ -69,8 +70,8 @@ export class MCPClientManager {
         "No authProvider provided in the transport options. This client will only support unauthenticated remote MCP Servers"
       );
     } else {
-      // reconnect with auth
       options.transport.authProvider.serverId = id;
+      // reconnect with auth
       if (options.reconnect?.oauthClientId) {
         options.transport.authProvider.clientId =
           options.reconnect?.oauthClientId;


### PR DESCRIPTION
Context:
When the Agent DO wakes up (triggering its onStart function), it attempts to connect to all MCP servers it has previously configured for the client. This is great for servers that either don't require authentication or have previously been authenticated with a successful OAuth flow. 

Problem:
There is a problem, however, if the onStart function is triggered during the course of authenticating a server. It's a problem because the connection process generates a new auth url (specifically a new "code" within the authurl) for any servers still requiring authentication. If you're currently trying to authenticate a server and that authurl changes before the process completes, you get a token exchange error.

Solution:
Excluding these authenticating servers from potential connection calls during onStart solves the problem and does not appear to negatively affect other servers.

Testing confirmations:
1. A previously connected server not requiring authentication will be reconnected after the DO wakes up from hibernation.
2. A previously connected and authenticated server will be reconnected after hibernation.
3. A previously connected but not yet authenticated server will still have the authorize button available after hibernation.
4. A previously connected and authenticated server requiring a token refresh will still be connected after hibernation.
5. OAuth completes where previously token exchange errors were received.
