### PR TITLE
MCP example: url mixup fix

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -9,9 +9,9 @@ npm install
 npm start
 ```
 
-You should have the MCP running on http://localhost:5173/ and your Agent on http://localhost:8787/sse
+You should have the MCP running on http://localhost:8787/sse and your Agent on http://localhost:5174
 
-Set your **Transport Type** to **SSE** and your **URL** to ``, then click **Connect**. You should see the following:
+Set your **Transport Type** to **SSE** and your **URL** to `http://localhost:8787/sse`, then click **Connect**. You should see the following:
 
 ![Image](https://github.com/user-attachments/assets/86ec7df4-71fd-40e9-b9f6-32f2f5e003e5)
 


### PR DESCRIPTION
MCP vs. Agent url mixup. Agent using port `5174`, as setup in `vite.config.ts`