### PR TITLE
MCP example url mixup number 2

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -9,9 +9,9 @@ npm install
 npm start
 ```
 
-You should have the MCP running on http://localhost:8787/sse and your Agent on http://localhost:5174
+You should have the MCP running on http://localhost:5174/sse and your Agent on http://localhost:5174
 
-Set your **Transport Type** to **SSE** and your **URL** to `http://localhost:8787/sse`, then click **Connect**. You should see the following:
+Set your **Transport Type** to **SSE** and your **URL** to `http://localhost:5174/sse`, then click **Connect**. You should see the following:
 
 ![Image](https://github.com/user-attachments/assets/86ec7df4-71fd-40e9-b9f6-32f2f5e003e5)
 


### PR DESCRIPTION
Sorry @threepointone, there was definitely a mixup but also in that last PR.
MCP server is running on 5174 in the example and should be removed I guess.

This lets it actually successfully run the example