### PR TITLE
Add agent eviction enforcement

### DIFF
--- a/.changeset/purple-singers-jump.md
+++ b/.changeset/purple-singers-jump.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Added a call to `this.ctx.abort('destroyed')` in the `destroy` method to ensure the agent is properly evicted during cleanup.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -916,6 +916,7 @@ export class Agent<Env, State = unknown> extends Server<Env> {
     // delete all alarms
     await this.ctx.storage.deleteAlarm();
     await this.ctx.storage.deleteAll();
+    this.ctx.abort("destroyed"); // enforce that the agent is evicted
   }
 
   /**


### PR DESCRIPTION
Added a call to `this.ctx.abort('destroyed')` in the `destroy` method to ensure the agent is properly evicted during cleanup.