### PR TITLE
Added mcp-protocol-version to CORS Access-Control-Allow-Headers

### DIFF
--- a/.changeset/proud-groups-lick.md
+++ b/.changeset/proud-groups-lick.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Adding a new MCP header to the CORS allowlist to follow the updated spec

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -21,7 +21,8 @@ function corsHeaders(_request: Request, corsOptions: CORSOptions = {}) {
   const origin = "*";
   return {
     "Access-Control-Allow-Headers":
-      corsOptions.headers || "Content-Type, mcp-session-id",
+      corsOptions.headers ||
+      "Content-Type, mcp-session-id, mcp-protocol-version",
     "Access-Control-Allow-Methods": corsOptions.methods || "GET, POST, OPTIONS",
     "Access-Control-Allow-Origin": corsOptions.origin || origin,
     "Access-Control-Expose-Headers":


### PR DESCRIPTION
Follows on from https://github.com/cloudflare/agents/pull/261. The most recent version of the SDK `1.13.x` now sends a `mcp-protocol-version` header as part of the Client -> Server communication. This is blocked by CORS by default, so adding it to our default allowlist.

I have verified that `mcp-protocol-version` is never sent from the Server -> Client, so it doesn't need to be included in the `Access-Control-Expose-Headers` header, unlike `mcp-session-id`