### PR TITLE
fix: refresh props for existing Durable Objects via serveSSE POST endpoint

### DIFF
--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -731,6 +731,7 @@ export abstract class McpAgent<
           // Get the Durable Object
           const id = namespace.idFromName(`sse:${sessionId}`);
           const doStub = namespace.get(id);
+          await doStub._init(ctx.props);
 
           // Forward the request to the Durable Object
           const error = await doStub.onSSEMcpMessage(sessionId, request);


### PR DESCRIPTION
Fixes #323

## Problem
When using a MCPAgent locally, the POST `/message` handler fetches the Durable Object using `idFromName("sse:${sessionId}")` but does not re-initialize or update the props context via `_init()` or similar.

This leads to stale or missing values inside `this.props`. For instance, in the Auth0 integration example, `this.props.tokenSet.accessToken` from `tokenExchangeCallback` never updates after the first token exchange. Even though the refresh token flow is correctly triggered, the updated access token never reaches the Durable Object instance, breaking authenticated API requests.

## Solution
Added a call to `await doStub._init(ctx.props)` before forwarding the request to the Durable Object in the POST `/message` handler. This ensures that the Durable Object instance has the latest props context, including updated access tokens from OAuth refresh flows.

## Testing
- All existing tests pass
- The fix follows the same pattern already used in the GET handler for initial SSE connections
- No breaking changes to the API