### PR TITLE
fix: dequeue items in DB after each task is complete

### DIFF
--- a/.changeset/puny-bikes-bow.md
+++ b/.changeset/puny-bikes-bow.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+fix: dequeue items in DB after each task is complete
+
+Prevents a single failure from causing all items in the queue from being retried (including previously processed items that were successful).

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -927,7 +927,6 @@ export class Agent<Env, State = unknown> extends Server<Env> {
     }
     this._flushingQueue = true;
     while (true) {
-      const executed: string[] = [];
       const result = this.sql<QueueItem<string>>`
       SELECT * FROM cf_agents_queues
       ORDER BY created_at ASC
@@ -959,12 +958,9 @@ export class Agent<Env, State = unknown> extends Server<Env> {
                 queueItem: QueueItem<string>
               ) => Promise<void>
             ).bind(this)(JSON.parse(row.payload as string), row);
-            executed.push(row.id);
+            await this.dequeue(row.id);
           }
         );
-      }
-      for (const id of executed) {
-        await this.dequeue(id);
       }
     }
     this._flushingQueue = false;


### PR DESCRIPTION
Prevents a single failure from causing all items in the queue from being retried (including previously processed items that were successful).