### PR TITLE
Fix email routing being case sensitive

### DIFF
--- a/.changeset/quick-maps-walk.md
+++ b/.changeset/quick-maps-walk.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Fix email routing to handle both CamelCase and kebab-case agent names
+Fix email routing to be case-insensitive for agent names

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1742,14 +1742,17 @@ export async function routeAgentEmail<Env>(
   if (!namespace) {
     // Provide helpful error message listing available agents
     const availableAgents = Object.keys(agentMap)
-      .filter(key => !key.includes('-')) // Show only original names, not kebab-case duplicates
-      .join(', ');
+      .filter((key) => !key.includes("-")) // Show only original names, not kebab-case duplicates
+      .join(", ");
     throw new Error(
       `Agent namespace '${routingInfo.agentName}' not found in environment. Available agents: ${availableAgents}`
     );
   }
 
-  const agent = await getAgentByName(namespace as unknown as AgentNamespace<Agent<Env>>, routingInfo.agentId);
+  const agent = await getAgentByName(
+    namespace as unknown as AgentNamespace<Agent<Env>>,
+    routingInfo.agentId
+  );
 
   // let's make a serialisable version of the email
   const serialisableEmail: AgentEmail = {

--- a/packages/agents/src/tests/email-routing.test.ts
+++ b/packages/agents/src/tests/email-routing.test.ts
@@ -15,7 +15,9 @@ declare module "cloudflare:test" {
 }
 
 // Mock ForwardableEmailMessage
-function createMockEmail(overrides: Partial<ForwardableEmailMessage> = {}): ForwardableEmailMessage {
+function createMockEmail(
+  overrides: Partial<ForwardableEmailMessage> = {}
+): ForwardableEmailMessage {
   return {
     from: "sender@example.com",
     to: "recipient@example.com",
@@ -98,9 +100,18 @@ describe("Email Resolver Case Sensitivity", () => {
       const resolver = createHeaderBasedEmailResolver();
 
       const testCases = [
-        { messageId: "<agent123@EmailAgent.domain.com>", expectedName: "EmailAgent" },
-        { messageId: "<agent123@email-agent.domain.com>", expectedName: "email-agent" },
-        { messageId: "<agent123@CaseSensitiveAgent.domain.com>", expectedName: "CaseSensitiveAgent" }
+        {
+          messageId: "<agent123@EmailAgent.domain.com>",
+          expectedName: "EmailAgent"
+        },
+        {
+          messageId: "<agent123@email-agent.domain.com>",
+          expectedName: "email-agent"
+        },
+        {
+          messageId: "<agent123@CaseSensitiveAgent.domain.com>",
+          expectedName: "CaseSensitiveAgent"
+        }
       ];
 
       for (const { messageId, expectedName } of testCases) {
@@ -175,12 +186,15 @@ describe("Email Resolver Case Sensitivity", () => {
     });
 
     it("should throw helpful error when agent namespace not found", async () => {
-      const resolver = async () => ({ agentName: "NonExistentAgent", agentId: "test" });
+      const resolver = async () => ({
+        agentName: "NonExistentAgent",
+        agentId: "test"
+      });
       const email = createMockEmail();
 
-      await expect(
-        routeAgentEmail(email, env, { resolver })
-      ).rejects.toThrow(/Agent namespace 'NonExistentAgent' not found in environment/);
+      await expect(routeAgentEmail(email, env, { resolver })).rejects.toThrow(
+        /Agent namespace 'NonExistentAgent' not found in environment/
+      );
     });
 
     it("should handle real-world email routing scenario", async () => {
@@ -221,10 +235,10 @@ describe("Email Resolver Case Sensitivity", () => {
       // Now all these variations should work:
 
       const testEmails = [
-        "CaseSensitiveAgent+bug-test@domain.com",     // Original format that was required
-        "case-sensitive-agent+bug-test@domain.com",   // Kebab-case format now also works
-        "EmailAgent+bug-test@domain.com",             // CamelCase format
-        "email-agent+bug-test@domain.com"             // Kebab-case format
+        "CaseSensitiveAgent+bug-test@domain.com", // Original format that was required
+        "case-sensitive-agent+bug-test@domain.com", // Kebab-case format now also works
+        "EmailAgent+bug-test@domain.com", // CamelCase format
+        "email-agent+bug-test@domain.com" // Kebab-case format
       ];
 
       const resolver = createAddressBasedEmailResolver("default");

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -104,7 +104,11 @@ export default {
     return new Response("Not found", { status: 404 });
   },
 
-  async email(_message: ForwardableEmailMessage, _env: Env, _ctx: ExecutionContext) {
+  async email(
+    _message: ForwardableEmailMessage,
+    _env: Env,
+    _ctx: ExecutionContext
+  ) {
     // Bring this in when we write tests for the complete email handler flow
   }
 };

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -24,7 +24,12 @@
   "main": "worker.ts",
   "migrations": [
     {
-      "new_sqlite_classes": ["TestMcpAgent", "TestEmailAgent", "TestCaseSensitiveAgent", "TestUserNotificationAgent"],
+      "new_sqlite_classes": [
+        "TestMcpAgent",
+        "TestEmailAgent",
+        "TestCaseSensitiveAgent",
+        "TestUserNotificationAgent"
+      ],
       "tag": "v1"
     }
   ]


### PR DESCRIPTION
Add support for both CamelCase and kebab-case agent names in email routing, similar to how partyserver does. The fix caches a mapping of agent names to handle case variations, ensuring emails can be routed correctly regardless of the case format used.

Also add tests covering all email resolver types and case variations. Intentionally testing only the resolvers, so we can add more exhaustive tests for the email resolver built on top of vitest-pool-workers later.

fixes #356 