### PR TITLE
feat(perf): reduce number of sql queries

### DIFF
--- a/.changeset/gold-states-kick.md
+++ b/.changeset/gold-states-kick.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+reduce number of sqlite queries when persisting messages


### PR DESCRIPTION
This PR resolves https://github.com/cloudflare/agents/issues/396.

Technically only the last message in the `messages` array needs to be written to the DB but for safety reasons I've adjusted the code to persist all messages that don't exist. I'm happy to update the code so it just grabs the last message in `messages` and store that instead if preferred!

Tested this by running in the playground.