### PR TITLE
feat: rename server property to mcp in MCP-related classes for improved developer experience

### DIFF
--- a/.changeset/mcp-property-rename.md
+++ b/.changeset/mcp-property-rename.md
@@ -1,0 +1,31 @@
+---
+"@cloudflare/agents": patch
+---
+
+Rename `server` property to `mcp` in MCP-related classes for better developer experience
+
+## Changes
+
+- **BREAKING**: Renamed `server` property to `mcp` in `McpAgent` class and related examples
+- **BREAKING**: Renamed `mcp` property to `mcpClientManager` in `Agent` class to avoid naming conflicts
+- Added backward compatibility support for `server` property in `McpAgent` with deprecation warning
+- Updated all MCP examples to use the new `mcp` property naming convention
+- Improved property naming consistency across the MCP implementation
+
+## Migration
+
+If you're using the `server` property in your `McpAgent` implementations, update your code:
+
+```ts
+// Before
+export class MyMcpAgent extends McpAgent {
+  server = new McpServer({...});
+}
+
+// After
+export class MyMcpAgent extends McpAgent {
+  mcp = new McpServer({...});
+}
+```
+
+The `server` property is still supported for backward compatibility but will be removed in a future version.

--- a/examples/mcp-elicitation-demo/README.md
+++ b/examples/mcp-elicitation-demo/README.md
@@ -28,7 +28,7 @@ type Env = {
 };
 
 export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
-  server = new McpServer({
+  mcp = new McpServer({
     name: "Elicitation Demo Server",
     version: "1.0.0"
   })
@@ -94,7 +94,7 @@ export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
 
   async init() {
     // Counter tool with user confirmation via elicitation
-    this.server.tool(
+    this.mcp.tool(
       "increment-counter",
       "Increment the counter with user confirmation",
       {
@@ -162,7 +162,7 @@ export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
     );
 
     // User creation tool with form-based elicitation
-    this.server.tool(
+    this.mcp.tool(
       "create-user",
       "Create a new user with form input",
       {
@@ -265,7 +265,7 @@ export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
 // Direct MCP connection
 export class MyMcpServer extends McpAgent {
   async init() {
-    this.server.tool(
+    this.mcp.tool(
       "my-tool",
       "My tool",
       { input: z.string() },

--- a/examples/mcp-elicitation-demo/src/server.ts
+++ b/examples/mcp-elicitation-demo/src/server.ts
@@ -17,7 +17,7 @@ type Env = {
 };
 
 export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
-  server = new McpServer({
+  mcp = new McpServer({
     name: "Elicitation Demo Server",
     version: "1.0.0"
   });
@@ -83,7 +83,7 @@ export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
 
   async init() {
     // Counter tool with user confirmation via elicitation
-    this.server.tool(
+    this.mcp.tool(
       "increment-counter",
       "Increment the counter with user confirmation",
       {
@@ -151,7 +151,7 @@ export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
     );
 
     // User creation tool with form-based elicitation
-    this.server.tool(
+    this.mcp.tool(
       "create-user",
       "Create a new user with form input",
       {
@@ -225,7 +225,7 @@ export class McpServerAgent extends McpAgent<Env, { counter: number }, {}> {
     );
 
     // Counter resource
-    this.server.resource("counter", "mcp://resource/counter", (uri: URL) => {
+    this.mcp.resource("counter", "mcp://resource/counter", (uri: URL) => {
       return {
         contents: [
           {

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -19,17 +19,17 @@ Inside your `McpAgent`'s `async init()` method, you can use the MCP SDK to defin
 
 ```ts
 export class MyMCP extends McpAgent<Env> {
-  server = new McpServer({
+  mcp = new McpServer({
     name: "Demo",
     version: "1.0.0"
   });
 
   async init() {
-    this.server.resource(`counter`, `mcp://resource/counter`, (uri) => {
+    this.mcp.resource(`counter`, `mcp://resource/counter`, (uri) => {
       // ...
     });
 
-    this.server.tool(
+    this.mcp.tool(
       "add",
       "Add two numbers together",
       { a: z.number(), b: z.number() },

--- a/examples/mcp/src/server.ts
+++ b/examples/mcp/src/server.ts
@@ -9,7 +9,7 @@ type Env = {
 type State = { counter: number };
 
 export class MyMCP extends McpAgent<Env, State, {}> {
-  server = new McpServer({
+  mcp = new McpServer({
     name: "Demo",
     version: "1.0.0"
   });
@@ -19,13 +19,13 @@ export class MyMCP extends McpAgent<Env, State, {}> {
   };
 
   async init() {
-    this.server.resource("counter", "mcp://resource/counter", (uri) => {
+    this.mcp.resource("counter", "mcp://resource/counter", (uri) => {
       return {
         contents: [{ text: String(this.state.counter), uri: uri.href }]
       };
     });
 
-    this.server.tool(
+    this.mcp.tool(
       "add",
       "Add to the counter, stored in the MCP",
       { a: z.number() },

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -411,7 +411,7 @@ type Env = {
 type State = { counter: number };
 
 export class MyMCP extends McpAgent<Env, State, {}> {
-  server = new McpServer({
+  mcp = new McpServer({
     name: "Demo",
     version: "1.0.0"
   });
@@ -421,13 +421,13 @@ export class MyMCP extends McpAgent<Env, State, {}> {
   };
 
   async init() {
-    this.server.resource("counter", "mcp://resource/counter", (uri) => {
+    this.mcp.resource("counter", "mcp://resource/counter", (uri) => {
       return {
         contents: [{ text: String(this.state.counter), uri: uri.href }]
       };
     });
 
-    this.server.tool(
+    this.mcp.tool(
       "add",
       "Add to the counter, stored in the MCP",
       { a: z.number() },


### PR DESCRIPTION
Technically there are some breaking changes here, but they're either done in a non-breaking way or they're breaking features I do not think are used (and are not documented).

Closes #425

- **BREAKING**: Renamed `server` property to `mcp` in `McpAgent` and updated related examples.
- **BREAKING**: Renamed `mcp` property to `mcpClientManager` in `Agent` class to avoid naming conflicts.
- Added backward compatibility for `server` property in `McpAgent` with a deprecation warning.
- Updated all MCP examples to reflect the new naming convention.
- Improved property naming consistency across the MCP implementation.