### PR TITLE
fix: pass agent._pk as id to useChat to prevent stale WebSocket instances

### DIFF
--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -326,7 +326,8 @@ export function useAgentChat<
   const useChatHelpers = useChat<ChatMessage>({
     ...rest,
     messages: initialMessages,
-    transport: customTransport
+    transport: customTransport,
+    id: agent._pk
   });
 
   const processedToolCalls = useRef(new Set<string>());


### PR DESCRIPTION
Pass the agent's unique identifier (`agent._pk`) as the `id` parameter to the useChat hook. This ensures that when useAgent creates multiple WebSocket instances, useAgentChat will get the updated connection associated with the current agent instance.

Fixes #439 