### PR TITLE
Fix MCP client to treat `client_uri` as a valid URL

### DIFF
--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -28,12 +28,16 @@ export class DurableObjectOAuthClientProvider implements AgentsOAuthProvider {
   get clientMetadata(): OAuthClientMetadata {
     return {
       client_name: this.clientName,
-      client_uri: "example.com",
+      client_uri: this.clientUri,
       grant_types: ["authorization_code", "refresh_token"],
       redirect_uris: [this.redirectUrl],
       response_types: ["code"],
       token_endpoint_auth_method: "none"
     };
+  }
+
+  get clientUri() {
+    return new URL(this.redirectUrl).origin;
   }
 
   get redirectUrl() {


### PR DESCRIPTION
A recent update in the [MCP TS SDK](https://github.com/modelcontextprotocol/typescript-sdk/pull/877/files#diff-a0fe23c86bd448c6fa4c60fe4d380daa65451fea86a9e760673a5a7c65292e88R171-R186) made the validation for for OAuth metadata stricter, requiring `client_uri` to be a proper URL. 

This change broke our MCP client transport, since we had `example.com` hardcoded as `client_uri`. This sets it to a reasonable value.