### PR TITLE
Silently handle writer close errors

### DIFF
--- a/.changeset/hot-dogs-camp.md
+++ b/.changeset/hot-dogs-camp.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Silently handle writer close errors

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -291,7 +291,7 @@ export const createStreamingHttpHandler = (
               // If we have received all the responses, close the connection
               if (requestIds.size === 0) {
                 ws?.close();
-                await writer.close();
+                await writer.close().catch(() => {});
               }
             } catch (error) {
               console.error("Error forwarding message to SSE:", error);
@@ -303,11 +303,7 @@ export const createStreamingHttpHandler = (
         // Handle WebSocket errors
         ws.addEventListener("error", (error) => {
           async function onError(_error: Event) {
-            try {
-              await writer.close();
-            } catch (_e) {
-              // Ignore errors when closing
-            }
+            await writer.close().catch(() => {});
           }
           onError(error).catch(console.error);
         });
@@ -315,11 +311,7 @@ export const createStreamingHttpHandler = (
         // Handle WebSocket closure
         ws.addEventListener("close", () => {
           async function onClose() {
-            try {
-              await writer.close();
-            } catch (error) {
-              console.error("Error closing SSE connection:", error);
-            }
+            await writer.close().catch(() => {});
           }
           onClose().catch(console.error);
         });


### PR DESCRIPTION
Since we're closing response writers in event handlers, we can't reliably know which one will run first and might try to close the same one twice. This PR simply makes them fail silently.

We only need to update Streamable HTTP handlers since SSE was already doing this.

Addresses #456