### PR TITLE
feat: Include reasoning text in finalized message

### DIFF
--- a/.changeset/plain-pigs-lead.md
+++ b/.changeset/plain-pigs-lead.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Include reasoning parts in finalized and persistet message.

--- a/packages/agents/src/ai-chat-agent.ts
+++ b/packages/agents/src/ai-chat-agent.ts
@@ -252,6 +252,7 @@ export class AIChatAgent<Env = unknown, State = unknown> extends Agent<
 
       const reader = response.body.getReader();
       let fullResponseText = ""; // Accumulate the assistant's response text
+      let fullReasoningText = ""; // Accumulate the assistant's reasoning
       // Track tool calls by toolCallid, so we can persist them as parts later
       const toolCalls = new Map<
         string,
@@ -338,6 +339,11 @@ export class AIChatAgent<Env = unknown, State = unknown> extends Agent<
                       return;
                     }
 
+                    case "reasoning-delta": {
+                      if (data.delta) fullReasoningText += data.delta;
+                      break;
+                    }
+
                     case "text-delta": {
                       if (data.delta) fullResponseText += data.delta;
                       break;
@@ -381,6 +387,10 @@ export class AIChatAgent<Env = unknown, State = unknown> extends Agent<
       Array.from(toolCalls.values()).forEach((t) => {
         messageParts.push(t as ChatMessage["parts"][number]);
       });
+
+      if (fullReasoningText.trim()) {
+        messageParts.push({ type: "reasoning", text: fullReasoningText });
+      }
 
       if (fullResponseText.trim()) {
         messageParts.push({ type: "text", text: fullResponseText });


### PR DESCRIPTION
The finalized message will now also include the final reasoning text.

In general one should consider if this part of the agent sdk shouldn't be reworked (a lot) because the current generation of reasoning models (Claude 4, GPT-5 and Grok 4) reason a little, call a tool and then continue to reason. I think this should also be persistet so people don't get confused. The ai-sdk probably already includes some code for this kind of persistence. Maybe the agent-sdk should just use that instead of rolling it's own.
