### PR TITLE
Store initialize requests and set them in onStart

### DIFF
--- a/.changeset/good-coats-poke.md
+++ b/.changeset/good-coats-poke.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Store initialize requests and set them in onStart

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -69,7 +69,7 @@ export abstract class McpAgent<
     await this.ctx.storage.put("initializeRequest", initializeRequest);
   }
 
-  getInitializeRequest() {
+  async getInitializeRequest() {
     return this.ctx.storage.get<JSONRPCMessage>("initializeRequest");
   }
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -65,12 +65,12 @@ export abstract class McpAgent<
    * Helpers
    */
 
-  setInitializeRequest(initializeRequest: JSONRPCMessage) {
-    this.ctx.storage.kv.put("initializeRequest", initializeRequest);
+  async setInitializeRequest(initializeRequest: JSONRPCMessage) {
+    await this.ctx.storage.put("initializeRequest", initializeRequest);
   }
 
   getInitializeRequest() {
-    return this.ctx.storage.kv.get<JSONRPCMessage>("initializeRequest");
+    return this.ctx.storage.get<JSONRPCMessage>("initializeRequest");
   }
 
   /** Read the transport type for this agent.
@@ -156,7 +156,7 @@ export abstract class McpAgent<
     // If the agent was previously initialized, we have to populate
     // the server again by sending the initialize request to make
     // client information available to the server.
-    const initializeRequest = this.getInitializeRequest();
+    const initializeRequest = await this.getInitializeRequest();
     if (initializeRequest) {
       this._transport.onmessage?.(initializeRequest);
     }

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -65,13 +65,12 @@ export abstract class McpAgent<
    * Helpers
    */
 
-  async setInitialized() {
-    // TODO: move to sync api once https://github.com/cloudflare/workerd/pull/4895 lands
-    await this.ctx.storage.put("initialized", true);
+  setInitializeRequest(initializeRequest: JSONRPCMessage) {
+    this.ctx.storage.kv.put("initializeRequest", initializeRequest);
   }
 
-  async isInitialized() {
-    return (await this.ctx.storage.get("initialized")) === true;
+  getInitializeRequest() {
+    return this.ctx.storage.kv.get<JSONRPCMessage>("initializeRequest");
   }
 
   /** Read the transport type for this agent.
@@ -153,6 +152,14 @@ export abstract class McpAgent<
     // Connect to the MCP server
     this._transport = this.initTransport();
     await server.connect(this._transport);
+
+    // If the agent was previously initialized, we have to populate
+    // the server again by sending the initialize request to make
+    // client information available to the server.
+    const initializeRequest = this.getInitializeRequest();
+    if (initializeRequest) {
+      this._transport.onmessage?.(initializeRequest);
+    }
   }
 
   /** Validates new WebSocket connections. */


### PR DESCRIPTION
The MCP TS SDK's Server [sets the client information](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/server/index.ts#L295-L296) when dealing with an `InitializeRequest` in memory.
 
This makes it so that IF an `McpAgent` hibernates or is evicted when already initialized, this data (e.g. `this.server.server.getClientCapabilities()`) will no longer be available since clients won't try to initialize again.

Since we were already storing a boolean to signal whether the `McpAgent` was initialized (only used internally, so I think it's OK to update this), we can store the `InitializeRequest` instead and send it on every startup when present, so `this.server` always has the data available.

~PS:  Also updated the methods to use the new KV sync API~