### PR TITLE
use header for session ids in streamable http GET streams

### DIFF
--- a/.changeset/polite-oranges-pretend.md
+++ b/.changeset/polite-oranges-pretend.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+use header for session ids in streamable http GET streams

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -374,7 +374,7 @@ export const createStreamingHttpHandler = (
         }
 
         // Require sessionId
-        const sessionId = url.searchParams.get("sessionId");
+        const sessionId = request.headers.get("mcp-session-id");
         if (!sessionId)
           return new Response("Missing sessionId", { status: 400 });
 

--- a/packages/agents/src/tests/shared/test-utils.ts
+++ b/packages/agents/src/tests/shared/test-utils.ts
@@ -185,7 +185,10 @@ export async function openStandaloneSSE(
   baseUrl = "http://example.com/mcp"
 ): Promise<ReadableStreamDefaultReader<Uint8Array>> {
   const request = new Request(`${baseUrl}?sessionId=${sessionId}`, {
-    headers: { Accept: "application/json, text/event-stream" },
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "mcp-session-id": sessionId
+    },
 
     method: "GET"
   });


### PR DESCRIPTION
In the Streamable HTTP handler we were reading the session ID from query parameters instead of the proper header.

That was the case for SSE but not for Streamable HTTP.