### PR TITLE
Refactor streamable HTTP transport

### DIFF
--- a/.changeset/tender-suns-decide.md
+++ b/.changeset/tender-suns-decide.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Refactor streamable HTTP transport

--- a/packages/agents/src/ai-types.ts
+++ b/packages/agents/src/ai-types.ts
@@ -11,6 +11,7 @@ export enum MessageType {
   CF_AGENT_CHAT_REQUEST_CANCEL = "cf_agent_chat_request_cancel",
 
   CF_AGENT_MCP_SERVERS = "cf_agent_mcp_servers",
+  CF_MCP_AGENT_EVENT = "cf_mcp_agent_event",
   CF_AGENT_STATE = "cf_agent_state",
   RPC = "rpc"
 }

--- a/packages/agents/src/mcp/transport.ts
+++ b/packages/agents/src/mcp/transport.ts
@@ -1,12 +1,23 @@
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type {
-  JSONRPCMessage,
-  RequestId
-} from "@modelcontextprotocol/sdk/types.js";
 import {
+  type MessageExtraInfo,
+  type RequestInfo,
   isJSONRPCError,
-  isJSONRPCResponse
+  isJSONRPCRequest,
+  isJSONRPCResponse,
+  type JSONRPCMessage,
+  JSONRPCMessageSchema,
+  type RequestId
 } from "@modelcontextprotocol/sdk/types.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { getCurrentAgent, type Connection } from "..";
+import type { McpAgent } from ".";
+import { MessageType } from "../ai-types";
+import {
+  MCP_HTTP_METHOD_HEADER,
+  MCP_MESSAGE_HEADER,
+  STANDALONE_SSE_MARKER
+} from "./utils";
 
 export class McpSSETransport implements Transport {
   sessionId?: string;
@@ -51,53 +62,251 @@ export class McpSSETransport implements Transport {
   }
 }
 
-export class McpStreamableHttpTransport implements Transport {
-  sessionId?: string;
-  // Set by the server in `server.connect(transport)`
+export type StreamId = string;
+export type EventId = string;
+
+// TODO: Implement this and make it opt-in?
+/**
+ * Interface for resumability support via event storage
+ */
+export interface EventStore {
+  /**
+   * Stores an event for later retrieval
+   * @param streamId ID of the stream the event belongs to
+   * @param message The JSON-RPC message to store
+   * @returns The generated event ID for the stored event
+   */
+  storeEvent(streamId: StreamId, message: JSONRPCMessage): Promise<EventId>;
+
+  replayEventsAfter(
+    lastEventId: EventId,
+    {
+      send
+    }: {
+      send: (eventId: EventId, message: JSONRPCMessage) => Promise<void>;
+    }
+  ): Promise<StreamId>;
+}
+
+/**
+ * Configuration options for StreamableHTTPServerTransport
+ */
+export interface StreamableHTTPServerTransportOptions {
+  /**
+   * A callback for session close events
+   * This is called when the server closes a session due to a DELETE request.
+   * Useful in cases when you need to clean up resources associated with the session.
+   * Note that this is different from the transport closing, if you are handling
+   * HTTP requests from multiple nodes you might want to close each
+   * StreamableHTTPServerTransport after a request is completed while still keeping the
+   * session open/running.
+   */
+  onsessionclosed?: () => void | Promise<void>;
+
+  /**
+   * If true, the server will return JSON responses instead of starting an SSE stream.
+   * This can be useful for simple request/response scenarios without streaming.
+   * Default is false (SSE streams are preferred).
+   */
+  enableJsonResponse?: boolean;
+
+  /**
+   * Event store for resumability support
+   * If provided, resumability will be enabled, allowing clients to reconnect and resume messages
+   */
+  eventStore?: EventStore;
+}
+
+export class StreamableHTTPServerTransport implements Transport {
+  // when sessionId is not set (undefined), it means the transport is in stateless mode
+  private _started = false;
+  private _eventStore?: EventStore;
+
+  // This is to keep track whether all messages from a single POST request have been answered.
+  // I's fine that we don't persist this since it's only for backwards compatibility as clients
+  // should no longer batch requests, per the spec.
+  private _requestResponseMap: Map<RequestId, JSONRPCMessage> = new Map();
+
+  sessionId: string;
   onclose?: () => void;
   onerror?: (error: Error) => void;
-  onmessage?: (message: JSONRPCMessage) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
 
-  // The server MAY use a standalone SSE stream to send requests/notifications.
-  private _getWebSocketForStandaloneSse: () => WebSocket | null;
+  constructor(options: StreamableHTTPServerTransportOptions) {
+    // CF override. We always use the provided sessionId that comes from the Agent.
+    const { agent } = getCurrentAgent<McpAgent>();
+    if (!agent)
+      throw new Error("McpAgent was not found in Transport constructor");
 
-  // Get the appropriate websocket connection for a given message id
-  private _getWebSocketForMessageID: (id: string) => WebSocket | null;
-
-  // Notify the server that a response has been sent for a given message id
-  // so that it may clean up it's mapping of message ids to connections
-  // once they are no longer needed
-  private _notifyResponseIdSent: (id: string) => void;
-
-  private _started = false;
-  constructor(
-    getWebSocketForMessageID: (id: string) => WebSocket | null,
-    notifyResponseIdSent: (id: string) => void,
-    getWebSocketForStandaloneSse: () => WebSocket | null
-  ) {
-    this._getWebSocketForMessageID = getWebSocketForMessageID;
-    this._notifyResponseIdSent = notifyResponseIdSent;
-    this._getWebSocketForStandaloneSse = getWebSocketForStandaloneSse;
+    this.sessionId = agent.getSessionId();
+    this._eventStore = options.eventStore;
   }
 
-  async start() {
-    // The transport does not manage the WebSocket connection since it's terminated
-    // by the Durable Object in order to allow hibernation. There's nothing to initialize.
+  /**
+   * Starts the transport. This is required by the Transport interface but is a no-op
+   * for the Streamable HTTP transport as connections are managed per-request.
+   */
+  async start(): Promise<void> {
     if (this._started) {
       throw new Error("Transport already started");
     }
     this._started = true;
   }
 
+  /**
+   * Handles GET requests for SSE stream
+   */
+  async handleGetRequest(req: Request): Promise<void> {
+    // Get the WS connection so we can tag it as the standalone stream
+    const { connection } = getCurrentAgent();
+    if (!connection)
+      throw new Error("Connection was not found in handleGetRequest");
+
+    // Handle resumability: check for Last-Event-ID header
+    if (this._eventStore) {
+      const lastEventId = req.headers.get("last-event-id");
+      if (lastEventId) {
+        await this.replayEvents(lastEventId);
+        return;
+      }
+    }
+
+    // TODO: look into using getConnections() for this
+    // Assign the response to the standalone SSE stream
+    connection.setState({
+      role: STANDALONE_SSE_MARKER
+    });
+  }
+
+  /**
+   * Replays events that would have been sent after the specified event ID
+   * Only used when resumability is enabled
+   */
+  private async replayEvents(lastEventId: string): Promise<void> {
+    if (!this._eventStore) {
+      return;
+    }
+
+    const { connection } = getCurrentAgent();
+    if (!connection)
+      throw new Error("Connection was not available in replayEvents");
+
+    try {
+      await this._eventStore?.replayEventsAfter(lastEventId, {
+        send: async (eventId: string, message: JSONRPCMessage) => {
+          try {
+            this.writeSSEEvent(connection, message, eventId);
+          } catch (error) {
+            this.onerror?.(error as Error);
+          }
+        }
+      });
+    } catch (error) {
+      this.onerror?.(error as Error);
+    }
+  }
+
+  /**
+   * Writes an event to the SSE stream with proper formatting
+   */
+  private writeSSEEvent(
+    connection: Connection,
+    message: JSONRPCMessage,
+    eventId?: string,
+    close?: boolean
+  ) {
+    let eventData = "event: message\n";
+    // Include event ID if provided - this is important for resumability
+    if (eventId) {
+      eventData += `id: ${eventId}\n`;
+    }
+    eventData += `data: ${JSON.stringify(message)}\n\n`;
+
+    return connection.send(
+      JSON.stringify({
+        type: MessageType.CF_MCP_AGENT_EVENT,
+        event: eventData,
+        close
+      })
+    );
+  }
+
+  /**
+   * Handles POST requests containing JSON-RPC messages
+   */
+  async handlePostRequest(
+    req: Request & { auth?: AuthInfo },
+    parsedBody: unknown
+  ): Promise<void> {
+    const authInfo: AuthInfo | undefined = req.auth;
+    const requestInfo: RequestInfo = {
+      headers: Object.fromEntries(req.headers.entries())
+    };
+    // Remove headers that are not part of the original request
+    delete requestInfo.headers[MCP_HTTP_METHOD_HEADER];
+    delete requestInfo.headers[MCP_MESSAGE_HEADER];
+    delete requestInfo.headers.upgrade;
+
+    const rawMessage = parsedBody;
+    let messages: JSONRPCMessage[];
+
+    // handle batch and single messages
+    if (Array.isArray(rawMessage)) {
+      messages = rawMessage.map((msg) => JSONRPCMessageSchema.parse(msg));
+    } else {
+      messages = [JSONRPCMessageSchema.parse(rawMessage)];
+    }
+
+    // check if it contains requests
+    const hasRequests = messages.some(isJSONRPCRequest);
+
+    if (!hasRequests) {
+      // We process without sending anything
+      for (const message of messages) {
+        this.onmessage?.(message, { authInfo, requestInfo });
+      }
+    } else if (hasRequests) {
+      const { connection } = getCurrentAgent();
+      if (!connection)
+        throw new Error("Connection was not found in handlePostRequest");
+
+      // We need to track by request ID to maintain the connection
+      const requestIds = messages
+        .filter(isJSONRPCRequest)
+        .map((message) => message.id);
+
+      connection.setState({
+        requestIds
+      });
+
+      // handle each message
+      for (const message of messages) {
+        this.onmessage?.(message, { authInfo, requestInfo });
+      }
+      // The server SHOULD NOT close the SSE stream before sending all JSON-RPC responses
+      // This will be handled by the send() method when responses are ready
+    }
+  }
+
+  async close(): Promise<void> {
+    // Close all SSE connections
+    const { agent } = getCurrentAgent();
+    if (!agent) throw new Error("Agent was not found in close");
+
+    for (const conn of agent.getConnections()) {
+      conn.close(1000, "Session closed");
+    }
+    this.onclose?.();
+  }
+
   async send(
     message: JSONRPCMessage,
     options?: { relatedRequestId?: RequestId }
-  ) {
-    if (!this._started) {
-      throw new Error("Transport not started");
-    }
-    let requestId = options?.relatedRequestId;
+  ): Promise<void> {
+    const { agent } = getCurrentAgent();
+    if (!agent) throw new Error("Agent was not found in send");
 
+    let requestId = options?.relatedRequestId;
     if (isJSONRPCResponse(message) || isJSONRPCError(message)) {
       // If the message is a response, use the request ID from the message
       requestId = message.id;
@@ -113,37 +322,64 @@ export class McpStreamableHttpTransport implements Transport {
           "Cannot send a response on a standalone SSE stream unless resuming a previous client request"
         );
       }
-      const standaloneSseSocket = this._getWebSocketForStandaloneSse();
-      if (!standaloneSseSocket) {
+
+      let standaloneConnection: Connection | undefined;
+      for (const conn of agent.getConnections<{ role?: string }>()) {
+        if (conn.state?.role === STANDALONE_SSE_MARKER)
+          standaloneConnection = conn;
+      }
+
+      if (standaloneConnection === undefined) {
         // The spec says the server MAY send messages on the stream, so it's ok to discard if no stream
         return;
       }
-      try {
-        standaloneSseSocket?.send(JSON.stringify(message));
-      } catch (error) {
-        this.onerror?.(error as Error);
+
+      // Generate and store event ID if event store is provided
+      let eventId: string | undefined;
+      if (this._eventStore) {
+        // Stores the event and gets the generated event ID
+        eventId = await this._eventStore.storeEvent(
+          standaloneConnection.id,
+          message
+        );
       }
+
+      // Send the message to the standalone SSE stream
+      this.writeSSEEvent(standaloneConnection, message, eventId);
       return;
     }
 
-    const websocket = this._getWebSocketForMessageID(requestId.toString());
-    if (!websocket) {
-      throw new Error(`Could not find WebSocket for message id: ${requestId}`);
+    // Get the response for this request
+    const connection = Array.from(
+      agent.getConnections<{ requestIds?: number[] }>()
+    ).find((conn) => conn.state?.requestIds?.includes(requestId as number));
+    if (!connection) {
+      throw new Error(
+        `No connection established for request ID: ${String(requestId)}`
+      );
     }
 
-    try {
-      websocket?.send(JSON.stringify(message));
-      // Cleanup on response/error
-      if (isJSONRPCResponse(message) || isJSONRPCError(message)) {
-        this._notifyResponseIdSent(message.id.toString());
+    let eventId: string | undefined;
+
+    if (this._eventStore) {
+      eventId = await this._eventStore.storeEvent(connection.id, message);
+    }
+
+    let shouldClose = false;
+
+    if (isJSONRPCResponse(message) || isJSONRPCError(message)) {
+      this._requestResponseMap.set(requestId, message);
+      const relatedIds = connection.state?.requestIds ?? [];
+      // Check if we have responses for all requests using this connection
+      shouldClose = relatedIds.every((id) => this._requestResponseMap.has(id));
+
+      if (shouldClose) {
+        // Clean up
+        for (const id of relatedIds) {
+          this._requestResponseMap.delete(id);
+        }
       }
-    } catch (error) {
-      this.onerror?.(error as Error);
     }
-  }
-
-  async close() {
-    // Similar to start, the only thing to do is to pass the event on to the server
-    this.onclose?.();
+    this.writeSSEEvent(connection, message, eventId, shouldClose);
   }
 }

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -11,13 +11,6 @@ import type { CORSOptions } from "./types";
 import { MessageType } from "../ai-types";
 
 /**
- * Tag placed in `connection.state.role` to mark the WebSocket that carries
- * the standalone SSE stream for a session. We use it to recover the connection
- * after hibernation.
- */
-export const STANDALONE_SSE_MARKER = "standalone-sse";
-
-/**
  * Since we use WebSockets to bridge the client to the
  * MCP transport in the Agent, we use this header to signal
  * the method of the original request the user made, while

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -1,15 +1,14 @@
 import {
   JSONRPCMessageSchema,
+  type JSONRPCMessage,
   InitializeRequestSchema,
   isJSONRPCResponse,
-  isJSONRPCError,
-  isJSONRPCNotification,
-  isJSONRPCRequest
+  isJSONRPCNotification
 } from "@modelcontextprotocol/sdk/types.js";
-import type { JSONRPCMessage } from "ai";
 import type { McpAgent } from ".";
 import { getAgentByName } from "..";
 import type { CORSOptions } from "./types";
+import { MessageType } from "../ai-types";
 
 /**
  * Tag placed in `connection.state.role` to mark the WebSocket that carries
@@ -19,10 +18,20 @@ import type { CORSOptions } from "./types";
 export const STANDALONE_SSE_MARKER = "standalone-sse";
 
 /**
- * Internal JSON-RPC notif method to attach current a
- * connection as the standalone SSE.
+ * Since we use WebSockets to bridge the client to the
+ * MCP transport in the Agent, we use this header to signal
+ * the method of the original request the user made, while
+ * leaving the WS Upgrade request as GET.
  */
-export const STANDALONE_SSE_METHOD = "cf/standalone_sse/attach";
+export const MCP_HTTP_METHOD_HEADER = "cf-mcp-method";
+
+/**
+ * Since we use WebSockets to bridge the client to the
+ * MCP transport in the Agent, we use this header to include
+ * the original request body.
+ */
+export const MCP_MESSAGE_HEADER = "cf-mcp-message";
+
 const MAXIMUM_MESSAGE_SIZE_BYTES = 4 * 1024 * 1024; // 4MB
 
 export const createStreamingHttpHandler = (
@@ -225,6 +234,8 @@ export const createStreamingHttpHandler = (
         const req = new Request(request.url, {
           headers: {
             ...existingHeaders,
+            [MCP_HTTP_METHOD_HEADER]: "POST",
+            [MCP_MESSAGE_HEADER]: JSON.stringify(messages),
             Upgrade: "websocket"
           }
         });
@@ -248,11 +259,6 @@ export const createStreamingHttpHandler = (
           return new Response(body, { status: 500 });
         }
 
-        // Keep track of the request ids that we have sent to the server
-        // so that we can close the connection once we have received
-        // all the responses
-        const requestIds: Set<string | number> = new Set();
-
         // Accept the WebSocket
         ws.accept();
 
@@ -266,30 +272,16 @@ export const createStreamingHttpHandler = (
                   : new TextDecoder().decode(event.data);
               const message = JSON.parse(data);
 
-              // validate that the message is a valid JSONRPC message
-              const result = JSONRPCMessageSchema.safeParse(message);
-              if (!result.success) {
-                // The message was not a valid JSONRPC message, so we will drop it
-                // PartyKit will broadcast state change messages to all connected clients
-                // and we need to filter those out so they are not passed to MCP clients
+              // We only forward events from the MCP server
+              if (message.type !== MessageType.CF_MCP_AGENT_EVENT) {
                 return;
               }
 
-              // If the message is a response or an error, remove the id from the set of
-              // request ids
-              if (
-                isJSONRPCResponse(result.data) ||
-                isJSONRPCError(result.data)
-              ) {
-                requestIds.delete(result.data.id);
-              }
-
               // Send the message as an SSE event
-              const messageText = `event: message\ndata: ${JSON.stringify(result.data)}\n\n`;
-              await writer.write(encoder.encode(messageText));
+              await writer.write(encoder.encode(message.event));
 
               // If we have received all the responses, close the connection
-              if (requestIds.size === 0) {
+              if (message.close) {
                 ws?.close();
                 await writer.close().catch(() => {});
               }
@@ -322,10 +314,6 @@ export const createStreamingHttpHandler = (
           (msg) => isJSONRPCNotification(msg) || isJSONRPCResponse(msg)
         );
         if (hasOnlyNotificationsOrResponses) {
-          for (const message of messages) {
-            ws.send(JSON.stringify(message));
-          }
-
           // closing the websocket will also close the SSE connection
           ws.close();
 
@@ -333,16 +321,6 @@ export const createStreamingHttpHandler = (
             headers: corsHeaders(request, corsOptions),
             status: 202
           });
-        }
-
-        for (const message of messages) {
-          if (isJSONRPCRequest(message)) {
-            // add each request id that we send off to a set
-            // so that we can keep track of which requests we
-            // still need a response for
-            requestIds.add(message.id);
-          }
-          ws.send(JSON.stringify(message));
         }
 
         // Return the SSE response. We handle closing the stream in the ws "message"
@@ -376,7 +354,17 @@ export const createStreamingHttpHandler = (
         // Require sessionId
         const sessionId = request.headers.get("mcp-session-id");
         if (!sessionId)
-          return new Response("Missing sessionId", { status: 400 });
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: -32000,
+                message: "Bad Request: Mcp-Session-Id header is required"
+              },
+              id: null,
+              jsonrpc: "2.0"
+            }),
+            { status: 400 }
+          );
 
         // Create SSE stream
         const { readable, writable } = new TransformStream();
@@ -410,6 +398,7 @@ export const createStreamingHttpHandler = (
           new Request(request.url, {
             headers: {
               ...existingHeaders,
+              [MCP_HTTP_METHOD_HEADER]: "GET",
               Upgrade: "websocket"
             }
           })
@@ -424,15 +413,6 @@ export const createStreamingHttpHandler = (
         }
         ws.accept();
 
-        // Signal the DO to use this connection as the standalone SSE stream
-        ws.send(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            method: STANDALONE_SSE_METHOD,
-            params: {}
-          })
-        );
-
         // Forward DO messages as SSE
         ws.addEventListener("message", (event) => {
           try {
@@ -441,10 +421,13 @@ export const createStreamingHttpHandler = (
                 typeof ev.data === "string"
                   ? ev.data
                   : new TextDecoder().decode(ev.data);
-              const parsed = JSONRPCMessageSchema.safeParse(JSON.parse(data));
-              if (!parsed.success) return;
-              const frame = `event: message\ndata: ${JSON.stringify(parsed.data)}\n\n`;
-              await writer.write(encoder.encode(frame));
+              const message = JSON.parse(data);
+
+              // We only forward events from the MCP server
+              if (message.type !== MessageType.CF_MCP_AGENT_EVENT) {
+                return;
+              }
+              await writer.write(encoder.encode(message.event));
             }
             onMessage(event).catch(console.error);
           } catch (e) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,8 @@
     "target": "ES2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
       "ES2022",
-      "DOM"
+      "DOM",
+      "DOM.Iterable"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     "jsx": "react-jsx" /* Specify what JSX code is generated. */,
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
Refactor the custom Streamable HTTP transport to closely match the behavior of the [MCP SDK's implementation](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/server/streamableHttp.ts)

This also updates how we bridge from the Worker to the transport within the agent.

**PREVIOUSLY**:
- The `McpAgent.serve(...)` handler in the Worker would get a POST request, read the body and make sure it was a valid JSON-RPC message and apply validation per the spec. (this we keep)
- Then, it would establish a WebSocket to the `McpAgent`, forward the JSON-RPC payloads over WS, keep a requestId -> connectionId map, send a private `cf/standalone_sse/attach` notif to bind the “standalone SSE stream” ([this](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server)) socket
- Close once all request IDs were answered.

**NOW**:
* Worker sets headers on the WS upgrade: `cf-mcp-method` (GET/POST) and `cf-mcp-message` (POST body JSON).
* Agent reads those headers in `onConnect` and calls `transport.handlePostRequest(...)` or `transport.handleGetRequest(...)`.
* New `StreamableHTTPServerTransport` replaces `McpStreamableHttpTransport`. It tracks `requestIds` and decides when to close.
* Outbound events go over WS as `{ type: "cf_mcp_agent_event", event, close }` and the worker writes `event` verbatim to SSE and closes when `close` is true.
* Kills the `requestId -> connectionId` map and the `cf/standalone_sse/attach` path, we track everything in the `connection.state`.

This allows us to have a transport that closely mimics the official one (except the validation, which we already do in the Worker handler), easier to maintain + more feature parity.
This also includes the `extra` parameter in tool handlers, with request information. So, the following also works now:
```typescript
    this.server.registerTool("someTool", {
     // params...
     }, async ({...}, extra) =>  {
       console.log(extra.requestInfo.headers);
       extra.sendNotification("someTool called...");
       return {
         content: [{ type: "text", text: ... }],
       }
});
```
