### PR TITLE
add step count limit and auto-send control for tool confirmations

### DIFF
--- a/guides/human-in-the-loop/src/server.ts
+++ b/guides/human-in-the-loop/src/server.ts
@@ -6,7 +6,8 @@ import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   type StreamTextOnFinishCallback,
-  streamText
+  streamText,
+  stepCountIs
 } from "ai";
 import { tools } from "./tools";
 import {
@@ -43,7 +44,8 @@ export class HumanInTheLoop extends AIChatAgent<Env> {
       messages: convertToModelMessages(this.messages),
       model: openai("gpt-4o"),
       onFinish,
-      tools
+      tools,
+      stopWhen: stepCountIs(5)
     });
 
     return result.toUIMessageStreamResponse({

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -8,7 +8,7 @@ import type {
 } from "ai";
 import { DefaultChatTransport } from "ai";
 import { nanoid } from "nanoid";
-import { use, useEffect, useMemo, useRef } from "react";
+import { use, useEffect, useRef } from "react";
 import type { OutgoingMessage } from "./ai-types";
 import { MessageType } from "./ai-types";
 import type { useAgent } from "./react";
@@ -338,10 +338,11 @@ export function useAgentChat<
 
   const processedToolCalls = useRef(new Set<string>());
 
-  // Track pending confirmations for the latest assistant message
-  const pendingConfirmations = useMemo(() => {
-    const lastMessage =
-      useChatHelpers.messages[useChatHelpers.messages.length - 1];
+  // Calculate pending confirmations for the latest assistant message
+  const lastMessage =
+    useChatHelpers.messages[useChatHelpers.messages.length - 1];
+
+  const pendingConfirmations = (() => {
     if (!lastMessage || lastMessage.role !== "assistant") {
       return { messageId: undefined, toolCallIds: new Set<string>() };
     }
@@ -357,7 +358,7 @@ export function useAgentChat<
       }
     }
     return { messageId: lastMessage.id, toolCallIds: pendingIds };
-  }, [useChatHelpers.messages, toolsRequiringConfirmation]);
+  })();
 
   const pendingConfirmationsRef = useRef(pendingConfirmations);
   pendingConfirmationsRef.current = pendingConfirmations;


### PR DESCRIPTION
fixes #477 

- added stopWhen: stepCountIs(5) for more than 2 steps prompts 
- for more than one confirmation added a function in ai-react to wait until there are no pending confirmations and only then send messages 