### PR TITLE
Fix OAuth callback handling and add HOST auto-detection

### DIFF
--- a/examples/mcp-client/.dev.vars.example
+++ b/examples/mcp-client/.dev.vars.example
@@ -1,1 +1,2 @@
-HOST=http://localhost:5173
+# Optional: Override the auto-detected host (defaults to request origin)
+# HOST=http://localhost:5173

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -1,5 +1,4 @@
 import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
-import { MCPClientManager } from "agents/mcp/client";
 
 type Env = {
   MyAgent: AgentNamespace<MyAgent>;
@@ -7,8 +6,6 @@ type Env = {
 };
 
 export class MyAgent extends Agent<Env, never> {
-  mcp = new MCPClientManager("my-agent", "1.0.0");
-
   async onRequest(request: Request): Promise<Response> {
     const reqUrl = new URL(request.url);
     if (reqUrl.pathname.endsWith("add-mcp") && request.method === "POST") {

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -2,7 +2,7 @@ import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
 
 type Env = {
   MyAgent: AgentNamespace<MyAgent>;
-  HOST: string;
+  HOST?: string; // Optional - will be derived from request if not provided
 };
 
 export class MyAgent extends Agent<Env, never> {
@@ -10,6 +10,7 @@ export class MyAgent extends Agent<Env, never> {
     const reqUrl = new URL(request.url);
     if (reqUrl.pathname.endsWith("add-mcp") && request.method === "POST") {
       const mcpServer = (await request.json()) as { url: string; name: string };
+      // Use HOST if provided, otherwise it will be derived from the request
       await this.addMcpServer(mcpServer.name, mcpServer.url, this.env.HOST);
       return new Response("Ok", { status: 200 });
     }

--- a/examples/mcp-client/wrangler.jsonc
+++ b/examples/mcp-client/wrangler.jsonc
@@ -27,8 +27,9 @@
     "logs": {
       "enabled": true
     }
-  },
-  "vars": {
-    "HOST": "<DEPLOYED_HOSTNAME>"
   }
+  // Optional: Override the auto-detected host
+  // "vars": {
+  //   "HOST": "<DEPLOYED_HOSTNAME>"
+  // }
 }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1514,12 +1514,21 @@ export class Agent<
       };
     }
 
+    // Detect transport type from URL pattern
+    let transportType: "sse" | "streamable-http" | "auto" = "auto";
+    if (url.endsWith("/sse")) {
+      transportType = "sse";
+    } else if (url.endsWith("/mcp")) {
+      transportType = "streamable-http";
+    }
+
     const { id, authUrl, clientId } = await this.mcp.connect(url, {
       client: options?.client,
       reconnect,
       transport: {
         ...headerTransportOpts,
-        authProvider
+        authProvider,
+        type: transportType
       }
     });
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -648,6 +648,13 @@ export class Agent<
 
             // from DO storage, reconnect to all servers not currently in the oauth flow using our saved auth information
             if (servers && Array.isArray(servers) && servers.length > 0) {
+              // Restore callback URLs for OAuth-enabled servers
+              servers.forEach((server) => {
+                if (server.callback_url) {
+                  this.mcp.registerCallbackUrl(server.callback_url);
+                }
+              });
+
               servers.forEach((server) => {
                 this._connectToMcpServerInternal(
                   server.name,
@@ -1525,6 +1532,7 @@ export class Agent<
 
   async removeMcpServer(id: string) {
     this.mcp.closeConnection(id);
+    this.mcp.unregisterCallbackUrl(id);
     this.sql`
       DELETE FROM cf_agents_mcp_servers WHERE id = ${id};
     `;

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -76,17 +76,20 @@ export class MCPClientManager {
       }
     }
 
-    this.mcpConnections[id] = new MCPClientConnection(
-      new URL(url),
-      {
-        name: this._name,
-        version: this._version
-      },
-      {
-        client: options.client ?? {},
-        transport: options.transport ?? {}
-      }
-    );
+    // During OAuth reconnect, reuse existing connection to preserve state
+    if (!options.reconnect?.oauthCode || !this.mcpConnections[id]) {
+      this.mcpConnections[id] = new MCPClientConnection(
+        new URL(url),
+        {
+          name: this._name,
+          version: this._version
+        },
+        {
+          client: options.client ?? {},
+          transport: options.transport ?? {}
+        }
+      );
+    }
 
     await this.mcpConnections[id].init(options.reconnect?.oauthCode);
 

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -176,6 +176,27 @@ export class MCPClientManager {
   }
 
   /**
+   * Register a callback URL for OAuth handling
+   * @param url The callback URL to register
+   */
+  registerCallbackUrl(url: string): void {
+    if (!this._callbackUrls.includes(url)) {
+      this._callbackUrls.push(url);
+    }
+  }
+
+  /**
+   * Unregister a callback URL
+   * @param serverId The server ID whose callback URL should be removed
+   */
+  unregisterCallbackUrl(serverId: string): void {
+    // Remove callback URLs that end with this serverId
+    this._callbackUrls = this._callbackUrls.filter(
+      (url) => !url.endsWith(`/${serverId}`)
+    );
+  }
+
+  /**
    * @returns namespaced list of tools
    */
   listTools(): NamespacedData["tools"] {


### PR DESCRIPTION
## Summary

This PR fixes OAuth callback handling for MCP servers and adds automatic HOST detection to simplify configuration.

## Changes

### OAuth Fixes
- Remove MCPClientManager override in MyAgent example that was preventing OAuth callbacks from working
- Add callback URL persistence across Durable Object hibernation 
- Fix connection reuse during OAuth reconnect to prevent state loss
- Add transport type detection from URL patterns to prevent OAuth code consumption

### Enhancement
- Make `callbackHost` parameter optional in `addMcpServer()` - automatically derives from request when not provided
- Update examples to reflect HOST as optional environment variable

## Test Plan
- [x] OAuth callbacks work with Linear MCP server
- [x] OAuth state persists across DO hibernation
- [x] SSE transport connections work with OAuth
- [x] HOST auto-detection works when variable is not set
- [x] Backward compatibility maintained for existing code
- [x] All checks pass (formatting, linting, typechecking)