### PR TITLE
Decouple OAuth authorization from transport selection

### DIFF
--- a/.changeset/yellow-owls-report.md
+++ b/.changeset/yellow-owls-report.md
@@ -1,0 +1,10 @@
+---
+"agents": patch
+---
+
+Fix OAuth authentication for MCP servers and add transport configuration
+
+- Fix authorization codes being consumed during transport fallback
+- Add transport type option to addMcpServer() for explicit control
+- Add configurable OAuth callback handling (redirects, custom responses)
+- Fix callback URL persistence across Durable Object hibernation

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -8,7 +8,7 @@ type Env = {
 
 export class MyAgent extends Agent<Env, never> {
   onStart() {
-    // Configure OAuth callback to use popup-closing behavior
+    // Optionally configure OAuth callback. Here we use popup-closing behavior since we're opening a window on the client 
     this.mcp.configureOAuthCallback({
       customHandler: (result: MCPClientOAuthResult) => {
         if (result.authSuccess) {

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -1,4 +1,5 @@
 import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
+import type { MCPClientOAuthResult } from "agents/mcp";
 
 type Env = {
   MyAgent: AgentNamespace<MyAgent>;
@@ -6,6 +7,28 @@ type Env = {
 };
 
 export class MyAgent extends Agent<Env, never> {
+  onStart() {
+    // Configure OAuth callback to use popup-closing behavior
+    this.mcp.configureOAuthCallback({
+      customHandler: (result: MCPClientOAuthResult) => {
+        if (result.authSuccess) {
+          return new Response("<script>window.close();</script>", {
+            headers: { "content-type": "text/html" },
+            status: 200
+          });
+        } else {
+          return new Response(
+            `<script>alert('Authentication failed: ${result.authError}'); window.close();</script>`,
+            {
+              headers: { "content-type": "text/html" },
+              status: 200
+            }
+          );
+        }
+      }
+    });
+  }
+
   async onRequest(request: Request): Promise<Response> {
     const reqUrl = new URL(request.url);
     if (reqUrl.pathname.endsWith("add-mcp") && request.method === "POST") {

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -8,7 +8,7 @@ type Env = {
 
 export class MyAgent extends Agent<Env, never> {
   onStart() {
-    // Optionally configure OAuth callback. Here we use popup-closing behavior since we're opening a window on the client 
+    // Optionally configure OAuth callback. Here we use popup-closing behavior since we're opening a window on the client
     this.mcp.configureOAuthCallback({
       customHandler: (result: MCPClientOAuthResult) => {
         if (result.authSuccess) {

--- a/packages/agents/src/core/events.ts
+++ b/packages/agents/src/core/events.ts
@@ -1,0 +1,52 @@
+export interface Disposable {
+  dispose(): void;
+}
+
+export function toDisposable(fn: () => void): Disposable {
+  return { dispose: fn };
+}
+
+export class DisposableStore implements Disposable {
+  private readonly _items: Disposable[] = [];
+
+  add<T extends Disposable>(d: T): T {
+    this._items.push(d);
+    return d;
+  }
+
+  dispose(): void {
+    while (this._items.length) {
+      try {
+        this._items.pop()!.dispose();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}
+
+export type Event<T> = (listener: (e: T) => void) => Disposable;
+
+export class Emitter<T> implements Disposable {
+  private _listeners: Set<(e: T) => void> = new Set();
+
+  readonly event: Event<T> = (listener) => {
+    this._listeners.add(listener);
+    return toDisposable(() => this._listeners.delete(listener));
+  };
+
+  fire(data: T): void {
+    for (const listener of [...this._listeners]) {
+      try {
+        listener(data);
+      } catch (err) {
+        // do not let one bad listener break others
+        console.error("Emitter listener error:", err);
+      }
+    }
+  }
+
+  dispose(): void {
+    this._listeners.clear();
+  }
+}

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -17,7 +17,7 @@ import {
   MCPClientConnection,
   type MCPTransportOptions
 } from "./client-connection";
-import type { BaseTransportType, TransportType } from "./types";
+import type { TransportType } from "./types";
 
 export type MCPClientOAuthCallbackConfig = {
   successRedirect?: string;

--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -12,10 +12,6 @@ export interface AgentsOAuthProvider extends OAuthClientProvider {
   authUrl: string | undefined;
   clientId: string | undefined;
   serverId: string | undefined;
-  // Transport tracking for OAuth flow
-  saveOAuthTransport(transportType: string): Promise<void>;
-  getOAuthTransport(): Promise<string | undefined>;
-  clearOAuthTransport(): Promise<void>;
 }
 
 export class DurableObjectOAuthClientProvider implements AgentsOAuthProvider {
@@ -159,22 +155,5 @@ export class DurableObjectOAuthClientProvider implements AgentsOAuthProvider {
       throw new Error("No code verifier found");
     }
     return codeVerifier;
-  }
-
-  /** Transport tracking for OAuth flow */
-  oauthTransportKey() {
-    return `/${this.clientName}/${this.serverId}/oauth_transport`;
-  }
-
-  async saveOAuthTransport(transportType: string): Promise<void> {
-    await this.storage.put(this.oauthTransportKey(), transportType);
-  }
-
-  async getOAuthTransport(): Promise<string | undefined> {
-    return await this.storage.get<string>(this.oauthTransportKey());
-  }
-
-  async clearOAuthTransport(): Promise<void> {
-    await this.storage.delete(this.oauthTransportKey());
   }
 }

--- a/packages/agents/src/mcp/errors.ts
+++ b/packages/agents/src/mcp/errors.ts
@@ -1,0 +1,19 @@
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isUnauthorized(error: unknown): boolean {
+  const msg = toErrorMessage(error);
+  return msg.includes("Unauthorized") || msg.includes("401");
+}
+
+export function isTransportNotImplemented(error: unknown): boolean {
+  const msg = toErrorMessage(error);
+  // Treat common "not implemented" surfaces as transport not supported
+  return (
+    msg.includes("404") ||
+    msg.includes("405") ||
+    msg.includes("Not Implemented") ||
+    msg.includes("not implemented")
+  );
+}

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -427,3 +427,9 @@ export {
   type ElicitRequest,
   type ElicitResult
 } from "@modelcontextprotocol/sdk/types.js";
+
+// Export OAuth-related types
+export type {
+  MCPClientOAuthResult,
+  MCPClientOAuthCallbackConfig
+} from "./client";

--- a/packages/agents/src/observability/agent.ts
+++ b/packages/agents/src/observability/agent.ts
@@ -1,0 +1,31 @@
+import type { BaseEvent } from "./base";
+
+/**
+ * Agent-specific observability events
+ * These track the lifecycle and operations of an Agent
+ */
+export type AgentObservabilityEvent =
+  | BaseEvent<"state:update", {}>
+  | BaseEvent<
+      "rpc",
+      {
+        method: string;
+        streaming?: boolean;
+      }
+    >
+  | BaseEvent<"message:request" | "message:response", {}>
+  | BaseEvent<"message:clear">
+  | BaseEvent<
+      "schedule:create" | "schedule:execute" | "schedule:cancel",
+      {
+        callback: string;
+        id: string;
+      }
+    >
+  | BaseEvent<"destroy">
+  | BaseEvent<
+      "connect",
+      {
+        connectionId: string;
+      }
+    >;

--- a/packages/agents/src/observability/base.ts
+++ b/packages/agents/src/observability/base.ts
@@ -1,0 +1,26 @@
+/**
+ * Base event structure for all observability events
+ */
+export type BaseEvent<
+  T extends string,
+  Payload extends Record<string, unknown> = {}
+> = {
+  type: T;
+  /**
+   * The unique identifier for the event
+   */
+  id: string;
+  /**
+   * The message to display in the logs for this event, should the implementation choose to display
+   * a human-readable message.
+   */
+  displayMessage: string;
+  /**
+   * The payload of the event
+   */
+  payload: Payload & Record<string, unknown>;
+  /**
+   * The timestamp of the event in milliseconds since epoch
+   */
+  timestamp: number;
+};

--- a/packages/agents/src/observability/index.ts
+++ b/packages/agents/src/observability/index.ts
@@ -1,65 +1,21 @@
 import { getCurrentAgent } from "../index";
-
-type BaseEvent<
-  T extends string,
-  Payload extends Record<string, unknown> = {}
-> = {
-  type: T;
-  /**
-   * The unique identifier for the event
-   */
-  id: string;
-  /**
-   * The message to display in the logs for this event, should the implementation choose to display
-   * a human-readable message.
-   */
-  displayMessage: string;
-  /**
-   * The payload of the event
-   */
-  payload: Payload;
-  /**
-   * The timestamp of the event in milliseconds since epoch
-   */
-  timestamp: number;
-};
+import type { AgentObservabilityEvent } from "./agent";
+import type { MCPObservabilityEvent } from "./mcp";
 
 /**
- * The type of events that can be emitted by an Agent
+ * Union of all observability event types from different domains
  */
 export type ObservabilityEvent =
-  | BaseEvent<"state:update", {}>
-  | BaseEvent<
-      "rpc",
-      {
-        method: string;
-        streaming?: boolean;
-      }
-    >
-  | BaseEvent<"message:request" | "message:response", {}>
-  | BaseEvent<"message:clear">
-  | BaseEvent<
-      "schedule:create" | "schedule:execute" | "schedule:cancel",
-      {
-        callback: string;
-        id: string;
-      }
-    >
-  | BaseEvent<"destroy">
-  | BaseEvent<
-      "connect",
-      {
-        connectionId: string;
-      }
-    >;
+  | AgentObservabilityEvent
+  | MCPObservabilityEvent;
 
 export interface Observability {
   /**
    * Emit an event for the Agent's observability implementation to handle.
    * @param event - The event to emit
-   * @param ctx - The execution context of the invocation
+   * @param ctx - The execution context of the invocation (optional)
    */
-  emit(event: ObservabilityEvent, ctx: DurableObjectState): void;
+  emit(event: ObservabilityEvent, ctx?: DurableObjectState): void;
 }
 
 /**

--- a/packages/agents/src/observability/mcp.ts
+++ b/packages/agents/src/observability/mcp.ts
@@ -1,0 +1,21 @@
+import type { BaseEvent } from "./base";
+
+/**
+ * MCP-specific observability events
+ * These track the lifecycle of MCP connections and operations
+ */
+export type MCPObservabilityEvent =
+  | BaseEvent<"mcp:client:preconnect", { serverId: string }>
+  | BaseEvent<
+      "mcp:client:connect",
+      { url: string; transport: string; state: string; error?: string }
+    >
+  | BaseEvent<
+      "mcp:client:authorize",
+      {
+        serverId: string;
+        authUrl: string;
+        clientId?: string;
+      }
+    >
+  | BaseEvent<"mcp:client:discover", {}>;

--- a/packages/agents/src/tests/mcp/client-connection.test.ts
+++ b/packages/agents/src/tests/mcp/client-connection.test.ts
@@ -6,6 +6,7 @@ import type {
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { z } from "zod";
 import { MCPClientConnection } from "../../mcp/client-connection";
+import type { MCPObservabilityEvent } from "../../observability/mcp";
 
 /**
  * Mock MCP server for testing different scenarios
@@ -95,7 +96,7 @@ describe("MCP Client Connection Integration", () => {
 
       // Mock all client methods to avoid real network calls
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
-      connection.client.getServerCapabilities = vi.fn().mockResolvedValue({
+      connection.client.getServerCapabilities = vi.fn().mockReturnValue({
         tools: { listChanged: true },
         resources: { listChanged: true },
         prompts: { listChanged: true }
@@ -175,7 +176,7 @@ describe("MCP Client Connection Integration", () => {
       );
 
       // Mock getServerCapabilities to return null
-      const mockGetCapabilities = vi.fn().mockResolvedValue(null);
+      const mockGetCapabilities = vi.fn().mockReturnValue(null);
       connection.client.getServerCapabilities = mockGetCapabilities;
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
 
@@ -198,7 +199,7 @@ describe("MCP Client Connection Integration", () => {
 
       // Mock successful responses
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
-      connection.client.getServerCapabilities = vi.fn().mockResolvedValue({
+      connection.client.getServerCapabilities = vi.fn().mockReturnValue({
         tools: { listChanged: true }
       });
       connection.client.getInstructions = vi
@@ -243,7 +244,7 @@ describe("MCP Client Connection Integration", () => {
 
       // Mock server with no tools capability
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
-      connection.client.getServerCapabilities = vi.fn().mockResolvedValue({
+      connection.client.getServerCapabilities = vi.fn().mockReturnValue({
         resources: { listChanged: true },
         prompts: { listChanged: true }
       });
@@ -282,7 +283,7 @@ describe("MCP Client Connection Integration", () => {
       // Mock method not found error for tools
       const methodNotFoundError = { code: -32601, message: "Method not found" };
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
-      connection.client.getServerCapabilities = vi.fn().mockResolvedValue({
+      connection.client.getServerCapabilities = vi.fn().mockReturnValue({
         tools: { listChanged: true }
       });
       connection.client.getInstructions = vi
@@ -306,11 +307,57 @@ describe("MCP Client Connection Integration", () => {
 
       expect(connection.connectionState).toBe("ready");
       expect(connection.tools).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "The server advertised support for the capability tools"
-        )
+
+      // Collect observability events during initialization
+      const observabilityEvents: MCPObservabilityEvent[] = [];
+      // We need to set up the listener before init to catch events
+      const newConnection = new MCPClientConnection(
+        new URL(serverUrl),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {}
+        }
       );
+
+      // Set up event listener before init
+      newConnection.onObservabilityEvent((event) => {
+        observabilityEvents.push(event);
+      });
+
+      // Mock the same error scenario
+      newConnection.client.connect = vi.fn().mockResolvedValue(undefined);
+      newConnection.client.getServerCapabilities = vi.fn().mockReturnValue({
+        tools: { listChanged: true }
+      });
+      newConnection.client.getInstructions = vi
+        .fn()
+        .mockResolvedValue("Test instructions");
+      newConnection.client.listTools = vi
+        .fn()
+        .mockRejectedValue({ code: -32601, message: "Method not found" });
+      newConnection.client.listResources = vi
+        .fn()
+        .mockResolvedValue({ resources: [] });
+      newConnection.client.listPrompts = vi
+        .fn()
+        .mockResolvedValue({ prompts: [] });
+      newConnection.client.listResourceTemplates = vi
+        .fn()
+        .mockResolvedValue({ resourceTemplates: [] });
+      newConnection.client.setNotificationHandler = vi.fn();
+
+      await newConnection.init();
+
+      // Now verify the observability event was fired (filter for discover events only)
+      const discoverEvents = observabilityEvents.filter(
+        (e) => e.type === "mcp:client:discover"
+      );
+      expect(discoverEvents).toHaveLength(1);
+      expect(discoverEvents[0].displayMessage).toContain(
+        "The server advertised support for the capability tools"
+      );
+      expect(discoverEvents[0].payload.capability).toBe("tools");
     });
   });
 
@@ -327,7 +374,7 @@ describe("MCP Client Connection Integration", () => {
 
       // Mock mixed success/failure scenario
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
-      connection.client.getServerCapabilities = vi.fn().mockResolvedValue({
+      connection.client.getServerCapabilities = vi.fn().mockReturnValue({
         tools: { listChanged: true },
         resources: { listChanged: true },
         prompts: { listChanged: true }
@@ -381,16 +428,74 @@ describe("MCP Client Connection Integration", () => {
       expect(connection.prompts[0].name).toBe("working-prompt");
       expect(connection.resourceTemplates).toEqual([]);
 
-      // Should log failures
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize instructions:",
-        expect.any(Error)
+      // Verify observability events for failures
+      const testConnection = new MCPClientConnection(
+        new URL(serverUrl),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {}
+        }
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize resources:",
-        expect.any(Error)
+
+      const observabilityEvents: MCPObservabilityEvent[] = [];
+      testConnection.onObservabilityEvent((event) => {
+        observabilityEvents.push(event);
+      });
+
+      // Re-setup the same failure scenario
+      testConnection.client.connect = vi.fn().mockResolvedValue(undefined);
+      testConnection.client.getServerCapabilities = vi.fn().mockReturnValue({
+        tools: { listChanged: true },
+        resources: { listChanged: true },
+        prompts: { listChanged: true }
+      });
+      testConnection.client.getInstructions = vi
+        .fn()
+        .mockRejectedValue(new Error("Instructions service down"));
+      testConnection.client.listTools = vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: "working-tool",
+            description: "A working tool",
+            inputSchema: { type: "object" }
+          }
+        ]
+      });
+      testConnection.client.setNotificationHandler = vi.fn();
+      testConnection.client.listResources = vi
+        .fn()
+        .mockRejectedValue(new Error("Resources service down"));
+      testConnection.client.listPrompts = vi.fn().mockResolvedValue({
+        prompts: [{ name: "working-prompt", description: "A working prompt" }]
+      });
+      testConnection.client.listResourceTemplates = vi
+        .fn()
+        .mockResolvedValue({ resourceTemplates: [] });
+
+      await testConnection.init();
+
+      // Should have fired events for the two failures (filter for discover events)
+      const discoverEvents = observabilityEvents.filter(
+        (e) => e.type === "mcp:client:discover"
       );
-      expect(consoleSpy).toHaveBeenCalledTimes(2);
+      expect(discoverEvents).toHaveLength(2);
+
+      const instructionsEvent = discoverEvents.find(
+        (e) => e.payload?.capability === "instructions"
+      );
+      expect(instructionsEvent).toBeDefined();
+      expect(instructionsEvent?.displayMessage).toContain(
+        "Failed to discover instructions"
+      );
+
+      const resourcesEvent = discoverEvents.find(
+        (e) => e.payload?.capability === "resources"
+      );
+      expect(resourcesEvent).toBeDefined();
+      expect(resourcesEvent?.displayMessage).toContain(
+        "Failed to discover resources"
+      );
     });
 
     it("should handle all capabilities failing", async () => {
@@ -405,7 +510,7 @@ describe("MCP Client Connection Integration", () => {
 
       // Mock all capabilities failing
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
-      connection.client.getServerCapabilities = vi.fn().mockResolvedValue({
+      connection.client.getServerCapabilities = vi.fn().mockReturnValue({
         tools: { listChanged: true },
         resources: { listChanged: true },
         prompts: { listChanged: true }
@@ -433,28 +538,62 @@ describe("MCP Client Connection Integration", () => {
       expect(connection.prompts).toEqual([]);
       expect(connection.resourceTemplates).toEqual([]);
 
-      // Should log all failures
-      expect(consoleSpy).toHaveBeenCalledTimes(5);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize instructions:",
-        serviceError
+      // Verify all failures are reported via observability events
+      const testConn = new MCPClientConnection(
+        new URL(serverUrl),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {}
+        }
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize tools:",
-        serviceError
+
+      const events: MCPObservabilityEvent[] = [];
+      testConn.onObservabilityEvent((event) => {
+        events.push(event);
+      });
+
+      const allServicesError = new Error("All services down");
+      testConn.client.connect = vi.fn().mockResolvedValue(undefined);
+      testConn.client.getServerCapabilities = vi.fn().mockReturnValue({
+        tools: { listChanged: true },
+        resources: { listChanged: true },
+        prompts: { listChanged: true }
+      });
+      testConn.client.getInstructions = vi
+        .fn()
+        .mockRejectedValue(allServicesError);
+      testConn.client.listTools = vi.fn().mockRejectedValue(allServicesError);
+      testConn.client.listResources = vi
+        .fn()
+        .mockRejectedValue(allServicesError);
+      testConn.client.listPrompts = vi.fn().mockRejectedValue(allServicesError);
+      testConn.client.listResourceTemplates = vi
+        .fn()
+        .mockRejectedValue(allServicesError);
+      testConn.client.setNotificationHandler = vi.fn();
+
+      await testConn.init();
+
+      // Should have events for all 5 failures (filter for discover events)
+      const discoverEvents = events.filter(
+        (e) => e.type === "mcp:client:discover"
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize resources:",
-        serviceError
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize prompts:",
-        serviceError
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize resource templates:",
-        serviceError
-      );
+      expect(discoverEvents).toHaveLength(5);
+
+      // Check each capability failure was reported
+      const capabilities = [
+        "instructions",
+        "tools",
+        "resources",
+        "prompts",
+        "resource templates"
+      ];
+      capabilities.forEach((cap) => {
+        const event = discoverEvents.find((e) => e.payload?.capability === cap);
+        expect(event).toBeDefined();
+        expect(event?.displayMessage).toContain(`Failed to discover ${cap}`);
+      });
     });
 
     it("should handle mixed error types gracefully", async () => {
@@ -468,7 +607,7 @@ describe("MCP Client Connection Integration", () => {
       );
 
       connection.client.connect = vi.fn().mockResolvedValue(undefined);
-      connection.client.getServerCapabilities = vi.fn().mockResolvedValue({
+      connection.client.getServerCapabilities = vi.fn().mockReturnValue({
         tools: { listChanged: true },
         resources: { listChanged: true }
       });
@@ -499,16 +638,67 @@ describe("MCP Client Connection Integration", () => {
       expect(connection.resources).toEqual([]);
       expect(connection.prompts).toEqual([]);
 
-      // Should log both types of errors
-      // Note: Method not found errors are handled by capabilityErrorHandler and logged differently
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "The server advertised support for the capability tools"
-        )
+      // Verify mixed error types are reported correctly via observability
+      const mixedErrorConn = new MCPClientConnection(
+        new URL(serverUrl),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {}
+        }
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to initialize resources:",
-        expect.any(Error)
+
+      const collectedEvents: MCPObservabilityEvent[] = [];
+      mixedErrorConn.onObservabilityEvent((event) => {
+        collectedEvents.push(event);
+      });
+
+      mixedErrorConn.client.connect = vi.fn().mockResolvedValue(undefined);
+      mixedErrorConn.client.getServerCapabilities = vi.fn().mockReturnValue({
+        tools: { listChanged: true },
+        resources: { listChanged: true }
+      });
+      mixedErrorConn.client.getInstructions = vi
+        .fn()
+        .mockResolvedValue("Working instructions");
+      mixedErrorConn.client.listTools = vi
+        .fn()
+        .mockRejectedValue({ code: -32601, message: "Method not found" });
+      mixedErrorConn.client.listResources = vi
+        .fn()
+        .mockRejectedValue(new Error("Network error"));
+      mixedErrorConn.client.listPrompts = vi
+        .fn()
+        .mockResolvedValue({ prompts: [] });
+      mixedErrorConn.client.listResourceTemplates = vi
+        .fn()
+        .mockResolvedValue({ resourceTemplates: [] });
+      mixedErrorConn.client.setNotificationHandler = vi.fn();
+
+      await mixedErrorConn.init();
+
+      // Should have events for both error types (filter for discover events)
+      const discoverEvents = collectedEvents.filter(
+        (e) => e.type === "mcp:client:discover"
+      );
+      expect(discoverEvents).toHaveLength(2);
+
+      // Method not found error should have specific message
+      const toolsEvent = discoverEvents.find(
+        (e) => e.payload?.capability === "tools"
+      );
+      expect(toolsEvent).toBeDefined();
+      expect(toolsEvent?.displayMessage).toContain(
+        "The server advertised support for the capability tools"
+      );
+
+      // Regular error for resources
+      const resourcesEvent = discoverEvents.find(
+        (e) => e.payload?.capability === "resources"
+      );
+      expect(resourcesEvent).toBeDefined();
+      expect(resourcesEvent?.displayMessage).toContain(
+        "Failed to discover resources"
       );
     });
   });

--- a/packages/agents/src/tests/mcp/client-connection.test.ts
+++ b/packages/agents/src/tests/mcp/client-connection.test.ts
@@ -573,12 +573,10 @@ describe("MCP Client Connection Integration", () => {
       await connection.init();
       expect(connection.connectionState).toBe("authenticating");
 
-      const successfulTransport =
-        await connection.completeAuthorization(authCode);
+      await connection.completeAuthorization(authCode);
       expect(connection.connectionState).toBe("connecting");
-      expect(successfulTransport).toBe("streamable-http"); // or whatever transport succeeded
 
-      await connection.establishConnection(successfulTransport);
+      await connection.establishConnection();
       expect(connection.connectionState).toBe("ready");
     });
 

--- a/packages/agents/src/tests/mcp/transports/auto.test.ts
+++ b/packages/agents/src/tests/mcp/transports/auto.test.ts
@@ -57,7 +57,7 @@ describe("Auto Transport Mode", () => {
         "auto"
       );
 
-      await expect(connection.init()).rejects.toThrow();
+      await connection.init();
       expect(connection.connectionState).toBe("failed");
     });
 
@@ -67,7 +67,7 @@ describe("Auto Transport Mode", () => {
         "auto"
       );
 
-      await expect(connection.init()).rejects.toThrow();
+      await connection.init();
       expect(connection.connectionState).toBe("failed");
     });
 
@@ -77,7 +77,7 @@ describe("Auto Transport Mode", () => {
         "sse"
       );
 
-      await expect(connection.init()).rejects.toThrow();
+      await connection.init();
       expect(connection.connectionState).toBe("failed");
     });
   });


### PR DESCRIPTION
OAuth and transport selection were tightly coupled, causing authorization codes to be consumed during transport fallback attempts. This led to "authorization code already used" errors and made OAuth-protected MCP servers unusable.

Split the OAuth flow into two distinct phases:
1. **OAuth completion** - Finishes auth and probes for working transport
2. **Connection establishment** - Connects using the appropriate transport

## Changes

- Remove transport tracking from OAuth provider (no longer needed)
- Add `finishAuthProbe()` to complete OAuth independently
- Allow transport type configuration in `addMcpServer()` options
- Add configurable OAuth callback handling (redirects, custom handlers)
- Fix callback URL persistence across Durable Object hibernation
- Add error helpers and logging for debugging

## Testing

- All existing tests pass
- OAuth flow tested with Linear MCP server
- Transport fallback tested with both SSE and streamable-http
- Callback URL persistence tested across DO hibernation

## Breaking Changes

None - all changes are backward compatible.