### PR TITLE
addMcpServer: added the serverId further upstream 

### DIFF
--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -45,7 +45,8 @@ export class DurableObjectOAuthClientProvider implements AgentsOAuthProvider {
   }
 
   get redirectUrl() {
-    return `${this.baseRedirectUrl}/${this.serverId}`;
+    //return `${this.baseRedirectUrl}/${this.serverId}`;
+    return `${this.baseRedirectUrl}`;
   }
 
   get clientId() {


### PR DESCRIPTION
MCP client Adding a new MCP server with Oauth2 :

Resolved the problem on the _callbackUrls (#488) and created the serverId upstream in the addMcpServer