### PR TITLE
Fix OAuth state parameter security vulnerability

### DIFF
--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -201,13 +201,13 @@ export class MCPClientManager {
       );
     }
     const code = url.searchParams.get("code");
-    const clientId = url.searchParams.get("state");
+    const state = url.searchParams.get("state");
     const urlParams = urlMatch.split("/");
     const serverId = urlParams[urlParams.length - 1];
     if (!code) {
       throw new Error("Unauthorized: no code provided");
     }
-    if (!clientId) {
+    if (!state) {
       throw new Error("Unauthorized: no state provided");
     }
 
@@ -227,6 +227,9 @@ export class MCPClientManager {
         "Trying to finalize authentication for a server connection without an authProvider"
       );
     }
+
+    // Get clientId from auth provider (stored during redirectToAuthorization) or fallback to state for backward compatibility
+    const clientId = conn.options.transport.authProvider.clientId || state;
 
     // Set the OAuth credentials
     conn.options.transport.authProvider.clientId = clientId;

--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -5,6 +5,7 @@ import type {
   OAuthClientMetadata,
   OAuthTokens
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { nanoid } from "nanoid";
 
 // A slight extension to the standard OAuthClientProvider interface because `redirectToAuthorization` doesn't give us the interface we need
 // This allows us to track authentication for a specific server and associated dynamic client registration
@@ -122,12 +123,16 @@ export class DurableObjectOAuthClientProvider implements AgentsOAuthProvider {
    * and require user interact to initiate the redirect flow
    */
   async redirectToAuthorization(authUrl: URL): Promise<void> {
-    // We want to track the client ID in state here because the typescript SSE client sometimes does
-    // a dynamic client registration AFTER generating this redirect URL.
     const client_id = authUrl.searchParams.get("client_id");
+
+    // Store clientId internally for later use by clientInformation()
     if (client_id) {
-      authUrl.searchParams.append("state", client_id);
+      this._clientId_ = client_id;
     }
+
+    // Generate secure random token for state parameter
+    const stateToken = nanoid();
+    authUrl.searchParams.set("state", stateToken);
     this._authUrl_ = authUrl.toString();
   }
 


### PR DESCRIPTION
Replace OAuth client_id values in state parameters with secure random tokens to prevent CSRF attacks and state prediction vulnerabilities.

The current implementation exposes the OAuth client_id directly in the state parameter, making it predictable and potentially enabling cross-site request forgery attacks.

## Solution

Replace state parameter with secure random tokens while storing clientId separately:

```typescript
// Before: Predictable state value
authUrl.searchParams.append("state", client_id);

// After: Secure random token
const stateToken = nanoid();
authUrl.searchParams.set("state", stateToken);
this._clientId_ = client_id; // Store separately
```

Update callback handler to read clientId from stored property instead of state parameter, with fallback to legacy behavior for backward compatibility.

## References

- **OAuth 2.0 Security BCP**: [RFC 6819](https://tools.ietf.org/html/rfc6819) - State parameter should be unguessable random values to prevent CSRF attacks
- **OWASP OAuth Guidelines**: State parameters should be cryptographically random

Supports both static and dynamic client registration flows while maintaining backward compatibility.