### PR TITLE
update our cache key in useAgentChat to include agent name (fix for #420)

### DIFF
--- a/examples/resumable-stream-chat/src/app.tsx
+++ b/examples/resumable-stream-chat/src/app.tsx
@@ -1,0 +1,112 @@
+import type { UIMessage as Message } from "ai";
+import "./styles.css";
+import { useAgentChatHttp } from "agents/use-agent-chat-http";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export default function Chat() {
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const [input, setInput] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  useEffect(() => {
+    // Set initial theme
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
+
+  // Scroll to bottom on mount
+  useEffect(() => {
+    scrollToBottom();
+  }, [scrollToBottom]);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "dark" ? "light" : "dark";
+    setTheme(newTheme);
+    document.documentElement.setAttribute("data-theme", newTheme);
+  };
+
+  const { messages, sendMessage, clearChatHistory } = useAgentChatHttp({
+    agent: "resumable-chat-agent",
+    enableResumableStreams: true
+  });
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (input.trim()) {
+        sendMessage({ role: "user", parts: [{ type: "text", text: input }] });
+        setInput("");
+      }
+    },
+    [input, sendMessage]
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value);
+  };
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    messages.length > 0 && scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  return (
+    <>
+      <div className="controls-container">
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="theme-switch"
+          data-theme={theme}
+          aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+        >
+          <div className="theme-switch-handle" />
+        </button>
+        <button
+          type="button"
+          onClick={clearChatHistory}
+          className="clear-history"
+        >
+          🗑️ Clear History
+        </button>
+      </div>
+
+      <div className="chat-container">
+        <div className="messages-wrapper">
+          {messages?.map((m: Message) => (
+            <div key={m.id} className="message">
+              <strong>{`${m.role}: `}</strong>
+              {m.parts?.map((part, i) => {
+                switch (part.type) {
+                  case "text":
+                    return (
+                      // biome-ignore lint/suspicious/noArrayIndexKey: vibes
+                      <div key={i} className="message-content">
+                        {part.text}
+                      </div>
+                    );
+                  default:
+                    return null;
+                }
+              })}
+              <br />
+            </div>
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <input
+            className="chat-input"
+            value={input}
+            placeholder="Say something..."
+            onChange={handleInputChange}
+          />
+        </form>
+      </div>
+    </>
+  );
+}

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -119,9 +119,10 @@
     "check:test:react": "vitest -r src/react-tests --watch false",
     "check:test:workers": "vitest -r src/tests --watch false",
     "evals": "(cd evals; evalite)",
-    "test": "vitest -r src/tests",
+    "test": "npm run test:workers && npm run test:react",
     "test:react": "vitest -r src/react-tests",
-    "test:e2e": "vitest run src/e2e/e2e.test.ts --sequence.concurrent"
+    "test:e2e": "vitest run src/e2e/e2e.test.ts --sequence.concurrent",
+    "test:workers": "vitest -r src/tests"
   },
   "type": "module",
   "types": "dist/index.d.ts",

--- a/packages/agents/src/ai-react.tsx
+++ b/packages/agents/src/ai-react.tsx
@@ -167,11 +167,14 @@ export function useAgentChat<
   function doGetInitialMessages(
     getInitialMessagesOptions: GetInitialMessagesOptions
   ) {
-    if (requestCache.has(agentUrlString)) {
-      return requestCache.get(agentUrlString)! as Promise<ChatMessage[]>;
+    // we need a unique cache key that includes both URL and agent identifiers, just URL wasn't enough
+    const cacheKey = `${agentUrlString}#${agent.agent}#${agent.name}`;
+
+    if (requestCache.has(cacheKey)) {
+      return requestCache.get(cacheKey)! as Promise<ChatMessage[]>;
     }
     const promise = getInitialMessagesFetch(getInitialMessagesOptions);
-    requestCache.set(agentUrlString, promise);
+    requestCache.set(cacheKey, promise);
     return promise;
   }
 
@@ -191,13 +194,14 @@ export function useAgentChat<
     if (!initialMessagesPromise) {
       return;
     }
-    requestCache.set(agentUrlString, initialMessagesPromise!);
+    const cacheKey = `${agentUrlString}#${agent.agent}#${agent.name}`;
+    requestCache.set(cacheKey, initialMessagesPromise!);
     return () => {
-      if (requestCache.get(agentUrlString) === initialMessagesPromise) {
-        requestCache.delete(agentUrlString);
+      if (requestCache.get(cacheKey) === initialMessagesPromise) {
+        requestCache.delete(cacheKey);
       }
     };
-  }, [agentUrlString, initialMessagesPromise]);
+  }, [agentUrlString, initialMessagesPromise, agent.agent, agent.name]);
 
   const aiFetch = useCallback(
     async (request: RequestInfo | URL, options: RequestInit = {}) => {

--- a/packages/agents/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/agents/src/react-tests/use-agent-chat.test.tsx
@@ -1,28 +1,34 @@
 import { StrictMode, Suspense, act } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render } from "vitest-browser-react";
 import { useAgentChat } from "../ai-react";
 import type { useAgent } from "../react";
 
-// mock the @ai-sdk/react package
+let useChatMock = vi.fn();
+
 vi.mock("@ai-sdk/react", () => ({
-  useChat: vi.fn((args) => ({
-    messages: args.initialMessages,
-    setMessages: vi.fn()
-  }))
+  useChat: (...args: unknown[]) => useChatMock(...args)
 }));
 
-/**
- * Unit tests for the hook functionality which mock the network
- * layer and @ai-sdk dependencies.
- */
+beforeEach(() => {
+  useChatMock = vi.fn((args) => ({
+    messages: args.messages || [],
+    setMessages: vi.fn(),
+    append: vi.fn(),
+    reload: vi.fn(),
+    stop: vi.fn(),
+    isLoading: false,
+    error: undefined
+  }));
+});
+
 describe("useAgentChat", () => {
   it("should cache initial message responses across re-renders", async () => {
-    // mocking the agent with a subset of fields used in useAgentChat
     const mockAgent: ReturnType<typeof useAgent> = {
       _pkurl: "ws://localhost:3000",
       _url: "ws://localhost:3000",
       addEventListener: vi.fn(),
+      agent: "Chat",
       id: "fake-agent",
       name: "fake-agent",
       removeEventListener: vi.fn(),
@@ -44,7 +50,6 @@ describe("useAgentChat", () => {
     ];
     const getInitialMessages = vi.fn(() => Promise.resolve(testMessages));
 
-    // We can observe how many times Suspense was triggered with this component.
     const suspenseRendered = vi.fn();
     const SuspenseObserver = () => {
       suspenseRendered();
@@ -56,14 +61,9 @@ describe("useAgentChat", () => {
         agent: mockAgent,
         getInitialMessages
       });
-
-      // NOTE: this only works because of how @ai-sdk/react is mocked to use
-      // the initialMessages prop as the messages state in the mock return value.
       return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
     };
 
-    // wrapping in act is required to resolve the suspense boundary during
-    // initial render.
     const screen = await act(() =>
       render(<TestComponent />, {
         wrapper: ({ children }) => (
@@ -83,7 +83,6 @@ describe("useAgentChat", () => {
     expect(getInitialMessages).toHaveBeenCalledTimes(1);
     expect(suspenseRendered).toHaveBeenCalled();
 
-    // reset our Suspense observer
     suspenseRendered.mockClear();
 
     await screen.rerender(<TestComponent />);
@@ -96,5 +95,228 @@ describe("useAgentChat", () => {
     // and the component does not suspend
     expect(getInitialMessages).toHaveBeenCalledTimes(1);
     expect(suspenseRendered).not.toHaveBeenCalled();
+  });
+
+  it("should refetch initial messages when the agent name changes", async () => {
+    // this is to test the fix for issue #420
+    // https://github.com/cloudflare/agents/issues/420
+
+    const mockAgent1: ReturnType<typeof useAgent> = {
+      _pkurl: "ws://localhost:3000",
+      _url: "ws://localhost:3000",
+      addEventListener: vi.fn(),
+      agent: "Chat",
+      id: "agent-1",
+      name: "thread-1",
+      removeEventListener: vi.fn(),
+      send: vi.fn()
+      // biome-ignore lint/suspicious/noExplicitAny: tests
+    } as any;
+
+    const mockAgent2: ReturnType<typeof useAgent> = {
+      _pkurl: "ws://localhost:3000",
+      _url: "ws://localhost:3000",
+      addEventListener: vi.fn(),
+      agent: "Chat",
+      id: "agent-2",
+      name: "thread-2",
+      removeEventListener: vi.fn(),
+      send: vi.fn()
+      // biome-ignore lint/suspicious/noExplicitAny: tests
+    } as any;
+
+    const messagesForAgent1 = [
+      {
+        id: "1",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Hi from thread 1" }]
+      },
+      {
+        id: "2",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "Hello from thread 1" }]
+      }
+    ];
+
+    const messagesForAgent2 = [
+      {
+        id: "3",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Hi from thread 2" }]
+      },
+      {
+        id: "4",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "Hello from thread 2" }]
+      }
+    ];
+
+    const getInitialMessages = vi.fn(
+      (options: { agent: string | undefined; name: string; url: string }) => {
+        if (options.name === "thread-1") {
+          return Promise.resolve(messagesForAgent1);
+        }
+        return Promise.resolve(messagesForAgent2);
+      }
+    );
+
+    const TestComponent = ({
+      agent
+    }: {
+      agent: ReturnType<typeof useAgent>;
+    }) => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages
+      });
+
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const screen = await act(() =>
+      render(<TestComponent agent={mockAgent1} />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+          </StrictMode>
+        )
+      })
+    );
+
+    // Wait for initial messages from agent 1
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent(JSON.stringify(messagesForAgent1));
+
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+    expect(getInitialMessages).toHaveBeenCalledWith({
+      agent: "Chat",
+      name: "thread-1",
+      url: expect.stringContaining("http://localhost:3000")
+    });
+
+    // Switch to agent 2
+    await act(() => screen.rerender(<TestComponent agent={mockAgent2} />));
+
+    // Messages should update to agent 2's messages
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent(JSON.stringify(messagesForAgent2));
+
+    // getInitialMessages should be called again for the new agent
+    expect(getInitialMessages).toHaveBeenCalledTimes(2);
+    expect(getInitialMessages).toHaveBeenCalledWith({
+      agent: "Chat",
+      name: "thread-2",
+      url: expect.stringContaining("http://localhost:3000")
+    });
+  });
+
+  it("should update messages when switching agents after messages have been appended", async () => {
+    // This verifies the specific scenario
+    // where messages don't update after the first agent receives new messages
+    // https://github.com/cloudflare/agents/issues/420
+
+    const mockAgent1: ReturnType<typeof useAgent> = {
+      _pkurl: "ws://localhost:3000",
+      _url: "ws://localhost:3000",
+      addEventListener: vi.fn(),
+      agent: "Chat",
+      id: "agent-1",
+      name: "thread-1",
+      removeEventListener: vi.fn(),
+      send: vi.fn()
+      // biome-ignore lint/suspicious/noExplicitAny: tests
+    } as any;
+
+    const mockAgent2: ReturnType<typeof useAgent> = {
+      _pkurl: "ws://localhost:3000",
+      _url: "ws://localhost:3000",
+      addEventListener: vi.fn(),
+      agent: "Chat",
+      id: "agent-2",
+      name: "thread-2",
+      removeEventListener: vi.fn(),
+      send: vi.fn()
+      // biome-ignore lint/suspicious/noExplicitAny: tests
+    } as any;
+
+    const initialMessagesForAgent1 = [
+      {
+        id: "1",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Initial message" }]
+      }
+    ];
+
+    const messagesForAgent2 = [
+      {
+        id: "3",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Thread 2 message" }]
+      }
+    ];
+
+    const getInitialMessages = vi.fn(
+      (options: { agent: string | undefined; name: string; url: string }) => {
+        if (options.name === "thread-1") {
+          return Promise.resolve(initialMessagesForAgent1);
+        }
+        return Promise.resolve(messagesForAgent2);
+      }
+    );
+
+    const TestComponent = ({
+      agent
+    }: {
+      agent: ReturnType<typeof useAgent>;
+    }) => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages
+      });
+
+      return (
+        <div>
+          <div data-testid="messages">{JSON.stringify(chat.messages)}</div>
+          <div data-testid="agent-name">{agent.name}</div>
+        </div>
+      );
+    };
+
+    const screen = await act(() =>
+      render(<TestComponent agent={mockAgent1} />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+          </StrictMode>
+        )
+      })
+    );
+
+    // Wait for initial render with agent 1
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent(JSON.stringify(initialMessagesForAgent1));
+
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+    // Now switch to agent 2
+    await act(() => screen.rerender(<TestComponent agent={mockAgent2} />));
+
+    await expect
+      .element(screen.getByTestId("agent-name"))
+      .toHaveTextContent("thread-2");
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent(JSON.stringify(messagesForAgent2));
+
+    // getInitialMessages should be called for both agents
+    expect(getInitialMessages).toHaveBeenCalledTimes(2);
+    expect(getInitialMessages).toHaveBeenNthCalledWith(2, {
+      agent: "Chat",
+      name: "thread-2",
+      url: expect.stringContaining("http://localhost:3000")
+    });
   });
 });


### PR DESCRIPTION
this fixes https://github.com/cloudflare/agents/issues/420

so previously when we switch from threadId-1 to threadId-2, we would use agentUrlString as the cache key, which in this cause would be identical for both agents and the cache would return the msgs for thread1, instead of thread2

wrote tests for the initial bug, failed as expected, added agent.name to the cacheKey and now all is passing