### PR TITLE
AI Playground improvements

### DIFF
--- a/site/ai-playground/src/app.tsx
+++ b/site/ai-playground/src/app.tsx
@@ -427,6 +427,11 @@ const App = () => {
                   {message.parts.map((part, i) => {
                     // Render text messages
                     if (part.type === "text") {
+                      // Skip empty text parts (e.g., when message only contains tool calls)
+                      if (!part.text || part.text.trim() === "") {
+                        return null;
+                      }
+
                       return (
                         <li
                           // biome-ignore lint/suspicious/noArrayIndexKey: it's fine
@@ -496,7 +501,9 @@ const App = () => {
                 </div>
               ))}
 
-              {!loading ? null : (
+              {(loading || streaming) &&
+              (messages[messages.length - 1].role !== "assistant" ||
+                messages[messages.length - 1].parts.length === 0) ? (
                 <li className="mb-3 flex items-start border-b border-b-gray-100 w-full py-2">
                   <div className="mr-3 w-[80px]">
                     <button
@@ -515,7 +522,7 @@ const App = () => {
                     />
                   </div>
                 </li>
-              )}
+              ) : null}
 
               {/*{messages.map((message, idx) =>*/}
               {/*  message.role === 'system' ? null : (*/}

--- a/site/ai-playground/src/components/McpServers.tsx
+++ b/site/ai-playground/src/components/McpServers.tsx
@@ -86,6 +86,20 @@ export function McpServers({ agent, mcpState, mcpLogs }: McpServersProps) {
     return sessionStorage.getItem("mcpBearerToken") || "";
   });
   const [showToken, setShowToken] = useState<boolean>(false);
+  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+
+  // Toggle tool expansion
+  const toggleToolExpansion = (toolName: string) => {
+    setExpandedTools((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(toolName)) {
+        newSet.delete(toolName);
+      } else {
+        newSet.add(toolName);
+      }
+      return newSet;
+    });
+  };
 
   // Handle connection
   const handleConnect = async () => {
@@ -583,21 +597,48 @@ export function McpServers({ agent, mcpState, mcpLogs }: McpServersProps) {
                 Available Tools ({mcpState.tools.length})
               </div>
               <div className="space-y-2 max-h-60 overflow-y-auto pr-2">
-                {mcpState.tools.map((tool: Tool) => (
-                  <div
-                    key={tool.name}
-                    className="bg-white rounded p-2 border border-green-200"
-                  >
-                    <div className="font-medium text-xs text-gray-900">
-                      {tool.name.replace("tool_", "").replace(/_/g, " ")}
+                {mcpState.tools.map((tool: Tool) => {
+                  const isExpanded = expandedTools.has(tool.name);
+                  return (
+                    <div
+                      key={tool.name}
+                      className="bg-white rounded border border-green-200"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => toggleToolExpansion(tool.name)}
+                        className="w-full flex items-center justify-between p-2 text-left hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <div className="font-medium text-xs text-gray-900">
+                          {tool.name.replace("tool_", "").replace(/_/g, " ")}
+                        </div>
+                        {tool.description && (
+                          <svg
+                            className={`w-3 h-3 text-gray-500 flex-shrink-0 ml-2 transform transition-transform ${
+                              isExpanded ? "rotate-180" : ""
+                            }`}
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <title>expand</title>
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M19 9l-7 7-7-7"
+                            />
+                          </svg>
+                        )}
+                      </button>
+                      {tool.description && isExpanded && (
+                        <div className="px-2 pb-2 text-xs text-gray-600 border-t border-gray-100 pt-2">
+                          {tool.description}
+                        </div>
+                      )}
                     </div>
-                    {tool.description && (
-                      <div className="text-xs text-gray-600 mt-1">
-                        {tool.description}
-                      </div>
-                    )}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           )}


### PR DESCRIPTION
- Since we're streaming as soon as we received the SSE response we'd stop showing the loading indicator. Fixed to show it properly.
- When the assistant called a tool we'd display tool call + result information but show an empty assistant message. Fixed to hide that.
- Tool descriptions can get long so they're collapsable now.
<img width="1500" height="1083" alt="image" src="https://github.com/user-attachments/assets/ae643e44-4e0c-4aa9-887d-e4a3282294b3" />
