### PR TITLE
Use Cloudflare-AI-playground as client name instead of sessionId for playground

### DIFF
--- a/site/ai-playground/src/app.tsx
+++ b/site/ai-playground/src/app.tsx
@@ -75,7 +75,7 @@ const App = () => {
 
   const agent = useAgent<Playground, PlaygroundState>({
     agent: "playground",
-    name: sessionId,
+    name: `Cloudflare-AI-Playground-${sessionId}`,
     onError(event) {
       console.error("[App] onError callback triggered with event:", event);
     },

--- a/site/ai-playground/src/components/Header.tsx
+++ b/site/ai-playground/src/components/Header.tsx
@@ -162,7 +162,7 @@ const Header = ({ onSetCodeVisible }: HeaderProps) => {
       </a>
       <a
         className="hover:bg-gray-50 text-sm cursor-pointer font-sm px-3 py-2 bg-white border border-gray-200 rounded-md shadow-sm flex items-center"
-        href="https://github.com/cloudflare/agents/tree/main/examples/ai-playground"
+        href="https://github.com/cloudflare/agents/tree/main/site/ai-playground"
         target="_blank"
         rel="noreferrer"
       >


### PR DESCRIPTION
This looks a lot friendlier
<img width="603" height="867" alt="Screenshot 2025-10-31 at 8 25 54 PM" src="https://github.com/user-attachments/assets/7a000f5e-c0e4-4902-b7bc-8f2844b979fd" />

than this!
<img width="608" height="866" alt="Screenshot 2025-10-31 at 8 23 50 PM" src="https://github.com/user-attachments/assets/77fa19b5-00ce-4b4f-a12b-0da653900152" />

