### PR TITLE
Refactor MCP server table management in Agent class

### DIFF
--- a/.changeset/hungry-turtles-shout.md
+++ b/.changeset/hungry-turtles-shout.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Refactor MCP server table management in Agent class
+
+Moved creation and deletion of the cf_agents_mcp_servers table from AgentMCPClientStorage to the Agent class. Removed redundant create and destroy methods from AgentMCPClientStorage and updated MCPClientManager to reflect these changes. Added comments to clarify usage in demo and test code.

--- a/examples/mcp-client/src/client.tsx
+++ b/examples/mcp-client/src/client.tsx
@@ -107,6 +107,7 @@ function App() {
           method: "POST"
         }
       );
+      // biome-ignore lint/suspicious/noExplicitAny: just a demo
       const data = (await response.json()) as { tools: any[]; error?: string };
 
       if (data.error) {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -432,6 +432,18 @@ export class Agent<
     );
 
     this.sql`
+        CREATE TABLE IF NOT EXISTS cf_agents_mcp_servers (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL,
+          server_url TEXT NOT NULL,
+          callback_url TEXT NOT NULL,
+          client_id TEXT,
+          auth_url TEXT,
+          server_options TEXT
+        )
+      `;
+
+    this.sql`
       CREATE TABLE IF NOT EXISTS cf_agents_state (
         id TEXT PRIMARY KEY NOT NULL,
         state TEXT
@@ -1310,6 +1322,7 @@ export class Agent<
    */
   async destroy() {
     // drop all tables
+    this.sql`DROP TABLE IF EXISTS cf_agents_mcp_servers`;
     this.sql`DROP TABLE IF EXISTS cf_agents_state`;
     this.sql`DROP TABLE IF EXISTS cf_agents_schedules`;
     this.sql`DROP TABLE IF EXISTS cf_agents_queues`;

--- a/packages/agents/src/mcp/client-storage.ts
+++ b/packages/agents/src/mcp/client-storage.ts
@@ -33,16 +33,6 @@ export interface OAuthClientStorage {
  */
 export interface MCPClientStorage extends OAuthClientStorage {
   /**
-   * Create the cf_agents_mcp_servers table if it doesn't exist
-   */
-  create(): Promise<void>;
-
-  /**
-   * Drop the cf_agents_mcp_servers table
-   */
-  destroy(): Promise<void>;
-
-  /**
    * Save or update an MCP server configuration
    */
   saveServer(server: MCPServerRow): Promise<void>;
@@ -83,24 +73,6 @@ export class AgentMCPClientStorage implements MCPClientStorage {
     ) => T[],
     private kv: SyncKvStorage
   ) {}
-
-  async create() {
-    this.sql`
-      CREATE TABLE IF NOT EXISTS cf_agents_mcp_servers (
-        id TEXT PRIMARY KEY NOT NULL,
-        name TEXT NOT NULL,
-        server_url TEXT NOT NULL,
-        callback_url TEXT NOT NULL,
-        client_id TEXT,
-        auth_url TEXT,
-        server_options TEXT
-      )
-    `;
-  }
-
-  async destroy() {
-    this.sql`DROP TABLE IF EXISTS cf_agents_mcp_servers`;
-  }
 
   async saveServer(server: MCPServerRow) {
     this.sql`

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -149,7 +149,6 @@ export class MCPClientManager {
       return;
     }
 
-    await this._storage.create();
     const servers = await this._storage.listServers();
 
     if (!servers || servers.length === 0) {
@@ -821,9 +820,6 @@ export class MCPClientManager {
       // Dispose manager-level emitters
       this._onServerStateChanged.dispose();
       this._onObservabilityEvent.dispose();
-
-      // Drop the storage table
-      await this._storage.destroy();
     }
   }
 

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -263,6 +263,7 @@ export class TestOAuthAgent extends Agent<Env> {
     clientId?: string | null
   ): Promise<void> {
     // Save server to database with callback URL
+    // biome-ignore lint/suspicious/noExplicitAny: just a test
     await (this.mcp as any)._storage.saveServer({
       id: serverId,
       name: serverName,


### PR DESCRIPTION
Moved creation and deletion of the cf_agents_mcp_servers table from AgentMCPClientStorage to the Agent class. Removed redundant create and destroy methods from AgentMCPClientStorage and updated MCPClientManager to reflect these changes. Added comments to clarify usage in demo and test code.