### PR TITLE
fix: move MCP SDK to peer dependencies

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@ai-sdk/openai": "2.0.73",
     "@cfworker/json-schema": "^4.1.1",
-    "@modelcontextprotocol/sdk": "^1.23.0",
     "ai": "5.0.103",
     "cron-schedule": "^6.0.0",
     "json-schema": "^0.4.0",
@@ -41,12 +40,14 @@
   },
   "devDependencies": {
     "@cloudflare/workers-oauth-provider": "^0.1.0",
+    "@modelcontextprotocol/sdk": "^1.23.0",
     "@types/yargs": "^17.0.35",
     "react": "*",
     "vitest-browser-react": "^1.0.1",
     "x402": "^0.7.3"
   },
   "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1.0.0",
     "react": "*",
     "viem": ">=2.0.0",
     "x402": "^0.7.1"


### PR DESCRIPTION
## Summary

Move `@modelcontextprotocol/sdk` from direct dependencies to peer dependencies, allowing consumers to control their own MCP SDK version.

## Problem

Currently, `@modelcontextprotocol/sdk` is pinned as a direct dependency (`"^1.23.0"`). This causes issues for consumers using different MCP SDK versions:

- Duplicate packages get installed
- Type mismatches when consumers reference MCP types (`Tool`, `Prompt`, `Resource`, `ServerCapabilities`) from their own code
- The agents package exposes MCP SDK types in its public API (e.g., `MCPServersState`, `McpAgent.server`)

## Solution

- `@modelcontextprotocol/sdk`: required peer dep (`>=1.0.0`)

Unlike the AI SDK packages where some are optional, MCP is a required peer dependency because:
1. MCP functionality is core to the package (every `Agent` has `this.mcp` built-in)
2. Types like `MCPServersState` and `McpAgent` are fundamental exports
3. The `McpAgent` abstract class directly exposes `McpServer | Server` types

## Breaking Changes

Consumers who don't already have `@modelcontextprotocol/sdk` installed will need to add it explicitly. However, anyone using MCP features is likely already interacting with MCP types.

Related to #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)