### PR TITLE
fix: scheduling should work

### DIFF
--- a/.changeset/ten-foxes-arrive.md
+++ b/.changeset/ten-foxes-arrive.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+fix: scheduling should work
+
+since we updated to zod v4, the schedule schema was broken. ai sdk's .jsonSchema function doesn't correctly work on tools created with zod v4. The fix, is to use the v3 version of zod for the schedule schema.

--- a/packages/agents/src/schedule.ts
+++ b/packages/agents/src/schedule.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Get the schedule prompt for a given event


### PR DESCRIPTION
since we updated to zod v4, the schedule schema was broken. ai sdk's .jsonSchema function doesn't correctly work on tools created with zod v4. The fix, is to use the v3 version of zod for the schedule schema.