### PR TITLE
Remove optional flag for 'ai' in peerDependenciesMeta

### DIFF
--- a/.changeset/tall-dodos-vanish.md
+++ b/.changeset/tall-dodos-vanish.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+fix: don't mark ai as optional under peerDependenciesMeta

--- a/package-lock.json
+++ b/package-lock.json
@@ -28050,9 +28050,6 @@
         "@ai-sdk/react": {
           "optional": true
         },
-        "ai": {
-          "optional": true
-        },
         "viem": {
           "optional": true
         },

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -64,9 +64,6 @@
     "@ai-sdk/react": {
       "optional": true
     },
-    "ai": {
-      "optional": true
-    },
     "viem": {
       "optional": true
     },


### PR DESCRIPTION
fixes https://github.com/cloudflare/agents/issues/751

The 'ai' package is no longer marked as optional under peerDependenciesMeta in agents/package.json. This change ensures that 'ai' is treated as a required peer dependency.