### PR TITLE
Fix React act environment setup in vitest browser tests

### DIFF
--- a/packages/ai-chat/src/react-tests/setup.ts
+++ b/packages/ai-chat/src/react-tests/setup.ts
@@ -1,0 +1,3 @@
+// properly set up the act environment for react-tests
+// @ts-expect-error - react specific API
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -10,6 +10,10 @@ import {
 } from "../react";
 import type { useAgent } from "agents/react";
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function createAgent({ name, url }: { name: string; url: string }) {
   const target = new EventTarget();
   const baseAgent = {
@@ -63,15 +67,17 @@ describe("useAgentChat", () => {
       return "Suspended";
     };
 
-    const screen = await act(() =>
-      render(<TestComponent />, {
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
         wrapper: ({ children }) => (
           <StrictMode>
             <Suspense fallback={<SuspenseObserver />}>{children}</Suspense>
           </StrictMode>
         )
-      })
-    );
+      });
+      await sleep(10);
+      return screen;
+    });
 
     await expect
       .element(screen.getByTestId("messages"))
@@ -123,15 +129,18 @@ describe("useAgentChat", () => {
       return "Suspended";
     };
 
-    const screen = await act(() =>
-      render(<TestComponent agent={agentA} />, {
+    const screen = await act(async () => {
+      const screen = render(<TestComponent agent={agentA} />, {
         wrapper: ({ children }) => (
           <StrictMode>
             <Suspense fallback={<SuspenseObserver />}>{children}</Suspense>
           </StrictMode>
         )
-      })
-    );
+      });
+
+      await sleep(10);
+      return screen;
+    });
 
     await expect
       .element(screen.getByTestId("messages"))
@@ -145,7 +154,10 @@ describe("useAgentChat", () => {
 
     suspenseRendered.mockClear();
 
-    await act(() => screen.rerender(<TestComponent agent={agentB} />));
+    await act(async () => {
+      screen.rerender(<TestComponent agent={agentB} />);
+      await sleep(10);
+    });
 
     await expect
       .element(screen.getByTestId("messages"))
@@ -219,7 +231,7 @@ describe("useAgentChat", () => {
         _options: PrepareSendMessagesRequestOptions<UIMessage>
       ): Promise<PrepareSendMessagesRequestResult> => {
         // Simulate async operation like fetching tool definitions
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await sleep(10);
         return {
           body: {
             clientTools: [
@@ -475,25 +487,23 @@ describe("useAgentChat client-side tool execution (issue #728)", () => {
       );
     };
 
-    const screen = await act(() =>
-      render(<TestComponent />, {
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
         wrapper: ({ children }) => (
           <StrictMode>
             <Suspense fallback="Loading...">{children}</Suspense>
           </StrictMode>
         )
-      })
-    );
+      });
+      // The tool should have been automatically executed
+      await sleep(10);
+      return screen;
+    });
 
     // Wait for initial messages to load
     await expect
       .element(screen.getByTestId("messages-count"))
       .toHaveTextContent("2");
-
-    // The tool should have been automatically executed
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    });
 
     // Verify the tool execute was called
     expect(mockExecute).toHaveBeenCalled();
@@ -574,15 +584,17 @@ describe("useAgentChat client-side tool execution (issue #728)", () => {
       );
     };
 
-    const screen = await act(() =>
-      render(<TestComponent />, {
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
         wrapper: ({ children }) => (
           <StrictMode>
             <Suspense fallback="Loading...">{children}</Suspense>
           </StrictMode>
         )
-      })
-    );
+      });
+      await sleep(10);
+      return screen;
+    });
 
     await expect
       .element(screen.getByTestId("messages-count"))

--- a/packages/ai-chat/src/react-tests/vitest.config.ts
+++ b/packages/ai-chat/src/react-tests/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       ],
       provider: "playwright"
     },
-    clearMocks: true
+    clearMocks: true,
+    setupFiles: ["./setup.ts"]
   }
 });

--- a/patches/vitest-browser-react+1.0.1.patch
+++ b/patches/vitest-browser-react+1.0.1.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/vitest-browser-react/dist/chunk-WWN7MBX6.js b/node_modules/vitest-browser-react/dist/chunk-WWN7MBX6.js
+index 61adcf7..b5d7645 100644
+--- a/node_modules/vitest-browser-react/dist/chunk-WWN7MBX6.js
++++ b/node_modules/vitest-browser-react/dist/chunk-WWN7MBX6.js
+@@ -3,6 +3,8 @@ import { debug, getElementLocatorSelectors } from "@vitest/browser/utils";
+ import React from "react";
+ import ReactDOMClient from "react-dom/client";
+ function act(cb) {
++  // This patch is needed to properly set up the act environment for react-tests. 
++  const originalIS_REACT_ACT_ENVIRONMENT = globalThis.IS_REACT_ACT_ENVIRONMENT;
+   const _act = React.act || React.unstable_act;
+   if (typeof _act !== "function") {
+     cb();
+@@ -12,7 +14,7 @@ function act(cb) {
+       _act(cb);
+     } finally {
+       ;
+-      globalThis.IS_REACT_ACT_ENVIRONMENT = false;
++      globalThis.IS_REACT_ACT_ENVIRONMENT = originalIS_REACT_ACT_ENVIRONMENT;
+     }
+   }
+ }


### PR DESCRIPTION
sunil: Since we were using plain react act() calls, I had to add a setup file for vitest that enabled the IS_REACT_ACT_ENVIRONMENT flag. Then I discovered that vitest-browser-react@1 has a bug where it would set the global IS_REACT_ACT_ENVIRONMENT to false after a run of it's own render (which wraps act()), so if you ran react's own act() after it, you'd get the "The current testing environment is not configured to support act(...)" error. After fixing that, react correctly identified some tests had mutations that weren't wrapped with act, so I fixed them with a small sleep helper.

copilot: Adds a setup file to properly set the IS_REACT_ACT_ENVIRONMENT global for React tests, updates vitest config to use this setup, and patches vitest-browser-react to restore the environment variable after act calls. Also refactors tests to use async act and a sleep helper for more reliable async behavior.