### PR TITLE
fix: handle invalid cron expressions in alarm handler

### DIFF
--- a/.changeset/validate-cron-input.md
+++ b/.changeset/validate-cron-input.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Validate cron expressions when scheduling tasks


### PR DESCRIPTION
`parseCronExpression` throws for malformed cron strings. In the alarm
  handler this prevents remaining schedules from executing and leaves
  the invalid schedule in the database, blocking future alarms.

  Wrap in try/catch and remove invalid schedules to unblock the loop.