### PR TITLE
fix: properly type tool error content in getAITools

### DIFF
--- a/.changeset/fix-mcp-error-type.md
+++ b/.changeset/fix-mcp-error-type.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+fix: properly type tool error content in getAITools

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -941,9 +941,12 @@ export class MCPClientManager {
                 serverId: tool.serverId
               });
               if (result.isError) {
-                const textContent = result.content[0];
+                const content = result.content as
+                  | Array<{ type: string; text?: string }>
+                  | undefined;
+                const textContent = content?.[0];
                 const message =
-                  textContent?.type === "text"
+                  textContent?.type === "text" && textContent.text
                     ? textContent.text
                     : "Tool call failed";
                 throw new Error(message);


### PR DESCRIPTION
 Remove @ts-expect-error by narrowing the content type before
  accessing the text property. Falls back to a generic message
  if content is empty or not text type.