### PR TITLE
docs: add OpenAI provider options documentation to scheduleSchema

### DIFF
--- a/.changeset/twelve-chefs-refuse.md
+++ b/.changeset/twelve-chefs-refuse.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+---
+
+docs: add OpenAI provider options documentation to scheduleSchema
+
+When using `scheduleSchema` with OpenAI models via the AI SDK, users must now pass `providerOptions: { openai: { strictJsonSchema: false } }` to `generateObject`. This is documented in the JSDoc for `scheduleSchema`.
+
+This is required because `@ai-sdk/openai` now defaults `strictJsonSchema` to `true`, which requires all schema properties to be in the `required` array. The `scheduleSchema` uses optional fields which are not compatible with this strict mode.

--- a/examples/playground/src/agents/scheduler.ts
+++ b/examples/playground/src/agents/scheduler.ts
@@ -41,6 +41,9 @@ export class Scheduler extends Agent<Env> {
           date: new Date()
         })} 
 Input to parse: "${event.input}"`,
+        providerOptions: {
+          openai: { strictJsonSchema: false }
+        },
         schema: scheduleSchema, // <- the shape of the object that the scheduler expects
         schemaDescription: "A task to be scheduled",
         schemaName: "task"

--- a/examples/playground/src/model.ts
+++ b/examples/playground/src/model.ts
@@ -5,7 +5,7 @@ import { env } from "cloudflare:workers";
 
 export const model: LanguageModelV3 = (() => {
   if (env.OPENAI_API_KEY) {
-    return openai("gpt-4");
+    return openai("gpt-4o");
   } else {
     const workersai = createWorkersAI({ binding: env.AI });
     return workersai("@cf/meta/llama-2-7b-chat-int8");

--- a/packages/agents/src/schedule.ts
+++ b/packages/agents/src/schedule.ts
@@ -73,7 +73,29 @@ export function unstable_getSchedulePrompt(event: { date: Date }) {
 }
 
 /**
- * The schema for the schedule prompt
+ * The schema for parsing natural language scheduling requests.
+ *
+ * @example
+ * ```typescript
+ * import { generateObject } from "ai";
+ * import { scheduleSchema, getSchedulePrompt } from "agents/schedule";
+ *
+ * const result = await generateObject({
+ *   model,
+ *   prompt: `${getSchedulePrompt({ date: new Date() })} Input: "${userInput}"`,
+ *   schema: scheduleSchema,
+ *   // Required for OpenAI to avoid strict JSON schema validation errors
+ *   providerOptions: {
+ *     openai: { strictJsonSchema: false }
+ *   }
+ * });
+ * ```
+ *
+ * @remarks
+ * When using this schema with OpenAI models via the AI SDK, you must pass
+ * `providerOptions: { openai: { strictJsonSchema: false } }` to `generateObject`.
+ * This is because the schema uses optional fields which are not compatible with
+ * OpenAI's strict structured outputs mode.
  */
 export const scheduleSchema = z.object({
   description: z.string().describe("A description of the task"),


### PR DESCRIPTION
When using `scheduleSchema` with OpenAI models via the AI SDK, users must now pass `providerOptions: { openai: { strictJsonSchema: false } }` to `generateObject`. This is documented in the JSDoc for `scheduleSchema`.

This is required because `@ai-sdk/openai` now defaults `strictJsonSchema` to `true`, which requires all schema properties to be in the `required` array. The `scheduleSchema` uses optional fields which are not compatible with this strict mode.