### PR TITLE
Move workflow API to agents/workflows subpath

### DIFF
--- a/.changeset/move-workflows-to-subpath.md
+++ b/.changeset/move-workflows-to-subpath.md
@@ -1,0 +1,10 @@
+---
+"agents": patch
+---
+
+Move workflow exports to `agents/workflows` subpath for better separation of concerns.
+
+```typescript
+import { AgentWorkflow } from "agents/workflows";
+import type { AgentWorkflowStep, WorkflowInfo } from "agents/workflows";
+```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -45,8 +45,8 @@ Create a Workflow that extends `AgentWorkflow` to get typed access to the origin
 
 ```typescript
 // src/workflows/processing.ts
-import { AgentWorkflow } from "agents";
-import type { AgentWorkflowEvent, AgentWorkflowStep } from "agents";
+import { AgentWorkflow } from "agents/workflows";
+import type { AgentWorkflowEvent, AgentWorkflowStep } from "agents/workflows";
 import type { MyAgent } from "../agent";
 
 type TaskParams = {

--- a/examples/workflows/src/server.ts
+++ b/examples/workflows/src/server.ts
@@ -9,13 +9,14 @@
  * - Approve/reject specific workflows from the Agent
  */
 
-import { Agent, AgentWorkflow, callable, routeAgentRequest } from "agents";
+import { Agent, callable, routeAgentRequest } from "agents";
+import { AgentWorkflow } from "agents/workflows";
 import type {
   AgentWorkflowEvent,
   AgentWorkflowStep,
   DefaultProgress,
   WorkflowInfo
-} from "agents";
+} from "agents/workflows";
 
 // Workflow parameters
 type TaskParams = {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -124,6 +124,11 @@
       "import": "./dist/schedule.js",
       "require": "./dist/schedule.js"
     },
+    "./workflows": {
+      "types": "./dist/workflows.d.ts",
+      "import": "./dist/workflows.js",
+      "require": "./dist/workflows.js"
+    },
     "./internal_context": {
       "types": "./dist/internal_context.d.ts",
       "import": "./dist/internal_context.js",

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -3220,32 +3220,3 @@ export class StreamingResponse {
     this._connection.send(JSON.stringify(response));
   }
 }
-
-// ==========================================
-// Workflow Integration Exports
-// ==========================================
-
-export { AgentWorkflow, WorkflowRejectedError } from "./workflow";
-export type {
-  AgentWorkflowEvent,
-  AgentWorkflowStep,
-  DefaultProgress,
-  WorkflowCallback,
-  WorkflowCallbackType,
-  WorkflowProgressCallback,
-  WorkflowCompleteCallback,
-  WorkflowErrorCallback,
-  WorkflowEventCallback,
-  WaitForApprovalOptions,
-  ApprovalEventPayload
-} from "./workflow";
-
-export type {
-  WorkflowStatus,
-  WorkflowTrackingRow,
-  RunWorkflowOptions,
-  WorkflowEventPayload,
-  WorkflowInfo,
-  WorkflowQueryCriteria,
-  WorkflowPage
-} from "./workflow-types";

--- a/packages/agents/src/tests/test-workflow.ts
+++ b/packages/agents/src/tests/test-workflow.ts
@@ -1,8 +1,8 @@
 /**
  * Test Workflow for integration testing AgentWorkflow functionality
  */
-import { AgentWorkflow } from "../workflow";
-import type { AgentWorkflowEvent, AgentWorkflowStep } from "../workflow";
+import { AgentWorkflow } from "../workflows";
+import type { AgentWorkflowEvent, AgentWorkflowStep } from "../workflows";
 import type { TestWorkflowAgent } from "./worker";
 
 /**

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -14,10 +14,9 @@ import {
   routeAgentRequest,
   type AgentEmail,
   type Connection,
-  type WSMessage,
-  type WorkflowStatus,
-  type WorkflowInfo
+  type WSMessage
 } from "../index.ts";
+import type { WorkflowStatus, WorkflowInfo } from "../workflows.ts";
 import type { MCPClientConnection } from "../mcp/client-connection";
 
 // Re-export test workflows for wrangler

--- a/packages/agents/src/tests/workflow-integration.test.ts
+++ b/packages/agents/src/tests/workflow-integration.test.ts
@@ -7,7 +7,8 @@
 import { env, introspectWorkflowInstance } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import type { Env } from "./worker";
-import { getAgentByName, type WorkflowInfo } from "..";
+import { getAgentByName } from "..";
+import type { WorkflowInfo } from "../workflows";
 
 declare module "cloudflare:test" {
   interface ProvidedEnv extends Env {}

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -1,7 +1,8 @@
 import { env } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import type { Env } from "./worker";
-import { getAgentByName, type WorkflowInfo } from "..";
+import { getAgentByName } from "..";
+import type { WorkflowInfo } from "../workflows";
 
 // Helper type for callback records
 type CallbackRecord = {

--- a/packages/agents/src/workflow-types.ts
+++ b/packages/agents/src/workflow-types.ts
@@ -3,6 +3,9 @@
  *
  * These types provide seamless integration between Cloudflare Agents
  * and Cloudflare Workflows for durable, multi-step background processing.
+ *
+ * Note: This file is kept separate from workflows.ts to avoid circular dependencies.
+ * Both index.ts (Agent class) and workflows.ts (AgentWorkflow class) import from here.
  */
 
 import type {

--- a/packages/agents/src/workflows.ts
+++ b/packages/agents/src/workflows.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { AgentWorkflow } from 'agents';
+ * import { AgentWorkflow } from 'agents/workflows';
  * import type { MyAgent } from './agent';
  *
  * type TaskParams = { taskId: string; data: string };
@@ -366,7 +366,14 @@ export type {
   WorkflowEventCallback,
   DefaultProgress,
   WaitForApprovalOptions,
-  ApprovalEventPayload
+  ApprovalEventPayload,
+  WorkflowStatus,
+  WorkflowTrackingRow,
+  RunWorkflowOptions,
+  WorkflowEventPayload,
+  WorkflowInfo,
+  WorkflowQueryCriteria,
+  WorkflowPage
 } from "./workflow-types";
 
 export { WorkflowRejectedError } from "./workflow-types";


### PR DESCRIPTION
Move workflow-related exports into a dedicated agents/workflows subpath. Renamed packages/agents/src/workflow.ts to workflows.ts, added the ./workflows export entry to package.json, removed workflow re-exports from index.ts, and updated imports across docs, examples, and tests to use "agents/workflows". Added a changeset for the patch release.