### PR TITLE
Move email utilities to agents/email

### DIFF
--- a/.changeset/open-candles-happen.md
+++ b/.changeset/open-candles-happen.md
@@ -1,5 +1,5 @@
 ---
-"agents": patch
+"agents": minor
 ---
 
 ### Secure Email Reply Routing
@@ -8,12 +8,29 @@ This release introduces secure email reply routing with HMAC-SHA256 signed heade
 
 #### Breaking Changes
 
+**Email utilities moved to `agents/email` subpath**: Email-specific resolvers and utilities have been moved to a dedicated subpath for better organization.
+
+```ts
+// Before
+import { createAddressBasedEmailResolver, signAgentHeaders } from "agents";
+
+// After
+import {
+  createAddressBasedEmailResolver,
+  signAgentHeaders
+} from "agents/email";
+```
+
+The following remain in root: `routeAgentEmail`, `createHeaderBasedEmailResolver` (deprecated).
+
 **`createHeaderBasedEmailResolver` removed**: This function now throws an error with migration guidance. It was removed because it trusted attacker-controlled email headers for routing.
 
 **Migration:**
 
 - For inbound mail: use `createAddressBasedEmailResolver(agentName)`
 - For reply flows: use `createSecureReplyEmailResolver(secret)` with signed headers
+
+See https://github.com/cloudflare/agents/blob/main/docs/email.md for details.
 
 **`EmailSendOptions` type removed**: This type was unused and has been removed.
 

--- a/docs/agent-class.md
+++ b/docs/agent-class.md
@@ -366,6 +366,9 @@ class MyAgent extends Agent {
 To route emails to your Agent, use `routeAgentEmail` in your Worker's email handler:
 
 ```ts
+import { routeAgentEmail } from "agents";
+import { createAddressBasedEmailResolver } from "agents/email";
+
 export default {
   async email(message, env, ctx) {
     await routeAgentEmail(message, env, {

--- a/docs/email.md
+++ b/docs/email.md
@@ -11,12 +11,8 @@ Agents can receive and process emails using Cloudflare's [Email Routing](https:/
 ## Quick Start
 
 ```ts
-import {
-  Agent,
-  createAddressBasedEmailResolver,
-  routeAgentEmail,
-  type AgentEmail
-} from "agents";
+import { Agent, routeAgentEmail } from "agents";
+import { createAddressBasedEmailResolver, type AgentEmail } from "agents/email";
 
 // Your Agent that handles emails
 export class EmailAgent extends Agent {
@@ -51,7 +47,7 @@ Resolvers determine which Agent instance receives an incoming email. Choose the 
 **Recommended for inbound mail.** Routes emails based on the recipient address.
 
 ```ts
-import { createAddressBasedEmailResolver } from "agents";
+import { createAddressBasedEmailResolver } from "agents/email";
 
 const resolver = createAddressBasedEmailResolver("EmailAgent");
 ```
@@ -71,7 +67,7 @@ The sub-address format (`agent+id@domain`) allows routing to different agent nam
 **For reply flows with signature verification.** Verifies that incoming emails are authentic replies to your outbound emails, preventing attackers from routing emails to arbitrary agent instances.
 
 ```ts
-import { createSecureReplyEmailResolver } from "agents";
+import { createSecureReplyEmailResolver } from "agents/email";
 
 const resolver = createSecureReplyEmailResolver(env.EMAIL_SECRET);
 ```
@@ -100,7 +96,7 @@ const resolver = createSecureReplyEmailResolver(env.EMAIL_SECRET, {
 **For single-instance routing.** Routes all emails to a specific agent instance regardless of the recipient address.
 
 ```ts
-import { createCatchAllEmailResolver } from "agents";
+import { createCatchAllEmailResolver } from "agents/email";
 
 const resolver = createCatchAllEmailResolver("EmailAgent", "default");
 ```
@@ -293,13 +289,12 @@ When an email is routed via `createSecureReplyEmailResolver`, the `replyToEmail(
 Here's a complete email agent with secure reply routing:
 
 ```ts
+import { Agent, routeAgentEmail } from "agents";
 import {
-  Agent,
   createAddressBasedEmailResolver,
   createSecureReplyEmailResolver,
-  routeAgentEmail,
   type AgentEmail
-} from "agents";
+} from "agents/email";
 import PostalMime from "postal-mime";
 
 interface Env {

--- a/examples/email-agent/README.md
+++ b/examples/email-agent/README.md
@@ -149,7 +149,16 @@ curl -X POST http://localhost:8787/api/test-security \
 
 ## Email Routing
 
-The agent supports multiple routing strategies:
+The agent supports multiple routing strategies. Import the resolvers from `agents/email`:
+
+```typescript
+import { routeAgentEmail } from "agents";
+import {
+  createSecureReplyEmailResolver,
+  createAddressBasedEmailResolver,
+  createCatchAllEmailResolver
+} from "agents/email";
+```
 
 ### 1. Secure Reply Routing (Recommended for replies)
 

--- a/examples/email-agent/src/index.ts
+++ b/examples/email-agent/src/index.ts
@@ -1,11 +1,9 @@
+import { Agent, routeAgentEmail, routeAgentRequest } from "agents";
 import {
-  Agent,
   createAddressBasedEmailResolver,
   createSecureReplyEmailResolver,
-  routeAgentEmail,
-  routeAgentRequest,
   type AgentEmail
-} from "agents";
+} from "agents/email";
 import PostalMime from "postal-mime";
 
 interface EmailData {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -158,6 +158,11 @@
       "types": "./dist/ai-types.d.ts",
       "import": "./dist/ai-types.js",
       "require": "./dist/ai-types.js"
+    },
+    "./email": {
+      "types": "./dist/email.d.ts",
+      "import": "./dist/email.js",
+      "require": "./dist/email.js"
     }
   },
   "publishConfig": {

--- a/packages/agents/src/email.ts
+++ b/packages/agents/src/email.ts
@@ -216,10 +216,11 @@ export type SecureReplyResolverOptions = {
 export function createHeaderBasedEmailResolver<Env>(): EmailResolver<Env> {
   throw new Error(
     "createHeaderBasedEmailResolver has been removed due to a security vulnerability. " +
-      "It trusted attacker-controlled email headers for routing, enabling IDOR attacks. " +
+      "It trusted attacker-controlled email headers for routing, enabling IDOR attacks.\n\n" +
       "Migration options:\n" +
       "  - For inbound mail: use createAddressBasedEmailResolver(agentName)\n" +
-      "  - For reply flows: use createSecureReplyEmailResolver(secret) with signed headers"
+      "  - For reply flows: use createSecureReplyEmailResolver(secret) with signed headers\n\n" +
+      "See https://github.com/cloudflare/agents/blob/main/docs/email.md for details."
   );
 }
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -3002,22 +3002,9 @@ export async function routeAgentRequest<Env>(
   return response;
 }
 
-// Email routing - resolvers and types from ./email
-export {
-  createHeaderBasedEmailResolver,
-  createSecureReplyEmailResolver,
-  createAddressBasedEmailResolver,
-  createCatchAllEmailResolver,
-  signAgentHeaders
-} from "./email";
-
-export type {
-  EmailResolverResult,
-  EmailResolver,
-  SecureReplyResolverOptions,
-  SignatureFailureReason,
-  AgentEmail
-} from "./email";
+// Email routing - deprecated resolver kept in root for upgrade discoverability
+// Other email utilities moved to agents/email subpath
+export { createHeaderBasedEmailResolver } from "./email";
 
 import type { EmailResolver } from "./email";
 

--- a/packages/agents/src/tests/email-routing.test.ts
+++ b/packages/agents/src/tests/email-routing.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { env } from "cloudflare:test";
+import { routeAgentEmail, getAgentByName } from "../index";
 import {
   createAddressBasedEmailResolver,
   createHeaderBasedEmailResolver,
   createSecureReplyEmailResolver,
   createCatchAllEmailResolver,
-  routeAgentEmail,
-  getAgentByName,
   signAgentHeaders
-} from "../index";
+} from "../email";
 import type { Env } from "./worker";
 
 // Declare module to get proper typing for env

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -12,10 +12,10 @@ import {
   Agent,
   callable,
   routeAgentRequest,
-  type AgentEmail,
   type Connection,
   type WSMessage
 } from "../index.ts";
+import type { AgentEmail } from "../email.ts";
 import type { WorkflowStatus, WorkflowInfo } from "../workflows.ts";
 import type { MCPClientConnection } from "../mcp/client-connection";
 


### PR DESCRIPTION
Move email-specific resolvers and types into a dedicated agents/email subpath and update imports across docs, examples, and tests. Add a ./email export in package.json and update package changelog to a minor release. Keep createHeaderBasedEmailResolver exported at the package root for upgrade discoverability but make it throw a migration error with guidance and a docs link; update examples/docs/tests to import other resolvers from agents/email.