### PR TITLE
Fix `useAgent` and `AgentClient` crashing when using `basePath` routing.

### DIFF
--- a/.changeset/fix-basepath-reconnect.md
+++ b/.changeset/fix-basepath-reconnect.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix `useAgent` and `AgentClient` crashing when using `basePath` routing. `PartySocket.reconnect()` requires `room` to be set, but `basePath` mode bypasses room-based URL construction. The fix provides `room` and `party` in socket options even when `basePath` is used, as a workaround pending a fix in partysocket.

--- a/examples/playground/src/server.ts
+++ b/examples/playground/src/server.ts
@@ -1,4 +1,4 @@
-import { routeAgentRequest, routeAgentEmail } from "agents";
+import { routeAgentRequest, routeAgentEmail, getAgentByName } from "agents";
 import {
   createAddressBasedEmailResolver,
   createSecureReplyEmailResolver
@@ -91,6 +91,20 @@ export default {
   },
 
   async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
+    const url = new URL(request.url);
+
+    // Custom basePath routing example:
+    // Routes /custom-routing/{instanceName} to a RoutingAgent instance.
+    // The server controls which agent instance handles the request,
+    // and the client connects using `basePath` instead of `agent` + `name`.
+    if (url.pathname.startsWith("/custom-routing/")) {
+      const instanceName = url.pathname.replace("/custom-routing/", "");
+      if (instanceName) {
+        const agent = await getAgentByName(env.RoutingAgent, instanceName);
+        return agent.fetch(request);
+      }
+    }
+
     return (
       (await routeAgentRequest(request, env)) ||
       new Response("Not found", { status: 404 })

--- a/packages/agents/src/client.ts
+++ b/packages/agents/src/client.ts
@@ -162,9 +162,19 @@ export class AgentClient<State = unknown> extends PartySocket {
   constructor(options: AgentClientOptions<State>) {
     const agentNamespace = camelCaseToKebabCase(options.agent);
 
-    // If basePath is provided, use it directly; otherwise construct from agent/name
+    // If basePath is provided, use it directly; otherwise construct from agent/name.
+    // WORKAROUND: When using basePath, we still set `room` and `party` because
+    // PartySocket.reconnect() requires `room` to be set, even though basePath bypasses
+    // the room-based URL construction. This should be removed once partysocket is fixed
+    // to skip the `room` check when `basePath` is provided.
     const socketOptions = options.basePath
-      ? { basePath: options.basePath, path: options.path, ...options }
+      ? {
+          basePath: options.basePath,
+          party: agentNamespace,
+          room: options.name || "default",
+          path: options.path,
+          ...options
+        }
       : {
           party: agentNamespace,
           prefix: "agents",

--- a/packages/agents/src/mcp/handler.ts
+++ b/packages/agents/src/mcp/handler.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   WorkerTransport,
   type WorkerTransportOptions

--- a/packages/agents/src/react-tests/cache-invalidation.test.tsx
+++ b/packages/agents/src/react-tests/cache-invalidation.test.tsx
@@ -395,7 +395,7 @@ describe("Cache invalidation on disconnect", () => {
     it("should invalidate correct cache entry when name changes before disconnect", async () => {
       const { host, protocol } = getTestWorkerHost();
       let capturedAgent: TestAgent | null = null;
-      let setNameFn: ((name: string) => void) | null = null;
+      let _setNameFn: ((name: string) => void) | null = null;
 
       // Pre-populate cache entries for both names
       const cacheKeyName1 = createCacheKey(
@@ -433,7 +433,7 @@ describe("Cache invalidation on disconnect", () => {
               capturedAgent = agent;
             }}
             onNameChange={(setName) => {
-              setNameFn = setName;
+              _setNameFn = setName;
             }}
           />
         </SuspenseWrapper>

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -433,10 +433,16 @@ export function useAgent<State>(
     resetReady();
   }
 
-  // If basePath is provided, use it directly; otherwise construct from agent/name
+  // If basePath is provided, use it directly; otherwise construct from agent/name.
+  // WORKAROUND: When using basePath, we still set `room` and `party` because
+  // PartySocket.reconnect() requires `room` to be set, even though basePath bypasses
+  // the room-based URL construction. This should be removed once partysocket is fixed
+  // to skip the `room` check when `basePath` is provided.
   const socketOptions = options.basePath
     ? {
         basePath: options.basePath,
+        party: agentNamespace,
+        room: options.name || "default",
         path: options.path,
         query: resolvedQuery,
         ...restOptions

--- a/site/ai-playground/src/components/McpServers.tsx
+++ b/site/ai-playground/src/components/McpServers.tsx
@@ -42,7 +42,7 @@ export function McpServers({ agent, mcpState, mcpLogs }: McpServersProps) {
   );
   const [showSettings, setShowSettings] = useState(false);
   const [showLocalhostWarning, setShowLocalhostWarning] = useState(false);
-  const [error, setError] = useState<string>("");
+  const [_error, setError] = useState<string>("");
   const [isConnecting, setIsConnecting] = useState(false);
   const [disconnectingServerId, setDisconnectingServerId] = useState<
     string | null
@@ -529,7 +529,7 @@ export function McpServers({ agent, mcpState, mcpLogs }: McpServersProps) {
                   </button>
                 </div>
                 {server.state === "failed" && server.error && (
-                  <div className="mt-2 text-xs text-red-600 break-words">
+                  <div className="mt-2 text-xs text-red-600 wrap-break-word">
                     {server.error}
                   </div>
                 )}


### PR DESCRIPTION
`PartySocket.reconnect()` requires `room` to be set, but `basePath` mode bypasses room-based URL construction. The fix provides `room` and `party` in socket options even when `basePath` is used, as a workaround pending a fix in partysocket.