### PR TITLE
Fix MCP OAuth callback URL leaking instance name

### DIFF
--- a/.changeset/fix-mcp-callback-path.md
+++ b/.changeset/fix-mcp-callback-path.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Fix MCP OAuth callback URL leaking instance name
+
+Add `callbackPath` option to `addMcpServer` to prevent instance name leakage in MCP OAuth callback URLs. When `sendIdentityOnConnect` is `false`, `callbackPath` is now required — the default callback URL would expose the instance name, undermining the security intent. Also fixes callback request detection to match via the `state` parameter instead of a loose `/callback` URL substring check, enabling custom callback paths.

--- a/packages/agents/src/tests/agents/state.ts
+++ b/packages/agents/src/tests/agents/state.ts
@@ -265,4 +265,41 @@ export class TestNoIdentityAgent extends Agent<
   updateState(state: TestState) {
     this.setState(state);
   }
+
+  // Test method: calls addMcpServer without callbackPath — should throw enforcement error
+  async testAddMcpServerWithoutCallbackPath(): Promise<{
+    threw: boolean;
+    message: string;
+  }> {
+    try {
+      await this.addMcpServer("test-server", "https://mcp.example.com", {
+        callbackHost: "https://example.com"
+      });
+      return { threw: false, message: "" };
+    } catch (err) {
+      return {
+        threw: true,
+        message: err instanceof Error ? err.message : String(err)
+      };
+    }
+  }
+
+  // Test method: calls addMcpServer with callbackPath — should not throw the enforcement error
+  async testAddMcpServerWithCallbackPath(): Promise<{
+    threw: boolean;
+    message: string;
+  }> {
+    try {
+      await this.addMcpServer("test-server", "https://mcp.example.com", {
+        callbackHost: "https://example.com",
+        callbackPath: "/mcp-callback"
+      });
+      return { threw: false, message: "" };
+    } catch (err) {
+      return {
+        threw: true,
+        message: err instanceof Error ? err.message : String(err)
+      };
+    }
+  }
 }

--- a/packages/agents/src/tests/mcp/add-mcp-server.test.ts
+++ b/packages/agents/src/tests/mcp/add-mcp-server.test.ts
@@ -20,6 +20,44 @@ type ResolvedArgs = {
   client?: unknown;
 };
 
+describe("addMcpServer callbackPath enforcement", () => {
+  it("should throw when sendIdentityOnConnect is false and callbackPath is not provided", async () => {
+    const agentStub = await getAgentByName(
+      env.TestNoIdentityAgent,
+      "test-no-callback-path"
+    );
+    const result =
+      (await agentStub.testAddMcpServerWithoutCallbackPath()) as unknown as {
+        threw: boolean;
+        message: string;
+      };
+
+    expect(result.threw).toBe(true);
+    expect(result.message).toContain(
+      "callbackPath is required in addMcpServer options when sendIdentityOnConnect is false"
+    );
+  });
+
+  it("should not throw enforcement error when sendIdentityOnConnect is false and callbackPath is provided", async () => {
+    const agentStub = await getAgentByName(
+      env.TestNoIdentityAgent,
+      "test-with-callback-path"
+    );
+    // This may fail for other reasons (can't connect to remote MCP server) but should NOT
+    // throw the callbackPath enforcement error
+    const result =
+      (await agentStub.testAddMcpServerWithCallbackPath()) as unknown as {
+        threw: boolean;
+        message: string;
+      };
+
+    expect(result.threw).toBe(true); // Throws for connection error, not enforcement
+    expect(result.message).not.toContain(
+      "callbackPath is required in addMcpServer options when sendIdentityOnConnect is false"
+    );
+  });
+});
+
 describe("addMcpServer API overloads", () => {
   describe("new options-based API", () => {
     it("should resolve options object with all fields", async () => {


### PR DESCRIPTION
Closes #854

## Problem

When an agent uses `sendIdentityOnConnect: false` to protect sensitive instance names (session IDs, user IDs), the MCP OAuth callback URL still exposes the raw instance name:

```
https://example.com/agents/secure-agent/secret-user-id-123/callback
```


This URL is sent to the remote OAuth provider as `redirect_uri`, displayed in the browser address bar, and saved in browser history — completely undermining the security intent. Additionally, the hardcoded `/agents/{class}/{name}/callback` pattern doesn't work for developers using `basePath` routing with `getAgentByName`.

## Design decisions

**`callbackPath` is required when `sendIdentityOnConnect: false`.**
Rather than silently hashing or obfuscating the instance name (which would require complex coordination between the routing layer and DO storage), we make the developer explicitly provide a safe callback path. This is consistent with how `basePath` already works — if you've opted into custom routing to protect instance names, you handle the routing yourself via `getAgentByName`. The error message is actionable and tells the developer exactly what to do.

**`callbackPath` is optional when `sendIdentityOnConnect: true`.**
The default auto-constructed URL (`/agents/{class}/{name}/callback`) still works for developers who haven't opted out of identity exposure. This keeps the simple case simple. Developers can still provide `callbackPath` if they prefer cleaner URLs or a different routing pattern.

**Callback detection uses `state` parameter with origin + pathname verification.**
Previously, `isCallbackRequest()` checked `url.includes("/callback")` as a loose heuristic — this would break with custom callback paths (e.g., `/mcp-oauth-return`). The `state` query parameter (format: `{nonce}.{serverId}`) is now the primary mechanism for identifying which server a callback belongs to. As defense-in-depth, we also verify that the request's origin and pathname match the registered `callback_url` for that server, preventing unrelated GET requests with a `state` param from being intercepted.

## Changes

- **`AddMcpServerOptions` type** — new `callbackPath?: string` field with JSDoc documenting it should be a plain path (no query strings or fragments)
- **`addMcpServer()`** — resolves `callbackPath`, enforces it when `sendIdentityOnConnect: false`, uses it for URL construction when provided. Also normalizes trailing slashes on `callbackHost` to prevent double-slash URLs.
- **`isCallbackRequest()`** — replaced loose `url.includes("/callback")` substring check with state-based server ID matching plus origin + pathname verification against the stored `callback_url`
- **Tests** — new unit tests for custom callback path detection, pathname-based matching, and origin defense-in-depth in `client-manager.test.ts`. New integration tests in `add-mcp-server.test.ts` verifying the `callbackPath` enforcement (throws when `sendIdentityOnConnect: false` without `callbackPath`, does not throw when `callbackPath` is provided).

## Notes for reviewers

- The `isCallbackRequest` change is the subtlest part. The old `/callback` substring check is replaced by a two-layer approach: (1) extract `serverId` from the `state` param and confirm it exists in storage, (2) verify the request's origin + pathname match the stored `callback_url` for that server. This is both more precise and more permissive than before — it works with any callback path while preventing false-positive interception.

- The runtime enforcement (throw when `sendIdentityOnConnect: false` without `callbackPath`) can't be done at the type level since `sendIdentityOnConnect` is on `static options` and `callbackPath` is on the `addMcpServer` call — TypeScript can't connect those two. The runtime error is clear and fails fast.
