### PR TITLE
Remove basePath room/party workaround

### DIFF
--- a/.changeset/fix-basepath-reconnect.md
+++ b/.changeset/fix-basepath-reconnect.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Fix `useAgent` and `AgentClient` crashing when using `basePath` routing. `PartySocket.reconnect()` requires `room` to be set, but `basePath` mode bypasses room-based URL construction. The fix provides `room` and `party` in socket options even when `basePath` is used, as a workaround pending a fix in partysocket.
+Fix `useAgent` and `AgentClient` crashing when using `basePath` routing.

--- a/.changeset/remove-basepath-workaround.md
+++ b/.changeset/remove-basepath-workaround.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Remove `room`/`party` workaround for `basePath` routing now that partysocket handles reconnect without requiring `room` to be set.

--- a/packages/agents/src/client.ts
+++ b/packages/agents/src/client.ts
@@ -164,19 +164,9 @@ export class AgentClient<State = unknown> extends PartySocket {
   constructor(options: AgentClientOptions<State>) {
     const agentNamespace = camelCaseToKebabCase(options.agent);
 
-    // If basePath is provided, use it directly; otherwise construct from agent/name.
-    // WORKAROUND: When using basePath, we still set `room` and `party` because
-    // PartySocket.reconnect() requires `room` to be set, even though basePath bypasses
-    // the room-based URL construction. This should be removed once partysocket is fixed
-    // to skip the `room` check when `basePath` is provided.
+    // If basePath is provided, use it directly; otherwise construct from agent/name
     const socketOptions = options.basePath
-      ? {
-          basePath: options.basePath,
-          party: agentNamespace,
-          room: options.name || "default",
-          path: options.path,
-          ...options
-        }
+      ? { basePath: options.basePath, path: options.path, ...options }
       : {
           party: agentNamespace,
           prefix: "agents",

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -434,16 +434,10 @@ export function useAgent<State>(
     resetReady();
   }
 
-  // If basePath is provided, use it directly; otherwise construct from agent/name.
-  // WORKAROUND: When using basePath, we still set `room` and `party` because
-  // PartySocket.reconnect() requires `room` to be set, even though basePath bypasses
-  // the room-based URL construction. This should be removed once partysocket is fixed
-  // to skip the `room` check when `basePath` is provided.
+  // If basePath is provided, use it directly; otherwise construct from agent/name
   const socketOptions = options.basePath
     ? {
         basePath: options.basePath,
-        party: agentNamespace,
-        room: options.name || "default",
         path: options.path,
         query: resolvedQuery,
         ...restOptions


### PR DESCRIPTION
Stop injecting `party`/`room` into socket options when `basePath` is provided. PartySocket now handles reconnects without requiring a `room`, so AgentClient and useAgent no longer add `party`/`room` for basePath mode. Update changesets to remove the previous workaround and simplify the earlier fix description.