### PR TITLE
Rename OAuth provider API to createMcpOAuthProvider

### DIFF
--- a/.changeset/fuzzy-states-matter.md
+++ b/.changeset/fuzzy-states-matter.md
@@ -2,4 +2,4 @@
 "agents": minor
 ---
 
-Add `createOAuthProvider` method to the `Agent` class, allowing subclasses to override the default OAuth provider used when connecting to MCP servers. This enables custom authentication strategies such as pre-registered client credentials or mTLS, beyond the built-in dynamic client registration.
+Add `createMcpOAuthProvider` method to the `Agent` class, allowing subclasses to override the default OAuth provider used when connecting to MCP servers. This enables custom authentication strategies such as pre-registered client credentials or mTLS, beyond the built-in dynamic client registration.

--- a/docs/mcp-client.md
+++ b/docs/mcp-client.md
@@ -194,20 +194,20 @@ this.mcp.configureOAuthCallback({
 
 ### Custom OAuth Provider
 
-By default, agents use dynamic client registration to authenticate with MCP servers. If you need to use a different OAuth strategy — such as pre-registered client credentials, mTLS-based authentication, or other mechanisms — override the `createOAuthProvider` method in your agent subclass:
+By default, agents use dynamic client registration to authenticate with MCP servers. If you need to use a different OAuth strategy — such as pre-registered client credentials, mTLS-based authentication, or other mechanisms — override the `createMcpOAuthProvider` method in your agent subclass:
 
 ```typescript
 import { Agent } from "agents";
-import type { AgentsOAuthProvider } from "agents";
+import type { AgentMcpOAuthProvider } from "agents";
 
 class MyAgent extends Agent {
-  createOAuthProvider(callbackUrl: string): AgentsOAuthProvider {
+  createMcpOAuthProvider(callbackUrl: string): AgentMcpOAuthProvider {
     return new MyCustomOAuthProvider(this.ctx.storage, this.name, callbackUrl);
   }
 }
 ```
 
-Your custom class must implement the `AgentsOAuthProvider` interface, which extends the MCP SDK's `OAuthClientProvider` with additional properties (`authUrl`, `clientId`, `serverId`) and methods (`checkState`, `consumeState`, `deleteCodeVerifier`) used by the agent's MCP connection lifecycle.
+Your custom class must implement the `AgentMcpOAuthProvider` interface, which extends the MCP SDK's `OAuthClientProvider` with additional properties (`authUrl`, `clientId`, `serverId`) and methods (`checkState`, `consumeState`, `deleteCodeVerifier`) used by the agent's MCP connection lifecycle.
 
 ## Using MCP Capabilities
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -36,7 +36,7 @@ import type {
 import { MCPConnectionState } from "./mcp/client-connection";
 import {
   DurableObjectOAuthClientProvider,
-  type AgentsOAuthProvider
+  type AgentMcpOAuthProvider
 } from "./mcp/do-oauth-client-provider";
 import type { TransportType } from "./mcp/types";
 import { genericObservability, type Observability } from "./observability";
@@ -235,6 +235,11 @@ function getNextCronTime(cron: string) {
 }
 
 export type { TransportType } from "./mcp/types";
+export type {
+  AgentMcpOAuthProvider,
+  /** @deprecated Use {@link AgentMcpOAuthProvider} instead. */
+  AgentsOAuthProvider
+} from "./mcp/do-oauth-client-provider";
 
 /**
  * MCP Server state update message from server -> Client
@@ -3409,7 +3414,7 @@ export class Agent<
 
     const id = nanoid(8);
 
-    const authProvider = this.createOAuthProvider(callbackUrl);
+    const authProvider = this.createMcpOAuthProvider(callbackUrl);
     authProvider.serverId = id;
 
     // Use the transport type specified in options, or default to "auto"
@@ -3523,7 +3528,7 @@ export class Agent<
    * @example
    * // Custom OAuth provider
    * class MyAgent extends Agent {
-   *   createOAuthProvider(callbackUrl: string): AgentsOAuthProvider {
+   *   createMcpOAuthProvider(callbackUrl: string): AgentMcpOAuthProvider {
    *     return new MyCustomOAuthProvider(
    *       this.ctx.storage,
    *       this.name,
@@ -3533,9 +3538,9 @@ export class Agent<
    * }
    *
    * @param callbackUrl The OAuth callback URL for the authorization flow
-   * @returns An {@link AgentsOAuthProvider} instance used by {@link addMcpServer}
+   * @returns An {@link AgentMcpOAuthProvider} instance used by {@link addMcpServer}
    */
-  createOAuthProvider(callbackUrl: string): AgentsOAuthProvider {
+  createMcpOAuthProvider(callbackUrl: string): AgentMcpOAuthProvider {
     return new DurableObjectOAuthClientProvider(
       this.ctx.storage,
       this.name,

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -31,7 +31,7 @@ import {
 import { nanoid } from "nanoid";
 import { Emitter, type Event } from "../core/events";
 import type { MCPObservabilityEvent } from "../observability/mcp";
-import type { AgentsOAuthProvider } from "./do-oauth-client-provider";
+import type { AgentMcpOAuthProvider } from "./do-oauth-client-provider";
 import {
   isTransportNotImplemented,
   isUnauthorized,
@@ -72,7 +72,7 @@ export type MCPTransportOptions = (
   | SSEClientTransportOptions
   | StreamableHTTPClientTransportOptions
 ) & {
-  authProvider?: AgentsOAuthProvider;
+  authProvider?: AgentMcpOAuthProvider;
   type?: TransportType;
 };
 

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -26,7 +26,7 @@ import {
 import { toErrorMessage } from "./errors";
 import type { TransportType } from "./types";
 import type { MCPServerRow } from "./client-storage";
-import type { AgentsOAuthProvider } from "./do-oauth-client-provider";
+import type { AgentMcpOAuthProvider } from "./do-oauth-client-provider";
 import { DurableObjectOAuthClientProvider } from "./do-oauth-client-provider";
 
 const defaultClientOptions: ConstructorParameters<typeof Client>[1] = {
@@ -219,7 +219,7 @@ export class MCPClientManager {
     callbackUrl: string,
     clientName: string,
     clientId?: string
-  ): AgentsOAuthProvider {
+  ): AgentMcpOAuthProvider {
     if (!this._storage) {
       throw new Error(
         "Cannot create auth provider: storage is not initialized"

--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -17,7 +17,7 @@ interface StoredState {
 
 // A slight extension to the standard OAuthClientProvider interface because `redirectToAuthorization` doesn't give us the interface we need
 // This allows us to track authentication for a specific server and associated dynamic client registration
-export interface AgentsOAuthProvider extends OAuthClientProvider {
+export interface AgentMcpOAuthProvider extends OAuthClientProvider {
   authUrl: string | undefined;
   clientId: string | undefined;
   serverId: string | undefined;
@@ -28,7 +28,12 @@ export interface AgentsOAuthProvider extends OAuthClientProvider {
   deleteCodeVerifier(): Promise<void>;
 }
 
-export class DurableObjectOAuthClientProvider implements AgentsOAuthProvider {
+/**
+ * @deprecated Use {@link AgentMcpOAuthProvider} instead.
+ */
+export type AgentsOAuthProvider = AgentMcpOAuthProvider;
+
+export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
   private _authUrl_: string | undefined;
   private _serverId_: string | undefined;
   private _clientId_: string | undefined;

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -1,6 +1,6 @@
 import { Agent } from "../../index.ts";
 import { DurableObjectOAuthClientProvider } from "../../mcp/do-oauth-client-provider";
-import type { AgentsOAuthProvider } from "../../mcp/do-oauth-client-provider";
+import type { AgentMcpOAuthProvider } from "../../mcp/do-oauth-client-provider";
 import type { MCPClientConnection } from "../../mcp/client-connection";
 
 // Test Agent for OAuth client side flows
@@ -214,11 +214,11 @@ export class TestOAuthAgent extends Agent<Record<string, unknown>> {
     this._mcpConnectionsInitialized = false;
   }
 
-  testCreateOAuthProvider(callbackUrl: string): {
+  testCreateMcpOAuthProvider(callbackUrl: string): {
     isDurableObjectProvider: boolean;
     callbackUrl: string;
   } {
-    const provider = this.createOAuthProvider(callbackUrl);
+    const provider = this.createMcpOAuthProvider(callbackUrl);
     return {
       isDurableObjectProvider:
         provider instanceof DurableObjectOAuthClientProvider,
@@ -227,13 +227,13 @@ export class TestOAuthAgent extends Agent<Record<string, unknown>> {
   }
 }
 
-// Test Agent that overrides createOAuthProvider with a custom implementation
+// Test Agent that overrides createMcpOAuthProvider with a custom implementation
 export class TestCustomOAuthAgent extends Agent<Record<string, unknown>> {
   observability = undefined;
 
   private _customProviderCallbackUrl: string | undefined;
 
-  createOAuthProvider(callbackUrl: string): AgentsOAuthProvider {
+  createMcpOAuthProvider(callbackUrl: string): AgentMcpOAuthProvider {
     this._customProviderCallbackUrl = callbackUrl;
     // Return a minimal mock that satisfies the interface
     return {
@@ -259,15 +259,15 @@ export class TestCustomOAuthAgent extends Agent<Record<string, unknown>> {
       invalidateCredentials: async () => {},
       saveCodeVerifier: async () => {},
       codeVerifier: async () => "mock-verifier"
-    } as AgentsOAuthProvider;
+    } as AgentMcpOAuthProvider;
   }
 
-  testCreateOAuthProvider(callbackUrl: string): {
+  testCreateMcpOAuthProvider(callbackUrl: string): {
     isDurableObjectProvider: boolean;
     clientId: string | undefined;
     callbackUrl: string | undefined;
   } {
-    const provider = this.createOAuthProvider(callbackUrl);
+    const provider = this.createMcpOAuthProvider(callbackUrl);
     return {
       isDurableObjectProvider:
         provider instanceof DurableObjectOAuthClientProvider,

--- a/packages/agents/src/tests/mcp/create-oauth-provider.test.ts
+++ b/packages/agents/src/tests/mcp/create-oauth-provider.test.ts
@@ -6,14 +6,14 @@ declare module "cloudflare:test" {
   interface ProvidedEnv extends Env {}
 }
 
-describe("createOAuthProvider", () => {
+describe("createMcpOAuthProvider", () => {
   it("should return a DurableObjectOAuthClientProvider by default", async () => {
     const agentId = env.TestOAuthAgent.idFromName("test-default-provider");
     const agentStub = env.TestOAuthAgent.get(agentId);
 
     await agentStub.setName("default");
 
-    const result = await agentStub.testCreateOAuthProvider(
+    const result = await agentStub.testCreateMcpOAuthProvider(
       "http://example.com/callback"
     );
 
@@ -27,7 +27,7 @@ describe("createOAuthProvider", () => {
 
     await agentStub.setName("default");
 
-    const result = await agentStub.testCreateOAuthProvider(
+    const result = await agentStub.testCreateMcpOAuthProvider(
       "http://example.com/custom-callback"
     );
 


### PR DESCRIPTION
Rename the agent OAuth provider API and types to clarify MCP-specific behavior. createOAuthProvider is renamed to createMcpOAuthProvider throughout the codebase (Agent class, client creation, connection, and tests), and the AgentsOAuthProvider type was renamed to AgentMcpOAuthProvider in do-oauth-client-provider.ts. A deprecated type alias AgentsOAuthProvider is kept for backwards compatibility. Documentation and the changeset were updated to reflect the new names. Tests and examples were updated accordingly; callers implementing the old names should migrate to createMcpOAuthProvider and AgentMcpOAuthProvider.