### PR TITLE
Add run worker first to Wrangler files for examples

### DIFF
--- a/examples/mcp-client/wrangler.jsonc
+++ b/examples/mcp-client/wrangler.jsonc
@@ -5,7 +5,8 @@
   "compatibility_flags": ["nodejs_compat"],
 
   "assets": {
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/agents/*"]
   },
   "durable_objects": {
     "bindings": [

--- a/examples/playground/wrangler.jsonc
+++ b/examples/playground/wrangler.jsonc
@@ -79,6 +79,7 @@
     "enabled": true
   },
   "assets": {
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/agents/*"]
   }
 }

--- a/examples/resumable-stream-chat/wrangler.jsonc
+++ b/examples/resumable-stream-chat/wrangler.jsonc
@@ -3,7 +3,8 @@
   "compatibility_date": "2026-01-28",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/agents/*"]
   },
   "durable_objects": {
     "bindings": [

--- a/examples/workflows/wrangler.jsonc
+++ b/examples/workflows/wrangler.jsonc
@@ -4,7 +4,8 @@
   "compatibility_date": "2026-01-28",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/agents/*"]
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
## Fix SPA asset routing intercepting agent requests
The `compatibility_date` bump to `2026-01-28` activates the `assets_navigation_prefers_asset_serving` flag (default since `2025-04-01`). This causes browser navigation requests — including OAuth callback redirects — to be served `index.html` by the asset pipeline before the Worker script runs.

For the `mcp-client` example, this means the OAuth popup never closes: the callback URL (`/agents/my-agent/{id}/callback?code=...`) gets served as the SPA instead of reaching `routeAgentRequest` → Durable Object → `handleMcpOAuthCallback`.

### Fix
Add `"run_worker_first": ["/agents/*"]` to all examples using `not_found_handling: "single-page-application"`, matching what `site/ai-playground` already does. This ensures all `/agents/*` requests bypass asset serving and reach the Worker.

_PR Description Generated by Opencode_