### PR TITLE
fix(ai-chat): sync client tools cache on tool result and align wire type

### DIFF
--- a/.changeset/sync-client-tools-cache-on-tool-result.md
+++ b/.changeset/sync-client-tools-cache-on-tool-result.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Sync `_lastClientTools` cache and SQLite when client tools arrive via `CF_AGENT_TOOL_RESULT`, and align the wire type with `ClientToolSchema` (`JSONSchema7` instead of `Record<string, unknown>`)

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -521,6 +521,12 @@ export class AIChatAgent<
           const { toolCallId, toolName, output, autoContinue, clientTools } =
             data;
 
+          // Update cached client tools so subsequent continuations use the latest schemas
+          if (clientTools?.length) {
+            this._lastClientTools = clientTools as ClientToolSchema[];
+            this._persistRequestContext();
+          }
+
           // Apply the tool result
           this._applyToolResult(toolCallId, toolName, output).then(
             (applied) => {

--- a/packages/ai-chat/src/types.ts
+++ b/packages/ai-chat/src/types.ts
@@ -1,4 +1,4 @@
-import type { UIMessage } from "ai";
+import type { JSONSchema7, UIMessage } from "ai";
 
 /**
  * Enum for message types to improve type safety and maintainability
@@ -133,7 +133,7 @@ export type IncomingMessage<ChatMessage extends UIMessage = UIMessage> =
       clientTools?: Array<{
         name: string;
         description?: string;
-        parameters?: Record<string, unknown>;
+        parameters?: JSONSchema7;
       }>;
     }
   | {


### PR DESCRIPTION
Update _lastClientTools and persist to SQLite when clientTools arrives via CF_AGENT_TOOL_RESULT, so multi-step tool chains and subsequent continuations always use the latest schemas. Previously the incoming tools were passed through but never cached, leaving _lastClientTools stale.

Also align the clientTools wire type in types.ts with the canonical ClientToolSchema by using JSONSchema7 for parameters instead of Record<string, unknown>.