### PR TITLE
feat: per-connection protocol message control

### DIFF
--- a/.changeset/protocol-messages-per-connection.md
+++ b/.changeset/protocol-messages-per-connection.md
@@ -1,0 +1,13 @@
+---
+"agents": minor
+---
+
+Add `shouldSendProtocolMessages` hook and `isConnectionProtocolEnabled` predicate for per-connection control of protocol text frames
+
+Adds the ability to suppress protocol messages (`CF_AGENT_IDENTITY`, `CF_AGENT_STATE`, `CF_AGENT_MCP_SERVERS`) on a per-connection basis. This is useful for binary-only clients (e.g. MQTT devices) that cannot handle JSON text frames.
+
+Override `shouldSendProtocolMessages(connection, ctx)` to return `false` for connections that should not receive protocol messages. These connections still fully participate in RPC and regular messaging — only the automatic protocol text frames are suppressed, both on connect and during broadcasts.
+
+Use `isConnectionProtocolEnabled(connection)` to check a connection's protocol status at any time.
+
+Also fixes `isConnectionReadonly` to correctly survive Durable Object hibernation by re-wrapping the connection when the in-memory accessor cache has been cleared.

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -21,6 +21,7 @@ export { TestDestroyScheduleAgent, TestScheduleAgent } from "./schedule";
 export { TestWorkflowAgent } from "./workflow";
 export { TestOAuthAgent, TestCustomOAuthAgent } from "./oauth";
 export { TestReadonlyAgent } from "./readonly";
+export { TestProtocolMessagesAgent } from "./protocol-messages";
 export { TestCallableAgent, TestParentAgent, TestChildAgent } from "./callable";
 export { TestQueueAgent } from "./queue";
 export { TestRaceAgent } from "./race";

--- a/packages/agents/src/tests/agents/protocol-messages.ts
+++ b/packages/agents/src/tests/agents/protocol-messages.ts
@@ -1,0 +1,132 @@
+import {
+  Agent,
+  callable,
+  getCurrentAgent,
+  type Connection
+} from "../../index.ts";
+import type { ConnectionContext } from "../../index.ts";
+
+/**
+ * Test Agent for the shouldSendProtocolMessages / isConnectionProtocolEnabled
+ * feature.
+ *
+ * Connections with `?protocol=false` in the query string will not receive
+ * protocol text frames (identity, state sync, MCP servers).
+ * Connections with `?readonly=true` are also marked readonly.
+ */
+export class TestProtocolMessagesAgent extends Agent<
+  Record<string, unknown>,
+  { count: number }
+> {
+  initialState = { count: 0 };
+  static options = { hibernate: true };
+
+  shouldSendProtocolMessages(
+    _connection: Connection,
+    ctx: ConnectionContext
+  ): boolean {
+    const url = new URL(ctx.request.url);
+    return url.searchParams.get("protocol") !== "false";
+  }
+
+  shouldConnectionBeReadonly(
+    _connection: Connection,
+    ctx: ConnectionContext
+  ): boolean {
+    const url = new URL(ctx.request.url);
+    return url.searchParams.get("readonly") === "true";
+  }
+
+  @callable()
+  async incrementCount() {
+    this.setState({ count: this.state.count + 1 });
+    return this.state.count;
+  }
+
+  @callable()
+  async getState() {
+    return this.state;
+  }
+
+  @callable()
+  async getMyConnectionId() {
+    const { connection } = getCurrentAgent();
+    return connection ? connection.id : null;
+  }
+
+  @callable()
+  async checkProtocolEnabled(connectionId: string) {
+    const conn = Array.from(this.getConnections()).find(
+      (c) => c.id === connectionId
+    );
+    return conn ? this.isConnectionProtocolEnabled(conn) : null;
+  }
+
+  @callable()
+  async checkReadonly(connectionId: string) {
+    const conn = Array.from(this.getConnections()).find(
+      (c) => c.id === connectionId
+    );
+    return conn ? this.isConnectionReadonly(conn) : null;
+  }
+
+  /** Returns connection.state (user-visible) for the given connection. */
+  @callable()
+  async getConnectionUserState(connectionId: string) {
+    const conn = Array.from(this.getConnections()).find(
+      (c) => c.id === connectionId
+    );
+    if (!conn) return null;
+    return {
+      state: conn.state,
+      isProtocolEnabled: this.isConnectionProtocolEnabled(conn),
+      isReadonly: this.isConnectionReadonly(conn)
+    };
+  }
+
+  /**
+   * Calls connection.setState(newState) on the given connection and returns
+   * the resulting user-visible state + flags. Tests that the wrapping
+   * preserves internal flags across setState calls.
+   */
+  @callable()
+  async setConnectionUserState(
+    connectionId: string,
+    newState: Record<string, unknown>
+  ) {
+    const conn = Array.from(this.getConnections()).find(
+      (c) => c.id === connectionId
+    );
+    if (!conn) return null;
+    conn.setState(newState);
+    return {
+      state: conn.state,
+      isProtocolEnabled: this.isConnectionProtocolEnabled(conn),
+      isReadonly: this.isConnectionReadonly(conn)
+    };
+  }
+
+  /**
+   * Calls connection.setState(prev => ({ ...prev, ...updates })) (callback
+   * form) and returns the result. Tests the callback branch of the wrapping.
+   */
+  @callable()
+  async setConnectionUserStateCallback(
+    connectionId: string,
+    updates: Record<string, unknown>
+  ) {
+    const conn = Array.from(this.getConnections()).find(
+      (c) => c.id === connectionId
+    );
+    if (!conn) return null;
+    conn.setState((prev: Record<string, unknown> | null) => ({
+      ...(prev ?? {}),
+      ...updates
+    }));
+    return {
+      state: conn.state,
+      isProtocolEnabled: this.isConnectionProtocolEnabled(conn),
+      isReadonly: this.isConnectionReadonly(conn)
+    };
+  }
+}

--- a/packages/agents/src/tests/protocol-messages.test.ts
+++ b/packages/agents/src/tests/protocol-messages.test.ts
@@ -1,0 +1,585 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import worker, { type Env } from "./worker";
+import { MessageType } from "../types";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}
+
+// ── Message types ─────────────────────────────────────────────────────
+
+interface IdentityMessage {
+  type: MessageType.CF_AGENT_IDENTITY;
+  name: string;
+  agent: string;
+}
+
+interface StateMessage {
+  type: MessageType.CF_AGENT_STATE;
+  state: { count?: number };
+}
+
+interface McpMessage {
+  type: MessageType.CF_AGENT_MCP_SERVERS;
+  mcp: unknown;
+}
+
+interface RpcMessage {
+  type: MessageType.RPC;
+  id: string;
+  success?: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+type TestMessage = IdentityMessage | StateMessage | McpMessage | RpcMessage;
+
+function isTestMessage(data: unknown): data is TestMessage {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    typeof (data as TestMessage).type === "string"
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+async function connectWS(path: string) {
+  const ctx = createExecutionContext();
+  const req = new Request(`http://example.com${path}`, {
+    headers: { Upgrade: "websocket" }
+  });
+  const res = await worker.fetch(req, env, ctx);
+  expect(res.status).toBe(101);
+  const ws = res.webSocket as WebSocket;
+  expect(ws).toBeDefined();
+  ws.accept();
+  return { ws, ctx };
+}
+
+function waitForMessage<T extends TestMessage>(
+  ws: WebSocket,
+  predicate: (data: TestMessage) => boolean,
+  timeoutMs = 5000
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.removeEventListener("message", handler);
+      reject(new Error(`waitForMessage timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const handler = (e: MessageEvent) => {
+      try {
+        const data: unknown = JSON.parse(e.data as string);
+        if (isTestMessage(data) && predicate(data)) {
+          clearTimeout(timer);
+          ws.removeEventListener("message", handler);
+          resolve(data as T);
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    };
+    ws.addEventListener("message", handler);
+  });
+}
+
+/** Collect all messages received within a time window. */
+function collectMessages(ws: WebSocket, durationMs = 500): Promise<unknown[]> {
+  return new Promise((resolve) => {
+    const messages: unknown[] = [];
+    const handler = (e: MessageEvent) => {
+      try {
+        messages.push(JSON.parse(e.data as string));
+      } catch {
+        messages.push(e.data);
+      }
+    };
+    ws.addEventListener("message", handler);
+    setTimeout(() => {
+      ws.removeEventListener("message", handler);
+      resolve(messages);
+    }, durationMs);
+  });
+}
+
+const BASE = "/agents/test-protocol-messages-agent";
+
+/** Connect with protocol enabled (default) and wait for state message. */
+async function connectProtocol(room: string) {
+  const { ws, ctx } = await connectWS(`${BASE}/${room}`);
+  await waitForMessage<StateMessage>(
+    ws,
+    (d) => d.type === MessageType.CF_AGENT_STATE
+  );
+  return { ws, ctx };
+}
+
+/** Connect with protocol disabled. */
+async function connectNoProtocol(room: string) {
+  const { ws, ctx } = await connectWS(`${BASE}/${room}?protocol=false`);
+  return { ws, ctx };
+}
+
+/** Send an RPC and return the parsed response. */
+async function sendRpc(
+  ws: WebSocket,
+  method: string,
+  args: unknown[] = []
+): Promise<RpcMessage> {
+  const id = Math.random().toString(36).slice(2);
+  ws.send(JSON.stringify({ type: MessageType.RPC, id, method, args }));
+  return waitForMessage<RpcMessage>(
+    ws,
+    (d) => d.type === MessageType.RPC && (d as RpcMessage).id === id
+  );
+}
+
+/** Extract protocol message types from an array of raw messages. */
+function protocolTypes(messages: unknown[]): string[] {
+  return messages
+    .filter(
+      (m): m is { type: string } =>
+        typeof m === "object" && m !== null && "type" in m
+    )
+    .map((m) => m.type)
+    .filter(
+      (t) =>
+        t === MessageType.CF_AGENT_IDENTITY ||
+        t === MessageType.CF_AGENT_STATE ||
+        t === MessageType.CF_AGENT_MCP_SERVERS
+    );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("Protocol Messages", () => {
+  describe("shouldSendProtocolMessages hook", () => {
+    it("should send identity, state, and mcp_servers to protocol-enabled connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectWS(`${BASE}/${room}`);
+
+      const messages = await collectMessages(ws, 1000);
+      ws.close();
+
+      const types = protocolTypes(messages);
+      expect(types).toContain(MessageType.CF_AGENT_IDENTITY);
+      expect(types).toContain(MessageType.CF_AGENT_STATE);
+      expect(types).toContain(MessageType.CF_AGENT_MCP_SERVERS);
+    }, 10000);
+
+    it("should NOT send any protocol messages to no-protocol connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectNoProtocol(room);
+
+      const messages = await collectMessages(ws, 1000);
+      ws.close();
+
+      const types = protocolTypes(messages);
+      expect(types).toHaveLength(0);
+    }, 10000);
+  });
+
+  describe("isConnectionProtocolEnabled predicate", () => {
+    it("should return true for protocol-enabled connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectProtocol(room);
+
+      const idMsg = await sendRpc(ws, "getMyConnectionId");
+      expect(idMsg.success).toBe(true);
+      const connId = idMsg.result as string;
+
+      const checkMsg = await sendRpc(ws, "checkProtocolEnabled", [connId]);
+      expect(checkMsg.success).toBe(true);
+      expect(checkMsg.result).toBe(true);
+
+      ws.close();
+    }, 10000);
+
+    it("should return false for no-protocol connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws: wsNoProto } = await connectNoProtocol(room);
+      const { ws: wsProto } = await connectProtocol(room);
+
+      const idMsg = await sendRpc(wsNoProto, "getMyConnectionId");
+      expect(idMsg.success).toBe(true);
+      const noProtoConnId = idMsg.result as string;
+
+      const checkMsg = await sendRpc(wsProto, "checkProtocolEnabled", [
+        noProtoConnId
+      ]);
+      expect(checkMsg.success).toBe(true);
+      expect(checkMsg.result).toBe(false);
+
+      wsNoProto.close();
+      wsProto.close();
+    }, 10000);
+  });
+
+  describe("RPC still works on no-protocol connections", () => {
+    it("should allow RPC calls from no-protocol connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectNoProtocol(room);
+
+      const rpcMsg = await sendRpc(ws, "getState");
+      expect(rpcMsg.success).toBe(true);
+      expect(rpcMsg.result).toEqual({ count: 0 });
+
+      ws.close();
+    }, 10000);
+
+    it("should allow mutating RPC calls from no-protocol connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectNoProtocol(room);
+
+      const rpcMsg = await sendRpc(ws, "incrementCount");
+      expect(rpcMsg.success).toBe(true);
+      expect(rpcMsg.result).toBe(1);
+
+      ws.close();
+    }, 10000);
+  });
+
+  describe("state broadcast filtering", () => {
+    it("should broadcast state to protocol-enabled connections but not no-protocol connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws: wsProto } = await connectProtocol(room);
+      const { ws: wsNoProto } = await connectNoProtocol(room);
+
+      const broadcastPromise = waitForMessage<StateMessage>(
+        wsProto,
+        (d) => d.type === MessageType.CF_AGENT_STATE && (d.state.count ?? 0) > 0
+      );
+
+      const noProtoMessages = collectMessages(wsNoProto, 2000);
+
+      const rpcMsg = await sendRpc(wsNoProto, "incrementCount");
+      expect(rpcMsg.success).toBe(true);
+
+      const broadcastMsg = await broadcastPromise;
+      expect(broadcastMsg.state.count).toBe(1);
+
+      const messages = await noProtoMessages;
+      const stateMessages = messages.filter(
+        (m): m is StateMessage =>
+          typeof m === "object" &&
+          m !== null &&
+          "type" in m &&
+          (m as StateMessage).type === MessageType.CF_AGENT_STATE
+      );
+      expect(stateMessages).toHaveLength(0);
+
+      wsProto.close();
+      wsNoProto.close();
+    }, 15000);
+
+    it("should exclude no-protocol connections from state broadcast when another client mutates", async () => {
+      const room = crypto.randomUUID();
+      const { ws: wsMutator } = await connectProtocol(room);
+      const { ws: wsObserver } = await connectProtocol(room);
+      const { ws: wsNoProto } = await connectNoProtocol(room);
+
+      const observerPromise = waitForMessage<StateMessage>(
+        wsObserver,
+        (d) => d.type === MessageType.CF_AGENT_STATE && (d.state.count ?? 0) > 0
+      );
+
+      const noProtoMessages = collectMessages(wsNoProto, 2000);
+
+      const rpcMsg = await sendRpc(wsMutator, "incrementCount");
+      expect(rpcMsg.success).toBe(true);
+
+      const broadcastMsg = await observerPromise;
+      expect(broadcastMsg.state.count).toBe(1);
+
+      const messages = await noProtoMessages;
+      const stateMessages = messages.filter(
+        (m): m is StateMessage =>
+          typeof m === "object" &&
+          m !== null &&
+          "type" in m &&
+          (m as StateMessage).type === MessageType.CF_AGENT_STATE
+      );
+      expect(stateMessages).toHaveLength(0);
+
+      wsMutator.close();
+      wsObserver.close();
+      wsNoProto.close();
+    }, 15000);
+  });
+
+  describe("mixed connections in the same room", () => {
+    it("should handle protocol and no-protocol connections coexisting", async () => {
+      const room = crypto.randomUUID();
+
+      const { ws: wsProto } = await connectProtocol(room);
+      const { ws: wsNoProto } = await connectNoProtocol(room);
+
+      // Both can make RPC calls
+      const protoState = await sendRpc(wsProto, "getState");
+      expect(protoState.success).toBe(true);
+      expect(protoState.result).toEqual({ count: 0 });
+
+      const noProtoState = await sendRpc(wsNoProto, "getState");
+      expect(noProtoState.success).toBe(true);
+      expect(noProtoState.result).toEqual({ count: 0 });
+
+      // Both can mutate
+      const inc1 = await sendRpc(wsProto, "incrementCount");
+      expect(inc1.success).toBe(true);
+      expect(inc1.result).toBe(1);
+
+      const inc2 = await sendRpc(wsNoProto, "incrementCount");
+      expect(inc2.success).toBe(true);
+      expect(inc2.result).toBe(2);
+
+      wsProto.close();
+      wsNoProto.close();
+    }, 15000);
+  });
+
+  describe("reconnection", () => {
+    it("should re-evaluate shouldSendProtocolMessages on reconnect", async () => {
+      const room = crypto.randomUUID();
+
+      // First connection with protocol disabled
+      const { ws: ws1 } = await connectNoProtocol(room);
+
+      // Set some state so it would be sent on reconnect
+      await sendRpc(ws1, "incrementCount");
+      ws1.close();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Reconnect with protocol enabled — should now receive protocol messages
+      const { ws: ws2 } = await connectWS(`${BASE}/${room}`);
+
+      const messages = await collectMessages(ws2, 1000);
+      ws2.close();
+
+      const types = protocolTypes(messages);
+      expect(types).toContain(MessageType.CF_AGENT_IDENTITY);
+      expect(types).toContain(MessageType.CF_AGENT_STATE);
+      expect(types).toContain(MessageType.CF_AGENT_MCP_SERVERS);
+    }, 15000);
+
+    it("should suppress protocol messages on reconnect when hook returns false", async () => {
+      const room = crypto.randomUUID();
+
+      // First connect with protocol enabled, set some state
+      const { ws: ws1 } = await connectProtocol(room);
+      await sendRpc(ws1, "incrementCount");
+      ws1.close();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Reconnect with protocol disabled
+      const { ws: ws2 } = await connectNoProtocol(room);
+
+      const messages = await collectMessages(ws2, 1000);
+      ws2.close();
+
+      const types = protocolTypes(messages);
+      expect(types).toHaveLength(0);
+    }, 15000);
+  });
+
+  describe("connection state wrapping", () => {
+    it("should hide _cf_no_protocol from connection.state", async () => {
+      const room = crypto.randomUUID();
+      const { ws: wsNoProto } = await connectNoProtocol(room);
+      const { ws: wsProto } = await connectProtocol(room);
+
+      // Get no-protocol connection's ID
+      const idMsg = await sendRpc(wsNoProto, "getMyConnectionId");
+      const noProtoConnId = idMsg.result as string;
+
+      // Ask the agent for connection.state of the no-protocol connection
+      const stateMsg = await sendRpc(wsProto, "getConnectionUserState", [
+        noProtoConnId
+      ]);
+      expect(stateMsg.success).toBe(true);
+      const result = stateMsg.result as {
+        state: Record<string, unknown> | null;
+        isProtocolEnabled: boolean;
+        isReadonly: boolean;
+      };
+
+      // The only key in connection state is _cf_no_protocol, which is hidden,
+      // so connection.state returns null (no user keys left)
+      expect(result.state).toBeNull();
+      // _cf_no_protocol should not appear
+      if (result.state !== null) {
+        expect(result.state).not.toHaveProperty("_cf_no_protocol");
+      }
+      // But isConnectionProtocolEnabled should still report false
+      expect(result.isProtocolEnabled).toBe(false);
+
+      wsNoProto.close();
+      wsProto.close();
+    }, 10000);
+
+    it("should preserve no-protocol flag when connection.setState(value) is called", async () => {
+      const room = crypto.randomUUID();
+      const { ws: wsNoProto } = await connectNoProtocol(room);
+      const { ws: wsProto } = await connectProtocol(room);
+
+      // Get no-protocol connection's ID
+      const idMsg = await sendRpc(wsNoProto, "getMyConnectionId");
+      const noProtoConnId = idMsg.result as string;
+
+      // Use the value form of connection.setState on the no-protocol connection
+      const setMsg = await sendRpc(wsProto, "setConnectionUserState", [
+        noProtoConnId,
+        { myData: "hello" }
+      ]);
+      expect(setMsg.success).toBe(true);
+      const result = setMsg.result as {
+        state: Record<string, unknown> | null;
+        isProtocolEnabled: boolean;
+      };
+
+      // User state should be updated
+      expect(result.state).toEqual({ myData: "hello" });
+      // _cf_no_protocol should NOT be visible in state
+      expect(result.state).not.toHaveProperty("_cf_no_protocol");
+      // But connection should still be no-protocol
+      expect(result.isProtocolEnabled).toBe(false);
+
+      wsNoProto.close();
+      wsProto.close();
+    }, 10000);
+
+    it("should preserve no-protocol flag when connection.setState(callback) is called", async () => {
+      const room = crypto.randomUUID();
+      const { ws: wsNoProto } = await connectNoProtocol(room);
+      const { ws: wsProto } = await connectProtocol(room);
+
+      // Get no-protocol connection's ID
+      const idMsg = await sendRpc(wsNoProto, "getMyConnectionId");
+      const noProtoConnId = idMsg.result as string;
+
+      // First set some user state via the value form
+      await sendRpc(wsProto, "setConnectionUserState", [
+        noProtoConnId,
+        { existing: "data" }
+      ]);
+
+      // Now use the callback form to merge additional data
+      const set2Msg = await sendRpc(wsProto, "setConnectionUserStateCallback", [
+        noProtoConnId,
+        { extra: "info" }
+      ]);
+      expect(set2Msg.success).toBe(true);
+      const result = set2Msg.result as {
+        state: Record<string, unknown> | null;
+        isProtocolEnabled: boolean;
+      };
+
+      // Both keys should be present
+      expect(result.state).toEqual({ existing: "data", extra: "info" });
+      // No internal flag leaked
+      expect(result.state).not.toHaveProperty("_cf_no_protocol");
+      // Still no-protocol
+      expect(result.isProtocolEnabled).toBe(false);
+
+      wsNoProto.close();
+      wsProto.close();
+    }, 10000);
+  });
+
+  describe("readonly + no-protocol combined", () => {
+    it("should support both flags on the same connection", async () => {
+      const room = crypto.randomUUID();
+
+      // Connect with both readonly and no-protocol
+      const { ws: wsBoth } = await connectWS(
+        `${BASE}/${room}?protocol=false&readonly=true`
+      );
+      // Connect a normal connection to inspect from
+      const { ws: wsNormal } = await connectProtocol(room);
+
+      // Get the dual-flag connection's ID
+      const idMsg = await sendRpc(wsBoth, "getMyConnectionId");
+      expect(idMsg.success).toBe(true);
+      const bothConnId = idMsg.result as string;
+
+      // Verify both flags are set
+      const checkProto = await sendRpc(wsNormal, "checkProtocolEnabled", [
+        bothConnId
+      ]);
+      expect(checkProto.success).toBe(true);
+      expect(checkProto.result).toBe(false);
+
+      const checkReadonly = await sendRpc(wsNormal, "checkReadonly", [
+        bothConnId
+      ]);
+      expect(checkReadonly.success).toBe(true);
+      expect(checkReadonly.result).toBe(true);
+
+      // connection.state should hide BOTH internal flags
+      const stateMsg = await sendRpc(wsNormal, "getConnectionUserState", [
+        bothConnId
+      ]);
+      expect(stateMsg.success).toBe(true);
+      const result = stateMsg.result as {
+        state: Record<string, unknown> | null;
+        isProtocolEnabled: boolean;
+        isReadonly: boolean;
+      };
+      expect(result.state).toBeNull();
+      expect(result.isProtocolEnabled).toBe(false);
+      expect(result.isReadonly).toBe(true);
+
+      // Mutating RPC should be blocked (readonly)
+      const incMsg = await sendRpc(wsBoth, "incrementCount");
+      expect(incMsg.success).toBe(false);
+      expect(incMsg.error).toBe("Connection is readonly");
+
+      // Read-only RPC should still work
+      const readMsg = await sendRpc(wsBoth, "getState");
+      expect(readMsg.success).toBe(true);
+      expect(readMsg.result).toEqual({ count: 0 });
+
+      wsBoth.close();
+      wsNormal.close();
+    }, 15000);
+
+    it("should preserve both flags when connection.setState is called", async () => {
+      const room = crypto.randomUUID();
+
+      const { ws: wsBoth } = await connectWS(
+        `${BASE}/${room}?protocol=false&readonly=true`
+      );
+      const { ws: wsNormal } = await connectProtocol(room);
+
+      // Get dual-flag connection's ID
+      const idMsg = await sendRpc(wsBoth, "getMyConnectionId");
+      const bothConnId = idMsg.result as string;
+
+      // Set user state on the dual-flag connection via a normal connection
+      const setMsg = await sendRpc(wsNormal, "setConnectionUserState", [
+        bothConnId,
+        { device: "sensor-1" }
+      ]);
+      expect(setMsg.success).toBe(true);
+      const result = setMsg.result as {
+        state: Record<string, unknown> | null;
+        isProtocolEnabled: boolean;
+        isReadonly: boolean;
+      };
+
+      // User state should be updated
+      expect(result.state).toEqual({ device: "sensor-1" });
+      // No internal flags leaked
+      expect(result.state).not.toHaveProperty("_cf_no_protocol");
+      expect(result.state).not.toHaveProperty("_cf_readonly");
+      // Both flags still active
+      expect(result.isProtocolEnabled).toBe(false);
+      expect(result.isReadonly).toBe(true);
+
+      wsBoth.close();
+      wsNormal.close();
+    }, 10000);
+  });
+});

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -22,6 +22,7 @@ export {
   TestOAuthAgent,
   TestCustomOAuthAgent,
   TestReadonlyAgent,
+  TestProtocolMessagesAgent,
   TestCallableAgent,
   TestParentAgent,
   TestChildAgent,
@@ -51,6 +52,7 @@ import type {
   TestMcpJurisdiction,
   TestDestroyScheduleAgent,
   TestReadonlyAgent,
+  TestProtocolMessagesAgent,
   TestScheduleAgent,
   TestWorkflowAgent,
   TestAddMcpServerAgent,
@@ -78,6 +80,7 @@ export type Env = {
   TEST_MCP_JURISDICTION: DurableObjectNamespace<TestMcpJurisdiction>;
   TestDestroyScheduleAgent: DurableObjectNamespace<TestDestroyScheduleAgent>;
   TestReadonlyAgent: DurableObjectNamespace<TestReadonlyAgent>;
+  TestProtocolMessagesAgent: DurableObjectNamespace<TestProtocolMessagesAgent>;
   TestScheduleAgent: DurableObjectNamespace<TestScheduleAgent>;
   TestWorkflowAgent: DurableObjectNamespace<TestWorkflowAgent>;
   TestAddMcpServerAgent: DurableObjectNamespace<TestAddMcpServerAgent>;

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -48,6 +48,10 @@
         "name": "TestReadonlyAgent"
       },
       {
+        "class_name": "TestProtocolMessagesAgent",
+        "name": "TestProtocolMessagesAgent"
+      },
+      {
         "class_name": "TestScheduleAgent",
         "name": "TestScheduleAgent"
       },
@@ -135,6 +139,7 @@
         "TestMcpJurisdiction",
         "TestDestroyScheduleAgent",
         "TestReadonlyAgent",
+        "TestProtocolMessagesAgent",
         "TestScheduleAgent",
         "TestWorkflowAgent",
         "TestAddMcpServerAgent",


### PR DESCRIPTION
Closes #881

## Summary

- Add `shouldSendProtocolMessages(connection, ctx)` — overridable hook on `Agent` (default: `true`). Called once during `onConnect` to decide whether protocol text frames should be sent to this connection.
- Add `isConnectionProtocolEnabled(connection)` — predicate to check a connection's protocol status at any time, including after hibernation.
- When `shouldSendProtocolMessages` returns `false`, the connection receives no `CF_AGENT_IDENTITY`, `CF_AGENT_STATE`, or `CF_AGENT_MCP_SERVERS` messages — neither on connect nor via subsequent broadcasts. RPC and regular messaging still work normally.
- Also fixes a latent bug where `isConnectionReadonly` would return incorrect results after Durable Object hibernation.

## Design decisions

### Why a per-connection hook, not `static options`?

The [original issue](https://github.com/cloudflare/agents/issues/881) identified two needs: (1) per-connection control for DOs that serve mixed connection types (e.g. MQTT binary clients alongside web monitoring clients), and (2) agent-level feature opt-out. Per @threepointone's [comment](https://github.com/cloudflare/agents/issues/881#issuecomment-2746289267), option (2) is just the degenerate case of (1) — a hook that always returns `false` is effectively agent-level. So we only need the hook.

### Why store the flag in connection state?

Same approach as `_cf_readonly`. The flag is persisted in the WebSocket attachment via `connection.setState`, which means it survives Durable Object hibernation. This is critical — @genmon [reported](https://github.com/cloudflare/agents/issues/881#issuecomment-2749133972) that PR #892 leaked `cf_agent_mcp_servers` messages after hibernation wake because the in-memory state was lost.

### How hibernation is handled

The core insight: both `isConnectionReadonly` and `isConnectionProtocolEnabled` call `_ensureConnectionWrapped(connection)` before reading the flag. This method is idempotent — if the `_rawStateAccessors` WeakMap already has the connection, it returns immediately. After hibernation, the WeakMap is empty, but the connection's `state` getter still reads from the persisted WebSocket attachment. `_ensureConnectionWrapped` re-captures that getter as `getRaw`, sets up the filtering overrides, and the predicate then reads the flag correctly. No separate fallback path needed.

This is cleaner than PRs #892/#893, which added a separate code path in the predicate that read `connection.state` directly when the WeakMap was empty — fragile because it depended on `_ensureConnectionWrapped` not having run yet.

### Generalized internal key handling

Rather than hardcoding `_cf_readonly` in `_ensureConnectionWrapped` (as the current code does), the connection state wrapping now uses `CF_INTERNAL_KEYS` (a `ReadonlySet`) with module-level helpers (`rawHasInternalKeys`, `stripInternalKeys`, `extractInternalFlags`). Adding a future internal flag means adding one entry to the set — the wrapping logic handles it automatically.

### `_broadcastProtocol` for filtered broadcasts

State broadcasts (`_setStateInternal`) and MCP broadcasts (`broadcastMcpServers`) now go through `_broadcastProtocol`, which builds an exclusion list of no-protocol connections and delegates to `this.broadcast()`. This keeps the filtering in one place.

## Usage example

```typescript
class MyAgent extends Agent {
  shouldSendProtocolMessages(connection, ctx) {
    // Suppress protocol messages for MQTT binary clients
    const url = new URL(ctx.request.url);
    return url.searchParams.get("protocol") !== "false";
    // Or check WebSocket subprotocol:
    // return ctx.request.headers.get("Sec-WebSocket-Protocol") !== "mqtt";
  }
}
```

## Notes for reviewers

1. **`isConnectionReadonly` bug fix** — The existing `isConnectionReadonly` had a latent hibernation bug: after DO hibernation, the `_rawStateAccessors` WeakMap is empty, so the method returned `false` for connections that were actually readonly. The `shouldConnectionBeReadonly` hook only runs during `onConnect`, which does NOT fire on hibernation wake. My fix (calling `_ensureConnectionWrapped` in the predicate) fixes this for both flags. This is a behavioral change to the readonly feature, but strictly a bug fix.

2. **No dynamic toggle** — Unlike `setConnectionReadonly(connection, bool)` which can be toggled at runtime, `_setConnectionNoProtocol` is private and only called during `onConnect`. This is intentional per the issue thread: "We don't need it to be able to be dynamically set." Protocol status is evaluated once on connect and persisted.

3. **All protocol message sites covered** — I audited every `MessageType.CF_AGENT_*` send site in `index.ts`. The three protocol types (`IDENTITY`, `STATE`, `MCP_SERVERS`) are filtered in `onConnect` (conditional block) and in broadcasts (`_broadcastProtocol`). `CF_AGENT_STATE_ERROR` is correctly NOT filtered — it's a direct reply to a specific connection that sent a bad state update, not an unsolicited broadcast.

4. **16 tests** covering: hook behavior (protocol sent / not sent on connect), predicate correctness, RPC on no-protocol connections, state broadcast filtering, mixed connections, reconnection re-evaluation, `connection.state` wrapping (flag hidden, preserved across `setState` value and callback forms), and readonly + no-protocol combination on the same connection.

## Test plan

- [x] `npm run build` passes
- [x] `npm run check` passes (sherif, exports, oxfmt, oxlint, typecheck across 42 projects)
- [x] `npm run test` — all 529+ tests pass (including 16 new protocol-messages tests)
- [x] Existing readonly tests still pass (generalized wrapping is backward compatible)


Made with [Cursor](https://cursor.com)