### PR TITLE
fix(ai-chat): persist tool approval state across page refresh

### DIFF
--- a/.changeset/fix-approval-persistence.md
+++ b/.changeset/fix-approval-persistence.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix tool approval UI not surviving page refresh, and fix invalid prompt error after approval
+
+- Handle `tool-approval-request` and `tool-output-denied` stream chunks in the server-side message builder. Previously these were only handled client-side, so the server never transitioned tool parts to `approval-requested` or `output-denied` state.
+- Persist the streaming message to SQLite (without broadcasting) when a tool enters `approval-requested` state. The stream is paused waiting for user approval, so this is a natural persistence point. Without this, refreshing the page would reload from SQLite where the tool was still in `input-available` state, showing "Running..." instead of the Approve/Reject UI.
+- On stream completion, update the early-persisted message in place rather than appending a duplicate.
+- Fix `_applyToolApproval` to merge with existing approval data instead of replacing it. Previously `approval: { approved }` would overwrite the entire object, losing the `id` field that `convertToModelMessages` needs to produce a valid `tool-approval-request` content part. This caused an `InvalidPromptError` on the continuation stream after approval.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -219,6 +219,14 @@ export class AIChatAgent<
   private _streamingMessage: ChatMessage | null = null;
 
   /**
+   * Tracks the ID of a streaming message that was persisted early due to
+   * a tool entering approval-requested state. When set, stream completion
+   * updates the existing persisted message instead of appending a new one.
+   * @internal
+   */
+  private _approvalPersistedMessageId: string | null = null;
+
+  /**
    * Promise that resolves when the current stream completes.
    * Used to wait for message persistence before continuing after tool results.
    * @internal
@@ -1562,6 +1570,36 @@ export class AIChatAgent<
             // step boundaries — all the part types needed for UIMessage.
             const handled = applyChunkToParts(message.parts, data);
 
+            // When a tool enters approval-requested state, the stream is
+            // paused waiting for user approval. Persist the streaming message
+            // immediately so the approval UI survives page refresh. Without
+            // this, a refresh would reload from SQLite where the tool part
+            // is still in input-available state, showing "Running..." instead
+            // of the Approve/Reject buttons.
+            if (
+              data.type === "tool-approval-request" &&
+              this._streamingMessage
+            ) {
+              // Persist directly to SQLite without broadcasting.
+              // The client already has this data from the SSE stream —
+              // broadcasting would cause the approval UI to render twice.
+              // We only need the SQL write so the state survives page refresh.
+              const snapshot: ChatMessage = {
+                ...this._streamingMessage,
+                parts: [...this._streamingMessage.parts]
+              };
+              const sanitized = this._sanitizeMessageForPersistence(snapshot);
+              const json = JSON.stringify(sanitized);
+              this.sql`
+                INSERT INTO cf_ai_chat_agent_messages (id, message)
+                VALUES (${sanitized.id}, ${json})
+                ON CONFLICT(id) DO UPDATE SET message = excluded.message
+              `;
+              // Track that we persisted early so stream completion can update
+              // in place rather than appending a duplicate.
+              this._approvalPersistedMessageId = sanitized.id;
+            }
+
             // Cross-message tool output fallback:
             // When a tool with needsApproval is approved, the continuation
             // stream emits tool-output-available/tool-output-error for a
@@ -1775,7 +1813,13 @@ export class AIChatAgent<
       (part) => ({
         ...part,
         state: "approval-responded",
-        approval: { approved }
+        // Merge with existing approval data to preserve the id field.
+        // convertToModelMessages needs approval.id to produce a valid
+        // tool-approval-request content part with approvalId.
+        approval: {
+          ...(part.approval as Record<string, unknown> | undefined),
+          approved
+        }
       })
     );
   }
@@ -1824,6 +1868,10 @@ export class AIChatAgent<
       const contentType = response.headers.get("content-type") || "";
       const isSSE = contentType.includes("text/event-stream"); // AI SDK v5 SSE format
       const streamCompleted = { value: false };
+      // Capture before try so it's available after finally.
+      // _approvalPersistedMessageId is set inside _streamSSEReply when a
+      // tool enters approval-requested state and the message is persisted early.
+      let earlyPersistedId: string | null = null;
 
       try {
         if (isSSE) {
@@ -1868,6 +1916,10 @@ export class AIChatAgent<
         // promise, even on error. Without this, tool continuations waiting on
         // _streamCompletionPromise would hang forever after a stream error.
         this._streamingMessage = null;
+        // Capture and clear early-persist tracking. The persistence block
+        // after the finally uses the local to update in place.
+        earlyPersistedId = this._approvalPersistedMessageId;
+        this._approvalPersistedMessageId = null;
         if (this._streamCompletionResolve) {
           this._streamCompletionResolve();
           this._streamCompletionResolve = null;
@@ -1896,7 +1948,18 @@ export class AIChatAgent<
       }
 
       if (message.parts.length > 0) {
-        if (continuation) {
+        if (earlyPersistedId) {
+          // Message already exists in this.messages from the early persist.
+          // Update it in place with the final streaming state.
+          // Note: early-persisted messages come from the initial stream
+          // (before approval), which is never a continuation. The
+          // continuation stream starts fresh after approval, so
+          // earlyPersistedId will always be null for continuations.
+          const updatedMessages = this.messages.map((msg) =>
+            msg.id === earlyPersistedId ? message : msg
+          );
+          await this.persistMessages(updatedMessages, excludeBroadcastIds);
+        } else if (continuation) {
           // Find the last assistant message and append parts to it
           let lastAssistantIdx = -1;
           for (let i = this.messages.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Problem

Three related bugs in the tool approval (`needsApproval`) flow:

1. **Approval UI doesn't survive page refresh.** The server-side message builder didn't handle `tool-approval-request` chunks from the AI SDK, so the tool part stayed in `input-available` state on the server. And streaming messages aren't persisted until the stream completes — so when the stream pauses for approval, a refresh reloads from SQLite where the tool was never saved as `approval-requested`.

2. **Duplicate approval UI.** The initial fix used `persistMessages()` for early persistence, which broadcasts to all clients. Since the client already has the data from the SSE stream, the approval UI rendered twice.

3. **`InvalidPromptError` after approving a tool.** `_applyToolApproval` set `approval: { approved }`, replacing the entire object and losing the `id` field. On the continuation stream, `convertToModelMessages` reads `approval.id` to produce `approvalId` in the `tool-approval-request` content part. With `id` gone, `approvalId` is `undefined`, and schema validation fails.

## Fix

### `message-builder.ts`

- **`tool-approval-request`** — New case: transitions tool part to `approval-requested` state with `approval.id`.
- **`tool-output-denied`** — New case: transitions tool part to `output-denied` state.
- Added `approvalId` to `StreamChunkData` type.

### `index.ts` — Early silent persistence

When `applyChunkToParts` processes a `tool-approval-request` chunk, the streaming message is immediately written to SQLite via a direct SQL upsert — no broadcast. The client already has the data from the SSE stream; broadcasting would cause the approval UI to render twice. `_approvalPersistedMessageId` tracks the early-persisted ID so stream completion can update in place.

### `index.ts` — `_applyToolApproval` preserves `approval.id`

Changed from `approval: { approved }` to `approval: { ...part.approval, approved }`. This merges the approval response with the existing data, preserving the `id` field that was set during `approval-requested`. When starting from `input-available` (no prior `approval` object), the spread of `undefined` is empty, so behavior is unchanged.

### `index.ts` — Clean `finally` handling

`_approvalPersistedMessageId` is captured into a local `earlyPersistedId` in the `finally` block and immediately cleared from the instance field. No stale state on error paths.

## Notes for reviewers

1. **Silent SQL write vs `persistMessages()`**: The early persistence writes directly to SQLite without calling `persistMessages()`. This means `this.messages` is NOT updated — only the DB row exists. On stream completion, the `earlyPersistedId` path calls `persistMessages()` which reloads from DB, so everything converges. The intermediate state where `this.messages` is out of sync with SQLite is brief and doesn't cause issues because the stream is paused.

2. **`_approvalPersistedMessageId` is per-instance, not per-stream.** Filed [#921](https://github.com/cloudflare/agents/issues/921) to track making it concurrent-safe if we ever support multiple simultaneous streams.

3. **The `tool-output-denied` chunk handler** is the counterpart to `tool-approval-request`. Without it, a rejected tool stays in `approval-requested` state on the server even though the client shows it as denied.

4. **Hibernation safe.** The SQLite write survives both page refresh and DO hibernation. When the DO wakes from a `CF_AGENT_TOOL_APPROVAL` message, `_applyToolApproval` already handles the transition from `approval-requested`.

5. **`earlyPersistedId` and `continuation` are mutually exclusive.** Early persistence only happens on the initial stream (before approval). The continuation stream starts fresh after approval — `earlyPersistedId` is always null.

## Tests (5 new, all passing)

- `applyChunkToParts: tool-approval-request > transitions tool part from input-available to approval-requested`
- `applyChunkToParts: tool-approval-request > does nothing if tool part not found`
- `applyChunkToParts: tool-output-denied > transitions tool part to output-denied state`
- `Tool approval persistence across reconnect > persisted messages include approval-requested state after approval-request chunk`
- Updated 3 existing tests to verify `approval.id` is preserved through the approval flow

## Test plan

- [x] `npm run build` passes
- [x] `npm run check` passes (42 projects typecheck)
- [x] All 161 ai-chat tests pass (22 test files)
- [x] All 530 agents tests pass (33 test files)