### PR TITLE
Add useUserId hook and scope demo agent names per user

### DIFF
--- a/examples/playground/src/demos/core/CallableDemo.tsx
+++ b/examples/playground/src/demos/core/CallableDemo.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 import { Button, Input, Surface, CodeBlock, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { CallableAgent } from "./callable-agent";
 
 export function CallableDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [methods, setMethods] = useState<
     Array<{ name: string; description?: string }>
@@ -20,7 +21,7 @@ export function CallableDemo() {
 
   const agent = useAgent<CallableAgent, {}>({
     agent: "callable-agent",
-    name: "callable-demo",
+    name: `callable-demo-${userId}`,
     onOpen: () => addLog("info", "connected"),
     onClose: () => addLog("info", "disconnected"),
     onError: () => addLog("error", "error", "Connection error")

--- a/examples/playground/src/demos/core/ConnectionsDemo.tsx
+++ b/examples/playground/src/demos/core/ConnectionsDemo.tsx
@@ -3,13 +3,14 @@ import { useState } from "react";
 import { Button, Input, Surface, Empty, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type {
   ConnectionsAgent,
   ConnectionsAgentState
 } from "./connections-agent";
 
 export function ConnectionsDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [connectionCount, setConnectionCount] = useState(0);
   const [broadcastMessage, setBroadcastMessage] = useState(
@@ -21,7 +22,7 @@ export function ConnectionsDemo() {
 
   const agent = useAgent<ConnectionsAgent, ConnectionsAgentState>({
     agent: "connections-agent",
-    name: "connections-demo",
+    name: `connections-demo-${userId}`,
     onOpen: () => {
       addLog("info", "connected");
       refreshConnectionCount();

--- a/examples/playground/src/demos/core/ReadonlyDemo.tsx
+++ b/examples/playground/src/demos/core/ReadonlyDemo.tsx
@@ -3,10 +3,10 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { Button, Surface, CodeBlock, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { ConnectionStatus } from "../../components";
+import { useUserId } from "../../hooks";
 import type { ReadonlyAgent, ReadonlyAgentState } from "./readonly-agent";
 
 const AGENT_NAME = "readonly-agent";
-const INSTANCE_NAME = "readonly-demo";
 
 const initialState: ReadonlyAgentState = {
   counter: 0,
@@ -23,6 +23,7 @@ const MAX_TOASTS = 5;
 
 /** A single connection panel — editor or viewer depending on `mode`. */
 function ConnectionPanel({ mode }: { mode: "edit" | "view" }) {
+  const userId = useUserId();
   const isViewer = mode === "view";
   const [state, setState] = useState<ReadonlyAgentState>(initialState);
   const [toasts, setToasts] = useState<Toast[]>([]);
@@ -46,7 +47,7 @@ function ConnectionPanel({ mode }: { mode: "edit" | "view" }) {
 
   const agent = useAgent<ReadonlyAgent, ReadonlyAgentState>({
     agent: AGENT_NAME,
-    name: INSTANCE_NAME,
+    name: `readonly-demo-${userId}`,
     // The viewer connects with ?mode=view, which the agent checks in shouldConnectionBeReadonly
     query: isViewer ? { mode: "view" } : undefined,
     onStateUpdate: (newState) => {

--- a/examples/playground/src/demos/core/RetryDemo.tsx
+++ b/examples/playground/src/demos/core/RetryDemo.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 import { Button, Input, Surface, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { RetryAgent, RetryAgentState } from "./retry-agent";
 
 export function RetryDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [succeedOn, setSucceedOn] = useState("3");
   const [failCount, setFailCount] = useState("2");
@@ -15,7 +16,7 @@ export function RetryDemo() {
 
   const agent = useAgent<RetryAgent, RetryAgentState>({
     agent: "retry-agent",
-    name: "retry-demo",
+    name: `retry-demo-${userId}`,
     onOpen: () => addLog("info", "connected"),
     onClose: () => addLog("info", "disconnected"),
     onError: () => addLog("error", "error", "Connection error"),

--- a/examples/playground/src/demos/core/RoutingDemo.tsx
+++ b/examples/playground/src/demos/core/RoutingDemo.tsx
@@ -4,19 +4,10 @@ import { useState, useEffect } from "react";
 import { Button, Input, Surface, Text, Radio } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { RoutingAgent, RoutingAgentState } from "./routing-agent";
 
 type RoutingStrategy = "per-user" | "shared" | "per-session" | "custom-path";
-
-function getStoredUserId(): string {
-  if (typeof window === "undefined") return "user-1";
-  const stored = localStorage.getItem("playground-user-id");
-  if (stored) return stored;
-  const newId = `user-${nanoid(6)}`;
-  localStorage.setItem("playground-user-id", newId);
-  return newId;
-}
 
 function getSessionId(): string {
   if (typeof window === "undefined") return "session-1";
@@ -29,8 +20,9 @@ function getSessionId(): string {
 }
 
 export function RoutingDemo() {
+  const initialUserId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
-  const [userId, setUserId] = useState(getStoredUserId);
+  const [userId, setUserId] = useState(initialUserId);
   const [strategy, setStrategy] = useState<RoutingStrategy>("per-user");
   const [connectionCount, setConnectionCount] = useState(0);
   const [agentInstanceName, setAgentInstanceName] = useState<string>("");

--- a/examples/playground/src/demos/core/ScheduleDemo.tsx
+++ b/examples/playground/src/demos/core/ScheduleDemo.tsx
@@ -4,10 +4,11 @@ import { useState, useEffect, useCallback } from "react";
 import { Button, Input, Surface, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { ScheduleAgent, ScheduleAgentState } from "./schedule-agent";
 
 export function ScheduleDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [delaySeconds, setDelaySeconds] = useState("5");
@@ -17,7 +18,7 @@ export function ScheduleDemo() {
 
   const agent = useAgent<ScheduleAgent, ScheduleAgentState>({
     agent: "schedule-agent",
-    name: "schedule-demo",
+    name: `schedule-demo-${userId}`,
     onOpen: () => {
       addLog("info", "connected");
       refreshSchedules();

--- a/examples/playground/src/demos/core/SqlDemo.tsx
+++ b/examples/playground/src/demos/core/SqlDemo.tsx
@@ -11,10 +11,11 @@ import {
 } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { SqlAgent } from "./sql-agent";
 
 export function SqlDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [tables, setTables] = useState<Array<{ name: string; type: string }>>(
     []
@@ -29,7 +30,7 @@ export function SqlDemo() {
 
   const agent = useAgent<SqlAgent, {}>({
     agent: "sql-agent",
-    name: "sql-demo",
+    name: `sql-demo-${userId}`,
     onOpen: () => {
       addLog("info", "connected");
       loadTables();

--- a/examples/playground/src/demos/core/StateDemo.tsx
+++ b/examples/playground/src/demos/core/StateDemo.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 import { Button, Input, Surface, CodeBlock, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { StateAgent, StateAgentState } from "./state-agent";
 
 export function StateDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [newItem, setNewItem] = useState("");
   const [customValue, setCustomValue] = useState("0");
@@ -18,7 +19,7 @@ export function StateDemo() {
 
   const agent = useAgent<StateAgent, StateAgentState>({
     agent: "state-agent",
-    name: "state-demo",
+    name: `state-demo-${userId}`,
     onStateUpdate: (newState, source) => {
       addLog("in", "state_update", { source, state: newState });
       if (newState) setState(newState);

--- a/examples/playground/src/demos/core/StreamingDemo.tsx
+++ b/examples/playground/src/demos/core/StreamingDemo.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 import { Button, Input, Surface, CodeBlock, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { StreamingAgent } from "./streaming-agent";
 
 export function StreamingDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [chunks, setChunks] = useState<unknown[]>([]);
   const [finalResult, setFinalResult] = useState<unknown>(null);
@@ -17,7 +18,7 @@ export function StreamingDemo() {
 
   const agent = useAgent<StreamingAgent, {}>({
     agent: "streaming-agent",
-    name: "streaming-demo",
+    name: `streaming-demo-${userId}`,
     onOpen: () => addLog("info", "connected"),
     onClose: () => addLog("info", "disconnected"),
     onError: () => addLog("error", "error", "Connection error")

--- a/examples/playground/src/demos/email/ReceiveDemo.tsx
+++ b/examples/playground/src/demos/email/ReceiveDemo.tsx
@@ -9,7 +9,7 @@ import {
 import { Button, Surface, Empty, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus, LocalDevBanner } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type {
   ReceiveEmailAgent,
   ReceiveEmailState,
@@ -17,6 +17,7 @@ import type {
 } from "./receive-email-agent";
 
 export function ReceiveDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [selectedEmail, setSelectedEmail] = useState<ParsedEmail | null>(null);
 
@@ -27,7 +28,7 @@ export function ReceiveDemo() {
 
   const agent = useAgent<ReceiveEmailAgent, ReceiveEmailState>({
     agent: "receive-email-agent",
-    name: "demo",
+    name: `email-receive-${userId}`,
     onStateUpdate: (newState) => {
       if (newState) {
         setState(newState);

--- a/examples/playground/src/demos/email/SecureDemo.tsx
+++ b/examples/playground/src/demos/email/SecureDemo.tsx
@@ -18,7 +18,7 @@ import {
 } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus, LocalDevBanner } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type {
   SecureEmailAgent,
   SecureEmailState,
@@ -29,6 +29,7 @@ import type {
 type TabType = "inbox" | "outbox";
 
 export function SecureDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [activeTab, setActiveTab] = useState<TabType>("inbox");
   const [selectedEmail, setSelectedEmail] = useState<ParsedEmail | null>(null);
@@ -44,7 +45,7 @@ export function SecureDemo() {
 
   const agent = useAgent<SecureEmailAgent, SecureEmailState>({
     agent: "secure-email-agent",
-    name: "demo",
+    name: `email-secure-${userId}`,
     onStateUpdate: (newState) => {
       if (newState) {
         setState(newState);

--- a/examples/playground/src/demos/multi-agent/SupervisorDemo.tsx
+++ b/examples/playground/src/demos/multi-agent/SupervisorDemo.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Button, Surface, Empty, Text } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type { ChildState } from "./child-agent";
 import type { SupervisorAgent, SupervisorState } from "./supervisor-agent";
 
@@ -14,13 +14,14 @@ interface ChildInfo {
 }
 
 export function SupervisorDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [children, setChildren] = useState<ChildInfo[]>([]);
   const [stats, setStats] = useState({ totalChildren: 0, totalCounter: 0 });
 
   const agent = useAgent<SupervisorAgent, SupervisorState>({
     agent: "supervisor-agent",
-    name: "demo-supervisor",
+    name: `demo-supervisor-${userId}`,
     onOpen: () => {
       addLog("info", "connected");
       refreshStats();

--- a/examples/playground/src/demos/workflow/ApprovalDemo.tsx
+++ b/examples/playground/src/demos/workflow/ApprovalDemo.tsx
@@ -19,7 +19,7 @@ import {
 } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type {
   ApprovalAgent,
   ApprovalAgentState,
@@ -146,6 +146,7 @@ function ApprovalCard({
 }
 
 export function WorkflowApprovalDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -154,7 +155,7 @@ export function WorkflowApprovalDemo() {
 
   const agent = useAgent<ApprovalAgent, ApprovalAgentState>({
     agent: "approval-agent",
-    name: "demo",
+    name: `workflow-approval-${userId}`,
     onStateUpdate: () => {
       refreshRequests();
     },

--- a/examples/playground/src/demos/workflow/BasicDemo.tsx
+++ b/examples/playground/src/demos/workflow/BasicDemo.tsx
@@ -20,7 +20,7 @@ import {
 } from "@cloudflare/kumo";
 import { DemoWrapper } from "../../layout";
 import { LogPanel, ConnectionStatus } from "../../components";
-import { useLogs } from "../../hooks";
+import { useLogs, useUserId } from "../../hooks";
 import type {
   BasicWorkflowAgent,
   BasicWorkflowState,
@@ -105,6 +105,7 @@ function WorkflowCard({ workflow }: { workflow: WorkflowWithProgress }) {
 }
 
 export function WorkflowBasicDemo() {
+  const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const [workflowName, setWorkflowName] = useState("Data Processing");
   const [stepCount, setStepCount] = useState(4);
@@ -113,7 +114,7 @@ export function WorkflowBasicDemo() {
 
   const agent = useAgent<BasicWorkflowAgent, BasicWorkflowState>({
     agent: "basic-workflow-agent",
-    name: "demo",
+    name: `workflow-basic-${userId}`,
     onStateUpdate: (newState) => {
       if (newState) {
         addLog("in", "state_update", {

--- a/examples/playground/src/hooks/index.ts
+++ b/examples/playground/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useLogs } from "./useLogs";
+export { useUserId } from "./useUserId";

--- a/examples/playground/src/hooks/useUserId.ts
+++ b/examples/playground/src/hooks/useUserId.ts
@@ -1,0 +1,18 @@
+import { nanoid } from "nanoid";
+import { useState } from "react";
+
+const STORAGE_KEY = "playground-user-id";
+
+function getOrCreateUserId(): string {
+  if (typeof window === "undefined") return "user-1";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) return stored;
+  const id = `user-${nanoid(6)}`;
+  localStorage.setItem(STORAGE_KEY, id);
+  return id;
+}
+
+export function useUserId(): string {
+  const [id] = useState(getOrCreateUserId);
+  return id;
+}


### PR DESCRIPTION
Add a new useUserId hook (stores a persistent user id in localStorage using nanoid) and export it from the hooks index. Update playground demos to import useUserId and append the user id to agent instance names (e.g. callable-demo-${userId}) so demo agents are scoped per browser/user. RoutingDemo was simplified to use the hook instead of its previous local getStoredUserId logic. No other behavior changes intended.