### PR TITLE
fix(codemode): call super.onRequest to enable /get-messages endpoint

### DIFF
--- a/examples/codemode/src/server.ts
+++ b/examples/codemode/src/server.ts
@@ -38,7 +38,7 @@ export class Codemode extends AIChatAgent<Env> {
     if (url.pathname.startsWith("/node-executor-callback/")) {
       return handleToolCallback(request, this.nodeExecutorRegistry);
     }
-    return new Response("Not found", { status: 404 });
+    return super.onRequest(request);
   }
 
   @callable({ description: "Set the executor type" })


### PR DESCRIPTION
## Summary
- Fix codemode example's onRequest to call super.onRequest(request) instead of returning 404

The onRequest override was returning 404 for all paths except /node-executor-callback/, which prevented AIChatAgent's /get-messages endpoint from working. This caused messages to not persist on page reload.

## Test plan
- Run codemode example, send a message, reload page, verify messages persist