### PR TITLE
Fix codemode tool prompt and README to request JavaScript

### DIFF
--- a/.changeset/petite-walls-invite.md
+++ b/.changeset/petite-walls-invite.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Updated default tool prompt to explicitly request JavaScript code from LLMs, preventing TypeScript syntax errors in the Dynamic Worker executor.

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -1,8 +1,8 @@
 # `@cloudflare/codemode`
 
-Instead of asking LLMs to call tools directly, Code Mode lets them write executable code that orchestrates multiple operations. LLMs are better at writing code than calling tools — they've seen millions of lines of real-world TypeScript but only contrived tool-calling examples.
+Instead of asking LLMs to call tools directly, Code Mode lets them write executable code that orchestrates multiple operations. LLMs are better at writing code than calling tools — they've seen millions of lines of real-world code but only contrived tool-calling examples.
 
-Code Mode converts your tools into TypeScript APIs and executes the generated code in secure, isolated sandboxes with millisecond startup times.
+Code Mode generates TypeScript type definitions from your tools for LLM context, and executes the generated JavaScript in secure, isolated sandboxes with millisecond startup times.
 
 > **Experimental** — may have breaking changes. Use with caution in production.
 

--- a/packages/codemode/src/tool.ts
+++ b/packages/codemode/src/tool.ts
@@ -10,7 +10,8 @@ const DEFAULT_DESCRIPTION = `Execute code to achieve a goal.
 Available:
 {{types}}
 
-Write an async arrow function that returns the result.
+Write an async arrow function in JavaScript that returns the result.
+Do NOT use TypeScript syntax — no type annotations, interfaces, or generics.
 Do NOT define named functions then call them — just write the arrow function body directly.
 
 Example: async () => { const r = await codemode.searchWeb({ query: "test" }); return r; }`;


### PR DESCRIPTION
## Summary
- Updated the default tool description (`DEFAULT_DESCRIPTION`) to explicitly tell the LLM to write JavaScript and avoid TypeScript syntax (type annotations, interfaces, generics)
- Updated README intro to say "executable JavaScript" instead of "executable code" / "TypeScript APIs"
- Clarified that TypeScript type definitions are generated for LLM context, but execution is JavaScript

The `DynamicWorkerExecutor` only accepts JavaScript — models that emit TypeScript syntax hit `SyntaxError: Unexpected token ':'` at runtime.

Closes #959

## Test plan
- [x] Verify LLMs no longer emit TypeScript annotations when using the codemode tool
- [x] Confirm generated code still executes correctly in the Dynamic Worker sandbox