### PR TITLE
fix: make callbackHost optional in addMcpServer for non-OAuth servers

### DIFF
--- a/.changeset/lazy-mcp-oauth.md
+++ b/.changeset/lazy-mcp-oauth.md
@@ -1,0 +1,11 @@
+---
+"agents": patch
+---
+
+Make `callbackHost` optional in `addMcpServer` for non-OAuth servers
+
+Previously, `addMcpServer()` always required a `callbackHost` (either explicitly or derived from the request context) and eagerly created an OAuth auth provider, even when connecting to MCP servers that do not use OAuth. This made simple non-OAuth connections unnecessarily difficult, especially from WebSocket callable methods where the request context origin is unreliable.
+
+Now, `callbackHost` and the OAuth auth provider are only required when the MCP server actually needs OAuth (returns a 401/AUTHENTICATING state). For non-OAuth servers, `addMcpServer("name", url)` works with no additional options. If an OAuth server is encountered without a `callbackHost`, a clear error is thrown: "This MCP server requires OAuth authentication. Provide callbackHost in addMcpServer options to enable the OAuth flow."
+
+The restore-from-storage flow also handles missing callback URLs gracefully, skipping auth provider creation for non-OAuth servers.

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -60,7 +60,7 @@ export type MCPOAuthCallbackResult =
 export type RegisterServerOptions = {
   url: string;
   name: string;
-  callbackUrl: string;
+  callbackUrl?: string;
   client?: ConstructorParameters<typeof Client>[1];
   transport?: MCPTransportOptions;
   authUrl?: string;
@@ -322,17 +322,20 @@ export class MCPClientManager {
         ? JSON.parse(server.server_options)
         : null;
 
-      const authProvider = this._createAuthProviderFn
-        ? this._createAuthProviderFn(server.callback_url)
-        : this.createAuthProvider(
-            server.id,
-            server.callback_url,
-            clientName,
-            server.client_id ?? undefined
-          );
-      authProvider.serverId = server.id;
-      if (server.client_id) {
-        authProvider.clientId = server.client_id;
+      let authProvider: AgentMcpOAuthProvider | undefined;
+      if (server.callback_url) {
+        authProvider = this._createAuthProviderFn
+          ? this._createAuthProviderFn(server.callback_url)
+          : this.createAuthProvider(
+              server.id,
+              server.callback_url,
+              clientName,
+              server.client_id ?? undefined
+            );
+        authProvider.serverId = server.id;
+        if (server.client_id) {
+          authProvider.clientId = server.client_id;
+        }
       }
 
       // Create the in-memory connection object (no need to save to storage - we just read from it!)
@@ -611,7 +614,7 @@ export class MCPClientManager {
       id,
       name: options.name,
       server_url: options.url,
-      callback_url: options.callbackUrl,
+      callback_url: options.callbackUrl ?? "",
       client_id: options.clientId ?? null,
       auth_url: options.authUrl ?? null,
       server_options: JSON.stringify({

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -333,6 +333,11 @@ export class TestAddMcpServerAgent extends Agent<Record<string, unknown>> {
     return this.lastResolvedArgs!;
   }
 
+  async testNoOptions(name: string, url: string) {
+    await this.addMcpServer(name, url);
+    return this.lastResolvedArgs!;
+  }
+
   async testLegacyApiWithOptions(
     name: string,
     url: string,

--- a/packages/agents/src/tests/agents/state.ts
+++ b/packages/agents/src/tests/agents/state.ts
@@ -302,4 +302,20 @@ export class TestNoIdentityAgent extends Agent<
       };
     }
   }
+
+  // Test method: calls addMcpServer without callbackHost — should skip callbackPath enforcement
+  async testAddMcpServerWithoutCallbackHost(): Promise<{
+    threw: boolean;
+    message: string;
+  }> {
+    try {
+      await this.addMcpServer("test-server", "https://mcp.example.com");
+      return { threw: false, message: "" };
+    } catch (err) {
+      return {
+        threw: true,
+        message: err instanceof Error ? err.message : String(err)
+      };
+    }
+  }
 }

--- a/packages/agents/src/tests/mcp/add-mcp-server.test.ts
+++ b/packages/agents/src/tests/mcp/add-mcp-server.test.ts
@@ -38,6 +38,25 @@ describe("addMcpServer callbackPath enforcement", () => {
     );
   });
 
+  it("should not throw enforcement error when sendIdentityOnConnect is false and no callbackHost is provided", async () => {
+    const agentStub = await getAgentByName(
+      env.TestNoIdentityAgent,
+      "test-no-callback-host"
+    );
+    const result =
+      (await agentStub.testAddMcpServerWithoutCallbackHost()) as unknown as {
+        threw: boolean;
+        message: string;
+      };
+
+    // May throw for connection error, but should NOT throw the callbackPath enforcement error
+    if (result.threw) {
+      expect(result.message).not.toContain(
+        "callbackPath is required in addMcpServer options when sendIdentityOnConnect is false"
+      );
+    }
+  });
+
   it("should not throw enforcement error when sendIdentityOnConnect is false and callbackPath is provided", async () => {
     const agentStub = await getAgentByName(
       env.TestNoIdentityAgent,
@@ -99,6 +118,26 @@ describe("addMcpServer API overloads", () => {
         url: "https://minimal.example.com",
         callbackHost: undefined,
         agentsPrefix: "agents", // default
+        transport: undefined,
+        client: undefined
+      });
+    });
+
+    it("should work with no options at all (no callbackHost needed for non-OAuth servers)", async () => {
+      const agentStub = await getAgentByName(
+        env.TestAddMcpServerAgent,
+        "test-no-options"
+      );
+      const result = await agentStub.testNoOptions(
+        "simple-server",
+        "https://simple.example.com"
+      );
+
+      expect(result).toEqual({
+        serverName: "simple-server",
+        url: "https://simple.example.com",
+        callbackHost: undefined,
+        agentsPrefix: "agents",
         transport: undefined,
         client: undefined
       });


### PR DESCRIPTION
`addMcpServer()` previously required a `callbackHost` (either explicitly or derived from the request context) and eagerly created an OAuth auth provider for every connection, even when the MCP server does not use OAuth. This made simple non-OAuth connections unnecessarily difficult — especially from `@callable` methods where the request context origin is unreliable (it's the WebSocket upgrade request, not the client's origin).

This PR defers OAuth setup to when it's actually needed:

- `callbackHost`, `callbackUrl`, and `authProvider` are only constructed when a `callbackHost` is available
- If the MCP server responds with `AUTHENTICATING` (401) but no `callbackUrl` was configured, a clear error is thrown: *"This MCP server requires OAuth authentication. Provide callbackHost in addMcpServer options to enable the OAuth flow."*
- The restore-from-storage flow skips `authProvider` creation for servers with no stored `callback_url`
- `callbackPath` enforcement for `sendIdentityOnConnect: false` is only applied when a `callbackHost` is present (no callback URL to protect otherwise)

### Before
```ts
// Always required callbackHost, even for non-OAuth servers
await this.addMcpServer("my-server", url, {
  callbackHost: "https://my-app.workers.dev"
});
```
### After
```ts
// Non-OAuth servers: just name and URL
await this.addMcpServer("my-server", url);

// OAuth servers: provide callbackHost
await this.addMcpServer("oauth-server", url, {
  callbackHost: "https://my-app.workers.dev"
});
```