### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - run: npm run build
 
       - id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.7.0
         with:
           version: npx tsx .github/changeset-version.ts
           publish: npx tsx .github/changeset-publish.ts


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `changesets/action` | [`v1`](https://github.com/changesets/action/releases/tag/v1) | [`v1.7.0`](https://github.com/changesets/action/releases/tag/v1.7.0) | [Release](https://github.com/changesets/action/releases/tag/v1.7.0) | release.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
