### PR TITLE
feat(ai-chat): expose requestId in OnChatMessageOptions

### DIFF
--- a/.changeset/expose-request-id.md
+++ b/.changeset/expose-request-id.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Expose `requestId` in `OnChatMessageOptions` so handlers can send properly-tagged error responses for pre-stream failures.
+
+Also fix `saveMessages()` to pass the full options object (`requestId`, `abortSignal`, `clientTools`, `body`) to `onChatMessage` and use a consistent request ID for `_reply`.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -941,8 +941,15 @@ export class AIChatAgent<
   async saveMessages(messages: ChatMessage[]) {
     await this.persistMessages(messages);
     await this._tryCatchChat(async () => {
-      const response = await this.onChatMessage(() => {});
-      if (response) this._reply(crypto.randomUUID(), response);
+      const requestId = nanoid();
+      const abortSignal = this._getAbortSignal(requestId);
+      const response = await this.onChatMessage(() => {}, {
+        requestId,
+        abortSignal,
+        clientTools: this._lastClientTools,
+        body: this._lastBody
+      });
+      if (response) this._reply(requestId, response);
     });
   }
 

--- a/packages/ai-chat/src/tests/request-id.test.ts
+++ b/packages/ai-chat/src/tests/request-id.test.ts
@@ -1,0 +1,312 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import { MessageType } from "../types";
+import type { UIMessage as ChatMessage } from "ai";
+import { connectChatWS, isUseChatResponseMessage } from "./test-utils";
+import { getAgentByName } from "agents";
+
+/**
+ * Helper: send a chat request and wait for the done response.
+ * Returns the request ID that was sent.
+ */
+async function sendChatAndWaitForDone(
+  ws: WebSocket,
+  requestId: string,
+  messages: ChatMessage[],
+  extraBody?: Record<string, unknown>
+): Promise<void> {
+  let resolvePromise: (value: boolean) => void;
+  const donePromise = new Promise<boolean>((res) => {
+    resolvePromise = res;
+  });
+
+  const timeout = setTimeout(() => resolvePromise(false), 2000);
+
+  const handler = (e: MessageEvent) => {
+    const data = JSON.parse(e.data as string);
+    if (data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && data.done) {
+      clearTimeout(timeout);
+      resolvePromise(true);
+    }
+  };
+  ws.addEventListener("message", handler);
+
+  ws.send(
+    JSON.stringify({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+      id: requestId,
+      init: {
+        method: "POST",
+        body: JSON.stringify({ messages, ...extraBody })
+      }
+    })
+  );
+
+  const done = await donePromise;
+  ws.removeEventListener("message", handler);
+  expect(done).toBe(true);
+
+  // Allow handler to finish
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+describe("requestId in OnChatMessageOptions", () => {
+  it("should pass the client-sent request ID on initial chat messages", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.clearCapturedContext();
+
+    const userMessage: ChatMessage = {
+      id: "msg1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    await sendChatAndWaitForDone(ws, "my-request-123", [userMessage]);
+
+    const capturedId = await agentStub.getCapturedRequestId();
+    expect(capturedId).toBe("my-request-123");
+
+    ws.close(1000);
+  });
+
+  it("should pass a server-generated requestId on tool result continuation", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    // Step 1: Send initial request so context is established
+    await sendChatAndWaitForDone(ws, "initial-req", [userMessage]);
+
+    // Step 2: Persist a tool call in input-available state
+    const toolCallId = "call_reqid_test";
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-testTool",
+            toolCallId,
+            state: "input-available",
+            input: {}
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    // Step 3: Clear captured state before continuation
+    await agentStub.clearCapturedContext();
+
+    // Step 4: Send tool result with autoContinue
+    ws.send(
+      JSON.stringify({
+        type: "cf_agent_tool_result",
+        toolCallId,
+        toolName: "testTool",
+        output: { success: true },
+        autoContinue: true
+      })
+    );
+
+    // Wait for continuation (500ms stream wait + processing)
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // Step 5: Verify a requestId was passed (server-generated, so just check it exists)
+    const capturedId = await agentStub.getCapturedRequestId();
+    expect(capturedId).toBeDefined();
+    expect(typeof capturedId).toBe("string");
+    expect(capturedId!.length).toBeGreaterThan(0);
+    // Should NOT be the initial request ID — it's a new continuation ID
+    expect(capturedId).not.toBe("initial-req");
+
+    ws.close(1000);
+  });
+
+  it("should pass a server-generated requestId on tool approval continuation", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    // Step 1: Send initial request
+    await sendChatAndWaitForDone(ws, "initial-req", [userMessage]);
+
+    // Step 2: Persist a tool call in approval-required state
+    const toolCallId = "call_approval_test";
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-testTool",
+            toolCallId,
+            state: "input-available",
+            input: {}
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    // Step 3: Clear captured state
+    await agentStub.clearCapturedContext();
+
+    // Step 4: Send approval with autoContinue
+    ws.send(
+      JSON.stringify({
+        type: "cf_agent_tool_approval",
+        toolCallId,
+        approved: true,
+        autoContinue: true
+      })
+    );
+
+    // Wait for continuation
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // Step 5: Verify requestId was passed
+    const capturedId = await agentStub.getCapturedRequestId();
+    expect(capturedId).toBeDefined();
+    expect(typeof capturedId).toBe("string");
+    expect(capturedId!.length).toBeGreaterThan(0);
+    expect(capturedId).not.toBe("initial-req");
+
+    ws.close(1000);
+  });
+
+  it("should tag response messages with requestId so the client can match them", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+    const receivedMessages: Array<{ id: string; done: boolean }> = [];
+
+    ws.addEventListener("message", (e: MessageEvent) => {
+      const data = JSON.parse(e.data as string);
+      if (isUseChatResponseMessage(data)) {
+        receivedMessages.push({ id: data.id, done: !!data.done });
+      }
+    });
+
+    const userMessage: ChatMessage = {
+      id: "msg1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+        id: "tagged-req-42",
+        init: {
+          method: "POST",
+          body: JSON.stringify({ messages: [userMessage] })
+        }
+      })
+    );
+
+    // Wait for the done message
+    await new Promise<void>((resolve) => {
+      const interval = setInterval(() => {
+        if (receivedMessages.some((m) => m.done)) {
+          clearInterval(interval);
+          resolve();
+        }
+      }, 50);
+      setTimeout(() => {
+        clearInterval(interval);
+        resolve();
+      }, 2000);
+    });
+
+    // ALL response messages should be tagged with the same request ID
+    expect(receivedMessages.length).toBeGreaterThan(0);
+    for (const msg of receivedMessages) {
+      expect(msg.id).toBe("tagged-req-42");
+    }
+
+    ws.close(1000);
+  });
+
+  it("should allow handlers to send error responses using requestId (pre-stream failure use case)", async () => {
+    // This is the primary use case from the PR:
+    // An onChatMessage handler validates the request body BEFORE starting a stream.
+    // If validation fails, it needs the requestId to send a properly-tagged error
+    // message that the client transport will accept (it filters by data.id === requestId).
+    //
+    // We test this by verifying that requestId is available and matches the
+    // wire-protocol ID, so a handler *could* send:
+    //   connection.send(JSON.stringify({
+    //     type: "cf_agent_use_chat_response",
+    //     id: options.requestId,
+    //     body: "validation error",
+    //     done: true,
+    //     error: true
+    //   }));
+
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.clearCapturedContext();
+
+    const userMessage: ChatMessage = {
+      id: "msg1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    const clientRequestId = "client-error-test-id";
+    await sendChatAndWaitForDone(ws, clientRequestId, [userMessage]);
+
+    // Verify the requestId received in onChatMessage matches exactly
+    // what the client sent as data.id — this is the contract that lets
+    // handlers send tagged error responses
+    const capturedId = await agentStub.getCapturedRequestId();
+    expect(capturedId).toBe(clientRequestId);
+
+    ws.close(1000);
+  });
+
+  it("should pass requestId with different values across sequential requests", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    // First request
+    await agentStub.clearCapturedContext();
+    await sendChatAndWaitForDone(ws, "req-alpha", [userMessage]);
+    const firstId = await agentStub.getCapturedRequestId();
+    expect(firstId).toBe("req-alpha");
+
+    // Second request with different ID
+    await agentStub.clearCapturedContext();
+    await sendChatAndWaitForDone(ws, "req-beta", [userMessage]);
+    const secondId = await agentStub.getCapturedRequestId();
+    expect(secondId).toBe("req-beta");
+
+    // They should be different
+    expect(firstId).not.toBe(secondId);
+
+    ws.close(1000);
+  });
+});

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -38,14 +38,17 @@ export class TestChatAgent extends AIChatAgent<Env> {
   private _capturedBody: Record<string, unknown> | undefined = undefined;
   // Store captured clientTools from onChatMessage options for testing
   private _capturedClientTools: ClientToolSchema[] | undefined = undefined;
+  // Store captured requestId from onChatMessage options for testing
+  private _capturedRequestId: string | undefined = undefined;
 
   async onChatMessage(
     _onFinish: StreamTextOnFinishCallback<ToolSet>,
     options?: OnChatMessageOptions
   ) {
-    // Capture the body and clientTools from options for testing
+    // Capture the body, clientTools, and requestId from options for testing
     this._capturedBody = options?.body;
     this._capturedClientTools = options?.clientTools;
+    this._capturedRequestId = options?.requestId;
 
     // Capture getCurrentAgent() context for testing
     const { agent, connection } = getCurrentAgent();
@@ -100,6 +103,7 @@ export class TestChatAgent extends AIChatAgent<Env> {
     this._nestedContext = null;
     this._capturedBody = undefined;
     this._capturedClientTools = undefined;
+    this._capturedRequestId = undefined;
   }
 
   getCapturedBody(): Record<string, unknown> | undefined {
@@ -108,6 +112,10 @@ export class TestChatAgent extends AIChatAgent<Env> {
 
   getCapturedClientTools(): ClientToolSchema[] | undefined {
     return this._capturedClientTools;
+  }
+
+  getCapturedRequestId(): string | undefined {
+    return this._capturedRequestId;
   }
 
   getPersistedMessages(): ChatMessage[] {


### PR DESCRIPTION
## Summary

- Add `requestId: string` to `OnChatMessageOptions`
- Pass the ID at all 3 `onChatMessage` call sites (initial request, tool continuation, approval continuation)

## Problem

`onChatMessage` handlers cannot send error responses for pre-stream failures (e.g. body validation, auth checks) because they lack the request ID needed to tag `CF_AGENT_USE_CHAT_RESPONSE` messages. The client transport filters by `data.id !== requestId`, so messages without the correct ID are silently dropped.

The connection is accessible via `getCurrentAgent().connection`, but without the request ID there is no way to construct a message the client will accept.

Current workarounds are all bad:
- **Throw** → `_tryCatchChat` → `onError` → PartyServer swallows it. Client stream hangs forever.
- **Return error Response** → `_reply` sends it as a normal assistant text message (no `error: true` flag). Client renders a Zod error as if the assistant said it.
- **`safeParse` + silent fallback** → Bad input is invisible. Works but masks client bugs.

## Solution

Expose the request ID that already exists at each call site:

| Call site | ID source |
|-----------|-----------|
| Initial chat request | `data.id` (client-generated) |
| Tool continuation | `continuationId` (server-generated via `nanoid()`) |
| Approval continuation | `continuationId` (server-generated via `nanoid()`) |

This lets `onChatMessage` send properly-tagged error responses:

```ts
async onChatMessage(onFinish, options) {
  const result = MySchema.safeParse(options?.body);
  if (!result.success) {
    const { connection } = getCurrentAgent();
    connection?.send(JSON.stringify({
      type: "cf_agent_use_chat_response",
      id: options.requestId,
      body: result.error.message,
      done: true,
      error: true,
    }));
    return; // no Response needed
  }
  // ... normal flow
}
```

Non-breaking: `requestId` is a new required field on `OnChatMessageOptions`, but this type is only constructed internally by `AIChatAgent` — user code receives it, never constructs it.