### PR TITLE
fix(ai-chat): ensure jsonSchema initialized before onChatMessage

### DIFF
--- a/.changeset/fix-jsonschema-init.md
+++ b/.changeset/fix-jsonschema-init.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix jsonSchema not initialized error when calling getAITools() in onChatMessage

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -362,6 +362,9 @@ export class AIChatAgent<
     // Wrap onMessage
     const _onMessage = this.onMessage.bind(this);
     this.onMessage = async (connection: Connection, message: WSMessage) => {
+      // Ensure jsonSchema is initialized for getAITools() (matches base Agent pattern)
+      await this.mcp.ensureJsonSchema();
+
       // Handle AIChatAgent's internal messages first
       if (typeof message === "string") {
         let data: IncomingMessage;


### PR DESCRIPTION
## Summary

- Fix `jsonSchema not initialized` error when calling `getAITools()` in `onChatMessage`

## Problem

After PR #565 (RPC transport), the base `Agent` class wraps `onMessage` to call `ensureJsonSchema()` before processing messages. However, `AIChatAgent` re-wraps `onMessage` in its constructor and handles chat messages directly without going through the base wrapper.

This caused `getAITools()` to throw "jsonSchema not initialized" when called in `onChatMessage()`.

## Fix

Add `await this.mcp.ensureJsonSchema()` to `AIChatAgent`'s `onMessage` wrapper, matching the pattern used in the base `Agent` class.

## Test plan

- [x] Deployed codemode example and verified chat messages work without error
- [x] Verified MCP tools can be retrieved via `getAITools()` in `onChatMessage`