### PR TITLE
fix: preserve Anthropic redacted_thinking blocks in message sanitization

### DIFF
--- a/.changeset/fix-redacted-thinking.md
+++ b/.changeset/fix-redacted-thinking.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix `_sanitizeMessageForPersistence` stripping Anthropic `redacted_thinking` blocks. The sanitizer now strips OpenAI ephemeral metadata first, then filters out only reasoning parts that are truly empty (no text and no remaining `providerMetadata`). This preserves Anthropic's `redacted_thinking` blocks (stored as empty-text reasoning parts with `providerMetadata.anthropic.redactedData`) while still removing OpenAI placeholders. Fixes #978.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -1219,36 +1219,25 @@ export class AIChatAgent<
    * Sanitizes a message for persistence by removing ephemeral provider-specific
    * data that should not be stored or sent back in subsequent requests.
    *
-   * This handles two issues with the OpenAI Responses API:
+   * Two-step process:
    *
-   * 1. **Duplicate item IDs**: The AI SDK's @ai-sdk/openai provider (v2.0.x+)
-   *    defaults to using OpenAI's Responses API which assigns unique itemIds
-   *    to each message part. When these IDs are persisted and sent back,
-   *    OpenAI rejects them as duplicates.
+   * 1. **Strip OpenAI ephemeral fields**: The AI SDK's @ai-sdk/openai provider
+   *    (v2.0.x+) defaults to using OpenAI's Responses API which assigns unique
+   *    itemIds and reasoningEncryptedContent to message parts. When persisted
+   *    and sent back, OpenAI rejects duplicate itemIds.
    *
-   * 2. **Empty reasoning parts**: OpenAI may return reasoning parts with empty
-   *    text and encrypted content. These cause "Non-OpenAI reasoning parts are
-   *    not supported" warnings when sent back via convertToModelMessages().
+   * 2. **Filter truly empty reasoning parts**: After stripping, reasoning parts
+   *    with no text and no remaining providerMetadata are removed. Parts that
+   *    still carry providerMetadata (e.g. Anthropic's redacted_thinking blocks
+   *    with providerMetadata.anthropic.redactedData) are preserved, as they
+   *    contain data required for round-tripping with the provider API.
    *
    * @param message - The message to sanitize
    * @returns A new message with ephemeral provider data removed
    */
   private _sanitizeMessageForPersistence(message: ChatMessage): ChatMessage {
-    // First, filter out empty reasoning parts (they have no useful content)
-    const filteredParts = message.parts.filter((part) => {
-      if (part.type === "reasoning") {
-        const reasoningPart = part as ReasoningUIPart;
-        // Remove reasoning parts that have no text content
-        // These are typically placeholders with only encrypted content
-        if (!reasoningPart.text || reasoningPart.text.trim() === "") {
-          return false;
-        }
-      }
-      return true;
-    });
-
-    // Then sanitize remaining parts by stripping OpenAI-specific ephemeral data
-    const sanitizedParts = filteredParts.map((part) => {
+    // First, strip OpenAI-specific ephemeral data from all parts
+    const strippedParts = message.parts.map((part) => {
       let sanitizedPart = part;
 
       // Strip providerMetadata.openai.itemId and reasoningEncryptedContent
@@ -1279,6 +1268,28 @@ export class AIChatAgent<
 
       return sanitizedPart;
     }) as ChatMessage["parts"];
+
+    // Then filter out reasoning parts that are truly empty (no text and no
+    // remaining providerMetadata). This removes OpenAI placeholders whose
+    // metadata was just stripped, while preserving provider-specific blocks
+    // like Anthropic's redacted_thinking that carry data in providerMetadata.
+    const sanitizedParts = strippedParts.filter((part) => {
+      if (part.type === "reasoning") {
+        const reasoningPart = part as ReasoningUIPart;
+        if (!reasoningPart.text || reasoningPart.text.trim() === "") {
+          if (
+            "providerMetadata" in reasoningPart &&
+            reasoningPart.providerMetadata &&
+            typeof reasoningPart.providerMetadata === "object" &&
+            Object.keys(reasoningPart.providerMetadata).length > 0
+          ) {
+            return true;
+          }
+          return false;
+        }
+      }
+      return true;
+    });
 
     return { ...message, parts: sanitizedParts };
   }


### PR DESCRIPTION
## Problem

`_sanitizeMessageForPersistence` in `AIChatAgent` was incorrectly stripping Anthropic's `redacted_thinking` blocks. These blocks are stored as reasoning parts with empty text but carry critical data in `providerMetadata.anthropic.redactedData`. When stripped, the Anthropic API rejects subsequent requests because the conversation history is incomplete.

Fixes #978

## Root Cause

The sanitizer filtered out **all** empty reasoning parts unconditionally. This was designed for OpenAI's ephemeral reasoning placeholders but also caught Anthropic's `redacted_thinking` blocks, which must be preserved for round-tripping.

## Solution

Refactored `_sanitizeMessageForPersistence` from a filter-then-strip approach to a **strip-then-filter** approach:

1. **Strip** OpenAI ephemeral metadata (`itemId`, `reasoningEncryptedContent`) from all parts first
2. **Filter** reasoning parts that are truly empty — no text AND no remaining `providerMetadata`

This is **provider-agnostic**: any provider that stores meaningful data in `providerMetadata` on reasoning parts will be preserved automatically. OpenAI placeholders (whose metadata was stripped in step 1) are still correctly removed. Future providers with similar patterns will work without code changes.

### How providers use `providerMetadata` on reasoning parts

| Provider | Metadata | Empty text? | Must preserve? |
|----------|----------|-------------|----------------|
| **Anthropic** | `{ anthropic: { redactedData: "..." } }` | Yes | Yes — required for API round-trip |
| **Anthropic** | `{ anthropic: { signature: "..." } }` | No (has thinking text) | Yes — but was never affected |
| **OpenAI** | `{ openai: { itemId: "...", reasoningEncryptedContent: "..." } }` | Can be | No — ephemeral, stripped |

## Changes

- **`packages/ai-chat/src/index.ts`** — Reordered sanitization steps + updated JSDoc
- **`packages/ai-chat/src/tests/sanitize-messages.test.ts`** — Added 2 new tests:
  - Anthropic `redacted_thinking` blocks (empty text + `providerMetadata.anthropic`) are preserved
  - OpenAI empty reasoning placeholders are still removed after strip-then-filter

## Testing

All 219 tests pass across 24 test files (`npm run test`).