### PR TITLE
fix(ai-chat): abort/cancel support for streaming responses

### DIFF
--- a/.changeset/fix-ai-chat-abort-cancel.md
+++ b/.changeset/fix-ai-chat-abort-cancel.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix abort/cancel support for streaming responses. The framework now properly cancels the reader loop when the abort signal fires and sends a done signal to the client. Added a warning log when cancellation arrives but the stream has not closed (indicating the user forgot to pass `abortSignal` to their LLM call). Also fixed vitest project configs to scope test file discovery and prevent e2e/react tests from being picked up by the wrong runner.

--- a/examples/ai-chat/src/client.tsx
+++ b/examples/ai-chat/src/client.tsx
@@ -19,6 +19,7 @@ import {
 } from "@cloudflare/agents-ui";
 import {
   PaperPlaneRightIcon,
+  StopIcon,
   TrashIcon,
   CheckCircleIcon,
   XCircleIcon,
@@ -54,6 +55,7 @@ function Chat() {
     sendMessage,
     clearHistory,
     addToolApprovalResponse,
+    stop,
     status
   } = useAgentChat({
     agent,
@@ -333,16 +335,27 @@ function Chat() {
               rows={2}
               className="flex-1 !ring-0 focus:!ring-0 !shadow-none !bg-transparent !outline-none"
             />
-            <Button
-              type="submit"
-              variant="primary"
-              shape="square"
-              aria-label="Send message"
-              disabled={!input.trim() || !isConnected || isStreaming}
-              icon={<PaperPlaneRightIcon size={18} />}
-              loading={isStreaming}
-              className="mb-0.5"
-            />
+            {isStreaming ? (
+              <Button
+                type="button"
+                variant="secondary"
+                shape="square"
+                aria-label="Stop streaming"
+                onClick={stop}
+                icon={<StopIcon size={18} weight="fill" />}
+                className="mb-0.5"
+              />
+            ) : (
+              <Button
+                type="submit"
+                variant="primary"
+                shape="square"
+                aria-label="Send message"
+                disabled={!input.trim() || !isConnected}
+                icon={<PaperPlaneRightIcon size={18} />}
+                className="mb-0.5"
+              />
+            )}
           </div>
         </form>
         <div className="flex justify-center pb-3">

--- a/examples/ai-chat/src/server.ts
+++ b/examples/ai-chat/src/server.ts
@@ -1,6 +1,6 @@
 import { createWorkersAI } from "workers-ai-provider";
 import { routeAgentRequest } from "agents";
-import { AIChatAgent } from "@cloudflare/ai-chat";
+import { AIChatAgent, type OnChatMessageOptions } from "@cloudflare/ai-chat";
 import {
   streamText,
   convertToModelMessages,
@@ -23,10 +23,11 @@ export class ChatAgent extends AIChatAgent {
   // Keep the last 200 messages in SQLite storage
   maxPersistedMessages = 200;
 
-  async onChatMessage() {
+  async onChatMessage(_onFinish: unknown, options?: OnChatMessageOptions) {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
+      abortSignal: options?.abortSignal,
       model: workersai("@cf/zai-org/glm-4.7-flash"),
       system:
         "You are a helpful assistant. You can check the weather, get the user's timezone, " +

--- a/packages/ai-chat/src/react-tests/vitest.config.ts
+++ b/packages/ai-chat/src/react-tests/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "react",
+    include: ["**/*.test.{ts,tsx}"],
     browser: {
       enabled: true,
       instances: [

--- a/packages/ai-chat/src/tests/cancel-request.test.ts
+++ b/packages/ai-chat/src/tests/cancel-request.test.ts
@@ -1,0 +1,280 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import { MessageType } from "../types";
+import type { UIMessage as ChatMessage } from "ai";
+import { connectChatWS, isUseChatResponseMessage } from "./test-utils";
+import { getAgentByName } from "agents";
+
+/**
+ * Helper: connect to the SlowStreamAgent
+ */
+function connectSlowStream(room: string) {
+  return connectChatWS(`/agents/slow-stream-agent/${room}`);
+}
+
+/**
+ * Helper: send a chat request with custom body fields
+ */
+function sendChatRequest(
+  ws: WebSocket,
+  requestId: string,
+  messages: ChatMessage[],
+  extraBody?: Record<string, unknown>
+) {
+  ws.send(
+    JSON.stringify({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+      id: requestId,
+      init: {
+        method: "POST",
+        body: JSON.stringify({ messages, ...extraBody })
+      }
+    })
+  );
+}
+
+/**
+ * Helper: send a cancel request
+ */
+function sendCancel(ws: WebSocket, requestId: string) {
+  ws.send(
+    JSON.stringify({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: requestId
+    })
+  );
+}
+
+/**
+ * Helper: collect messages from a WebSocket until a done message arrives or timeout
+ */
+function collectMessages(
+  ws: WebSocket,
+  timeoutMs = 5000
+): Promise<{ messages: unknown[]; timedOut: boolean }> {
+  const messages: unknown[] = [];
+  let resolve: (value: { messages: unknown[]; timedOut: boolean }) => void;
+  const promise = new Promise<{ messages: unknown[]; timedOut: boolean }>(
+    (r) => {
+      resolve = r;
+    }
+  );
+
+  const timeout = setTimeout(() => {
+    ws.removeEventListener("message", handler);
+    resolve({ messages, timedOut: true });
+  }, timeoutMs);
+
+  function handler(e: MessageEvent) {
+    const data = JSON.parse(e.data as string);
+    messages.push(data);
+    if (isUseChatResponseMessage(data) && data.done) {
+      clearTimeout(timeout);
+      ws.removeEventListener("message", handler);
+      resolve({ messages, timedOut: false });
+    }
+  }
+
+  ws.addEventListener("message", handler);
+  return promise;
+}
+
+const userMessage: ChatMessage = {
+  id: "msg1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }]
+};
+
+describe("Cancel request", () => {
+  it("cancel during plaintext streaming sends done and stops chunks", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const requestId = "req-cancel-plain";
+
+    // Start collecting messages
+    const collecting = collectMessages(ws);
+
+    // Send a slow plaintext streaming request (20 chunks × 50ms = ~1s total)
+    sendChatRequest(ws, requestId, [userMessage], {
+      format: "plaintext",
+      chunkCount: 20,
+      chunkDelayMs: 50
+    });
+
+    // Wait for a couple of chunks to arrive, then cancel
+    await new Promise((r) => setTimeout(r, 200));
+    sendCancel(ws, requestId);
+
+    const { messages, timedOut } = await collecting;
+    expect(timedOut).toBe(false);
+
+    // Should have received a done message
+    const chatResponses = messages.filter(isUseChatResponseMessage);
+    const doneMsg = chatResponses.find((m) => m.done === true);
+    expect(doneMsg).toBeDefined();
+
+    // Should NOT have received all 20 chunks worth of text-delta events
+    // (we cancelled after ~200ms, which is ~4 chunks at 50ms each)
+    const textDeltas = chatResponses.filter((m) => {
+      if (!m.body || typeof m.body !== "string" || m.body.length === 0)
+        return false;
+      try {
+        const parsed = JSON.parse(m.body);
+        return parsed.type === "text-delta";
+      } catch {
+        return false;
+      }
+    });
+    expect(textDeltas.length).toBeLessThan(20);
+
+    ws.close(1000);
+  });
+
+  it("cancel during SSE streaming sends done and stops chunks", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const requestId = "req-cancel-sse";
+
+    const collecting = collectMessages(ws);
+
+    sendChatRequest(ws, requestId, [userMessage], {
+      format: "sse",
+      chunkCount: 20,
+      chunkDelayMs: 50
+    });
+
+    // Wait for some chunks then cancel
+    await new Promise((r) => setTimeout(r, 200));
+    sendCancel(ws, requestId);
+
+    const { messages, timedOut } = await collecting;
+    expect(timedOut).toBe(false);
+
+    // Should have received a done message
+    const chatResponses = messages.filter(isUseChatResponseMessage);
+    const doneMsg = chatResponses.find((m) => m.done === true);
+    expect(doneMsg).toBeDefined();
+
+    // Should have fewer chunks than a full stream
+    const dataChunks = chatResponses.filter(
+      (m) => m.body && typeof m.body === "string" && m.body.length > 0
+    );
+    expect(dataChunks.length).toBeLessThan(20);
+
+    ws.close(1000);
+  });
+
+  it("abort controller is cleaned up after cancel", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    const requestId = "req-cancel-cleanup";
+    const collecting = collectMessages(ws);
+
+    sendChatRequest(ws, requestId, [userMessage], {
+      format: "plaintext",
+      chunkCount: 20,
+      chunkDelayMs: 50
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    sendCancel(ws, requestId);
+
+    await collecting;
+
+    // Allow cleanup to complete
+    await new Promise((r) => setTimeout(r, 200));
+
+    const count = await agentStub.getAbortControllerCount();
+    expect(count).toBe(0);
+
+    ws.close(1000);
+  });
+
+  it("cancel with abortSignal wired to stream stops faster", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const requestId = "req-cancel-with-signal";
+    const collecting = collectMessages(ws);
+
+    sendChatRequest(ws, requestId, [userMessage], {
+      format: "plaintext",
+      useAbortSignal: true,
+      chunkCount: 20,
+      chunkDelayMs: 50
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    sendCancel(ws, requestId);
+
+    const { messages, timedOut } = await collecting;
+    expect(timedOut).toBe(false);
+
+    // Should have received done
+    const chatResponses = messages.filter(isUseChatResponseMessage);
+    const doneMsg = chatResponses.find((m) => m.done === true);
+    expect(doneMsg).toBeDefined();
+
+    // Abort controller should be cleaned up
+    await new Promise((r) => setTimeout(r, 200));
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+    const count = await agentStub.getAbortControllerCount();
+    expect(count).toBe(0);
+
+    ws.close(1000);
+  });
+
+  it("completing a full stream without cancel produces no abort-related issues", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const requestId = "req-no-cancel";
+    const collecting = collectMessages(ws);
+
+    // Send a fast request that completes naturally
+    sendChatRequest(ws, requestId, [userMessage], {
+      format: "plaintext",
+      chunkCount: 3,
+      chunkDelayMs: 10
+    });
+
+    const { messages, timedOut } = await collecting;
+    expect(timedOut).toBe(false);
+
+    // Should have received all chunks + done
+    const chatResponses = messages.filter(isUseChatResponseMessage);
+    const doneMsg = chatResponses.find((m) => m.done === true);
+    expect(doneMsg).toBeDefined();
+
+    // Should have all 3 text-delta events
+    const textDeltas = chatResponses.filter((m) => {
+      if (!m.body || typeof m.body !== "string" || m.body.length === 0)
+        return false;
+      try {
+        const parsed = JSON.parse(m.body);
+        return parsed.type === "text-delta";
+      } catch {
+        return false;
+      }
+    });
+    expect(textDeltas.length).toBe(3);
+
+    // Abort controller should be cleaned up
+    await new Promise((r) => setTimeout(r, 100));
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+    const count = await agentStub.getAbortControllerCount();
+    expect(count).toBe(0);
+
+    ws.close(1000);
+  });
+});

--- a/packages/ai-chat/src/tests/vitest.config.ts
+++ b/packages/ai-chat/src/tests/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 export default defineWorkersConfig({
   test: {
     name: "workers",
+    include: ["**/*.test.ts"],
     deps: {
       optimizer: {
         ssr: {

--- a/packages/ai-chat/src/tests/wrangler.jsonc
+++ b/packages/ai-chat/src/tests/wrangler.jsonc
@@ -21,6 +21,10 @@
       {
         "class_name": "AgentWithoutSuperCall",
         "name": "AgentWithoutSuperCall"
+      },
+      {
+        "class_name": "SlowStreamAgent",
+        "name": "SlowStreamAgent"
       }
     ]
   },
@@ -37,6 +41,10 @@
     {
       "new_sqlite_classes": ["AgentWithoutSuperCall"],
       "tag": "v3"
+    },
+    {
+      "new_sqlite_classes": ["SlowStreamAgent"],
+      "tag": "v4"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the stop button in AI Chat so it properly aborts streaming responses, and adds a framework-level safety net for cancellation.

### What changed

**Framework (`@cloudflare/ai-chat`)**

- **Abort signal propagation in `_reply`, `_streamSSEReply`, `_sendPlaintextReply`**: When the abort signal fires, the reader loop is now cancelled and a done signal is sent to the client. Previously, cancelling a request would send the cancel message but the server-side stream would keep running until it finished naturally.
- **Warning log**: If cancellation arrives but the stream has not closed, a warning is logged suggesting the developer forgot to pass `abortSignal` to their LLM call (e.g. `streamText`). This helps catch a common misconfiguration.

**Example (`examples/ai-chat`)**

- Pass `options.abortSignal` through to `streamText` in `server.ts` so the upstream LLM call is actually cancelled when the user hits stop.

**Test infrastructure**

- Added `cancel-request.test.ts` with 5 tests covering: plaintext cancel, SSE cancel, abort controller cleanup, cancel with abortSignal wired, and full stream completion without cancel.
- Added `SlowStreamAgent` test fixture that streams chunks with configurable delays.
- Fixed vitest project configs (`src/tests/vitest.config.ts`, `src/react-tests/vitest.config.ts`) to add explicit `include` patterns. Without these, vitest's default glob was picking up `e2e/*.spec.ts` files and trying to run them in the Workers pool (causing `No such module "node:child_process"` errors) and react-test files in the wrong runner.

### Reviewer notes

- The core abort logic lives in `packages/ai-chat/src/index.ts` around the `_reply`, `_streamSSEReply`, and `_sendPlaintextReply` methods. Look for the `abortSignal` event listener pattern — when abort fires, we cancel the reader, send the done signal, and log a warning if the stream was still open.
- The vitest config fix is minimal (`include` globs) but important — without it, `npm run test` from the ai-chat package root would fail on CI because Playwright e2e tests and browser-mode react tests got picked up by the Workers pool. The e2e tests are intentionally separate and run via `npm run test:e2e` / the nightly CI workflow.
- The `SlowStreamAgent` in `worker.ts` is a test-only Durable Object. It simulates a slow LLM by yielding chunks with `setTimeout` delays, which gives the cancel tests enough time to send a cancel message mid-stream.
- All 223 existing tests continue to pass, plus the 5 new cancel tests.

### Testing

```bash
# Unit/integration tests (workers pool)
cd packages/ai-chat && npx vitest run

# 25 files, 223 tests — all pass
```