### PR TITLE
fix(ai-chat): terminate WebSocket chat transport stream on abort

### DIFF
--- a/.changeset/ws-transport-abort-stream.md
+++ b/.changeset/ws-transport-abort-stream.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Terminate the WebSocket chat transport stream when the abort signal fires so
+clients exit the "streaming" state after stop/cancel.

--- a/packages/ai-chat/src/tests/ws-transport-abort.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-abort.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import type { UIMessage as ChatMessage, UIMessageChunk } from "ai";
+import { connectChatWS } from "./test-utils";
+import { WebSocketChatTransport } from "../ws-chat-transport";
+
+function connectSlowStream(room: string) {
+  return connectChatWS(`/agents/slow-stream-agent/${room}`);
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error("Timed out")), timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  }) as Promise<T>;
+}
+
+async function readUntilDoneOrAbort(
+  reader: ReadableStreamDefaultReader<unknown>,
+  timeoutMs: number
+) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error("Timed out waiting for stream to end");
+
+    try {
+      const result = await withTimeout(reader.read(), remaining);
+      if (result.done) return;
+    } catch (err) {
+      if (err && typeof err === "object" && "name" in err) {
+        if ((err as { name: unknown }).name === "AbortError") return;
+      }
+      throw err;
+    }
+  }
+}
+
+async function collectChunks(
+  stream: ReadableStream<UIMessageChunk>,
+  timeoutMs: number
+): Promise<UIMessageChunk[]> {
+  const reader = stream.getReader();
+  const chunks: UIMessageChunk[] = [];
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error("Timed out collecting chunks");
+
+    const result = await withTimeout(reader.read(), remaining);
+    if (result.done) break;
+    chunks.push(result.value);
+  }
+  return chunks;
+}
+
+const userMessage: ChatMessage = {
+  id: "msg1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }]
+};
+
+describe("WebSocketChatTransport abort", () => {
+  it("terminates the stream when abortSignal fires mid-stream", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      const transport = new WebSocketChatTransport<ChatMessage>({
+        agent: ws
+      });
+      const abortController = new AbortController();
+
+      const stream = await transport.sendMessages({
+        chatId: "chat",
+        messages: [userMessage],
+        abortSignal: abortController.signal,
+        trigger: "submit-message",
+        body: {
+          format: "plaintext",
+          chunkCount: 20,
+          chunkDelayMs: 50
+        }
+      });
+
+      const reader = stream.getReader();
+
+      // Abort mid-stream. Without proper stream termination, this would hang.
+      setTimeout(() => abortController.abort(), 200);
+
+      await expect(readUntilDoneOrAbort(reader, 5000)).resolves.toBeUndefined();
+    } finally {
+      ws.close(1000);
+    }
+  });
+
+  it("terminates immediately when abortSignal is already aborted", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      const transport = new WebSocketChatTransport<ChatMessage>({
+        agent: ws
+      });
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      const stream = await transport.sendMessages({
+        chatId: "chat",
+        messages: [userMessage],
+        abortSignal: abortController.signal,
+        trigger: "submit-message",
+        body: {
+          format: "plaintext",
+          chunkCount: 20,
+          chunkDelayMs: 50
+        }
+      });
+
+      const reader = stream.getReader();
+
+      // Should terminate immediately — no waiting for chunks
+      await expect(readUntilDoneOrAbort(reader, 1000)).resolves.toBeUndefined();
+    } finally {
+      ws.close(1000);
+    }
+  });
+
+  it("stream.cancel() sends cancel to server and terminates", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      const transport = new WebSocketChatTransport<ChatMessage>({
+        agent: ws
+      });
+
+      const stream = await transport.sendMessages({
+        chatId: "chat",
+        messages: [userMessage],
+        abortSignal: undefined,
+        trigger: "submit-message",
+        body: {
+          format: "plaintext",
+          chunkCount: 20,
+          chunkDelayMs: 50
+        }
+      });
+
+      // Let a few chunks arrive
+      await new Promise((r) => setTimeout(r, 200));
+
+      // cancel() should not hang — it sends CF_AGENT_CHAT_REQUEST_CANCEL
+      // and terminates the stream
+      await expect(withTimeout(stream.cancel(), 2000)).resolves.toBeUndefined();
+    } finally {
+      ws.close(1000);
+    }
+  });
+
+  it("completes normally when stream finishes without abort", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      const transport = new WebSocketChatTransport<ChatMessage>({
+        agent: ws
+      });
+
+      const stream = await transport.sendMessages({
+        chatId: "chat",
+        messages: [userMessage],
+        abortSignal: undefined,
+        trigger: "submit-message",
+        body: {
+          format: "plaintext",
+          chunkCount: 3,
+          chunkDelayMs: 10
+        }
+      });
+
+      const chunks = await collectChunks(stream, 5000);
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+    } finally {
+      ws.close(1000);
+    }
+  });
+});

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -107,25 +107,53 @@ export class WebSocketChatTransport<
     // Track this request so the onAgentMessage handler skips it
     this.activeRequestIds?.add(requestId);
 
-    // Handle abort from the caller (only if the stream has not already completed)
-    options.abortSignal?.addEventListener("abort", () => {
-      if (completed) return;
-      this.agent.send(
-        JSON.stringify({
-          id: requestId,
-          type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL
-        })
-      );
-      this.activeRequestIds?.delete(requestId);
-      abortController.abort();
-    });
-
     // Create a ReadableStream<UIMessageChunk> that emits parsed chunks
     // as they arrive over the WebSocket
     const agent = this.agent;
     const activeIds = this.activeRequestIds;
+
+    // Single cleanup helper — every terminal path (done, error, abort)
+    // goes through here exactly once.
+    const finish = (action: () => void) => {
+      if (completed) return;
+      completed = true;
+      try {
+        action();
+      } catch {
+        // Stream may already be closed
+      }
+      activeIds?.delete(requestId);
+      abortController.abort();
+    };
+
+    const abortError = new Error("Aborted");
+    abortError.name = "AbortError";
+
+    // Abort handler: send cancel to server, then terminate the stream.
+    // Used by both the caller's abortSignal and stream.cancel().
+    const onAbort = () => {
+      if (completed) return;
+      try {
+        agent.send(
+          JSON.stringify({
+            id: requestId,
+            type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL
+          })
+        );
+      } catch {
+        // Ignore failures (e.g. agent already disconnected)
+      }
+      finish(() => streamController.error(abortError));
+    };
+
+    // streamController is assigned synchronously by start(), so it is
+    // always available by the time onAbort or onMessage can fire.
+    let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+
     const stream = new ReadableStream<UIMessageChunk>({
       start(controller) {
+        streamController = controller;
+
         const onMessage = (event: MessageEvent) => {
           try {
             const data = JSON.parse(
@@ -136,10 +164,7 @@ export class WebSocketChatTransport<
             if (data.id !== requestId) return;
 
             if (data.error) {
-              completed = true;
-              controller.error(new Error(data.body));
-              activeIds?.delete(requestId);
-              abortController.abort();
+              finish(() => controller.error(new Error(data.body)));
               return;
             }
 
@@ -154,14 +179,7 @@ export class WebSocketChatTransport<
             }
 
             if (data.done) {
-              completed = true;
-              try {
-                controller.close();
-              } catch {
-                // Stream may already be closed
-              }
-              activeIds?.delete(requestId);
-              abortController.abort();
+              finish(() => controller.close());
             }
           } catch {
             // Ignore non-JSON messages
@@ -173,9 +191,15 @@ export class WebSocketChatTransport<
         });
       },
       cancel() {
-        abortController.abort();
+        onAbort();
       }
     });
+
+    // Handle abort from the caller
+    if (options.abortSignal) {
+      options.abortSignal.addEventListener("abort", onAbort, { once: true });
+      if (options.abortSignal.aborted) onAbort();
+    }
 
     // Send the request over WebSocket
     agent.send(


### PR DESCRIPTION
## Summary

Fixes #985

The `ReadableStream` returned by `WebSocketChatTransport.sendMessages()` was never terminated when the caller's `AbortSignal` fired or `stream.cancel()` was called. This left `useChat` stuck in the "streaming" state after the user clicked Stop/Cancel.

## What changed

**`packages/ai-chat/src/ws-chat-transport.ts`**

- All three terminal paths (done, error, abort) now funnel through a single `finish(action)` helper that gates on a `completed` flag, cleans up `activeRequestIds`, and detaches the WS listener via `abortController.abort()`.
- `onAbort()` sends `CF_AGENT_CHAT_REQUEST_CANCEL` to the server (best-effort), then errors the stream with an `AbortError` via `finish()`.
- `stream.cancel()` delegates to `onAbort()`, so cancelling the stream from the consumer side also notifies the server.
- The caller's `abortSignal` listener is registered with `{ once: true }` and handles already-aborted signals.

**`packages/ai-chat/src/tests/ws-transport-abort.test.ts`** (new)

Four test cases exercising the transport directly:
1. **Mid-stream abort** — aborts after 200ms, verifies the stream terminates (the original regression)
2. **Pre-aborted signal** — passes an already-aborted signal, verifies immediate termination
3. **`stream.cancel()`** — verifies cancel completes without hanging
4. **Normal completion** — sanity check that the happy path still works through the transport

## How this differs from the proposed fix in #985

The [community fix](https://github.com/Jerrynh770/agents/commit/7e77dcecf66c70f4430be2df001fabe87830cd36) is correct and solves the bug, but our implementation simplifies the approach:

| Aspect | Proposed fix | This PR |
|---|---|---|
| State flags | Two flags (`abortRequested` + `completed`) | One flag (`completed`) |
| Cleanup helpers | Two functions (`requestAbort` + `completeAbort`) | One function (`finish`) |
| `start()` race guard | Checks `abortRequested` in `start()` to handle "abort before stream starts" | Removed — `start()` runs synchronously during `ReadableStream` construction, so `streamController` is always set before any listener can fire |
| Cleanup duplication | `done`/`error` paths in `onMessage` have separate inline cleanup | All paths use `finish()` |
| Tests | 1 test (mid-stream abort) | 4 tests |

## Notes for reviewers

- **Definite assignment assertion**: `let streamController!: ReadableStreamDefaultController` uses `!` which is new to this codebase. The comment above it explains why it is safe (synchronous `start()`). If you prefer `| undefined` with optional chaining, happy to change.
- **Pre-aborted signal still sends the WS request**: If the signal is already aborted when `sendMessages()` is called, `onAbort()` fires immediately but the request is still sent on the next line. This is harmless — the server receives the cancel and stops, and the client stream is already errored. Adding a guard would be possible but adds complexity for a negligible edge case.
- **Hibernation**: This change is client-side only and does not affect the server-side resumable streaming mechanism. Stream resumption after hibernation/reconnect flows through the `useAgentChat` hook's `onAgentMessage` handler (`CF_AGENT_STREAM_RESUMING` protocol), which is a separate path from the transport's `ReadableStream`.
- **All 206 tests pass** across 25 test files (`npx vitest --project workers --run`).