### PR TITLE
fix: flush replayed stream state and handle orphaned streams after hibernation

### DIFF
--- a/.changeset/fix-hibernated-stream-state.md
+++ b/.changeset/fix-hibernated-stream-state.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix active streams losing UI state after reconnect and dead streams after DO hibernation.
+
+- Send `replayComplete` signal after replaying stored chunks for live streams, so the client flushes accumulated parts to React state immediately instead of waiting for the next live chunk.
+- Detect orphaned streams (restored from SQLite after hibernation with no live LLM reader) via `_isLive` flag on `ResumableStream`. On reconnect, send `done: true`, complete the stream, and reconstruct/persist the partial assistant message from stored chunks.
+- Client-side: flush `activeStreamRef` on `replayComplete` (keeps stream alive for subsequent live chunks) and on `done` during replay (finalizes orphaned streams).

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -1174,6 +1174,13 @@ export function useAgentChat<
               flushActiveStreamToMessages(activeMsg);
             }
             activeStreamRef.current = null;
+          } else if (data.replayComplete && activeMsg) {
+            // Replay of stored chunks is complete but the stream is still
+            // active (e.g. model is still thinking). Flush the accumulated
+            // parts to React state so the UI shows progress. Without this,
+            // replayed chunks sit in activeStreamRef unflushed until the
+            // next live chunk arrives.
+            flushActiveStreamToMessages(activeMsg);
           }
           break;
         }

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -7,6 +7,7 @@ import type {
 import { getCurrentAgent, routeAgentRequest } from "agents";
 import { MessageType, type OutgoingMessage } from "../types";
 import type { ClientToolSchema } from "../";
+import { ResumableStream } from "../resumable-stream";
 
 // Type helper for tool call parts - extracts from ChatMessage parts
 type TestToolCallPart = Extract<
@@ -293,6 +294,16 @@ export class TestChatAgent extends AIChatAgent<Env> {
     // We do this by starting and immediately completing a dummy stream
     const dummyId = this._startStream("cleanup-trigger");
     this._completeStream(dummyId);
+  }
+
+  /**
+   * Simulate DO hibernation wake by reinitializing the ResumableStream.
+   * The new instance calls restore() which reads from SQLite and sets
+   * _activeStreamId, but _isLive remains false (no live LLM reader).
+   * This mimics the DO constructor running after eviction.
+   */
+  testSimulateHibernationWake(): void {
+    this._resumableStream = new ResumableStream(this.sql.bind(this));
   }
 
   /**

--- a/packages/ai-chat/src/types.ts
+++ b/packages/ai-chat/src/types.ts
@@ -54,6 +54,8 @@ export type OutgoingMessage<ChatMessage extends UIMessage = UIMessage> =
       continuation?: boolean;
       /** Whether this chunk is being replayed from storage (stream resumption) */
       replay?: boolean;
+      /** Signals that replay of stored chunks is complete (stream is still active) */
+      replayComplete?: boolean;
     }
   | {
       /** Indicates the server is resuming an active stream */


### PR DESCRIPTION
## Problem

When a client reconnects to an active stream, `replayChunks()` sends all stored chunks from SQLite but the client UI never updates until the next **live** chunk arrives from the LLM. This creates a jarring UX where the user sees a blank assistant message despite the server having already produced content.

A second, more severe problem: when a Durable Object **hibernates** during an active stream, the `ReadableStream` reader from the LLM is lost permanently. On wake, the stream appears active in SQLite but no live chunks will ever arrive — a "dead stream" that leaves the client stuck with a loading indicator forever.

Fixes #896

---

## Root Cause

### Bug 1: Replay chunks not flushed to React state

The client-side `useAgentChat` hook skips `flushActiveStreamToMessages()` for replay chunks (by design — to avoid intermediate renders during the tight replay loop). However, after all replay chunks were sent, the server never signaled "replay is done but the stream is still live." The accumulated parts sat in `activeStreamRef` unflushed until the next live chunk arrived from the LLM.

### Bug 2: Orphaned streams after hibernation

When a DO is evicted and later wakes, the constructor calls `ResumableStream.restore()` which reads the active stream from SQLite. But the `ReadableStream` reader that was consuming the LLM response is gone — it existed only in the previous instance's memory. The stream looks active but will never produce another chunk.

---

## Solution

### Server: `replayComplete` signal for live streams

After `replayChunks()` sends all stored chunks for a stream that is still live (has an active LLM reader), it now sends a final message with `replayComplete: true`. This tells the client: "I've sent everything I have stored — flush your accumulated state to the UI. More live chunks may follow."

### Server: `_isLive` flag + orphaned stream detection

`ResumableStream` now tracks whether the active stream was `start()`-ed in the current instance (`_isLive = true`) vs restored from SQLite after hibernation (`_isLive = false`). When `replayChunks()` detects an orphaned stream:

1. Sends `done: true` to the client (stream is over)
2. Marks the stream as `completed` in SQLite
3. Returns the `streamId` to the caller

The caller (`AIChatAgent`) then reconstructs the partial assistant message from stored chunks using `applyChunkToParts()` and persists it via `persistMessages()`, so it survives further page refreshes.

### Client: flush on `replayComplete` and `done`

In `react.tsx`, the `CF_AGENT_USE_CHAT_RESPONSE` handler now:
- On `replayComplete`: flushes `activeStreamRef` to React state but **keeps it alive** (live chunks continue appending)
- On `done` during replay: flushes and **nulls out** `activeStreamRef` (stream is finalized)

---

## Edge Cases Handled

| Scenario | Behavior |
|----------|----------|
| Orphaned stream with **zero chunks** | Stream completed cleanly, no empty assistant message persisted |
| Orphaned stream with **tool call parts** | `applyChunkToParts` reconstructs both text and tool-invocation parts correctly |
| **Double ACK** after orphaned stream finalized | `hasActiveStream()` returns false on second ACK → no-op, no duplicate messages |
| `start` chunk missing (row-size guard dropped it) | Fallback message ID generated; message still persisted |

---

## Files Changed

| File | Change |
|------|--------|
| `src/types.ts` | Add optional `replayComplete` field to `CF_AGENT_USE_CHAT_RESPONSE` |
| `src/resumable-stream.ts` | Add `_isLive` flag, `isLive` getter; rewrite `replayChunks` with three-way branch |
| `src/index.ts` | ACK handler uses `replayChunks` return value; new `_persistOrphanedStream` method |
| `src/react.tsx` | Flush on `replayComplete` (keep stream alive) and `done` during replay (finalize) |
| `src/tests/worker.ts` | Add `testSimulateHibernationWake` helper |
| `src/tests/resumable-streaming.test.ts` | 5 new server tests |
| `src/react-tests/use-agent-chat.test.tsx` | 3 new React hook tests |

---

## Reviewer Notes

- **`_isLive` intentionally defaults to `false`** — `restore()` is called in the constructor and leaves it false. Only `start()` sets it to `true`. This means any stream that exists in SQLite when the DO wakes is treated as orphaned unless `start()` was called in the current instance.

- **`replayChunks` return type changed from `void` to `string | null`** — internal-only API, not in public exports. The returned `streamId` is used by the caller to know it should persist the orphaned message.

- **`testSimulateHibernationWake` replaces `_resumableStream` but not other instance fields** (`_streamCompletionPromise`, `_pendingResumeConnections`). In a real hibernation wake the entire DO is reconstructed. This is sufficient for testing because those fields are only relevant for live streams, and the test uses fresh WebSocket connections.

- **The `replayComplete` message has `done: false`** — this is intentional. The stream is still active; we're just signaling that stored chunks have been replayed. The client keeps `activeStreamRef` alive for subsequent live chunks.

- **All 237 server tests + 26 React tests pass.**