### PR TITLE
fix: remove redundant unawaited updateProps calls in MCP handlers

### DIFF
--- a/.changeset/fix-unawaited-updateprops.md
+++ b/.changeset/fix-unawaited-updateprops.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Remove redundant unawaited `updateProps` calls in MCP transport handlers that caused sporadic "Failed to pop isolated storage stack frame" errors in test environments. Props are already delivered through `getAgentByName` → `onStart`, making the extra calls unnecessary. Also removes the RPC experimental warning from `addMcpServer`.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -329,8 +329,6 @@ export type AddRpcMcpServerOptions = {
   props?: Record<string, unknown>;
 };
 
-let _didWarnRpcExperimental = false;
-
 const STATE_ROW_ID = "cf_state_row_id";
 const STATE_WAS_CHANGED = "cf_state_was_changed";
 
@@ -3909,14 +3907,6 @@ export class Agent<
 
     // RPC transport path: second argument is a DurableObjectNamespace
     if (typeof urlOrBinding !== "string") {
-      if (!_didWarnRpcExperimental) {
-        _didWarnRpcExperimental = true;
-        console.warn(
-          "[agents] addMcpServer with a Durable Object binding (RPC transport) is experimental. " +
-            "The API may change between releases. " +
-            "We'd love your feedback: https://github.com/cloudflare/agents/issues/548"
-        );
-      }
       const rpcOpts = callbackHostOrOptions as
         | AddRpcMcpServerOptions
         | undefined;

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -242,7 +242,6 @@ export const createStreamingHttpHandler = (
             Upgrade: "websocket"
           }
         });
-        if (ctx.props) agent.updateProps(ctx.props as Record<string, unknown>);
         const response = await agent.fetch(req);
 
         // Get the WebSocket
@@ -399,7 +398,6 @@ export const createStreamingHttpHandler = (
           existingHeaders[k] = v;
         });
 
-        if (ctx.props) agent.updateProps(ctx.props as Record<string, unknown>);
         const response = await agent.fetch(
           new Request(request.url, {
             headers: {
@@ -563,7 +561,6 @@ export const createLegacySseHandler = (
       request.headers.forEach((value, key) => {
         existingHeaders[key] = value;
       });
-      if (ctx.props) agent.updateProps(ctx.props as Record<string, unknown>);
       const response = await agent.fetch(
         new Request(request.url, {
           headers: {


### PR DESCRIPTION
Fixes #1007

## Problem

Sporadic "Failed to pop isolated storage stack frame" errors in test environments when using `McpAgent`. The vitest-pool-workers test runner detects unawaited Durable Object storage operations during teardown.

## Root Cause

Three `agent.updateProps(ctx.props)` calls in `packages/agents/src/mcp/utils.ts` were fire-and-forget RPC calls (not awaited). Each call dispatches `ctx.storage.put("props", ...)` inside the Durable Object, but the returned Promise was never awaited in the outer Worker handler.

These calls were also **redundant** — `getAgentByName()` already passes props via the `x-partykit-props` header, which triggers `onStart(props)` → `await updateProps(props)` inside the DO. The unawaited calls simply repeated the same storage write with the same data.

## Changes

- **`packages/agents/src/mcp/utils.ts`**: Removed 3 redundant unawaited `updateProps` calls (Streamable HTTP POST, Streamable HTTP GET, Legacy SSE GET)
- **`packages/agents/src/index.ts`**: Removed RPC experimental warning from `addMcpServer`
- **`packages/agents/src/tests/mcp/mcp-protocol.test.ts`**: Added props tests for Streamable HTTP GET and RPC transport paths

## Verification

- `npm run check` — all 45 projects typecheck ✅
- `npm run test` — 267 tests pass ✅
- MCP-specific tests — 346 tests pass (18 files) ✅