### PR TITLE
feat(observability): replace console.log with diagnostics_channel, add typed subscribe helper and ai-chat events

### DIFF
--- a/.changeset/diagnostics-channel-observability.md
+++ b/.changeset/diagnostics-channel-observability.md
@@ -1,59 +1,60 @@
 ---
-"agents": patch
+"agents": minor
 ---
 
-Replace `console.log`-based observability with `node:diagnostics_channel`.
+Overhaul observability: `diagnostics_channel`, leaner events, error tracking.
 
-### What changed
+### Breaking changes to `agents/observability` types
 
-The default `genericObservability` implementation no longer logs every event to the console. Instead, events are published to named diagnostics channels using the Node.js `diagnostics_channel` API. Publishing to a channel with no subscribers is a no-op, which eliminates the logspam problem where every state update, RPC call, schedule execution, and workflow event would unconditionally hit stdout.
+- **`BaseEvent`**: Removed `id` and `displayMessage` fields. Events now contain only `type`, `payload`, and `timestamp`. The `payload` type is now strict — accessing undeclared fields is a type error. Narrow on `event.type` before accessing payload properties.
+- **`Observability.emit()`**: Removed the optional `ctx` second parameter.
+- **`AgentObservabilityEvent`**: Split combined union types so each event has its own discriminant (enables proper `Extract`-based type narrowing). Added new error event types.
+
+If you have a custom `Observability` implementation, update your `emit` signature to `emit(event: ObservabilityEvent): void`.
+
+### diagnostics_channel replaces console.log
+
+The default `genericObservability` implementation no longer logs every event to the console. Instead, events are published to named diagnostics channels using the Node.js `diagnostics_channel` API. Publishing to a channel with no subscribers is a no-op, eliminating logspam.
 
 Seven named channels, one per event domain:
 
 - `agents:state` — state sync events
-- `agents:rpc` — RPC method calls (including streaming)
-- `agents:message` — message request/response/clear
-- `agents:schedule` — schedule create/execute/cancel and retry events
+- `agents:rpc` — RPC method calls and errors
+- `agents:message` — message request/response/clear/cancel/error + tool result/approval
+- `agents:schedule` — schedule and queue create/execute/cancel/retry/error events
 - `agents:lifecycle` — connection and destroy events
 - `agents:workflow` — workflow start/event/approve/reject/terminate/pause/resume/restart
 - `agents:mcp` — MCP client connect/authorize/discover events
 
+### New error events
+
+Error events are now emitted at failure sites instead of (or alongside) `console.error`:
+
+- `rpc:error` — RPC method failures (includes method name and error message)
+- `schedule:error` — schedule callback failures after all retries exhausted
+- `queue:error` — queue callback failures after all retries exhausted
+
+### Reduced boilerplate
+
+All 20+ inline `emit` blocks in the Agent class have been replaced with a private `_emit()` helper that auto-generates timestamps, reducing each call site from ~10 lines to 1.
+
 ### Typed subscribe helper
 
-A new `subscribe()` function is exported from `agents/observability` that provides full type narrowing per channel:
+A new `subscribe()` function is exported from `agents/observability` with full type narrowing per channel:
 
 ```ts
 import { subscribe } from "agents/observability";
 
 const unsub = subscribe("rpc", (event) => {
-  // event is fully typed: { type: "rpc", payload: { method: string, streaming?: boolean }, ... }
+  // event is fully typed as rpc | rpc:error
   console.log(event.payload.method);
 });
-
-// Clean up when done
-unsub();
 ```
 
-### Tail Worker integration (production observability)
+### Tail Worker integration
 
-In production, all messages published to any diagnostics channel are automatically forwarded to Tail Workers. No subscription code is needed in the agent itself — just attach a Tail Worker and access events via `event.diagnosticsChannelEvents`:
-
-```ts
-export default {
-  async tail(events) {
-    for (const event of events) {
-      for (const msg of event.diagnosticsChannelEvents) {
-        // msg.channel is "agents:rpc", "agents:workflow", etc.
-        // msg.message is the typed event payload
-        console.log(msg.timestamp, msg.channel, msg.message);
-      }
-    }
-  }
-};
-```
-
-This means you get structured, filterable observability in production with zero overhead in the agent's hot path.
+In production, all diagnostics channel messages are automatically forwarded to Tail Workers via `event.diagnosticsChannelEvents` — no subscription needed in the agent itself.
 
 ### TracingChannel potential
 
-The `diagnostics_channel` API also provides `TracingChannel`, which expresses start/end/error spans for async operations with `AsyncLocalStorage` integration. This opens the door to tracing RPC calls, workflow steps, and schedule executions end-to-end — correlating nested operations via request IDs stored in async context — without any manual instrumentation in user code.
+The `diagnostics_channel` API also provides `TracingChannel` for start/end/error spans with `AsyncLocalStorage` integration, opening the door to end-to-end tracing of RPC calls, workflow steps, and schedule executions.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,44 +1,187 @@
 # Observability
 
-`Agent` instances uses the `observability` property to emit various internal events that can be used for logging and monitoring.
+Agents emit structured events for every significant operation — RPC calls, state changes, schedule execution, workflow transitions, MCP connections, and more. These events are published to [diagnostics channels](https://developers.cloudflare.com/workers/runtime-apis/nodejs/diagnostics-channel/) and are silent by default (zero overhead when nobody is listening).
 
-The default behavior is to `console.log()` the event value.
+## Event structure
 
-```
+Every event has three fields:
+
+```ts
 {
-  displayMessage: 'State updated',
-  id: 'EnOzrS_tEo_8dHy5oyl8q',
-  payload: {},
-  timestamp: 1758005142787,
-  type: 'state:update'
+  type: "rpc",                        // what happened
+  payload: { method: "getWeather" },  // details
+  timestamp: 1758005142787            // when (ms since epoch)
 }
 ```
 
-This can be configured by overriding the property with an implementation of the `Observability` interface. This interface has a single `emit()` method that takes an `ObservabilityEvent`.
+## Channels
+
+Events are routed to seven named channels based on their type:
+
+| Channel            | Event types                                                                                                                                                      | Description                         |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `agents:state`     | `state:update`                                                                                                                                                   | State sync events                   |
+| `agents:rpc`       | `rpc`, `rpc:error`                                                                                                                                               | RPC method calls and failures       |
+| `agents:message`   | `message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`                                        | Chat message and tool lifecycle     |
+| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `queue:retry`, `queue:error`                                       | Scheduled and queued task lifecycle |
+| `agents:lifecycle` | `connect`, `destroy`                                                                                                                                             | Agent connection and teardown       |
+| `agents:workflow`  | `workflow:start`, `workflow:event`, `workflow:approved`, `workflow:rejected`, `workflow:terminated`, `workflow:paused`, `workflow:resumed`, `workflow:restarted` | Workflow state transitions          |
+| `agents:mcp`       | `mcp:client:preconnect`, `mcp:client:connect`, `mcp:client:authorize`, `mcp:client:discover`                                                                     | MCP client operations               |
+
+## Subscribing to events
+
+### Typed subscribe helper
+
+The `subscribe()` function from `agents/observability` provides type-safe access to events on a specific channel:
+
+```ts
+import { subscribe } from "agents/observability";
+
+const unsub = subscribe("rpc", (event) => {
+  if (event.type === "rpc") {
+    console.log(`RPC call: ${event.payload.method}`);
+  }
+  if (event.type === "rpc:error") {
+    console.error(
+      `RPC failed: ${event.payload.method} — ${event.payload.error}`
+    );
+  }
+});
+
+// Clean up when done
+unsub();
+```
+
+The callback is fully typed — `event` is narrowed to only the event types that flow through that channel.
+
+### Raw diagnostics_channel
+
+You can also subscribe directly using the Node.js API:
+
+```ts
+import { subscribe } from "node:diagnostics_channel";
+
+subscribe("agents:schedule", (event) => {
+  console.log(event);
+});
+```
+
+## Tail Workers (production)
+
+In production, all diagnostics channel messages are automatically forwarded to [Tail Workers](https://developers.cloudflare.com/workers/observability/tail-workers/). No subscription code is needed in the agent itself — attach a Tail Worker and access events via `event.diagnosticsChannelEvents`:
+
+```ts
+export default {
+  async tail(events) {
+    for (const event of events) {
+      for (const msg of event.diagnosticsChannelEvents) {
+        // msg.channel is "agents:rpc", "agents:workflow", etc.
+        // msg.message is the typed event payload
+        console.log(msg.timestamp, msg.channel, msg.message);
+      }
+    }
+  }
+};
+```
+
+This gives you structured, filterable observability in production with zero overhead in the agent hot path.
+
+## Custom observability
+
+You can override the default implementation by providing your own `Observability` interface:
 
 ```ts
 import { Agent } from "agents";
-import { type Observability } from "agents/observability";
+import type { Observability } from "agents/observability";
 
-const observability: Observability = {
+const myObservability: Observability = {
   emit(event) {
-    if (event.type === "connect") {
-      console.log(event.timestamp, event.payload.connectionId);
+    // Send to your logging service, filter events, etc.
+    if (event.type === "rpc:error") {
+      myLogger.error(event.payload.method, event.payload.error);
     }
   }
 };
 
 class MyAgent extends Agent {
-  override observability = observability;
+  override observability = myObservability;
 }
 ```
 
-Or, alternatively, you can set the property to `undefined` to ignore all events.
+Set `observability` to `undefined` to disable all event emission:
 
 ```ts
-import { Agent } from "agents";
-
 class MyAgent extends Agent {
   override observability = undefined;
 }
 ```
+
+## Event reference
+
+### RPC events
+
+| Type        | Payload                  | When                            |
+| ----------- | ------------------------ | ------------------------------- |
+| `rpc`       | `{ method, streaming? }` | A `@callable` method is invoked |
+| `rpc:error` | `{ method, error }`      | A `@callable` method throws     |
+
+### State events
+
+| Type           | Payload | When                   |
+| -------------- | ------- | ---------------------- |
+| `state:update` | `{}`    | `setState()` is called |
+
+### Message and tool events (`AIChatAgent`)
+
+These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track the chat message lifecycle, including client-side tool interactions.
+
+| Type               | Payload                    | When                                |
+| ------------------ | -------------------------- | ----------------------------------- |
+| `message:request`  | `{}`                       | A chat message is received          |
+| `message:response` | `{}`                       | A chat response stream completes    |
+| `message:clear`    | `{}`                       | Chat history is cleared             |
+| `message:cancel`   | `{ requestId }`            | A streaming request is cancelled    |
+| `message:error`    | `{ error }`                | A chat stream fails                 |
+| `tool:result`      | `{ toolCallId, toolName }` | A client tool result is received    |
+| `tool:approval`    | `{ toolCallId, approved }` | A tool call is approved or rejected |
+
+### Schedule and queue events
+
+| Type               | Payload                                  | When                                         |
+| ------------------ | ---------------------------------------- | -------------------------------------------- |
+| `schedule:create`  | `{ callback, id }`                       | A schedule is created                        |
+| `schedule:execute` | `{ callback, id }`                       | A scheduled callback starts                  |
+| `schedule:cancel`  | `{ callback, id }`                       | A schedule is cancelled                      |
+| `schedule:retry`   | `{ callback, id, attempt, maxAttempts }` | A scheduled callback is retried              |
+| `schedule:error`   | `{ callback, id, error, attempts }`      | A scheduled callback fails after all retries |
+| `queue:retry`      | `{ callback, id, attempt, maxAttempts }` | A queued callback is retried                 |
+| `queue:error`      | `{ callback, id, error, attempts }`      | A queued callback fails after all retries    |
+
+### Lifecycle events
+
+| Type      | Payload            | When                                  |
+| --------- | ------------------ | ------------------------------------- |
+| `connect` | `{ connectionId }` | A WebSocket connection is established |
+| `destroy` | `{}`               | The agent is destroyed                |
+
+### Workflow events
+
+| Type                  | Payload                         | When                           |
+| --------------------- | ------------------------------- | ------------------------------ |
+| `workflow:start`      | `{ workflowId, workflowName? }` | A workflow instance is started |
+| `workflow:event`      | `{ workflowId, eventType? }`    | An event is sent to a workflow |
+| `workflow:approved`   | `{ workflowId, reason? }`       | A workflow is approved         |
+| `workflow:rejected`   | `{ workflowId, reason? }`       | A workflow is rejected         |
+| `workflow:terminated` | `{ workflowId, workflowName? }` | A workflow is terminated       |
+| `workflow:paused`     | `{ workflowId, workflowName? }` | A workflow is paused           |
+| `workflow:resumed`    | `{ workflowId, workflowName? }` | A workflow is resumed          |
+| `workflow:restarted`  | `{ workflowId, workflowName? }` | A workflow is restarted        |
+
+### MCP events
+
+| Type                    | Payload                                 | When                                         |
+| ----------------------- | --------------------------------------- | -------------------------------------------- |
+| `mcp:client:preconnect` | `{ serverId }`                          | Before connecting to an MCP server           |
+| `mcp:client:connect`    | `{ url, transport, state, error? }`     | An MCP connection attempt completes or fails |
+| `mcp:client:authorize`  | `{ serverId, authUrl, clientId? }`      | An MCP OAuth flow begins                     |
+| `mcp:client:discover`   | `{ url?, state?, error?, capability? }` | MCP capability discovery succeeds or fails   |

--- a/packages/agents/src/e2e-tests/worker.ts
+++ b/packages/agents/src/e2e-tests/worker.ts
@@ -29,8 +29,6 @@ export type SlowFiberSnapshot = {
 const FiberAgent = withFibers(Agent, { debugFibers: true });
 
 export class FiberTestAgent extends FiberAgent<Record<string, unknown>> {
-  observability = undefined;
-
   /**
    * A slow fiber that takes ~1 second per step.
    * Checkpoints after each step.

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -28,7 +28,6 @@ import {
   type ServerCapabilities,
   ToolListChangedNotificationSchema
 } from "@modelcontextprotocol/sdk/types.js";
-import { nanoid } from "nanoid";
 import { Emitter, type Event } from "../core/events";
 import type { MCPObservabilityEvent } from "../observability/mcp";
 import type { AgentMcpOAuthProvider } from "./do-oauth-client-provider";
@@ -172,29 +171,25 @@ export class MCPClientConnection {
 
       this._onObservabilityEvent.fire({
         type: "mcp:client:connect",
-        displayMessage: `Connected successfully using ${res.transport} transport for ${this.url.toString()}`,
         payload: {
           url: this.url.toString(),
           transport: res.transport,
           state: this.connectionState
         },
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
       return undefined;
     } else if (res.state === MCPConnectionState.FAILED && res.error) {
       const errorMessage = toErrorMessage(res.error);
       this._onObservabilityEvent.fire({
         type: "mcp:client:connect",
-        displayMessage: `Failed to connect to ${this.url.toString()}: ${errorMessage}`,
         payload: {
           url: this.url.toString(),
           transport: transportType,
           state: this.connectionState,
           error: errorMessage
         },
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
       return errorMessage;
     }
@@ -342,13 +337,11 @@ export class MCPClientConnection {
     } catch (error) {
       this._onObservabilityEvent.fire({
         type: "mcp:client:discover",
-        displayMessage: `Failed to discover capabilities for ${this.url.toString()}: ${toErrorMessage(error)}`,
         payload: {
           url: this.url.toString(),
           error: toErrorMessage(error)
         },
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
 
       throw error;
@@ -375,13 +368,11 @@ export class MCPClientConnection {
     ) {
       this._onObservabilityEvent.fire({
         type: "mcp:client:discover",
-        displayMessage: `Discovery skipped for ${this.url.toString()}, state is ${this.connectionState}`,
         payload: {
           url: this.url.toString(),
           state: this.connectionState
         },
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
       return {
         success: false,
@@ -440,12 +431,10 @@ export class MCPClientConnection {
 
       this._onObservabilityEvent.fire({
         type: "mcp:client:discover",
-        displayMessage: `Discovery completed for ${this.url.toString()}`,
         payload: {
           url: this.url.toString()
         },
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
 
       return { success: true };
@@ -694,14 +683,12 @@ export class MCPClientConnection {
         const url = this.url.toString();
         this._onObservabilityEvent.fire({
           type: "mcp:client:discover",
-          displayMessage: `The server advertised support for the capability ${method.split("/")[0]}, but returned "Method not found" for '${method}' for ${url}`,
           payload: {
             url,
             capability: method.split("/")[0],
             error: toErrorMessage(e)
           },
-          timestamp: Date.now(),
-          id: nanoid()
+          timestamp: Date.now()
         });
         return empty;
       }

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -649,15 +649,13 @@ export class MCPClientManager {
       } catch (error) {
         this._onObservabilityEvent.fire({
           type: "mcp:client:connect",
-          displayMessage: `Failed to complete OAuth reconnection for ${id} for ${url}`,
           payload: {
             url: url,
             transport: options.transport?.type ?? "auto",
             state: this.mcpConnections[id].connectionState,
             error: toErrorMessage(error)
           },
-          timestamp: Date.now(),
-          id
+          timestamp: Date.now()
         });
         // Re-throw to signal failure to the caller
         throw error;
@@ -847,6 +845,12 @@ export class MCPClientManager {
           // Broadcast again so clients receive the auth_url
           this._onServerStateChanged.fire();
         }
+
+        this._onObservabilityEvent.fire({
+          type: "mcp:client:authorize",
+          payload: { serverId: id, authUrl, clientId },
+          timestamp: Date.now()
+        });
 
         return {
           state: conn.connectionState,
@@ -1055,10 +1059,8 @@ export class MCPClientManager {
     if (!conn) {
       this._onObservabilityEvent.fire({
         type: "mcp:client:discover",
-        displayMessage: `Connection not found for ${serverId}`,
         payload: {},
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
       return undefined;
     }
@@ -1091,10 +1093,8 @@ export class MCPClientManager {
     if (!conn) {
       this._onObservabilityEvent.fire({
         type: "mcp:client:preconnect",
-        displayMessage: `Connection not found for serverId: ${serverId}`,
         payload: { serverId },
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
       return;
     }
@@ -1106,14 +1106,12 @@ export class MCPClientManager {
     ) {
       this._onObservabilityEvent.fire({
         type: "mcp:client:connect",
-        displayMessage: `establishConnection skipped for ${serverId}, already in ${conn.connectionState} state`,
         payload: {
           url: conn.url.toString(),
           transport: conn.options.transport.type || "unknown",
           state: conn.connectionState
         },
-        timestamp: Date.now(),
-        id: nanoid()
+        timestamp: Date.now()
       });
       return;
     }
@@ -1136,14 +1134,12 @@ export class MCPClientManager {
 
     this._onObservabilityEvent.fire({
       type: "mcp:client:connect",
-      displayMessage: `establishConnection completed for ${serverId}, final state: ${conn.connectionState}`,
       payload: {
         url: conn.url.toString(),
         transport: conn.options.transport.type || "unknown",
         state: conn.connectionState
       },
-      timestamp: Date.now(),
-      id: nanoid()
+      timestamp: Date.now()
     });
   }
 

--- a/packages/agents/src/observability/agent.ts
+++ b/packages/agents/src/observability/agent.ts
@@ -5,52 +5,48 @@ import type { BaseEvent } from "./base";
  * These track the lifecycle and operations of an Agent
  */
 export type AgentObservabilityEvent =
-  | BaseEvent<"state:update", {}>
-  | BaseEvent<
-      "rpc",
-      {
-        method: string;
-        streaming?: boolean;
-      }
-    >
-  | BaseEvent<"message:request" | "message:response", {}>
+  | BaseEvent<"state:update">
+  | BaseEvent<"rpc", { method: string; streaming?: boolean }>
+  | BaseEvent<"rpc:error", { method: string; error: string }>
+  | BaseEvent<"message:request">
+  | BaseEvent<"message:response">
   | BaseEvent<"message:clear">
+  | BaseEvent<"message:cancel", { requestId: string }>
+  | BaseEvent<"message:error", { error: string }>
+  | BaseEvent<"tool:result", { toolCallId: string; toolName: string }>
+  | BaseEvent<"tool:approval", { toolCallId: string; approved: boolean }>
+  | BaseEvent<"schedule:create", { callback: string; id: string }>
+  | BaseEvent<"schedule:execute", { callback: string; id: string }>
+  | BaseEvent<"schedule:cancel", { callback: string; id: string }>
   | BaseEvent<
-      "schedule:create" | "schedule:execute" | "schedule:cancel",
-      {
-        callback: string;
-        id: string;
-      }
+      "schedule:retry",
+      { callback: string; id: string; attempt: number; maxAttempts: number }
     >
   | BaseEvent<
-      "queue:retry" | "schedule:retry",
-      {
-        callback: string;
-        id: string;
-        attempt: number;
-        maxAttempts: number;
-      }
+      "schedule:error",
+      { callback: string; id: string; error: string; attempts: number }
+    >
+  | BaseEvent<
+      "queue:retry",
+      { callback: string; id: string; attempt: number; maxAttempts: number }
+    >
+  | BaseEvent<
+      "queue:error",
+      { callback: string; id: string; error: string; attempts: number }
     >
   | BaseEvent<"destroy">
+  | BaseEvent<"connect", { connectionId: string }>
+  | BaseEvent<"workflow:start", { workflowId: string; workflowName?: string }>
+  | BaseEvent<"workflow:event", { workflowId: string; eventType?: string }>
+  | BaseEvent<"workflow:approved", { workflowId: string; reason?: string }>
+  | BaseEvent<"workflow:rejected", { workflowId: string; reason?: string }>
   | BaseEvent<
-      "connect",
-      {
-        connectionId: string;
-      }
+      "workflow:terminated",
+      { workflowId: string; workflowName?: string }
     >
+  | BaseEvent<"workflow:paused", { workflowId: string; workflowName?: string }>
+  | BaseEvent<"workflow:resumed", { workflowId: string; workflowName?: string }>
   | BaseEvent<
-      | "workflow:start"
-      | "workflow:event"
-      | "workflow:approved"
-      | "workflow:rejected"
-      | "workflow:terminated"
-      | "workflow:paused"
-      | "workflow:resumed"
-      | "workflow:restarted",
-      {
-        workflowId: string;
-        workflowName?: string;
-        eventType?: string;
-        reason?: string;
-      }
+      "workflow:restarted",
+      { workflowId: string; workflowName?: string }
     >;

--- a/packages/agents/src/observability/base.ts
+++ b/packages/agents/src/observability/base.ts
@@ -3,22 +3,13 @@
  */
 export type BaseEvent<
   T extends string,
-  Payload extends Record<string, unknown> = {}
+  Payload extends Record<string, unknown> = Record<string, never>
 > = {
   type: T;
   /**
-   * The unique identifier for the event
-   */
-  id: string;
-  /**
-   * The message to display in the logs for this event, should the implementation choose to display
-   * a human-readable message.
-   */
-  displayMessage: string;
-  /**
    * The payload of the event
    */
-  payload: Payload & Record<string, unknown>;
+  payload: Payload;
   /**
    * The timestamp of the event in milliseconds since epoch
    */

--- a/packages/agents/src/observability/index.ts
+++ b/packages/agents/src/observability/index.ts
@@ -18,9 +18,8 @@ export interface Observability {
   /**
    * Emit an event for the Agent's observability implementation to handle.
    * @param event - The event to emit
-   * @param ctx - The execution context of the invocation (optional)
    */
-  emit(event: ObservabilityEvent, ctx?: DurableObjectState): void;
+  emit(event: ObservabilityEvent): void;
 }
 
 /**
@@ -54,10 +53,11 @@ export const channels = {
 function getChannel(type: string): Channel {
   if (type.startsWith("mcp:")) return channels.mcp;
   if (type.startsWith("workflow:")) return channels.workflow;
-  if (type.startsWith("schedule:") || type === "queue:retry")
+  if (type.startsWith("schedule:") || type.startsWith("queue:"))
     return channels.schedule;
-  if (type.startsWith("message:")) return channels.message;
-  if (type === "rpc") return channels.rpc;
+  if (type.startsWith("message:") || type.startsWith("tool:"))
+    return channels.message;
+  if (type === "rpc" || type.startsWith("rpc:")) return channels.rpc;
   if (type.startsWith("state:")) return channels.state;
   // connect, destroy
   return channels.lifecycle;
@@ -80,11 +80,14 @@ export const genericObservability: Observability = {
  */
 export type ChannelEventMap = {
   state: Extract<ObservabilityEvent, { type: `state:${string}` }>;
-  rpc: Extract<ObservabilityEvent, { type: "rpc" }>;
-  message: Extract<ObservabilityEvent, { type: `message:${string}` }>;
+  rpc: Extract<ObservabilityEvent, { type: "rpc" | `rpc:${string}` }>;
+  message: Extract<
+    ObservabilityEvent,
+    { type: `message:${string}` | `tool:${string}` }
+  >;
   schedule: Extract<
     ObservabilityEvent,
-    { type: `schedule:${string}` | "queue:retry" }
+    { type: `schedule:${string}` | `queue:${string}` }
   >;
   lifecycle: Extract<ObservabilityEvent, { type: "connect" | "destroy" }>;
   workflow: Extract<ObservabilityEvent, { type: `workflow:${string}` }>;

--- a/packages/agents/src/observability/mcp.ts
+++ b/packages/agents/src/observability/mcp.ts
@@ -18,4 +18,12 @@ export type MCPObservabilityEvent =
         clientId?: string;
       }
     >
-  | BaseEvent<"mcp:client:discover", {}>;
+  | BaseEvent<
+      "mcp:client:discover",
+      {
+        url?: string;
+        state?: string;
+        error?: string;
+        capability?: string;
+      }
+    >;

--- a/packages/agents/src/tests/agents/callable.ts
+++ b/packages/agents/src/tests/agents/callable.ts
@@ -6,7 +6,6 @@ export class TestCallableAgent extends Agent<
   Record<string, unknown>,
   { value: number }
 > {
-  observability = undefined;
   initialState = { value: 0 };
 
   // Basic sync method
@@ -111,8 +110,6 @@ export class TestCallableAgent extends Agent<
 
 // Base class with @callable methods for testing prototype chain traversal
 export class TestParentAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   @callable({ description: "Parent method from base class" })
   parentMethod(): string {
     return "from parent";

--- a/packages/agents/src/tests/agents/email.ts
+++ b/packages/agents/src/tests/agents/email.ts
@@ -3,7 +3,6 @@ import type { AgentEmail } from "../../email.ts";
 
 // Test email agents
 export class TestEmailAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
   emailsReceived: AgentEmail[] = [];
 
   async onEmail(email: AgentEmail) {
@@ -18,7 +17,6 @@ export class TestEmailAgent extends Agent<Record<string, unknown>> {
 }
 
 export class TestCaseSensitiveAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
   emailsReceived: AgentEmail[] = [];
 
   async onEmail(email: AgentEmail) {
@@ -31,7 +29,6 @@ export class TestCaseSensitiveAgent extends Agent<Record<string, unknown>> {
 }
 
 export class TestUserNotificationAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
   emailsReceived: AgentEmail[] = [];
 
   async onEmail(email: AgentEmail) {

--- a/packages/agents/src/tests/agents/fiber.ts
+++ b/packages/agents/src/tests/agents/fiber.ts
@@ -23,8 +23,6 @@ type RecoveredFiberInfo = {
 const FiberAgent = withFibers(Agent, { debugFibers: true });
 
 export class TestFiberAgent extends FiberAgent<Record<string, unknown>> {
-  observability = undefined;
-
   // ── Tracking arrays for test assertions ──────────────────────────
 
   executionLog: string[] = [];

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -32,7 +32,6 @@ export class TestMcpAgent extends McpAgent<
   unknown,
   Props
 > {
-  observability = undefined;
   private tempToolHandle?: { remove: () => void };
 
   server = new McpServer(
@@ -228,8 +227,6 @@ export class TestMcpAgent extends McpAgent<
 
 // Test MCP Agent for jurisdiction feature
 export class TestMcpJurisdiction extends McpAgent<Record<string, unknown>> {
-  observability = undefined;
-
   server = new McpServer(
     { name: "test-jurisdiction-server", version: "1.0.0" },
     { capabilities: { tools: {} } }
@@ -253,8 +250,6 @@ export class TestMcpJurisdiction extends McpAgent<Record<string, unknown>> {
 export class TestRpcMcpClientAgent extends Agent<{
   MCP_OBJECT: DurableObjectNamespace;
 }> {
-  observability = undefined;
-
   async testAddRpcMcpServer() {
     try {
       await this.addMcpServer(
@@ -489,8 +484,6 @@ export class TestRpcMcpClientAgent extends Agent<{
 // Uses a private helper to resolve arguments without actually connecting,
 // since overriding the overloaded addMcpServer is fragile.
 export class TestAddMcpServerAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   private _resolveArgs(
     serverName: string,
     url: string,

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -6,8 +6,6 @@ import type { MCPClientOAuthResult } from "../../mcp/client.ts";
 
 // Test Agent for OAuth client side flows
 export class TestOAuthAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   async onRequest(_request: Request): Promise<Response> {
     return new Response("Test OAuth Agent");
   }
@@ -226,8 +224,6 @@ export class TestOAuthAgent extends Agent<Record<string, unknown>> {
 
 // Test Agent that overrides createMcpOAuthProvider with a custom implementation
 export class TestCustomOAuthAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   private _customProviderCallbackUrl: string | undefined;
 
   createMcpOAuthProvider(callbackUrl: string): AgentMcpOAuthProvider {

--- a/packages/agents/src/tests/agents/queue.ts
+++ b/packages/agents/src/tests/agents/queue.ts
@@ -2,7 +2,6 @@ import { Agent, callable } from "../../index.ts";
 
 export class TestQueueAgent extends Agent<Record<string, unknown>> {
   static options = { retry: { maxAttempts: 1 } };
-  observability = undefined;
 
   // Track which callbacks were executed and in what order
   executedCallbacks: string[] = [];

--- a/packages/agents/src/tests/agents/race.ts
+++ b/packages/agents/src/tests/agents/race.ts
@@ -6,8 +6,6 @@ export class TestRaceAgent extends Agent<Record<string, unknown>> {
   initialState = { hello: "world" };
   static options = { hibernate: true };
 
-  observability = undefined;
-
   async onConnect(conn: Connection<{ tagged: boolean }>) {
     // Simulate real async setup to widen the window a bit
     conn.setState({ tagged: true });

--- a/packages/agents/src/tests/agents/retry.ts
+++ b/packages/agents/src/tests/agents/retry.ts
@@ -11,8 +11,6 @@ import { Agent, callable, type RetryOptions } from "../../index.ts";
  * test correctly uses .rejects.toThrow().
  */
 export class TestRetryAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   // ── this.retry() ─────────────────────────────────────────────────
 
   @callable()
@@ -307,8 +305,6 @@ export class TestRetryAgent extends Agent<Record<string, unknown>> {
  * Test agent with custom class-level retry defaults via static options.
  */
 export class TestRetryDefaultsAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   static options = {
     retry: { maxAttempts: 5, baseDelayMs: 10, maxDelayMs: 50 }
   };

--- a/packages/agents/src/tests/agents/schedule.ts
+++ b/packages/agents/src/tests/agents/schedule.ts
@@ -4,7 +4,6 @@ export class TestDestroyScheduleAgent extends Agent<
   Record<string, unknown>,
   { status: string }
 > {
-  observability = undefined;
   initialState = {
     status: "unscheduled"
   };
@@ -20,8 +19,6 @@ export class TestDestroyScheduleAgent extends Agent<
 }
 
 export class TestScheduleAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   // A no-op callback method for testing schedules
   testCallback() {
     // Intentionally empty - used for testing schedule creation

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -10,8 +10,6 @@ import {
  * Test Agent for session memory tests (default config, microCompact enabled)
  */
 export class TestSessionAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   // Session wrapper (default: microCompact enabled)
   session = new Session(new AgentSessionProvider(this));
 
@@ -68,8 +66,6 @@ export class TestSessionAgent extends Agent<Record<string, unknown>> {
 export class TestSessionAgentNoMicroCompaction extends Agent<
   Record<string, unknown>
 > {
-  observability = undefined;
-
   session = new Session(new AgentSessionProvider(this), {
     microCompaction: false
   });
@@ -101,8 +97,6 @@ export class TestSessionAgentNoMicroCompaction extends Agent<
 export class TestSessionAgentCustomRules extends Agent<
   Record<string, unknown>
 > {
-  observability = undefined;
-
   session = new Session(new AgentSessionProvider(this), {
     microCompaction: {
       truncateToolOutputs: 100, // Very low threshold for testing

--- a/packages/agents/src/tests/agents/state.ts
+++ b/packages/agents/src/tests/agents/state.ts
@@ -8,8 +8,6 @@ export type TestState = {
 };
 
 export class TestStateAgent extends Agent<Record<string, unknown>, TestState> {
-  observability = undefined;
-
   initialState: TestState = {
     count: 0,
     items: [],
@@ -93,8 +91,6 @@ export class TestStateAgent extends Agent<Record<string, unknown>, TestState> {
 
 // Test Agent without initialState to test undefined behavior
 export class TestStateAgentNoInitial extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   // No initialState defined - should return undefined
 
   getState() {
@@ -111,8 +107,6 @@ export class TestThrowingStateAgent extends Agent<
   Record<string, unknown>,
   TestState
 > {
-  observability = undefined;
-
   initialState: TestState = {
     count: 0,
     items: [],
@@ -176,8 +170,6 @@ export class TestPersistedStateAgent extends Agent<
   Record<string, unknown>,
   TestState
 > {
-  observability = undefined;
-
   initialState: TestState = {
     count: 0,
     items: [],
@@ -216,8 +208,6 @@ export class TestBothHooksAgent extends Agent<
   Record<string, unknown>,
   TestState
 > {
-  observability = undefined;
-
   initialState: TestState = {
     count: 0,
     items: [],
@@ -247,8 +237,6 @@ export class TestNoIdentityAgent extends Agent<
   Record<string, unknown>,
   TestState
 > {
-  observability = undefined;
-
   // Opt out of sending identity to clients (for security-sensitive instance names)
   static options = { sendIdentityOnConnect: false };
 

--- a/packages/agents/src/tests/agents/wait-connections.ts
+++ b/packages/agents/src/tests/agents/wait-connections.ts
@@ -5,8 +5,6 @@ import { Agent } from "../../index.ts";
  * Simulates the full hibernation → restore → wait → getAITools flow.
  */
 export class TestWaitConnectionsAgent extends Agent<Record<string, unknown>> {
-  observability = undefined;
-
   async onRequest(_request: Request): Promise<Response> {
     return new Response("TestWaitConnectionsAgent");
   }

--- a/packages/agents/src/tests/agents/workflow.ts
+++ b/packages/agents/src/tests/agents/workflow.ts
@@ -12,8 +12,6 @@ type WorkflowEnv = {
 
 // Test Agent for Workflow integration
 export class TestWorkflowAgent extends Agent<WorkflowEnv> {
-  observability = undefined;
-
   // Track callbacks received for testing
   private _callbacksReceived: Array<{
     type: string;

--- a/packages/agents/src/tests/mcp/client-connection.test.ts
+++ b/packages/agents/src/tests/mcp/client-connection.test.ts
@@ -387,13 +387,11 @@ describe("MCP Client Connection Integration", () => {
       expect(discoverEvents).toHaveLength(2);
 
       // First event should be the method-not-found warning
-      expect(discoverEvents[0].displayMessage).toContain(
-        "The server advertised support for the capability tools"
-      );
       expect(discoverEvents[0].payload.capability).toBe("tools");
+      expect(discoverEvents[0].payload.error).toBeDefined();
 
       // Second event should be the completion event
-      expect(discoverEvents[1].displayMessage).toContain("Discovery completed");
+      expect(discoverEvents[1].payload.url).toBeDefined();
     });
   });
 
@@ -516,9 +514,7 @@ describe("MCP Client Connection Integration", () => {
         (e) => e.type === "mcp:client:discover"
       );
       expect(discoverEvents).toHaveLength(1);
-      expect(discoverEvents[0].displayMessage).toContain(
-        "Failed to discover capabilities"
-      );
+      expect(discoverEvents[0].payload.error).toBeDefined();
     });
 
     it("should fail and set connection to failed state when discovery fails", async () => {
@@ -609,9 +605,7 @@ describe("MCP Client Connection Integration", () => {
         (e) => e.type === "mcp:client:discover"
       );
       expect(discoverEvents).toHaveLength(1);
-      expect(discoverEvents[0].displayMessage).toContain(
-        "Failed to discover capabilities"
-      );
+      expect(discoverEvents[0].payload.error).toBeDefined();
     });
 
     it("should fail on first error during discovery", async () => {

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -2727,8 +2727,7 @@ describe("MCPClientManager OAuth Integration", () => {
       // Should fire observability event about missing connection
       expect(observabilitySpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: "mcp:client:discover",
-          displayMessage: expect.stringContaining("Connection not found")
+          type: "mcp:client:discover"
         })
       );
     });
@@ -2758,7 +2757,9 @@ describe("MCPClientManager OAuth Integration", () => {
       expect(observabilitySpy).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "mcp:client:discover",
-          displayMessage: expect.stringContaining("skipped")
+          payload: expect.objectContaining({
+            state: "connecting"
+          })
         })
       );
 
@@ -2808,7 +2809,9 @@ describe("MCPClientManager OAuth Integration", () => {
       expect(observabilitySpy).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "mcp:client:discover",
-          displayMessage: expect.stringContaining("Discovery completed")
+          payload: expect.objectContaining({
+            url: expect.any(String)
+          })
         })
       );
     });
@@ -2885,19 +2888,15 @@ describe("MCPClientManager OAuth Integration", () => {
         manager.fireObservabilityEvent(event);
       });
 
-      const observabilityEvents: string[] = [];
+      const observabilityTypes: string[] = [];
       manager.onObservabilityEvent((event) => {
-        if (event.displayMessage) {
-          observabilityEvents.push(event.displayMessage);
-        }
+        observabilityTypes.push(event.type);
       });
 
       await manager.discoverIfConnected(serverId);
 
       // Should have completion event
-      expect(observabilityEvents).toContainEqual(
-        expect.stringContaining("Discovery completed")
-      );
+      expect(observabilityTypes).toContain("mcp:client:discover");
     });
 
     it("should work as a manual refresh for tools (discover)", async () => {

--- a/packages/agents/src/tests/observability.test.ts
+++ b/packages/agents/src/tests/observability.test.ts
@@ -1,0 +1,330 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { getAgentByName, type RPCRequest, type RPCResponse } from "../index";
+import { MessageType } from "../types";
+import {
+  genericObservability,
+  subscribe,
+  type ObservabilityEvent
+} from "../observability";
+import type { Env } from "./worker";
+import worker from "./worker";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}
+
+// ── subscribe() helper ──────────────────────────────────────────────
+
+describe("subscribe()", () => {
+  it("should receive events published via genericObservability", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("rpc", (event) => {
+      received.push(event);
+    });
+
+    genericObservability.emit({
+      type: "rpc",
+      payload: { method: "testMethod", streaming: false },
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe("rpc");
+    if (received[0].type === "rpc") {
+      expect(received[0].payload.method).toBe("testMethod");
+    }
+
+    unsub();
+  });
+
+  it("should stop receiving events after unsubscribe", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("rpc", (event) => {
+      received.push(event);
+    });
+
+    genericObservability.emit({
+      type: "rpc",
+      payload: { method: "before" },
+      timestamp: Date.now()
+    });
+
+    unsub();
+
+    genericObservability.emit({
+      type: "rpc",
+      payload: { method: "after" },
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(1);
+    if (received[0].type === "rpc") {
+      expect(received[0].payload.method).toBe("before");
+    }
+  });
+
+  it("should only receive events for the subscribed channel", () => {
+    const rpcEvents: ObservabilityEvent[] = [];
+    const stateEvents: ObservabilityEvent[] = [];
+
+    const unsubRpc = subscribe("rpc", (event) => rpcEvents.push(event));
+    const unsubState = subscribe("state", (event) => stateEvents.push(event));
+
+    genericObservability.emit({
+      type: "rpc",
+      payload: { method: "test" },
+      timestamp: Date.now()
+    });
+
+    genericObservability.emit({
+      type: "state:update",
+      payload: {},
+      timestamp: Date.now()
+    });
+
+    expect(rpcEvents).toHaveLength(1);
+    expect(stateEvents).toHaveLength(1);
+    expect(rpcEvents[0].type).toBe("rpc");
+    expect(stateEvents[0].type).toBe("state:update");
+
+    unsubRpc();
+    unsubState();
+  });
+});
+
+// ── Channel routing ─────────────────────────────────────────────────
+
+describe("channel routing", () => {
+  it("should route rpc:error to the rpc channel", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("rpc", (event) => received.push(event));
+
+    genericObservability.emit({
+      type: "rpc:error",
+      payload: { method: "broken", error: "fail" },
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe("rpc:error");
+
+    unsub();
+  });
+
+  it("should route schedule:* and queue:* to the schedule channel", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("schedule", (event) => received.push(event));
+
+    const scheduleTypes = [
+      "schedule:create",
+      "schedule:execute",
+      "schedule:cancel",
+      "schedule:retry",
+      "schedule:error",
+      "queue:retry",
+      "queue:error"
+    ] as const;
+
+    for (const type of scheduleTypes) {
+      genericObservability.emit({
+        type,
+        payload: { callback: "cb", id: "1" },
+        timestamp: Date.now()
+      } as ObservabilityEvent);
+    }
+
+    expect(received).toHaveLength(scheduleTypes.length);
+
+    unsub();
+  });
+
+  it("should route workflow:* to the workflow channel", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("workflow", (event) => received.push(event));
+
+    genericObservability.emit({
+      type: "workflow:start",
+      payload: { workflowId: "wf-1", workflowName: "test" },
+      timestamp: Date.now()
+    });
+
+    genericObservability.emit({
+      type: "workflow:approved",
+      payload: { workflowId: "wf-1", reason: "lgtm" },
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(2);
+    expect(received[0].type).toBe("workflow:start");
+    expect(received[1].type).toBe("workflow:approved");
+
+    unsub();
+  });
+
+  it("should route connect and destroy to the lifecycle channel", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("lifecycle", (event) => received.push(event));
+
+    genericObservability.emit({
+      type: "connect",
+      payload: { connectionId: "conn-1" },
+      timestamp: Date.now()
+    });
+
+    genericObservability.emit({
+      type: "destroy",
+      payload: {},
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(2);
+    expect(received[0].type).toBe("connect");
+    expect(received[1].type).toBe("destroy");
+
+    unsub();
+  });
+
+  it("should route message:* to the message channel", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("message", (event) => received.push(event));
+
+    genericObservability.emit({
+      type: "message:request",
+      payload: {},
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe("message:request");
+
+    unsub();
+  });
+
+  it("should route mcp:* to the mcp channel", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("mcp", (event) => received.push(event));
+
+    genericObservability.emit({
+      type: "mcp:client:connect",
+      payload: { url: "http://test", transport: "sse", state: "connected" },
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe("mcp:client:connect");
+
+    unsub();
+  });
+});
+
+// ── Error event emission (integration) ──────────────────────────────
+
+// Helper to connect via WebSocket
+async function connectWS(path: string) {
+  const ctx = createExecutionContext();
+  const req = new Request(`http://example.com${path}`, {
+    headers: { Upgrade: "websocket" }
+  });
+  const res = await worker.fetch(req, env, ctx);
+  expect(res.status).toBe(101);
+  const ws = res.webSocket as WebSocket;
+  expect(ws).toBeDefined();
+  ws.accept();
+  return { ws, ctx };
+}
+
+// Helper to skip initial messages (identity, state, mcp_servers)
+async function skipInitialMessages(ws: WebSocket): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    await new Promise<void>((resolve) => {
+      ws.addEventListener("message", () => resolve(), { once: true });
+    });
+  }
+}
+
+// Helper to send RPC and wait for response
+async function callRPC(
+  ws: WebSocket,
+  method: string,
+  args: unknown[] = []
+): Promise<RPCResponse> {
+  const id = Math.random().toString(36).slice(2);
+  const request: RPCRequest = { type: MessageType.RPC, id, method, args };
+  ws.send(JSON.stringify(request));
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`RPC timeout for ${method}`)),
+      2000
+    );
+    const handler = (e: MessageEvent) => {
+      const msg = JSON.parse(e.data as string) as RPCResponse;
+      if (msg.type === MessageType.RPC && msg.id === id) {
+        if (msg.success && (msg as { done?: boolean }).done === false) return;
+        clearTimeout(timer);
+        ws.removeEventListener("message", handler);
+        resolve(msg);
+      }
+    };
+    ws.addEventListener("message", handler);
+  });
+}
+
+describe("error event emission", () => {
+  it("should emit rpc:error when a callable method throws", async () => {
+    const errors: ObservabilityEvent[] = [];
+    const unsub = subscribe("rpc", (event) => {
+      if (event.type === "rpc:error") {
+        errors.push(event);
+      }
+    });
+
+    const { ws } = await connectWS(
+      `/agents/test-callable-agent/rpc-error-obs-${crypto.randomUUID()}`
+    );
+    await skipInitialMessages(ws);
+
+    // Call a method that does not exist (privateMethod is not @callable)
+    const response = await callRPC(ws, "privateMethod");
+    expect(response.success).toBe(false);
+
+    ws.close();
+    unsub();
+
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].type).toBe("rpc:error");
+    if (errors[0].type === "rpc:error") {
+      expect(errors[0].payload.method).toBe("privateMethod");
+    }
+  });
+
+  it("should emit queue:error when a queue callback fails", async () => {
+    const errors: ObservabilityEvent[] = [];
+    const unsub = subscribe("schedule", (event) => {
+      if (event.type === "queue:error") {
+        errors.push(event);
+      }
+    });
+
+    const agentStub = await getAgentByName(
+      env.TestQueueAgent,
+      "queue-error-obs-test"
+    );
+
+    // Enqueue a throwing callback
+    await agentStub.enqueueThrowing("fail");
+
+    // Wait for the flush to complete
+    await agentStub.waitForFlush(2000);
+
+    unsub();
+
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].type).toBe("queue:error");
+    if (errors[0].type === "queue:error") {
+      expect(errors[0].payload.callback).toBe("throwingCallback");
+      expect(errors[0].payload.error).toBeDefined();
+    }
+  });
+});

--- a/packages/ai-chat/e2e/worker.ts
+++ b/packages/ai-chat/e2e/worker.ts
@@ -23,8 +23,6 @@ export type Env = {
  * Simple agent that returns plain text — used by the basic protocol tests.
  */
 export class ChatAgent extends AIChatAgent<Env> {
-  observability = undefined;
-
   async onChatMessage() {
     return new Response("Hello from e2e agent!", {
       headers: { "Content-Type": "text/plain" }
@@ -37,8 +35,6 @@ export class ChatAgent extends AIChatAgent<Env> {
  * Used by the LLM e2e tests that verify real SSE streaming, tool calls, etc.
  */
 export class LlmChatAgent extends AIChatAgent<Env> {
-  observability = undefined;
-
   async onChatMessage(_onFinish?: unknown, options?: OnChatMessageOptions) {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
@@ -88,8 +84,6 @@ export class LlmChatAgent extends AIChatAgent<Env> {
  * and the test must send CF_AGENT_TOOL_RESULT to continue.
  */
 export class ClientToolAgent extends AIChatAgent<Env> {
-  observability = undefined;
-
   async onChatMessage() {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
@@ -117,8 +111,6 @@ export class ClientToolAgent extends AIChatAgent<Env> {
  * Used to test stream resumption by disconnecting mid-stream.
  */
 export class SlowAgent extends AIChatAgent<Env> {
-  observability = undefined;
-
   async onChatMessage() {
     // Create a stream that sends chunks with delays
     const encoder = new TextEncoder();
@@ -149,8 +141,6 @@ export class SlowAgent extends AIChatAgent<Env> {
  * Agent configured with a bad API key to test error handling.
  */
 export class BadKeyAgent extends AIChatAgent<Env> {
-  observability = undefined;
-
   async onChatMessage() {
     const openai = createOpenAI({ apiKey: "sk-invalid-key-for-testing" });
 

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -26,7 +26,6 @@ export type Env = {
 };
 
 export class TestChatAgent extends AIChatAgent<Env> {
-  observability = undefined;
   // Store captured context for testing
   private _capturedContext: {
     hasAgent: boolean;
@@ -355,8 +354,6 @@ export class TestChatAgent extends AIChatAgent<Env> {
  * - `chunkDelayMs`: delay between chunks in ms (default: 50)
  */
 export class SlowStreamAgent extends AIChatAgent<Env> {
-  observability = undefined;
-
   async onChatMessage(
     _onFinish: StreamTextOnFinishCallback<ToolSet>,
     options?: OnChatMessageOptions
@@ -422,7 +419,6 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
 
 // Test agents for waitForMcpConnections config
 export class WaitMcpTrueAgent extends AIChatAgent<Env> {
-  observability = undefined;
   waitForMcpConnections = true as const;
 
   async onChatMessage() {
@@ -435,7 +431,6 @@ export class WaitMcpTrueAgent extends AIChatAgent<Env> {
 }
 
 export class WaitMcpTimeoutAgent extends AIChatAgent<Env> {
-  observability = undefined;
   waitForMcpConnections = { timeout: 1000 };
 
   async onChatMessage() {
@@ -448,7 +443,6 @@ export class WaitMcpTimeoutAgent extends AIChatAgent<Env> {
 }
 
 export class WaitMcpFalseAgent extends AIChatAgent<Env> {
-  observability = undefined;
   waitForMcpConnections = false as const;
 
   async onChatMessage() {

--- a/packages/codemode/e2e/worker.ts
+++ b/packages/codemode/e2e/worker.ts
@@ -63,8 +63,6 @@ const pmTools = {
 };
 
 export class CodemodeAgent extends Agent<Env> {
-  observability = undefined;
-
   async onRequest(request: Request): Promise<Response> {
     const url = new URL(request.url);
 


### PR DESCRIPTION
## Summary

Overhaul the observability system to use Node.js `diagnostics_channel` instead of `console.log`. Events are now silent by default (zero overhead when nobody is listening), fully typed with strict payloads, and automatically forwarded to Tail Workers in production.

**30 files changed, 849 insertions, 472 deletions.**

---

## What changed

### 1. `diagnostics_channel` replaces `console.log`

The default `genericObservability` implementation no longer logs every event to the console. Instead, events are published to named diagnostics channels using the Node.js `diagnostics_channel` API. Publishing to a channel with no subscribers is a no-op — this eliminates the logspam that the old system produced.

Seven named channels, one per event domain:

| Channel | Events |
|---------|--------|
| `agents:state` | `state:update` |
| `agents:rpc` | `rpc`, `rpc:error` |
| `agents:message` | `message:request/response/clear/cancel/error`, `tool:result/approval` |
| `agents:schedule` | `schedule:create/execute/cancel/retry/error`, `queue:retry/error` |
| `agents:lifecycle` | `connect`, `destroy` |
| `agents:workflow` | `workflow:start/event/approved/rejected/terminated/paused/resumed/restarted` |
| `agents:mcp` | `mcp:client:preconnect/connect/authorize/discover` |

### 2. Strict `BaseEvent` type

`BaseEvent` has been simplified to three fields: `type`, `payload`, and `timestamp`. The removed fields are:

- **`id`** (was `nanoid()`-generated) — removed because diagnostics channels provide ordering; IDs added no value and increased bundle size
- **`displayMessage`** (human-readable string) — removed because structured `type` + `payload` is more useful for programmatic consumption; display formatting belongs in the subscriber

The `payload` type is now **strict** — accessing undeclared fields is a type error. This forces consumers to narrow on `event.type` before accessing payload properties, catching mismatches at compile time:

```ts
// Before (loose): event.payload.anything was allowed
// After (strict): must narrow first
if (event.type === "rpc:error") {
  console.log(event.payload.method); // ✅ typed
}
```

### 3. New error events

Error events are emitted at failure sites alongside `console.error`:

- `rpc:error` — when a `@callable` method throws (includes `method` and `error`)
- `schedule:error` — when a schedule callback fails after all retries
- `queue:error` — when a queue callback fails after all retries

Design decision: we kept `console.error` at these sites so errors remain visible in local dev even without subscribers, while also emitting structured events for production monitoring.

### 4. `_emit()` private helper

All 28 inline `emit` blocks in the Agent class have been replaced with a private `_emit(type, payload?)` helper that auto-generates timestamps. This reduced each call site from ~6 lines to 1 and eliminated the scattered `nanoid()` / `displayMessage` boilerplate.

### 5. Typed `subscribe()` helper

A new `subscribe()` function exported from `agents/observability` provides type-safe event subscription per channel:

```ts
import { subscribe } from "agents/observability";

const unsub = subscribe("rpc", (event) => {
  // event is typed as rpc | rpc:error — full autocomplete
  if (event.type === "rpc:error") {
    console.error(event.payload.method, event.payload.error);
  }
});

unsub(); // clean up
```

Implementation: wraps `node:diagnostics_channel` subscribe/unsubscribe with a `ChannelEventMap` that maps each channel key to its `Extract<>`-ed event union. The cast through `unknown` in the handler is safe because we control both the publish and subscribe sides.

### 6. AIChatAgent observability events

Added 5 new event types emitted by `AIChatAgent` in `@cloudflare/ai-chat`:

| Event | Payload | When |
|-------|---------|------|
| `message:clear` | `{}` | Client clears chat history |
| `message:cancel` | `{ requestId }` | Client cancels a streaming request |
| `message:error` | `{ error }` | Chat stream fails |
| `tool:result` | `{ toolCallId, toolName }` | Client sends a tool execution result |
| `tool:approval` | `{ toolCallId, approved }` | Client approves or rejects a tool call |

These are routed to the `agents:message` channel alongside the existing `message:request` and `message:response` events. The `tool:` prefix is deliberately routed to `message` (not a separate channel) because tool interactions are part of the chat message lifecycle.

### 7. Missing `mcp:client:authorize` emit

The `mcp:client:authorize` event type existed but was never actually fired. Added the emit in `MCPClientManager.connectToServer()` when the OAuth flow enters `AUTHENTICATING` state with an `authUrl`.

### 8. Test agent cleanup

Removed `observability = undefined` overrides from all test agents. These were silencing observability during tests, which masked bugs and prevented testing the observability system itself. The new diagnostics_channel approach is silent by default (no subscribers = no work), so these overrides are unnecessary.

---

## Design decisions

### Why `diagnostics_channel` over EventEmitter or custom pub/sub?

1. **Zero overhead** — `channel.publish()` with no subscribers is a single boolean check, not a function call
2. **Tail Worker integration** — Cloudflare Workers automatically forward all diagnostics channel messages to Tail Workers via `event.diagnosticsChannelEvents`. No agent-side code needed for production observability
3. **TracingChannel future** — `diagnostics_channel` also provides `TracingChannel` for start/end/error spans with `AsyncLocalStorage` integration, opening the door to end-to-end distributed tracing
4. **Standard API** — part of the Node.js compatibility layer in Workers, no additional dependencies

### Why strict payloads instead of `Record<string, unknown>`?

The loose payload type allowed consumers to access arbitrary fields without narrowing, leading to runtime errors when event shapes changed. The strict type (`Record<string, never>` default) forces narrowing on `event.type` first, which is the correct pattern for discriminated unions and catches payload mismatches at compile time.

### Why route `tool:` events to the `message` channel?

Tool results and approvals are part of the chat conversation flow — they happen between `message:request` and `message:response`. A subscriber monitoring chat interactions needs to see tool events to understand the full picture. A separate `agents:tool` channel would fragment this view.

### Why keep `console.error` alongside error event emission?

Error events are the most time-sensitive — developers need to see them immediately during local development. Requiring a diagnostics_channel subscriber just to see errors would be a poor DX regression. The pattern is: `console.error` for humans, `_emit("rpc:error", ...)` for machines.

---

## Breaking changes

- **`BaseEvent`**: `id` and `displayMessage` fields removed. `payload` type is now strict.
- **`Observability.emit()`**: Removed the optional `ctx` second parameter.
- **`AgentObservabilityEvent`**: Each event type now has its own discriminant (was a combined union with shared fields). This enables `Extract<>`-based type narrowing.

If you have a custom `Observability` implementation, update your `emit` signature to `emit(event: ObservabilityEvent): void`.

---

## Notes for reviewers

- **`packages/agents/src/index.ts`** — The diff is large because every inline `emit()` block was replaced with a one-liner `_emit()` call. The logic is unchanged; it is purely mechanical cleanup. Focus on the `_emit` helper definition at line ~739.
- **`packages/agents/src/observability/index.ts`** — This is the core of the change. Review `getChannel()` routing, `ChannelEventMap` type mapping, and the `subscribe()` helper.
- **`packages/agents/src/observability/base.ts`** — The `Record<string, never>` default payload is intentional. It means events with no declared payload fields will error if you try to access `payload.foo`. This is the desired behavior.
- **`packages/ai-chat/src/index.ts`** — 8 emit sites total. The emit calls use `this.observability?.emit()` directly (not `_emit`) because `AIChatAgent` does not have the private helper — it inherits `observability` from the base `Agent` class.
- **Test agents** (`src/tests/agents/*.ts`) — All `observability = undefined` lines were removed. This is safe because `genericObservability` with no subscribers does zero work.
- **`mcp/client.ts` line 849** — New `mcp:client:authorize` emit. Was a dead type before this change.
- **331-line new test file** (`observability.test.ts`) — Covers subscribe/unsubscribe lifecycle, channel routing for all 7 channels, and integration tests for `rpc:error` and `queue:error` emission via real WebSocket connections.

## Testing

- 45/45 TypeScript projects typecheck
- 1031 tests pass (764 workers + 267 ai-chat)
- Zero test failures, zero new skips