### PR TITLE
feat: add `Agent.keepAliveWhile()` scoped callback API

### DIFF
--- a/.changeset/keep-alive-agent.md
+++ b/.changeset/keep-alive-agent.md
@@ -3,6 +3,6 @@
 "@cloudflare/ai-chat": patch
 ---
 
-Add experimental `keepAlive()` method to the Agent class. Keeps the Durable Object alive via alarm heartbeats (every 30 seconds), preventing idle eviction during long-running work. Returns a disposer function to stop the heartbeat.
+Add experimental `keepAlive()` and `keepAliveWhile()` methods to the Agent class. Keeps the Durable Object alive via alarm heartbeats (every 30 seconds), preventing idle eviction during long-running work. `keepAlive()` returns a disposer function; `keepAliveWhile(fn)` runs an async function and automatically cleans up the heartbeat when it completes.
 
-`AIChatAgent` now automatically calls `keepAlive()` during `_reply()` streaming, preventing idle eviction during long LLM generations.
+`AIChatAgent` now automatically calls `keepAliveWhile()` during `_reply()` streaming, preventing idle eviction during long LLM generations.

--- a/docs/agent-class.md
+++ b/docs/agent-class.md
@@ -440,7 +440,7 @@ class MyAgent extends Agent {
 
 ### `this.keepAlive`
 
-`this.keepAlive()` prevents the Durable Object from being evicted due to inactivity by creating a 30-second heartbeat schedule. Returns a disposer function to stop the heartbeat. See [Keeping the Agent Alive](./scheduling.md#keeping-the-agent-alive) for full documentation.
+`this.keepAlive()` prevents the Durable Object from being evicted due to inactivity by creating a 30-second heartbeat schedule. Returns a disposer function to stop the heartbeat. For scoped work, use `this.keepAliveWhile(fn)` which automatically cleans up when the function completes. See [Keeping the Agent Alive](./scheduling.md#keeping-the-agent-alive) for full documentation.
 
 ### Routing
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -244,6 +244,19 @@ try {
 
 The returned disposer function cancels the heartbeat. Always call it when the work is done — otherwise the heartbeat continues indefinitely.
 
+### keepAliveWhile()
+
+For scoped work, use `keepAliveWhile()` — it runs an async function and automatically cleans up the heartbeat when it completes (or throws):
+
+```typescript
+const result = await this.keepAliveWhile(async () => {
+  const data = await longRunningComputation();
+  return data;
+});
+```
+
+This is the recommended approach since you cannot forget to dispose the heartbeat.
+
 ### How it works
 
 `keepAlive()` calls `scheduleEvery(30, "_cf_keepAliveHeartbeat")` under the hood. The internal `_cf_keepAliveHeartbeat` callback is a no-op — the alarm firing itself is what resets the inactivity timer. Because it uses the scheduling system:
@@ -786,6 +799,16 @@ async keepAlive(): Promise<() => void>
 Create a 30-second heartbeat schedule that prevents the Durable Object from being evicted due to inactivity. Returns a disposer function that cancels the heartbeat when called. The disposer is idempotent — calling it multiple times is safe.
 
 See [Keeping the Agent Alive](#keeping-the-agent-alive) for usage details.
+
+### keepAliveWhile()
+
+```typescript
+async keepAliveWhile<T>(fn: () => Promise<T>): Promise<T>
+```
+
+Run an async function while keeping the Durable Object alive. The heartbeat is automatically started before the function runs and stopped when it completes (whether it succeeds or throws). Returns the value returned by the function.
+
+This is the recommended way to use keepAlive — it guarantees cleanup.
 
 ## Limits
 

--- a/packages/agents/src/experimental/forever.ts
+++ b/packages/agents/src/experimental/forever.ts
@@ -110,7 +110,12 @@ type Constructor<T = object> = new (...args: any[]) => T;
 type AgentLike = Constructor<
   Pick<
     Agent<Cloudflare.Env>,
-    "sql" | "scheduleEvery" | "cancelSchedule" | "alarm" | "keepAlive"
+    | "sql"
+    | "scheduleEvery"
+    | "cancelSchedule"
+    | "alarm"
+    | "keepAlive"
+    | "keepAliveWhile"
   >
 >;
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2319,6 +2319,33 @@ export class Agent<
   }
 
   /**
+   * Run an async function while keeping the Durable Object alive.
+   * The heartbeat is automatically stopped when the function completes
+   * (whether it succeeds or throws).
+   *
+   * This is the recommended way to use keepAlive — it guarantees cleanup
+   * so you cannot forget to dispose the heartbeat.
+   *
+   * @experimental This API may change between releases.
+   *
+   * @example
+   * ```ts
+   * const result = await this.keepAliveWhile(async () => {
+   *   const data = await longRunningComputation();
+   *   return data;
+   * });
+   * ```
+   */
+  async keepAliveWhile<T>(fn: () => Promise<T>): Promise<T> {
+    const dispose = await this.keepAlive();
+    try {
+      return await fn();
+    } finally {
+      dispose();
+    }
+  }
+
+  /**
    * Internal no-op callback invoked by the keepAlive heartbeat schedule.
    * Its only purpose is to keep the DO alive — the alarm machinery
    * handles the rest.

--- a/packages/agents/src/tests/agents/keep-alive.ts
+++ b/packages/agents/src/tests/agents/keep-alive.ts
@@ -37,6 +37,25 @@ export class TestKeepAliveAgent extends Agent<Record<string, unknown>> {
   }
 
   @callable()
+  async runWithKeepAliveWhile(): Promise<string> {
+    return this.keepAliveWhile(async () => {
+      return "completed";
+    });
+  }
+
+  @callable()
+  async runWithKeepAliveWhileError(): Promise<string> {
+    try {
+      await this.keepAliveWhile(async () => {
+        throw new Error("task failed");
+      });
+      return "should not reach";
+    } catch {
+      return "caught";
+    }
+  }
+
+  @callable()
   async getHeartbeatSchedule(): Promise<{
     id: string;
     callback: string;

--- a/packages/agents/src/tests/keep-alive.test.ts
+++ b/packages/agents/src/tests/keep-alive.test.ts
@@ -61,6 +61,30 @@ describe("keepAlive", () => {
     expect(await agent.getHeartbeatScheduleCount()).toBe(0);
   });
 
+  it("keepAliveWhile should return the function result and clean up", async () => {
+    const agent = await getAgentByName(env.TestKeepAliveAgent, "while-success");
+
+    expect(await agent.getHeartbeatScheduleCount()).toBe(0);
+
+    const result = await agent.runWithKeepAliveWhile();
+    expect(result).toBe("completed");
+
+    // Heartbeat should be cleaned up after the function completes
+    expect(await agent.getHeartbeatScheduleCount()).toBe(0);
+  });
+
+  it("keepAliveWhile should clean up even when the function throws", async () => {
+    const agent = await getAgentByName(env.TestKeepAliveAgent, "while-error");
+
+    expect(await agent.getHeartbeatScheduleCount()).toBe(0);
+
+    const result = await agent.runWithKeepAliveWhileError();
+    expect(result).toBe("caught");
+
+    // Heartbeat should be cleaned up despite the error
+    expect(await agent.getHeartbeatScheduleCount()).toBe(0);
+  });
+
   it("should support multiple concurrent keepAlive calls", async () => {
     const agent = await getAgentByName(
       env.TestKeepAliveAgent,

--- a/packages/ai-chat/src/experimental/forever.ts
+++ b/packages/ai-chat/src/experimental/forever.ts
@@ -39,7 +39,10 @@ console.warn(
 type Constructor<T = object> = new (...args: any[]) => T;
 
 type AIChatAgentLike = Constructor<
-  Pick<AIChatAgent, "scheduleEvery" | "cancelSchedule" | "keepAlive">
+  Pick<
+    AIChatAgent,
+    "scheduleEvery" | "cancelSchedule" | "keepAlive" | "keepAliveWhile"
+  >
 >;
 
 export function withDurableChat<TBase extends AIChatAgentLike>(Base: TBase) {


### PR DESCRIPTION
## Summary

Adds `keepAliveWhile(fn)` to the `Agent` class — a scoped version of `keepAlive()` that runs an async function while keeping the Durable Object alive, and automatically cleans up the heartbeat when the function completes (or throws).

This builds on the `keepAlive()` method (from #1029) and is now the recommended way to prevent idle eviction during long-running work.

## Motivation

The manual `keepAlive()` + disposer pattern requires developers to remember to call the disposer in a `finally` block. `keepAliveWhile(fn)` makes this structural — you cannot forget to clean up:

```ts
// Before (manual)
const dispose = await this.keepAlive();
try {
  await longWork();
} finally {
  dispose();
}

// After (scoped — recommended)
await this.keepAliveWhile(async () => {
  await longWork();
});
```

Both APIs remain available. `keepAlive()` is still useful when the lifetime spans multiple event callbacks (e.g., `onConnect` → `onClose`).

## Changes

| File | What changed |
|------|-------------|
| `packages/agents/src/index.ts` | Added `keepAliveWhile<T>(fn)` method |
| `packages/ai-chat/src/index.ts` | `_reply()` now uses `keepAliveWhile()` instead of manual `keepAlive()` + `.finally()` |
| `packages/agents/src/experimental/forever.ts` | Added `keepAliveWhile` to `AgentLike` Pick type |
| `packages/ai-chat/src/experimental/forever.ts` | Added `keepAliveWhile` to `AIChatAgentLike` Pick type |
| `packages/agents/src/tests/agents/keep-alive.ts` | Added `runWithKeepAliveWhile()` and `runWithKeepAliveWhileError()` test methods |
| `packages/agents/src/tests/keep-alive.test.ts` | 2 new tests: success path (returns result + cleans up) and error path (cleans up despite throw) |
| `docs/scheduling.md` | Documented `keepAliveWhile()` in the "Keeping the Agent Alive" section and API reference |
| `docs/agent-class.md` | Updated one-liner to mention `keepAliveWhile` |
| `.changeset/keep-alive-agent.md` | Updated to cover both methods |

## Notes for reviewers

- **`keepAliveWhile` is intentionally simple** — 7 lines, delegates entirely to `keepAlive()` with try/finally. No new scheduling primitives.
- **AIChatAgent `_reply()`** is now cleaner: `this.keepAliveWhile(() => this._tryCatchChat(...))` replaces the previous `keepAlive()` + `.finally(() => dispose())` pattern.
- **The experimental fiber module still uses `keepAlive()` directly** in `_startFiber` — this is intentional because the disposer needs to be passed through the retry loop across multiple `_runFiber` iterations. `keepAliveWhile` does not fit that pattern.
- **Generic return type** — `keepAliveWhile<T>(fn: () => Promise<T>): Promise<T>` preserves the caller's return type, so `const result = await this.keepAliveWhile(async () => 42)` correctly infers `number`.

## Testing

- 6 keepAlive tests total (4 for `keepAlive()`, 2 for `keepAliveWhile()`)
- All 290 existing tests pass
- 45/45 projects typecheck
- Build clean, exports valid, formatting clean, lint clean