### PR TITLE
fix(ai-chat): preserve server-generated messages when client appends new messages

### DIFF
--- a/.changeset/fix-preserve-server-messages.md
+++ b/.changeset/fix-preserve-server-messages.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+fix(ai-chat): preserve server-generated assistant messages when client appends new messages
+
+The `_deleteStaleRows` reconciliation in `persistMessages` now only deletes DB rows when the incoming message set is a subset of the server state (e.g. regenerate trims the conversation). When the client sends new message IDs not yet known to the server, stale deletion is skipped to avoid destroying assistant messages the client hasn't seen.


### PR DESCRIPTION
## Problem

The `_deleteStaleRows` reconciliation in `persistMessages` (added in #1014 for regenerate support) was too aggressive. When a client sent a chat request with new messages that didn't include the full server history, it deleted server-generated assistant messages the client hadn't seen yet.

This caused the "multiple messages accumulate in conversation" e2e test to fail: the second request's `persistMessages` call deleted the first assistant message because it wasn't in the incoming message set.

## Fix

Gate stale row deletion on whether the incoming messages are a **subset** of the server state. This distinguishes:

- **Regenerate/trim**: all incoming IDs exist in server state → delete stale rows ✓
- **Append new messages**: incoming set contains IDs unknown to server → skip deletion, preserve server messages ✓

## Changes

- `packages/ai-chat/src/index.ts`: Add `isSubsetOfServer` guard before stale row deletion
- `packages/ai-chat/src/tests/regenerate-message.test.ts`: Add regression test

## Testing

- 33/33 e2e tests pass (including previously failing "multiple messages accumulate")
- 291/291 unit tests pass (including all regenerate tests + new regression test)