### PR TITLE
Observability: add agent identity, new events, and email channel

### DIFF
--- a/.changeset/observability-agent-identity.md
+++ b/.changeset/observability-agent-identity.md
@@ -1,0 +1,10 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+---
+
+Add `agent` and `name` fields to observability events, identifying which agent class and instance emitted each event.
+
+New events: `disconnect` (WebSocket close), `email:receive`, `email:reply`, `queue:create`, and a new `agents:email` channel.
+
+Make `_emit` protected so subclasses can use it. Update `AIChatAgent` to use `_emit` so message/tool events carry agent identity.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,29 +4,34 @@ Agents emit structured events for every significant operation — RPC calls, sta
 
 ## Event structure
 
-Every event has three fields:
+Every event has these fields:
 
 ```ts
 {
   type: "rpc",                        // what happened
+  agent: "MyAgent",                   // which agent class emitted it
+  name: "user-123",                   // which agent instance (Durable Object name)
   payload: { method: "getWeather" },  // details
   timestamp: 1758005142787            // when (ms since epoch)
 }
 ```
 
+`agent` and `name` identify the source agent — `agent` is the class name and `name` is the Durable Object instance name.
+
 ## Channels
 
-Events are routed to seven named channels based on their type:
+Events are routed to eight named channels based on their type:
 
 | Channel            | Event types                                                                                                                                                      | Description                         |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `agents:state`     | `state:update`                                                                                                                                                   | State sync events                   |
 | `agents:rpc`       | `rpc`, `rpc:error`                                                                                                                                               | RPC method calls and failures       |
 | `agents:message`   | `message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`                                        | Chat message and tool lifecycle     |
-| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `queue:retry`, `queue:error`                                       | Scheduled and queued task lifecycle |
-| `agents:lifecycle` | `connect`, `destroy`                                                                                                                                             | Agent connection and teardown       |
+| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `queue:create`, `queue:retry`, `queue:error`                       | Scheduled and queued task lifecycle |
+| `agents:lifecycle` | `connect`, `disconnect`, `destroy`                                                                                                                               | Agent connection and teardown       |
 | `agents:workflow`  | `workflow:start`, `workflow:event`, `workflow:approved`, `workflow:rejected`, `workflow:terminated`, `workflow:paused`, `workflow:resumed`, `workflow:restarted` | Workflow state transitions          |
 | `agents:mcp`       | `mcp:client:preconnect`, `mcp:client:connect`, `mcp:client:authorize`, `mcp:client:discover`                                                                     | MCP client operations               |
+| `agents:email`     | `email:receive`, `email:reply`                                                                                                                                   | Email processing                    |
 
 ## Subscribing to events
 
@@ -154,15 +159,17 @@ These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track
 | `schedule:cancel`  | `{ callback, id }`                       | A schedule is cancelled                      |
 | `schedule:retry`   | `{ callback, id, attempt, maxAttempts }` | A scheduled callback is retried              |
 | `schedule:error`   | `{ callback, id, error, attempts }`      | A scheduled callback fails after all retries |
+| `queue:create`     | `{ callback, id }`                       | A task is enqueued                           |
 | `queue:retry`      | `{ callback, id, attempt, maxAttempts }` | A queued callback is retried                 |
 | `queue:error`      | `{ callback, id, error, attempts }`      | A queued callback fails after all retries    |
 
 ### Lifecycle events
 
-| Type      | Payload            | When                                  |
-| --------- | ------------------ | ------------------------------------- |
-| `connect` | `{ connectionId }` | A WebSocket connection is established |
-| `destroy` | `{}`               | The agent is destroyed                |
+| Type         | Payload                          | When                                  |
+| ------------ | -------------------------------- | ------------------------------------- |
+| `connect`    | `{ connectionId }`               | A WebSocket connection is established |
+| `disconnect` | `{ connectionId, code, reason }` | A WebSocket connection is closed      |
+| `destroy`    | `{}`                             | The agent is destroyed                |
 
 ### Workflow events
 
@@ -185,3 +192,10 @@ These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track
 | `mcp:client:connect`    | `{ url, transport, state, error? }`     | An MCP connection attempt completes or fails |
 | `mcp:client:authorize`  | `{ serverId, authUrl, clientId? }`      | An MCP OAuth flow begins                     |
 | `mcp:client:discover`   | `{ url?, state?, error?, capability? }` | MCP capability discovery succeeds or fails   |
+
+### Email events
+
+| Type            | Payload                  | When                  |
+| --------------- | ------------------------ | --------------------- |
+| `email:receive` | `{ from, to, subject? }` | An email is received  |
+| `email:reply`   | `{ from, to, subject? }` | A reply email is sent |

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -738,12 +738,14 @@ export class Agent<
    * Emit an observability event with auto-generated timestamp.
    * @internal
    */
-  private _emit(
+  protected _emit(
     type: ObservabilityEvent["type"],
     payload: Record<string, unknown> = {}
   ): void {
     this.observability?.emit({
       type,
+      agent: this._ParentClass.name,
+      name: this.name,
       payload,
       timestamp: Date.now()
     } as ObservabilityEvent);
@@ -901,7 +903,11 @@ export class Agent<
     // Emit MCP observability events
     this._disposables.add(
       this.mcp.onObservabilityEvent((event) => {
-        this.observability?.emit(event);
+        this.observability?.emit({
+          ...event,
+          agent: this._ParentClass.name,
+          name: this.name
+        });
       })
     );
     // Compute persistence-hook dispatch mode once.
@@ -1160,6 +1166,26 @@ export class Agent<
 
           this._emit("connect", { connectionId: connection.id });
           return this._tryCatch(() => _onConnect(connection, ctx));
+        }
+      );
+    };
+
+    const _onClose = this.onClose.bind(this);
+    this.onClose = (
+      connection: Connection,
+      code: number,
+      reason: string,
+      wasClean: boolean
+    ) => {
+      return agentContext.run(
+        { agent: this, connection, request: undefined, email: undefined },
+        () => {
+          this._emit("disconnect", {
+            connectionId: connection.id,
+            code,
+            reason
+          });
+          return _onClose(connection, code, reason, wasClean);
         }
       );
     };
@@ -1595,6 +1621,11 @@ export class Agent<
     return agentContext.run(
       { agent: this, connection: undefined, request: undefined, email: email },
       async () => {
+        this._emit("email:receive", {
+          from: email.from,
+          to: email.to,
+          subject: email.headers.get("subject") ?? undefined
+        });
         if ("onEmail" in this && typeof this.onEmail === "function") {
           return this._tryCatch(() =>
             (this.onEmail as (email: AgentEmail) => Promise<void>)(email)
@@ -1682,6 +1713,16 @@ export class Agent<
         from: email.to,
         raw: msg.asRaw(),
         to: email.from
+      });
+
+      // Emit after the send succeeds — from/to are swapped because
+      // this is a reply: the agent (email.to) is now the sender.
+      const rawSubject = email.headers.get("subject");
+      this._emit("email:reply", {
+        from: email.to,
+        to: email.from,
+        subject:
+          options.subject ?? (rawSubject ? `Re: ${rawSubject}` : undefined)
       });
     });
   }
@@ -1853,6 +1894,8 @@ export class Agent<
       INSERT OR REPLACE INTO cf_agents_queues (id, payload, callback, retry_options)
       VALUES (${id}, ${JSON.stringify(payload)}, ${callback}, ${retryJson})
     `;
+
+    this._emit("queue:create", { callback: callback as string, id });
 
     void this._flushQueue().catch((e) => {
       console.error("Error flushing queue:", e);

--- a/packages/agents/src/observability/agent.ts
+++ b/packages/agents/src/observability/agent.ts
@@ -26,6 +26,7 @@ export type AgentObservabilityEvent =
       "schedule:error",
       { callback: string; id: string; error: string; attempts: number }
     >
+  | BaseEvent<"queue:create", { callback: string; id: string }>
   | BaseEvent<
       "queue:retry",
       { callback: string; id: string; attempt: number; maxAttempts: number }
@@ -36,6 +37,12 @@ export type AgentObservabilityEvent =
     >
   | BaseEvent<"destroy">
   | BaseEvent<"connect", { connectionId: string }>
+  | BaseEvent<
+      "disconnect",
+      { connectionId: string; code: number; reason: string }
+    >
+  | BaseEvent<"email:receive", { from: string; to: string; subject?: string }>
+  | BaseEvent<"email:reply", { from: string; to: string; subject?: string }>
   | BaseEvent<"workflow:start", { workflowId: string; workflowName?: string }>
   | BaseEvent<"workflow:event", { workflowId: string; eventType?: string }>
   | BaseEvent<"workflow:approved", { workflowId: string; reason?: string }>

--- a/packages/agents/src/observability/base.ts
+++ b/packages/agents/src/observability/base.ts
@@ -7,6 +7,17 @@ export type BaseEvent<
 > = {
   type: T;
   /**
+   * The class name of the agent that emitted this event
+   * (e.g. "MyChatAgent").
+   * Always present on events emitted by an Agent instance.
+   */
+  agent?: string;
+  /**
+   * The instance name (Durable Object ID name) of the agent.
+   * Always present on events emitted by an Agent instance.
+   */
+  name?: string;
+  /**
    * The payload of the event
    */
   payload: Payload;

--- a/packages/agents/src/observability/index.ts
+++ b/packages/agents/src/observability/index.ts
@@ -44,7 +44,8 @@ export const channels = {
   schedule: channel("agents:schedule"),
   lifecycle: channel("agents:lifecycle"),
   workflow: channel("agents:workflow"),
-  mcp: channel("agents:mcp")
+  mcp: channel("agents:mcp"),
+  email: channel("agents:email")
 } as const;
 
 /**
@@ -59,7 +60,8 @@ function getChannel(type: string): Channel {
     return channels.message;
   if (type === "rpc" || type.startsWith("rpc:")) return channels.rpc;
   if (type.startsWith("state:")) return channels.state;
-  // connect, destroy
+  if (type.startsWith("email:")) return channels.email;
+  // connect, disconnect, destroy
   return channels.lifecycle;
 }
 
@@ -89,9 +91,13 @@ export type ChannelEventMap = {
     ObservabilityEvent,
     { type: `schedule:${string}` | `queue:${string}` }
   >;
-  lifecycle: Extract<ObservabilityEvent, { type: "connect" | "destroy" }>;
+  lifecycle: Extract<
+    ObservabilityEvent,
+    { type: "connect" | "disconnect" | "destroy" }
+  >;
   workflow: Extract<ObservabilityEvent, { type: `workflow:${string}` }>;
   mcp: Extract<ObservabilityEvent, { type: `mcp:${string}` }>;
+  email: Extract<ObservabilityEvent, { type: `email:${string}` }>;
 };
 
 /**

--- a/packages/agents/src/tests/observability.test.ts
+++ b/packages/agents/src/tests/observability.test.ts
@@ -25,12 +25,16 @@ describe("subscribe()", () => {
 
     genericObservability.emit({
       type: "rpc",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { method: "testMethod", streaming: false },
       timestamp: Date.now()
     });
 
     expect(received).toHaveLength(1);
     expect(received[0].type).toBe("rpc");
+    expect(received[0].agent).toBe("test-agent");
+    expect(received[0].name).toBe("inst-1");
     if (received[0].type === "rpc") {
       expect(received[0].payload.method).toBe("testMethod");
     }
@@ -46,6 +50,8 @@ describe("subscribe()", () => {
 
     genericObservability.emit({
       type: "rpc",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { method: "before" },
       timestamp: Date.now()
     });
@@ -54,6 +60,8 @@ describe("subscribe()", () => {
 
     genericObservability.emit({
       type: "rpc",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { method: "after" },
       timestamp: Date.now()
     });
@@ -73,12 +81,16 @@ describe("subscribe()", () => {
 
     genericObservability.emit({
       type: "rpc",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { method: "test" },
       timestamp: Date.now()
     });
 
     genericObservability.emit({
       type: "state:update",
+      agent: "test-agent",
+      name: "inst-1",
       payload: {},
       timestamp: Date.now()
     });
@@ -102,6 +114,8 @@ describe("channel routing", () => {
 
     genericObservability.emit({
       type: "rpc:error",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { method: "broken", error: "fail" },
       timestamp: Date.now()
     });
@@ -122,6 +136,7 @@ describe("channel routing", () => {
       "schedule:cancel",
       "schedule:retry",
       "schedule:error",
+      "queue:create",
       "queue:retry",
       "queue:error"
     ] as const;
@@ -129,6 +144,8 @@ describe("channel routing", () => {
     for (const type of scheduleTypes) {
       genericObservability.emit({
         type,
+        agent: "test-agent",
+        name: "inst-1",
         payload: { callback: "cb", id: "1" },
         timestamp: Date.now()
       } as ObservabilityEvent);
@@ -145,12 +162,16 @@ describe("channel routing", () => {
 
     genericObservability.emit({
       type: "workflow:start",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { workflowId: "wf-1", workflowName: "test" },
       timestamp: Date.now()
     });
 
     genericObservability.emit({
       type: "workflow:approved",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { workflowId: "wf-1", reason: "lgtm" },
       timestamp: Date.now()
     });
@@ -162,25 +183,38 @@ describe("channel routing", () => {
     unsub();
   });
 
-  it("should route connect and destroy to the lifecycle channel", () => {
+  it("should route connect, disconnect, and destroy to the lifecycle channel", () => {
     const received: ObservabilityEvent[] = [];
     const unsub = subscribe("lifecycle", (event) => received.push(event));
 
     genericObservability.emit({
       type: "connect",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { connectionId: "conn-1" },
       timestamp: Date.now()
     });
 
     genericObservability.emit({
+      type: "disconnect",
+      agent: "test-agent",
+      name: "inst-1",
+      payload: { connectionId: "conn-1", code: 1000, reason: "normal" },
+      timestamp: Date.now()
+    });
+
+    genericObservability.emit({
       type: "destroy",
+      agent: "test-agent",
+      name: "inst-1",
       payload: {},
       timestamp: Date.now()
     });
 
-    expect(received).toHaveLength(2);
+    expect(received).toHaveLength(3);
     expect(received[0].type).toBe("connect");
-    expect(received[1].type).toBe("destroy");
+    expect(received[1].type).toBe("disconnect");
+    expect(received[2].type).toBe("destroy");
 
     unsub();
   });
@@ -191,6 +225,8 @@ describe("channel routing", () => {
 
     genericObservability.emit({
       type: "message:request",
+      agent: "test-agent",
+      name: "inst-1",
       payload: {},
       timestamp: Date.now()
     });
@@ -201,12 +237,41 @@ describe("channel routing", () => {
     unsub();
   });
 
+  it("should route email:* to the email channel", () => {
+    const received: ObservabilityEvent[] = [];
+    const unsub = subscribe("email", (event) => received.push(event));
+
+    genericObservability.emit({
+      type: "email:receive",
+      agent: "test-agent",
+      name: "inst-1",
+      payload: { from: "a@b.com", to: "c@d.com", subject: "hi" },
+      timestamp: Date.now()
+    });
+
+    genericObservability.emit({
+      type: "email:reply",
+      agent: "test-agent",
+      name: "inst-1",
+      payload: { from: "c@d.com", to: "a@b.com", subject: "Re: hi" },
+      timestamp: Date.now()
+    });
+
+    expect(received).toHaveLength(2);
+    expect(received[0].type).toBe("email:receive");
+    expect(received[1].type).toBe("email:reply");
+
+    unsub();
+  });
+
   it("should route mcp:* to the mcp channel", () => {
     const received: ObservabilityEvent[] = [];
     const unsub = subscribe("mcp", (event) => received.push(event));
 
     genericObservability.emit({
       type: "mcp:client:connect",
+      agent: "test-agent",
+      name: "inst-1",
       payload: { url: "http://test", transport: "sse", state: "connected" },
       timestamp: Date.now()
     });
@@ -218,7 +283,7 @@ describe("channel routing", () => {
   });
 });
 
-// ── Error event emission (integration) ──────────────────────────────
+// ── Event emission (integration) ─────────────────────────────────────
 
 // Helper to connect via WebSocket
 async function connectWS(path: string) {
@@ -271,7 +336,7 @@ async function callRPC(
   });
 }
 
-describe("error event emission", () => {
+describe("event emission (integration)", () => {
   it("should emit rpc:error when a callable method throws", async () => {
     const errors: ObservabilityEvent[] = [];
     const unsub = subscribe("rpc", (event) => {
@@ -294,8 +359,45 @@ describe("error event emission", () => {
 
     expect(errors.length).toBeGreaterThanOrEqual(1);
     expect(errors[0].type).toBe("rpc:error");
+    expect(errors[0].agent).toBe("TestCallableAgent");
+    expect(errors[0].name).toBeDefined();
     if (errors[0].type === "rpc:error") {
       expect(errors[0].payload.method).toBe("privateMethod");
+    }
+  });
+
+  it("should emit disconnect when a WebSocket closes", async () => {
+    const events: ObservabilityEvent[] = [];
+    const unsub = subscribe("lifecycle", (event) => {
+      events.push(event);
+    });
+
+    const { ws } = await connectWS(
+      `/agents/test-callable-agent/disconnect-obs-${crypto.randomUUID()}`
+    );
+    await skipInitialMessages(ws);
+
+    // Close triggers disconnect event
+    ws.close();
+
+    // Give the close handler a tick to fire
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    unsub();
+
+    const connects = events.filter((e) => e.type === "connect");
+    const disconnects = events.filter((e) => e.type === "disconnect");
+
+    expect(connects.length).toBeGreaterThanOrEqual(1);
+    expect(connects[0].agent).toBe("TestCallableAgent");
+    expect(connects[0].name).toBeDefined();
+
+    expect(disconnects.length).toBeGreaterThanOrEqual(1);
+    expect(disconnects[0].agent).toBe("TestCallableAgent");
+    expect(disconnects[0].name).toBeDefined();
+    if (disconnects[0].type === "disconnect") {
+      expect(disconnects[0].payload.connectionId).toBeDefined();
+      expect(typeof disconnects[0].payload.code).toBe("number");
     }
   });
 
@@ -322,6 +424,8 @@ describe("error event emission", () => {
 
     expect(errors.length).toBeGreaterThanOrEqual(1);
     expect(errors[0].type).toBe("queue:error");
+    expect(errors[0].agent).toBeDefined();
+    expect(errors[0].name).toBeDefined();
     if (errors[0].type === "queue:error") {
       expect(errors[0].payload.callback).toBe("throwingCallback");
       expect(errors[0].payload.error).toBeDefined();

--- a/packages/ai-chat/CHANGELOG.md
+++ b/packages/ai-chat/CHANGELOG.md
@@ -124,7 +124,7 @@
   addToolOutput({
     toolCallId: invocation.toolCallId,
     state: "output-error",
-    errorText: "User declined: insufficient permissions",
+    errorText: "User declined: insufficient permissions"
   });
   ```
 

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -452,11 +452,7 @@ export class AIChatAgent<
             _deleteStaleRows: true
           });
 
-          this.observability?.emit({
-            payload: {},
-            timestamp: Date.now(),
-            type: "message:request"
-          });
+          this._emit("message:request");
 
           const chatMessageId = data.id;
           const abortSignal = this._getAbortSignal(chatMessageId);
@@ -518,11 +514,7 @@ export class AIChatAgent<
             { type: MessageType.CF_AGENT_CHAT_CLEAR },
             [connection.id]
           );
-          this.observability?.emit({
-            type: "message:clear",
-            payload: {},
-            timestamp: Date.now()
-          });
+          this._emit("message:clear");
           return;
         }
 
@@ -536,11 +528,7 @@ export class AIChatAgent<
         // Handle request cancellation
         if (data.type === MessageType.CF_AGENT_CHAT_REQUEST_CANCEL) {
           this._cancelChatRequest(data.id);
-          this.observability?.emit({
-            type: "message:cancel",
-            payload: { requestId: data.id },
-            timestamp: Date.now()
-          });
+          this._emit("message:cancel", { requestId: data.id });
           return;
         }
 
@@ -600,11 +588,7 @@ export class AIChatAgent<
           const overrideState =
             state === "output-error" ? "output-error" : undefined;
 
-          this.observability?.emit({
-            type: "tool:result",
-            payload: { toolCallId, toolName },
-            timestamp: Date.now()
-          });
+          this._emit("tool:result", { toolCallId, toolName });
 
           // Apply the tool result
           this._applyToolResult(
@@ -692,11 +676,7 @@ export class AIChatAgent<
         // Handle client-side tool approval response
         if (data.type === MessageType.CF_AGENT_TOOL_APPROVAL) {
           const { toolCallId, approved, autoContinue } = data;
-          this.observability?.emit({
-            type: "tool:approval",
-            payload: { toolCallId, approved },
-            timestamp: Date.now()
-          });
+          this._emit("tool:approval", { toolCallId, approved });
           this._applyToolApproval(toolCallId, approved).then((applied) => {
             // Auto-continue for both approvals and rejections so the LLM
             // sees the tool_result and can respond accordingly.
@@ -2314,12 +2294,8 @@ export class AIChatAgent<
               type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
               ...(continuation && { continuation: true })
             });
-            this.observability?.emit({
-              type: "message:error",
-              payload: {
-                error: error instanceof Error ? error.message : String(error)
-              },
-              timestamp: Date.now()
+            this._emit("message:error", {
+              error: error instanceof Error ? error.message : String(error)
             });
           }
           throw error;
@@ -2345,11 +2321,7 @@ export class AIChatAgent<
           if (chatMessageId) {
             this._removeAbortController(chatMessageId);
             if (streamCompleted.value) {
-              this.observability?.emit({
-                payload: {},
-                timestamp: Date.now(),
-                type: "message:response"
-              });
+              this._emit("message:response");
             }
           }
         }


### PR DESCRIPTION
## Summary

Add `agent` and `name` fields to all observability events so every event identifies which agent class and instance emitted it. Add new events for previously unobserved operations, and fix AIChatAgent events that were missing identity.

## Changes

### Agent identity on all events (`packages/agents`, `packages/ai-chat`)

Every observability event now carries two optional fields on `BaseEvent`:

- **`agent`** — the class name of the agent (e.g. `"MyChatAgent"`)
- **`name`** — the Durable Object instance name (e.g. `"user-123"`)

These are populated automatically by the `Agent` base class in `_emit()` and injected into forwarded MCP events.

**AIChatAgent fix:** Previously, `AIChatAgent` called `this.observability?.emit()` directly for 7 event types (`message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`), which meant those events were missing `agent` and `name`. Now uses the inherited `_emit()` method. This required changing `_emit` from `private` to `protected`.

### New events

| Event | Channel | When |
|-------|---------|------|
| `disconnect` | `agents:lifecycle` | WebSocket connection closes (pairs with existing `connect`) |
| `email:receive` | `agents:email` | Agent receives an email via `routeAgentEmail()` |
| `email:reply` | `agents:email` | Agent successfully sends a reply via `replyToEmail()` |
| `queue:create` | `agents:schedule` | Task is enqueued via `this.queue()` |

### New `agents:email` channel

Email events are routed to a dedicated `agents:email` diagnostics channel, with corresponding `ChannelEventMap` typing and `subscribe("email", ...)` support.

### `onClose` wrapper

Added `agentContext.run()` wrapper around the `onClose` lifecycle hook for consistency with `onConnect`, `onMessage`, and `onStart`. This means `getCurrentAgent()` now works inside user `onClose` overrides.

## Files changed

| File | What changed |
|------|-------------|
| `packages/agents/src/observability/base.ts` | Added optional `agent` and `name` fields to `BaseEvent` |
| `packages/agents/src/observability/agent.ts` | Added `disconnect`, `email:receive`, `email:reply`, `queue:create` event types |
| `packages/agents/src/observability/index.ts` | Added `agents:email` channel, `email:*` routing, `disconnect` in lifecycle type map |
| `packages/agents/src/index.ts` | `_emit` → `protected`; wrapped `onClose`; emit sites for `disconnect`, `email:receive`, `email:reply`, `queue:create` |
| `packages/ai-chat/src/index.ts` | Replaced 7 `this.observability?.emit()` calls with `this._emit()` |
| `packages/agents/src/tests/observability.test.ts` | Added tests for `disconnect` routing, `email` channel routing, `queue:create` routing, disconnect integration test |
| `docs/observability.md` | Updated channels table (8 channels), new event reference sections |
| `.changeset/observability-agent-identity.md` | Patch changeset for `agents` and `@cloudflare/ai-chat` |

## Notes for reviewers

1. **Not a breaking change.** `agent`/`name` are optional on `BaseEvent`, new events are additive union members, `private` → `protected` strictly widens access. Existing consumers are unaffected.

2. **`_emit` is `protected` but still marked `@internal`.** This is intentional — it is needed by `@cloudflare/ai-chat` (which extends `Agent`), but we do not want external subclasses to rely on it as stable API.

3. **`email:reply` emits after the send.** The emit is placed after `await email.reply()` succeeds, so failed sends do not produce events. `email:receive` emits before the handler runs (the email *was* received regardless of handler outcome).

4. **MCP events get identity via forwarding, not `_emit`.** The MCP layer (`MCPClientManager`) fires raw events without identity. The `Agent` class injects `agent`/`name` when forwarding them. This keeps `MCPClientManager` decoupled from agent identity — reviewed and intentional.

5. **`onClose` now runs inside `agentContext.run()`.** This is consistent with all other lifecycle wrappers and enables `getCurrentAgent()` in user `onClose` overrides. Low risk since `onClose` previously had no wrapper at all.

## Verification

- `npx vitest run src/tests/observability.test.ts` — **13/13 pass**
- `npx tsx scripts/typecheck.ts` — **46/46 projects pass**
- `npm run build` — succeeds