### PR TITLE
fix(ai-chat): server responds with RESUME_NONE when no active stream exists

### DIFF
--- a/.changeset/resume-none-response.md
+++ b/.changeset/resume-none-response.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Server now responds with `CF_AGENT_STREAM_RESUME_NONE` when a client sends `CF_AGENT_STREAM_RESUME_REQUEST` and no active stream exists. This collapses the previous 5-second timeout to a single WebSocket round-trip, fixing the UI stall on every conversation open/switch/refresh when there is no active stream.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -539,6 +539,12 @@ export class AIChatAgent<
         if (data.type === MessageType.CF_AGENT_STREAM_RESUME_REQUEST) {
           if (this._resumableStream.hasActiveStream()) {
             this._notifyStreamResuming(connection);
+          } else {
+            connection.send(
+              JSON.stringify({
+                type: MessageType.CF_AGENT_STREAM_RESUME_NONE
+              })
+            );
           }
           return;
         }

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -1052,6 +1052,12 @@ export function useAgentChat<
           });
           break;
 
+        case MessageType.CF_AGENT_STREAM_RESUME_NONE:
+          // Server confirmed no active stream — let the transport
+          // resolve reconnectToStream immediately with null.
+          customTransport.handleStreamResumeNone();
+          break;
+
         case MessageType.CF_AGENT_STREAM_RESUMING:
           if (!resume) return;
           // Let the transport handle it if reconnectToStream is waiting.

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -601,7 +601,7 @@ describe("Resumable Streaming", () => {
       ws2.close(1000);
     });
 
-    it("CF_AGENT_STREAM_RESUME_REQUEST with no active stream is a no-op", async () => {
+    it("CF_AGENT_STREAM_RESUME_REQUEST with no active stream sends RESUME_NONE", async () => {
       const room = crypto.randomUUID();
       const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
       const messages = collectMessages(ws);
@@ -620,6 +620,16 @@ describe("Resumable Streaming", () => {
       // Should NOT get CF_AGENT_STREAM_RESUMING
       const resumeMsg = messages.find(isStreamResumingMessage);
       expect(resumeMsg).toBeUndefined();
+
+      // Should get CF_AGENT_STREAM_RESUME_NONE
+      const noneMsg = messages.find(
+        (m) =>
+          typeof m === "object" &&
+          m !== null &&
+          "type" in m &&
+          m.type === MessageType.CF_AGENT_STREAM_RESUME_NONE
+      );
+      expect(noneMsg).toBeDefined();
 
       ws.close(1000);
     });

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -109,6 +109,44 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(activeRequestIds.has("req-tracked")).toBe(true);
   });
 
+  // ── handleStreamResumeNone basics ────────────────────────────────────
+
+  it("handleStreamResumeNone returns false when no reconnectToStream is pending", () => {
+    expect(transport.handleStreamResumeNone()).toBe(false);
+  });
+
+  it("handleStreamResumeNone resolves reconnectToStream with null immediately", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+
+    const handled = transport.handleStreamResumeNone();
+    expect(handled).toBe(true);
+
+    const result = await promise;
+    expect(result).toBeNull();
+  });
+
+  it("handleStreamResumeNone clears both resolvers so subsequent calls return false", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+
+    transport.handleStreamResumeNone();
+    await promise;
+
+    expect(transport.handleStreamResumeNone()).toBe(false);
+    expect(transport.handleStreamResuming({ id: "late" })).toBe(false);
+  });
+
+  it("handleStreamResuming after handleStreamResumeNone does not double-resolve", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+
+    // RESUME_NONE arrives first
+    transport.handleStreamResumeNone();
+    const result = await promise;
+    expect(result).toBeNull();
+
+    // Late STREAM_RESUMING should be ignored
+    expect(transport.handleStreamResuming({ id: "req-late" })).toBe(false);
+  });
+
   // ── Timeout behavior ─────────────────────────────────────────────────
 
   it("resolves null after timeout when no handleStreamResuming is called", async () => {

--- a/packages/ai-chat/src/types.ts
+++ b/packages/ai-chat/src/types.ts
@@ -16,6 +16,8 @@ export enum MessageType {
   CF_AGENT_STREAM_RESUME_ACK = "cf_agent_stream_resume_ack",
   /** Sent by client after message handler is ready, requesting stream resume check */
   CF_AGENT_STREAM_RESUME_REQUEST = "cf_agent_stream_resume_request",
+  /** Sent by server when client requests resume but no active stream exists */
+  CF_AGENT_STREAM_RESUME_NONE = "cf_agent_stream_resume_none",
 
   /** Client sends tool result to server (for client-side tools) */
   CF_AGENT_TOOL_RESULT = "cf_agent_tool_result",
@@ -68,6 +70,10 @@ export type OutgoingMessage<ChatMessage extends UIMessage = UIMessage> =
       type: MessageType.CF_AGENT_MESSAGE_UPDATED;
       /** The updated message */
       message: ChatMessage;
+    }
+  | {
+      /** Server responds to resume request when no active stream exists */
+      type: MessageType.CF_AGENT_STREAM_RESUME_NONE;
     };
 
 /**

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -66,6 +66,9 @@ export class WebSocketChatTransport<
   // Pending resume resolver — set by reconnectToStream, called by
   // handleStreamResuming when onAgentMessage sees CF_AGENT_STREAM_RESUMING.
   private _resumeResolver: ((data: { id: string }) => void) | null = null;
+  // Pending "no stream" resolver — called by handleStreamResumeNone
+  // when onAgentMessage sees CF_AGENT_STREAM_RESUME_NONE.
+  private _resumeNoneResolver: (() => void) | null = null;
 
   constructor(options: WebSocketChatTransportOptions<ChatMessage>) {
     this.agent = options.agent;
@@ -82,6 +85,17 @@ export class WebSocketChatTransport<
   handleStreamResuming(data: { id: string }): boolean {
     if (!this._resumeResolver) return false;
     this._resumeResolver(data);
+    return true;
+  }
+
+  /**
+   * Called by onAgentMessage when it receives CF_AGENT_STREAM_RESUME_NONE.
+   * If reconnectToStream is waiting, resolves the promise with null
+   * immediately (no 5-second timeout). Returns true if handled.
+   */
+  handleStreamResumeNone(): boolean {
+    if (!this._resumeNoneResolver) return false;
+    this._resumeNoneResolver();
     return true;
   }
 
@@ -253,9 +267,15 @@ export class WebSocketChatTransport<
         if (resolved) return;
         resolved = true;
         this._resumeResolver = null;
+        this._resumeNoneResolver = null;
         if (timeout) clearTimeout(timeout);
         resolve(value);
       };
+
+      // Set the "no stream" resolver that handleStreamResumeNone() will call.
+      // When onAgentMessage sees CF_AGENT_STREAM_RESUME_NONE, it calls
+      // handleStreamResumeNone() which resolves immediately with null.
+      this._resumeNoneResolver = () => done(null);
 
       // Set the resolver that handleStreamResuming() will call.
       // When onAgentMessage sees CF_AGENT_STREAM_RESUMING, it calls
@@ -292,8 +312,10 @@ export class WebSocketChatTransport<
         // WebSocket may already be closed
       }
 
-      // Timeout: if no CF_AGENT_STREAM_RESUMING arrives (no active
-      // stream, or WebSocket never connects), resolve null.
+      // Safety-net timeout: if the WebSocket never connects or the
+      // server is unreachable, resolve null. Under normal operation
+      // the server responds with STREAM_RESUMING or STREAM_RESUME_NONE
+      // well before this fires.
       timeout = setTimeout(() => done(null), 5000);
     });
   }


### PR DESCRIPTION
Fixes #1054

## Problem

When `resume: true` (default), `reconnectToStream()` sends `CF_AGENT_STREAM_RESUME_REQUEST` on mount. If no stream is active, the server stays silent and the client waits the full 5-second timeout before `status` returns to `'ready'`. This blocks the UI on every conversation open/switch/refresh — the most common case.

## Fix

The server now always responds to `CF_AGENT_STREAM_RESUME_REQUEST`:

- **Active stream**: `CF_AGENT_STREAM_RESUMING` (unchanged)
- **No active stream**: `CF_AGENT_STREAM_RESUME_NONE` (new)

This collapses the 5-second timeout to a single WebSocket round-trip. The timeout is kept as a safety net for connectivity failures.

## Changes

- **`types.ts`**: Added `CF_AGENT_STREAM_RESUME_NONE` to `MessageType` enum and `OutgoingMessage` union
- **`index.ts`** (server): Send `RESUME_NONE` in the else branch of the `RESUME_REQUEST` handler
- **`ws-chat-transport.ts`**: Added `handleStreamResumeNone()` method and `_resumeNoneResolver` to resolve `reconnectToStream` with `null` immediately
- **`react.tsx`**: Handle `CF_AGENT_STREAM_RESUME_NONE` in `onAgentMessage`
- **Tests**: Updated server test, added 4 transport tests for the new message type