### PR TITLE
fix(workflows): await _workflow_updateState RPC calls in _wrapStep

### DIFF
--- a/.changeset/tired-wasps-throw.md
+++ b/.changeset/tired-wasps-throw.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix missing `await` on `_workflow_updateState` RPC calls in `AgentWorkflow._wrapStep()` for `updateAgentState`, `mergeAgentState`, and `resetAgentState`, which could cause state updates to be silently lost.

--- a/packages/agents/src/workflows.ts
+++ b/packages/agents/src/workflows.ts
@@ -259,7 +259,7 @@ export class AgentWorkflow<
 
     wrappedStep.updateAgentState = async (state: unknown): Promise<void> => {
       await step.do(`__agent_updateState_${stepCounter++}`, async () => {
-        this.agent._workflow_updateState("set", state);
+        await this.agent._workflow_updateState("set", state);
       });
     };
 
@@ -267,13 +267,13 @@ export class AgentWorkflow<
       partialState: Record<string, unknown>
     ): Promise<void> => {
       await step.do(`__agent_mergeState_${stepCounter++}`, async () => {
-        this.agent._workflow_updateState("merge", partialState);
+        await this.agent._workflow_updateState("merge", partialState);
       });
     };
 
     wrappedStep.resetAgentState = async (): Promise<void> => {
       await step.do(`__agent_resetState_${stepCounter++}`, async () => {
-        this.agent._workflow_updateState("reset");
+        await this.agent._workflow_updateState("reset");
       });
     };
 


### PR DESCRIPTION
## Fix

Adds missing `await` to three `_workflow_updateState` RPC calls inside `step.do()` callbacks in `AgentWorkflow._wrapStep()`.

**Affected methods:** `updateAgentState`, `mergeAgentState`, `resetAgentState`

Without `await`, the `step.do()` callback returns immediately, the Workflows engine marks the step as durably completed, and the workflow moves on — but the RPC may not have been delivered to the Agent yet. This can cause state updates to be silently lost.

The other wrapped methods (`reportComplete`, `reportError`, `sendEvent`) already correctly `await` their RPC calls.

Fixes #1067

Credit to @zeke for the detailed writeup and root cause analysis.