### PR TITLE
fix(ai-chat): avoid duplicate assistant messages during approval continuations

### DIFF
--- a/.changeset/issue-1108-continuation-merge.md
+++ b/.changeset/issue-1108-continuation-merge.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Preserve the existing assistant message during tool approval continuations so live client state does not render duplicate assistant messages or tool parts

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -1710,3 +1710,190 @@ describe("useAgentChat stream resumption (issue #896)", () => {
       .toHaveTextContent("replayed-and live!");
   });
 });
+
+describe("useAgentChat tool approval continuations (issue #1108)", () => {
+  function createAgentWithTarget({ name, url }: { name: string; url: string }) {
+    const target = new EventTarget();
+    const agent = createAgent({ name, url });
+    (agent as unknown as Record<string, unknown>).addEventListener =
+      target.addEventListener.bind(target);
+    (agent as unknown as Record<string, unknown>).removeEventListener =
+      target.removeEventListener.bind(target);
+    return { agent, target };
+  }
+
+  function dispatch(target: EventTarget, data: Record<string, unknown>) {
+    target.dispatchEvent(
+      new MessageEvent("message", { data: JSON.stringify(data) })
+    );
+  }
+
+  const initialMessages: UIMessage[] = [
+    {
+      id: "assistant-local",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-dangerousAction",
+          toolCallId: "tc-approval-1",
+          state: "approval-responded",
+          input: { action: "delete" },
+          approval: { id: "approval-req-1", approved: true }
+        }
+      ]
+    }
+  ];
+
+  function TestComponent({ agent }: { agent: ReturnType<typeof useAgent> }) {
+    const chat = useAgentChat({
+      agent,
+      getInitialMessages: () => Promise.resolve(initialMessages)
+    });
+    const assistantMessages = chat.messages.filter(
+      (message) => message.role === "assistant"
+    );
+    const textPart = assistantMessages
+      .flatMap((message) => message.parts)
+      .find((part) => part.type === "text") as { text?: string } | undefined;
+    const toolPartsCount = assistantMessages.reduce((count, message) => {
+      return (
+        count +
+        message.parts.filter(
+          (part) => "toolCallId" in part && part.toolCallId === "tc-approval-1"
+        ).length
+      );
+    }, 0);
+
+    return (
+      <div>
+        <div data-testid="assistant-count">{assistantMessages.length}</div>
+        <div data-testid="assistant-ids">
+          {assistantMessages.map((message) => message.id).join(",")}
+        </div>
+        <div data-testid="tool-parts-count">{toolPartsCount}</div>
+        <div data-testid="text">{textPart?.text ?? ""}</div>
+      </div>
+    );
+  }
+
+  it("keeps the existing assistant id for continuation start chunks", async () => {
+    const { agent, target } = createAgentWithTarget({
+      name: "continuation-start-id",
+      url: "ws://localhost:3000/agents/chat/continuation-start-id?_pk=abc"
+    });
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent agent={agent} />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("assistant-count"))
+      .toHaveTextContent("1");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-continuation-start",
+        continuation: true,
+        body: '{"type":"start","messageId":"assistant-stream"}',
+        done: false
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("assistant-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("assistant-ids"))
+      .toHaveTextContent("assistant-local");
+    await expect
+      .element(screen.getByTestId("tool-parts-count"))
+      .toHaveTextContent("1");
+  });
+
+  it("keeps merging continuations when broadcasts replace assistant ids mid-stream", async () => {
+    const { agent, target } = createAgentWithTarget({
+      name: "continuation-remap-id",
+      url: "ws://localhost:3000/agents/chat/continuation-remap-id?_pk=abc"
+    });
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent agent={agent} />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-continuation-remap",
+        continuation: true,
+        body: '{"type":"start","messageId":"assistant-stream"}',
+        done: false
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-continuation-remap",
+        continuation: true,
+        body: '{"type":"text-start","id":"text-1"}',
+        done: false
+      });
+      await sleep(10);
+    });
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_chat_messages",
+        messages: [
+          {
+            id: "assistant-server",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-dangerousAction",
+                toolCallId: "tc-approval-1",
+                state: "approval-responded",
+                input: { action: "delete" },
+                approval: { id: "approval-req-1", approved: true }
+              }
+            ]
+          }
+        ]
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-continuation-remap",
+        continuation: true,
+        body: '{"type":"text-delta","id":"text-1","delta":"done"}',
+        done: false
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("assistant-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("assistant-ids"))
+      .toHaveTextContent("assistant-server");
+    await expect
+      .element(screen.getByTestId("tool-parts-count"))
+      .toHaveTextContent("1");
+    await expect.element(screen.getByTestId("text")).toHaveTextContent("done");
+  });
+});

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -937,6 +937,7 @@ export function useAgentChat<
   const activeStreamRef = useRef<{
     id: string;
     messageId: string;
+    continuation: boolean;
     parts: ChatMessage["parts"];
     metadata?: Record<string, unknown>;
   } | null>(null);
@@ -950,16 +951,29 @@ export function useAgentChat<
     (activeMsg: {
       id: string;
       messageId: string;
+      continuation: boolean;
       parts: ChatMessage["parts"];
       metadata?: Record<string, unknown>;
     }) => {
       setMessages((prevMessages: ChatMessage[]) => {
-        const existingIdx = prevMessages.findIndex(
+        let existingIdx = prevMessages.findIndex(
           (m) => m.id === activeMsg.messageId
         );
 
+        if (existingIdx < 0 && activeMsg.continuation) {
+          for (let i = prevMessages.length - 1; i >= 0; i--) {
+            if (prevMessages[i].role === "assistant") {
+              existingIdx = i;
+              break;
+            }
+          }
+        }
+
+        const messageId =
+          existingIdx >= 0 ? prevMessages[existingIdx].id : activeMsg.messageId;
+
         const partialMessage = {
-          id: activeMsg.messageId,
+          id: messageId,
           role: "assistant" as const,
           parts: [...activeMsg.parts],
           ...(activeMsg.metadata != null && { metadata: activeMsg.metadata })
@@ -1077,6 +1091,7 @@ export function useAgentChat<
           activeStreamRef.current = {
             id: data.id,
             messageId: nanoid(),
+            continuation: false,
             parts: []
           };
           agentRef.current.send(
@@ -1127,6 +1142,7 @@ export function useAgentChat<
             activeStreamRef.current = {
               id: data.id,
               messageId,
+              continuation: isContinuation,
               parts: existingParts,
               metadata: existingMetadata
             };
@@ -1170,7 +1186,11 @@ export function useAgentChat<
                   chunkData.type === "finish" ||
                   chunkData.type === "message-metadata")
               ) {
-                if (chunkData.messageId != null && chunkData.type === "start") {
+                if (
+                  chunkData.messageId != null &&
+                  chunkData.type === "start" &&
+                  !isContinuation
+                ) {
                   activeMsg.messageId = chunkData.messageId;
                 }
                 if (chunkData.messageMetadata != null) {


### PR DESCRIPTION
## Summary
- keep continuation streams pinned to the existing assistant message instead of replacing that target with a new `start` chunk `messageId`
- fall back to the last assistant message when a continuation target id disappears after a `CF_AGENT_CHAT_MESSAGES` broadcast, avoiding duplicate live messages/tool parts
- add regression coverage for both continuation-id overwrite and mid-stream assistant-id replacement

Fixes #1108.

## Testing
- `npm run test:react -- use-agent-chat.test.tsx` in `packages/ai-chat`
- `npm run build` in `packages/ai-chat`
- `npm run check` in repo root *(currently fails on pre-existing missing export files in unrelated packages: `agents`, `@cloudflare/think`, `@cloudflare/voice`, `@cloudflare/worker-bundler`, `@cloudflare/shell`)*

## Reviewer Notes
- the key behavior change is in `packages/ai-chat/src/react.tsx`: continuation streams now preserve the assistant id selected at stream setup
- the new `continuation` flag on `activeStreamRef` only scopes the merge fallback for continuation streams; non-continuation streams still adopt the streamed `start` chunk id as before
- the second regression test intentionally simulates the race from the issue by replacing assistant ids via `CF_AGENT_CHAT_MESSAGES` between continuation chunks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
