### PR TITLE
Prepare @cloudflare/think for first publish

### DIFF
--- a/.changeset/tidy-hounds-care.md
+++ b/.changeset/tidy-hounds-care.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+first publish

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -10,7 +10,6 @@
   ],
   "type": "module",
   "version": "0.0.1",
-  "private": true,
   "license": "MIT",
   "repository": {
     "directory": "packages/think",


### PR DESCRIPTION
Remove "private": true from packages/think/package.json to allow publishing, and add .changeset/tidy-hounds-care.md declaring a patch release for @cloudflare/think (first publish).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
