### PR TITLE
feat: strongly-typed AgentClient with call inference and stub proxy

### DIFF
--- a/.changeset/typed-agent-client.md
+++ b/.changeset/typed-agent-client.md
@@ -1,0 +1,58 @@
+---
+"agents": minor
+---
+
+feat: strongly-typed `AgentClient` with `call` inference and `stub` proxy
+
+`AgentClient` now accepts an optional agent type parameter for full type inference on RPC calls, matching the typed experience that `useAgent` already provides.
+
+**New: typed `call` and `stub`**
+
+When an agent type is provided, `call()` infers method names, argument types, and return types from the agent's methods. A new `stub` property provides a direct RPC-style proxy — call agent methods as if they were local functions:
+
+```typescript
+const client = new AgentClient<MyAgent>({
+  agent: "my-agent",
+  host: window.location.host
+});
+
+// Typed call — method name autocompletes, args and return type inferred
+const value = await client.call("getValue");
+
+// Typed stub — direct RPC-style proxy
+await client.stub.getValue();
+await client.stub.add(1, 2);
+```
+
+State is automatically inferred from the agent type, so `onStateUpdate` is also typed:
+
+```typescript
+const client = new AgentClient<MyAgent>({
+  agent: "my-agent",
+  host: window.location.host,
+  onStateUpdate: (state) => {
+    // state is typed as MyAgent's state type
+  }
+});
+```
+
+**Backward compatible**
+
+Existing untyped usage continues to work without changes:
+
+```typescript
+const client = new AgentClient({ agent: "my-agent", host: "..." });
+client.call("anyMethod", [args]); // still works
+client.call<number>("add", [1, 2]); // explicit return type still works
+client.stub.anyMethod("arg1", 123); // untyped stub also available
+```
+
+The previous `AgentClient<State>` pattern is preserved — `new AgentClient<{ count: number }>({...})` still correctly types `onStateUpdate` and leaves `call`/`stub` untyped.
+
+**Breaking: `call` is now an instance property instead of a prototype method**
+
+`AgentClient.prototype.call` no longer exists. The `call` function is assigned per-instance in the constructor (via `.bind()`). This is required for the conditional type system to switch between typed and untyped signatures. Normal usage (`client.call(...)`) is unaffected, but code that reflects on the prototype or subclasses that override `call` as a method may need adjustment.
+
+**Shared type utilities**
+
+The RPC type utilities (`AgentMethods`, `AgentStub`, `RPCMethods`, etc.) are now exported from `agents/client` so they can be shared between `AgentClient` and `useAgent`, and are available to consumers who need them for advanced typing scenarios.

--- a/packages/agents/src/client.ts
+++ b/packages/agents/src/client.ts
@@ -3,12 +3,15 @@ import {
   PartySocket,
   type PartySocketOptions
 } from "partysocket";
-import type { RPCRequest, RPCResponse } from "./";
+import type { Agent, RPCRequest, RPCResponse } from "./";
 import type {
+  Method,
+  RPCMethod,
   SerializableReturnValue,
   SerializableValue
 } from "./serializable";
 import { MessageType } from "./types";
+import { camelCaseToKebabCase } from "./utils";
 
 /**
  * Options for creating an AgentClient
@@ -107,12 +110,134 @@ export type AgentClientFetchOptions = Omit<
   basePath?: string;
 };
 
-import { camelCaseToKebabCase } from "./utils";
+// ---- Shared RPC Type Utilities ----
+
+type AllOptional<T> = T extends [infer A, ...infer R]
+  ? undefined extends A
+    ? AllOptional<R>
+    : false
+  : true;
+
+export type RPCMethods<T> = {
+  [K in keyof T as T[K] extends RPCMethod<T[K]> ? K : never]: RPCMethod<T[K]>;
+};
+
+type OptionalParametersMethod<T extends RPCMethod> =
+  AllOptional<Parameters<T>> extends true ? T : never;
+
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any -- generic agent type constraint
+export type AgentMethods<T> = Omit<RPCMethods<T>, keyof Agent<any, any>>;
+
+export type OptionalAgentMethods<T> = {
+  [K in keyof AgentMethods<T> as AgentMethods<T>[K] extends OptionalParametersMethod<
+    AgentMethods<T>[K]
+  >
+    ? K
+    : never]: OptionalParametersMethod<AgentMethods<T>[K]>;
+};
+
+export type RequiredAgentMethods<T> = Omit<
+  AgentMethods<T>,
+  keyof OptionalAgentMethods<T>
+>;
+
+export type AgentPromiseReturnType<T, K extends keyof AgentMethods<T>> =
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- generic promise return type
+  ReturnType<AgentMethods<T>[K]> extends Promise<any>
+    ? ReturnType<AgentMethods<T>[K]>
+    : Promise<ReturnType<AgentMethods<T>[K]>>;
+
+export type AgentStub<T> = {
+  [K in keyof AgentMethods<T>]: (
+    ...args: Parameters<AgentMethods<T>[K]>
+  ) => AgentPromiseReturnType<AgentMethods<T>, K>;
+};
+
+export type UntypedAgentStub = Record<string, Method>;
+
+type AgentClientStub<AgentT> = keyof AgentMethods<AgentT> extends never
+  ? UntypedAgentStub
+  : AgentStub<AgentT>;
+
+type OptionalArgsAgentClientCall<AgentT> = <
+  K extends keyof OptionalAgentMethods<AgentT>
+>(
+  method: K,
+  args?: Parameters<OptionalAgentMethods<AgentT>[K]>,
+  options?: CallOptions | StreamOptions
+) => AgentPromiseReturnType<AgentT, K>;
+
+type RequiredArgsAgentClientCall<AgentT> = <
+  K extends keyof RequiredAgentMethods<AgentT>
+>(
+  method: K,
+  args: Parameters<RequiredAgentMethods<AgentT>[K]>,
+  options?: CallOptions | StreamOptions
+) => AgentPromiseReturnType<AgentT, K>;
+
+type TypedAgentClientCall<AgentT> = OptionalArgsAgentClientCall<AgentT> &
+  RequiredArgsAgentClientCall<AgentT>;
+
+type UntypedAgentClientCall = {
+  <T extends SerializableReturnValue>(
+    method: string,
+    args?: SerializableValue[],
+    options?: CallOptions | StreamOptions
+  ): Promise<T>;
+  <T = unknown>(
+    method: string,
+    args?: unknown[],
+    options?: CallOptions | StreamOptions
+  ): Promise<T>;
+};
+
+type AgentClientCall<AgentT> = keyof AgentMethods<AgentT> extends never
+  ? UntypedAgentClientCall
+  : TypedAgentClientCall<AgentT>;
+
+/**
+ * Creates a proxy that wraps RPC method calls.
+ * Internal JS methods (toJSON, then, etc.) return undefined to avoid
+ * triggering RPC calls during serialization (e.g., console.log)
+ */
+export function createStubProxy<T = Record<string, Method>>(
+  call: (method: string, args: unknown[]) => unknown
+): T {
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- proxy needs any for dynamic method access
+  return new Proxy<any>(
+    {},
+    {
+      get: (_target, method) => {
+        if (
+          typeof method === "symbol" ||
+          method === "toJSON" ||
+          method === "then" ||
+          method === "catch" ||
+          method === "finally" ||
+          method === "valueOf" ||
+          method === "toString" ||
+          method === "constructor" ||
+          method === "prototype" ||
+          method === "$$typeof" ||
+          method === "@@toStringTag" ||
+          method === "asymmetricMatch" ||
+          method === "nodeType"
+        ) {
+          return undefined;
+        }
+        return (...args: unknown[]) => call(method as string, args);
+      }
+    }
+  );
+}
 
 /**
  * WebSocket client for connecting to an Agent
  */
-export class AgentClient<State = unknown> extends PartySocket {
+export class AgentClient<
+  AgentT = unknown,
+  State = AgentT extends { get state(): infer S } ? S : AgentT
+> extends PartySocket {
   /**
    * @deprecated Use agentFetch instead
    */
@@ -123,6 +248,8 @@ export class AgentClient<State = unknown> extends PartySocket {
   }
   agent: string;
   name: string;
+  call: AgentClientCall<AgentT>;
+  stub: AgentClientStub<AgentT>;
 
   /**
    * Whether the client has received identity from the server.
@@ -147,7 +274,6 @@ export class AgentClient<State = unknown> extends PartySocket {
       resolve: (value: unknown) => void;
       reject: (error: Error) => void;
       stream?: StreamOptions;
-      type?: unknown;
     }
   >();
   private _readyPromise!: Promise<void>;
@@ -294,6 +420,11 @@ export class AgentClient<State = unknown> extends PartySocket {
       // Reject any remaining pending calls (e.g., from unexpected disconnect)
       this._rejectPendingCalls("Connection closed");
     });
+
+    this.call = this._callImpl.bind(this) as AgentClientCall<AgentT>;
+    this.stub = createStubProxy((method, args) =>
+      this._callImpl(method, args)
+    ) as AgentClientStub<AgentT>;
   }
 
   /**
@@ -330,28 +461,16 @@ export class AgentClient<State = unknown> extends PartySocket {
   }
 
   /**
-   * Call a method on the Agent
-   * @param method Name of the method to call
-   * @param args Arguments to pass to the method
-   * @param options Options for the call (timeout, streaming) or legacy StreamOptions
-   * @returns Promise that resolves with the method's return value
+   * Call a method on the Agent.
+   * When AgentT is provided, method names are inferred from the agent's methods.
+   * Falls back to untyped string-based calls when AgentT is not provided.
    */
-  call<T extends SerializableReturnValue>(
-    method: string,
-    args?: SerializableValue[],
-    options?: CallOptions | StreamOptions
-  ): Promise<T>;
-  call<T = unknown>(
-    method: string,
-    args?: unknown[],
-    options?: CallOptions | StreamOptions
-  ): Promise<T>;
-  async call<T>(
+  private async _callImpl(
     method: string,
     args: unknown[] = [],
     options?: CallOptions | StreamOptions
-  ): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
       const id = crypto.randomUUID();
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -372,7 +491,6 @@ export class AgentClient<State = unknown> extends PartySocket {
           const pending = this._pendingCalls.get(id);
           this._pendingCalls.delete(id);
           const errorMessage = `RPC call to ${method} timed out after ${timeout}ms`;
-          // Call stream onError callback if present (for streaming calls)
           pending?.stream?.onError?.(errorMessage);
           reject(new Error(errorMessage));
         }, timeout);
@@ -385,10 +503,9 @@ export class AgentClient<State = unknown> extends PartySocket {
         },
         resolve: (value: unknown) => {
           if (timeoutId) clearTimeout(timeoutId);
-          resolve(value as T);
+          resolve(value);
         },
-        stream: streamOptions,
-        type: null as T
+        stream: streamOptions
       });
 
       const request: RPCRequest = {

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -1,10 +1,17 @@
 import type { PartySocket } from "partysocket";
 import { usePartySocket } from "partysocket/react";
 import { useCallback, useRef, use, useMemo, useState, useEffect } from "react";
-import type { Agent, MCPServersState, RPCRequest, RPCResponse } from "./";
-import type { StreamOptions } from "./client";
+import type { MCPServersState, RPCRequest, RPCResponse } from "./";
+import type {
+  AgentPromiseReturnType,
+  AgentStub,
+  OptionalAgentMethods,
+  RequiredAgentMethods,
+  StreamOptions,
+  UntypedAgentStub
+} from "./client";
+import { createStubProxy } from "./client";
 import { camelCaseToKebabCase } from "./utils";
-import type { Method, RPCMethod } from "./serializable";
 import { MessageType } from "./types";
 
 type QueryObject = Record<string, string | null>;
@@ -51,45 +58,6 @@ function setCacheEntry(
 
 function deleteCacheEntry(key: string): void {
   queryCache.delete(key);
-}
-
-/**
- * Creates a proxy that wraps RPC method calls.
- * Internal JS methods (toJSON, then, etc.) return undefined to avoid
- * triggering RPC calls during serialization (e.g., console.log)
- */
-function createStubProxy<T = Record<string, Method>>(
-  call: (method: string, args: unknown[]) => unknown
-): T {
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- proxy needs any for dynamic method access
-  return new Proxy<any>(
-    {},
-    {
-      get: (_target, method) => {
-        // Skip internal JavaScript methods that shouldn't trigger RPC calls.
-        // These are commonly accessed by console.log, JSON.stringify, and other
-        // serialization utilities.
-        if (
-          typeof method === "symbol" ||
-          method === "toJSON" ||
-          method === "then" ||
-          method === "catch" ||
-          method === "finally" ||
-          method === "valueOf" ||
-          method === "toString" ||
-          method === "constructor" ||
-          method === "prototype" ||
-          method === "$$typeof" ||
-          method === "@@toStringTag" ||
-          method === "asymmetricMatch" ||
-          method === "nodeType"
-        ) {
-          return undefined;
-        }
-        return (...args: unknown[]) => call(method as string, args);
-      }
-    }
-  );
 }
 
 // Export for testing purposes
@@ -169,42 +137,6 @@ export type UseAgentOptions<State = unknown> = Omit<
   path?: string;
 };
 
-type AllOptional<T> = T extends [infer A, ...infer R]
-  ? undefined extends A
-    ? AllOptional<R>
-    : false
-  : true; // no params means optional by default
-
-type RPCMethods<T> = {
-  [K in keyof T as T[K] extends RPCMethod<T[K]> ? K : never]: RPCMethod<T[K]>;
-};
-
-type OptionalParametersMethod<T extends RPCMethod> =
-  AllOptional<Parameters<T>> extends true ? T : never;
-
-// all methods of the Agent, excluding the ones that are declared in the base Agent class
-// oxlint-disable-next-line @typescript-eslint/no-explicit-any -- generic agent type constraint
-type AgentMethods<T> = Omit<RPCMethods<T>, keyof Agent<any, any>>;
-
-type OptionalAgentMethods<T> = {
-  [K in keyof AgentMethods<T> as AgentMethods<T>[K] extends OptionalParametersMethod<
-    AgentMethods<T>[K]
-  >
-    ? K
-    : never]: OptionalParametersMethod<AgentMethods<T>[K]>;
-};
-
-type RequiredAgentMethods<T> = Omit<
-  AgentMethods<T>,
-  keyof OptionalAgentMethods<T>
->;
-
-type AgentPromiseReturnType<T, K extends keyof AgentMethods<T>> =
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- generic promise return type
-  ReturnType<AgentMethods<T>[K]> extends Promise<any>
-    ? ReturnType<AgentMethods<T>[K]>
-    : Promise<ReturnType<AgentMethods<T>[K]>>;
-
 type OptionalArgsAgentMethodCall<AgentT> = <
   K extends keyof OptionalAgentMethods<AgentT>
 >(
@@ -229,15 +161,6 @@ type UntypedAgentMethodCall = <T = unknown>(
   args?: unknown[],
   streamOptions?: StreamOptions
 ) => Promise<T>;
-
-type AgentStub<T> = {
-  [K in keyof AgentMethods<T>]: (
-    ...args: Parameters<AgentMethods<T>[K]>
-  ) => AgentPromiseReturnType<AgentMethods<T>, K>;
-};
-
-// we neet to use Method instead of RPCMethod here for retro-compatibility
-type UntypedAgentStub = Record<string, Method>;
 
 /**
  * React hook for connecting to an Agent

--- a/packages/agents/src/tests-d/agent-client-stub.test-d.ts
+++ b/packages/agents/src/tests-d/agent-client-stub.test-d.ts
@@ -1,0 +1,116 @@
+import type { env } from "cloudflare:workers";
+import { Agent, callable } from "..";
+import { AgentClient } from "../client";
+
+declare class A extends Agent<typeof env, {}> {
+  prop: string;
+  f1: () => number;
+  f2: (a: string) => void;
+  f3: (a: number, b: string) => Promise<string>;
+  f4: (a?: string) => void;
+  f5: (a: string | undefined) => void;
+  f6: () => Promise<void>;
+  nonSerializableParams: (a: string, b: { c: Date }) => void;
+  nonSerializableReturn: (a: string) => Date;
+}
+
+const { stub } = new AgentClient<A, {}>({
+  agent: "test",
+  host: "localhost"
+});
+
+stub.f1() satisfies Promise<number>;
+// @ts-expect-error
+stub.f1(1) satisfies Promise<number>;
+
+stub.f2("test") satisfies Promise<void>;
+// @ts-expect-error should receive a [string]
+stub.f2();
+// @ts-expect-error
+stub.f2(1);
+
+stub.f3(1, "test") satisfies Promise<string>;
+// @ts-expect-error should receive a [number, string]
+stub.f3() satisfies Promise<string>;
+// @ts-expect-error
+stub.f3(1) satisfies Promise<string>;
+
+stub.f4() satisfies Promise<void>;
+stub.f4() satisfies Promise<void>;
+stub.f4(undefined) satisfies Promise<void>;
+
+// @ts-expect-error should receive a [string | undefined]
+stub.f5() satisfies Promise<void>;
+stub.f5(undefined) satisfies Promise<void>;
+
+stub.f6() satisfies Promise<void>;
+
+// @ts-expect-error should not have base Agent methods
+stub.setState({ prop: "test" });
+
+// @ts-expect-error Date parameter not serializable
+stub.nonSerializableParams("test", { c: new Date() });
+// @ts-expect-error Date return not serializable
+stub.nonSerializableReturn("test");
+
+// Backward compat: untyped client
+const untypedClient = new AgentClient({
+  agent: "test",
+  host: "localhost"
+});
+
+untypedClient.call("anyMethod");
+untypedClient.call("anyMethod", [1, 2, 3]);
+untypedClient.stub.anyMethod("arg1", 123);
+
+// Backward compat: state-only generic (no agent type)
+const stateClient = new AgentClient<unknown, { count: number }>({
+  agent: "test",
+  host: "localhost",
+  onStateUpdate: (state) => {
+    state.count satisfies number;
+  }
+});
+stateClient.call("anyMethod");
+stateClient.stub.anyMethod("arg1");
+
+// Backward compat: state as first generic (pre-existing pattern)
+const legacyClient = new AgentClient<{ count: number }>({
+  agent: "test",
+  host: "localhost",
+  onStateUpdate: (state) => {
+    state.count satisfies number;
+  }
+});
+legacyClient.call("anyMethod");
+legacyClient.stub.anyMethod("arg1");
+
+// Agent type infers state
+class MyAgent extends Agent<typeof env, { count: number; name: string }> {
+  @callable()
+  sayHello(name?: string): string {
+    return `Hello, ${name ?? "World"}!`;
+  }
+
+  @callable()
+  async perform(_task: string, _p1?: number): Promise<void> {}
+
+  nonRpc(): void {}
+}
+
+const typedClient = new AgentClient<MyAgent>({
+  agent: "my-agent",
+  host: "localhost",
+  onStateUpdate: (state) => {
+    state.count satisfies number;
+    state.name satisfies string;
+  }
+});
+
+typedClient.stub.sayHello() satisfies Promise<string>;
+// @ts-expect-error first argument is not a string
+await typedClient.stub.sayHello(1);
+await typedClient.stub.perform("some task", 1);
+await typedClient.stub.perform("another task");
+// @ts-expect-error requires parameters
+await typedClient.stub.perform();

--- a/packages/agents/src/tests-d/typed-agent-client.test-d.ts
+++ b/packages/agents/src/tests-d/typed-agent-client.test-d.ts
@@ -1,0 +1,61 @@
+import type { env } from "cloudflare:workers";
+import { Agent } from "..";
+import { AgentClient } from "../client";
+
+declare class A extends Agent<typeof env, {}> {
+  prop: string;
+  f1: () => number;
+  f2: (a: string) => void;
+  f3: (a: number, b: string) => Promise<string>;
+  f4: (a?: string) => void;
+  f5: (a: string | undefined) => void;
+  f6: () => Promise<void>;
+  f7: (a: string | undefined, b: number) => Promise<void>;
+  f8: (a: string | undefined, b?: number) => Promise<void>;
+  nonSerializableParams: (a: string, b: { c: Date }) => void;
+  nonSerializableReturn: (a: string) => Date;
+}
+
+const client = new AgentClient<A, {}>({
+  agent: "test",
+  host: "localhost"
+});
+
+client.call("f1") satisfies Promise<number>;
+// @ts-expect-error
+client.call("f1", [1]) satisfies Promise<number>;
+
+client.call("f2", ["test"]) satisfies Promise<void>;
+// @ts-expect-error should receive a [string]
+client.call("f2");
+// @ts-expect-error
+client.call("f2", [1]);
+
+client.call("f3", [1, "test"]) satisfies Promise<string>;
+// @ts-expect-error should receive a [number, string]
+client.call("f3") satisfies Promise<string>;
+// @ts-expect-error
+client.call("f3", [1]) satisfies Promise<string>;
+
+client.call("f4") satisfies Promise<void>;
+client.call("f4", []) satisfies Promise<void>;
+client.call("f4", [undefined]) satisfies Promise<void>;
+
+client.call("f5") satisfies Promise<void>;
+// @ts-expect-error should receive a [string | undefined]
+client.call("f5", []) satisfies Promise<void>;
+client.call("f5", [undefined]) satisfies Promise<void>;
+
+client.call("f6") satisfies Promise<void>;
+
+// @ts-expect-error should receive a [string | undefined, number]
+client.call("f7") satisfies Promise<void>;
+client.call("f7", [undefined, 1]) satisfies Promise<void>;
+
+client.call("f8") satisfies Promise<void>;
+client.call("f8", [undefined, undefined]) satisfies Promise<void>;
+
+// @ts-expect-error Date parameter not serializable — excluded from typed call
+client.call("nonSerializableParams", ["test", { c: new Date() }]);
+// @ts-expect-error Date return not serializable — excluded from typed call
+client.call("nonSerializableReturn", ["test"]);

--- a/packages/ai-chat/src/tests/chat-turn-serialization.test.ts
+++ b/packages/ai-chat/src/tests/chat-turn-serialization.test.ts
@@ -98,7 +98,7 @@ describe("AIChatAgent chat turn serialization", () => {
     sendChatRequest(ws, "req-turn-1", [firstUserMessage], {
       format: "plaintext",
       chunkCount: 8,
-      chunkDelayMs: 40
+      chunkDelayMs: 100
     });
 
     await delay(60);
@@ -117,7 +117,7 @@ describe("AIChatAgent chat turn serialization", () => {
       {
         format: "plaintext",
         chunkCount: 8,
-        chunkDelayMs: 40
+        chunkDelayMs: 100
       }
     );
 
@@ -153,7 +153,7 @@ describe("AIChatAgent chat turn serialization", () => {
     sendChatRequest(ws, "req-save-1", [firstUserMessage], {
       format: "plaintext",
       chunkCount: 8,
-      chunkDelayMs: 40
+      chunkDelayMs: 100
     });
 
     await delay(60);


### PR DESCRIPTION
## Summary

Closes https://github.com/cloudflare/agents/issues/1144

- **Typed `call` and `stub`**: `AgentClient` now accepts an optional agent type parameter (`AgentClient<MyAgent>`) for full type inference on RPC calls — method names autocomplete, argument types and return types are inferred. A new `stub` property provides direct RPC-style proxy calls (`client.stub.getValue()`) matching `useAgent`'s typed experience.
- **State inference**: State type is automatically inferred from the agent type, so `onStateUpdate` is also typed without needing a second generic parameter.
- **Backward compatible**: Existing untyped usage (`AgentClient<State>`, `new AgentClient({...})`) continues to work without changes.
- **Shared type utilities**: RPC type utilities (`AgentMethods`, `AgentStub`, `RPCMethods`, etc.) extracted to `agents/client` and shared with `useAgent` in `agents/react`, eliminating duplication.
- **Flaky test fix**: Increased `chunkDelayMs` in two `chat-turn-serialization` tests from 40ms to 100ms to prevent timer-precision races in the Workers runtime.

## Breaking change

`call` is now an instance property (bound in constructor) instead of a prototype method. `AgentClient.prototype.call` no longer exists. Normal usage (`client.call(...)`) is unaffected; only code reflecting on the prototype or subclasses overriding `call` as a method would need adjustment. Marked as a minor semver bump in the changeset.

## Test plan

- [x] All 745 agents workers tests pass
- [x] All 310 ai-chat tests pass (including previously flaky `chat-turn-serialization`)
- [x] All 65 projects typecheck successfully
- [x] New type-level tests verify typed `call`, typed `stub`, non-serializable method exclusion, base Agent method exclusion, backward compat for `AgentClient<State>` and untyped usage
- [x] `npm run check` passes (sherif, exports, oxfmt, oxlint, typecheck)


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
