### PR TITLE
keepAlive: replace schedule rows with ref-counted alarms

### DIFF
--- a/.changeset/keepalive-ref-count.md
+++ b/.changeset/keepalive-ref-count.md
@@ -1,0 +1,11 @@
+---
+"agents": patch
+---
+
+Replace schedule-based keepAlive with lightweight ref-counted alarms
+
+- `keepAlive()` no longer creates schedule rows or emits `schedule:create`/`schedule:execute`/`schedule:cancel` observability events — it uses an in-memory ref count and feeds directly into `_scheduleNextAlarm()`
+- multiple concurrent `keepAlive()` callers now share a single alarm cycle instead of each creating their own interval schedule row
+- add `_onAlarmHousekeeping()` hook (called on every alarm cycle) for extensions like the fiber mixin to run housekeeping without coupling to the scheduling system
+- bump internal schema to v2 with a migration that cleans up orphaned `_cf_keepAliveHeartbeat` schedule rows from the previous implementation
+- remove `@experimental` from `keepAlive()` and `keepAliveWhile()`

--- a/design/think.md
+++ b/design/think.md
@@ -356,7 +356,7 @@ spawn → running → [stash checkpoints] → completed
                                            → recovered → running (retry)
 ```
 
-Recovery works via the `keepAlive` heartbeat: when the DO restarts after eviction, `_cf_keepAliveHeartbeat` detects fibers marked as `running` that aren't in the active set and triggers `onFibersRecovered`, which by default restarts them with their last checkpoint.
+Recovery works via the `_onAlarmHousekeeping` hook: when the DO restarts after eviction and an alarm fires, the fiber mixin's override of `_onAlarmHousekeeping` detects fibers marked as `running` that are not in the in-memory active set and triggers `onFibersRecovered`, which by default restarts them with their last checkpoint.
 
 ## Tools
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -299,11 +299,9 @@ This is the recommended approach since you cannot forget to dispose the heartbea
 
 ### How it works
 
-`keepAlive()` calls `scheduleEvery(30, "_cf_keepAliveHeartbeat")` under the hood. The internal `_cf_keepAliveHeartbeat` callback is a no-op — the alarm firing itself is what resets the inactivity timer. Because it uses the scheduling system:
+`keepAlive()` uses an in-memory reference count and the Durable Object alarm system directly. Each call increments the count; the disposer decrements it. While the count is above zero, `_scheduleNextAlarm()` ensures an alarm fires every 30 seconds, which resets the inactivity timer. No schedule rows are created and no observability events are emitted — the heartbeat is invisible to `getSchedules()` and the `agents:schedule` diagnostics channel.
 
-- The heartbeat does not conflict with your own schedules (the scheduling system multiplexes through a single alarm slot)
-- The heartbeat shows up in `getSchedules()` if you need to inspect it
-- Multiple concurrent `keepAlive()` calls each get their own schedule, so they do not interfere with each other
+The heartbeat does not conflict with your own schedules — the alarm system multiplexes all schedules and the keepAlive heartbeat through a single alarm slot.
 
 ### Multiple concurrent callers
 
@@ -313,11 +311,11 @@ Each `keepAlive()` call returns an independent disposer:
 const dispose1 = await this.keepAlive();
 const dispose2 = await this.keepAlive();
 
-// Both heartbeats are active
-dispose1(); // Only cancels the first heartbeat
-// Agent is still alive via dispose2's heartbeat
+// Both heartbeats are active (ref count = 2)
+dispose1(); // Decrements ref count to 1
+// Agent is still alive via dispose2's ref
 
-dispose2(); // Now the agent can go idle
+dispose2(); // Ref count reaches 0 — agent can go idle
 ```
 
 ### AIChatAgent

--- a/packages/agents/src/experimental/forever.ts
+++ b/packages/agents/src/experimental/forever.ts
@@ -153,12 +153,9 @@ export function withFibers<TBase extends typeof Agent>(
       }
     }
 
-    // ── Heartbeat callback override ───────────────────────────────
+    // ── Alarm housekeeping override ─────────────────────────────────
 
-    // Override the base Agent's no-op heartbeat to add fiber recovery.
-    // The scheduler dispatches by string name, so this override runs
-    // when the keepAlive schedule fires.
-    /** @internal */ async _cf_keepAliveHeartbeat() {
+    /** @internal */ async _onAlarmHousekeeping() {
       await this._checkInterruptedFibers();
     }
 
@@ -522,8 +519,6 @@ export function withFibers<TBase extends typeof Agent>(
             interrupted.length
           );
 
-          this._cleanupOrphanedHeartbeats();
-
           try {
             await this.onFibersRecovered(interrupted);
           } catch (e) {
@@ -533,14 +528,6 @@ export function withFibers<TBase extends typeof Agent>(
       } finally {
         this._fiberRecoveryInProgress = false;
       }
-    }
-
-    /** @internal */ _cleanupOrphanedHeartbeats() {
-      this.sql`
-        DELETE FROM cf_agents_schedules
-        WHERE callback = '_cf_keepAliveHeartbeat'
-      `;
-      this._fiberDebug("cleaned up orphaned heartbeat schedules");
     }
 
     /** @internal */ _maybeCleanupFibers() {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -396,7 +396,7 @@ const KEEP_ALIVE_INTERVAL_MS = 30_000;
  * The constructor stores this as a row in cf_agents_state and checks it
  * on wake to skip DDL on established DOs.
  */
-const CURRENT_SCHEMA_VERSION = 1;
+const CURRENT_SCHEMA_VERSION = 2;
 
 const SCHEMA_VERSION_ROW_ID = "cf_schema_version";
 const STATE_ROW_ID = "cf_state_row_id";
@@ -690,6 +690,15 @@ export class Agent<
 
   /** True when this agent runs as a facet (sub-agent) inside a parent. */
   private _isFacet = false;
+
+  /**
+   * Number of active keepAlive() callers. When > 0, `_scheduleNextAlarm()`
+   * caps the next alarm at KEEP_ALIVE_INTERVAL_MS so the DO stays alive.
+   * Purely in-memory — lost on eviction, which is correct because the
+   * in-memory work keepAlive was protecting is also lost.
+   * @internal
+   */
+  _keepAliveRefs = 0;
 
   private _ParentClass: typeof Agent<Env, State> =
     Object.getPrototypeOf(this).constructor;
@@ -1041,6 +1050,14 @@ export class Agent<
         "DELETE FROM cf_agents_state WHERE id = ?",
         STATE_WAS_CHANGED
       );
+
+      // v2: keepAlive no longer uses schedule rows. Remove any orphaned
+      // heartbeat schedules left over from the previous implementation.
+      if (schemaVersion < 2) {
+        this.ctx.storage.sql.exec(
+          "DELETE FROM cf_agents_schedules WHERE callback = '_cf_keepAliveHeartbeat'"
+        );
+      }
 
       // Mark schema as up-to-date
       this.sql`
@@ -2633,9 +2650,8 @@ export class Agent<
    *
    * Use this when you have long-running work and need to prevent the
    * DO from going idle (eviction after ~70-140s of inactivity).
-   * The heartbeat fires every 30 seconds via the scheduling system.
-   *
-   * @experimental This API may change between releases.
+   * The heartbeat fires every 30 seconds via the alarm system, without
+   * creating schedule rows or emitting observability events.
    *
    * @example
    * ```ts
@@ -2654,19 +2670,17 @@ export class Agent<
           "Use keepAlive() from the parent agent instead."
       );
     }
-    const heartbeatSeconds = Math.ceil(KEEP_ALIVE_INTERVAL_MS / 1000);
-    const schedule = await this.scheduleEvery(
-      heartbeatSeconds,
-      "_cf_keepAliveHeartbeat" as keyof this,
-      undefined,
-      { _idempotent: false }
-    );
+    this._keepAliveRefs++;
+
+    if (this._keepAliveRefs === 1) {
+      await this._scheduleNextAlarm();
+    }
 
     let disposed = false;
     return () => {
       if (disposed) return;
       disposed = true;
-      void this.cancelSchedule(schedule.id);
+      this._keepAliveRefs = Math.max(0, this._keepAliveRefs - 1);
     };
   }
 
@@ -2677,8 +2691,6 @@ export class Agent<
    *
    * This is the recommended way to use keepAlive — it guarantees cleanup
    * so you cannot forget to dispose the heartbeat.
-   *
-   * @experimental This API may change between releases.
    *
    * @example
    * ```ts
@@ -2698,13 +2710,13 @@ export class Agent<
   }
 
   /**
-   * Internal no-op callback invoked by the keepAlive heartbeat schedule.
-   * Its only purpose is to keep the DO alive — the alarm machinery
-   * handles the rest.
+   * Hook invoked on every alarm cycle, after schedule processing.
+   * Override in subclasses (e.g. the fiber mixin) to run
+   * housekeeping — such as detecting fibers interrupted by eviction.
    * @internal
    */
-  async _cf_keepAliveHeartbeat(): Promise<void> {
-    // intentionally empty — the alarm firing is what keeps the DO alive
+  async _onAlarmHousekeeping(): Promise<void> {
+    // intentionally empty — override point for extensions
   }
 
   private async _scheduleNextAlarm() {
@@ -2760,6 +2772,12 @@ export class Agent<
         nextTimeMs === null
           ? recoveryTimeMs
           : Math.min(nextTimeMs, recoveryTimeMs);
+    }
+
+    if (this._keepAliveRefs > 0) {
+      const keepAliveMs = nowMs + KEEP_ALIVE_INTERVAL_MS;
+      nextTimeMs =
+        nextTimeMs === null ? keepAliveMs : Math.min(nextTimeMs, keepAliveMs);
     }
 
     if (nextTimeMs !== null) {
@@ -2928,6 +2946,8 @@ export class Agent<
       }
     }
     if (this._destroyed) return;
+
+    await this._onAlarmHousekeeping();
 
     // Schedule the next alarm
     await this._scheduleNextAlarm();

--- a/packages/agents/src/tests/agents/fiber.ts
+++ b/packages/agents/src/tests/agents/fiber.ts
@@ -152,6 +152,10 @@ export class TestFiberAgent extends FiberAgent {
     return this.testKeepAliveCount;
   }
 
+  async getKeepAliveRefCount(): Promise<number> {
+    return this._keepAliveRefs;
+  }
+
   async getHeartbeatScheduleCount(): Promise<number> {
     const result = this.sql<{ count: number }>`
       SELECT COUNT(*) as count FROM cf_agents_schedules

--- a/packages/agents/src/tests/agents/keep-alive.ts
+++ b/packages/agents/src/tests/agents/keep-alive.ts
@@ -1,21 +1,18 @@
 import { Agent } from "../../index.ts";
 
 export class TestKeepAliveAgent extends Agent {
-  private _keepAliveDisposer: (() => void) | null = null;
-  keepAliveCallCount = 0;
+  private _keepAliveDisposers: Array<() => void> = [];
 
   async startKeepAlive(): Promise<string> {
     const dispose = await this.keepAlive();
-    this._keepAliveDisposer = dispose;
-    this.keepAliveCallCount++;
+    this._keepAliveDisposers.push(dispose);
     return "started";
   }
 
   async stopKeepAlive(): Promise<string> {
-    if (this._keepAliveDisposer) {
-      this._keepAliveDisposer();
-      this._keepAliveDisposer = null;
-      this.keepAliveCallCount--;
+    const dispose = this._keepAliveDisposers.pop();
+    if (dispose) {
+      dispose();
     }
     return "stopped";
   }
@@ -35,5 +32,16 @@ export class TestKeepAliveAgent extends Agent {
     } catch {
       return "caught";
     }
+  }
+
+  async getKeepAliveRefCount(): Promise<number> {
+    return this._keepAliveRefs;
+  }
+
+  async getScheduleCount(): Promise<number> {
+    const result = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_agents_schedules
+    `;
+    return result[0].count;
   }
 }

--- a/packages/agents/src/tests/fiber.test.ts
+++ b/packages/agents/src/tests/fiber.test.ts
@@ -564,65 +564,46 @@ describe("fiber operations", () => {
     });
   });
 
-  // ── Heartbeat schedule lifecycle ───────────────────────────────────
+  // ── keepAlive ref counting in fibers ────────────────────────────────
 
-  describe("heartbeat schedules", () => {
-    it("should create a heartbeat schedule when a fiber is spawned", async () => {
+  describe("keepAlive refs", () => {
+    it("should hold a keepAlive ref while a fiber is running", async () => {
       const agent = await getAgentByName(
         env.TestFiberAgent,
-        "heartbeat-create"
+        "keepalive-ref-during"
       );
 
-      // No heartbeat schedules before spawning
-      const before =
-        (await agent.getHeartbeatScheduleCount()) as unknown as number;
+      const before = (await agent.getKeepAliveRefCount()) as unknown as number;
       expect(before).toBe(0);
 
-      // Spawn a slow fiber
+      // Spawn a slow fiber — it acquires a keepAlive ref
       await agent.spawn("slowWork", { durationMs: 500 });
-
-      // Should have a heartbeat schedule now
       await agent.waitFor(100);
-      const during =
-        (await agent.getHeartbeatScheduleCount()) as unknown as number;
+
+      const during = (await agent.getKeepAliveRefCount()) as unknown as number;
       expect(during).toBeGreaterThanOrEqual(1);
 
-      // Wait for fiber to complete — heartbeat should be cleaned up
+      // Wait for fiber to complete — ref should be released
       await agent.waitFor(600);
-      const after =
-        (await agent.getHeartbeatScheduleCount()) as unknown as number;
+
+      const after = (await agent.getKeepAliveRefCount()) as unknown as number;
       expect(after).toBe(0);
     });
 
-    it("should clean up orphaned heartbeat schedules on recovery", async () => {
+    it("should not create any schedule rows for keepAlive", async () => {
       const agent = await getAgentByName(
         env.TestFiberAgent,
-        "heartbeat-orphan-cleanup"
+        "keepalive-no-schedules"
       );
 
-      // Spawn a slow fiber — this creates a heartbeat schedule
-      const fiberId = (await agent.spawn("slowWork", {
-        durationMs: 10000
-      })) as unknown as string;
+      await agent.startKeepAlive();
       await agent.waitFor(100);
 
-      // Verify heartbeat exists
-      const beforeEviction =
-        (await agent.getHeartbeatScheduleCount()) as unknown as number;
-      expect(beforeEviction).toBeGreaterThanOrEqual(1);
+      // keepAlive should use refs, not schedule rows
+      const schedules = await agent.getHeartbeatScheduleCount();
+      expect(schedules as unknown as number).toBe(0);
 
-      // Simulate eviction — heartbeat schedule persists in SQLite (orphaned)
-      await agent.simulateEviction(fiberId);
-
-      // Trigger alarm → recovery → cleans up orphaned heartbeats → creates new ones
-      await agent.triggerAlarm();
-      await agent.waitFor(200);
-
-      // The orphaned heartbeat was cleaned up, and recovery created a new one
-      // for the restarted fiber. There should be exactly 1 (not 2+).
-      const afterRecovery =
-        (await agent.getHeartbeatScheduleCount()) as unknown as number;
-      expect(afterRecovery).toBe(1);
+      await agent.stopKeepAlive();
     });
   });
 

--- a/packages/agents/src/tests/keep-alive.test.ts
+++ b/packages/agents/src/tests/keep-alive.test.ts
@@ -5,39 +5,41 @@ import { getAgentByName } from "..";
 import type { TestKeepAliveAgent } from "./agents/keep-alive";
 
 describe("keepAlive", () => {
-  it("should create a heartbeat schedule when started", async () => {
+  it("should increment _keepAliveRefs when started", async () => {
     const agent = await getAgentByName(
       env.TestKeepAliveAgent,
       "create-heartbeat"
     );
 
-    // No heartbeat schedules initially
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
+
+    await agent.startKeepAlive();
+    expect(await getKeepAliveRefs(agent)).toBe(1);
+  });
+
+  it("should not create any schedule rows", async () => {
+    const agent = await getAgentByName(
+      env.TestKeepAliveAgent,
+      "no-schedule-rows"
+    );
 
     await agent.startKeepAlive();
 
-    // Should have created exactly one heartbeat schedule
-    expect(await getHeartbeatCount(agent)).toBe(1);
-
-    // Verify the schedule properties
-    const schedule = await getHeartbeatSchedule(agent);
-    expect(schedule).toBeDefined();
-    expect(schedule?.callback).toBe("_cf_keepAliveHeartbeat");
-    expect(schedule?.type).toBe("interval");
-    expect(schedule?.intervalSeconds).toBe(30);
+    const scheduleCount = (await agent.getScheduleCount()) as unknown as number;
+    expect(scheduleCount).toBe(0);
   });
 
-  it("should remove the heartbeat schedule when disposed", async () => {
+  it("should decrement refs when disposed", async () => {
     const agent = await getAgentByName(
       env.TestKeepAliveAgent,
       "dispose-heartbeat"
     );
 
     await agent.startKeepAlive();
-    expect(await getHeartbeatCount(agent)).toBe(1);
+    expect(await getKeepAliveRefs(agent)).toBe(1);
 
     await agent.stopKeepAlive();
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
   });
 
   it("should be idempotent when disposed multiple times", async () => {
@@ -47,39 +49,36 @@ describe("keepAlive", () => {
     );
 
     await agent.startKeepAlive();
-    expect(await getHeartbeatCount(agent)).toBe(1);
+    expect(await getKeepAliveRefs(agent)).toBe(1);
 
-    // First dispose removes the schedule
     await agent.stopKeepAlive();
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
 
-    // Second dispose is a no-op (doesn't throw)
+    // Second dispose is a no-op (doesn't go negative)
     await agent.stopKeepAlive();
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
   });
 
   it("keepAliveWhile should return the function result and clean up", async () => {
     const agent = await getAgentByName(env.TestKeepAliveAgent, "while-success");
 
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
 
     const result = await agent.runWithKeepAliveWhile();
     expect(result).toBe("completed");
 
-    // Heartbeat should be cleaned up after the function completes
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
   });
 
   it("keepAliveWhile should clean up even when the function throws", async () => {
     const agent = await getAgentByName(env.TestKeepAliveAgent, "while-error");
 
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
 
     const result = await agent.runWithKeepAliveWhileError();
     expect(result).toBe("caught");
 
-    // Heartbeat should be cleaned up despite the error
-    expect(await getHeartbeatCount(agent)).toBe(0);
+    expect(await getKeepAliveRefs(agent)).toBe(0);
   });
 
   it("should support multiple concurrent keepAlive calls", async () => {
@@ -91,52 +90,38 @@ describe("keepAlive", () => {
     await agent.startKeepAlive();
     await agent.startKeepAlive();
 
-    // Each call creates its own schedule
-    expect(await getHeartbeatCount(agent)).toBe(2);
-    expect(await getKeepAliveCallCount(agent)).toBe(2);
+    expect(await getKeepAliveRefs(agent)).toBe(2);
 
-    // Stopping only cancels the latest disposer
+    // Disposing one should decrement, not clear
     await agent.stopKeepAlive();
-    expect(await getHeartbeatCount(agent)).toBe(1);
-    expect(await getKeepAliveCallCount(agent)).toBe(1);
+    expect(await getKeepAliveRefs(agent)).toBe(1);
+
+    await agent.stopKeepAlive();
+    expect(await getKeepAliveRefs(agent)).toBe(0);
+  });
+
+  it("refs should never go below zero", async () => {
+    const agent = await getAgentByName(
+      env.TestKeepAliveAgent,
+      "no-negative-refs"
+    );
+
+    // Dispose without ever starting
+    await agent.stopKeepAlive();
+    expect(await getKeepAliveRefs(agent)).toBe(0);
+
+    // Start once, dispose twice
+    await agent.startKeepAlive();
+    await agent.stopKeepAlive();
+    await agent.stopKeepAlive();
+    expect(await getKeepAliveRefs(agent)).toBe(0);
   });
 });
 
-// Helper functions using runInDurableObject for direct internal access
-async function getHeartbeatCount(
+async function getKeepAliveRefs(
   stub: DurableObjectStub<TestKeepAliveAgent>
 ): Promise<number> {
   return runInDurableObject(stub, (instance) => {
-    const result = instance.sql<{ count: number }>`
-      SELECT COUNT(*) as count FROM cf_agents_schedules
-      WHERE callback = '_cf_keepAliveHeartbeat'
-    `;
-    return result[0].count;
-  });
-}
-
-async function getHeartbeatSchedule(
-  stub: DurableObjectStub<TestKeepAliveAgent>
-) {
-  return runInDurableObject(stub, (instance) => {
-    const result = instance.sql<{
-      id: string;
-      callback: string;
-      type: string;
-      intervalSeconds: number;
-    }>`
-      SELECT id, callback, type, intervalSeconds FROM cf_agents_schedules
-      WHERE callback = '_cf_keepAliveHeartbeat'
-      LIMIT 1
-    `;
-    return result[0] ?? null;
-  });
-}
-
-async function getKeepAliveCallCount(
-  stub: DurableObjectStub<TestKeepAliveAgent>
-): Promise<number> {
-  return runInDurableObject(stub, (instance) => {
-    return instance.keepAliveCallCount;
+    return instance._keepAliveRefs;
   });
 }

--- a/packages/agents/src/tests/schema-and-state-optimization.test.ts
+++ b/packages/agents/src/tests/schema-and-state-optimization.test.ts
@@ -18,7 +18,7 @@ import { describe, expect, it } from "vitest";
 import { getAgentByName } from "..";
 
 /**
- * Schema DDL snapshot — the canonical DDL for CURRENT_SCHEMA_VERSION = 1.
+ * Schema DDL snapshot — the canonical DDL for the current CURRENT_SCHEMA_VERSION.
  *
  * If you change any table definition in the Agent constructor (add/remove
  * columns, change constraints, add tables, etc.), this snapshot will break.
@@ -100,7 +100,7 @@ describe("schema version gating", () => {
     );
 
     const version = await agent.getSchemaVersion();
-    expect(version).toBe(1);
+    expect(version).toBe(2);
   });
 
   it("should have all required tables after construction", async () => {
@@ -119,9 +119,9 @@ describe("schema version gating", () => {
   it("should reset to 0 after deleting version row and restore via migration", async () => {
     const name = `schema-upgrade-${crypto.randomUUID()}`;
 
-    // Create agent — sets schema version to 1
+    // Create agent — sets schema version
     const agent = await getAgentByName(env.TestStateAgent, name);
-    expect(await agent.getSchemaVersion()).toBe(1);
+    expect(await agent.getSchemaVersion()).toBe(2);
 
     // Set some state
     await agent.updateState({
@@ -136,7 +136,7 @@ describe("schema version gating", () => {
 
     // Re-run migration manually (constructor won't re-run on same DO)
     await agent.runSchemaMigration();
-    expect(await agent.getSchemaVersion()).toBe(1);
+    expect(await agent.getSchemaVersion()).toBe(2);
 
     // State should be preserved through re-migration
     const state = await agent.getState();
@@ -181,7 +181,7 @@ describe("schema version gating", () => {
     });
 
     // Verify version is set
-    expect(await agent.getSchemaVersion()).toBe(1);
+    expect(await agent.getSchemaVersion()).toBe(2);
 
     // State should still be intact
     const state = await agent.getState();
@@ -199,7 +199,7 @@ describe("schema version gating", () => {
     );
 
     const version = await agent.getSchemaVersion();
-    expect(version).toBe(1);
+    expect(version).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Eliminates observability event noise from `keepAlive()`** — no longer creates schedule rows or emits `schedule:create`/`schedule:execute`/`schedule:cancel` events every 30 seconds. Uses an in-memory ref count that feeds directly into `_scheduleNextAlarm()`.
- **Multiple concurrent `keepAlive()` callers share a single alarm cycle** instead of each creating their own interval schedule row (N fibers → 1 alarm, not N schedule rows).
- **Adds `_onAlarmHousekeeping()` hook** called on every alarm cycle, replacing the old `_cf_keepAliveHeartbeat` callback. The fiber mixin overrides this for eviction recovery instead of coupling to the scheduling system.
- **Schema v2 migration** cleans up orphaned `_cf_keepAliveHeartbeat` schedule rows from the previous implementation (without this, upgrading users would hit a tight alarm loop from stale rows).
- Removes `@experimental` from `keepAlive()` and `keepAliveWhile()`.

## Test plan

- [x] All 855 existing tests pass (3 consecutive full-suite runs)
- [x] `npm run check` passes (lint, typecheck, format, export validation)
- [x] Updated keep-alive tests verify ref counting, no schedule rows, dispose idempotency, negative-ref guard
- [x] Updated fiber tests verify keepAlive refs during fiber execution and absence of schedule rows
- [x] Schema version tests updated for v2
- [x] Docs updated (`docs/scheduling.md`, `design/think.md`)


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
