### PR TITLE
fix(ai-chat): prevent hibernation from dropping tool continuations

### DIFF
--- a/.changeset/funny-plums-shop.md
+++ b/.changeset/funny-plums-shop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Prevent hibernation from silently dropping tool auto-continuations. Wrap `_queueAutoContinuation` in `keepAliveWhile` so the DO stays alive from the moment a continuation is queued until it finishes streaming. Also adds test coverage for continuation edge cases.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -1179,53 +1179,59 @@ export class AIChatAgent<
     prerequisite?: Promise<boolean>
   ) {
     const epoch = this._chatEpoch;
-    this._runExclusiveChatTurn(requestId, async () => {
-      if (this._chatEpoch !== epoch) {
-        this._clearPendingAutoContinuation(true);
-        return;
-      }
-
-      if (prerequisite) {
-        const applied = await prerequisite;
-        if (!applied) {
+    // keepAliveWhile prevents hibernation while the continuation is
+    // waiting in the turn queue, applying the prerequisite, or streaming.
+    // Without this the DO can hibernate between receiving the tool result
+    // and starting to stream, silently dropping the continuation.
+    this.keepAliveWhile(() =>
+      this._runExclusiveChatTurn(requestId, async () => {
+        if (this._chatEpoch !== epoch) {
           this._clearPendingAutoContinuation(true);
           return;
         }
-      }
 
-      const abortSignal = this._getAbortSignal(requestId);
-
-      return this._tryCatchChat(async () => {
-        return agentContext.run(
-          {
-            agent: this,
-            connection,
-            request: undefined,
-            email: undefined
-          },
-          async () => {
-            const response = await this.onChatMessage(
-              async (_finishResult) => {},
-              {
-                requestId,
-                abortSignal,
-                clientTools,
-                body
-              }
-            );
-
-            if (response) {
-              await this._reply(requestId, response, [], {
-                continuation: true,
-                chatMessageId: requestId
-              });
-            } else {
-              this._clearPendingAutoContinuation(true);
-            }
+        if (prerequisite) {
+          const applied = await prerequisite;
+          if (!applied) {
+            this._clearPendingAutoContinuation(true);
+            return;
           }
-        );
-      });
-    }).catch((error) => {
+        }
+
+        const abortSignal = this._getAbortSignal(requestId);
+
+        return this._tryCatchChat(async () => {
+          return agentContext.run(
+            {
+              agent: this,
+              connection,
+              request: undefined,
+              email: undefined
+            },
+            async () => {
+              const response = await this.onChatMessage(
+                async (_finishResult) => {},
+                {
+                  requestId,
+                  abortSignal,
+                  clientTools,
+                  body
+                }
+              );
+
+              if (response) {
+                await this._reply(requestId, response, [], {
+                  continuation: true,
+                  chatMessageId: requestId
+                });
+              } else {
+                this._clearPendingAutoContinuation(true);
+              }
+            }
+          );
+        });
+      })
+    ).catch((error) => {
       this._clearPendingAutoContinuation(true);
       console.error(errorPrefix, error);
     });

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -1459,6 +1459,13 @@ describe("useAgentChat tool continuation status (issue #1157)", () => {
         body: '{"type":"text-start","id":"t1"}',
         done: false
       });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "server-cont-1",
+        continuation: true,
+        body: '{"type":"text-delta","id":"t1","delta":"Hello"}',
+        done: false
+      });
       await sleep(10);
     });
 
@@ -1560,6 +1567,13 @@ describe("useAgentChat tool continuation status (issue #1157)", () => {
         id: "server-cont-approval",
         continuation: true,
         body: '{"type":"text-start","id":"t2"}',
+        done: false
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "server-cont-approval",
+        continuation: true,
+        body: '{"type":"text-delta","id":"t2","delta":"Approved"}',
         done: false
       });
       await sleep(10);

--- a/packages/ai-chat/src/tests/client-tools-continuation.test.ts
+++ b/packages/ai-chat/src/tests/client-tools-continuation.test.ts
@@ -129,6 +129,22 @@ describe("Client tools continuation", () => {
       parts: [{ type: "text", text: "Hello" }]
     };
 
+    let initialResolvePromise: (value: boolean) => void;
+    const initialDonePromise = new Promise<boolean>((res) => {
+      initialResolvePromise = res;
+    });
+
+    const initialTimeout = setTimeout(() => initialResolvePromise(false), 3000);
+
+    ws.addEventListener("message", function initialHandler(e: MessageEvent) {
+      const data = JSON.parse(e.data as string);
+      if (data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && data.done) {
+        clearTimeout(initialTimeout);
+        initialResolvePromise(true);
+        ws.removeEventListener("message", initialHandler);
+      }
+    });
+
     // Send an initial request with delayMs so the stored body makes the
     // continuation wait long enough for the client to request a resume.
     ws.send(
@@ -142,7 +158,8 @@ describe("Client tools continuation", () => {
       })
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 400));
+    const initialDone = await initialDonePromise;
+    expect(initialDone).toBe(true);
 
     const agentStub = await getAgentByName(env.TestChatAgent, room);
     await agentStub.persistMessages([
@@ -182,16 +199,29 @@ describe("Client tools continuation", () => {
       })
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    const waitForMessage = async (
+      predicate: (message: Record<string, unknown>) => boolean,
+      timeoutMs = 3000
+    ) => {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const match = receivedMessages.find(predicate);
+        if (match) {
+          return match;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      return undefined;
+    };
+
+    const resumingMessage = (await waitForMessage(
+      (message) => message.type === MessageType.CF_AGENT_STREAM_RESUMING
+    )) as { id: string } | undefined;
 
     const noneMessages = receivedMessages.filter(
       (message) => message.type === MessageType.CF_AGENT_STREAM_RESUME_NONE
     );
     expect(noneMessages).toHaveLength(0);
-
-    const resumingMessage = receivedMessages.find(
-      (message) => message.type === MessageType.CF_AGENT_STREAM_RESUMING
-    ) as { id: string } | undefined;
     expect(resumingMessage).toBeDefined();
 
     ws.send(
@@ -201,14 +231,122 @@ describe("Client tools continuation", () => {
       })
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    const doneMessages = receivedMessages.filter(
+    const doneMessage = await waitForMessage(
       (message) =>
         message.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
         message.done === true
     );
-    expect(doneMessages.length).toBeGreaterThan(0);
+    expect(doneMessage).toBeDefined();
+
+    ws.close(1000);
+  });
+
+  it("should send resume-none when an auto-continuation returns no body", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+    const userMessage: ChatMessage = {
+      id: "msg-no-body",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    let initialResolvePromise: (value: boolean) => void;
+    const initialDonePromise = new Promise<boolean>((res) => {
+      initialResolvePromise = res;
+    });
+
+    const initialTimeout = setTimeout(() => initialResolvePromise(false), 3000);
+
+    ws.addEventListener("message", function initialHandler(e: MessageEvent) {
+      const data = JSON.parse(e.data as string);
+      if (data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && data.done) {
+        clearTimeout(initialTimeout);
+        initialResolvePromise(true);
+        ws.removeEventListener("message", initialHandler);
+      }
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+        id: "req-no-body",
+        init: {
+          method: "POST",
+          body: JSON.stringify({
+            messages: [userMessage],
+            delayMs: 150,
+            emptyContinuationResponse: true
+          })
+        }
+      })
+    );
+
+    const initialDone = await initialDonePromise;
+    expect(initialDone).toBe(true);
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-no-body",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId: "call_no_body_resume",
+            state: "input-available",
+            input: { color: "blue" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    const receivedMessages: Array<Record<string, unknown>> = [];
+    ws.addEventListener("message", (e: MessageEvent) => {
+      receivedMessages.push(JSON.parse(e.data as string));
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_TOOL_RESULT,
+        toolCallId: "call_no_body_resume",
+        toolName: "changeBackgroundColor",
+        output: { success: true },
+        autoContinue: true
+      })
+    );
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST
+      })
+    );
+
+    const waitForMessage = async (
+      predicate: (message: Record<string, unknown>) => boolean,
+      timeoutMs = 3000
+    ) => {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const match = receivedMessages.find(predicate);
+        if (match) {
+          return match;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      return undefined;
+    };
+
+    const noneMessage = await waitForMessage(
+      (message) => message.type === MessageType.CF_AGENT_STREAM_RESUME_NONE
+    );
+    expect(noneMessage).toBeDefined();
+
+    const resumingMessage = receivedMessages.find(
+      (message) => message.type === MessageType.CF_AGENT_STREAM_RESUMING
+    );
+    expect(resumingMessage).toBeUndefined();
 
     ws.close(1000);
   });
@@ -301,6 +439,109 @@ describe("Client tools continuation", () => {
     // Client tools should be undefined after chat clear
     const continuationClientTools = await agentStub.getCapturedClientTools();
     expect(continuationClientTools).toBeUndefined();
+
+    ws.close(1000);
+  });
+
+  it("sends STREAM_RESUME_NONE when chat clear cancels a pending tool continuation", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+    const userMessage: ChatMessage = {
+      id: "msg-clear-pending",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+
+    let initialResolvePromise: (value: boolean) => void;
+    const initialDonePromise = new Promise<boolean>((res) => {
+      initialResolvePromise = res;
+    });
+
+    const initialTimeout = setTimeout(() => initialResolvePromise(false), 3000);
+
+    ws.addEventListener("message", function initialHandler(e: MessageEvent) {
+      const data = JSON.parse(e.data as string);
+      if (data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && data.done) {
+        clearTimeout(initialTimeout);
+        initialResolvePromise(true);
+        ws.removeEventListener("message", initialHandler);
+      }
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+        id: "req-clear-pending",
+        init: {
+          method: "POST",
+          body: JSON.stringify({ messages: [userMessage], delayMs: 150 })
+        }
+      })
+    );
+
+    const initialDone = await initialDonePromise;
+    expect(initialDone).toBe(true);
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-clear-pending",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId: "call_clear_pending_resume",
+            state: "input-available",
+            input: { color: "blue" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    const receivedMessages: Array<Record<string, unknown>> = [];
+    ws.addEventListener("message", (e: MessageEvent) => {
+      receivedMessages.push(JSON.parse(e.data as string));
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_TOOL_RESULT,
+        toolCallId: "call_clear_pending_resume",
+        toolName: "changeBackgroundColor",
+        output: { success: true },
+        autoContinue: true
+      })
+    );
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST
+      })
+    );
+
+    ws.send(JSON.stringify({ type: MessageType.CF_AGENT_CHAT_CLEAR }));
+
+    const waitForMessage = async (
+      predicate: (message: Record<string, unknown>) => boolean,
+      timeoutMs = 3000
+    ) => {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const match = receivedMessages.find(predicate);
+        if (match) {
+          return match;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      return undefined;
+    };
+
+    const noneMessage = await waitForMessage(
+      (message) => message.type === MessageType.CF_AGENT_STREAM_RESUME_NONE
+    );
+    expect(noneMessage).toBeDefined();
 
     ws.close(1000);
   });

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -99,6 +99,22 @@ export class TestChatAgent extends AIChatAgent<Env> {
       return chainedContinuationResponse;
     }
 
+    const lastAssistant = [...this.messages]
+      .reverse()
+      .find((message) => message.role === "assistant");
+
+    if (
+      options?.body?.emptyContinuationResponse === true &&
+      lastAssistant?.parts.some(
+        (part) =>
+          part.type.startsWith("tool-") &&
+          "state" in part &&
+          part.state === "output-available"
+      )
+    ) {
+      return new Response(null);
+    }
+
     // Simple echo response for testing
     return new Response("Hello from chat agent!", {
       headers: { "Content-Type": "text/plain" }

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -427,6 +427,29 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     }
   });
 
+  it("tool continuation stream closes immediately when send() throws", async () => {
+    const failAgent = createMockAgent();
+    failAgent.send = () => {
+      throw new Error("WebSocket closed");
+    };
+    const failTransport = new WebSocketChatTransport<ChatMessage>({
+      agent: failAgent
+    });
+
+    failTransport.expectToolContinuation();
+
+    const stream = (await failTransport.reconnectToStream({
+      chatId: "chat-1"
+    })) as ReadableStream<UIMessageChunk>;
+
+    const reader = stream.getReader();
+    const result = await reader.read();
+
+    expect(result.done).toBe(true);
+    expect(failTransport.handleStreamResuming({ id: "late" })).toBe(false);
+    expect(failTransport.handleStreamResumeNone()).toBe(false);
+  });
+
   // ── No activeRequestIds (optional) ───────────────────────────────────
 
   // ── Double STREAM_RESUMING (server sends from onConnect + RESUME_REQUEST) ──


### PR DESCRIPTION
## Summary

Prevents Durable Object hibernation from silently dropping tool auto-continuations, and adds test coverage for continuation edge cases.

The core status tracking fix for #1157 landed in #1162. This PR addresses a hibernation safety gap in that implementation and adds tests for edge cases that weren't covered.

## What changed

### Hibernation fix: `_queueAutoContinuation` wrapped in `keepAliveWhile`

**File:** `packages/ai-chat/src/index.ts`

`_queueAutoContinuation` fires off `_runExclusiveChatTurn` as a fire-and-forget promise. Between receiving a tool result and the continuation starting to stream, the DO has no `keepAlive` ref — if the runtime decides to hibernate during that window, the continuation promise is silently abandoned. The tool result is persisted (SQLite), but the LLM follow-up never runs.

This wraps the entire continuation lifecycle in `keepAliveWhile` so the DO stays alive from queueing through streaming completion. `_reply()` already calls `keepAliveWhile` internally, but `keepAlive` is ref-counted so nesting is safe.

### Test coverage for continuation edge cases

- **Empty continuation body** (`client-tools-continuation.test.ts`): when `onChatMessage` returns `Response(null)`, the client receives `STREAM_RESUME_NONE` (not `STREAM_RESUMING`)
- **Chat clear during pending continuation** (`client-tools-continuation.test.ts`): clearing chat while a tool continuation is pending sends `STREAM_RESUME_NONE` to waiting connections
- **Transport send failure** (`ws-transport-resume.test.ts`): when `agent.send()` throws during tool continuation stream setup, the stream closes cleanly and handshake resolvers are cleared
- **Streaming status assertion** (`use-agent-chat.test.tsx`): tool continuation React tests now dispatch `text-delta` chunks and assert `status === "streaming"` before completion
- **Event-based test helpers** (`client-tools-continuation.test.ts`): replaced flaky `setTimeout`-based waits with `waitForMessage` polling helpers

## Test plan

- [ ] `npm run test:workers -w @cloudflare/ai-chat -- src/tests/client-tools-continuation.test.ts`
- [ ] `npm run test:react -w @cloudflare/ai-chat -- src/react-tests/use-agent-chat.test.tsx`
- [ ] `npm run test -w @cloudflare/ai-chat -- src/tests/ws-transport-resume.test.ts`
- [ ] `npx tsc -p packages/ai-chat/tsconfig.json --noEmit`

Closes #1157.