### PR TITLE
feat(experimental): Session API with chainable builder

### DIFF
--- a/experimental/session-memory/src/client.tsx
+++ b/experimental/session-memory/src/client.tsx
@@ -4,26 +4,89 @@ import {
   Badge,
   InputArea,
   Empty,
+  Surface,
+  Text,
   PoweredByCloudflare
 } from "@cloudflare/kumo";
 import {
-  PaperPlaneRightIcon,
   TrashIcon,
   ArrowsClockwiseIcon,
   ChatCircleDotsIcon,
+  CaretRightIcon,
+  CheckCircleIcon,
   StackIcon,
   MoonIcon,
-  SunIcon
+  SunIcon,
+  PaperPlaneRightIcon
 } from "@phosphor-icons/react";
 import { useAgent } from "agents/react";
 import type { ChatAgent } from "./server";
 import type { UIMessage } from "ai";
 
-function getMessageText(message: UIMessage): string {
-  return message.parts
-    .filter((p): p is { type: "text"; text: string } => p.type === "text")
-    .map((p) => p.text)
-    .join("\n");
+// Tool parts come as "dynamic-tool" with input/output fields
+type ToolPart = Extract<UIMessage["parts"][number], { type: string }> & {
+  toolCallId: string;
+  toolName: string;
+  state: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+};
+
+function isToolPart(part: UIMessage["parts"][number]): part is ToolPart {
+  return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+}
+
+function ToolCard({ part }: { part: ToolPart }) {
+  const [open, setOpen] = useState(false);
+  const done = part.state === "output-available";
+  const label = [part.input?.action, part.input?.label]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Surface className="rounded-xl ring ring-kumo-line overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-2.5 cursor-pointer hover:bg-kumo-elevated transition-colors"
+        onClick={() => setOpen(!open)}
+      >
+        <CaretRightIcon
+          size={12}
+          className={`text-kumo-secondary transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <Text size="xs" bold>
+          {part.toolName}
+        </Text>
+        {label && (
+          <span className="font-mono text-xs text-kumo-secondary truncate">
+            {label}
+          </span>
+        )}
+        {done && (
+          <CheckCircleIcon
+            size={14}
+            className="text-green-500 ml-auto shrink-0"
+          />
+        )}
+      </button>
+      {open && (
+        <div className="px-3 pb-3 border-t border-kumo-line space-y-2 pt-2">
+          {part.input && (
+            <pre className="font-mono text-xs text-kumo-subtle bg-kumo-elevated rounded p-2 overflow-x-auto whitespace-pre-wrap">
+              {JSON.stringify(part.input, null, 2)}
+            </pre>
+          )}
+          {part.output != null && (
+            <pre className="font-mono text-xs text-green-600 dark:text-green-400 bg-green-500/5 border border-green-500/20 rounded p-2 overflow-x-auto whitespace-pre-wrap">
+              {typeof part.output === "string"
+                ? part.output
+                : JSON.stringify(part.output, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </Surface>
+  );
 }
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
@@ -97,22 +160,14 @@ function Chat() {
     }, [])
   });
 
-  // Fetch messages once on connect
-  useEffect(() => {
-    if (connectionStatus !== "connected" || hasFetched.current) return;
+  // Load messages once on connect
+  if (connectionStatus === "connected" && !hasFetched.current) {
     hasFetched.current = true;
-
-    const load = async () => {
-      try {
-        await agent.ready;
-        const msgs = await agent.call<UIMessage[]>("getMessages");
-        setMessages(msgs);
-      } catch (err) {
-        console.error("Failed to fetch messages:", err);
-      }
-    };
-    load();
-  }, [connectionStatus, agent]);
+    agent
+      .call<UIMessage[]>("getMessages")
+      .then(setMessages)
+      .catch(console.error);
+  }
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -121,59 +176,23 @@ function Chat() {
   const send = useCallback(async () => {
     const text = input.trim();
     if (!text || isLoading) return;
-
     setInput("");
     setIsLoading(true);
-
     const userMsg: UIMessage = {
       id: `user-${crypto.randomUUID()}`,
       role: "user",
       parts: [{ type: "text", text }]
     };
     setMessages((prev) => [...prev, userMsg]);
-
     try {
-      const response = await agent.call<string>("chat", [text, userMsg.id]);
-      const assistantMsg: UIMessage = {
-        id: `assistant-${crypto.randomUUID()}`,
-        role: "assistant",
-        parts: [{ type: "text", text: response }]
-      };
-      setMessages((prev) => [...prev, assistantMsg]);
+      const msg = await agent.call<UIMessage>("chat", [text, userMsg.id]);
+      setMessages((prev) => [...prev, msg]);
     } catch (err) {
       console.error("Failed to send:", err);
     } finally {
       setIsLoading(false);
     }
   }, [input, isLoading, agent]);
-
-  const clearHistory = async () => {
-    try {
-      await agent.call("clearMessages");
-      setMessages([]);
-    } catch (err) {
-      console.error("Failed to clear:", err);
-    }
-  };
-
-  const compactSession = async () => {
-    setIsCompacting(true);
-    try {
-      const result = await agent.call<{ success: boolean; error?: string }>(
-        "compact"
-      );
-      if (result.success) {
-        const msgs = await agent.call<UIMessage[]>("getMessages");
-        setMessages(msgs);
-      } else {
-        alert(`Compaction failed: ${result.error}`);
-      }
-    } catch (err) {
-      console.error("Failed to compact:", err);
-    } finally {
-      setIsCompacting(false);
-    }
-  };
 
   const isConnected = connectionStatus === "connected";
 
@@ -185,10 +204,7 @@ function Chat() {
             <h1 className="text-lg font-semibold text-kumo-default">
               Session Memory
             </h1>
-            <Badge variant="secondary">
-              <StackIcon size={12} weight="bold" className="mr-1" />
-              Compaction
-            </Badge>
+            <Badge variant="secondary">{messages.length} msgs</Badge>
           </div>
           <div className="flex items-center gap-3">
             <ConnectionIndicator status={connectionStatus} />
@@ -196,15 +212,34 @@ function Chat() {
             <Button
               variant="secondary"
               icon={<ArrowsClockwiseIcon size={16} />}
-              onClick={compactSession}
+              onClick={async () => {
+                setIsCompacting(true);
+                try {
+                  await agent.call("compact");
+                  setMessages(await agent.call<UIMessage[]>("getMessages"));
+                } catch (err) {
+                  console.error("Compact failed:", err);
+                } finally {
+                  setIsCompacting(false);
+                }
+              }}
               disabled={isCompacting || isLoading || messages.length < 4}
+              loading={isCompacting}
             >
               Compact
             </Button>
             <Button
               variant="secondary"
               icon={<TrashIcon size={16} />}
-              onClick={clearHistory}
+              onClick={async () => {
+                try {
+                  await agent.call("clearMessages");
+                  setMessages([]);
+                } catch (err) {
+                  console.error("Clear failed:", err);
+                }
+              }}
+              disabled={messages.length === 0}
             >
               Clear
             </Button>
@@ -218,43 +253,74 @@ function Chat() {
             <Empty
               icon={<ChatCircleDotsIcon size={32} />}
               title="Start a conversation"
-              description="Messages persist in SQLite. Try compacting after a few exchanges."
+              description="Messages persist in SQLite. The agent saves facts to memory and manages todos via tools. Try compacting after a few exchanges."
             />
           )}
 
           {messages.map((message) => {
-            const text = getMessageText(message);
-            if (!text) return null;
-
             if (message.role === "user") {
               return (
                 <div key={message.id} className="flex justify-end">
-                  <div className="max-w-[85%] px-4 py-2.5 rounded-2xl rounded-br-md bg-kumo-contrast text-kumo-inverse leading-relaxed">
-                    {text}
+                  <div className="max-w-[80%] px-4 py-2.5 rounded-2xl rounded-br-md bg-kumo-contrast text-kumo-inverse text-sm leading-relaxed">
+                    {message.parts
+                      .filter((p) => p.type === "text")
+                      .map((p) => (p.type === "text" ? p.text : ""))
+                      .join("")}
                   </div>
                 </div>
               );
             }
 
+            const isCompaction = message.id.startsWith("compaction_");
             return (
-              <div key={message.id} className="flex justify-start">
-                <div className="max-w-[85%] px-4 py-2.5 rounded-2xl rounded-bl-md bg-kumo-base text-kumo-default leading-relaxed whitespace-pre-wrap">
-                  {text}
-                </div>
+              <div key={message.id} className="space-y-2">
+                {isCompaction && (
+                  <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 font-semibold">
+                    <StackIcon size={12} weight="bold" /> Compacted Summary
+                  </div>
+                )}
+                {message.parts.map((part, i) => {
+                  if (part.type === "text" && part.text?.trim()) {
+                    return (
+                      <div key={i} className="flex justify-start">
+                        <Surface
+                          className={`max-w-[80%] rounded-2xl rounded-bl-md ring ${isCompaction ? "ring-amber-200 dark:ring-amber-800 bg-amber-50 dark:bg-amber-950/30" : "ring-kumo-line"}`}
+                        >
+                          <div className="px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap">
+                            {part.text}
+                          </div>
+                        </Surface>
+                      </div>
+                    );
+                  }
+                  if (isToolPart(part)) {
+                    return (
+                      <div key={part.toolCallId ?? i} className="max-w-[80%]">
+                        <ToolCard part={part} />
+                      </div>
+                    );
+                  }
+                  return null;
+                })}
               </div>
             );
           })}
 
           {isLoading && (
             <div className="flex justify-start">
-              <div className="max-w-[85%] px-4 py-2.5 rounded-2xl rounded-bl-md bg-kumo-base text-kumo-default">
+              <div className="px-4 py-2.5 rounded-2xl rounded-bl-md bg-kumo-base">
                 <span className="inline-block w-2 h-2 bg-kumo-brand rounded-full mr-1 animate-pulse" />
-                <span className="inline-block w-2 h-2 bg-kumo-brand rounded-full mr-1 animate-pulse delay-100" />
-                <span className="inline-block w-2 h-2 bg-kumo-brand rounded-full animate-pulse delay-200" />
+                <span
+                  className="inline-block w-2 h-2 bg-kumo-brand rounded-full mr-1 animate-pulse"
+                  style={{ animationDelay: "150ms" }}
+                />
+                <span
+                  className="inline-block w-2 h-2 bg-kumo-brand rounded-full animate-pulse"
+                  style={{ animationDelay: "300ms" }}
+                />
               </div>
             </div>
           )}
-
           <div ref={messagesEndRef} />
         </div>
       </div>
@@ -277,7 +343,11 @@ function Chat() {
                   send();
                 }
               }}
-              placeholder="Type a message..."
+              placeholder={
+                isConnected
+                  ? "Ask me anything... I'll remember important facts."
+                  : "Connecting..."
+              }
               disabled={!isConnected || isLoading}
               rows={2}
               className="flex-1 !ring-0 focus:!ring-0 !shadow-none !bg-transparent !outline-none"
@@ -285,8 +355,7 @@ function Chat() {
             <Button
               type="submit"
               variant="primary"
-              shape="square"
-              aria-label="Send message"
+              size="sm"
               disabled={!input.trim() || !isConnected || isLoading}
               icon={<PaperPlaneRightIcon size={18} />}
               className="mb-0.5"

--- a/experimental/session-memory/src/server.ts
+++ b/experimental/session-memory/src/server.ts
@@ -1,84 +1,128 @@
 /**
  * Session Memory Example
  *
- * Demonstrates Agent with Session-managed messages and compaction.
+ * Demonstrates the Session API with:
+ * - Context blocks (memory, todos) with frozen system prompt
+ * - update_context AI tool (replace + append)
+ * - Non-destructive compaction via onCompaction() builder
+ * - Read-time tool output truncation
  */
 
 import { Agent, callable, routeAgentRequest } from "agents";
+import { Session } from "agents/experimental/memory/session";
 import {
-  Session,
-  AgentSessionProvider
-} from "agents/experimental/memory/session";
-import type { CompactResult } from "agents/experimental/memory/session";
+  truncateOlderMessages,
+  createCompactFunction
+} from "agents/experimental/memory/utils";
 import type { UIMessage } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
-import { generateText, convertToModelMessages } from "ai";
-
-async function compactMessages(
-  messages: UIMessage[],
-  ai: Ai
-): Promise<UIMessage[]> {
-  if (messages.length === 0) return [];
-
-  const workersai = createWorkersAI({ binding: ai });
-  const { text } = await generateText({
-    model: workersai("@cf/moonshotai/kimi-k2.5"),
-    system:
-      "Summarize this conversation concisely, preserving key decisions, facts, and context.",
-    messages: await convertToModelMessages(messages)
-  });
-
-  return [
-    {
-      id: `summary-${crypto.randomUUID()}`,
-      role: "assistant",
-      parts: [{ type: "text", text: `[Conversation Summary]\n${text}` }]
-    }
-  ];
-}
+import { generateText, convertToModelMessages, stepCountIs } from "ai";
 
 export class ChatAgent extends Agent<Env> {
-  session = new Session(new AgentSessionProvider(this), {
-    compaction: {
-      tokenThreshold: 10000,
-      fn: (msgs) => compactMessages(msgs, this.env.AI)
-    }
-  });
+  session = Session.create(this)
+    .withContext("soul", {
+      initialContent:
+        "You are a helpful assistant with persistent memory. Use the update_context tool to save important facts to memory and manage your todo list.",
+      readonly: true
+    })
+    .withContext("memory", {
+      description: "Learned facts — save important things here",
+      maxTokens: 1100
+    })
+    .withContext("todos", {
+      description: "Task list",
+      maxTokens: 2000
+    })
+    .onCompaction(
+      createCompactFunction({
+        summarize: (prompt) =>
+          generateText({ model: this.getAI(), prompt }).then((r) => r.text),
+        protectHead: 1,
+        minTailMessages: 2,
+        tailTokenBudget: 100
+      })
+    )
+    .withCachedPrompt();
+
+  private getAI() {
+    return createWorkersAI({ binding: this.env.AI })(
+      "@cf/moonshotai/kimi-k2.5",
+      { sessionAffinity: this.sessionAffinity }
+    );
+  }
 
   @callable()
-  async chat(message: string, messageId?: string): Promise<string> {
-    await this.session.append({
+  async chat(message: string, messageId?: string): Promise<UIMessage> {
+    this.session.appendMessage({
       id: messageId ?? `user-${crypto.randomUUID()}`,
       role: "user",
       parts: [{ type: "text", text: message }]
     });
 
-    const workersai = createWorkersAI({ binding: this.env.AI });
-    const { text } = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.5", {
-        sessionAffinity: this.sessionAffinity
-      }),
-      system: "You are a helpful assistant.",
-      messages: await convertToModelMessages(this.session.getMessages())
+    // Auto-compact after 6 messages so it's easy to demo
+    if (this.session.needsCompaction(6)) {
+      await this.session.compact();
+    }
+
+    const history = this.session.getHistory();
+    const truncated = truncateOlderMessages(history);
+
+    const result = await generateText({
+      model: this.getAI(),
+      system: await this.session.freezeSystemPrompt(),
+      messages: await convertToModelMessages(truncated),
+      tools: await this.session.tools(),
+      stopWhen: stepCountIs(5)
     });
 
-    await this.session.append({
+    const parts: UIMessage["parts"] = [];
+
+    for (const step of result.steps) {
+      for (const tc of step.toolCalls) {
+        const tr = step.toolResults.find((r) => r.toolCallId === tc.toolCallId);
+        parts.push({
+          type: "dynamic-tool",
+          toolName: tc.toolName,
+          toolCallId: tc.toolCallId,
+          state: tr ? "output-available" : "input-available",
+          input: tc.input,
+          ...(tr ? { output: tr.output } : {})
+        } as unknown as UIMessage["parts"][number]);
+      }
+    }
+
+    if (result.text) {
+      parts.push({ type: "text", text: result.text });
+    }
+
+    const assistantMsg: UIMessage = {
       id: `assistant-${crypto.randomUUID()}`,
       role: "assistant",
-      parts: [{ type: "text", text }]
-    });
+      parts
+    };
 
-    return text;
+    this.session.appendMessage(assistantMsg);
+    return assistantMsg;
+  }
+
+  @callable()
+  async compact(): Promise<{ success: boolean; removed?: number }> {
+    try {
+      const removed = await this.session.compact();
+      return { success: true, removed: removed ?? 0 };
+    } catch {
+      return { success: false };
+    }
   }
 
   @callable()
   getMessages(): UIMessage[] {
-    return this.session.getMessages();
+    return this.session.getHistory();
   }
 
   @callable()
-  async compact(): Promise<CompactResult> {
-    return this.session.compact();
+  search(query: string) {
+    return this.session.search(query);
   }
 
   @callable()

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -157,6 +157,11 @@
       "import": "./dist/experimental/memory/session/index.js",
       "require": "./dist/experimental/memory/session/index.js"
     },
+    "./experimental/memory/utils": {
+      "types": "./dist/experimental/memory/utils/index.d.ts",
+      "import": "./dist/experimental/memory/utils/index.js",
+      "require": "./dist/experimental/memory/utils/index.js"
+    },
     "./x402": {
       "types": "./dist/mcp/x402.d.ts",
       "import": "./dist/mcp/x402.js",

--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -17,7 +17,8 @@ async function main() {
       "src/observability/index.ts",
       "src/codemode/ai.ts",
       "src/experimental/forever.ts",
-      "src/experimental/memory/session/index.ts"
+      "src/experimental/memory/session/index.ts",
+      "src/experimental/memory/utils/index.ts"
     ],
     deps: {
       skipNodeModulesBundle: true,

--- a/packages/agents/src/experimental/memory/index.ts
+++ b/packages/agents/src/experimental/memory/index.ts
@@ -4,10 +4,15 @@
  * @experimental
  */
 
-// Session Memory - conversation history with AI SDK compatibility
 export {
   Session,
   AgentSessionProvider,
+  AgentContextProvider,
   type MessageQueryOptions,
-  type SessionProvider
+  type SessionProvider,
+  type SearchResult,
+  type StoredCompaction,
+  type ContextConfig,
+  type ContextBlock,
+  type SessionOptions
 } from "./session";

--- a/packages/agents/src/experimental/memory/session/context.ts
+++ b/packages/agents/src/experimental/memory/session/context.ts
@@ -1,0 +1,337 @@
+/**
+ * Context Block Management
+ *
+ * Persistent key-value blocks (MEMORY, USER, SOUL, etc.) that are:
+ * - Loaded from their providers at init
+ * - Frozen into a snapshot when toSystemPrompt() is called
+ * - Updated via setBlock() which writes to the provider immediately
+ *   but does NOT update the frozen snapshot (preserves LLM prefix cache)
+ * - Re-snapshotted on next toSystemPrompt() call
+ */
+
+import { jsonSchema, type ToolSet } from "ai";
+import { estimateStringTokens } from "../utils/tokens";
+
+/**
+ * Storage interface for a single context block.
+ * Each block can have its own backing store (R2, SQLite, KV, in-memory, etc.)
+ * If `set` is omitted, the block is readonly.
+ */
+export interface ContextProvider {
+  get(): Promise<string | null>;
+  set?(content: string): Promise<void>;
+}
+
+/**
+ * Configuration for a context block.
+ */
+export interface ContextConfig {
+  /** Block label — used as key and in tool descriptions */
+  label: string;
+  /** Human-readable description (shown to AI in tool) */
+  description?: string;
+  /** Initial content — used when provider returns null or is absent */
+  initialContent?: string;
+  /** Maximum tokens allowed. Enforced on set. */
+  maxTokens?: number;
+  /** If true, AI cannot modify this block via tools */
+  readonly?: boolean;
+  /** Storage provider. If omitted, auto-wired to SQLite when using builder. */
+  provider?: ContextProvider;
+}
+
+/**
+ * A loaded context block with computed token count.
+ */
+export interface ContextBlock {
+  label: string;
+  description?: string;
+  content: string;
+  tokens: number;
+  maxTokens?: number;
+  readonly?: boolean;
+}
+
+/**
+ * Manages context blocks with frozen snapshot support.
+ */
+export class ContextBlocks {
+  private configs: ContextConfig[];
+  private blocks = new Map<string, ContextBlock>();
+  private snapshot: string | null = null;
+  private loaded = false;
+  private promptStore: ContextProvider | null;
+
+  constructor(configs: ContextConfig[], promptStore?: ContextProvider) {
+    this.configs = configs;
+    this.promptStore = promptStore ?? null;
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  /**
+   * Load all blocks from their providers.
+   * Called once at session init.
+   */
+  async load(): Promise<void> {
+    for (const config of this.configs) {
+      let content: string | null = null;
+
+      if (config.provider) {
+        content = await config.provider.get();
+      }
+
+      content = content ?? config.initialContent ?? "";
+
+      this.blocks.set(config.label, {
+        label: config.label,
+        description: config.description,
+        content,
+        tokens: estimateStringTokens(content),
+        maxTokens: config.maxTokens,
+        readonly: config.readonly
+      });
+    }
+    this.loaded = true;
+  }
+
+  /**
+   * Get a block by label.
+   */
+  getBlock(label: string): ContextBlock | null {
+    return this.blocks.get(label) ?? null;
+  }
+
+  /**
+   * Get all blocks.
+   */
+  getBlocks(): ContextBlock[] {
+    return Array.from(this.blocks.values());
+  }
+
+  /**
+   * Set block content. Writes to provider immediately.
+   * Does NOT update the frozen snapshot.
+   */
+  async setBlock(label: string, content: string): Promise<ContextBlock> {
+    if (!this.loaded) await this.load();
+    const config = this.configs.find((c) => c.label === label);
+    const existing = this.blocks.get(label);
+
+    if (existing?.readonly || config?.readonly) {
+      throw new Error(`Block "${label}" is readonly`);
+    }
+
+    const tokens = estimateStringTokens(content);
+    const maxTokens = config?.maxTokens ?? existing?.maxTokens;
+
+    if (maxTokens !== undefined && tokens > maxTokens) {
+      throw new Error(
+        `Block "${label}" exceeds maxTokens: ${tokens} > ${maxTokens}`
+      );
+    }
+
+    const block: ContextBlock = {
+      label,
+      description: config?.description ?? existing?.description,
+      content,
+      tokens,
+      maxTokens,
+      readonly: false
+    };
+
+    this.blocks.set(label, block);
+
+    // Write to provider immediately (durable)
+    if (config?.provider?.set) {
+      await config.provider.set(content);
+    }
+
+    // Snapshot is NOT updated — frozen until next toSystemPrompt() call
+
+    return block;
+  }
+
+  /**
+   * Append content to a block.
+   */
+  async appendToBlock(label: string, content: string): Promise<ContextBlock> {
+    if (!this.loaded) await this.load();
+    const existing = this.blocks.get(label);
+    if (!existing) {
+      throw new Error(`Block "${label}" not found`);
+    }
+    return this.setBlock(label, existing.content + content);
+  }
+
+  /**
+   * Get the system prompt string with context blocks.
+   *
+   * Returns a frozen snapshot: first call renders and caches,
+   * subsequent calls return the same string (preserves LLM prefix cache).
+   * Call refreshSnapshot() to re-render after block changes take effect.
+   */
+  toSystemPrompt(): string {
+    if (!this.loaded) {
+      throw new Error("Context blocks not loaded. Call load() first.");
+    }
+
+    // Return frozen snapshot if already captured
+    if (this.snapshot !== null) {
+      return this.snapshot;
+    }
+
+    return this.captureSnapshot();
+  }
+
+  /**
+   * Force re-render the snapshot from current block state.
+   * Call this at the start of a new session to pick up changes
+   * made by setBlock() during the previous session.
+   */
+  refreshSnapshot(): string {
+    return this.captureSnapshot();
+  }
+
+  private captureSnapshot(): string {
+    const parts: string[] = [];
+    const sep = "═".repeat(46);
+
+    for (const block of this.blocks.values()) {
+      if (!block.content) continue;
+
+      let header = block.label.toUpperCase();
+      if (block.description) header += ` (${block.description})`;
+      if (block.maxTokens) {
+        const pct = Math.round((block.tokens / block.maxTokens) * 100);
+        header += ` [${pct}% — ${block.tokens}/${block.maxTokens} tokens]`;
+      }
+      if (block.readonly) header += " [readonly]";
+
+      parts.push(`${sep}\n${header}\n${sep}\n${block.content}`);
+    }
+
+    this.snapshot = parts.join("\n\n");
+    return this.snapshot;
+  }
+
+  /**
+   * Get writable blocks (for tool description).
+   */
+  getWritableBlocks(): ContextBlock[] {
+    return Array.from(this.blocks.values()).filter((b) => !b.readonly);
+  }
+
+  /**
+   * Get writable block configs — doesn't require blocks to be loaded.
+   */
+  getWritableConfigs(): ContextConfig[] {
+    return this.configs.filter((c) => !c.readonly);
+  }
+
+  // ── Public API ──────────────────────────────────────────────────
+
+  /**
+   * Frozen system prompt. On first call:
+   * 1. Checks store for a persisted prompt (survives DO eviction)
+   * 2. If none, loads blocks from providers, renders, and persists
+   *
+   * Subsequent calls return the stored version — true prefix cache stability.
+   */
+  async freezeSystemPrompt(): Promise<string> {
+    if (this.promptStore) {
+      const stored = await this.promptStore.get();
+      if (stored) return stored;
+    }
+
+    if (!this.loaded) await this.load();
+    const prompt = this.toSystemPrompt();
+
+    if (prompt && this.promptStore?.set) {
+      await this.promptStore.set(prompt);
+    }
+
+    return prompt;
+  }
+
+  /**
+   * Re-render the system prompt from current block state and persist.
+   * Call after compaction or at session boundaries to pick up writes.
+   */
+  async refreshSystemPrompt(): Promise<string> {
+    if (!this.loaded) await this.load();
+    const prompt = this.refreshSnapshot();
+
+    if (prompt && this.promptStore?.set) {
+      await this.promptStore.set(prompt);
+    }
+
+    return prompt;
+  }
+
+  /**
+   * AI tool for updating context blocks. Loads blocks lazily on first execute.
+   */
+  async tools(): Promise<ToolSet> {
+    if (!this.loaded) await this.load();
+
+    const writable = this.getWritableBlocks();
+    if (writable.length === 0) return {};
+
+    const blockDescriptions = writable
+      .map((b) => `- "${b.label}": ${b.description ?? "no description"}`)
+      .join("\n");
+
+    const ctx = this;
+
+    return {
+      update_context: {
+        description: `Update a context block. Available blocks:\n${blockDescriptions}\n\nWrites are durable and persist across sessions.`,
+        inputSchema: jsonSchema({
+          type: "object" as const,
+          properties: {
+            label: {
+              type: "string" as const,
+              enum: writable.map((b) => b.label),
+              description: "Block label to update"
+            },
+            content: {
+              type: "string" as const,
+              description: "Content to write"
+            },
+            action: {
+              type: "string" as const,
+              enum: ["replace", "append"],
+              description: "replace (default) or append"
+            }
+          },
+          required: ["label", "content"]
+        }),
+        execute: async ({
+          label,
+          content,
+          action
+        }: {
+          label: string;
+          content: string;
+          action?: string;
+        }) => {
+          try {
+            const block =
+              action === "append"
+                ? await ctx.appendToBlock(label, content)
+                : await ctx.setBlock(label, content);
+            const usage = block.maxTokens
+              ? `${Math.round((block.tokens / block.maxTokens) * 100)}% (${block.tokens}/${block.maxTokens} tokens)`
+              : `${block.tokens} tokens`;
+            return `Written to ${label}. Usage: ${usage}`;
+          } catch (err) {
+            return `Error: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+      }
+    };
+  }
+}

--- a/packages/agents/src/experimental/memory/session/index.ts
+++ b/packages/agents/src/experimental/memory/session/index.ts
@@ -1,42 +1,49 @@
 /**
- * Session Memory
+ * Session — conversation history with branching, compaction overlays,
+ * context blocks, search, and AI tools.
  *
- * Conversation history storage with AI SDK compatibility.
- * Use UIMessage from "ai" package for message types.
- *
- * microCompaction is enabled by default - it truncates tool outputs and
- * long text parts in older messages without requiring an LLM.
- *
- * @example
+ * @example Builder API (recommended)
  * ```typescript
- * import { Session, AgentSessionProvider } from "agents/experimental/memory/session";
+ * import { Session } from "agents/experimental/memory/session";
  *
- * // Default: microCompaction enabled
- * session = new Session(new AgentSessionProvider(this));
+ * const session = Session.create(this)
+ *   .withContext("soul", { initialContent: "You are helpful.", readonly: true })
+ *   .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+ *   .withContext("todos", { description: "Task list", maxTokens: 2000 })
+ *   .withCachedPrompt();
  *
- * // With auto-compaction threshold
- * session = new Session(new AgentSessionProvider(this), {
- *   compaction: { tokenThreshold: 20000, fn: summarize }
- * });
+ * // Custom storage (R2, KV, etc.)
+ * const session = Session.create(this)
+ *   .withContext("workspace", {
+ *     provider: {
+ *       get: () => env.BUCKET.get("ws.md").then(o => o?.text() ?? null),
+ *       set: (c) => env.BUCKET.put("ws.md", c),
+ *     }
+ *   })
+ *   .withCachedPrompt();
  *
- * // Custom microCompaction rules
- * session = new Session(new AgentSessionProvider(this), {
- *   microCompaction: { truncateToolOutputs: 2000, keepRecent: 10 }
- * });
+ * // Read-only from external source
+ * const session = Session.create(this)
+ *   .withContext("config", {
+ *     readonly: true,
+ *     provider: { get: () => env.KV.get("agent-config") },
+ *   })
+ *   .withCachedPrompt();
  * ```
  */
 
+export type { MessageQueryOptions, SessionOptions } from "./types";
+
 export type {
-  MessageQueryOptions,
-  MicroCompactionRules,
-  CompactFunction,
-  CompactionConfig,
-  CompactResult,
-  SessionProviderOptions
-} from "./types";
+  SessionProvider,
+  SearchResult,
+  StoredCompaction
+} from "./provider";
 
-export type { SessionProvider } from "./provider";
+export type { ContextConfig, ContextBlock } from "./context";
 
-export { Session } from "./session";
+export { Session, type SessionContextOptions } from "./session";
 
 export { AgentSessionProvider, type SqlProvider } from "./providers/agent";
+
+export { AgentContextProvider } from "./providers/agent-context";

--- a/packages/agents/src/experimental/memory/session/provider.ts
+++ b/packages/agents/src/experimental/memory/session/provider.ts
@@ -1,65 +1,73 @@
 /**
  * Session Provider Interface
  *
- * Pure storage interface that all session providers must implement.
- * Compaction orchestration lives in the Session wrapper, not here.
+ * Pure storage for tree-structured messages with compaction overlays and search.
  */
 
 import type { UIMessage } from "ai";
-import type { MessageQueryOptions } from "./types";
+
+export interface SearchResult {
+  id: string;
+  role: string;
+  content: string;
+  createdAt: string;
+  sessionId?: string;
+}
+
+export interface StoredCompaction {
+  id: string;
+  summary: string;
+  fromMessageId: string;
+  toMessageId: string;
+  createdAt: string;
+}
 
 /**
- * Session storage provider interface.
- *
- * Implement this interface to create custom session storage backends.
- * Providers handle CRUD only — compaction is orchestrated by the Session wrapper.
+ * Session storage provider.
+ * Messages are tree-structured via parentId for branching.
  */
 export interface SessionProvider {
-  /**
-   * Get messages with optional filtering
-   */
-  getMessages(options?: MessageQueryOptions): UIMessage[];
+  // ── Read ────────────────────────────────────────────────────────
 
-  /**
-   * Get a single message by ID
-   */
   getMessage(id: string): UIMessage | null;
 
   /**
-   * Get the last N messages (most recent)
+   * Get conversation as a path from root to leaf.
+   * Applies compaction overlays. If leafId is null, uses the latest leaf.
    */
-  getLastMessages(n: number): UIMessage[];
+  getHistory(leafId?: string | null): UIMessage[];
+
+  getLatestLeaf(): UIMessage | null;
+
+  getBranches(messageId: string): UIMessage[];
+
+  getPathLength(leafId?: string | null): number;
+
+  // ── Write ──────────────────────────────────────────────────────
 
   /**
-   * Append one or more messages to storage.
+   * Append a message. Parented to the latest leaf unless parentId is provided.
+   * Idempotent — same message.id twice is a no-op.
    */
-  appendMessages(messages: UIMessage | UIMessage[]): Promise<void>;
+  appendMessage(message: UIMessage, parentId?: string | null): void;
 
-  /**
-   * Update an existing message
-   */
   updateMessage(message: UIMessage): void;
 
-  /**
-   * Delete messages by ID
-   */
   deleteMessages(messageIds: string[]): void;
 
-  /**
-   * Clear all messages
-   */
   clearMessages(): void;
 
-  /**
-   * Fetch messages outside the recent window (for microCompaction).
-   * Returns all messages except the most recent `keepRecent`.
-   */
-  getOlderMessages(keepRecent: number): UIMessage[];
+  // ── Compaction ─────────────────────────────────────────────────
 
-  /**
-   * Bulk replace all messages (used by compact).
-   * Clears existing messages and inserts the new ones,
-   * preserving original created_at timestamps where possible.
-   */
-  replaceMessages(messages: UIMessage[]): Promise<void>;
+  addCompaction(
+    summary: string,
+    fromMessageId: string,
+    toMessageId: string
+  ): StoredCompaction;
+
+  getCompactions(): StoredCompaction[];
+
+  // ── Search ─────────────────────────────────────────────────────
+
+  searchMessages?(query: string, limit?: number): SearchResult[];
 }

--- a/packages/agents/src/experimental/memory/session/providers/agent-context.ts
+++ b/packages/agents/src/experimental/memory/session/providers/agent-context.ts
@@ -1,0 +1,49 @@
+/**
+ * SQLite Context Block Provider
+ *
+ * Default durable storage for context blocks using DO SQLite.
+ * Each block is a row in cf_agents_context_blocks.
+ */
+
+import type { ContextProvider } from "../context";
+import type { SqlProvider } from "./agent";
+
+export class AgentContextProvider implements ContextProvider {
+  private agent: SqlProvider;
+  private label: string;
+  private initialized = false;
+
+  constructor(agent: SqlProvider, label: string) {
+    this.agent = agent;
+    this.label = label;
+  }
+
+  private ensureTable(): void {
+    if (this.initialized) return;
+    this.agent.sql`
+      CREATE TABLE IF NOT EXISTS cf_agents_context_blocks (
+        label TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `;
+    this.initialized = true;
+  }
+
+  async get(): Promise<string | null> {
+    this.ensureTable();
+    const rows = this.agent.sql<{ content: string }>`
+      SELECT content FROM cf_agents_context_blocks WHERE label = ${this.label}
+    `;
+    return rows[0]?.content ?? null;
+  }
+
+  async set(content: string): Promise<void> {
+    this.ensureTable();
+    this.agent.sql`
+      INSERT INTO cf_agents_context_blocks (label, content)
+      VALUES (${this.label}, ${content})
+      ON CONFLICT(label) DO UPDATE SET content = ${content}, updated_at = CURRENT_TIMESTAMP
+    `;
+  }
+}

--- a/packages/agents/src/experimental/memory/session/providers/agent.ts
+++ b/packages/agents/src/experimental/memory/session/providers/agent.ts
@@ -1,18 +1,17 @@
 /**
  * Agent Session Provider
  *
- * Pure storage provider that uses the Agent's DO SQLite storage.
- * Compaction is orchestrated by the Session wrapper, not here.
+ * SQLite-backed provider with tree-structured messages (branching),
+ * compaction overlays, and FTS5 search.
  */
 
 import type { UIMessage } from "ai";
-import type { SessionProvider } from "../provider";
-import type { MessageQueryOptions } from "../types";
+import type {
+  SessionProvider,
+  SearchResult,
+  StoredCompaction
+} from "../provider";
 
-/**
- * Interface for objects that provide a sql tagged template method.
- * This matches the Agent class's sql method signature.
- */
 export interface SqlProvider {
   sql<T = Record<string, string | number | boolean | null>>(
     strings: TemplateStringsArray,
@@ -20,261 +19,355 @@ export interface SqlProvider {
   ): T[];
 }
 
-/**
- * Session provider that wraps an Agent's SQLite storage.
- * Provides pure CRUD — compaction is handled by the Session wrapper.
- *
- * @example
- * ```typescript
- * import { Session, AgentSessionProvider } from "agents/experimental/memory/session";
- *
- * // In your Agent class:
- * session = new Session(new AgentSessionProvider(this));
- *
- * // With compaction options:
- * session = new Session(new AgentSessionProvider(this), {
- *   microCompaction: { truncateToolOutputs: 2000, keepRecent: 10 },
- *   compaction: { tokenThreshold: 20000, fn: summarize }
- * });
- * ```
- */
 export class AgentSessionProvider implements SessionProvider {
   private agent: SqlProvider;
   private initialized = false;
-
-  constructor(agent: SqlProvider) {
-    this.agent = agent;
-  }
+  private sessionId: string;
 
   /**
-   * Ensure the messages table exists
+   * @param agent - Agent or any object with a `sql` tagged template method
+   * @param sessionId - Optional session ID to isolate multiple sessions in the same DO.
+   *                    Messages are filtered by session_id within shared tables.
    */
+  constructor(agent: SqlProvider, sessionId?: string) {
+    this.agent = agent;
+    this.sessionId = sessionId ?? "";
+  }
+
   private ensureTable(): void {
     if (this.initialized) return;
 
     this.agent.sql`
-      CREATE TABLE IF NOT EXISTS cf_agents_session_messages (
+      CREATE TABLE IF NOT EXISTS assistant_messages (
         id TEXT PRIMARY KEY,
-        message TEXT NOT NULL,
+        session_id TEXT NOT NULL DEFAULT '',
+        parent_id TEXT,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `;
-    this.initialized = true;
-  }
 
-  /**
-   * Get all messages in AI SDK format
-   */
-  getMessages(options?: MessageQueryOptions): UIMessage[] {
-    this.ensureTable();
-
-    if (
-      options?.limit !== undefined &&
-      (!Number.isInteger(options.limit) || options.limit < 0)
-    ) {
-      throw new Error("limit must be a non-negative integer");
-    }
-    if (
-      options?.offset !== undefined &&
-      (!Number.isInteger(options.offset) || options.offset < 0)
-    ) {
-      throw new Error("offset must be a non-negative integer");
-    }
-
-    type Row = { id: string; message: string; created_at: string };
-    const role = options?.role ?? null;
-    const before = options?.before?.toISOString() ?? null;
-    const after = options?.after?.toISOString() ?? null;
-    const limit = options?.limit ?? -1;
-    const offset = options?.offset ?? 0;
-
-    const rows = this.agent.sql<Row>`
-      SELECT id, message, created_at FROM cf_agents_session_messages
-      WHERE (${role} IS NULL OR json_extract(message, '$.role') = ${role})
-        AND (${before} IS NULL OR created_at < ${before})
-        AND (${after} IS NULL OR created_at > ${after})
-      ORDER BY created_at ASC, rowid ASC
-      LIMIT ${limit} OFFSET ${offset}
-    `;
-
-    return this.parseRows(rows);
-  }
-
-  /**
-   * Append one or more messages to storage.
-   */
-  async appendMessages(messages: UIMessage | UIMessage[]): Promise<void> {
-    this.ensureTable();
-
-    const messageArray = Array.isArray(messages) ? messages : [messages];
-    const now = new Date().toISOString();
-
-    for (const message of messageArray) {
-      const json = JSON.stringify(message);
-      this.agent.sql`
-        INSERT INTO cf_agents_session_messages (id, message, created_at)
-        VALUES (${message.id}, ${json}, ${now})
-        ON CONFLICT(id) DO UPDATE SET message = excluded.message
-      `;
-    }
-  }
-
-  /**
-   * Update an existing message
-   */
-  updateMessage(message: UIMessage): void {
-    this.ensureTable();
-
-    const json = JSON.stringify(message);
     this.agent.sql`
-      UPDATE cf_agents_session_messages
-      SET message = ${json}
-      WHERE id = ${message.id}
-    `;
-  }
-
-  /**
-   * Delete messages by their IDs
-   */
-  deleteMessages(messageIds: string[]): void {
-    this.ensureTable();
-
-    for (const id of messageIds) {
-      this.agent.sql`DELETE FROM cf_agents_session_messages WHERE id = ${id}`;
-    }
-  }
-
-  /**
-   * Clear all messages from the session
-   */
-  clearMessages(): void {
-    this.ensureTable();
-    this.agent.sql`DELETE FROM cf_agents_session_messages`;
-  }
-
-  /**
-   * Get a single message by ID
-   */
-  getMessage(id: string): UIMessage | null {
-    this.ensureTable();
-
-    const rows = this.agent.sql<{ message: string }>`
-      SELECT message FROM cf_agents_session_messages WHERE id = ${id}
+      CREATE INDEX IF NOT EXISTS idx_assistant_msg_parent
+      ON assistant_messages(parent_id)
     `;
 
-    if (rows.length === 0) return null;
-
-    try {
-      const parsed = JSON.parse(rows[0].message);
-      return this.isValidMessage(parsed) ? parsed : null;
-    } catch {
-      return null;
-    }
-  }
-
-  /**
-   * Get the last N messages (most recent)
-   */
-  getLastMessages(n: number): UIMessage[] {
-    this.ensureTable();
-
-    const rows = this.agent.sql<{ message: string }>`
-      SELECT message FROM cf_agents_session_messages
-      ORDER BY created_at DESC, rowid DESC
-      LIMIT ${n}
+    this.agent.sql`
+      CREATE INDEX IF NOT EXISTS idx_assistant_msg_session
+      ON assistant_messages(session_id)
     `;
 
-    return this.parseRows([...rows].reverse());
-  }
-
-  /**
-   * Fetch messages outside the recent window (for microCompaction).
-   * Returns all messages except the most recent `keepRecent`.
-   */
-  getOlderMessages(keepRecent: number): UIMessage[] {
-    this.ensureTable();
-
-    type Row = { id: string; message: string };
-    const rows = this.agent.sql<Row>`
-      SELECT id, message FROM cf_agents_session_messages
-      WHERE rowid NOT IN (
-        SELECT rowid FROM cf_agents_session_messages
-        ORDER BY created_at DESC, rowid DESC
-        LIMIT ${keepRecent}
+    this.agent.sql`
+      CREATE TABLE IF NOT EXISTS assistant_compactions (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL DEFAULT '',
+        summary TEXT NOT NULL,
+        from_message_id TEXT NOT NULL,
+        to_message_id TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `;
 
+    this.agent.sql`
+      CREATE VIRTUAL TABLE IF NOT EXISTS assistant_fts
+      USING fts5(id UNINDEXED, session_id UNINDEXED, role UNINDEXED, content, tokenize='porter unicode61')
+    `;
+
+    // Reserved for SessionManager metadata (PR #1167) and Think integration (PR #1169)
+    this.agent.sql`
+      CREATE TABLE IF NOT EXISTS assistant_config (
+        session_id TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        PRIMARY KEY (session_id, key)
+      )
+    `;
+
+    this.initialized = true;
+  }
+
+  // ── Read ───────────────────────────────────────────────────────
+
+  getMessage(id: string): UIMessage | null {
+    this.ensureTable();
+    const rows = this.agent.sql<{ content: string }>`
+      SELECT content FROM assistant_messages WHERE id = ${id} AND session_id = ${this.sessionId}
+    `;
+    return rows.length > 0 ? this.parse(rows[0].content) : null;
+  }
+
+  getHistory(leafId?: string | null): UIMessage[] {
+    this.ensureTable();
+
+    const leaf = leafId
+      ? this.agent.sql<{ id: string }>`
+          SELECT id FROM assistant_messages WHERE id = ${leafId} AND session_id = ${this.sessionId}
+        `[0]
+      : this.latestLeafRow();
+
+    if (!leaf) return [];
+
+    const path = this.agent.sql<{ content: string }>`
+      WITH RECURSIVE path AS (
+        SELECT *, 0 as depth FROM assistant_messages WHERE id = ${leaf.id}
+        UNION ALL
+        SELECT m.*, p.depth + 1 FROM assistant_messages m
+        JOIN path p ON m.id = p.parent_id
+        WHERE m.session_id = ${this.sessionId}
+      )
+      SELECT content FROM path ORDER BY depth DESC
+    `;
+
+    const messages = this.parseRows(path);
+    const compactions = this.getCompactions();
+    if (compactions.length === 0) return messages;
+    return this.applyCompactions(messages, compactions);
+  }
+
+  getLatestLeaf(): UIMessage | null {
+    this.ensureTable();
+    const row = this.latestLeafRow();
+    return row ? this.parse(row.content) : null;
+  }
+
+  getBranches(messageId: string): UIMessage[] {
+    this.ensureTable();
+    const rows = this.agent.sql<{ content: string }>`
+      SELECT content FROM assistant_messages
+      WHERE parent_id = ${messageId} AND session_id = ${this.sessionId} ORDER BY created_at ASC
+    `;
     return this.parseRows(rows);
   }
 
-  /**
-   * Bulk replace all messages.
-   * Preserves original created_at timestamps for surviving messages.
-   */
-  async replaceMessages(messages: UIMessage[]): Promise<void> {
+  getPathLength(leafId?: string | null): number {
     this.ensureTable();
+    const leaf = leafId
+      ? this.agent.sql<{ id: string }>`
+          SELECT id FROM assistant_messages WHERE id = ${leafId} AND session_id = ${this.sessionId}
+        `[0]
+      : this.latestLeafRow();
+    if (!leaf) return 0;
 
-    // Build timestamp map from existing messages before clearing
-    type Row = { id: string; created_at: string };
-    const existingRows = this.agent.sql<Row>`
-      SELECT id, created_at FROM cf_agents_session_messages
+    const rows = this.agent.sql<{ count: number }>`
+      WITH RECURSIVE path AS (
+        SELECT id, parent_id FROM assistant_messages WHERE id = ${leaf.id}
+        UNION ALL
+        SELECT m.id, m.parent_id FROM assistant_messages m
+        JOIN path p ON m.id = p.parent_id
+        WHERE m.session_id = ${this.sessionId}
+      )
+      SELECT COUNT(*) as count FROM path
     `;
-    const timestampMap = new Map<string, string>();
-    for (const row of existingRows) {
-      timestampMap.set(row.id, row.created_at);
+    return rows[0]?.count ?? 0;
+  }
+
+  // ── Write ──────────────────────────────────────────────────────
+
+  appendMessage(message: UIMessage, parentId?: string | null): void {
+    this.ensureTable();
+    // Skip if message already exists (INSERT OR IGNORE idempotency)
+    const existing = this.agent.sql<{ id: string }>`
+      SELECT id FROM assistant_messages WHERE id = ${message.id} AND session_id = ${this.sessionId}
+    `;
+    if (existing.length > 0) return;
+
+    const parent = parentId ?? this.latestLeafRow()?.id ?? null;
+    const json = JSON.stringify(message);
+
+    this.agent.sql`
+      INSERT INTO assistant_messages (id, session_id, parent_id, role, content)
+      VALUES (${message.id}, ${this.sessionId}, ${parent}, ${message.role}, ${json})
+    `;
+    this.indexFTS(message);
+  }
+
+  updateMessage(message: UIMessage): void {
+    this.ensureTable();
+    this.agent.sql`
+      UPDATE assistant_messages SET content = ${JSON.stringify(message)}
+      WHERE id = ${message.id} AND session_id = ${this.sessionId}
+    `;
+    this.indexFTS(message);
+  }
+
+  deleteMessages(messageIds: string[]): void {
+    this.ensureTable();
+    for (const id of messageIds) {
+      this.agent
+        .sql`DELETE FROM assistant_messages WHERE id = ${id} AND session_id = ${this.sessionId}`;
+      this.deleteFTS(id);
     }
+  }
 
-    // Durable Objects auto-coalesces all synchronous SQL writes within
-    // a single I/O gate into one atomic batch — no explicit transaction needed.
-    this.agent.sql`DELETE FROM cf_agents_session_messages`;
+  clearMessages(): void {
+    this.ensureTable();
+    this.agent
+      .sql`DELETE FROM assistant_messages WHERE session_id = ${this.sessionId}`;
+    this.agent
+      .sql`DELETE FROM assistant_compactions WHERE session_id = ${this.sessionId}`;
+    // FTS5 requires delete by rowid
+    const ftsRows = this.agent.sql<{ rowid: number }>`
+      SELECT rowid FROM assistant_fts WHERE session_id = ${this.sessionId}
+    `;
+    for (const row of ftsRows) {
+      this.agent.sql`DELETE FROM assistant_fts WHERE rowid = ${row.rowid}`;
+    }
+  }
 
-    const now = new Date().toISOString();
-    for (const message of messages) {
-      const json = JSON.stringify(message);
-      const created_at = timestampMap.get(message.id) ?? now;
+  // ── Compaction ─────────────────────────────────────────────────
+
+  addCompaction(
+    summary: string,
+    fromMessageId: string,
+    toMessageId: string
+  ): StoredCompaction {
+    this.ensureTable();
+    const id = crypto.randomUUID();
+    this.agent.sql`
+      INSERT INTO assistant_compactions (id, session_id, summary, from_message_id, to_message_id)
+      VALUES (${id}, ${this.sessionId}, ${summary}, ${fromMessageId}, ${toMessageId})
+    `;
+    return {
+      id,
+      summary,
+      fromMessageId,
+      toMessageId,
+      createdAt: new Date().toISOString()
+    };
+  }
+
+  getCompactions(): StoredCompaction[] {
+    this.ensureTable();
+    type Row = {
+      id: string;
+      summary: string;
+      from_message_id: string;
+      to_message_id: string;
+      created_at: string;
+    };
+    return this.agent.sql<Row>`
+      SELECT * FROM assistant_compactions WHERE session_id = ${this.sessionId} ORDER BY created_at ASC
+    `.map((r) => ({
+      id: r.id,
+      summary: r.summary,
+      fromMessageId: r.from_message_id,
+      toMessageId: r.to_message_id,
+      createdAt: r.created_at
+    }));
+  }
+
+  // ── Search ─────────────────────────────────────────────────────
+
+  searchMessages(query: string, limit = 20): SearchResult[] {
+    this.ensureTable();
+    return this.agent.sql<{ id: string; role: string; content: string }>`
+      SELECT id, role, content FROM assistant_fts
+      WHERE assistant_fts MATCH ${query} AND session_id = ${this.sessionId}
+      ORDER BY rank LIMIT ${limit}
+    `.map((r) => ({
+      id: r.id,
+      role: r.role,
+      content: r.content,
+      createdAt: ""
+    }));
+  }
+
+  // ── Internal ───────────────────────────────────────────────────
+
+  private latestLeafRow(): { id: string; content: string } | null {
+    const rows = this.agent.sql<{ id: string; content: string }>`
+      SELECT m.id, m.content FROM assistant_messages m
+      LEFT JOIN assistant_messages c ON c.parent_id = m.id AND c.session_id = ${this.sessionId}
+      WHERE c.id IS NULL AND m.session_id = ${this.sessionId}
+      ORDER BY m.created_at DESC, m.rowid DESC LIMIT 1
+    `;
+    return rows[0] ?? null;
+  }
+
+  private indexFTS(message: UIMessage): void {
+    const text = message.parts
+      .filter((p) => p.type === "text")
+      .map((p) => (p as { text: string }).text)
+      .join(" ");
+    if (text) {
+      // FTS5 has no unique constraint — delete before insert to avoid duplicates
+      this.deleteFTS(message.id);
       this.agent.sql`
-        INSERT INTO cf_agents_session_messages (id, message, created_at)
-        VALUES (${message.id}, ${json}, ${created_at})
-        ON CONFLICT(id) DO UPDATE SET message = excluded.message
+        INSERT INTO assistant_fts (id, session_id, role, content)
+        VALUES (${message.id}, ${this.sessionId}, ${message.role}, ${text})
       `;
     }
   }
 
-  /**
-   * Validate message structure
-   */
-  private isValidMessage(msg: unknown): msg is UIMessage {
-    if (typeof msg !== "object" || msg === null) return false;
-    const m = msg as Record<string, unknown>;
-
-    if (typeof m.id !== "string" || m.id.length === 0) return false;
-    if (m.role !== "user" && m.role !== "assistant" && m.role !== "system") {
-      return false;
+  private deleteFTS(id: string): void {
+    const rows = this.agent.sql<{ rowid: number }>`
+      SELECT rowid FROM assistant_fts WHERE id = ${id} AND session_id = ${this.sessionId}
+    `;
+    for (const row of rows) {
+      this.agent.sql`DELETE FROM assistant_fts WHERE rowid = ${row.rowid}`;
     }
-    if (!Array.isArray(m.parts)) return false;
-
-    return true;
   }
 
-  /**
-   * Parse message rows from SQL results into UIMessages.
-   */
-  private parseRows(rows: { id?: string; message: string }[]): UIMessage[] {
-    const messages: UIMessage[] = [];
-    for (const row of rows) {
-      try {
-        const parsed = JSON.parse(row.message);
-        if (this.isValidMessage(parsed)) {
-          messages.push(parsed);
-        }
-      } catch {
-        if (row.id) {
-          console.warn(
-            `[AgentSessionProvider] Skipping malformed message ${row.id}`
-          );
+  private applyCompactions(
+    messages: UIMessage[],
+    compactions: StoredCompaction[]
+  ): UIMessage[] {
+    const ids = messages.map((m) => m.id);
+    const result: UIMessage[] = [];
+    let i = 0;
+    while (i < messages.length) {
+      // Find all compactions starting at this message, pick the latest
+      // (widest range) so newer compactions supersede older ones
+      const matching = compactions.filter((c) => c.fromMessageId === ids[i]);
+      const comp =
+        matching.length > 1 ? matching[matching.length - 1] : matching[0];
+      if (comp) {
+        const endIdx = ids.indexOf(comp.toMessageId);
+        if (endIdx >= i) {
+          result.push({
+            id: `compaction_${comp.id}`,
+            role: "assistant",
+            parts: [
+              {
+                type: "text",
+                text: `[Previous conversation summary]\n${comp.summary}`
+              }
+            ],
+            createdAt: new Date()
+          } as UIMessage);
+          i = endIdx + 1;
+          continue;
         }
       }
+      result.push(messages[i]);
+      i++;
     }
-    return messages;
+    return result;
+  }
+
+  private parse(json: string): UIMessage | null {
+    try {
+      const msg = JSON.parse(json);
+      if (
+        typeof msg?.id === "string" &&
+        typeof msg?.role === "string" &&
+        Array.isArray(msg?.parts)
+      ) {
+        return msg;
+      }
+    } catch {
+      /* skip */
+    }
+    return null;
+  }
+
+  private parseRows(rows: { content: string }[]): UIMessage[] {
+    const result: UIMessage[] = [];
+    for (const row of rows) {
+      const msg = this.parse(row.content);
+      if (msg) result.push(msg);
+    }
+    return result;
   }
 }

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -1,128 +1,324 @@
 /**
- * Session — top-level API for conversation history with compaction.
- *
- * Wraps any SessionProvider (pure storage) and orchestrates compaction:
- * - microCompaction on every append() — cheap, no LLM
- * - full compaction when token threshold exceeded — user-supplied fn
+ * Session — conversation history, context blocks, compaction, search, and tools.
  */
 
+import type { ToolSet } from "ai";
 import type { UIMessage } from "ai";
-import type { SessionProvider } from "./provider";
-import type {
-  MessageQueryOptions,
-  SessionProviderOptions,
-  CompactResult
-} from "./types";
+import type { SessionProvider, StoredCompaction } from "./provider";
+import type { SessionOptions } from "./types";
 import {
-  parseMicroCompactionRules,
-  microCompact,
-  type ResolvedMicroCompactionRules
-} from "../utils/compaction";
-import { estimateMessageTokens } from "../utils/tokens";
+  ContextBlocks,
+  type ContextBlock,
+  type ContextConfig,
+  type ContextProvider
+} from "./context";
+import { AgentSessionProvider, type SqlProvider } from "./providers/agent";
+import { AgentContextProvider } from "./providers/agent-context";
+
+export type SessionContextOptions = Omit<ContextConfig, "label">;
+
+// Raw builder entry — provider resolved at init time so chain order doesn't matter
+interface PendingContext {
+  label: string;
+  options: SessionContextOptions;
+}
 
 export class Session {
-  private storage: SessionProvider;
-  private microCompactionRules: ResolvedMicroCompactionRules | null;
-  private compactionConfig: SessionProviderOptions["compaction"] | null;
+  private storage!: SessionProvider;
+  private context!: ContextBlocks;
 
-  constructor(storage: SessionProvider, options?: SessionProviderOptions) {
+  // Builder state — only used with Session.create()
+  private _agent?: SqlProvider;
+  private _sessionId?: string;
+  private _pending?: PendingContext[];
+  private _cachedPrompt?: ContextProvider | true;
+  private _compactionFn?:
+    | ((messages: UIMessage[]) => Promise<UIMessage[]>)
+    | null;
+  private _ready = false;
+
+  constructor(storage: SessionProvider, options?: SessionOptions) {
     this.storage = storage;
-
-    const mc = options?.microCompaction ?? true;
-    this.microCompactionRules = parseMicroCompactionRules(mc);
-    this.compactionConfig = options?.compaction ?? null;
+    this.context = new ContextBlocks(
+      options?.context ?? [],
+      options?.promptStore
+    );
+    this._ready = true;
   }
 
-  // ── Read (delegated to storage) ────────────────────────────────────
+  /**
+   * Chainable session creation with auto-wired SQLite providers.
+   * Chain methods in any order — providers are resolved lazily on first use.
+   *
+   * @example
+   * ```ts
+   * const session = Session.create(this)
+   *   .withContext("soul", { initialContent: "You are helpful.", readonly: true })
+   *   .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+   *   .withCachedPrompt();
+   *
+   * // Custom storage (R2, KV, etc.)
+   * const session = Session.create(this)
+   *   .withContext("workspace", {
+   *     provider: {
+   *       get: () => env.BUCKET.get("ws.md").then(o => o?.text() ?? null),
+   *       set: (c) => env.BUCKET.put("ws.md", c),
+   *     }
+   *   })
+   *   .withCachedPrompt();
+   * ```
+   */
+  static create(agent: SqlProvider): Session {
+    const session: Session = Object.create(Session.prototype);
+    session._agent = agent;
+    session._pending = [];
+    session._ready = false;
+    return session;
+  }
 
-  getMessages(options?: MessageQueryOptions): UIMessage[] {
-    return this.storage.getMessages(options);
+  // ── Builder methods ─────────────────────────────────────────────
+
+  forSession(sessionId: string): this {
+    this._sessionId = sessionId;
+    return this;
+  }
+
+  withContext(label: string, options?: SessionContextOptions): this {
+    this._pending!.push({ label, options: options ?? {} });
+    return this;
+  }
+
+  withCachedPrompt(provider?: ContextProvider): this {
+    this._cachedPrompt = provider ?? true;
+    return this;
+  }
+
+  /**
+   * Register a compaction function. Called by `compact()` to compress
+   * message history into a summary overlay.
+   */
+  onCompaction(fn: (messages: UIMessage[]) => Promise<UIMessage[]>): this {
+    this._compactionFn = fn;
+    return this;
+  }
+
+  // ── Lazy init ───────────────────────────────────────────────────
+
+  private _ensureReady(): void {
+    if (this._ready) return;
+
+    // Resolve context configs — sessionId is final by now
+    const configs: ContextConfig[] = (this._pending ?? []).map(
+      ({ label, options: opts }) => {
+        let provider = opts.provider;
+        if (!provider && !opts.readonly) {
+          const key = this._sessionId ? `${label}_${this._sessionId}` : label;
+          provider = new AgentContextProvider(this._agent!, key);
+        }
+        return {
+          label,
+          description: opts.description,
+          initialContent: opts.initialContent,
+          maxTokens: opts.maxTokens,
+          readonly: opts.readonly,
+          provider
+        };
+      }
+    );
+
+    // Resolve prompt store
+    let promptStore: ContextProvider | undefined;
+    if (this._cachedPrompt === true) {
+      const key = this._sessionId
+        ? `_system_prompt_${this._sessionId}`
+        : "_system_prompt";
+      promptStore = new AgentContextProvider(this._agent!, key);
+    } else if (this._cachedPrompt) {
+      promptStore = this._cachedPrompt;
+    }
+
+    this.storage = new AgentSessionProvider(this._agent!, this._sessionId);
+    this.context = new ContextBlocks(configs, promptStore);
+    this._ready = true;
+  }
+
+  // ── History (tree-structured) ─────────────────────────────────
+
+  getHistory(leafId?: string | null): UIMessage[] {
+    this._ensureReady();
+    return this.storage.getHistory(leafId);
   }
 
   getMessage(id: string): UIMessage | null {
+    this._ensureReady();
     return this.storage.getMessage(id);
   }
 
-  getLastMessages(n: number): UIMessage[] {
-    return this.storage.getLastMessages(n);
+  getLatestLeaf(): UIMessage | null {
+    this._ensureReady();
+    return this.storage.getLatestLeaf();
   }
 
-  // ── Write (delegated + compaction) ─────────────────────────────────
+  getBranches(messageId: string): UIMessage[] {
+    this._ensureReady();
+    return this.storage.getBranches(messageId);
+  }
 
-  async append(messages: UIMessage | UIMessage[]): Promise<void> {
-    // 1. Storage inserts
-    await this.storage.appendMessages(messages);
+  getPathLength(leafId?: string | null): number {
+    this._ensureReady();
+    return this.storage.getPathLength(leafId);
+  }
 
-    // 2. Full compaction if token threshold exceeded — runs instead of microCompaction
-    if (this.shouldAutoCompact()) {
-      const result = await this.compact();
-      if (result.success) return;
-      // Fall through to microCompaction if full compaction failed
-    }
+  // ── Write ─────────────────────────────────────────────────────
 
-    // 3. MicroCompaction on older messages (only if no full compaction)
-    if (this.microCompactionRules) {
-      const rules = this.microCompactionRules;
-      const older = this.storage.getOlderMessages(rules.keepRecent);
-
-      if (older.length > 0) {
-        const compacted = microCompact(older, rules);
-        for (let i = 0; i < older.length; i++) {
-          if (compacted[i] !== older[i]) {
-            this.storage.updateMessage(compacted[i]);
-          }
-        }
-      }
-    }
+  appendMessage(message: UIMessage, parentId?: string | null): void {
+    this._ensureReady();
+    this.storage.appendMessage(message, parentId);
   }
 
   updateMessage(message: UIMessage): void {
+    this._ensureReady();
     this.storage.updateMessage(message);
   }
 
   deleteMessages(messageIds: string[]): void {
+    this._ensureReady();
     this.storage.deleteMessages(messageIds);
   }
 
   clearMessages(): void {
+    this._ensureReady();
     this.storage.clearMessages();
   }
 
-  // ── Compaction ─────────────────────────────────────────────────────
+  // ── Compaction ────────────────────────────────────────────────
 
-  async compact(): Promise<CompactResult> {
-    const messages = this.storage.getMessages();
+  addCompaction(
+    summary: string,
+    fromMessageId: string,
+    toMessageId: string
+  ): StoredCompaction {
+    this._ensureReady();
+    return this.storage.addCompaction(summary, fromMessageId, toMessageId);
+  }
 
-    if (messages.length === 0) {
-      return { success: true };
-    }
+  getCompactions(): StoredCompaction[] {
+    this._ensureReady();
+    return this.storage.getCompactions();
+  }
 
-    try {
-      let result = messages;
-
-      if (this.compactionConfig?.fn) {
-        result = await this.compactionConfig.fn(result);
-      }
-
-      await this.storage.replaceMessages(result);
-
-      return { success: true };
-    } catch (err) {
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : String(err)
-      };
-    }
+  needsCompaction(maxMessages?: number): boolean {
+    this._ensureReady();
+    return this.getHistory().length > (maxMessages ?? 100);
   }
 
   /**
-   * Pre-check for auto-compaction using token estimate heuristic.
+   * Run the registered compaction function and store the result as an overlay.
+   * Requires `onCompaction()` to be called first.
+   * Returns the number of messages removed, or null if compaction was skipped.
    */
-  private shouldAutoCompact(): boolean {
-    if (!this.compactionConfig?.tokenThreshold) return false;
+  async compact(): Promise<number | null> {
+    this._ensureReady();
+    if (!this._compactionFn) {
+      throw new Error(
+        "No compaction function registered. Call onCompaction() first."
+      );
+    }
 
-    const messages = this.storage.getMessages();
-    const approxTokens = estimateMessageTokens(messages);
-    return approxTokens > this.compactionConfig.tokenThreshold;
+    const history = this.getHistory();
+    if (history.length < 4) return null;
+
+    const compacted = await this._compactionFn(history);
+    const keptIds = new Set(compacted.map((m) => m.id));
+    const removed = history.filter(
+      (m) => !keptIds.has(m.id) && !m.id.startsWith("compaction_")
+    );
+
+    if (removed.length === 0) return 0;
+
+    const summaryMsg = compacted.find((m) =>
+      m.id.startsWith("compaction-summary-")
+    );
+    if (summaryMsg) {
+      const summaryText = summaryMsg.parts
+        .filter((p) => p.type === "text")
+        .map((p) => (p as { text: string }).text)
+        .join("\n");
+
+      const existing = this.getCompactions();
+      const fromId =
+        existing.length > 0 ? existing[0].fromMessageId : removed[0].id;
+
+      this.addCompaction(summaryText, fromId, removed[removed.length - 1].id);
+    }
+
+    await this.refreshSystemPrompt();
+    return removed.length;
+  }
+
+  // ── Context Blocks ────────────────────────────────────────────
+
+  getContextBlock(label: string): ContextBlock | null {
+    this._ensureReady();
+    return this.context.getBlock(label);
+  }
+
+  getContextBlocks(): ContextBlock[] {
+    this._ensureReady();
+    return this.context.getBlocks();
+  }
+
+  async replaceContextBlock(
+    label: string,
+    content: string
+  ): Promise<ContextBlock> {
+    this._ensureReady();
+    return this.context.setBlock(label, content);
+  }
+
+  async appendContextBlock(
+    label: string,
+    content: string
+  ): Promise<ContextBlock> {
+    this._ensureReady();
+    return this.context.appendToBlock(label, content);
+  }
+
+  // ── System Prompt ─────────────────────────────────────────────
+
+  async freezeSystemPrompt(): Promise<string> {
+    this._ensureReady();
+    return this.context.freezeSystemPrompt();
+  }
+
+  async refreshSystemPrompt(): Promise<string> {
+    this._ensureReady();
+    return this.context.refreshSystemPrompt();
+  }
+
+  // ── Search ────────────────────────────────────────────────────
+
+  search(
+    query: string,
+    options?: { limit?: number }
+  ): Array<{
+    id: string;
+    role: string;
+    content: string;
+    createdAt: string;
+  }> {
+    this._ensureReady();
+    if (!this.storage.searchMessages) {
+      throw new Error("Session provider does not support search");
+    }
+    return this.storage.searchMessages(query, options?.limit ?? 20);
+  }
+
+  // ── Tools ─────────────────────────────────────────────────────
+
+  /** Returns update_context tool for writing to context blocks. */
+  async tools(): Promise<ToolSet> {
+    this._ensureReady();
+    return this.context.tools();
   }
 }

--- a/packages/agents/src/experimental/memory/session/types.ts
+++ b/packages/agents/src/experimental/memory/session/types.ts
@@ -1,109 +1,27 @@
 /**
- * Session Memory Types
+ * Session Types
  */
 
-import type { UIMessage } from "ai";
+import type { ContextConfig, ContextProvider } from "./context";
 
 /**
  * Options for querying messages
  */
 export interface MessageQueryOptions {
-  /** Maximum number of messages to return */
   limit?: number;
-  /** Number of messages to skip */
   offset?: number;
-  /** Only return messages created before this timestamp */
   before?: Date;
-  /** Only return messages created after this timestamp */
   after?: Date;
-  /** Filter by role */
   role?: "user" | "assistant" | "system";
 }
 
 /**
- * Granular microCompaction rules.
- * Each rule can be true (use default), false (disable), or a number (custom threshold).
+ * Options for creating a Session.
  */
-export interface MicroCompactionRules {
-  /**
-   * Truncate tool outputs over this size (in chars).
-   * @default 30000 chars
-   */
-  truncateToolOutputs?: boolean | number;
+export interface SessionOptions {
+  /** Context blocks for the system prompt. */
+  context?: ContextConfig[];
 
-  /**
-   * Truncate text parts over this size in older messages (in chars).
-   * @default 10000 chars
-   */
-  truncateText?: boolean | number;
-
-  /**
-   * Number of recent messages to keep intact (not truncated).
-   * @default 4
-   */
-  keepRecent?: number;
-}
-
-/**
- * Compaction function - user implements this to decide how to compact messages.
- * Could summarize with LLM, truncate, filter, or anything else.
- *
- * @param messages Current messages in the session
- * @returns New messages to replace the current ones
- */
-export type CompactFunction = (messages: UIMessage[]) => Promise<UIMessage[]>;
-
-/**
- * Configuration for full compaction (LLM summarization)
- */
-export interface CompactionConfig {
-  /**
-   * Token threshold for automatic compaction.
-   * When estimated tokens exceed this, compact() is called automatically on append().
-   * If not set, auto-compaction is disabled (you can still call compact() manually).
-   */
-  tokenThreshold?: number;
-
-  /**
-   * Function to compact messages.
-   * Receives current messages as stored, returns new messages.
-   */
-  fn: CompactFunction;
-}
-
-/**
- * Result of compaction operation
- */
-export interface CompactResult {
-  /** Whether compaction succeeded */
-  success: boolean;
-  /** Error message if compaction failed */
-  error?: string;
-}
-
-/**
- * Options for creating a session provider
- */
-export interface SessionProviderOptions {
-  /**
-   * Lightweight compaction that doesn't require LLM calls.
-   * Truncates tool outputs and long text in older messages.
-   *
-   * Runs automatically on every `append()` — older messages (beyond `keepRecent`)
-   * are truncated in storage.
-   * This is a destructive operation: original content is permanently replaced.
-   * `getMessages()` returns stored content as-is (already compacted).
-   *
-   * - `true` - enable with default rules
-   * - `false` - disable
-   * - `{ ... }` - enable with custom rules
-   *
-   * @default true
-   */
-  microCompaction?: boolean | MicroCompactionRules;
-
-  /**
-   * Full compaction with custom function (typically LLM summarization).
-   */
-  compaction?: CompactionConfig;
+  /** Provider for persisting the frozen system prompt. */
+  promptStore?: ContextProvider;
 }

--- a/packages/agents/src/experimental/memory/utils/compaction-helpers.ts
+++ b/packages/agents/src/experimental/memory/utils/compaction-helpers.ts
@@ -1,0 +1,496 @@
+/**
+ * Compaction Helpers
+ *
+ * Utilities for full compaction (LLM-based summarization).
+ * Used by the reference compaction implementation and available
+ * for custom CompactFunction implementations.
+ */
+
+import type { UIMessage } from "ai";
+import { estimateMessageTokens } from "./tokens";
+
+// ── Tool Pair Alignment ──────────────────────────────────────────────
+
+/**
+ * Check if a message contains tool invocations.
+ */
+function hasToolCalls(msg: UIMessage): boolean {
+  return msg.parts.some(
+    (p) => p.type.startsWith("tool-") || p.type === "dynamic-tool"
+  );
+}
+
+/**
+ * Get tool call IDs from a message's parts.
+ */
+function getToolCallIds(msg: UIMessage): Set<string> {
+  const ids = new Set<string>();
+  for (const part of msg.parts) {
+    if (
+      (part.type.startsWith("tool-") || part.type === "dynamic-tool") &&
+      "toolCallId" in part
+    ) {
+      ids.add((part as { toolCallId: string }).toolCallId);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Check if a message is a tool result referencing a specific call ID.
+ */
+function isToolResultFor(msg: UIMessage, callIds: Set<string>): boolean {
+  return msg.parts.some(
+    (p) =>
+      (p.type.startsWith("tool-") || p.type === "dynamic-tool") &&
+      "toolCallId" in p &&
+      callIds.has((p as { toolCallId: string }).toolCallId)
+  );
+}
+
+/**
+ * Align a boundary index forward to avoid splitting tool call/result groups.
+ * If the boundary falls between an assistant message with tool calls and its
+ * tool results, move it forward past the results.
+ */
+export function alignBoundaryForward(
+  messages: UIMessage[],
+  idx: number
+): number {
+  if (idx <= 0 || idx >= messages.length) return idx;
+
+  // Check if the message before the boundary has tool calls
+  const prev = messages[idx - 1];
+  if (prev.role === "assistant" && hasToolCalls(prev)) {
+    const callIds = getToolCallIds(prev);
+    // Skip forward past any tool results for these calls
+    while (idx < messages.length && isToolResultFor(messages[idx], callIds)) {
+      idx++;
+    }
+  }
+
+  return idx;
+}
+
+/**
+ * Align a boundary index backward to avoid splitting tool call/result groups.
+ * If the boundary falls in the middle of tool results, move it backward to
+ * include the assistant message that made the calls.
+ */
+export function alignBoundaryBackward(
+  messages: UIMessage[],
+  idx: number
+): number {
+  if (idx <= 0 || idx >= messages.length) return idx;
+
+  // If the message at idx is a tool result, walk backward to find the call
+  while (idx > 0) {
+    const msg = messages[idx];
+    if (msg.role === "assistant" && hasToolCalls(msg)) {
+      break; // This is a tool call message — include it
+    }
+    // Check if this looks like a tool result (assistant message following another)
+    const prev = messages[idx - 1];
+    if (prev.role === "assistant" && hasToolCalls(prev)) {
+      const callIds = getToolCallIds(prev);
+      if (isToolResultFor(msg, callIds)) {
+        idx--; // Move back to include the call
+        continue;
+      }
+    }
+    break;
+  }
+
+  return idx;
+}
+
+// ── Token-Budget Tail Protection ─────────────────────────────────────
+
+/**
+ * Find the compression end boundary using a token budget for the tail.
+ * Walks backward from the end, accumulating tokens until budget is reached.
+ * Returns the index where compression should stop (everything from this
+ * index onward is protected).
+ *
+ * @param messages All messages
+ * @param headEnd Index where the protected head ends (compression starts here)
+ * @param tailTokenBudget Maximum tokens to keep in the tail
+ * @param minTailMessages Minimum messages to protect in the tail (fallback)
+ */
+export function findTailCutByTokens(
+  messages: UIMessage[],
+  headEnd: number,
+  tailTokenBudget = 20000,
+  minTailMessages = 4
+): number {
+  const n = messages.length;
+  let accumulated = 0;
+  let cutIdx = n;
+
+  for (let i = n - 1; i >= headEnd; i--) {
+    const msgTokens = estimateMessageTokens([messages[i]]);
+
+    if (accumulated + msgTokens > tailTokenBudget) {
+      break;
+    }
+    accumulated += msgTokens;
+    cutIdx = i;
+  }
+
+  // Fallback: ensure at least minTailMessages stay
+  const fallbackCut = n - minTailMessages;
+  if (cutIdx > fallbackCut && fallbackCut >= headEnd) {
+    cutIdx = fallbackCut;
+  }
+
+  // Align to avoid splitting tool groups
+  return alignBoundaryBackward(messages, cutIdx);
+}
+
+// ── Tool Pair Sanitization ───────────────────────────────────────────
+
+/**
+ * Fix orphaned tool call/result pairs after compaction.
+ *
+ * Two failure modes:
+ * 1. Tool result references a call_id whose assistant tool_call was removed
+ *    → Remove the orphaned result
+ * 2. Assistant has tool_calls whose results were dropped
+ *    → Add stub results so the API doesn't error
+ *
+ * @param messages Messages after compaction
+ * @returns Sanitized messages with no orphaned pairs
+ */
+export function sanitizeToolPairs(messages: UIMessage[]): UIMessage[] {
+  // Build set of surviving tool call IDs (from assistant messages)
+  const survivingCallIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role === "assistant") {
+      for (const id of getToolCallIds(msg)) {
+        survivingCallIds.add(id);
+      }
+    }
+  }
+
+  // Build set of tool result IDs
+  const resultCallIds = new Set<string>();
+  for (const msg of messages) {
+    for (const part of msg.parts) {
+      if (
+        (part.type.startsWith("tool-") || part.type === "dynamic-tool") &&
+        "toolCallId" in part &&
+        "output" in part
+      ) {
+        resultCallIds.add((part as { toolCallId: string }).toolCallId);
+      }
+    }
+  }
+
+  // Remove orphaned results (results whose calls were dropped)
+  const orphanedResults = new Set<string>();
+  for (const id of resultCallIds) {
+    if (!survivingCallIds.has(id)) {
+      orphanedResults.add(id);
+    }
+  }
+
+  let result = messages;
+  if (orphanedResults.size > 0) {
+    result = result.map((msg) => {
+      const filteredParts = msg.parts.filter((part) => {
+        if (
+          (part.type.startsWith("tool-") || part.type === "dynamic-tool") &&
+          "toolCallId" in part &&
+          "output" in part
+        ) {
+          return !orphanedResults.has(
+            (part as { toolCallId: string }).toolCallId
+          );
+        }
+        return true;
+      });
+      if (filteredParts.length !== msg.parts.length) {
+        return { ...msg, parts: filteredParts } as UIMessage;
+      }
+      return msg;
+    });
+  }
+
+  // Add stub results for calls whose results were dropped
+  const missingResults = new Set<string>();
+  for (const id of survivingCallIds) {
+    if (!resultCallIds.has(id) && !orphanedResults.has(id)) {
+      missingResults.add(id);
+    }
+  }
+
+  if (missingResults.size > 0) {
+    const patched: UIMessage[] = [];
+    for (const msg of result) {
+      patched.push(msg);
+      if (msg.role === "assistant") {
+        for (const id of getToolCallIds(msg)) {
+          if (missingResults.has(id)) {
+            // Find the tool name from the call
+            const callPart = msg.parts.find(
+              (p) =>
+                "toolCallId" in p &&
+                (p as { toolCallId: string }).toolCallId === id
+            ) as { toolName?: string } | undefined;
+
+            patched.push({
+              id: `stub-${id}`,
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool-result" as const,
+                  toolCallId: id,
+                  toolName: callPart?.toolName ?? "unknown",
+                  result:
+                    "[Result from earlier conversation — see context summary above]"
+                } as unknown as UIMessage["parts"][number]
+              ],
+              createdAt: new Date()
+            } as UIMessage);
+          }
+        }
+      }
+    }
+    result = patched;
+  }
+
+  // Remove empty messages (all parts filtered out)
+  return result.filter((msg) => msg.parts.length > 0);
+}
+
+// ── Summary Budget ───────────────────────────────────────────────────
+
+/**
+ * Compute a summary token budget based on the content being compressed.
+ * 20% of the compressed content, clamped to 2K-8K tokens.
+ */
+export function computeSummaryBudget(messages: UIMessage[]): number {
+  const contentTokens = estimateMessageTokens(messages);
+  const budget = Math.floor(contentTokens * 0.2);
+  return Math.max(2000, Math.min(budget, 8000));
+}
+
+// ── Structured Summary Prompt ────────────────────────────────────────
+
+/**
+ * Build a prompt for LLM summarization of compressed messages.
+ *
+ * @param messages Messages to summarize
+ * @param previousSummary Previous summary for iterative updates (or null for first compaction)
+ * @param budget Target token count for the summary
+ */
+export function buildSummaryPrompt(
+  messages: UIMessage[],
+  previousSummary: string | null,
+  budget: number
+): string {
+  const content = messages
+    .map((msg) => {
+      const textParts = msg.parts
+        .filter((p) => p.type === "text")
+        .map((p) => (p as { text: string }).text)
+        .join("\n");
+
+      const toolParts = msg.parts
+        .filter((p) => p.type.startsWith("tool-") || p.type === "dynamic-tool")
+        .map((p) => {
+          const tp = p as {
+            toolName?: string;
+            input?: unknown;
+            output?: unknown;
+          };
+          const parts = [`[Tool: ${tp.toolName ?? "unknown"}]`];
+          if (tp.input)
+            parts.push(`Input: ${JSON.stringify(tp.input).slice(0, 500)}`);
+          if (tp.output)
+            parts.push(`Output: ${String(tp.output).slice(0, 500)}`);
+          return parts.join("\n");
+        })
+        .join("\n");
+
+      return `[${msg.role}]\n${textParts}${toolParts ? "\n" + toolParts : ""}`;
+    })
+    .join("\n\n---\n\n");
+
+  if (previousSummary) {
+    return `You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
+
+PREVIOUS SUMMARY:
+${previousSummary}
+
+NEW TURNS TO INCORPORATE:
+${content}
+
+Update the summary using this exact structure. PRESERVE existing information that is still relevant. ADD new progress. Move items from "In Progress" to "Done" when completed. Remove information only if it is clearly obsolete.
+
+## Goal
+[What the user is trying to accomplish]
+
+## Progress
+### Done
+[Completed work — include specific file paths, commands run, results obtained]
+### In Progress
+[Work currently underway]
+
+## Key Decisions
+[Important technical decisions and why they were made]
+
+## Relevant Files
+[Files read, modified, or created — with brief note on each]
+
+## Next Steps
+[What needs to happen next to continue the work]
+
+## Critical Context
+[Any specific values, error messages, configuration details that must be preserved]
+
+Target ~${budget} tokens. Be specific — include file paths, command outputs, error messages. Write only the summary body.`;
+  }
+
+  return `Create a structured handoff summary of this conversation for a later assistant that will continue the work. Be specific and concrete.
+
+CONVERSATION TO SUMMARIZE:
+${content}
+
+Use this exact structure:
+
+## Goal
+[What the user is trying to accomplish]
+
+## Progress
+### Done
+[Completed work — include specific file paths, commands run, results obtained]
+### In Progress
+[Work currently underway]
+
+## Key Decisions
+[Important technical decisions and why they were made]
+
+## Relevant Files
+[Files read, modified, or created — with brief note on each]
+
+## Next Steps
+[What needs to happen next to continue the work]
+
+## Critical Context
+[Any specific values, error messages, configuration details that must be preserved]
+
+Target ~${budget} tokens. Be specific — include file paths, command outputs, error messages. Write only the summary body.`;
+}
+
+// ── Reference Compaction Implementation ──────────────────────────────
+
+export interface CompactOptions {
+  /**
+   * Function to call the LLM for summarization.
+   * Takes a user prompt string, returns the LLM's text response.
+   */
+  summarize: (prompt: string) => Promise<string>;
+
+  /** Number of head messages to protect (default: 2) */
+  protectHead?: number;
+
+  /** Token budget for tail protection (default: 20000) */
+  tailTokenBudget?: number;
+
+  /** Minimum tail messages to protect (default: 4) */
+  minTailMessages?: number;
+}
+
+/**
+ * Reference compaction implementation.
+ *
+ * Implements the full hermes-style compaction algorithm:
+ * 1. Protect head messages (first N)
+ * 2. Protect tail by token budget (walk backward)
+ * 3. Align boundaries to tool call groups
+ * 4. Summarize middle section with LLM (structured format)
+ * 5. Sanitize orphaned tool pairs
+ * 6. Iterative summary updates on subsequent compactions
+ *
+ * @example
+ * ```typescript
+ * import { createCompactFunction } from "agents/experimental/memory/utils";
+ *
+ * const session = new Session(provider, {
+ *   compaction: {
+ *     tokenThreshold: 100000,
+ *     fn: createCompactFunction({
+ *       summarize: (prompt) => generateText({ model, prompt }).then(r => r.text)
+ *     })
+ *   }
+ * });
+ * ```
+ */
+export function createCompactFunction(opts: CompactOptions) {
+  const protectHead = opts.protectHead ?? 2;
+  const tailTokenBudget = opts.tailTokenBudget ?? 20000;
+  const minTailMessages = opts.minTailMessages ?? 4;
+
+  let previousSummary: string | null = null;
+
+  return async (messages: UIMessage[]): Promise<UIMessage[]> => {
+    if (messages.length <= protectHead + minTailMessages) {
+      return messages; // Too few messages to compact
+    }
+
+    // 1. Find compression boundaries
+    let compressStart = protectHead;
+    compressStart = alignBoundaryForward(messages, compressStart);
+
+    let compressEnd = findTailCutByTokens(
+      messages,
+      compressStart,
+      tailTokenBudget,
+      minTailMessages
+    );
+
+    if (compressEnd <= compressStart) {
+      return messages; // Nothing to compress
+    }
+
+    const middleMessages = messages.slice(compressStart, compressEnd);
+
+    // 2. Generate summary
+    const budget = computeSummaryBudget(middleMessages);
+    const prompt = buildSummaryPrompt(middleMessages, previousSummary, budget);
+    const summary = await opts.summarize(prompt);
+    previousSummary = summary;
+
+    // 3. Assemble compressed messages
+    const compressed: UIMessage[] = [];
+
+    // Protected head
+    for (let i = 0; i < compressStart; i++) {
+      compressed.push(messages[i]);
+    }
+
+    // Summary as assistant message
+    if (summary.trim()) {
+      compressed.push({
+        id: `compaction-summary-${Date.now()}`,
+        role: "assistant",
+        parts: [
+          {
+            type: "text" as const,
+            text: `[Context Summary — earlier conversation compressed]\n\n${summary}`
+          }
+        ],
+        createdAt: new Date()
+      } as UIMessage);
+    }
+
+    // Protected tail
+    for (let i = compressEnd; i < messages.length; i++) {
+      compressed.push(messages[i]);
+    }
+
+    // 4. Sanitize tool pairs
+    return sanitizeToolPairs(compressed);
+  };
+}

--- a/packages/agents/src/experimental/memory/utils/compaction.ts
+++ b/packages/agents/src/experimental/memory/utils/compaction.ts
@@ -1,135 +1,98 @@
 /**
- * MicroCompaction Utilities
+ * Read-time context truncation.
  *
- * Internal pure functions for lightweight compaction (no LLM).
- * Not exported to users — used by the Session wrapper.
+ * Truncates older tool outputs and long text before sending to the LLM.
+ * Does NOT mutate stored messages — operates on a copy.
  */
 
 import type { UIMessage } from "ai";
-import type { MicroCompactionRules } from "../session/types";
 
-/** Default thresholds for microCompaction rules (in chars) */
-export const DEFAULTS = {
-  truncateToolOutputs: 30000,
-  truncateText: 10000,
-  keepRecent: 4
-};
-
-/** Resolved microCompaction rules with actual numeric thresholds */
-export interface ResolvedMicroCompactionRules {
-  truncateToolOutputs: number | false;
-  truncateText: number | false;
-  keepRecent: number;
+export interface TruncateOptions {
+  /** Number of recent messages to keep intact (default: 4) */
+  keepRecent?: number;
+  /** Max chars for tool outputs in older messages (default: 500) */
+  maxToolOutputChars?: number;
+  /** Max chars for text parts in older messages (default: 10000) */
+  maxTextChars?: number;
 }
 
 /**
- * Parse microCompaction config into resolved rules.
- * Returns null if disabled.
+ * Truncate tool outputs and long text in older messages.
+ * Returns a new array — input messages are not mutated.
+ *
+ * Recent messages (last `keepRecent`) are left intact.
+ * Older messages get tool outputs and long text truncated.
+ *
+ * Use in assembleContext() before sending to the LLM:
+ * ```typescript
+ * async assembleContext() {
+ *   const history = this.sessions.getHistory(this._sessionId);
+ *   const truncated = truncateOlderMessages(history);
+ *   return convertToModelMessages(truncated);
+ * }
+ * ```
  */
-export function parseMicroCompactionRules(
-  config: boolean | MicroCompactionRules
-): ResolvedMicroCompactionRules | null {
-  if (config === false) return null;
+export function truncateOlderMessages(
+  messages: UIMessage[],
+  options?: TruncateOptions
+): UIMessage[] {
+  const keepRecent = options?.keepRecent ?? 4;
+  const maxToolOutput = options?.maxToolOutputChars ?? 500;
+  const maxText = options?.maxTextChars ?? 10000;
 
-  if (config === true) {
-    return {
-      truncateToolOutputs: DEFAULTS.truncateToolOutputs,
-      truncateText: DEFAULTS.truncateText,
-      keepRecent: DEFAULTS.keepRecent
-    };
-  }
+  if (messages.length <= keepRecent) return messages;
 
-  // Custom rules object — validate numeric values
-  const keepRecent = config.keepRecent ?? DEFAULTS.keepRecent;
-  if (!Number.isInteger(keepRecent) || keepRecent < 0) {
-    throw new Error("keepRecent must be a non-negative integer");
-  }
+  const cutoff = messages.length - keepRecent;
+  const result: UIMessage[] = [];
 
-  const truncateToolOutputs =
-    config.truncateToolOutputs === false
-      ? false
-      : config.truncateToolOutputs === true ||
-          config.truncateToolOutputs === undefined
-        ? DEFAULTS.truncateToolOutputs
-        : config.truncateToolOutputs;
-  if (typeof truncateToolOutputs === "number" && truncateToolOutputs <= 0) {
-    throw new Error("truncateToolOutputs must be a positive number");
-  }
+  for (let i = 0; i < messages.length; i++) {
+    if (i >= cutoff) {
+      result.push(messages[i]);
+      continue;
+    }
 
-  const truncateText =
-    config.truncateText === false
-      ? false
-      : config.truncateText === true || config.truncateText === undefined
-        ? DEFAULTS.truncateText
-        : config.truncateText;
-  if (typeof truncateText === "number" && truncateText <= 0) {
-    throw new Error("truncateText must be a positive number");
-  }
+    const msg = messages[i];
+    let changed = false;
 
-  return { truncateToolOutputs, truncateText, keepRecent };
-}
+    const truncatedParts = msg.parts.map((part) => {
+      // Truncate tool outputs
+      if (
+        (part.type.startsWith("tool-") || part.type === "dynamic-tool") &&
+        "output" in part
+      ) {
+        const output = (part as { output?: unknown }).output;
+        if (output !== undefined) {
+          const str =
+            typeof output === "string" ? output : JSON.stringify(output);
+          if (str.length > maxToolOutput) {
+            changed = true;
+            return {
+              ...part,
+              output: `${str.slice(0, maxToolOutput)}... [truncated ${str.length} chars]`
+            };
+          }
+        }
+      }
 
-/**
- * Truncate oversized parts in a single message.
- * Returns the same reference if nothing changed (allows callers to skip no-op updates).
- */
-function truncateMessageParts(
-  msg: UIMessage,
-  rules: ResolvedMicroCompactionRules
-): UIMessage {
-  let changed = false;
-
-  const compactedParts = msg.parts.map((part) => {
-    // Truncate tool outputs
-    if (
-      rules.truncateToolOutputs !== false &&
-      (part.type.startsWith("tool-") || part.type === "dynamic-tool") &&
-      "output" in part
-    ) {
-      const toolPart = part as { output?: unknown };
-      if (toolPart.output !== undefined) {
-        const outputJson = JSON.stringify(toolPart.output);
-        if (outputJson.length > rules.truncateToolOutputs) {
+      // Truncate long text
+      if (part.type === "text" && "text" in part) {
+        const text = (part as { text: string }).text;
+        if (text.length > maxText) {
           changed = true;
           return {
             ...part,
-            output: `[Truncated ${outputJson.length} bytes] ${outputJson.slice(0, 500)}...`
+            text: `${text.slice(0, maxText)}... [truncated ${text.length} chars]`
           };
         }
       }
-    }
 
-    // Truncate long text parts
-    if (
-      rules.truncateText !== false &&
-      part.type === "text" &&
-      "text" in part
-    ) {
-      const textPart = part as { type: "text"; text: string };
-      if (textPart.text.length > rules.truncateText) {
-        changed = true;
-        return {
-          ...part,
-          text: `${textPart.text.slice(0, rules.truncateText)}... [truncated ${textPart.text.length} chars]`
-        };
-      }
-    }
+      return part;
+    });
 
-    return part;
-  });
+    result.push(
+      changed ? ({ ...msg, parts: truncatedParts } as UIMessage) : msg
+    );
+  }
 
-  return changed ? ({ ...msg, parts: compactedParts } as UIMessage) : msg;
-}
-
-/**
- * Apply microCompaction to an array of messages.
- * Returns same reference for unchanged messages (enables skip-update optimization).
- *
- * No keepRecent logic — the caller decides which messages to pass.
- */
-export function microCompact(
-  messages: UIMessage[],
-  rules: ResolvedMicroCompactionRules
-): UIMessage[] {
-  return messages.map((msg) => truncateMessageParts(msg, rules));
+  return result;
 }

--- a/packages/agents/src/experimental/memory/utils/index.ts
+++ b/packages/agents/src/experimental/memory/utils/index.ts
@@ -5,3 +5,16 @@ export {
   WORDS_TOKEN_MULTIPLIER,
   TOKENS_PER_MESSAGE
 } from "./tokens";
+
+export { truncateOlderMessages, type TruncateOptions } from "./compaction";
+
+export {
+  createCompactFunction,
+  sanitizeToolPairs,
+  alignBoundaryForward,
+  alignBoundaryBackward,
+  findTailCutByTokens,
+  computeSummaryBudget,
+  buildSummaryPrompt,
+  type CompactOptions
+} from "./compaction-helpers";

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -39,11 +39,7 @@ export { TestRetryAgent, TestRetryDefaultsAgent } from "./retry";
 export { TestFiberAgent } from "./fiber";
 export { TestKeepAliveAgent } from "./keep-alive";
 export { TestMigrationAgent } from "./migration";
-export {
-  TestSessionAgent,
-  TestSessionAgentNoMicroCompaction,
-  TestSessionAgentCustomRules
-} from "./session";
+export { TestSessionAgent, TestSessionAgentWithContext } from "./session";
 export { TestWaitConnectionsAgent } from "./wait-connections";
 export {
   TestSubAgentParent,

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -3,36 +3,24 @@ import { Agent } from "../../index";
 import {
   Session,
   AgentSessionProvider,
-  type CompactResult
+  type StoredCompaction,
+  type ContextBlock
 } from "../../experimental/memory/session";
 
 /**
- * Test Agent for session memory tests (default config, microCompact enabled)
+ * Test Agent — full Session API
  */
 export class TestSessionAgent extends Agent {
-  // Session wrapper (default: microCompact enabled)
   session = new Session(new AgentSessionProvider(this));
 
-  // ── Test helper methods (callable via DO RPC) ──────────────────────
+  // ── Messages ────────────────────────────────────────────────────
 
-  getMessages(): UIMessage[] {
-    return this.session.getMessages();
+  appendMessage(message: UIMessage, parentId?: string): void {
+    this.session.appendMessage(message, parentId);
   }
 
-  getMessagesWithOptions(options: {
-    limit?: number;
-    offset?: number;
-    role?: "user" | "assistant" | "system";
-  }): UIMessage[] {
-    return this.session.getMessages(options);
-  }
-
-  async appendMessage(message: UIMessage): Promise<void> {
-    await this.session.append(message);
-  }
-
-  async appendMessages(messages: UIMessage[]): Promise<void> {
-    await this.session.append(messages);
+  getMessage(id: string): UIMessage | null {
+    return this.session.getMessage(id);
   }
 
   updateMessage(message: UIMessage): void {
@@ -47,77 +35,86 @@ export class TestSessionAgent extends Agent {
     this.session.clearMessages();
   }
 
-  getMessage(id: string): UIMessage | null {
-    return this.session.getMessage(id);
+  // ── History (tree) ──────────────────────────────────────────────
+
+  getHistory(leafId?: string): UIMessage[] {
+    return this.session.getHistory(leafId);
   }
 
-  getLastMessages(n: number): UIMessage[] {
-    return this.session.getLastMessages(n);
+  getLatestLeaf(): UIMessage | null {
+    return this.session.getLatestLeaf();
   }
 
-  async compact(): Promise<CompactResult> {
-    return this.session.compact();
+  getBranches(messageId: string): UIMessage[] {
+    return this.session.getBranches(messageId);
+  }
+
+  getPathLength(): number {
+    return this.session.getPathLength();
+  }
+
+  // ── Compaction ──────────────────────────────────────────────────
+
+  addCompaction(
+    summary: string,
+    fromId: string,
+    toId: string
+  ): StoredCompaction {
+    return this.session.addCompaction(summary, fromId, toId);
+  }
+
+  getCompactions(): StoredCompaction[] {
+    return this.session.getCompactions();
+  }
+
+  needsCompaction(max?: number): boolean {
+    return this.session.needsCompaction(max);
+  }
+
+  // ── Search ──────────────────────────────────────────────────────
+
+  search(query: string): Array<{ id: string; role: string; content: string }> {
+    return this.session.search(query);
   }
 }
 
 /**
- * Test Agent with microCompact disabled
+ * Test Agent — context blocks with frozen snapshot
  */
-export class TestSessionAgentNoMicroCompaction extends Agent<Cloudflare.Env> {
+export class TestSessionAgentWithContext extends Agent<Cloudflare.Env> {
   session = new Session(new AgentSessionProvider(this), {
-    microCompaction: false
+    context: [
+      { label: "memory", description: "Persistent notes", maxTokens: 500 },
+      {
+        label: "soul",
+        description: "Identity",
+        initialContent: "You are helpful.",
+        readonly: true
+      }
+    ]
   });
 
-  getMessages(): UIMessage[] {
-    return this.session.getMessages();
+  async freezeSystemPrompt(): Promise<string> {
+    return this.session.freezeSystemPrompt();
   }
 
-  async appendMessage(message: UIMessage): Promise<void> {
-    await this.session.append(message);
+  async refreshSystemPrompt(): Promise<string> {
+    return this.session.refreshSystemPrompt();
   }
 
-  async appendMessages(messages: UIMessage[]): Promise<void> {
-    await this.session.append(messages);
+  async setBlock(label: string, content: string): Promise<ContextBlock> {
+    return this.session.replaceContextBlock(label, content);
   }
 
-  clearMessages(): void {
-    this.session.clearMessages();
+  getBlock(label: string): ContextBlock | null {
+    return this.session.getContextBlock(label);
   }
 
-  async compact(): Promise<CompactResult> {
-    return this.session.compact();
-  }
-}
-
-/**
- * Test Agent with custom microCompact rules
- */
-export class TestSessionAgentCustomRules extends Agent<Cloudflare.Env> {
-  session = new Session(new AgentSessionProvider(this), {
-    microCompaction: {
-      truncateToolOutputs: 100, // Very low threshold for testing
-      truncateText: 200,
-      keepRecent: 2
-    }
-  });
-
-  getMessages(): UIMessage[] {
-    return this.session.getMessages();
+  getBlocks(): ContextBlock[] {
+    return this.session.getContextBlocks();
   }
 
-  async appendMessage(message: UIMessage): Promise<void> {
-    await this.session.append(message);
-  }
-
-  async appendMessages(messages: UIMessage[]): Promise<void> {
-    await this.session.append(messages);
-  }
-
-  clearMessages(): void {
-    this.session.clearMessages();
-  }
-
-  async compact(): Promise<CompactResult> {
-    return this.session.compact();
+  async getTools(): Promise<Record<string, unknown>> {
+    return this.session.tools();
   }
 }

--- a/packages/agents/src/tests/experimental/memory/session/provider.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/provider.test.ts
@@ -2,626 +2,325 @@ import type { UIMessage } from "ai";
 import { env } from "cloudflare:workers";
 import { describe, expect, it, beforeEach } from "vitest";
 import { getAgentByName } from "../../../..";
-import type {
-  MessageQueryOptions,
-  CompactResult
-} from "../../../../experimental/memory/session";
 
 /**
- * Typed stub interface for TestSessionAgent
+ * Typed stub for TestSessionAgent (tree-structured Session API)
  */
 interface SessionAgentStub {
-  getMessages(): Promise<UIMessage[]>;
-  getMessagesWithOptions(options: MessageQueryOptions): Promise<UIMessage[]>;
-  appendMessage(message: UIMessage): Promise<void>;
-  appendMessages(messages: UIMessage[]): Promise<void>;
+  appendMessage(message: UIMessage, parentId?: string): Promise<void>;
+  getMessage(id: string): Promise<UIMessage | null>;
   updateMessage(message: UIMessage): Promise<void>;
   deleteMessages(ids: string[]): Promise<void>;
   clearMessages(): Promise<void>;
-  getMessage(id: string): Promise<UIMessage | null>;
-  getLastMessages(n: number): Promise<UIMessage[]>;
-  compact(): Promise<CompactResult>;
+  getHistory(leafId?: string): Promise<UIMessage[]>;
+  getLatestLeaf(): Promise<UIMessage | null>;
+  getBranches(messageId: string): Promise<UIMessage[]>;
+  getPathLength(): Promise<number>;
+  addCompaction(
+    summary: string,
+    fromId: string,
+    toId: string
+  ): Promise<unknown>;
+  getCompactions(): Promise<unknown[]>;
+  needsCompaction(max?: number): Promise<boolean>;
+  search(
+    query: string
+  ): Promise<Array<{ id: string; role: string; content: string }>>;
 }
 
-/** Helper to get a typed agent stub */
-async function getSessionAgent(name: string): Promise<SessionAgentStub> {
+async function getAgent(name: string): Promise<SessionAgentStub> {
   return getAgentByName(
     env.TestSessionAgent,
     name
   ) as unknown as Promise<SessionAgentStub>;
 }
 
-async function getSessionAgentNoMicroCompact(
-  name: string
-): Promise<SessionAgentStub> {
-  return getAgentByName(
-    env.TestSessionAgentNoMicroCompaction,
-    name
-  ) as unknown as Promise<SessionAgentStub>;
-}
-
-async function getSessionAgentCustomRules(
-  name: string
-): Promise<SessionAgentStub> {
-  return getAgentByName(
-    env.TestSessionAgentCustomRules,
-    name
-  ) as unknown as Promise<SessionAgentStub>;
-}
-
-describe("AgentSessionProvider", () => {
-  let instanceName: string;
-
+describe("AgentSessionProvider — tree-structured messages", () => {
+  let name: string;
   beforeEach(() => {
-    instanceName = `session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    name = `test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   });
 
-  describe("basic operations", () => {
-    it("should start with no messages", async () => {
-      const agent = await getSessionAgent(instanceName);
-      const messages = await agent.getMessages();
-
-      expect(messages).toEqual([]);
-    });
-
-    it("should append and retrieve a single message", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      const message: UIMessage = {
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "Hello, world!" }]
-      };
-
-      await agent.appendMessage(message);
-      const messages = await agent.getMessages();
-
-      expect(messages).toHaveLength(1);
-      expect(messages[0].id).toBe("msg-1");
-      expect(messages[0].role).toBe("user");
-      expect(messages[0].parts[0]).toEqual({
-        type: "text",
-        text: "Hello, world!"
-      });
-    });
-
-    it("should append multiple messages at once", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      const messages: UIMessage[] = [
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "Hello" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Hi there!" }]
-        },
-        {
-          id: "msg-3",
-          role: "user",
-          parts: [{ type: "text", text: "How are you?" }]
-        }
-      ];
-
-      await agent.appendMessages(messages);
-      const retrieved = await agent.getMessages();
-
-      expect(retrieved).toHaveLength(3);
-      expect(retrieved.map((m) => m.id)).toEqual(["msg-1", "msg-2", "msg-3"]);
-    });
-
-    it("should get a single message by ID", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "First" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Second" }]
-        }
-      ]);
-
-      const message = await agent.getMessage("msg-2");
-      expect(message).not.toBeNull();
-      expect(message?.id).toBe("msg-2");
-      expect(message?.role).toBe("assistant");
-
-      const notFound = await agent.getMessage("nonexistent");
-      expect(notFound).toBeNull();
-    });
-
-    it("should get the last N messages", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "First" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Second" }]
-        },
-        { id: "msg-3", role: "user", parts: [{ type: "text", text: "Third" }] },
-        {
-          id: "msg-4",
-          role: "assistant",
-          parts: [{ type: "text", text: "Fourth" }]
-        }
-      ]);
-
-      const lastTwo = await agent.getLastMessages(2);
-      expect(lastTwo).toHaveLength(2);
-      expect(lastTwo.map((m) => m.id)).toEqual(["msg-3", "msg-4"]);
-    });
+  it("starts with empty history", async () => {
+    const agent = await getAgent(name);
+    const history = await agent.getHistory();
+    expect(history).toEqual([]);
   });
 
-  describe("update and delete", () => {
-    it("should update an existing message", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessage({
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "Original" }]
-      });
-
-      await agent.updateMessage({
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "Updated" }]
-      });
-
-      const messages = await agent.getMessages();
-      expect(messages).toHaveLength(1);
-      expect(messages[0].parts[0]).toEqual({ type: "text", text: "Updated" });
+  it("append and retrieve messages", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "assistant",
+      parts: [{ type: "text", text: "Hi" }]
     });
 
-    it("should upsert on append with existing ID", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessage({
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "Original" }]
-      });
-
-      await agent.appendMessage({
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "Replaced" }]
-      });
-
-      const messages = await agent.getMessages();
-      expect(messages).toHaveLength(1);
-      expect(messages[0].parts[0]).toEqual({ type: "text", text: "Replaced" });
-    });
-
-    it("should delete messages by ID", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "First" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Second" }]
-        },
-        { id: "msg-3", role: "user", parts: [{ type: "text", text: "Third" }] }
-      ]);
-
-      await agent.deleteMessages(["msg-2"]);
-
-      const messages = await agent.getMessages();
-      expect(messages).toHaveLength(2);
-      expect(messages.map((m) => m.id)).toEqual(["msg-1", "msg-3"]);
-    });
-
-    it("should clear all messages", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "First" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Second" }]
-        }
-      ]);
-
-      await agent.clearMessages();
-
-      const messages = await agent.getMessages();
-      expect(messages).toEqual([]);
-    });
+    const history = await agent.getHistory();
+    expect(history).toHaveLength(2);
+    expect(history[0].id).toBe("m1");
+    expect(history[1].id).toBe("m2");
   });
 
-  describe("query options", () => {
-    it("should limit results", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "First" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Second" }]
-        },
-        { id: "msg-3", role: "user", parts: [{ type: "text", text: "Third" }] }
-      ]);
-
-      const messages = await agent.getMessagesWithOptions({ limit: 2 });
-      expect(messages).toHaveLength(2);
-      expect(messages.map((m) => m.id)).toEqual(["msg-1", "msg-2"]);
+  it("getMessage by ID", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
     });
 
-    it("should offset results", async () => {
-      const agent = await getSessionAgent(instanceName);
+    const msg = await agent.getMessage("m1");
+    expect(msg?.id).toBe("m1");
 
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "First" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Second" }]
-        },
-        { id: "msg-3", role: "user", parts: [{ type: "text", text: "Third" }] }
-      ]);
-
-      const messages = await agent.getMessagesWithOptions({ offset: 1 });
-      expect(messages).toHaveLength(2);
-      expect(messages.map((m) => m.id)).toEqual(["msg-2", "msg-3"]);
-    });
-
-    it("should filter by role", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessages([
-        {
-          id: "msg-1",
-          role: "user",
-          parts: [{ type: "text", text: "User 1" }]
-        },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Assistant 1" }]
-        },
-        {
-          id: "msg-3",
-          role: "user",
-          parts: [{ type: "text", text: "User 2" }]
-        },
-        {
-          id: "msg-4",
-          role: "assistant",
-          parts: [{ type: "text", text: "Assistant 2" }]
-        }
-      ]);
-
-      const userMessages = await agent.getMessagesWithOptions({ role: "user" });
-      expect(userMessages).toHaveLength(2);
-      expect(userMessages.every((m) => m.role === "user")).toBe(true);
-
-      const assistantMessages = await agent.getMessagesWithOptions({
-        role: "assistant"
-      });
-      expect(assistantMessages).toHaveLength(2);
-      expect(assistantMessages.every((m) => m.role === "assistant")).toBe(true);
-    });
+    const missing = await agent.getMessage("nope");
+    expect(missing).toBeNull();
   });
 
-  describe("microCompaction", () => {
-    it("should truncate tool outputs on append", async () => {
-      const agent = await getSessionAgentCustomRules(instanceName);
-
-      // Add messages with large tool output (keepRecent=2, so first 2 get compacted)
-      const largeOutput = "x".repeat(500);
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "Hello" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [
-            {
-              type: "tool-invocation",
-              toolCallId: "call-1",
-              input: {},
-              state: "output-available",
-              output: largeOutput
-            }
-          ]
-        },
-        {
-          id: "msg-3",
-          role: "user",
-          parts: [{ type: "text", text: "Thanks" }]
-        },
-        {
-          id: "msg-4",
-          role: "assistant",
-          parts: [{ type: "text", text: "You're welcome" }]
-        }
-      ]);
-
-      // microCompaction runs automatically on append — check results
-      const messages = await agent.getMessages();
-      expect(messages).toHaveLength(4);
-
-      // msg-2 (older) should have truncated output
-      const msg2 = messages.find((m) => m.id === "msg-2");
-      expect(msg2).toBeDefined();
-      const toolPart = msg2?.parts[0] as { output?: unknown };
-      expect(typeof toolPart.output).toBe("string");
-      expect((toolPart.output as string).includes("[Truncated")).toBe(true);
+  it("tree structure — parentId links messages", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Root" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "assistant",
+      parts: [{ type: "text", text: "Reply" }]
     });
 
-    it("should truncate long text parts in older messages on append", async () => {
-      const agent = await getSessionAgentCustomRules(instanceName);
-
-      const longText = "y".repeat(500);
-      await agent.appendMessages([
-        {
-          id: "msg-1",
-          role: "user",
-          parts: [{ type: "text", text: longText }]
-        },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Short" }]
-        },
-        { id: "msg-3", role: "user", parts: [{ type: "text", text: "Hello" }] },
-        {
-          id: "msg-4",
-          role: "assistant",
-          parts: [{ type: "text", text: "Hi" }]
-        }
-      ]);
-
-      // microCompaction runs automatically on append
-      const messages = await agent.getMessages();
-      const msg1 = messages.find((m) => m.id === "msg-1");
-      const textPart = msg1?.parts[0] as { text?: string };
-      expect(textPart.text?.includes("[truncated")).toBe(true);
-      expect(textPart.text?.length).toBeLessThan(longText.length);
-    });
-
-    it("should keep recent messages intact", async () => {
-      const agent = await getSessionAgentCustomRules(instanceName);
-
-      // Custom rules: keepRecent = 2
-      const longText = "z".repeat(500);
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "Old" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Also old" }]
-        },
-        {
-          id: "msg-3",
-          role: "user",
-          parts: [{ type: "text", text: longText }]
-        }, // Recent
-        {
-          id: "msg-4",
-          role: "assistant",
-          parts: [{ type: "text", text: longText }]
-        } // Recent
-      ]);
-
-      // microCompaction runs on append — recent messages should be intact
-      const messages = await agent.getMessages();
-
-      // msg-3 and msg-4 are recent (keepRecent=2), should not be truncated
-      const msg3 = messages.find((m) => m.id === "msg-3");
-      const msg4 = messages.find((m) => m.id === "msg-4");
-
-      expect((msg3!.parts[0] as { text: string }).text).toBe(longText);
-      expect((msg4!.parts[0] as { text: string }).text).toBe(longText);
-    });
-
-    it("should not truncate when microCompaction is disabled", async () => {
-      const agent = await getSessionAgentNoMicroCompact(instanceName);
-
-      const longText = "a".repeat(5000);
-      await agent.appendMessages([
-        {
-          id: "msg-1",
-          role: "user",
-          parts: [{ type: "text", text: longText }]
-        },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Hi" }]
-        },
-        { id: "msg-3", role: "user", parts: [{ type: "text", text: "Bye" }] },
-        {
-          id: "msg-4",
-          role: "assistant",
-          parts: [{ type: "text", text: "Goodbye" }]
-        }
-      ]);
-
-      // microCompaction disabled — nothing should be truncated
-      const messages = await agent.getMessages();
-      const msg1 = messages.find((m) => m.id === "msg-1");
-
-      expect((msg1!.parts[0] as { text: string }).text).toBe(longText);
-    });
+    const history = await agent.getHistory();
+    expect(history.map((m) => m.id)).toEqual(["m1", "m2"]);
+    expect(await agent.getPathLength()).toBe(2);
   });
 
-  describe("persistence", () => {
-    it("should persist messages across agent instance lookups", async () => {
-      const agent1 = await getSessionAgent(instanceName);
-      await agent1.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "Hello" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "Hi there!" }]
-        }
-      ]);
-
-      const agent2 = await getSessionAgent(instanceName);
-      const messages = await agent2.getMessages();
-
-      expect(messages).toHaveLength(2);
-      expect(messages.map((m) => m.id)).toEqual(["msg-1", "msg-2"]);
+  it("branching — multiple children of same parent", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Question" }]
     });
-  });
-
-  describe("input validation", () => {
-    it("should reject negative limit", async () => {
-      const agent = await getSessionAgent(instanceName);
-      try {
-        await agent.getMessagesWithOptions({ limit: -1 });
-        expect.unreachable("should have thrown");
-      } catch (e) {
-        expect(String(e)).toContain("limit must be a non-negative integer");
-      }
-    });
-
-    it("should reject negative offset", async () => {
-      const agent = await getSessionAgent(instanceName);
-      try {
-        await agent.getMessagesWithOptions({ offset: -1 });
-        expect.unreachable("should have thrown");
-      } catch (e) {
-        expect(String(e)).toContain("offset must be a non-negative integer");
-      }
-    });
-
-    it("should reject non-integer limit", async () => {
-      const agent = await getSessionAgent(instanceName);
-      try {
-        await agent.getMessagesWithOptions({ limit: 1.5 });
-        expect.unreachable("should have thrown");
-      } catch (e) {
-        expect(String(e)).toContain("limit must be a non-negative integer");
-      }
-    });
-  });
-
-  describe("date filtering", () => {
-    it("should filter messages with before", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessage({
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "First" }]
-      });
-
-      // Small delay to ensure different timestamps
-      await new Promise((r) => setTimeout(r, 50));
-      const midpoint = new Date();
-      await new Promise((r) => setTimeout(r, 50));
-
-      await agent.appendMessage({
-        id: "msg-2",
+    // Two branches from m1
+    await agent.appendMessage(
+      {
+        id: "m2a",
         role: "assistant",
-        parts: [{ type: "text", text: "Second" }]
-      });
-
-      const before = await agent.getMessagesWithOptions({ before: midpoint });
-      expect(before).toHaveLength(1);
-      expect(before[0].id).toBe("msg-1");
-    });
-
-    it("should filter messages with after", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      await agent.appendMessage({
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "First" }]
-      });
-
-      await new Promise((r) => setTimeout(r, 50));
-      const midpoint = new Date();
-      await new Promise((r) => setTimeout(r, 50));
-
-      await agent.appendMessage({
-        id: "msg-2",
+        parts: [{ type: "text", text: "Answer A" }]
+      },
+      "m1"
+    );
+    await agent.appendMessage(
+      {
+        id: "m2b",
         role: "assistant",
-        parts: [{ type: "text", text: "Second" }]
-      });
+        parts: [{ type: "text", text: "Answer B" }]
+      },
+      "m1"
+    );
 
-      const after = await agent.getMessagesWithOptions({ after: midpoint });
-      expect(after).toHaveLength(1);
-      expect(after[0].id).toBe("msg-2");
-    });
+    const branches = await agent.getBranches("m1");
+    expect(branches).toHaveLength(2);
+    expect(branches.map((m) => m.id).sort()).toEqual(["m2a", "m2b"]);
 
-    it("should filter with role + before combined", async () => {
-      const agent = await getSessionAgent(instanceName);
+    // Latest leaf is m2b (most recent)
+    const leaf = await agent.getLatestLeaf();
+    expect(leaf?.id).toBe("m2b");
 
-      await agent.appendMessages([
-        { id: "msg-1", role: "user", parts: [{ type: "text", text: "U1" }] },
-        {
-          id: "msg-2",
-          role: "assistant",
-          parts: [{ type: "text", text: "A1" }]
-        }
-      ]);
+    // getHistory from m2a branch
+    const historyA = await agent.getHistory("m2a");
+    expect(historyA.map((m) => m.id)).toEqual(["m1", "m2a"]);
 
-      await new Promise((r) => setTimeout(r, 50));
-      const midpoint = new Date();
-      await new Promise((r) => setTimeout(r, 50));
-
-      await agent.appendMessages([
-        { id: "msg-3", role: "user", parts: [{ type: "text", text: "U2" }] },
-        {
-          id: "msg-4",
-          role: "assistant",
-          parts: [{ type: "text", text: "A2" }]
-        }
-      ]);
-
-      const result = await agent.getMessagesWithOptions({
-        role: "user",
-        before: midpoint
-      });
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe("msg-1");
-    });
+    // getHistory from m2b branch
+    const historyB = await agent.getHistory("m2b");
+    expect(historyB.map((m) => m.id)).toEqual(["m1", "m2b"]);
   });
 
-  describe("timestamp preservation", () => {
-    it("should preserve created_at after compact", async () => {
-      const agent = await getSessionAgent(instanceName);
-
-      // Append messages with timestamps spread apart
-      await agent.appendMessage({
-        id: "msg-1",
-        role: "user",
-        parts: [{ type: "text", text: "Hello" }]
-      });
-      await new Promise((r) => setTimeout(r, 50));
-      const midpoint = new Date();
-      await new Promise((r) => setTimeout(r, 50));
-      await agent.appendMessage({
-        id: "msg-2",
-        role: "assistant",
-        parts: [{ type: "text", text: "Hi" }]
-      });
-      await agent.appendMessage({
-        id: "msg-3",
-        role: "user",
-        parts: [{ type: "text", text: "Bye" }]
-      });
-
-      // Compact
-      await agent.compact();
-
-      // Verify before/after filtering still works (timestamps preserved)
-      const before = await agent.getMessagesWithOptions({ before: midpoint });
-      expect(before).toHaveLength(1);
-      expect(before[0].id).toBe("msg-1");
-
-      const after = await agent.getMessagesWithOptions({ after: midpoint });
-      expect(after).toHaveLength(2);
-      expect(after.map((m) => m.id)).toEqual(["msg-2", "msg-3"]);
+  it("updateMessage", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Original" }]
     });
+    await agent.updateMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Updated" }]
+    });
+
+    const msg = await agent.getMessage("m1");
+    expect(msg?.parts[0]).toEqual({ type: "text", text: "Updated" });
+  });
+
+  it("clearMessages", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Hi" }]
+    });
+    await agent.clearMessages();
+
+    expect(await agent.getHistory()).toEqual([]);
+    expect(await agent.getPathLength()).toBe(0);
+  });
+
+  it("idempotent append — same ID is no-op", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "First" }]
+    });
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Duplicate" }]
+    });
+
+    const history = await agent.getHistory();
+    expect(history).toHaveLength(1);
+    // INSERT OR IGNORE — keeps the first
+    expect(history[0].parts[0]).toEqual({ type: "text", text: "First" });
+  });
+
+  it("needsCompaction threshold", async () => {
+    const agent = await getAgent(name);
+    for (let i = 0; i < 5; i++) {
+      await agent.appendMessage({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `msg ${i}` }]
+      });
+    }
+
+    expect(await agent.needsCompaction(10)).toBe(false);
+    expect(await agent.needsCompaction(3)).toBe(true);
+  });
+
+  it("compaction overlays — addCompaction replaces range in getHistory", async () => {
+    const agent = await getAgent(name);
+    for (let i = 0; i < 6; i++) {
+      await agent.appendMessage({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `msg ${i}` }]
+      });
+    }
+
+    // Compact middle messages (m1-m3)
+    await agent.addCompaction("Summary of m1-m3", "m1", "m3");
+
+    const history = await agent.getHistory();
+    // m0 + compaction_summary + m4 + m5
+    expect(history).toHaveLength(4);
+    expect(history[0].id).toBe("m0");
+    expect(history[1].id).toMatch(/^compaction_/);
+    expect(history[1].parts[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("Summary of m1-m3")
+    });
+    expect(history[2].id).toBe("m4");
+    expect(history[3].id).toBe("m5");
+
+    // Compactions are stored
+    const compactions = await agent.getCompactions();
+    expect(compactions).toHaveLength(1);
+  });
+
+  it("iterative compaction — new overlay supersedes old one at same fromId", async () => {
+    const agent = await getAgent(name);
+
+    // Add 10 messages
+    for (let i = 0; i < 10; i++) {
+      await agent.appendMessage({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `msg ${i}` }]
+      });
+    }
+
+    // First compaction: summarize m1-m7, keep m0 (head) and m8-m9 (tail)
+    await agent.addCompaction("Summary round 1", "m1", "m7");
+
+    let history = await agent.getHistory();
+    // m0 + summary1 + m8 + m9
+    expect(history).toHaveLength(4);
+    expect(history[0].id).toBe("m0");
+    expect(history[1].id).toMatch(/^compaction_/);
+    expect(history[2].id).toBe("m8");
+    expect(history[3].id).toBe("m9");
+
+    // Add more messages
+    for (let i = 10; i < 15; i++) {
+      await agent.appendMessage({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `msg ${i}` }]
+      });
+    }
+
+    // Second compaction: supersede old one, cover m1-m12
+    // (new summary incorporates round 1 summary + m8-m12)
+    await agent.addCompaction("Summary round 2", "m1", "m12");
+
+    history = await agent.getHistory();
+    // m0 + summary2 + m13 + m14 (NOT summary1 — superseded)
+    expect(history).toHaveLength(4);
+    expect(history[0].id).toBe("m0");
+    expect(history[1].id).toMatch(/^compaction_/);
+    expect(history[1].parts[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("Summary round 2")
+    });
+    expect(history[2].id).toBe("m13");
+    expect(history[3].id).toBe("m14");
+
+    // Both compactions stored, but only the latest applies
+    const compactions = await agent.getCompactions();
+    expect(compactions).toHaveLength(2);
+  });
+
+  it("FTS search", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "I love TypeScript" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "assistant",
+      parts: [{ type: "text", text: "Great choice" }]
+    });
+    await agent.appendMessage({
+      id: "m3",
+      role: "user",
+      parts: [{ type: "text", text: "Python is also good" }]
+    });
+
+    const results = await agent.search("TypeScript");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].content).toContain("TypeScript");
+  });
+
+  it("persistence across agent lookups", async () => {
+    const agent1 = await getAgent(name);
+    await agent1.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    });
+
+    const agent2 = await getAgent(name);
+    const history = await agent2.getHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].id).toBe("m1");
   });
 });

--- a/packages/agents/src/tests/experimental/memory/session/session.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/session.test.ts
@@ -1,0 +1,500 @@
+import { describe, expect, it } from "vitest";
+import { Session } from "../../../../experimental/memory/session/session";
+import {
+  ContextBlocks,
+  type ContextProvider
+} from "../../../../experimental/memory/session/context";
+import type { SessionProvider } from "../../../../experimental/memory/session/provider";
+
+// ── Test helpers ────────────────────────────────────────────────
+
+type ToolExecuteFn = {
+  execute: (args: {
+    label: string;
+    content: string;
+    action?: string;
+  }) => Promise<string>;
+};
+
+// ── In-memory block provider for pure unit tests ────────────────
+
+class MemoryBlockProvider implements ContextProvider {
+  private value: string | null;
+  constructor(initial: string | null = null) {
+    this.value = initial;
+  }
+  async get() {
+    return this.value;
+  }
+  async set(content: string) {
+    this.value = content;
+  }
+}
+
+// ── Pure unit tests (no DO needed) ──────────────────────────────
+
+describe("ContextBlocks — frozen system prompt", () => {
+  it("toSystemPrompt returns same value on repeated calls", async () => {
+    const blocks = new ContextBlocks([
+      { label: "soul", initialContent: "You are helpful.", readonly: true },
+      {
+        label: "memory",
+        description: "Facts",
+        maxTokens: 1100,
+        provider: new MemoryBlockProvider("likes TypeScript")
+      }
+    ]);
+    await blocks.load();
+
+    const p1 = blocks.toSystemPrompt();
+    const p2 = blocks.toSystemPrompt();
+
+    expect(p1).toBe(p2);
+    expect(p1).toContain("SOUL");
+    expect(p1).toContain("You are helpful.");
+    expect(p1).toContain("MEMORY");
+    expect(p1).toContain("likes TypeScript");
+  });
+
+  it("setBlock does NOT change frozen prompt", async () => {
+    const provider = new MemoryBlockProvider("original");
+    const blocks = new ContextBlocks([
+      { label: "memory", maxTokens: 1100, provider }
+    ]);
+    await blocks.load();
+
+    const frozen = blocks.toSystemPrompt();
+    expect(frozen).toContain("original");
+
+    await blocks.setBlock("memory", "updated");
+
+    // Provider updated
+    expect(await provider.get()).toBe("updated");
+    // Prompt still frozen
+    expect(blocks.toSystemPrompt()).toBe(frozen);
+    expect(blocks.toSystemPrompt()).toContain("original");
+  });
+
+  it("refreshSnapshot picks up changes", async () => {
+    const blocks = new ContextBlocks([
+      {
+        label: "memory",
+        maxTokens: 1100,
+        provider: new MemoryBlockProvider("v1")
+      }
+    ]);
+    await blocks.load();
+
+    const v1 = blocks.toSystemPrompt();
+    await blocks.setBlock("memory", "v2");
+
+    // Still frozen
+    expect(blocks.toSystemPrompt()).toBe(v1);
+
+    // Refresh
+    const v2 = blocks.refreshSnapshot();
+    expect(v2).toContain("v2");
+    expect(v2).not.toContain("v1");
+    expect(blocks.toSystemPrompt()).toBe(v2);
+  });
+
+  it("readonly blocks reject writes", async () => {
+    const blocks = new ContextBlocks([
+      { label: "soul", initialContent: "identity", readonly: true }
+    ]);
+    await blocks.load();
+    await expect(blocks.setBlock("soul", "hacked")).rejects.toThrow("readonly");
+  });
+
+  it("maxTokens enforcement", async () => {
+    const blocks = new ContextBlocks([
+      { label: "memory", maxTokens: 10, provider: new MemoryBlockProvider("") }
+    ]);
+    await blocks.load();
+    const long = "word ".repeat(50);
+    await expect(blocks.setBlock("memory", long)).rejects.toThrow(
+      "exceeds maxTokens"
+    );
+  });
+
+  it("uses plain text format, not XML", async () => {
+    const blocks = new ContextBlocks([
+      { label: "soul", initialContent: "helpful", readonly: true },
+      {
+        label: "memory",
+        description: "Facts",
+        maxTokens: 500,
+        provider: new MemoryBlockProvider("coffee")
+      }
+    ]);
+    await blocks.load();
+    const prompt = blocks.toSystemPrompt();
+
+    expect(prompt).toContain("═");
+    expect(prompt).toContain("SOUL");
+    expect(prompt).toContain("MEMORY");
+    expect(prompt).not.toContain("<context_block");
+  });
+});
+
+const stubProvider: SessionProvider = {
+  getMessage: () => null,
+  getHistory: () => [],
+  getLatestLeaf: () => null,
+  getBranches: () => [],
+  getPathLength: () => 0,
+  appendMessage: () => {},
+  updateMessage: () => {},
+  deleteMessages: () => {},
+  clearMessages: () => {},
+  addCompaction: () => ({
+    id: "",
+    summary: "",
+    fromMessageId: "",
+    toMessageId: "",
+    createdAt: ""
+  }),
+  getCompactions: () => []
+};
+
+describe("Session — tools() without load", () => {
+  it("tools() returns tool schema with loaded blocks", async () => {
+    const session = new Session(stubProvider, {
+      context: [
+        { label: "soul", initialContent: "identity", readonly: true },
+        {
+          label: "memory",
+          description: "Learned facts",
+          maxTokens: 1100,
+          provider: new MemoryBlockProvider("")
+        },
+        {
+          label: "todos",
+          description: "Task list",
+          maxTokens: 2000,
+          provider: new MemoryBlockProvider("")
+        }
+      ]
+    });
+
+    const tools = await session.tools();
+    expect(tools).toHaveProperty("update_context");
+    const tool = tools.update_context as { description: string };
+
+    // Lists writable blocks, not readonly
+    expect(tool.description).toContain("memory");
+    expect(tool.description).toContain("todos");
+    expect(tool.description).not.toContain("soul");
+  });
+
+  it("tools() execute lazily loads and writes to provider", async () => {
+    const memProvider = new MemoryBlockProvider("");
+    const session = new Session(stubProvider, {
+      context: [
+        {
+          label: "memory",
+          description: "Facts",
+          maxTokens: 1100,
+          provider: memProvider
+        }
+      ]
+    });
+
+    const tool = (await session.tools())
+      .update_context as unknown as ToolExecuteFn;
+
+    const result = await tool.execute({
+      label: "memory",
+      content: "user likes coffee"
+    });
+    expect(result).toContain("Written to memory");
+    expect(result).toContain("tokens");
+    expect(await memProvider.get()).toBe("user likes coffee");
+  });
+
+  it("tools() execute append works", async () => {
+    const memProvider = new MemoryBlockProvider("fact1");
+    const session = new Session(stubProvider, {
+      context: [
+        {
+          label: "memory",
+          description: "Facts",
+          maxTokens: 1100,
+          provider: memProvider
+        }
+      ]
+    });
+
+    const tool = (await session.tools())
+      .update_context as unknown as ToolExecuteFn;
+    const result = await tool.execute({
+      label: "memory",
+      content: "\nfact2",
+      action: "append"
+    });
+    expect(result).toContain("Written to memory");
+    expect(await memProvider.get()).toBe("fact1\nfact2");
+  });
+
+  it("tools() execute rejects readonly blocks gracefully", async () => {
+    const session = new Session(stubProvider, {
+      context: [
+        { label: "soul", initialContent: "identity", readonly: true },
+        {
+          label: "memory",
+          description: "Facts",
+          maxTokens: 1100,
+          provider: new MemoryBlockProvider("")
+        }
+      ]
+    });
+
+    const tool = (await session.tools())
+      .update_context as unknown as ToolExecuteFn;
+    const result = await tool.execute({ label: "soul", content: "hacked" });
+    expect(result).toContain("Error");
+    expect(result).toContain("readonly");
+  });
+
+  it("tools() returns empty when no writable blocks", async () => {
+    const session = new Session(stubProvider, {
+      context: [{ label: "soul", initialContent: "identity", readonly: true }]
+    });
+    expect(Object.keys(await session.tools())).toHaveLength(0);
+  });
+});
+
+// ── Session.create() builder tests ──────────────────────────────
+
+// Minimal SqlProvider stub that records SQL calls
+function createSqlStub() {
+  const calls: string[] = [];
+  const data = new Map<string, string>();
+
+  const sql = <T = Record<string, string | number | boolean | null>>(
+    strings: TemplateStringsArray,
+    ...values: (string | number | boolean | null)[]
+  ): T[] => {
+    const query = strings.join("?");
+    calls.push(query);
+
+    // Handle CREATE TABLE
+    if (
+      query.includes("CREATE TABLE") ||
+      query.includes("CREATE VIRTUAL TABLE") ||
+      query.includes("CREATE INDEX")
+    ) {
+      return [] as T[];
+    }
+
+    // Handle context block get
+    if (query.includes("SELECT content FROM cf_agents_context_blocks")) {
+      const label = values[0] as string;
+      const content = data.get(label);
+      if (content) return [{ content }] as T[];
+      return [] as T[];
+    }
+
+    // Handle context block set
+    if (query.includes("INSERT INTO cf_agents_context_blocks")) {
+      const label = values[0] as string;
+      const content = values[1] as string;
+      data.set(label, content);
+      return [] as T[];
+    }
+
+    return [] as T[];
+  };
+
+  return { sql, calls, data };
+}
+
+describe("Session.create() builder", () => {
+  it("Session.create returns a Session", () => {
+    const { sql } = createSqlStub();
+    const session = Session.create({ sql });
+    expect(session).toBeInstanceOf(Session);
+  });
+
+  it("minimal create works", async () => {
+    const { sql } = createSqlStub();
+    const session = Session.create({ sql });
+    // Should be usable immediately — no .build() needed
+    expect(session.getHistory()).toEqual([]);
+  });
+
+  it("withContext adds writable blocks with auto-created provider", async () => {
+    const { sql, data } = createSqlStub();
+    const session = Session.create({ sql }).withContext("memory", {
+      description: "Facts",
+      maxTokens: 1100
+    });
+
+    const tools = await session.tools();
+    expect(tools).toHaveProperty("update_context");
+
+    // Execute the tool — it should write through to the auto-created provider
+    const tool = tools.update_context as unknown as ToolExecuteFn;
+    await tool.execute({ label: "memory", content: "test fact" });
+    expect(data.get("memory")).toBe("test fact");
+  });
+
+  it("withContext readonly blocks do not get auto provider", async () => {
+    const { sql } = createSqlStub();
+    const session = Session.create({ sql }).withContext("soul", {
+      initialContent: "You are helpful.",
+      readonly: true
+    });
+
+    // No writable blocks → empty tools
+    const tools = await session.tools();
+    expect(Object.keys(tools)).toHaveLength(0);
+
+    // But the prompt should include the soul block
+    const prompt = await session.freezeSystemPrompt();
+    expect(prompt).toContain("SOUL");
+    expect(prompt).toContain("You are helpful.");
+  });
+
+  it("withCachedPrompt auto-creates prompt store", async () => {
+    const { sql, data } = createSqlStub();
+    const session = Session.create({ sql })
+      .withContext("soul", { initialContent: "Be kind.", readonly: true })
+      .withCachedPrompt();
+
+    const prompt = await session.freezeSystemPrompt();
+    expect(prompt).toContain("Be kind.");
+
+    // Should have persisted to the auto-created store
+    expect(data.get("_system_prompt")).toBe(prompt);
+
+    // Second call returns same value (frozen)
+    const prompt2 = await session.freezeSystemPrompt();
+    expect(prompt2).toBe(prompt);
+  });
+
+  it("forSession namespaces provider keys", async () => {
+    const { sql, data } = createSqlStub();
+    const session = Session.create({ sql })
+      .forSession("chat-123")
+      .withContext("memory", { maxTokens: 1100 })
+      .withCachedPrompt();
+
+    // Write via tool
+    const tools = await session.tools();
+    const tool = tools.update_context as unknown as ToolExecuteFn;
+    await tool.execute({ label: "memory", content: "namespaced fact" });
+
+    // Key should be namespaced
+    expect(data.get("memory_chat-123")).toBe("namespaced fact");
+    expect(data.has("memory")).toBe(false);
+
+    // Prompt store should also be namespaced
+    await session.freezeSystemPrompt();
+    expect(data.has("_system_prompt_chat-123")).toBe(true);
+    expect(data.has("_system_prompt")).toBe(false);
+  });
+
+  it("withContext accepts explicit provider", async () => {
+    const customProvider = new MemoryBlockProvider("custom data");
+    const { sql } = createSqlStub();
+    const session = Session.create({ sql }).withContext("memory", {
+      maxTokens: 1100,
+      provider: customProvider
+    });
+
+    const prompt = await session.freezeSystemPrompt();
+    expect(prompt).toContain("custom data");
+  });
+
+  it("initialContent seeds writable block on first load", async () => {
+    const { sql, data } = createSqlStub();
+    const session = Session.create({ sql }).withContext("notes", {
+      initialContent: "default notes",
+      maxTokens: 500
+    });
+
+    // Block should start with initialContent since provider returns null
+    const prompt = await session.freezeSystemPrompt();
+    expect(prompt).toContain("default notes");
+
+    // But it's writable — tool should work
+    const tools = await session.tools();
+    const tool = tools.update_context as unknown as ToolExecuteFn;
+    await tool.execute({ label: "notes", content: "updated notes" });
+    expect(data.get("notes")).toBe("updated notes");
+  });
+
+  it("readonly provider with get-only rejects writes", async () => {
+    const { sql } = createSqlStub();
+    const session = Session.create({ sql }).withContext("config", {
+      readonly: true,
+      provider: {
+        get: async () => "loaded from external"
+      }
+    });
+
+    // Should load from provider
+    const prompt = await session.freezeSystemPrompt();
+    expect(prompt).toContain("loaded from external");
+
+    // No writable blocks → empty tools
+    const tools = await session.tools();
+    expect(Object.keys(tools)).toHaveLength(0);
+  });
+
+  it("initialContent + provider — provider wins, initialContent is fallback", async () => {
+    const { sql } = createSqlStub();
+
+    // Provider returns data → initialContent ignored
+    const session1 = Session.create({ sql }).withContext("memory", {
+      initialContent: "seed value",
+      provider: new MemoryBlockProvider("from provider")
+    });
+    const prompt1 = await session1.freezeSystemPrompt();
+    expect(prompt1).toContain("from provider");
+    expect(prompt1).not.toContain("seed value");
+
+    // Provider returns null → initialContent used
+    const session2 = Session.create({ sql }).withContext("memory", {
+      initialContent: "seed value",
+      provider: new MemoryBlockProvider(null)
+    });
+    const prompt2 = await session2.freezeSystemPrompt();
+    expect(prompt2).toContain("seed value");
+  });
+
+  it("forSession before withContext namespaces correctly", async () => {
+    const { sql, data } = createSqlStub();
+
+    const session = Session.create({ sql })
+      .forSession("abc")
+      .withContext("memory", { maxTokens: 500 })
+      .withCachedPrompt();
+
+    const tools = await session.tools();
+    const tool = tools.update_context as unknown as ToolExecuteFn;
+    await tool.execute({ label: "memory", content: "test" });
+    expect(data.get("memory_abc")).toBe("test");
+  });
+
+  it("withContext before forSession still namespaces correctly", async () => {
+    const { sql, data } = createSqlStub();
+
+    // withContext BEFORE forSession — providers resolved lazily, so order doesn't matter
+    const session = Session.create({ sql })
+      .withContext("memory", { maxTokens: 500 })
+      .withCachedPrompt()
+      .forSession("xyz");
+
+    const tools = await session.tools();
+    const tool = tools.update_context as unknown as ToolExecuteFn;
+    await tool.execute({ label: "memory", content: "late namespace" });
+    expect(data.get("memory_xyz")).toBe("late namespace");
+    expect(data.has("memory")).toBe(false);
+
+    await session.freezeSystemPrompt();
+    expect(data.has("_system_prompt_xyz")).toBe(true);
+    expect(data.has("_system_prompt")).toBe(false);
+  });
+});

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -40,8 +40,7 @@ export {
   TestKeepAliveAgent,
   TestMigrationAgent,
   TestSessionAgent,
-  TestSessionAgentNoMicroCompaction,
-  TestSessionAgentCustomRules,
+  TestSessionAgentWithContext,
   TestWaitConnectionsAgent,
   TestSubAgentParent,
   CounterSubAgent,
@@ -102,8 +101,7 @@ import type {
   TestKeepAliveAgent,
   TestMigrationAgent,
   TestSessionAgent,
-  TestSessionAgentNoMicroCompaction,
-  TestSessionAgentCustomRules,
+  TestSessionAgentWithContext,
   TestWaitConnectionsAgent,
   TestSubAgentParent,
   TestConnectionUriAgent
@@ -144,8 +142,7 @@ export type Env = {
   TestKeepAliveAgent: DurableObjectNamespace<TestKeepAliveAgent>;
   TestMigrationAgent: DurableObjectNamespace<TestMigrationAgent>;
   TestSessionAgent: DurableObjectNamespace<TestSessionAgent>;
-  TestSessionAgentNoMicroCompaction: DurableObjectNamespace<TestSessionAgentNoMicroCompaction>;
-  TestSessionAgentCustomRules: DurableObjectNamespace<TestSessionAgentCustomRules>;
+  TestSessionAgentWithContext: DurableObjectNamespace<TestSessionAgentWithContext>;
   TestWaitConnectionsAgent: DurableObjectNamespace<TestWaitConnectionsAgent>;
   TestSubAgentParent: DurableObjectNamespace<TestSubAgentParent>;
   TestConnectionUriAgent: DurableObjectNamespace<TestConnectionUriAgent>;

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -147,12 +147,8 @@
         "name": "TestSessionAgent"
       },
       {
-        "class_name": "TestSessionAgentNoMicroCompaction",
-        "name": "TestSessionAgentNoMicroCompaction"
-      },
-      {
-        "class_name": "TestSessionAgentCustomRules",
-        "name": "TestSessionAgentCustomRules"
+        "class_name": "TestSessionAgentWithContext",
+        "name": "TestSessionAgentWithContext"
       },
       {
         "class_name": "TestWaitConnectionsAgent",
@@ -242,8 +238,7 @@
         "TestFiberAgent",
         "TestKeepAliveAgent",
         "TestSessionAgent",
-        "TestSessionAgentNoMicroCompaction",
-        "TestSessionAgentCustomRules",
+        "TestSessionAgentWithContext",
         "TestWaitConnectionsAgent",
         "TestSubAgentParent",
         "CounterSubAgent",


### PR DESCRIPTION
## Summary

Core session primitives for the agents package — tree-structured messages, context blocks with frozen system prompts, non-destructive compaction, FTS5 search, and AI tools. Chainable builder API for zero-boilerplate setup.

Foundation for SessionManager (#1167) and Think integration (#1169).

---

## Builder API

```ts
const session = Session.create(this)
  .withContext("soul", { initialContent: "You are helpful.", readonly: true })
  .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
  .withContext("todos", { description: "Task list", maxTokens: 2000 })
  .onCompaction(createCompactFunction({
    summarize: (prompt) => generateText({ model, prompt }).then(r => r.text),
    protectHead: 1,
    minTailMessages: 2,
    tailTokenBudget: 100
  }))
  .withCachedPrompt();

// In chat handler:
await session.appendMessage(userMsg);
if (session.needsCompaction(6)) await session.compact();
const history = session.getHistory();
const tools = await session.tools();  // update_context tool
```

**`Session.create()`** accepts a `SqlProvider` (DO Agent) for auto-wired SQLite, or any `SessionProvider` directly for custom storage (PlanetScale, etc.).

**Builder methods** (any order):
- `.withContext(label, options)` — add context block. `initialContent` is the seed (used when provider returns null). `readonly: true` = AI can't modify.
- `.onCompaction(fn)` — register compaction function. `session.compact()` runs it and stores the overlay.
- `.withCachedPrompt(provider?)` — freeze system prompt for LLM prefix cache stability.
- `.forSession(id)` — namespace all provider keys for multi-session isolation.

**Lazy init** — no `.build()` needed. Returns a real `Session`; providers resolved on first use.

### ContextConfig

```ts
interface ContextConfig {
  label: string;
  description?: string;        // shown to AI in tool
  initialContent?: string;     // seed value — fallback when provider returns null
  maxTokens?: number;          // enforced on write
  readonly?: boolean;          // AI can't modify via tools
  provider?: ContextProvider;  // custom storage (omit = auto-wired SQLite)
}

// Builder uses Omit<ContextConfig, "label">
type SessionContextOptions = Omit<ContextConfig, "label">;
```

### ContextProvider

```ts
interface ContextProvider {
  get(): Promise<string | null>;
  set?(content: string): Promise<void>;  // optional — omit for read-only storage
}
```

Not exported publicly — users pass `provider: { get, set }` inline or use `AgentContextProvider`.

---

## Context blocks (`context.ts`)

Persistent key-value blocks rendered into a plain text system prompt (Hermes-style):

```
══════════════════════════════════════════════
SOUL [readonly]
══════════════════════════════════════════════
You are helpful.

══════════════════════════════════════════════
MEMORY (Learned facts) [45% — 495/1100 tokens]
══════════════════════════════════════════════
User likes TypeScript. Prefers short responses.
```

**Frozen prompt** — `freezeSystemPrompt()` persists the rendered prompt. Subsequent calls return the stored version (survives DO eviction). `refreshSystemPrompt()` re-renders after compaction or block writes.

**Tools** — `session.tools()` returns `update_context` with `label` as an **enum** of writable block names. Descriptions are static (no dynamic usage %) for cache key stability. Execute response returns live usage stats.

---

## Compaction

**`onCompaction(fn)`** registers a compaction function on the builder. `session.compact()` runs it:
1. Calls the function with current history
2. Identifies removed messages (filters synthetic `compaction_` IDs)
3. Stores an overlay via `addCompaction(summary, fromId, toId)`
4. Refreshes the system prompt
5. Returns count of removed messages

Iterative compaction: new overlays at the same `fromId` supersede older ones. Uses `getCompactions()[0].fromMessageId` as the range start so each compaction incorporates previous summaries.

`createCompactFunction()` is the reference implementation — configurable head/tail protection with LLM summarization of the middle.

---

## AgentSessionProvider (`providers/agent.ts`)

SQLite-backed tree-structured messages:

- **`content` column** — matches Think's existing schema (no migration)
- **`session_id` scoping** — every query filters by `session_id`, including CTE recursive steps (prevents cross-session traversal)
- **FTS5** — porter stemmer, delete-by-rowid (FTS5 doesn't support `DELETE WHERE id = ?`), delete-before-insert to avoid duplicates
- **Compaction overlays** — applied at read time in `getHistory()`, originals stay in DB
- **`assistant_config` table** — reserved for SessionManager (#1167) and Think (#1169)
- `SqlProvider` defined once in `agent.ts`, imported by `agent-context.ts`

---

## Design decisions

| Decision | Rationale |
|----------|-----------|
| `initialContent` naming | Not `defaultContent` or `content` — makes clear it's a seed value, not the current value |
| `ContextProvider.set` optional | Enables read-only providers (e.g., R2 get-only, KV get-only) |
| `SessionContextOptions = Omit<ContextConfig, "label">` | Single source of truth — builder type derived from config type |
| CTE recursive step filters `session_id` | Prevents cross-session message traversal (Bonk review feedback) |
| FTS5 delete-by-rowid | FTS5 virtual tables don't support `DELETE WHERE id = ?` |
| `needsCompaction()` uses `getHistory().length` | Post-compaction count, not raw path length |
| No changeset | Experimental API under `agents/experimental/` |
| Tool label is an enum | Prevents LLM from hallucinating block names |

---

## Stack
1. **this PR** ← `main`
2. #1167 SessionManager + multi-session example ← this
3. #1169 Think integration ← 2

## Test plan
- 20+ unit tests: context blocks, frozen prompt, tools, builder API, namespacing, chain order independence, initialContent paths
- 13 provider tests: tree structure, branching, compaction overlays, iterative compaction, FTS search, persistence
- `npm run check` passes (0 new errors)
