### PR TITLE
feat(think): integrate agents Session API

### DIFF
--- a/.changeset/session-api-think.md
+++ b/.changeset/session-api-think.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Replace internal SessionManager with shared agents Session API. getSystemPrompt() is now async. Adds chainable builder API for context block configuration.

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -153,7 +153,7 @@ export class ChatSession extends Think<Env, AgentConfig> {
     });
   }
 
-  override getSystemPrompt(): string {
+  override async getSystemPrompt(): Promise<string> {
     const config = this.getConfig();
     if (config?.systemPrompt) return config.systemPrompt;
 

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -29,7 +29,7 @@ export class TestAssistant extends Think<Env> {
     );
   }
 
-  getSystemPrompt(): string {
+  async getSystemPrompt(): Promise<string> {
     return `You are a helpful assistant with access to a workspace filesystem.
 You can read, write, edit, find, grep, and delete files.
 When asked to write a file, use the write tool. When asked to read a file, use the read tool.

--- a/packages/think/src/session/index.ts
+++ b/packages/think/src/session/index.ts
@@ -1,36 +1,26 @@
 /**
- * SessionManager — persistent conversation state with branching and compaction.
- *
- * Provides:
- *   - Multiple named sessions (conversations)
- *   - Tree-structured messages (parent_id for branching)
- *   - History retrieval following a branch path
- *   - Compaction (summarize old messages to save context)
- *   - Compatible with AI SDK's UIMessage type
- *
- * Usage:
- *   const sessions = new SessionManager(agent);
- *   const session = sessions.create("my-chat");
- *   sessions.append(session.id, { id: "msg1", role: "user", parts: [...] });
- *   const history = sessions.getHistory(session.id); // UIMessage[]
+ * Think SessionManager — re-exports from agents Session API
+ * with Think-specific truncation utilities.
  */
-import type { UIMessage } from "ai";
-import { SessionStorage } from "./storage";
-import type { Session, Compaction } from "./storage";
 
-export type { Session, Compaction } from "./storage";
+export {
+  SessionManager,
+  type SessionInfo,
+  type SessionManagerOptions
+} from "agents/experimental/memory/session";
 
-// ── Truncation utilities ──────────────────────────────────────────
+// Keep backward compat
+export type { SessionInfo as Session } from "agents/experimental/memory/session";
+export type { StoredCompaction as Compaction } from "agents/experimental/memory/session";
+
+// ── Truncation utilities ─────────────────────────────────────────
 
 const DEFAULT_MAX_CHARS = 30_000;
 const ELLIPSIS = "\n\n... [truncated] ...\n\n";
 
-/**
- * Truncate from the head (keep the end of the content).
- */
 export function truncateHead(
   text: string,
-  maxChars: number = DEFAULT_MAX_CHARS
+  maxChars = DEFAULT_MAX_CHARS
 ): string {
   if (text.length <= maxChars) return text;
   const keep = maxChars - ELLIPSIS.length;
@@ -38,12 +28,9 @@ export function truncateHead(
   return ELLIPSIS + text.slice(-keep);
 }
 
-/**
- * Truncate from the tail (keep the start of the content).
- */
 export function truncateTail(
   text: string,
-  maxChars: number = DEFAULT_MAX_CHARS
+  maxChars = DEFAULT_MAX_CHARS
 ): string {
   if (text.length <= maxChars) return text;
   const keep = maxChars - ELLIPSIS.length;
@@ -51,23 +38,16 @@ export function truncateTail(
   return text.slice(0, keep) + ELLIPSIS;
 }
 
-/**
- * Truncate by line count (keep the first N lines).
- */
-export function truncateLines(text: string, maxLines: number = 200): string {
+export function truncateLines(text: string, maxLines = 200): string {
   const lines = text.split("\n");
   if (lines.length <= maxLines) return text;
   const kept = lines.slice(0, maxLines).join("\n");
-  const omitted = lines.length - maxLines;
-  return kept + `\n\n... [${omitted} more lines truncated] ...`;
+  return kept + `\n\n... [${lines.length - maxLines} more lines truncated] ...`;
 }
 
-/**
- * Truncate from both ends, keeping the start and end.
- */
 export function truncateMiddle(
   text: string,
-  maxChars: number = DEFAULT_MAX_CHARS
+  maxChars = DEFAULT_MAX_CHARS
 ): string {
   if (text.length <= maxChars) return text;
   const halfKeep = Math.floor((maxChars - ELLIPSIS.length) / 2);
@@ -75,9 +55,6 @@ export function truncateMiddle(
   return text.slice(0, halfKeep) + ELLIPSIS + text.slice(-halfKeep);
 }
 
-/**
- * Smart truncation for tool output.
- */
 export function truncateToolOutput(
   output: string,
   options: {
@@ -91,9 +68,7 @@ export function truncateToolOutput(
     maxLines = 500,
     strategy = "tail"
   } = options;
-
   let result = truncateLines(output, maxLines);
-
   if (result.length > maxChars) {
     switch (strategy) {
       case "head":
@@ -102,315 +77,10 @@ export function truncateToolOutput(
       case "middle":
         result = truncateMiddle(result, maxChars);
         break;
-      case "tail":
       default:
         result = truncateTail(result, maxChars);
         break;
     }
   }
-
   return result;
-}
-
-// Mirrors Agent.sql — kept structural to avoid importing the 4k-line Agent class.
-interface AgentLike {
-  sql: (
-    strings: TemplateStringsArray,
-    ...values: (string | number | boolean | null)[]
-  ) => Array<Record<string, unknown>>;
-}
-
-export interface SessionManagerOptions {
-  /**
-   * Maximum number of messages on the current branch before
-   * needsCompaction() returns true. Default: 100.
-   */
-  maxContextMessages?: number;
-
-  /**
-   * Raw SQL exec function for batch operations (e.g. DELETE ... WHERE id IN (...)).
-   * When provided, batch deletes use a single query instead of N individual ones.
-   *
-   * Typically: `(query, ...values) => { agent.ctx.storage.sql.exec(query, ...values); }`
-   */
-  exec?: (
-    query: string,
-    ...values: (string | number | boolean | null)[]
-  ) => void;
-}
-
-export class SessionManager {
-  private _storage: SessionStorage;
-  private _options: SessionManagerOptions;
-
-  constructor(agent: AgentLike, options: SessionManagerOptions = {}) {
-    this._storage = new SessionStorage(agent.sql.bind(agent), options.exec);
-    this._options = {
-      maxContextMessages: 100,
-      ...options
-    };
-  }
-
-  // ── Session lifecycle ──────────────────────────────────────────
-
-  /**
-   * Create a new session with a name.
-   */
-  create(name: string): Session {
-    return this._storage.createSession(crypto.randomUUID(), name);
-  }
-
-  /**
-   * Get a session by ID.
-   */
-  get(sessionId: string): Session | null {
-    return this._storage.getSession(sessionId);
-  }
-
-  /**
-   * List all sessions, most recently updated first.
-   */
-  list(): Session[] {
-    return this._storage.listSessions();
-  }
-
-  /**
-   * Delete a session and all its messages and compactions.
-   */
-  delete(sessionId: string): void {
-    this._storage.deleteSession(sessionId);
-  }
-
-  /**
-   * Clear all messages and compactions for a session without
-   * deleting the session itself.
-   */
-  clearMessages(sessionId: string): void {
-    this._storage.clearSessionMessages(sessionId);
-  }
-
-  /**
-   * Rename a session.
-   */
-  rename(sessionId: string, name: string): void {
-    this._storage.renameSession(sessionId, name);
-  }
-
-  // ── Messages ───────────────────────────────────────────────────
-
-  /**
-   * Append a message to a session. If parentId is not provided,
-   * the message is appended after the latest leaf.
-   *
-   * Idempotent — appending the same message.id twice is a no-op.
-   *
-   * Returns the stored message ID.
-   */
-  append(sessionId: string, message: UIMessage, parentId?: string): string {
-    const resolvedParent =
-      parentId ?? this._storage.getLatestLeaf(sessionId)?.id ?? null;
-
-    const id = message.id || crypto.randomUUID();
-    this._storage.appendMessage(id, sessionId, resolvedParent, message);
-    return id;
-  }
-
-  /**
-   * Insert or update a message. First call inserts, subsequent calls
-   * update the content. Enables incremental persistence.
-   *
-   * Idempotent on insert, content-updating on subsequent calls.
-   */
-  upsert(sessionId: string, message: UIMessage, parentId?: string): string {
-    const resolvedParent =
-      parentId ?? this._storage.getLatestLeaf(sessionId)?.id ?? null;
-    const id = message.id || crypto.randomUUID();
-    this._storage.upsertMessage(id, sessionId, resolvedParent, message);
-    return id;
-  }
-
-  /**
-   * Delete a single message by ID.
-   * Children of the deleted message naturally become path roots
-   * (their parent_id points to a missing row, truncating the CTE walk).
-   */
-  deleteMessage(messageId: string): void {
-    this._storage.deleteMessage(messageId);
-  }
-
-  /**
-   * Delete multiple messages by ID.
-   */
-  deleteMessages(messageIds: string[]): void {
-    this._storage.deleteMessages(messageIds);
-  }
-
-  /**
-   * Append multiple messages in sequence (each parented to the previous).
-   * Returns the ID of the last appended message.
-   */
-  appendAll(
-    sessionId: string,
-    messages: UIMessage[],
-    parentId?: string
-  ): string | null {
-    let lastId = parentId ?? null;
-    for (const msg of messages) {
-      const resolvedParent =
-        lastId ?? this._storage.getLatestLeaf(sessionId)?.id ?? null;
-      const id = msg.id || crypto.randomUUID();
-      this._storage.appendMessage(id, sessionId, resolvedParent, msg);
-      lastId = id;
-    }
-    return lastId;
-  }
-
-  /**
-   * Get the conversation history for a session as UIMessage[].
-   *
-   * If leafId is provided, returns the path from root to that leaf
-   * (a specific branch). Otherwise returns the path to the most
-   * recent leaf (the "current" branch).
-   *
-   * If compactions exist, older messages covered by a compaction
-   * are replaced with a system message containing the summary.
-   */
-  getHistory(sessionId: string, leafId?: string): UIMessage[] {
-    const leaf = leafId
-      ? this._storage.getMessage(leafId)
-      : this._storage.getLatestLeaf(sessionId);
-
-    if (!leaf) return [];
-
-    const storedPath = this._storage.getMessagePath(leaf.id);
-    const compactions = this._storage.getCompactions(sessionId);
-
-    if (compactions.length === 0) {
-      return storedPath.map((m) => this._storage.parseMessage(m));
-    }
-
-    return this._applyCompactions(storedPath, compactions);
-  }
-
-  /**
-   * Get the total message count for a session (across all branches).
-   */
-  getMessageCount(sessionId: string): number {
-    return this._storage.getMessageCount(sessionId);
-  }
-
-  /**
-   * Check if the session's current branch needs compaction.
-   * Uses a count-only query — does not load message content.
-   */
-  needsCompaction(sessionId: string): boolean {
-    const leaf = this._storage.getLatestLeaf(sessionId);
-    if (!leaf) return false;
-    const pathLen = this._storage.getPathLength(leaf.id);
-    return pathLen > (this._options.maxContextMessages ?? 100);
-  }
-
-  // ── Branching ──────────────────────────────────────────────────
-
-  /**
-   * Get the children of a message (branches from that point).
-   */
-  getBranches(messageId: string): UIMessage[] {
-    const children = this._storage.getChildren(messageId);
-    return children.map((m) => this._storage.parseMessage(m));
-  }
-
-  /**
-   * Fork a session at a specific message, creating a new session
-   * with the history up to that point copied over.
-   */
-  fork(atMessageId: string, newName: string): Session {
-    const newSession = this.create(newName);
-    const path = this._storage.getMessagePath(atMessageId);
-
-    let parentId: string | null = null;
-    for (const stored of path) {
-      const msg = this._storage.parseMessage(stored);
-      const newId = crypto.randomUUID();
-      this._storage.appendMessage(newId, newSession.id, parentId, msg);
-      parentId = newId;
-    }
-
-    return newSession;
-  }
-
-  // ── Compaction ─────────────────────────────────────────────────
-
-  /**
-   * Add a compaction record. The summary replaces messages from
-   * fromMessageId to toMessageId in context assembly.
-   *
-   * Typically called after using an LLM to summarize older messages.
-   */
-  addCompaction(
-    sessionId: string,
-    summary: string,
-    fromMessageId: string,
-    toMessageId: string
-  ): Compaction {
-    return this._storage.addCompaction(
-      crypto.randomUUID(),
-      sessionId,
-      summary,
-      fromMessageId,
-      toMessageId
-    );
-  }
-
-  /**
-   * Get all compaction records for a session.
-   */
-  getCompactions(sessionId: string): Compaction[] {
-    return this._storage.getCompactions(sessionId);
-  }
-
-  // ── Internal ───────────────────────────────────────────────────
-
-  private _applyCompactions(
-    path: Array<{ id: string; content: string }>,
-    compactions: Compaction[]
-  ): UIMessage[] {
-    const pathIds = path.map((m) => m.id);
-    const result: UIMessage[] = [];
-    let i = 0;
-
-    while (i < path.length) {
-      // Check if any compaction starts at this message
-      const compaction = compactions.find(
-        (c) => c.from_message_id === pathIds[i]
-      );
-
-      if (compaction) {
-        // Only apply if the compaction's end is also on this path
-        const endIdx = pathIds.indexOf(compaction.to_message_id);
-        if (endIdx >= i) {
-          result.push({
-            id: `compaction_${compaction.id}`,
-            role: "system",
-            parts: [
-              {
-                type: "text",
-                text: `[Previous conversation summary]\n${compaction.summary}`
-              }
-            ]
-          });
-          i = endIdx + 1;
-        } else {
-          // Compaction doesn't span this path — skip it, emit message as-is
-          result.push(JSON.parse(path[i].content) as UIMessage);
-          i++;
-        }
-      } else {
-        result.push(JSON.parse(path[i].content) as UIMessage);
-        i++;
-      }
-    }
-
-    return result;
-  }
 }

--- a/packages/think/src/tests/agents/assistant-agent-loop.ts
+++ b/packages/think/src/tests/agents/assistant-agent-loop.ts
@@ -157,7 +157,7 @@ export class LoopTestAgent extends Think {
     return createMockModel();
   }
 
-  getSystemPrompt(): string {
+  async getSystemPrompt(): Promise<string> {
     return "You are a test assistant.";
   }
 
@@ -193,7 +193,7 @@ export class LoopToolTestAgent extends Think {
     return createMockToolModel();
   }
 
-  getSystemPrompt(): string {
+  async getSystemPrompt(): Promise<string> {
     return "You are a test assistant with tools.";
   }
 

--- a/packages/think/src/tests/agents/assistant-session.ts
+++ b/packages/think/src/tests/agents/assistant-session.ts
@@ -4,7 +4,7 @@ import { SessionManager } from "../../session/index";
 import type { Session, Compaction } from "../../session/index";
 
 export class TestAssistantSessionAgent extends Agent {
-  private _sessions = new SessionManager(this);
+  private _sessions = SessionManager.create(this);
 
   // ── Session lifecycle ──────────────────────────────────────────
 
@@ -59,16 +59,19 @@ export class TestAssistantSessionAgent extends Agent {
 
   // ── Branching ──────────────────────────────────────────────────
 
-  async getBranches(messageId: string): Promise<UIMessage[]> {
-    return this._sessions.getBranches(messageId);
+  async getBranches(
+    sessionId: string,
+    messageId: string
+  ): Promise<UIMessage[]> {
+    return this._sessions.getSession(sessionId).getBranches(messageId);
   }
 
   async forkSession(
-    _sessionId: string,
+    sessionId: string,
     atMessageId: string,
     newName: string
   ): Promise<Session> {
-    return this._sessions.fork(atMessageId, newName);
+    return this._sessions.fork(sessionId, atMessageId, newName);
   }
 
   // ── Compaction ─────────────────────────────────────────────────

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -276,8 +276,8 @@ export class ThinkTestAgent extends Think {
     return createMockModel(this._response);
   }
 
-  async setMaxPersistedMessages(max: number | null): Promise<void> {
-    this.maxPersistedMessages = max ?? undefined;
+  async setMaxPersistedMessages(_max: number | null): Promise<void> {
+    // maxPersistedMessages was removed — storage bounds handled by compaction
   }
 
   async getChatErrorLog(): Promise<string[]> {

--- a/packages/think/src/tests/assistant-agent.test.ts
+++ b/packages/think/src/tests/assistant-agent.test.ts
@@ -406,7 +406,7 @@ describe("AssistantAgent — streaming flow", () => {
     // Session should now exist
     sessions = (await agent.getSessions()) as unknown as Session[];
     expect(sessions.length).toBe(1);
-    expect(sessions[0].name).toBe("New Chat");
+    expect(sessions[0].name).toBe("hello");
 
     // Current session should be set
     const currentId = (await agent.getCurrentSessionId()) as unknown as string;

--- a/packages/think/src/tests/assistant-session.test.ts
+++ b/packages/think/src/tests/assistant-session.test.ts
@@ -252,6 +252,7 @@ describe("session — branching", () => {
     );
 
     const branches = (await agent.getBranches(
+      session.id,
       rootId
     )) as unknown as UIMessage[];
     expect(branches.length).toBe(2);
@@ -323,8 +324,8 @@ describe("session — compaction", () => {
     )) as unknown as UIMessage[];
     // Should be: 1 compaction summary + 2 remaining messages = 3
     expect(history.length).toBe(3);
-    // First should be the compaction summary (system role)
-    expect(history[0].role).toBe("system");
+    // First should be the compaction summary
+    expect(history[0].role).toBe("assistant");
     expect(history[0].parts[0]).toMatchObject({
       type: "text",
       text: expect.stringContaining("Previous conversation summary")

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -337,17 +337,11 @@ describe("Think — maxPersistedMessages", () => {
     count = await agent.getMessageCount();
     expect(count).toBe(4);
 
-    // Third turn: would be 6, but should be trimmed to 4
+    // Third turn: 6 messages total — setMaxPersistedMessages is a no-op
+    // (non-destructive compaction via overlays replaces message pruning)
     await agent.testChat("Turn 3");
     count = await agent.getMessageCount();
-    expect(count).toBe(4);
-
-    // Verify the oldest messages were removed
-    const history = await agent.getHistory();
-    expect(history).toHaveLength(4);
-    // Should have turns 2 and 3 (turn 1 should be gone)
-    const roles = (history as Array<{ role: string }>).map((m) => m.role);
-    expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(count).toBe(6);
   });
 
   it("should not enforce bounds when maxPersistedMessages is null", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -29,7 +29,7 @@
  *   - Error handling with partial message persistence
  *   - Message sanitization (strips OpenAI ephemeral metadata)
  *   - Row size enforcement (compacts large tool outputs)
- *   - Configurable storage bounds (maxPersistedMessages)
+ *   - Context blocks for persistent memory (getContextBlocks)
  *   - Incremental persistence (skips unchanged messages)
  *   - Richer input (accepts UIMessage or string)
  *
@@ -57,12 +57,7 @@
  */
 
 import type { LanguageModel, ModelMessage, ToolSet, UIMessage } from "ai";
-import {
-  convertToModelMessages,
-  pruneMessages,
-  stepCountIs,
-  streamText
-} from "ai";
+import { convertToModelMessages, stepCountIs, streamText } from "ai";
 import {
   Agent,
   __DO_NOT_USE_WILL_BREAK__agentContext as agentContext
@@ -72,7 +67,11 @@ import type { Workspace } from "@cloudflare/shell";
 import { withFibers } from "agents/experimental/forever";
 import type { FiberMethods } from "agents/experimental/forever";
 import { SessionManager } from "./session/index";
-import type { Session } from "./session/index";
+import type { SessionInfo } from "./session/index";
+import { AgentContextProvider } from "agents/experimental/memory/session";
+import type { ContextConfig } from "agents/experimental/memory/session";
+import { truncateOlderMessages } from "agents/experimental/memory/utils";
+type Session = SessionInfo;
 import { applyChunkToParts } from "./message-builder";
 import type { StreamChunkData } from "./message-builder";
 import { sanitizeMessage, enforceRowSizeLimit } from "./sanitize";
@@ -193,23 +192,13 @@ export class Think<
   fibers = false;
 
   /**
-   * Maximum number of messages to keep in storage per session.
-   * When exceeded, oldest messages are deleted after each persist.
-   * Set to `undefined` (default) for no limit.
-   *
-   * This controls storage only — it does not affect what's sent to the LLM.
-   * Use `pruneMessages()` in `assembleContext()` to control LLM context.
-   */
-  maxPersistedMessages: number | undefined = undefined;
-
-  /**
    * Cache of last-persisted JSON for each message ID.
    * Used for incremental persistence: skip SQL writes for unchanged messages.
    * @internal
    */
   private _persistedMessageCache: Map<string, string> = new Map();
 
-  private _sessionId: string | null = null;
+  protected _sessionId: string | null = null;
   private _abortControllers = new Map<string, AbortController>();
   private _clearGeneration = 0;
 
@@ -258,11 +247,23 @@ export class Think<
   }
 
   onStart() {
-    this.sessions = new SessionManager(this, {
-      exec: (query, ...values) => {
-        this.ctx.storage.sql.exec(query, ...values);
-      }
-    });
+    // Wire context blocks — use shared (non-namespaced) providers so
+    // memory persists across session splits during compaction
+    const blockDefs = this.getContextBlocks();
+    const mgr = SessionManager.create(this);
+    for (const def of blockDefs) {
+      mgr.withContext(def.label, {
+        description: def.description,
+        initialContent: def.initialContent,
+        maxTokens: def.maxTokens,
+        readonly: def.readonly,
+        provider: def.readonly
+          ? undefined
+          : new AgentContextProvider(this, def.label)
+      });
+    }
+    this.sessions = mgr;
+
     const existing = this.sessions.list();
     if (existing.length > 0) {
       this._sessionId = existing[0].id;
@@ -291,15 +292,46 @@ export class Think<
 
   /**
    * Return the system prompt for the assistant.
-   * Override to customize instructions.
+   *
+   * Default: renders context blocks as the system prompt (frozen snapshot).
+   * If no context blocks are configured, returns a default prompt.
+   * Override for full control over the system prompt.
    */
-  getSystemPrompt(): string {
+  async getSystemPrompt(): Promise<string> {
+    // If we have a session with context blocks, use the frozen snapshot
+    if (this._sessionId) {
+      const session = this.sessions.getSession(this._sessionId);
+      const contextPrompt = await session.freezeSystemPrompt();
+      if (contextPrompt) return contextPrompt;
+    }
     return "You are a helpful assistant.";
+  }
+
+  /**
+   * Return context block definitions for persistent memory.
+   * Override to add blocks like memory, todos, user profile, etc.
+   * Blocks are stored in DO SQLite automatically.
+   *
+   * ```typescript
+   * getContextBlocks() {
+   *   return [
+   *     { label: "memory", description: "Learned facts", maxTokens: 1100 },
+   *     { label: "todos", description: "Task list", maxTokens: 2000 },
+   *     { label: "soul", initialContent: "You are helpful.", readonly: true },
+   *   ];
+   * }
+   * ```
+   */
+  getContextBlocks(): Omit<ContextConfig, "provider">[] {
+    return [];
   }
 
   /**
    * Return the tools available to the assistant.
    * Override to provide workspace tools, custom tools, etc.
+   *
+   * Context block tools (update_context) are merged in automatically
+   * if getContextBlocks() returns any writable blocks.
    */
   getTools(): ToolSet {
     return {};
@@ -354,14 +386,41 @@ export class Think<
 
   /**
    * Assemble the model messages from the current conversation history.
-   * Override to customize context assembly (e.g. inject memory,
-   * project context, or apply compaction).
+   *
+   * Checks if compaction is needed and runs onCompact() if so.
+   * Then reloads history (which applies compaction overlays)
+   * and converts to model format.
+   *
+   * Override to customize context assembly.
    */
   async assembleContext(): Promise<ModelMessage[]> {
-    return pruneMessages({
-      messages: await convertToModelMessages(this.messages),
-      toolCalls: "before-last-2-messages"
-    });
+    if (this._sessionId && this.sessions.needsCompaction(this._sessionId)) {
+      await this.onCompact();
+      this.messages = this.sessions.getHistory(this._sessionId);
+    }
+
+    // Truncate older tool outputs at read time (stored messages stay intact)
+    const truncated = truncateOlderMessages(this.messages);
+    return convertToModelMessages(truncated);
+  }
+
+  /**
+   * Called when the conversation exceeds maxContextMessages.
+   *
+   * Default: no-op (compaction is opt-in).
+   * Override to generate a summary and split the session:
+   *
+   * ```typescript
+   * async onCompact() {
+   *   const history = this.sessions.getHistory(this._sessionId!);
+   *   const summary = await generateText({ model: this.getModel(), prompt: buildSummaryPrompt(history) });
+   *   const newSession = this.sessions.compactAndSplit(this._sessionId!, summary.text);
+   *   this._sessionId = newSession.id;
+   * }
+   * ```
+   */
+  async onCompact(): Promise<void> {
+    // No-op by default — override to implement
   }
 
   /**
@@ -382,12 +441,15 @@ export class Think<
    */
   async onChatMessage(options?: ChatMessageOptions): Promise<StreamableResult> {
     const baseTools = this.getTools();
-    const tools = options?.tools
-      ? { ...baseTools, ...options.tools }
-      : baseTools;
+    // Merge context block tools (update_context) if configured
+    const contextTools = this._sessionId
+      ? await this.sessions.getSession(this._sessionId).tools()
+      : {};
+    const tools = { ...baseTools, ...contextTools, ...options?.tools };
+
     return streamText({
       model: this.getModel(),
-      system: this.getSystemPrompt(),
+      system: await this.getSystemPrompt(),
       messages: await this.assembleContext(),
       tools,
       stopWhen: stepCountIs(this.getMaxSteps()),
@@ -688,10 +750,14 @@ export class Think<
     const incomingMessages = parsed.messages;
     if (!Array.isArray(incomingMessages)) return;
 
-    // Ensure a session exists
+    // Ensure a session exists — title from first user message
     if (!this._sessionId) {
-      const session = this.sessions.create("New Chat");
-      this._sessionId = session.id;
+      const firstUserMsg = incomingMessages.find((m) => m.role === "user");
+      const title = firstUserMsg
+        ? this._titleFromMessage(firstUserMsg)
+        : "New Chat";
+      const created = this.sessions.create(title);
+      this._sessionId = created.id;
     }
 
     // Persist incoming messages to session (idempotent via INSERT OR IGNORE)
@@ -816,7 +882,26 @@ export class Think<
               }
               break;
             }
-            case "finish":
+            case "finish": {
+              if (data.messageMetadata != null) {
+                message.metadata = message.metadata
+                  ? { ...message.metadata, ...data.messageMetadata }
+                  : data.messageMetadata;
+              }
+              // Track usage
+              const usage = (data as Record<string, unknown>).usage as
+                | { promptTokens?: number; completionTokens?: number }
+                | undefined;
+              if (usage && this._sessionId) {
+                this.sessions.addUsage(
+                  this._sessionId,
+                  usage.promptTokens ?? 0,
+                  usage.completionTokens ?? 0,
+                  0 // cost not available from stream
+                );
+              }
+              break;
+            }
             case "message-metadata": {
               if (data.messageMetadata != null) {
                 message.metadata = message.metadata
@@ -915,11 +1000,6 @@ export class Think<
       this._persistedMessageCache.set(safe.id, json);
     }
 
-    // Enforce storage bounds
-    if (this.maxPersistedMessages != null) {
-      this._enforceMaxPersistedMessages();
-    }
-
     this.messages = this.sessions.getHistory(this._sessionId);
   }
 
@@ -936,26 +1016,15 @@ export class Think<
   }
 
   /**
-   * Delete oldest messages on the current branch when count exceeds
-   * maxPersistedMessages. Uses path-based count (not total across all
-   * branches) and individual deletes to preserve branch structure.
+   * Generate a session title from the first user message.
    * @internal
    */
-  private _enforceMaxPersistedMessages(): void {
-    if (this.maxPersistedMessages == null || !this._sessionId) return;
-
-    // Use current branch history, not total message count across all branches
-    const history = this.sessions.getHistory(this._sessionId);
-    if (history.length <= this.maxPersistedMessages) return;
-
-    const excess = history.length - this.maxPersistedMessages;
-    const toRemove = history.slice(0, excess);
-
-    // Delete individual messages — preserves branch structure
-    this.sessions.deleteMessages(toRemove.map((m) => m.id));
-    for (const msg of toRemove) {
-      this._persistedMessageCache.delete(msg.id);
-    }
+  private _titleFromMessage(msg: UIMessage): string {
+    const text = msg.parts
+      .filter((p) => p.type === "text")
+      .map((p) => (p as { text: string }).text)
+      .join(" ");
+    return text.slice(0, 60) || "New Chat";
   }
 
   /**


### PR DESCRIPTION
## Summary

Replace Think's internal SessionManager with the shared one from agents/experimental/memory/session.

### Changes
- `session/index.ts` — now re-exports from agents + truncation utilities (removed 366-line `storage.ts`)
- `getSystemPrompt()` — now async to support `freezeSystemPrompt()`
- `_sessionId` — `protected` so `onCompact()` overrides can access it
- `onStart()` — uses `SessionManager.create(this).withContext(...)` builder
- Context blocks use shared (non-namespaced) providers so memory persists across session splits
- `maxPersistedMessages` removed — use `onCompact()` for storage bounds
- Test agent updated for new `fork()`, `getBranches()` signatures

### Not breaking for existing Think DOs
Column is `content` (preserved from Think's existing schema). No migration needed.

### Notes for reviewers
- Think's `getContextBlocks()` returns `Omit<ContextConfig, "provider">[]` — builder creates `AgentContextProvider` for writable blocks
- `onCompact()` is a no-op by default (opt-in) — `assembleContext()` calls it when `needsCompaction()` returns true
- Patch changeset included for `@cloudflare/think`

## Stack
1. #1166 Session API core ← `main`
2. #1167 SessionManager + multi-session example ← 1
3. **this PR** ← 2

## Test plan
- Think tests pass (pre-existing `@cloudflare/shell` failures on main unrelated)
- Both `agents` and `think` packages build successfully