### PR TITLE
Workspace: accept SqlStorage, D1, or custom SqlBackend via options object

### DIFF
--- a/.changeset/workspace-sql-backend.md
+++ b/.changeset/workspace-sql-backend.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/shell": minor
+---
+
+Replace tagged-template SQL host interface with a plain `SqlBackend` interface. Workspace now accepts `SqlStorage`, `D1Database`, or any custom `{ query, run }` backend via a single options object. This makes Workspace usable from any Durable Object or D1 database, not just Agents.

--- a/design/workspace.md
+++ b/design/workspace.md
@@ -44,7 +44,7 @@ Files below the inline threshold (default 1.5 MB) store content directly in the 
 
 ### Namespace isolation
 
-Multiple `Workspace` instances can coexist on one Agent by using different `namespace` values. Each namespace gets its own table. A `WeakMap<WorkspaceHost, Set<string>>` registry prevents accidental duplicate registration on the same agent.
+Multiple `Workspace` instances can coexist on one Agent by using different `namespace` values. Each namespace gets its own table. A `WeakMap<SqlSource, Set<string>>` registry prevents accidental duplicate registration on the same SQL source.
 
 Namespace names must match `^[a-zA-Z][a-zA-Z0-9_]*$` — they are interpolated into SQL table names at construction time (not as query parameters), so the strict validation is a security boundary.
 
@@ -113,7 +113,7 @@ The API surface is large: files, directories, symlinks, glob, diff, streaming, c
 
 ### Why per-instance Workspace instead of a mixin on Agent?
 
-Agents may need multiple workspaces with different configurations — different namespaces, different R2 buckets, different execution settings. Composition (`new Workspace(this, opts)`) is more flexible than inheritance. The `WorkspaceHost` interface is minimal (`sql` + optional `name`), so it could work with non-Agent hosts in the future.
+Agents may need multiple workspaces with different configurations — different namespaces, different R2 buckets, different execution settings. Composition (`new Workspace({ sql, ...opts })`) is more flexible than inheritance. The `SqlBackend` interface is minimal (`query` + `run`), and the constructor auto-detects `SqlStorage` (DO) and `D1Database` directly, so Workspace works with any SQL source — not just Agents.
 
 ### Why symlinks?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@
 - [Chat Agents](./chat-agents.md) - `AIChatAgent` class and `useAgentChat` React hook
 - TODO: [Using AI Models](./using-ai-models.md) - OpenAI, Anthropic, Workers AI, and other providers
 - TODO: [RAG (Retrieval Augmented Generation)](./rag.md) - Vector search with Vectorize
+- [Workspace (Experimental)](./workspace.md) - Durable virtual filesystem backed by SQLite + R2
 - [Codemode (Experimental)](./codemode.md) - LLM-generated executable code for tool orchestration
 - [Client Tools Continuation](./client-tools-continuation.md) - Handling tool calls across client/server
 - [Resumable Streaming](./resumable-streaming.md) - Automatic stream resumption on disconnect

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,0 +1,325 @@
+# Workspace
+
+Workspace provides a durable virtual filesystem backed by SQLite and optional R2 large-file storage. It works with any Durable Object that has SQLite storage, D1 databases, or custom SQL backends.
+
+> **Experimental** — this feature may have breaking changes in future releases.
+
+## Installation
+
+```sh
+npm install @cloudflare/shell
+```
+
+## Quick start
+
+```typescript
+import { Agent } from "agents";
+import { Workspace } from "@cloudflare/shell";
+
+class MyAgent extends Agent<Env> {
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+  });
+
+  async onMessage(conn, msg) {
+    await this.workspace.writeFile("/hello.txt", "world");
+    const content = await this.workspace.readFile("/hello.txt");
+    conn.send(content); // "world"
+  }
+}
+```
+
+## SQL backends
+
+Workspace accepts any SQL source via the `sql` option. The constructor auto-detects which type you pass.
+
+### Durable Object SQLite (SqlStorage)
+
+Any Durable Object with SQLite storage — not just Agents:
+
+```typescript
+// Inside any Durable Object
+const workspace = new Workspace({ sql: ctx.storage.sql });
+```
+
+### D1
+
+```typescript
+// Using a D1 database binding
+const workspace = new Workspace({ sql: env.MY_DB });
+```
+
+### Custom backend
+
+Implement the `SqlBackend` interface for any other SQL source:
+
+```typescript
+import type { SqlBackend } from "@cloudflare/shell";
+
+const backend: SqlBackend = {
+  query(sql, ...params) {
+    // Return rows as an array of objects
+    return myDb.execute(sql, params);
+  },
+  run(sql, ...params) {
+    // Execute without returning rows
+    myDb.execute(sql, params);
+  }
+};
+
+const workspace = new Workspace({ sql: backend });
+```
+
+`query` and `run` may return synchronously or return a Promise — Workspace handles both.
+
+## Constructor options
+
+All options are passed as a single object to `new Workspace(options)`.
+
+| Option            | Type                                     | Default      | Description                                      |
+| ----------------- | ---------------------------------------- | ------------ | ------------------------------------------------ |
+| `sql`             | `SqlStorage \| D1Database \| SqlBackend` | **required** | SQL backend for file metadata and inline content |
+| `namespace`       | `string`                                 | `"default"`  | Table namespace for isolation                    |
+| `r2`              | `R2Bucket`                               | `null`       | R2 bucket for large files                        |
+| `r2Prefix`        | `string`                                 | `name`       | Key prefix for R2 objects                        |
+| `inlineThreshold` | `number`                                 | `1_500_000`  | Byte size above which files spill to R2          |
+| `name`            | `string \| () => string \| undefined`    | `undefined`  | Name for R2 prefix fallback and observability    |
+| `onChange`        | `(event: WorkspaceChangeEvent) => void`  | `undefined`  | Callback fired on create, update, and delete     |
+
+### Lazy name resolution
+
+In Durable Objects, `this.name` is not available at class field initialization time. Pass a function to defer evaluation:
+
+```typescript
+class MyAgent extends Agent<Env> {
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name // evaluated when needed, not at construction
+  });
+}
+```
+
+## File operations
+
+### Read and write
+
+```typescript
+await workspace.writeFile(
+  "/config.json",
+  '{"debug": true}',
+  "application/json"
+);
+const content = await workspace.readFile("/config.json"); // string | null
+```
+
+`readFile` returns `null` for missing files. It throws `EISDIR` if the path is a directory.
+
+### Binary files
+
+```typescript
+await workspace.writeFileBytes("/image.png", pngBytes, "image/png");
+const bytes = await workspace.readFileBytes("/image.png"); // Uint8Array | null
+```
+
+### Streaming
+
+```typescript
+const stream = await workspace.readFileStream("/large.bin");
+await workspace.writeFileStream("/upload.bin", requestBody);
+```
+
+`writeFileStream` collects all chunks before deciding inline vs R2 storage. The maximum stream size is 100 MB.
+
+### Append
+
+```typescript
+await workspace.appendFile("/log.txt", "new line\n");
+```
+
+For inline UTF-8 files, this is an efficient SQL `UPDATE content = content || ?`. For R2-backed files, it reads, concatenates, and rewrites.
+
+### Delete
+
+```typescript
+const deleted = await workspace.deleteFile("/old.txt"); // true | false
+```
+
+Returns `false` for missing files. Throws `EISDIR` for directories — use `rm()` instead.
+
+## Directory operations
+
+```typescript
+await workspace.mkdir("/src/components", { recursive: true });
+
+const entries = await workspace.readDir("/src"); // FileInfo[]
+// Each entry: { path, name, type, mimeType, size, createdAt, updatedAt }
+
+const matches = await workspace.glob("/src/**/*.ts"); // FileInfo[]
+```
+
+### Remove
+
+```typescript
+await workspace.rm("/src", { recursive: true });
+await workspace.rm("/maybe-missing", { force: true }); // no error if absent
+```
+
+### Copy and move
+
+```typescript
+await workspace.cp("/src", "/backup", { recursive: true });
+await workspace.mv("/old.txt", "/new.txt");
+```
+
+## Stat and existence
+
+```typescript
+const stat = await workspace.stat("/file.txt"); // FileStat | null
+// { path, name, type, mimeType, size, createdAt, updatedAt }
+
+const exists = await workspace.exists("/file.txt"); // true for files and dirs
+const isFile = await workspace.fileExists("/file.txt"); // true only for files
+```
+
+`stat` follows symlinks. Use `lstat` to get the symlink entry itself.
+
+## Symlinks
+
+```typescript
+await workspace.symlink("/real.txt", "/link.txt");
+
+const target = await workspace.readlink("/link.txt"); // "/real.txt"
+const stat = await workspace.lstat("/link.txt"); // type: "symlink"
+```
+
+Reading or writing through a symlink follows the target chain (up to 40 levels). Both absolute and relative targets are supported.
+
+## Diff
+
+```typescript
+const diff = await workspace.diff("/a.txt", "/b.txt"); // unified diff string
+const diff2 = await workspace.diffContent("/file.txt", newContent); // compare against string
+```
+
+Returns an empty string when the inputs are identical. Files larger than 10,000 lines are rejected.
+
+## Workspace info
+
+```typescript
+const info = await workspace.getWorkspaceInfo();
+// { fileCount, directoryCount, totalBytes, r2FileCount }
+```
+
+## Namespace isolation
+
+Multiple Workspace instances can coexist on the same SQL source by using different namespaces. Each namespace gets its own table (`cf_workspace_<namespace>`):
+
+```typescript
+const code = new Workspace({ sql: ctx.storage.sql, namespace: "code" });
+const data = new Workspace({ sql: ctx.storage.sql, namespace: "data" });
+```
+
+Namespace names must start with a letter and contain only alphanumeric characters or underscores.
+
+## R2 large-file storage
+
+Files below the inline threshold (default 1.5 MB) are stored directly in SQLite. Larger files store metadata in SQLite and content in R2:
+
+```typescript
+const workspace = new Workspace({
+  sql: this.ctx.storage.sql,
+  r2: this.env.WORKSPACE_FILES,
+  name: () => this.name,
+  inlineThreshold: 2_000_000 // 2 MB
+});
+```
+
+R2 keys follow the pattern `{name}/{namespace}{path}`. If no `r2Prefix` is provided, `name` is used as the prefix.
+
+When a file exceeds the threshold but no R2 bucket is configured, the file is stored inline with a console warning.
+
+## Change events
+
+Pass an `onChange` callback to react to file changes in real time:
+
+```typescript
+const workspace = new Workspace({
+  sql: this.ctx.storage.sql,
+  onChange: (event) => {
+    // event: { type: "create" | "update" | "delete", path, entryType }
+    this.broadcast(JSON.stringify(event));
+  }
+});
+```
+
+## Observability
+
+Workspace publishes structured events to the `agents:workspace` diagnostics channel via `node:diagnostics_channel`. Events are emitted for reads, writes, deletes, mkdir, rm, cp, and mv. Each event includes the workspace name, namespace, and operation-specific payload.
+
+```typescript
+import { subscribe } from "node:diagnostics_channel";
+
+subscribe("agents:workspace", (message) => {
+  console.log(message);
+  // { type: "workspace:write", name: "my-agent", payload: { path, size, storage, namespace }, timestamp }
+});
+```
+
+The channel is only active when subscribers exist — zero overhead otherwise.
+
+## Using with codemode
+
+Workspace integrates with `@cloudflare/codemode` to give sandboxed code access to the filesystem via a `state` object. Use `stateTools()` from `@cloudflare/shell/workers`:
+
+```typescript
+import { Workspace } from "@cloudflare/shell";
+import { stateTools } from "@cloudflare/shell/workers";
+import { DynamicWorkerExecutor, resolveProvider } from "@cloudflare/codemode";
+
+class MyAgent extends Agent<Env> {
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+  });
+
+  async run(code: string) {
+    const executor = new DynamicWorkerExecutor({ loader: this.env.LOADER });
+    return executor.execute(code, [
+      resolveProvider(stateTools(this.workspace))
+    ]);
+  }
+}
+```
+
+Inside the sandbox, the `state` object exposes file operations, search/replace, JSON helpers, archive tools, and more. See [Codemode](./codemode.md) for details.
+
+## Types
+
+```typescript
+import type {
+  SqlBackend,
+  SqlSource,
+  SqlParam,
+  WorkspaceOptions,
+  EntryType, // "file" | "directory" | "symlink"
+  FileInfo, // { path, name, type, mimeType, size, createdAt, updatedAt, target? }
+  FileStat, // same as FileInfo
+  WorkspaceChangeEvent, // { type, path, entryType }
+  WorkspaceChangeType // "create" | "update" | "delete"
+} from "@cloudflare/shell";
+```
+
+## Path handling
+
+- Paths are normalized: leading `/` is added if missing, `..` and `.` segments are resolved, duplicate slashes are collapsed
+- Maximum path length is 4,096 characters
+- `writeFile` and `writeFileBytes` automatically create parent directories
+
+## Security considerations
+
+- **Path traversal** — `..` segments are resolved during normalization, preventing directory escape
+- **SQL injection** — table names derive from the namespace, which is validated against `^[a-zA-Z][a-zA-Z0-9_]*$`; all query parameters use parameterized queries
+- **Symlink loops** — resolution is capped at 40 levels, raising `ELOOP` on cycles
+- **Stream size** — `writeFileStream` rejects streams exceeding 100 MB
+- **Diff size** — `diff` and `diffContent` reject files exceeding 10,000 lines

--- a/examples/assistant/README.md
+++ b/examples/assistant/README.md
@@ -26,7 +26,7 @@ import { Workspace } from "@cloudflare/shell";
 
 // Sub-agent — dynamically configured per instance
 export class ChatSession extends Think<Env, AgentConfig> {
-  workspace = new Workspace(this);
+  workspace = new Workspace({ sql: this.ctx.storage.sql });
 
   getModel() {
     const config = this.getConfig();

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -140,7 +140,10 @@ type AgentRow = {
 
 export class ChatSession extends Think<Env, AgentConfig> {
   fibers = true;
-  workspace = new Workspace(this);
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+  });
 
   override getModel(): LanguageModel {
     const config = this.getConfig();
@@ -782,7 +785,10 @@ class OrchestratorBridge extends ToolBridge {
 
 export class MyAssistant extends FiberAgent<Env, AppState> {
   initialState: AppState = { agents: [] };
-  sharedWorkspace = new Workspace(this);
+  sharedWorkspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+  });
 
   #activeStreams = new Map<
     string,

--- a/experimental/worker-bundler-playground/src/server.ts
+++ b/experimental/worker-bundler-playground/src/server.ts
@@ -29,7 +29,10 @@ export interface AppState {
 }
 
 export class WorkerPlayground extends AIChatAgent<Env> {
-  workspace = new Workspace(this);
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+  });
   currentAppResult?: CreateAppResult;
   buildVersion = 0;
 

--- a/experimental/workspace-chat/README.md
+++ b/experimental/workspace-chat/README.md
@@ -26,7 +26,7 @@ import { stateTools } from "@cloudflare/shell/workers";
 import { DynamicWorkerExecutor, resolveProvider } from "@cloudflare/codemode";
 
 export class WorkspaceChatAgent extends AIChatAgent {
-  workspace = new Workspace(this, { namespace: "ws" });
+  workspace = new Workspace({ sql: this.ctx.storage.sql, namespace: "ws" });
 
   async onChatMessage(_onFinish, options) {
     return streamText({

--- a/experimental/workspace-chat/src/server.ts
+++ b/experimental/workspace-chat/src/server.ts
@@ -22,7 +22,11 @@ import { stateTools } from "@cloudflare/shell/workers";
  * Workspace's SQLite + R2 hybrid storage.
  */
 export class WorkspaceChatAgent extends AIChatAgent {
-  workspace = new Workspace(this, { namespace: "ws" });
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    namespace: "ws",
+    name: () => this.name
+  });
 
   maxPersistedMessages = 200;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,6 +1285,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.35.tgz",
       "integrity": "sha512-g3wA57IAQFb+3j4YuFndgkUdXyRETZVvbfAWM+UX7bZSxA3xjes0v3XKgIdKdekPtDGsh4ZX2byHD0gJIMPfiA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.19"
@@ -1335,6 +1336,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
       "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -1347,6 +1349,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
       "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@standard-schema/spec": "^1.1.0",
@@ -2584,6 +2587,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2853,6 +2857,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3946,6 +3951,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/kumo/-/kumo-1.15.0.tgz",
       "integrity": "sha512-cbdVMSkp+pzb6lo0vbDNVreICfzgwTN+T3GFfIivWd/vnYEVW/Ff2DE5Hhnfld9W/pddk+xmQ6bwa56tVk0uoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@shikijs/langs": "^4.0.0",
@@ -4182,7 +4188,8 @@
       "version": "4.20260317.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260317.1.tgz",
       "integrity": "sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==",
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -4229,6 +4236,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -6028,6 +6036,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6241,6 +6250,7 @@
       "integrity": "sha512-/uu0eece5IozgfGOQ0Rq5T6DmDkOkpq/ThJGW26BkU0iSNgSngcL1JkO8/9VmUi2qs3SyKizv3ipQrvH2F8IzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@openai/agents-core": "0.8.0",
         "@openai/agents-openai": "0.8.0",
@@ -6355,6 +6365,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7035,6 +7046,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
       "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7158,6 +7170,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7174,6 +7187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7190,6 +7204,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7206,6 +7221,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7222,6 +7238,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7238,6 +7255,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7254,6 +7272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7270,6 +7289,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7286,6 +7306,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7302,6 +7323,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7318,6 +7340,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7334,6 +7357,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7350,6 +7374,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7363,6 +7388,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
       "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7379,6 +7405,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7389,6 +7416,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -7399,6 +7427,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7415,6 +7444,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7430,6 +7460,7 @@
       "integrity": "sha512-q9pE8+47bQNHb5eWVcE6oXppA+JTSwvnrhH53m0ZuHuK5MLvwsLoWrWzBTFQqQ06BVxz1gp0HblLsch8o6pvZw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "picomatch": "^4.0.3"
       },
@@ -8566,6 +8597,7 @@
       "integrity": "sha512-BMWrPJCpJNXPsXeqQOXrg6eHBTZcAVwmc9UFQkcWYeC/B50ilIwVmBQUzCvUq+2R5jz5+MBCY4gEqtH6ERju3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/ai-event-client": "0.1.1",
         "partial-json": "^0.1.7"
@@ -8769,6 +8801,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -8778,6 +8811,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8787,6 +8821,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8912,6 +8947,7 @@
       "integrity": "sha512-2RU7pZELY9/aVMLmABNy1HeZ4FX23FXGY1jRuHLHgWa2zaAE49aNW2GLzebW+BmbTZIKKyFF1QXvk7DEWViUCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -8994,6 +9030,7 @@
       "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.0",
         "pathe": "^2.0.3"
@@ -9008,6 +9045,7 @@
       "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.0",
         "@vitest/utils": "4.1.0",
@@ -9309,6 +9347,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.134.tgz",
       "integrity": "sha512-YalNEaavld/kE444gOcsMKXdVVRGEe0SK77fAFcWYcqLg+a7xKnEet8bdfrEAJTfnMjj01rhgrIL10903w1a5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.77",
         "@ai-sdk/provider": "3.0.8",
@@ -9621,6 +9660,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.0.8.tgz",
       "integrity": "sha512-DCPeb8GKOoFWh+8whB7Qi/kKWD/6NcQ9nd1QVNzJFxgHkea3WYrNroQRq4whmBdjhkYPTLS/1gmUAl2iA2Es2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^3.0.0",
         "@astrojs/internal-helpers": "0.8.0",
@@ -10614,6 +10654,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12244,6 +12285,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -13243,7 +13285,8 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
       "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
+      "peer": true
     },
     "node_modules/h3": {
       "version": "1.15.6",
@@ -13549,6 +13592,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14124,6 +14168,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -14429,6 +14474,7 @@
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
       "devOptional": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -14460,6 +14506,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14500,6 +14547,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14520,6 +14568,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14540,6 +14589,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14560,6 +14610,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14580,6 +14631,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14620,6 +14672,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14640,6 +14693,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14660,6 +14714,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14680,6 +14735,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14700,6 +14756,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17223,6 +17280,7 @@
       "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
       "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-polyfill": "^0.0.4"
       },
@@ -17546,6 +17604,7 @@
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.2"
       },
@@ -17973,6 +18032,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18022,6 +18082,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18785,6 +18846,7 @@
       "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.115.0",
         "@rolldown/pluginutils": "1.0.0-rc.9"
@@ -18920,6 +18982,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20553,6 +20616,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -20640,6 +20704,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20731,6 +20796,7 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -21319,6 +21385,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -21976,6 +22043,7 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -22172,6 +22240,7 @@
       "integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -22201,6 +22270,7 @@
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.76.0.tgz",
       "integrity": "sha512-Wan+CU5a0tu4HIxGOrzjNbkmxCT27HUmzrMj6kc7aoAnjSLv50Ggcn2Ant7wNQrD6xW3g31phKupZJgTZ8wZfQ==",
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
         "@cloudflare/unenv-preset": "2.16.0",
@@ -22371,6 +22441,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -22414,6 +22485,7 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -22538,6 +22610,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -22579,7 +22652,6 @@
       "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
       "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/packages/ai-chat/CHANGELOG.md
+++ b/packages/ai-chat/CHANGELOG.md
@@ -13,7 +13,6 @@
 ### Minor Changes
 
 - [#1150](https://github.com/cloudflare/agents/pull/1150) [`81a8710`](https://github.com/cloudflare/agents/commit/81a8710938ec1c7a8e388fda936d1724409d74d6) Thanks [@threepointone](https://github.com/threepointone)! - feat: add `sanitizeMessageForPersistence` hook and built-in Anthropic tool payload truncation
-
   - **New protected hook**: `sanitizeMessageForPersistence(message)` — override this method to apply custom transformations to messages before they are persisted to storage. Runs after built-in sanitization. Default is identity (returns message unchanged).
   - **Anthropic provider-executed tool truncation**: Large string values in `input` and `output` of provider-executed tool parts (e.g. Anthropic `code_execution`, `text_editor`) are now automatically truncated. These server-side tool payloads can exceed 200KB and are dead weight once the model has consumed the result.
 
@@ -24,7 +23,6 @@
 ### Patch Changes
 
 - [#1151](https://github.com/cloudflare/agents/pull/1151) [`b0c52a5`](https://github.com/cloudflare/agents/commit/b0c52a541625b9fbfc631cd17c0f38c40f43c7f5) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - fix(ai-chat): simplify turn coordination API
-
   - rename `waitForPendingInteractionResolution()` to `waitUntilStable()` and make it wait for a fully stable conversation state, including queued continuation turns
   - add `resetTurnState()` for scoped clear handlers that need to abort active work and invalidate queued continuations
   - demote `isChatTurnActive()`, `waitForIdle()`, and `abortActiveTurn()` to private — their behavior is subsumed by `waitUntilStable()` and `resetTurnState()`
@@ -33,12 +31,10 @@
 - [#1106](https://github.com/cloudflare/agents/pull/1106) [`3184282`](https://github.com/cloudflare/agents/commit/3184282412fe0908a7eca5e117ff02b64541c860) Thanks [@threepointone](https://github.com/threepointone)! - fix: abort/stop no longer creates duplicate split messages (issue [#1100](https://github.com/cloudflare/agents/issues/1100))
 
   When a user clicked stop during an active stream, the assistant message was split into two separate messages. This happened because `onAbort` in the transport immediately removed the `requestId` from `activeRequestIds`, causing `onAgentMessage` to treat in-flight server chunks as a new broadcast.
-
   - `WebSocketChatTransport`: `onAbort` now keeps the `requestId` in `activeRequestIds` so in-flight server chunks are correctly skipped by the dedup guard
   - `useAgentChat`: `onAgentMessage` now cleans up the kept ID when receiving `done: true`, preventing a minor memory leak
 
 - [#1142](https://github.com/cloudflare/agents/pull/1142) [`5651ece`](https://github.com/cloudflare/agents/commit/5651eced85c04bfaf5660922467c74de7dc0896e) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - fix(ai-chat): serialize chat turns and expose turn control helpers
-
   - queue `onChatMessage()` + `_reply()` work so user requests, tool continuations, and `saveMessages()` never stream concurrently
   - make `saveMessages()` wait for the queued turn to finish before resolving, and reuse the request id for reply cleanup
   - skip queued continuations and `saveMessages()` calls that were enqueued before a chat clear
@@ -82,7 +78,6 @@
 - [#1013](https://github.com/cloudflare/agents/pull/1013) [`11aaaff`](https://github.com/cloudflare/agents/commit/11aaaffb89c375eba9bedf97074ced556dcdd0e7) Thanks [@threepointone](https://github.com/threepointone)! - Fix Gemini "missing thought_signature" error when using client-side tools with `addToolOutput`.
 
   The server-side message builder (`applyChunkToParts`) was dropping `providerMetadata` from tool-input stream chunks instead of storing it as `callProviderMetadata` on tool UIMessage parts. When `convertToModelMessages` later read the persisted messages for the continuation call, `callProviderMetadata` was undefined, so Gemini never received its `thought_signature` back and rejected the request.
-
   - Preserve `callProviderMetadata` (mapped from stream `providerMetadata`) on tool parts in `tool-input-start`, `tool-input-available`, and `tool-input-error` handlers — both create and update paths
   - Preserve `providerExecuted` on tool parts (used by `convertToModelMessages` for provider-executed tools like Gemini code execution)
   - Preserve `title` on tool parts (tool display name)
@@ -90,7 +85,6 @@
   - Add 13 regression tests covering all affected codepaths
 
 - [#989](https://github.com/cloudflare/agents/pull/989) [`8404954`](https://github.com/cloudflare/agents/commit/8404954029a62244a87ec38691639f5b8ce9e615) Thanks [@threepointone](https://github.com/threepointone)! - Fix active streams losing UI state after reconnect and dead streams after DO hibernation.
-
   - Send `replayComplete` signal after replaying stored chunks for live streams, so the client flushes accumulated parts to React state immediately instead of waiting for the next live chunk.
   - Detect orphaned streams (restored from SQLite after hibernation with no live LLM reader) via `_isLive` flag on `ResumableStream`. On reconnect, send `done: true`, complete the stream, and reconstruct/persist the partial assistant message from stored chunks.
   - Client-side: flush `activeStreamRef` on `replayComplete` (keeps stream alive for subsequent live chunks) and on `done` during replay (finalizes orphaned streams).
@@ -130,7 +124,6 @@
   so when `regenerate()` removed the last assistant message from the client's
   array, the old row persisted in SQLite. On the next `_loadMessagesFromDb`,
   the stale assistant message reappeared in `this.messages`, causing:
-
   - Anthropic models to reject with HTTP 400 (conversation must end with a
     user message)
   - Duplicate/phantom assistant messages across reconnects
@@ -162,14 +155,12 @@
 - [#999](https://github.com/cloudflare/agents/pull/999) [`95753da`](https://github.com/cloudflare/agents/commit/95753da49cb68e9e9e486e047b588004163a27fb) Thanks [@threepointone](https://github.com/threepointone)! - Fix `useChat` `status` staying `"ready"` during stream resumption after page refresh.
 
   Four issues prevented stream resumption from working:
-
   1. **addEventListener race:** `onAgentMessage` always handled `CF_AGENT_STREAM_RESUMING` before the transport's listener, bypassing the AI SDK pipeline.
   2. **Transport instance instability:** `useMemo` created new transport instances across renders and Strict Mode cycles. When `_pk` changed (async queries, socket recreation), the resolver was stranded on the old transport while `onAgentMessage` called `handleStreamResuming` on the new one.
   3. **Chat recreation on `_pk` change:** Using `agent._pk` as the `useChat` `id` caused the AI SDK to recreate the Chat when the socket changed, abandoning the in-flight `makeRequest` (including resume). The resume effect wouldn't re-fire on the new Chat.
   4. **Double STREAM_RESUMING:** The server sends `STREAM_RESUMING` from both `onConnect` and the `RESUME_REQUEST` handler, causing duplicate ACKs and double replay without deduplication.
 
   Fixes:
-
   - Replace `addEventListener`-based detection with `handleStreamResuming()` — a synchronous method `onAgentMessage` calls directly, eliminating the race.
   - Make the transport a true singleton (`useRef`, created once). Update `transport.agent` every render so sends/listeners always use the latest socket. The resolver survives `_pk` changes because the transport instance never changes.
   - Use a stable Chat ID (`initialMessagesCacheKey` based on URL + agent + name) instead of `agent._pk`, preventing Chat recreation on socket changes.
@@ -200,7 +191,7 @@
   addToolOutput({
     toolCallId: invocation.toolCallId,
     state: "output-error",
-    errorText: "User declined: insufficient permissions",
+    errorText: "User declined: insufficient permissions"
   });
   ```
 
@@ -261,7 +252,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
 - [#899](https://github.com/cloudflare/agents/pull/899) [`04c6411`](https://github.com/cloudflare/agents/commit/04c6411c9a73fe48784d7ce86150d62cf54becda) Thanks [@threepointone](https://github.com/threepointone)! - Refactor AIChatAgent: extract ResumableStream class, add WebSocket ChatTransport, simplify SSE parsing.
 
   **Bug fixes:**
-
   - Fix `setMessages` functional updater sending empty array to server
   - Fix `_sendPlaintextReply` creating multiple text parts instead of one
   - Fix uncaught exception on empty/invalid request body
@@ -276,7 +266,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   - Fix `completed` guard on abort listener to prevent redundant cancel after stream completion
 
   **New features:**
-
   - `maxPersistedMessages` — cap SQLite message storage with automatic oldest-message deletion
   - `body` option on `useAgentChat` — send custom data with every request (static or dynamic)
   - Incremental persistence with hash-based cache to skip redundant SQL writes
@@ -286,13 +275,11 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   - Full tool streaming lifecycle in message-builder (tool-input-start/delta/error, tool-output-error)
 
   **Docs:**
-
   - New `docs/chat-agents.md` — comprehensive AIChatAgent and useAgentChat reference
   - Rewritten README, migration guides, human-in-the-loop, resumable streaming, client tools docs
   - New `examples/ai-chat/` example with modern patterns and Workers AI
 
   **Deprecations (with console.warn):**
-
   - `createToolsFromClientSchemas()`, `extractClientToolSchemas()`, `detectToolsRequiringConfirmation()`
   - `tools`, `toolsRequiringConfirmation`, `experimental_automaticToolResolution` options
   - `addToolResult()` (use `addToolOutput()`)
@@ -316,7 +303,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   `useAgentChat` now invokes the `onData` callback for `data-*` chunks on the stream resumption and cross-tab broadcast codepaths, which bypass the AI SDK's internal pipeline. For new messages sent via the transport, the AI SDK already invokes `onData` internally. This is the correct way to consume transient data parts on the client since they are not added to `message.parts`.
 
 - [#922](https://github.com/cloudflare/agents/pull/922) [`c8e5244`](https://github.com/cloudflare/agents/commit/c8e524499d902229e8ac83afd6cf2864f888cecc) Thanks [@threepointone](https://github.com/threepointone)! - Fix tool approval UI not surviving page refresh, and fix invalid prompt error after approval
-
   - Handle `tool-approval-request` and `tool-output-denied` stream chunks in the server-side message builder. Previously these were only handled client-side, so the server never transitioned tool parts to `approval-requested` or `output-denied` state.
   - Persist the streaming message to SQLite (without broadcasting) when a tool enters `approval-requested` state. The stream is paused waiting for user approval, so this is a natural persistence point. Without this, refreshing the page would reload from SQLite where the tool was still in `input-available` state, showing "Running..." instead of the Approve/Reject UI.
   - On stream completion, update the early-persisted message in place rather than appending a duplicate.

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -336,7 +336,7 @@ import { Workspace } from "@cloudflare/shell";
 import { stateTools } from "@cloudflare/shell/workers";
 
 export class MyAgent extends Agent<Env> {
-  workspace = new Workspace(this);
+  workspace = new Workspace({ sql: this.ctx.storage.sql });
 
   getCodemodeTool() {
     const executor = new DynamicWorkerExecutor({ loader: this.env.LOADER });

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -53,7 +53,11 @@ import { stateTools } from "@cloudflare/shell/workers";
 import { DynamicWorkerExecutor, resolveProvider } from "@cloudflare/codemode";
 
 class MyAgent extends Agent<Env> {
-  workspace = new Workspace(this, { r2: this.env.MY_BUCKET });
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    r2: this.env.MY_BUCKET,
+    name: () => this.name
+  });
 
   async run(code: string) {
     const executor = new DynamicWorkerExecutor({ loader: this.env.LOADER });

--- a/packages/shell/src/filesystem.ts
+++ b/packages/shell/src/filesystem.ts
@@ -3,95 +3,116 @@ import { channel } from "node:diagnostics_channel";
 /**
  * Workspace — durable file storage backed by SQLite + optional R2.
  *
- * The `WorkspaceHost` interface accepts any object that provides async
- * `sqlQuery` / `sqlRun` tagged-template helpers.  For Agents whose built-in
- * `sql` is synchronous, pass `legacyWorkspaceHost(this)` or use the
- * `LegacyWorkspaceHost` union — the constructor detects and wraps it
- * automatically so `new Workspace(this)` keeps working unchanged.
+ * Accepts any `SqlBackend` (two methods: `query` and `run`), or
+ * auto-detects `SqlStorage` (DO built-in) and `D1Database` directly.
  *
  * ```ts
- * import { Agent } from "agents";
- * import { Workspace } from "@cloudflare/shell";
+ * // Durable Object (any DO with SQLite storage)
+ * const workspace = new Workspace({ sql: ctx.storage.sql });
  *
+ * // D1
+ * const workspace = new Workspace({ sql: env.MY_DB });
+ *
+ * // Agent (with R2 and lazy name for observability)
  * class MyAgent extends Agent<Env> {
- *   workspace = new Workspace(this, {
+ *   workspace = new Workspace({
+ *     sql: this.ctx.storage.sql,
  *     r2: this.env.WORKSPACE_FILES,
+ *     name: () => this.name,
  *   });
- *
- *   async onMessage(conn, msg) {
- *     await this.workspace.writeFile("/hello.txt", "world");
- *     const content = await this.workspace.readFile("/hello.txt");
- *   }
  * }
  * ```
  *
  * @module workspace
  */
 
-// ── Host interface ───────────────────────────────────────────────────
+// ── SQL backend interface ────────────────────────────────────────────
 
-/** Async SQL host — supports D1 or any Promise-returning SQL backend. */
-export interface WorkspaceHost {
-  sqlQuery<T = Record<string, string | number | boolean | null>>(
-    strings: TemplateStringsArray,
-    ...values: (string | number | boolean | null)[]
-  ): Promise<T[]>;
-  sqlRun(
-    strings: TemplateStringsArray,
-    ...values: (string | number | boolean | null)[]
-  ): Promise<void>;
-  /** Durable Object ID / name — used as the default R2 key prefix. */
-  name?: string;
-}
+export type SqlParam = string | number | boolean | null;
 
 /**
- * Backward-compat host for Agents whose built-in `sql` is synchronous.
- * Pass `this` directly; the `Workspace` constructor wraps it automatically.
+ * Minimal SQL interface: query rows and run statements.
+ * Return values may be sync or async — Workspace awaits either.
  */
-export interface LegacyWorkspaceHost {
-  sql<T = Record<string, string | number | boolean | null>>(
-    strings: TemplateStringsArray,
-    ...values: (string | number | boolean | null)[]
-  ): T[];
-  name?: string;
+export interface SqlBackend {
+  query<T = Record<string, SqlParam>>(
+    sql: string,
+    ...params: SqlParam[]
+  ): T[] | Promise<T[]>;
+  run(sql: string, ...params: SqlParam[]): void | Promise<void>;
 }
 
-function adaptHost(host: WorkspaceHost | LegacyWorkspaceHost): WorkspaceHost {
-  if ("sqlQuery" in host) return host as WorkspaceHost;
-  const legacy = host as LegacyWorkspaceHost;
-  return {
-    sqlQuery<T = Record<string, string | number | boolean | null>>(
-      strings: TemplateStringsArray,
-      ...values: (string | number | boolean | null)[]
-    ): Promise<T[]> {
-      return Promise.resolve(legacy.sql<T>(strings, ...values));
-    },
-    sqlRun(
-      strings: TemplateStringsArray,
-      ...values: (string | number | boolean | null)[]
-    ): Promise<void> {
-      legacy.sql(strings, ...values);
-      return Promise.resolve();
-    },
-    get name() {
-      return legacy.name;
-    }
-  };
+/** Auto-detect: accepts SqlStorage, D1Database, or a raw SqlBackend. */
+export type SqlSource = SqlStorage | D1Database | SqlBackend;
+
+function isSqlStorage(src: SqlSource): src is SqlStorage {
+  return typeof src === "object" && src !== null && "databaseSize" in src;
+}
+
+function isD1Database(src: SqlSource): src is D1Database {
+  return (
+    typeof src === "object" &&
+    src !== null &&
+    "prepare" in src &&
+    "batch" in src
+  );
+}
+
+function toBackend(src: SqlSource): SqlBackend {
+  if (isSqlStorage(src)) {
+    const storage = src;
+    return {
+      query(sql: string, ...params: SqlParam[]) {
+        return [...storage.exec(sql, ...params)] as never;
+      },
+      run(sql: string, ...params: SqlParam[]) {
+        storage.exec(sql, ...params);
+      }
+    };
+  }
+  if (isD1Database(src)) {
+    const db = src;
+    return {
+      async query(sql: string, ...params: SqlParam[]) {
+        const r = await db
+          .prepare(sql)
+          .bind(...params)
+          .all();
+        return r.results as never;
+      },
+      async run(sql: string, ...params: SqlParam[]) {
+        await db
+          .prepare(sql)
+          .bind(...params)
+          .run();
+      }
+    };
+  }
+  return src;
 }
 
 // ── Options ──────────────────────────────────────────────────────────
 
 export interface WorkspaceOptions {
+  /** SQL backend — SqlStorage, D1Database, or a custom SqlBackend. */
+  sql: SqlSource;
   /** Namespace to isolate this workspace's tables (default: "default"). */
   namespace?: string;
   /** R2 bucket for large-file storage (optional). */
   r2?: R2Bucket;
-  /** Prefix for R2 object keys. Defaults to `host.name`. */
+  /** Prefix for R2 object keys. Defaults to `name`. */
   r2Prefix?: string;
   /** Byte threshold for spilling files to R2 (default: 1_500_000). */
   inlineThreshold?: number;
   /** Called when files/directories change. */
   onChange?: (event: WorkspaceChangeEvent) => void;
+  /**
+   * Name used as default R2 prefix and in observability events.
+   * Accepts a string or a function for lazy evaluation (useful when
+   * the name isn't available at class field initialization time, e.g.
+   * in Durable Objects where `this.name` is set after construction).
+   */
+  name?: string | (() => string | undefined);
 }
 
 // ── Public types ─────────────────────────────────────────────────────
@@ -134,18 +155,15 @@ const MAX_PATH_LENGTH = 4096;
 const MAX_SYMLINK_TARGET_LENGTH = 4096;
 const MAX_MKDIR_DEPTH = 100;
 
-const workspaceRegistry = new WeakMap<
-  WorkspaceHost | LegacyWorkspaceHost,
-  Set<string>
->();
+const workspaceRegistry = new WeakMap<SqlSource, Set<string>>();
 
 const wsChannel = channel("agents:workspace");
 
 // ── Workspace class ──────────────────────────────────────────────────
 
 export class Workspace {
-  private readonly host: WorkspaceHost;
-  private readonly originalHost: WorkspaceHost | LegacyWorkspaceHost;
+  private readonly sql: SqlBackend;
+  private readonly _nameOrFn: string | (() => string | undefined) | undefined;
   private readonly namespace: string;
   private readonly tableName: string;
   private readonly indexName: string;
@@ -156,40 +174,39 @@ export class Workspace {
     | ((event: WorkspaceChangeEvent) => void)
     | undefined;
   private initialized = false;
-  private readonly sqlCache = new Map<
-    TemplateStringsArray,
-    TemplateStringsArray
-  >();
 
-  constructor(
-    host: WorkspaceHost | LegacyWorkspaceHost,
-    options?: WorkspaceOptions
-  ) {
-    const ns = options?.namespace ?? "default";
+  constructor(options: WorkspaceOptions) {
+    const { sql: source } = options;
+    const ns = options.namespace ?? "default";
     if (!VALID_NAMESPACE.test(ns)) {
       throw new Error(
         `Invalid workspace namespace "${ns}": must start with a letter and contain only alphanumeric characters or underscores`
       );
     }
 
-    const registered = workspaceRegistry.get(host) ?? new Set<string>();
+    const registered = workspaceRegistry.get(source) ?? new Set<string>();
     if (registered.has(ns)) {
       throw new Error(
         `Workspace namespace "${ns}" is already registered on this agent`
       );
     }
     registered.add(ns);
-    workspaceRegistry.set(host, registered);
+    workspaceRegistry.set(source, registered);
 
-    this.originalHost = host;
-    this.host = adaptHost(host);
+    this.sql = toBackend(source);
+    this._nameOrFn = options.name;
     this.namespace = ns;
     this.tableName = `cf_workspace_${ns}`;
     this.indexName = `cf_workspace_${ns}_parent`;
-    this.r2 = options?.r2 ?? null;
-    this.r2Prefix = options?.r2Prefix;
-    this.threshold = options?.inlineThreshold ?? DEFAULT_INLINE_THRESHOLD;
-    this.onChange = options?.onChange;
+    this.r2 = options.r2 ?? null;
+    this.r2Prefix = options.r2Prefix;
+    this.threshold = options.inlineThreshold ?? DEFAULT_INLINE_THRESHOLD;
+    this.onChange = options.onChange;
+  }
+
+  private get _name(): string | undefined {
+    const v = this._nameOrFn;
+    return typeof v === "function" ? v() : v;
   }
 
   private emit(
@@ -203,44 +220,10 @@ export class Workspace {
   private _observe(type: string, payload: Record<string, unknown>): void {
     wsChannel.publish({
       type,
-      name: this.host.name,
+      name: this._name,
       payload: { ...payload, namespace: this.namespace },
       timestamp: Date.now()
     });
-  }
-
-  // ── SQL helpers ─────────────────────────────────────────────────
-
-  private async sqlQuery<T = Record<string, string | number | boolean | null>>(
-    strings: TemplateStringsArray,
-    ...values: (string | number | boolean | null)[]
-  ): Promise<T[]> {
-    const tsa = this.resolveTsa(strings);
-    return this.host.sqlQuery<T>(tsa, ...values);
-  }
-
-  private async sqlRun(
-    strings: TemplateStringsArray,
-    ...values: (string | number | boolean | null)[]
-  ): Promise<void> {
-    const tsa = this.resolveTsa(strings);
-    return this.host.sqlRun(tsa, ...values);
-  }
-
-  private resolveTsa(strings: TemplateStringsArray): TemplateStringsArray {
-    let tsa = this.sqlCache.get(strings);
-    if (!tsa) {
-      const replaced = strings.map((s) =>
-        s
-          .replace(/__TABLE__/g, this.tableName)
-          .replace(/__INDEX__/g, this.indexName)
-      );
-      tsa = Object.assign(replaced, {
-        raw: replaced
-      }) as unknown as TemplateStringsArray;
-      this.sqlCache.set(strings, tsa);
-    }
-    return tsa;
   }
 
   // ── Lazy table init ─────────────────────────────────────────────
@@ -249,8 +232,11 @@ export class Workspace {
     if (this.initialized) return;
     this.initialized = true;
 
-    await this.sqlRun`
-      CREATE TABLE IF NOT EXISTS __TABLE__ (
+    const T = this.tableName;
+    const I = this.indexName;
+
+    await this.sql.run(`
+      CREATE TABLE IF NOT EXISTS ${T} (
         path            TEXT PRIMARY KEY,
         parent_path     TEXT NOT NULL,
         name            TEXT NOT NULL,
@@ -265,27 +251,26 @@ export class Workspace {
         created_at      INTEGER NOT NULL DEFAULT (unixepoch()),
         modified_at     INTEGER NOT NULL DEFAULT (unixepoch())
       )
-    `;
+    `);
 
-    await this.sqlRun`
-      CREATE INDEX IF NOT EXISTS __INDEX__
-        ON __TABLE__(parent_path)
-    `;
+    await this.sql.run(`CREATE INDEX IF NOT EXISTS ${I} ON ${T}(parent_path)`);
 
     const hasRoot =
       (
-        await this.sqlQuery<{ cnt: number }>`
-          SELECT COUNT(*) AS cnt FROM __TABLE__ WHERE path = '/'
-        `
+        await this.sql.query<{ cnt: number }>(
+          `SELECT COUNT(*) AS cnt FROM ${T} WHERE path = '/'`
+        )
       )[0]?.cnt ?? 0;
 
     if (hasRoot === 0) {
       const now = Math.floor(Date.now() / 1000);
-      await this.sqlRun`
-        INSERT INTO __TABLE__
+      await this.sql.run(
+        `INSERT INTO ${T}
           (path, parent_path, name, type, size, created_at, modified_at)
-        VALUES ('/', '', '', 'directory', 0, ${now}, ${now})
-      `;
+        VALUES ('/', '', '', 'directory', 0, ?, ?)`,
+        now,
+        now
+      );
     }
   }
 
@@ -297,11 +282,11 @@ export class Workspace {
 
   private resolveR2Prefix(): string {
     if (this.r2Prefix !== undefined) return this.r2Prefix;
-    const name = this.host.name;
+    const name = this._name;
     if (!name) {
       throw new Error(
-        "[Workspace] R2 is configured but no r2Prefix was provided and host.name is not available. " +
-          "Either pass r2Prefix in WorkspaceOptions or ensure the host exposes a name property."
+        "[Workspace] R2 is configured but no r2Prefix was provided and no name is available. " +
+          "Either pass r2Prefix in WorkspaceOptions or provide a name."
       );
     }
     return name;
@@ -317,9 +302,11 @@ export class Workspace {
     if (depth > MAX_SYMLINK_DEPTH) {
       throw new Error(`ELOOP: too many levels of symbolic links: ${path}`);
     }
-    const rows = await this.sqlQuery<{ type: string; target: string | null }>`
-      SELECT type, target FROM __TABLE__ WHERE path = ${path}
-    `;
+    const T = this.tableName;
+    const rows = await this.sql.query<{
+      type: string;
+      target: string | null;
+    }>(`SELECT type, target FROM ${T} WHERE path = ?`, path);
     const r = rows[0];
     if (!r || r.type !== "symlink" || !r.target) return path;
     const resolved = r.target.startsWith("/")
@@ -347,33 +334,42 @@ export class Workspace {
     const parentPath = getParent(normalized);
     const name = getBasename(normalized);
     const now = Math.floor(Date.now() / 1000);
+    const T = this.tableName;
 
     await this.ensureParentDir(parentPath);
 
     const existing = (
-      await this.sqlQuery<{ type: string }>`
-        SELECT type FROM __TABLE__ WHERE path = ${normalized}
-      `
+      await this.sql.query<{ type: string }>(
+        `SELECT type FROM ${T} WHERE path = ?`,
+        normalized
+      )
     )[0];
     if (existing) {
       throw new Error(`EEXIST: path already exists: ${linkPath}`);
     }
 
-    await this.sqlRun`
-      INSERT INTO __TABLE__
+    await this.sql.run(
+      `INSERT INTO ${T}
         (path, parent_path, name, type, target, size, created_at, modified_at)
-      VALUES
-        (${normalized}, ${parentPath}, ${name}, 'symlink', ${target}, 0, ${now}, ${now})
-    `;
+      VALUES (?, ?, ?, 'symlink', ?, 0, ?, ?)`,
+      normalized,
+      parentPath,
+      name,
+      target,
+      now,
+      now
+    );
     this.emit("create", normalized, "symlink");
   }
 
   async readlink(path: string): Promise<string> {
     await this.ensureInit();
     const normalized = normalizePath(path);
-    const rows = await this.sqlQuery<{ type: string; target: string | null }>`
-      SELECT type, target FROM __TABLE__ WHERE path = ${normalized}
-    `;
+    const T = this.tableName;
+    const rows = await this.sql.query<{
+      type: string;
+      target: string | null;
+    }>(`SELECT type, target FROM ${T} WHERE path = ?`, normalized);
     const r = rows[0];
     if (!r) throw new Error(`ENOENT: no such file or directory: ${path}`);
     if (r.type !== "symlink" || !r.target)
@@ -384,7 +380,8 @@ export class Workspace {
   async lstat(path: string): Promise<FileStat | null> {
     await this.ensureInit();
     const normalized = normalizePath(path);
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       path: string;
       name: string;
       type: string;
@@ -393,10 +390,11 @@ export class Workspace {
       created_at: number;
       modified_at: number;
       target: string | null;
-    }>`
-      SELECT path, name, type, mime_type, size, created_at, modified_at, target
-      FROM __TABLE__ WHERE path = ${normalized}
-    `;
+    }>(
+      `SELECT path, name, type, mime_type, size, created_at, modified_at, target
+      FROM ${T} WHERE path = ?`,
+      normalized
+    );
     const r = rows[0];
     if (!r) return null;
     return toFileInfo(r);
@@ -408,7 +406,8 @@ export class Workspace {
     await this.ensureInit();
     const normalized = normalizePath(path);
     const resolved = await this.resolveSymlink(normalized);
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       path: string;
       name: string;
       type: string;
@@ -417,10 +416,11 @@ export class Workspace {
       created_at: number;
       modified_at: number;
       target: string | null;
-    }>`
-      SELECT path, name, type, mime_type, size, created_at, modified_at, target
-      FROM __TABLE__ WHERE path = ${resolved}
-    `;
+    }>(
+      `SELECT path, name, type, mime_type, size, created_at, modified_at, target
+      FROM ${T} WHERE path = ?`,
+      resolved
+    );
     const r = rows[0];
     if (!r) return null;
     return toFileInfo(r);
@@ -432,16 +432,18 @@ export class Workspace {
     await this.ensureInit();
     const normalized = normalizePath(path);
     const resolved = await this.resolveSymlink(normalized);
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       type: string;
       storage_backend: string;
       r2_key: string | null;
       content: string | null;
       content_encoding: string;
-    }>`
-      SELECT type, storage_backend, r2_key, content, content_encoding
-      FROM __TABLE__ WHERE path = ${resolved}
-    `;
+    }>(
+      `SELECT type, storage_backend, r2_key, content, content_encoding
+      FROM ${T} WHERE path = ?`,
+      resolved
+    );
     const r = rows[0];
     if (!r) return null;
     if (r.type !== "file") throw new Error(`EISDIR: ${path} is a directory`);
@@ -473,16 +475,18 @@ export class Workspace {
     await this.ensureInit();
     const normalized = normalizePath(path);
     const resolved = await this.resolveSymlink(normalized);
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       type: string;
       storage_backend: string;
       r2_key: string | null;
       content: string | null;
       content_encoding: string;
-    }>`
-      SELECT type, storage_backend, r2_key, content, content_encoding
-      FROM __TABLE__ WHERE path = ${resolved}
-    `;
+    }>(
+      `SELECT type, storage_backend, r2_key, content, content_encoding
+      FROM ${T} WHERE path = ?`,
+      resolved
+    );
     const r = rows[0];
     if (!r) return null;
     if (r.type !== "file") throw new Error(`EISDIR: ${path} is a directory`);
@@ -524,16 +528,15 @@ export class Workspace {
     const parentPath = getParent(normalized);
     const name = getBasename(normalized);
     const now = Math.floor(Date.now() / 1000);
+    const T = this.tableName;
 
     await this.ensureParentDir(parentPath);
 
     const existing = (
-      await this.sqlQuery<{
+      await this.sql.query<{
         storage_backend: string;
         r2_key: string | null;
-      }>`
-        SELECT storage_backend, r2_key FROM __TABLE__ WHERE path = ${normalized}
-      `
+      }>(`SELECT storage_backend, r2_key FROM ${T} WHERE path = ?`, normalized)
     )[0];
 
     const r2 = this.getR2();
@@ -547,13 +550,11 @@ export class Workspace {
         httpMetadata: { contentType: mimeType }
       });
       try {
-        await this.sqlRun`
-          INSERT INTO __TABLE__
+        await this.sql.run(
+          `INSERT INTO ${T}
             (path, parent_path, name, type, mime_type, size,
              storage_backend, r2_key, content_encoding, content, created_at, modified_at)
-          VALUES
-            (${normalized}, ${parentPath}, ${name}, 'file', ${mimeType}, ${size},
-             'r2', ${key}, 'base64', NULL, ${now}, ${now})
+          VALUES (?, ?, ?, 'file', ?, ?, 'r2', ?, 'base64', NULL, ?, ?)
           ON CONFLICT(path) DO UPDATE SET
             mime_type         = excluded.mime_type,
             size              = excluded.size,
@@ -561,8 +562,16 @@ export class Workspace {
             r2_key            = excluded.r2_key,
             content_encoding  = 'base64',
             content           = NULL,
-            modified_at       = excluded.modified_at
-        `;
+            modified_at       = excluded.modified_at`,
+          normalized,
+          parentPath,
+          name,
+          mimeType,
+          size,
+          key,
+          now,
+          now
+        );
       } catch (sqlErr) {
         try {
           await r2.delete(key);
@@ -590,13 +599,11 @@ export class Workspace {
         await r2.delete(existing.r2_key);
       }
       const b64 = bytesToBase64(bytes);
-      await this.sqlRun`
-        INSERT INTO __TABLE__
+      await this.sql.run(
+        `INSERT INTO ${T}
           (path, parent_path, name, type, mime_type, size,
            storage_backend, r2_key, content_encoding, content, created_at, modified_at)
-        VALUES
-          (${normalized}, ${parentPath}, ${name}, 'file', ${mimeType}, ${size},
-           'inline', NULL, 'base64', ${b64}, ${now}, ${now})
+        VALUES (?, ?, ?, 'file', ?, ?, 'inline', NULL, 'base64', ?, ?, ?)
         ON CONFLICT(path) DO UPDATE SET
           mime_type         = excluded.mime_type,
           size              = excluded.size,
@@ -604,8 +611,16 @@ export class Workspace {
           r2_key            = NULL,
           content_encoding  = 'base64',
           content           = excluded.content,
-          modified_at       = excluded.modified_at
-      `;
+          modified_at       = excluded.modified_at`,
+        normalized,
+        parentPath,
+        name,
+        mimeType,
+        size,
+        b64,
+        now,
+        now
+      );
       this.emit(existing ? "update" : "create", normalized, "file");
       this._observe("workspace:write", {
         path: normalized,
@@ -631,16 +646,15 @@ export class Workspace {
     const bytes = TEXT_ENCODER.encode(content);
     const size = bytes.byteLength;
     const now = Math.floor(Date.now() / 1000);
+    const T = this.tableName;
 
     await this.ensureParentDir(parentPath);
 
     const existing = (
-      await this.sqlQuery<{
+      await this.sql.query<{
         storage_backend: string;
         r2_key: string | null;
-      }>`
-        SELECT storage_backend, r2_key FROM __TABLE__ WHERE path = ${normalized}
-      `
+      }>(`SELECT storage_backend, r2_key FROM ${T} WHERE path = ?`, normalized)
     )[0];
 
     const r2 = this.getR2();
@@ -657,13 +671,11 @@ export class Workspace {
       });
 
       try {
-        await this.sqlRun`
-          INSERT INTO __TABLE__
+        await this.sql.run(
+          `INSERT INTO ${T}
             (path, parent_path, name, type, mime_type, size,
              storage_backend, r2_key, content_encoding, content, created_at, modified_at)
-          VALUES
-            (${normalized}, ${parentPath}, ${name}, 'file', ${mimeType}, ${size},
-             'r2', ${key}, 'utf8', NULL, ${now}, ${now})
+          VALUES (?, ?, ?, 'file', ?, ?, 'r2', ?, 'utf8', NULL, ?, ?)
           ON CONFLICT(path) DO UPDATE SET
             mime_type         = excluded.mime_type,
             size              = excluded.size,
@@ -671,8 +683,16 @@ export class Workspace {
             r2_key            = excluded.r2_key,
             content_encoding  = 'utf8',
             content           = NULL,
-            modified_at       = excluded.modified_at
-        `;
+            modified_at       = excluded.modified_at`,
+          normalized,
+          parentPath,
+          name,
+          mimeType,
+          size,
+          key,
+          now,
+          now
+        );
       } catch (sqlErr) {
         try {
           await r2.delete(key);
@@ -701,13 +721,11 @@ export class Workspace {
         await r2.delete(existing.r2_key);
       }
 
-      await this.sqlRun`
-        INSERT INTO __TABLE__
+      await this.sql.run(
+        `INSERT INTO ${T}
           (path, parent_path, name, type, mime_type, size,
            storage_backend, r2_key, content_encoding, content, created_at, modified_at)
-        VALUES
-          (${normalized}, ${parentPath}, ${name}, 'file', ${mimeType}, ${size},
-           'inline', NULL, 'utf8', ${content}, ${now}, ${now})
+        VALUES (?, ?, ?, 'file', ?, ?, 'inline', NULL, 'utf8', ?, ?, ?)
         ON CONFLICT(path) DO UPDATE SET
           mime_type         = excluded.mime_type,
           size              = excluded.size,
@@ -715,8 +733,16 @@ export class Workspace {
           r2_key            = NULL,
           content_encoding  = 'utf8',
           content           = excluded.content,
-          modified_at       = excluded.modified_at
-      `;
+          modified_at       = excluded.modified_at`,
+        normalized,
+        parentPath,
+        name,
+        mimeType,
+        size,
+        content,
+        now,
+        now
+      );
       this.emit(existing ? "update" : "create", normalized, "file");
       this._observe("workspace:write", {
         path: normalized,
@@ -733,16 +759,18 @@ export class Workspace {
     await this.ensureInit();
     const normalized = normalizePath(path);
     const resolved = await this.resolveSymlink(normalized);
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       type: string;
       storage_backend: string;
       r2_key: string | null;
       content: string | null;
       content_encoding: string;
-    }>`
-      SELECT type, storage_backend, r2_key, content, content_encoding
-      FROM __TABLE__ WHERE path = ${resolved}
-    `;
+    }>(
+      `SELECT type, storage_backend, r2_key, content, content_encoding
+      FROM ${T} WHERE path = ?`,
+      resolved
+    );
     const r = rows[0];
     if (!r) return null;
     if (r.type !== "file") throw new Error(`EISDIR: ${path} is a directory`);
@@ -819,16 +847,18 @@ export class Workspace {
   ): Promise<void> {
     await this.ensureInit();
     const normalized = await this.resolveSymlink(normalizePath(path));
+    const T = this.tableName;
 
     const row = (
-      await this.sqlQuery<{
+      await this.sql.query<{
         type: string;
         storage_backend: string;
         content_encoding: string;
-      }>`
-        SELECT type, storage_backend, content_encoding
-        FROM __TABLE__ WHERE path = ${normalized}
-      `
+      }>(
+        `SELECT type, storage_backend, content_encoding
+        FROM ${T} WHERE path = ?`,
+        normalized
+      )
     )[0];
 
     if (!row) {
@@ -843,13 +873,17 @@ export class Workspace {
     if (row.storage_backend === "inline" && row.content_encoding === "utf8") {
       const appendSize = TEXT_ENCODER.encode(content).byteLength;
       const now = Math.floor(Date.now() / 1000);
-      await this.sqlRun`
-        UPDATE __TABLE__ SET
-          content = content || ${content},
-          size = size + ${appendSize},
-          modified_at = ${now}
-        WHERE path = ${normalized}
-      `;
+      await this.sql.run(
+        `UPDATE ${T} SET
+          content = content || ?,
+          size = size + ?,
+          modified_at = ?
+        WHERE path = ?`,
+        content,
+        appendSize,
+        now,
+        normalized
+      );
       this.emit("update", normalized, "file");
       return;
     }
@@ -861,13 +895,15 @@ export class Workspace {
   async deleteFile(path: string): Promise<boolean> {
     await this.ensureInit();
     const normalized = normalizePath(path);
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       type: string;
       storage_backend: string;
       r2_key: string | null;
-    }>`
-      SELECT type, storage_backend, r2_key FROM __TABLE__ WHERE path = ${normalized}
-    `;
+    }>(
+      `SELECT type, storage_backend, r2_key FROM ${T} WHERE path = ?`,
+      normalized
+    );
     if (!rows[0]) return false;
     if (rows[0].type === "directory")
       throw new Error(`EISDIR: ${path} is a directory — use rm() instead`);
@@ -877,7 +913,7 @@ export class Workspace {
       if (r2) await r2.delete(rows[0].r2_key);
     }
 
-    await this.sqlRun`DELETE FROM __TABLE__ WHERE path = ${normalized}`;
+    await this.sql.run(`DELETE FROM ${T} WHERE path = ?`, normalized);
     this.emit("delete", normalized, rows[0].type as EntryType);
     this._observe("workspace:delete", { path: normalized });
     return true;
@@ -886,18 +922,22 @@ export class Workspace {
   async fileExists(path: string): Promise<boolean> {
     await this.ensureInit();
     const resolved = await this.resolveSymlink(normalizePath(path));
-    const rows = await this.sqlQuery<{ type: string }>`
-      SELECT type FROM __TABLE__ WHERE path = ${resolved}
-    `;
+    const T = this.tableName;
+    const rows = await this.sql.query<{ type: string }>(
+      `SELECT type FROM ${T} WHERE path = ?`,
+      resolved
+    );
     return rows.length > 0 && rows[0].type === "file";
   }
 
   async exists(path: string): Promise<boolean> {
     await this.ensureInit();
     const normalized = normalizePath(path);
-    const rows = await this.sqlQuery<{ cnt: number }>`
-      SELECT COUNT(*) AS cnt FROM __TABLE__ WHERE path = ${normalized}
-    `;
+    const T = this.tableName;
+    const rows = await this.sql.query<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM ${T} WHERE path = ?`,
+      normalized
+    );
     return (rows[0]?.cnt ?? 0) > 0;
   }
 
@@ -911,7 +951,8 @@ export class Workspace {
     const normalized = normalizePath(dir);
     const limit = opts?.limit ?? 1000;
     const offset = opts?.offset ?? 0;
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       path: string;
       name: string;
       type: string;
@@ -919,13 +960,16 @@ export class Workspace {
       size: number;
       created_at: number;
       modified_at: number;
-    }>`
-      SELECT path, name, type, mime_type, size, created_at, modified_at
-      FROM __TABLE__
-      WHERE parent_path = ${normalized}
+    }>(
+      `SELECT path, name, type, mime_type, size, created_at, modified_at
+      FROM ${T}
+      WHERE parent_path = ?
       ORDER BY type ASC, name ASC
-      LIMIT ${limit} OFFSET ${offset}
-    `;
+      LIMIT ? OFFSET ?`,
+      normalized,
+      limit,
+      offset
+    );
     return rows.map(toFileInfo);
   }
 
@@ -935,8 +979,9 @@ export class Workspace {
     const prefix = getGlobPrefix(normalized);
     const likePattern = escapeLike(prefix) + "%";
     const regex = globToRegex(normalized);
+    const T = this.tableName;
 
-    const rows = await this.sqlQuery<{
+    const rows = await this.sql.query<{
       path: string;
       name: string;
       type: string;
@@ -945,12 +990,14 @@ export class Workspace {
       created_at: number;
       modified_at: number;
       target: string | null;
-    }>`
-      SELECT path, name, type, mime_type, size, created_at, modified_at, target
-      FROM __TABLE__
-      WHERE path LIKE ${likePattern} ESCAPE ${LIKE_ESCAPE}
-      ORDER BY path
-    `;
+    }>(
+      `SELECT path, name, type, mime_type, size, created_at, modified_at, target
+      FROM ${T}
+      WHERE path LIKE ? ESCAPE ?
+      ORDER BY path`,
+      likePattern,
+      LIKE_ESCAPE
+    );
 
     return rows.filter((r) => regex.test(r.path)).map(toFileInfo);
   }
@@ -968,10 +1015,12 @@ export class Workspace {
     }
     const normalized = normalizePath(path);
     if (normalized === "/") return;
+    const T = this.tableName;
 
-    const existing = await this.sqlQuery<{ type: string }>`
-      SELECT type FROM __TABLE__ WHERE path = ${normalized}
-    `;
+    const existing = await this.sql.query<{ type: string }>(
+      `SELECT type FROM ${T} WHERE path = ?`,
+      normalized
+    );
 
     if (existing.length > 0) {
       if (existing[0].type === "directory" && opts?.recursive) return;
@@ -983,9 +1032,10 @@ export class Workspace {
     }
 
     const parentPath = getParent(normalized);
-    const parentRows = await this.sqlQuery<{ type: string }>`
-      SELECT type FROM __TABLE__ WHERE path = ${parentPath}
-    `;
+    const parentRows = await this.sql.query<{ type: string }>(
+      `SELECT type FROM ${T} WHERE path = ?`,
+      parentPath
+    );
 
     if (!parentRows[0]) {
       if (opts?.recursive) {
@@ -999,11 +1049,16 @@ export class Workspace {
 
     const name = getBasename(normalized);
     const now = Math.floor(Date.now() / 1000);
-    await this.sqlRun`
-      INSERT INTO __TABLE__
+    await this.sql.run(
+      `INSERT INTO ${T}
         (path, parent_path, name, type, size, created_at, modified_at)
-      VALUES (${normalized}, ${parentPath}, ${name}, 'directory', 0, ${now}, ${now})
-    `;
+      VALUES (?, ?, ?, 'directory', 0, ?, ?)`,
+      normalized,
+      parentPath,
+      name,
+      now,
+      now
+    );
     this.emit("create", normalized, "directory");
     this._observe("workspace:mkdir", {
       path: normalized,
@@ -1019,10 +1074,12 @@ export class Workspace {
     const normalized = normalizePath(path);
     if (normalized === "/")
       throw new Error("EPERM: cannot remove root directory");
+    const T = this.tableName;
 
-    const rows = await this.sqlQuery<{ type: string }>`
-      SELECT type FROM __TABLE__ WHERE path = ${normalized}
-    `;
+    const rows = await this.sql.query<{ type: string }>(
+      `SELECT type FROM ${T} WHERE path = ?`,
+      normalized
+    );
 
     if (!rows[0]) {
       if (opts?.force) return;
@@ -1030,9 +1087,10 @@ export class Workspace {
     }
 
     if (rows[0].type === "directory") {
-      const children = await this.sqlQuery<{ cnt: number }>`
-        SELECT COUNT(*) AS cnt FROM __TABLE__ WHERE parent_path = ${normalized}
-      `;
+      const children = await this.sql.query<{ cnt: number }>(
+        `SELECT COUNT(*) AS cnt FROM ${T} WHERE parent_path = ?`,
+        normalized
+      );
       if ((children[0]?.cnt ?? 0) > 0) {
         if (!opts?.recursive) {
           throw new Error(`ENOTEMPTY: directory not empty: ${path}`);
@@ -1041,12 +1099,13 @@ export class Workspace {
       }
     } else {
       const fileRow = (
-        await this.sqlQuery<{
+        await this.sql.query<{
           storage_backend: string;
           r2_key: string | null;
-        }>`
-          SELECT storage_backend, r2_key FROM __TABLE__ WHERE path = ${normalized}
-        `
+        }>(
+          `SELECT storage_backend, r2_key FROM ${T} WHERE path = ?`,
+          normalized
+        )
       )[0];
       if (fileRow?.storage_backend === "r2" && fileRow.r2_key) {
         const r2 = this.getR2();
@@ -1054,7 +1113,7 @@ export class Workspace {
       }
     }
 
-    await this.sqlRun`DELETE FROM __TABLE__ WHERE path = ${normalized}`;
+    await this.sql.run(`DELETE FROM ${T} WHERE path = ?`, normalized);
     this.emit("delete", normalized, rows[0].type as EntryType);
     this._observe("workspace:rm", {
       path: normalized,
@@ -1131,12 +1190,14 @@ export class Workspace {
 
     const destParent = getParent(destNorm);
     const destName = getBasename(destNorm);
+    const T = this.tableName;
     await this.ensureParentDir(destParent);
 
     const existingDest = (
-      await this.sqlQuery<{ type: string }>`
-        SELECT type FROM __TABLE__ WHERE path = ${destNorm}
-      `
+      await this.sql.query<{ type: string }>(
+        `SELECT type FROM ${T} WHERE path = ?`,
+        destNorm
+      )
     )[0];
     if (existingDest) {
       if (existingDest.type === "directory") {
@@ -1147,12 +1208,10 @@ export class Workspace {
 
     if (srcStat.type === "file") {
       const row = (
-        await this.sqlQuery<{
+        await this.sql.query<{
           storage_backend: string;
           r2_key: string | null;
-        }>`
-          SELECT storage_backend, r2_key FROM __TABLE__ WHERE path = ${srcNorm}
-        `
+        }>(`SELECT storage_backend, r2_key FROM ${T} WHERE path = ?`, srcNorm)
       )[0];
       if (row?.storage_backend === "r2" && row.r2_key) {
         const r2 = this.getR2();
@@ -1166,15 +1225,21 @@ export class Workspace {
           }
           await r2.delete(row.r2_key);
           const now = Math.floor(Date.now() / 1000);
-          await this.sqlRun`
-            UPDATE __TABLE__ SET
-              path = ${destNorm},
-              parent_path = ${destParent},
-              name = ${destName},
-              r2_key = ${newKey},
-              modified_at = ${now}
-            WHERE path = ${srcNorm}
-          `;
+          await this.sql.run(
+            `UPDATE ${T} SET
+              path = ?,
+              parent_path = ?,
+              name = ?,
+              r2_key = ?,
+              modified_at = ?
+            WHERE path = ?`,
+            destNorm,
+            destParent,
+            destName,
+            newKey,
+            now,
+            srcNorm
+          );
           this.emit("delete", srcNorm, "file");
           this.emit("create", destNorm, "file");
           this._observe("workspace:mv", {
@@ -1187,14 +1252,19 @@ export class Workspace {
     }
 
     const now = Math.floor(Date.now() / 1000);
-    await this.sqlRun`
-      UPDATE __TABLE__ SET
-        path = ${destNorm},
-        parent_path = ${destParent},
-        name = ${destName},
-        modified_at = ${now}
-      WHERE path = ${srcNorm}
-    `;
+    await this.sql.run(
+      `UPDATE ${T} SET
+        path = ?,
+        parent_path = ?,
+        name = ?,
+        modified_at = ?
+      WHERE path = ?`,
+      destNorm,
+      destParent,
+      destName,
+      now,
+      srcNorm
+    );
     this.emit("delete", srcNorm, srcStat.type);
     this.emit("create", destNorm, srcStat.type);
     this._observe("workspace:mv", { src: srcNorm, dest: destNorm });
@@ -1245,19 +1315,20 @@ export class Workspace {
     r2FileCount: number;
   }> {
     await this.ensureInit();
-    const rows = await this.sqlQuery<{
+    const T = this.tableName;
+    const rows = await this.sql.query<{
       files: number;
       dirs: number;
       total: number;
       r2files: number;
-    }>`
-      SELECT
+    }>(
+      `SELECT
         SUM(CASE WHEN type = 'file'                               THEN 1 ELSE 0 END) AS files,
         SUM(CASE WHEN type = 'directory'                          THEN 1 ELSE 0 END) AS dirs,
         COALESCE(SUM(CASE WHEN type = 'file' THEN size ELSE 0 END), 0)               AS total,
         SUM(CASE WHEN type = 'file' AND storage_backend = 'r2'   THEN 1 ELSE 0 END) AS r2files
-      FROM __TABLE__
-    `;
+      FROM ${T}`
+    );
     return {
       fileCount: rows[0]?.files ?? 0,
       directoryCount: rows[0]?.dirs ?? 0,
@@ -1271,10 +1342,11 @@ export class Workspace {
   /** @internal */
   async _getAllPaths(): Promise<string[]> {
     await this.ensureInit();
+    const T = this.tableName;
     return (
-      await this.sqlQuery<{ path: string }>`
-        SELECT path FROM __TABLE__ ORDER BY path
-      `
+      await this.sql.query<{ path: string }>(
+        `SELECT path FROM ${T} ORDER BY path`
+      )
     ).map((r) => r.path);
   }
 
@@ -1283,19 +1355,24 @@ export class Workspace {
     await this.ensureInit();
     const normalized = normalizePath(path);
     const ts = Math.floor(mtime.getTime() / 1000);
-    await this.sqlRun`
-      UPDATE __TABLE__ SET modified_at = ${ts} WHERE path = ${normalized}
-    `;
+    const T = this.tableName;
+    await this.sql.run(
+      `UPDATE ${T} SET modified_at = ? WHERE path = ?`,
+      ts,
+      normalized
+    );
   }
 
   // ── Private helpers ────────────────────────────────────────────
 
   private async ensureParentDir(dirPath: string): Promise<void> {
     if (!dirPath || dirPath === "/") return;
+    const T = this.tableName;
 
-    const rows = await this.sqlQuery<{ type: string }>`
-      SELECT type FROM __TABLE__ WHERE path = ${dirPath}
-    `;
+    const rows = await this.sql.query<{ type: string }>(
+      `SELECT type FROM ${T} WHERE path = ?`,
+      dirPath
+    );
     if (rows[0]) {
       if (rows[0].type !== "directory") {
         throw new Error(`ENOTDIR: ${dirPath} is not a directory`);
@@ -1306,9 +1383,10 @@ export class Workspace {
     const missing: string[] = [dirPath];
     let current = getParent(dirPath);
     while (current && current !== "/") {
-      const r = await this.sqlQuery<{ type: string }>`
-        SELECT type FROM __TABLE__ WHERE path = ${current}
-      `;
+      const r = await this.sql.query<{ type: string }>(
+        `SELECT type FROM ${T} WHERE path = ?`,
+        current
+      );
       if (r[0]) {
         if (r[0].type !== "directory") {
           throw new Error(`ENOTDIR: ${current} is not a directory`);
@@ -1324,24 +1402,32 @@ export class Workspace {
       const p = missing[i];
       const parentPath = getParent(p);
       const name = getBasename(p);
-      await this.sqlRun`
-        INSERT INTO __TABLE__
+      await this.sql.run(
+        `INSERT INTO ${T}
           (path, parent_path, name, type, size, created_at, modified_at)
-        VALUES (${p}, ${parentPath}, ${name}, 'directory', 0, ${now}, ${now})
-      `;
+        VALUES (?, ?, ?, 'directory', 0, ?, ?)`,
+        p,
+        parentPath,
+        name,
+        now,
+        now
+      );
       this.emit("create", p, "directory");
     }
   }
 
   private async deleteDescendants(dirPath: string): Promise<void> {
     const pattern = escapeLike(dirPath) + "/%";
+    const T = this.tableName;
 
-    const r2Rows = await this.sqlQuery<{ r2_key: string }>`
-      SELECT r2_key FROM __TABLE__
-      WHERE path LIKE ${pattern} ESCAPE ${LIKE_ESCAPE}
+    const r2Rows = await this.sql.query<{ r2_key: string }>(
+      `SELECT r2_key FROM ${T}
+      WHERE path LIKE ? ESCAPE ?
         AND storage_backend = 'r2'
-        AND r2_key IS NOT NULL
-    `;
+        AND r2_key IS NOT NULL`,
+      pattern,
+      LIKE_ESCAPE
+    );
 
     if (r2Rows.length > 0) {
       const r2 = this.getR2();
@@ -1351,8 +1437,11 @@ export class Workspace {
       }
     }
 
-    await this
-      .sqlRun`DELETE FROM __TABLE__ WHERE path LIKE ${pattern} ESCAPE ${LIKE_ESCAPE}`;
+    await this.sql.run(
+      `DELETE FROM ${T} WHERE path LIKE ? ESCAPE ?`,
+      pattern,
+      LIKE_ESCAPE
+    );
   }
 }
 

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,8 +1,9 @@
 // ── Workspace (durable SQLite + R2 filesystem) ───────────────────────
 export {
   Workspace,
-  type WorkspaceHost,
-  type LegacyWorkspaceHost,
+  type SqlBackend,
+  type SqlSource,
+  type SqlParam,
   type WorkspaceOptions,
   type EntryType,
   type FileInfo,

--- a/packages/shell/src/tests/agents/workspace.ts
+++ b/packages/shell/src/tests/agents/workspace.ts
@@ -7,18 +7,25 @@ import {
   Workspace,
   type FileInfo,
   type FileStat,
+  type SqlBackend,
+  type SqlParam,
   type WorkspaceChangeEvent
 } from "../../filesystem";
 
 export class TestWorkspaceAgent extends Agent {
-  workspace = new Workspace(this);
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+  });
   changeLog: WorkspaceChangeEvent[] = [];
   observabilityLog: Record<string, unknown>[] = [];
   private _observabilityHandler:
     | ((message: unknown, name: string | symbol) => void)
     | null = null;
-  wsWithEvents = new Workspace(this, {
+  wsWithEvents = new Workspace({
+    sql: this.ctx.storage.sql,
     namespace: "evts",
+    name: () => this.name,
     onChange: (event) => {
       this.changeLog.push(event);
     }
@@ -306,5 +313,65 @@ export class TestWorkspaceAgent extends Agent {
 
   async clearObservabilityLog(): Promise<void> {
     this.observabilityLog = [];
+  }
+
+  // ── Custom SqlBackend tests ──────────────────────────────────────
+
+  async customBackendRoundtrip(): Promise<string | null> {
+    const self = this;
+    const sqlBackend: SqlBackend = {
+      query(sql: string, ...params: SqlParam[]) {
+        return [...self.ctx.storage.sql.exec(sql, ...params)] as never;
+      },
+      run(sql: string, ...params: SqlParam[]) {
+        self.ctx.storage.sql.exec(sql, ...params);
+      }
+    };
+    const ws = new Workspace({ sql: sqlBackend, namespace: "custom" });
+    await ws.writeFile("/custom.txt", "via-custom-backend");
+    return ws.readFile("/custom.txt");
+  }
+
+  async asyncBackendRoundtrip(): Promise<string | null> {
+    const self = this;
+    const sqlBackend: SqlBackend = {
+      async query(sql: string, ...params: SqlParam[]) {
+        return [...self.ctx.storage.sql.exec(sql, ...params)] as never;
+      },
+      async run(sql: string, ...params: SqlParam[]) {
+        self.ctx.storage.sql.exec(sql, ...params);
+      }
+    };
+    const ws = new Workspace({ sql: sqlBackend, namespace: "asyncCustom" });
+    await ws.writeFile("/async.txt", "via-async-backend");
+    return ws.readFile("/async.txt");
+  }
+
+  async staticNameRoundtrip(): Promise<string | null> {
+    const ws = new Workspace({
+      sql: this.ctx.storage.sql,
+      namespace: "staticName",
+      name: "my-static-name"
+    });
+    await ws.writeFile("/named.txt", "static-name-ok");
+    return ws.readFile("/named.txt");
+  }
+
+  async lazyNameRoundtrip(): Promise<{
+    content: string | null;
+    resolvedName: boolean;
+  }> {
+    let nameResolved = false;
+    const ws = new Workspace({
+      sql: this.ctx.storage.sql,
+      namespace: "lazyName",
+      name: () => {
+        nameResolved = true;
+        return this.name;
+      }
+    });
+    await ws.writeFile("/lazy.txt", "lazy-name-ok");
+    const content = await ws.readFile("/lazy.txt");
+    return { content, resolvedName: nameResolved };
   }
 }

--- a/packages/shell/src/tests/workspace.test.ts
+++ b/packages/shell/src/tests/workspace.test.ts
@@ -4,6 +4,54 @@ import { getAgentByName } from "agents";
 import type { FileInfo, FileStat } from "../filesystem";
 import { StateBatchOperationError } from "../index";
 import { createWorkspaceStateBackend } from "../workspace";
+
+// ═══════════════════════════════════════════════════════════════════
+// SqlBackend / detection / name — DO-backed tests
+// ═══════════════════════════════════════════════════════════════════
+
+describe("Workspace — custom SqlBackend", () => {
+  it("write + read roundtrip through a custom { query, run } backend", async () => {
+    const agent = await getAgentByName(
+      env.TestWorkspaceAgent,
+      "custom-backend"
+    );
+    const content = await agent.customBackendRoundtrip();
+    expect(content).toBe("via-custom-backend");
+  });
+
+  it("works with an async (Promise-returning) backend", async () => {
+    const agent = await getAgentByName(env.TestWorkspaceAgent, "async-backend");
+    const content = await agent.asyncBackendRoundtrip();
+    expect(content).toBe("via-async-backend");
+  });
+});
+
+describe("Workspace — name option", () => {
+  it("accepts a static string name", async () => {
+    const agent = await getAgentByName(env.TestWorkspaceAgent, "static-name");
+    const content = await agent.staticNameRoundtrip();
+    expect(content).toBe("static-name-ok");
+  });
+
+  it("accepts a lazy function name that defers evaluation", async () => {
+    const agent = await getAgentByName(env.TestWorkspaceAgent, "lazy-name");
+    const result = (await agent.lazyNameRoundtrip()) as {
+      content: string | null;
+      resolvedName: boolean;
+    };
+    expect(result.content).toBe("lazy-name-ok");
+  });
+});
+
+describe("Workspace — SqlStorage detection", () => {
+  it("auto-detects ctx.storage.sql as SqlStorage", async () => {
+    const agent = await getAgentByName(env.TestWorkspaceAgent, "sql-detect");
+    await agent.write("/detect.txt", "via sql storage");
+    const content = await agent.read("/detect.txt");
+    expect(content).toBe("via sql storage");
+  });
+});
+
 // ── DO agent helpers ──────────────────────────────────────────────────────
 
 async function freshAgent(name: string) {

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -15,7 +15,7 @@ import { createWorkspaceTools } from "@cloudflare/think/tools/workspace";
 import { Workspace } from "@cloudflare/shell";
 
 export class ChatSession extends Think<Env> {
-  workspace = new Workspace(this);
+  workspace = new Workspace({ sql: this.ctx.storage.sql });
 
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -16,7 +16,11 @@ type Env = {
 };
 
 export class TestAssistant extends Think<Env> {
-  workspace = new Workspace(this, { r2: this.env.R2 });
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    r2: this.env.R2,
+    name: () => this.name
+  });
 
   getModel(): LanguageModel {
     return createWorkersAI({ binding: this.env.AI })(

--- a/packages/think/src/tests/agents/assistant-tools.ts
+++ b/packages/think/src/tests/agents/assistant-tools.ts
@@ -3,7 +3,10 @@ import { Workspace } from "@cloudflare/shell";
 import { createWorkspaceTools } from "../../tools/workspace";
 
 export class TestAssistantToolsAgent extends Agent {
-  workspace = new Workspace(this);
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+  });
 
   private getTools() {
     return createWorkspaceTools(this.workspace);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -43,7 +43,7 @@
  * import { Workspace } from "@cloudflare/shell";
  *
  * export class ChatSession extends Think<Env> {
- *   workspace = new Workspace(this);
+ *   workspace = new Workspace({ sql: this.ctx.storage.sql, name: () => this.name });
  *
  *   getModel() {
  *     return createWorkersAI({ binding: this.env.AI })("@cf/moonshotai/kimi-k2.5");

--- a/packages/think/src/tools/workspace.ts
+++ b/packages/think/src/tools/workspace.ts
@@ -100,7 +100,7 @@ function workspaceGrepOps(ws: Workspace): GrepOperations {
  * import { createWorkspaceTools } from "@cloudflare/think";
  *
  * class MyAgent extends Agent<Env> {
- *   workspace = new Workspace(this);
+ *   workspace = new Workspace({ sql: this.ctx.storage.sql, name: () => this.name });
  *
  *   async onChatMessage() {
  *     const tools = createWorkspaceTools(this.workspace);


### PR DESCRIPTION
## Summary

- Replaces the tagged-template `WorkspaceHost` / `LegacyWorkspaceHost` interfaces with a plain `SqlBackend` interface (`query` + `run`)
- Constructor now takes a single options object: `new Workspace({ sql, namespace?, r2?, name?, ... })`
- Auto-detects `SqlStorage` (any DO with SQLite), `D1Database`, or a custom `{ query, run }` backend
- Supports lazy `name` via `() => string` for DO lifecycle compatibility
- Adds user-facing docs at `docs/workspace.md`
- Updates all consumers (examples, think, experimental) to the new API
- Adds tests for custom SqlBackend, async backend, and name resolution

## Test plan

- [x] All 194 shell package tests pass (`npx nx run @cloudflare/shell:test`)
- [x] Build passes (`npx nx run @cloudflare/shell:build`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify examples still work locally (`cd examples/assistant && npm start`)
- [ ] Verify experimental/workspace-chat still works locally


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
