### PR TITLE
refactor(ai-chat): split canonical replay state from display persistence

### DIFF
--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -330,12 +330,20 @@ export class AIChatAgent<
   private _lastBody: Record<string, unknown> | undefined;
 
   /**
-   * Cache of last-persisted JSON for each message ID.
+   * Cache of last-persisted display JSON for each message ID.
    * Used for incremental persistence: skip SQL writes for unchanged messages.
    * Lost on hibernation, repopulated from SQLite on wake.
    * @internal
    */
-  private _persistedMessageCache: Map<string, string> = new Map();
+  private _persistedDisplayMessageCache: Map<string, string> = new Map();
+
+  /**
+   * Cache of last-persisted canonical JSON for each message ID.
+   * Used for incremental persistence: skip SQL writes for unchanged messages.
+   * Lost on hibernation, repopulated from SQLite on wake.
+   * @internal
+   */
+  private _persistedCanonicalMessageCache: Map<string, string> = new Map();
 
   /** Maximum serialized message size before compaction (bytes). 1.8MB with headroom below SQLite's 2MB limit. */
   private static ROW_MAX_BYTES = 1_800_000;
@@ -404,6 +412,12 @@ export class AIChatAgent<
   constructor(ctx: AgentContext, env: Env) {
     super(ctx, env);
     this.sql`create table if not exists cf_ai_chat_agent_messages (
+      id text primary key,
+      message text not null,
+      created_at datetime default current_timestamp
+    )`;
+
+    this.sql`create table if not exists cf_ai_chat_agent_messages_canonical (
       id text primary key,
       message text not null,
       created_at datetime default current_timestamp
@@ -611,12 +625,14 @@ export class AIChatAgent<
         if (data.type === MessageType.CF_AGENT_CHAT_CLEAR) {
           this.resetTurnState();
           this.sql`delete from cf_ai_chat_agent_messages`;
+          this.sql`delete from cf_ai_chat_agent_messages_canonical`;
           this._resumableStream.clearAll();
           this._pendingResumeConnections.clear();
           this._lastClientTools = undefined;
           this._lastBody = undefined;
           this._persistRequestContext();
-          this._persistedMessageCache.clear();
+          this._persistedDisplayMessageCache.clear();
+          this._persistedCanonicalMessageCache.clear();
           this.messages = [];
           this._broadcastChatMessage(
             { type: MessageType.CF_AGENT_CHAT_CLEAR },
@@ -786,7 +802,7 @@ export class AIChatAgent<
       return this._tryCatchChat(async () => {
         const url = new URL(request.url);
         if (url.pathname.split("/").pop() === "get-messages") {
-          return Response.json(this._loadMessagesFromDb());
+          return Response.json(this._loadDisplayMessagesFromDb());
         }
         return _onRequest(request);
       });
@@ -1139,23 +1155,62 @@ export class AIChatAgent<
   }
 
   private _loadMessagesFromDb(): ChatMessage[] {
+    return this._loadCanonicalMessagesFromDb();
+  }
+
+  private _loadDisplayMessagesFromDb(): ChatMessage[] {
     const rows =
-      this.sql`select * from cf_ai_chat_agent_messages order by created_at` ||
-      [];
+      this.sql<{ id: string; message: string }>`
+        select id, message from cf_ai_chat_agent_messages order by created_at
+      ` || [];
 
-    // Populate the persistence cache from DB so incremental persistence
-    // can skip SQL writes for messages already stored.
-    this._persistedMessageCache.clear();
+    this._persistedDisplayMessageCache.clear();
 
+    return this._parsePersistedMessages(
+      rows,
+      this._persistedDisplayMessageCache
+    );
+  }
+
+  private _loadCanonicalMessagesFromDb(): ChatMessage[] {
+    const displayRows =
+      this.sql<{ id: string; message: string }>`
+        select id, message from cf_ai_chat_agent_messages order by created_at
+      ` || [];
+    const canonicalRows =
+      this.sql<{ id: string; message: string }>`
+        select id, message from cf_ai_chat_agent_messages_canonical
+      ` || [];
+
+    const canonicalById = new Map(
+      canonicalRows.map((row) => [row.id, row.message])
+    );
+
+    this._persistedDisplayMessageCache.clear();
+    this._persistedCanonicalMessageCache.clear();
+
+    for (const row of displayRows) {
+      this._persistedDisplayMessageCache.set(row.id, row.message);
+    }
+
+    return this._parsePersistedMessages(
+      displayRows.map((row) => ({
+        id: row.id,
+        message: canonicalById.get(row.id) ?? row.message
+      })),
+      this._persistedCanonicalMessageCache
+    );
+  }
+
+  private _parsePersistedMessages(
+    rows: Array<{ id: string; message: string }>,
+    cache: Map<string, string>
+  ): ChatMessage[] {
     return rows
       .map((row) => {
         try {
-          const messageStr = row.message as string;
-          const parsed = JSON.parse(messageStr) as ChatMessage;
+          const parsed = JSON.parse(row.message) as ChatMessage;
 
-          // Structural validation: ensure required fields exist and have
-          // the correct types. This catches corrupted rows, manual tampering,
-          // or schema drift from older versions without crashing the agent.
           if (!isValidMessageStructure(parsed)) {
             console.warn(
               `[AIChatAgent] Skipping invalid message ${row.id}: ` +
@@ -1164,8 +1219,7 @@ export class AIChatAgent<
             return null;
           }
 
-          // Cache the raw JSON keyed by message ID
-          this._persistedMessageCache.set(parsed.id, messageStr);
+          cache.set(parsed.id, row.message);
           return parsed;
         } catch (error) {
           console.error(`Failed to parse message ${row.id}:`, error);
@@ -1515,8 +1569,9 @@ export class AIChatAgent<
   /**
    * Override this method to apply custom transformations to messages before
    * they are persisted to storage. This hook runs **after** the built-in
-   * sanitization (OpenAI metadata stripping, Anthropic provider-executed tool
-   * payload truncation, empty reasoning part filtering).
+   * canonical sanitization (OpenAI metadata stripping and empty reasoning part
+   * filtering) and **before** the display projection compacts large tool
+   * payloads for client-facing persistence.
    *
    * The default implementation returns the message unchanged.
    *
@@ -1597,22 +1652,18 @@ export class AIChatAgent<
     // Persist only new or changed messages (incremental persistence).
     // Compares serialized JSON against a cache of last-persisted versions.
     for (const message of mergedMessages) {
-      const sanitizedMessage = this._sanitizeMessageForPersistence(message);
-      const resolved = this._resolveMessageForToolMerge(sanitizedMessage);
-      const safe = this._enforceRowSizeLimit(resolved);
-      const json = JSON.stringify(safe);
+      const persisted = this._buildMessagePersistencePair(message);
 
-      // Skip SQL write if the message is identical to what's already persisted
-      if (this._persistedMessageCache.get(safe.id) === json) {
+      if (
+        this._persistedDisplayMessageCache.get(persisted.display.id) ===
+          persisted.displayJson &&
+        this._persistedCanonicalMessageCache.get(persisted.canonical.id) ===
+          persisted.canonicalJson
+      ) {
         continue;
       }
 
-      this.sql`
-        insert into cf_ai_chat_agent_messages (id, message)
-        values (${safe.id}, ${json})
-        on conflict(id) do update set message = excluded.message
-      `;
-      this._persistedMessageCache.set(safe.id, json);
+      this._writePersistedMessagePair(persisted);
     }
 
     // Reconcile: delete DB rows not present in the incoming message set.
@@ -1636,10 +1687,7 @@ export class AIChatAgent<
           ` || [];
         for (const row of allDbRows) {
           if (!keepIds.has(row.id)) {
-            this.sql`
-              delete from cf_ai_chat_agent_messages where id = ${row.id}
-            `;
-            this._persistedMessageCache.delete(row.id);
+            this._deletePersistedMessage(row.id);
           }
         }
       }
@@ -1660,6 +1708,70 @@ export class AIChatAgent<
       },
       excludeBroadcastIds
     );
+  }
+
+  private _buildMessagePersistencePair(message: ChatMessage): {
+    canonical: ChatMessage;
+    canonicalJson: string;
+    display: ChatMessage;
+    displayJson: string;
+  } {
+    const sanitized = this._sanitizeMessageForPersistence(message);
+    const canonical = this._resolveMessageForToolMerge(sanitized);
+    const display = this._enforceRowSizeLimit(
+      this._projectMessageForDisplay(canonical)
+    );
+
+    return {
+      canonical,
+      canonicalJson: JSON.stringify(canonical),
+      display,
+      displayJson: JSON.stringify(display)
+    };
+  }
+
+  private _projectMessageForDisplay(message: ChatMessage): ChatMessage {
+    return {
+      ...message,
+      parts: message.parts.map((part) =>
+        AIChatAgent._truncateProviderExecutedToolPayloads(part)
+      ) as ChatMessage["parts"]
+    };
+  }
+
+  private _writePersistedMessagePair(pair: {
+    canonical: ChatMessage;
+    canonicalJson: string;
+    display: ChatMessage;
+    displayJson: string;
+  }): void {
+    this.sql`
+      insert into cf_ai_chat_agent_messages (id, message)
+      values (${pair.display.id}, ${pair.displayJson})
+      on conflict(id) do update set message = excluded.message
+    `;
+    this.sql`
+      insert into cf_ai_chat_agent_messages_canonical (id, message)
+      values (${pair.canonical.id}, ${pair.canonicalJson})
+      on conflict(id) do update set message = excluded.message
+    `;
+
+    this._persistedDisplayMessageCache.set(pair.display.id, pair.displayJson);
+    this._persistedCanonicalMessageCache.set(
+      pair.canonical.id,
+      pair.canonicalJson
+    );
+  }
+
+  private _deletePersistedMessage(id: string): void {
+    this.sql`
+      delete from cf_ai_chat_agent_messages where id = ${id}
+    `;
+    this.sql`
+      delete from cf_ai_chat_agent_messages_canonical where id = ${id}
+    `;
+    this._persistedDisplayMessageCache.delete(id);
+    this._persistedCanonicalMessageCache.delete(id);
   }
 
   /**
@@ -1930,18 +2042,13 @@ export class AIChatAgent<
    *    itemIds and reasoningEncryptedContent to message parts. When persisted
    *    and sent back, OpenAI rejects duplicate itemIds.
    *
-   * 2. **Truncate provider-executed tool payloads**: Server-side tool
-   *    executions (e.g. Anthropic code_execution, text_editor) can produce
-   *    200KB+ payloads in `input` and `output`. These are truncated since the
-   *    model has already consumed the results.
-   *
-   * 3. **Filter truly empty reasoning parts**: After stripping, reasoning parts
+   * 2. **Filter truly empty reasoning parts**: After stripping, reasoning parts
    *    with no text and no remaining providerMetadata are removed. Parts that
    *    still carry providerMetadata (e.g. Anthropic's redacted_thinking blocks
    *    with providerMetadata.anthropic.redactedData) are preserved, as they
    *    contain data required for round-tripping with the provider API.
    *
-   * 4. **User hook**: Calls the overridable `sanitizeMessageForPersistence()`
+   * 3. **User hook**: Calls the overridable `sanitizeMessageForPersistence()`
    *    method, allowing subclasses to apply custom transformations.
    *
    * @param message - The message to sanitize
@@ -1976,11 +2083,6 @@ export class AIChatAgent<
           "callProviderMetadata"
         );
       }
-
-      // Truncate large payloads in provider-executed tool parts
-      // (e.g. Anthropic code_execution / text_editor)
-      sanitizedPart =
-        AIChatAgent._truncateProviderExecutedToolPayloads(sanitizedPart);
 
       return sanitizedPart;
     }) as ChatMessage["parts"];
@@ -2186,8 +2288,7 @@ export class AIChatAgent<
 
     if (toDelete && toDelete.length > 0) {
       for (const row of toDelete) {
-        this.sql`delete from cf_ai_chat_agent_messages where id = ${row.id}`;
-        this._persistedMessageCache.delete(row.id);
+        this._deletePersistedMessage(row.id);
       }
     }
   }
@@ -2404,21 +2505,14 @@ export class AIChatAgent<
       }) as ChatMessage["parts"];
 
       if (updated) {
-        const updatedMessage: ChatMessage = this._sanitizeMessageForPersistence(
-          { ...message, parts: updatedParts }
-        );
-        const safe = this._enforceRowSizeLimit(updatedMessage);
-        const json = JSON.stringify(safe);
+        const persisted = this._buildMessagePersistencePair({
+          ...message,
+          parts: updatedParts
+        });
+        this._writePersistedMessagePair(persisted);
 
-        this.sql`
-          update cf_ai_chat_agent_messages 
-          set message = ${json}
-          where id = ${message.id}
-        `;
-        this._persistedMessageCache.set(message.id, json);
-
-        const persisted = this._loadMessagesFromDb();
-        this.messages = autoTransformMessages(persisted);
+        const reloaded = this._loadMessagesFromDb();
+        this.messages = autoTransformMessages(reloaded);
       }
     }
 
@@ -2566,16 +2660,11 @@ export class AIChatAgent<
                 ...this._streamingMessage,
                 parts: [...this._streamingMessage.parts]
               };
-              const sanitized = this._sanitizeMessageForPersistence(snapshot);
-              const json = JSON.stringify(sanitized);
-              this.sql`
-                INSERT INTO cf_ai_chat_agent_messages (id, message)
-                VALUES (${sanitized.id}, ${json})
-                ON CONFLICT(id) DO UPDATE SET message = excluded.message
-              `;
+              const persisted = this._buildMessagePersistencePair(snapshot);
+              this._writePersistedMessagePair(persisted);
               // Track that we persisted early so stream completion can update
               // in place rather than appending a duplicate.
-              this._approvalPersistedMessageId = sanitized.id;
+              this._approvalPersistedMessageId = persisted.canonical.id;
             }
 
             // Cross-message tool output fallback:

--- a/packages/ai-chat/src/tests/canonical-display-projection.test.ts
+++ b/packages/ai-chat/src/tests/canonical-display-projection.test.ts
@@ -1,0 +1,227 @@
+import { env, exports } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import type { UIMessage as ChatMessage } from "ai";
+import { getAgentByName } from "agents";
+import { MessageType } from "../types";
+import { connectChatWS } from "./test-utils";
+
+function makeProviderExecutedMessage(id: string): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-code_execution",
+        toolCallId: `${id}-tool`,
+        toolName: "code_execution",
+        state: "output-available",
+        input: { code: "print('done')" },
+        providerExecuted: true,
+        output: {
+          type: "encrypted_code_execution_result",
+          encryptedStdout: "s".repeat(5_548),
+          preview: "p".repeat(10_000)
+        }
+      }
+    ]
+  } as unknown as ChatMessage;
+}
+
+describe("Canonical persistence and display projection", () => {
+  it("stores canonical and display variants separately", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.persistMessages([makeProviderExecutedMessage("pair-1")]);
+
+    const canonical = (await agentStub.getCanonicalMessages()) as ChatMessage[];
+    const display = (await agentStub.getPersistedMessages()) as ChatMessage[];
+
+    const canonicalOutput = (
+      canonical[0].parts[0] as { output: Record<string, unknown> }
+    ).output;
+    const displayOutput = (
+      display[0].parts[0] as { output: Record<string, unknown> }
+    ).output;
+
+    expect(canonicalOutput.preview).toHaveLength(10_000);
+    expect(displayOutput.preview as string).toContain(
+      "… [truncated, original length: 10000]"
+    );
+    expect(displayOutput.encryptedStdout).toBe(canonicalOutput.encryptedStdout);
+
+    ws.close(1000);
+  });
+
+  it("keeps live replay state canonical while get-messages returns display projection", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.persistMessages([makeProviderExecutedMessage("pair-2")]);
+
+    const liveMessages =
+      (await agentStub.getLiveMessagesForTest()) as ChatMessage[];
+    const liveOutput = (
+      liveMessages[0].parts[0] as { output: Record<string, unknown> }
+    ).output;
+    expect(liveOutput.preview).toHaveLength(10_000);
+
+    ws.close(1000);
+
+    const res = await exports.default.fetch(
+      `http://example.com/agents/test-chat-agent/${room}/get-messages`
+    );
+    expect(res.status).toBe(200);
+
+    const returned = (await res.json()) as ChatMessage[];
+    const returnedOutput = (
+      returned[0].parts[0] as { output: Record<string, unknown> }
+    ).output;
+    expect(returnedOutput.preview as string).toContain(
+      "… [truncated, original length: 10000]"
+    );
+  });
+
+  it("falls back to display rows when canonical rows are missing", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.persistMessages([makeProviderExecutedMessage("pair-3")]);
+    await agentStub.deleteCanonicalMessage("pair-3");
+
+    const loaded =
+      (await agentStub.loadCanonicalMessagesForTest()) as ChatMessage[];
+    const output = (loaded[0].parts[0] as { output: Record<string, unknown> })
+      .output;
+
+    expect(output.preview as string).toContain(
+      "… [truncated, original length: 10000]"
+    );
+
+    ws.close(1000);
+  });
+
+  it("updates canonical and display stores together for tool-result mutations", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.persistMessages([
+      {
+        id: "tool-user",
+        role: "user",
+        parts: [{ type: "text", text: "Run code" }]
+      },
+      {
+        id: "tool-assistant",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-code_execution",
+            toolCallId: "tool-call-1",
+            toolName: "code_execution",
+            state: "input-available",
+            input: { code: "print('done')" },
+            providerExecuted: true
+          }
+        ]
+      } as unknown as ChatMessage
+    ]);
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_TOOL_RESULT,
+        toolCallId: "tool-call-1",
+        toolName: "code_execution",
+        output: {
+          type: "encrypted_code_execution_result",
+          encryptedStdout: "s".repeat(5_548),
+          preview: "p".repeat(10_000)
+        }
+      })
+    );
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const canonical = (await agentStub.getCanonicalMessages()) as ChatMessage[];
+    const display = (await agentStub.getPersistedMessages()) as ChatMessage[];
+
+    const canonicalOutput = (
+      canonical[1].parts[0] as { output: Record<string, unknown> }
+    ).output;
+    const displayOutput = (
+      display[1].parts[0] as { output: Record<string, unknown> }
+    ).output;
+
+    expect(canonicalOutput.preview).toHaveLength(10_000);
+    expect(displayOutput.preview as string).toContain(
+      "… [truncated, original length: 10000]"
+    );
+
+    ws.close(1000);
+  });
+
+  it("clears canonical rows alongside display rows", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.persistMessages([
+      {
+        id: "clear-canonical-user",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }]
+      },
+      makeProviderExecutedMessage("clear-canonical-assistant")
+    ]);
+
+    expect(await agentStub.getMessageCount()).toBe(2);
+    expect(await agentStub.getCanonicalMessageCount()).toBe(2);
+
+    ws.send(JSON.stringify({ type: MessageType.CF_AGENT_CHAT_CLEAR }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(await agentStub.getMessageCount()).toBe(0);
+    expect(await agentStub.getCanonicalMessageCount()).toBe(0);
+
+    ws.close(1000);
+  });
+
+  it("trims canonical rows when maxPersistedMessages deletes old history", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    await agentStub.setMaxPersistedMessages(1);
+
+    await agentStub.persistMessages([
+      {
+        id: "max-1",
+        role: "user",
+        parts: [{ type: "text", text: "first" }]
+      },
+      {
+        id: "max-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "second" }]
+      }
+    ]);
+
+    const display = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const canonical = (await agentStub.getCanonicalMessages()) as ChatMessage[];
+
+    expect(display.map((message) => message.id)).toEqual(["max-2"]);
+    expect(canonical.map((message) => message.id)).toEqual(["max-2"]);
+
+    ws.close(1000);
+  });
+});

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -279,6 +279,33 @@ export class TestChatAgent extends AIChatAgent<Env> {
     return rawMessages;
   }
 
+  getCanonicalMessages(): ChatMessage[] {
+    const rawMessages = (
+      this.sql`
+        select * from cf_ai_chat_agent_messages_canonical order by created_at
+      ` || []
+    ).map((row) => {
+      return JSON.parse(row.message as string);
+    });
+    return rawMessages;
+  }
+
+  loadCanonicalMessagesForTest(): ChatMessage[] {
+    return (
+      this as unknown as { _loadMessagesFromDb(): ChatMessage[] }
+    )._loadMessagesFromDb();
+  }
+
+  getLiveMessagesForTest(): ChatMessage[] {
+    return this.messages;
+  }
+
+  deleteCanonicalMessage(id: string): void {
+    this.sql`
+      delete from cf_ai_chat_agent_messages_canonical where id = ${id}
+    `;
+  }
+
   async testPersistToolCall(messageId: string, toolName: string) {
     const toolCallPart: TestToolCallPart = {
       type: `tool-${toolName}`,
@@ -491,6 +518,13 @@ export class TestChatAgent extends AIChatAgent<Env> {
   getMessageCount(): number {
     const result = this.sql<{ cnt: number }>`
       select count(*) as cnt from cf_ai_chat_agent_messages
+    `;
+    return result?.[0]?.cnt ?? 0;
+  }
+
+  getCanonicalMessageCount(): number {
+    const result = this.sql<{ cnt: number }>`
+      select count(*) as cnt from cf_ai_chat_agent_messages_canonical
     `;
     return result?.[0]?.cnt ?? 0;
   }


### PR DESCRIPTION
## Summary
- add a canonical persistence path for `AIChatAgent` message history while keeping the existing persisted row shape as a display projection
- load `this.messages` from canonical rows, but keep `/get-messages` and other storage-facing reads on the compact display projection for compatibility
- add regression coverage for canonical/display divergence, canonical fallback, point updates, clear-history cleanup, and max-history trimming

## Why
The hotfix in #1188 stops the common Anthropic replay-token corruption path, but the underlying persistence model still conflates two different concerns:
- exact state needed to replay a conversation back to a provider
- compact state we persist and expose to clients for storage/debug/UI use

That coupling is what made it easy for truncation logic to damage replay-critical data. This PR creates an internal boundary between those concerns without changing the public API surface.

## What changed
### Persistence model
- kept `cf_ai_chat_agent_messages` as the display-projection table
- added `cf_ai_chat_agent_messages_canonical` as the canonical replay table
- split the incremental persistence cache into display + canonical caches

### Read/write flow
- `persistMessages()` now builds and writes a pair for each message:
  - canonical message: sanitized + tool-merge-resolved
  - display message: canonical message projected through provider payload truncation + row-size enforcement
- `_loadMessagesFromDb()` now loads canonical rows, with fallback to display rows when canonical rows are absent
- `/get-messages` now explicitly serves the display projection
- persisted tool-result / approval updates and early approval persistence now write both representations
- clear-history and max-history trimming now delete both representations together

### Tests
Added a dedicated regression suite that verifies:
- canonical and display payloads diverge where expected
- live replay state stays canonical while `/get-messages` stays display-oriented
- canonical loading falls back to display rows for backward compatibility
- tool-result updates keep canonical + display rows in sync
- clear-history and `maxPersistedMessages` clean up canonical rows too

## Reviewer Notes
- this is intentionally a stacked follow-up on top of #1188; please review commit-by-commit starting from that hotfix
- the goal here is architectural separation with minimal behavior drift, not a full persistence redesign or blob/chunk storage system
- I kept the existing user hook contract intact by running `sanitizeMessageForPersistence()` before canonical persistence; display projection is then derived from that canonical result
- I also kept the existing display table and `/get-messages` contract so current clients continue to see the same compacted/sanitized shape
- canonical loads fall back to display rows on missing canonical data so older rows and partial upgrades do not break startup or replay
- this PR does **not** yet solve the pathological case where a canonical message itself exceeds D1 row limits; that would need chunking/externalization in a later step if we decide the added complexity is worth it

## Review Invariants
- every persisted write/delete path must update or remove both canonical and display rows together
- `this.messages` must always come from canonical state, never from the display projection
- `/get-messages` and other client-facing reads must continue to return the display projection, not canonical-only payloads
- missing canonical rows must fall back cleanly to display rows so startup and replay stay backward-compatible
- cleanup paths (`clear`, trimming, early approval persistence) must not leave orphaned canonical rows behind
- this is still a dual-write design, so the main thing to verify is that all mutation paths preserve those invariants consistently

## Testing
- `npm run test:workers -w @cloudflare/ai-chat`
- `npm run check`

## Stacking
- Base PR: #1188
- This PR should be reviewed/merged after #1188, then retargeted to `main`