### PR TITLE
Add message concurrency controls to AIChatAgent

### DIFF
--- a/.changeset/nasty-pumpkins-juggle.md
+++ b/.changeset/nasty-pumpkins-juggle.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/ai-chat": minor
+---
+
+Add `AIChatAgent.messageConcurrency` to control overlapping `sendMessage()`
+submits with `queue`, `latest`, `merge`, `drop`, and `debounce` strategies.
+Enhance `saveMessages()` to accept a functional form for deriving messages
+from the latest transcript, and return `{ requestId, status }` so callers
+can detect skipped turns.

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -143,6 +143,9 @@ export class ChatAgent extends AIChatAgent {
   // Limit stored messages (optional)
   maxPersistedMessages = 200;
 
+  // Collapse overlapping user submits to the latest one (optional)
+  // messageConcurrency = "latest";
+
   async onChatMessage(onFinish?, options?) {
     // onFinish: optional callback for streamText (cleanup is automatic)
     // options.abortSignal: cancel signal
@@ -230,6 +233,59 @@ async onChatMessage() {
 }
 ```
 
+### `messageConcurrency`
+
+Controls what happens when a new `sendMessage()` submit arrives while another
+chat turn is already active or queued.
+
+| Value                           | Behavior                                                             |
+| ------------------------------- | -------------------------------------------------------------------- |
+| `"queue"`                       | Process every submit in order (default, existing behavior)           |
+| `"latest"`                      | Keep only the newest overlapping submit                              |
+| `"merge"`                       | Collapse overlapping queued user messages into one follow-up submit  |
+| `"drop"`                        | Ignore overlapping submits entirely                                  |
+| `{ strategy: "debounce", ... }` | Wait for a quiet period, then run only the latest overlapping submit |
+
+```typescript
+export class ChatAgent extends AIChatAgent {
+  messageConcurrency = "latest";
+}
+```
+
+Debounce uses the same trailing-edge semantics as chat apps that wait for the
+user to finish sending a burst of short messages:
+
+```typescript
+export class ChatAgent extends AIChatAgent {
+  messageConcurrency = {
+    strategy: "debounce",
+    debounceMs: 1000
+  };
+}
+```
+
+**Choosing a strategy:**
+
+- Building a focused assistant where each turn matters? Use `"latest"` — the user can correct themselves mid-stream and only the final message gets a response.
+- Building a messaging or chat app where every message should be processed? Use `"queue"` (default) or `"merge"` to collapse rapid-fire messages into one turn.
+- Want to prevent accidental double-sends? Use `"drop"` — overlapping submits are rejected and the client rolls back.
+- Users send bursts of short messages (like a messaging app)? Use `"debounce"` to wait for a quiet window before responding.
+
+**What the user sees:**
+
+- `"queue"` — every message gets its own assistant response, in order. Standard chat behavior.
+- `"latest"` — all user messages appear in the transcript, but only the last overlapping message gets an assistant response. Earlier overlapping messages sit in the history with no reply.
+- `"merge"` — overlapping user messages are collapsed into one combined message in the transcript, which gets a single assistant response.
+- `"drop"` — the overlapping message briefly appears (optimistic), then disappears when the server sends back the rollback.
+- `"debounce"` — same as `"latest"`, but the response waits for a quiet period before starting.
+
+Notes:
+
+- This setting only applies to overlapping `sendMessage()` submits (`trigger: "submit-message"`)
+- `regenerate()`, tool continuations, approvals, clears, and programmatic `saveMessages()` calls keep the existing serialized behavior
+- `"latest"` and `"debounce"` still persist the skipped user messages in `this.messages`; they only suppress extra model turns
+- `"drop"` rejects the overlapping submit before it is persisted
+
 ### `waitForMcpConnections`
 
 Controls whether `AIChatAgent` waits for MCP server connections to settle before calling `onChatMessage`. This ensures `this.mcp.getAITools()` returns the full set of tools, especially after Durable Object hibernation when connections are being restored in the background.
@@ -258,19 +314,29 @@ For lower-level control, call `this.mcp.waitForConnections()` directly inside yo
 
 ### `persistMessages` and `saveMessages`
 
-For advanced cases, you can manually persist messages:
+For advanced cases (schedule callbacks, webhook handlers, background tasks),
+you can manually persist messages or queue programmatic turns:
 
 ```typescript
 // Persist messages without triggering a new response
 await this.persistMessages(messages);
 
-// Persist messages AND trigger onChatMessage (e.g., programmatic messages)
-await this.saveMessages(messages);
+// Persist messages AND trigger onChatMessage
+await this.saveMessages([...this.messages, newMessage]);
+
+// Functional form: derive from latest transcript at execution time
+// (e.g., from a schedule() callback or webhook handler)
+await this.saveMessages((messages) => [...messages, syntheticMessage]);
 ```
 
-`saveMessages()` waits for any active chat turn to finish before it starts a
-new one, so scheduled or programmatic messages do not overlap an in-flight
-stream.
+Use the functional form when background work needs to append or transform
+messages against the latest persisted transcript when the turn actually starts.
+This avoids stale baselines when multiple `saveMessages()` calls queue up
+behind active work.
+
+`saveMessages()` returns `{ requestId, status }` so callers can detect whether
+the turn ran (`"completed"`) or was skipped because the chat was cleared
+(`"skipped"`).
 
 ### `onChatResponse`
 
@@ -321,8 +387,10 @@ Responses triggered from inside `onChatResponse` do not fire the hook concurrent
 ### Turn coordination helpers
 
 `AIChatAgent` serializes chat turns — WebSocket requests, tool continuations,
-and `saveMessages()` calls all run one at a time. Most subclasses do not need to
-think about this; the SDK handles the queuing automatically.
+`saveMessages()` calls all run one at a time. Most subclasses do not need to
+think about this; the SDK handles the queuing automatically. If you configure
+`messageConcurrency`, that policy decides which overlapping `sendMessage()` submits
+make it into the queue.
 
 Coordination becomes relevant when your subclass runs code **outside** the
 normal `onChatMessage()` flow — for example, a `schedule()` callback that
@@ -342,8 +410,9 @@ Three protected helpers cover these cases:
 #### How the turn lifecycle works
 
 A chat turn starts when a WebSocket message or `saveMessages()` call enters the
-queue and ends after the `_reply()` stream finishes and the final assistant
-message is persisted. If a tool result or approval arrives with
+queue and ends after the `_reply()` stream
+finishes and the final assistant message is persisted. If a tool result or
+approval arrives with
 `autoContinue: true`, a continuation turn is queued automatically — the
 conversation is not stable until that continuation finishes too.
 
@@ -375,7 +444,7 @@ async onTaskComplete(payload: { result: string }) {
     parts: [{ type: "text" as const, text: `Task result: ${payload.result}` }]
   };
 
-  await this.saveMessages([...this.messages, syntheticMessage]);
+  await this.saveMessages((messages) => [...messages, syntheticMessage]);
 }
 ```
 

--- a/examples/ai-chat/src/server.ts
+++ b/examples/ai-chat/src/server.ts
@@ -170,8 +170,8 @@ export class ChatAgent extends AIChatAgent {
     const ready = await this.waitUntilStable({ timeout: 10_000 });
     if (!ready) return;
 
-    await this.saveMessages([
-      ...this.messages,
+    await this.saveMessages((messages) => [
+      ...messages,
       {
         id: nanoid(),
         role: "user" as const,

--- a/packages/ai-chat/CHANGELOG.md
+++ b/packages/ai-chat/CHANGELOG.md
@@ -16,7 +16,10 @@
 
 ### Patch Changes
 
-- [#1183](https://github.com/cloudflare/agents/pull/1183) [`324b296`](https://github.com/cloudflare/agents/commit/324b29638878234dfb4d8f810c929cad0028b717) Thanks [@threepointone](https://github.com/threepointone)! - Fix waitForIdle race and relax test assertion
+- [#1183](https://github.com/cloudflare/agents/pull/1183)
+  [`324b296`](https://github.com/cloudflare/agents/commit/324b29638878234dfb4d8f810c929cad0028b717)
+  Thanks [@threepointone](https://github.com/threepointone)! - Fix
+  waitForIdle race and relax test assertion
 
   Make waitForIdle robust against races by looping until \_chatTurnQueue is stable (capture the current promise, await it, and repeat if it changed). Update the related test: rename it to reflect behavior and relax the assertion to accept 1–2 started request IDs (documenting the nondeterministic coalescing window under load), since rapid auto-continued tool results may coalesce or form sequential turns depending on timing.
 
@@ -24,21 +27,42 @@
 
 ### Patch Changes
 
-- [#1179](https://github.com/cloudflare/agents/pull/1179) [`adc86f8`](https://github.com/cloudflare/agents/commit/adc86f805475ea5deabf40be9f04e2540dee529b) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Coalesce rapid client-side tool results and approvals into a single auto-continuation turn so ai-chat avoids duplicate model continuations and extra streamed output.
+- [#1179](https://github.com/cloudflare/agents/pull/1179)
+  [`adc86f8`](https://github.com/cloudflare/agents/commit/adc86f805475ea5deabf40be9f04e2540dee529b)
+  Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Coalesce rapid
+  client-side tool results and approvals into a single auto-continuation
+  turn so ai-chat avoids duplicate model continuations and extra streamed
+  output.
 
 ## 0.2.2
 
 ### Patch Changes
 
-- [#1178](https://github.com/cloudflare/agents/pull/1178) [`253345e`](https://github.com/cloudflare/agents/commit/253345e2dfc5a279572e03e24e48ddc58f10151d) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Fix multi-tab tool continuations so only the originating connection waits for the pending resume handshake, while other tabs continue receiving live stream updates.
+- [#1178](https://github.com/cloudflare/agents/pull/1178)
+  [`253345e`](https://github.com/cloudflare/agents/commit/253345e2dfc5a279572e03e24e48ddc58f10151d)
+  Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Fix multi-tab
+  tool continuations so only the originating connection waits for the
+  pending resume handshake, while other tabs continue receiving live stream
+  updates.
 
 ## 0.2.1
 
 ### Patch Changes
 
-- [#1162](https://github.com/cloudflare/agents/pull/1162) [`7053b49`](https://github.com/cloudflare/agents/commit/7053b495380075bd9e3cb39edd454c8e9b0059f2) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Fix chained tool-approval continuations so they keep streaming into the existing assistant message instead of splitting later continuation steps into a new persisted message.
+- [#1162](https://github.com/cloudflare/agents/pull/1162)
+  [`7053b49`](https://github.com/cloudflare/agents/commit/7053b495380075bd9e3cb39edd454c8e9b0059f2)
+  Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Fix chained
+  tool-approval continuations so they keep streaming into the existing
+  assistant message instead of splitting later continuation steps into a new
+  persisted message.
 
-- [#1161](https://github.com/cloudflare/agents/pull/1161) [`c131923`](https://github.com/cloudflare/agents/commit/c13192311984182df82253c4754b058e7f39a63d) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Prevent hibernation from silently dropping tool auto-continuations. Wrap `_queueAutoContinuation` in `keepAliveWhile` so the DO stays alive from the moment a continuation is queued until it finishes streaming. Also adds test coverage for continuation edge cases.
+- [#1161](https://github.com/cloudflare/agents/pull/1161)
+  [`c131923`](https://github.com/cloudflare/agents/commit/c13192311984182df82253c4754b058e7f39a63d)
+  Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - Prevent
+  hibernation from silently dropping tool auto-continuations. Wrap
+  `_queueAutoContinuation` in `keepAliveWhile` so the DO stays alive from
+  the moment a continuation is queued until it finishes streaming. Also
+  adds test coverage for continuation edge cases.
 
 ## 0.2.0
 

--- a/packages/ai-chat/README.md
+++ b/packages/ai-chat/README.md
@@ -200,6 +200,62 @@ Disable with `resume: false`:
 const { messages } = useAgentChat({ agent, resume: false });
 ```
 
+## Overlapping Messages
+
+When users submit a new message while another turn is still active, `AIChatAgent`
+can queue, collapse, or drop the overlap server-side:
+
+```typescript
+export class ChatAgent extends AIChatAgent {
+  messageConcurrency = "latest";
+
+  async onChatMessage() {
+    // ...
+  }
+}
+```
+
+Available strategies:
+
+- `"queue"` (default) — process every submit in order
+- `"latest"` — keep only the newest overlapping submit and skip any older queued overlap turns
+- `"merge"` — queue overlapping submits, then collapse their queued user messages into one combined follow-up user turn
+- `"drop"` — ignore overlapping submits
+- `{ strategy: "debounce", debounceMs: 750 }` — wait for a quiet window, then run only the latest submit
+
+**Choosing a strategy:** Use `"latest"` for focused assistants where the user
+can correct themselves mid-stream. Use `"queue"` or `"merge"` for messaging
+apps where every message matters. Use `"drop"` to prevent double-sends. Use
+`"debounce"` when users send bursts of short messages.
+
+**What the user sees:** With `"queue"`, every message gets its own response.
+With `"latest"`, all messages appear but only the last overlapping one gets a
+response. With `"merge"`, overlapping messages are collapsed into one. With
+`"drop"`, the overlapping message briefly appears then disappears (rollback).
+
+This setting only affects overlapping `sendMessage()` submits. Regenerate,
+tool continuations, approvals, and programmatic `saveMessages()` calls keep the
+existing serialized behavior. When `debounceMs` is missing or invalid,
+`AIChatAgent` falls back to the default `750` ms window.
+
+Pass a function to `saveMessages()` to derive from the latest transcript when
+the turn actually starts — useful for schedule callbacks and webhook handlers
+where messages may have changed since the call was made:
+
+```typescript
+await this.saveMessages((messages) => [
+  ...messages,
+  {
+    id: crypto.randomUUID(),
+    role: "user",
+    parts: [{ type: "text", text: "Scheduled follow-up" }]
+  }
+]);
+```
+
+`saveMessages()` returns `{ requestId, status }` — check `status` to detect
+whether the turn was skipped (e.g. because the chat was cleared while queued).
+
 ## Storage Management
 
 ### Limiting stored messages
@@ -281,16 +337,18 @@ async onChatMessage(onFinish, options) {
 
 Extends `Agent` from the `agents` package.
 
-| Property / Method                    | Type                  | Description                                                                     |
-| ------------------------------------ | --------------------- | ------------------------------------------------------------------------------- |
-| `messages`                           | `UIMessage[]`         | Current conversation messages (loaded from SQLite)                              |
-| `maxPersistedMessages`               | `number \| undefined` | Max messages to keep in SQLite. Default: unlimited                              |
-| `onChatMessage(onFinish?, options?)` | Override              | Handle incoming chat messages. Return a `Response`. `onFinish` is optional.     |
-| `persistMessages(messages)`          | `Promise<void>`       | Manually persist messages (usually automatic)                                   |
-| `saveMessages(messages)`             | `Promise<void>`       | Persist messages and trigger `onChatMessage`                                    |
-| `waitUntilStable()`                  | `Promise<boolean>`    | Protected helper to wait until the conversation is fully stable                 |
-| `resetTurnState()`                   | `void`                | Protected helper to abort the active turn and invalidate queued continuations   |
-| `hasPendingInteraction()`            | `boolean`             | Protected helper to detect pending tool input or approval in assistant messages |
+| Property / Method                    | Type                          | Description                                                                                       |
+| ------------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| `messages`                           | `UIMessage[]`                 | Current conversation messages (loaded from SQLite)                                                |
+| `maxPersistedMessages`               | `number \| undefined`         | Max messages to keep in SQLite. Default: unlimited                                                |
+| `messageConcurrency`                 | `MessageConcurrency`          | Concurrency strategy for `sendMessage()` submits. Default: `"queue"`                              |
+| `onChatMessage(onFinish?, options?)` | Override                      | Handle incoming chat messages. Return a `Response`. `onFinish` is optional.                       |
+| `onChatResponse(result)`             | Override                      | Called after a chat turn completes. `result` has `message`, `requestId`, `status`, `continuation` |
+| `persistMessages(messages)`          | `Promise<void>`               | Manually persist messages (usually automatic)                                                     |
+| `saveMessages(messages)`             | `Promise<SaveMessagesResult>` | Persist messages and trigger `onChatMessage`. Accepts array or function.                          |
+| `waitUntilStable()`                  | `Promise<boolean>`            | Protected helper to wait until the conversation is fully stable                                   |
+| `resetTurnState()`                   | `void`                        | Protected helper to abort the active turn and invalidate queued continuations                     |
+| `hasPendingInteraction()`            | `boolean`                     | Protected helper to detect pending tool input or approval in assistant messages                   |
 
 ### `useAgentChat(options)`
 

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -96,6 +96,35 @@ export type ClientToolSchema = {
   parameters?: JSONSchema7;
 };
 
+export type MessageConcurrency =
+  | "queue"
+  | "latest"
+  | "merge"
+  | "drop"
+  | {
+      strategy: "debounce";
+      debounceMs?: number;
+    };
+
+type ChatRequestTrigger = "submit-message" | "regenerate-message";
+
+type NormalizedMessageConcurrency =
+  | "queue"
+  | "latest"
+  | "merge"
+  | "drop"
+  | {
+      strategy: "debounce";
+      debounceMs: number;
+    };
+
+type SubmitConcurrencyDecision = {
+  action: "execute" | "drop";
+  submitSequence: number | null;
+  debounceUntilMs: number | null;
+  mergeQueuedMessages: boolean;
+};
+
 /**
  * Result passed to the `onChatResponse` lifecycle hook after a chat turn completes.
  */
@@ -153,6 +182,16 @@ export type OnChatMessageOptions = {
    * chat is cleared via `CF_AGENT_CHAT_CLEAR`.
    */
   body?: Record<string, unknown>;
+};
+
+/**
+ * Result returned by `saveMessages()`.
+ */
+export type SaveMessagesResult = {
+  /** Server-generated request ID for the chat turn. */
+  requestId: string;
+  /** Whether the turn ran or was skipped (e.g. because the chat was cleared). */
+  status: "completed" | "skipped";
 };
 
 /**
@@ -287,6 +326,24 @@ export class AIChatAgent<
    */
   private _chatEpoch = 0;
 
+  /** Number of active or queued chat turns per chat epoch. */
+  private _queuedChatTurnCountsByEpoch = new Map<number, number>();
+
+  /** First queued overlap message index for merge strategy, keyed by epoch. */
+  private _mergeQueuedUserStartIndexByEpoch = new Map<number, number>();
+
+  /** Monotonic sequence for overlapping submit-message requests. */
+  private _submitSequence = 0;
+
+  /** Latest overlapping submit-message sequence kept for latest/debounce. */
+  private _latestOverlappingSubmitSequence = 0;
+
+  /** Active debounce timer handle, cleared on resetTurnState. */
+  private _activeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Resolve callback for the active debounce promise. */
+  private _activeDebounceResolve: (() => void) | null = null;
+
   /**
    * Set of connection IDs that are pending stream resume.
    * These connections have received CF_AGENT_STREAM_RESUMING but haven't sent ACK yet.
@@ -377,6 +434,9 @@ export class AIChatAgent<
    */
   private static AUTO_CONTINUATION_COALESCE_MS = 10;
 
+  /** Default wait for trailing-edge debounced overlapping submits. */
+  private static MESSAGE_DEBOUNCE_MS = 750;
+
   /** Measure UTF-8 byte length of a string (accurate for SQLite row limits). */
   private static _byteLength(s: string): number {
     return textEncoder.encode(s).byteLength;
@@ -399,6 +459,25 @@ export class AIChatAgent<
    * ```
    */
   maxPersistedMessages: number | undefined = undefined;
+
+  /**
+   * Controls how overlapping user submit requests behave while another chat
+   * turn is already active or queued.
+   *
+   * - `"queue"` (default) — queue every submit and process them in order.
+   * - `"latest"` — keep only the latest overlapping submit; superseded submits
+   *   still persist their user messages, but do not start their own model turn.
+   * - `"merge"` — queue overlapping submits, then collapse their trailing user
+   *   messages into one combined user turn before the latest queued turn runs.
+   * - `"drop"` — ignore overlapping submits entirely.
+   * - `{ strategy: "debounce" }` — trailing-edge latest with a quiet window.
+   *
+   * This setting only applies to `sendMessage()` / `trigger: "submit-message"`
+   * requests. Regenerations, tool continuations, approvals, clears, and
+   * programmatic `saveMessages()` calls keep their existing serialized
+   * behavior.
+   */
+  messageConcurrency: MessageConcurrency = "queue";
 
   /**
    * When enabled, waits for all MCP server connections to be ready before
@@ -544,98 +623,168 @@ export class AIChatAgent<
             [key: string]: unknown;
           };
           const chatMessageId = data.id;
+          const transformedMessages = autoTransformMessages(messages);
+          const requestTrigger: ChatRequestTrigger =
+            _trigger === "regenerate-message"
+              ? "regenerate-message"
+              : "submit-message";
+          const requestClientTools = clientTools?.length
+            ? clientTools
+            : undefined;
+          const requestBody =
+            Object.keys(customBody).length > 0 ? customBody : undefined;
+          const epoch = this._chatEpoch;
+          const concurrencyDecision =
+            this._getSubmitConcurrencyDecision(requestTrigger);
 
-          return this._runExclusiveChatTurn(chatMessageId, async () => {
-            // Optionally wait for in-flight MCP connections to settle (e.g. after hibernation restore)
-            // so that getAITools() returns the full set of tools in onChatMessage
-            if (this.waitForMcpConnections) {
-              const timeout =
-                typeof this.waitForMcpConnections === "object"
-                  ? this.waitForMcpConnections.timeout
-                  : undefined;
-              await this.mcp.waitForConnections(
-                timeout != null ? { timeout } : undefined
-              );
-            }
+          if (concurrencyDecision.action === "drop") {
+            this._rollbackDroppedSubmit(connection);
+            this._completeSkippedRequest(connection, chatMessageId);
+            return;
+          }
 
-            // Store client tools and body for use during tool continuations
-            this._lastClientTools = clientTools?.length
-              ? clientTools
-              : undefined;
-            this._lastBody =
-              Object.keys(customBody).length > 0 ? customBody : undefined;
-            this._persistRequestContext();
+          // Persist and broadcast user messages before entering the turn
+          // queue so other tabs see the new message immediately and so
+          // overlapping submits under latest/merge/debounce can inspect
+          // the full message list when their turn starts.
+          this._broadcastChatMessage(
+            {
+              messages: transformedMessages,
+              type: MessageType.CF_AGENT_CHAT_MESSAGES
+            },
+            [connection.id]
+          );
 
-            // Automatically transform any incoming messages
-            const transformedMessages = autoTransformMessages(messages);
+          await this.persistMessages(transformedMessages, [connection.id], {
+            _deleteStaleRows: true
+          });
 
-            this._broadcastChatMessage(
-              {
-                messages: transformedMessages,
-                type: MessageType.CF_AGENT_CHAT_MESSAGES
-              },
-              [connection.id]
-            );
+          if (concurrencyDecision.mergeQueuedMessages) {
+            await this._mergeQueuedUserMessages(epoch);
+          }
 
-            await this.persistMessages(transformedMessages, [connection.id], {
-              _deleteStaleRows: true
-            });
+          return this._runExclusiveChatTurn(
+            chatMessageId,
+            async () => {
+              if (this._chatEpoch !== epoch) {
+                this._completeSkippedRequest(connection, chatMessageId);
+                return;
+              }
 
-            this._emit("message:request");
+              if (
+                this._isSupersededSubmit(concurrencyDecision.submitSequence)
+              ) {
+                this._completeSkippedRequest(connection, chatMessageId);
+                return;
+              }
 
-            const abortSignal = this._getAbortSignal(chatMessageId);
+              if (concurrencyDecision.debounceUntilMs !== null) {
+                await this._waitForTimestamp(
+                  concurrencyDecision.debounceUntilMs
+                );
 
-            return this._tryCatchChat(async () => {
-              // Wrap in agentContext.run() to propagate connection context to onChatMessage
-              // This ensures getCurrentAgent() returns the connection inside tool execute functions
-              return agentContext.run(
-                {
-                  agent: this,
-                  connection,
-                  request: undefined,
-                  email: undefined
-                },
-                async () => {
-                  const response = await this.onChatMessage(
-                    async (_finishResult) => {
-                      // User-provided hook. Cleanup is now handled by _reply,
-                      // so this is optional for the user to pass to streamText.
-                    },
-                    {
-                      requestId: chatMessageId,
-                      abortSignal,
-                      clientTools,
-                      body: this._lastBody
-                    }
-                  );
+                if (this._chatEpoch !== epoch) {
+                  this._completeSkippedRequest(connection, chatMessageId);
+                  return;
+                }
 
-                  if (response) {
-                    await this._reply(
-                      chatMessageId,
-                      response,
-                      [connection.id],
+                if (
+                  this._isSupersededSubmit(concurrencyDecision.submitSequence)
+                ) {
+                  this._completeSkippedRequest(connection, chatMessageId);
+                  return;
+                }
+              }
+
+              // Re-merge inside the lock: more overlapping submits may have
+              // persisted additional user messages while this turn was queued.
+              if (concurrencyDecision.mergeQueuedMessages) {
+                await this._mergeQueuedUserMessages(epoch);
+
+                if (this._chatEpoch !== epoch) {
+                  this._completeSkippedRequest(connection, chatMessageId);
+                  return;
+                }
+
+                if (
+                  this._isSupersededSubmit(concurrencyDecision.submitSequence)
+                ) {
+                  this._completeSkippedRequest(connection, chatMessageId);
+                  return;
+                }
+              }
+
+              // Optionally wait for in-flight MCP connections to settle (e.g. after hibernation restore)
+              // so that getAITools() returns the full set of tools in onChatMessage
+              if (this.waitForMcpConnections) {
+                const timeout =
+                  typeof this.waitForMcpConnections === "object"
+                    ? this.waitForMcpConnections.timeout
+                    : undefined;
+                await this.mcp.waitForConnections(
+                  timeout != null ? { timeout } : undefined
+                );
+              }
+
+              this._setRequestContext(requestClientTools, requestBody);
+
+              this._emit("message:request");
+
+              const abortSignal = this._getAbortSignal(chatMessageId);
+
+              return this._tryCatchChat(async () => {
+                // Wrap in agentContext.run() to propagate connection context to onChatMessage
+                // This ensures getCurrentAgent() returns the connection inside tool execute functions
+                return agentContext.run(
+                  {
+                    agent: this,
+                    connection,
+                    request: undefined,
+                    email: undefined
+                  },
+                  async () => {
+                    const response = await this.onChatMessage(
+                      async (_finishResult) => {
+                        // User-provided hook. Cleanup is now handled by _reply,
+                        // so this is optional for the user to pass to streamText.
+                      },
                       {
-                        chatMessageId
+                        requestId: chatMessageId,
+                        abortSignal,
+                        clientTools: requestClientTools,
+                        body: requestBody
                       }
                     );
-                  } else {
-                    console.warn(
-                      `[AIChatAgent] onChatMessage returned no response for chatMessageId: ${chatMessageId}`
-                    );
-                    this._broadcastChatMessage(
-                      {
-                        body: "No response was generated by the agent.",
-                        done: true,
-                        id: chatMessageId,
-                        type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
-                      },
-                      [connection.id]
-                    );
+
+                    if (response) {
+                      await this._reply(
+                        chatMessageId,
+                        response,
+                        [connection.id],
+                        {
+                          chatMessageId
+                        }
+                      );
+                    } else {
+                      console.warn(
+                        `[AIChatAgent] onChatMessage returned no response for chatMessageId: ${chatMessageId}`
+                      );
+                      this._broadcastChatMessage(
+                        {
+                          body: "No response was generated by the agent.",
+                          done: true,
+                          id: chatMessageId,
+                          type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
+                        },
+                        [connection.id]
+                      );
+                    }
                   }
-                }
-              );
-            });
-          });
+                );
+              });
+            },
+            { epoch }
+          );
         }
 
         // Handle clear chat
@@ -1227,6 +1376,300 @@ export class AIChatAgent<
     } while (this._chatTurnQueue !== queue);
   }
 
+  private _normalizeMessageConcurrency(): NormalizedMessageConcurrency {
+    if (typeof this.messageConcurrency === "string") {
+      return this.messageConcurrency;
+    }
+
+    const debounceMs = this.messageConcurrency.debounceMs;
+
+    return {
+      strategy: "debounce",
+      debounceMs:
+        typeof debounceMs === "number" &&
+        Number.isFinite(debounceMs) &&
+        debounceMs >= 0
+          ? debounceMs
+          : AIChatAgent.MESSAGE_DEBOUNCE_MS
+    };
+  }
+
+  private _getSubmitConcurrencyDecision(
+    trigger: ChatRequestTrigger
+  ): SubmitConcurrencyDecision {
+    const queuedTurnsInCurrentEpoch =
+      this._queuedChatTurnCountsByEpoch.get(this._chatEpoch) ?? 0;
+
+    if (trigger !== "submit-message" || queuedTurnsInCurrentEpoch === 0) {
+      return {
+        action: "execute",
+        submitSequence: null,
+        debounceUntilMs: null,
+        mergeQueuedMessages: false
+      };
+    }
+
+    const concurrency = this._normalizeMessageConcurrency();
+    if (concurrency === "drop") {
+      return {
+        action: "drop",
+        submitSequence: null,
+        debounceUntilMs: null,
+        mergeQueuedMessages: false
+      };
+    }
+
+    if (concurrency === "queue") {
+      return {
+        action: "execute",
+        submitSequence: null,
+        debounceUntilMs: null,
+        mergeQueuedMessages: false
+      };
+    }
+
+    const submitSequence = ++this._submitSequence;
+    this._latestOverlappingSubmitSequence = submitSequence;
+
+    if (concurrency === "latest") {
+      return {
+        action: "execute",
+        submitSequence,
+        debounceUntilMs: null,
+        mergeQueuedMessages: false
+      };
+    }
+
+    if (concurrency === "merge") {
+      if (!this._mergeQueuedUserStartIndexByEpoch.has(this._chatEpoch)) {
+        this._mergeQueuedUserStartIndexByEpoch.set(
+          this._chatEpoch,
+          this.messages.length
+        );
+      }
+
+      return {
+        action: "execute",
+        submitSequence,
+        debounceUntilMs: null,
+        mergeQueuedMessages: true
+      };
+    }
+
+    return {
+      action: "execute",
+      submitSequence,
+      debounceUntilMs: Date.now() + concurrency.debounceMs,
+      mergeQueuedMessages: false
+    };
+  }
+
+  private _isSupersededSubmit(submitSequence: number | null): boolean {
+    return (
+      submitSequence !== null &&
+      submitSequence < this._latestOverlappingSubmitSequence
+    );
+  }
+
+  private async _waitForTimestamp(timestampMs: number): Promise<void> {
+    const remainingMs = timestampMs - Date.now();
+    if (remainingMs <= 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this._activeDebounceResolve = resolve;
+      this._activeDebounceTimer = setTimeout(() => {
+        this._activeDebounceTimer = null;
+        this._activeDebounceResolve = null;
+        resolve();
+      }, remainingMs);
+    });
+  }
+
+  private _cancelActiveDebounce(): void {
+    if (this._activeDebounceTimer !== null) {
+      clearTimeout(this._activeDebounceTimer);
+      this._activeDebounceTimer = null;
+    }
+    if (this._activeDebounceResolve !== null) {
+      this._activeDebounceResolve();
+      this._activeDebounceResolve = null;
+    }
+  }
+
+  private async _mergeQueuedUserMessages(
+    epoch = this._chatEpoch
+  ): Promise<void> {
+    const mergedMessages = this._getMergedQueuedUserMessages(epoch);
+    if (!mergedMessages) {
+      return;
+    }
+
+    await this.persistMessages(mergedMessages, [], {
+      _deleteStaleRows: true
+    });
+  }
+
+  private _getMergedQueuedUserMessages(epoch: number): ChatMessage[] | null {
+    const queuedUserStart = this._mergeQueuedUserStartIndexByEpoch.get(epoch);
+    if (queuedUserStart === undefined) {
+      return null;
+    }
+
+    let queuedUserEnd = queuedUserStart;
+    while (this.messages[queuedUserEnd]?.role === "user") {
+      queuedUserEnd++;
+    }
+
+    if (
+      queuedUserEnd === queuedUserStart &&
+      queuedUserStart < this.messages.length
+    ) {
+      console.warn(
+        `[AIChatAgent] merge: expected user messages at index ${queuedUserStart} ` +
+          `but found role="${this.messages[queuedUserStart]?.role}"; skipping merge`
+      );
+    }
+
+    const queuedUserMessages = this.messages.slice(
+      queuedUserStart,
+      queuedUserEnd
+    );
+    if (queuedUserMessages.length < 2) {
+      return null;
+    }
+
+    return [
+      ...this.messages.slice(0, queuedUserStart),
+      AIChatAgent._mergeUserMessages(queuedUserMessages),
+      ...this.messages.slice(queuedUserEnd)
+    ];
+  }
+
+  private static _mergeUserMessages(messages: ChatMessage[]): ChatMessage {
+    const [firstMessage, ...remainingMessages] = messages;
+    if (!firstMessage) {
+      throw new Error("cannot merge an empty message list");
+    }
+
+    let mergedParts = AIChatAgent._cloneMessageParts(firstMessage.parts);
+    for (const message of remainingMessages) {
+      AIChatAgent._appendMergedText(mergedParts, "\n\n");
+      mergedParts = AIChatAgent._mergeMessageParts(mergedParts, message.parts);
+    }
+
+    const lastMessage = messages[messages.length - 1] ?? firstMessage;
+    return {
+      ...lastMessage,
+      parts: mergedParts
+    };
+  }
+
+  private static _mergeMessageParts(
+    currentParts: ChatMessage["parts"],
+    nextParts: ChatMessage["parts"]
+  ): ChatMessage["parts"] {
+    const mergedParts = AIChatAgent._cloneMessageParts(currentParts);
+
+    for (const part of nextParts) {
+      if (part.type === "text") {
+        AIChatAgent._appendMergedText(mergedParts, part.text);
+        continue;
+      }
+
+      mergedParts.push(part);
+    }
+
+    return mergedParts;
+  }
+
+  private static _cloneMessageParts(
+    parts: ChatMessage["parts"]
+  ): ChatMessage["parts"] {
+    return [...parts];
+  }
+
+  private static _appendMergedText(
+    parts: ChatMessage["parts"],
+    text: string
+  ): void {
+    if (text.length === 0) {
+      return;
+    }
+
+    const lastPart = parts[parts.length - 1];
+    if (lastPart?.type === "text") {
+      parts[parts.length - 1] = {
+        ...lastPart,
+        text: lastPart.text + text
+      };
+      return;
+    }
+
+    const textPart: TextUIPart = {
+      type: "text",
+      text
+    };
+    parts.push(textPart);
+  }
+
+  private _setRequestContext(
+    clientTools?: ClientToolSchema[],
+    body?: Record<string, unknown>
+  ) {
+    this._lastClientTools = clientTools?.length ? clientTools : undefined;
+    this._lastBody = body && Object.keys(body).length > 0 ? body : undefined;
+    this._persistRequestContext();
+  }
+
+  private _messagesForClientSync(): ChatMessage[] {
+    if (!this._streamingMessage || this._streamingMessage.parts.length === 0) {
+      return this.messages;
+    }
+
+    const existingIdx = this.messages.findIndex(
+      (message) => message.id === this._streamingMessage?.id
+    );
+
+    if (existingIdx >= 0) {
+      return this.messages.map((message, idx) =>
+        idx === existingIdx && this._streamingMessage
+          ? this._streamingMessage
+          : message
+      );
+    }
+
+    return [...this.messages, this._streamingMessage];
+  }
+
+  private _sendDirectMessage(
+    connection: Connection,
+    message: OutgoingMessage
+  ): void {
+    try {
+      connection.send(JSON.stringify(message));
+    } catch {
+      // Connection closed before the server could reply.
+    }
+  }
+
+  private _completeSkippedRequest(connection: Connection, requestId: string) {
+    this._sendDirectMessage(connection, {
+      body: "",
+      done: true,
+      id: requestId,
+      type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
+    });
+  }
+
+  private _rollbackDroppedSubmit(connection: Connection) {
+    this._sendDirectMessage(connection, {
+      messages: this._messagesForClientSync(),
+      type: MessageType.CF_AGENT_CHAT_MESSAGES
+    });
+  }
+
   /** `true` when an assistant message is waiting on a client tool result or approval. */
   protected hasPendingInteraction(): boolean {
     if (
@@ -1313,8 +1756,10 @@ export class AIChatAgent<
    * the built-in handler calls it automatically.
    */
   protected resetTurnState(): void {
+    this._mergeQueuedUserStartIndexByEpoch.delete(this._chatEpoch);
     this._chatEpoch++;
     this._destroyAbortControllers();
+    this._cancelActiveDebounce();
     this._pendingInteractionPromise = null;
     this._activeAutoContinuationRequestId = null;
     this._activeAutoContinuationConnectionId = null;
@@ -1357,10 +1802,17 @@ export class AIChatAgent<
    */
   private async _runExclusiveChatTurn<T>(
     requestId: string,
-    fn: () => Promise<T>
+    fn: () => Promise<T>,
+    options?: { epoch?: number }
   ): Promise<T> {
     const previousTurn = this._chatTurnQueue;
     let releaseTurn = () => {};
+    const epoch = options?.epoch ?? this._chatEpoch;
+
+    this._queuedChatTurnCountsByEpoch.set(
+      epoch,
+      (this._queuedChatTurnCountsByEpoch.get(epoch) ?? 0) + 1
+    );
 
     this._chatTurnQueue = new Promise<void>((resolve) => {
       releaseTurn = resolve;
@@ -1373,6 +1825,13 @@ export class AIChatAgent<
       return await fn();
     } finally {
       this._activeChatTurnRequestId = null;
+      const nextCount = (this._queuedChatTurnCountsByEpoch.get(epoch) ?? 1) - 1;
+      if (nextCount <= 0) {
+        this._queuedChatTurnCountsByEpoch.delete(epoch);
+        this._mergeQueuedUserStartIndexByEpoch.delete(epoch);
+      } else {
+        this._queuedChatTurnCountsByEpoch.set(epoch, nextCount);
+      }
       releaseTurn();
 
       if (
@@ -1479,73 +1938,112 @@ export class AIChatAgent<
     // before the continuation starts.  keepAlive() is called inside the
     // turn to prevent hibernation while waiting for prerequisites /
     // streaming, without deferring the queue registration.
-    this._runExclusiveChatTurn(requestId, async () => {
-      const dispose = await this.keepAlive();
-      try {
-        if (this._chatEpoch !== epoch) {
-          this._clearAllAutoContinuationState(true);
-          return;
-        }
+    this._runExclusiveChatTurn(
+      requestId,
+      async () => {
+        const dispose = await this.keepAlive();
+        try {
+          if (this._chatEpoch !== epoch) {
+            this._clearAllAutoContinuationState(true);
+            return;
+          }
 
-        const applied = await this._awaitPendingAutoContinuationPrerequisite();
-        if (!applied) {
-          this._clearAllAutoContinuationState(true);
-          return;
-        }
+          const applied =
+            await this._awaitPendingAutoContinuationPrerequisite();
+          if (!applied) {
+            this._clearAllAutoContinuationState(true);
+            return;
+          }
 
-        const connection = this._pendingAutoContinuationConnection;
-        if (!connection) {
-          this._clearAllAutoContinuationState(true);
-          return;
-        }
+          const connection = this._pendingAutoContinuationConnection;
+          if (!connection) {
+            this._clearAllAutoContinuationState(true);
+            return;
+          }
 
-        const clientTools = this._pendingAutoContinuationClientTools;
-        const body = this._pendingAutoContinuationBody;
-        this._pendingAutoContinuationPastCoalesce = true;
+          const clientTools = this._pendingAutoContinuationClientTools;
+          const body = this._pendingAutoContinuationBody;
+          this._pendingAutoContinuationPastCoalesce = true;
 
-        const abortSignal = this._getAbortSignal(requestId);
+          const abortSignal = this._getAbortSignal(requestId);
 
-        return this._tryCatchChat(async () => {
-          return agentContext.run(
-            {
-              agent: this,
-              connection,
-              request: undefined,
-              email: undefined
-            },
-            async () => {
-              const response = await this.onChatMessage(
-                async (_finishResult) => {},
-                {
-                  requestId,
-                  abortSignal,
-                  clientTools,
-                  body
+          return this._tryCatchChat(async () => {
+            return agentContext.run(
+              {
+                agent: this,
+                connection,
+                request: undefined,
+                email: undefined
+              },
+              async () => {
+                const response = await this.onChatMessage(
+                  async (_finishResult) => {},
+                  {
+                    requestId,
+                    abortSignal,
+                    clientTools,
+                    body
+                  }
+                );
+
+                if (response) {
+                  await this._reply(requestId, response, [], {
+                    continuation: true,
+                    chatMessageId: requestId
+                  });
+                  this._activateDeferredAutoContinuation();
+                } else {
+                  this._clearPendingAutoContinuation(true);
+                  this._activateDeferredAutoContinuation();
                 }
-              );
-
-              if (response) {
-                await this._reply(requestId, response, [], {
-                  continuation: true,
-                  chatMessageId: requestId
-                });
-                this._activateDeferredAutoContinuation();
-              } else {
-                this._clearPendingAutoContinuation(true);
-                this._activateDeferredAutoContinuation();
               }
-            }
-          );
-        });
-      } finally {
-        dispose();
-      }
-    }).catch((error) => {
+            );
+          });
+        } finally {
+          dispose();
+        }
+      },
+      { epoch }
+    ).catch((error) => {
       const errorPrefix =
         this._pendingAutoContinuationErrorPrefix ??
         "[AIChatAgent] Auto-continuation failed:";
       this._clearAllAutoContinuationState(true);
       console.error(errorPrefix, error);
+    });
+  }
+
+  private async _runProgrammaticChatTurn(
+    requestId: string,
+    clientTools?: ClientToolSchema[],
+    body?: Record<string, unknown>
+  ): Promise<void> {
+    this._setRequestContext(clientTools, body);
+
+    await this._tryCatchChat(async () => {
+      return agentContext.run(
+        {
+          agent: this,
+          connection: undefined,
+          request: undefined,
+          email: undefined
+        },
+        async () => {
+          const abortSignal = this._getAbortSignal(requestId);
+          const response = await this.onChatMessage(() => {}, {
+            requestId,
+            abortSignal,
+            clientTools,
+            body
+          });
+
+          if (response) {
+            await this._reply(requestId, response, [], {
+              chatMessageId: requestId
+            });
+          }
+        }
+      );
     });
   }
 
@@ -1569,7 +2067,7 @@ export class AIChatAgent<
   /**
    * Called after a chat turn completes and the assistant message has been
    * persisted. The turn lock is released before this hook runs, so it is
-   * safe to call `saveMessages` or `enqueueTurn` from inside.
+   * safe to call `saveMessages` from inside.
    *
    * Fires for all turn completion paths: WebSocket chat requests,
    * `saveMessages`, and auto-continuation.
@@ -1636,36 +2134,68 @@ export class AIChatAgent<
   }
 
   /**
-   * Save messages on the server side
-   * @param messages Chat messages to save
+   * Persist messages and trigger `onChatMessage()` for a new response.
+   *
+   * Waits for any active chat turn to finish before starting, so scheduled
+   * or programmatic messages never overlap an in-flight stream.
+   *
+   * Pass a function to derive the next message list from the latest
+   * persisted `this.messages` when the turn actually starts. This avoids
+   * stale baselines when multiple `saveMessages()` calls queue up behind
+   * active work:
+   *
+   * ```ts
+   * await this.saveMessages((messages) => [...messages, syntheticMessage]);
+   * ```
+   *
+   * Returns `{ requestId, status }` so callers can detect whether the turn
+   * ran (`"completed"`) or was skipped because the chat was cleared
+   * (`"skipped"`).
    */
-  async saveMessages(messages: ChatMessage[]) {
+  async saveMessages(
+    messages:
+      | ChatMessage[]
+      | ((
+          currentMessages: ChatMessage[]
+        ) => ChatMessage[] | Promise<ChatMessage[]>)
+  ): Promise<SaveMessagesResult> {
     const requestId = nanoid();
     const clientTools = this._lastClientTools;
     const body = this._lastBody;
     const epoch = this._chatEpoch;
+    let status: SaveMessagesResult["status"] = "completed";
 
-    await this._runExclusiveChatTurn(requestId, async () => {
-      if (this._chatEpoch !== epoch) return;
-
-      await this.persistMessages(messages);
-
-      await this._tryCatchChat(async () => {
-        const abortSignal = this._getAbortSignal(requestId);
-        const response = await this.onChatMessage(() => {}, {
-          requestId,
-          abortSignal,
-          clientTools,
-          body
-        });
-
-        if (response) {
-          await this._reply(requestId, response, [], {
-            chatMessageId: requestId
-          });
+    await this._runExclusiveChatTurn(
+      requestId,
+      async () => {
+        if (this._chatEpoch !== epoch) {
+          status = "skipped";
+          return;
         }
-      });
-    });
+
+        const resolvedMessages =
+          typeof messages === "function"
+            ? await messages(this.messages)
+            : messages;
+
+        if (this._chatEpoch !== epoch) {
+          status = "skipped";
+          return;
+        }
+
+        await this.persistMessages(resolvedMessages);
+
+        if (this._chatEpoch !== epoch) {
+          status = "skipped";
+          return;
+        }
+
+        await this._runProgrammaticChatTurn(requestId, clientTools, body);
+      },
+      { epoch }
+    );
+
+    return { requestId, status };
   }
 
   async persistMessages(

--- a/packages/ai-chat/src/tests/message-concurrency.test.ts
+++ b/packages/ai-chat/src/tests/message-concurrency.test.ts
@@ -1,0 +1,849 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import type { UIMessage as ChatMessage } from "ai";
+import { getAgentByName } from "agents";
+import type { ChatResponseResult } from "../";
+import { MessageType, type OutgoingMessage } from "../types";
+import { connectChatWS, isUseChatResponseMessage } from "./test-utils";
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function expectDebounceGap(
+  firstStart: number | null,
+  secondStart: number | null,
+  minimumGapMs: number
+) {
+  expect(firstStart).not.toBeNull();
+  expect(secondStart).not.toBeNull();
+
+  if (firstStart === null || secondStart === null) {
+    return;
+  }
+
+  const sortedStarts = [firstStart, secondStart].sort((a, b) => a - b);
+  expect(sortedStarts[1] - sortedStarts[0]).toBeGreaterThanOrEqual(
+    minimumGapMs
+  );
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 4000,
+  intervalMs = 25
+) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+
+    await delay(intervalMs);
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+function sendChatRequest(
+  ws: WebSocket,
+  requestId: string,
+  messages: ChatMessage[],
+  extraBody?: Record<string, unknown>
+) {
+  ws.send(
+    JSON.stringify({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+      id: requestId,
+      init: {
+        method: "POST",
+        body: JSON.stringify({ messages, ...extraBody })
+      }
+    })
+  );
+}
+
+function recordMessages(ws: WebSocket): OutgoingMessage[] {
+  const seen: OutgoingMessage[] = [];
+  ws.addEventListener("message", (event: MessageEvent) => {
+    try {
+      seen.push(JSON.parse(event.data as string) as OutgoingMessage);
+    } catch {
+      // Ignore non-JSON messages.
+    }
+  });
+  return seen;
+}
+
+function waitForDone(ws: WebSocket, requestId: string, timeoutMs = 5000) {
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.removeEventListener("message", onMessage);
+      reject(new Error(`Timed out waiting for done: ${requestId}`));
+    }, timeoutMs);
+
+    function onMessage(event: MessageEvent) {
+      const data = JSON.parse(event.data as string);
+      if (
+        isUseChatResponseMessage(data) &&
+        data.id === requestId &&
+        data.done
+      ) {
+        clearTimeout(timeout);
+        ws.removeEventListener("message", onMessage);
+        resolve();
+      }
+    }
+
+    ws.addEventListener("message", onMessage);
+  });
+}
+
+const firstUserMessage: ChatMessage = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }]
+};
+
+const secondUserMessage: ChatMessage = {
+  id: "user-2",
+  role: "user",
+  parts: [{ type: "text", text: "Second" }]
+};
+
+const thirdUserMessage: ChatMessage = {
+  id: "user-3",
+  role: "user",
+  parts: [{ type: "text", text: "Third" }]
+};
+
+describe("AIChatAgent messageConcurrency", () => {
+  it("latest runs only the newest overlapping submit while preserving queued user messages", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/latest-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.LatestMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-latest-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 6,
+      chunkDelayMs: 60
+    });
+    await delay(40);
+
+    sendChatRequest(ws, "req-latest-2", [firstUserMessage, secondUserMessage], {
+      format: "plaintext",
+      chunkCount: 6,
+      chunkDelayMs: 60
+    });
+    await delay(20);
+
+    sendChatRequest(
+      ws,
+      "req-latest-3",
+      [firstUserMessage, secondUserMessage, thirdUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 6,
+        chunkDelayMs: 60
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    });
+    await agentStub.waitForIdleForTest();
+
+    expect(await agentStub.getStartedRequestIds()).toEqual([
+      "req-latest-1",
+      "req-latest-3"
+    ]);
+
+    const persistedMessages =
+      (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const userTexts = persistedMessages
+      .filter((message) => message.role === "user")
+      .flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : []
+        )
+      );
+
+    expect(userTexts).toEqual(
+      expect.arrayContaining(["Hello", "Second", "Third"])
+    );
+
+    ws.close(1000);
+  });
+
+  it("drop rejects overlapping submits, sends rollback state, and never starts a second turn", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/drop-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const seenMessages = recordMessages(ws);
+    const agentStub = await getAgentByName(
+      env.DropMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-drop-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 8,
+      chunkDelayMs: 50
+    });
+    await delay(40);
+
+    sendChatRequest(ws, "req-drop-2", [firstUserMessage, secondUserMessage], {
+      format: "plaintext",
+      chunkCount: 8,
+      chunkDelayMs: 50
+    });
+
+    await waitForDone(ws, "req-drop-2");
+    await delay(50);
+
+    expect(await agentStub.getStartedRequestIds()).toEqual(["req-drop-1"]);
+
+    const rollbackMessage = [...seenMessages]
+      .reverse()
+      .find((message) => message.type === MessageType.CF_AGENT_CHAT_MESSAGES);
+    expect(rollbackMessage).toBeDefined();
+    if (rollbackMessage?.type === MessageType.CF_AGENT_CHAT_MESSAGES) {
+      const rollbackTexts = rollbackMessage.messages.flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : []
+        )
+      );
+      expect(rollbackTexts).not.toContain("Second");
+    }
+
+    await agentStub.waitForIdleForTest();
+
+    const persistedMessages =
+      (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const userTexts = persistedMessages
+      .filter((message) => message.role === "user")
+      .flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : []
+        )
+      );
+
+    expect(userTexts).toEqual(["Hello"]);
+
+    ws.close(1000);
+  });
+
+  it("merge concatenates overlapping queued user messages into one follow-up turn", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/merge-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.MergeMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-merge-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 6,
+      chunkDelayMs: 60
+    });
+    await delay(40);
+
+    sendChatRequest(ws, "req-merge-2", [firstUserMessage, secondUserMessage], {
+      format: "plaintext",
+      chunkCount: 6,
+      chunkDelayMs: 60
+    });
+    await delay(20);
+
+    sendChatRequest(
+      ws,
+      "req-merge-3",
+      [firstUserMessage, secondUserMessage, thirdUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 6,
+        chunkDelayMs: 60
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    });
+    await agentStub.waitForIdleForTest();
+
+    expect(await agentStub.getStartedRequestIds()).toEqual([
+      "req-merge-1",
+      "req-merge-3"
+    ]);
+
+    const persistedMessages =
+      (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const userMessages = persistedMessages.filter(
+      (message) => message.role === "user"
+    );
+    const userTexts = userMessages.flatMap((message) =>
+      message.parts.flatMap((part) => (part.type === "text" ? [part.text] : []))
+    );
+
+    expect(userTexts).toEqual(
+      expect.arrayContaining(["Hello", "Second\n\nThird"])
+    );
+    expect(userMessages).toHaveLength(2);
+
+    ws.close(1000);
+  });
+
+  it("debounce waits for a quiet period and then runs only the latest submit", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/debounce-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.DebounceMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-debounce-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 2,
+      chunkDelayMs: 20
+    });
+    await delay(5);
+
+    sendChatRequest(
+      ws,
+      "req-debounce-2",
+      [firstUserMessage, secondUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 2,
+        chunkDelayMs: 20
+      }
+    );
+    await delay(15);
+
+    sendChatRequest(
+      ws,
+      "req-debounce-3",
+      [firstUserMessage, secondUserMessage, thirdUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 2,
+        chunkDelayMs: 20
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    });
+    await agentStub.waitForIdleForTest();
+
+    expect(await agentStub.getStartedRequestIds()).toEqual([
+      "req-debounce-1",
+      "req-debounce-3"
+    ]);
+
+    const firstStart = await agentStub.getRequestStartTime("req-debounce-1");
+    const thirdStart = await agentStub.getRequestStartTime("req-debounce-3");
+    expect(firstStart).not.toBeNull();
+    expect(thirdStart).not.toBeNull();
+
+    if (firstStart !== null && thirdStart !== null) {
+      expect(thirdStart - firstStart).toBeGreaterThanOrEqual(80);
+    }
+
+    const persistedMessages =
+      (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const userTexts = persistedMessages
+      .filter((message) => message.role === "user")
+      .flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : []
+        )
+      );
+
+    expect(userTexts).toEqual(
+      expect.arrayContaining(["Hello", "Second", "Third"])
+    );
+
+    ws.close(1000);
+  });
+
+  it("falls back to the default debounce window when debounceMs is omitted", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/missing-debounce-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.MissingDebounceMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-missing-debounce-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 5,
+      chunkDelayMs: 50
+    });
+
+    sendChatRequest(
+      ws,
+      "req-missing-debounce-2",
+      [firstUserMessage, secondUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 1,
+        chunkDelayMs: 10
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    }, 5000);
+    await agentStub.waitForIdleForTest();
+
+    const firstStart = await agentStub.getRequestStartTime(
+      "req-missing-debounce-1"
+    );
+    const secondStart = await agentStub.getRequestStartTime(
+      "req-missing-debounce-2"
+    );
+
+    expectDebounceGap(firstStart, secondStart, 700);
+
+    ws.close(1000);
+  });
+
+  it("falls back to the default debounce window when debounceMs is invalid", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/invalid-debounce-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.InvalidDebounceMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-invalid-debounce-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 5,
+      chunkDelayMs: 50
+    });
+
+    sendChatRequest(
+      ws,
+      "req-invalid-debounce-2",
+      [firstUserMessage, secondUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 1,
+        chunkDelayMs: 10
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    }, 5000);
+    await agentStub.waitForIdleForTest();
+
+    const firstStart = await agentStub.getRequestStartTime(
+      "req-invalid-debounce-1"
+    );
+    const secondStart = await agentStub.getRequestStartTime(
+      "req-invalid-debounce-2"
+    );
+
+    expectDebounceGap(firstStart, secondStart, 700);
+
+    ws.close(1000);
+  });
+
+  it("applies messageConcurrency only to submit-message requests, not regenerate", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/drop-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.DropMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-regen-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 6,
+      chunkDelayMs: 50
+    });
+    await delay(40);
+
+    sendChatRequest(ws, "req-regen-2", [firstUserMessage], {
+      trigger: "regenerate-message",
+      format: "plaintext",
+      chunkCount: 4,
+      chunkDelayMs: 40
+    });
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    });
+    await agentStub.waitForIdleForTest();
+
+    expect(await agentStub.getStartedRequestIds()).toEqual([
+      "req-regen-1",
+      "req-regen-2"
+    ]);
+
+    ws.close(1000);
+  });
+
+  it("clear skips queued latest submits before they start", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/latest-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.LatestMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-clear-1", [firstUserMessage], {
+      format: "plaintext",
+      useAbortSignal: true,
+      chunkCount: 8,
+      chunkDelayMs: 50
+    });
+    await delay(40);
+
+    sendChatRequest(ws, "req-clear-2", [firstUserMessage, secondUserMessage], {
+      format: "plaintext",
+      chunkCount: 8,
+      chunkDelayMs: 50
+    });
+    await delay(20);
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_CHAT_CLEAR
+      })
+    );
+
+    await waitForDone(ws, "req-clear-2");
+    await agentStub.waitForIdleForTest();
+
+    expect(await agentStub.getStartedRequestIds()).toEqual(["req-clear-1"]);
+
+    const persistedMessages =
+      (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const userTexts = persistedMessages
+      .filter((message) => message.role === "user")
+      .flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : []
+        )
+      );
+    expect(userTexts).not.toContain("Second");
+
+    ws.close(1000);
+  });
+
+  it("does not treat post-clear submits as overlapping with a stale epoch turn", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/drop-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.DropMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-clear-stale-1", [firstUserMessage], {
+      format: "plaintext",
+      responseDelayMs: 300,
+      chunkCount: 1,
+      chunkDelayMs: 10
+    });
+    await delay(20);
+
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_CHAT_CLEAR
+      })
+    );
+
+    sendChatRequest(ws, "req-clear-stale-2", [secondUserMessage], {
+      format: "plaintext",
+      chunkCount: 1,
+      chunkDelayMs: 10
+    });
+
+    await waitUntil(async () => {
+      const persistedMessages =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      const userTexts = persistedMessages
+        .filter((message) => message.role === "user")
+        .flatMap((message) =>
+          message.parts.flatMap((part) =>
+            part.type === "text" ? [part.text] : []
+          )
+        );
+
+      return userTexts.includes("Second");
+    }, 5000);
+    await expect(
+      agentStub.waitUntilStableForTest({ timeout: 15_000 })
+    ).resolves.toBe(true);
+
+    expect(await agentStub.getStartedRequestIds()).toEqual([
+      "req-clear-stale-1",
+      "req-clear-stale-2"
+    ]);
+
+    const persistedMessages =
+      (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const userTexts = persistedMessages
+      .filter((message) => message.role === "user")
+      .flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : []
+        )
+      );
+
+    expect(userTexts).toContain("Second");
+
+    ws.close(1000);
+  });
+
+  it("latest: onChatResponse fires only for the turn that actually runs, not superseded ones", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/latest-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.LatestMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-resp-latest-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 6,
+      chunkDelayMs: 60
+    });
+    await delay(40);
+
+    sendChatRequest(
+      ws,
+      "req-resp-latest-2",
+      [firstUserMessage, secondUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 6,
+        chunkDelayMs: 60
+      }
+    );
+    await delay(20);
+
+    sendChatRequest(
+      ws,
+      "req-resp-latest-3",
+      [firstUserMessage, secondUserMessage, thirdUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 6,
+        chunkDelayMs: 60
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    });
+    await agentStub.waitForIdleForTest();
+
+    const results =
+      (await agentStub.getChatResponseResults()) as ChatResponseResult[];
+    const resultRequestIds = results.map((r) => r.requestId);
+
+    expect(resultRequestIds).toEqual([
+      "req-resp-latest-1",
+      "req-resp-latest-3"
+    ]);
+    expect(results.every((r) => r.status === "completed")).toBe(true);
+
+    ws.close(1000);
+  });
+
+  it("drop: onChatResponse fires only for the accepted turn, not the dropped one", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/drop-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.DropMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-resp-drop-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 8,
+      chunkDelayMs: 50
+    });
+    await delay(40);
+
+    sendChatRequest(
+      ws,
+      "req-resp-drop-2",
+      [firstUserMessage, secondUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 8,
+        chunkDelayMs: 50
+      }
+    );
+
+    await waitForDone(ws, "req-resp-drop-2");
+    await agentStub.waitForIdleForTest();
+
+    const results =
+      (await agentStub.getChatResponseResults()) as ChatResponseResult[];
+    const resultRequestIds = results.map((r) => r.requestId);
+
+    expect(resultRequestIds).toEqual(["req-resp-drop-1"]);
+    expect(results[0]).toMatchObject({ status: "completed" });
+
+    ws.close(1000);
+  });
+
+  it("merge: onChatResponse fires once for the first turn and once for the merged turn", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(
+      `/agents/merge-message-concurrency-agent/${room}`
+    );
+    await delay(50);
+
+    const agentStub = await getAgentByName(
+      env.MergeMessageConcurrencyAgent,
+      room
+    );
+
+    sendChatRequest(ws, "req-resp-merge-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 6,
+      chunkDelayMs: 60
+    });
+    await delay(40);
+
+    sendChatRequest(
+      ws,
+      "req-resp-merge-2",
+      [firstUserMessage, secondUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 6,
+        chunkDelayMs: 60
+      }
+    );
+    await delay(20);
+
+    sendChatRequest(
+      ws,
+      "req-resp-merge-3",
+      [firstUserMessage, secondUserMessage, thirdUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 6,
+        chunkDelayMs: 60
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    });
+    await agentStub.waitForIdleForTest();
+
+    const results =
+      (await agentStub.getChatResponseResults()) as ChatResponseResult[];
+    const resultRequestIds = results.map((r) => r.requestId);
+
+    expect(resultRequestIds).toEqual(["req-resp-merge-1", "req-resp-merge-3"]);
+    expect(results.every((r) => r.status === "completed")).toBe(true);
+
+    ws.close(1000);
+  });
+
+  it("queue: onChatResponse fires for every turn when messageConcurrency is queue", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/slow-stream-agent/${room}`);
+    await delay(50);
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    sendChatRequest(ws, "req-resp-queue-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 3,
+      chunkDelayMs: 30
+    });
+    await delay(20);
+
+    sendChatRequest(
+      ws,
+      "req-resp-queue-2",
+      [firstUserMessage, secondUserMessage],
+      {
+        format: "plaintext",
+        chunkCount: 3,
+        chunkDelayMs: 30
+      }
+    );
+
+    await waitUntil(async () => {
+      const started = await agentStub.getStartedRequestIds();
+      return started.length === 2;
+    });
+    await agentStub.waitForIdleForTest();
+
+    const results =
+      (await agentStub.getChatResponseResults()) as ChatResponseResult[];
+    const resultRequestIds = results.map((r) => r.requestId);
+
+    expect(resultRequestIds).toEqual(["req-resp-queue-1", "req-resp-queue-2"]);
+    expect(results.every((r) => r.status === "completed")).toBe(true);
+
+    ws.close(1000);
+  });
+});

--- a/packages/ai-chat/src/tests/programmatic-turns.test.ts
+++ b/packages/ai-chat/src/tests/programmatic-turns.test.ts
@@ -1,0 +1,164 @@
+import { env } from "cloudflare:workers";
+import type { UIMessage as ChatMessage } from "ai";
+import { getAgentByName } from "agents";
+import { describe, expect, it } from "vitest";
+import { MessageType } from "../types";
+import { connectChatWS } from "./test-utils";
+
+function connectSlowStream(room: string) {
+  return connectChatWS(`/agents/slow-stream-agent/${room}`);
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sendChatRequest(
+  ws: WebSocket,
+  requestId: string,
+  messages: ChatMessage[],
+  extraBody?: Record<string, unknown>
+) {
+  ws.send(
+    JSON.stringify({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+      id: requestId,
+      init: {
+        method: "POST",
+        body: JSON.stringify({ messages, ...extraBody })
+      }
+    })
+  );
+}
+
+const firstUserMessage: ChatMessage = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }]
+};
+
+describe("AIChatAgent programmatic turns via saveMessages", () => {
+  it("queues saveMessages behind an active websocket turn", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await delay(50);
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    sendChatRequest(ws, "req-programmatic-1", [firstUserMessage], {
+      format: "plaintext",
+      chunkCount: 8,
+      chunkDelayMs: 100
+    });
+
+    await delay(60);
+
+    const queuedPromise = agentStub.enqueueSyntheticUserMessage(
+      "Scheduled follow-up",
+      {
+        body: {
+          format: "plaintext",
+          chunkCount: 8,
+          chunkDelayMs: 100
+        }
+      }
+    );
+    const waitForIdlePromise = agentStub.waitForIdleForTest();
+
+    await delay(100);
+
+    expect(await agentStub.getStartedRequestIds()).toEqual([
+      "req-programmatic-1"
+    ]);
+    expect(await agentStub.isChatTurnActiveForTest()).toBe(true);
+
+    await expect(
+      Promise.race([
+        waitForIdlePromise.then(() => "idle"),
+        delay(100).then(() => "pending")
+      ])
+    ).resolves.toBe("pending");
+
+    const queuedResult = await queuedPromise;
+    await waitForIdlePromise;
+
+    expect(queuedResult.status).toBe("completed");
+    const startedIds = await agentStub.getStartedRequestIds();
+    expect(startedIds).toHaveLength(2);
+    expect(startedIds[0]).toBe("req-programmatic-1");
+    expect(await agentStub.getPersistedUserTexts()).toEqual([
+      "Hello",
+      "Scheduled follow-up"
+    ]);
+
+    ws.close(1000);
+  });
+
+  it("evaluates queued programmatic messages against the latest transcript", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    agentStub.setTestBody({
+      format: "plaintext",
+      responseDelayMs: 100,
+      chunkCount: 1,
+      chunkDelayMs: 10
+    });
+
+    const [firstResult, secondResult] =
+      await agentStub.enqueueSyntheticUserMessagesInOrder([
+        { text: "First" },
+        { text: "Second" }
+      ]);
+
+    await agentStub.waitForIdleForTest();
+
+    expect(firstResult.status).toBe("completed");
+    expect(secondResult.status).toBe("completed");
+    expect(await agentStub.getStartedRequestIds()).toHaveLength(2);
+    expect(await agentStub.getPersistedUserTexts()).toEqual([
+      "First",
+      "Second"
+    ]);
+  });
+
+  it("marks queued programmatic turns as skipped after chat clear", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await delay(50);
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    sendChatRequest(ws, "req-programmatic-clear-1", [firstUserMessage], {
+      format: "plaintext",
+      useAbortSignal: true,
+      chunkCount: 12,
+      chunkDelayMs: 40
+    });
+
+    await delay(80);
+
+    const queuedPromise = agentStub.enqueueSyntheticUserMessage("Skipped", {
+      body: {
+        format: "plaintext",
+        chunkCount: 8,
+        chunkDelayMs: 100
+      }
+    });
+
+    await delay(20);
+
+    ws.send(JSON.stringify({ type: MessageType.CF_AGENT_CHAT_CLEAR }));
+
+    const queuedResult = await queuedPromise;
+    await agentStub.waitForIdleForTest();
+
+    expect(queuedResult.status).toBe("skipped");
+    expect(await agentStub.getStartedRequestIds()).toEqual([
+      "req-programmatic-clear-1"
+    ]);
+    expect(await agentStub.getPersistedUserTexts()).toEqual([]);
+
+    ws.close(1000);
+  });
+});

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1,7 +1,8 @@
 import {
   AIChatAgent,
+  type ChatResponseResult,
   type OnChatMessageOptions,
-  type ChatResponseResult
+  type SaveMessagesResult
 } from "../";
 import type {
   UIMessage as ChatMessage,
@@ -48,6 +49,12 @@ export type Env = {
   ResponseContinuationAgent: DurableObjectNamespace<ResponseContinuationAgent>;
   ResponseThrowingAgent: DurableObjectNamespace<ResponseThrowingAgent>;
   ResponseSaveMessagesAgent: DurableObjectNamespace<ResponseSaveMessagesAgent>;
+  LatestMessageConcurrencyAgent: DurableObjectNamespace<LatestMessageConcurrencyAgent>;
+  MergeMessageConcurrencyAgent: DurableObjectNamespace<MergeMessageConcurrencyAgent>;
+  DropMessageConcurrencyAgent: DurableObjectNamespace<DropMessageConcurrencyAgent>;
+  DebounceMessageConcurrencyAgent: DurableObjectNamespace<DebounceMessageConcurrencyAgent>;
+  InvalidDebounceMessageConcurrencyAgent: DurableObjectNamespace<InvalidDebounceMessageConcurrencyAgent>;
+  MissingDebounceMessageConcurrencyAgent: DurableObjectNamespace<MissingDebounceMessageConcurrencyAgent>;
   WaitMcpTrueAgent: DurableObjectNamespace<WaitMcpTrueAgent>;
   WaitMcpTimeoutAgent: DurableObjectNamespace<WaitMcpTimeoutAgent>;
   WaitMcpFalseAgent: DurableObjectNamespace<WaitMcpFalseAgent>;
@@ -572,6 +579,8 @@ export class CustomSanitizeAgent extends AIChatAgent<Env> {
  */
 export class SlowStreamAgent extends AIChatAgent<Env> {
   private _startedRequestIds: string[] = [];
+  private _requestStartTimes = new Map<string, number>();
+  private _chatResponseResults: ChatResponseResult[] = [];
 
   async onChatMessage(
     _onFinish: StreamTextOnFinishCallback<ToolSet>,
@@ -579,6 +588,7 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
   ) {
     if (options?.requestId) {
       this._startedRequestIds.push(options.requestId);
+      this._requestStartTimes.set(options.requestId, Date.now());
     }
 
     const body = options?.body as
@@ -649,6 +659,20 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
     return [...this._startedRequestIds];
   }
 
+  getPersistedMessages(): ChatMessage[] {
+    const rawMessages = (
+      this.sql`select * from cf_ai_chat_agent_messages order by created_at` ||
+      []
+    ).map((row) => {
+      return JSON.parse(row.message as string);
+    });
+    return rawMessages;
+  }
+
+  getRequestStartTime(requestId: string): number | null {
+    return this._requestStartTimes.get(requestId) ?? null;
+  }
+
   isChatTurnActiveForTest(): boolean {
     return (
       this as unknown as { isChatTurnActive(): boolean }
@@ -682,6 +706,63 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
     };
 
     await this.saveMessages([...this.messages, message]);
+  }
+
+  setTestBody(body: Record<string, unknown>): void {
+    (this as unknown as { _lastBody: Record<string, unknown> })._lastBody =
+      body;
+  }
+
+  async enqueueSyntheticUserMessage(
+    text: string,
+    options?: {
+      body?: Record<string, unknown>;
+    }
+  ): Promise<SaveMessagesResult> {
+    if (options?.body) {
+      this.setTestBody(options.body);
+    }
+    return this.saveMessages((messages) => [
+      ...messages,
+      {
+        id: `enqueued-${crypto.randomUUID()}`,
+        role: "user",
+        parts: [{ type: "text", text }]
+      }
+    ]);
+  }
+
+  async enqueueSyntheticUserMessagesInOrder(
+    messages: Array<{
+      text: string;
+      body?: Record<string, unknown>;
+    }>
+  ): Promise<SaveMessagesResult[]> {
+    return Promise.all(
+      messages.map((message) =>
+        this.enqueueSyntheticUserMessage(message.text, {
+          body: message.body
+        })
+      )
+    );
+  }
+
+  getPersistedUserTexts(): string[] {
+    return this.getPersistedMessages()
+      .filter((message) => message.role === "user")
+      .flatMap((message) =>
+        message.parts.flatMap((part) =>
+          part.type === "text" ? [part.text] : []
+        )
+      );
+  }
+
+  protected async onChatResponse(result: ChatResponseResult) {
+    this._chatResponseResults.push(result);
+  }
+
+  getChatResponseResults(): ChatResponseResult[] {
+    return [...this._chatResponseResults];
   }
 
   async persistToolCallMessage(
@@ -948,6 +1029,38 @@ export class ResponseSaveMessagesAgent extends AIChatAgent<Env> {
       []
     ).map((row) => JSON.parse(row.message as string));
   }
+}
+
+export class LatestMessageConcurrencyAgent extends SlowStreamAgent {
+  messageConcurrency = "latest" as const;
+}
+
+export class MergeMessageConcurrencyAgent extends SlowStreamAgent {
+  messageConcurrency = "merge" as const;
+}
+
+export class DropMessageConcurrencyAgent extends SlowStreamAgent {
+  messageConcurrency = "drop" as const;
+}
+
+export class DebounceMessageConcurrencyAgent extends SlowStreamAgent {
+  messageConcurrency = {
+    strategy: "debounce",
+    debounceMs: 80
+  } as const;
+}
+
+export class InvalidDebounceMessageConcurrencyAgent extends SlowStreamAgent {
+  messageConcurrency = {
+    strategy: "debounce",
+    debounceMs: Number.NaN
+  } as const;
+}
+
+export class MissingDebounceMessageConcurrencyAgent extends SlowStreamAgent {
+  messageConcurrency = {
+    strategy: "debounce"
+  } as const;
 }
 
 // Test agents for waitForMcpConnections config

--- a/packages/ai-chat/src/tests/wrangler.jsonc
+++ b/packages/ai-chat/src/tests/wrangler.jsonc
@@ -49,6 +49,30 @@
         "name": "ResponseSaveMessagesAgent"
       },
       {
+        "class_name": "LatestMessageConcurrencyAgent",
+        "name": "LatestMessageConcurrencyAgent"
+      },
+      {
+        "class_name": "MergeMessageConcurrencyAgent",
+        "name": "MergeMessageConcurrencyAgent"
+      },
+      {
+        "class_name": "DropMessageConcurrencyAgent",
+        "name": "DropMessageConcurrencyAgent"
+      },
+      {
+        "class_name": "DebounceMessageConcurrencyAgent",
+        "name": "DebounceMessageConcurrencyAgent"
+      },
+      {
+        "class_name": "InvalidDebounceMessageConcurrencyAgent",
+        "name": "InvalidDebounceMessageConcurrencyAgent"
+      },
+      {
+        "class_name": "MissingDebounceMessageConcurrencyAgent",
+        "name": "MissingDebounceMessageConcurrencyAgent"
+      },
+      {
         "class_name": "WaitMcpTrueAgent",
         "name": "WaitMcpTrueAgent"
       },
@@ -82,14 +106,20 @@
     },
     {
       "new_sqlite_classes": [
-        "WaitMcpTrueAgent",
-        "WaitMcpTimeoutAgent",
-        "WaitMcpFalseAgent"
+        "LatestMessageConcurrencyAgent",
+        "MergeMessageConcurrencyAgent",
+        "DropMessageConcurrencyAgent",
+        "DebounceMessageConcurrencyAgent",
+        "InvalidDebounceMessageConcurrencyAgent"
       ],
       "tag": "v5"
     },
     {
-      "new_sqlite_classes": ["CustomSanitizeAgent"],
+      "new_sqlite_classes": [
+        "WaitMcpTrueAgent",
+        "WaitMcpTimeoutAgent",
+        "WaitMcpFalseAgent"
+      ],
       "tag": "v6"
     },
     {
@@ -100,6 +130,14 @@
         "ResponseSaveMessagesAgent"
       ],
       "tag": "v7"
+    },
+    {
+      "new_sqlite_classes": ["CustomSanitizeAgent"],
+      "tag": "v8"
+    },
+    {
+      "new_sqlite_classes": ["MissingDebounceMessageConcurrencyAgent"],
+      "tag": "v9"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add `AIChatAgent.messageConcurrency` to control how overlapping `sendMessage()` submits behave while another chat turn is active. Five strategies: `queue` (default), `latest`, `merge`, `drop`, and `debounce`.

Also enhance `saveMessages()` to accept a functional form for deriving messages from the latest transcript, and return `{ requestId, status }` so callers can detect skipped turns.

Rebased on top of #1228 (`onChatResponse` hook). The two features share the same turn executor and integrate cleanly — `onChatResponse` fires only for turns that actually call `_reply()`, so superseded/dropped turns correctly do not trigger the hook.

## Usage

### Configuring a strategy

```ts
import { AIChatAgent } from "@cloudflare/ai-chat";

export class ChatAgent extends AIChatAgent {
  // Keep only the latest overlapping submit
  messageConcurrency = "latest";

  async onChatMessage() {
    // ...
    return result.toUIMessageStreamResponse();
  }
}
```

### Choosing a strategy

- **Focused assistant** (one question at a time): `"latest"` — user can correct themselves mid-stream, only the last message gets a response
- **Messaging/chat app** (every message matters): `"queue"` (default) or `"merge"` to collapse rapid-fire messages into one turn
- **Prevent double-sends**: `"drop"` — overlapping submits are rejected and the client rolls back
- **Burst messages**: `{ strategy: "debounce", debounceMs: 750 }` — wait for a quiet window before responding

### What the user sees

| Strategy | Client behavior |
|---|---|
| `"queue"` | Every message gets its own assistant response, in order |
| `"latest"` | All messages appear in the transcript, but only the last overlapping one gets a response |
| `"merge"` | Overlapping messages are collapsed into one combined message, which gets a single response |
| `"drop"` | The overlapping message briefly appears (optimistic), then disappears (server rollback) |
| `"debounce"` | Same as `"latest"`, but the response waits for a quiet period before starting |

### Enhanced `saveMessages()`

Pass a function to derive from the latest transcript at execution time — useful for schedule callbacks and webhook handlers where the message list may have changed since the call was made:

```ts
// From a schedule() callback or webhook handler:
await this.saveMessages((messages) => [
  ...messages,
  {
    id: nanoid(),
    role: "user",
    parts: [{ type: "text", text: `Task result: ${result}` }]
  }
]);
```

Check `status` to detect whether the turn was skipped:

```ts
const { status } = await this.saveMessages((messages) => [...messages, msg]);
if (status === "skipped") {
  // Chat was cleared while we were queued — retry or log
}
```

## Strategy details

- **`"queue"`** — default. Every submit is persisted and every submit gets its own turn once earlier work finishes.
- **`"latest"`** — persists overlapping submits, but only the newest queued overlap turn actually runs `onChatMessage()`. Older queued overlap turns receive an empty `done: true` response and complete without calling the model.
- **`"merge"`** — persists overlapping submits while the active turn runs, then rewrites the queued tail of user messages into one combined user message before the latest queued turn starts.
- **`"drop"`** — rejects overlapping submits before persistence and broadcasts the server transcript back so the client rolls back its optimistic state.
- **`{ strategy: "debounce", debounceMs }`** — behaves like `"latest"`, but waits for a quiet window before starting the surviving queued overlap turn. Falls back to 750ms when `debounceMs` is missing or invalid.

## Scope and exemptions

`messageConcurrency` applies **only** to overlapping `sendMessage()` / `trigger: "submit-message"` requests. The following are exempt and always serialize normally:

- `regenerate()` / `trigger: "regenerate-message"`
- Tool continuations (auto-continue after tool results)
- Tool approvals (HITL `CF_AGENT_TOOL_APPROVAL`)
- `saveMessages()` (programmatic turns)
- `CF_AGENT_CHAT_CLEAR`

This means HITL tool approval flows work correctly with all strategies. Approvals enter the turn queue via `_queueAutoContinuation`, which bypasses `_getSubmitConcurrencyDecision` entirely. In `"drop"` mode, a user cannot send a new message while an approval continuation is queued — consistent with drop semantics ("one thing at a time").

## Architecture

The implementation keeps a single turn executor (`_chatTurnQueue` / `_runExclusiveChatTurn`). All concurrency state is epoch-scoped and cleaned up in `resetTurnState()`:

- `_queuedChatTurnCountsByEpoch` — tracks active/queued turns per epoch to detect overlaps
- `_mergeQueuedUserStartIndexByEpoch` — marks where overlapping user messages begin for merge
- `_submitSequence` / `_latestOverlappingSubmitSequence` — monotonic counters for superseding
- `_activeDebounceTimer` / `_activeDebounceResolve` — cancellable debounce timer, cleared on `resetTurnState()`

User messages are persisted and broadcast **before** entering the turn lock (so other tabs see them immediately). The concurrency decision is computed eagerly at submit time; the turn body checks epoch + superseded status when it finally runs.

The `onChatResponse` hook (from #1228) integrates naturally: it fires only when `_reply()` pushes a result to `_pendingChatResponseResults`. Superseded turns never call `_reply`, so the hook correctly fires only for turns that produced a response.

## What changed

| File | Change |
|---|---|
| `packages/ai-chat/src/index.ts` | Core implementation: concurrency decision, epoch tracking, merge helpers, debounce timer, enhanced `saveMessages()`, `agentContext.run()` for programmatic turns |
| `packages/ai-chat/src/tests/message-concurrency.test.ts` | 13 tests: all strategies, onChatResponse interaction, regenerate exempt, clear/epoch behavior |
| `packages/ai-chat/src/tests/programmatic-turns.test.ts` | 3 tests: `saveMessages()` queuing, functional form, skipped-after-clear |
| `packages/ai-chat/src/tests/worker.ts` | Test agents for each strategy, `onChatResponse` tracking on `SlowStreamAgent` |
| `packages/ai-chat/src/tests/wrangler.jsonc` | DO bindings and migrations for test agents |
| `docs/chat-agents.md` | Strategy docs, decision guide, UX descriptions, `saveMessages()` functional form |
| `packages/ai-chat/README.md` | Overlapping Messages section, API table updates |
| `examples/ai-chat/src/server.ts` | `sendProactiveMessage` uses `saveMessages()` functional form |
| `.changeset/nasty-pumpkins-juggle.md` | Minor changeset |

## Reviewer notes

- **Start with `packages/ai-chat/src/index.ts`** — the submit-message handler (line ~625) is where concurrency decisions happen, and `_runExclusiveChatTurn` (line ~1800) is where epoch tracking and `onChatResponse` drain coexist.
- **`saveMessages()` replaces the old `enqueueTurn()` API** from earlier iterations. One method, two forms (array or function), returns `{ requestId, status }`. No new methods to learn.
- **Persistence happens outside the turn lock** — this is intentional. The comment at line ~646 explains why. Other tabs see user messages immediately; the turn queue only serializes the model call.
- **`_mergeQueuedUserMessages` is called twice for merge mode** — once outside the lock (line ~662) and once inside (line ~701). The comment at line ~699 explains: more overlapping submits may arrive while the turn is queued.
- **Debounce timer is cancelled on clear** — `_cancelActiveDebounce()` in `resetTurnState()` prevents the DO from staying alive unnecessarily after a clear.
- **`_runProgrammaticChatTurn` wraps in `agentContext.run()`** — so `getCurrentAgent()` works inside programmatic turns, matching the WS and auto-continuation paths.
- **Hibernation safe** — all new state is ephemeral and only meaningful during active turn processing. After hibernation, epoch counts reset to 0, first submit bypasses concurrency (no active turns to overlap with). User messages are in SQLite.
- **No transport protocol changes** — skipped or collapsed work completes through existing `CF_AGENT_USE_CHAT_RESPONSE` frames with `done: true`.

## Testing

```bash
# Concurrency + programmatic turn tests
npx vitest --project workers src/tests/message-concurrency.test.ts src/tests/programmatic-turns.test.ts

# Full ai-chat test suite (340 tests)
npx vitest --project workers

# Full repo checks (all 69 projects typecheck)
npm run check
```

All passing.