### PR TITLE
fix(codemode): unwrap MCP content wrappers in codeMcpServer

### DIFF
--- a/.changeset/unwrap-mcp-result.md
+++ b/.changeset/unwrap-mcp-result.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Unwrap MCP content wrappers in `codeMcpServer` so sandbox code sees plain values instead of raw `{ content: [{ type: "text", text }] }` objects. Error responses (`isError`) now throw proper exceptions catchable via try/catch, and `structuredContent` is returned directly when present.

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -37,6 +37,54 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+type CallToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+/**
+ * Unwrap an MCP CallToolResult so sandbox code sees plain values,
+ * consistent with how createCodeTool exposes tool results.
+ *
+ * Priority:
+ * 1. Compat `toolResult` → return directly
+ * 2. `isError` → throw so sandbox gets a proper exception
+ * 3. `structuredContent` → authoritative typed value when present
+ * 4. All-text content → JSON.parse or raw string
+ * 5. Mixed content (text + images/audio/resources) → return as-is,
+ *    since binary content has no clean plain-value representation
+ */
+function unwrapMcpResult(result: CallToolResult): unknown {
+  if ("toolResult" in result) {
+    return result.toolResult;
+  }
+
+  if (result.isError) {
+    const msg =
+      result.content
+        .filter((c) => c.type === "text")
+        .map((c) => ("text" in c ? c.text : ""))
+        .join("\n") || "Tool call failed";
+    throw new Error(msg);
+  }
+
+  if (result.structuredContent != null) {
+    return result.structuredContent;
+  }
+
+  const allText =
+    result.content.length > 0 && result.content.every((c) => c.type === "text");
+  if (allText) {
+    const text = result.content
+      .map((c) => ("text" in c ? c.text : ""))
+      .join("\n");
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  return result;
+}
+
 // -- codeMcpServer --
 
 const CODE_DESCRIPTION = `Execute code to achieve a goal.
@@ -86,7 +134,9 @@ export async function codeMcpServer(
   }
   const types = generateTypesFromJsonSchema(toolDescriptors);
 
-  // Build executor fns — each upstream tool is a direct method
+  // Build executor fns — each upstream tool is a direct method.
+  // Unwrap MCP content wrappers so sandbox code sees plain values,
+  // consistent with how createCodeTool returns results.
   const fns: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
   for (const tool of tools) {
     const toolName = tool.name;
@@ -95,7 +145,7 @@ export async function codeMcpServer(
         name: toolName,
         arguments: args as Record<string, unknown>
       });
-      return result;
+      return unwrapMcpResult(result);
     };
   }
 

--- a/packages/codemode/src/tests/mcp.test.ts
+++ b/packages/codemode/src/tests/mcp.test.ts
@@ -98,7 +98,7 @@ describe("codeMcpServer", () => {
       }
     });
 
-    expect(JSON.parse(callText(result)).content[0].text).toBe("42");
+    expect(JSON.parse(callText(result))).toBe(42);
 
     await client.close();
   });
@@ -114,15 +114,13 @@ describe("codeMcpServer", () => {
       arguments: {
         code: `async () => {
           const sum = await codemode.add({ a: 5, b: 3 });
-          const greeting = await codemode.greet({ name: "Result is " + sum.content[0].text });
+          const greeting = await codemode.greet({ name: "Result is " + sum });
           return greeting;
         }`
       }
     });
 
-    expect(JSON.parse(callText(result)).content[0].text).toBe(
-      "Hello, Result is 8!"
-    );
+    expect(callText(result)).toBe("Hello, Result is 8!");
 
     await client.close();
   });
@@ -177,6 +175,169 @@ describe("codeMcpServer", () => {
     });
 
     expect(callText(result)).toBe("null");
+
+    await client.close();
+  });
+
+  it("code tool should unwrap JSON array from single text content", async () => {
+    const upstream = createUpstreamServer();
+    upstream.registerTool(
+      "get_items",
+      { description: "Return a JSON array", inputSchema: {} },
+      async () => ({
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify([
+              { id: 1, name: "a" },
+              { id: 2, name: "b" }
+            ])
+          }
+        ]
+      })
+    );
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const wrapped = await codeMcpServer({ server: upstream, executor });
+    const client = await connectClient(wrapped);
+
+    const result = await client.callTool({
+      name: "code",
+      arguments: {
+        code: `async () => {
+          const items = await codemode.get_items({});
+          return items.filter(i => i.id === 2);
+        }`
+      }
+    });
+
+    expect(JSON.parse(callText(result))).toEqual([{ id: 2, name: "b" }]);
+
+    await client.close();
+  });
+
+  it("code tool should surface upstream isError as a sandbox exception", async () => {
+    const upstream = createUpstreamServer();
+    upstream.registerTool(
+      "fail",
+      { description: "Always fails", inputSchema: {} },
+      async () => ({
+        content: [{ type: "text" as const, text: "something went wrong" }],
+        isError: true
+      })
+    );
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const wrapped = await codeMcpServer({ server: upstream, executor });
+    const client = await connectClient(wrapped);
+
+    const result = await client.callTool({
+      name: "code",
+      arguments: {
+        code: "async () => { return await codemode.fail({}); }"
+      }
+    });
+
+    expect(callText(result)).toBe("Error: something went wrong");
+    expect(result.isError).toBe(true);
+
+    await client.close();
+  });
+
+  it("code tool should concatenate multi-text content into a single string", async () => {
+    const upstream = createUpstreamServer();
+    upstream.registerTool(
+      "multi_text",
+      { description: "Return multiple text items", inputSchema: {} },
+      async () => ({
+        content: [
+          { type: "text" as const, text: "line one" },
+          { type: "text" as const, text: "line two" }
+        ]
+      })
+    );
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const wrapped = await codeMcpServer({ server: upstream, executor });
+    const client = await connectClient(wrapped);
+
+    const result = await client.callTool({
+      name: "code",
+      arguments: {
+        code: `async () => {
+          const text = await codemode.multi_text({});
+          return text;
+        }`
+      }
+    });
+
+    expect(callText(result)).toBe("line one\nline two");
+
+    await client.close();
+  });
+
+  it("code tool should unwrap JSON object from single text content", async () => {
+    const upstream = createUpstreamServer();
+    upstream.registerTool(
+      "get_user",
+      {
+        description: "Return a user object",
+        inputSchema: { id: z.number() }
+      },
+      async ({ id }) => ({
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ id, name: "Alice", active: true })
+          }
+        ]
+      })
+    );
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const wrapped = await codeMcpServer({ server: upstream, executor });
+    const client = await connectClient(wrapped);
+
+    const result = await client.callTool({
+      name: "code",
+      arguments: {
+        code: `async () => {
+          const user = await codemode.get_user({ id: 7 });
+          return user.name + " is " + (user.active ? "active" : "inactive");
+        }`
+      }
+    });
+
+    expect(callText(result)).toBe("Alice is active");
+
+    await client.close();
+  });
+
+  it("sandbox code should be able to try/catch upstream isError", async () => {
+    const upstream = createUpstreamServer();
+    upstream.registerTool(
+      "maybe_fail",
+      { description: "Might fail", inputSchema: {} },
+      async () => ({
+        content: [{ type: "text" as const, text: "not found" }],
+        isError: true
+      })
+    );
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const wrapped = await codeMcpServer({ server: upstream, executor });
+    const client = await connectClient(wrapped);
+
+    const result = await client.callTool({
+      name: "code",
+      arguments: {
+        code: `async () => {
+          try {
+            await codemode.maybe_fail({});
+            return "should not reach";
+          } catch (e) {
+            return "caught: " + e.message;
+          }
+        }`
+      }
+    });
+
+    expect(callText(result)).toBe("caught: not found");
 
     await client.close();
   });


### PR DESCRIPTION
## Summary

Fixes #1203

`codeMcpServer` was passing raw MCP `CallToolResult` objects (`{ content: [{ type: "text", text: "..." }] }`) into the sandbox. LLM-generated code expects plain values (consistent with how `createCodeTool` works), so every tool call required the LLM to discover the wrapping, manually dig into `.content[0].text`, and `JSON.parse` — wasting sandbox executions and producing fragile code.

This PR adds an `unwrapMcpResult` function that converts `CallToolResult` into plain values before they reach the sandbox:

| Response shape | Sandbox sees |
|---|---|
| Single text content with valid JSON | Parsed value (`number`, `object`, `array`, etc.) |
| Single text content, not valid JSON | Raw string |
| Multiple text content items | Joined text (`\n`-separated), with JSON.parse attempted |
| `isError: true` | **Thrown `Error`** — catchable via try/catch in sandbox |
| `structuredContent` present | The structured content object directly |
| `toolResult` (compat format) | The tool result directly |
| Mixed content (text + image/audio) | Raw result as-is (no clean plain-value representation) |

## What changed

**`packages/codemode/src/mcp.ts`**
- Added `unwrapMcpResult()` with typed `CallToolResult` parameter (derived from `Client["callTool"]`)
- Wired it into `codeMcpServer`'s tool functions so `client.callTool()` results are unwrapped before reaching the executor

**`packages/codemode/src/tests/mcp.test.ts`**
- Fixed 2 existing tests that were working around the bug (accessing `.content[0].text` manually)
- Added 6 new tests:
  - Unwrap JSON array → sandbox can `.filter()` directly
  - Unwrap JSON object → sandbox can access `.name`, `.active` directly
  - `isError` propagates as sandbox exception
  - `isError` is catchable via try/catch in sandbox code
  - Multi-text content concatenated into single string
  - (existing) chaining now uses plain values instead of `.content[0].text`

## Test plan

- [x] All 21 `codeMcpServer` / `openApiMcpServer` tests pass
- [x] Full test suite passes (126 tests across 7 suites)
- [x] `npm run check` passes (sherif, export checks, oxfmt, oxlint, typecheck across 68 projects)


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
