### PR TITLE
feat(mcp): add `transport: "auto"` for McpAgent.serve()

### DIFF
--- a/.changeset/auto-transport.md
+++ b/.changeset/auto-transport.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Add `transport: "auto"` option for `McpAgent.serve()` that serves both Streamable HTTP and legacy SSE on the same endpoint. Capable clients use Streamable HTTP automatically, while older SSE-only clients continue to work transparently.

--- a/docs/mcp-transports.md
+++ b/docs/mcp-transports.md
@@ -50,9 +50,19 @@ Clients connect using the `streamable-http` transport:
 await agent.addMcpServer("my-server", "https://your-worker.workers.dev/mcp");
 ```
 
+## Auto Transport
+
+The **auto** transport serves both Streamable HTTP and legacy SSE on the same endpoint. Capable clients use Streamable HTTP automatically, while older SSE-only clients continue to work.
+
+```typescript
+export default MyMCP.serve("/mcp", { transport: "auto" });
+```
+
+The handler distinguishes between the two protocols based on the request shape — no configuration or content negotiation is required from clients. This is useful when migrating from SSE to Streamable HTTP without breaking existing clients.
+
 ## SSE Transport (Deprecated)
 
-We also support the legacy **SSE (Server-Sent Events)** transport, but it's deprecated in favor of Streamable HTTP.
+We also support the legacy **SSE (Server-Sent Events)** transport, but it is deprecated in favor of Streamable HTTP.
 
 If you need SSE transport for compatibility:
 
@@ -284,11 +294,12 @@ export class MyMCP extends McpAgent<Env, State> {
 
 ## Choosing a transport
 
-| Transport           | Use when                              | Pros                                     | Cons                            |
-| ------------------- | ------------------------------------- | ---------------------------------------- | ------------------------------- |
-| **Streamable HTTP** | External MCP servers, production apps | Standard protocol, secure, supports auth | Slight network overhead         |
-| **RPC**             | Internal agents                       | Fastest, simplest setup                  | No auth, Service Bindings only  |
-| **SSE**             | Legacy compatibility                  | Backwards compatible                     | Deprecated, use Streamable HTTP |
+| Transport           | Use when                                 | Pros                                     | Cons                            |
+| ------------------- | ---------------------------------------- | ---------------------------------------- | ------------------------------- |
+| **Streamable HTTP** | External MCP servers, production apps    | Standard protocol, secure, supports auth | Slight network overhead         |
+| **Auto**            | Migrating from SSE, mixed client support | Serves both protocols on one endpoint    | Reserves `{path}/message` route |
+| **RPC**             | Internal agents                          | Fastest, simplest setup                  | No auth, Service Bindings only  |
+| **SSE**             | Legacy compatibility                     | Backwards compatible                     | Deprecated, use Streamable HTTP |
 
 ## Examples
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -15,6 +15,7 @@ import type { Connection, ConnectionContext } from "../";
 import { Agent } from "../index";
 import type { BaseTransportType, MaybePromise, ServeOptions } from "./types";
 import {
+  createAutoHandler,
   createLegacySseHandler,
   createStreamingHttpHandler,
   handleCORS,
@@ -477,7 +478,6 @@ export abstract class McpAgent<
 
         switch (transport) {
           case "streamable-http": {
-            // Streamable HTTP transport handling
             const handleStreamableHttp = createStreamingHttpHandler(
               path,
               namespace,
@@ -486,16 +486,22 @@ export abstract class McpAgent<
             return handleStreamableHttp(request, ctx);
           }
           case "sse": {
-            // Legacy SSE transport handling
             const handleLegacySse = createLegacySseHandler(path, namespace, {
               corsOptions,
               jurisdiction
             });
             return handleLegacySse(request, ctx);
           }
+          case "auto": {
+            const handleAuto = createAutoHandler(path, namespace, {
+              corsOptions,
+              jurisdiction
+            });
+            return handleAuto(request, ctx);
+          }
           default:
             return new Response(
-              "Invalid MCP transport mode. Only `streamable-http` or `sse` are allowed.",
+              "Invalid MCP transport mode. Only `streamable-http`, `sse`, or `auto` are allowed.",
               { status: 500 }
             );
         }

--- a/packages/agents/src/mcp/types.ts
+++ b/packages/agents/src/mcp/types.ts
@@ -18,7 +18,7 @@ export interface CORSOptions {
 export interface ServeOptions {
   binding?: string;
   corsOptions?: CORSOptions;
-  transport?: BaseTransportType;
+  transport?: TransportType;
   jurisdiction?: DurableObjectJurisdiction;
 }
 

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -722,6 +722,70 @@ export const createLegacySseHandler = (
   };
 };
 
+/**
+ * Auto-negotiating handler that serves both streamable HTTP and legacy SSE
+ * on the same path. Streamable-HTTP-capable clients are preferred; legacy SSE
+ * clients fall back transparently.
+ *
+ * Discrimination rules:
+ *  - POST to `{basePath}/message` → legacy SSE (the sub-path is SSE-only)
+ *  - POST to `{basePath}` → streamable HTTP
+ *  - GET  with `mcp-session-id` header → streamable HTTP (standalone SSE reconnect)
+ *  - GET  without `mcp-session-id` → legacy SSE (new SSE connection)
+ *  - DELETE → streamable HTTP (SSE has no session teardown)
+ */
+export const createAutoHandler = (
+  basePath: string,
+  namespace: DurableObjectNamespace<McpAgent>,
+  options: {
+    corsOptions?: CORSOptions;
+    jurisdiction?: DurableObjectJurisdiction;
+  } = {}
+) => {
+  const handleStreamableHttp = createStreamingHttpHandler(
+    basePath,
+    namespace,
+    options
+  );
+  const handleLegacySse = createLegacySseHandler(basePath, namespace, options);
+
+  const messagePattern = new URLPattern({
+    pathname: `${basePath}/message`
+  });
+
+  return async (request: Request, ctx: ExecutionContext) => {
+    const url = new URL(request.url);
+
+    if (request.method === "DELETE") {
+      return handleStreamableHttp(request, ctx);
+    }
+
+    if (request.method === "POST" && messagePattern.test(url)) {
+      return handleLegacySse(request, ctx);
+    }
+
+    if (request.method === "POST") {
+      return handleStreamableHttp(request, ctx);
+    }
+
+    if (request.method === "GET" && request.headers.has("mcp-session-id")) {
+      return handleStreamableHttp(request, ctx);
+    }
+
+    if (request.method === "GET") {
+      return handleLegacySse(request, ctx);
+    }
+
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: {
+        Allow: "GET, POST, DELETE",
+        ...corsHeaders(request, options.corsOptions)
+      }
+    });
+  };
+};
+
 // CORS helper functions
 export function corsHeaders(_request: Request, corsOptions: CORSOptions = {}) {
   const origin = corsOptions.origin || "*";

--- a/packages/agents/src/tests/mcp/auto-transport.test.ts
+++ b/packages/agents/src/tests/mcp/auto-transport.test.ts
@@ -1,0 +1,327 @@
+import { env } from "cloudflare:workers";
+import { createExecutionContext } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import worker from "../worker";
+import {
+  TEST_MESSAGES,
+  sendPostRequest,
+  readSSEEvent,
+  parseSSEData,
+  expectValidToolsList,
+  expectValidGreetResult,
+  initializeStreamableHTTPServer
+} from "../shared/test-utils";
+
+const AUTO_BASE = "http://example.com/auto";
+
+/**
+ * Establish a legacy SSE connection via the auto endpoint.
+ * GET without mcp-session-id → auto handler routes to SSE.
+ */
+async function establishSSEViaAuto(ctx: ExecutionContext) {
+  const request = new Request(AUTO_BASE);
+  const sseStream = await worker.fetch(request, env, ctx);
+
+  expect(sseStream.status).toBe(200);
+  expect(sseStream.headers.get("content-type")).toBe("text/event-stream");
+
+  const reader = sseStream.body?.getReader();
+  if (!reader) throw new Error("No reader available");
+
+  const { value } = await reader.read();
+  const event = new TextDecoder().decode(value);
+
+  const lines = event.split("\n");
+  expect(lines[0]).toBe("event: endpoint");
+  expect(lines[1]).toContain("/auto/message");
+
+  const sessionId = lines[1].split("=")[1];
+  expect(sessionId).toBeDefined();
+
+  return { sessionId, reader };
+}
+
+describe("Auto Transport", () => {
+  describe("Routing: Streamable HTTP requests", () => {
+    it("should handle POST to base path as streamable HTTP", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx, AUTO_BASE);
+
+      const response = await sendPostRequest(
+        ctx,
+        AUTO_BASE,
+        TEST_MESSAGES.toolsList,
+        sessionId
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/event-stream");
+      const sseText = await readSSEEvent(response);
+      const result = parseSSEData(sseText);
+      expectValidToolsList(result);
+    });
+
+    it("should handle DELETE as streamable HTTP", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx, AUTO_BASE);
+
+      const deleteReq = new Request(AUTO_BASE, {
+        method: "DELETE",
+        headers: { "mcp-session-id": sessionId }
+      });
+
+      const response = await worker.fetch(deleteReq, env, ctx);
+      expect(response.status).toBe(204);
+    });
+
+    it("should handle GET with mcp-session-id as streamable HTTP standalone SSE", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx, AUTO_BASE);
+
+      const getReq = new Request(AUTO_BASE, {
+        method: "GET",
+        headers: {
+          Accept: "application/json, text/event-stream",
+          "mcp-session-id": sessionId
+        }
+      });
+
+      const response = await worker.fetch(getReq, env, ctx);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/event-stream");
+      expect(response.headers.get("mcp-session-id")).toBe(sessionId);
+    });
+  });
+
+  describe("Routing: Legacy SSE requests", () => {
+    it("should handle GET without mcp-session-id as legacy SSE", async () => {
+      const ctx = createExecutionContext();
+      const { sessionId } = await establishSSEViaAuto(ctx);
+      expect(sessionId).toBeTruthy();
+    });
+
+    it("should handle POST to /message as legacy SSE", async () => {
+      const ctx = createExecutionContext();
+      const { sessionId, reader } = await establishSSEViaAuto(ctx);
+
+      const postReq = new Request(
+        `${AUTO_BASE}/message?sessionId=${sessionId}`,
+        {
+          method: "POST",
+          body: JSON.stringify(TEST_MESSAGES.toolsList),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const response = await worker.fetch(postReq, env, ctx);
+      expect(response.status).toBe(202);
+
+      const { value } = await reader.read();
+      const event = new TextDecoder().decode(value);
+      const result = JSON.parse(event.split("\n")[1].replace("data: ", ""));
+      expectValidToolsList(result);
+    });
+  });
+
+  describe("Protocol: full tool invocation through auto", () => {
+    it("should invoke greet tool via streamable HTTP through auto", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx, AUTO_BASE);
+
+      const response = await sendPostRequest(
+        ctx,
+        AUTO_BASE,
+        TEST_MESSAGES.greetTool,
+        sessionId
+      );
+
+      expect(response.status).toBe(200);
+      const sseText = await readSSEEvent(response);
+      const result = parseSSEData(sseText);
+      expectValidGreetResult(result, "Test User");
+    });
+
+    it("should invoke greet tool via legacy SSE through auto", async () => {
+      const ctx = createExecutionContext();
+      const { sessionId, reader } = await establishSSEViaAuto(ctx);
+
+      const greetReq = new Request(
+        `${AUTO_BASE}/message?sessionId=${sessionId}`,
+        {
+          method: "POST",
+          body: JSON.stringify(TEST_MESSAGES.greetTool),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const response = await worker.fetch(greetReq, env, ctx);
+      expect(response.status).toBe(202);
+
+      const { value } = await reader.read();
+      const event = new TextDecoder().decode(value);
+      const result = JSON.parse(event.split("\n")[1].replace("data: ", ""));
+      expectValidGreetResult(result, "Test User");
+    });
+  });
+
+  describe("Coexistence: both transports on the same path", () => {
+    it("should serve streamable HTTP and SSE clients simultaneously", async () => {
+      const ctx = createExecutionContext();
+
+      const streamableSessionId = await initializeStreamableHTTPServer(
+        ctx,
+        AUTO_BASE
+      );
+
+      const { sessionId: sseSessionId, reader: sseReader } =
+        await establishSSEViaAuto(ctx);
+
+      const streamableResponse = await sendPostRequest(
+        ctx,
+        AUTO_BASE,
+        TEST_MESSAGES.greetTool,
+        streamableSessionId
+      );
+      expect(streamableResponse.status).toBe(200);
+      const streamableText = await readSSEEvent(streamableResponse);
+      const streamableResult = parseSSEData(streamableText);
+      expectValidGreetResult(streamableResult, "Test User");
+
+      const sseReq = new Request(
+        `${AUTO_BASE}/message?sessionId=${sseSessionId}`,
+        {
+          method: "POST",
+          body: JSON.stringify(TEST_MESSAGES.greetTool),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+      const sseResponse = await worker.fetch(sseReq, env, ctx);
+      expect(sseResponse.status).toBe(202);
+
+      const { value } = await sseReader.read();
+      const sseEvent = new TextDecoder().decode(value);
+      const sseResult = JSON.parse(
+        sseEvent.split("\n")[1].replace("data: ", "")
+      );
+      expectValidGreetResult(sseResult, "Test User");
+    });
+  });
+
+  describe("Notifications and non-request messages", () => {
+    it("should return 202 for notification-only POST via streamable HTTP", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx, AUTO_BASE);
+
+      const notification = {
+        jsonrpc: "2.0",
+        method: "notifications/initialized"
+      };
+
+      const response = await sendPostRequest(
+        ctx,
+        AUTO_BASE,
+        notification as unknown as import("@modelcontextprotocol/sdk/types.js").JSONRPCMessage,
+        sessionId
+      );
+
+      expect(response.status).toBe(202);
+    });
+  });
+
+  describe("CORS", () => {
+    it("should handle OPTIONS preflight through auto endpoint", async () => {
+      const ctx = createExecutionContext();
+
+      const optionsReq = new Request(AUTO_BASE, { method: "OPTIONS" });
+      const response = await worker.fetch(optionsReq, env, ctx);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+        "POST"
+      );
+      expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+        "DELETE"
+      );
+      expect(response.headers.get("Access-Control-Allow-Headers")).toContain(
+        "mcp-session-id"
+      );
+    });
+
+    it("should include Allow header on 405 responses", async () => {
+      const ctx = createExecutionContext();
+
+      const putReq = new Request(AUTO_BASE, { method: "PUT" });
+      const response = await worker.fetch(putReq, env, ctx);
+
+      expect(response.status).toBe(405);
+      expect(response.headers.get("Allow")).toBe("GET, POST, DELETE");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should return 405 for unsupported methods", async () => {
+      const ctx = createExecutionContext();
+
+      const putReq = new Request(AUTO_BASE, { method: "PUT" });
+      const response = await worker.fetch(putReq, env, ctx);
+      expect(response.status).toBe(405);
+    });
+
+    it("should return 400 for DELETE without mcp-session-id", async () => {
+      const ctx = createExecutionContext();
+
+      const deleteReq = new Request(AUTO_BASE, { method: "DELETE" });
+      const response = await worker.fetch(deleteReq, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 404 for DELETE with unknown session", async () => {
+      const ctx = createExecutionContext();
+
+      const deleteReq = new Request(AUTO_BASE, {
+        method: "DELETE",
+        headers: { "mcp-session-id": "nonexistent-session-id" }
+      });
+      const response = await worker.fetch(deleteReq, env, ctx);
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 for POST with unknown session via streamable HTTP", async () => {
+      const ctx = createExecutionContext();
+
+      const response = await sendPostRequest(
+        ctx,
+        AUTO_BASE,
+        TEST_MESSAGES.toolsList,
+        "nonexistent-session-id"
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("should reject streamable HTTP POST without proper Accept header", async () => {
+      const ctx = createExecutionContext();
+
+      const request = new Request(AUTO_BASE, {
+        method: "POST",
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+        headers: { "Content-Type": "application/json" }
+      });
+
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(406);
+    });
+
+    it("should reject SSE POST to /message without sessionId", async () => {
+      const ctx = createExecutionContext();
+
+      const request = new Request(`${AUTO_BASE}/message`, {
+        method: "POST",
+        body: JSON.stringify(TEST_MESSAGES.toolsList),
+        headers: { "Content-Type": "application/json" }
+      });
+
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -182,6 +182,14 @@ export default {
       return McpAgentImpl.serve("/mcp").fetch(request, env, ctx);
     }
 
+    if (url.pathname === "/auto" || url.pathname === "/auto/message") {
+      return McpAgentImpl.serve("/auto", { transport: "auto" }).fetch(
+        request,
+        env,
+        ctx
+      );
+    }
+
     if (url.pathname === "/500") {
       return new Response("Internal Server Error", { status: 500 });
     }


### PR DESCRIPTION
## Summary

Adds a new `transport: "auto"` option to `McpAgent.serve()` that serves both **Streamable HTTP** and **legacy SSE** on the same endpoint. Capable clients get the modern Streamable HTTP protocol automatically, while older SSE-only clients continue to work transparently — no client changes required.

```typescript
// Serve both transports on a single path
export default MyMCP.serve("/mcp", { transport: "auto" });
```

### How it works

The auto handler composes the existing `createStreamingHttpHandler` and `createLegacySseHandler` with a thin routing layer that discriminates by request shape:

| Request | Routes to |
|---------|-----------|
| `DELETE` | Streamable HTTP (SSE has no session teardown) |
| `POST {path}/message` | Legacy SSE (the `/message` sub-path is SSE-only) |
| `POST {path}` | Streamable HTTP |
| `GET` with `mcp-session-id` header | Streamable HTTP (standalone SSE reconnect) |
| `GET` without `mcp-session-id` | Legacy SSE (new connection) |
| Other methods | 405 Method Not Allowed |

The two protocols have completely non-overlapping HTTP signatures, so routing is deterministic — no heuristics or content negotiation.

### What changed

- **`packages/agents/src/mcp/utils.ts`** — Added `createAutoHandler` that composes both existing handlers
- **`packages/agents/src/mcp/types.ts`** — Widened `ServeOptions.transport` from `BaseTransportType` to `TransportType` (which already included `"auto"`)
- **`packages/agents/src/mcp/index.ts`** — Added `"auto"` case to `serve()` switch
- **`docs/mcp-transports.md`** — Documented auto transport and updated comparison table

### Design decisions

- **`serveSSE()` unchanged** — stays as `transport: "sse"`. Auto is opt-in via `serve(path, { transport: "auto" })`. No silent behavior changes for existing users.
- **`{path}/message` is reserved** — in auto mode, this sub-path is captured by the SSE handler. This is the same reservation SSE already makes.
- **No changes to DO internals** — the auto handler picks the right name prefix (`sse:` or `streamable-http:`) at the edge, so `getTransportType()` / `initTransport()` inside the DO work as-is.

## Test plan

17 new tests in `auto-transport.test.ts` covering:

- [x] **Routing** (5 tests): POST→streamable, POST /message→SSE, GET+header→streamable, GET-header→SSE, DELETE→streamable
- [x] **Protocol** (2 tests): Full tool invocation end-to-end through each transport
- [x] **Coexistence** (1 test): Both transports active simultaneously with correct responses
- [x] **Notifications** (1 test): Notification-only POST returns 202
- [x] **CORS** (2 tests): OPTIONS preflight, 405 includes Allow header
- [x] **Edge cases** (6 tests): 405 for PUT, 400/404 for bad DELETE, 404 for unknown session, 406 for bad Accept, 400 for missing sessionId

All 791 tests pass (47 test files).


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
