### PR TITLE
Add codemode e2e tests and test worker endpoints

### DIFF
--- a/packages/codemode/e2e/executor.spec.ts
+++ b/packages/codemode/e2e/executor.spec.ts
@@ -1,0 +1,347 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Deterministic e2e tests for the codemode executor pipeline.
+ *
+ * These bypass the LLM entirely — they POST raw code to the /execute
+ * endpoint and verify the result. This tests the full HTTP → Worker →
+ * WorkerLoader → dynamic sandbox → RPC dispatch → result pipeline.
+ */
+
+async function execute(
+  request: import("@playwright/test").APIRequestContext,
+  baseURL: string,
+  code: string,
+  preset = "default"
+): Promise<{ result?: unknown; error?: string; logs?: string[] }> {
+  const res = await request.post(`${baseURL}/execute`, {
+    headers: { "Content-Type": "application/json" },
+    data: { code, preset }
+  });
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+async function mcpExecute(
+  request: import("@playwright/test").APIRequestContext,
+  baseURL: string,
+  code: string
+): Promise<{ text: string; isError: boolean }> {
+  const res = await request.post(`${baseURL}/mcp/execute`, {
+    headers: { "Content-Type": "application/json" },
+    data: { code }
+  });
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+// ── Basic execution ───────────────────────────────────────────────
+
+test.describe("Direct executor e2e", () => {
+  test("simple expression returns result", async ({ request, baseURL }) => {
+    const result = await execute(request, baseURL!, "async () => 42");
+    expect(result.result).toBe(42);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("bare expression is normalized and executed", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await execute(request, baseURL!, "1 + 1");
+    expect(result.result).toBe(2);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("markdown fences are stripped", async ({ request, baseURL }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      "```js\nasync () => 99\n```"
+    );
+    expect(result.result).toBe(99);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("tool call via default codemode namespace", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      "async () => await codemode.addNumbers({ a: 3, b: 4 })"
+    );
+    expect(result.result).toEqual({ result: 7 });
+    expect(result.error).toBeUndefined();
+  });
+
+  test("multiple sequential tool calls", async ({ request, baseURL }) => {
+    const code = `async () => {
+      const w = await codemode.getWeather({ city: "NYC" });
+      const sum = await codemode.addNumbers({ a: w.temperature, b: 10 });
+      return { weather: w, sum: sum.result };
+    }`;
+    const result = await execute(request, baseURL!, code);
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({
+      weather: { city: "NYC", temperature: 22, condition: "Sunny" },
+      sum: 32
+    });
+  });
+});
+
+// ── Multi-provider namespaces ─────────────────────────────────────
+
+test.describe("Multi-provider namespaces e2e", () => {
+  test("code can call tools from two different namespaces", async ({
+    request,
+    baseURL
+  }) => {
+    const code = `async () => {
+      const w = await codemode.getWeather({ city: "Berlin" });
+      const product = await math.multiply({ a: w.temperature, b: 3 });
+      return { city: w.city, tripled: product.result };
+    }`;
+    const result = await execute(request, baseURL!, code, "multi");
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ city: "Berlin", tripled: 66 });
+  });
+
+  test("error in one namespace does not break the other", async ({
+    request,
+    baseURL
+  }) => {
+    const code = `async () => {
+      try {
+        await math.divide({ a: 10, b: 0 });
+      } catch (e) {
+        const sum = await codemode.addNumbers({ a: 1, b: 2 });
+        return { caught: e.message, sum: sum.result };
+      }
+    }`;
+    const result = await execute(request, baseURL!, code, "multi");
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({
+      caught: "Division by zero",
+      sum: 3
+    });
+  });
+});
+
+// ── positionalArgs ────────────────────────────────────────────────
+
+test.describe("positionalArgs e2e", () => {
+  test("tool receives individual positional arguments", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      'async () => await state.concat("hello", "world")',
+      "positional"
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBe("hello world");
+  });
+});
+
+// ── Custom modules ────────────────────────────────────────────────
+
+test.describe("Custom modules e2e", () => {
+  test("sandbox can import custom module", async ({ request, baseURL }) => {
+    const code = `async () => {
+      const { greet, double } = await import("helpers.js");
+      return { greeting: greet("world"), doubled: double(21) };
+    }`;
+    const result = await execute(request, baseURL!, code, "withModules");
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({
+      greeting: "hello world",
+      doubled: 42
+    });
+  });
+});
+
+// ── Error handling ────────────────────────────────────────────────
+
+test.describe("Sandbox error handling e2e", () => {
+  test("code that throws returns error", async ({ request, baseURL }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      'async () => { throw new Error("boom"); }'
+    );
+    expect(result.error).toBe("boom");
+  });
+
+  test("execution timeout returns error", async ({ request, baseURL }) => {
+    // Use async sleep (not sync loop) so the Promise.race timeout can fire
+    const result = await execute(
+      request,
+      baseURL!,
+      "async () => { await new Promise(r => setTimeout(r, 30000)); return 'done'; }",
+      "timeout"
+    );
+    expect(result.error).toContain("timed out");
+  });
+
+  test("calling non-existent tool returns error", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      "async () => await codemode.nonexistent({})"
+    );
+    expect(result.error).toContain("nonexistent");
+  });
+});
+
+// ── Console capture ───────────────────────────────────────────────
+
+test.describe("Console capture e2e", () => {
+  test("console.log output is captured in logs", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      `async () => {
+        console.log("hello from sandbox");
+        console.warn("watch out");
+        console.error("bad thing");
+        return "done";
+      }`
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBe("done");
+    expect(result.logs).toContain("hello from sandbox");
+    expect(result.logs).toContain("[warn] watch out");
+    expect(result.logs).toContain("[error] bad thing");
+  });
+});
+
+// ── Network isolation ─────────────────────────────────────────────
+
+test.describe("Network isolation e2e", () => {
+  test("fetch is blocked in sandbox by default", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      'async () => { const r = await fetch("https://example.com"); return r.status; }'
+    );
+    expect(result.error).toBeDefined();
+  });
+});
+
+// ── Schema validation ─────────────────────────────────────────────
+
+test.describe("Schema validation e2e", () => {
+  test("valid input passes schema validation", async ({ request, baseURL }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      "async () => await codemode.strictAdd({ a: 10, b: 20 })",
+      "validated"
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ result: 30 });
+  });
+
+  test("invalid input is rejected by schema validation", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await execute(
+      request,
+      baseURL!,
+      'async () => await codemode.strictAdd({ a: "not-a-number", b: 20 })',
+      "validated"
+    );
+    expect(result.error).toBeDefined();
+  });
+});
+
+// ── MCP codeMcpServer pipeline ────────────────────────────────────
+
+test.describe("MCP codeMcpServer e2e", () => {
+  test("code tool calls upstream MCP tool and returns result", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await mcpExecute(
+      request,
+      baseURL!,
+      "async () => await codemode.add({ a: 10, b: 32 })"
+    );
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.text)).toBe(42);
+  });
+
+  test("code tool chains multiple upstream calls", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await mcpExecute(
+      request,
+      baseURL!,
+      `async () => {
+        const sum = await codemode.add({ a: 5, b: 3 });
+        const greeting = await codemode.greet({ name: "Sum is " + sum });
+        return greeting;
+      }`
+    );
+    expect(result.isError).toBe(false);
+    expect(result.text).toBe("Hello, Sum is 8!");
+  });
+
+  test("upstream error surfaces as sandbox exception", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await mcpExecute(
+      request,
+      baseURL!,
+      "async () => await codemode.fail_always({})"
+    );
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("something went wrong");
+  });
+
+  test("upstream error is catchable with try/catch in sandbox", async ({
+    request,
+    baseURL
+  }) => {
+    const result = await mcpExecute(
+      request,
+      baseURL!,
+      `async () => {
+        try {
+          await codemode.fail_always({});
+          return "should not reach";
+        } catch (e) {
+          return "caught: " + e.message;
+        }
+      }`
+    );
+    expect(result.isError).toBe(false);
+    expect(result.text).toBe("caught: something went wrong");
+  });
+
+  test("non-existent tool returns error", async ({ request, baseURL }) => {
+    const result = await mcpExecute(
+      request,
+      baseURL!,
+      "async () => await codemode.nope({})"
+    );
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("nope");
+  });
+});

--- a/packages/codemode/e2e/llm-codemode.spec.ts
+++ b/packages/codemode/e2e/llm-codemode.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * LLM-dependent e2e tests for codemode with Workers AI.
+ *
+ * These verify the full pipeline including LLM code generation:
+ *   user prompt → LLM generates code → createCodeTool → DynamicWorkerExecutor
+ *   → sandboxed Worker → tool dispatch via RPC → result → LLM response.
+ *
+ * Uses Workers AI (@cf/moonshotai/kimi-k2.5) — no API key needed.
+ */
+
+async function runChat(
+  request: import("@playwright/test").APIRequestContext,
+  baseURL: string,
+  userMessage: string,
+  endpoint = "/run"
+): Promise<string> {
+  const res = await request.post(`${baseURL}${endpoint}`, {
+    headers: { "Content-Type": "application/json" },
+    data: {
+      messages: [
+        {
+          id: `msg-${crypto.randomUUID()}`,
+          role: "user",
+          parts: [{ type: "text", text: userMessage }]
+        }
+      ]
+    },
+    timeout: 45_000
+  });
+  expect(res.ok()).toBe(true);
+  return res.text();
+}
+
+// ── Multi-provider with LLM ───────────────────────────────────────
+
+test.describe("Multi-provider LLM e2e", () => {
+  test.setTimeout(45_000);
+
+  test("LLM uses math namespace to multiply numbers", async ({
+    request,
+    baseURL
+  }) => {
+    const response = await runChat(
+      request,
+      baseURL!,
+      "What is 6 times 7? Use the codemode tool with the math.multiply function.",
+      "/run-multi"
+    );
+
+    expect(response).toContain("42");
+  });
+
+  test("LLM combines tools from both namespaces", async ({
+    request,
+    baseURL
+  }) => {
+    const response = await runChat(
+      request,
+      baseURL!,
+      "First add 10 and 5 using codemode.addNumbers, then multiply the result by 3 using math.multiply. Use the codemode tool to write code that does both.",
+      "/run-multi"
+    );
+
+    // 10 + 5 = 15, 15 * 3 = 45
+    const lower = response.toLowerCase();
+    expect(
+      lower.includes("45") || lower.includes("15") || lower.includes("multiply")
+    ).toBe(true);
+  });
+});
+
+// ── generateTypes ─────────────────────────────────────────────────
+
+test.describe("generateTypes e2e", () => {
+  test.setTimeout(15_000);
+
+  test("multi-provider types include both namespaces", async ({
+    request,
+    baseURL
+  }) => {
+    const res = await request.get(`${baseURL}/types/multi`);
+    expect(res.ok()).toBe(true);
+
+    const data = await res.json();
+    const types = data.types as string;
+
+    expect(types).toContain("declare const codemode");
+    expect(types).toContain("declare const math");
+    expect(types).toContain("addNumbers");
+    expect(types).toContain("getWeather");
+    expect(types).toContain("multiply");
+    expect(types).toContain("divide");
+  });
+});

--- a/packages/codemode/e2e/worker.ts
+++ b/packages/codemode/e2e/worker.ts
@@ -8,15 +8,21 @@ import {
 } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
 import { z } from "zod";
-import { createCodeTool } from "../src/ai";
+import { createCodeTool, resolveProvider } from "../src/ai";
 import { DynamicWorkerExecutor } from "../src/index";
 import { generateTypes } from "../src/ai";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { codeMcpServer } from "../src/mcp";
 
 type Env = {
   AI: Ai;
   LOADER: WorkerLoader;
   CodemodeAgent: DurableObjectNamespace<CodemodeAgent>;
 };
+
+// ── Tool definitions ──────────────────────────────────────────────
 
 const pmTools = {
   createProject: tool({
@@ -62,6 +68,42 @@ const pmTools = {
     })
   })
 };
+
+const mathTools = {
+  multiply: tool({
+    description: "Multiply two numbers",
+    inputSchema: z.object({
+      a: z.number().describe("First number"),
+      b: z.number().describe("Second number")
+    }),
+    execute: async ({ a, b }) => ({ result: a * b })
+  }),
+
+  divide: tool({
+    description: "Divide two numbers",
+    inputSchema: z.object({
+      a: z.number().describe("Numerator"),
+      b: z.number().describe("Denominator")
+    }),
+    execute: async ({ a, b }) => {
+      if (b === 0) throw new Error("Division by zero");
+      return { result: a / b };
+    }
+  })
+};
+
+const validatedTools = {
+  strictAdd: tool({
+    description: "Add two numbers (strict validation)",
+    inputSchema: z.object({
+      a: z.number(),
+      b: z.number()
+    }),
+    execute: async ({ a, b }) => ({ result: a + b })
+  })
+};
+
+// ── Agent ─────────────────────────────────────────────────────────
 
 export class CodemodeAgent extends Agent<Env> {
   async onRequest(request: Request): Promise<Response> {
@@ -112,6 +154,184 @@ When asked about projects, use createProject or listProjects via codemode.`,
   }
 }
 
+// ── Direct executor endpoint ──────────────────────────────────────
+
+type ExecuteBody = {
+  code: string;
+  preset?: string;
+};
+
+async function handleExecute(body: ExecuteBody, env: Env): Promise<Response> {
+  const { code, preset = "default" } = body;
+
+  if (preset === "timeout") {
+    const executor = new DynamicWorkerExecutor({
+      loader: env.LOADER,
+      timeout: 100
+    });
+    const result = await executor.execute(code, [
+      resolveProvider({ tools: pmTools })
+    ]);
+    return Response.json(result);
+  }
+
+  if (preset === "withModules") {
+    const executor = new DynamicWorkerExecutor({
+      loader: env.LOADER,
+      modules: {
+        "helpers.js":
+          'export function greet(name) { return "hello " + name; }\nexport function double(n) { return n * 2; }'
+      }
+    });
+    const result = await executor.execute(code, [
+      resolveProvider({ tools: pmTools })
+    ]);
+    return Response.json(result);
+  }
+
+  const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+
+  if (preset === "multi") {
+    const result = await executor.execute(code, [
+      resolveProvider({ tools: pmTools }),
+      resolveProvider({ name: "math", tools: mathTools })
+    ]);
+    return Response.json(result);
+  }
+
+  if (preset === "positional") {
+    const concatFn = async (...args: unknown[]) => {
+      return (args as string[]).join(" ");
+    };
+    const result = await executor.execute(code, [
+      {
+        name: "state",
+        fns: { concat: concatFn },
+        positionalArgs: true
+      }
+    ]);
+    return Response.json(result);
+  }
+
+  if (preset === "validated") {
+    const result = await executor.execute(code, [
+      resolveProvider({ tools: validatedTools })
+    ]);
+    return Response.json(result);
+  }
+
+  const result = await executor.execute(code, [
+    resolveProvider({ tools: pmTools })
+  ]);
+  return Response.json(result);
+}
+
+// ── MCP executor endpoint ─────────────────────────────────────────
+
+async function handleMcpExecute(
+  body: { code: string },
+  env: Env
+): Promise<Response> {
+  const upstream = new McpServer({
+    name: "test-tools",
+    version: "1.0.0"
+  });
+
+  upstream.registerTool(
+    "add",
+    {
+      description: "Add two numbers",
+      inputSchema: {
+        a: z.number().describe("First number"),
+        b: z.number().describe("Second number")
+      }
+    },
+    async ({ a, b }) => ({
+      content: [{ type: "text" as const, text: String(a + b) }]
+    })
+  );
+
+  upstream.registerTool(
+    "greet",
+    {
+      description: "Generate a greeting",
+      inputSchema: {
+        name: z.string().describe("Name to greet")
+      }
+    },
+    async ({ name }) => ({
+      content: [{ type: "text" as const, text: `Hello, ${name}!` }]
+    })
+  );
+
+  upstream.registerTool(
+    "fail_always",
+    {
+      description: "Always fails",
+      inputSchema: {}
+    },
+    async () => ({
+      content: [{ type: "text" as const, text: "something went wrong" }],
+      isError: true
+    })
+  );
+
+  const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+  const wrapped = await codeMcpServer({ server: upstream, executor });
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await wrapped.connect(serverTransport);
+  const client = new Client({ name: "e2e-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+
+  const result = await client.callTool({
+    name: "code",
+    arguments: { code: body.code }
+  });
+
+  await client.close();
+
+  const text = (result.content as Array<{ type: string; text: string }>)[0]
+    .text;
+  return Response.json({
+    text,
+    isError: result.isError ?? false
+  });
+}
+
+// ── LLM multi-provider endpoint ───────────────────────────────────
+
+async function handleRunMulti(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as { messages: UIMessage[] };
+
+  const workersai = createWorkersAI({ binding: env.AI });
+  const model = workersai("@cf/moonshotai/kimi-k2.5");
+
+  const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+
+  const codemode = createCodeTool({
+    tools: [{ tools: pmTools }, { name: "math", tools: mathTools }],
+    executor
+  });
+
+  const result = streamText({
+    model,
+    system: `You are a helpful assistant with access to a codemode tool.
+The codemode tool lets you write JavaScript code. You have two namespaces:
+- \`codemode\` for weather, projects, and adding numbers
+- \`math\` for multiplying and dividing numbers
+Keep responses very short (1-2 sentences max).`,
+    messages: await convertToModelMessages(body.messages),
+    tools: { codemode },
+    stopWhen: stepCountIs(5)
+  });
+
+  return result.toTextStreamResponse();
+}
+
+// ── Fetch handler ─────────────────────────────────────────────────
+
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
     const url = new URL(request.url);
@@ -136,8 +356,30 @@ export default {
       );
     }
 
+    if (url.pathname === "/run-multi" && request.method === "POST") {
+      return handleRunMulti(request, env);
+    }
+
+    if (url.pathname === "/execute" && request.method === "POST") {
+      const body = (await request.json()) as ExecuteBody;
+      return handleExecute(body, env);
+    }
+
+    if (url.pathname === "/mcp/execute" && request.method === "POST") {
+      const body = (await request.json()) as { code: string };
+      return handleMcpExecute(body, env);
+    }
+
     if (url.pathname === "/types") {
       return Response.json({ types: generateTypes(pmTools) });
+    }
+
+    if (url.pathname === "/types/multi") {
+      return Response.json({
+        types: [generateTypes(pmTools), generateTypes(mathTools, "math")].join(
+          "\n\n"
+        )
+      });
     }
 
     return new Response("OK");


### PR DESCRIPTION
Introduce end-to-end Playwright tests and extend the test worker to serve test-specific endpoints. Adds two new specs (executor.spec.ts and llm-codemode.spec.ts) that cover direct executor flows, multi-provider namespaces, positional args, custom modules, schema validation, console capture, network isolation, and LLM-driven code generation. Update worker.ts to support these tests by: importing resolveProvider; adding math and validated tool sets; wiring presets (timeout, withModules, multi, positional, validated) into a new /execute handler; adding an MCP-backed /mcp/execute handler using McpServer, InMemoryTransport and Client via codeMcpServer; adding an LLM /run-multi endpoint using createCodeTool and Workers AI; and exposing combined type output at /types/multi. These changes enable deterministic e2e coverage of the full HTTP → Worker → sandbox → tool RPC → result pipeline and LLM integration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
