### PR TITLE
Narrow Think peer dep on shell from * to >=0.2.0

### DIFF
--- a/.changeset/fix-think-shell-peer-dep.md
+++ b/.changeset/fix-think-shell-peer-dep.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Fix `@cloudflare/shell` peer dependency to require `>=0.2.0`. Previously, npm could resolve an incompatible shell version, causing runtime errors. If you hit `Workspace` constructor errors, upgrade `@cloudflare/shell` to 0.2.0 or later.

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@cloudflare/codemode": ">=0.0.7 <1.0.0",
-    "@cloudflare/shell": "*",
+    "@cloudflare/shell": ">=0.2.0 <1.0.0",
     "agents": ">=0.7.0 <1.0.0",
     "ai": "^6.0.0",
     "zod": "^4.0.0"


### PR DESCRIPTION
Shell 0.2.0 changed the Workspace constructor from `(host, options?)` to `(options)`. Think uses the new form, so the wildcard allowed npm to resolve a shell version that breaks at runtime.

Found while building a standalone project that depends on the published npm packages rather than the monorepo workspace — `npm install` resolved shell 0.1.1 against Think, and the Workspace constructor mismatch caused failures.