### PR TITLE
fix(ai-chat): exclude query params from useAgentChat cache key

### DIFF
--- a/.changeset/fix-cache-key-query-params.md
+++ b/.changeset/fix-cache-key-query-params.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix `useAgentChat` cache key including query params, which broke stream resume with cross-domain auth. Auth tokens (and other query params) change across page loads, causing cache misses that re-trigger Suspense and interrupt the stream resume handshake. The cache key now uses agent identity only (origin + pathname + agent + name), keeping it stable across token rotations.

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -438,6 +438,144 @@ describe("useAgentChat", () => {
   });
 });
 
+describe("useAgentChat cache key stability (issue #1223)", () => {
+  it("should not refetch when only query params change (e.g. auth token rotation)", async () => {
+    const agentWithTokenA = createAgent({
+      name: "thread-auth",
+      url: "ws://localhost:3000/agents/chat/thread-auth?_pk=abc&token=jwt-token-1"
+    });
+
+    const agentWithTokenB = createAgent({
+      name: "thread-auth",
+      url: "ws://localhost:3000/agents/chat/thread-auth?_pk=abc&token=jwt-token-2"
+    });
+
+    const testMessages = [
+      {
+        id: "1",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Hi" }]
+      }
+    ];
+
+    const getInitialMessages = vi.fn(() => Promise.resolve(testMessages));
+
+    const TestComponent = ({
+      agent
+    }: {
+      agent: ReturnType<typeof useAgent>;
+    }) => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages
+      });
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const suspenseRendered = vi.fn();
+    const SuspenseObserver = () => {
+      suspenseRendered();
+      return "Suspended";
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent agent={agentWithTokenA} />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback={<SuspenseObserver />}>{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent(JSON.stringify(testMessages));
+
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+
+    suspenseRendered.mockClear();
+
+    // Simulate page reload with a new JWT — only query param changes
+    await act(async () => {
+      screen.rerender(<TestComponent agent={agentWithTokenB} />);
+      await sleep(10);
+    });
+
+    // Should NOT have re-fetched or re-triggered Suspense
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+    expect(suspenseRendered).not.toHaveBeenCalled();
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent(JSON.stringify(testMessages));
+  });
+
+  it("should still refetch when agent name changes even with query params", async () => {
+    const agentA = createAgent({
+      name: "thread-a",
+      url: "ws://localhost:3000/agents/chat/thread-a?_pk=abc&token=jwt-1"
+    });
+
+    const agentB = createAgent({
+      name: "thread-b",
+      url: "ws://localhost:3000/agents/chat/thread-b?_pk=abc&token=jwt-1"
+    });
+
+    const getInitialMessages = vi.fn(async ({ name }: { name: string }) => [
+      {
+        id: "1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: `Hello from ${name}` }]
+      }
+    ]);
+
+    const TestComponent = ({
+      agent
+    }: {
+      agent: ReturnType<typeof useAgent>;
+    }) => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages
+      });
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent agent={agentA} />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("Hello from thread-a");
+
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+
+    // Switch to a different agent (different name) — should refetch
+    await act(async () => {
+      screen.rerender(<TestComponent agent={agentB} />);
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("Hello from thread-b");
+
+    expect(getInitialMessages).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("useAgentChat client-side tool execution (issue #728)", () => {
   it("should update tool part state from input-available to output-available when addToolResult is called", async () => {
     const agent = createAgent({

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -463,10 +463,11 @@ export function useAgentChat<
   agentUrl.searchParams.delete("_pk");
   const agentUrlString = agentUrl.toString();
 
-  // we need to include agent.name in cache key to prevent collisions during agent switching.
-  // The URL may be stale between updateProperties() and reconnect(), but agent.name
-  // is updated synchronously, so each thread gets its own cache entry
-  const initialMessagesCacheKey = `${agentUrlString}|${agent.agent ?? ""}|${agent.name ?? ""}`;
+  // Build cache key from agent identity only (origin + pathname + agent + name).
+  // Query params like auth tokens change across page loads and must NOT
+  // bust the cache — otherwise Suspense re-triggers and breaks stream resume.
+  // See https://github.com/cloudflare/agents/issues/1223
+  const initialMessagesCacheKey = `${agentUrl.origin}${agentUrl.pathname}|${agent.agent ?? ""}|${agent.name ?? ""}`;
 
   // Keep a ref to always point to the latest agent instance.
   // Updated synchronously during render (not in useEffect) so the


### PR DESCRIPTION
## Summary

Fixes #1223

- **Strip query params from the `useAgentChat` initial messages cache key.** The cache key now uses `origin + pathname + agent + name` instead of the full URL. Auth tokens (and other query params like `_pk`) change across page loads, which was busting the cache, re-triggering Suspense, and breaking the `CF_AGENT_STREAM_RESUMING` / `CF_AGENT_STREAM_RESUME_ACK` handshake.
- The fetch URL (`agentUrlString`) still includes all query params, so auth tokens are sent on the `/get-messages` HTTP request as before.
- The `id` passed to `useChat` is also stabilized, keeping the AI SDK's internal Chat object alive across token rotations.

## Test plan

- [x] Added test: cache key is stable when only query params change (simulating JWT rotation)
- [x] Added test: cache key still changes when agent name changes (even with query params present)
- [x] All 339 existing ai-chat tests pass (33 test files)
- [x] Build passes
- [x] Changeset included


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
