### PR TITLE
fix(shell): wrap git fs adapter unlink with fsError for proper ENOENT code

### DIFF
--- a/.changeset/fix-git-unlink-enoent.md
+++ b/.changeset/fix-git-unlink-enoent.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/shell": patch
+---
+
+Fix `git.clone()` without `depth` failing with `ENOENT: .git/shallow`. The git fs adapter's `unlink` now wraps errors with `.code` so isomorphic-git can handle missing files gracefully.

--- a/packages/shell/src/git/fs-adapter.ts
+++ b/packages/shell/src/git/fs-adapter.ts
@@ -119,7 +119,11 @@ export function createGitFs(fs: FileSystem) {
       },
 
       async unlink(path: string): Promise<void> {
-        await fs.rm(path);
+        try {
+          await fs.rm(path);
+        } catch (err) {
+          throw fsError(path, err);
+        }
       },
 
       async readdir(path: string): Promise<string[]> {

--- a/packages/shell/src/tests/git-fs-adapter.test.ts
+++ b/packages/shell/src/tests/git-fs-adapter.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for the git fs adapter (createGitFs).
+ *
+ * Uses InMemoryFs so these run without a Durable Object or network access.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryFs } from "../fs/in-memory-fs";
+import { createGitFs } from "../git/fs-adapter";
+
+function setup() {
+  const fs = new InMemoryFs();
+  const gitFs = createGitFs(fs).promises;
+  return { fs, gitFs };
+}
+
+describe("createGitFs", () => {
+  describe("unlink", () => {
+    it("deletes an existing file", async () => {
+      const { fs, gitFs } = setup();
+      await fs.writeFile("/file.txt", "content");
+      await gitFs.unlink("/file.txt");
+      await expect(fs.exists("/file.txt")).resolves.toBe(false);
+    });
+
+    it("throws with code ENOENT for missing files", async () => {
+      const { gitFs } = setup();
+      try {
+        await gitFs.unlink("/nonexistent.txt");
+        expect.unreachable("should have thrown");
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error & { code: string }).code).toBe("ENOENT");
+      }
+    });
+  });
+});


### PR DESCRIPTION
… code

isomorphic-git's FileSystem.rm() catches errors with err.code === 'ENOENT' to silently ignore missing files. The Workspace filesystem throws errors without a .code property, so unlink on a missing file (e.g. .git/shallow during non-shallow clone) propagated as an unhandled error.

Wrap unlink with the existing fsError() helper, matching the pattern already used by readFile, stat, lstat, and readlink in the same file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
