### PR TITLE
Rewrite session-skills example with Think + widen useAgentChat agent type

### DIFF
--- a/.changeset/widen-agent-chat-type.md
+++ b/.changeset/widen-agent-chat-type.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Widen `useAgentChat` agent prop type to accept both typed and untyped `useAgent` connections. Previously, `useAgent<MyAgent>()` results could not be passed to `useAgentChat` due to incompatible `call` types. The agent prop now uses a structural type matching only the fields `useAgentChat` actually uses.

--- a/experimental/session-skills/README.md
+++ b/experimental/session-skills/README.md
@@ -1,26 +1,44 @@
 # Session Skills
 
-Demonstrates on-demand skill loading from R2 via the `SkillProvider` context provider.
+Demonstrates on-demand skill loading from R2 using Think and the `SkillProvider` context provider.
 
-> ⚠️ **Experimental** — this API will break between releases.
+> **Experimental** — this API will break between releases.
 
 ## How It Works
 
 Skills are documents stored in R2. Their metadata (key + description) is rendered into the system prompt so the model always knows what's available. The full content is loaded on demand when the model calls `load_context`.
 
-```typescript
-import { Session, R2SkillProvider } from "agents/experimental/memory/session";
+Think handles the entire chat lifecycle — streaming, tool calls, message persistence, and the WebSocket protocol. The server only defines the model, session configuration, and skills CRUD:
 
-Session.create(this)
-  .withContext("soul", {
-    provider: { get: async () => "You are a helpful assistant." }
-  })
-  .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
-  .withContext("skills", {
-    provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" })
-  })
-  .withCachedPrompt();
+```typescript
+import { Think } from "@cloudflare/think";
+import type { Session } from "@cloudflare/think";
+import { R2SkillProvider } from "agents/experimental/memory/session";
+
+export class SkillsAgent extends Think<Env> {
+  getModel() {
+    return createWorkersAI({ binding: this.env.AI })(
+      "@cf/moonshotai/kimi-k2.5"
+    );
+  }
+
+  configureSession(session: Session) {
+    return session
+      .withContext("soul", {
+        provider: { get: async () => "You are a helpful assistant." }
+      })
+      .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+      .withContext("skills", {
+        provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" })
+      })
+      .onCompaction(createCompactFunction({ ... }))
+      .compactAfter(1000)
+      .withCachedPrompt();
+  }
+}
 ```
+
+The client uses `useAgentChat` for the chat interface and `useAgent<SkillsAgent>()` for typed RPC to the skills sidebar.
 
 ### Provider Hierarchy
 
@@ -34,7 +52,7 @@ The `SkillProvider` extends `ContextProvider`. Provider shape determines behavio
 
 ### Generated Tools
 
-- **`set_context`** — write to any writable block. For skill blocks, requires `key` and optional `description`
+- **`set_context`** — write to any writable block (e.g. save facts to memory)
 - **`load_context`** — load a skill's full content by key (only when skill providers exist)
 
 ## The Example

--- a/experimental/session-skills/package.json
+++ b/experimental/session-skills/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@cloudflare/ai-chat": "*",
     "@cloudflare/kumo": "^1.17.0",
+    "@cloudflare/think": "*",
     "@phosphor-icons/react": "^2.1.10",
     "agents": "*",
     "ai": "^6.0.149",

--- a/experimental/session-skills/src/client.tsx
+++ b/experimental/session-skills/src/client.tsx
@@ -7,6 +7,7 @@ import {
   Surface,
   Text
 } from "@cloudflare/kumo";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
 import {
   BookOpenIcon,
   CaretRightIcon,
@@ -22,26 +23,17 @@ import {
   XIcon
 } from "@phosphor-icons/react";
 import { useAgent } from "agents/react";
+import { isToolUIPart, getToolName } from "ai";
 import type { UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Skill, SkillsAgent } from "./server";
 
-type ToolPart = Extract<UIMessage["parts"][number], { type: string }> & {
-  toolCallId: string;
-  toolName: string;
-  state: string;
-  input?: Record<string, unknown>;
-  output?: unknown;
-};
-
-function isToolPart(part: UIMessage["parts"][number]): part is ToolPart {
-  return part.type === "dynamic-tool" || part.type.startsWith("tool-");
-}
-
-function ToolCard({ part }: { part: ToolPart }) {
+function ToolCard({ part }: { part: UIMessage["parts"][number] }) {
   const [open, setOpen] = useState(false);
-  const done = part.state === "output-available";
-  const label = [part.input?.action, part.input?.label, part.input?.key]
+  const toolPart = part as Record<string, unknown>;
+  const done = toolPart.state === "output-available";
+  const input = toolPart.input as Record<string, unknown> | undefined;
+  const label = [input?.action, input?.label, input?.key]
     .filter(Boolean)
     .join(" ");
 
@@ -57,7 +49,7 @@ function ToolCard({ part }: { part: ToolPart }) {
           className={`text-kumo-secondary transition-transform ${open ? "rotate-90" : ""}`}
         />
         <Text size="xs" bold>
-          {part.toolName}
+          {isToolUIPart(part) ? getToolName(part) : "tool"}
         </Text>
         {label && (
           <span className="font-mono text-xs text-kumo-secondary truncate">
@@ -73,16 +65,16 @@ function ToolCard({ part }: { part: ToolPart }) {
       </button>
       {open && (
         <div className="px-3 pb-3 border-t border-kumo-line space-y-2 pt-2">
-          {part.input && (
+          {input && (
             <pre className="font-mono text-xs text-kumo-subtle bg-kumo-elevated rounded p-2 overflow-x-auto whitespace-pre-wrap">
-              {JSON.stringify(part.input, null, 2)}
+              {JSON.stringify(input, null, 2)}
             </pre>
           )}
-          {part.output != null && (
+          {toolPart.output != null && (
             <pre className="font-mono text-xs text-green-600 dark:text-green-400 bg-green-500/5 border border-green-500/20 rounded p-2 overflow-x-auto whitespace-pre-wrap">
-              {typeof part.output === "string"
-                ? part.output
-                : JSON.stringify(part.output, null, 2)}
+              {typeof toolPart.output === "string"
+                ? toolPart.output
+                : JSON.stringify(toolPart.output, null, 2)}
             </pre>
           )}
         </div>
@@ -358,115 +350,30 @@ function Chat() {
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("connecting");
   const [input, setInput] = useState("");
-  const [messages, setMessages] = useState<UIMessage[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const hasFetched = useRef(false);
-  const abortRef = useRef<(() => void) | null>(null);
 
   const agent = useAgent<SkillsAgent>({
     agent: "SkillsAgent",
     name: "default",
     onOpen: useCallback(() => setConnectionStatus("connected"), []),
-    onClose: useCallback(() => {
-      setConnectionStatus("disconnected");
-      hasFetched.current = false;
-    }, [])
+    onClose: useCallback(() => setConnectionStatus("disconnected"), [])
   });
 
   const isConnected = connectionStatus === "connected";
 
-  if (isConnected && !hasFetched.current) {
-    hasFetched.current = true;
-    agent
-      .call<UIMessage[]>("getMessages")
-      .then(setMessages)
-      .catch(console.error);
-  }
+  const { messages, sendMessage, clearHistory, stop, isStreaming } =
+    useAgentChat({ agent });
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const stop = useCallback(() => {
-    abortRef.current?.();
-    abortRef.current = null;
-    setIsLoading(false);
-  }, []);
-
-  const send = useCallback(async () => {
+  const send = useCallback(() => {
     const text = input.trim();
-    if (!text || isLoading) return;
+    if (!text || isStreaming) return;
     setInput("");
-    setIsLoading(true);
-    const userMsg: UIMessage = {
-      id: `user-${crypto.randomUUID()}`,
-      role: "user",
-      parts: [{ type: "text", text }]
-    };
-    setMessages((prev) => [...prev, userMsg]);
-
-    const streamId = `streaming-${crypto.randomUUID()}`;
-    let stopped = false;
-    abortRef.current = () => {
-      stopped = true;
-    };
-
-    try {
-      await agent.call("chat", [text, userMsg.id], {
-        onChunk: (chunk: unknown) => {
-          if (stopped) return;
-          const c = chunk as { type?: string; text?: string };
-          if (c.type === "text-delta" && c.text) {
-            setMessages((prev) => {
-              const existing = prev.find((m) => m.id === streamId);
-              if (existing) {
-                const oldText =
-                  existing.parts[0]?.type === "text"
-                    ? existing.parts[0].text
-                    : "";
-                return prev.map((m) =>
-                  m.id === streamId
-                    ? {
-                        ...m,
-                        parts: [
-                          { type: "text" as const, text: oldText + c.text }
-                        ]
-                      }
-                    : m
-                );
-              }
-              return [
-                ...prev,
-                {
-                  id: streamId,
-                  role: "assistant" as const,
-                  parts: [{ type: "text" as const, text: c.text! }]
-                }
-              ];
-            });
-          }
-        },
-        onDone: (final: unknown) => {
-          if (stopped) return;
-          const f = final as { message?: UIMessage };
-          if (f.message) {
-            setMessages((prev) =>
-              prev.map((m) => (m.id === streamId ? f.message! : m))
-            );
-          }
-        },
-        onError: (err: string) => {
-          console.error("Stream error:", err);
-        }
-      });
-    } catch (err) {
-      if (!stopped) console.error("Failed to send:", err);
-    } finally {
-      abortRef.current = null;
-      setIsLoading(false);
-    }
-  }, [input, isLoading, agent]);
+    sendMessage({ role: "user", parts: [{ type: "text", text }] });
+  }, [input, isStreaming, sendMessage]);
 
   return (
     <div className="flex h-screen bg-kumo-elevated">
@@ -486,14 +393,7 @@ function Chat() {
               <Button
                 variant="secondary"
                 icon={<TrashIcon size={16} />}
-                onClick={async () => {
-                  try {
-                    await agent.call("clearMessages");
-                    setMessages([]);
-                  } catch (err) {
-                    console.error("Clear failed:", err);
-                  }
-                }}
+                onClick={clearHistory}
                 disabled={messages.length === 0}
               >
                 Clear
@@ -504,11 +404,11 @@ function Chat() {
 
         <div className="flex-1 overflow-y-auto">
           <div className="max-w-3xl mx-auto px-5 py-6 space-y-5">
-            {messages.length === 0 && !isLoading && (
+            {messages.length === 0 && !isStreaming && (
               <Empty
                 icon={<BookOpenIcon size={32} />}
                 title="Skills-powered chat"
-                description="Create skills in the sidebar, then ask the agent to use them. It will load skills on demand via the get_catalog tool."
+                description="Create skills in the sidebar, then ask the agent to use them. It will load skills on demand via the load_context tool."
               />
             )}
 
@@ -540,9 +440,14 @@ function Chat() {
                         </div>
                       );
                     }
-                    if (isToolPart(part)) {
+                    if (isToolUIPart(part)) {
                       return (
-                        <div key={part.toolCallId ?? i} className="max-w-[80%]">
+                        <div
+                          key={
+                            (part as { toolCallId?: string }).toolCallId ?? i
+                          }
+                          className="max-w-[80%]"
+                        >
                           <ToolCard part={part} />
                         </div>
                       );
@@ -553,8 +458,12 @@ function Chat() {
               );
             })}
 
-            {isLoading &&
-              !messages.some((m) => m.id.startsWith("streaming-")) && (
+            {isStreaming &&
+              !messages.some(
+                (m) =>
+                  m.role === "assistant" &&
+                  m.parts.some((p) => p.type === "text" && p.text)
+              ) && (
                 <div className="flex justify-start">
                   <div className="px-4 py-2.5 rounded-2xl rounded-bl-md bg-kumo-base">
                     <span className="inline-block w-2 h-2 bg-kumo-brand rounded-full mr-1 animate-pulse" />
@@ -594,11 +503,11 @@ function Chat() {
                 placeholder={
                   isConnected ? "Ask me to use a skill..." : "Connecting..."
                 }
-                disabled={!isConnected || isLoading}
+                disabled={!isConnected || isStreaming}
                 rows={2}
                 className="flex-1 !ring-0 focus:!ring-0 !shadow-none !bg-transparent !outline-none"
               />
-              {isLoading ? (
+              {isStreaming ? (
                 <Button
                   type="button"
                   variant="destructive"

--- a/experimental/session-skills/src/server.ts
+++ b/experimental/session-skills/src/server.ts
@@ -74,7 +74,7 @@ export class SkillsAgent extends Think<Env> {
     const listed = await this.env.SKILLS_BUCKET.list({
       prefix: "skills/",
       include: ["customMetadata"]
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     return listed.objects.map((obj) => ({
       key: obj.key.slice("skills/".length),

--- a/experimental/session-skills/src/server.ts
+++ b/experimental/session-skills/src/server.ts
@@ -1,30 +1,18 @@
 /**
- * Session Skills Example
+ * Session Skills Example — rewritten with Think
  *
- * Demonstrates the Catalog Provider with:
- * - Skills stored in R2, loaded on demand via `get_catalog` tool
- * - Session memory with context blocks (soul, memory)
- * - Callable methods to manage skills from the UI sidebar
+ * Think handles the entire chat lifecycle (streaming, tool calls,
+ * message persistence, WebSocket protocol). This file only contains:
+ *   - Model + session configuration
+ *   - Skills CRUD callables for the sidebar
  */
 
-import {
-  Agent,
-  callable,
-  routeAgentRequest,
-  type StreamingResponse
-} from "agents";
-import { R2SkillProvider, Session } from "agents/experimental/memory/session";
-import {
-  createCompactFunction,
-  truncateOlderMessages
-} from "agents/experimental/memory/utils";
-import type { UIMessage } from "ai";
-import {
-  convertToModelMessages,
-  generateText,
-  stepCountIs,
-  streamText
-} from "ai";
+import { callable, routeAgentRequest } from "agents";
+import { R2SkillProvider } from "agents/experimental/memory/session";
+import { createCompactFunction } from "agents/experimental/memory/utils";
+import { generateText } from "ai";
+import type { Session } from "@cloudflare/think";
+import { Think } from "@cloudflare/think";
 import { createWorkersAI } from "workers-ai-provider";
 
 export interface Skill {
@@ -33,109 +21,50 @@ export interface Skill {
   size?: number;
 }
 
-export class SkillsAgent extends Agent<Env> {
-  session = Session.create(this)
-    .withContext("soul", {
-      provider: {
-        get: async () =>
-          [
-            "You are a helpful assistant with access to skills.",
-            "When a user asks you to do something, check the SKILLS section for a relevant skill and use load_context to load it.",
-            "Use set_context to save important facts to memory."
-          ].join("\n")
-      }
-    })
-    .withContext("memory", {
-      description: "Learned facts — save important things here",
-      maxTokens: 1100
-    })
-    .withContext("skills", {
-      provider: new R2SkillProvider(this.env.SKILLS_BUCKET, {
-        prefix: "skills/"
-      })
-    })
-    .onCompaction(
-      createCompactFunction({
-        summarize: (prompt) =>
-          generateText({
-            model: createWorkersAI({ binding: this.env.AI })(
-              "@cf/zai-org/glm-4.7-flash"
-            ),
-            prompt
-          }).then((r) => r.text),
-        tailTokenBudget: 150,
-        minTailMessages: 1
-      })
-    )
-    .compactAfter(1000)
-    .withCachedPrompt();
-
-  private getAI() {
+export class SkillsAgent extends Think<Env> {
+  getModel() {
     return createWorkersAI({ binding: this.env.AI })(
       "@cf/moonshotai/kimi-k2.5",
       { sessionAffinity: this.sessionAffinity }
     );
   }
 
-  // ── Chat ────────────────────────────────────────────────────────
-
-  @callable({ streaming: true })
-  async chat(
-    stream: StreamingResponse,
-    message: string,
-    messageId?: string
-  ): Promise<void> {
-    await this.session.appendMessage({
-      id: messageId ?? `user-${crypto.randomUUID()}`,
-      role: "user",
-      parts: [{ type: "text", text: message }]
-    });
-
-    const history = this.session.getHistory();
-    const truncated = truncateOlderMessages(history);
-
-    const result = streamText({
-      model: this.getAI(),
-      system: await this.session.freezeSystemPrompt(),
-      messages: await convertToModelMessages(truncated),
-      tools: await this.session.tools(),
-      stopWhen: stepCountIs(5)
-    });
-
-    for await (const chunk of result.textStream) {
-      stream.send({ type: "text-delta", text: chunk });
-    }
-
-    const parts: UIMessage["parts"] = [];
-    const steps = await result.steps;
-
-    for (const step of steps) {
-      for (const tc of step.toolCalls) {
-        const tr = step.toolResults.find((r) => r.toolCallId === tc.toolCallId);
-        parts.push({
-          type: "dynamic-tool",
-          toolName: tc.toolName,
-          toolCallId: tc.toolCallId,
-          state: tr ? "output-available" : "input-available",
-          input: tc.input,
-          ...(tr ? { output: tr.output } : {})
-        } as unknown as UIMessage["parts"][number]);
-      }
-    }
-
-    const text = await result.text;
-    if (text) {
-      parts.push({ type: "text", text });
-    }
-
-    const assistantMsg: UIMessage = {
-      id: `assistant-${crypto.randomUUID()}`,
-      role: "assistant",
-      parts
-    };
-
-    await this.session.appendMessage(assistantMsg);
-    stream.end({ message: assistantMsg });
+  configureSession(session: Session) {
+    return session
+      .withContext("soul", {
+        provider: {
+          get: async () =>
+            [
+              "You are a helpful assistant with access to skills.",
+              "When a user asks you to do something, check the SKILLS section for a relevant skill and use load_context to load it.",
+              "Use set_context to save important facts to memory."
+            ].join("\n")
+        }
+      })
+      .withContext("memory", {
+        description: "Learned facts — save important things here",
+        maxTokens: 1100
+      })
+      .withContext("skills", {
+        provider: new R2SkillProvider(this.env.SKILLS_BUCKET, {
+          prefix: "skills/"
+        })
+      })
+      .onCompaction(
+        createCompactFunction({
+          summarize: (prompt) =>
+            generateText({
+              model: createWorkersAI({ binding: this.env.AI })(
+                "@cf/zai-org/glm-4.7-flash"
+              ),
+              prompt
+            }).then((r) => r.text),
+          tailTokenBudget: 150,
+          minTailMessages: 1
+        })
+      )
+      .compactAfter(1000)
+      .withCachedPrompt();
   }
 
   // ── Skills management (called from sidebar) ─────────────────────
@@ -177,18 +106,6 @@ export class SkillsAgent extends Agent<Env> {
   async deleteSkill(key: string): Promise<{ success: boolean }> {
     await this.env.SKILLS_BUCKET.delete(`skills/${key}`);
     return { success: true };
-  }
-
-  // ── History ─────────────────────────────────────────────────────
-
-  @callable()
-  getMessages(): UIMessage[] {
-    return this.session.getHistory();
-  }
-
-  @callable()
-  clearMessages(): void {
-    this.session.clearMessages();
   }
 }
 

--- a/experimental/session-skills/wrangler.jsonc
+++ b/experimental/session-skills/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "agents-session-skills-example",
   "main": "src/server.ts",
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "experimental"],
   "ai": {
     "binding": "AI",
     "remote": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1053,6 +1053,7 @@
       "dependencies": {
         "@cloudflare/ai-chat": "*",
         "@cloudflare/kumo": "^1.17.0",
+        "@cloudflare/think": "*",
         "@phosphor-icons/react": "^2.1.10",
         "agents": "*",
         "ai": "^6.0.149",
@@ -1159,8 +1160,7 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ai-sdk/amazon-bedrock": {
       "version": "4.0.90",
@@ -1430,6 +1430,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.40.tgz",
       "integrity": "sha512-mhJQJh/CijoHOHby0jYeWZVCflyc6vVLz8LJ+XLEkoOl47/BsEJzhDz7YRZnrmDnO1oXtqq/awfgwPyd4VStWg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23"
@@ -1463,6 +1464,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
       "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -1475,6 +1477,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
       "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@standard-schema/spec": "^1.1.0",
@@ -1801,6 +1804,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2079,6 +2083,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3796,7 +3801,8 @@
       "version": "4.20260405.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
       "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3833,6 +3839,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3907,6 +3914,7 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5692,6 +5700,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5905,6 +5914,7 @@
       "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@openai/agents-core": "0.8.3",
         "@openai/agents-openai": "0.8.3",
@@ -6019,6 +6029,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6698,6 +6709,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
       "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8220,6 +8232,7 @@
       "integrity": "sha512-b1GDenJs2udQfjFMnAWZ6WX9RLg04O9wC85V4cSD8phuVMJscs+Qp0UkNj7FTc+V1ggqf4Pz1jLFfqjLO2z3mg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/ai-event-client": "0.2.0",
         "partial-json": "^0.1.7"
@@ -8845,6 +8858,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8854,6 +8868,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -9006,6 +9021,7 @@
       "integrity": "sha512-D3Q+YozvSpiFaLPgd6/OMbyqEIZeucSe6AHJJ7VnNJKQhIyBE60TlBZlxzwM8bvjzQE9ZnYWQCPeCw5pnhbiNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -9088,6 +9104,7 @@
       "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.3",
         "pathe": "^2.0.3"
@@ -9102,6 +9119,7 @@
       "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.3",
         "@vitest/utils": "4.1.3",
@@ -9393,8 +9411,7 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -9414,6 +9431,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.149.tgz",
       "integrity": "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.91",
         "@ai-sdk/provider": "3.0.8",
@@ -9680,6 +9698,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.4.tgz",
       "integrity": "sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
         "@astrojs/internal-helpers": "0.8.0",
@@ -10253,6 +10272,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -10506,6 +10526,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -11074,6 +11095,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -11495,6 +11517,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12399,7 +12422,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -12418,7 +12440,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -12431,7 +12452,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -12444,7 +12464,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -12453,22 +12472,19 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12598,6 +12614,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -13628,7 +13645,8 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
       "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
+      "peer": true
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -13938,6 +13956,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14591,6 +14610,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -14947,6 +14967,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -17807,6 +17828,7 @@
       "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
       "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-polyfill": "^0.0.4"
       },
@@ -18124,6 +18146,7 @@
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -18606,6 +18629,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18655,6 +18679,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19293,6 +19318,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20913,6 +20939,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -21105,6 +21132,7 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -21684,6 +21712,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -21811,6 +21840,7 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -22116,6 +22146,7 @@
       "integrity": "sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -22145,6 +22176,7 @@
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.80.0.tgz",
       "integrity": "sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ==",
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
         "@cloudflare/unenv-preset": "2.16.0",
@@ -22270,6 +22302,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -22313,6 +22346,7 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -22430,6 +22464,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -22471,7 +22506,6 @@
       "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
       "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/packages/ai-chat/CHANGELOG.md
+++ b/packages/ai-chat/CHANGELOG.md
@@ -15,7 +15,6 @@
   `Think` now extends `Agent` directly (no mixin). Fiber support is inherited from the base class.
 
   **Breaking (experimental APIs only):**
-
   - Removed `withFibers` mixin (`agents/experimental/forever`)
   - Removed `withDurableChat` mixin (`@cloudflare/ai-chat/experimental/forever`)
   - Removed `./experimental/forever` export from both packages
@@ -26,7 +25,6 @@
 - [#1270](https://github.com/cloudflare/agents/pull/1270) [`87b4512`](https://github.com/cloudflare/agents/commit/87b4512985e47de659bf970a65a6d1951f5855fe) Thanks [@threepointone](https://github.com/threepointone)! - Wire Session into Think as the storage layer, achieving full feature parity with AIChatAgent plus Session-backed advantages.
 
   **Think (`@cloudflare/think`):**
-
   - Session integration: `this.messages` backed by `session.getHistory()`, tree-structured messages, context blocks, compaction, FTS5 search
   - `configureSession()` override for context blocks, compaction, search, skills (sync or async)
   - `assembleContext()` returns `{ system, messages }` with context block composition
@@ -45,12 +43,10 @@
   - Constructor wraps `onStart` — subclasses never need `super.onStart()`
 
   **agents (`agents/chat`):**
-
   - Extract `AbortRegistry`, `applyToolUpdate` + builders, `parseProtocolMessage` into shared `agents/chat` layer
   - Add `applyChunkToParts` export for fiber recovery
 
   **AIChatAgent (`@cloudflare/ai-chat`):**
-
   - Refactor to use shared `AbortRegistry` from `agents/chat`
   - Add `continuation` flag to `OnChatMessageOptions`
   - Export `getAgentMessages()` and tool part helpers
@@ -183,7 +179,6 @@
 ### Minor Changes
 
 - [#1150](https://github.com/cloudflare/agents/pull/1150) [`81a8710`](https://github.com/cloudflare/agents/commit/81a8710938ec1c7a8e388fda936d1724409d74d6) Thanks [@threepointone](https://github.com/threepointone)! - feat: add `sanitizeMessageForPersistence` hook and built-in Anthropic tool payload truncation
-
   - **New protected hook**: `sanitizeMessageForPersistence(message)` — override this method to apply custom transformations to messages before they are persisted to storage. Runs after built-in sanitization. Default is identity (returns message unchanged).
   - **Anthropic provider-executed tool truncation**: Large string values in `input` and `output` of provider-executed tool parts (e.g. Anthropic `code_execution`, `text_editor`) are now automatically truncated. These server-side tool payloads can exceed 200KB and are dead weight once the model has consumed the result.
 
@@ -194,7 +189,6 @@
 ### Patch Changes
 
 - [#1151](https://github.com/cloudflare/agents/pull/1151) [`b0c52a5`](https://github.com/cloudflare/agents/commit/b0c52a541625b9fbfc631cd17c0f38c40f43c7f5) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - fix(ai-chat): simplify turn coordination API
-
   - rename `waitForPendingInteractionResolution()` to `waitUntilStable()` and make it wait for a fully stable conversation state, including queued continuation turns
   - add `resetTurnState()` for scoped clear handlers that need to abort active work and invalidate queued continuations
   - demote `isChatTurnActive()`, `waitForIdle()`, and `abortActiveTurn()` to private — their behavior is subsumed by `waitUntilStable()` and `resetTurnState()`
@@ -203,12 +197,10 @@
 - [#1106](https://github.com/cloudflare/agents/pull/1106) [`3184282`](https://github.com/cloudflare/agents/commit/3184282412fe0908a7eca5e117ff02b64541c860) Thanks [@threepointone](https://github.com/threepointone)! - fix: abort/stop no longer creates duplicate split messages (issue [#1100](https://github.com/cloudflare/agents/issues/1100))
 
   When a user clicked stop during an active stream, the assistant message was split into two separate messages. This happened because `onAbort` in the transport immediately removed the `requestId` from `activeRequestIds`, causing `onAgentMessage` to treat in-flight server chunks as a new broadcast.
-
   - `WebSocketChatTransport`: `onAbort` now keeps the `requestId` in `activeRequestIds` so in-flight server chunks are correctly skipped by the dedup guard
   - `useAgentChat`: `onAgentMessage` now cleans up the kept ID when receiving `done: true`, preventing a minor memory leak
 
 - [#1142](https://github.com/cloudflare/agents/pull/1142) [`5651ece`](https://github.com/cloudflare/agents/commit/5651eced85c04bfaf5660922467c74de7dc0896e) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - fix(ai-chat): serialize chat turns and expose turn control helpers
-
   - queue `onChatMessage()` + `_reply()` work so user requests, tool continuations, and `saveMessages()` never stream concurrently
   - make `saveMessages()` wait for the queued turn to finish before resolving, and reuse the request id for reply cleanup
   - skip queued continuations and `saveMessages()` calls that were enqueued before a chat clear
@@ -252,7 +244,6 @@
 - [#1013](https://github.com/cloudflare/agents/pull/1013) [`11aaaff`](https://github.com/cloudflare/agents/commit/11aaaffb89c375eba9bedf97074ced556dcdd0e7) Thanks [@threepointone](https://github.com/threepointone)! - Fix Gemini "missing thought_signature" error when using client-side tools with `addToolOutput`.
 
   The server-side message builder (`applyChunkToParts`) was dropping `providerMetadata` from tool-input stream chunks instead of storing it as `callProviderMetadata` on tool UIMessage parts. When `convertToModelMessages` later read the persisted messages for the continuation call, `callProviderMetadata` was undefined, so Gemini never received its `thought_signature` back and rejected the request.
-
   - Preserve `callProviderMetadata` (mapped from stream `providerMetadata`) on tool parts in `tool-input-start`, `tool-input-available`, and `tool-input-error` handlers — both create and update paths
   - Preserve `providerExecuted` on tool parts (used by `convertToModelMessages` for provider-executed tools like Gemini code execution)
   - Preserve `title` on tool parts (tool display name)
@@ -260,7 +251,6 @@
   - Add 13 regression tests covering all affected codepaths
 
 - [#989](https://github.com/cloudflare/agents/pull/989) [`8404954`](https://github.com/cloudflare/agents/commit/8404954029a62244a87ec38691639f5b8ce9e615) Thanks [@threepointone](https://github.com/threepointone)! - Fix active streams losing UI state after reconnect and dead streams after DO hibernation.
-
   - Send `replayComplete` signal after replaying stored chunks for live streams, so the client flushes accumulated parts to React state immediately instead of waiting for the next live chunk.
   - Detect orphaned streams (restored from SQLite after hibernation with no live LLM reader) via `_isLive` flag on `ResumableStream`. On reconnect, send `done: true`, complete the stream, and reconstruct/persist the partial assistant message from stored chunks.
   - Client-side: flush `activeStreamRef` on `replayComplete` (keeps stream alive for subsequent live chunks) and on `done` during replay (finalizes orphaned streams).
@@ -300,7 +290,6 @@
   so when `regenerate()` removed the last assistant message from the client's
   array, the old row persisted in SQLite. On the next `_loadMessagesFromDb`,
   the stale assistant message reappeared in `this.messages`, causing:
-
   - Anthropic models to reject with HTTP 400 (conversation must end with a
     user message)
   - Duplicate/phantom assistant messages across reconnects
@@ -332,14 +321,12 @@
 - [#999](https://github.com/cloudflare/agents/pull/999) [`95753da`](https://github.com/cloudflare/agents/commit/95753da49cb68e9e9e486e047b588004163a27fb) Thanks [@threepointone](https://github.com/threepointone)! - Fix `useChat` `status` staying `"ready"` during stream resumption after page refresh.
 
   Four issues prevented stream resumption from working:
-
   1. **addEventListener race:** `onAgentMessage` always handled `CF_AGENT_STREAM_RESUMING` before the transport's listener, bypassing the AI SDK pipeline.
   2. **Transport instance instability:** `useMemo` created new transport instances across renders and Strict Mode cycles. When `_pk` changed (async queries, socket recreation), the resolver was stranded on the old transport while `onAgentMessage` called `handleStreamResuming` on the new one.
   3. **Chat recreation on `_pk` change:** Using `agent._pk` as the `useChat` `id` caused the AI SDK to recreate the Chat when the socket changed, abandoning the in-flight `makeRequest` (including resume). The resume effect wouldn't re-fire on the new Chat.
   4. **Double STREAM_RESUMING:** The server sends `STREAM_RESUMING` from both `onConnect` and the `RESUME_REQUEST` handler, causing duplicate ACKs and double replay without deduplication.
 
   Fixes:
-
   - Replace `addEventListener`-based detection with `handleStreamResuming()` — a synchronous method `onAgentMessage` calls directly, eliminating the race.
   - Make the transport a true singleton (`useRef`, created once). Update `transport.agent` every render so sends/listeners always use the latest socket. The resolver survives `_pk` changes because the transport instance never changes.
   - Use a stable Chat ID (`initialMessagesCacheKey` based on URL + agent + name) instead of `agent._pk`, preventing Chat recreation on socket changes.
@@ -370,7 +357,7 @@
   addToolOutput({
     toolCallId: invocation.toolCallId,
     state: "output-error",
-    errorText: "User declined: insufficient permissions",
+    errorText: "User declined: insufficient permissions"
   });
   ```
 
@@ -431,7 +418,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
 - [#899](https://github.com/cloudflare/agents/pull/899) [`04c6411`](https://github.com/cloudflare/agents/commit/04c6411c9a73fe48784d7ce86150d62cf54becda) Thanks [@threepointone](https://github.com/threepointone)! - Refactor AIChatAgent: extract ResumableStream class, add WebSocket ChatTransport, simplify SSE parsing.
 
   **Bug fixes:**
-
   - Fix `setMessages` functional updater sending empty array to server
   - Fix `_sendPlaintextReply` creating multiple text parts instead of one
   - Fix uncaught exception on empty/invalid request body
@@ -446,7 +432,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   - Fix `completed` guard on abort listener to prevent redundant cancel after stream completion
 
   **New features:**
-
   - `maxPersistedMessages` — cap SQLite message storage with automatic oldest-message deletion
   - `body` option on `useAgentChat` — send custom data with every request (static or dynamic)
   - Incremental persistence with hash-based cache to skip redundant SQL writes
@@ -456,13 +441,11 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   - Full tool streaming lifecycle in message-builder (tool-input-start/delta/error, tool-output-error)
 
   **Docs:**
-
   - New `docs/chat-agents.md` — comprehensive AIChatAgent and useAgentChat reference
   - Rewritten README, migration guides, human-in-the-loop, resumable streaming, client tools docs
   - New `examples/ai-chat/` example with modern patterns and Workers AI
 
   **Deprecations (with console.warn):**
-
   - `createToolsFromClientSchemas()`, `extractClientToolSchemas()`, `detectToolsRequiringConfirmation()`
   - `tools`, `toolsRequiringConfirmation`, `experimental_automaticToolResolution` options
   - `addToolResult()` (use `addToolOutput()`)
@@ -486,7 +469,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   `useAgentChat` now invokes the `onData` callback for `data-*` chunks on the stream resumption and cross-tab broadcast codepaths, which bypass the AI SDK's internal pipeline. For new messages sent via the transport, the AI SDK already invokes `onData` internally. This is the correct way to consume transient data parts on the client since they are not added to `message.parts`.
 
 - [#922](https://github.com/cloudflare/agents/pull/922) [`c8e5244`](https://github.com/cloudflare/agents/commit/c8e524499d902229e8ac83afd6cf2864f888cecc) Thanks [@threepointone](https://github.com/threepointone)! - Fix tool approval UI not surviving page refresh, and fix invalid prompt error after approval
-
   - Handle `tool-approval-request` and `tool-output-denied` stream chunks in the server-side message builder. Previously these were only handled client-side, so the server never transitioned tool parts to `approval-requested` or `output-denied` state.
   - Persist the streaming message to SQLite (without broadcasting) when a tool enters `approval-requested` state. The stream is paused waiting for user approval, so this is a natural persistence point. Without this, refreshing the page would reload from SQLite where the tool was still in `input-available` state, showing "Running..." instead of the Approve/Reject UI.
   - On stream completion, update the early-persisted message in place rather than appending a duplicate.

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -12,8 +12,10 @@ import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { OutgoingMessage } from "./types";
 import { MessageType } from "./types";
 import { broadcastTransition, type BroadcastStreamState } from "agents/chat";
-import { WebSocketChatTransport } from "./ws-chat-transport";
-import type { useAgent } from "agents/react";
+import {
+  WebSocketChatTransport,
+  type AgentConnection
+} from "./ws-chat-transport";
 
 /**
  * One-shot deprecation warnings (warns once per key per session).
@@ -362,11 +364,16 @@ export type OnToolCallCallback = (options: {
  * Options for the useAgentChat hook
  */
 type UseAgentChatOptions<
-  State,
+  // oxlint-disable-next-line no-unused-vars -- kept for backward compat
+  State = unknown,
   ChatMessage extends UIMessage = UIMessage
 > = Omit<UseChatParams<ChatMessage>, "fetch" | "onToolCall"> & {
-  /** Agent connection from useAgent */
-  agent: ReturnType<typeof useAgent<State>>;
+  /** Agent connection from useAgent (accepts both typed and untyped agents) */
+  agent: AgentConnection & {
+    agent: string;
+    name: string;
+    getHttpUrl: () => string;
+  };
   getInitialMessages?:
     | undefined
     | null
@@ -548,6 +555,7 @@ export function detectToolsRequiringConfirmation(
 }
 
 export function useAgentChat<
+  // oxlint-disable-next-line no-unused-vars -- kept for backward compat
   State = unknown,
   ChatMessage extends UIMessage = UIMessage
 >(
@@ -784,7 +792,7 @@ export function useAgentChat<
         // Apply user's prepareSendMessagesRequest callback (overrides body option)
         if (prepareSendMessagesRequestRef.current) {
           const userResult = await prepareSendMessagesRequestRef.current({
-            id: agentRef.current._pk,
+            id: (agentRef.current as unknown as { _pk: string })._pk,
             messages: msgs,
             trigger,
             messageId

--- a/packages/codemode/CHANGELOG.md
+++ b/packages/codemode/CHANGELOG.md
@@ -41,20 +41,19 @@
   ```typescript
   import {
     createCodeTool,
-    tanstackTools,
+    tanstackTools
   } from "@cloudflare/codemode/tanstack-ai";
   import { chat } from "@tanstack/ai";
 
   const codeTool = createCodeTool({
     tools: [tanstackTools(myServerTools)],
-    executor,
+    executor
   });
 
   const stream = chat({ adapter, tools: [codeTool], messages });
   ```
 
   **Exports:**
-
   - `createCodeTool` — returns a TanStack AI `ServerTool` (via `toolDefinition().server()`)
   - `tanstackTools` — converts a `TanStackTool[]` into a `ToolProvider` with pre-generated types
   - `generateTypes` — generates TypeScript type definitions from TanStack AI tools
@@ -73,7 +72,6 @@
 ### Patch Changes
 
 - [#1114](https://github.com/cloudflare/agents/pull/1114) [`5d88b81`](https://github.com/cloudflare/agents/commit/5d88b810cda4edc4f55ea6bc619a376efa9b8f4d) Thanks [@mattzcarey](https://github.com/mattzcarey)! - Add `@cloudflare/codemode/mcp` barrel export with two functions:
-
   - `codeMcpServer({ server, executor })` — wraps an MCP server with a single `code` tool where each upstream tool becomes a typed `codemode.*` method
   - `openApiMcpServer({ spec, executor, request })` — creates `search` + `execute` MCP tools from an OpenAPI spec with host-side request proxying and automatic `$ref` resolution
 
@@ -96,7 +94,6 @@
   ```
 
   The main entry point (`@cloudflare/codemode`) no longer requires the `ai` or `zod` peer dependencies. It now exports:
-
   - `sanitizeToolName` — sanitize tool names into valid JS identifiers
   - `normalizeCode` — normalize LLM-generated code into async arrow functions
   - `generateTypesFromJsonSchema` — generate TypeScript type definitions from plain JSON Schema (no AI SDK needed)
@@ -129,7 +126,6 @@
 - [#973](https://github.com/cloudflare/agents/pull/973) [`969fbff`](https://github.com/cloudflare/agents/commit/969fbff702d5702c1f0ea6faaecb3dfd0431a01b) Thanks [@threepointone](https://github.com/threepointone)! - Update dependencies
 
 - [#960](https://github.com/cloudflare/agents/pull/960) [`179b8cb`](https://github.com/cloudflare/agents/commit/179b8cbc60bc9e6ac0d2ee26c430d842950f5f08) Thanks [@mattzcarey](https://github.com/mattzcarey)! - Harden JSON Schema to TypeScript converter for production use
-
   - Add depth and circular reference guards to prevent stack overflows on recursive or deeply nested schemas
   - Add `$ref` resolution for internal JSON Pointers (`#/definitions/...`, `#/$defs/...`, `#`)
   - Add tuple support (`prefixItems` for JSON Schema 2020-12, array `items` for draft-07)

--- a/packages/hono-agents/CHANGELOG.md
+++ b/packages/hono-agents/CHANGELOG.md
@@ -68,7 +68,6 @@
 ### Patch Changes
 
 - [#739](https://github.com/cloudflare/agents/pull/739) [`e9b6bb7`](https://github.com/cloudflare/agents/commit/e9b6bb7ea2727e4692d9191108c5609c6a44d9d9) Thanks [@threepointone](https://github.com/threepointone)! - update all dependencies
-
   - remove the changesets cli patch, as well as updating node version, so we don't need to explicitly install newest npm
   - lock mcp sdk version till we figure out how to do breaking changes correctly
   - removes stray permissions block from release.yml

--- a/packages/think/CHANGELOG.md
+++ b/packages/think/CHANGELOG.md
@@ -7,7 +7,6 @@
 - [#1270](https://github.com/cloudflare/agents/pull/1270) [`87b4512`](https://github.com/cloudflare/agents/commit/87b4512985e47de659bf970a65a6d1951f5855fe) Thanks [@threepointone](https://github.com/threepointone)! - Wire Session into Think as the storage layer, achieving full feature parity with AIChatAgent plus Session-backed advantages.
 
   **Think (`@cloudflare/think`):**
-
   - Session integration: `this.messages` backed by `session.getHistory()`, tree-structured messages, context blocks, compaction, FTS5 search
   - `configureSession()` override for context blocks, compaction, search, skills (sync or async)
   - `assembleContext()` returns `{ system, messages }` with context block composition
@@ -26,12 +25,10 @@
   - Constructor wraps `onStart` — subclasses never need `super.onStart()`
 
   **agents (`agents/chat`):**
-
   - Extract `AbortRegistry`, `applyToolUpdate` + builders, `parseProtocolMessage` into shared `agents/chat` layer
   - Add `applyChunkToParts` export for fiber recovery
 
   **AIChatAgent (`@cloudflare/ai-chat`):**
-
   - Refactor to use shared `AbortRegistry` from `agents/chat`
   - Add `continuation` flag to `OnChatMessageOptions`
   - Export `getAgentMessages()` and tool part helpers
@@ -46,7 +43,6 @@
   `Think` now extends `Agent` directly (no mixin). Fiber support is inherited from the base class.
 
   **Breaking (experimental APIs only):**
-
   - Removed `withFibers` mixin (`agents/experimental/forever`)
   - Removed `withDurableChat` mixin (`@cloudflare/ai-chat/experimental/forever`)
   - Removed `./experimental/forever` export from both packages


### PR DESCRIPTION
## Summary

- **Rewrite `experimental/session-skills` to use Think** instead of raw `Agent` + manual streaming. The server drops from 203 to 120 lines — the entire `chat` callable (streaming, tool call handling, message persistence) is replaced by Think's built-in chat lifecycle. The client switches from manual `agent.call("chat", ...)` streaming to `useAgentChat`, cutting ~100 lines of plumbing.

- **Widen `useAgentChat` agent prop type** (`@cloudflare/ai-chat` patch). Previously, `useAgent<MyAgent>()` (typed overload) couldn't be passed to `useAgentChat` because the `call` field types were incompatible. Since `useAgentChat` never uses `call` or `stub`, the prop now uses a structural type matching only the fields it actually accesses (`send`, `addEventListener`, `removeEventListener`, `getHttpUrl`, `agent`, `name`).

## Changes

| File | What |
|------|------|
| `packages/ai-chat/src/react.tsx` | Replace `ReturnType<typeof useAgent<State>>` with `AgentConnection & { agent, name, getHttpUrl }` |
| `experimental/session-skills/src/server.ts` | `extends Think<Env>` with `getModel()` + `configureSession()`, remove manual chat/history callables |
| `experimental/session-skills/src/client.tsx` | Use `useAgentChat` for chat, `useAgent<SkillsAgent>()` for typed sidebar RPC |
| `experimental/session-skills/package.json` | Add `@cloudflare/think` dependency |
| `experimental/session-skills/wrangler.jsonc` | Add `experimental` compatibility flag |
| `.changeset/widen-agent-chat-type.md` | Patch changeset for `@cloudflare/ai-chat` |

## Test plan

- [ ] `npx nx run @cloudflare/ai-chat:build` passes
- [ ] Verify no type errors in `experimental/session-skills`
- [ ] `npm run check` passes
- [ ] Manual test: `cd experimental/session-skills && npm start` — chat works, skills CRUD works, streaming works


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
