### PR TITLE
feat(worker-bundler): add typescript support for worker-bundler 

### DIFF
--- a/.changeset/fix-message-concurrency-race.md
+++ b/.changeset/fix-message-concurrency-race.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix race condition in `messageConcurrency` where rapid overlapping submits could bypass the `latest`/`merge`/`debounce` strategy. The concurrency decision checked `queuedCount()` before the turn was enqueued, but an intervening `await persistMessages()` allowed a second message handler to see a stale count of zero and skip supersede checks. A pending-enqueue counter now bridges this gap so overlapping submits are always detected.

--- a/.changeset/worker-bundler-filesystem.md
+++ b/.changeset/worker-bundler-filesystem.md
@@ -10,7 +10,7 @@ back the virtual filesystem with persistent or custom storage — for example, a
 `DurableObjectKVFileSystem` that buffers writes in memory and flushes to Durable
 Object KV on demand, avoiding a KV write for every individual file operation.
 
-Two concrete implementations are exported from the package:
+Three concrete implementations are exported from the package:
 
 - `InMemoryFileSystem` — a `Map`-backed filesystem suitable for tests and
   in-process pipelines. Accepts an optional seed object or `Map` of initial
@@ -19,6 +19,14 @@ Two concrete implementations are exported from the package:
   write-overlay. Writes accumulate in memory and are flushed to KV in one batch
   when `flush()` is called. Reads are served from the overlay first, so callers
   always observe their own writes immediately.
+- `DurableObjectRawFileSystem` — a thin Durable Object KV-backed filesystem
+  with no buffering. Every write is committed to KV synchronously. Use when
+  per-write durability is preferred over batching.
+
+`createFileSystemSnapshot` creates an `InMemoryFileSystem` from any sync or
+async iterable of `[path, content]` pairs, bridging async storage backends
+(e.g. `Workspace` from `@cloudflare/shell`) to the synchronous `FileSystem`
+interface.
 
 The `FileSystem.read()` method returns `string | null` (null = file does not
 exist) rather than an empty string, eliminating the need for a separate

--- a/.changeset/worker-bundler-filesystem.md
+++ b/.changeset/worker-bundler-filesystem.md
@@ -1,0 +1,28 @@
+---
+"@cloudflare/worker-bundler": minor
+---
+
+Introduce `FileSystem` abstraction for all bundler APIs.
+
+The `files` option on `createWorker` and `createApp` now accepts any `FileSystem`
+implementation in addition to a plain `Record<string, string>`. This lets callers
+back the virtual filesystem with persistent or custom storage — for example, a
+`DurableObjectKVFileSystem` that buffers writes in memory and flushes to Durable
+Object KV on demand, avoiding a KV write for every individual file operation.
+
+Two concrete implementations are exported from the package:
+
+- `InMemoryFileSystem` — a `Map`-backed filesystem suitable for tests and
+  in-process pipelines. Accepts an optional seed object or `Map` of initial
+  files.
+- `DurableObjectKVFileSystem` — a Durable Object KV-backed filesystem with a
+  write-overlay. Writes accumulate in memory and are flushed to KV in one batch
+  when `flush()` is called. Reads are served from the overlay first, so callers
+  always observe their own writes immediately.
+
+The `FileSystem.read()` method returns `string | null` (null = file does not
+exist) rather than an empty string, eliminating the need for a separate
+`exists()` check.
+
+Plain `Record<string, string>` objects continue to work unchanged — they are
+wrapped in an `InMemoryFileSystem` automatically.

--- a/.changeset/worker-bundler-standalone-install.md
+++ b/.changeset/worker-bundler-standalone-install.md
@@ -1,0 +1,13 @@
+---
+"@cloudflare/worker-bundler": minor
+---
+
+Export `installDependencies`, `hasDependencies`, and `InstallResult` so callers
+can pre-warm a `FileSystem` with npm packages independently of `createWorker` or
+`createApp`.
+
+When `createWorker` or `createApp` encounter a `FileSystem` that already contains
+a package under `node_modules/`, that package is skipped during installation,
+avoiding redundant network fetches. This makes a second call to
+`installDependencies` (or the internal call inside `createWorker`) a no-op for
+packages that were pre-installed into the same `FileSystem`.

--- a/.changeset/worker-bundler-typescript-language-service.md
+++ b/.changeset/worker-bundler-typescript-language-service.md
@@ -1,0 +1,18 @@
+---
+"@cloudflare/worker-bundler": minor
+---
+
+Add in-process TypeScript language service via `createTypescriptLanguageService`.
+
+`createTypescriptLanguageService` wraps any `FileSystem` in a
+`TypescriptFileSystem` that mirrors every write and delete into an underlying
+virtual TypeScript environment. Diagnostics returned by the language service
+always reflect the current state of the filesystem — an edit that fixes a type
+error immediately clears `getSemanticDiagnostics`.
+
+TypeScript is pre-bundled as a browser-safe artifact so it runs inside the
+Workers runtime without Node.js APIs. Lib declarations are fetched from the
+TypeScript npm tarball at runtime.
+
+Exposed under a separate `./typescript` subpath export to keep the TypeScript
+bundle out of the main import path.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -66,7 +66,7 @@ This project incorporates code from the following open-source projects.
 
 ### TypeScript
 
-- **License**: MIT License
+- **License**: Apache License 2.0
 - **Repository**: https://github.com/microsoft/typescript
 - **Copyright**: Copyright (c) Microsoft Corporation
 - **Full License**: [licenses/apache-2.0-typescript.txt](licenses/apache-2.0-typescript.txt)

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -64,4 +64,86 @@ This project incorporates code from the following open-source projects.
   > See the License for the specific language governing permissions and
   > limitations under the License.
 
+### TypeScript
+
+- **License**: MIT License
+- **Repository**: https://github.com/microsoft/typescript
+- **Copyright**: Copyright (c) Microsoft Corporation
+- **Full License**: [licenses/apache-2.0-typescript.txt](licenses/apache-2.0-typescript.txt)
+- **Notice**:
+  > Apache License
+  >
+  > Version 2.0, January 2004
+  >
+  > http://www.apache.org/licenses/
+  >
+  > TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+  >
+  > 1. Definitions.
+  >
+  > "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+  >
+  > "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+  >
+  > "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+  >
+  > "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+  >
+  > "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+  >
+  > "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+  >
+  > "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+  >
+  > "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+  >
+  > "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+  >
+  > "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+  >
+  > 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+  > 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+  > 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+  >
+  > You must give any other recipients of the Work or Derivative Works a copy of this License; and
+  >
+  > You must cause any modified files to carry prominent notices stating that You changed the files; and
+  >
+  > You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+  >
+  > If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+  >
+  > 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+  > 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+  > 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+  > 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+  > 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+  >
+  > END OF TERMS AND CONDITIONS
+
+### TypeScript VFS
+
+- **License**: MIT License
+- **Repository**: https://github.com/microsoft/TypeScript-Website/tree/v2/packages/typescript-vfs
+- **Copyright**: Copyright (c) Microsoft Corporation
+- **Full License**: [licenses/mit-typescript-vfs.txt](licenses/mit-typescript-vfs.txt)
+- **Notice**:
+  > The MIT License (MIT)
+  > Copyright (c) Microsoft Corporation
+  >
+  > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+  > associated documentation files (the "Software"), to deal in the Software without restriction,
+  > including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  > and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+  > subject to the following conditions:
+  >
+  > The above copyright notice and this permission notice shall be included in all copies or substantial
+  > portions of the Software.
+  >
+  > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+  > NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  > IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  > WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  > SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 ---

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -16,6 +16,8 @@ This directory contains the full license texts for third-party dependencies.
 - `apache-2.0-coinbase-x402.txt` - Coinbase x402 (Apache 2.0)
 - `mit-ethanniser-x402-mcp.txt` - ethanniser/x402-mcp (MIT)
 - `apache-2.0-vercel-ai-sdk.txt` - Vercel AI SDK (Apache 2.0)
+- `mit-typescript-vfs.txt` - TypeScript VFS (MIT)
+- `apache-2.0-typescript.txt` - TypeScript (Apache 2.0)
 
 ## Adding New Licenses
 

--- a/licenses/apache-2.0-typescript.txt
+++ b/licenses/apache-2.0-typescript.txt
@@ -1,0 +1,55 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/ 
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/licenses/mit-typescript-vfs.txt
+++ b/licenses/mit-typescript-vfs.txt
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,8 +1159,7 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ai-sdk/amazon-bedrock": {
       "version": "4.0.90",
@@ -1430,6 +1429,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.40.tgz",
       "integrity": "sha512-mhJQJh/CijoHOHby0jYeWZVCflyc6vVLz8LJ+XLEkoOl47/BsEJzhDz7YRZnrmDnO1oXtqq/awfgwPyd4VStWg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23"
@@ -1463,6 +1463,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
       "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -1475,6 +1476,7 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
       "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@standard-schema/spec": "^1.1.0",
@@ -1801,6 +1803,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2079,6 +2082,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3796,7 +3800,8 @@
       "version": "4.20260405.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
       "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3833,6 +3838,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3907,6 +3913,7 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5692,6 +5699,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5905,6 +5913,7 @@
       "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@openai/agents-core": "0.8.3",
         "@openai/agents-openai": "0.8.3",
@@ -6019,6 +6028,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6698,6 +6708,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
       "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8220,6 +8231,7 @@
       "integrity": "sha512-b1GDenJs2udQfjFMnAWZ6WX9RLg04O9wC85V4cSD8phuVMJscs+Qp0UkNj7FTc+V1ggqf4Pz1jLFfqjLO2z3mg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/ai-event-client": "0.2.0",
         "partial-json": "^0.1.7"
@@ -8845,6 +8857,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8854,6 +8867,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -9018,6 +9032,7 @@
       "integrity": "sha512-D3Q+YozvSpiFaLPgd6/OMbyqEIZeucSe6AHJJ7VnNJKQhIyBE60TlBZlxzwM8bvjzQE9ZnYWQCPeCw5pnhbiNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -9100,6 +9115,7 @@
       "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.3",
         "pathe": "^2.0.3"
@@ -9114,6 +9130,7 @@
       "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.3",
         "@vitest/utils": "4.1.3",
@@ -9405,8 +9422,7 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -9426,6 +9442,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.149.tgz",
       "integrity": "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.91",
         "@ai-sdk/provider": "3.0.8",
@@ -9692,6 +9709,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.4.tgz",
       "integrity": "sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
         "@astrojs/internal-helpers": "0.8.0",
@@ -10265,6 +10283,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -10518,6 +10537,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -11086,6 +11106,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -11507,6 +11528,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12411,7 +12433,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -12430,7 +12451,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -12443,7 +12463,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -12456,7 +12475,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -12465,22 +12483,19 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12610,6 +12625,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -13640,7 +13656,8 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
       "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
+      "peer": true
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -13950,6 +13967,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14603,6 +14621,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -14959,6 +14978,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -17819,6 +17839,7 @@
       "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
       "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-polyfill": "^0.0.4"
       },
@@ -18136,6 +18157,7 @@
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -18618,6 +18640,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18667,6 +18690,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19305,6 +19329,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20925,6 +20950,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -21025,6 +21051,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21116,6 +21143,7 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -21695,6 +21723,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -21822,6 +21851,7 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -22127,6 +22157,7 @@
       "integrity": "sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -22156,6 +22187,7 @@
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.80.0.tgz",
       "integrity": "sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ==",
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
         "@cloudflare/unenv-preset": "2.16.0",
@@ -22281,6 +22313,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -22324,6 +22357,7 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -22441,6 +22475,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -22482,7 +22517,6 @@
       "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
       "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,7 +1159,8 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ai-sdk/amazon-bedrock": {
       "version": "4.0.90",
@@ -1429,7 +1430,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.40.tgz",
       "integrity": "sha512-mhJQJh/CijoHOHby0jYeWZVCflyc6vVLz8LJ+XLEkoOl47/BsEJzhDz7YRZnrmDnO1oXtqq/awfgwPyd4VStWg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23"
@@ -1463,7 +1463,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
       "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -1476,7 +1475,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
       "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@standard-schema/spec": "^1.1.0",
@@ -1803,7 +1801,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2082,7 +2079,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3800,8 +3796,7 @@
       "version": "4.20260405.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
       "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3838,7 +3833,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3913,7 +3907,6 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5699,7 +5692,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5913,7 +5905,6 @@
       "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@openai/agents-core": "0.8.3",
         "@openai/agents-openai": "0.8.3",
@@ -6028,7 +6019,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6708,7 +6698,6 @@
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
       "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8231,7 +8220,6 @@
       "integrity": "sha512-b1GDenJs2udQfjFMnAWZ6WX9RLg04O9wC85V4cSD8phuVMJscs+Qp0UkNj7FTc+V1ggqf4Pz1jLFfqjLO2z3mg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/ai-event-client": "0.2.0",
         "partial-json": "^0.1.7"
@@ -8857,7 +8845,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8867,7 +8854,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8928,6 +8914,18 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript/vfs": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.4.tgz",
+      "integrity": "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -9020,7 +9018,6 @@
       "integrity": "sha512-D3Q+YozvSpiFaLPgd6/OMbyqEIZeucSe6AHJJ7VnNJKQhIyBE60TlBZlxzwM8bvjzQE9ZnYWQCPeCw5pnhbiNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -9103,7 +9100,6 @@
       "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.3",
         "pathe": "^2.0.3"
@@ -9118,7 +9114,6 @@
       "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.3",
         "@vitest/utils": "4.1.3",
@@ -9410,7 +9405,8 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -9430,7 +9426,6 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.149.tgz",
       "integrity": "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.91",
         "@ai-sdk/provider": "3.0.8",
@@ -9697,7 +9692,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.4.tgz",
       "integrity": "sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
         "@astrojs/internal-helpers": "0.8.0",
@@ -10271,7 +10265,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -10525,7 +10518,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -11094,7 +11086,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -11516,7 +11507,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12421,6 +12411,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -12439,6 +12430,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -12451,6 +12443,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -12463,6 +12456,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -12471,19 +12465,22 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12613,7 +12610,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -13644,8 +13640,7 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
       "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
-      "peer": true
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -13955,7 +13950,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14609,7 +14603,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -14966,7 +14959,6 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -17827,7 +17819,6 @@
       "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
       "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "event-target-polyfill": "^0.0.4"
       },
@@ -18145,7 +18136,6 @@
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -18628,7 +18618,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18678,7 +18667,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19317,7 +19305,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20938,7 +20925,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -21038,7 +21024,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21131,7 +21116,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -21711,7 +21695,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -21839,7 +21822,6 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -22145,7 +22127,6 @@
       "integrity": "sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -22175,7 +22156,6 @@
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.80.0.tgz",
       "integrity": "sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ==",
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
         "@cloudflare/unenv-preset": "2.16.0",
@@ -22301,7 +22281,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -22345,7 +22324,6 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -22463,7 +22441,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -22505,6 +22482,7 @@
       "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
       "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -22849,12 +22827,14 @@
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
+        "@typescript/vfs": "^1.6.4",
         "es-module-lexer": "^2.0.0",
         "esbuild-wasm": "0.28.0",
         "resolve.exports": "^2.0.3",
         "semver": "^7.7.4",
         "smol-toml": "^1.6.1",
-        "sucrase": "^3.35.1"
+        "sucrase": "^3.35.1",
+        "typescript": "^6.0.2"
       },
       "devDependencies": {
         "@types/semver": "^7.7.1"

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -321,6 +321,15 @@ export class AIChatAgent<
   /** Latest overlapping submit-message sequence kept for latest/debounce. */
   private _latestOverlappingSubmitSequence = 0;
 
+  /**
+   * Tracks requests that have passed concurrency decision but haven't
+   * yet been enqueued into `_turnQueue`. Bridges the gap caused by
+   * `await persistMessages()` between the decision and the enqueue,
+   * preventing a race where a subsequent message sees `queuedCount()=0`
+   * and skips concurrency handling.
+   */
+  private _pendingEnqueueCount = 0;
+
   /** Active debounce timer handle, cleared on resetTurnState. */
   private _activeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -573,6 +582,11 @@ export class AIChatAgent<
             return;
           }
 
+          // Track that this request is past the concurrency decision but
+          // not yet enqueued in _turnQueue. Decremented synchronously
+          // before _runExclusiveChatTurn (which increments queuedCount).
+          this._pendingEnqueueCount++;
+
           // Persist and broadcast user messages before entering the turn
           // queue so other tabs see the new message immediately and so
           // overlapping submits under latest/merge/debounce can inspect
@@ -593,6 +607,7 @@ export class AIChatAgent<
             await this._mergeQueuedUserMessages(epoch);
           }
 
+          this._pendingEnqueueCount--;
           return this._runExclusiveChatTurn(
             chatMessageId,
             async () => {
@@ -1314,7 +1329,8 @@ export class AIChatAgent<
   private _getSubmitConcurrencyDecision(
     trigger: ChatRequestTrigger
   ): SubmitConcurrencyDecision {
-    const queuedTurnsInCurrentEpoch = this._turnQueue.queuedCount();
+    const queuedTurnsInCurrentEpoch =
+      this._turnQueue.queuedCount() + this._pendingEnqueueCount;
 
     if (trigger !== "submit-message" || queuedTurnsInCurrentEpoch === 0) {
       return {
@@ -1680,6 +1696,7 @@ export class AIChatAgent<
     this._turnQueue.reset();
     this._abortRegistry.destroyAll();
     this._cancelActiveDebounce();
+    this._pendingEnqueueCount = 0;
     this._pendingInteractionPromise = null;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -586,28 +586,29 @@ export class AIChatAgent<
           // not yet enqueued in _turnQueue. Decremented synchronously
           // before _runExclusiveChatTurn (which increments queuedCount).
           this._pendingEnqueueCount++;
+          try {
+            // Persist and broadcast user messages before entering the turn
+            // queue so other tabs see the new message immediately and so
+            // overlapping submits under latest/merge/debounce can inspect
+            // the full message list when their turn starts.
+            this._broadcastChatMessage(
+              {
+                messages: transformedMessages,
+                type: MessageType.CF_AGENT_CHAT_MESSAGES
+              },
+              [connection.id]
+            );
 
-          // Persist and broadcast user messages before entering the turn
-          // queue so other tabs see the new message immediately and so
-          // overlapping submits under latest/merge/debounce can inspect
-          // the full message list when their turn starts.
-          this._broadcastChatMessage(
-            {
-              messages: transformedMessages,
-              type: MessageType.CF_AGENT_CHAT_MESSAGES
-            },
-            [connection.id]
-          );
+            await this.persistMessages(transformedMessages, [connection.id], {
+              _deleteStaleRows: true
+            });
 
-          await this.persistMessages(transformedMessages, [connection.id], {
-            _deleteStaleRows: true
-          });
-
-          if (concurrencyDecision.mergeQueuedMessages) {
-            await this._mergeQueuedUserMessages(epoch);
+            if (concurrencyDecision.mergeQueuedMessages) {
+              await this._mergeQueuedUserMessages(epoch);
+            }
+          } finally {
+            this._pendingEnqueueCount--;
           }
-
-          this._pendingEnqueueCount--;
           return this._runExclusiveChatTurn(
             chatMessageId,
             async () => {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -607,7 +607,10 @@ export class AIChatAgent<
               await this._mergeQueuedUserMessages(epoch);
             }
           } finally {
-            this._pendingEnqueueCount--;
+            this._pendingEnqueueCount = Math.max(
+              0,
+              this._pendingEnqueueCount - 1
+            );
           }
           return this._runExclusiveChatTurn(
             chatMessageId,

--- a/packages/ai-chat/src/tests/message-concurrency.test.ts
+++ b/packages/ai-chat/src/tests/message-concurrency.test.ts
@@ -822,7 +822,7 @@ describe("AIChatAgent messageConcurrency", () => {
       chunkCount: 3,
       chunkDelayMs: 30
     });
-    await delay(20);
+    await delay(50);
 
     sendChatRequest(
       ws,

--- a/packages/worker-bundler/README.md
+++ b/packages/worker-bundler/README.md
@@ -107,16 +107,16 @@ Static assets are served with proper content types, ETags, and caching. Requests
 
 Bundles source files into a Worker.
 
-| Option       | Type                     | Default                        | Description                                                       |
-| ------------ | ------------------------ | ------------------------------ | ----------------------------------------------------------------- |
-| `files`      | `Record<string, string>` | _required_                     | Input files (path → content)                                      |
-| `entryPoint` | `string`                 | auto-detected                  | Entry point file path                                             |
-| `bundle`     | `boolean`                | `true`                         | Bundle all dependencies into one file                             |
-| `externals`  | `string[]`               | `[]`                           | Modules to exclude from bundling (`cloudflare:*` always external) |
-| `target`     | `string`                 | `'es2022'`                     | Target environment                                                |
-| `minify`     | `boolean`                | `false`                        | Minify output                                                     |
-| `sourcemap`  | `boolean`                | `false`                        | Generate inline source maps                                       |
-| `registry`   | `string`                 | `'https://registry.npmjs.org'` | npm registry URL                                                  |
+| Option       | Type                                   | Default                        | Description                                                       |
+| ------------ | -------------------------------------- | ------------------------------ | ----------------------------------------------------------------- |
+| `files`      | `Record<string, string> \| FileSystem` | _required_                     | Input files — plain object or any `FileSystem` implementation     |
+| `entryPoint` | `string`                               | auto-detected                  | Entry point file path                                             |
+| `bundle`     | `boolean`                              | `true`                         | Bundle all dependencies into one file                             |
+| `externals`  | `string[]`                             | `[]`                           | Modules to exclude from bundling (`cloudflare:*` always external) |
+| `target`     | `string`                               | `'es2022'`                     | Target environment                                                |
+| `minify`     | `boolean`                              | `false`                        | Minify output                                                     |
+| `sourcemap`  | `boolean`                              | `false`                        | Generate inline source maps                                       |
+| `registry`   | `string`                               | `'https://registry.npmjs.org'` | npm registry URL                                                  |
 
 Returns:
 
@@ -133,19 +133,19 @@ Returns:
 
 Builds a full-stack app: server Worker + client bundle + static assets.
 
-| Option        | Type                                    | Default       | Description                                     |
-| ------------- | --------------------------------------- | ------------- | ----------------------------------------------- |
-| `files`       | `Record<string, string>`                | _required_    | All source files (server + client)              |
-| `server`      | `string`                                | auto-detected | Server entry point (Worker fetch handler)       |
-| `client`      | `string \| string[]`                    | —             | Client entry point(s) to bundle for the browser |
-| `assets`      | `Record<string, string \| ArrayBuffer>` | —             | Static assets (pathname → content)              |
-| `assetConfig` | `AssetConfig`                           | —             | Asset serving configuration                     |
-| `bundle`      | `boolean`                               | `true`        | Bundle server dependencies                      |
-| `externals`   | `string[]`                              | `[]`          | Modules to exclude from bundling                |
-| `target`      | `string`                                | `'es2022'`    | Server target environment                       |
-| `minify`      | `boolean`                               | `false`       | Minify output                                   |
-| `sourcemap`   | `boolean`                               | `false`       | Generate source maps                            |
-| `registry`    | `string`                                | npm default   | npm registry URL                                |
+| Option        | Type                                    | Default       | Description                                         |
+| ------------- | --------------------------------------- | ------------- | --------------------------------------------------- |
+| `files`       | `Record<string, string> \| FileSystem`  | _required_    | All source files — plain object or any `FileSystem` |
+| `server`      | `string`                                | auto-detected | Server entry point (Worker fetch handler)           |
+| `client`      | `string \| string[]`                    | —             | Client entry point(s) to bundle for the browser     |
+| `assets`      | `Record<string, string \| ArrayBuffer>` | —             | Static assets (pathname → content)                  |
+| `assetConfig` | `AssetConfig`                           | —             | Asset serving configuration                         |
+| `bundle`      | `boolean`                               | `true`        | Bundle server dependencies                          |
+| `externals`   | `string[]`                              | `[]`          | Modules to exclude from bundling                    |
+| `target`      | `string`                                | `'es2022'`    | Server target environment                           |
+| `minify`      | `boolean`                               | `false`       | Minify output                                       |
+| `sourcemap`   | `boolean`                               | `false`       | Generate source maps                                |
+| `registry`    | `string`                                | npm default   | npm registry URL                                    |
 
 Returns everything from `createWorker` plus:
 
@@ -489,12 +489,220 @@ interface Env {
 }
 ```
 
+## File System
+
+The bundler operates on a `FileSystem` interface — a minimal, synchronous abstraction for reading, writing, and listing files. All bundler APIs (`createWorker`, `createApp`) accept either a plain `Record<string, string>` (auto-wrapped in `InMemoryFileSystem`) or any `FileSystem` implementation.
+
+```ts
+interface FileSystem {
+  read(path: string): string | null;
+  write(path: string, content: string): void;
+  delete(path: string): void;
+  list(prefix?: string): string[];
+  flush(): Promise<void>;
+}
+```
+
+### Implementations
+
+**`InMemoryFileSystem`** — `Map`-backed, no persistence. Accepts a seed object or `Map`:
+
+```ts
+import { InMemoryFileSystem } from "@cloudflare/worker-bundler";
+
+const fs = new InMemoryFileSystem({
+  "src/index.ts": "export default { fetch() { return new Response('ok'); } };"
+});
+```
+
+**`DurableObjectKVFileSystem`** — Writes are buffered in memory and flushed to Durable Object KV in one batch. Reads see buffered writes immediately:
+
+```ts
+import { DurableObjectKVFileSystem } from "@cloudflare/worker-bundler";
+
+const fs = new DurableObjectKVFileSystem(this.ctx.storage);
+fs.write("src/index.ts", code);
+
+const result = await createWorker({ files: fs });
+
+// Persist everything (source + installed node_modules) to KV
+await fs.flush();
+```
+
+After flushing, the filesystem is durable — a subsequent `createWorker` call on a new `DurableObjectKVFileSystem` over the same storage will find `node_modules` already present and skip installation entirely.
+
+**`DurableObjectRawFileSystem`** — Every write goes directly to KV with no buffering. Use when writing a small number of files where per-write durability is preferred:
+
+```ts
+import { DurableObjectRawFileSystem } from "@cloudflare/worker-bundler";
+
+const fs = new DurableObjectRawFileSystem(this.ctx.storage);
+```
+
+### Snapshotting from async sources
+
+The `FileSystem` interface is synchronous because esbuild and TypeScript require synchronous file access. To bridge from an async storage backend (like `Workspace` from `@cloudflare/shell`), use `createFileSystemSnapshot`:
+
+```ts
+import { createFileSystemSnapshot } from "@cloudflare/worker-bundler";
+
+// Accepts any sync or async iterable of [path, content] pairs
+async function* workspaceFiles(workspace) {
+  for (const entry of workspace.glob("**/*.{ts,tsx,json}")) {
+    const content = await workspace.readFile(entry.path);
+    if (content !== null) yield [entry.path, content];
+  }
+}
+
+const fs = await createFileSystemSnapshot(workspaceFiles(workspace));
+const result = await createWorker({ files: fs });
+```
+
+## Pre-installing Dependencies
+
+`installDependencies` is exported separately so you can pre-warm a filesystem with npm packages independently of `createWorker`:
+
+```ts
+import {
+  installDependencies,
+  DurableObjectKVFileSystem,
+  createWorker
+} from "@cloudflare/worker-bundler";
+
+const fs = new DurableObjectKVFileSystem(this.ctx.storage);
+fs.write("package.json", JSON.stringify({ dependencies: { hono: "^4.0.0" } }));
+fs.write("src/index.ts", code);
+
+// Install once, flush to KV
+await installDependencies(fs);
+await fs.flush();
+
+// On subsequent requests, createWorker finds node_modules already
+// present and skips installation — no network requests
+const result = await createWorker({ files: fs });
+```
+
+This is useful for separating the install step (slow, network-bound) from the bundle step (fast, CPU-only), and for persisting installed packages across DO restarts.
+
+## TypeScript Language Service
+
+A full TypeScript language service runs in-process inside the Workers runtime. Import it from the `./typescript` subpath to keep the TypeScript bundle (~5 MB) out of the main entry:
+
+```ts
+import { createTypescriptLanguageService } from "@cloudflare/worker-bundler/typescript";
+import { InMemoryFileSystem } from "@cloudflare/worker-bundler";
+
+const fileSystem = new InMemoryFileSystem({
+  "tsconfig.json": JSON.stringify({
+    compilerOptions: {
+      lib: ["es2024"],
+      target: "ES2024",
+      module: "ES2022",
+      moduleResolution: "bundler",
+      strict: true,
+      skipLibCheck: true
+    }
+  }),
+  "src/index.ts": `
+    const worker: ExportedHandler = {
+      async fetch() {
+        return new Response("Hello, world!");
+      }
+    };
+    export default worker;
+  `
+});
+
+const { fileSystem: tsFileSystem, languageService } =
+  await createTypescriptLanguageService({ fileSystem });
+
+// Get diagnostics
+const errors = languageService.getSemanticDiagnostics("src/index.ts");
+```
+
+The returned `fileSystem` wraps the original and keeps the TypeScript environment in sync — write through it to see updated diagnostics immediately:
+
+```ts
+// Fix an error
+tsFileSystem.write("src/index.ts", correctedCode);
+
+// Diagnostics now reflect the fix
+const errors = languageService.getSemanticDiagnostics("src/index.ts");
+// => []
+```
+
+### With `installDependencies`
+
+Install type packages into the filesystem before creating the language service to get full type coverage:
+
+```ts
+import {
+  installDependencies,
+  InMemoryFileSystem
+} from "@cloudflare/worker-bundler";
+import { createTypescriptLanguageService } from "@cloudflare/worker-bundler/typescript";
+
+const fs = new InMemoryFileSystem({
+  "package.json": JSON.stringify({
+    dependencies: { "@cloudflare/workers-types": "^4.20260405.1" }
+  }),
+  "tsconfig.json": JSON.stringify({
+    compilerOptions: {
+      lib: ["es2024"],
+      strict: true,
+      skipLibCheck: true,
+      types: ["@cloudflare/workers-types/index.d.ts"]
+    }
+  }),
+  "src/index.ts": workerSource
+});
+
+await installDependencies(fs);
+
+const { languageService } = await createTypescriptLanguageService({
+  fileSystem: fs
+});
+const diagnostics = languageService.getSemanticDiagnostics("src/index.ts");
+```
+
+### Integrating with Workspace
+
+When using `Workspace` from `@cloudflare/shell` as durable storage, snapshot source files into an `InMemoryFileSystem` for type checking:
+
+```ts
+import { createFileSystemSnapshot } from "@cloudflare/worker-bundler";
+import { createTypescriptLanguageService } from "@cloudflare/worker-bundler/typescript";
+
+// 1. Snapshot source files from Workspace (async reads)
+async function* sourceFiles(workspace) {
+  for (const entry of workspace.glob("**/*.{ts,tsx,json}")) {
+    const content = await workspace.readFile(entry.path);
+    if (content !== null) yield [entry.path, content];
+  }
+}
+
+const fs = await createFileSystemSnapshot(sourceFiles(workspace));
+
+// 2. Create language service (synchronous reads during init)
+const { fileSystem, languageService } = await createTypescriptLanguageService({
+  fileSystem: fs
+});
+
+// 3. Get diagnostics
+const errors = languageService.getSemanticDiagnostics("src/index.ts");
+
+// 4. On edits, update both the TS environment and durable storage
+fileSystem.write("src/index.ts", newContent);
+await workspace.writeFile("src/index.ts", newContent);
+```
+
 ## Known Limitations
 
 - **Flat node_modules** — All packages are installed into a single flat directory. If two packages need different incompatible versions of the same transitive dependency, only one version is installed.
 - **Long file paths in tarballs** — The tar parser handles classic headers but not POSIX extended (PAX) headers. Packages with paths longer than 100 characters may have those files silently truncated.
 - **Text files only from npm** — Only text files (`.js`, `.json`, `.css`, etc.) are extracted from tarballs. Binary files like `.wasm` or `.node` are skipped.
 - **No recursion depth limit** — Transitive dependency resolution has no depth limit. A pathological dependency tree could cause excessive network requests.
+- **TypeScript lib declarations fetched at runtime** — `createTypescriptLanguageService` downloads the TypeScript npm tarball (~23 MB) on every call to extract the standard library `.d.ts` files (~3.7 MB). There is no caching — each cold start of a Durable Object that creates a language service incurs this fetch. A future improvement would pre-bundle these declarations at build time (following the same pattern as the TypeScript compiler bundle).
 
 ## License
 

--- a/packages/worker-bundler/package.json
+++ b/packages/worker-bundler/package.json
@@ -18,6 +18,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./typescript": {
+      "types": "./dist/typescript.d.ts",
+      "import": "./dist/typescript.js"
     }
   },
   "files": [
@@ -29,12 +33,14 @@
     "test": "vitest run --config src/tests/vitest.config.ts"
   },
   "dependencies": {
+    "@typescript/vfs": "^1.6.4",
     "es-module-lexer": "^2.0.0",
     "esbuild-wasm": "0.28.0",
     "resolve.exports": "^2.0.3",
     "semver": "^7.7.4",
     "smol-toml": "^1.6.1",
-    "sucrase": "^3.35.1"
+    "sucrase": "^3.35.1",
+    "typescript": "^6.0.2"
   },
   "devDependencies": {
     "@types/semver": "^7.7.1"

--- a/packages/worker-bundler/scripts/build.ts
+++ b/packages/worker-bundler/scripts/build.ts
@@ -3,51 +3,58 @@ import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "tsdown";
+import {
+  bundleTypeScriptForWorkers,
+  removeBundledTypeScript
+} from "./typescript-browser-bundle";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = join(__dirname, "..");
 
 async function main() {
-  await build({
-    clean: true,
-    dts: true,
-    entry: ["src/index.ts"],
-    deps: {
-      skipNodeModulesBundle: true,
-      neverBundle: ["cloudflare:workers", "./esbuild.wasm"]
-    },
-    format: "esm",
-    sourcemap: true,
-    fixedExtension: false
-  });
+  await bundleTypeScriptForWorkers(packageRoot);
 
-  // Copy esbuild.wasm from esbuild-wasm package into dist/
-  const possiblePaths = [
-    join(packageRoot, "node_modules/esbuild-wasm/esbuild.wasm"),
-    join(packageRoot, "../../node_modules/esbuild-wasm/esbuild.wasm")
-  ];
+  try {
+    await build({
+      clean: true,
+      dts: true,
+      entry: ["src/index.ts", "src/typescript.ts"],
+      deps: {
+        skipNodeModulesBundle: true,
+        neverBundle: ["cloudflare:workers", "./esbuild.wasm"]
+      },
+      format: "esm",
+      sourcemap: true,
+      fixedExtension: false
+    });
 
-  let wasmSource: string | null = null;
-  for (const p of possiblePaths) {
-    if (existsSync(p)) {
-      wasmSource = p;
-      break;
+    // Copy esbuild.wasm from esbuild-wasm package into dist/
+    const possiblePaths = [
+      join(packageRoot, "node_modules/esbuild-wasm/esbuild.wasm"),
+      join(packageRoot, "../../node_modules/esbuild-wasm/esbuild.wasm")
+    ];
+
+    let wasmSource: string | null = null;
+    for (const p of possiblePaths) {
+      if (existsSync(p)) {
+        wasmSource = p;
+        break;
+      }
     }
+
+    if (!wasmSource) {
+      throw new Error("Could not find esbuild.wasm!");
+    }
+
+    const wasmDest = join(packageRoot, "dist/esbuild.wasm");
+    copyFileSync(wasmSource, wasmDest);
+    console.log("Copied esbuild.wasm to dist/");
+
+    // then run oxfmt on the generated .d.ts files
+    execSync("oxfmt --write ./dist/*.d.ts");
+  } finally {
+    removeBundledTypeScript(packageRoot);
   }
-
-  if (!wasmSource) {
-    console.error("Error: Could not find esbuild.wasm!");
-    process.exit(1);
-  }
-
-  const wasmDest = join(packageRoot, "dist/esbuild.wasm");
-  copyFileSync(wasmSource, wasmDest);
-  console.log("Copied esbuild.wasm to dist/");
-
-  // then run oxfmt on the generated .d.ts files
-  execSync("oxfmt --write ./dist/*.d.ts");
-
-  process.exit(0);
 }
 
 main().catch((err) => {

--- a/packages/worker-bundler/scripts/typescript-browser-bundle.ts
+++ b/packages/worker-bundler/scripts/typescript-browser-bundle.ts
@@ -1,0 +1,46 @@
+import { build } from "esbuild";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+// `typescript`'s published entry is Node/CJS-oriented and was crashing when we
+// imported it inside Workers with node-compatibility enabled due to ESM/CJS issues.
+// This helper builds a temporary browser-targeted ESM bundle that `src/typecheck.ts`
+// can safely import in both runtime and worker-test environments.
+
+export function getTypeScriptBrowserBundlePath(packageRoot: string): string {
+  return path.join(packageRoot, "src/vendor/typescript.browser.js");
+}
+
+export async function bundleTypeScriptForWorkers(
+  packageRoot: string
+): Promise<string> {
+  const require = createRequire(path.join(packageRoot, "package.json"));
+  const outputPath = getTypeScriptBrowserBundlePath(packageRoot);
+
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+
+  await build({
+    bundle: true,
+    define: {
+      "process.browser": "true"
+    },
+    entryPoints: [require.resolve("typescript/lib/typescript.js")],
+    format: "esm",
+    legalComments: "eof",
+    minify: true,
+    outfile: outputPath,
+    platform: "browser",
+    target: ["es2022"]
+  });
+
+  return outputPath;
+}
+
+export function removeBundledTypeScript(packageRoot: string): void {
+  const outputPath = getTypeScriptBrowserBundlePath(packageRoot);
+
+  if (existsSync(outputPath)) {
+    rmSync(outputPath);
+  }
+}

--- a/packages/worker-bundler/src/app.ts
+++ b/packages/worker-bundler/src/app.ts
@@ -14,6 +14,11 @@ import { transformAndResolve } from "./transformer";
 import type { AssetConfig, AssetManifest } from "./asset-handler";
 import { buildAssetManifest } from "./asset-handler";
 import type { CreateWorkerResult, Files } from "./types";
+import {
+  InMemoryFileSystem,
+  isFileSystem,
+  type FileSystem
+} from "./file-system";
 import { detectEntryPoint } from "./utils";
 import { showExperimentalWarning } from "./experimental";
 
@@ -23,9 +28,10 @@ import { showExperimentalWarning } from "./experimental";
 export interface CreateAppOptions {
   /**
    * Input files — keys are paths relative to project root, values are file contents.
-   * Should include both server and client source files.
+   * Accepts a plain object (which is wrapped in an InMemoryFileSystem automatically)
+   * or any FileSystem implementation for custom storage backends.
    */
-  files: Files;
+  files: Files | FileSystem;
 
   /**
    * Server entry point (the Worker fetch handler).
@@ -129,31 +135,34 @@ export async function createApp(
   options: CreateAppOptions
 ): Promise<CreateAppResult> {
   showExperimentalWarning("createApp");
-  let {
+  const {
     files,
     bundle = true,
-    externals = [],
+    externals: rawExternals = [],
     target = "es2022",
     minify = false,
     sourcemap = false,
     registry
   } = options;
 
+  const fileSystem: FileSystem = isFileSystem(files)
+    ? files
+    : new InMemoryFileSystem(files);
+
   // Always treat cloudflare:* as external
-  externals = ["cloudflare:", ...externals];
+  const externals = ["cloudflare:", ...rawExternals];
 
   // Parse wrangler config
-  const wranglerConfig = parseWranglerConfig(files);
+  const wranglerConfig = parseWranglerConfig(fileSystem);
   const nodejsCompat = hasNodejsCompat(wranglerConfig);
 
   // Install npm dependencies if needed
   const installWarnings: string[] = [];
-  if (hasDependencies(files)) {
+  if (hasDependencies(fileSystem)) {
     const installResult = await installDependencies(
-      files,
+      fileSystem,
       registry ? { registry } : {}
     );
-    files = installResult.files;
     installWarnings.push(...installResult.warnings);
   }
 
@@ -168,14 +177,14 @@ export async function createApp(
   const clientBundles: string[] = [];
 
   for (const clientEntry of clientEntries) {
-    if (!(clientEntry in files)) {
+    if (fileSystem.read(clientEntry) === null) {
       throw new Error(
         `Client entry point "${clientEntry}" not found in files.`
       );
     }
 
     const clientResult = await bundleWithEsbuild(
-      files,
+      fileSystem,
       clientEntry,
       externals,
       "es2022",
@@ -214,7 +223,8 @@ export async function createApp(
   const assetManifest = await buildAssetManifest(allAssets);
 
   // ── Step 3: Build server Worker ───────────────────────────────────
-  const serverEntry = options.server ?? detectEntryPoint(files, wranglerConfig);
+  const serverEntry =
+    options.server ?? detectEntryPoint(fileSystem, wranglerConfig);
 
   if (!serverEntry) {
     throw new Error(
@@ -222,14 +232,14 @@ export async function createApp(
     );
   }
 
-  if (!(serverEntry in files)) {
+  if (fileSystem.read(serverEntry) === null) {
     throw new Error(`Server entry point "${serverEntry}" not found in files.`);
   }
 
   let serverResult: CreateWorkerResult;
   if (bundle) {
     serverResult = await bundleWithEsbuild(
-      files,
+      fileSystem,
       serverEntry,
       externals,
       target,
@@ -238,7 +248,11 @@ export async function createApp(
       nodejsCompat
     );
   } else {
-    serverResult = await transformAndResolve(files, serverEntry, externals);
+    serverResult = await transformAndResolve(
+      fileSystem,
+      serverEntry,
+      externals
+    );
   }
 
   const result: CreateAppResult = {

--- a/packages/worker-bundler/src/bundler.ts
+++ b/packages/worker-bundler/src/bundler.ts
@@ -9,13 +9,14 @@ import * as esbuild from "esbuild-wasm/lib/browser.js";
 // @ts-expect-error - WASM module import
 import esbuildWasm from "./esbuild.wasm";
 import { resolveModule } from "./resolver";
-import type { CreateWorkerResult, Files, Modules } from "./types";
+import type { FileSystem } from "./file-system";
+import type { CreateWorkerResult, Modules } from "./types";
 
 /**
  * Bundle files using esbuild-wasm
  */
 export async function bundleWithEsbuild(
-  files: Files,
+  files: FileSystem,
   entryPoint: string,
   externals: string[],
   target: string,
@@ -79,7 +80,7 @@ export async function bundleWithEsbuild(
         const normalizedPath = args.path.startsWith("/")
           ? args.path.slice(1)
           : args.path;
-        if (normalizedPath in files) {
+        if (files.read(normalizedPath) !== null) {
           return { path: normalizedPath, namespace: "virtual" };
         }
 
@@ -88,8 +89,8 @@ export async function bundleWithEsbuild(
 
       // Load files from virtual file system
       build.onLoad({ filter: /.*/, namespace: "virtual" }, (args) => {
-        const content = files[args.path];
-        if (content === undefined) {
+        const content = files.read(args.path);
+        if (content === null) {
           return { errors: [{ text: `File not found: ${args.path}` }] };
         }
 
@@ -137,7 +138,7 @@ export async function bundleWithEsbuild(
 function resolveRelativePath(
   resolveDir: string,
   relativePath: string,
-  files: Files
+  files: FileSystem
 ): string | undefined {
   // Normalize the resolve directory
   const dir = resolveDir.replace(/^\//, "");
@@ -157,14 +158,14 @@ function resolveRelativePath(
   const resolved = parts.join("/");
 
   // Try exact match
-  if (resolved in files) {
+  if (files.read(resolved) !== null) {
     return resolved;
   }
 
   // Try adding extensions
   const extensions = [".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs"];
   for (const ext of extensions) {
-    if (resolved + ext in files) {
+    if (files.read(resolved + ext) !== null) {
       return resolved + ext;
     }
   }
@@ -172,7 +173,7 @@ function resolveRelativePath(
   // Try index files
   for (const ext of extensions) {
     const indexPath = `${resolved}/index${ext}`;
-    if (indexPath in files) {
+    if (files.read(indexPath) !== null) {
       return indexPath;
     }
   }

--- a/packages/worker-bundler/src/config.ts
+++ b/packages/worker-bundler/src/config.ts
@@ -6,7 +6,8 @@
  */
 
 import { parse as parseToml } from "smol-toml";
-import type { Files, WranglerConfig } from "./types";
+import type { WranglerConfig } from "./types";
+import type { FileSystem } from "./file-system";
 
 /**
  * Parse wrangler configuration from files.
@@ -17,19 +18,21 @@ import type { Files, WranglerConfig } from "./types";
  * @param files - Virtual file system
  * @returns Parsed wrangler config, or undefined if no config file found
  */
-export function parseWranglerConfig(files: Files): WranglerConfig | undefined {
+export function parseWranglerConfig(
+  files: FileSystem
+): WranglerConfig | undefined {
   // Try each config file format in order of preference
-  const tomlContent = files["wrangler.toml"];
+  const tomlContent = files.read("wrangler.toml");
   if (tomlContent) {
     return parseWranglerToml(tomlContent);
   }
 
-  const jsonContent = files["wrangler.json"];
+  const jsonContent = files.read("wrangler.json");
   if (jsonContent) {
     return parseWranglerJson(jsonContent);
   }
 
-  const jsoncContent = files["wrangler.jsonc"];
+  const jsoncContent = files.read("wrangler.jsonc");
   if (jsoncContent) {
     return parseWranglerJsonc(jsoncContent);
   }

--- a/packages/worker-bundler/src/file-system.ts
+++ b/packages/worker-bundler/src/file-system.ts
@@ -75,8 +75,9 @@ export class InMemoryFileSystem implements FileSystem {
 }
 
 /**
- * A generic write-overlay on top of any `FileSystem`. Not exported — intended
- * as an implementation detail for higher-level filesystem classes.
+ * A generic write-overlay on top of any `FileSystem`. Not re-exported from the
+ * package entry point — intended as an implementation detail for higher-level
+ * filesystem classes.
  *
  * Writes and deletes are buffered in memory keyed by the raw (untransformed)
  * path. Reads are served from the write buffer first; deleted paths return

--- a/packages/worker-bundler/src/file-system.ts
+++ b/packages/worker-bundler/src/file-system.ts
@@ -250,6 +250,39 @@ export class DurableObjectKVFileSystem implements FileSystem {
   }
 }
 
+/**
+ * Creates an `InMemoryFileSystem` from an async source of file entries.
+ *
+ * This is the bridge between async storage backends (e.g. a Durable Object
+ * `Workspace` backed by SQLite/R2) and the synchronous `FileSystem` interface
+ * required by the bundler and TypeScript language service.
+ *
+ * @example
+ * ```ts
+ * // Snapshot a Workspace into a bundler-compatible FileSystem
+ * async function* workspaceFiles(workspace) {
+ *   for (const entry of workspace.glob("**\/*.{ts,tsx,json}")) {
+ *     const content = await workspace.readFile(entry.path);
+ *     if (content !== null) yield [entry.path, content];
+ *   }
+ * }
+ *
+ * const fs = await createFileSystemSnapshot(workspaceFiles(workspace));
+ * const { languageService } = await createTypescriptLanguageService({ fileSystem: fs });
+ * ```
+ */
+export async function createFileSystemSnapshot(
+  entries:
+    | AsyncIterable<readonly [string, string]>
+    | Iterable<readonly [string, string]>
+): Promise<InMemoryFileSystem> {
+  const fs = new InMemoryFileSystem();
+  for await (const [path, content] of entries) {
+    fs.write(path, content);
+  }
+  return fs;
+}
+
 export function isFileSystem(
   obj: FileSystem | Record<string, string>
 ): obj is FileSystem {

--- a/packages/worker-bundler/src/file-system.ts
+++ b/packages/worker-bundler/src/file-system.ts
@@ -52,28 +52,53 @@ export class InMemoryFileSystem implements FileSystem {
 }
 
 /**
- * A filesystem backed by Durable Object KV storage. Writes are buffered in an
- * in-memory overlay and only persisted to KV when `flush()` is called, avoiding
- * the cost of a KV write on every individual file operation. Reads are served
- * from the overlay when possible, falling back to KV, so callers always observe
- * their own writes immediately regardless of whether `flush()` has been called.
+ * A generic write-overlay on top of any `FileSystem`. Not exported — intended
+ * as an implementation detail for higher-level filesystem classes.
+ *
+ * Writes are buffered in an in-memory `Map` keyed by the raw (untransformed)
+ * path. Reads are served from the buffer first, then delegated to the inner
+ * filesystem. `flush()` drains the buffer by calling `inner.write()` for every
+ * pending entry, awaits `inner.flush()`, and then clears the buffer.
  */
-export class DurableObjectKVFileSystem implements FileSystem {
-  /**
-   * An in-memory buffer of pending writes. Null until the first write occurs.
-   *
-   * Writes are held here rather than being sent directly to Durable Object KV
-   * because KV I/O is comparatively expensive due to I/O gates blocking
-   * side-effects until writes are confirmed durable. Reads consult the overlay
-   * first so callers always observe their own writes immediately. The buffered
-   * entries are only persisted to KV when `flush()` is called explicitly.
-   *
-   * Keys are stored in their fully-formatted form (i.e. with the path prefix
-   * already applied) so they can be passed to `kv.put` directly during flush
-   * without any transformation.
-   */
-  private writeOverlay: Map<string, string> | null = null;
+class OverlayFileSystem implements FileSystem {
+  private overlay: Map<string, string> | null = null;
 
+  constructor(private readonly inner: FileSystem) {}
+
+  read(path: string): string | null {
+    return this.overlay?.get(path) ?? this.inner.read(path);
+  }
+
+  write(path: string, content: string): void {
+    if (this.overlay === null) {
+      this.overlay = new Map();
+    }
+    this.overlay.set(path, content);
+  }
+
+  async flush(): Promise<void> {
+    if (this.overlay === null) {
+      return;
+    }
+    for (const [path, content] of this.overlay) {
+      this.inner.write(path, content);
+    }
+    await this.inner.flush();
+    this.overlay = null;
+  }
+}
+
+/**
+ * A filesystem backed directly by Durable Object KV storage. Every write is
+ * committed to KV synchronously with no in-memory buffering, and `flush()` is
+ * a no-op.
+ *
+ * Use this when you want immediate, per-write durability and the overhead of
+ * individual KV writes is acceptable — for example, when seeding a small number
+ * of files. For bulk write workloads, prefer `DurableObjectKVFileSystem`, which
+ * batches all writes into a single flush.
+ */
+export class DurableObjectRawFileSystem implements FileSystem {
   /**
    * @param storage The Durable Object storage instance to persist files to.
    * @param prefix  An optional path prefix prepended to every key stored in KV.
@@ -81,39 +106,63 @@ export class DurableObjectKVFileSystem implements FileSystem {
    *                from any other keys the Durable Object may store.
    */
   constructor(
-    private storage: DurableObjectStorage,
-    private prefix: string = "bundle/"
+    private readonly storage: DurableObjectStorage,
+    private readonly prefix: string = "bundle/"
   ) {}
 
   read(path: string): string | null {
-    const realPath = this.formatPath(path);
-    return (
-      this.writeOverlay?.get(realPath) ??
-      this.storage.kv.get<string>(realPath) ??
-      null
-    );
+    return this.storage.kv.get<string>(this.formatPath(path)) ?? null;
   }
 
   write(path: string, content: string): void {
-    if (this.writeOverlay === null) {
-      this.writeOverlay = new Map();
-    }
-    const realPath = this.formatPath(path);
-    this.writeOverlay.set(realPath, content);
+    this.storage.kv.put(this.formatPath(path), content);
   }
 
-  async flush(): Promise<void> {
-    if (this.writeOverlay === null) {
-      return;
-    }
-    for (const [key, value] of this.writeOverlay) {
-      this.storage.kv.put(key, value);
-    }
-    this.writeOverlay = null;
+  flush(): Promise<void> {
+    return Promise.resolve();
   }
 
   private formatPath(path: string): string {
     return `${this.prefix}${path}`;
+  }
+}
+
+/**
+ * A filesystem backed by Durable Object KV storage with a write-overlay.
+ * Writes are buffered in memory and only persisted to KV when `flush()` is
+ * called, avoiding the cost of a KV write on every individual file operation.
+ * Reads are served from the overlay when possible, falling back to KV, so
+ * callers always observe their own writes immediately.
+ *
+ * Implemented as an `OverlayFileSystem` wrapping a `DurableObjectRawFileSystem`.
+ * Use `DurableObjectRawFileSystem` directly if you want immediate per-write KV
+ * durability without buffering.
+ */
+export class DurableObjectKVFileSystem implements FileSystem {
+  private readonly fs: OverlayFileSystem;
+
+  /**
+   * @param storage The Durable Object storage instance to persist files to.
+   * @param prefix  An optional path prefix prepended to every key stored in KV.
+   *                Defaults to `"bundle/"`, which namespaces bundle files away
+   *                from any other keys the Durable Object may store.
+   */
+  constructor(storage: DurableObjectStorage, prefix: string = "bundle/") {
+    this.fs = new OverlayFileSystem(
+      new DurableObjectRawFileSystem(storage, prefix)
+    );
+  }
+
+  read(path: string): string | null {
+    return this.fs.read(path);
+  }
+
+  write(path: string, content: string): void {
+    this.fs.write(path, content);
+  }
+
+  flush(): Promise<void> {
+    return this.fs.flush();
   }
 }
 

--- a/packages/worker-bundler/src/file-system.ts
+++ b/packages/worker-bundler/src/file-system.ts
@@ -14,6 +14,13 @@ export interface FileSystem {
   write(path: string, content: string): void;
 
   /**
+   * Returns the logical paths of all files in the filesystem, optionally
+   * filtered to those whose path starts with `prefix`.
+   * @param prefix Optional path prefix to filter results.
+   */
+  list(prefix?: string): string[];
+
+  /**
    * Depending on the implementation of the filesystem writes may be buffered
    * in-memory to avoid (comparatively) expensive I/O operations. This method
    * gives users of the filesystem a way to ensure that all writes are flushed
@@ -46,6 +53,12 @@ export class InMemoryFileSystem implements FileSystem {
     this.files.set(path, content);
   }
 
+  list(prefix?: string): string[] {
+    return Array.from(this.files.keys()).filter(
+      (path) => prefix === undefined || path.startsWith(prefix)
+    );
+  }
+
   flush(): Promise<void> {
     return Promise.resolve();
   }
@@ -60,7 +73,7 @@ export class InMemoryFileSystem implements FileSystem {
  * filesystem. `flush()` drains the buffer by calling `inner.write()` for every
  * pending entry, awaits `inner.flush()`, and then clears the buffer.
  */
-class OverlayFileSystem implements FileSystem {
+export class OverlayFileSystem implements FileSystem {
   private overlay: Map<string, string> | null = null;
 
   constructor(private readonly inner: FileSystem) {}
@@ -74,6 +87,22 @@ class OverlayFileSystem implements FileSystem {
       this.overlay = new Map();
     }
     this.overlay.set(path, content);
+  }
+
+  list(prefix?: string): string[] {
+    const innerPaths = this.inner.list(prefix);
+    if (this.overlay === null) {
+      return innerPaths;
+    }
+    // Union of inner paths and overlay paths, with overlay entries taking
+    // precedence (Set deduplicates paths that appear in both).
+    const result = new Set(innerPaths);
+    for (const path of this.overlay.keys()) {
+      if (prefix === undefined || path.startsWith(prefix)) {
+        result.add(path);
+      }
+    }
+    return Array.from(result);
   }
 
   async flush(): Promise<void> {
@@ -118,6 +147,19 @@ export class DurableObjectRawFileSystem implements FileSystem {
     this.storage.kv.put(this.formatPath(path), content);
   }
 
+  list(prefix?: string): string[] {
+    const formattedPrefix =
+      prefix !== undefined ? this.formatPath(prefix) : this.prefix;
+    // kv.list() returns Iterable<[key, value]>. Strip the storage prefix from
+    // each key so callers always receive logical paths, consistent with
+    // InMemoryFileSystem.list().
+    const result: string[] = [];
+    for (const [key] of this.storage.kv.list({ prefix: formattedPrefix })) {
+      result.push(key.slice(this.prefix.length));
+    }
+    return result;
+  }
+
   flush(): Promise<void> {
     return Promise.resolve();
   }
@@ -159,6 +201,10 @@ export class DurableObjectKVFileSystem implements FileSystem {
 
   write(path: string, content: string): void {
     this.fs.write(path, content);
+  }
+
+  list(prefix?: string): string[] {
+    return this.fs.list(prefix);
   }
 
   flush(): Promise<void> {

--- a/packages/worker-bundler/src/file-system.ts
+++ b/packages/worker-bundler/src/file-system.ts
@@ -1,0 +1,124 @@
+export interface FileSystem {
+  /**
+   * Reads a file from the file system.
+   * @param path The path to the file.
+   * @returns The contents of the file, or `null` if the file does not exist.
+   */
+  read(path: string): string | null;
+
+  /**
+   * Writes a file to the file system.
+   * @param path The path to the file.
+   * @param content The contents of the file.
+   */
+  write(path: string, content: string): void;
+
+  /**
+   * Depending on the implementation of the filesystem writes may be buffered
+   * in-memory to avoid (comparatively) expensive I/O operations. This method
+   * gives users of the filesystem a way to ensure that all writes are flushed
+   * to disk.
+   */
+  flush(): Promise<void>;
+}
+
+/**
+ * A simple in-memory filesystem backed by a `Map`. Intended for use in tests
+ * and build pipelines where persistence is not required.
+ */
+export class InMemoryFileSystem implements FileSystem {
+  private files: Map<string, string> = new Map();
+
+  /**
+   * @param files Optional initial file contents. Accepts either a plain object
+   * (keys are paths, values are file contents) or a `Map`. Defaults to an
+   * empty filesystem.
+   */
+  constructor(files: Record<string, string> | Map<string, string> = new Map()) {
+    this.files = files instanceof Map ? files : new Map(Object.entries(files));
+  }
+
+  read(path: string): string | null {
+    return this.files.get(path) ?? null;
+  }
+
+  write(path: string, content: string): void {
+    this.files.set(path, content);
+  }
+
+  flush(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * A filesystem backed by Durable Object KV storage. Writes are buffered in an
+ * in-memory overlay and only persisted to KV when `flush()` is called, avoiding
+ * the cost of a KV write on every individual file operation. Reads are served
+ * from the overlay when possible, falling back to KV, so callers always observe
+ * their own writes immediately regardless of whether `flush()` has been called.
+ */
+export class DurableObjectKVFileSystem implements FileSystem {
+  /**
+   * An in-memory buffer of pending writes. Null until the first write occurs.
+   *
+   * Writes are held here rather than being sent directly to Durable Object KV
+   * because KV I/O is comparatively expensive due to I/O gates blocking
+   * side-effects until writes are confirmed durable. Reads consult the overlay
+   * first so callers always observe their own writes immediately. The buffered
+   * entries are only persisted to KV when `flush()` is called explicitly.
+   *
+   * Keys are stored in their fully-formatted form (i.e. with the path prefix
+   * already applied) so they can be passed to `kv.put` directly during flush
+   * without any transformation.
+   */
+  private writeOverlay: Map<string, string> | null = null;
+
+  /**
+   * @param storage The Durable Object storage instance to persist files to.
+   * @param prefix  An optional path prefix prepended to every key stored in KV.
+   *                Defaults to `"bundle/"`, which namespaces bundle files away
+   *                from any other keys the Durable Object may store.
+   */
+  constructor(
+    private storage: DurableObjectStorage,
+    private prefix: string = "bundle/"
+  ) {}
+
+  read(path: string): string | null {
+    const realPath = this.formatPath(path);
+    return (
+      this.writeOverlay?.get(realPath) ??
+      this.storage.kv.get<string>(realPath) ??
+      null
+    );
+  }
+
+  write(path: string, content: string): void {
+    if (this.writeOverlay === null) {
+      this.writeOverlay = new Map();
+    }
+    const realPath = this.formatPath(path);
+    this.writeOverlay.set(realPath, content);
+  }
+
+  async flush(): Promise<void> {
+    if (this.writeOverlay === null) {
+      return;
+    }
+    for (const [key, value] of this.writeOverlay) {
+      this.storage.kv.put(key, value);
+    }
+    this.writeOverlay = null;
+  }
+
+  private formatPath(path: string): string {
+    return `${this.prefix}${path}`;
+  }
+}
+
+export function isFileSystem(
+  obj: FileSystem | Record<string, string>
+): obj is FileSystem {
+  return "read" in obj && typeof obj.read === "function";
+}

--- a/packages/worker-bundler/src/file-system.ts
+++ b/packages/worker-bundler/src/file-system.ts
@@ -14,6 +14,12 @@ export interface FileSystem {
   write(path: string, content: string): void;
 
   /**
+   * Deletes a file from the file system.
+   * @param path The path to the file.
+   */
+  delete(path: string): void;
+
+  /**
    * Returns the logical paths of all files in the filesystem, optionally
    * filtered to those whose path starts with `prefix`.
    * @param prefix Optional path prefix to filter results.
@@ -53,6 +59,10 @@ export class InMemoryFileSystem implements FileSystem {
     this.files.set(path, content);
   }
 
+  delete(path: string): void {
+    this.files.delete(path);
+  }
+
   list(prefix?: string): string[] {
     return Array.from(this.files.keys()).filter(
       (path) => prefix === undefined || path.startsWith(prefix)
@@ -68,18 +78,26 @@ export class InMemoryFileSystem implements FileSystem {
  * A generic write-overlay on top of any `FileSystem`. Not exported — intended
  * as an implementation detail for higher-level filesystem classes.
  *
- * Writes are buffered in an in-memory `Map` keyed by the raw (untransformed)
- * path. Reads are served from the buffer first, then delegated to the inner
- * filesystem. `flush()` drains the buffer by calling `inner.write()` for every
- * pending entry, awaits `inner.flush()`, and then clears the buffer.
+ * Writes and deletes are buffered in memory keyed by the raw (untransformed)
+ * path. Reads are served from the write buffer first; deleted paths return
+ * `null`; remaining reads are delegated to the inner filesystem. `flush()`
+ * drains deletes and writes into the inner filesystem, awaits `inner.flush()`,
+ * and then clears the buffers.
  */
 export class OverlayFileSystem implements FileSystem {
   private overlay: Map<string, string> | null = null;
+  private deletions: Set<string> | null = null;
 
   constructor(private readonly inner: FileSystem) {}
 
   read(path: string): string | null {
-    return this.overlay?.get(path) ?? this.inner.read(path);
+    if (this.overlay?.has(path)) {
+      return this.overlay.get(path) ?? null;
+    }
+    if (this.deletions?.has(path)) {
+      return null;
+    }
+    return this.inner.read(path);
   }
 
   write(path: string, content: string): void {
@@ -87,17 +105,25 @@ export class OverlayFileSystem implements FileSystem {
       this.overlay = new Map();
     }
     this.overlay.set(path, content);
+    this.deletions?.delete(path);
+  }
+
+  delete(path: string): void {
+    this.overlay?.delete(path);
+    if (this.deletions === null) {
+      this.deletions = new Set();
+    }
+    this.deletions.add(path);
   }
 
   list(prefix?: string): string[] {
-    const innerPaths = this.inner.list(prefix);
-    if (this.overlay === null) {
-      return innerPaths;
-    }
+    const innerPaths = this.inner
+      .list(prefix)
+      .filter((path) => !this.deletions?.has(path));
     // Union of inner paths and overlay paths, with overlay entries taking
     // precedence (Set deduplicates paths that appear in both).
     const result = new Set(innerPaths);
-    for (const path of this.overlay.keys()) {
+    for (const path of this.overlay?.keys() ?? []) {
       if (prefix === undefined || path.startsWith(prefix)) {
         result.add(path);
       }
@@ -106,14 +132,18 @@ export class OverlayFileSystem implements FileSystem {
   }
 
   async flush(): Promise<void> {
-    if (this.overlay === null) {
+    if (this.overlay === null && this.deletions === null) {
       return;
     }
-    for (const [path, content] of this.overlay) {
+    for (const path of this.deletions ?? []) {
+      this.inner.delete(path);
+    }
+    for (const [path, content] of this.overlay ?? []) {
       this.inner.write(path, content);
     }
     await this.inner.flush();
     this.overlay = null;
+    this.deletions = null;
   }
 }
 
@@ -145,6 +175,10 @@ export class DurableObjectRawFileSystem implements FileSystem {
 
   write(path: string, content: string): void {
     this.storage.kv.put(this.formatPath(path), content);
+  }
+
+  delete(path: string): void {
+    this.storage.kv.delete(this.formatPath(path));
   }
 
   list(prefix?: string): string[] {
@@ -203,6 +237,10 @@ export class DurableObjectKVFileSystem implements FileSystem {
     this.fs.write(path, content);
   }
 
+  delete(path: string): void {
+    this.fs.delete(path);
+  }
+
   list(prefix?: string): string[] {
     return this.fs.list(prefix);
   }
@@ -215,5 +253,10 @@ export class DurableObjectKVFileSystem implements FileSystem {
 export function isFileSystem(
   obj: FileSystem | Record<string, string>
 ): obj is FileSystem {
-  return "read" in obj && typeof obj.read === "function";
+  return (
+    "read" in obj &&
+    typeof obj.read === "function" &&
+    "delete" in obj &&
+    typeof obj.delete === "function"
+  );
 }

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -50,6 +50,7 @@ export { inferContentType, isTextContentType } from "./mime";
 // Re-export file-system
 export {
   DurableObjectKVFileSystem,
+  DurableObjectRawFileSystem,
   InMemoryFileSystem,
   type FileSystem
 } from "./file-system";

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -11,6 +11,11 @@ import { transformAndResolve } from "./transformer";
 import type { CreateWorkerOptions, CreateWorkerResult } from "./types";
 import { detectEntryPoint } from "./utils";
 import { showExperimentalWarning } from "./experimental";
+import {
+  InMemoryFileSystem,
+  isFileSystem,
+  type FileSystem
+} from "./file-system";
 
 // Re-export types
 export type {
@@ -76,27 +81,33 @@ export async function createWorker(
     registry
   } = options;
 
+  let fileSystem: FileSystem;
+  if (isFileSystem(files)) {
+    fileSystem = files;
+  } else {
+    fileSystem = new InMemoryFileSystem(files);
+  }
+
   // Always treat cloudflare:* modules as external (runtime-provided)
   externals = ["cloudflare:", ...externals];
 
   // Parse wrangler config for compatibility settings
-  const wranglerConfig = parseWranglerConfig(files);
+  const wranglerConfig = parseWranglerConfig(fileSystem);
   const nodejsCompat = hasNodejsCompat(wranglerConfig);
 
   // Auto-install dependencies if package.json has dependencies
   const installWarnings: string[] = [];
-  if (hasDependencies(files)) {
+  if (hasDependencies(fileSystem)) {
     const installResult = await installDependencies(
-      files,
+      fileSystem,
       registry ? { registry } : {}
     );
-    files = installResult.files;
     installWarnings.push(...installResult.warnings);
   }
 
   // Detect entry point (priority: explicit option > wrangler main > package.json > defaults)
   const entryPoint =
-    options.entryPoint ?? detectEntryPoint(files, wranglerConfig);
+    options.entryPoint ?? detectEntryPoint(fileSystem, wranglerConfig);
 
   if (!entryPoint) {
     throw new Error(
@@ -104,14 +115,14 @@ export async function createWorker(
     );
   }
 
-  if (!(entryPoint in files)) {
+  if (fileSystem.read(entryPoint) === null) {
     throw new Error(`Entry point "${entryPoint}" not found in files.`);
   }
 
   if (bundle) {
     // Try bundling with esbuild-wasm
     const result = await bundleWithEsbuild(
-      files,
+      fileSystem,
       entryPoint,
       externals,
       target,
@@ -134,7 +145,7 @@ export async function createWorker(
   } else {
     // No bundling - transform files and resolve dependencies
     // Note: sourcemaps are not supported in transform mode (output mirrors input structure)
-    const result = await transformAndResolve(files, entryPoint, externals);
+    const result = await transformAndResolve(fileSystem, entryPoint, externals);
 
     // Add wrangler config if a config file was found
     if (wranglerConfig !== undefined) {

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -42,6 +42,13 @@ export type {
 // Re-export MIME utilities
 export { inferContentType, isTextContentType } from "./mime";
 
+// Re-export file-system
+export {
+  DurableObjectKVFileSystem,
+  InMemoryFileSystem,
+  type FileSystem
+} from "./file-system";
+
 /**
  * Creates a worker bundle from source files.
  *

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -49,6 +49,7 @@ export { inferContentType, isTextContentType } from "./mime";
 
 // Re-export file-system
 export {
+  createFileSystemSnapshot,
   DurableObjectKVFileSystem,
   DurableObjectRawFileSystem,
   InMemoryFileSystem,

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -54,6 +54,13 @@ export {
   type FileSystem
 } from "./file-system";
 
+// Re-export installer utilities
+export {
+  installDependencies,
+  hasDependencies,
+  type InstallResult
+} from "./installer";
+
 /**
  * Creates a worker bundle from source files.
  *

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -308,7 +308,7 @@ function resolveVersion(
 /**
  * Fetch and extract package files from npm tarball.
  */
-async function fetchPackageFiles(
+export async function fetchPackageFiles(
   name: string,
   metadata: PackageJson
 ): Promise<Record<string, string>> {

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -6,7 +6,7 @@
  */
 
 import * as semver from "semver";
-import type { Files } from "./types";
+import type { FileSystem } from "./file-system";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
@@ -70,11 +70,6 @@ interface InstallOptions {
 
 interface InstallResult {
   /**
-   * Files with node_modules populated
-   */
-  files: Files;
-
-  /**
    * Packages that were installed
    */
   installed: string[];
@@ -91,24 +86,23 @@ interface InstallResult {
  * Reads the package.json from the files, resolves all dependencies,
  * and populates node_modules with the package contents.
  *
- * @param files - Virtual file system containing package.json
+ * @param fileSystem - Virtual file system containing package.json
  * @param options - Installation options
- * @returns Files with node_modules populated
+ * @returns Metadata about the installation
  */
 export async function installDependencies(
-  files: Files,
+  fileSystem: FileSystem,
   options: InstallOptions = {}
 ): Promise<InstallResult> {
   const { dev = false, registry = NPM_REGISTRY } = options;
 
   const result: InstallResult = {
-    files: { ...files },
     installed: [],
     warnings: []
   };
 
   // Read package.json
-  const packageJsonContent = files["package.json"];
+  const packageJsonContent = fileSystem.read("package.json");
   if (!packageJsonContent) {
     return result; // No package.json, nothing to install
   }
@@ -143,6 +137,7 @@ export async function installDependencies(
         name,
         versionRange,
         result,
+        fileSystem,
         installedPackages,
         inProgress,
         registry
@@ -160,6 +155,7 @@ async function installPackage(
   name: string,
   versionRange: string,
   result: InstallResult,
+  fileSystem: FileSystem,
   installedPackages: Map<string, string>,
   inProgress: Map<string, Promise<void>>,
   registry: string
@@ -206,7 +202,7 @@ async function installPackage(
 
       // Add files to node_modules
       for (const [filePath, content] of Object.entries(packageFiles)) {
-        result.files[`node_modules/${name}/${filePath}`] = content;
+        fileSystem.write(`node_modules/${name}/${filePath}`, content);
       }
 
       // Install dependencies in parallel
@@ -217,6 +213,7 @@ async function installPackage(
             depName,
             depVersion,
             result,
+            fileSystem,
             installedPackages,
             inProgress,
             registry
@@ -505,8 +502,8 @@ function isTextFile(path: string): boolean {
 /**
  * Check if files contain a package.json with dependencies that need installing.
  */
-export function hasDependencies(files: Files): boolean {
-  const packageJson = files["package.json"];
+export function hasDependencies(files: FileSystem): boolean {
+  const packageJson = files.read("package.json");
   if (!packageJson) return false;
 
   try {

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -68,9 +68,10 @@ interface InstallOptions {
   registry?: string;
 }
 
-interface InstallResult {
+export interface InstallResult {
   /**
-   * Packages that were installed
+   * Packages that were freshly installed in this call.
+   * Packages already present in the filesystem are skipped and not listed here.
    */
   installed: string[];
 
@@ -160,8 +161,19 @@ async function installPackage(
   inProgress: Map<string, Promise<void>>,
   registry: string
 ): Promise<void> {
-  // Skip if already installed
+  // Skip if already installed in this run
   if (installedPackages.has(name)) {
+    return;
+  }
+
+  // Skip if the package already exists in the filesystem. This allows
+  // installDependencies to be called on a pre-warmed FileSystem (e.g. after a
+  // prior standalone installDependencies call, or a DO filesystem loaded from
+  // KV) without triggering redundant network fetches for packages that are
+  // already present. Transitive deps are assumed to also be present when the
+  // top-level package.json is found.
+  if (fileSystem.read(`node_modules/${name}/package.json`) !== null) {
+    installedPackages.set(name, "existing");
     return;
   }
 

--- a/packages/worker-bundler/src/resolver.ts
+++ b/packages/worker-bundler/src/resolver.ts
@@ -1,13 +1,13 @@
 // Use the asm.js version to avoid WASM (works in workerd)
 import { parse } from "es-module-lexer/js";
 import * as resolveExports from "resolve.exports";
-import type { Files } from "./types";
+import type { FileSystem } from "./file-system";
 
 export interface ResolveOptions {
   /**
    * All files in the virtual file system
    */
-  files: Files;
+  files: FileSystem;
 
   /**
    * Directory of the importing file (relative to root)
@@ -94,7 +94,7 @@ export function resolveModule(
 function resolveRelative(
   specifier: string,
   importer: string,
-  files: Files,
+  files: FileSystem,
   extensions: string[]
 ): string | undefined {
   // Get the directory of the importer
@@ -111,7 +111,7 @@ function resolveRelative(
  */
 function resolvePackage(
   specifier: string,
-  files: Files,
+  files: FileSystem,
   conditions: string[],
   extensions: string[]
 ): ResolveResult {
@@ -120,7 +120,7 @@ function resolvePackage(
 
   // Look for the package in node_modules
   const packageJsonPath = `node_modules/${packageName}/package.json`;
-  const packageJson = files[packageJsonPath];
+  const packageJson = files.read(packageJsonPath);
 
   if (!packageJson) {
     // Package not found in files, mark as external
@@ -145,7 +145,7 @@ function resolvePackage(
       const resolvedPath = resolved[0];
       if (resolvedPath) {
         const fullPath = `node_modules/${packageName}/${normalizeRelativePath(resolvedPath)}`;
-        if (fullPath in files) {
+        if (files.read(fullPath) !== null) {
           return { path: fullPath, external: false };
         }
       }
@@ -160,7 +160,7 @@ function resolvePackage(
   });
   if (legacyEntry && typeof legacyEntry === "string") {
     const fullPath = `node_modules/${packageName}/${normalizeRelativePath(legacyEntry)}`;
-    if (fullPath in files) {
+    if (files.read(fullPath) !== null) {
       return { path: fullPath, external: false };
     }
   }
@@ -184,21 +184,21 @@ function resolvePackage(
  */
 function resolveWithExtensions(
   path: string,
-  files: Files,
+  files: FileSystem,
   extensions: string[]
 ): string | undefined {
   // Normalize the path
   const normalized = normalizePath(path);
 
   // Try exact match first
-  if (normalized in files) {
+  if (files.read(normalized) !== null) {
     return normalized;
   }
 
   // Try adding extensions
   for (const ext of extensions) {
     const withExt = normalized + ext;
-    if (withExt in files) {
+    if (files.read(withExt) !== null) {
       return withExt;
     }
   }
@@ -206,7 +206,7 @@ function resolveWithExtensions(
   // Try index files
   for (const ext of extensions) {
     const indexPath = `${normalized}/index${ext}`;
-    if (indexPath in files) {
+    if (files.read(indexPath) !== null) {
       return indexPath;
     }
   }

--- a/packages/worker-bundler/src/tests/cloudflare-test.d.ts
+++ b/packages/worker-bundler/src/tests/cloudflare-test.d.ts
@@ -1,5 +1,6 @@
 declare namespace Cloudflare {
   interface Env {
     LOADER: WorkerLoader;
+    FS_TEST: DurableObjectNamespace<import("./test-main").FsTestDO>;
   }
 }

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -3,7 +3,9 @@ import { env } from "cloudflare:workers";
 import { createWorker } from "../index";
 import { parseWranglerConfig, hasNodejsCompat } from "../config";
 import { detectEntryPoint } from "../utils";
-import type { CreateWorkerOptions, Files } from "../types";
+import { runInDurableObject } from "cloudflare:test";
+import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
+import type { CreateWorkerOptions } from "../types";
 
 let testId = 0;
 
@@ -354,62 +356,150 @@ describe("createWorker output validation", () => {
   });
 });
 
+describe("createWorker with explicit FileSystem instances", () => {
+  // These tests verify that createWorker works correctly when given an explicit
+  // FileSystem instance rather than a plain Files object, and that the installer
+  // writes node_modules entries back into the provided FileSystem so they are
+  // immediately readable and (for DO storage) persist to KV after flush().
+  //
+  // is-number@7.0.0 is used as a minimal, dependency-free npm package.
+
+  const PACKAGE_JSON = JSON.stringify({
+    dependencies: { "is-number": "7.0.0" }
+  });
+  const WORKER_SRC = [
+    'import isNumber from "is-number";',
+    "export default {",
+    "  fetch() { return new Response(String(isNumber(42))); }",
+    "};"
+  ].join("\n");
+
+  it("InMemoryFileSystem: bundles correctly and node_modules are populated", async () => {
+    const fs = new InMemoryFileSystem({
+      "package.json": PACKAGE_JSON,
+      "src/index.ts": WORKER_SRC
+    });
+
+    const result = await createWorker({ files: fs });
+
+    expect(result.mainModule).toBe("bundle.js");
+    expect(typeof result.modules["bundle.js"]).toBe("string");
+
+    // The installer should have written is-number into the InMemoryFileSystem.
+    expect(fs.read("node_modules/is-number/package.json")).not.toBeNull();
+
+    // Smoke-test: load and run the bundled worker.
+    const id = "test-worker-" + testId++;
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: result.mainModule,
+      modules: result.modules,
+      compatibilityDate: "2026-01-01"
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(await response.text()).toBe("true");
+  });
+
+  it("DurableObjectKVFileSystem: bundles correctly, node_modules readable from overlay then persisted to KV after flush", async () => {
+    const stub = env.FS_TEST.get(env.FS_TEST.idFromName("bundler-do-fs"));
+
+    await runInDurableObject(stub, async (_instance, state) => {
+      const doFs = new DurableObjectKVFileSystem(state.storage);
+      doFs.write("package.json", PACKAGE_JSON);
+      doFs.write("src/index.ts", WORKER_SRC);
+
+      const result = await createWorker({ files: doFs });
+
+      expect(result.mainModule).toBe("bundle.js");
+      expect(typeof result.modules["bundle.js"]).toBe("string");
+
+      // Before flush, the installer's writes are buffered in the overlay and
+      // readable immediately via read().
+      expect(doFs.read("node_modules/is-number/package.json")).not.toBeNull();
+
+      // And since we haven't flushed yet, the KV should be empty
+      expect(
+        state.storage.kv.get<string>(
+          "bundle/node_modules/is-number/package.json"
+        )
+      ).toBeUndefined();
+
+      // After flush, every overlay entry is persisted to Durable Object KV.
+      await doFs.flush();
+      expect(
+        state.storage.kv.get<string>(
+          "bundle/node_modules/is-number/package.json"
+        )
+      ).not.toBeNull();
+    });
+  });
+});
+
 describe("detectEntryPoint", () => {
   it("detects from wrangler config main", () => {
-    const files: Files = { "src/worker.ts": "export default {}" };
+    const files = new InMemoryFileSystem({
+      "src/worker.ts": "export default {}"
+    });
     const config = { main: "src/worker.ts" };
     expect(detectEntryPoint(files, config)).toBe("src/worker.ts");
   });
 
   it("strips ./ from wrangler config main", () => {
-    const files: Files = { "src/worker.ts": "export default {}" };
+    const files = new InMemoryFileSystem({
+      "src/worker.ts": "export default {}"
+    });
     const config = { main: "./src/worker.ts" };
     expect(detectEntryPoint(files, config)).toBe("src/worker.ts");
   });
 
   it("detects from package.json main field", () => {
-    const files: Files = {
+    const files = new InMemoryFileSystem({
       "package.json": JSON.stringify({ main: "./lib/index.js" }),
       "lib/index.js": "export default {}"
-    };
+    });
     expect(detectEntryPoint(files, undefined)).toBe("lib/index.js");
   });
 
   it("detects from package.json exports field", () => {
-    const files: Files = {
+    const files = new InMemoryFileSystem({
       "package.json": JSON.stringify({
         exports: { ".": { import: "./src/entry.ts" } }
       }),
       "src/entry.ts": "export default {}"
-    };
+    });
     expect(detectEntryPoint(files, undefined)).toBe("src/entry.ts");
   });
 
   it("falls back to src/index.ts default", () => {
-    const files: Files = { "src/index.ts": "export default {}" };
+    const files = new InMemoryFileSystem({
+      "src/index.ts": "export default {}"
+    });
     expect(detectEntryPoint(files, undefined)).toBe("src/index.ts");
   });
 
   it("falls back to index.ts default", () => {
-    const files: Files = { "index.ts": "export default {}" };
+    const files = new InMemoryFileSystem({ "index.ts": "export default {}" });
     expect(detectEntryPoint(files, undefined)).toBe("index.ts");
   });
 
   it("returns undefined when no entry found", () => {
-    const files: Files = { "lib/other.ts": "export const x = 1;" };
+    const files = new InMemoryFileSystem({
+      "lib/other.ts": "export const x = 1;"
+    });
     expect(detectEntryPoint(files, undefined)).toBeUndefined();
   });
 });
 
 describe("parseWranglerConfig", () => {
   it("parses wrangler.toml", () => {
-    const files: Files = {
+    const files = new InMemoryFileSystem({
       "wrangler.toml": [
         'main = "src/index.ts"',
         'compatibility_date = "2026-01-01"',
         'compatibility_flags = ["nodejs_compat"]'
       ].join("\n")
-    };
+    });
     const config = parseWranglerConfig(files);
     expect(config).toBeDefined();
     expect(config?.main).toBe("src/index.ts");
@@ -418,19 +508,19 @@ describe("parseWranglerConfig", () => {
   });
 
   it("parses wrangler.json", () => {
-    const files: Files = {
+    const files = new InMemoryFileSystem({
       "wrangler.json": JSON.stringify({
         main: "src/index.ts",
         compatibility_date: "2026-01-01"
       })
-    };
+    });
     const config = parseWranglerConfig(files);
     expect(config?.main).toBe("src/index.ts");
     expect(config?.compatibilityDate).toBe("2026-01-01");
   });
 
   it("parses wrangler.jsonc with comments", () => {
-    const files: Files = {
+    const files = new InMemoryFileSystem({
       "wrangler.jsonc": [
         "{",
         "  // Entry point",
@@ -439,19 +529,23 @@ describe("parseWranglerConfig", () => {
         '  "compatibility_date": "2026-01-01"',
         "}"
       ].join("\n")
-    };
+    });
     const config = parseWranglerConfig(files);
     expect(config?.main).toBe("src/index.ts");
     expect(config?.compatibilityDate).toBe("2026-01-01");
   });
 
   it("returns undefined when no config file exists", () => {
-    const files: Files = { "src/index.ts": "export default {}" };
+    const files = new InMemoryFileSystem({
+      "src/index.ts": "export default {}"
+    });
     expect(parseWranglerConfig(files)).toBeUndefined();
   });
 
   it("returns empty object for invalid toml", () => {
-    const files: Files = { "wrangler.toml": "not valid toml {{{" };
+    const files = new InMemoryFileSystem({
+      "wrangler.toml": "not valid toml {{{"
+    });
     const config = parseWranglerConfig(files);
     expect(config).toEqual({});
   });

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
 import { createWorker, installDependencies } from "../index";
 import { parseWranglerConfig, hasNodejsCompat } from "../config";
@@ -6,6 +6,7 @@ import { detectEntryPoint } from "../utils";
 import { runInDurableObject } from "cloudflare:test";
 import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
 import type { CreateWorkerOptions } from "../types";
+import { createTypescriptLanguageService } from "../typescript";
 
 let testId = 0;
 
@@ -422,6 +423,62 @@ describe("installDependencies (standalone)", () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+});
+
+describe("installDependencies + createTypeChecker e2e", () => {
+  it("installs worker types into a filesystem and typechecks a worker source", async () => {
+    const fs = new InMemoryFileSystem({
+      "package.json": JSON.stringify({
+        dependencies: {
+          "@cloudflare/workers-types": "^4.20260405.1"
+        }
+      }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          lib: ["es2024"],
+          target: "ES2024",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          allowSyntheticDefaultImports: true,
+          strict: true,
+          skipLibCheck: true,
+          types: ["@cloudflare/workers-types/index.d.ts"]
+        }
+      }),
+      "src/index.ts": [
+        "const worker: ExportedHandler = {",
+        "async fetch() {",
+        '    return new Response("10");',
+        "  }",
+        "};",
+        "",
+        "export default worker;"
+      ].join("\n")
+    });
+
+    const installResult = await installDependencies(fs);
+
+    expect(
+      installResult.installed.some((pkg) =>
+        pkg.startsWith("@cloudflare/workers-types@")
+      )
+    ).toBe(true);
+    expect(
+      fs.read("node_modules/@cloudflare/workers-types/package.json")
+    ).not.toBeNull();
+
+    const { languageService } = await createTypescriptLanguageService({
+      fileSystem: fs
+    });
+
+    const compilerOptionsDiagnostics =
+      await languageService.getCompilerOptionsDiagnostics();
+    const semanticDiagnostics =
+      await languageService.getSemanticDiagnostics("src/index.ts");
+
+    expect(compilerOptionsDiagnostics).toEqual([]);
+    expect(semanticDiagnostics).toEqual([]);
   });
 });
 

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { env } from "cloudflare:workers";
-import { createWorker } from "../index";
+import { createWorker, installDependencies } from "../index";
 import { parseWranglerConfig, hasNodejsCompat } from "../config";
 import { detectEntryPoint } from "../utils";
 import { runInDurableObject } from "cloudflare:test";
@@ -27,6 +27,16 @@ async function buildAndFetch(
   }));
   return worker.getEntrypoint().fetch(request);
 }
+
+// Shared fixtures used by the installer and FileSystem integration tests.
+// is-number@7.0.0 is a minimal, dependency-free npm package.
+const PACKAGE_JSON = JSON.stringify({ dependencies: { "is-number": "7.0.0" } });
+const WORKER_SRC = [
+  'import isNumber from "is-number";',
+  "export default {",
+  "  fetch() { return new Response(String(isNumber(42))); }",
+  "};"
+].join("\n");
 
 describe("createWorker e2e (build + load + fetch)", () => {
   it("bundles and runs a simple worker", async () => {
@@ -356,23 +366,70 @@ describe("createWorker output validation", () => {
   });
 });
 
+describe("installDependencies (standalone)", () => {
+  it("installs packages into a FileSystem and reports what was installed", async () => {
+    const fs = new InMemoryFileSystem({
+      "package.json": PACKAGE_JSON,
+      "src/index.ts": WORKER_SRC
+    });
+
+    const result = await installDependencies(fs);
+
+    expect(result.warnings).toHaveLength(0);
+    expect(result.installed).toContain("is-number@7.0.0");
+    expect(fs.read("node_modules/is-number/package.json")).not.toBeNull();
+  });
+
+  it("skips packages whose node_modules entry already exists in the filesystem", async () => {
+    // Pre-seed is-number to simulate a filesystem loaded from a prior install
+    // (e.g. a DO KV store that was flushed and reloaded).
+    const fs = new InMemoryFileSystem({
+      "package.json": PACKAGE_JSON,
+      "node_modules/is-number/package.json": JSON.stringify({
+        name: "is-number",
+        version: "7.0.0"
+      }),
+      "node_modules/is-number/index.js": "// stub module"
+    });
+
+    const result = await installDependencies(fs);
+
+    // Nothing should have been fetched — the package was already present.
+    expect(result.installed).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("createWorker does not re-install packages already present from a prior installDependencies call", async () => {
+    const fs = new InMemoryFileSystem({
+      "package.json": PACKAGE_JSON,
+      "src/index.ts": WORKER_SRC
+    });
+
+    // Pre-install independently — this is the only place a real network fetch
+    // should occur.
+    const installResult = await installDependencies(fs);
+    expect(installResult.installed).toContain("is-number@7.0.0");
+
+    // Spy on fetch after the first install. Any call during createWorker would
+    // mean the skip guard failed and a redundant network request was made.
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    try {
+      const workerResult = await createWorker({ files: fs });
+      expect(workerResult.mainModule).toBe("bundle.js");
+      expect(workerResult.warnings).toBeUndefined();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
 describe("createWorker with explicit FileSystem instances", () => {
   // These tests verify that createWorker works correctly when given an explicit
   // FileSystem instance rather than a plain Files object, and that the installer
   // writes node_modules entries back into the provided FileSystem so they are
   // immediately readable and (for DO storage) persist to KV after flush().
-  //
-  // is-number@7.0.0 is used as a minimal, dependency-free npm package.
-
-  const PACKAGE_JSON = JSON.stringify({
-    dependencies: { "is-number": "7.0.0" }
-  });
-  const WORKER_SRC = [
-    'import isNumber from "is-number";',
-    "export default {",
-    "  fetch() { return new Response(String(isNumber(42))); }",
-    "};"
-  ].join("\n");
 
   it("InMemoryFileSystem: bundles correctly and node_modules are populated", async () => {
     const fs = new InMemoryFileSystem({

--- a/packages/worker-bundler/src/tests/file-system.test.ts
+++ b/packages/worker-bundler/src/tests/file-system.test.ts
@@ -3,6 +3,7 @@ import { runInDurableObject } from "cloudflare:test";
 import { describe, it, expect } from "vitest";
 import {
   InMemoryFileSystem,
+  OverlayFileSystem,
   DurableObjectKVFileSystem,
   DurableObjectRawFileSystem
 } from "../file-system";
@@ -37,6 +38,20 @@ describe("InMemoryFileSystem", () => {
     const fs = new InMemoryFileSystem({ "foo.ts": "v1" });
     fs.write("foo.ts", "v2");
     expect(fs.read("foo.ts")).toBe("v2");
+  });
+
+  it("delete removes existing content", () => {
+    const fs = new InMemoryFileSystem({ "foo.ts": "content" });
+    fs.delete("foo.ts");
+    expect(fs.read("foo.ts")).toBeNull();
+    expect(fs.list()).toEqual([]);
+  });
+
+  it("delete is a no-op for a missing path", () => {
+    const fs = new InMemoryFileSystem();
+    fs.delete("missing.ts");
+    expect(fs.read("missing.ts")).toBeNull();
+    expect(fs.list()).toEqual([]);
   });
 
   it("writes to different paths are independent", () => {
@@ -81,6 +96,54 @@ describe("InMemoryFileSystem", () => {
     await expect(fs.flush()).resolves.toBeUndefined();
     // State is preserved after flush
     expect(fs.read("foo.ts")).toBe("content");
+  });
+});
+
+// ── OverlayFileSystem ────────────────────────────────────────────────
+
+describe("OverlayFileSystem", () => {
+  it("delete hides inner files before flush", () => {
+    const inner = new InMemoryFileSystem({ "index.ts": "persisted" });
+    const fs = new OverlayFileSystem(inner);
+
+    fs.delete("index.ts");
+
+    expect(fs.read("index.ts")).toBeNull();
+    expect(fs.list()).toEqual([]);
+    expect(inner.read("index.ts")).toBe("persisted");
+  });
+
+  it("flush persists deletes to the inner filesystem", async () => {
+    const inner = new InMemoryFileSystem({ "index.ts": "persisted" });
+    const fs = new OverlayFileSystem(inner);
+
+    fs.delete("index.ts");
+    await fs.flush();
+
+    expect(inner.read("index.ts")).toBeNull();
+    expect(inner.list()).toEqual([]);
+  });
+
+  it("delete removes pending overlay writes", () => {
+    const inner = new InMemoryFileSystem();
+    const fs = new OverlayFileSystem(inner);
+
+    fs.write("index.ts", "new");
+    fs.delete("index.ts");
+
+    expect(fs.read("index.ts")).toBeNull();
+    expect(fs.list()).toEqual([]);
+  });
+
+  it("write after delete restores the file", () => {
+    const inner = new InMemoryFileSystem({ "index.ts": "persisted" });
+    const fs = new OverlayFileSystem(inner);
+
+    fs.delete("index.ts");
+    fs.write("index.ts", "replacement");
+
+    expect(fs.read("index.ts")).toBe("replacement");
+    expect(fs.list()).toEqual(["index.ts"]);
   });
 });
 
@@ -182,6 +245,56 @@ describe("DurableObjectKVFileSystem", () => {
     );
   });
 
+  it("delete hides persisted KV entries before flush", async () => {
+    await runInDurableObject(
+      makeStub("delete-hides-persisted"),
+      async (_instance, state) => {
+        state.storage.kv.put("bundle/index.ts", "persisted");
+        const fs = new DurableObjectKVFileSystem(state.storage);
+
+        fs.delete("index.ts");
+
+        expect(fs.read("index.ts")).toBeNull();
+        expect(fs.list()).toEqual([]);
+        expect(state.storage.kv.get<string>("bundle/index.ts")).toBe(
+          "persisted"
+        );
+      }
+    );
+  });
+
+  it("flush persists deletes to KV", async () => {
+    await runInDurableObject(
+      makeStub("delete-flushes"),
+      async (_instance, state) => {
+        state.storage.kv.put("bundle/index.ts", "persisted");
+        const fs = new DurableObjectKVFileSystem(state.storage);
+
+        fs.delete("index.ts");
+        await fs.flush();
+
+        expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
+        expect(fs.read("index.ts")).toBeNull();
+      }
+    );
+  });
+
+  it("delete removes pending overlay writes before flush", async () => {
+    await runInDurableObject(
+      makeStub("delete-overlay-write"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage);
+
+        fs.write("index.ts", "new");
+        fs.delete("index.ts");
+        await fs.flush();
+
+        expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
+        expect(fs.read("index.ts")).toBeNull();
+      }
+    );
+  });
+
   it("custom prefix is applied to KV keys", async () => {
     await runInDurableObject(
       makeStub("custom-prefix"),
@@ -274,6 +387,21 @@ describe("DurableObjectRawFileSystem", () => {
         const fs = new DurableObjectRawFileSystem(state.storage);
         fs.write("index.ts", "content");
         expect(fs.read("index.ts")).toBe("content");
+      }
+    );
+  });
+
+  it("delete removes content immediately from KV", async () => {
+    await runInDurableObject(
+      makeStub("raw-delete"),
+      async (_instance, state) => {
+        const fs = new DurableObjectRawFileSystem(state.storage);
+        fs.write("index.ts", "content");
+
+        fs.delete("index.ts");
+
+        expect(fs.read("index.ts")).toBeNull();
+        expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
       }
     );
   });

--- a/packages/worker-bundler/src/tests/file-system.test.ts
+++ b/packages/worker-bundler/src/tests/file-system.test.ts
@@ -48,6 +48,33 @@ describe("InMemoryFileSystem", () => {
     expect(fs.read("c.ts")).toBeNull();
   });
 
+  it("list returns all paths", () => {
+    const fs = new InMemoryFileSystem({
+      "src/index.ts": "",
+      "src/utils.ts": "",
+      "README.md": ""
+    });
+    expect(fs.list().sort()).toEqual([
+      "README.md",
+      "src/index.ts",
+      "src/utils.ts"
+    ]);
+  });
+
+  it("list filters by prefix", () => {
+    const fs = new InMemoryFileSystem({
+      "src/index.ts": "",
+      "src/utils.ts": "",
+      "README.md": ""
+    });
+    expect(fs.list("src/").sort()).toEqual(["src/index.ts", "src/utils.ts"]);
+  });
+
+  it("list returns empty array when nothing matches", () => {
+    const fs = new InMemoryFileSystem({ "src/index.ts": "" });
+    expect(fs.list("lib/")).toEqual([]);
+  });
+
   it("flush is a no-op that resolves immediately", async () => {
     const fs = new InMemoryFileSystem();
     fs.write("foo.ts", "content");
@@ -168,6 +195,51 @@ describe("DurableObjectKVFileSystem", () => {
       }
     );
   });
+
+  it("list returns overlay entries before flush", async () => {
+    await runInDurableObject(
+      makeStub("kv-list-overlay"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        fs.write("src/index.ts", "");
+        fs.write("src/utils.ts", "");
+        expect(fs.list("src/").sort()).toEqual([
+          "src/index.ts",
+          "src/utils.ts"
+        ]);
+      }
+    );
+  });
+
+  it("list merges overlay and persisted KV entries after partial flush", async () => {
+    await runInDurableObject(
+      makeStub("kv-list-merge"),
+      async (_instance, state) => {
+        // Persist one file to KV
+        state.storage.kv.put("bundle/persisted.ts", "");
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        // Add a new file via the overlay (not yet flushed)
+        fs.write("overlay.ts", "");
+        const paths = fs.list().sort();
+        expect(paths).toContain("persisted.ts");
+        expect(paths).toContain("overlay.ts");
+      }
+    );
+  });
+
+  it("list deduplicates paths that exist in both overlay and KV", async () => {
+    await runInDurableObject(
+      makeStub("kv-list-dedup"),
+      async (_instance, state) => {
+        // Seed KV with a file
+        state.storage.kv.put("bundle/index.ts", "old");
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        // Write to overlay — same path should only appear once in list()
+        fs.write("index.ts", "new");
+        expect(fs.list()).toEqual(["index.ts"]);
+      }
+    );
+  });
 });
 
 // ── DurableObjectRawFileSystem ───────────────────────────────────────
@@ -226,6 +298,36 @@ describe("DurableObjectRawFileSystem", () => {
         fs.write("index.ts", "content");
         expect(state.storage.kv.get<string>("src/index.ts")).toBe("content");
         expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
+      }
+    );
+  });
+
+  it("list returns logical paths (without storage prefix)", async () => {
+    await runInDurableObject(makeStub("raw-list"), async (_instance, state) => {
+      const fs = new DurableObjectRawFileSystem(state.storage);
+      fs.write("src/index.ts", "");
+      fs.write("src/utils.ts", "");
+      fs.write("README.md", "");
+      expect(fs.list().sort()).toEqual([
+        "README.md",
+        "src/index.ts",
+        "src/utils.ts"
+      ]);
+    });
+  });
+
+  it("list filters by prefix", async () => {
+    await runInDurableObject(
+      makeStub("raw-list-prefix"),
+      async (_instance, state) => {
+        const fs = new DurableObjectRawFileSystem(state.storage);
+        fs.write("src/index.ts", "");
+        fs.write("src/utils.ts", "");
+        fs.write("README.md", "");
+        expect(fs.list("src/").sort()).toEqual([
+          "src/index.ts",
+          "src/utils.ts"
+        ]);
       }
     );
   });

--- a/packages/worker-bundler/src/tests/file-system.test.ts
+++ b/packages/worker-bundler/src/tests/file-system.test.ts
@@ -1,7 +1,11 @@
 import { env } from "cloudflare:workers";
 import { runInDurableObject } from "cloudflare:test";
 import { describe, it, expect } from "vitest";
-import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
+import {
+  InMemoryFileSystem,
+  DurableObjectKVFileSystem,
+  DurableObjectRawFileSystem
+} from "../file-system";
 
 // ── InMemoryFileSystem ───────────────────────────────────────────────
 
@@ -159,6 +163,67 @@ describe("DurableObjectKVFileSystem", () => {
         fs.write("index.ts", "content");
         await fs.flush();
         // Key should use the custom prefix, not the default "bundle/"
+        expect(state.storage.kv.get<string>("src/index.ts")).toBe("content");
+        expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
+      }
+    );
+  });
+});
+
+// ── DurableObjectRawFileSystem ───────────────────────────────────────
+
+describe("DurableObjectRawFileSystem", () => {
+  it("read returns null for a missing path", async () => {
+    await runInDurableObject(
+      makeStub("raw-read-null"),
+      async (_instance, state) => {
+        const fs = new DurableObjectRawFileSystem(state.storage);
+        expect(fs.read("index.ts")).toBeNull();
+      }
+    );
+  });
+
+  it("write persists immediately to KV without a flush", async () => {
+    await runInDurableObject(
+      makeStub("raw-write-immediate"),
+      async (_instance, state) => {
+        const fs = new DurableObjectRawFileSystem(state.storage);
+        fs.write("index.ts", "hello");
+        // Unlike DurableObjectKVFileSystem, no flush() is needed
+        expect(state.storage.kv.get<string>("bundle/index.ts")).toBe("hello");
+      }
+    );
+  });
+
+  it("read returns content written via write", async () => {
+    await runInDurableObject(
+      makeStub("raw-write-read"),
+      async (_instance, state) => {
+        const fs = new DurableObjectRawFileSystem(state.storage);
+        fs.write("index.ts", "content");
+        expect(fs.read("index.ts")).toBe("content");
+      }
+    );
+  });
+
+  it("flush is a no-op", async () => {
+    await runInDurableObject(
+      makeStub("raw-flush-noop"),
+      async (_instance, state) => {
+        const fs = new DurableObjectRawFileSystem(state.storage);
+        fs.write("index.ts", "content");
+        await expect(fs.flush()).resolves.toBeUndefined();
+        expect(fs.read("index.ts")).toBe("content");
+      }
+    );
+  });
+
+  it("custom prefix is applied to KV keys", async () => {
+    await runInDurableObject(
+      makeStub("raw-custom-prefix"),
+      async (_instance, state) => {
+        const fs = new DurableObjectRawFileSystem(state.storage, "src/");
+        fs.write("index.ts", "content");
         expect(state.storage.kv.get<string>("src/index.ts")).toBe("content");
         expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
       }

--- a/packages/worker-bundler/src/tests/file-system.test.ts
+++ b/packages/worker-bundler/src/tests/file-system.test.ts
@@ -5,7 +5,8 @@ import {
   InMemoryFileSystem,
   OverlayFileSystem,
   DurableObjectKVFileSystem,
-  DurableObjectRawFileSystem
+  DurableObjectRawFileSystem,
+  createFileSystemSnapshot
 } from "../file-system";
 
 // ── InMemoryFileSystem ───────────────────────────────────────────────
@@ -458,5 +459,54 @@ describe("DurableObjectRawFileSystem", () => {
         ]);
       }
     );
+  });
+});
+
+// ── createFileSystemSnapshot ─────────────────────────────────────────
+
+describe("createFileSystemSnapshot", () => {
+  it("creates a filesystem from a sync iterable of entries", async () => {
+    const entries: Array<readonly [string, string]> = [
+      ["src/index.ts", "export default 1;"],
+      ["src/utils.ts", "export const x = 2;"]
+    ];
+
+    const fs = await createFileSystemSnapshot(entries);
+
+    expect(fs.read("src/index.ts")).toBe("export default 1;");
+    expect(fs.read("src/utils.ts")).toBe("export const x = 2;");
+    expect(fs.list().sort()).toEqual(["src/index.ts", "src/utils.ts"]);
+  });
+
+  it("creates a filesystem from an async iterable of entries", async () => {
+    async function* generate() {
+      yield ["a.ts", "aaa"] as const;
+      yield ["b.ts", "bbb"] as const;
+    }
+
+    const fs = await createFileSystemSnapshot(generate());
+
+    expect(fs.read("a.ts")).toBe("aaa");
+    expect(fs.read("b.ts")).toBe("bbb");
+    expect(fs.list().sort()).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("returns an empty filesystem for an empty iterable", async () => {
+    const fs = await createFileSystemSnapshot([]);
+
+    expect(fs.list()).toEqual([]);
+    expect(fs.read("anything")).toBeNull();
+  });
+
+  it("last write wins when entries contain duplicate paths", async () => {
+    const entries: Array<readonly [string, string]> = [
+      ["index.ts", "v1"],
+      ["index.ts", "v2"]
+    ];
+
+    const fs = await createFileSystemSnapshot(entries);
+
+    expect(fs.read("index.ts")).toBe("v2");
+    expect(fs.list()).toEqual(["index.ts"]);
   });
 });

--- a/packages/worker-bundler/src/tests/file-system.test.ts
+++ b/packages/worker-bundler/src/tests/file-system.test.ts
@@ -1,0 +1,167 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
+
+// ── InMemoryFileSystem ───────────────────────────────────────────────
+
+describe("InMemoryFileSystem", () => {
+  it("read returns null for a missing path", () => {
+    const fs = new InMemoryFileSystem();
+    expect(fs.read("index.ts")).toBeNull();
+  });
+
+  it("can be seeded from a plain object", () => {
+    const fs = new InMemoryFileSystem({ "index.ts": "export default 1" });
+    expect(fs.read("index.ts")).toBe("export default 1");
+  });
+
+  it("can be seeded from a Map", () => {
+    const fs = new InMemoryFileSystem(
+      new Map([["index.ts", "export default 1"]])
+    );
+    expect(fs.read("index.ts")).toBe("export default 1");
+  });
+
+  it("write then read returns the written content", () => {
+    const fs = new InMemoryFileSystem();
+    fs.write("foo.ts", "const x = 1");
+    expect(fs.read("foo.ts")).toBe("const x = 1");
+  });
+
+  it("write overwrites existing content", () => {
+    const fs = new InMemoryFileSystem({ "foo.ts": "v1" });
+    fs.write("foo.ts", "v2");
+    expect(fs.read("foo.ts")).toBe("v2");
+  });
+
+  it("writes to different paths are independent", () => {
+    const fs = new InMemoryFileSystem();
+    fs.write("a.ts", "aaa");
+    fs.write("b.ts", "bbb");
+    expect(fs.read("a.ts")).toBe("aaa");
+    expect(fs.read("b.ts")).toBe("bbb");
+    expect(fs.read("c.ts")).toBeNull();
+  });
+
+  it("flush is a no-op that resolves immediately", async () => {
+    const fs = new InMemoryFileSystem();
+    fs.write("foo.ts", "content");
+    await expect(fs.flush()).resolves.toBeUndefined();
+    // State is preserved after flush
+    expect(fs.read("foo.ts")).toBe("content");
+  });
+});
+
+// ── DurableObjectKVFileSystem ────────────────────────────────────────
+
+// Each test gets its own uniquely-named DO instance so that direct KV writes
+// in one test cannot contaminate another. DO storage is backed by an in-memory
+// SQLite database that persists across runInDurableObject calls within the same
+// test run, so sharing an ID across tests would cause cross-test interference.
+function makeStub(id: string) {
+  return env.FS_TEST.get(env.FS_TEST.idFromName(id));
+}
+
+describe("DurableObjectKVFileSystem", () => {
+  it("read returns null for a missing path", async () => {
+    await runInDurableObject(
+      makeStub("read-null"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        expect(fs.read("index.ts")).toBeNull();
+      }
+    );
+  });
+
+  it("write then read returns the written content from the overlay", async () => {
+    await runInDurableObject(
+      makeStub("write-read"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        fs.write("index.ts", "export default 1");
+        expect(fs.read("index.ts")).toBe("export default 1");
+      }
+    );
+  });
+
+  it("write does not immediately persist to KV — flush is required", async () => {
+    await runInDurableObject(
+      makeStub("write-no-persist"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        fs.write("index.ts", "export default 1");
+        // Key should not be in KV yet (still buffered in the overlay)
+        expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
+      }
+    );
+  });
+
+  it("flush writes all overlay entries to KV", async () => {
+    await runInDurableObject(
+      makeStub("flush-writes"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        fs.write("a.ts", "aaa");
+        fs.write("b.ts", "bbb");
+        await fs.flush();
+        expect(state.storage.kv.get<string>("bundle/a.ts")).toBe("aaa");
+        expect(state.storage.kv.get<string>("bundle/b.ts")).toBe("bbb");
+      }
+    );
+  });
+
+  it("flush clears the overlay so subsequent reads fall back to KV", async () => {
+    await runInDurableObject(
+      makeStub("flush-clears"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        fs.write("index.ts", "v1");
+        await fs.flush();
+        // Update KV directly to "v2" — the overlay is gone, so fs must read from KV
+        state.storage.kv.put("bundle/index.ts", "v2");
+        expect(fs.read("index.ts")).toBe("v2");
+      }
+    );
+  });
+
+  it("read falls back to KV when the path is not in the overlay", async () => {
+    await runInDurableObject(
+      makeStub("read-kv-fallback"),
+      async (_instance, state) => {
+        // Write directly to KV, bypassing the overlay
+        state.storage.kv.put("bundle/index.ts", "from-kv");
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        expect(fs.read("index.ts")).toBe("from-kv");
+      }
+    );
+  });
+
+  it("overlay shadows KV — overlay value wins before flush", async () => {
+    await runInDurableObject(
+      makeStub("overlay-shadows"),
+      async (_instance, state) => {
+        // Seed KV with an old value
+        state.storage.kv.put("bundle/index.ts", "old");
+        const fs = new DurableObjectKVFileSystem(state.storage);
+        // Write a newer value into the overlay
+        fs.write("index.ts", "new");
+        expect(fs.read("index.ts")).toBe("new");
+      }
+    );
+  });
+
+  it("custom prefix is applied to KV keys", async () => {
+    await runInDurableObject(
+      makeStub("custom-prefix"),
+      async (_instance, state) => {
+        const fs = new DurableObjectKVFileSystem(state.storage, "src/");
+        fs.write("index.ts", "content");
+        await fs.flush();
+        // Key should use the custom prefix, not the default "bundle/"
+        expect(state.storage.kv.get<string>("src/index.ts")).toBe("content");
+        expect(state.storage.kv.get("bundle/index.ts")).toBeUndefined();
+      }
+    );
+  });
+});

--- a/packages/worker-bundler/src/tests/global-setup.ts
+++ b/packages/worker-bundler/src/tests/global-setup.ts
@@ -1,18 +1,26 @@
 import { copyFileSync, existsSync, unlinkSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-
+import {
+  bundleTypeScriptForWorkers,
+  removeBundledTypeScript
+} from "../../scripts/typescript-browser-bundle";
 const require = createRequire(import.meta.url);
 const wasmSrc = require.resolve("esbuild-wasm/esbuild.wasm");
 const wasmDest = path.resolve(import.meta.dirname, "../esbuild.wasm");
+const packageRoot = path.resolve(import.meta.dirname, "../..");
 
-export function setup() {
+export async function setup() {
+  await bundleTypeScriptForWorkers(packageRoot);
+
   if (!existsSync(wasmDest)) {
     copyFileSync(wasmSrc, wasmDest);
   }
 }
 
 export function teardown() {
+  removeBundledTypeScript(packageRoot);
+
   if (existsSync(wasmDest)) {
     unlinkSync(wasmDest);
   }

--- a/packages/worker-bundler/src/tests/test-main.ts
+++ b/packages/worker-bundler/src/tests/test-main.ts
@@ -1,0 +1,18 @@
+/**
+ * Test entry point for the worker-bundler test suite.
+ *
+ * Re-exports the full public API from the real index so that all existing
+ * tests continue to work unmodified, and additionally exports Durable Object
+ * classes that are only needed as test fixtures (e.g. to obtain a real
+ * DurableObjectStorage instance via runInDurableObject).
+ */
+export * from "../index";
+
+import { DurableObject } from "cloudflare:workers";
+
+/**
+ * Minimal Durable Object used as a test fixture for DurableObjectKVFileSystem
+ * tests. It has no business logic of its own; its sole purpose is to provide
+ * a real DurableObjectStorage instance via runInDurableObject().
+ */
+export class FsTestDO extends DurableObject {}

--- a/packages/worker-bundler/src/tests/typescript.test.ts
+++ b/packages/worker-bundler/src/tests/typescript.test.ts
@@ -91,4 +91,32 @@ describe("createTypescriptLanguageService", () => {
       environment.languageService.getSemanticDiagnostics("index.ts")
     ).toEqual([]);
   });
+
+  it("writes a new file not in the original root set", async () => {
+    const fileSystem = new InMemoryFileSystem({
+      "tsconfig.json": tsconfig,
+      "index.ts": 'import { helper } from "./utils";'
+    });
+
+    const environment = await createTypescriptLanguageService({ fileSystem });
+
+    expect(
+      environment.languageService.getSemanticDiagnostics("index.ts")
+    ).not.toHaveLength(0);
+
+    environment.fileSystem.write(
+      "utils.ts",
+      "export function helper(): void {}"
+    );
+
+    expect(fileSystem.read("utils.ts")).toBe(
+      "export function helper(): void {}"
+    );
+    expect(
+      environment.languageService.getProgram()!.getSourceFile("utils.ts")
+    ).toBeDefined();
+    expect(
+      environment.languageService.getSemanticDiagnostics("utils.ts")
+    ).toEqual([]);
+  });
 });

--- a/packages/worker-bundler/src/tests/typescript.test.ts
+++ b/packages/worker-bundler/src/tests/typescript.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryFileSystem } from "../file-system";
+import { createTypescriptLanguageService } from "../typescript";
+
+const tsconfig = JSON.stringify({ compilerOptions: { lib: ["es2024"] } });
+
+describe("createTypescriptLanguageService", () => {
+  it("creates a type checker in the workers test environment", async () => {
+    vi.stubGlobal("localStorage", undefined);
+
+    const fileSystem = new InMemoryFileSystem({
+      "tsconfig.json": tsconfig,
+      "index.ts": "const values: Array<number> = [];"
+    });
+
+    const environment = await createTypescriptLanguageService({ fileSystem });
+
+    expect(
+      environment.languageService.getProgram()!.getSourceFile("index.ts")
+    ).toBeDefined();
+    expect(
+      environment.languageService.getSemanticDiagnostics("index.ts")
+    ).toEqual([]);
+  });
+
+  it("updates the backing filesystem and refreshes diagnostics", async () => {
+    const fileSystem = new InMemoryFileSystem({
+      "tsconfig.json": tsconfig,
+      "index.ts": 'const value: number = "nope";'
+    });
+
+    const environment = await createTypescriptLanguageService({ fileSystem });
+
+    expect(
+      environment.languageService.getSemanticDiagnostics("index.ts")
+    ).toHaveLength(1);
+
+    environment.fileSystem.write("index.ts", "const value: number = 1;");
+
+    expect(fileSystem.read("index.ts")).toBe("const value: number = 1;");
+    expect(
+      environment.languageService.getSemanticDiagnostics("index.ts")
+    ).toEqual([]);
+  });
+
+  it("deletes files from the backing filesystem", async () => {
+    const fileSystem = new InMemoryFileSystem({
+      "tsconfig.json": tsconfig,
+      "index.ts": "export const value = 1;"
+    });
+
+    const environment = await createTypescriptLanguageService({ fileSystem });
+
+    environment.fileSystem.delete("index.ts");
+
+    expect(fileSystem.read("index.ts")).toBeNull();
+    expect(
+      environment.languageService.getProgram()!.getSourceFile("index.ts")
+    ).toBeUndefined();
+  });
+
+  it("reports semantic compiler errors", async () => {
+    const fileSystem = new InMemoryFileSystem({
+      "tsconfig.json": tsconfig,
+      "index.ts": 'const value: number = "nope";'
+    });
+
+    const environment = await createTypescriptLanguageService({ fileSystem });
+
+    const diagnostics =
+      environment.languageService.getSemanticDiagnostics("index.ts");
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe(2322);
+    expect(diagnostics[0]?.messageText).toBe(
+      "Type 'string' is not assignable to type 'number'."
+    );
+  });
+
+  it("uses default compiler options when no tsconfig.json is present", async () => {
+    const fileSystem = new InMemoryFileSystem({
+      "index.ts": "const value = 1;"
+    });
+
+    const environment = await createTypescriptLanguageService({ fileSystem });
+
+    expect(
+      environment.languageService.getProgram()!.getSourceFile("index.ts")
+    ).toBeDefined();
+    expect(
+      environment.languageService.getSemanticDiagnostics("index.ts")
+    ).toEqual([]);
+  });
+});

--- a/packages/worker-bundler/src/tests/wrangler.jsonc
+++ b/packages/worker-bundler/src/tests/wrangler.jsonc
@@ -9,10 +9,26 @@
     "enable_nodejs_v8_module",
     "enable_nodejs_process_v2"
   ],
-  "main": "../index.ts",
+  // test-main.ts re-exports the real index.ts and additionally exports
+  // Durable Object classes that are only needed as test fixtures.
+  "main": "test-main.ts",
   "worker_loaders": [
     {
       "binding": "LOADER"
     }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        // Minimal DO fixture used by DurableObjectKVFileSystem tests to obtain
+        // a real DurableObjectStorage instance via runInDurableObject().
+        "name": "FS_TEST",
+        "class_name": "FsTestDO"
+      }
+    ]
+  },
+  "migrations": [
+    // FsTestDO needs SQLite storage because storage.kv is backed by SQLite.
+    { "tag": "v1", "new_sqlite_classes": ["FsTestDO"] }
   ]
 }

--- a/packages/worker-bundler/src/transformer.ts
+++ b/packages/worker-bundler/src/transformer.ts
@@ -1,6 +1,7 @@
 import { transform } from "sucrase";
 import { parseImports, resolveModule } from "./resolver";
-import type { CreateWorkerResult, Files, Modules } from "./types";
+import type { FileSystem } from "./file-system";
+import type { CreateWorkerResult, Modules } from "./types";
 
 export interface TransformResult {
   code: string;
@@ -145,7 +146,7 @@ export function getOutputPath(filePath: string): string {
  * This produces multiple modules instead of a single bundle.
  */
 export async function transformAndResolve(
-  files: Files,
+  files: FileSystem,
   entryPoint: string,
   externals: string[]
 ): Promise<CreateWorkerResult> {
@@ -163,8 +164,8 @@ export async function transformAndResolve(
     if (!filePath || processed.has(filePath)) continue;
     processed.add(filePath);
 
-    const content = files[filePath];
-    if (content === undefined) {
+    const content = files.read(filePath);
+    if (content === null) {
       warnings.push(`File not found: ${filePath}`);
       continue;
     }
@@ -222,8 +223,8 @@ export async function transformAndResolve(
 
   // Second pass: transform files and rewrite imports
   for (const [sourcePath, outputPath] of pathMap) {
-    const content = files[sourcePath];
-    if (content === undefined || !isJavaScriptFile(sourcePath)) continue;
+    const content = files.read(sourcePath);
+    if (content === null || !isJavaScriptFile(sourcePath)) continue;
 
     let transformedCode: string;
 
@@ -274,7 +275,7 @@ export async function transformAndResolve(
 function rewriteImports(
   code: string,
   importer: string,
-  files: Files,
+  files: FileSystem,
   pathMap: Map<string, string>,
   externals: string[]
 ): string {

--- a/packages/worker-bundler/src/types.ts
+++ b/packages/worker-bundler/src/types.ts
@@ -1,3 +1,5 @@
+import type { FileSystem } from "./file-system";
+
 /**
  * Input files for the bundler
  * Keys are file paths, values are file contents
@@ -27,7 +29,7 @@ export interface CreateWorkerOptions {
   /**
    * Input files - keys are paths relative to project root, values are file contents
    */
-  files: Files;
+  files: Files | FileSystem;
 
   /**
    * Entry point file path (relative to project root)

--- a/packages/worker-bundler/src/typescript.ts
+++ b/packages/worker-bundler/src/typescript.ts
@@ -1,0 +1,238 @@
+/**
+ * This file adapts the virtual TypeScript environment machinery from
+ * `@typescript/vfs` to this package's filesystem abstraction.
+ *
+ * The original implementation lives in the TypeScript Website repository:
+ * https://github.com/microsoft/TypeScript-Website/tree/v2/packages/typescript-vfs
+ */
+import {
+  createVirtualTypeScriptEnvironment,
+  type VirtualTypeScriptEnvironment
+} from "@typescript/vfs";
+import type TypeScript from "typescript";
+import type { FileSystem } from "./file-system.js";
+import { fetchPackageFiles } from "./installer.js";
+import ts from "./vendor/typescript.browser.js";
+
+const TYPECHECK_ROOT_FILE_PATTERN = /(?:\.d)?\.(?:ts|tsx|cts|mts)$/;
+
+type CreateTypeCheckerOptions = {
+  fileSystem: FileSystem;
+};
+
+/**
+ * Creates a TypeScript language service for the provided filesystem. Compiler
+ * options are read from a `tsconfig.json` file in the filesystem; if none is
+ * present, TypeScript's default options are used.
+ *
+ * The returned `fileSystem` wraps the input filesystem and mirrors subsequent
+ * writes and deletes into the virtual TypeScript environment, so callers
+ * should keep using that wrapper after initialization if they want later
+ * edits to be reflected in diagnostics and completions.
+ *
+ * @param options.fileSystem Project files to expose to the language service.
+ * A `tsconfig.json` at the root of the filesystem is parsed for compiler
+ * options.
+ * @returns The wrapped filesystem and the underlying TypeScript language
+ * service.
+ */
+export async function createTypescriptLanguageService(
+  options: CreateTypeCheckerOptions
+) {
+  const compilerOptions = parseTsConfig(options.fileSystem);
+
+  // The compiler won't accept non-typescript files as root files
+  const keys = options.fileSystem
+    .list()
+    .filter((path) => TYPECHECK_ROOT_FILE_PATTERN.test(path));
+  const system = await createSystem(options.fileSystem, compilerOptions);
+
+  const typescriptEnv = createVirtualTypeScriptEnvironment(
+    system,
+    keys,
+    ts,
+    compilerOptions
+  );
+
+  return {
+    fileSystem: new TypescriptFileSystem(options.fileSystem, typescriptEnv),
+    languageService: typescriptEnv.languageService
+  };
+}
+
+/**
+ * A `FileSystem` wrapper that keeps a virtual TypeScript environment in sync
+ * with filesystem mutations.
+ */
+class TypescriptFileSystem implements FileSystem {
+  constructor(
+    private innerFs: FileSystem,
+    private typescriptEnv: VirtualTypeScriptEnvironment
+  ) {}
+  read(path: string): string | null {
+    return this.innerFs.read(path);
+  }
+  write(path: string, content: string): void {
+    this.innerFs.write(path, content);
+    this.typescriptEnv.updateFile(path, content);
+  }
+  delete(path: string): void {
+    this.innerFs.delete(path);
+    this.typescriptEnv.deleteFile(path);
+  }
+  list(prefix?: string): string[] {
+    return this.innerFs.list(prefix);
+  }
+  flush(): Promise<void> {
+    return this.innerFs.flush();
+  }
+}
+
+/**
+ * Reads and parses `tsconfig.json` from the filesystem, returning the
+ * resulting compiler options. Falls back to TypeScript's defaults when no
+ * `tsconfig.json` is present.
+ */
+function parseTsConfig(fileSystem: FileSystem): TypeScript.CompilerOptions {
+  const configContent = fileSystem.read("tsconfig.json");
+  if (configContent === null) {
+    return {};
+  }
+
+  const { config, error } = ts.readConfigFile(
+    "tsconfig.json",
+    () => configContent
+  );
+  if (error !== undefined) {
+    throw new Error(
+      `tsconfig.json: ${ts.flattenDiagnosticMessageText(error.messageText, "\n")}`
+    );
+  }
+
+  const normalizePath = (path: string): string =>
+    path.startsWith("/") ? path.slice(1) : path;
+
+  const parseConfigHost: TypeScript.ParseConfigHost = {
+    useCaseSensitiveFileNames: true,
+    readDirectory: (rootDir, extensions) => {
+      const prefix = rootDir === "/" ? undefined : normalizePath(rootDir);
+      return fileSystem
+        .list(prefix)
+        .filter((f) => extensions.some((ext) => f.endsWith(ext)))
+        .map((f) => `/${f}`);
+    },
+    fileExists: (path) => fileSystem.read(normalizePath(path)) !== null,
+    readFile: (path) => fileSystem.read(normalizePath(path)) ?? undefined
+  };
+
+  const { options } = ts.parseJsonConfigFileContent(
+    config,
+    parseConfigHost,
+    "/"
+  );
+  return options;
+}
+
+// Adapted from @typescript/vfs's MIT-licensed createSystem implementation
+// https://github.com/microsoft/TypeScript-Website/blob/119f931a639c9215a27311fde459c6db0b8718e4/packages/typescript-vfs/src/index.ts#L494
+async function createSystem(
+  fileSystem: FileSystem,
+  compileOptions: TypeScript.CompilerOptions
+): Promise<TypeScript.System> {
+  const libs = compileOptions.lib ?? [];
+
+  const libraryFiles = await createDefaultTypeScriptLibMap();
+
+  const normalizeProjectPath = (path: string): string =>
+    path.startsWith("/") ? path.slice(1) : path;
+
+  function readFile(fileName: string): string | undefined {
+    const normalizedPath = normalizeProjectPath(fileName);
+
+    const file = fileSystem.read(normalizedPath);
+    if (file !== null) {
+      return file;
+    }
+
+    // If it's a d.ts file we first check if the file is a "blessed" lib by
+    // being included in compilerOptions.libs, and then fallback to being a
+    // file present in typescript's `lib/lib.*.d.ts`.
+    if (normalizedPath.endsWith(".d.ts")) {
+      if (libs.includes(normalizedPath.slice(0, -5))) {
+        return libraryFiles.get(`lib.${normalizedPath}`);
+      }
+
+      if (libraryFiles.has(normalizedPath)) {
+        return libraryFiles.get(normalizedPath);
+      }
+    }
+
+    return undefined;
+  }
+
+  function listFiles(prefix?: string): string[] {
+    const result = new Set<string>(
+      fileSystem.list(
+        prefix === undefined ? undefined : normalizeProjectPath(prefix)
+      )
+    );
+
+    for (const path of libraryFiles.keys()) {
+      if (prefix === undefined || path.startsWith(prefix)) {
+        result.add(path);
+      }
+    }
+
+    return Array.from(result);
+  }
+
+  function unimplemented(): never {
+    throw new Error("unimplemented");
+  }
+
+  return {
+    args: [],
+    newLine: "\n",
+    useCaseSensitiveFileNames: true,
+    getDirectories: () => [],
+    getCurrentDirectory: () => "/",
+    readFile,
+    directoryExists: (directory: string) =>
+      listFiles(normalizeProjectPath(directory)).length > 0,
+    fileExists: (fileName: string) => readFile(fileName) !== undefined,
+    resolvePath: (path: string) => path,
+    readDirectory: (directory: string) =>
+      directory === "/" ? listFiles() : listFiles(directory),
+    writeFile: (path, content) => {
+      fileSystem.write(normalizeProjectPath(path), content);
+    },
+    deleteFile: (path) => {
+      fileSystem.delete(normalizeProjectPath(path));
+    },
+    getExecutingFilePath: unimplemented,
+    createDirectory: unimplemented,
+    exit: unimplemented,
+    write: unimplemented
+  };
+}
+
+// Fetches the lib types from the TypeScript NPM package.
+async function createDefaultTypeScriptLibMap(): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+
+  const files = await fetchPackageFiles("typescript", {
+    name: "typescript",
+    version: "6.0.2",
+    dist: {
+      tarball: "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz"
+    }
+  });
+
+  for (const [file, contents] of Object.entries(files)) {
+    if (!file.startsWith("lib/lib.") || !file.endsWith(".d.ts")) continue;
+
+    result.set(`${file.substring(4)}`, contents);
+  }
+
+  return result;
+}

--- a/packages/worker-bundler/src/typescript.ts
+++ b/packages/worker-bundler/src/typescript.ts
@@ -74,7 +74,11 @@ class TypescriptFileSystem implements FileSystem {
   }
   write(path: string, content: string): void {
     this.innerFs.write(path, content);
-    this.typescriptEnv.updateFile(path, content);
+    if (this.typescriptEnv.getSourceFile(path)) {
+      this.typescriptEnv.updateFile(path, content);
+    } else {
+      this.typescriptEnv.createFile(path, content);
+    }
   }
   delete(path: string): void {
     this.innerFs.delete(path);

--- a/packages/worker-bundler/src/utils.ts
+++ b/packages/worker-bundler/src/utils.ts
@@ -2,14 +2,15 @@
  * Utility functions.
  */
 
-import type { Files, WranglerConfig } from "./types";
+import type { WranglerConfig } from "./types";
+import type { FileSystem } from "./file-system";
 
 /**
  * Detect entry point from wrangler config, package.json, or use defaults.
  * Priority: wrangler main > package.json exports/module/main > default paths
  */
 export function detectEntryPoint(
-  files: Files,
+  files: FileSystem,
   wranglerConfig: WranglerConfig | undefined
 ): string | undefined {
   // First, check wrangler config main field
@@ -18,7 +19,7 @@ export function detectEntryPoint(
   }
 
   // Try to read package.json
-  const packageJsonContent = files["package.json"];
+  const packageJsonContent = files.read("package.json");
   if (packageJsonContent) {
     try {
       const pkg = JSON.parse(packageJsonContent) as {
@@ -76,7 +77,7 @@ export function detectEntryPoint(
   ];
 
   for (const entry of defaultEntries) {
-    if (entry in files) {
+    if (files.read(entry) !== null) {
       return entry;
     }
   }

--- a/packages/worker-bundler/src/vendor/.gitignore
+++ b/packages/worker-bundler/src/vendor/.gitignore
@@ -1,0 +1,1 @@
+typescript.browser.js

--- a/packages/worker-bundler/src/vendor/typescript.browser.d.ts
+++ b/packages/worker-bundler/src/vendor/typescript.browser.d.ts
@@ -1,0 +1,3 @@
+declare const ts: typeof import("typescript");
+
+export default ts;


### PR DESCRIPTION
Adds support for the TypeScript language service to `@cloudflare/worker-bundler` as well a new virtual file-system abstraction for interfacing with the code for bundled workers. This is primarily to allow efficient storage of Worker code in Durable Objects.

# Example

```ts
const inputFileSystem = new InMemoryFileSystem({
  "package.json": JSON.stringify({
    dependencies: {
      "@cloudflare/workers-types": "^4.20260405.1"
    }
  }),
  "tsconfig.json": JSON.stringify({
    compilerOptions: {
      lib: ["es2024"],
      target: "ES2024",
      module: "ES2022",
      moduleResolution: "bundler",
      allowSyntheticDefaultImports: true,
      strict: true,
      skipLibCheck: true,
      types: ["@cloudflare/workers-types/index.d.ts"]
    }
  }),
  "src/index.ts": `
    const worker: ExportedHandler = {
    
    async fetch() {
        return new Response("Hello, world!");
      }
    };
    
    export default worker;
  `
});

const installResult = await installDependencies(inputFileSystem);
const { fileSystem, languageService } = await createTypescriptLanguageService({ fileSystem: inputFileSystem });
```

# Separate `./typescript` export

The TypeScript bundle is large (~5 MB minified). Importing it unconditionally from the main entry point would penalise every caller that only needs bundling. The language service is therefore exported under its own subpath:

```ts
import { createTypescriptLanguageService } from "@cloudflare/worker-bundler/typescript";
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
