### PR TITLE
docs + refactor: Session API documentation and AI SDK decoupling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@
 - [Server-Driven Messages](./server-driven-messages.md) - Autonomous agent workflows: scheduled follow-ups, queue processing, webhooks, chained reasoning
 - TODO: [Using AI Models](./using-ai-models.md) - OpenAI, Anthropic, Workers AI, and other providers
 - TODO: [RAG (Retrieval Augmented Generation)](./rag.md) - Vector search with Vectorize
+- [Sessions (Experimental)](./sessions.md) - Persistent conversation storage with tree-structured messages, context blocks, compaction, and search
 - [Workspace (Experimental)](./workspace.md) - Durable virtual filesystem backed by SQLite + R2
 - [Codemode (Experimental)](./codemode.md) - LLM-generated executable code for tool orchestration
 - [Client Tools Continuation](./client-tools-continuation.md) - Handling tool calls across client/server

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,785 @@
+# Sessions (Experimental)
+
+The Session API provides persistent conversation storage for agents, with tree-structured messages, context blocks, compaction, full-text search, and AI-controllable tools. It runs entirely on Durable Object SQLite — no external database needed.
+
+> **Experimental.** The Session API is under `agents/experimental/memory/session`. The API surface is stable but may evolve before graduating to the main package.
+
+## Quick Start
+
+```typescript
+import { Agent } from "agents";
+import { Session } from "agents/experimental/memory/session";
+
+class MyAgent extends Agent {
+  session = Session.create(this)
+    .withContext("soul", {
+      provider: { get: async () => "You are a helpful assistant." }
+    })
+    .withContext("memory", {
+      description: "Learned facts about the user",
+      maxTokens: 1100
+    })
+    .withCachedPrompt();
+
+  async onMessage(message) {
+    await this.session.appendMessage(message);
+    const history = this.session.getHistory();
+    const system = await this.session.freezeSystemPrompt();
+    const tools = await this.session.tools();
+    // Pass history, system prompt, and tools to your LLM
+  }
+}
+```
+
+## Session
+
+`Session` manages a single conversation's messages, context blocks, and compaction state.
+
+### Creating a Session
+
+There are two ways to create a Session:
+
+**Builder API (recommended)** — uses `Session.create(agent)` with a chainable builder. Context providers without an explicit `provider` option are auto-wired to SQLite.
+
+```typescript
+const session = Session.create(this)
+  .withContext("soul", { provider: { get: async () => "You are helpful." } })
+  .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+  .withCachedPrompt()
+  .onCompaction(myCompactFn)
+  .compactAfter(100_000);
+```
+
+**Direct constructor** — takes a `SessionProvider` and options directly. Used when you want full control over providers.
+
+```typescript
+import { AgentSessionProvider, AgentContextProvider } from "agents/experimental/memory/session";
+
+const session = new Session(new AgentSessionProvider(this), {
+  context: [
+    { label: "memory", description: "Notes", maxTokens: 500, provider: new AgentContextProvider(this, "memory") },
+    { label: "soul", provider: { get: async () => "You are helpful." } }
+  ]
+});
+```
+
+### Builder Methods
+
+All builder methods return `this` for chaining. Order doesn't matter — providers are resolved lazily on first use.
+
+| Method | Description |
+|--------|-------------|
+| `Session.create(agent)` | Static factory. `agent` is any object with a `sql` tagged template method (i.e. your Agent/DO). |
+| `.forSession(sessionId)` | Namespace this session by ID. Required for multi-session isolation when not using SessionManager. Context provider keys and storage are scoped to this ID. |
+| `.withContext(label, options?)` | Add a context block. See [Context Blocks](#context-blocks). |
+| `.withCachedPrompt(provider?)` | Enable system prompt persistence. The prompt is frozen on first use and survives DO hibernation/eviction. Without an explicit provider, auto-wires to SQLite. |
+| `.onCompaction(fn)` | Register a compaction function. See [Compaction](#compaction). |
+| `.compactAfter(tokenThreshold)` | Auto-compact when estimated token count exceeds the threshold. Checked after each `appendMessage()`. Requires `.onCompaction()`. |
+
+### Messages
+
+Messages use the Vercel AI SDK's `UIMessage` type. The session stores them in a tree structure via `parent_id`, enabling branching conversations.
+
+```typescript
+// Append — auto-parents to the latest leaf unless parentId is specified
+await session.appendMessage(message);
+await session.appendMessage(message, parentId);
+
+// Update an existing message (matched by message.id)
+session.updateMessage(message);
+
+// Delete specific messages
+session.deleteMessages(["msg-1", "msg-2"]);
+
+// Clear all messages and skill state
+session.clearMessages();
+```
+
+> **Note:** `appendMessage()` is `async` because it may trigger auto-compaction. The underlying storage write is synchronous (SQLite), but the compaction step involves an LLM call. All other write methods (`updateMessage`, `deleteMessages`, `clearMessages`) are synchronous.
+
+#### Reading History
+
+```typescript
+// Linear history from root to the latest leaf
+const messages = session.getHistory();
+
+// History to a specific leaf (for branching)
+const branch = session.getHistory(leafId);
+
+// Get a single message
+const msg = session.getMessage("msg-1");
+
+// Get the newest message
+const latest = session.getLatestLeaf();
+
+// Count messages in path
+const count = session.getPathLength();
+```
+
+#### Branching
+
+Messages form a tree. When you `appendMessage` with a `parentId` that already has children, you create a branch. Use `getBranches()` to get sibling responses at a given point:
+
+```typescript
+// Get all responses that share the same parent as messageId
+const siblings = session.getBranches(messageId);
+```
+
+This powers features like response regeneration — the original response and the regenerated one are siblings in the tree, and `getHistory(leafId)` walks the chosen path.
+
+### Search
+
+Full-text search over the conversation history using SQLite FTS5:
+
+```typescript
+const results = session.search("deployment Friday", { limit: 10 });
+// Returns: Array<{ id, role, content, createdAt? }>
+```
+
+Uses porter stemming and unicode tokenization. The search covers all messages in the session.
+
+> **Note:** `search()` throws if the session provider doesn't support search. The built-in `AgentSessionProvider` supports it.
+
+### WebSocket Broadcasts
+
+When the Session's `agent` object has a `broadcast()` method (all `Agent` subclasses do), the Session automatically broadcasts status events over WebSocket after each write operation:
+
+- **`CF_AGENT_SESSION`** — phase (`"idle"` or `"compacting"`), `tokenEstimate`, `tokenThreshold`
+- **`CF_AGENT_SESSION_ERROR`** — emitted on compaction failure
+
+This allows connected clients to display real-time token usage and compaction status.
+
+---
+
+## Context Blocks
+
+Context blocks are persistent key-value sections injected into the system prompt. Each block has a **label**, optional **description**, and a **provider** that determines its behavior.
+
+### Provider Types
+
+There are four provider types, detected by duck-typing:
+
+| Provider | Interface | Behavior | AI Tool |
+|----------|-----------|----------|---------|
+| **ContextProvider** | `get()` | Read-only block in system prompt | — |
+| **WritableContextProvider** | `get()` + `set()` | Writable via AI | `set_context` |
+| **SkillProvider** | `get()` + `load()` + `set?()` | On-demand keyed documents. `get()` returns a metadata listing; `load(key)` fetches full content. | `load_context`, `unload_context`, `set_context` |
+| **SearchProvider** | `get()` + `search()` + `set?()` | Full-text searchable entries. `get()` returns a summary; `search(query)` runs FTS5. | `search_context`, `set_context` |
+
+All providers also support an optional `init(label)` method, called before first use with the block's label.
+
+### Built-in Providers
+
+**`AgentContextProvider`** — SQLite-backed writable context. This is what you get by default when using the builder without an explicit provider.
+
+```typescript
+import { AgentContextProvider } from "agents/experimental/memory/session";
+
+// Explicit usage — key determines the SQLite row
+new AgentContextProvider(this, "memory")
+```
+
+**`R2SkillProvider`** — Cloudflare R2 bucket for on-demand document loading. Skills are listed in the system prompt as metadata; the model loads full content on demand via `load_context`.
+
+```typescript
+import { R2SkillProvider } from "agents/experimental/memory/session";
+
+Session.create(this)
+  .withContext("skills", {
+    provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" })
+  })
+```
+
+Descriptions are stored in R2 custom metadata (`description` key).
+
+**`AgentSearchProvider`** — SQLite FTS5 searchable context. Entries are indexed and searchable by the model via `search_context`.
+
+```typescript
+import { AgentSearchProvider } from "agents/experimental/memory/session";
+
+Session.create(this)
+  .withContext("knowledge", {
+    description: "Searchable knowledge base",
+    provider: new AgentSearchProvider(this)
+  })
+```
+
+### Adding and Removing Context at Runtime
+
+Blocks can be added and removed dynamically after initialization — useful for extensions:
+
+```typescript
+// Add a new block (auto-wires to SQLite if no provider given)
+await session.addContext("extension-notes", { description: "From extension X", maxTokens: 500 });
+
+// Remove it
+session.removeContext("extension-notes");
+
+// Rebuild the system prompt to reflect changes
+await session.refreshSystemPrompt();
+```
+
+> **Note:** `addContext` and `removeContext` do NOT automatically update the frozen system prompt. You must call `refreshSystemPrompt()` afterward.
+
+### Reading Context Blocks
+
+```typescript
+// Single block
+const block = session.getContextBlock("memory");
+// block: { label, description?, content, tokens, maxTokens?, writable, isSkill, isSearchable }
+
+// All blocks
+const blocks = session.getContextBlocks();
+```
+
+### Writing to Context Blocks
+
+```typescript
+// Replace content entirely
+await session.replaceContextBlock("memory", "User likes coffee.");
+
+// Append content
+await session.appendContextBlock("memory", "\nUser prefers dark roast.");
+```
+
+> **Note:** Writing to a context block updates the provider immediately but does NOT update the frozen system prompt snapshot. This is intentional — it preserves the LLM prefix cache. Call `refreshSystemPrompt()` when you want changes reflected in the prompt.
+
+### System Prompt
+
+The system prompt is built from all context blocks with headers and metadata:
+
+```
+══════════════════════════════════════════════
+SOUL (Identity) [readonly]
+══════════════════════════════════════════════
+You are a helpful assistant.
+
+══════════════════════════════════════════════
+MEMORY (Learned facts) [45% — 495/1100 tokens]
+══════════════════════════════════════════════
+User likes coffee.
+User prefers dark roast.
+```
+
+```typescript
+// Freeze — first call renders and persists, subsequent calls return the cached value
+const prompt = await session.freezeSystemPrompt();
+
+// Refresh — re-render from current block state and persist
+const updated = await session.refreshSystemPrompt();
+```
+
+The frozen prompt survives DO hibernation and eviction when `withCachedPrompt()` is enabled. After eviction, the next `freezeSystemPrompt()` call loads from SQLite rather than re-rendering.
+
+### Skills (Load/Unload)
+
+Skills are on-demand documents stored in a `SkillProvider` (e.g. R2). The model sees a metadata listing in the system prompt and can load full content on demand:
+
+```typescript
+// Unload a skill to free context space (rewrites the tool result in history)
+session.unloadSkill("skills", "api-reference");
+
+// Check what's currently loaded
+const loaded = session.getLoadedSkillKeys(); // Set<"skills:api-reference">
+```
+
+After hibernation/eviction, loaded skills are reconstructed by scanning conversation history for `load_context` tool results. This means skill state survives restarts without additional storage.
+
+> **Weird:** The skill restoration scans the entire conversation history looking for `load_context` tool invocations in assistant messages with `state: "output-available"`. When you unload a skill, it doesn't delete the tool result — it rewrites the `output` field to `"[skill unloaded: key]"` in-place. This means the original loaded content is permanently lost from history after unload.
+
+---
+
+## AI Tools
+
+Session automatically generates tools based on the provider types of your context blocks. Pass these to your LLM alongside your own tools.
+
+```typescript
+const tools = await session.tools();
+// Merge with your own tools:
+const allTools = { ...tools, ...myTools };
+```
+
+### `set_context`
+
+Generated when any writable block exists. Writes to regular blocks, skill blocks (keyed), or search blocks (keyed).
+
+- For regular blocks: `{ label, content, action: "replace" | "append" }`
+- For skill blocks: `{ label, key, content, description? }`
+- For search blocks: `{ label, key, content }`
+
+Enforces `maxTokens` limits. Returns a usage string like `"Written to memory. Usage: 45% (495/1100 tokens)"`.
+
+### `load_context`
+
+Generated when any skill block exists. Loads full content by key from a `SkillProvider`.
+
+- Input: `{ label, key }`
+- Returns the document content, or `"Not found: key"`
+
+### `unload_context`
+
+Generated alongside `load_context`. Frees context space by unloading a previously loaded skill.
+
+- Input: `{ label, key }`
+- Rewrites the tool result in conversation history to a short marker
+- The skill remains available for re-loading
+
+The tool's description dynamically lists currently loaded skills.
+
+### `search_context`
+
+Generated when any search block exists. Full-text search within a searchable context block.
+
+- Input: `{ label, query }`
+- Returns top 10 results by FTS5 rank, or `"No results found."`
+
+### `session_search`
+
+Available on `SessionManager` only (not on individual sessions). Searches across all sessions.
+
+- Input: `{ query }`
+- Returns results from all sessions, or `"No results found."`
+
+Use `{ ...sessionTools, ...manager.tools() }` to give the model both per-session and cross-session tools.
+
+---
+
+## Compaction
+
+Compaction summarizes older messages to keep conversations within token limits. Original messages are preserved in SQLite — the summary is a non-destructive overlay applied at read time.
+
+### Setup
+
+```typescript
+import { createCompactFunction } from "agents/experimental/memory/utils/compaction-helpers";
+
+const session = Session.create(this)
+  .withContext("memory", { maxTokens: 1100 })
+  .onCompaction(
+    createCompactFunction({
+      summarize: (prompt) =>
+        generateText({ model: myModel, prompt }).then((r) => r.text),
+      protectHead: 3,        // Keep first 3 messages (default: 3)
+      tailTokenBudget: 20000, // Protect ~20K tokens at the tail (default: 20000)
+      minTailMessages: 2     // Always keep at least 2 tail messages (default: 2)
+    })
+  )
+  .compactAfter(100_000);   // Auto-compact at 100K estimated tokens
+```
+
+### How It Works
+
+1. **Protect head** — first N messages are never compacted (default 3)
+2. **Protect tail** — walk backward from the end, accumulating tokens up to a budget (default 20K tokens)
+3. **Align boundaries** — shift boundaries to avoid splitting tool call/result pairs
+4. **Summarize middle** — send the middle section to an LLM with a structured format (Topic, Key Points, Current State, Open Items)
+5. **Store overlay** — saved in `assistant_compactions` table, keyed by `fromMessageId` and `toMessageId`
+6. **Iterative** — on subsequent compactions, the existing summary is passed to the LLM to update rather than replace
+
+When `getHistory()` is called, compaction overlays are applied transparently — the compacted range is replaced by a synthetic message with id `compaction_<id>`.
+
+### Manual Compaction
+
+```typescript
+// Run registered compaction function
+const result = await session.compact();
+
+// Or manage overlays directly
+session.addCompaction("Summary of messages 1-50", "msg-1", "msg-50");
+const overlays = session.getCompactions();
+```
+
+### Auto-Compaction
+
+When `.compactAfter(threshold)` is set, `appendMessage()` checks the estimated token count after each write. If it exceeds the threshold, `compact()` is called automatically. Auto-compaction failure is non-fatal — the message is already saved.
+
+> **Note:** Token estimation is heuristic (not tiktoken). It uses `max(chars/4, words*1.3)` with 4 tokens per-message overhead. This is intentional — tiktoken would add 80-120MB heap overhead, which exceeds Cloudflare Workers' 128MB limit.
+
+> **Weird:** Compaction is iterative but single-overlay. Each new compaction extends from the earliest existing compaction's `fromMessageId` to the new end. So you always have at most one active compaction overlay per session, and it keeps growing. The previous compaction rows remain in the database but are superseded by the latest one (which covers a wider range). `getCompactions()` returns all of them, but `getHistory()` applies the latest one.
+
+---
+
+## SessionManager
+
+`SessionManager` is a registry for multiple named sessions within a single Durable Object. It provides lifecycle management, convenience methods, and cross-session search.
+
+### Creating a SessionManager
+
+```typescript
+import { SessionManager } from "agents/experimental/memory/session";
+
+const manager = SessionManager.create(this)
+  .withContext("soul", { provider: { get: async () => "You are helpful." } })
+  .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+  .withCachedPrompt()
+  .maxContextMessages(100)
+  .onCompaction(myCompactFn)
+  .compactAfter(100_000)
+  .withSearchableHistory("history");
+```
+
+Context blocks, prompt caching, and compaction settings are propagated to all sessions created through the manager. Provider keys are automatically namespaced by session ID (e.g. `memory_<sessionId>`).
+
+### Builder Methods
+
+| Method | Description |
+|--------|-------------|
+| `SessionManager.create(agent)` | Static factory. |
+| `.withContext(label, options?)` | Add context block template for all sessions. |
+| `.withCachedPrompt(provider?)` | Enable prompt persistence for all sessions. |
+| `.maxContextMessages(count)` | Set a message count threshold for `needsCompaction()` (default: 100). |
+| `.onCompaction(fn)` | Register compaction function for all sessions. |
+| `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions. |
+| `.withSearchableHistory(label)` | Add a cross-session searchable history block to every session. The model can search past conversations from any session. |
+
+### Session Lifecycle
+
+```typescript
+// Create a new session
+const info = manager.create("My Chat");
+// info: { id, name, parent_session_id, model, source, input_tokens, output_tokens, estimated_cost, end_reason, created_at, updated_at }
+
+// Create with metadata
+const info2 = manager.create("My Chat", {
+  parentSessionId: "parent-id",
+  model: "claude-sonnet-4-20250514",
+  source: "web"
+});
+
+// Get session metadata (null if not found)
+const session = manager.get(sessionId);
+
+// List all sessions (ordered by updated_at DESC)
+const sessions = manager.list();
+
+// Rename
+manager.rename(sessionId, "New Name");
+
+// Delete (clears messages too)
+manager.delete(sessionId);
+```
+
+### Accessing Sessions
+
+```typescript
+// Get or create the Session instance for an ID
+// Lazy — creates on first access, caches for subsequent calls
+const session = manager.getSession(sessionId);
+```
+
+### Message Convenience Methods
+
+These delegate to the underlying Session but also update the session's `updated_at` timestamp:
+
+```typescript
+// Append a single message
+await manager.append(sessionId, message, parentId?);
+
+// Add or update (upsert)
+await manager.upsert(sessionId, message, parentId?);
+
+// Batch append (auto-chains parent IDs)
+await manager.appendAll(sessionId, messages, parentId?);
+
+// Read history
+const history = manager.getHistory(sessionId, leafId?);
+
+// Message count
+const count = manager.getMessageCount(sessionId);
+
+// Clear messages
+manager.clearMessages(sessionId);
+
+// Delete specific messages
+manager.deleteMessages(sessionId, ["msg-1"]);
+```
+
+### Forking
+
+Fork a session at a specific message — copies history up to that point into a new session:
+
+```typescript
+const forked = await manager.fork(sessionId, atMessageId, "Forked Chat");
+// forked.parent_session_id === sessionId
+```
+
+> **Weird:** Fork copies messages with new UUIDs, not the original IDs. This means message IDs in the forked session won't match the original. The fork also doesn't copy compaction overlays — the forked session starts clean with the materialized history.
+
+### Compaction
+
+```typescript
+// Check if a session exceeds maxContextMessages
+if (manager.needsCompaction(sessionId)) { ... }
+
+// Add a compaction overlay
+manager.addCompaction(sessionId, summary, fromId, toId);
+
+// Get overlays
+const compactions = manager.getCompactions(sessionId);
+
+// Compact and split — marks old session as ended, creates a continuation
+const continuation = await manager.compactAndSplit(sessionId, summary, "Continued Chat");
+// continuation.parent_session_id === sessionId
+// Old session gets end_reason = "compaction"
+```
+
+`compactAndSplit` is different from regular compaction — it creates a new session with a summary message instead of an in-place overlay. The original session is marked with `end_reason: "compaction"`.
+
+### Usage Tracking
+
+```typescript
+manager.addUsage(sessionId, inputTokens, outputTokens, cost);
+// Increments input_tokens, output_tokens, and estimated_cost on the session row
+```
+
+### Cross-Session Search
+
+```typescript
+// Search across all sessions (FTS5)
+const results = manager.search("deployment Friday", { limit: 20 });
+// Returns: Array<{ id, role, content, createdAt }>
+
+// Get tools for the model (includes session_search)
+const tools = manager.tools();
+```
+
+> **Note:** `manager.search()` uses a separate FTS5 index (`assistant_fts`) from per-session search. Messages are indexed into this table by the `AgentSessionProvider` when appended. The `session_search` tool limits results to 10.
+
+> **Weird:** `manager.search()` silently returns an empty array on FTS5 query errors (malformed queries, etc.) rather than throwing.
+
+---
+
+## Storage
+
+All storage is in Durable Object SQLite. Tables are created lazily on first use.
+
+### Tables
+
+**`assistant_messages`** — Tree-structured messages.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Message ID |
+| `session_id` | TEXT | Empty string for single-session; set for multi-session |
+| `parent_id` | TEXT | Parent message ID (null for roots) |
+| `role` | TEXT | `user`, `assistant`, `system` |
+| `content` | TEXT | JSON-serialized `UIMessage` |
+| `created_at` | DATETIME | Auto-set |
+
+**`assistant_compactions`** — Compaction overlays.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Random UUID |
+| `session_id` | TEXT | Scoped to session |
+| `summary` | TEXT | LLM-generated summary |
+| `from_message_id` | TEXT | Start of compacted range |
+| `to_message_id` | TEXT | End of compacted range |
+| `created_at` | DATETIME | Auto-set |
+
+**`assistant_fts`** — FTS5 virtual table for message search. Tokenizer: `porter unicode61`.
+
+**`assistant_sessions`** — Session registry (SessionManager only).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Random UUID |
+| `name` | TEXT | Display name |
+| `parent_session_id` | TEXT | For forks/splits |
+| `model` | TEXT | Optional model identifier |
+| `source` | TEXT | Optional source identifier |
+| `input_tokens` | INTEGER | Cumulative input tokens |
+| `output_tokens` | INTEGER | Cumulative output tokens |
+| `estimated_cost` | REAL | Cumulative cost |
+| `end_reason` | TEXT | `"compaction"` when split |
+| `created_at` | DATETIME | Auto-set |
+| `updated_at` | DATETIME | Updated on message ops |
+
+**`cf_agents_context_blocks`** — Persistent context block storage (`AgentContextProvider`).
+
+**`cf_agents_search_entries`** + **`cf_agents_search_fts`** — Searchable context entries and FTS5 index (`AgentSearchProvider`).
+
+---
+
+## Custom Providers
+
+You can implement any of the four provider interfaces to plug in your own storage:
+
+```typescript
+// Read-only context
+const myProvider: ContextProvider = {
+  get: async () => "Static content here"
+};
+
+// Writable context (enables set_context tool)
+const myWritable: WritableContextProvider = {
+  get: async () => fetchFromMyDB(),
+  set: async (content) => saveToMyDB(content)
+};
+
+// Skill provider (enables load_context tool)
+const mySkills: SkillProvider = {
+  get: async () => "- api-ref: API Reference\n- guide: User Guide",
+  load: async (key) => fetchDocument(key),
+  set: async (key, content, description) => saveDocument(key, content, description) // optional
+};
+
+// Search provider (enables search_context tool)
+const mySearch: SearchProvider = {
+  get: async () => "42 entries indexed",
+  search: async (query) => searchMyIndex(query),
+  set: async (key, content) => indexContent(key, content) // optional
+};
+```
+
+You can also implement `SessionProvider` to replace the SQLite storage entirely:
+
+```typescript
+const myStorage: SessionProvider = {
+  getMessage(id) { ... },
+  getHistory(leafId?) { ... },
+  getLatestLeaf() { ... },
+  getBranches(messageId) { ... },
+  getPathLength(leafId?) { ... },
+  appendMessage(message, parentId?) { ... },
+  updateMessage(message) { ... },
+  deleteMessages(messageIds) { ... },
+  clearMessages() { ... },
+  addCompaction(summary, fromId, toId) { ... },
+  getCompactions() { ... },
+  searchMessages(query, limit) { ... } // optional
+};
+```
+
+---
+
+## Utilities
+
+Exported from `agents/experimental/memory/utils`:
+
+### Token Estimation
+
+```typescript
+import { estimateStringTokens, estimateMessageTokens } from "agents/experimental/memory/utils/tokens";
+
+estimateStringTokens("Hello world");      // heuristic: max(chars/4, words*1.3)
+estimateMessageTokens(messages);           // sum with 4 tokens per-message overhead
+```
+
+### Compaction Helpers
+
+```typescript
+import {
+  createCompactFunction,
+  isCompactionMessage,
+  sanitizeToolPairs,
+  alignBoundaryForward,
+  alignBoundaryBackward,
+  findTailCutByTokens,
+  computeSummaryBudget,
+  buildSummaryPrompt,
+  COMPACTION_PREFIX
+} from "agents/experimental/memory/utils/compaction-helpers";
+```
+
+- `createCompactFunction(options)` — Full compaction implementation. See [Compaction](#compaction).
+- `isCompactionMessage(msg)` — Check if a message is a compaction overlay (id starts with `compaction_`).
+- `sanitizeToolPairs(messages)` — Fix orphaned tool call/result pairs after compaction. Removes orphaned results and adds stub results for calls whose results were dropped.
+- `alignBoundaryForward/Backward(messages, idx)` — Shift a boundary index to avoid splitting tool call/result groups.
+- `findTailCutByTokens(messages, headEnd, budget, minMessages)` — Find where to stop compressing using a token budget.
+- `computeSummaryBudget(messages)` — 20% of compressed content tokens (minimum 100).
+- `buildSummaryPrompt(messages, previousSummary, budget)` — Structured prompt for LLM summarization.
+
+---
+
+## Exports
+
+Everything is exported from `agents/experimental/memory/session`:
+
+```typescript
+import {
+  // Core
+  Session,
+  SessionManager,
+
+  // Providers
+  AgentSessionProvider,
+  AgentContextProvider,
+  AgentSearchProvider,
+  R2SkillProvider,
+
+  // Type guards
+  isWritableProvider,
+  isSkillProvider,
+  isSearchProvider,
+
+  // Types
+  type SessionContextOptions,
+  type SessionInfo,
+  type SessionManagerOptions,
+  type SessionOptions,
+  type MessageQueryOptions,
+  type ContextBlock,
+  type ContextConfig,
+  type ContextProvider,
+  type WritableContextProvider,
+  type SkillProvider,
+  type SearchProvider,
+  type SearchResult,
+  type SessionProvider,
+  type StoredCompaction,
+  type SqlProvider,
+} from "agents/experimental/memory/session";
+```
+
+Compaction utilities from `agents/experimental/memory/utils/compaction-helpers`:
+
+```typescript
+import {
+  createCompactFunction,
+  isCompactionMessage,
+  sanitizeToolPairs,
+  COMPACTION_PREFIX,
+  type CompactResult,
+  type CompactOptions,
+} from "agents/experimental/memory/utils/compaction-helpers";
+```
+
+Token utilities from `agents/experimental/memory/utils/tokens`:
+
+```typescript
+import {
+  estimateStringTokens,
+  estimateMessageTokens,
+} from "agents/experimental/memory/utils/tokens";
+```
+
+---
+
+## Gotchas and Quirks
+
+Things that might surprise you:
+
+1. **Lazy initialization.** Sessions created with the builder don't initialize until first use. The first call to any method (e.g. `getHistory()`) triggers `_ensureReady()`, which creates SQLite tables, resolves providers, loads context blocks, and restores skill state from history. This means the first operation is slower than subsequent ones.
+
+2. **Snapshot freezing is sticky.** `freezeSystemPrompt()` caches the result. Writing to a context block does NOT update the cached snapshot — you must explicitly call `refreshSystemPrompt()`. This is deliberate (LLM prefix cache optimization), but easy to miss.
+
+3. **`appendMessage` is async, other writes are sync.** `appendMessage` is async only because it may trigger auto-compaction (which calls an LLM). The actual SQLite write is synchronous. `updateMessage`, `deleteMessages`, and `clearMessages` are all synchronous.
+
+4. **Skills survive hibernation via history scanning.** On initialization, the session scans the entire conversation history looking for `load_context` tool results to reconstruct which skills are loaded. This is clever but means initialization cost scales with conversation length.
+
+5. **Compaction overlays are superseding, not stacking.** Each compaction extends from the earliest existing `fromMessageId`. So you always have one effective overlay that keeps growing. Old compaction rows remain in the database but are unused. `getCompactions()` returns all rows, which can be confusing.
+
+6. **`needsCompaction` on SessionManager uses message count, not tokens.** The `maxContextMessages` setting counts messages via `getPathLength()`. The `compactAfter` threshold on Session uses estimated tokens. These are independent mechanisms — you might hit one before the other.
+
+7. **Search is silently absent.** `session.search()` throws if the provider doesn't support search, but `manager.search()` swallows FTS5 errors and returns `[]`. The `searchMessages` method on `SessionProvider` is optional (`searchMessages?`).
+
+8. **Fork copies with new IDs.** When forking via `SessionManager.fork()`, all messages get new UUIDs. If you're storing message IDs externally (e.g. for bookmarks), they won't survive a fork.
+
+9. **`removeContext` doesn't fire skill unload callbacks.** If you remove a context block that had loaded skills, the skill tracking is cleaned up but the conversation history is NOT rewritten. The tool results from those skills remain in history with their full content.
+
+10. **FTS5 query sanitization.** Both `AgentSearchProvider.search()` and `SessionManager.search()` quote individual words to prevent FTS5 syntax injection. This means you can't use FTS5 operators like `OR`, `NOT`, or `NEAR` — they'll be treated as literal search terms.
+
+11. **Auto-compaction failure is silent.** When `compactAfter` triggers and the compaction function throws, the error is emitted via WebSocket broadcast but the `appendMessage` call still succeeds. The message is saved; only the compaction is skipped.
+
+12. **`MessageQueryOptions` is exported but unused.** The type exists in `types.ts` with `limit`, `offset`, `before`, `after`, and `role` fields, but no Session or SessionManager method accepts it. It appears to be a forward-looking type that isn't wired up yet.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -412,7 +412,6 @@ const manager = SessionManager.create(this)
   .withContext("soul", { provider: { get: async () => "You are helpful." } })
   .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
   .withCachedPrompt()
-  .maxContextMessages(100)
   .onCompaction(myCompactFn)
   .compactAfter(100_000)
   .withSearchableHistory("history");
@@ -427,7 +426,6 @@ Context blocks, prompt caching, and compaction settings are propagated to all se
 | `SessionManager.create(agent)` | Static factory. |
 | `.withContext(label, options?)` | Add context block template for all sessions. |
 | `.withCachedPrompt(provider?)` | Enable prompt persistence for all sessions. |
-| `.maxContextMessages(count)` | Set a message count threshold for `needsCompaction()` (default: 100). |
 | `.onCompaction(fn)` | Register compaction function for all sessions. |
 | `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions. |
 | `.withSearchableHistory(label)` | Add a cross-session searchable history block to every session. The model can search past conversations from any session. |
@@ -508,9 +506,6 @@ const forked = await manager.fork(sessionId, atMessageId, "Forked Chat");
 ### Compaction
 
 ```typescript
-// Check if a session exceeds maxContextMessages
-if (manager.needsCompaction(sessionId)) { ... }
-
 // Add a compaction overlay
 manager.addCompaction(sessionId, summary, fromId, toId);
 
@@ -718,7 +713,6 @@ import {
   type SessionInfo,
   type SessionManagerOptions,
   type SessionOptions,
-  type MessageQueryOptions,
   type ContextBlock,
   type ContextConfig,
   type ContextProvider,
@@ -770,16 +764,13 @@ Things that might surprise you:
 
 5. **Compaction overlays are superseding, not stacking.** Each compaction extends from the earliest existing `fromMessageId`. So you always have one effective overlay that keeps growing. Old compaction rows remain in the database but are unused. `getCompactions()` returns all rows, which can be confusing.
 
-6. **`needsCompaction` on SessionManager uses message count, not tokens.** The `maxContextMessages` setting counts messages via `getPathLength()`. The `compactAfter` threshold on Session uses estimated tokens. These are independent mechanisms — you might hit one before the other.
+6. **Search is silently absent.** `session.search()` throws if the provider doesn't support search, but `manager.search()` swallows FTS5 errors and returns `[]`. The `searchMessages` method on `SessionProvider` is optional (`searchMessages?`).
 
-7. **Search is silently absent.** `session.search()` throws if the provider doesn't support search, but `manager.search()` swallows FTS5 errors and returns `[]`. The `searchMessages` method on `SessionProvider` is optional (`searchMessages?`).
+7. **Fork copies with new IDs.** When forking via `SessionManager.fork()`, all messages get new UUIDs. If you're storing message IDs externally (e.g. for bookmarks), they won't survive a fork.
 
-8. **Fork copies with new IDs.** When forking via `SessionManager.fork()`, all messages get new UUIDs. If you're storing message IDs externally (e.g. for bookmarks), they won't survive a fork.
+8. **`removeContext` doesn't fire skill unload callbacks.** If you remove a context block that had loaded skills, the skill tracking is cleaned up but the conversation history is NOT rewritten. The tool results from those skills remain in history with their full content.
 
-9. **`removeContext` doesn't fire skill unload callbacks.** If you remove a context block that had loaded skills, the skill tracking is cleaned up but the conversation history is NOT rewritten. The tool results from those skills remain in history with their full content.
+9. **FTS5 query sanitization.** Both `AgentSearchProvider.search()` and `SessionManager.search()` quote individual words to prevent FTS5 syntax injection. This means you can't use FTS5 operators like `OR`, `NOT`, or `NEAR` — they'll be treated as literal search terms.
 
-10. **FTS5 query sanitization.** Both `AgentSearchProvider.search()` and `SessionManager.search()` quote individual words to prevent FTS5 syntax injection. This means you can't use FTS5 operators like `OR`, `NOT`, or `NEAR` — they'll be treated as literal search terms.
+10. **Auto-compaction failure is silent.** When `compactAfter` triggers and the compaction function throws, the error is emitted via WebSocket broadcast but the `appendMessage` call still succeeds. The message is saved; only the compaction is skipped.
 
-11. **Auto-compaction failure is silent.** When `compactAfter` triggers and the compaction function throws, the error is emitted via WebSocket broadcast but the `appendMessage` call still succeeds. The message is saved; only the compaction is skipped.
-
-12. **`MessageQueryOptions` is exported but unused.** The type exists in `types.ts` with `limit`, `offset`, `before`, `after`, and `role` fields, but no Session or SessionManager method accepts it. It appears to be a forward-looking type that isn't wired up yet.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -86,7 +86,7 @@ All builder methods return `this` for chaining. Order doesn't matter — provide
 
 ### Messages
 
-Messages use the Vercel AI SDK's `UIMessage` type. The session stores them in a tree structure via `parent_id`, enabling branching conversations.
+Messages use the `SessionMessage` type — a minimal shape with `id`, `role`, `parts`, and optional `createdAt`. The Vercel AI SDK's `UIMessage` is structurally compatible and can be passed directly without conversion. The session stores messages in a tree structure via `parent_id`, enabling branching conversations.
 
 ```typescript
 // Append — auto-parents to the latest leaf unless parentId is specified
@@ -126,14 +126,14 @@ const count = session.getPathLength();
 
 #### Branching
 
-Messages form a tree. When you `appendMessage` with a `parentId` that already has children, you create a branch. Use `getBranches()` to get sibling responses at a given point:
+Messages form a tree. When you `appendMessage` with a `parentId` that already has children, you create a branch. Use `getBranches()` to get all child messages branching from a given point:
 
 ```typescript
-// Get all responses that share the same parent as messageId
-const siblings = session.getBranches(messageId);
+// Get all child messages that branch from messageId (e.g. multiple responses to a user message)
+const branches = session.getBranches(messageId);
 ```
 
-This powers features like response regeneration — the original response and the regenerated one are siblings in the tree, and `getHistory(leafId)` walks the chosen path.
+This powers features like response regeneration — pass the user message ID to get both the original and regenerated responses. `getHistory(leafId)` walks the chosen path.
 
 ### Search
 
@@ -571,7 +571,7 @@ All storage is in Durable Object SQLite. Tables are created lazily on first use.
 | `session_id` | TEXT     | Empty string for single-session; set for multi-session |
 | `parent_id`  | TEXT     | Parent message ID (null for roots)                     |
 | `role`       | TEXT     | `user`, `assistant`, `system`                          |
-| `content`    | TEXT     | JSON-serialized `UIMessage`                            |
+| `content`    | TEXT     | JSON-serialized `SessionMessage`                       |
 | `created_at` | DATETIME | Auto-set                                               |
 
 **`assistant_compactions`** — Compaction overlays.
@@ -726,6 +726,8 @@ import {
   isSearchProvider,
 
   // Types
+  type SessionMessage,
+  type SessionMessagePart,
   type SessionContextOptions,
   type SessionInfo,
   type SessionManagerOptions,

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -53,11 +53,19 @@ const session = Session.create(this)
 **Direct constructor** — takes a `SessionProvider` and options directly. Used when you want full control over providers.
 
 ```typescript
-import { AgentSessionProvider, AgentContextProvider } from "agents/experimental/memory/session";
+import {
+  AgentSessionProvider,
+  AgentContextProvider
+} from "agents/experimental/memory/session";
 
 const session = new Session(new AgentSessionProvider(this), {
   context: [
-    { label: "memory", description: "Notes", maxTokens: 500, provider: new AgentContextProvider(this, "memory") },
+    {
+      label: "memory",
+      description: "Notes",
+      maxTokens: 500,
+      provider: new AgentContextProvider(this, "memory")
+    },
     { label: "soul", provider: { get: async () => "You are helpful." } }
   ]
 });
@@ -67,14 +75,14 @@ const session = new Session(new AgentSessionProvider(this), {
 
 All builder methods return `this` for chaining. Order doesn't matter — providers are resolved lazily on first use.
 
-| Method | Description |
-|--------|-------------|
-| `Session.create(agent)` | Static factory. `agent` is any object with a `sql` tagged template method (i.e. your Agent/DO). |
-| `.forSession(sessionId)` | Namespace this session by ID. Required for multi-session isolation when not using SessionManager. Context provider keys and storage are scoped to this ID. |
-| `.withContext(label, options?)` | Add a context block. See [Context Blocks](#context-blocks). |
-| `.withCachedPrompt(provider?)` | Enable system prompt persistence. The prompt is frozen on first use and survives DO hibernation/eviction. Without an explicit provider, auto-wires to SQLite. |
-| `.onCompaction(fn)` | Register a compaction function. See [Compaction](#compaction). |
-| `.compactAfter(tokenThreshold)` | Auto-compact when estimated token count exceeds the threshold. Checked after each `appendMessage()`. Requires `.onCompaction()`. |
+| Method                          | Description                                                                                                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Session.create(agent)`         | Static factory. `agent` is any object with a `sql` tagged template method (i.e. your Agent/DO).                                                               |
+| `.forSession(sessionId)`        | Namespace this session by ID. Required for multi-session isolation when not using SessionManager. Context provider keys and storage are scoped to this ID.    |
+| `.withContext(label, options?)` | Add a context block. See [Context Blocks](#context-blocks).                                                                                                   |
+| `.withCachedPrompt(provider?)`  | Enable system prompt persistence. The prompt is frozen on first use and survives DO hibernation/eviction. Without an explicit provider, auto-wires to SQLite. |
+| `.onCompaction(fn)`             | Register a compaction function. See [Compaction](#compaction).                                                                                                |
+| `.compactAfter(tokenThreshold)` | Auto-compact when estimated token count exceeds the threshold. Checked after each `appendMessage()`. Requires `.onCompaction()`.                              |
 
 ### Messages
 
@@ -159,12 +167,12 @@ Context blocks are persistent key-value sections injected into the system prompt
 
 There are four provider types, detected by duck-typing:
 
-| Provider | Interface | Behavior | AI Tool |
-|----------|-----------|----------|---------|
-| **ContextProvider** | `get()` | Read-only block in system prompt | — |
-| **WritableContextProvider** | `get()` + `set()` | Writable via AI | `set_context` |
-| **SkillProvider** | `get()` + `load()` + `set?()` | On-demand keyed documents. `get()` returns a metadata listing; `load(key)` fetches full content. | `load_context`, `unload_context`, `set_context` |
-| **SearchProvider** | `get()` + `search()` + `set?()` | Full-text searchable entries. `get()` returns a summary; `search(query)` runs FTS5. | `search_context`, `set_context` |
+| Provider                    | Interface                       | Behavior                                                                                         | AI Tool                                         |
+| --------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| **ContextProvider**         | `get()`                         | Read-only block in system prompt                                                                 | —                                               |
+| **WritableContextProvider** | `get()` + `set()`               | Writable via AI                                                                                  | `set_context`                                   |
+| **SkillProvider**           | `get()` + `load()` + `set?()`   | On-demand keyed documents. `get()` returns a metadata listing; `load(key)` fetches full content. | `load_context`, `unload_context`, `set_context` |
+| **SearchProvider**          | `get()` + `search()` + `set?()` | Full-text searchable entries. `get()` returns a summary; `search(query)` runs FTS5.              | `search_context`, `set_context`                 |
 
 All providers also support an optional `init(label)` method, called before first use with the block's label.
 
@@ -176,7 +184,7 @@ All providers also support an optional `init(label)` method, called before first
 import { AgentContextProvider } from "agents/experimental/memory/session";
 
 // Explicit usage — key determines the SQLite row
-new AgentContextProvider(this, "memory")
+new AgentContextProvider(this, "memory");
 ```
 
 **`R2SkillProvider`** — Cloudflare R2 bucket for on-demand document loading. Skills are listed in the system prompt as metadata; the model loads full content on demand via `load_context`.
@@ -184,10 +192,9 @@ new AgentContextProvider(this, "memory")
 ```typescript
 import { R2SkillProvider } from "agents/experimental/memory/session";
 
-Session.create(this)
-  .withContext("skills", {
-    provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" })
-  })
+Session.create(this).withContext("skills", {
+  provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" })
+});
 ```
 
 Descriptions are stored in R2 custom metadata (`description` key).
@@ -197,11 +204,10 @@ Descriptions are stored in R2 custom metadata (`description` key).
 ```typescript
 import { AgentSearchProvider } from "agents/experimental/memory/session";
 
-Session.create(this)
-  .withContext("knowledge", {
-    description: "Searchable knowledge base",
-    provider: new AgentSearchProvider(this)
-  })
+Session.create(this).withContext("knowledge", {
+  description: "Searchable knowledge base",
+  provider: new AgentSearchProvider(this)
+});
 ```
 
 ### Adding and Removing Context at Runtime
@@ -210,7 +216,10 @@ Blocks can be added and removed dynamically after initialization — useful for 
 
 ```typescript
 // Add a new block (auto-wires to SQLite if no provider given)
-await session.addContext("extension-notes", { description: "From extension X", maxTokens: 500 });
+await session.addContext("extension-notes", {
+  description: "From extension X",
+  maxTokens: 500
+});
 
 // Remove it
 session.removeContext("extension-notes");
@@ -359,12 +368,12 @@ const session = Session.create(this)
     createCompactFunction({
       summarize: (prompt) =>
         generateText({ model: myModel, prompt }).then((r) => r.text),
-      protectHead: 3,        // Keep first 3 messages (default: 3)
+      protectHead: 3, // Keep first 3 messages (default: 3)
       tailTokenBudget: 20000, // Protect ~20K tokens at the tail (default: 20000)
-      minTailMessages: 2     // Always keep at least 2 tail messages (default: 2)
+      minTailMessages: 2 // Always keep at least 2 tail messages (default: 2)
     })
   )
-  .compactAfter(100_000);   // Auto-compact at 100K estimated tokens
+  .compactAfter(100_000); // Auto-compact at 100K estimated tokens
 ```
 
 ### How It Works
@@ -421,13 +430,13 @@ Context blocks, prompt caching, and compaction settings are propagated to all se
 
 ### Builder Methods
 
-| Method | Description |
-|--------|-------------|
-| `SessionManager.create(agent)` | Static factory. |
-| `.withContext(label, options?)` | Add context block template for all sessions. |
-| `.withCachedPrompt(provider?)` | Enable prompt persistence for all sessions. |
-| `.onCompaction(fn)` | Register compaction function for all sessions. |
-| `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions. |
+| Method                          | Description                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `SessionManager.create(agent)`  | Static factory.                                                                                                          |
+| `.withContext(label, options?)` | Add context block template for all sessions.                                                                             |
+| `.withCachedPrompt(provider?)`  | Enable prompt persistence for all sessions.                                                                              |
+| `.onCompaction(fn)`             | Register compaction function for all sessions.                                                                           |
+| `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions.                                                                                 |
 | `.withSearchableHistory(label)` | Add a cross-session searchable history block to every session. The model can search past conversations from any session. |
 
 ### Session Lifecycle
@@ -513,7 +522,11 @@ manager.addCompaction(sessionId, summary, fromId, toId);
 const compactions = manager.getCompactions(sessionId);
 
 // Compact and split — marks old session as ended, creates a continuation
-const continuation = await manager.compactAndSplit(sessionId, summary, "Continued Chat");
+const continuation = await manager.compactAndSplit(
+  sessionId,
+  summary,
+  "Continued Chat"
+);
 // continuation.parent_session_id === sessionId
 // Old session gets end_reason = "compaction"
 ```
@@ -552,43 +565,43 @@ All storage is in Durable Object SQLite. Tables are created lazily on first use.
 
 **`assistant_messages`** — Tree-structured messages.
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | TEXT PK | Message ID |
-| `session_id` | TEXT | Empty string for single-session; set for multi-session |
-| `parent_id` | TEXT | Parent message ID (null for roots) |
-| `role` | TEXT | `user`, `assistant`, `system` |
-| `content` | TEXT | JSON-serialized `UIMessage` |
-| `created_at` | DATETIME | Auto-set |
+| Column       | Type     | Notes                                                  |
+| ------------ | -------- | ------------------------------------------------------ |
+| `id`         | TEXT PK  | Message ID                                             |
+| `session_id` | TEXT     | Empty string for single-session; set for multi-session |
+| `parent_id`  | TEXT     | Parent message ID (null for roots)                     |
+| `role`       | TEXT     | `user`, `assistant`, `system`                          |
+| `content`    | TEXT     | JSON-serialized `UIMessage`                            |
+| `created_at` | DATETIME | Auto-set                                               |
 
 **`assistant_compactions`** — Compaction overlays.
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | TEXT PK | Random UUID |
-| `session_id` | TEXT | Scoped to session |
-| `summary` | TEXT | LLM-generated summary |
-| `from_message_id` | TEXT | Start of compacted range |
-| `to_message_id` | TEXT | End of compacted range |
-| `created_at` | DATETIME | Auto-set |
+| Column            | Type     | Notes                    |
+| ----------------- | -------- | ------------------------ |
+| `id`              | TEXT PK  | Random UUID              |
+| `session_id`      | TEXT     | Scoped to session        |
+| `summary`         | TEXT     | LLM-generated summary    |
+| `from_message_id` | TEXT     | Start of compacted range |
+| `to_message_id`   | TEXT     | End of compacted range   |
+| `created_at`      | DATETIME | Auto-set                 |
 
 **`assistant_fts`** — FTS5 virtual table for message search. Tokenizer: `porter unicode61`.
 
 **`assistant_sessions`** — Session registry (SessionManager only).
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | TEXT PK | Random UUID |
-| `name` | TEXT | Display name |
-| `parent_session_id` | TEXT | For forks/splits |
-| `model` | TEXT | Optional model identifier |
-| `source` | TEXT | Optional source identifier |
-| `input_tokens` | INTEGER | Cumulative input tokens |
-| `output_tokens` | INTEGER | Cumulative output tokens |
-| `estimated_cost` | REAL | Cumulative cost |
-| `end_reason` | TEXT | `"compaction"` when split |
-| `created_at` | DATETIME | Auto-set |
-| `updated_at` | DATETIME | Updated on message ops |
+| Column              | Type     | Notes                      |
+| ------------------- | -------- | -------------------------- |
+| `id`                | TEXT PK  | Random UUID                |
+| `name`              | TEXT     | Display name               |
+| `parent_session_id` | TEXT     | For forks/splits           |
+| `model`             | TEXT     | Optional model identifier  |
+| `source`            | TEXT     | Optional source identifier |
+| `input_tokens`      | INTEGER  | Cumulative input tokens    |
+| `output_tokens`     | INTEGER  | Cumulative output tokens   |
+| `estimated_cost`    | REAL     | Cumulative cost            |
+| `end_reason`        | TEXT     | `"compaction"` when split  |
+| `created_at`        | DATETIME | Auto-set                   |
+| `updated_at`        | DATETIME | Updated on message ops     |
 
 **`cf_agents_context_blocks`** — Persistent context block storage (`AgentContextProvider`).
 
@@ -616,7 +629,8 @@ const myWritable: WritableContextProvider = {
 const mySkills: SkillProvider = {
   get: async () => "- api-ref: API Reference\n- guide: User Guide",
   load: async (key) => fetchDocument(key),
-  set: async (key, content, description) => saveDocument(key, content, description) // optional
+  set: async (key, content, description) =>
+    saveDocument(key, content, description) // optional
 };
 
 // Search provider (enables search_context tool)
@@ -655,10 +669,13 @@ Exported from `agents/experimental/memory/utils`:
 ### Token Estimation
 
 ```typescript
-import { estimateStringTokens, estimateMessageTokens } from "agents/experimental/memory/utils/tokens";
+import {
+  estimateStringTokens,
+  estimateMessageTokens
+} from "agents/experimental/memory/utils/tokens";
 
-estimateStringTokens("Hello world");      // heuristic: max(chars/4, words*1.3)
-estimateMessageTokens(messages);           // sum with 4 tokens per-message overhead
+estimateStringTokens("Hello world"); // heuristic: max(chars/4, words*1.3)
+estimateMessageTokens(messages); // sum with 4 tokens per-message overhead
 ```
 
 ### Compaction Helpers
@@ -722,7 +739,7 @@ import {
   type SearchResult,
   type SessionProvider,
   type StoredCompaction,
-  type SqlProvider,
+  type SqlProvider
 } from "agents/experimental/memory/session";
 ```
 
@@ -735,7 +752,7 @@ import {
   sanitizeToolPairs,
   COMPACTION_PREFIX,
   type CompactResult,
-  type CompactOptions,
+  type CompactOptions
 } from "agents/experimental/memory/utils/compaction-helpers";
 ```
 
@@ -744,7 +761,7 @@ Token utilities from `agents/experimental/memory/utils/tokens`:
 ```typescript
 import {
   estimateStringTokens,
-  estimateMessageTokens,
+  estimateMessageTokens
 } from "agents/experimental/memory/utils/tokens";
 ```
 
@@ -773,4 +790,3 @@ Things that might surprise you:
 9. **FTS5 query sanitization.** Both `AgentSearchProvider.search()` and `SessionManager.search()` quote individual words to prevent FTS5 syntax injection. This means you can't use FTS5 operators like `OR`, `NOT`, or `NEAR` — they'll be treated as literal search terms.
 
 10. **Auto-compaction failure is silent.** When `compactAfter` triggers and the compaction function throws, the error is emitted via WebSocket broadcast but the `appendMessage` call still succeeds. The message is saved; only the compaction is skipped.
-

--- a/experimental/session-memory/src/server.ts
+++ b/experimental/session-memory/src/server.ts
@@ -85,7 +85,7 @@ export class ChatAgent extends Agent<Env> {
     const result = streamText({
       model: this.getAI(),
       system: await this.session.freezeSystemPrompt(),
-      messages: await convertToModelMessages(truncated),
+      messages: await convertToModelMessages(truncated as UIMessage[]),
       tools: await this.session.tools(),
       stopWhen: stepCountIs(5)
     });
@@ -140,7 +140,7 @@ export class ChatAgent extends Agent<Env> {
 
   @callable()
   getMessages(): UIMessage[] {
-    return this.session.getHistory();
+    return this.session.getHistory() as UIMessage[];
   }
 
   @callable()

--- a/experimental/session-multichat/README.md
+++ b/experimental/session-multichat/README.md
@@ -72,7 +72,6 @@ SessionManager.create(agent)
   .onCompaction(fn)                  // register compaction function
   .compactAfter(tokenThreshold)      // auto-compact threshold
   .withCachedPrompt(provider?)       // cache frozen system prompt
-  .maxContextMessages(count)         // limit context messages per session
 ```
 
 ## Session Lifecycle

--- a/experimental/session-multichat/src/server.ts
+++ b/experimental/session-multichat/src/server.ts
@@ -106,7 +106,7 @@ export class MultiSessionAgent extends Agent<Env> {
     const result = streamText({
       model: this.getAI(),
       system: await session.freezeSystemPrompt(),
-      messages: await convertToModelMessages(truncated),
+      messages: await convertToModelMessages(truncated as UIMessage[]),
       tools: { ...(await session.tools()), ...this.manager.tools() },
       stopWhen: stepCountIs(5)
     });
@@ -149,7 +149,7 @@ export class MultiSessionAgent extends Agent<Env> {
 
   @callable()
   getHistory(chatId: string): UIMessage[] {
-    return this.manager.getSession(chatId).getHistory();
+    return this.manager.getSession(chatId).getHistory() as UIMessage[];
   }
 
   @callable()

--- a/experimental/session-search/src/server.ts
+++ b/experimental/session-search/src/server.ts
@@ -92,7 +92,7 @@ export class SearchAgent extends Agent<Env> {
     const result = streamText({
       model: this.getAI(),
       system: await this.session.freezeSystemPrompt(),
-      messages: await convertToModelMessages(truncated),
+      messages: await convertToModelMessages(truncated as UIMessage[]),
       tools: await this.session.tools(),
       stopWhen: stepCountIs(5)
     });
@@ -135,7 +135,7 @@ export class SearchAgent extends Agent<Env> {
 
   @callable()
   getMessages(): UIMessage[] {
-    return this.session.getHistory();
+    return this.session.getHistory() as UIMessage[];
   }
 
   @callable()

--- a/packages/agents/src/experimental/memory/index.ts
+++ b/packages/agents/src/experimental/memory/index.ts
@@ -8,7 +8,6 @@ export {
   Session,
   AgentSessionProvider,
   AgentContextProvider,
-  type MessageQueryOptions,
   type SessionProvider,
   type SearchResult,
   type StoredCompaction,

--- a/packages/agents/src/experimental/memory/session/context.ts
+++ b/packages/agents/src/experimental/memory/session/context.ts
@@ -15,7 +15,8 @@
  * - SearchProvider (get+search+set?)  → searchable via search_context tool
  */
 
-import { jsonSchema, type ToolSet } from "ai";
+import type { ToolSet } from "ai";
+import { z } from "zod";
 import { estimateStringTokens } from "../utils/tokens";
 import { isSearchProvider, type SearchProvider } from "./search";
 import { isSkillProvider, type SkillProvider } from "./skills";
@@ -651,9 +652,9 @@ export class ContextBlocks {
 
       toolSet.set_context = {
         description: `Write to a context block. Available blocks:\n${blockDescriptions.join("\n")}\n\nWrites are durable and persist across sessions.`,
-        inputSchema: jsonSchema({
+        inputSchema: z.fromJSONSchema({
           type: "object" as const,
-          properties: properties as Record<string, object>,
+          properties: properties as Record<string, Record<string, unknown>>,
           required
         }),
         execute: async ({
@@ -713,7 +714,7 @@ export class ContextBlocks {
           "Available skill blocks: " +
           skillLabels.map((l) => `"${l}"`).join(", ") +
           ". Check the system prompt for available keys.",
-        inputSchema: jsonSchema({
+        inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: {
             label: {
@@ -746,7 +747,7 @@ export class ContextBlocks {
           (loadedList.length > 0
             ? " Currently loaded: " + loadedList.join(", ") + "."
             : " No skills currently loaded."),
-        inputSchema: jsonSchema({
+        inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: {
             label: {
@@ -782,7 +783,7 @@ export class ContextBlocks {
           "Available searchable blocks: " +
           searchLabels.map((l) => `"${l}"`).join(", ") +
           ".",
-        inputSchema: jsonSchema({
+        inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: {
             label: {

--- a/packages/agents/src/experimental/memory/session/index.ts
+++ b/packages/agents/src/experimental/memory/session/index.ts
@@ -49,4 +49,8 @@ export type { SearchProvider } from "./search";
 export { AgentSearchProvider, isSearchProvider } from "./search";
 export type { SkillProvider } from "./skills";
 export { isSkillProvider, R2SkillProvider } from "./skills";
-export type { SessionOptions } from "./types";
+export type {
+  SessionMessage,
+  SessionMessagePart,
+  SessionOptions
+} from "./types";

--- a/packages/agents/src/experimental/memory/session/index.ts
+++ b/packages/agents/src/experimental/memory/session/index.ts
@@ -49,4 +49,4 @@ export type { SearchProvider } from "./search";
 export { AgentSearchProvider, isSearchProvider } from "./search";
 export type { SkillProvider } from "./skills";
 export { isSkillProvider, R2SkillProvider } from "./skills";
-export type { MessageQueryOptions, SessionOptions } from "./types";
+export type { SessionOptions } from "./types";

--- a/packages/agents/src/experimental/memory/session/manager.ts
+++ b/packages/agents/src/experimental/memory/session/manager.ts
@@ -35,13 +35,10 @@ interface PendingManagerContext {
   options: SessionContextOptions;
 }
 
-export interface SessionManagerOptions {
-  maxContextMessages?: number;
-}
+export interface SessionManagerOptions {}
 
 export class SessionManager {
   private agent!: SqlProvider;
-  private _maxContextMessages = 100;
   private _pending: PendingManagerContext[] = [];
   private _cachedPrompt?: WritableContextProvider | true;
   private _compactionFn?:
@@ -53,9 +50,8 @@ export class SessionManager {
   private _tableReady = false;
   private _ready = false;
 
-  constructor(agent: SqlProvider, options: SessionManagerOptions = {}) {
+  constructor(agent: SqlProvider, _options: SessionManagerOptions = {}) {
     this.agent = agent;
-    this._maxContextMessages = options.maxContextMessages ?? 100;
     this._ready = true;
     this._ensureTable();
   }
@@ -69,7 +65,7 @@ export class SessionManager {
    *   .withContext("soul", { provider: { get: async () => "You are helpful." } })
    *   .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
    *   .withCachedPrompt()
-   *   .maxContextMessages(50);
+   *   .compactAfter(100_000);
    *
    * // Each getSession(id) auto-creates namespaced providers:
    * //   memory key: "memory_<sessionId>"
@@ -80,7 +76,6 @@ export class SessionManager {
   static create(agent: SqlProvider): SessionManager {
     const mgr: SessionManager = Object.create(SessionManager.prototype);
     mgr.agent = agent;
-    mgr._maxContextMessages = 100;
     mgr._pending = [];
     mgr._compactionFn = null;
     mgr._tokenThreshold = undefined;
@@ -99,11 +94,6 @@ export class SessionManager {
 
   withCachedPrompt(provider?: WritableContextProvider): this {
     this._cachedPrompt = provider ?? true;
-    return this;
-  }
-
-  maxContextMessages(count: number): this {
-    this._maxContextMessages = count;
     return this;
   }
 
@@ -367,12 +357,6 @@ export class SessionManager {
   }
 
   // ── Compaction ────────────────────────────────────────────────
-
-  needsCompaction(sessionId: string): boolean {
-    return (
-      this.getSession(sessionId).getPathLength() > this._maxContextMessages
-    );
-  }
 
   addCompaction(
     sessionId: string,

--- a/packages/agents/src/experimental/memory/session/manager.ts
+++ b/packages/agents/src/experimental/memory/session/manager.ts
@@ -6,14 +6,15 @@
  * Cross-session search and tools.
  */
 
-import type { UIMessage } from "ai";
-import { jsonSchema, type ToolSet } from "ai";
+import type { ToolSet } from "ai";
+import { z } from "zod";
 import type { CompactResult } from "../utils/compaction-helpers";
 import type { WritableContextProvider } from "./context";
 import type { StoredCompaction } from "./provider";
 import type { SqlProvider } from "./providers/agent";
 import type { SearchProvider } from "./search";
 import { Session, type SessionContextOptions } from "./session";
+import type { SessionMessage } from "./types";
 
 export interface SessionInfo {
   id: string;
@@ -42,7 +43,7 @@ export class SessionManager {
   private _pending: PendingManagerContext[] = [];
   private _cachedPrompt?: WritableContextProvider | true;
   private _compactionFn?:
-    | ((messages: UIMessage[]) => Promise<CompactResult | null>)
+    | ((messages: SessionMessage[]) => Promise<CompactResult | null>)
     | null;
   private _tokenThreshold?: number;
   private _sessions = new Map<string, Session>();
@@ -102,7 +103,7 @@ export class SessionManager {
    * Called by `Session.compact()` to compress message history.
    */
   onCompaction(
-    fn: (messages: UIMessage[]) => Promise<CompactResult | null>
+    fn: (messages: SessionMessage[]) => Promise<CompactResult | null>
   ): this {
     this._compactionFn = fn;
     return this;
@@ -268,7 +269,7 @@ export class SessionManager {
 
   async append(
     sessionId: string,
-    message: UIMessage,
+    message: SessionMessage,
     parentId?: string
   ): Promise<string> {
     await this.getSession(sessionId).appendMessage(message, parentId);
@@ -278,7 +279,7 @@ export class SessionManager {
 
   async upsert(
     sessionId: string,
-    message: UIMessage,
+    message: SessionMessage,
     parentId?: string
   ): Promise<string> {
     const session = this.getSession(sessionId);
@@ -294,7 +295,7 @@ export class SessionManager {
 
   async appendAll(
     sessionId: string,
-    messages: UIMessage[],
+    messages: SessionMessage[],
     parentId?: string
   ): Promise<string | null> {
     const session = this.getSession(sessionId);
@@ -307,7 +308,7 @@ export class SessionManager {
     return lastParent;
   }
 
-  getHistory(sessionId: string, leafId?: string): UIMessage[] {
+  getHistory(sessionId: string, leafId?: string): SessionMessage[] {
     return this.getSession(sessionId).getHistory(leafId);
   }
 
@@ -327,7 +328,7 @@ export class SessionManager {
 
   // ── Branching ──────────────────────────────────────────────────
 
-  getBranches(sessionId: string, messageId: string): UIMessage[] {
+  getBranches(sessionId: string, messageId: string): SessionMessage[] {
     return this.getSession(sessionId).getBranches(messageId);
   }
 
@@ -347,7 +348,7 @@ export class SessionManager {
     let parentId: string | null = null;
     for (const msg of history) {
       const newId = crypto.randomUUID();
-      const copy: UIMessage = { ...msg, id: newId };
+      const copy: SessionMessage = { ...msg, id: newId };
       await newSession.appendMessage(copy, parentId);
       parentId = newId;
     }
@@ -454,7 +455,7 @@ export class SessionManager {
       session_search: {
         description:
           "Search past conversations for relevant context. Searches across all sessions.",
-        inputSchema: jsonSchema({
+        inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: {
             query: { type: "string" as const, description: "Search query" }

--- a/packages/agents/src/experimental/memory/session/provider.ts
+++ b/packages/agents/src/experimental/memory/session/provider.ts
@@ -4,7 +4,7 @@
  * Pure storage for tree-structured messages with compaction overlays and search.
  */
 
-import type { UIMessage } from "ai";
+import type { SessionMessage } from "./types";
 
 export interface SearchResult {
   id: string;
@@ -29,17 +29,17 @@ export interface StoredCompaction {
 export interface SessionProvider {
   // ── Read ────────────────────────────────────────────────────────
 
-  getMessage(id: string): UIMessage | null;
+  getMessage(id: string): SessionMessage | null;
 
   /**
    * Get conversation as a path from root to leaf.
    * Applies compaction overlays. If leafId is null, uses the latest leaf.
    */
-  getHistory(leafId?: string | null): UIMessage[];
+  getHistory(leafId?: string | null): SessionMessage[];
 
-  getLatestLeaf(): UIMessage | null;
+  getLatestLeaf(): SessionMessage | null;
 
-  getBranches(messageId: string): UIMessage[];
+  getBranches(messageId: string): SessionMessage[];
 
   getPathLength(leafId?: string | null): number;
 
@@ -49,9 +49,9 @@ export interface SessionProvider {
    * Append a message. Parented to the latest leaf unless parentId is provided.
    * Idempotent — same message.id twice is a no-op.
    */
-  appendMessage(message: UIMessage, parentId?: string | null): void;
+  appendMessage(message: SessionMessage, parentId?: string | null): void;
 
-  updateMessage(message: UIMessage): void;
+  updateMessage(message: SessionMessage): void;
 
   deleteMessages(messageIds: string[]): void;
 

--- a/packages/agents/src/experimental/memory/session/providers/agent.ts
+++ b/packages/agents/src/experimental/memory/session/providers/agent.ts
@@ -5,7 +5,7 @@
  * compaction overlays, and FTS5 search.
  */
 
-import type { UIMessage } from "ai";
+import type { SessionMessage } from "../types";
 import type {
   SessionProvider,
   SearchResult,
@@ -90,7 +90,7 @@ export class AgentSessionProvider implements SessionProvider {
 
   // ── Read ───────────────────────────────────────────────────────
 
-  getMessage(id: string): UIMessage | null {
+  getMessage(id: string): SessionMessage | null {
     this.ensureTable();
     const rows = this.agent.sql<{ content: string }>`
       SELECT content FROM assistant_messages WHERE id = ${id} AND session_id = ${this.sessionId}
@@ -98,7 +98,7 @@ export class AgentSessionProvider implements SessionProvider {
     return rows.length > 0 ? this.parse(rows[0].content) : null;
   }
 
-  getHistory(leafId?: string | null): UIMessage[] {
+  getHistory(leafId?: string | null): SessionMessage[] {
     this.ensureTable();
 
     const leaf = leafId
@@ -126,13 +126,13 @@ export class AgentSessionProvider implements SessionProvider {
     return this.applyCompactions(messages, compactions);
   }
 
-  getLatestLeaf(): UIMessage | null {
+  getLatestLeaf(): SessionMessage | null {
     this.ensureTable();
     const row = this.latestLeafRow();
     return row ? this.parse(row.content) : null;
   }
 
-  getBranches(messageId: string): UIMessage[] {
+  getBranches(messageId: string): SessionMessage[] {
     this.ensureTable();
     const rows = this.agent.sql<{ content: string }>`
       SELECT content FROM assistant_messages
@@ -165,7 +165,7 @@ export class AgentSessionProvider implements SessionProvider {
 
   // ── Write ──────────────────────────────────────────────────────
 
-  appendMessage(message: UIMessage, parentId?: string | null): void {
+  appendMessage(message: SessionMessage, parentId?: string | null): void {
     this.ensureTable();
     // Skip if message already exists (INSERT OR IGNORE idempotency)
     const existing = this.agent.sql<{ id: string }>`
@@ -192,7 +192,7 @@ export class AgentSessionProvider implements SessionProvider {
     this.indexFTS(message);
   }
 
-  updateMessage(message: UIMessage): void {
+  updateMessage(message: SessionMessage): void {
     this.ensureTable();
     this.agent.sql`
       UPDATE assistant_messages SET content = ${JSON.stringify(message)}
@@ -303,7 +303,7 @@ export class AgentSessionProvider implements SessionProvider {
     return rows[0] ?? null;
   }
 
-  private indexFTS(message: UIMessage): void {
+  private indexFTS(message: SessionMessage): void {
     const text = message.parts
       .filter((p) => p.type === "text")
       .map((p) => (p as { text: string }).text)
@@ -328,11 +328,11 @@ export class AgentSessionProvider implements SessionProvider {
   }
 
   private applyCompactions(
-    messages: UIMessage[],
+    messages: SessionMessage[],
     compactions: StoredCompaction[]
-  ): UIMessage[] {
+  ): SessionMessage[] {
     const ids = messages.map((m) => m.id);
-    const result: UIMessage[] = [];
+    const result: SessionMessage[] = [];
     let i = 0;
     while (i < messages.length) {
       // Find all compactions starting at this message, pick the latest
@@ -353,7 +353,7 @@ export class AgentSessionProvider implements SessionProvider {
               }
             ],
             createdAt: new Date()
-          } as UIMessage);
+          } as SessionMessage);
           i = endIdx + 1;
           continue;
         }
@@ -364,7 +364,7 @@ export class AgentSessionProvider implements SessionProvider {
     return result;
   }
 
-  private parse(json: string): UIMessage | null {
+  private parse(json: string): SessionMessage | null {
     try {
       const msg = JSON.parse(json);
       if (
@@ -380,8 +380,8 @@ export class AgentSessionProvider implements SessionProvider {
     return null;
   }
 
-  private parseRows(rows: { content: string }[]): UIMessage[] {
-    const result: UIMessage[] = [];
+  private parseRows(rows: { content: string }[]): SessionMessage[] {
+    const result: SessionMessage[] = [];
     for (const row of rows) {
       const msg = this.parse(row.content);
       if (msg) result.push(msg);

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -3,9 +3,8 @@
  */
 
 import type { ToolSet } from "ai";
-import type { UIMessage } from "ai";
 import type { SessionProvider, StoredCompaction } from "./provider";
-import type { SessionOptions } from "./types";
+import type { SessionMessage, SessionOptions } from "./types";
 import {
   ContextBlocks,
   type ContextBlock,
@@ -51,7 +50,7 @@ export class Session {
   private _pending?: PendingContext[];
   private _cachedPrompt?: WritableContextProvider | true;
   private _compactionFn?:
-    | ((messages: UIMessage[]) => Promise<CompactResult | null>)
+    | ((messages: SessionMessage[]) => Promise<CompactResult | null>)
     | null;
   private _tokenThreshold?: number;
   private _ready = false;
@@ -117,7 +116,7 @@ export class Session {
    * message history into a summary overlay.
    */
   onCompaction(
-    fn: (messages: UIMessage[]) => Promise<CompactResult | null>
+    fn: (messages: SessionMessage[]) => Promise<CompactResult | null>
   ): this {
     this._compactionFn = fn;
     return this;
@@ -187,15 +186,18 @@ export class Session {
     for (const msg of history) {
       if (msg.role !== "assistant") continue;
       for (const part of msg.parts) {
-        const p = part as Record<string, unknown>;
-        if (p.toolName === "load_context" && p.state === "output-available") {
-          const input = p.input as { label?: string; key?: string } | undefined;
+        if (
+          part.toolName === "load_context" &&
+          part.state === "output-available"
+        ) {
+          const input = part.input as
+            | { label?: string; key?: string }
+            | undefined;
           if (input?.label && input?.key) {
             const id = `${input.label}:${input.key}`;
-            const output = p.output;
             if (
-              typeof output === "string" &&
-              output.startsWith("[skill unloaded:")
+              typeof part.output === "string" &&
+              part.output.startsWith("[skill unloaded:")
             ) {
               loaded.delete(id);
             } else {
@@ -203,10 +205,12 @@ export class Session {
             }
           }
         } else if (
-          p.toolName === "unload_context" &&
-          p.state === "output-available"
+          part.toolName === "unload_context" &&
+          part.state === "output-available"
         ) {
-          const input = p.input as { label?: string; key?: string } | undefined;
+          const input = part.input as
+            | { label?: string; key?: string }
+            | undefined;
           if (input?.label && input?.key) {
             loaded.delete(`${input.label}:${input.key}`);
           }
@@ -231,12 +235,16 @@ export class Session {
 
       let changed = false;
       const newParts = msg.parts.map((part) => {
-        const p = part as Record<string, unknown>;
-        if (p.toolName === "load_context" && p.state === "output-available") {
-          const input = p.input as { label?: string; key?: string } | undefined;
+        if (
+          part.toolName === "load_context" &&
+          part.state === "output-available"
+        ) {
+          const input = part.input as
+            | { label?: string; key?: string }
+            | undefined;
           if (input?.label === label && input?.key === key) {
             changed = true;
-            return { ...p, output: `[skill unloaded: ${key}]` };
+            return { ...part, output: `[skill unloaded: ${key}]` };
           }
         }
         return part;
@@ -245,7 +253,7 @@ export class Session {
       if (changed) {
         this.storage.updateMessage({
           ...msg,
-          parts: newParts as UIMessage["parts"]
+          parts: newParts as SessionMessage["parts"]
         });
         return;
       }
@@ -254,22 +262,22 @@ export class Session {
 
   // ── History (tree-structured) ─────────────────────────────────
 
-  getHistory(leafId?: string | null): UIMessage[] {
+  getHistory(leafId?: string | null): SessionMessage[] {
     this._ensureReady();
     return this.storage.getHistory(leafId);
   }
 
-  getMessage(id: string): UIMessage | null {
+  getMessage(id: string): SessionMessage | null {
     this._ensureReady();
     return this.storage.getMessage(id);
   }
 
-  getLatestLeaf(): UIMessage | null {
+  getLatestLeaf(): SessionMessage | null {
     this._ensureReady();
     return this.storage.getLatestLeaf();
   }
 
-  getBranches(messageId: string): UIMessage[] {
+  getBranches(messageId: string): SessionMessage[] {
     this._ensureReady();
     return this.storage.getBranches(messageId);
   }
@@ -307,7 +315,7 @@ export class Session {
   // ── Write ─────────────────────────────────────────────────────
 
   async appendMessage(
-    message: UIMessage,
+    message: SessionMessage,
     parentId?: string | null
   ): Promise<void> {
     this._ensureReady();
@@ -328,7 +336,7 @@ export class Session {
     }
   }
 
-  updateMessage(message: UIMessage): void {
+  updateMessage(message: SessionMessage): void {
     this._ensureReady();
     this.storage.updateMessage(message);
     this._emitStatus("idle");

--- a/packages/agents/src/experimental/memory/session/types.ts
+++ b/packages/agents/src/experimental/memory/session/types.ts
@@ -5,17 +5,6 @@
 import type { ContextConfig, WritableContextProvider } from "./context";
 
 /**
- * Options for querying messages
- */
-export interface MessageQueryOptions {
-  limit?: number;
-  offset?: number;
-  before?: Date;
-  after?: Date;
-  role?: "user" | "assistant" | "system";
-}
-
-/**
  * Options for creating a Session.
  */
 export interface SessionOptions {

--- a/packages/agents/src/experimental/memory/session/types.ts
+++ b/packages/agents/src/experimental/memory/session/types.ts
@@ -5,6 +5,33 @@
 import type { ContextConfig, WritableContextProvider } from "./context";
 
 /**
+ * Minimal message part shape used by Session internals.
+ * Vercel AI SDK's `UIMessagePart` is structurally compatible.
+ */
+export interface SessionMessagePart {
+  type: string;
+  text?: string;
+  toolCallId?: string;
+  toolName?: string;
+  input?: unknown;
+  output?: unknown;
+  state?: string;
+  result?: unknown;
+}
+
+/**
+ * Minimal message shape used by Session internals.
+ * Vercel AI SDK's `UIMessage` is structurally compatible — you can pass
+ * `UIMessage` objects directly without conversion.
+ */
+export interface SessionMessage {
+  id: string;
+  role: string;
+  parts: SessionMessagePart[];
+  createdAt?: Date;
+}
+
+/**
  * Options for creating a Session.
  */
 export interface SessionOptions {

--- a/packages/agents/src/experimental/memory/utils/compaction-helpers.ts
+++ b/packages/agents/src/experimental/memory/utils/compaction-helpers.ts
@@ -6,7 +6,7 @@
  * for custom CompactFunction implementations.
  */
 
-import type { UIMessage } from "ai";
+import type { SessionMessage } from "../session/types";
 import { estimateMessageTokens } from "./tokens";
 
 // ── Compaction ID constants ─────────────────────────────────────────
@@ -15,7 +15,7 @@ import { estimateMessageTokens } from "./tokens";
 export const COMPACTION_PREFIX = "compaction_";
 
 /** Check if a message is a compaction message */
-export function isCompactionMessage(msg: UIMessage): boolean {
+export function isCompactionMessage(msg: SessionMessage): boolean {
   return msg.id.startsWith(COMPACTION_PREFIX);
 }
 
@@ -24,7 +24,7 @@ export function isCompactionMessage(msg: UIMessage): boolean {
 /**
  * Check if a message contains tool invocations.
  */
-function hasToolCalls(msg: UIMessage): boolean {
+function hasToolCalls(msg: SessionMessage): boolean {
   return msg.parts.some(
     (p) => p.type.startsWith("tool-") || p.type === "dynamic-tool"
   );
@@ -33,7 +33,7 @@ function hasToolCalls(msg: UIMessage): boolean {
 /**
  * Get tool call IDs from a message's parts.
  */
-function getToolCallIds(msg: UIMessage): Set<string> {
+function getToolCallIds(msg: SessionMessage): Set<string> {
   const ids = new Set<string>();
   for (const part of msg.parts) {
     if (
@@ -49,7 +49,7 @@ function getToolCallIds(msg: UIMessage): Set<string> {
 /**
  * Check if a message is a tool result referencing a specific call ID.
  */
-function isToolResultFor(msg: UIMessage, callIds: Set<string>): boolean {
+function isToolResultFor(msg: SessionMessage, callIds: Set<string>): boolean {
   return msg.parts.some(
     (p) =>
       (p.type.startsWith("tool-") || p.type === "dynamic-tool") &&
@@ -64,7 +64,7 @@ function isToolResultFor(msg: UIMessage, callIds: Set<string>): boolean {
  * tool results, move it forward past the results.
  */
 export function alignBoundaryForward(
-  messages: UIMessage[],
+  messages: SessionMessage[],
   idx: number
 ): number {
   if (idx <= 0 || idx >= messages.length) return idx;
@@ -88,7 +88,7 @@ export function alignBoundaryForward(
  * include the assistant message that made the calls.
  */
 export function alignBoundaryBackward(
-  messages: UIMessage[],
+  messages: SessionMessage[],
   idx: number
 ): number {
   if (idx <= 0 || idx >= messages.length) return idx;
@@ -128,7 +128,7 @@ export function alignBoundaryBackward(
  * @param minTailMessages Minimum messages to protect in the tail (fallback)
  */
 export function findTailCutByTokens(
-  messages: UIMessage[],
+  messages: SessionMessage[],
   headEnd: number,
   tailTokenBudget = 20000,
   minTailMessages = 2
@@ -170,7 +170,9 @@ export function findTailCutByTokens(
  * @param messages Messages after compaction
  * @returns Sanitized messages with no orphaned pairs
  */
-export function sanitizeToolPairs(messages: UIMessage[]): UIMessage[] {
+export function sanitizeToolPairs(
+  messages: SessionMessage[]
+): SessionMessage[] {
   // Build set of surviving tool call IDs (from assistant messages)
   const survivingCallIds = new Set<string>();
   for (const msg of messages) {
@@ -219,7 +221,7 @@ export function sanitizeToolPairs(messages: UIMessage[]): UIMessage[] {
         return true;
       });
       if (filteredParts.length !== msg.parts.length) {
-        return { ...msg, parts: filteredParts } as UIMessage;
+        return { ...msg, parts: filteredParts } as SessionMessage;
       }
       return msg;
     });
@@ -234,7 +236,7 @@ export function sanitizeToolPairs(messages: UIMessage[]): UIMessage[] {
   }
 
   if (missingResults.size > 0) {
-    const patched: UIMessage[] = [];
+    const patched: SessionMessage[] = [];
     for (const msg of result) {
       patched.push(msg);
       if (msg.role === "assistant") {
@@ -257,10 +259,10 @@ export function sanitizeToolPairs(messages: UIMessage[]): UIMessage[] {
                   toolName: callPart?.toolName ?? "unknown",
                   result:
                     "[Result from earlier conversation — see context summary above]"
-                } as unknown as UIMessage["parts"][number]
+                } as unknown as SessionMessage["parts"][number]
               ],
               createdAt: new Date()
-            } as UIMessage);
+            } as SessionMessage);
           }
         }
       }
@@ -278,7 +280,7 @@ export function sanitizeToolPairs(messages: UIMessage[]): UIMessage[] {
  * Compute a summary token budget based on the content being compressed.
  * 20% of the compressed content, clamped to 2K-8K tokens.
  */
-export function computeSummaryBudget(messages: UIMessage[]): number {
+export function computeSummaryBudget(messages: SessionMessage[]): number {
   const contentTokens = estimateMessageTokens(messages);
   // Summary is ~20% of the content being compressed.
   // The summary replaces the compressed middle, so it's sized relative
@@ -298,7 +300,7 @@ export function computeSummaryBudget(messages: UIMessage[]): number {
  * @param budget Target token count for the summary
  */
 export function buildSummaryPrompt(
-  messages: UIMessage[],
+  messages: SessionMessage[],
   previousSummary: string | null,
   budget: number
 ): string {
@@ -439,7 +441,7 @@ export function createCompactFunction(opts: CompactOptions) {
   const tailTokenBudget = opts.tailTokenBudget ?? 20000;
   const minTailMessages = opts.minTailMessages ?? 2;
 
-  return async (messages: UIMessage[]): Promise<CompactResult | null> => {
+  return async (messages: SessionMessage[]): Promise<CompactResult | null> => {
     if (messages.length <= protectHead + minTailMessages) {
       return null;
     }

--- a/packages/agents/src/experimental/memory/utils/compaction.ts
+++ b/packages/agents/src/experimental/memory/utils/compaction.ts
@@ -5,7 +5,7 @@
  * Does NOT mutate stored messages — operates on a copy.
  */
 
-import type { UIMessage } from "ai";
+import type { SessionMessage } from "../session/types";
 
 export interface TruncateOptions {
   /** Number of recent messages to keep intact (default: 4) */
@@ -33,9 +33,9 @@ export interface TruncateOptions {
  * ```
  */
 export function truncateOlderMessages(
-  messages: UIMessage[],
+  messages: SessionMessage[],
   options?: TruncateOptions
-): UIMessage[] {
+): SessionMessage[] {
   const keepRecent = options?.keepRecent ?? 4;
   const maxToolOutput = options?.maxToolOutputChars ?? 500;
   const maxText = options?.maxTextChars ?? 10000;
@@ -43,7 +43,7 @@ export function truncateOlderMessages(
   if (messages.length <= keepRecent) return messages;
 
   const cutoff = messages.length - keepRecent;
-  const result: UIMessage[] = [];
+  const result: SessionMessage[] = [];
 
   for (let i = 0; i < messages.length; i++) {
     if (i >= cutoff) {
@@ -90,7 +90,7 @@ export function truncateOlderMessages(
     });
 
     result.push(
-      changed ? ({ ...msg, parts: truncatedParts } as UIMessage) : msg
+      changed ? ({ ...msg, parts: truncatedParts } as SessionMessage) : msg
     );
   }
 

--- a/packages/agents/src/experimental/memory/utils/tokens.ts
+++ b/packages/agents/src/experimental/memory/utils/tokens.ts
@@ -21,7 +21,7 @@
  * compaction triggers before context windows are actually exceeded.
  */
 
-import type { UIMessage } from "ai";
+import type { SessionMessage } from "../session/types";
 
 /** Approximate characters per token for English text */
 export const CHARS_PER_TOKEN = 4;
@@ -57,7 +57,7 @@ export function estimateStringTokens(text: string): number {
  *
  * This is a heuristic. Do not use where exact counts are required.
  */
-export function estimateMessageTokens(messages: UIMessage[]): number {
+export function estimateMessageTokens(messages: SessionMessage[]): number {
   let tokens = 0;
   for (const msg of messages) {
     tokens += TOKENS_PER_MESSAGE;

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -1,10 +1,10 @@
-import type { UIMessage } from "ai";
 import { Agent } from "../../index";
 import {
   Session,
   AgentSessionProvider,
   AgentContextProvider,
   AgentSearchProvider,
+  type SessionMessage,
   type StoredCompaction,
   type ContextBlock
 } from "../../experimental/memory/session";
@@ -17,15 +17,18 @@ export class TestSessionAgent extends Agent {
 
   // ── Messages ────────────────────────────────────────────────────
 
-  async appendMessage(message: UIMessage, parentId?: string): Promise<void> {
+  async appendMessage(
+    message: SessionMessage,
+    parentId?: string
+  ): Promise<void> {
     await this.session.appendMessage(message, parentId);
   }
 
-  getMessage(id: string): UIMessage | null {
+  getMessage(id: string): SessionMessage | null {
     return this.session.getMessage(id);
   }
 
-  updateMessage(message: UIMessage): void {
+  updateMessage(message: SessionMessage): void {
     this.session.updateMessage(message);
   }
 
@@ -39,15 +42,15 @@ export class TestSessionAgent extends Agent {
 
   // ── History (tree) ──────────────────────────────────────────────
 
-  getHistory(leafId?: string): UIMessage[] {
+  getHistory(leafId?: string): SessionMessage[] {
     return this.session.getHistory(leafId);
   }
 
-  getLatestLeaf(): UIMessage | null {
+  getLatestLeaf(): SessionMessage | null {
     return this.session.getLatestLeaf();
   }
 
-  getBranches(messageId: string): UIMessage[] {
+  getBranches(messageId: string): SessionMessage[] {
     return this.session.getBranches(messageId);
   }
 

--- a/packages/agents/src/tests/experimental/memory/session/session.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/session.test.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:workers";
-import type { UIMessage } from "ai";
+import type { SessionMessage } from "../../../../experimental/memory/session/types";
 import { describe, expect, it, beforeEach } from "vitest";
 import { getAgentByName } from "../../../..";
 import { Session } from "../../../../experimental/memory/session/session";
@@ -562,9 +562,9 @@ describe("ContextBlocks — edge cases", () => {
 // ── Compaction tests ─────────────────────────────────────────────
 
 function createCompactableSession(
-  compactFn: (msgs: UIMessage[]) => Promise<CompactResult | null>
+  compactFn: (msgs: SessionMessage[]) => Promise<CompactResult | null>
 ) {
-  const messages: UIMessage[] = [];
+  const messages: SessionMessage[] = [];
   const compactions: StoredCompaction[] = [];
 
   const storage: SessionProvider = {
@@ -804,7 +804,7 @@ describe("Session.compact()", () => {
   });
 
   it("appendMessage does not auto-compact without compaction function", async () => {
-    const messages: UIMessage[] = [];
+    const messages: SessionMessage[] = [];
     const storage: SessionProvider = {
       getMessage: () => null,
       getHistory: () => messages,
@@ -843,10 +843,10 @@ describe("Session.compact()", () => {
     // Simulate getHistory() returning overlay messages from a previous compaction.
     // The compaction function should receive these overlays (filtering is its job),
     // and Session.compact() should store correct real message IDs.
-    const messages: UIMessage[] = [];
+    const messages: SessionMessage[] = [];
     const compactions: StoredCompaction[] = [];
 
-    const overlayMsg: UIMessage = {
+    const overlayMsg: SessionMessage = {
       id: `${COMPACTION_PREFIX}c1`,
       role: "assistant",
       parts: [{ type: "text", text: "Previous summary" }]
@@ -904,7 +904,7 @@ describe("Session.compact()", () => {
     // The compaction function returns real message IDs (m4-m5)
     const session = new Session(storage);
     type Internals = {
-      _compactionFn: (m: UIMessage[]) => Promise<CompactResult | null>;
+      _compactionFn: (m: SessionMessage[]) => Promise<CompactResult | null>;
     };
     (session as unknown as Internals)._compactionFn = async (
       msgs
@@ -937,7 +937,7 @@ describe("Session.compact()", () => {
 
   it("compact broadcasts status to connected clients", async () => {
     const broadcasts: string[] = [];
-    const messages: UIMessage[] = [];
+    const messages: SessionMessage[] = [];
     const compactions: StoredCompaction[] = [];
 
     const storage: SessionProvider = {
@@ -967,7 +967,7 @@ describe("Session.compact()", () => {
     const session = new Session(storage);
     // Wire internals
     type Internals = {
-      _compactionFn: (m: UIMessage[]) => Promise<CompactResult | null>;
+      _compactionFn: (m: SessionMessage[]) => Promise<CompactResult | null>;
       _broadcaster: { broadcast(msg: string): void };
     };
     const internals = session as unknown as Internals;
@@ -1018,7 +1018,7 @@ describe("createCompactFunction", () => {
     });
 
     // 6 messages <= protectHead(2) + minTailMessages(4) = 6
-    const messages: UIMessage[] = Array.from({ length: 6 }, (_, i) => ({
+    const messages: SessionMessage[] = Array.from({ length: 6 }, (_, i) => ({
       id: `m${i}`,
       role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
       parts: [{ type: "text" as const, text: `message ${i}` }]
@@ -1036,7 +1036,7 @@ describe("createCompactFunction", () => {
     });
 
     // 20 messages > protectHead(1) + minTailMessages(2), low tail budget leaves middle to compress
-    const messages: UIMessage[] = Array.from({ length: 20 }, (_, i) => ({
+    const messages: SessionMessage[] = Array.from({ length: 20 }, (_, i) => ({
       id: `m${i}`,
       role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
       parts: [

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -204,7 +204,7 @@ export class ThinkClientToolsAgent extends Think {
   }
 
   async getBranches(messageId: string): Promise<UIMessage[]> {
-    return this.session.getBranches(messageId);
+    return this.session.getBranches(messageId) as UIMessage[];
   }
 
   async setMessageConcurrency(concurrency: MessageConcurrency): Promise<void> {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -500,7 +500,7 @@ export class Think<
    * Always fresh — reads from Session's tree-structured storage.
    */
   get messages(): UIMessage[] {
-    return this.session.getHistory();
+    return this.session.getHistory() as UIMessage[];
   }
 
   private _aborts = new AbortRegistry();
@@ -807,7 +807,7 @@ export class Think<
     const system = frozenPrompt || this.getSystemPrompt();
 
     const history = this.session.getHistory();
-    const truncated = truncateOlderMessages(history);
+    const truncated = truncateOlderMessages(history) as UIMessage[];
     const messages = pruneMessages({
       messages: await convertToModelMessages(truncated),
       toolCalls: "before-last-2-messages"


### PR DESCRIPTION
## Summary

- Adds comprehensive documentation for the experimental Session API (`agents/experimental/memory/session`) covering Session, SessionManager, context blocks (all 4 provider types), compaction, AI tools, search, storage schema, custom providers, and exported utilities
- Includes a "Gotchas and Quirks" section noting 10 surprising behaviors
- Removes dead session API surface: `MessageQueryOptions`, `needsCompaction()`, `maxContextMessages()`
- Decouples Session from AI SDK runtime dependency:
  - Defines minimal `SessionMessage`/`SessionMessagePart` types — Vercel AI SDK's `UIMessage` is structurally compatible
  - Swaps `jsonSchema()` from `ai` to `z.fromJSONSchema()` from zod (matching `MCPClientManager.getAITools()` pattern)
  - Keeps `ToolSet` as type-only import (zero runtime cost)
- Fixes `getBranches()` doc (returns children, not siblings)
- Adds sessions.md to docs/index.md
- Removes stale `maxContextMessages` reference from session-multichat README

## Test plan

- [x] `npm run check` passes (all 73 projects typecheck)
- [ ] Review doc accuracy against source code
- [ ] Verify code examples compile/run