### PR TITLE
fix(mcp): handle cold wake in handleMcpMessage RPC entry point

### DIFF
--- a/.changeset/fix-mcp-rpc-cold-wake.md
+++ b/.changeset/fix-mcp-rpc-cold-wake.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix `McpAgent.handleMcpMessage` crashing with "Attempting to read .name before it was set" when the Durable Object wakes from hibernation via native DO RPC. The method now calls `__unsafe_ensureInitialized()` to hydrate `this.name` from storage and run `onStart()` before processing messages, matching the pattern used by `_workflow_*` RPC methods and `alarm()`.

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -393,21 +393,7 @@ export abstract class McpAgent<
   async handleMcpMessage(
     message: JSONRPCMessage | JSONRPCMessage[]
   ): Promise<JSONRPCMessage | JSONRPCMessage[] | undefined> {
-    if (!this._transport) {
-      this.props = await this.ctx.storage.get("props");
-
-      await this.init();
-      const server = await this.server;
-
-      this._transport = this.initTransport();
-
-      if (!this._transport) {
-        throw new Error("Failed to initialize transport");
-      }
-      await server.connect(this._transport);
-
-      await this.reinitializeServer();
-    }
+    await this.__unsafe_ensureInitialized();
 
     if (!(this._transport instanceof RPCServerTransport)) {
       throw new Error("Expected RPC transport");

--- a/packages/agents/src/tests/mcp/transports/rpc.test.ts
+++ b/packages/agents/src/tests/mcp/transports/rpc.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
 import { RPCClientTransport, RPCServerTransport } from "../../../mcp/rpc";
 import type {
   JSONRPCMessage,
@@ -11,6 +12,7 @@ import {
   expectValidToolsList,
   expectValidGreetResult
 } from "../../shared/test-utils";
+import type { McpAgent } from "../../../mcp";
 
 describe("RPC Transport", () => {
   describe("RPCClientTransport", () => {
@@ -481,6 +483,62 @@ describe("RPC Transport", () => {
 
       expect(result.content).toBeDefined();
       expect(Array.isArray(result.content)).toBe(true);
+    });
+  });
+
+  describe("Cold Wake Initialization (issue #1282)", () => {
+    async function seedStorageForColdWake(
+      stub: DurableObjectStub<McpAgent>,
+      doName: string
+    ) {
+      await runInDurableObject(stub, async (instance) => {
+        const ctx = (instance as unknown as { ctx: DurableObjectState }).ctx;
+        await ctx.storage.put("__ps_name", doName);
+      });
+    }
+
+    it("should hydrate name and run onStart when handleMcpMessage is the first entry point", async () => {
+      const doName = "rpc:cold-wake-init";
+      const id = env.MCP_OBJECT.idFromName(doName);
+      const stub = env.MCP_OBJECT.get(id);
+
+      // Seed __ps_name directly, bypassing setName/onStart.
+      // Simulates a DO that was previously initialized, hibernated,
+      // and wakes cold — #_name is unset, only storage has the name.
+      await seedStorageForColdWake(stub, doName);
+
+      // Call handleMcpMessage directly via RPC — the native DO RPC
+      // entry point that bypasses fetch/alarm/webSocket paths.
+      // Before the fix, this threw "Attempting to read .name on
+      // TestMcpAgent before it was set" because __unsafe_ensureInitialized
+      // was never called.
+      const response = await stub.handleMcpMessage(TEST_MESSAGES.initialize);
+
+      expect(response).toBeDefined();
+      expect(response).toHaveProperty("result");
+    });
+
+    it("should handle tool calls after cold wake via handleMcpMessage", async () => {
+      const doName = "rpc:cold-wake-tools";
+      const id = env.MCP_OBJECT.idFromName(doName);
+      const stub = env.MCP_OBJECT.get(id);
+
+      await seedStorageForColdWake(stub, doName);
+
+      // Initialize the MCP server first
+      await stub.handleMcpMessage(TEST_MESSAGES.initialize);
+
+      // Now call a tool — verifies the server is fully functional
+      const toolResult = await stub.handleMcpMessage(TEST_MESSAGES.greetTool);
+
+      expect(toolResult).toBeDefined();
+      expect(toolResult).toHaveProperty("result");
+      const content = (
+        toolResult as unknown as {
+          result: { content: Array<{ text: string }> };
+        }
+      ).result.content;
+      expect(content[0].text).toContain("Test User");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1282.

- `McpAgent.handleMcpMessage` is a native DO RPC method that bypasses PartyServer's `fetch`/`alarm`/`webSocket` entry points where `#ensureInitialized()` normally runs. When the MCP server DO wakes from hibernation via this path, `this.name` was never hydrated from storage, causing a crash.
- Replaced the hand-rolled 15-line cold-start block inside `handleMcpMessage` with a single `await this.__unsafe_ensureInitialized()` call, matching the pattern used by `_workflow_handleCallback`, `_workflow_broadcast`, `_workflow_updateState`, and `alarm()`.
- This eliminates a duplicate initialization path that was both incomplete (missed name hydration) and divergent from `onStart` (missed Agent-level MCP client restore, workflow checks, etc.).

## Test plan

- [x] Added two regression tests that simulate cold wake by seeding `__ps_name` directly in storage (bypassing `setName`/`onStart`), then calling `handleMcpMessage` as the first entry point
- [x] First test verifies initialize message succeeds after cold wake
- [x] Second test verifies full tool call flow works after cold wake
- [x] All 26 RPC transport tests pass
- [x] Build passes
- [x] Type checks pass


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
