### PR TITLE
Re-enable SubAgent tests

### DIFF
--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -6,7 +6,7 @@ function uniqueName() {
   return `sub-agent-test-${Math.random().toString(36).slice(2)}`;
 }
 
-describe.skip("SubAgent", () => {
+describe("SubAgent", () => {
   it("should create a sub-agent and call RPC methods on it", async () => {
     const name = uniqueName();
     const agent = await getAgentByName(env.TestSubAgentParent, name);


### PR DESCRIPTION
## Summary
- Removes `.skip` from the `SubAgent` test suite in `packages/agents/src/tests/sub-agent.test.ts` so the tests run in CI again.

## Test plan
- CI should pass with the SubAgent tests now executing.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
