### PR TITLE
fix: remove false-positive cancel warning in AIChatAgent

### DIFF
--- a/.changeset/remove-false-positive-cancel-warning.md
+++ b/.changeset/remove-false-positive-cancel-warning.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Remove false-positive "Stream was still active when cancel was received" warning that fired on every cancellation, even when the user correctly passed `abortSignal` to `streamText()`

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -3272,11 +3272,6 @@ export class AIChatAgent<
 
     // If we exited due to abort, send a done signal so clients know the stream ended
     if (!streamCompleted.value) {
-      console.warn(
-        "[AIChatAgent] Stream was still active when cancel was received. " +
-          "Pass options.abortSignal to streamText() in your onChatMessage() " +
-          "to cancel the upstream LLM call and avoid wasted work."
-      );
       this._completeStream(streamId);
       streamCompleted.value = true;
       this._broadcastChatMessage({
@@ -3398,11 +3393,6 @@ export class AIChatAgent<
 
     // If we exited due to abort, send a done signal so clients know the stream ended
     if (!streamCompleted.value) {
-      console.warn(
-        "[AIChatAgent] Stream was still active when cancel was received. " +
-          "Pass options.abortSignal to streamText() in your onChatMessage() " +
-          "to cancel the upstream LLM call and avoid wasted work."
-      );
       textPart.state = "done";
       this._broadcastTextEvent(
         streamId,


### PR DESCRIPTION
## Summary

- Removes the `console.warn` about "Stream was still active when cancel was received" from both `_streamSSEReply` and `_sendPlaintextReply`
- The warning fired on **every** cancellation — even when the user correctly passed `abortSignal` to `streamText()` — because the internal safety-net `reader.cancel()` always races ahead of the stream's natural termination
- Fixes #1288

## Context

When the abort signal fires, our listener immediately calls `reader.cancel()`, which resolves `reader.read()` with `{ done: true }`. This is indistinguishable from the stream ending naturally because the user wired `abortSignal` to `streamText()`. Both produce the same state, so the warning was a false positive in the correctly-wired case.

The safety-net `reader.cancel()` mechanism (which prevents broadcasting further chunks) is preserved — only the misleading warning is removed.

## Test plan

- [x] All 5 existing cancel tests pass (`cancel-request.test.ts`)
- [x] All 5 abort transport tests pass (`ws-transport-abort.test.ts`)
- [x] No tests reference the warning text


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
