### PR TITLE
Docs: Long-running agents, durable execution, and chat recovery

### DIFF
--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -565,6 +565,110 @@ async onChatMessage(_onFinish, options) {
 
 If you do not pass `abortSignal` to `streamText`, the LLM call will continue running in the background even after the user cancels. Always forward it when possible.
 
+### Stream Recovery
+
+When a Durable Object is evicted mid-stream (code update, inactivity timeout, resource limit), the LLM connection is severed permanently and the in-memory streaming state is lost. `unstable_chatRecovery` wraps each chat turn in a [`runFiber()`](./durable-execution.md), providing automatic `keepAlive` during streaming and a recovery hook on restart.
+
+```typescript
+export class ChatAgent extends AIChatAgent {
+  override unstable_chatRecovery = true;
+}
+```
+
+When enabled, every `onChatMessage` call runs inside a fiber. If the agent is evicted mid-stream, the fiber row survives in SQLite. On the next activation, the framework detects the interrupted fiber, reconstructs the partial response from buffered stream chunks, and calls `onChatRecovery`.
+
+#### `onChatRecovery`
+
+Override to implement provider-specific recovery. The default behavior persists the partial response and schedules a continuation via `continueLastTurn()`.
+
+```typescript
+export class ChatAgent extends AIChatAgent {
+  override unstable_chatRecovery = true;
+
+  override async onChatRecovery(
+    ctx: ChatRecoveryContext
+  ): Promise<ChatRecoveryOptions> {
+    // Inspect what was generated before eviction
+    console.log(`Recovered ${ctx.partialText.length} chars of partial text`);
+
+    // Default: persist partial + schedule continuation
+    return {};
+  }
+}
+```
+
+**`ChatRecoveryContext`:**
+
+| Field             | Type                                   | Description                                                           |
+| ----------------- | -------------------------------------- | --------------------------------------------------------------------- |
+| `streamId`        | `string`                               | ID of the interrupted stream                                          |
+| `requestId`       | `string`                               | ID of the original chat request                                       |
+| `partialText`     | `string`                               | Text generated before eviction                                        |
+| `partialParts`    | `MessagePart[]`                        | Message parts (text, reasoning, tool calls) generated before eviction |
+| `recoveryData`    | `unknown \| null`                      | Data from `this.stash()` — entirely user-controlled                   |
+| `messages`        | `ChatMessage[]`                        | Full conversation history                                             |
+| `lastBody`        | `Record<string, unknown> \| undefined` | The original request body                                             |
+| `lastClientTools` | `ClientToolSchema[] \| undefined`      | Client tool schemas from the original request                         |
+
+**`ChatRecoveryOptions`:**
+
+| Field      | Default | Description                                       |
+| ---------- | ------- | ------------------------------------------------- |
+| `persist`  | `true`  | Save the partial response as an assistant message |
+| `continue` | `true`  | Schedule a continuation via `continueLastTurn()`  |
+
+Common return values:
+
+- `{}` — persist partial + auto-continue (default, works with providers that support assistant prefill)
+- `{ continue: false }` — persist partial but do not auto-continue (handle continuation yourself)
+- `{ persist: false, continue: false }` — handle everything yourself (e.g., retrieve a completed response from the provider)
+
+#### `continueLastTurn`
+
+Appends to the last assistant message by re-calling `onChatMessage` with the saved request body. The response is streamed as a continuation — appended to the existing assistant message, not a new one. No synthetic user message is created.
+
+```typescript
+protected continueLastTurn(body?: Record<string, unknown>): Promise<SaveMessagesResult>;
+```
+
+Called automatically by the default recovery path. Can also be called manually from scheduled callbacks or other entry points. The optional `body` parameter merges with the saved `_lastBody`.
+
+#### Stashing recovery data
+
+Use `this.stash()` inside `onChatMessage` to persist provider-specific data for recovery. The stash is stored in the fiber's SQLite row, separate from agent state, and available as `ctx.recoveryData` in `onChatRecovery`.
+
+```typescript
+async onChatMessage(_onFinish, options) {
+  const result = streamText({
+    model: openai("gpt-5.4"),
+    messages: await convertToModelMessages(this.messages),
+    providerOptions: { openai: { store: true } },
+    includeRawChunks: true,
+    onChunk: ({ chunk }) => {
+      if (chunk.type === "raw") {
+        const raw = chunk.rawValue as { type?: string; response?: { id?: string } };
+        if (raw?.type === "response.created" && raw.response?.id) {
+          this.stash({ responseId: raw.response.id });
+        }
+      }
+    }
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+#### Recovery strategies by provider
+
+The right strategy depends on whether the provider supports assistant prefill and whether the response continues server-side after disconnection:
+
+| Provider               | Strategy                                                     | Token cost |
+| ---------------------- | ------------------------------------------------------------ | ---------- |
+| Workers AI             | `continueLastTurn()` — model continues via assistant prefill | Low        |
+| OpenAI (Responses API) | Retrieve completed response by ID — zero wasted tokens       | Zero       |
+| Anthropic              | Persist partial, send a synthetic user message to continue   | Medium     |
+
+For a complete multi-provider implementation, see the [`forever-chat` example](../experimental/forever-chat/) and the [`forever.md` design doc](../experimental/forever.md). For how chat recovery fits into the broader long-running agents story, see [Long-Running Agents: Recovering interrupted LLM streams](./long-running-agents.md#recovering-interrupted-llm-streams).
+
 ## Client API
 
 ### `useAgentChat`
@@ -1349,11 +1453,11 @@ The originating client receives the streaming response. All other clients receiv
 
 ### Exports
 
-| Import path                 | Exports                                             |
-| --------------------------- | --------------------------------------------------- |
-| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`       |
-| `@cloudflare/ai-chat/react` | `useAgentChat`                                      |
-| `@cloudflare/ai-chat/types` | `MessageType`, `OutgoingMessage`, `IncomingMessage` |
+| Import path                 | Exports                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------- |
+| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`, `ChatRecoveryContext`, `ChatRecoveryOptions` |
+| `@cloudflare/ai-chat/react` | `useAgentChat`                                                                              |
+| `@cloudflare/ai-chat/types` | `MessageType`, `OutgoingMessage`, `IncomingMessage`                                         |
 
 ### WebSocket Protocol
 
@@ -1383,6 +1487,8 @@ The chat protocol uses typed JSON messages over WebSocket:
 ## Related Docs
 
 - [Client SDK](./client-sdk.md) — `useAgent` hook and `AgentClient` class
+- [Durable Execution](./durable-execution.md) — `runFiber()`, `stash()`, and crash recovery
+- [Long-Running Agents](./long-running-agents.md) — lifecycle, recovery patterns, and provider-specific strategies
 - [Human in the Loop](./human-in-the-loop.md) — Approval flows and manual intervention patterns
 - [Resumable Streaming](./resumable-streaming.md) — How stream resumption works
 - [Client Tools Continuation](./client-tools-continuation.md) — Advanced client-side tool patterns

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -1,0 +1,30 @@
+# Durable Execution
+
+Run work that survives Durable Object eviction. `runFiber()` registers a task in SQLite, keeps the agent alive during execution, lets you checkpoint intermediate state with `stash()`, and calls `onFiberRecovered()` on the next activation if the agent was evicted mid-task.
+
+> This page covers the full API. For how fibers fit into the bigger picture, see [Long-Running Agents](./long-running-agents.md).
+
+## Why fibers exist
+
+Durable Objects get evicted for three reasons:
+
+1. **Inactivity timeout** — ~70–140 seconds with no incoming requests or open WebSockets
+2. **Code updates / runtime restarts** — non-deterministic, 1–2x per day
+3. **Alarm handler timeout** — 15 minutes
+
+For AI agents, eviction during active work is catastrophic: the upstream LLM connection is severed permanently, in-memory state is lost, and multi-turn agent loops lose their position entirely.
+
+Fibers solve this with two layers:
+
+| Layer | Primitive | Purpose |
+| --- | --- | --- |
+| 1 | `keepAlive()` | Prevents idle eviction via alarm heartbeats |
+| 2 | `runFiber()` | Durable execution — registered in SQLite, checkpointable, recoverable |
+
+`keepAlive()` prevents eviction. `runFiber()` makes eviction survivable.
+
+## API
+
+TODO: Full API reference for `runFiber`, `stash`, `onFiberRecovered`, `FiberContext`, `FiberRecoveryContext`, `keepAlive`, `keepAliveWhile`. Cover inline vs fire-and-forget patterns, concurrent fibers, checkpoint semantics, and testing recovery locally.
+
+See [`forever.md`](../experimental/forever.md) for the current design doc with full details.

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -2,7 +2,36 @@
 
 Run work that survives Durable Object eviction. `runFiber()` registers a task in SQLite, keeps the agent alive during execution, lets you checkpoint intermediate state with `stash()`, and calls `onFiberRecovered()` on the next activation if the agent was evicted mid-task.
 
-> This page covers the full API. For how fibers fit into the bigger picture, see [Long-Running Agents](./long-running-agents.md).
+> For how fibers fit into the bigger picture of building agents that run for weeks or months, see [Long-Running Agents](./long-running-agents.md).
+
+## Quick start
+
+```typescript
+import { Agent } from "agents";
+import type { FiberRecoveryContext } from "agents";
+
+class MyAgent extends Agent {
+  async doWork() {
+    await this.runFiber("my-task", async (ctx) => {
+      const step1 = await expensiveOperation();
+      ctx.stash({ step1 });
+
+      const step2 = await anotherExpensiveOperation(step1);
+      this.setState({ ...this.state, result: step2 });
+    });
+  }
+
+  async onFiberRecovered(ctx: FiberRecoveryContext) {
+    if (ctx.name !== "my-task") return;
+    const snapshot = ctx.snapshot as { step1: unknown } | null;
+    if (snapshot) {
+      // Resume from the checkpoint — step1 is done, run step2
+      const step2 = await anotherExpensiveOperation(snapshot.step1);
+      this.setState({ ...this.state, result: step2 });
+    }
+  }
+}
+```
 
 ## Why fibers exist
 
@@ -12,19 +41,302 @@ Durable Objects get evicted for three reasons:
 2. **Code updates / runtime restarts** — non-deterministic, 1–2x per day
 3. **Alarm handler timeout** — 15 minutes
 
-For AI agents, eviction during active work is catastrophic: the upstream LLM connection is severed permanently, in-memory state is lost, and multi-turn agent loops lose their position entirely.
+When eviction happens mid-work, the upstream HTTP connection (to an LLM provider, an API, a database) is severed permanently. In-memory state — streaming buffers, partial responses, loop counters — is lost. Multi-turn agent loops lose their position entirely.
 
-Fibers solve this with two layers:
+`keepAlive()` reduces the chance of eviction. `runFiber()` makes eviction survivable.
 
-| Layer | Primitive | Purpose |
-| --- | --- | --- |
-| 1 | `keepAlive()` | Prevents idle eviction via alarm heartbeats |
-| 2 | `runFiber()` | Durable execution — registered in SQLite, checkpointable, recoverable |
+For work that should run independently of the agent with per-step retries and multi-step orchestration, use [Workflows](./workflows.md) instead. Fibers are for work that is part of the agent's own execution. See [Long-Running Agents: Workflows vs agent-internal patterns](./long-running-agents.md#when-to-use-workflows-vs-agent-internal-patterns) for a comparison.
 
-`keepAlive()` prevents eviction. `runFiber()` makes eviction survivable.
+## `keepAlive()`
 
-## API
+Prevents idle eviction by creating a 30-second alarm heartbeat that resets the inactivity timer.
 
-TODO: Full API reference for `runFiber`, `stash`, `onFiberRecovered`, `FiberContext`, `FiberRecoveryContext`, `keepAlive`, `keepAliveWhile`. Cover inline vs fire-and-forget patterns, concurrent fibers, checkpoint semantics, and testing recovery locally.
+```typescript
+class Agent {
+  keepAlive(): Promise<() => void>;
+  keepAliveWhile<T>(fn: () => Promise<T>): Promise<T>;
+}
+```
 
-See [`forever.md`](../experimental/forever.md) for the current design doc with full details.
+`keepAliveWhile()` is the recommended approach — it runs an async function and automatically cleans up the heartbeat when it completes or throws:
+
+```typescript
+const result = await this.keepAliveWhile(async () => {
+  return await slowAPICall();
+});
+```
+
+For manual control, `keepAlive()` returns a disposer. Always call it when done — otherwise the heartbeat continues indefinitely:
+
+```typescript
+const dispose = await this.keepAlive();
+try {
+  await longWork();
+} finally {
+  dispose();
+}
+```
+
+### How it works
+
+While any `keepAlive` ref is held, an alarm fires every 30 seconds that resets the inactivity timer. When all disposers are called, alarms stop and the DO can go idle naturally.
+
+The heartbeat is invisible to `getSchedules()` — no schedule rows are created. It does not conflict with your own schedules; the alarm system multiplexes all schedules and the keepAlive heartbeat through a single alarm slot.
+
+### Configurable interval
+
+Default: 30 seconds. The inactivity timeout is ~70–140 seconds, so 30 seconds gives comfortable margin. Override via static options:
+
+```typescript
+class MyAgent extends Agent {
+  static options = { keepAliveIntervalMs: 2_000 }; // useful for testing recovery locally
+}
+```
+
+### When to use keepAlive vs runFiber
+
+`keepAlive` prevents eviction but does nothing about recovery. If the agent _is_ evicted despite the heartbeat (code update, alarm timeout, resource limit), any in-progress work is lost.
+
+`runFiber` calls `keepAlive` internally _and_ persists the work in SQLite so it can be recovered. Use `keepAlive` alone when the work is cheap to redo or does not need checkpointing. Use `runFiber` when the work is expensive and you need to resume from where you left off.
+
+| Scenario                                         | Use                         |
+| ------------------------------------------------ | --------------------------- |
+| Waiting on a slow API call                       | `keepAlive()`               |
+| Streaming an LLM response (via `AIChatAgent`)    | Automatic (built in)        |
+| Multi-step computation with intermediate results | `runFiber()`                |
+| Background research loop that takes 10+ minutes  | `runFiber()` with `stash()` |
+
+## `runFiber()`
+
+Durable execution with checkpointing and recovery.
+
+```typescript
+class Agent {
+  runFiber<T>(name: string, fn: (ctx: FiberContext) => Promise<T>): Promise<T>;
+  stash(data: unknown): void;
+  onFiberRecovered(ctx: FiberRecoveryContext): Promise<void>;
+}
+
+type FiberContext = {
+  id: string;
+  stash(data: unknown): void;
+  snapshot: unknown | null;
+};
+
+type FiberRecoveryContext = {
+  id: string;
+  name: string;
+  snapshot: unknown | null;
+};
+```
+
+### Lifecycle
+
+#### Normal execution
+
+```
+runFiber("work", fn)
+  ├─ INSERT row into cf_agents_runs
+  ├─ keepAlive() — heartbeat starts
+  ├─ Execute fn(ctx)
+  │    ├─ ctx.stash(data) → UPDATE snapshot in SQLite
+  │    ├─ ctx.stash(data) → UPDATE snapshot in SQLite
+  │    └─ return result
+  ├─ DELETE row from cf_agents_runs
+  ├─ keepAlive dispose — heartbeat stops
+  └─ Return result to caller
+```
+
+#### Eviction and recovery
+
+```
+[DO evicted — all in-memory state lost]
+
+  On next activation:
+  ├─ Request/connection → onStart() → _checkRunFibers()     [primary path]
+  │  OR
+  ├─ Persisted alarm fires → _onAlarmHousekeeping()          [fallback path]
+
+  _checkRunFibers():
+  ├─ SELECT * FROM cf_agents_runs
+  ├─ For each orphaned row:
+  │    ├─ Parse snapshot from JSON
+  │    ├─ Call onFiberRecovered(ctx)
+  │    └─ DELETE the row
+  └─ If onFiberRecovered calls runFiber() again → new row, normal execution
+```
+
+Both recovery paths call the same hook. The alarm path is critical for background agents that have no incoming client connections — the persisted alarm wakes the agent on its own.
+
+#### Error during execution
+
+```
+fn(ctx) throws Error
+  ├─ DELETE row from cf_agents_runs
+  ├─ keepAlive dispose
+  └─ Error propagates to caller (or logged if fire-and-forget)
+```
+
+No automatic retries. Recovery logic belongs in `onFiberRecovered`, where you have the snapshot and full context about what went wrong.
+
+### Inline vs fire-and-forget
+
+`runFiber()` supports both patterns:
+
+```typescript
+// Inline — await the result
+const result = await this.runFiber("work", async (ctx) => {
+  return computeExpensiveThing();
+});
+
+// Fire-and-forget — caller does not wait
+void this.runFiber("background", async (ctx) => {
+  await longRunningProcess();
+});
+```
+
+If the DO is evicted during an inline `await`, the caller is gone. On recovery, `onFiberRecovered` fires — it cannot return a result to the original caller. This is the inherent limitation of durable execution across process boundaries. For long-running work that is likely to outlive a single DO lifetime, fire-and-forget with checkpoint/recovery is the safer pattern.
+
+## Checkpoints with `stash()`
+
+`ctx.stash(data)` writes to SQLite **synchronously**. There is no async gap between "I decided to save" and "it is saved." If eviction happens after `stash()` returns, the data is guaranteed to be in SQLite.
+
+Each call **fully replaces** the previous snapshot — it is not a merge. Write the complete recovery state you need:
+
+```typescript
+await this.runFiber("research", async (ctx) => {
+  const steps = ["search", "analyze", "synthesize"];
+  const completed: string[] = [];
+  const results: Record<string, unknown> = {};
+
+  for (const step of steps) {
+    results[step] = await executeStep(step);
+    completed.push(step);
+
+    ctx.stash({
+      completed,
+      results,
+      pendingSteps: steps.slice(completed.length)
+    });
+  }
+});
+```
+
+### `this.stash()` vs `ctx.stash()`
+
+Both do the same thing. `ctx.stash()` uses a direct closure over the fiber ID. `this.stash()` uses `AsyncLocalStorage` to find the currently executing fiber — it works correctly even with concurrent fibers, since each fiber's ALS context is independent.
+
+`this.stash()` is convenient when calling from nested functions that do not have access to `ctx`. It throws if called outside a `runFiber` callback.
+
+## Recovery
+
+Override `onFiberRecovered` to handle interrupted fibers. The default implementation logs a warning and deletes the row.
+
+```typescript
+class ResearchAgent extends Agent {
+  async onFiberRecovered(ctx: FiberRecoveryContext) {
+    if (ctx.name !== "research") return;
+
+    const snapshot = ctx.snapshot as {
+      completed: string[];
+      results: Record<string, unknown>;
+      pendingSteps: string[];
+    } | null;
+
+    if (snapshot && snapshot.pendingSteps.length > 0) {
+      // Resume from where we left off
+      void this.runFiber("research", async (fiberCtx) => {
+        const { completed, results, pendingSteps } = snapshot;
+
+        for (const step of pendingSteps) {
+          results[step] = await this.executeStep(step);
+          completed.push(step);
+
+          fiberCtx.stash({
+            completed,
+            results,
+            pendingSteps: pendingSteps.slice(pendingSteps.indexOf(step) + 1)
+          });
+        }
+      });
+    }
+  }
+}
+```
+
+Key points:
+
+- **The original lambda is gone.** On recovery, you only have the `name` and `snapshot`. The lambda cannot be serialized — recovery logic must be in the hook.
+- **The row is deleted after the hook runs.** If you want to continue the work, call `runFiber()` again inside the hook — this creates a new row.
+- **You control what recovery means.** Retry from the beginning, resume from a checkpoint, skip and notify the user, or do nothing. The framework does not impose a strategy.
+- **If the hook throws, the row is still deleted.** You do not get a second chance at recovery. If your recovery logic can fail, catch errors and handle them (e.g., schedule a retry, log, or re-create the fiber).
+
+### Chat recovery
+
+`AIChatAgent` builds on fibers for LLM streaming recovery. When `unstable_chatRecovery` is enabled, each chat turn is wrapped in a fiber automatically. The framework handles the internal recovery path and exposes `onChatRecovery` for provider-specific strategies. See [Long-Running Agents: Recovering interrupted LLM streams](./long-running-agents.md#recovering-interrupted-llm-streams) and the [`forever-chat` example](../experimental/forever-chat/).
+
+## Concurrent fibers
+
+Multiple fibers can run at the same time. Each has its own row in SQLite with its own snapshot, and each calls `keepAlive()` independently (ref-counted, so the DO stays alive until all fibers complete).
+
+```typescript
+// Run two fibers concurrently
+void this.runFiber("fetch-data", async (ctx) => {
+  /* ... */
+});
+void this.runFiber("process-queue", async (ctx) => {
+  /* ... */
+});
+```
+
+On recovery, `_checkRunFibers()` iterates all orphaned rows and calls `onFiberRecovered` for each. Use `ctx.name` to distinguish between fiber types in your recovery hook.
+
+## Testing locally
+
+In `wrangler dev`, fiber recovery works identically to production. SQLite and alarm state persist to disk between restarts.
+
+1. Start your agent and trigger a fiber (`runFiber`)
+2. Kill the wrangler process (Ctrl-C or SIGKILL)
+3. Restart wrangler
+4. Recovery fires automatically — via `onStart()` if a request arrives, or via the persisted alarm if no clients connect
+
+The E2E test in `packages/agents/src/e2e-tests/` validates this: it starts wrangler, spawns a fiber, kills the process with SIGKILL, restarts with the same persist directory, and verifies the fiber recovers automatically.
+
+## API reference
+
+### `runFiber(name, fn)`
+
+Execute a durable fiber. The fiber is registered in SQLite before `fn` runs and deleted after it completes (or throws). `keepAlive()` is held for the duration.
+
+- **`name`** — identifier for the fiber, used in `onFiberRecovered` to distinguish fiber types. Not unique — multiple fibers can share a name.
+- **`fn`** — async function receiving a `FiberContext`. Closures work naturally (`this` and local variables are captured).
+- **Returns** — the value returned by `fn`. If the DO is evicted before completion, the return value is lost; recovery happens through the hook.
+
+### `stash(data)` / `ctx.stash(data)`
+
+Checkpoint the current fiber's state. Writes synchronously to SQLite. Each call fully replaces the previous snapshot. `data` must be JSON-serializable.
+
+### `onFiberRecovered(ctx)`
+
+Called once per orphaned fiber row on agent restart. Override to implement recovery. The row is deleted after this hook returns.
+
+- **`ctx.id`** — unique fiber ID
+- **`ctx.name`** — the name passed to `runFiber()`
+- **`ctx.snapshot`** — the last `stash()` data, or `null` if `stash()` was never called
+
+### `keepAlive()`
+
+Create a 30-second alarm heartbeat. Returns a disposer function. Idempotent — calling the disposer multiple times is safe.
+
+### `keepAliveWhile(fn)`
+
+Run an async function while keeping the DO alive. Heartbeat starts before `fn` and stops when it completes or throws. Returns the value returned by `fn`.
+
+## Related
+
+- [Long-Running Agents](./long-running-agents.md) — how fibers compose with schedules, plans, and async operations
+- [Scheduling](./scheduling.md) — `keepAlive` details and the alarm system
+- [Workflows](./workflows.md) — durable multi-step execution outside the agent
+- [Chat Agents](./chat-agents.md) — `unstable_chatRecovery` and `onChatRecovery`
+- [`forever-chat` example](../experimental/forever-chat/) — multi-provider LLM recovery demo
+- [`forever.md` design doc](../experimental/forever.md) — internal design details, tradeoffs, and architecture

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@
 - [Queue](./queue.md) - Immediate background task execution
 - [Scheduling](./scheduling.md) - Delayed, scheduled, and cron-based tasks
 - [Retries](./retries.md) - Automatic retries with exponential backoff and jitter
+- [Durable Execution](./durable-execution.md) - `runFiber()`, `stash()`, and crash recovery for long tasks
 - [Workflows](./workflows.md) - Durable multi-step processing with Cloudflare Workflows
 - [Human in the Loop](./human-in-the-loop.md) - Approval flows and manual intervention
 
@@ -88,6 +89,7 @@
 
 ## Advanced Topics
 
+- [Long-Running Agents](./long-running-agents.md) - Building agents that persist for weeks or months: lifecycle, recovery, async operations, and planning
 - TODO: [SQL API](./sql.md) - Using `this.sql` for direct database queries
 - TODO: [Memory & Persistence](./memory.md) - Long-term storage patterns
 - [Configuration](./configuration.md) - wrangler.jsonc setup, types, secrets, and deployment

--- a/docs/long-running-agents.md
+++ b/docs/long-running-agents.md
@@ -582,7 +582,9 @@ export class ProjectManager extends Agent<ProjectState> {
     }
     this.setState({
       ...this.state,
-      tasks: this.state.tasks.filter((t) => t.status !== "complete")
+      tasks: this.state.tasks.filter(
+        (t) => !toArchive.some((a) => a.id === t.id)
+      )
     });
 
     // Clean up old workflow tracking records

--- a/docs/long-running-agents.md
+++ b/docs/long-running-agents.md
@@ -1,0 +1,705 @@
+# Long-Running Agents
+
+Build agents that persist for days, weeks, or months — surviving restarts, waking on demand, and managing work that spans far longer than any single request.
+
+## Why Cloudflare for long-running agents
+
+Agents spend most of their time waiting. Waiting for user input (seconds to days), LLM responses (seconds to minutes), tool results (seconds to hours), human approvals (hours to days), or scheduled wake-ups (minutes to months). On a traditional VM or container, you pay for all that idle time. An agent that is 99% dormant and 1% active still costs you 100% of a server.
+
+Durable Objects invert this model. An agent exists as an addressable entity with persistent state, but consumes zero compute when hibernated. When something happens — an HTTP request, a WebSocket message, a scheduled alarm, an inbound email — the platform wakes the agent, loads its state from SQLite, and hands it the event. The agent does its work, then goes back to sleep.
+
+This is the [actor model](https://en.wikipedia.org/wiki/Actor_model): each agent has an identity, durable state, and wakes on message. You do not manage servers, routing, health checks, or restart logic. The platform handles placement, scaling, and recovery.
+
+The economics follow directly:
+
+|                                               | VMs / Containers                               | Durable Objects                   |
+| --------------------------------------------- | ---------------------------------------------- | --------------------------------- |
+| **Idle cost**                                 | Full compute cost, always                      | Zero (hibernated)                 |
+| **Scaling**                                   | Provision and manage capacity                  | Automatic, per-agent              |
+| **State**                                     | External database required                     | Built-in SQLite                   |
+| **Recovery**                                  | You build it (process managers, health checks) | Platform restarts, state survives |
+| **Identity / routing**                        | You build it (load balancers, sticky sessions) | Built-in (name → agent)           |
+| **10,000 agents, each active 1% of the time** | 10,000 always-on instances                     | ~100 active at any moment         |
+
+For agents — which are inherently bursty, stateful, and long-lived — this is a natural fit.
+
+## The lifecycle of a long-running agent
+
+A long-running agent is not a process that runs continuously. It is an entity that **exists** continuously but **runs** intermittently. Understanding the lifecycle is key to building agents that work reliably over long timelines.
+
+```
+Wake → onStart() → handle events → idle (~2 min) → hibernation
+  ▲                                                      │
+  └──────────────── alarm or request wakes agent ────────┘
+
+Eviction (crash / redeploy) can happen at any point.
+State persists in SQLite. Agent restarts on next event.
+```
+
+### What survives
+
+- **`this.state`** — persisted to SQLite on every `setState()` call
+- **`this.sql` data** — all SQLite tables you create
+- **Scheduled tasks** — stored in SQLite, trigger alarms to wake the agent
+- **Connection state** — `connection.setState()` data for each WebSocket client
+- **Fiber checkpoints** — `stash()` data from `runFiber()`
+
+Higher-level abstractions built on SQLite — such as [Workspace](./workspace.md) files, [Session](./sessions.md) messages, and MCP connection state — also survive, since they are backed by the same SQLite storage.
+
+### What does not survive
+
+- **In-memory variables** — class fields not stored via `setState()` or `this.sql`
+- **Running timers** — `setTimeout`, `setInterval` are lost on hibernation/eviction
+- **Open fetch requests** — in-flight HTTP calls are abandoned
+- **Local closures** — callbacks and promise chains are lost
+
+The implication: any work that matters must be persisted or recoverable. The SDK provides primitives for this — schedules, fibers, queues — but understanding the boundary between "in-memory" and "durable" is essential.
+
+## Running example: a project manager agent
+
+Throughout this doc, we build up a project manager agent that:
+
+- Lives for the duration of a project (weeks or months)
+- Tracks tasks, assigns work to sub-agents, and reports progress
+- Wakes up on schedule to check deadlines and send reminders
+- Reacts to external events (webhooks from GitHub, emails from team members)
+- Handles long-running operations (CI pipelines, code reviews, deployments)
+- Survives any number of restarts and evictions along the way
+
+```typescript
+import { Agent } from "agents";
+
+type ProjectState = {
+  name: string;
+  status: "planning" | "active" | "review" | "complete";
+  tasks: Task[];
+  plan: Plan | null;
+};
+
+type Task = {
+  id: string;
+  title: string;
+  status: "pending" | "in_progress" | "blocked" | "complete";
+  assignee?: string;
+  dueDate?: string;
+  externalJobId?: string;
+};
+
+export class ProjectManager extends Agent<ProjectState> {
+  initialState: ProjectState = {
+    name: "",
+    status: "planning",
+    tasks: [],
+    plan: null
+  };
+}
+```
+
+The `Plan` type is introduced in [Planning as a durability strategy](#planning-as-a-durability-strategy). We add capabilities to this agent section by section.
+
+## Waking up: how agents get activated
+
+A hibernated agent can be woken by any of these sources:
+
+| Wake source              | How it works                                                                                                                                                                            | Example                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **HTTP request**         | Any request to the agent's URL triggers `onRequest()`                                                                                                                                   | A webhook from GitHub                   |
+| **WebSocket connection** | A client connects, triggering `onConnect()`                                                                                                                                             | A team member opens the dashboard       |
+| **RPC call**             | Another Worker or agent calls a method via [service binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/) or [`@callable`](./callable-methods.md) | A coordinator agent delegates a task    |
+| **Scheduled alarm**      | A stored schedule fires, triggering `alarm()` → your callback                                                                                                                           | Daily standup reminder at 9am           |
+| **Email**                | An inbound email triggers `email()`                                                                                                                                                     | A team member replies to a status email |
+
+The pattern extends naturally to any event source that can reach a Worker — anything from telephony webhooks to chat platform bots. An external signal arrives, the platform wakes the agent, and the agent handles it.
+
+The agent does not need to be "started" or "deployed" separately for each wake source — they all route to the same Durable Object instance. The agent's identity (its name) is the routing key.
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async onStart() {
+    // Daily deadline check at 9am UTC — idempotent, safe across restarts
+    await this.schedule(
+      "0 9 * * *",
+      "checkDeadlines",
+      {},
+      {
+        idempotent: true
+      }
+    );
+
+    // Progress sync every 30 minutes
+    await this.scheduleEvery(1800, "syncProgress");
+  }
+
+  async onRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname.endsWith("/github-webhook")) {
+      const event = await request.json();
+      await this.handleGitHubEvent(event);
+      return new Response("OK");
+    }
+
+    return Response.json({
+      project: this.state.name,
+      status: this.state.status
+    });
+  }
+
+  // Scheduled callbacks — the agent wakes, runs the method, goes back to sleep
+  async checkDeadlines() {
+    /* ... find overdue tasks, broadcast alerts ... */
+  }
+  async syncProgress() {
+    /* ... check on sub-agents, update task statuses ... */
+  }
+}
+```
+
+## Staying alive during long work
+
+Sometimes an agent needs to do work that takes longer than the idle eviction window (~70–140 seconds). Streaming an LLM response, orchestrating a multi-step tool chain, or waiting on a slow API all risk the agent being evicted mid-flight.
+
+`keepAlive()` prevents this by creating a heartbeat that resets the inactivity timer:
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async generateProjectPlan(goal: string) {
+    const result = await this.keepAliveWhile(async () => {
+      const plan = await this.callLLM(`Create a project plan for: ${goal}`);
+      const tasks = await this.callLLM(
+        `Break this into tasks: ${JSON.stringify(plan)}`
+      );
+      return { plan, tasks };
+    });
+
+    this.setState({
+      ...this.state,
+      status: "active",
+      plan: result.plan,
+      tasks: result.tasks
+    });
+  }
+}
+```
+
+`keepAliveWhile()` is the recommended approach — it guarantees the heartbeat is cleaned up when the work finishes (or throws). For manual control, `keepAlive()` returns a disposer:
+
+```typescript
+const dispose = await this.keepAlive();
+try {
+  await longWork();
+} finally {
+  dispose();
+}
+```
+
+### When keepAlive is not enough
+
+`keepAlive` is for work measured in minutes, not hours. For truly long-running operations, use a different strategy:
+
+| Duration         | Strategy                                                  |
+| ---------------- | --------------------------------------------------------- |
+| Seconds          | Normal request handling                                   |
+| Minutes          | `keepAlive()` / `keepAliveWhile()`                        |
+| Minutes to hours | [Workflows](./workflows.md)                               |
+| Hours to days    | Async pattern: start job → hibernate → wake on completion |
+
+## Surviving crashes: fibers and recovery
+
+An agent can be evicted at any time — a deploy, a platform restart, or hitting resource limits. If the agent was mid-task, that work is lost unless it was checkpointed.
+
+[`runFiber()`](./durable-execution.md) provides crash-recoverable execution. It persists a row in SQLite for the duration of the work, and lets you `stash()` intermediate state. If the agent is evicted, the fiber row survives, and `onFiberRecovered()` is called on the next activation.
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async executeTask(task: Task) {
+    await this.runFiber(`task:${task.id}`, async (ctx) => {
+      const resources = await this.gatherResources(task);
+      ctx.stash({ phase: "prepared", resources, task });
+
+      const result = await this.runSubAgent(task, resources);
+      ctx.stash({ phase: "executed", result, task });
+
+      await this.updateTaskStatus(task.id, "complete", result);
+    });
+  }
+
+  async onFiberRecovered(ctx: FiberRecoveryContext) {
+    if (!ctx.name.startsWith("task:")) return;
+    const { phase, task } = ctx.snapshot as { phase: string; task: Task };
+
+    if (phase === "prepared") {
+      await this.executeTask(task);
+    } else if (phase === "executed") {
+      await this.updateTaskStatus(
+        task.id,
+        "complete",
+        (ctx.snapshot as { result: unknown }).result
+      );
+    }
+  }
+}
+```
+
+The pattern is: **checkpoint before expensive work, recover from the last checkpoint.** This is not automatic replay — you decide what recovery means for your domain.
+
+> **Testing recovery locally:** In `wrangler dev`, fiber recovery works identically to production. Kill the wrangler process (Ctrl-C or SIGKILL), restart it, and recovery fires automatically. If a request or WebSocket connection arrives first, `onStart()` runs `_checkRunFibers()` eagerly. If the agent has no incoming connections, the persisted alarm fires on its own and triggers recovery via `_onAlarmHousekeeping()` — this is critical for background agents that have no clients. Either path calls your `onFiberRecovered` hook. SQLite and alarm state persist to disk between restarts.
+
+For the full API reference — `FiberContext`, `FiberRecoveryContext`, concurrent fibers, inline vs fire-and-forget patterns — see [Durable Execution](./durable-execution.md).
+
+## Handling long async operations
+
+Some operations take hours: a CI pipeline, a design review, generating a complex artifact. The agent cannot (and should not) stay alive for the entire duration. Instead, it starts the work, hibernates, and wakes up when the result arrives.
+
+### Pattern: webhook callback
+
+The agent starts an external job and registers itself as the callback URL:
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async startCIPipeline(task: Task) {
+    const response = await fetch("https://ci.example.com/api/pipelines", {
+      method: "POST",
+      body: JSON.stringify({
+        repo: "org/project",
+        branch: "main",
+        callback_url: `${this.url}/ci-callback?taskId=${task.id}`
+      })
+    });
+
+    const { pipelineId } = await response.json();
+    this.updateTask(task.id, {
+      status: "in_progress",
+      externalJobId: pipelineId
+    });
+    // Agent can now hibernate — it will wake when the CI service POSTs to the callback
+  }
+
+  async onRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname.endsWith("/ci-callback")) {
+      const taskId = url.searchParams.get("taskId");
+      const result = await request.json();
+      this.updateTask(taskId, {
+        status: result.status === "success" ? "complete" : "blocked"
+      });
+      return new Response("OK");
+    }
+    // ... other routes
+  }
+}
+```
+
+### Pattern: polling with schedule
+
+When the external service does not support callbacks, poll on a schedule:
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async startVideoGeneration(task: Task) {
+    const response = await fetch("https://video-api.example.com/generate", {
+      method: "POST",
+      body: JSON.stringify({ prompt: task.title })
+    });
+    const { jobId } = await response.json();
+    this.updateTask(task.id, { status: "in_progress", externalJobId: jobId });
+    await this.schedule(60, "pollExternalJob", {
+      taskId: task.id,
+      jobId,
+      attempt: 1
+    });
+  }
+
+  async pollExternalJob(payload: {
+    taskId: string;
+    jobId: string;
+    attempt: number;
+  }) {
+    const response = await fetch(
+      `https://video-api.example.com/status/${payload.jobId}`
+    );
+    const status = await response.json();
+
+    if (status.state === "complete" || status.state === "failed") {
+      this.updateTask(payload.taskId, {
+        status: status.state === "complete" ? "complete" : "blocked"
+      });
+      return;
+    }
+
+    // Still running — check again with backoff (max 10 minutes)
+    const nextDelay = Math.min(60 * payload.attempt, 600);
+    await this.schedule(nextDelay, "pollExternalJob", {
+      ...payload,
+      attempt: payload.attempt + 1
+    });
+  }
+}
+```
+
+### Pattern: workflow delegation
+
+For operations that need durable multi-step execution with retries, delegate to a [Workflow](./workflows.md):
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async startDeployment(task: Task) {
+    const instanceId = await this.runWorkflow("DEPLOY_WORKFLOW", {
+      taskId: task.id,
+      environment: "production"
+    });
+    this.updateTask(task.id, {
+      status: "in_progress",
+      externalJobId: instanceId
+    });
+  }
+
+  async onWorkflowComplete(
+    workflowName: string,
+    instanceId: string,
+    result?: unknown
+  ) {
+    const task = this.state.tasks.find((t) => t.externalJobId === instanceId);
+    if (task) this.updateTask(task.id, { status: "complete" });
+  }
+}
+```
+
+## Reconstructing context after a long wait
+
+When an agent hibernates and wakes up hours later with a tool result or webhook callback, it faces a challenge: the LLM needs context to continue reasoning. The original prompt, the in-flight tool call, the reasoning chain — all gone from memory. Most agent frameworks assume tool calls complete within the LLM's timeout and do not address this directly.
+
+Three approaches work today:
+
+**Replay the full conversation history.** `AIChatAgent` persists all messages in SQLite. When the result arrives, append it to the history and re-invoke the LLM. This is the simplest approach but re-processes the entire context window.
+
+**Stash a continuation summary.** Before hibernating, persist a compact description of what the agent was doing and what to do with the result:
+
+```typescript
+ctx.stash({
+  task: "Waiting for CI results",
+  onSuccess: "Mark task complete, move to next step in plan",
+  onFailure: "Notify team, schedule retry in 1 hour",
+  relevantContext: { taskId, planStep: 3 }
+});
+```
+
+On recovery, use the stash to construct a focused prompt rather than replaying everything.
+
+**Use the plan as context.** If the agent has a structured plan, the plan itself provides sufficient context: "I am on step 3 of 7, the step was 'run CI pipeline', the result just arrived." This is the most robust approach for long-running agents — the plan is both a recovery mechanism and a context reconstruction strategy. See the next section.
+
+## Planning as a durability strategy
+
+A structured plan is not just useful for showing progress to users — it is a durability mechanism. An agent with a plan can recover from any interruption by looking at where it left off.
+
+```typescript
+type Plan = {
+  goal: string;
+  steps: PlanStep[];
+  currentStep: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type PlanStep = {
+  id: string;
+  description: string;
+  status: "pending" | "in_progress" | "complete" | "failed" | "skipped";
+  result?: unknown;
+};
+
+export class ProjectManager extends Agent<ProjectState> {
+  async createPlan(goal: string) {
+    const steps = await this.keepAliveWhile(async () => {
+      return this.callLLM(`
+        Break down this project goal into concrete steps.
+        Return a JSON array of { id, description } objects.
+        Goal: ${goal}
+      `);
+    });
+
+    this.setState({
+      ...this.state,
+      plan: {
+        goal,
+        steps: steps.map((s: { id: string; description: string }) => ({
+          ...s,
+          status: "pending" as const
+        })),
+        currentStep: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }
+    });
+
+    await this.schedule(0, "executeNextStep");
+  }
+
+  async executeNextStep() {
+    const { plan } = this.state;
+    if (!plan || plan.currentStep >= plan.steps.length) {
+      this.setState({ ...this.state, status: "complete" });
+      return;
+    }
+
+    const step = plan.steps[plan.currentStep];
+
+    try {
+      const result = await this.keepAliveWhile(() => this.executeStep(step));
+
+      // Update plan state — advance to next step
+      const updatedSteps = plan.steps.map((s) =>
+        s.id === step.id ? { ...s, status: "complete" as const, result } : s
+      );
+      this.setState({
+        ...this.state,
+        plan: {
+          ...plan,
+          steps: updatedSteps,
+          currentStep: plan.currentStep + 1,
+          updatedAt: new Date().toISOString()
+        }
+      });
+
+      // Schedule next step — the agent can hibernate between steps
+      await this.schedule(0, "executeNextStep");
+    } catch (error) {
+      // Mark step failed — could re-plan, retry, or ask for human input
+      const updatedSteps = plan.steps.map((s) =>
+        s.id === step.id ? { ...s, status: "failed" as const } : s
+      );
+      this.setState({
+        ...this.state,
+        plan: {
+          ...plan,
+          steps: updatedSteps,
+          updatedAt: new Date().toISOString()
+        }
+      });
+    }
+  }
+}
+```
+
+This pattern has several advantages for long-running agents:
+
+- **Recovery is trivial** — on restart, check `plan.currentStep` and resume
+- **Progress is visible** — clients see which steps are done and what is next
+- **Re-planning is possible** — if a step fails or requirements change, the agent can revise the remaining steps without losing completed work
+- **Human oversight** — the plan is a natural approval checkpoint ("here is what I am going to do — proceed?")
+- **Context reconstruction** — the plan tells the LLM where it is, what happened, and what to do next, without replaying the full conversation
+
+## Delegating to sub-agents
+
+A project manager does not do everything itself. It delegates specialized work to sub-agents — each with their own identity, state, and lifecycle.
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async delegateTask(task: Task) {
+    // Get a stub to a specialized agent (same DO namespace, unique name)
+    const researcher = this.subAgent(ResearchAgent, `research-${task.id}`);
+
+    // Call methods on the sub-agent via RPC — this wakes the sub-agent
+    const findings = await researcher.research(task.title);
+
+    this.updateTask(task.id, { status: "complete" });
+    return findings;
+  }
+}
+```
+
+Sub-agents are independent Durable Objects. They have their own state, their own schedules, and their own lifecycle. The parent does not need to stay alive while the sub-agent works — it can start the work, hibernate, and be woken by a callback or scheduled check.
+
+For chat-oriented sub-agents, [Think](./think/index.md) provides `chat()` for RPC streaming between parent and child agents. See [Sub-agents and Programmatic Turns](./think/sub-agents.md).
+
+## Recovering interrupted LLM streams
+
+LLM streaming is the most common case where eviction causes problems. The upstream connection to the provider is severed permanently — you cannot resume an OpenAI or Anthropic stream mid-generation.
+
+`AIChatAgent` addresses this with `unstable_chatRecovery`, which wraps each chat turn in a `runFiber`. This provides automatic `keepAlive` during streaming and a recovery hook when the agent restarts:
+
+```typescript
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import type {
+  ChatRecoveryContext,
+  ChatRecoveryOptions
+} from "@cloudflare/ai-chat";
+
+class ProjectChat extends AIChatAgent<Env> {
+  override unstable_chatRecovery = true;
+
+  override async onChatRecovery(
+    ctx: ChatRecoveryContext
+  ): Promise<ChatRecoveryOptions> {
+    // ctx.partialText    — text generated before eviction
+    // ctx.recoveryData   — whatever you stashed via this.stash()
+    // ctx.messages        — full conversation history
+
+    // Default: persist partial response + schedule continuation
+    return {};
+  }
+}
+```
+
+The right recovery strategy depends on the LLM provider:
+
+| Provider               | Strategy                            | How it works                                                                  | Token cost |
+| ---------------------- | ----------------------------------- | ----------------------------------------------------------------------------- | ---------- |
+| Workers AI             | Continue from partial               | `continueLastTurn()` — model continues via assistant prefill                  | Low        |
+| OpenAI (Responses API) | Retrieve completed response         | Stash `responseId` during streaming, `GET /v1/responses/{id}` on recovery     | Zero       |
+| Anthropic              | Synthetic continuation              | Persist partial, send a synthetic user message asking the model to continue   | Medium     |
+| Other                  | Try prefill, fall back to synthetic | `continueLastTurn()` if the provider supports it, synthetic message otherwise | Varies     |
+
+For a complete multi-provider implementation with full code for each strategy, see the [`forever-chat` example](../experimental/forever-chat/) and the [`forever.md` design doc](../experimental/forever.md).
+
+[Think](./think/index.md) exposes `unstable_chatRecovery` as a configuration toggle — the recovery machinery is handled for you without implementing `onChatRecovery` yourself.
+
+## Managing state over time
+
+An agent that runs for months accumulates data: conversation history, timeline events, completed tasks, schedule records. Without management, this grows unbounded.
+
+### Housekeeping
+
+Schedule periodic cleanup to prune old data and archive completed work:
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async onStart() {
+    await this.schedule("0 0 * * *", "housekeeping", {}, { idempotent: true });
+  }
+
+  async housekeeping() {
+    // Archive completed tasks older than 30 days
+    const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const toArchive = this.state.tasks.filter(
+      (t) => t.status === "complete" && (t.completedAt ?? 0) < cutoff
+    );
+    for (const task of toArchive) {
+      this
+        .sql`INSERT INTO archived_tasks (id, data) VALUES (${task.id}, ${JSON.stringify(task)})`;
+    }
+    this.setState({
+      ...this.state,
+      tasks: this.state.tasks.filter((t) => t.status !== "complete")
+    });
+
+    // Clean up old workflow tracking records
+    this.deleteWorkflows({
+      status: ["complete", "errored"],
+      createdBefore: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    });
+  }
+}
+```
+
+### Conversation history management
+
+For agents that use `AIChatAgent`, conversation history can grow large over extended lifespans. Without management, a 3-month conversation will exhaust the LLM's context window long before the project ends.
+
+The [Session API](./sessions.md) addresses this directly:
+
+- **Compaction** — automatically summarizes older messages when the estimated token count exceeds a threshold. The summary replaces the middle of the conversation as a non-destructive overlay. Original messages remain in SQLite for audit.
+- **Context blocks** — persistent structured sections injected into the system prompt (identity, memory, learned facts). The agent or the LLM can write to these blocks, and they survive hibernation and eviction.
+- **Multi-session management** — `SessionManager` provides a registry of named sessions within a single agent, with forking, cross-session search, and `compactAndSplit` for splitting long conversations into linked continuations.
+
+For simpler cases: keep only the last N messages in the active context (sliding window), or selectively retain messages that contain decisions and approvals while pruning routine exchanges.
+
+## End of life
+
+A long-running agent eventually completes its purpose. The project ships, the investigation concludes, the monitoring window closes. Clean up explicitly:
+
+```typescript
+export class ProjectManager extends Agent<ProjectState> {
+  async completeProject() {
+    // Cancel remaining schedules
+    const schedules = this.getSchedules();
+    for (const schedule of schedules) {
+      await this.cancelSchedule(schedule.id);
+    }
+
+    // Archive final state
+    this.setState({ ...this.state, status: "complete" });
+
+    // Optionally destroy the Durable Object entirely
+    // All SQLite data, schedules, and state are permanently deleted
+    await this.destroy();
+  }
+}
+```
+
+`this.destroy()` is permanent. If you may need the agent's data later, archive it to an external store (R2, D1, or an API call) before destroying. For agents that might be reactivated, simply mark them as complete and let them hibernate — they cost nothing when idle.
+
+## When to use Workflows vs agent-internal patterns
+
+Both Workflows and agent-internal primitives (schedules, fibers, queues) support long-running work. The right choice depends on the nature of the work:
+
+|                    | Agent-internal                                         | Workflows                                |
+| ------------------ | ------------------------------------------------------ | ---------------------------------------- |
+| **Best for**       | Agent-centric work: scheduling, polling, state updates | Independent multi-step pipelines         |
+| **Durability**     | SQLite (survives eviction)                             | Workflow engine (survives everything)    |
+| **Retries**        | `this.retry()`, schedule-level retries                 | Per-step retries with backoff            |
+| **Max duration**   | Minutes per activation (with `keepAlive`)              | 30 minutes per step, unlimited steps     |
+| **Human approval** | Build it yourself (state + WebSocket)                  | Built-in `waitForApproval()`             |
+| **Complexity**     | Lower — everything is in the agent                     | Higher — separate class, wrangler config |
+
+A pragmatic rule: if the work is about the agent managing its own lifecycle (checking deadlines, syncing state, sending reminders), use schedules and fibers. If the work is a discrete pipeline that could fail and retry independently (deploy, data processing, report generation), use a Workflow.
+
+The project manager agent uses both: schedules for its own rhythms (daily standups, progress syncs), and Workflows for heavyweight operations (deployments, CI pipelines).
+
+## Think: batteries included
+
+If you are building a chat-oriented long-running agent and want these patterns built in rather than assembling them yourself, [`Think`](./think/index.md) provides them out of the box:
+
+- **Sessions with compaction** — non-destructive conversation summarization, context blocks, cross-session search
+- **Fiber-based recovery** — `unstable_chatRecovery` as a configuration toggle
+- **Sub-agent RPC** — `chat()` for parent-child streaming
+- **Persistent memory** — LLM-writable context blocks that survive hibernation
+- **Workspace and code execution** — built-in file tools and sandboxed execution
+
+Override `getModel()` and `configureSession()` and the durability machinery is handled for you. Think is the opinionated path; the primitives described in this doc are what Think is built on.
+
+## Summary
+
+Long-running agents on Cloudflare are not long-running processes. They are durable entities that wake, work, and sleep — potentially over weeks or months. The key primitives:
+
+| Primitive                              | Purpose                                                        |
+| -------------------------------------- | -------------------------------------------------------------- |
+| **`setState()` / `this.sql`**          | Persist state across activations                               |
+| **`schedule()` / `scheduleEvery()`**   | Wake the agent at future times                                 |
+| **`keepAlive()` / `keepAliveWhile()`** | Prevent eviction during active work                            |
+| **`runFiber()` / `stash()`**           | Checkpoint and recover long tasks                              |
+| **`unstable_chatRecovery`**            | Recover interrupted LLM streams                                |
+| **`onRequest()` / `email()` / RPC**    | Wake on external events                                        |
+| **`runWorkflow()`**                    | Delegate heavyweight multi-step work                           |
+| **`subAgent()`**                       | Delegate specialized work to child agents                      |
+| **Session API**                        | Manage conversation history, compaction, and context over time |
+| **Structured plans in state**          | Enable recovery, visibility, and re-planning                   |
+
+For the project manager agent, these compose into an agent that:
+
+1. **Plans** — breaks goals into steps, persists the plan in state
+2. **Executes** — runs steps one at a time, hibernating between them
+3. **Reacts** — wakes on webhooks, emails, and schedules
+4. **Recovers** — resumes from the last checkpoint after any interruption
+5. **Delegates** — hands off work to sub-agents and Workflows
+6. **Maintains** — prunes old data, archives completed work, manages its own lifecycle
+7. **Ends** — cleans up and destroys itself when the project is done
+
+The agent does not need to run continuously to do any of this. It just needs to exist.
+
+## Related
+
+- [Durable Execution](./durable-execution.md) — `runFiber()`, `stash()`, and crash recovery
+- [Scheduling](./scheduling.md) — delayed, cron, and interval tasks
+- [Retries](./retries.md) — retry options and patterns
+- [Workflows](./workflows.md) — durable multi-step processing
+- [State Management](./state.md) — `setState()` and persistence
+- [Sessions](./sessions.md) — persistent conversation storage, compaction, and context blocks
+- [Think](./think/index.md) — opinionated chat agent with built-in durability
+- [HTTP & WebSockets](./http-websockets.md) — lifecycle hooks and hibernation
+- [Callable Methods](./callable-methods.md) — RPC via `@callable` and service bindings
+- [Email Routing](./email.md) — receiving inbound email
+- [Webhooks](./webhooks.md) — receiving external events
+- [Human in the Loop](./human-in-the-loop.md) — approval flows
+- [Resumable Streaming](./resumable-streaming.md) — client-side stream resumption on disconnect
+- [`forever-chat` example](../experimental/forever-chat/) — multi-provider LLM recovery demo

--- a/docs/long-running-agents.md
+++ b/docs/long-running-agents.md
@@ -499,7 +499,10 @@ A project manager does not do everything itself. It delegates specialized work t
 export class ProjectManager extends Agent<ProjectState> {
   async delegateTask(task: Task) {
     // Get a stub to a specialized agent (same DO namespace, unique name)
-    const researcher = this.subAgent(ResearchAgent, `research-${task.id}`);
+    const researcher = await this.subAgent(
+      ResearchAgent,
+      `research-${task.id}`
+    );
 
     // Call methods on the sub-agent via RPC — this wakes the sub-agent
     const findings = await researcher.research(task.title);

--- a/docs/long-running-agents.md
+++ b/docs/long-running-agents.md
@@ -249,11 +249,11 @@ For the full API reference — `FiberContext`, `FiberRecoveryContext`, concurren
 
 ## Handling long async operations
 
-Some operations take hours: a CI pipeline, a design review, generating a complex artifact. The agent cannot (and should not) stay alive for the entire duration. Instead, it starts the work, hibernates, and wakes up when the result arrives.
+The project manager frequently kicks off work that takes far longer than any single activation — a CI pipeline runs for 20 minutes, a design review takes a day, a video asset takes hours to generate. The agent should not stay alive for any of this. Instead, it starts the work, persists the job ID in state, and hibernates. When the result arrives — via a callback, a poll, or a workflow completion — the agent wakes, correlates the result, and moves on.
 
 ### Pattern: webhook callback
 
-The agent starts an external job and registers itself as the callback URL:
+The project manager starts a CI pipeline for a task. The pipeline takes 20 minutes. Rather than holding a connection open, the agent registers its own URL as the callback and goes to sleep:
 
 ```typescript
 export class ProjectManager extends Agent<ProjectState> {
@@ -292,7 +292,7 @@ export class ProjectManager extends Agent<ProjectState> {
 
 ### Pattern: polling with schedule
 
-When the external service does not support callbacks, poll on a schedule:
+Not every external service supports callbacks. When the project manager submits a video asset for generation, it needs to check back periodically until the job completes:
 
 ```typescript
 export class ProjectManager extends Agent<ProjectState> {
@@ -339,7 +339,7 @@ export class ProjectManager extends Agent<ProjectState> {
 
 ### Pattern: workflow delegation
 
-For operations that need durable multi-step execution with retries, delegate to a [Workflow](./workflows.md):
+A production deployment involves multiple steps that must each retry independently — build, test, stage, promote. The project manager should not manage these steps internally; it delegates to a [Workflow](./workflows.md) that handles retries and step sequencing:
 
 ```typescript
 export class ProjectManager extends Agent<ProjectState> {
@@ -367,7 +367,9 @@ export class ProjectManager extends Agent<ProjectState> {
 
 ## Reconstructing context after a long wait
 
-When an agent hibernates and wakes up hours later with a tool result or webhook callback, it faces a challenge: the LLM needs context to continue reasoning. The original prompt, the in-flight tool call, the reasoning chain — all gone from memory. Most agent frameworks assume tool calls complete within the LLM's timeout and do not address this directly.
+The CI pipeline finishes 20 minutes later. The webhook wakes the project manager. The task status is updated. But now what? If the agent was using an LLM to orchestrate work — deciding which task to run next, drafting a status report, reasoning about blockers — it needs to pick up that reasoning thread. The original prompt, the in-flight tool call, the chain of thought — all gone from memory.
+
+This is the fundamental challenge of long-running AI agents. Most frameworks assume tool calls complete within the LLM's timeout and do not address this directly.
 
 Three approaches work today:
 
@@ -514,9 +516,9 @@ For chat-oriented sub-agents, [Think](./think/index.md) provides `chat()` for RP
 
 ## Recovering interrupted LLM streams
 
-LLM streaming is the most common case where eviction causes problems. The upstream connection to the provider is severed permanently — you cannot resume an OpenAI or Anthropic stream mid-generation.
+The patterns above handle the project manager's coordination work — scheduling, delegating, polling. But the project manager also uses an LLM directly: generating plans, summarizing progress, drafting status emails. Those LLM calls stream tokens over a connection that cannot be resumed if the agent is evicted mid-response.
 
-`AIChatAgent` addresses this with `unstable_chatRecovery`, which wraps each chat turn in a `runFiber`. This provides automatic `keepAlive` during streaming and a recovery hook when the agent restarts:
+For chat-oriented agents built on `AIChatAgent`, this is an even sharper problem — the user is watching the response stream in real time and sees it stop mid-sentence. `unstable_chatRecovery` wraps each chat turn in a `runFiber`, providing automatic `keepAlive` during streaming and a recovery hook when the agent restarts:
 
 ```typescript
 import { AIChatAgent } from "@cloudflare/ai-chat";

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -333,8 +333,6 @@ dispose2(); // Ref count reaches 0 — agent can go idle
 | Short request-response handlers             | No — not needed                        |
 | Background work via scheduling or workflows | No — alarms already keep the DO active |
 
-> **Note:** `keepAlive()` is marked `@experimental` and may change between releases.
-
 ## Managing Schedules
 
 ### Get a Schedule


### PR DESCRIPTION
## Summary

- **New doc: `docs/long-running-agents.md`** — conceptual guide covering why Cloudflare is a natural fit for long-running agents (actor model, economics of waiting), the agent lifecycle (hibernation, eviction, recovery), and patterns for waking on signals, staying alive during work, surviving crashes, handling async operations, reconstructing AI context, planning as a durability strategy, delegating to sub-agents, recovering LLM streams, managing state over time, and end-of-life cleanup. Uses a project manager agent as a running example throughout.

- **New doc: `docs/durable-execution.md`** — reference doc for `keepAlive()`, `runFiber()`, `stash()`, and `onFiberRecovered()`. Covers the API, lifecycle diagrams, inline vs fire-and-forget patterns, checkpoint semantics, concurrent fibers, and testing recovery locally. Links to `forever.md` for internal design details.

- **Updated: `docs/chat-agents.md`** — added Stream Recovery section documenting `unstable_chatRecovery`, `onChatRecovery`, `ChatRecoveryContext`, `ChatRecoveryOptions`, `continueLastTurn()`, stashing recovery data, and provider-specific strategies (Workers AI, OpenAI Responses API, Anthropic).

- **Updated: `docs/index.md`** — added entries for both new docs (Long-Running Agents in Advanced Topics, Durable Execution in Background Processing).

- **Updated: `docs/scheduling.md`** — removed `@experimental` note on `keepAlive()`.

## Test plan

- [ ] Verify all cross-doc `#anchor` links resolve correctly
- [ ] Verify code examples are syntactically valid TypeScript
- [ ] Read through each doc for clarity and completeness

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
