### PR TITLE
feat(voice): per-call continuous STT sessions

### DIFF
--- a/.changeset/preroll-backfill.md
+++ b/.changeset/preroll-backfill.md
@@ -1,0 +1,27 @@
+---
+"@cloudflare/voice": minor
+---
+
+Switch to per-call continuous STT sessions. Breaking API change.
+
+The transcriber session is now created at `start_call` and lives for the entire call duration. The model handles turn detection — no client-side `start_of_speech`/`end_of_speech` required for STT. Voice agents use `keepAlive` to prevent DO eviction during calls.
+
+New API:
+
+- `transcriber` property replaces `stt`, `streamingStt`, and `vad`
+- `createTranscriber(connection)` hook for runtime model switching
+- `WorkersAIFluxSTT` — per-call Flux sessions (recommended for `withVoice`)
+- `WorkersAINova3STT` — per-call Nova 3 streaming sessions (recommended for `withVoiceInput`)
+- `query` option on `VoiceClientOptions` — pass query params to the WebSocket URL (e.g. for model selection)
+- Throws at `start_call` if no transcriber is configured
+- Duplicate `start_call` is silently ignored when already in a call
+
+Removed:
+
+- `stt` (batch STT), `streamingStt` (per-utterance streaming), `vad` (server-side VAD)
+- `WorkersAISTT`, `WorkersAIVAD`, `pcmToWav`
+- `prerollMs`, `vadThreshold`, `vadPushbackSeconds`, `vadRetryMs`, `minAudioBytes` options
+- `VoiceInputAgentOptions` type
+- `beforeTranscribe` hook (audio is fed continuously, not in batches)
+- `vad_ms` and `stt_ms` from pipeline metrics
+- Hibernation support (`withVoice` and `withVoiceInput` now require `Agent`, not partyserver `Server`)

--- a/design/voice.md
+++ b/design/voice.md
@@ -41,29 +41,27 @@ SFU integration is documented as an advanced option in `docs/voice.md`.
 
 ### `withVoice(Agent)` — full conversational voice agent
 
-Full pipeline: audio buffering, VAD, STT, LLM (`onTurn`), sentence chunking, streaming TTS, interruption handling, conversation persistence (SQLite), and pipeline metrics. Requires `stt` (or `streamingStt`) and `tts` providers. Supports hibernation via `_unsafe_setConnectionFlag`/`_unsafe_getConnectionFlag`.
+Full pipeline: continuous STT, LLM (`onTurn`), sentence chunking, streaming TTS, interruption handling, conversation persistence (SQLite), and pipeline metrics. Requires `transcriber` and `tts` providers. Supports hibernation via `_unsafe_setConnectionFlag`/`_unsafe_getConnectionFlag`. Recommended transcriber: `WorkersAIFluxSTT` (Flux has built-in conversational turn detection).
 
 ### `withVoiceInput(Agent)` — STT-only voice input
 
-Lightweight pipeline: audio buffering, VAD, STT, then `onTranscript()` callback. No TTS, no `onTurn`, no response generation, no conversation persistence. For dictation/voice input UIs. Does **not** support hibernation (no call state persistence — if the DO hibernates mid-call, the client must re-send `start_call`).
+Lightweight pipeline: continuous STT, then `onTranscript()` callback. No TTS, no `onTurn`, no response generation, no conversation persistence. For dictation/voice input UIs. Recommended transcriber: `WorkersAINova3STT` (Nova 3 has better raw transcription accuracy).
 
 Both mixins share `AudioConnectionManager` for per-connection state and use the same wire protocol.
 
-### `VoiceAgentOptions` extends `VoiceInputAgentOptions`
+### `VoiceAgentOptions`
 
-Shared options: `minAudioBytes`, `vadThreshold`, `vadPushbackSeconds`, `vadRetryMs`. Voice-only additions: `historyLimit`, `audioFormat`, `maxMessageCount`.
+Voice-only options: `historyLimit`, `audioFormat`, `maxMessageCount`.
 
 ## Pipeline stages
 
-1. **Audio buffering** — binary frames accumulate per-connection in `AudioConnectionManager`. Capped at 30 seconds (`MAX_AUDIO_BUFFER_BYTES = 960KB`). Oldest chunks dropped when full. `initConnection()` is guarded against double-init (duplicate `start_call` does not reset the buffer). `clearAudioBuffer()` is guarded against phantom state (only clears if the connection exists in the map).
+1. **Audio buffering + continuous STT** — binary frames accumulate per-connection in `AudioConnectionManager`. Capped at 30 seconds (`MAX_AUDIO_BUFFER_BYTES = 960KB`). Each chunk is simultaneously buffered and fed to the active transcriber session via `session.feed()`. The transcriber session is created at `start_call` and lives for the entire call.
 
-2. **Client-side silence detection** — AudioWorklet monitors RMS. 500ms of silence triggers `end_of_speech`. Configurable via `silenceThreshold` and `silenceDurationMs`. `toggleMute()` immediately sends `end_of_speech` when muting mid-speech — otherwise no audio frames arrive, the silence timer never starts, and the server deadlocks. `#processAudioLevel` gates on `#isMuted` to prevent false speech detection when a custom `audioInput` keeps reporting levels while muted.
+2. **Client-side speech detection (UI only)** — AudioWorklet monitors RMS. `start_of_speech` / `end_of_speech` messages drive local UI state (speaking indicators, audio level). The server ignores these for STT — the model handles turn detection. This makes the client thinner and more portable (mobile, embedded, etc. clients only need mic capture + WebSocket).
 
-3. **Server-side VAD** (optional) — confirms end-of-turn via `this.vad.checkEndOfTurn()`. Runs on silence events only, not every frame. If VAD rejects, the tail of the buffer (`vadPushbackSeconds`, default 2s) is pushed back and a **retry timer** (`vadRetryMs`, default 3000ms) starts. On fire, the pipeline re-runs with VAD skipped. This prevents deadlock: after the client sends `end_of_speech` it sets `#isSpeaking = false`, so no further `end_of_speech` arrives until the user speaks again. The timer is cleared on new `end_of_speech`, `interrupt`, `end_call`, or disconnect. If no VAD provider is set, every `end_of_speech` is treated as confirmed.
+3. **Model-driven turn detection** — the transcriber model detects utterance boundaries. Flux fires `EndOfTurn` events with a stable transcript. Nova 3 uses `endpointing` + `speech_final` results. The mixin maps `onUtterance` to `onTurn` (withVoice) or `onTranscript` (withVoiceInput).
 
-4. **STT** — two modes:
-   - **Batch** — `this.stt.transcribe()` after end-of-speech. `WorkersAISTT` wraps audio in a WAV header for Workers AI.
-   - **Streaming** — `this.streamingStt` creates a per-utterance session. Audio fed in real time via `session.feed()`. At end-of-speech, `session.finish()` flushes (~50ms). Interim transcripts relayed as `transcript_interim`. Eliminates STT latency from the critical path.
+4. **Interrupt handling** — on interrupt, the LLM+TTS pipeline is aborted but the transcriber session stays alive. The model continues receiving audio and will detect the next turn naturally. This is simpler than the old per-utterance model where interrupt required aborting the STT session, clearing buffers, and resetting EOT state.
 
 5. **LLM** (withVoice only) — `onTurn()` receives transcript, conversation history, and `AbortSignal`.
 
@@ -83,16 +81,12 @@ Subclasses set providers as class properties:
 
 ```ts
 class MyAgent extends VoiceAgent<Env> {
-  stt = new WorkersAISTT(this.env.AI);
-  tts = new ElevenLabsTTS({ apiKey: this.env.ELEVENLABS_KEY });
-  vad = new WorkersAIVAD(this.env.AI);
-  streamingStt = new DeepgramStreamingSTT({ apiKey: this.env.DEEPGRAM_KEY });
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
+  tts = new WorkersAITTS(this.env.AI);
 }
 ```
 
-Class field initializers run after `super()`, so `this.env` is available. If `streamingStt` is set it takes precedence over batch `stt`. VAD is optional — if unset, every `end_of_speech` is treated as confirmed.
-
-Workers AI convenience classes accept a loose `AiLike` interface. Any object satisfying the provider interfaces works, including inline objects.
+Class field initializers run after `super()`, so `this.env` is available. Override `createTranscriber(connection)` for runtime model switching. Workers AI convenience classes accept a loose `AiLike` interface. Any object satisfying the `Transcriber` interface works.
 
 ### `onTurn` return type: `string | AsyncIterable<string> | ReadableStream`
 
@@ -217,14 +211,13 @@ Phone → Twilio → WebSocket → TwilioAdapter → WebSocket → VoiceAgent DO
 
 Both mixins support:
 
-| Hook                                  | Purpose                                      |
-| ------------------------------------- | -------------------------------------------- |
-| `beforeCallStart(connection)`         | Return `false` to reject the call            |
-| `onCallStart(connection)`             | Called after call is accepted                |
-| `onCallEnd(connection)`               | Called when call ends                        |
-| `onInterrupt(connection)`             | Called when user interrupts the agent        |
-| `beforeTranscribe(audio, connection)` | Transform audio before STT; `null` skips     |
-| `afterTranscribe(text, connection)`   | Transform transcript after STT; `null` skips |
+| Hook                                | Purpose                                      |
+| ----------------------------------- | -------------------------------------------- |
+| `beforeCallStart(connection)`       | Return `false` to reject the call            |
+| `onCallStart(connection)`           | Called after call is accepted                |
+| `onCallEnd(connection)`             | Called when call ends                        |
+| `onInterrupt(connection)`           | Called when user interrupts the agent        |
+| `afterTranscribe(text, connection)` | Transform transcript after STT; `null` skips |
 
 `withVoice` adds:
 
@@ -273,23 +266,22 @@ Defined in `types.ts`:
 
 Exported from `@cloudflare/voice`:
 
-| Class              | Interface     | Default model                  |
-| ------------------ | ------------- | ------------------------------ |
-| `WorkersAISTT`     | `STTProvider` | `@cf/deepgram/nova-3`          |
-| `WorkersAIFluxSTT` | `STTProvider` | `@cf/deepgram/nova-3`          |
-| `WorkersAITTS`     | `TTSProvider` | `@cf/deepgram/aura-1`          |
-| `WorkersAIVAD`     | `VADProvider` | `@cf/pipecat-ai/smart-turn-v2` |
+| Class               | Interface     | Default model         | Recommended for  |
+| ------------------- | ------------- | --------------------- | ---------------- |
+| `WorkersAIFluxSTT`  | `Transcriber` | `@cf/deepgram/flux`   | `withVoice`      |
+| `WorkersAINova3STT` | `Transcriber` | `@cf/deepgram/nova-3` | `withVoiceInput` |
+| `WorkersAITTS`      | `TTSProvider` | `@cf/deepgram/aura-1` | Both             |
 
 All accept an `AiLike` binding (typically `this.env.AI`).
 
 ### External providers
 
-| Package                        | Class                  | Interface                              |
-| ------------------------------ | ---------------------- | -------------------------------------- |
-| `@cloudflare/voice-elevenlabs` | `ElevenLabsTTS`        | `TTSProvider` + `StreamingTTSProvider` |
-| `@cloudflare/voice-deepgram`   | `DeepgramStreamingSTT` | `StreamingSTTProvider`                 |
+| Package                        | Class           | Interface                              |
+| ------------------------------ | --------------- | -------------------------------------- |
+| `@cloudflare/voice-elevenlabs` | `ElevenLabsTTS` | `TTSProvider` + `StreamingTTSProvider` |
+| `@cloudflare/voice-deepgram`   | `DeepgramSTT`   | `Transcriber`                          |
 
-Any object satisfying the provider interfaces works — use inline objects for quick custom logic.
+Any object satisfying the `Transcriber` interface works.
 
 ## Streaming STT
 
@@ -298,20 +290,25 @@ Eliminates transcription latency by streaming audio to an external STT service i
 ### Session lifecycle
 
 ```
-start_of_speech → createSession()
+start_call → createSession()
      ↓
-  feed(chunk) ←── audio frames
+  feed(chunk) ←── all audio frames
      ↓
-  end_of_speech → finish() → transcript (~50ms)
+  model detects utterance → onUtterance(transcript)
+     ↓
+  pipeline runs (LLM + TTS)
+     ↓
+  back to listening (session stays alive)
+     ↓
+  end_call → close()
 ```
 
 Callbacks fire during the session:
 
 - `onInterim(text)` — unstable partial transcript, relayed as `transcript_interim`
-- `onFinal(text)` — stable segment, accumulated for display
-- `onEndOfTurn(text)` — provider-driven end-of-turn, triggers LLM+TTS immediately without waiting for client `end_of_speech`
+- `onUtterance(text)` — model-driven utterance boundary, triggers pipeline
 
-Session is created on `start_of_speech`. Audio chunks are forwarded to `session.feed()` alongside normal buffer accumulation. At end-of-speech (after VAD), `session.finish()` flushes the provider. On interrupt/disconnect, `session.abort()` closes immediately.
+Session is created at `start_call` and lives for the entire call. All audio is fed continuously — no pre-roll needed since there is no gap between speech onset and session creation. The model handles turn detection (Flux `EndOfTurn`, Nova 3 `speech_final` + endpointing). On interrupt, the LLM+TTS pipeline is aborted but the transcriber session stays alive. On `end_call` or disconnect, `session.close()` releases resources.
 
 ### Interaction with VAD
 
@@ -319,7 +316,7 @@ VAD still runs on end-of-speech. If VAD rejects, the session stays alive. The VA
 
 ### Interaction with hooks
 
-`beforeTranscribe` is skipped when streaming STT is active (audio was already fed incrementally). `afterTranscribe` still runs on the final transcript.
+`afterTranscribe` runs on the transcript before the pipeline processes it.
 
 ### Provider-driven EOT
 
@@ -352,18 +349,18 @@ Mismatch logs a warning. Future: server may reject incompatible clients.
 
 ### Server → Client (`VoiceServerMessage`)
 
-| Message              | Fields                                                               | Purpose                                             |
-| -------------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
-| `welcome`            | `protocol_version`                                                   | Server announces protocol version                   |
-| `audio_config`       | `format`, `sampleRate?`                                              | Declares audio format for this call                 |
-| `status`             | `status`                                                             | Pipeline state: idle, listening, thinking, speaking |
-| `transcript`         | `role`, `text`                                                       | Complete transcript entry                           |
-| `transcript_start`   | `role`                                                               | Streaming transcript begins                         |
-| `transcript_delta`   | `text`                                                               | Streaming transcript chunk                          |
-| `transcript_end`     | `text`                                                               | Streaming transcript complete                       |
-| `transcript_interim` | `text`                                                               | Interim transcript from streaming STT               |
-| `metrics`            | `vad_ms`, `stt_ms`, `llm_ms`, `tts_ms`, `first_audio_ms`, `total_ms` | Pipeline timing (withVoice only)                    |
-| `error`              | `message`                                                            | Error description                                   |
+| Message              | Fields                                           | Purpose                                             |
+| -------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| `welcome`            | `protocol_version`                               | Server announces protocol version                   |
+| `audio_config`       | `format`, `sampleRate?`                          | Declares audio format for this call                 |
+| `status`             | `status`                                         | Pipeline state: idle, listening, thinking, speaking |
+| `transcript`         | `role`, `text`                                   | Complete transcript entry                           |
+| `transcript_start`   | `role`                                           | Streaming transcript begins                         |
+| `transcript_delta`   | `text`                                           | Streaming transcript chunk                          |
+| `transcript_end`     | `text`                                           | Streaming transcript complete                       |
+| `transcript_interim` | `text`                                           | Interim transcript from streaming STT               |
+| `metrics`            | `llm_ms`, `tts_ms`, `first_audio_ms`, `total_ms` | Pipeline timing (withVoice only)                    |
+| `error`              | `message`                                        | Error description                                   |
 
 Binary frames flow in both directions. Client sends 16kHz 16-bit mono PCM. Server sends audio in the format declared by `audio_config` (default: MP3).
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -20,9 +20,8 @@ Built on Cloudflare Durable Objects, you get:
 - **Automatic conversation persistence** — messages stored in SQLite, survive restarts
 - **Streaming TTS** — LLM tokens are sentence-chunked and synthesized concurrently
 - **Interruption handling** — user speech during playback cancels the current response
-- **Voice activity detection** — optional server-side VAD confirms end-of-turn
-- **Streaming STT** — optional real-time transcription with interim results
-- **Pipeline hooks** — intercept and transform audio/text at every stage
+- **Continuous STT** — per-call transcriber session, model handles turn detection
+- **Pipeline hooks** — intercept and transform text at every stage
 
 > **Experimental.** This API is under active development and will break between releases. Pin your version.
 
@@ -40,21 +39,18 @@ npm install @cloudflare/voice agents
 import { Agent } from "agents";
 import {
   withVoice,
-  WorkersAISTT,
+  WorkersAIFluxSTT,
   WorkersAITTS,
-  WorkersAIVAD,
   type VoiceTurnContext
 } from "@cloudflare/voice";
 
 const VoiceAgent = withVoice(Agent);
 
 export class MyAgent extends VoiceAgent<Env> {
-  stt = new WorkersAISTT(this.env.AI);
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
   tts = new WorkersAITTS(this.env.AI);
-  vad = new WorkersAIVAD(this.env.AI);
 
   async onTurn(transcript: string, context: VoiceTurnContext) {
-    // Return a string for single-shot TTS
     return "Hello! I heard you say: " + transcript;
   }
 }
@@ -120,26 +116,23 @@ function VoiceUI() {
 
 ```
 Browser                              Durable Object (withVoice)
-┌──────────┐   binary PCM (16kHz)    ┌──────────────────────────┐
-│ Mic      │ ──────────────────────► │ Audio buffer             │
-│          │                         │   ↓                      │
-│          │   JSON: end_of_speech   │ VAD (optional)           │
-│          │ ──────────────────────► │   ↓                      │
-│          │                         │ STT                      │
-│          │   JSON: transcript      │   ↓                      │
-│          │ ◄────────────────────── │ onTurn() → your LLM code │
-│          │   binary: audio         │   ↓ (sentence chunking)  │
-│ Speaker  │ ◄────────────────────── │ TTS                      │
+┌──────────┐                         ┌──────────────────────────┐
+│ Mic      │   binary PCM (16kHz)    │ Transcriber session      │
+│          │ ──────────────────────► │ (per-call, continuous)   │
+│          │                         │   ↓ model detects turn   │
+│          │   JSON: transcript      │ onTurn() → your LLM code │
+│          │ ◄────────────────────── │   ↓ (sentence chunking)  │
+│          │   binary: audio         │ TTS                      │
+│ Speaker  │ ◄────────────────────── │                          │
 └──────────┘                         └──────────────────────────┘
 ```
 
 1. The client captures mic audio and sends it as binary WebSocket frames (16kHz mono 16-bit PCM)
-2. Client-side silence detection sends `end_of_speech` after 500ms of silence
-3. Server-side VAD (if configured) confirms end-of-turn
-4. STT transcribes the audio (batch or streaming)
-5. Your `onTurn()` method runs — typically an LLM call
-6. The response is sentence-chunked and synthesized via TTS
-7. Audio streams back to the client for playback
+2. Audio streams continuously to the transcriber session (created at `start_call`, lives for the entire call)
+3. The STT model detects when the user finishes an utterance and fires `onUtterance`
+4. Your `onTurn()` method runs — typically an LLM call
+5. The response is sentence-chunked and synthesized via TTS
+6. Audio streams back to the client for playback
 
 ## Server API: `withVoice`
 
@@ -149,29 +142,31 @@ Browser                              Durable Object (withVoice)
 
 Set providers as class properties. Class field initializers run after `super()`, so `this.env` is available.
 
-| Property       | Type                   | Required | Description                             |
-| -------------- | ---------------------- | -------- | --------------------------------------- |
-| `stt`          | `STTProvider`          | Yes\*    | Batch speech-to-text                    |
-| `tts`          | `TTSProvider`          | Yes      | Text-to-speech                          |
-| `vad`          | `VADProvider`          | No       | Voice activity detection                |
-| `streamingStt` | `StreamingSTTProvider` | No       | Streaming STT (replaces `stt` when set) |
-
-\*Not required if `streamingStt` is set.
+| Property      | Type          | Required | Description                      |
+| ------------- | ------------- | -------- | -------------------------------- |
+| `transcriber` | `Transcriber` | Yes      | Continuous per-call STT provider |
+| `tts`         | `TTSProvider` | Yes      | Text-to-speech                   |
 
 ```typescript
-import {
-  withVoice,
-  WorkersAISTT,
-  WorkersAITTS,
-  WorkersAIVAD
-} from "@cloudflare/voice";
+import { withVoice, WorkersAIFluxSTT, WorkersAITTS } from "@cloudflare/voice";
 
 const VoiceAgent = withVoice(Agent);
 
 export class MyAgent extends VoiceAgent<Env> {
-  stt = new WorkersAISTT(this.env.AI);
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
   tts = new WorkersAITTS(this.env.AI);
-  vad = new WorkersAIVAD(this.env.AI);
+}
+```
+
+For runtime model switching (e.g. Flux vs Nova 3 dropdown), override `createTranscriber`:
+
+```typescript
+export class MyAgent extends VoiceAgent<Env> {
+  tts = new WorkersAITTS(this.env.AI);
+
+  createTranscriber(connection: Connection): Transcriber {
+    return new WorkersAIFluxSTT(this.env.AI);
+  }
 }
 ```
 
@@ -236,12 +231,11 @@ The `context` object provides:
 
 Intercept and transform data at each pipeline stage. Return `null` to skip the current utterance.
 
-| Method                                     | Receives          | Can skip? |
-| ------------------------------------------ | ----------------- | --------- |
-| `beforeTranscribe(audio, connection)`      | Raw PCM after VAD | Yes       |
-| `afterTranscribe(transcript, connection)`  | STT text          | Yes       |
-| `beforeSynthesize(text, connection)`       | Text before TTS   | Yes       |
-| `afterSynthesize(audio, text, connection)` | Audio after TTS   | Yes       |
+| Method                                     | Receives        | Can skip? |
+| ------------------------------------------ | --------------- | --------- |
+| `afterTranscribe(transcript, connection)`  | STT text        | Yes       |
+| `beforeSynthesize(text, connection)`       | Text before TTS | Yes       |
+| `afterSynthesize(audio, text, connection)` | Audio after TTS | Yes       |
 
 ```typescript
 export class MyAgent extends VoiceAgent<Env> {
@@ -276,11 +270,7 @@ Pass options to `withVoice()` as the second argument:
 const VoiceAgent = withVoice(Agent, {
   historyLimit: 20, // Max messages loaded for context (default: 20)
   audioFormat: "mp3", // Audio format sent to client (default: "mp3")
-  maxMessageCount: 1000, // Max messages in SQLite (default: 1000)
-  minAudioBytes: 16000, // Min audio to process, 0.5s (default: 16000)
-  vadThreshold: 0.5, // VAD probability threshold (default: 0.5)
-  vadPushbackSeconds: 2, // Audio pushed back on VAD reject (default: 2)
-  vadRetryMs: 3000 // Retry delay after VAD reject (default: 3000)
+  maxMessageCount: 1000 // Max messages in SQLite (default: 1000)
 });
 ```
 
@@ -290,16 +280,15 @@ const VoiceAgent = withVoice(Agent, {
 
 ```typescript
 import { Agent } from "agents";
-import { withVoiceInput, WorkersAIFluxSTT } from "@cloudflare/voice";
+import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
 
 const InputAgent = withVoiceInput(Agent);
 
 export class DictationAgent extends InputAgent<Env> {
-  streamingStt = new WorkersAIFluxSTT(this.env.AI);
+  transcriber = new WorkersAINova3STT(this.env.AI);
 
   onTranscript(text: string, connection: Connection) {
     console.log("User said:", text);
-    // Save to storage, trigger a search, forward to another service, etc.
   }
 }
 ```
@@ -310,11 +299,12 @@ Called after each utterance is transcribed. Override this to process the transcr
 
 ### Hooks
 
-`withVoiceInput` supports the same lifecycle and STT pipeline hooks as `withVoice`:
+`withVoiceInput` supports the same lifecycle hooks as `withVoice`:
 
 - `beforeCallStart(connection)` — return `false` to reject
 - `onCallStart(connection)`, `onCallEnd(connection)`, `onInterrupt(connection)`
-- `beforeTranscribe(audio, connection)`, `afterTranscribe(transcript, connection)`
+- `createTranscriber(connection)` — override for runtime model switching
+- `afterTranscribe(transcript, connection)` — filter or transform transcripts
 
 It does **not** have TTS hooks (`beforeSynthesize`, `afterSynthesize`) or `onTurn`.
 
@@ -452,30 +442,26 @@ client.disconnect();
 
 No API keys required — use your Workers AI binding:
 
-| Class              | Type          | Default Model                  |
-| ------------------ | ------------- | ------------------------------ |
-| `WorkersAISTT`     | Batch STT     | `@cf/deepgram/nova-3`          |
-| `WorkersAIFluxSTT` | Streaming STT | `@cf/deepgram/nova-3`          |
-| `WorkersAITTS`     | TTS           | `@cf/deepgram/aura-1`          |
-| `WorkersAIVAD`     | VAD           | `@cf/pipecat-ai/smart-turn-v2` |
+| Class               | Type           | Default Model         | Recommended for  |
+| ------------------- | -------------- | --------------------- | ---------------- |
+| `WorkersAIFluxSTT`  | Continuous STT | `@cf/deepgram/flux`   | `withVoice`      |
+| `WorkersAINova3STT` | Continuous STT | `@cf/deepgram/nova-3` | `withVoiceInput` |
+| `WorkersAITTS`      | TTS            | `@cf/deepgram/aura-1` | Both             |
 
 ```typescript
 import {
-  WorkersAISTT,
-  WorkersAITTS,
-  WorkersAIVAD,
-  WorkersAIFluxSTT
+  WorkersAIFluxSTT,
+  WorkersAINova3STT,
+  WorkersAITTS
 } from "@cloudflare/voice";
 
-// Default options
-stt = new WorkersAISTT(this.env.AI);
+transcriber = new WorkersAIFluxSTT(this.env.AI);
 tts = new WorkersAITTS(this.env.AI);
-vad = new WorkersAIVAD(this.env.AI);
 
 // Custom options
-stt = new WorkersAISTT(this.env.AI, {
-  model: "@cf/deepgram/nova-3",
-  language: "en"
+transcriber = new WorkersAIFluxSTT(this.env.AI, {
+  eotThreshold: 0.8,
+  keyterms: ["Cloudflare", "Workers"]
 });
 tts = new WorkersAITTS(this.env.AI, {
   model: "@cf/deepgram/aura-1",
@@ -485,11 +471,11 @@ tts = new WorkersAITTS(this.env.AI, {
 
 ### Third-Party Providers
 
-| Package                        | Class                  | Description             |
-| ------------------------------ | ---------------------- | ----------------------- |
-| `@cloudflare/voice-deepgram`   | `DeepgramStreamingSTT` | Real-time streaming STT |
-| `@cloudflare/voice-elevenlabs` | `ElevenLabsTTS`        | High-quality TTS        |
-| `@cloudflare/voice-twilio`     | Twilio adapter         | Telephony (phone calls) |
+| Package                        | Class           | Description             |
+| ------------------------------ | --------------- | ----------------------- |
+| `@cloudflare/voice-deepgram`   | `DeepgramSTT`   | Continuous STT          |
+| `@cloudflare/voice-elevenlabs` | `ElevenLabsTTS` | High-quality TTS        |
+| `@cloudflare/voice-twilio`     | Twilio adapter  | Telephony (phone calls) |
 
 **ElevenLabs TTS:**
 
@@ -497,7 +483,7 @@ tts = new WorkersAITTS(this.env.AI, {
 import { ElevenLabsTTS } from "@cloudflare/voice-elevenlabs";
 
 export class MyAgent extends VoiceAgent<Env> {
-  stt = new WorkersAISTT(this.env.AI);
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
   tts = new ElevenLabsTTS({
     apiKey: this.env.ELEVENLABS_API_KEY,
     voiceId: "21m00Tcm4TlvDq8ikWAM"
@@ -505,66 +491,31 @@ export class MyAgent extends VoiceAgent<Env> {
 }
 ```
 
-**Deepgram Streaming STT:**
+**Deepgram STT:**
 
 ```typescript
-import { DeepgramStreamingSTT } from "@cloudflare/voice-deepgram";
+import { DeepgramSTT } from "@cloudflare/voice-deepgram";
 
 export class MyAgent extends VoiceAgent<Env> {
-  streamingStt = new DeepgramStreamingSTT({
+  transcriber = new DeepgramSTT({
     apiKey: this.env.DEEPGRAM_API_KEY
   });
   tts = new WorkersAITTS(this.env.AI);
 }
 ```
 
-### Custom Providers
+## Continuous STT
 
-Any object satisfying the provider interface works:
-
-```typescript
-export class MyAgent extends VoiceAgent<Env> {
-  stt = {
-    transcribe: async (audio: ArrayBuffer, signal?: AbortSignal) => {
-      const resp = await fetch("https://my-stt.example.com/v1/transcribe", {
-        method: "POST",
-        body: audio,
-        signal
-      });
-      return ((await resp.json()) as { text: string }).text;
-    }
-  };
-
-  tts = {
-    synthesize: async (text: string, signal?: AbortSignal) => {
-      const resp = await fetch("https://my-tts.example.com/v1/synthesize", {
-        method: "POST",
-        body: JSON.stringify({ text }),
-        headers: { "Content-Type": "application/json" },
-        signal
-      });
-      return resp.arrayBuffer();
-    }
-  };
-}
-```
-
-## Streaming STT
-
-Streaming STT transcribes audio in real time as the user speaks, eliminating the latency of batch transcription. When a streaming STT provider is set, the pipeline creates a per-utterance session that receives audio chunks incrementally.
-
-The client receives `transcript_interim` messages with partial results as the user speaks. By the time the user stops, the transcript is already (nearly) ready — `session.finish()` typically takes ~50ms.
+The transcriber session is created at `start_call` and lives for the entire call. All audio is fed continuously — the model handles speech boundary detection (turn detection). The client receives `transcript_interim` messages with partial results as the user speaks.
 
 ```typescript
 export class MyAgent extends VoiceAgent<Env> {
-  // Streaming STT replaces batch stt when set
-  streamingStt = new DeepgramStreamingSTT({
+  transcriber = new DeepgramSTT({
     apiKey: this.env.DEEPGRAM_API_KEY
   });
   tts = new WorkersAITTS(this.env.AI);
 
   async onTurn(transcript: string, context: VoiceTurnContext) {
-    // transcript is the final, stable text
     return "You said: " + transcript;
   }
 }
@@ -579,7 +530,7 @@ const { interimTranscript, transcript } = useVoiceAgent({ agent: "MyAgent" });
 // transcript contains finalized messages
 ```
 
-Some streaming STT providers (like Deepgram) support **provider-driven end-of-turn**: the provider detects when the user has finished speaking and triggers the LLM pipeline immediately, bypassing client-side silence detection. This further reduces latency.
+All transcriber providers use **model-driven turn detection** — the model detects when the user has finished speaking and triggers the pipeline. The client does not need to send `end_of_speech` for STT; `start_of_speech` and `end_of_speech` are only used for client-side UI state (speaking indicators, audio level).
 
 ## Text Messages
 
@@ -677,8 +628,6 @@ Phone → Twilio → WebSocket → TwilioAdapter → WebSocket → VoiceAgent
 const { metrics } = useVoiceAgent({ agent: "MyAgent" });
 
 // metrics: {
-//   vad_ms: 45,          // VAD check time
-//   stt_ms: 120,         // STT transcription time
 //   llm_ms: 850,         // LLM response time
 //   tts_ms: 200,         // Cumulative TTS synthesis time
 //   first_audio_ms: 950, // Time to first audio byte
@@ -698,7 +647,7 @@ const history = this.getConversationHistory(20);
 this.saveMessage("assistant", "Welcome! How can I help?");
 ```
 
-History survives Durable Object restarts, hibernation, and client reconnections.
+History survives Durable Object restarts and client reconnections. Voice agents use `keepAlive` to prevent eviction during active calls.
 
 ## Examples
 

--- a/examples/playground/src/demos/voice/VoiceDemo.tsx
+++ b/examples/playground/src/demos/voice/VoiceDemo.tsx
@@ -129,14 +129,6 @@ export function VoiceDemo() {
             </span>
             <span className="text-kumo-line">/</span>
             <span>
-              LLM <span className="text-kumo-default">{metrics.llm_ms}ms</span>
-            </span>
-            <span className="text-kumo-line">/</span>
-            <span>
-              TTS <span className="text-kumo-default">{metrics.tts_ms}ms</span>
-            </span>
-            <span className="text-kumo-line">/</span>
-            <span>
               First audio{" "}
               <span className="text-kumo-default">
                 {metrics.first_audio_ms}ms

--- a/examples/playground/src/demos/voice/VoiceDemo.tsx
+++ b/examples/playground/src/demos/voice/VoiceDemo.tsx
@@ -121,11 +121,11 @@ export function VoiceDemo() {
         {metrics && (
           <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] text-kumo-secondary font-mono">
             <span>
-              VAD <span className="text-kumo-default">{metrics.vad_ms}ms</span>
+              LLM <span className="text-kumo-default">{metrics.llm_ms}ms</span>
             </span>
             <span className="text-kumo-line">/</span>
             <span>
-              STT <span className="text-kumo-default">{metrics.stt_ms}ms</span>
+              TTS <span className="text-kumo-default">{metrics.tts_ms}ms</span>
             </span>
             <span className="text-kumo-line">/</span>
             <span>

--- a/examples/playground/src/demos/voice/voice-agent.ts
+++ b/examples/playground/src/demos/voice/voice-agent.ts
@@ -11,7 +11,7 @@ import { createWorkersAI } from "workers-ai-provider";
 const VoiceAgent = withVoice(Agent);
 
 export class PlaygroundVoiceAgent extends VoiceAgent<Env> {
-  streamingStt = new WorkersAIFluxSTT(this.env.AI);
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
   tts = new WorkersAITTS(this.env.AI);
 
   async onTurn(transcript: string, context: VoiceTurnContext) {

--- a/examples/voice-agent/src/client.tsx
+++ b/examples/voice-agent/src/client.tsx
@@ -201,14 +201,6 @@ function WebRTCApp() {
           </span>
           <span className="text-kumo-line">/</span>
           <span>
-            LLM <span className="text-kumo-default">{metrics.llm_ms}ms</span>
-          </span>
-          <span className="text-kumo-line">/</span>
-          <span>
-            TTS <span className="text-kumo-default">{metrics.tts_ms}ms</span>
-          </span>
-          <span className="text-kumo-line">/</span>
-          <span>
             First audio{" "}
             <span className="text-kumo-default">
               {metrics.first_audio_ms}ms
@@ -663,14 +655,6 @@ function App() {
         {/* Latency metrics */}
         {metrics && (
           <div className="mb-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] text-kumo-secondary font-mono">
-            <span>
-              LLM <span className="text-kumo-default">{metrics.llm_ms}ms</span>
-            </span>
-            <span className="text-kumo-line">/</span>
-            <span>
-              TTS <span className="text-kumo-default">{metrics.tts_ms}ms</span>
-            </span>
-            <span className="text-kumo-line">/</span>
             <span>
               LLM <span className="text-kumo-default">{metrics.llm_ms}ms</span>
             </span>

--- a/examples/voice-agent/src/client.tsx
+++ b/examples/voice-agent/src/client.tsx
@@ -193,11 +193,11 @@ function WebRTCApp() {
       {metrics && (
         <div className="mb-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] text-kumo-secondary font-mono">
           <span>
-            VAD <span className="text-kumo-default">{metrics.vad_ms}ms</span>
+            LLM <span className="text-kumo-default">{metrics.llm_ms}ms</span>
           </span>
           <span className="text-kumo-line">/</span>
           <span>
-            STT <span className="text-kumo-default">{metrics.stt_ms}ms</span>
+            TTS <span className="text-kumo-default">{metrics.tts_ms}ms</span>
           </span>
           <span className="text-kumo-line">/</span>
           <span>
@@ -344,6 +344,7 @@ function App() {
   const [transport, setTransport] = useState<"websocket" | "webrtc">(
     "websocket"
   );
+  const [sttModel, setSttModel] = useState<"flux" | "nova-3">("flux");
 
   const {
     status,
@@ -361,6 +362,7 @@ function App() {
   } = useVoiceAgent({
     agent: "my-voice-agent",
     name: sessionId,
+    query: { model: sttModel },
     onReconnect: () => {
       setToast("Reconnected to agent.");
     }
@@ -572,6 +574,25 @@ function App() {
           </Button>
         </div>
 
+        {/* STT model selector */}
+        <div className="mb-4 flex items-center justify-center gap-2">
+          <span className="text-xs text-kumo-secondary">STT Model:</span>
+          <Button
+            variant={sttModel === "flux" ? "primary" : "ghost"}
+            size="sm"
+            onClick={() => setSttModel("flux")}
+          >
+            Flux
+          </Button>
+          <Button
+            variant={sttModel === "nova-3" ? "primary" : "ghost"}
+            size="sm"
+            onClick={() => setSttModel("nova-3")}
+          >
+            Nova 3
+          </Button>
+        </div>
+
         {/* Toast notification */}
         {toast && (
           <div className="mb-4 px-4 py-2.5 rounded-lg bg-blue-500/10 border border-blue-500/20 text-sm text-blue-600 dark:text-blue-400">
@@ -643,11 +664,11 @@ function App() {
         {metrics && (
           <div className="mb-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] text-kumo-secondary font-mono">
             <span>
-              VAD <span className="text-kumo-default">{metrics.vad_ms}ms</span>
+              LLM <span className="text-kumo-default">{metrics.llm_ms}ms</span>
             </span>
             <span className="text-kumo-line">/</span>
             <span>
-              STT <span className="text-kumo-default">{metrics.stt_ms}ms</span>
+              TTS <span className="text-kumo-default">{metrics.tts_ms}ms</span>
             </span>
             <span className="text-kumo-line">/</span>
             <span>

--- a/examples/voice-agent/src/server.ts
+++ b/examples/voice-agent/src/server.ts
@@ -7,8 +7,10 @@ import {
 import {
   withVoice,
   WorkersAIFluxSTT,
+  WorkersAINova3STT,
   WorkersAITTS,
-  type VoiceTurnContext
+  type VoiceTurnContext,
+  type Transcriber
 } from "@cloudflare/voice";
 import { streamText, tool, stepCountIs } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
@@ -26,15 +28,16 @@ You have tools available:
 Use tools when the user's request matches. After calling a tool, incorporate the result naturally into your spoken response.`;
 
 export class MyVoiceAgent extends VoiceAgent<Env> {
-  // --- Providers ---
-  // Flux: streaming STT with built-in end-of-turn detection via Workers AI.
-  // No API key needed — uses the AI binding directly.
-  streamingStt = new WorkersAIFluxSTT(this.env.AI);
-
   tts = new WorkersAITTS(this.env.AI);
 
-  // No VAD needed — Flux has built-in turn detection.
-  // Client-side silence detection still triggers the pipeline.
+  createTranscriber(connection: Connection): Transcriber {
+    const url = new URL(connection.url ?? "http://localhost");
+    const model = url.searchParams.get("model");
+    if (model === "nova-3") {
+      return new WorkersAINova3STT(this.env.AI);
+    }
+    return new WorkersAIFluxSTT(this.env.AI);
+  }
 
   // --- Single-speaker enforcement ---
   //

--- a/examples/voice-agent/wrangler.jsonc
+++ b/examples/voice-agent/wrangler.jsonc
@@ -23,7 +23,6 @@
     }
   ],
   "assets": {
-    "directory": "public",
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*", "/sfu/*"]
   }

--- a/examples/voice-agent/wrangler.jsonc
+++ b/examples/voice-agent/wrangler.jsonc
@@ -23,7 +23,8 @@
     }
   ],
   "assets": {
+    "directory": "public",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/agents/*"]
+    "run_worker_first": ["/agents/*", "/sfu/*"]
   }
 }

--- a/examples/voice-input/README.md
+++ b/examples/voice-input/README.md
@@ -2,7 +2,7 @@
 
 Voice-to-text dictation example using the `useVoiceInput` hook from `@cloudflare/voice`.
 
-Captures microphone audio, streams it to a PartyServer-based Durable Object for real-time speech-to-text using Workers AI, and displays the transcript in a text area.
+Captures microphone audio, streams it to an Agent Durable Object for real-time speech-to-text using Workers AI, and displays the transcript in a text area.
 
 ## Run it
 
@@ -19,13 +19,13 @@ No API keys needed — uses Workers AI (bound via `wrangler.jsonc`).
 Uses `withVoiceInput` — a lightweight mixin that only does STT. No TTS provider, no `onTurn` handler needed:
 
 ```typescript
-import { Server } from "partyserver";
-import { withVoiceInput, WorkersAIFluxSTT } from "@cloudflare/voice";
+import { Agent } from "agents";
+import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
 
-const InputServer = withVoiceInput(Server);
+const InputAgent = withVoiceInput(Agent);
 
-export class VoiceInputAgent extends InputServer<Env> {
-  streamingStt = new WorkersAIFluxSTT(this.env.AI);
+export class VoiceInputAgent extends InputAgent<Env> {
+  transcriber = new WorkersAINova3STT(this.env.AI);
 
   onTranscript(text, connection) {
     console.log("User said:", text);

--- a/examples/voice-input/src/server.ts
+++ b/examples/voice-input/src/server.ts
@@ -1,18 +1,17 @@
-import { Server, routePartykitRequest, type Connection } from "partyserver";
-import { withVoiceInput, WorkersAIFluxSTT } from "@cloudflare/voice";
+import { Agent, routeAgentRequest, type Connection } from "agents";
+import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
 
-const InputServer = withVoiceInput(Server);
+const InputAgent = withVoiceInput(Agent);
 
 /**
- * Voice-to-text input server using PartyServer.
+ * Voice-to-text input agent.
  *
- * Uses streaming STT to transcribe speech in real time. No TTS or LLM
- * pipeline — each utterance is transcribed and sent back to the client
- * immediately. The optional `onTranscript` hook lets you process each
- * utterance on the server side.
+ * Uses Nova 3 continuous STT to transcribe speech in real time. No TTS or
+ * LLM pipeline — each utterance is transcribed and sent back to the client
+ * immediately.
  */
-export class VoiceInputAgent extends InputServer<Env> {
-  streamingStt = new WorkersAIFluxSTT(this.env.AI);
+export class VoiceInputAgent extends InputAgent<Env> {
+  transcriber = new WorkersAINova3STT(this.env.AI);
 
   onTranscript(text: string, _connection: Connection) {
     console.log(`[VoiceInputAgent] Transcribed: "${text}"`);
@@ -22,7 +21,7 @@ export class VoiceInputAgent extends InputServer<Env> {
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
     return (
-      (await routePartykitRequest(request, env, { prefix: "agents" })) ||
+      (await routeAgentRequest(request, env)) ||
       new Response("Not found", { status: 404 })
     );
   }

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -1,6 +1,6 @@
 # @cloudflare/voice
 
-Voice pipeline for [Cloudflare Agents](https://github.com/cloudflare/agents) -- STT, TTS, VAD, streaming, and real-time audio over WebSocket.
+Voice pipeline for [Cloudflare Agents](https://github.com/cloudflare/agents) -- continuous STT, TTS, streaming, and real-time audio over WebSocket.
 
 > **Experimental.** This API is under active development and will break between releases. Pin your version and expect to rewrite when upgrading.
 
@@ -20,17 +20,24 @@ npm install @cloudflare/voice
 
 ## Server: full voice agent (`withVoice`)
 
-Adds the complete voice pipeline: audio buffering, VAD, STT, LLM turn handling, streaming TTS, interruption, and conversation persistence.
+Adds the complete voice pipeline: continuous STT, LLM turn handling, streaming TTS, interruption, and conversation persistence.
 
 ```typescript
 import { Agent } from "agents";
-import { withVoice, type VoiceTurnContext } from "@cloudflare/voice";
+import {
+  withVoice,
+  WorkersAIFluxSTT,
+  WorkersAITTS,
+  type VoiceTurnContext
+} from "@cloudflare/voice";
 
 const VoiceAgent = withVoice(Agent);
 
 export class MyAgent extends VoiceAgent<Env> {
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
+  tts = new WorkersAITTS(this.env.AI);
+
   async onTurn(transcript: string, context: VoiceTurnContext) {
-    // Return a string or AsyncIterable<string> (for streaming TTS)
     return "Hello! I heard you say: " + transcript;
   }
 }
@@ -38,18 +45,17 @@ export class MyAgent extends VoiceAgent<Env> {
 
 ### Provider properties
 
-| Property       | Type                   | Required | Description                                |
-| -------------- | ---------------------- | -------- | ------------------------------------------ |
-| `stt`          | `STTProvider`          | No       | Batch speech-to-text (default: Workers AI) |
-| `tts`          | `TTSProvider`          | Yes      | Text-to-speech (default: Workers AI)       |
-| `vad`          | `VADProvider`          | No       | Voice activity detection                   |
-| `streamingStt` | `StreamingSTTProvider` | No       | Streaming STT for real-time transcripts    |
+| Property      | Type          | Required | Description                      |
+| ------------- | ------------- | -------- | -------------------------------- |
+| `transcriber` | `Transcriber` | Yes      | Continuous per-call STT provider |
+| `tts`         | `TTSProvider` | Yes      | Text-to-speech provider          |
 
 ### Lifecycle hooks
 
 | Method                           | Description                                                                        |
 | -------------------------------- | ---------------------------------------------------------------------------------- |
 | `onTurn(transcript, context)`    | **Required.** Handle a user utterance. Return `string` or `AsyncIterable<string>`. |
+| `createTranscriber(connection)`  | Override to create a transcriber dynamically per connection.                       |
 | `onCallStart(connection)`        | Called when a voice call begins.                                                   |
 | `onCallEnd(connection)`          | Called when a voice call ends.                                                     |
 | `onInterrupt(connection)`        | Called when user interrupts playback.                                              |
@@ -60,7 +66,6 @@ export class MyAgent extends VoiceAgent<Env> {
 
 | Method                                     | Description                                          |
 | ------------------------------------------ | ---------------------------------------------------- |
-| `beforeTranscribe(audio, connection)`      | Process audio before STT. Return `null` to skip.     |
 | `afterTranscribe(transcript, connection)`  | Process transcript after STT. Return `null` to skip. |
 | `beforeSynthesize(text, connection)`       | Process text before TTS. Return `null` to skip.      |
 | `afterSynthesize(audio, text, connection)` | Process audio after TTS. Return `null` to skip.      |
@@ -78,13 +83,13 @@ export class MyAgent extends VoiceAgent<Env> {
 STT-only mixin -- no TTS, no LLM. Use when you only need speech-to-text (e.g., dictation, transcription).
 
 ```typescript
-import { Server } from "partyserver";
-import { withVoiceInput, WorkersAIFluxSTT } from "@cloudflare/voice";
+import { Agent } from "agents";
+import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
 
-const InputServer = withVoiceInput(Server);
+const InputAgent = withVoiceInput(Agent);
 
-export class VoiceInputAgent extends InputServer<Env> {
-  streamingStt = new WorkersAIFluxSTT(this.env.AI);
+export class DictationAgent extends InputAgent<Env> {
+  transcriber = new WorkersAINova3STT(this.env.AI);
 
   onTranscript(text: string, connection: Connection) {
     console.log("User said:", text);
@@ -124,7 +129,7 @@ For voice input only:
 import { useVoiceInput } from "@cloudflare/voice/react";
 
 const { transcript, interimTranscript, isListening, start, stop, clear } =
-  useVoiceInput({ agent: "VoiceInputAgent" });
+  useVoiceInput({ agent: "DictationAgent" });
 ```
 
 ## Client: vanilla JavaScript
@@ -143,18 +148,17 @@ await client.startCall();
 
 All default providers use Workers AI bindings -- no API keys required:
 
-| Class              | Type          | Workers AI model                  |
-| ------------------ | ------------- | --------------------------------- |
-| `WorkersAISTT`     | Batch STT     | `@cf/deepgram/nova-3`             |
-| `WorkersAIFluxSTT` | Streaming STT | `@cf/deepgram/nova-3` (WebSocket) |
-| `WorkersAITTS`     | TTS           | `@cf/deepgram/aura-1`             |
-| `WorkersAIVAD`     | VAD           | `@cf/pipecat-ai/smart-turn-v2`    |
+| Class               | Type           | Workers AI model      | Recommended for  |
+| ------------------- | -------------- | --------------------- | ---------------- |
+| `WorkersAIFluxSTT`  | Continuous STT | `@cf/deepgram/flux`   | `withVoice`      |
+| `WorkersAINova3STT` | Continuous STT | `@cf/deepgram/nova-3` | `withVoiceInput` |
+| `WorkersAITTS`      | TTS            | `@cf/deepgram/aura-1` | Both             |
 
 ## Third-party providers
 
 | Package                        | What it provides                         |
 | ------------------------------ | ---------------------------------------- |
-| `@cloudflare/voice-deepgram`   | Streaming STT (Deepgram Nova)            |
+| `@cloudflare/voice-deepgram`   | Continuous STT (Deepgram Nova)           |
 | `@cloudflare/voice-elevenlabs` | TTS (ElevenLabs)                         |
 | `@cloudflare/voice-twilio`     | Telephony adapter (Twilio Media Streams) |
 
@@ -162,4 +166,3 @@ All default providers use Workers AI bindings -- no API keys required:
 
 - [`examples/voice-agent`](../../examples/voice-agent) -- full voice agent example
 - [`examples/voice-input`](../../examples/voice-input) -- voice input (dictation) example
-- [`experimental/voice.md`](../../experimental/voice.md) -- detailed API reference and protocol docs

--- a/packages/voice/src/audio-pipeline.ts
+++ b/packages/voice/src/audio-pipeline.ts
@@ -125,7 +125,19 @@ export class AudioConnectionManager {
     this.#activePipeline.delete(connectionId);
   }
 
-  clearPipelineAbort(connectionId: string): void {
-    this.#activePipeline.delete(connectionId);
+  /**
+   * Clear a pipeline abort controller only if it still matches the
+   * given signal. Prevents a finished pipeline from deleting a
+   * successor pipeline's controller in a concurrent scenario.
+   */
+  clearPipelineAbort(connectionId: string, signal?: AbortSignal): void {
+    if (signal) {
+      const controller = this.#activePipeline.get(connectionId);
+      if (controller && controller.signal === signal) {
+        this.#activePipeline.delete(connectionId);
+      }
+    } else {
+      this.#activePipeline.delete(connectionId);
+    }
   }
 }

--- a/packages/voice/src/audio-pipeline.ts
+++ b/packages/voice/src/audio-pipeline.ts
@@ -4,30 +4,10 @@
  */
 
 import type {
-  StreamingSTTProvider,
-  StreamingSTTSession,
-  StreamingSTTSessionOptions
+  Transcriber,
+  TranscriberSession,
+  TranscriberSessionOptions
 } from "./types";
-
-// --- Audio utilities ---
-
-export function concatenateBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
-  const totalLength = buffers.reduce((sum, buf) => sum + buf.byteLength, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const buf of buffers) {
-    result.set(new Uint8Array(buf), offset);
-    offset += buf.byteLength;
-  }
-  return result.buffer;
-}
-
-// --- Default option values ---
-
-export const DEFAULT_VAD_THRESHOLD = 0.5;
-export const DEFAULT_MIN_AUDIO_BYTES = 16000; // 0.5s at 16kHz mono 16-bit
-export const DEFAULT_VAD_PUSHBACK_SECONDS = 2;
-export const DEFAULT_VAD_RETRY_MS = 3000;
 
 /** Max audio buffer size per connection: 30 seconds at 16kHz mono 16-bit = 960KB. */
 export const MAX_AUDIO_BUFFER_BYTES = 960_000;
@@ -48,14 +28,12 @@ export function sendVoiceJSON(
 
 /**
  * Manages per-connection audio pipeline state for voice mixins.
- * Owns the Maps/Sets for audio buffers, STT sessions, timers, and abort controllers.
+ * Owns the Maps for audio buffers, transcriber sessions, and abort controllers.
  * Does not own pipeline orchestration — that stays in each mixin.
  */
 export class AudioConnectionManager {
   #audioBuffers = new Map<string, ArrayBuffer[]>();
-  #sttSessions = new Map<string, StreamingSTTSession>();
-  #vadRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  #eotTriggered = new Set<string>();
+  #transcriberSessions = new Map<string, TranscriberSession>();
   #activePipeline = new Map<string, AbortController>();
   constructor(_logPrefix: string) {}
 
@@ -74,9 +52,7 @@ export class AudioConnectionManager {
   cleanup(connectionId: string): void {
     this.abortPipeline(connectionId);
     this.#audioBuffers.delete(connectionId);
-    this.abortSTTSession(connectionId);
-    this.clearVadRetry(connectionId);
-    this.#eotTriggered.delete(connectionId);
+    this.closeTranscriberSession(connectionId);
   }
 
   // --- Audio buffering ---
@@ -94,23 +70,11 @@ export class AudioConnectionManager {
       totalBytes -= buffer.shift()!.byteLength;
     }
 
-    // Feed to streaming STT session if active
-    const session = this.#sttSessions.get(connectionId);
+    // Feed to transcriber session if active
+    const session = this.#transcriberSessions.get(connectionId);
     if (session) {
       session.feed(chunk);
     }
-  }
-
-  /**
-   * Concatenate and clear the audio buffer for a connection.
-   * Returns null if no audio or buffer doesn't exist.
-   */
-  getAndClearAudio(connectionId: string): ArrayBuffer | null {
-    const chunks = this.#audioBuffers.get(connectionId);
-    if (!chunks || chunks.length === 0) return null;
-    const audio = concatenateBuffers(chunks);
-    this.#audioBuffers.set(connectionId, []);
-    return audio;
   }
 
   clearAudioBuffer(connectionId: string): void {
@@ -119,63 +83,28 @@ export class AudioConnectionManager {
     }
   }
 
-  pushbackAudio(connectionId: string, audio: ArrayBuffer): void {
-    const buffer = this.#audioBuffers.get(connectionId);
-    if (buffer) {
-      buffer.unshift(audio);
-    } else {
-      this.#audioBuffers.set(connectionId, [audio]);
-    }
+  // --- Transcriber sessions ---
+
+  hasTranscriberSession(connectionId: string): boolean {
+    return this.#transcriberSessions.has(connectionId);
   }
 
-  // --- STT sessions ---
-
-  hasSTTSession(connectionId: string): boolean {
-    return this.#sttSessions.has(connectionId);
-  }
-
-  startSTTSession(
+  startTranscriberSession(
     connectionId: string,
-    provider: StreamingSTTProvider,
-    options: StreamingSTTSessionOptions
+    transcriber: Transcriber,
+    options: TranscriberSessionOptions
   ): void {
-    const session = provider.createSession(options);
-    this.#sttSessions.set(connectionId, session);
+    this.closeTranscriberSession(connectionId);
+    const session = transcriber.createSession(options);
+    this.#transcriberSessions.set(connectionId, session);
   }
 
-  async flushSTTSession(connectionId: string): Promise<string> {
-    const session = this.#sttSessions.get(connectionId);
-    if (!session) return "";
-    const transcript = await session.finish();
-    this.#sttSessions.delete(connectionId);
-    return transcript;
-  }
-
-  abortSTTSession(connectionId: string): void {
-    const session = this.#sttSessions.get(connectionId);
+  closeTranscriberSession(connectionId: string): void {
+    const session = this.#transcriberSessions.get(connectionId);
     if (session) {
-      session.abort();
-      this.#sttSessions.delete(connectionId);
+      session.close();
+      this.#transcriberSessions.delete(connectionId);
     }
-  }
-
-  /** Remove the STT session without aborting (used after provider-driven EOT). */
-  removeSTTSession(connectionId: string): void {
-    this.#sttSessions.delete(connectionId);
-  }
-
-  // --- EOT tracking ---
-
-  isEOTTriggered(connectionId: string): boolean {
-    return this.#eotTriggered.has(connectionId);
-  }
-
-  setEOTTriggered(connectionId: string): void {
-    this.#eotTriggered.add(connectionId);
-  }
-
-  clearEOT(connectionId: string): void {
-    this.#eotTriggered.delete(connectionId);
   }
 
   // --- Pipeline abort ---
@@ -198,30 +127,5 @@ export class AudioConnectionManager {
 
   clearPipelineAbort(connectionId: string): void {
     this.#activePipeline.delete(connectionId);
-  }
-
-  // --- VAD retry ---
-
-  scheduleVadRetry(
-    connectionId: string,
-    callback: () => void,
-    retryMs: number
-  ): void {
-    this.clearVadRetry(connectionId);
-    this.#vadRetryTimers.set(
-      connectionId,
-      setTimeout(() => {
-        this.#vadRetryTimers.delete(connectionId);
-        callback();
-      }, retryMs)
-    );
-  }
-
-  clearVadRetry(connectionId: string): void {
-    const timer = this.#vadRetryTimers.get(connectionId);
-    if (timer) {
-      clearTimeout(timer);
-      this.#vadRetryTimers.delete(connectionId);
-    }
   }
 }

--- a/packages/voice/src/react-tests/useVoiceAgent.test.tsx
+++ b/packages/voice/src/react-tests/useVoiceAgent.test.tsx
@@ -478,8 +478,6 @@ describe("useVoiceAgent", () => {
       act(() => {
         fireJSON({
           type: "metrics",
-          vad_ms: 120,
-          stt_ms: 350,
           llm_ms: 800,
           tts_ms: 200,
           first_audio_ms: 1470,
@@ -490,8 +488,6 @@ describe("useVoiceAgent", () => {
       await vi.waitFor(() => {
         const m = getResult().metrics;
         expect(m).not.toBeNull();
-        expect(m!.vad_ms).toBe(120);
-        expect(m!.stt_ms).toBe(350);
         expect(m!.llm_ms).toBe(800);
         expect(m!.tts_ms).toBe(200);
         expect(m!.first_audio_ms).toBe(1470);
@@ -613,8 +609,6 @@ describe("useVoiceAgent", () => {
         fireJSON({ type: "error", message: "old error" });
         fireJSON({
           type: "metrics",
-          vad_ms: 1,
-          stt_ms: 1,
           llm_ms: 1,
           tts_ms: 1,
           first_audio_ms: 1,

--- a/packages/voice/src/tests/agents/voice-input.ts
+++ b/packages/voice/src/tests/agents/voice-input.ts
@@ -1,104 +1,59 @@
 import { Agent, type Connection, type WSMessage } from "agents";
 import { withVoiceInput } from "../../voice-input";
 import type {
-  STTProvider,
-  VADProvider,
-  StreamingSTTProvider,
-  StreamingSTTSession,
-  StreamingSTTSessionOptions
+  Transcriber,
+  TranscriberSession,
+  TranscriberSessionOptions
 } from "../../types";
 
-// --- Stub providers ---
+// --- Test transcriber stub ---
 
-/** Deterministic batch STT: returns a fixed transcript. */
-class TestSTT implements STTProvider {
-  async transcribe(_audioData: ArrayBuffer): Promise<string> {
-    return "test input transcript";
-  }
-}
-
-/** VAD that always confirms end-of-turn. */
-class TestVAD implements VADProvider {
-  async checkEndOfTurn(
-    _audioData: ArrayBuffer
-  ): Promise<{ isComplete: boolean; probability: number }> {
-    return { isComplete: true, probability: 1.0 };
-  }
-}
-
-/** Streaming STT session with deterministic behavior. */
-class TestStreamingSTTSession implements StreamingSTTSession {
+/**
+ * Deterministic continuous transcriber session for tests.
+ * Fires onUtterance every `utteranceThreshold` bytes accumulated.
+ * Fires onInterim on every feed() with a running byte count.
+ */
+class TestTranscriberSession implements TranscriberSession {
   #totalBytes = 0;
-  #aborted = false;
+  #utteranceCount = 0;
+  #closed = false;
   #onInterim: ((text: string) => void) | undefined;
+  #onUtterance: ((text: string) => void) | undefined;
+  #utteranceThreshold: number;
 
-  constructor(options?: StreamingSTTSessionOptions) {
+  constructor(options?: TranscriberSessionOptions, utteranceThreshold = 20000) {
     this.#onInterim = options?.onInterim;
+    this.#onUtterance = options?.onUtterance;
+    this.#utteranceThreshold = utteranceThreshold;
   }
 
   feed(chunk: ArrayBuffer): void {
-    if (this.#aborted) return;
-    this.#totalBytes += chunk.byteLength;
-    this.#onInterim?.(`hearing ${this.#totalBytes} bytes`);
-  }
-
-  async finish(): Promise<string> {
-    if (this.#aborted) return "";
-    return `streaming input (${this.#totalBytes} bytes)`;
-  }
-
-  abort(): void {
-    this.#aborted = true;
-  }
-}
-
-class TestStreamingSTT implements StreamingSTTProvider {
-  createSession(options?: StreamingSTTSessionOptions): StreamingSTTSession {
-    return new TestStreamingSTTSession(options);
-  }
-}
-
-/** EOT-capable streaming STT: fires onEndOfTurn at >= 20000 bytes. */
-class TestEOTStreamingSTTSession implements StreamingSTTSession {
-  #totalBytes = 0;
-  #aborted = false;
-  #eotFired = false;
-  #onInterim: ((text: string) => void) | undefined;
-  #onFinal: ((text: string) => void) | undefined;
-  #onEndOfTurn: ((text: string) => void) | undefined;
-
-  constructor(options?: StreamingSTTSessionOptions) {
-    this.#onInterim = options?.onInterim;
-    this.#onFinal = options?.onFinal;
-    this.#onEndOfTurn = options?.onEndOfTurn;
-  }
-
-  feed(chunk: ArrayBuffer): void {
-    if (this.#aborted) return;
+    if (this.#closed) return;
     this.#totalBytes += chunk.byteLength;
     this.#onInterim?.(`hearing ${this.#totalBytes} bytes`);
 
-    if (this.#totalBytes >= 20000 && !this.#eotFired) {
-      this.#eotFired = true;
-      const transcript = `eot input (${this.#totalBytes} bytes)`;
-      this.#onFinal?.(transcript);
-      this.#onEndOfTurn?.(transcript);
+    const nextThreshold = (this.#utteranceCount + 1) * this.#utteranceThreshold;
+    if (this.#totalBytes >= nextThreshold) {
+      this.#utteranceCount++;
+      const transcript = `utterance ${this.#utteranceCount} (${this.#totalBytes} bytes)`;
+      this.#onUtterance?.(transcript);
     }
   }
 
-  async finish(): Promise<string> {
-    if (this.#aborted) return "";
-    return `eot input (${this.#totalBytes} bytes)`;
-  }
-
-  abort(): void {
-    this.#aborted = true;
+  close(): void {
+    this.#closed = true;
   }
 }
 
-class TestEOTStreamingSTT implements StreamingSTTProvider {
-  createSession(options?: StreamingSTTSessionOptions): StreamingSTTSession {
-    return new TestEOTStreamingSTTSession(options);
+class TestTranscriber implements Transcriber {
+  #utteranceThreshold: number;
+
+  constructor(utteranceThreshold = 20000) {
+    this.#utteranceThreshold = utteranceThreshold;
+  }
+
+  createSession(options?: TranscriberSessionOptions): TranscriberSession {
+    return new TestTranscriberSession(options, this.#utteranceThreshold);
   }
 }
 
@@ -107,14 +62,13 @@ class TestEOTStreamingSTT implements StreamingSTTProvider {
 const InputBase = withVoiceInput(Agent);
 
 /**
- * Basic batch STT voice input agent.
+ * Continuous STT voice input agent with test transcriber.
  * Tracks onTranscript calls and consumer lifecycle invocations for assertions.
  */
 export class TestVoiceInputAgent extends InputBase {
   static options = { hibernate: false };
 
-  stt = new TestSTT();
-  vad = new TestVAD();
+  transcriber = new TestTranscriber();
 
   #transcripts: string[] = [];
   #connectCount = 0;
@@ -125,10 +79,8 @@ export class TestVoiceInputAgent extends InputBase {
     this.#transcripts.push(text);
   }
 
-  // Consumer lifecycle methods — these should be called by the mixin wrapper
   onConnect(connection: Connection) {
     this.#connectCount++;
-    // Verify we can still use Agent's connection
     console.log(`[TestVoiceInput] consumer onConnect: ${connection.id}`);
   }
 
@@ -138,7 +90,6 @@ export class TestVoiceInputAgent extends InputBase {
   }
 
   onMessage(connection: Connection, message: WSMessage) {
-    // This should only receive non-voice messages
     if (typeof message === "string") {
       let parsed: Record<string, unknown>;
       try {
@@ -169,80 +120,12 @@ export class TestVoiceInputAgent extends InputBase {
 }
 
 /**
- * Streaming STT voice input agent.
- */
-export class TestStreamingVoiceInputAgent extends InputBase {
-  static options = { hibernate: false };
-
-  streamingStt = new TestStreamingSTT();
-
-  #transcripts: string[] = [];
-
-  onTranscript(text: string, _connection: Connection) {
-    this.#transcripts.push(text);
-  }
-
-  onMessage(connection: Connection, message: WSMessage) {
-    if (typeof message === "string") {
-      let parsed: Record<string, unknown>;
-      try {
-        parsed = JSON.parse(message);
-      } catch {
-        return;
-      }
-      if (parsed.type === "_get_state") {
-        connection.send(
-          JSON.stringify({
-            type: "_state",
-            transcripts: this.#transcripts
-          })
-        );
-      }
-    }
-  }
-}
-
-/**
- * EOT-capable streaming STT voice input agent.
- */
-export class TestEotVoiceInputAgent extends InputBase {
-  static options = { hibernate: false };
-
-  streamingStt = new TestEOTStreamingSTT();
-
-  #transcripts: string[] = [];
-
-  onTranscript(text: string, _connection: Connection) {
-    this.#transcripts.push(text);
-  }
-
-  onMessage(connection: Connection, message: WSMessage) {
-    if (typeof message === "string") {
-      let parsed: Record<string, unknown>;
-      try {
-        parsed = JSON.parse(message);
-      } catch {
-        return;
-      }
-      if (parsed.type === "_get_state") {
-        connection.send(
-          JSON.stringify({
-            type: "_state",
-            transcripts: this.#transcripts
-          })
-        );
-      }
-    }
-  }
-}
-
-/**
  * Voice input agent that rejects calls via beforeCallStart.
  */
 export class TestRejectCallVoiceInputAgent extends InputBase {
   static options = { hibernate: false };
 
-  stt = new TestSTT();
+  transcriber = new TestTranscriber();
 
   beforeCallStart(_connection: Connection): boolean {
     return false;

--- a/packages/voice/src/tests/agents/voice.ts
+++ b/packages/voice/src/tests/agents/voice.ts
@@ -155,3 +155,46 @@ export class TestVoiceAgent extends VoiceBase {
     );
   }
 }
+
+/**
+ * Test VoiceAgent that returns empty strings from onTurn.
+ * Used to test the empty response guard.
+ */
+export class TestEmptyResponseVoiceAgent extends VoiceBase {
+  static options = { hibernate: false };
+
+  transcriber = new TestTranscriber();
+  tts = new TestTTS();
+
+  async onTurn(
+    _transcript: string,
+    _context: VoiceTurnContext
+  ): Promise<string> {
+    return "";
+  }
+
+  onMessage(connection: Connection, message: WSMessage) {
+    if (typeof message !== "string") return;
+    try {
+      const parsed = JSON.parse(message);
+      if (parsed.type === "_get_message_count") {
+        connection.send(
+          JSON.stringify({
+            type: "_message_count",
+            count: this.getMessageCount()
+          })
+        );
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  getMessageCount(): number {
+    return (
+      this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_voice_messages
+    `[0]?.count ?? 0
+    );
+  }
+}

--- a/packages/voice/src/tests/agents/voice.ts
+++ b/packages/voice/src/tests/agents/voice.ts
@@ -1,20 +1,11 @@
 import { Agent, type Connection, type WSMessage } from "agents";
 import { withVoice, type VoiceTurnContext } from "../../voice";
 import type {
-  STTProvider,
   TTSProvider,
-  VADProvider,
-  StreamingSTTProvider,
-  StreamingSTTSession,
-  StreamingSTTSessionOptions
+  Transcriber,
+  TranscriberSession,
+  TranscriberSessionOptions
 } from "../../types";
-
-/** Deterministic STT provider for tests. */
-class TestSTT implements STTProvider {
-  async transcribe(_audioData: ArrayBuffer): Promise<string> {
-    return "test transcript";
-  }
-}
 
 /** Deterministic TTS provider for tests — encodes text as bytes. */
 class TestTTS implements TTSProvider {
@@ -28,27 +19,67 @@ class TestTTS implements TTSProvider {
   }
 }
 
-/** Deterministic VAD provider for tests — always confirms end-of-turn. */
-class TestVAD implements VADProvider {
-  async checkEndOfTurn(
-    _audioData: ArrayBuffer
-  ): Promise<{ isComplete: boolean; probability: number }> {
-    return { isComplete: true, probability: 1.0 };
+/**
+ * Deterministic continuous transcriber session for tests.
+ * Fires onUtterance every `utteranceThreshold` bytes accumulated.
+ */
+class TestTranscriberSession implements TranscriberSession {
+  #totalBytes = 0;
+  #utteranceCount = 0;
+  #closed = false;
+  #onInterim: ((text: string) => void) | undefined;
+  #onUtterance: ((text: string) => void) | undefined;
+  #utteranceThreshold: number;
+
+  constructor(options?: TranscriberSessionOptions, utteranceThreshold = 20000) {
+    this.#onInterim = options?.onInterim;
+    this.#onUtterance = options?.onUtterance;
+    this.#utteranceThreshold = utteranceThreshold;
+  }
+
+  feed(chunk: ArrayBuffer): void {
+    if (this.#closed) return;
+    this.#totalBytes += chunk.byteLength;
+    this.#onInterim?.(`hearing ${this.#totalBytes} bytes`);
+
+    const nextThreshold = (this.#utteranceCount + 1) * this.#utteranceThreshold;
+    if (this.#totalBytes >= nextThreshold) {
+      this.#utteranceCount++;
+      const transcript = `utterance ${this.#utteranceCount} (${this.#totalBytes} bytes)`;
+      this.#onUtterance?.(transcript);
+    }
+  }
+
+  close(): void {
+    this.#closed = true;
   }
 }
+
+class TestTranscriber implements Transcriber {
+  #utteranceThreshold: number;
+
+  constructor(utteranceThreshold = 20000) {
+    this.#utteranceThreshold = utteranceThreshold;
+  }
+
+  createSession(options?: TranscriberSessionOptions): TranscriberSession {
+    return new TestTranscriberSession(options, this.#utteranceThreshold);
+  }
+}
+
+// --- Test agents ---
 
 const VoiceBase = withVoice(Agent);
 
 /**
- * Test VoiceAgent that echoes back the transcript (no real AI).
- * Uses deterministic test providers for STT/TTS/VAD.
+ * Test VoiceAgent with continuous transcriber.
+ * Echoes back the transcript (no real AI).
  */
 export class TestVoiceAgent extends VoiceBase {
   static options = { hibernate: false };
 
-  stt = new TestSTT();
+  transcriber = new TestTranscriber();
   tts = new TestTTS();
-  vad = new TestVAD();
 
   #callStartCount = 0;
   #callEndCount = 0;
@@ -82,7 +113,6 @@ export class TestVoiceAgent extends VoiceBase {
     if (typeof message !== "string") return;
     try {
       const parsed = JSON.parse(message);
-      // Control messages for testing
       switch (parsed.type) {
         case "_set_before_call_start":
           this.#beforeCallStartResult = parsed.value;
@@ -90,273 +120,6 @@ export class TestVoiceAgent extends VoiceBase {
             JSON.stringify({ type: "_ack", command: parsed.type })
           );
           break;
-        case "_get_counts":
-          connection.send(
-            JSON.stringify({
-              type: "_counts",
-              callStart: this.#callStartCount,
-              callEnd: this.#callEndCount,
-              interrupt: this.#interruptCount
-            })
-          );
-          break;
-        case "_get_message_count":
-          connection.send(
-            JSON.stringify({
-              type: "_message_count",
-              count: this.getMessageCount()
-            })
-          );
-          break;
-        case "_force_end_call":
-          this.forceEndCall(connection);
-          break;
-      }
-    } catch {
-      // ignore
-    }
-  }
-
-  getCallStartCount(): number {
-    return this.#callStartCount;
-  }
-
-  getCallEndCount(): number {
-    return this.#callEndCount;
-  }
-
-  getInterruptCount(): number {
-    return this.#interruptCount;
-  }
-
-  setBeforeCallStartResult(result: boolean) {
-    this.#beforeCallStartResult = result;
-  }
-
-  getMessageCount(): number {
-    return (
-      this.sql<{ count: number }>`
-      SELECT COUNT(*) as count FROM cf_voice_messages
-    `[0]?.count ?? 0
-    );
-  }
-}
-
-// --- Streaming STT test provider ---
-
-/**
- * Deterministic streaming STT provider for tests.
- *
- * Simulates a real streaming STT service:
- * - feed() accumulates audio bytes
- * - Fires onInterim after each feed() with a running byte count
- * - Fires onFinal when accumulated bytes cross a threshold (10000)
- * - finish() returns the final transcript based on total bytes received
- */
-class TestStreamingSTTSession implements StreamingSTTSession {
-  #totalBytes = 0;
-  #finalSegments: string[] = [];
-  #aborted = false;
-  #onInterim: ((text: string) => void) | undefined;
-  #onFinal: ((text: string) => void) | undefined;
-
-  constructor(options?: StreamingSTTSessionOptions) {
-    this.#onInterim = options?.onInterim;
-    this.#onFinal = options?.onFinal;
-  }
-
-  feed(chunk: ArrayBuffer): void {
-    if (this.#aborted) return;
-    this.#totalBytes += chunk.byteLength;
-
-    // Fire interim with running byte count
-    this.#onInterim?.(`hearing ${this.#totalBytes} bytes`);
-
-    // Fire final segment every 10000 bytes
-    if (this.#totalBytes >= (this.#finalSegments.length + 1) * 10000) {
-      const segment = `segment-${this.#finalSegments.length + 1}`;
-      this.#finalSegments.push(segment);
-      this.#onFinal?.(segment);
-    }
-  }
-
-  async finish(): Promise<string> {
-    if (this.#aborted) return "";
-    // Return a deterministic transcript based on total bytes
-    return `streaming transcript (${this.#totalBytes} bytes)`;
-  }
-
-  abort(): void {
-    this.#aborted = true;
-  }
-}
-
-class TestStreamingSTT implements StreamingSTTProvider {
-  createSession(options?: StreamingSTTSessionOptions): StreamingSTTSession {
-    return new TestStreamingSTTSession(options);
-  }
-}
-
-// --- EOT-capable streaming STT test provider ---
-
-/**
- * Streaming STT session that fires onEndOfTurn when enough audio arrives.
- * Simulates a provider with built-in end-of-turn detection (like Flux).
- *
- * Behavior:
- * - feed() accumulates bytes and fires onInterim
- * - When total bytes >= 20000, fires onEndOfTurn with a stable transcript
- * - finish() returns the transcript (may be called before or after EOT)
- */
-class TestEOTStreamingSTTSession implements StreamingSTTSession {
-  #totalBytes = 0;
-  #aborted = false;
-  #eotFired = false;
-  #onInterim: ((text: string) => void) | undefined;
-  #onFinal: ((text: string) => void) | undefined;
-  #onEndOfTurn: ((text: string) => void) | undefined;
-
-  constructor(options?: StreamingSTTSessionOptions) {
-    this.#onInterim = options?.onInterim;
-    this.#onFinal = options?.onFinal;
-    this.#onEndOfTurn = options?.onEndOfTurn;
-  }
-
-  feed(chunk: ArrayBuffer): void {
-    if (this.#aborted) return;
-    this.#totalBytes += chunk.byteLength;
-
-    this.#onInterim?.(`hearing ${this.#totalBytes} bytes`);
-
-    // Fire EOT once when we have enough audio
-    if (this.#totalBytes >= 20000 && !this.#eotFired) {
-      this.#eotFired = true;
-      const transcript = `eot transcript (${this.#totalBytes} bytes)`;
-      this.#onFinal?.(transcript);
-      this.#onEndOfTurn?.(transcript);
-    }
-  }
-
-  async finish(): Promise<string> {
-    if (this.#aborted) return "";
-    return `eot transcript (${this.#totalBytes} bytes)`;
-  }
-
-  abort(): void {
-    this.#aborted = true;
-  }
-}
-
-class TestEOTStreamingSTT implements StreamingSTTProvider {
-  createSession(options?: StreamingSTTSessionOptions): StreamingSTTSession {
-    return new TestEOTStreamingSTTSession(options);
-  }
-}
-
-/**
- * VAD that rejects the first end-of-speech per connection, then accepts.
- * Used to test the VAD retry timer recovery path.
- */
-class TestRejectingVAD implements VADProvider {
-  #callCount = 0;
-
-  async checkEndOfTurn(
-    _audioData: ArrayBuffer
-  ): Promise<{ isComplete: boolean; probability: number }> {
-    this.#callCount++;
-    if (this.#callCount === 1) {
-      // First call: reject
-      return { isComplete: false, probability: 0.1 };
-    }
-    // Subsequent calls: accept
-    return { isComplete: true, probability: 1.0 };
-  }
-}
-
-const VoiceBaseVadRetry = withVoice(Agent, { vadRetryMs: 200 });
-
-/**
- * Test VoiceAgent whose VAD rejects the first end-of-speech.
- * Uses a short vadRetryMs (200ms) so the retry timer fires quickly in tests.
- * Verifies the deadlock recovery: client sends end_of_speech → VAD rejects →
- * retry timer fires → processes without VAD.
- */
-export class TestVadRetryVoiceAgent extends VoiceBaseVadRetry {
-  static options = { hibernate: false };
-
-  stt = new TestSTT();
-  tts = new TestTTS();
-  vad = new TestRejectingVAD();
-
-  async onTurn(
-    transcript: string,
-    _context: VoiceTurnContext
-  ): Promise<string> {
-    return `Echo: ${transcript}`;
-  }
-}
-
-/**
- * Test VoiceAgent that uses streaming STT instead of batch STT.
- * Echoes back the streaming transcript.
- */
-export class TestStreamingVoiceAgent extends VoiceBase {
-  static options = { hibernate: false };
-
-  streamingStt = new TestStreamingSTT();
-  tts = new TestTTS();
-  vad = new TestVAD();
-
-  async onTurn(
-    transcript: string,
-    _context: VoiceTurnContext
-  ): Promise<string> {
-    return `Echo: ${transcript}`;
-  }
-}
-
-/**
- * Test VoiceAgent that uses an EOT-capable streaming STT provider.
- * The provider fires onEndOfTurn when it accumulates >= 20000 bytes,
- * which triggers the pipeline immediately without waiting for the
- * client to send end_of_speech.
- *
- * No VAD is configured — Flux-like providers handle turn detection.
- */
-export class TestEotVoiceAgent extends VoiceBase {
-  static options = { hibernate: false };
-
-  streamingStt = new TestEOTStreamingSTT();
-  tts = new TestTTS();
-
-  #callStartCount = 0;
-  #callEndCount = 0;
-  #interruptCount = 0;
-
-  async onTurn(
-    transcript: string,
-    _context: VoiceTurnContext
-  ): Promise<string> {
-    return `Echo: ${transcript}`;
-  }
-
-  onCallStart(_connection: Connection) {
-    this.#callStartCount++;
-  }
-
-  onCallEnd(_connection: Connection) {
-    this.#callEndCount++;
-  }
-
-  onInterrupt(_connection: Connection) {
-    this.#interruptCount++;
-  }
-
-  onMessage(connection: Connection, message: WSMessage) {
-    if (typeof message !== "string") return;
-    try {
-      const parsed = JSON.parse(message);
-      switch (parsed.type) {
         case "_get_counts":
           connection.send(
             JSON.stringify({

--- a/packages/voice/src/tests/audio-pipeline.test.ts
+++ b/packages/voice/src/tests/audio-pipeline.test.ts
@@ -143,3 +143,53 @@ describe("AudioConnectionManager — transcriber sessions", () => {
     expect(session.fed).toHaveLength(2);
   });
 });
+
+// --- Pipeline abort ownership ---
+
+describe("AudioConnectionManager — clearPipelineAbort ownership", () => {
+  it("clearPipelineAbort with matching signal deletes the controller", () => {
+    const cm = new AudioConnectionManager("test");
+    cm.initConnection("c1");
+
+    const signal = cm.createPipelineAbort("c1");
+    cm.clearPipelineAbort("c1", signal);
+
+    // Controller was cleared — abortPipeline is now a no-op
+    // Verify by creating a new one (should not throw or abort)
+    const signal2 = cm.createPipelineAbort("c1");
+    expect(signal2.aborted).toBe(false);
+  });
+
+  it("clearPipelineAbort with stale signal does NOT delete successor controller", () => {
+    const cm = new AudioConnectionManager("test");
+    cm.initConnection("c1");
+
+    // Pipeline A starts
+    const signalA = cm.createPipelineAbort("c1");
+
+    // Pipeline B starts (aborts A, installs B's controller)
+    const signalB = cm.createPipelineAbort("c1");
+    expect(signalA.aborted).toBe(true);
+    expect(signalB.aborted).toBe(false);
+
+    // Pipeline A's finally block runs — should NOT delete B's controller
+    cm.clearPipelineAbort("c1", signalA);
+
+    // Pipeline B should still be interruptible
+    cm.abortPipeline("c1");
+    expect(signalB.aborted).toBe(true);
+  });
+
+  it("clearPipelineAbort without signal always deletes (backward compat)", () => {
+    const cm = new AudioConnectionManager("test");
+    cm.initConnection("c1");
+
+    const signal = cm.createPipelineAbort("c1");
+    cm.clearPipelineAbort("c1");
+
+    // Controller was unconditionally cleared
+    cm.abortPipeline("c1");
+    // signal is NOT aborted because the controller was already removed
+    expect(signal.aborted).toBe(false);
+  });
+});

--- a/packages/voice/src/tests/audio-pipeline.test.ts
+++ b/packages/voice/src/tests/audio-pipeline.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for AudioConnectionManager — transcriber session lifecycle.
+ */
+import { describe, expect, it } from "vitest";
+import { AudioConnectionManager } from "../audio-pipeline";
+import type {
+  Transcriber,
+  TranscriberSession,
+  TranscriberSessionOptions
+} from "../types";
+
+// --- Helpers ---
+
+function makeAudio(bytes: number): ArrayBuffer {
+  const buf = new ArrayBuffer(bytes);
+  const view = new Uint8Array(buf);
+  for (let i = 0; i < bytes; i++) view[i] = i & 0xff;
+  return buf;
+}
+
+class SpySession implements TranscriberSession {
+  fed: ArrayBuffer[] = [];
+  closed = false;
+
+  feed(chunk: ArrayBuffer): void {
+    this.fed.push(chunk);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+class SpyTranscriber implements Transcriber {
+  lastSession: SpySession | null = null;
+
+  createSession(_options?: TranscriberSessionOptions): TranscriberSession {
+    this.lastSession = new SpySession();
+    return this.lastSession;
+  }
+}
+
+// --- Transcriber session lifecycle ---
+
+describe("AudioConnectionManager — transcriber sessions", () => {
+  it("creates a transcriber session at start", () => {
+    const cm = new AudioConnectionManager("test");
+    const transcriber = new SpyTranscriber();
+    cm.initConnection("c1");
+
+    cm.startTranscriberSession("c1", transcriber, {});
+
+    expect(cm.hasTranscriberSession("c1")).toBe(true);
+    expect(transcriber.lastSession).not.toBeNull();
+  });
+
+  it("feeds audio to the transcriber session via bufferAudio", () => {
+    const cm = new AudioConnectionManager("test");
+    const transcriber = new SpyTranscriber();
+    cm.initConnection("c1");
+    cm.startTranscriberSession("c1", transcriber, {});
+
+    cm.bufferAudio("c1", makeAudio(1000));
+    cm.bufferAudio("c1", makeAudio(2000));
+
+    const session = transcriber.lastSession!;
+    expect(session.fed).toHaveLength(2);
+    expect(session.fed[0].byteLength).toBe(1000);
+    expect(session.fed[1].byteLength).toBe(2000);
+  });
+
+  it("closes the transcriber session on closeTranscriberSession", () => {
+    const cm = new AudioConnectionManager("test");
+    const transcriber = new SpyTranscriber();
+    cm.initConnection("c1");
+    cm.startTranscriberSession("c1", transcriber, {});
+
+    cm.closeTranscriberSession("c1");
+
+    expect(transcriber.lastSession!.closed).toBe(true);
+    expect(cm.hasTranscriberSession("c1")).toBe(false);
+  });
+
+  it("closes the transcriber session on cleanup", () => {
+    const cm = new AudioConnectionManager("test");
+    const transcriber = new SpyTranscriber();
+    cm.initConnection("c1");
+    cm.startTranscriberSession("c1", transcriber, {});
+
+    cm.cleanup("c1");
+
+    expect(transcriber.lastSession!.closed).toBe(true);
+    expect(cm.hasTranscriberSession("c1")).toBe(false);
+  });
+
+  it("replaces existing session when starting a new one", () => {
+    const cm = new AudioConnectionManager("test");
+    const transcriber = new SpyTranscriber();
+    cm.initConnection("c1");
+
+    cm.startTranscriberSession("c1", transcriber, {});
+    const first = transcriber.lastSession!;
+
+    cm.startTranscriberSession("c1", transcriber, {});
+    const second = transcriber.lastSession!;
+
+    expect(first.closed).toBe(true);
+    expect(second.closed).toBe(false);
+    expect(first).not.toBe(second);
+  });
+
+  it("does not feed audio when no session is active", () => {
+    const cm = new AudioConnectionManager("test");
+    cm.initConnection("c1");
+
+    cm.bufferAudio("c1", makeAudio(1000));
+    // No crash, audio just buffered
+  });
+
+  it("session survives abortPipeline (interrupt does not close session)", () => {
+    const cm = new AudioConnectionManager("test");
+    const transcriber = new SpyTranscriber();
+    cm.initConnection("c1");
+    cm.startTranscriberSession("c1", transcriber, {});
+
+    cm.abortPipeline("c1");
+
+    expect(transcriber.lastSession!.closed).toBe(false);
+    expect(cm.hasTranscriberSession("c1")).toBe(true);
+  });
+
+  it("continues feeding after pipeline abort", () => {
+    const cm = new AudioConnectionManager("test");
+    const transcriber = new SpyTranscriber();
+    cm.initConnection("c1");
+    cm.startTranscriberSession("c1", transcriber, {});
+
+    cm.bufferAudio("c1", makeAudio(1000));
+    cm.abortPipeline("c1");
+    cm.bufferAudio("c1", makeAudio(2000));
+
+    const session = transcriber.lastSession!;
+    expect(session.fed).toHaveLength(2);
+  });
+});

--- a/packages/voice/src/tests/voice-input.test.ts
+++ b/packages/voice/src/tests/voice-input.test.ts
@@ -1,15 +1,15 @@
 /**
- * Server-side VoiceInput mixin tests.
+ * Server-side VoiceInput mixin tests with continuous transcriber.
  *
- * Uses test agents that stub STT providers with deterministic results.
  * Tests cover: voice protocol, consumer lifecycle passthrough, message
- * routing, batch STT pipeline, streaming STT pipeline, provider-driven
- * EOT, onTranscript hook, beforeCallStart rejection, and interrupt handling.
+ * routing, continuous STT pipeline, multi-turn, onTranscript hook,
+ * beforeCallStart rejection, and interrupt handling.
  */
 import { env } from "cloudflare:workers";
 import { createExecutionContext } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import worker from "./worker";
+
 // --- Helpers ---
 
 async function connectWS(path: string) {
@@ -72,17 +72,11 @@ function waitForType(ws: WebSocket, type: string) {
   );
 }
 
-/** Create a chunk of silent PCM audio (zeros). */
-function makeSilentAudio(bytes: number): ArrayBuffer {
-  return new ArrayBuffer(bytes);
-}
-
 let instanceCounter = 0;
 function uniquePath(agent: string) {
   return `/agents/${agent}/voice-input-test-${++instanceCounter}`;
 }
 
-/** Request internal state from a test agent. */
 async function getAgentState(ws: WebSocket) {
   sendJSON(ws, { type: "_get_state" });
   const msg = (await waitForType(ws, "_state")) as Record<string, unknown>;
@@ -147,35 +141,10 @@ describe("VoiceInput — consumer lifecycle passthrough", () => {
     ws.close();
   });
 
-  it("calls consumer onClose", async () => {
-    // Connect two clients to the same instance so we can query state after close
-    const instancePath = uniquePath("test-voice-input-agent");
-
-    const { ws: ws1 } = await connectWS(instancePath);
-    await waitForStatus(ws1, "idle");
-
-    // Close first connection
-    ws1.close();
-    // Give the DO time to process the close
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    // Connect second client to same instance and query state
-    const { ws: ws2 } = await connectWS(instancePath);
-    await waitForStatus(ws2, "idle");
-
-    const state = await getAgentState(ws2);
-    // Two connects (ws1 + ws2), one close (ws1)
-    expect(state.connectCount).toBe(2);
-    expect(state.closeCount).toBe(1);
-
-    ws2.close();
-  });
-
   it("forwards non-voice messages to consumer onMessage", async () => {
     const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
     await waitForStatus(ws, "idle");
 
-    // Send a custom (non-voice) message
     sendJSON(ws, { type: "_custom", data: "hello from client" });
     await waitForType(ws, "_ack");
 
@@ -184,206 +153,82 @@ describe("VoiceInput — consumer lifecycle passthrough", () => {
 
     ws.close();
   });
-
-  it("does NOT forward voice protocol messages to consumer onMessage", async () => {
-    const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
-    await waitForStatus(ws, "idle");
-
-    // Send voice protocol messages — these should be intercepted
-    sendJSON(ws, { type: "hello" });
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send a custom message to verify consumer onMessage works
-    sendJSON(ws, { type: "_custom", data: "after voice msgs" });
-    await waitForType(ws, "_ack");
-
-    const state = await getAgentState(ws);
-    // Only the _custom message should have reached onMessage
-    expect(state.customMessages).toEqual(["after voice msgs"]);
-
-    ws.close();
-  });
 });
 
-describe("VoiceInput — batch STT pipeline", () => {
-  it("transcribes audio and calls onTranscript", async () => {
+describe("VoiceInput — continuous STT pipeline", () => {
+  it("creates transcriber session at start_call and transcribes on model-driven utterance", async () => {
     const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    // Send enough audio to exceed minAudioBytes (default 16000)
-    ws.send(makeSilentAudio(20000));
+    // Send enough audio to trigger the test transcriber (threshold = 20000 bytes)
+    for (let i = 0; i < 5; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
 
-    // Signal end of speech
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Should get a transcript message
+    // Wait for the transcript — the test transcriber fires onUtterance at 20000+ bytes
     const transcript = (await waitForType(ws, "transcript")) as Record<
       string,
       unknown
     >;
     expect(transcript.role).toBe("user");
-    expect(transcript.text).toBe("test input transcript");
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
 
-    // Should return to listening
     await waitForStatus(ws, "listening");
 
-    // Verify onTranscript was called
     const state = await getAgentState(ws);
-    expect(state.transcripts).toEqual(["test input transcript"]);
+    expect(state.transcripts).toHaveLength(1);
 
     ws.close();
   });
 
-  it("discards audio that is too short", async () => {
+  it("sends interim transcripts during audio streaming", async () => {
     const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    // Send audio below minAudioBytes threshold
-    ws.send(makeSilentAudio(100));
+    ws.send(new ArrayBuffer(5000));
 
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Should return to listening without a transcript
-    await waitForStatus(ws, "listening");
-
-    // Verify no transcript was generated
-    const state = await getAgentState(ws);
-    expect(state.transcripts).toEqual([]);
-
-    ws.close();
-  });
-
-  it("handles multiple utterances", async () => {
-    const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // First utterance
-    ws.send(makeSilentAudio(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-    await waitForType(ws, "transcript");
-    await waitForStatus(ws, "listening");
-
-    // Second utterance
-    ws.send(makeSilentAudio(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-    await waitForType(ws, "transcript");
-    await waitForStatus(ws, "listening");
-
-    const state = await getAgentState(ws);
-    expect(state.transcripts).toEqual([
-      "test input transcript",
-      "test input transcript"
-    ]);
-
-    ws.close();
-  });
-});
-
-describe("VoiceInput — streaming STT pipeline", () => {
-  it("transcribes with streaming STT and emits interim transcripts", async () => {
-    const { ws } = await connectWS(
-      uniquePath("test-streaming-voice-input-agent")
-    );
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Start speech to create streaming session
-    sendJSON(ws, { type: "start_of_speech" });
-
-    // Send audio in chunks
-    ws.send(makeSilentAudio(10000));
-    ws.send(makeSilentAudio(10000));
-
-    // Should get interim transcripts
     const interim = (await waitForType(ws, "transcript_interim")) as Record<
       string,
       unknown
     >;
     expect(interim.text).toBeDefined();
-
-    // End speech to flush
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Should get final transcript
-    const transcript = (await waitForType(ws, "transcript")) as Record<
-      string,
-      unknown
-    >;
-    expect(transcript.role).toBe("user");
-    expect(typeof transcript.text).toBe("string");
-    expect((transcript.text as string).includes("streaming input")).toBe(true);
-
-    await waitForStatus(ws, "listening");
-
-    const state = await getAgentState(ws);
-    expect(state.transcripts).toHaveLength(1);
+    expect((interim.text as string).includes("hearing")).toBe(true);
 
     ws.close();
   });
-});
 
-describe("VoiceInput — provider-driven EOT", () => {
-  it("emits transcript on provider EOT without end_of_speech", async () => {
-    const { ws } = await connectWS(uniquePath("test-eot-voice-input-agent"));
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    sendJSON(ws, { type: "start_of_speech" });
-
-    // Send enough audio to trigger EOT (>= 20000 bytes)
-    for (let i = 0; i < 5; i++) {
-      ws.send(makeSilentAudio(5000));
-    }
-
-    // Provider fires onEndOfTurn — should get transcript without end_of_speech
-    const transcript = (await waitForType(ws, "transcript")) as Record<
-      string,
-      unknown
-    >;
-    expect(transcript.role).toBe("user");
-    expect((transcript.text as string).includes("eot input")).toBe(true);
-
-    await waitForStatus(ws, "listening");
-
-    const state = await getAgentState(ws);
-    expect(state.transcripts).toHaveLength(1);
-
-    ws.close();
-  });
-});
-
-describe("VoiceInput — interrupt", () => {
-  it("aborts in-flight STT on interrupt", async () => {
+  it("handles multi-turn — second utterance works after first", async () => {
     const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    // Send audio
-    ws.send(makeSilentAudio(20000));
-
-    // Interrupt before end_of_speech
-    sendJSON(ws, { type: "interrupt" });
+    // First utterance (20000 bytes)
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+    await waitForType(ws, "transcript");
     await waitForStatus(ws, "listening");
 
-    // No transcript should have been generated
+    // Second utterance (another 20000 bytes, total 40000)
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+    const transcript = (await waitForType(ws, "transcript")) as Record<
+      string,
+      unknown
+    >;
+    expect((transcript.text as string).includes("utterance 2")).toBe(true);
+
     const state = await getAgentState(ws);
-    expect(state.transcripts).toEqual([]);
+    expect(state.transcripts).toHaveLength(2);
 
     ws.close();
   });
@@ -396,138 +241,89 @@ describe("VoiceInput — beforeCallStart rejection", () => {
     );
     await waitForStatus(ws, "idle");
 
-    // start_call should be rejected — no listening status should appear
     sendJSON(ws, { type: "start_call" });
 
-    // Send a second start_call to confirm the agent is still in idle state
-    // (if it were listening, we'd see a status change)
-    sendJSON(ws, { type: "start_call" });
-
-    // Give a moment for any messages to arrive
     await new Promise((resolve) => setTimeout(resolve, 300));
 
-    // The agent should still be in idle — no "listening" status was sent
-    // We verify by connecting and checking no transition happened
     ws.close();
   });
 });
 
-describe("VoiceInput — double start_call", () => {
-  it("does not reset audio buffer on duplicate start_call", async () => {
+describe("VoiceInput — edge cases", () => {
+  it("audio sent before start_call is silently dropped", async () => {
+    const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
+    await waitForStatus(ws, "idle");
+
+    ws.send(new ArrayBuffer(30000));
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    // Only audio after start_call should reach the transcriber
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const transcript = (await waitForType(ws, "transcript")) as Record<
+      string,
+      unknown
+    >;
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
+    // 20000 bytes, not 50000 (the 30000 before start_call was dropped)
+    expect((transcript.text as string).includes("20000")).toBe(true);
+
+    ws.close();
+  });
+
+  it("afterTranscribe returning null suppresses the utterance", async () => {
+    // The default afterTranscribe returns the transcript as-is.
+    // We test the base behavior here — a subclass returning null
+    // would need a custom agent. But we can verify the hook is called
+    // by checking that transcripts arrive with the expected text.
     const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    // Send audio
-    ws.send(makeSilentAudio(20000));
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
 
-    // Send duplicate start_call — should NOT reset the buffer
-    sendJSON(ws, { type: "start_call" });
-    // Wait for the second listening status from the duplicate start_call
-    await waitForStatus(ws, "listening");
-
-    // End speech — should still have the audio from before the duplicate start_call
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    // Audio should still be present (not lost by duplicate start_call)
-    expect(transcript.text).toBe("test input transcript");
+    const transcript = (await waitForType(ws, "transcript")) as Record<
+      string,
+      unknown
+    >;
+    // afterTranscribe passes through by default
+    expect(transcript.text).toBeDefined();
+    expect((transcript.text as string).length).toBeGreaterThan(0);
 
     ws.close();
   });
 });
 
-describe("VoiceInput — interrupt before start_call", () => {
-  it("does not create phantom in-call state", async () => {
-    const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
-    await waitForStatus(ws, "idle");
-
-    // Send interrupt before start_call — should not create phantom state
-    sendJSON(ws, { type: "interrupt" });
-
-    // Now send audio — it should be silently dropped (not buffered)
-    ws.send(makeSilentAudio(20000));
-
-    // Give a moment for processing
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    // Now start a proper call — should work normally
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send audio and end_of_speech — should produce a transcript
-    ws.send(makeSilentAudio(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    // Should produce a normal transcript (audio after start_call was processed)
-    expect(transcript.text).toBe("test input transcript");
-
-    ws.close();
-  });
-});
-
-describe("VoiceInput — no TTS or response generation", () => {
-  it("does not send audio_config or agent transcript", async () => {
+describe("VoiceInput — start_of_speech and end_of_speech are no-ops", () => {
+  it("ignores start_of_speech and end_of_speech for STT", async () => {
     const { ws } = await connectWS(uniquePath("test-voice-input-agent"));
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    ws.send(makeSilentAudio(20000));
+    // These should not create/flush sessions — they are ignored
+    sendJSON(ws, { type: "start_of_speech" });
     sendJSON(ws, { type: "end_of_speech" });
 
-    // Collect all messages until we get back to listening
-    const messages: Record<string, unknown>[] = [];
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error("Timeout collecting messages")),
-        5000
-      );
-      const handler = (e: MessageEvent) => {
-        if (typeof e.data === "string") {
-          const msg = JSON.parse(e.data);
-          messages.push(msg);
-          if (msg.type === "status" && msg.status === "listening") {
-            clearTimeout(timer);
-            ws.removeEventListener("message", handler);
-            resolve();
-          }
-        }
-      };
-      ws.addEventListener("message", handler);
-    });
+    // Audio still flows to the continuous session
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
 
-    // Should NOT have audio_config, agent transcript, or TTS audio
-    const types = messages.map((m) => m.type);
-    expect(types).not.toContain("audio_config");
-    expect(
-      messages.filter((m) => m.type === "transcript" && m.role === "agent")
-    ).toHaveLength(0);
-
-    // Should have user transcript
-    expect(
-      messages.filter((m) => m.type === "transcript" && m.role === "user")
-    ).toHaveLength(1);
+    const transcript = (await waitForType(ws, "transcript")) as Record<
+      string,
+      unknown
+    >;
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
 
     ws.close();
   });

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -227,6 +227,27 @@ describe("VoiceAgent — continuous STT pipeline", () => {
 
     ws.close();
   });
+
+  it("sends thinking status before speaking during voice pipeline", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    // Should see thinking before speaking
+    await waitForStatus(ws, "thinking");
+    await waitForStatus(ws, "speaking");
+
+    // Should eventually get back to listening
+    await waitForStatus(ws, "listening");
+
+    ws.close();
+  });
 });
 
 describe("VoiceAgent — multi-turn", () => {

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -524,3 +524,97 @@ describe("VoiceAgent — call lifecycle counts", () => {
     ws.close();
   });
 });
+
+// --- Empty response tests (uses TestEmptyResponseVoiceAgent) ---
+
+let emptyInstanceCounter = 0;
+function uniqueEmptyPath() {
+  return `/agents/test-empty-response-voice-agent/empty-test-${++emptyInstanceCounter}`;
+}
+
+async function connectEmptyWS(path: string) {
+  const ctx = createExecutionContext();
+  const req = new Request(`http://example.com${path}`, {
+    headers: { Upgrade: "websocket" }
+  });
+  const res = await worker.fetch(req, env, ctx);
+  expect(res.status).toBe(101);
+  const ws = res.webSocket as WebSocket;
+  expect(ws).toBeDefined();
+  ws.accept();
+  return { ws, ctx };
+}
+
+describe("VoiceAgent — empty response handling", () => {
+  it("sends error and does not save message when onTurn returns empty string", async () => {
+    const { ws } = await connectEmptyWS(uniqueEmptyPath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    // Send enough audio to trigger utterance
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    // Should get an error message about empty response
+    const error = (await waitForType(ws, "error")) as Record<string, unknown>;
+    expect(error.message).toBe("No response generated");
+
+    // Should go back to listening
+    await waitForStatus(ws, "listening");
+
+    // Should NOT have saved any assistant message
+    sendJSON(ws, { type: "_get_message_count" });
+    const count = (await waitForType(ws, "_message_count")) as Record<
+      string,
+      unknown
+    >;
+    // Only the user message should be saved, not an empty assistant message
+    expect(count.count).toBe(1);
+
+    ws.close();
+  });
+
+  it("does not emit metrics for empty response", async () => {
+    const { ws } = await connectEmptyWS(uniqueEmptyPath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    // Collect all messages until we get back to listening
+    const messages: Record<string, unknown>[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Timeout collecting messages")),
+        5000
+      );
+      const handler = (e: MessageEvent) => {
+        if (typeof e.data === "string") {
+          const msg = JSON.parse(e.data);
+          messages.push(msg);
+          if (msg.type === "status" && msg.status === "listening") {
+            clearTimeout(timer);
+            ws.removeEventListener("message", handler);
+            resolve();
+          }
+        }
+      };
+      ws.addEventListener("message", handler);
+    });
+
+    // Should NOT have received metrics
+    const types = messages.map((m) => m.type);
+    expect(types).not.toContain("metrics");
+    // Should have received an error
+    expect(types).toContain("error");
+
+    ws.close();
+  });
+});

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -1,14 +1,15 @@
 /**
- * Server-side VoiceAgent tests.
+ * Server-side VoiceAgent tests with continuous transcriber.
  *
- * Uses a TestVoiceAgent that stubs STT/TTS/VAD with deterministic results.
- * Tests cover: voice protocol, pipeline flow, conversation persistence,
- * interruption handling, text messages, and the beforeCallStart hook.
+ * Tests cover: voice protocol, continuous STT pipeline flow,
+ * multi-turn conversation, interruption handling (session survives),
+ * text messages, conversation persistence, and the beforeCallStart hook.
  */
 import { env } from "cloudflare:workers";
 import { createExecutionContext } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import worker from "./worker";
+
 // --- Helpers ---
 
 async function connectWS(path: string) {
@@ -24,7 +25,6 @@ async function connectWS(path: string) {
   return { ws, ctx };
 }
 
-/** Collect messages until we find one matching the predicate, or timeout. */
 function waitForMessageMatching(
   ws: WebSocket,
   predicate: (msg: unknown) => boolean,
@@ -51,15 +51,11 @@ function sendJSON(ws: WebSocket, msg: Record<string, unknown>) {
   ws.send(JSON.stringify(msg));
 }
 
-// Use unique instance names to avoid interference between tests
 let instanceCounter = 0;
 function uniquePath() {
   return `/agents/test-voice-agent/voice-test-${++instanceCounter}`;
 }
 
-// --- Tests ---
-
-/** Wait for a voice status message with a specific status value. */
 function waitForStatus(ws: WebSocket, status: string) {
   return waitForMessageMatching(
     ws,
@@ -71,11 +67,21 @@ function waitForStatus(ws: WebSocket, status: string) {
   );
 }
 
+function waitForType(ws: WebSocket, type: string) {
+  return waitForMessageMatching(
+    ws,
+    (m) =>
+      typeof m === "object" &&
+      m !== null &&
+      (m as Record<string, unknown>).type === type
+  );
+}
+
+// --- Tests ---
+
 describe("VoiceAgent — protocol", () => {
   it("sends idle status on connect", async () => {
     const { ws } = await connectWS(uniquePath());
-    // Agent base class sends cf_agent_identity and cf_agent_mcp_servers first;
-    // wait specifically for the voice idle status.
     const msg = await waitForStatus(ws, "idle");
     expect(msg).toEqual({ type: "status", status: "idle" });
     ws.close();
@@ -103,121 +109,35 @@ describe("VoiceAgent — protocol", () => {
     expect(msg).toEqual({ type: "status", status: "idle" });
     ws.close();
   });
-});
 
-describe("VoiceAgent — reconnect during call", () => {
-  it("resumes call on new connection to same instance (simulates PartySocket reconnect)", async () => {
-    // Use a fixed path so both connections hit the same DO instance
-    const path = uniquePath();
+  it("sends audio_config on start_call", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
 
-    // First connection: start a call
-    const { ws: ws1 } = await connectWS(path);
-    await waitForStatus(ws1, "idle");
-    sendJSON(ws1, { type: "start_call" });
-    await waitForStatus(ws1, "listening");
-
-    // Send some audio and get a transcript (proves call is working)
-    ws1.send(new ArrayBuffer(20000));
-    sendJSON(ws1, { type: "end_of_speech" });
-    await waitForMessageMatching(
-      ws1,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    );
-
-    // Disconnect (simulates network drop)
-    ws1.close();
-
-    // Second connection: reconnect to the same instance
-    const { ws: ws2 } = await connectWS(path);
-    await waitForStatus(ws2, "idle");
-
-    // Client would re-send start_call on reconnect
-    sendJSON(ws2, { type: "start_call" });
-    await waitForStatus(ws2, "listening");
-
-    // Send audio on the new connection — should work normally
-    ws2.send(new ArrayBuffer(20000));
-    sendJSON(ws2, { type: "end_of_speech" });
-
-    const transcript = (await waitForMessageMatching(
-      ws2,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("test transcript");
-    ws2.close();
-  });
-
-  it("preserves conversation history across reconnect", async () => {
-    const path = uniquePath();
-
-    // First connection: have a conversation
-    const { ws: ws1 } = await connectWS(path);
-    await waitForStatus(ws1, "idle");
-    sendJSON(ws1, { type: "start_call" });
-    await waitForStatus(ws1, "listening");
-
-    ws1.send(new ArrayBuffer(20000));
-    sendJSON(ws1, { type: "end_of_speech" });
-
-    // Wait for assistant response (conversation saved to SQLite)
-    await waitForMessageMatching(
-      ws1,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    );
-
-    ws1.close();
-
-    // Second connection: new call on the same instance
-    const { ws: ws2 } = await connectWS(path);
-    await waitForStatus(ws2, "idle");
-    sendJSON(ws2, { type: "start_call" });
-    await waitForStatus(ws2, "listening");
-
-    // Send another turn
-    ws2.send(new ArrayBuffer(20000));
-    sendJSON(ws2, { type: "end_of_speech" });
-
-    // Should still produce a response (history preserved in SQLite)
-    const transcript = (await waitForMessageMatching(
-      ws2,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("Echo: test transcript");
-    ws2.close();
+    sendJSON(ws, { type: "start_call" });
+    const config = (await waitForType(ws, "audio_config")) as Record<
+      string,
+      unknown
+    >;
+    expect(config.format).toBe("mp3");
+    ws.close();
   });
 });
 
-describe("VoiceAgent — audio pipeline", () => {
-  it("processes audio and returns user transcript on end_of_speech", async () => {
+describe("VoiceAgent — continuous STT pipeline", () => {
+  it("transcribes audio and echoes back via onTurn", async () => {
     const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    // Send enough audio data (> minAudioBytes = 16000)
-    ws.send(new ArrayBuffer(20000));
+    // Send enough audio to trigger utterance (20000 bytes)
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
 
-    // Trigger end of speech
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Wait for the user transcript message
+    // Wait for user transcript
     const transcript = (await waitForMessageMatching(
       ws,
       (m) =>
@@ -227,30 +147,59 @@ describe("VoiceAgent — audio pipeline", () => {
         (m as Record<string, unknown>).role === "user"
     )) as Record<string, unknown>;
 
-    expect(transcript.text).toBe("test transcript");
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
+
+    // Wait for assistant echo
+    const transcriptEnd = (await waitForType(ws, "transcript_end")) as Record<
+      string,
+      unknown
+    >;
+    expect((transcriptEnd.text as string).includes("Echo:")).toBe(true);
+
     ws.close();
   });
 
-  it("returns assistant response after processing", async () => {
+  it("sends interim transcripts during audio streaming", async () => {
     const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
+    ws.send(new ArrayBuffer(5000));
 
-    // Wait for the assistant transcript_end
-    const transcriptEnd = (await waitForMessageMatching(
+    const interim = (await waitForType(ws, "transcript_interim")) as Record<
+      string,
+      unknown
+    >;
+    expect(interim.text).toBeDefined();
+    expect((interim.text as string).includes("hearing")).toBe(true);
+
+    ws.close();
+  });
+
+  it("clears interim transcript before emitting final", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    // Should get interim clear (empty text) before the user transcript
+    const cleared = (await waitForMessageMatching(
       ws,
       (m) =>
         typeof m === "object" &&
         m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
+        (m as Record<string, unknown>).type === "transcript_interim" &&
+        (m as Record<string, unknown>).text === ""
     )) as Record<string, unknown>;
+    expect(cleared.text).toBe("");
 
-    expect(transcriptEnd.text).toBe("Echo: test transcript");
     ws.close();
   });
 
@@ -261,1045 +210,280 @@ describe("VoiceAgent — audio pipeline", () => {
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
 
-    // Wait for metrics
-    const metrics = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "metrics"
-    )) as Record<string, unknown>;
-
-    expect(metrics).toHaveProperty("vad_ms");
-    expect(metrics).toHaveProperty("stt_ms");
+    const metrics = (await waitForType(ws, "metrics")) as Record<
+      string,
+      unknown
+    >;
     expect(metrics).toHaveProperty("llm_ms");
     expect(metrics).toHaveProperty("tts_ms");
     expect(metrics).toHaveProperty("first_audio_ms");
     expect(metrics).toHaveProperty("total_ms");
+    expect(metrics).not.toHaveProperty("vad_ms");
+    expect(metrics).not.toHaveProperty("stt_ms");
+
+    ws.close();
+  });
+});
+
+describe("VoiceAgent — multi-turn", () => {
+  it("handles second utterance after first pipeline completes", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    // First utterance
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    await waitForMessageMatching(
+      ws,
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as Record<string, unknown>).type === "transcript" &&
+        (m as Record<string, unknown>).role === "user"
+    );
+
+    // Wait for pipeline to complete (back to listening)
+    await waitForStatus(ws, "listening");
+
+    // Second utterance (need another 20000 bytes, total 40000)
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const transcript = (await waitForMessageMatching(
+      ws,
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as Record<string, unknown>).type === "transcript" &&
+        (m as Record<string, unknown>).role === "user"
+    )) as Record<string, unknown>;
+
+    expect((transcript.text as string).includes("utterance 2")).toBe(true);
+
+    ws.close();
+  });
+
+  it("persists conversation messages across turns", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    // Wait for full pipeline (user + assistant)
+    await waitForMessageMatching(
+      ws,
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as Record<string, unknown>).type === "transcript_end"
+    );
+
+    await waitForStatus(ws, "listening");
+
+    // Check message count
+    sendJSON(ws, { type: "_get_message_count" });
+    const count = (await waitForType(ws, "_message_count")) as Record<
+      string,
+      unknown
+    >;
+    expect(count.count).toBe(2); // user + assistant
+
+    ws.close();
+  });
+});
+
+describe("VoiceAgent — interrupt", () => {
+  it("aborts pipeline on interrupt but session survives for next turn", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    // Send some audio, then interrupt before utterance threshold
+    ws.send(new ArrayBuffer(10000));
+    sendJSON(ws, { type: "interrupt" });
+    await waitForStatus(ws, "listening");
+
+    // Session should still be alive — send more audio to reach threshold
+    ws.send(new ArrayBuffer(10000));
+
+    // Should still get a transcript because the session survived
+    const transcript = (await waitForMessageMatching(
+      ws,
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as Record<string, unknown>).type === "transcript" &&
+        (m as Record<string, unknown>).role === "user"
+    )) as Record<string, unknown>;
+
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
+
+    ws.close();
+  });
+
+  it("counts interrupts", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    sendJSON(ws, { type: "interrupt" });
+    await waitForStatus(ws, "listening");
+
+    sendJSON(ws, { type: "_get_counts" });
+    const counts = (await waitForType(ws, "_counts")) as Record<
+      string,
+      unknown
+    >;
+    expect(counts.interrupt).toBe(1);
 
     ws.close();
   });
 });
 
 describe("VoiceAgent — text messages", () => {
-  it("handles text_message without an active call (text-only response)", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "text_message", text: "hello" });
-
-    // Wait for the assistant transcript_end
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: hello");
-
-    // Should end with idle status (not listening, since no call is active)
-    const idleStatus = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "idle"
-    )) as Record<string, unknown>;
-
-    expect(idleStatus.status).toBe("idle");
-    ws.close();
-  });
-
-  it("ignores text_message with missing text field", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    // Send text_message without text field — should not crash
-    sendJSON(ws, { type: "text_message" });
-
-    // Prove connection is still alive by sending a valid message
-    sendJSON(ws, { type: "text_message", text: "alive" });
-
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: alive");
-    ws.close();
-  });
-
-  it("ignores empty text_message", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "text_message", text: "" });
-
-    // Prove connection is still alive
-    sendJSON(ws, { type: "text_message", text: "still works" });
-
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: still works");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — interruption", () => {
-  it("returns to listening status after interrupt", async () => {
+  it("processes text messages through the pipeline", async () => {
     const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    // Send audio and trigger pipeline
-    ws.send(new ArrayBuffer(20000));
+    sendJSON(ws, { type: "text_message", text: "Hello from text" });
+
+    const transcript = (await waitForMessageMatching(
+      ws,
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as Record<string, unknown>).type === "transcript" &&
+        (m as Record<string, unknown>).role === "user"
+    )) as Record<string, unknown>;
+
+    expect(transcript.text).toBe("Hello from text");
+
+    const transcriptEnd = (await waitForType(ws, "transcript_end")) as Record<
+      string,
+      unknown
+    >;
+    expect(transcriptEnd.text).toBe("Echo: Hello from text");
+
+    ws.close();
+  });
+});
+
+describe("VoiceAgent — start_of_speech / end_of_speech are no-ops", () => {
+  it("ignores start_of_speech and end_of_speech", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    sendJSON(ws, { type: "start_of_speech" });
     sendJSON(ws, { type: "end_of_speech" });
 
-    // Immediately interrupt
-    sendJSON(ws, { type: "interrupt" });
+    // Audio still flows to the continuous session
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
 
-    // Should eventually return to listening
-    const listeningStatus = (await waitForMessageMatching(
+    const transcript = (await waitForMessageMatching(
       ws,
       (m) =>
         typeof m === "object" &&
         m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
+        (m as Record<string, unknown>).type === "transcript" &&
+        (m as Record<string, unknown>).role === "user"
     )) as Record<string, unknown>;
 
-    expect(listeningStatus.status).toBe("listening");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — non-voice messages", () => {
-  it("does not crash on unknown JSON message types", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    // Send a custom message type
-    sendJSON(ws, { type: "custom_event", data: "hello" });
-
-    // Prove connection is still alive
-    sendJSON(ws, { type: "text_message", text: "still alive" });
-
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: still alive");
-    ws.close();
-  });
-
-  it("does not crash on non-JSON string messages", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    // Send non-JSON text
-    ws.send("this is not json {{{");
-
-    // Prove connection is still alive
-    sendJSON(ws, { type: "text_message", text: "works" });
-
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: works");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — beforeCallStart rejection", () => {
-  it("does not transition to listening when beforeCallStart returns false", async () => {
-    const path = uniquePath();
-    const { ws } = await connectWS(path);
-    await waitForStatus(ws, "idle");
-
-    // Toggle beforeCallStart to false via a control message
-    sendJSON(ws, { type: "_set_before_call_start", value: false });
-
-    // Wait for the ack to ensure the flag is set
-    await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "_ack"
-    );
-
-    // Now try to start a call — should be rejected silently
-    sendJSON(ws, { type: "start_call" });
-
-    // Prove the agent is still functional and in idle state:
-    // send a text_message which should work and return idle (not listening)
-    sendJSON(ws, { type: "text_message", text: "still idle" });
-
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: still idle");
-
-    // Should return to idle (not listening), proving start_call was rejected
-    const idleStatus = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "idle"
-    )) as Record<string, unknown>;
-
-    expect(idleStatus.status).toBe("idle");
-    ws.close();
-  });
-
-  it("transitions to listening when beforeCallStart returns true (default)", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    const msg = await waitForStatus(ws, "listening");
-    expect(msg).toEqual({ type: "status", status: "listening" });
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — audio_config", () => {
-  it("sends audio_config message on start_call", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-
-    // audio_config should arrive before listening status
-    const config = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "audio_config"
-    )) as Record<string, unknown>;
-
-    expect(config.format).toBe("mp3");
-
-    // listening should follow
-    await waitForStatus(ws, "listening");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — format negotiation", () => {
-  it("sends configured format even when client requests a different one", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    // Client requests pcm16, but the test agent is configured for mp3
-    sendJSON(ws, { type: "start_call", preferred_format: "pcm16" });
-
-    const config = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "audio_config"
-    )) as Record<string, unknown>;
-
-    // Server always sends its configured format
-    expect(config.format).toBe("mp3");
-    await waitForStatus(ws, "listening");
-    ws.close();
-  });
-
-  it("sends configured format when client does not request one", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-
-    const config = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "audio_config"
-    )) as Record<string, unknown>;
-
-    expect(config.format).toBe("mp3");
-    await waitForStatus(ws, "listening");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — audio buffer limits", () => {
-  it("does not process audio shorter than minAudioBytes", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send very short audio (less than 16000 bytes)
-    ws.send(new ArrayBuffer(100));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Should get listening status back (not thinking/processing)
-    const msg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(msg.status).toBe("listening");
-    ws.close();
-  });
-
-  it("ignores audio chunks when not in a call", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    // Send audio without start_call — should be silently ignored
-    ws.send(new ArrayBuffer(20000));
-
-    // Prove connection is still alive
-    sendJSON(ws, { type: "text_message", text: "alive" });
-
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: alive");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — protocol versioning", () => {
-  it("sends welcome message with protocol_version on connect", async () => {
-    const { ws } = await connectWS(uniquePath());
-
-    const welcome = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "welcome"
-    )) as Record<string, unknown>;
-
-    expect(welcome.type).toBe("welcome");
-    expect(typeof welcome.protocol_version).toBe("number");
-    ws.close();
-  });
-
-  it("accepts hello message without crashing", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    // Send hello (like VoiceClient does on connect)
-    sendJSON(ws, { type: "hello", protocol_version: 1 });
-
-    // Prove connection is still alive
-    sendJSON(ws, { type: "text_message", text: "after hello" });
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: after hello");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — lifecycle hook counting", () => {
-  it("increments onCallStart and onCallEnd counters", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    sendJSON(ws, { type: "end_call" });
-    await waitForStatus(ws, "idle");
-
-    // Query the hook counters
-    sendJSON(ws, { type: "_get_counts" });
-    const counts = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "_counts"
-    )) as Record<string, unknown>;
-
-    expect(counts.callStart).toBe(1);
-    expect(counts.callEnd).toBe(1);
-    expect(counts.interrupt).toBe(0);
-    ws.close();
-  });
-
-  it("increments onInterrupt counter", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Wait for pipeline to start
-    await waitForStatus(ws, "thinking");
-
-    sendJSON(ws, { type: "interrupt" });
-    await waitForStatus(ws, "listening");
-
-    sendJSON(ws, { type: "_get_counts" });
-    const counts = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "_counts"
-    )) as Record<string, unknown>;
-
-    expect(counts.interrupt).toBe(1);
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
     ws.close();
   });
 });
 
 describe("VoiceAgent — forceEndCall", () => {
-  it("ends call and returns to idle when forceEndCall is triggered", async () => {
+  it("programmatically ends a call", async () => {
     const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    // Trigger forceEndCall via control message
     sendJSON(ws, { type: "_force_end_call" });
+    const msg = await waitForStatus(ws, "idle");
+    expect(msg).toEqual({ type: "status", status: "idle" });
 
-    const idleStatus = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "idle"
-    )) as Record<string, unknown>;
-
-    expect(idleStatus.status).toBe("idle");
-
-    // Verify onCallEnd was called
-    sendJSON(ws, { type: "_get_counts" });
-    const counts = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "_counts"
-    )) as Record<string, unknown>;
-
-    expect(counts.callStart).toBe(1);
-    expect(counts.callEnd).toBe(1);
     ws.close();
   });
+});
 
-  it("is a no-op when not in a call", async () => {
+describe("VoiceAgent — edge cases", () => {
+  it("audio sent before start_call is silently dropped", async () => {
     const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");
 
-    // forceEndCall when not in a call — should not crash
-    sendJSON(ws, { type: "_force_end_call" });
+    // Send audio before starting a call — should not crash
+    ws.send(new ArrayBuffer(20000));
 
-    // Prove connection is still alive
-    sendJSON(ws, { type: "text_message", text: "still alive" });
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: still alive");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — binary TTS audio", () => {
-  it("sends binary audio data after assistant response", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
+    // Now start a proper call — should work normally
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Wait for binary audio data from server
-    const audioData = await new Promise<ArrayBuffer>((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error("Timeout waiting for binary audio")),
-        5000
-      );
-      const handler = (e: MessageEvent) => {
-        if (e.data instanceof ArrayBuffer) {
-          clearTimeout(timer);
-          ws.removeEventListener("message", handler);
-          resolve(e.data);
-        }
-      };
-      ws.addEventListener("message", handler);
-    });
-
-    // TestTTS encodes text as bytes, so audio should be non-empty
-    expect(audioData.byteLength).toBeGreaterThan(0);
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — conversation persistence", () => {
-  it("accumulates messages in SQLite across turns", async () => {
-    const path = uniquePath();
-    const { ws } = await connectWS(path);
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // First turn
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-    await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    );
-
-    // Wait for listening status (pipeline complete)
-    await waitForStatus(ws, "listening");
-
-    // Second turn
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-    await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    );
-
-    // Check message count: 2 user + 2 assistant = 4
-    sendJSON(ws, { type: "_get_message_count" });
-    const countMsg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "_message_count"
-    )) as Record<string, unknown>;
-
-    expect(countMsg.count).toBe(4);
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — text_message during active call", () => {
-  it("returns to listening (not idle) after text_message during a call", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send text message while in a call
-    sendJSON(ws, { type: "text_message", text: "mid-call text" });
-
-    // Wait for assistant response
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: mid-call text");
-
-    // Should return to listening (not idle) since call is still active
-    const listeningStatus = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        ((m as Record<string, unknown>).status === "listening" ||
-          (m as Record<string, unknown>).status === "idle")
-    )) as Record<string, unknown>;
-
-    expect(listeningStatus.status).toBe("listening");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — multiple sequential turns", () => {
-  it("handles two audio turns in the same call", async () => {
-    const { ws } = await connectWS(uniquePath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // First turn
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const t1 = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(t1.text).toBe("test transcript");
-
-    // Wait for pipeline to finish (listening again)
-    await waitForStatus(ws, "listening");
-
-    // Second turn
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const t2 = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(t2.text).toBe("test transcript");
-    ws.close();
-  });
-});
-
-describe("VoiceAgent — multiple connections", () => {
-  it("allows two clients to start calls on the same DO instance", async () => {
-    const path = uniquePath();
-
-    const { ws: ws1 } = await connectWS(path);
-    await waitForStatus(ws1, "idle");
-    sendJSON(ws1, { type: "start_call" });
-    await waitForStatus(ws1, "listening");
-
-    // Second connection to the same DO
-    const { ws: ws2 } = await connectWS(path);
-    await waitForStatus(ws2, "idle");
-    sendJSON(ws2, { type: "start_call" });
-    await waitForStatus(ws2, "listening");
-
-    // Both connections should process audio independently
-    ws1.send(new ArrayBuffer(20000));
-    sendJSON(ws1, { type: "end_of_speech" });
-
-    const t1 = (await waitForMessageMatching(
-      ws1,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(t1.text).toBe("test transcript");
-
-    ws2.send(new ArrayBuffer(20000));
-    sendJSON(ws2, { type: "end_of_speech" });
-
-    const t2 = (await waitForMessageMatching(
-      ws2,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(t2.text).toBe("test transcript");
-
-    ws1.close();
-    ws2.close();
-  });
-
-  it("one client ending call does not affect the other", async () => {
-    const path = uniquePath();
-
-    const { ws: ws1 } = await connectWS(path);
-    await waitForStatus(ws1, "idle");
-    sendJSON(ws1, { type: "start_call" });
-    await waitForStatus(ws1, "listening");
-
-    const { ws: ws2 } = await connectWS(path);
-    await waitForStatus(ws2, "idle");
-    sendJSON(ws2, { type: "start_call" });
-    await waitForStatus(ws2, "listening");
-
-    // Client 1 ends their call
-    sendJSON(ws1, { type: "end_call" });
-    await waitForStatus(ws1, "idle");
-
-    // Client 2 should still be able to process audio
-    ws2.send(new ArrayBuffer(20000));
-    sendJSON(ws2, { type: "end_of_speech" });
-
-    const t2 = (await waitForMessageMatching(
-      ws2,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(t2.text).toBe("test transcript");
-
-    ws1.close();
-    ws2.close();
-  });
-});
-
-// --- VAD retry recovery tests ---
-
-/** Connect to the VAD-retry test agent. */
-async function connectVadRetryWS(path: string) {
-  const ctx = createExecutionContext();
-  const req = new Request(`http://example.com${path}`, {
-    headers: { Upgrade: "websocket" }
-  });
-  const res = await worker.fetch(req, env, ctx);
-  expect(res.status).toBe(101);
-  const ws = res.webSocket as WebSocket;
-  expect(ws).toBeDefined();
-  ws.accept();
-  return { ws, ctx };
-}
-
-let vadRetryCounter = 0;
-function uniqueVadRetryPath() {
-  return `/agents/test-vad-retry-voice-agent/vad-retry-${++vadRetryCounter}`;
-}
-
-describe("VoiceAgent — VAD retry recovery", () => {
-  it("processes audio after VAD rejects and retry timer fires", async () => {
-    const { ws } = await connectVadRetryWS(uniqueVadRetryPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send enough audio to pass minAudioBytes
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // VAD rejects first time → server sends "listening" (not "thinking")
-    // Then retry timer fires after 200ms → processes without VAD
-    // We should eventually see the user transcript
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("test transcript");
-
-    // And the assistant response
-    const assistantEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(assistantEnd.text).toBe("Echo: test transcript");
-    ws.close();
-  });
-
-  it("cancels VAD retry timer when user speaks again", async () => {
-    const { ws } = await connectVadRetryWS(uniqueVadRetryPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // First end_of_speech — VAD rejects, retry timer starts
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Before the 200ms retry timer fires, send a new end_of_speech
-    // This clears the old timer and triggers a fresh pipeline run.
-    // The second VAD call accepts.
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("test transcript");
-    ws.close();
-  });
-});
-
-// --- Streaming STT tests ---
-
-/** Connect to the streaming STT test agent. */
-async function connectStreamingWS(path: string) {
-  const ctx = createExecutionContext();
-  const req = new Request(`http://example.com${path}`, {
-    headers: { Upgrade: "websocket" }
-  });
-  const res = await worker.fetch(req, env, ctx);
-  expect(res.status).toBe(101);
-  const ws = res.webSocket as WebSocket;
-  expect(ws).toBeDefined();
-  ws.accept();
-  return { ws, ctx };
-}
-
-let streamingInstanceCounter = 0;
-function uniqueStreamingPath() {
-  return `/agents/test-streaming-voice-agent/streaming-test-${++streamingInstanceCounter}`;
-}
-
-/** Collect all messages matching a type until another message type arrives or timeout. */
-function collectMessages(
-  ws: WebSocket,
-  type: string,
-  timeout = 3000
-): Promise<unknown[]> {
-  return new Promise((resolve) => {
-    const collected: unknown[] = [];
-    const timer = setTimeout(() => {
-      ws.removeEventListener("message", handler);
-      resolve(collected);
-    }, timeout);
-    const handler = (e: MessageEvent) => {
-      if (typeof e.data !== "string") return;
-      try {
-        const msg = JSON.parse(e.data);
-        if (msg.type === type) {
-          collected.push(msg);
-        }
-      } catch {
-        // ignore
-      }
-    };
-    ws.addEventListener("message", handler);
-    // Also resolve when we get a transcript (user) which means pipeline finished STT
-    const doneHandler = (e: MessageEvent) => {
-      if (typeof e.data !== "string") return;
-      try {
-        const msg = JSON.parse(e.data);
-        if (msg.type === "transcript" && msg.role === "user") {
-          clearTimeout(timer);
-          ws.removeEventListener("message", handler);
-          ws.removeEventListener("message", doneHandler);
-          resolve(collected);
-        }
-      } catch {
-        // ignore
-      }
-    };
-    ws.addEventListener("message", doneHandler);
-  });
-}
-
-describe("Streaming STT — basic pipeline", () => {
-  it("produces transcript via streaming STT (no batch stt needed)", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send enough audio for minAudioBytes (> 16000)
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Wait for user transcript
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    // TestStreamingSTTSession.finish() returns "streaming transcript (N bytes)"
-    expect(transcript.text).toBe("streaming transcript (20000 bytes)");
-    ws.close();
-  });
-
-  it("sends transcript_interim messages during audio streaming", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Start collecting interim messages before sending audio
-    const interimPromise = collectMessages(ws, "transcript_interim");
-
-    // Send audio in multiple chunks to trigger interim callbacks
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(5000));
-    ws.send(new ArrayBuffer(5000));
-    ws.send(new ArrayBuffer(10000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const interims = await interimPromise;
-
-    // Should have received at least one interim message
-    expect(interims.length).toBeGreaterThan(0);
-
-    // Each interim should have a text field
-    for (const interim of interims) {
-      expect(interim).toHaveProperty("type", "transcript_interim");
-      expect(interim).toHaveProperty("text");
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
     }
 
-    ws.close();
-  });
-
-  it("returns assistant response after streaming STT", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Wait for assistant transcript_end
-    const transcriptEnd = (await waitForMessageMatching(
+    const transcript = (await waitForMessageMatching(
       ws,
       (m) =>
         typeof m === "object" &&
         m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
+        (m as Record<string, unknown>).type === "transcript" &&
+        (m as Record<string, unknown>).role === "user"
     )) as Record<string, unknown>;
 
-    expect(transcriptEnd.text).toBe("Echo: streaming transcript (20000 bytes)");
+    // Should only contain audio from after start_call (20000 bytes)
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
+
     ws.close();
   });
 
-  it("sends pipeline metrics after streaming STT processing", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
+  it("double start_call is ignored when already in a call", async () => {
+    const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
 
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
+    ws.send(new ArrayBuffer(10000));
 
-    const metrics = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "metrics"
-    )) as Record<string, unknown>;
-
-    expect(metrics).toHaveProperty("vad_ms");
-    expect(metrics).toHaveProperty("stt_ms");
-    expect(metrics).toHaveProperty("llm_ms");
-    expect(metrics).toHaveProperty("tts_ms");
-    expect(metrics).toHaveProperty("first_audio_ms");
-    expect(metrics).toHaveProperty("total_ms");
-
-    // STT should be very fast — it's just a flush, not full transcription
-    expect(metrics.stt_ms).toBeLessThan(100);
-
-    ws.close();
-  });
-});
-
-describe("Streaming STT — start_of_speech", () => {
-  it("handles explicit start_of_speech message", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
+    // Duplicate start_call — should be silently ignored
     sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
 
-    // Explicitly signal speech start (like new VoiceClient would)
-    sendJSON(ws, { type: "start_of_speech" });
+    // Small delay to ensure the message was processed
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
-    // Send audio
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
+    // Send more audio — session still alive from first start_call
+    ws.send(new ArrayBuffer(10000));
 
     const transcript = (await waitForMessageMatching(
       ws,
@@ -1310,650 +494,33 @@ describe("Streaming STT — start_of_speech", () => {
         (m as Record<string, unknown>).role === "user"
     )) as Record<string, unknown>;
 
-    expect(transcript.text).toBe("streaming transcript (20000 bytes)");
-    ws.close();
-  });
+    // Both chunks of audio (10000 + 10000 = 20000) reached the same session
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
+    expect((transcript.text as string).includes("20000")).toBe(true);
 
-  it("returns to listening without start_of_speech (no auto-creation)", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // No start_of_speech — audio is buffered but no STT session created.
-    // end_of_speech falls through to the batch STT path which gracefully
-    // returns to listening when no batch STT provider is configured.
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const msg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(msg.status).toBe("listening");
     ws.close();
   });
 });
 
-describe("Streaming STT — interruption", () => {
-  it("aborts streaming STT session on interrupt", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
+describe("VoiceAgent — call lifecycle counts", () => {
+  it("tracks call start and end counts", async () => {
+    const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");
 
     sendJSON(ws, { type: "start_call" });
     await waitForStatus(ws, "listening");
-
-    // Send audio to create a session
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    // Interrupt before end_of_speech
-    sendJSON(ws, { type: "interrupt" });
-
-    // Should return to listening
-    const listeningStatus = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(listeningStatus.status).toBe("listening");
-
-    // Now send new audio — should create a fresh session and work normally
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(25000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("streaming transcript (25000 bytes)");
-    ws.close();
-  });
-
-  it("aborts streaming STT session on end_call", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    ws.send(new ArrayBuffer(20000));
 
     sendJSON(ws, { type: "end_call" });
-
-    const idleStatus = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "idle"
-    )) as Record<string, unknown>;
-
-    expect(idleStatus.status).toBe("idle");
-    ws.close();
-  });
-});
-
-describe("Streaming STT — short audio rejection", () => {
-  it("aborts session and returns to listening on short audio", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
     await waitForStatus(ws, "idle");
 
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
+    sendJSON(ws, { type: "_get_counts" });
+    const counts = (await waitForType(ws, "_counts")) as Record<
+      string,
+      unknown
+    >;
+    expect(counts.callStart).toBe(1);
+    expect(counts.callEnd).toBe(1);
 
-    // Send very short audio (< minAudioBytes = 16000)
-    ws.send(new ArrayBuffer(100));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Should get listening status back (session aborted, no processing)
-    const msg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(msg.status).toBe("listening");
-    ws.close();
-  });
-});
-
-// --- Provider-driven EOT tests ---
-
-/** Connect to the EOT test agent. */
-async function connectEOTWS(path: string) {
-  const ctx = createExecutionContext();
-  const req = new Request(`http://example.com${path}`, {
-    headers: { Upgrade: "websocket" }
-  });
-  const res = await worker.fetch(req, env, ctx);
-  expect(res.status).toBe(101);
-  const ws = res.webSocket as WebSocket;
-  expect(ws).toBeDefined();
-  ws.accept();
-  return { ws, ctx };
-}
-
-let eotInstanceCounter = 0;
-function uniqueEOTPath() {
-  return `/agents/test-eot-voice-agent/eot-test-${++eotInstanceCounter}`;
-}
-
-describe("Provider-driven EOT — basic pipeline", () => {
-  it("triggers pipeline immediately when provider fires onEndOfTurn", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send 20000 bytes — TestEOTStreamingSTTSession fires onEndOfTurn at this threshold
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    // Pipeline should start WITHOUT sending end_of_speech
-    // Wait for user transcript
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("eot transcript (20000 bytes)");
-    ws.close();
-  });
-
-  it("returns assistant response after provider-driven EOT", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: eot transcript (20000 bytes)");
-    ws.close();
-  });
-
-  it("sends binary TTS audio after provider-driven EOT", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    const audioData = await new Promise<ArrayBuffer>((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error("Timeout waiting for binary audio")),
-        5000
-      );
-      const handler = (e: MessageEvent) => {
-        if (e.data instanceof ArrayBuffer) {
-          clearTimeout(timer);
-          ws.removeEventListener("message", handler);
-          resolve(e.data);
-        }
-      };
-      ws.addEventListener("message", handler);
-    });
-
-    expect(audioData.byteLength).toBeGreaterThan(0);
-    ws.close();
-  });
-
-  it("sends pipeline metrics with zero VAD and STT times", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    const metrics = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "metrics"
-    )) as Record<string, unknown>;
-
-    expect(metrics).toHaveProperty("vad_ms", 0);
-    expect(metrics).toHaveProperty("stt_ms", 0);
-    expect(metrics).toHaveProperty("llm_ms");
-    expect(metrics).toHaveProperty("tts_ms");
-    expect(metrics).toHaveProperty("first_audio_ms");
-    expect(metrics).toHaveProperty("total_ms");
-
-    ws.close();
-  });
-});
-
-describe("Provider-driven EOT — late end_of_speech", () => {
-  it("ignores late end_of_speech after provider-driven EOT", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send enough audio to trigger EOT
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    // Wait for the pipeline to start (user transcript confirms it)
-    await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    );
-
-    // Now send a late end_of_speech — this should be ignored
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Wait for the pipeline to complete normally
-    const transcriptEnd = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    )) as Record<string, unknown>;
-
-    expect(transcriptEnd.text).toBe("Echo: eot transcript (20000 bytes)");
-
-    // Should return to listening (not double-process)
-    await waitForStatus(ws, "listening");
-    ws.close();
-  });
-});
-
-describe("Provider-driven EOT — multiple turns", () => {
-  it("handles two EOT-driven turns in the same call", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // First turn: send audio to trigger EOT
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    const t1 = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(t1.text).toBe("eot transcript (20000 bytes)");
-
-    // Wait for pipeline to finish (listening again)
-    await waitForStatus(ws, "listening");
-
-    // Second turn: send audio to trigger another EOT
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    const t2 = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(t2.text).toBe("eot transcript (20000 bytes)");
-    ws.close();
-  });
-
-  it("accumulates messages in SQLite across EOT-driven turns", async () => {
-    const path = uniqueEOTPath();
-    const { ws } = await connectEOTWS(path);
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // First turn
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    );
-    await waitForStatus(ws, "listening");
-
-    // Second turn
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    );
-
-    // Check message count: 2 user + 2 assistant = 4
-    sendJSON(ws, { type: "_get_message_count" });
-    const countMsg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "_message_count"
-    )) as Record<string, unknown>;
-
-    expect(countMsg.count).toBe(4);
-    ws.close();
-  });
-});
-
-describe("Provider-driven EOT — interruption", () => {
-  it("handles interrupt during EOT-triggered pipeline", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Trigger EOT
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    // Wait for pipeline to start processing
-    await waitForStatus(ws, "speaking");
-
-    // Interrupt during processing
-    sendJSON(ws, { type: "interrupt" });
-
-    // Should return to listening
-    const listeningStatus = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(listeningStatus.status).toBe("listening");
-
-    // New turn should work normally
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("eot transcript (20000 bytes)");
-    ws.close();
-  });
-});
-
-describe("Provider-driven EOT — sub-threshold audio", () => {
-  it("does not trigger EOT when audio is below provider threshold", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send less than 20000 bytes — EOT won't fire
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(10000));
-
-    // Now send end_of_speech manually — should be processed via
-    // normal streaming STT path (finish() returns the transcript)
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // minAudioBytes is 16000, we only sent 10000 — too short
-    // Should return to listening without processing
-    const msg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(msg.status).toBe("listening");
-    ws.close();
-  });
-
-  it("processes via finish() when above minAudioBytes but below EOT threshold", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send 18000 bytes — above minAudioBytes (16000) but below EOT threshold (20000)
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(18000));
-
-    // EOT won't fire. Use end_of_speech to trigger finish()
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Should process via streaming STT finish() path
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    // TestEOTStreamingSTTSession.finish() returns "eot transcript (N bytes)"
-    expect(transcript.text).toBe("eot transcript (18000 bytes)");
-    ws.close();
-  });
-});
-
-describe("Provider-driven EOT — interim transcripts", () => {
-  it("sends transcript_interim messages before EOT triggers", async () => {
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Start collecting interim messages
-    const interimPromise = collectMessages(ws, "transcript_interim");
-
-    // Send audio in chunks — each feed() fires onInterim
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(5000));
-    ws.send(new ArrayBuffer(5000));
-    ws.send(new ArrayBuffer(5000));
-    ws.send(new ArrayBuffer(5000)); // Total 20000 — triggers EOT
-
-    const interims = await interimPromise;
-
-    // Should have received interim messages before the final transcript
-    expect(interims.length).toBeGreaterThan(0);
-
-    for (const interim of interims) {
-      expect(interim).toHaveProperty("type", "transcript_interim");
-      expect(interim).toHaveProperty("text");
-    }
-
-    ws.close();
-  });
-});
-
-// --- Regression tests for streaming-only graceful fallback ---
-
-describe("Streaming STT — graceful fallback without batch STT", () => {
-  it("returns to listening when end_of_speech arrives without streaming session (streaming-only agent)", async () => {
-    // Regression: when only streamingStt is configured (no batch stt),
-    // end_of_speech without a preceding start_of_speech should return
-    // to listening instead of throwing "No STT provider configured".
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // Send audio without start_of_speech
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    // Should gracefully return to listening (no crash)
-    const msg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(msg.status).toBe("listening");
-
-    // Prove agent is still functional after the fallback
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    expect(transcript.text).toBe("streaming transcript (20000 bytes)");
-    ws.close();
-  });
-
-  it("EOT agent returns to listening when end_of_speech arrives without streaming session", async () => {
-    // Same regression for EOT agent (no batch stt, no vad)
-    const { ws } = await connectEOTWS(uniqueEOTPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const msg = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "status" &&
-        (m as Record<string, unknown>).status === "listening"
-    )) as Record<string, unknown>;
-
-    expect(msg.status).toBe("listening");
-    ws.close();
-  });
-});
-
-describe("Streaming STT — no phantom sessions after end_of_speech", () => {
-  it("does not create phantom sessions when audio continues after end_of_speech", async () => {
-    const { ws } = await connectStreamingWS(uniqueStreamingPath());
-    await waitForStatus(ws, "idle");
-
-    sendJSON(ws, { type: "start_call" });
-    await waitForStatus(ws, "listening");
-
-    // First turn: normal flow
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript_end"
-    );
-
-    await waitForStatus(ws, "listening");
-
-    // Simulate audio continuing after end_of_speech (like ScriptProcessorNode).
-    // Without auto-creation, this should NOT create a phantom STT session.
-    ws.send(new ArrayBuffer(20000));
-
-    // Now do a second proper turn — should work normally
-    sendJSON(ws, { type: "start_of_speech" });
-    ws.send(new ArrayBuffer(20000));
-    sendJSON(ws, { type: "end_of_speech" });
-
-    const transcript = (await waitForMessageMatching(
-      ws,
-      (m) =>
-        typeof m === "object" &&
-        m !== null &&
-        (m as Record<string, unknown>).type === "transcript" &&
-        (m as Record<string, unknown>).role === "user"
-    )) as Record<string, unknown>;
-
-    // Should only reflect the second turn's audio (20000 bytes),
-    // not accumulated phantom audio
-    expect(transcript.text).toBe("streaming transcript (20000 bytes)");
     ws.close();
   });
 });

--- a/packages/voice/src/tests/worker.ts
+++ b/packages/voice/src/tests/worker.ts
@@ -1,27 +1,15 @@
 import { routeAgentRequest } from "agents";
 
-export {
-  TestVoiceAgent,
-  TestStreamingVoiceAgent,
-  TestVadRetryVoiceAgent,
-  TestEotVoiceAgent
-} from "./agents/voice";
+export { TestVoiceAgent } from "./agents/voice";
 
 export {
   TestVoiceInputAgent,
-  TestStreamingVoiceInputAgent,
-  TestEotVoiceInputAgent,
   TestRejectCallVoiceInputAgent
 } from "./agents/voice-input";
 
 export type Env = {
   TestVoiceAgent: DurableObjectNamespace;
-  TestStreamingVoiceAgent: DurableObjectNamespace;
-  TestVadRetryVoiceAgent: DurableObjectNamespace;
-  TestEotVoiceAgent: DurableObjectNamespace;
   TestVoiceInputAgent: DurableObjectNamespace;
-  TestStreamingVoiceInputAgent: DurableObjectNamespace;
-  TestEotVoiceInputAgent: DurableObjectNamespace;
   TestRejectCallVoiceInputAgent: DurableObjectNamespace;
 };
 

--- a/packages/voice/src/tests/worker.ts
+++ b/packages/voice/src/tests/worker.ts
@@ -1,6 +1,6 @@
 import { routeAgentRequest } from "agents";
 
-export { TestVoiceAgent } from "./agents/voice";
+export { TestVoiceAgent, TestEmptyResponseVoiceAgent } from "./agents/voice";
 
 export {
   TestVoiceInputAgent,
@@ -9,6 +9,7 @@ export {
 
 export type Env = {
   TestVoiceAgent: DurableObjectNamespace;
+  TestEmptyResponseVoiceAgent: DurableObjectNamespace;
   TestVoiceInputAgent: DurableObjectNamespace;
   TestRejectCallVoiceInputAgent: DurableObjectNamespace;
 };

--- a/packages/voice/src/tests/wrangler.jsonc
+++ b/packages/voice/src/tests/wrangler.jsonc
@@ -17,28 +17,8 @@
         "name": "TestVoiceAgent"
       },
       {
-        "class_name": "TestStreamingVoiceAgent",
-        "name": "TestStreamingVoiceAgent"
-      },
-      {
-        "class_name": "TestVadRetryVoiceAgent",
-        "name": "TestVadRetryVoiceAgent"
-      },
-      {
-        "class_name": "TestEotVoiceAgent",
-        "name": "TestEotVoiceAgent"
-      },
-      {
         "class_name": "TestVoiceInputAgent",
         "name": "TestVoiceInputAgent"
-      },
-      {
-        "class_name": "TestStreamingVoiceInputAgent",
-        "name": "TestStreamingVoiceInputAgent"
-      },
-      {
-        "class_name": "TestEotVoiceInputAgent",
-        "name": "TestEotVoiceInputAgent"
       },
       {
         "class_name": "TestRejectCallVoiceInputAgent",
@@ -51,12 +31,7 @@
     {
       "new_sqlite_classes": [
         "TestVoiceAgent",
-        "TestStreamingVoiceAgent",
-        "TestVadRetryVoiceAgent",
-        "TestEotVoiceAgent",
         "TestVoiceInputAgent",
-        "TestStreamingVoiceInputAgent",
-        "TestEotVoiceInputAgent",
         "TestRejectCallVoiceInputAgent"
       ],
       "tag": "v1"

--- a/packages/voice/src/tests/wrangler.jsonc
+++ b/packages/voice/src/tests/wrangler.jsonc
@@ -17,6 +17,10 @@
         "name": "TestVoiceAgent"
       },
       {
+        "class_name": "TestEmptyResponseVoiceAgent",
+        "name": "TestEmptyResponseVoiceAgent"
+      },
+      {
         "class_name": "TestVoiceInputAgent",
         "name": "TestVoiceInputAgent"
       },
@@ -31,6 +35,7 @@
     {
       "new_sqlite_classes": [
         "TestVoiceAgent",
+        "TestEmptyResponseVoiceAgent",
         "TestVoiceInputAgent",
         "TestRejectCallVoiceInputAgent"
       ],

--- a/packages/voice/src/types.ts
+++ b/packages/voice/src/types.ts
@@ -52,8 +52,6 @@ export type VoiceServerMessage =
   | { type: "transcript_interim"; text: string }
   | {
       type: "metrics";
-      vad_ms: number;
-      stt_ms: number;
       llm_ms: number;
       tts_ms: number;
       first_audio_ms: number;
@@ -64,8 +62,6 @@ export type VoiceServerMessage =
 // --- Pipeline metrics (structured form for consumers) ---
 
 export interface VoicePipelineMetrics {
-  vad_ms: number;
-  stt_ms: number;
   llm_ms: number;
   tts_ms: number;
   first_audio_ms: number;
@@ -82,10 +78,6 @@ export interface TranscriptMessage {
 
 // --- Provider interfaces ---
 
-export interface STTProvider {
-  transcribe(audioData: ArrayBuffer, signal?: AbortSignal): Promise<string>;
-}
-
 export interface TTSProvider {
   synthesize(text: string, signal?: AbortSignal): Promise<ArrayBuffer | null>;
 }
@@ -97,62 +89,53 @@ export interface StreamingTTSProvider {
   ): AsyncGenerator<ArrayBuffer>;
 }
 
-export interface VADProvider {
-  checkEndOfTurn(
-    audioData: ArrayBuffer
-  ): Promise<{ isComplete: boolean; probability: number }>;
-}
-
-// --- Streaming STT ---
+// --- Transcriber (continuous per-call STT) ---
 
 /**
- * Streaming speech-to-text provider.
+ * Continuous speech-to-text provider.
  *
- * Unlike the batch `STTProvider`, this transcribes audio incrementally
- * as it arrives, producing interim and final results in real time.
- * This eliminates STT latency from the critical path — by the time
- * the user stops speaking, the transcript is already (nearly) ready.
+ * Creates a per-call session that receives audio continuously from
+ * `start_call` to `end_call`. The model handles turn detection
+ * internally — there is no client-side speech boundary signaling
+ * required for STT.
  *
- * Session lifecycle is per-utterance: one session per speech segment.
+ * The session fires `onUtterance` when the model detects a complete
+ * utterance (e.g. Flux `EndOfTurn`, Nova 3 `speech_final` +
+ * endpointing). The voice pipeline maps this to `onTurn` (withVoice)
+ * or `onTranscript` (withVoiceInput).
  */
-export interface StreamingSTTProvider {
-  /** Create a new transcription session for one utterance. */
-  createSession(options?: StreamingSTTSessionOptions): StreamingSTTSession;
+export interface Transcriber {
+  /** Create a new transcription session for one call. */
+  createSession(options?: TranscriberSessionOptions): TranscriberSession;
 }
 
-export interface StreamingSTTSessionOptions {
+export interface TranscriberSessionOptions {
   /** Language code (e.g. "en"). */
   language?: string;
-  /** Abort signal — aborted on interrupt or disconnect. */
-  signal?: AbortSignal;
   /**
    * Called when the provider produces an interim (unstable) transcript.
    * This text may change as more audio arrives.
    */
   onInterim?: (text: string) => void;
   /**
-   * Called when the provider finalizes a transcript segment.
-   * This text is stable and will not change.
-   * A single utterance may produce multiple onFinal calls
-   * (e.g. the provider segments by clause or sentence).
-   */
-  onFinal?: (text: string) => void;
-  /**
-   * Called when the provider detects end-of-turn server-side.
-   * The transcript is the complete, stable text for this turn.
+   * Called when the model detects a complete utterance.
+   * The transcript is the stable text for this turn.
    *
-   * When set, the voice pipeline will start processing (LLM + TTS)
-   * immediately without waiting for the client to send end_of_speech.
-   * This eliminates client-side silence detection latency.
-   *
-   * Not all providers support this — it is optional. Providers that
-   * do not detect end-of-turn (e.g. Deepgram with endpointing disabled)
-   * should leave this unused.
+   * For Flux: fires on `EndOfTurn`.
+   * For Nova 3: fires on `Results` with `speech_final: true`.
    */
-  onEndOfTurn?: (text: string) => void;
+  onUtterance?: (transcript: string) => void;
 }
 
-export interface StreamingSTTSession {
+/**
+ * A per-call transcription session. Lives for the entire call duration.
+ *
+ * Unlike per-utterance sessions, this session is never finished or
+ * aborted mid-call. It receives all audio continuously and the model
+ * handles speech boundary detection. On interrupt, the LLM+TTS
+ * pipeline is aborted but the transcriber session stays alive.
+ */
+export interface TranscriberSession {
   /**
    * Feed raw PCM audio (16kHz mono 16-bit LE).
    * Fire-and-forget — the session buffers internally as needed.
@@ -160,17 +143,10 @@ export interface StreamingSTTSession {
   feed(chunk: ArrayBuffer): void;
 
   /**
-   * Signal that the speaker has finished.
-   * Flushes any buffered audio and returns the final, stable transcript.
-   * The session is closed after this call and cannot be reused.
+   * Close the session and release resources.
+   * Called at end_call or disconnect — not on interrupt.
    */
-  finish(): Promise<string>;
-
-  /**
-   * Abort the session and release resources immediately.
-   * No final transcript is produced. Used on interrupt/disconnect.
-   */
-  abort(): void;
+  close(): void;
 }
 
 // --- Audio input ---

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -44,6 +44,9 @@ export interface VoiceClientOptions {
   /** Host to connect to. @default window.location.host */
   host?: string;
 
+  /** Query parameters appended to the WebSocket URL. */
+  query?: Record<string, string | null | undefined>;
+
   /**
    * Custom transport for sending/receiving data.
    * Defaults to a WebSocket transport via PartySocket.
@@ -166,14 +169,24 @@ function computeRMS(samples: Float32Array): number {
  */
 export class WebSocketVoiceTransport implements VoiceTransport {
   #socket: PartySocket | null = null;
-  #options: { agent: string; name?: string; host?: string };
+  #options: {
+    agent: string;
+    name?: string;
+    host?: string;
+    query?: Record<string, string | null | undefined>;
+  };
 
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: ((error?: unknown) => void) | null = null;
   onmessage: ((data: string | ArrayBuffer | Blob) => void) | null = null;
 
-  constructor(options: { agent: string; name?: string; host?: string }) {
+  constructor(options: {
+    agent: string;
+    name?: string;
+    host?: string;
+    query?: Record<string, string | null | undefined>;
+  }) {
     this.#options = options;
   }
 
@@ -202,7 +215,8 @@ export class WebSocketVoiceTransport implements VoiceTransport {
       party: agentNamespace,
       room: this.#options.name ?? "default",
       host: this.#options.host ?? window.location.host,
-      prefix: "agents"
+      prefix: "agents",
+      query: this.#options.query
     });
 
     socket.onopen = () => this.onopen?.();
@@ -372,7 +386,8 @@ export class VoiceClient {
       new WebSocketVoiceTransport({
         agent: this.#options.agent,
         name: this.#options.name,
-        host: this.#options.host
+        host: this.#options.host,
+        query: this.#options.query
       });
 
     transport.onopen = () => {
@@ -588,6 +603,18 @@ export class VoiceClient {
         // Final transcript arrived — clear interim
         this.#interimTranscript = null;
         this.#emit("interimtranscript", null);
+
+        // New user utterance while agent is playing -- stop playback.
+        // With continuous STT, the model detects the user's speech
+        // server-side, so this arrives before the client's interrupt
+        // detection fires.
+        if (msg.role === "user" && this.#isPlaying) {
+          this.#activeSource?.stop();
+          this.#activeSource = null;
+          this.#playbackQueue = [];
+          this.#isPlaying = false;
+        }
+
         this.#transcript = [
           ...this.#transcript,
           {
@@ -637,8 +664,6 @@ export class VoiceClient {
       }
       case "metrics":
         this.#metrics = {
-          vad_ms: msg.vad_ms as number,
-          stt_ms: msg.stt_ms as number,
           llm_ms: msg.llm_ms as number,
           tts_ms: msg.tts_ms as number,
           first_audio_ms: msg.first_audio_ms as number,

--- a/packages/voice/src/voice-input.ts
+++ b/packages/voice/src/voice-input.ts
@@ -330,11 +330,13 @@ export function withVoiceInput<TBase extends AgentLike>(
         );
       }
 
-      sendVoiceJSON(
-        connection,
-        { type: "status", status: "listening" },
-        "VoiceInput"
-      );
+      if (this.#cm.isInCall(connection.id)) {
+        sendVoiceJSON(
+          connection,
+          { type: "status", status: "listening" },
+          "VoiceInput"
+        );
+      }
     }
   }
 

--- a/packages/voice/src/voice-input.ts
+++ b/packages/voice/src/voice-input.ts
@@ -223,6 +223,9 @@ export function withVoiceInput<TBase extends AgentLike>(
 
       const provider = this.createTranscriber(connection) ?? this.transcriber;
       if (!provider) {
+        console.error(
+          "[VoiceInput] No transcriber configured. Set 'transcriber' on your VoiceInput subclass or override createTranscriber()."
+        );
         sendVoiceJSON(
           connection,
           {

--- a/packages/voice/src/voice-input.ts
+++ b/packages/voice/src/voice-input.ts
@@ -295,25 +295,36 @@ export function withVoiceInput<TBase extends AgentLike>(
     // --- Internal: transcript emission ---
 
     async #emitTranscript(connection: Connection, transcript: string) {
-      const userText = await this.afterTranscribe(transcript, connection);
-      if (!userText) return;
-
-      sendVoiceJSON(
-        connection,
-        { type: "transcript_interim", text: "" },
-        "VoiceInput"
-      );
-
-      sendVoiceJSON(
-        connection,
-        { type: "transcript", role: "user", text: userText },
-        "VoiceInput"
-      );
-
       try {
+        const userText = await this.afterTranscribe(transcript, connection);
+        if (!userText) return;
+
+        sendVoiceJSON(
+          connection,
+          { type: "transcript_interim", text: "" },
+          "VoiceInput"
+        );
+
+        sendVoiceJSON(
+          connection,
+          { type: "transcript", role: "user", text: userText },
+          "VoiceInput"
+        );
+
         await this.onTranscript(userText, connection);
       } catch (err) {
-        console.error("[VoiceInput] onTranscript error:", err);
+        console.error("[VoiceInput] transcript error:", err);
+        sendVoiceJSON(
+          connection,
+          {
+            type: "error",
+            message:
+              err instanceof Error
+                ? err.message
+                : "Transcript processing failed"
+          },
+          "VoiceInput"
+        );
       }
 
       sendVoiceJSON(

--- a/packages/voice/src/voice-input.ts
+++ b/packages/voice/src/voice-input.ts
@@ -218,8 +218,13 @@ export function withVoiceInput<TBase extends AgentLike>(
     async #handleStartCall(connection: Connection) {
       if (this.#cm.isInCall(connection.id)) return;
 
+      this.#cm.initConnection(connection.id);
+
       const allowed = await this.beforeCallStart(connection);
-      if (!allowed) return;
+      if (!allowed) {
+        this.#cm.cleanup(connection.id);
+        return;
+      }
 
       const provider = this.createTranscriber(connection) ?? this.transcriber;
       if (!provider) {
@@ -235,10 +240,9 @@ export function withVoiceInput<TBase extends AgentLike>(
           },
           "VoiceInput"
         );
+        this.#cm.cleanup(connection.id);
         return;
       }
-
-      this.#cm.initConnection(connection.id);
 
       const dispose = await this.keepAlive();
       this.#keepAliveDispose.set(connection.id, dispose);

--- a/packages/voice/src/voice-input.ts
+++ b/packages/voice/src/voice-input.ts
@@ -223,9 +223,16 @@ export function withVoiceInput<TBase extends AgentLike>(
 
       const provider = this.createTranscriber(connection) ?? this.transcriber;
       if (!provider) {
-        throw new Error(
-          "No transcriber configured. Set 'transcriber' on your VoiceInput subclass or override createTranscriber()."
+        sendVoiceJSON(
+          connection,
+          {
+            type: "error",
+            message:
+              "No transcriber configured. Set 'transcriber' on your VoiceInput subclass or override createTranscriber()."
+          },
+          "VoiceInput"
         );
+        return;
       }
 
       this.#cm.initConnection(connection.id);

--- a/packages/voice/src/voice-input.ts
+++ b/packages/voice/src/voice-input.ts
@@ -8,12 +8,12 @@
  *
  * Usage:
  *   import { Agent } from "agents";
- *   import { withVoiceInput, WorkersAIFluxSTT } from "@cloudflare/voice";
+ *   import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
  *
  *   const InputAgent = withVoiceInput(Agent);
  *
  *   class MyAgent extends InputAgent<Env> {
- *     streamingStt = new WorkersAIFluxSTT(this.env.AI);
+ *     transcriber = new WorkersAINova3STT(this.env.AI);
  *
  *     onTranscript(text, connection) {
  *       console.log("User said:", text);
@@ -23,65 +23,41 @@
  * @experimental This API is not yet stable and may change.
  */
 
-import type { Connection, WSMessage } from "agents";
+import type { Agent, Connection, WSMessage } from "agents";
 import { VOICE_PROTOCOL_VERSION } from "./types";
-import type { STTProvider, VADProvider, StreamingSTTProvider } from "./types";
-import {
-  AudioConnectionManager,
-  sendVoiceJSON,
-  DEFAULT_VAD_THRESHOLD,
-  DEFAULT_MIN_AUDIO_BYTES,
-  DEFAULT_VAD_PUSHBACK_SECONDS,
-  DEFAULT_VAD_RETRY_MS
-} from "./audio-pipeline";
-
-// --- Public types ---
-
-/** Configuration options for the voice input mixin. */
-export interface VoiceInputAgentOptions {
-  /** Minimum audio bytes to process (16kHz mono 16-bit). @default 16000 (0.5s) */
-  minAudioBytes?: number;
-  /** VAD probability threshold — only used when `vad` is set. @default 0.5 */
-  vadThreshold?: number;
-  /** Seconds of audio to push back to buffer when VAD rejects. @default 2 */
-  vadPushbackSeconds?: number;
-  /** Milliseconds to wait after VAD rejects before retrying without VAD. @default 3000 */
-  vadRetryMs?: number;
-}
+import type { Transcriber } from "./types";
+import { AudioConnectionManager, sendVoiceJSON } from "./audio-pipeline";
 
 // --- Mixin ---
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- mixin constructor constraint
 type Constructor<T = object> = new (...args: any[]) => T;
 
+type AgentLike = Constructor<Pick<Agent<Cloudflare.Env>, "keepAlive">>;
+
 /** Public surface of the voice input mixin, used as an explicit return type to satisfy TS6 declaration emit. */
 export interface VoiceInputMixinMembers {
-  stt?: STTProvider;
-  streamingStt?: StreamingSTTProvider;
-  vad?: VADProvider;
+  transcriber?: Transcriber;
   onTranscript(text: string, connection: Connection): void | Promise<void>;
+  createTranscriber(connection: Connection): Transcriber | null;
   beforeCallStart(connection: Connection): boolean | Promise<boolean>;
   onCallStart(connection: Connection): void | Promise<void>;
   onCallEnd(connection: Connection): void | Promise<void>;
   onInterrupt(connection: Connection): void | Promise<void>;
-  beforeTranscribe(
-    audio: ArrayBuffer,
-    connection: Connection
-  ): ArrayBuffer | null | Promise<ArrayBuffer | null>;
   afterTranscribe(
     transcript: string,
     connection: Connection
   ): string | null | Promise<string | null>;
 }
 
-type VoiceInputMixinReturn<TBase extends Constructor> = TBase &
+type VoiceInputMixinReturn<TBase extends AgentLike> = TBase &
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- mixin constructor must accept any args
   (new (...args: any[]) => VoiceInputMixinMembers);
 
 /**
  * Voice-to-text input mixin. Adds STT-only voice input to an Agent class.
  *
- * Subclasses must set an `stt` or `streamingStt` provider property.
+ * Subclasses must set a `transcriber` property (or override `createTranscriber`).
  * No TTS provider is needed. Override `onTranscript` to handle each
  * transcribed utterance.
  *
@@ -91,12 +67,12 @@ type VoiceInputMixinReturn<TBase extends Constructor> = TBase &
  * @example
  * ```typescript
  * import { Agent } from "agents";
- * import { withVoiceInput, WorkersAIFluxSTT } from "@cloudflare/voice";
+ * import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
  *
  * const InputAgent = withVoiceInput(Agent);
  *
  * class MyAgent extends InputAgent<Env> {
- *   streamingStt = new WorkersAIFluxSTT(this.env.AI);
+ *   transcriber = new WorkersAINova3STT(this.env.AI);
  *
  *   onTranscript(text, connection) {
  *     console.log("User said:", text);
@@ -104,37 +80,16 @@ type VoiceInputMixinReturn<TBase extends Constructor> = TBase &
  * }
  * ```
  */
-export function withVoiceInput<TBase extends Constructor>(
-  Base: TBase,
-  voiceInputOptions?: VoiceInputAgentOptions
+export function withVoiceInput<TBase extends AgentLike>(
+  Base: TBase
 ): VoiceInputMixinReturn<TBase> {
-  console.log(
-    "[@cloudflare/voice] Note: The voice API is experimental and may change between releases. Pin your version to avoid surprises."
-  );
-
-  const opts = voiceInputOptions ?? {};
-
-  function opt<K extends keyof VoiceInputAgentOptions>(
-    key: K,
-    fallback: NonNullable<VoiceInputAgentOptions[K]>
-  ): NonNullable<VoiceInputAgentOptions[K]> {
-    return (opts[key] ?? fallback) as NonNullable<VoiceInputAgentOptions[K]>;
-  }
-
   class VoiceInputMixin extends Base {
-    // --- Provider properties (set by subclass) ---
+    /** Continuous transcriber provider. */
+    transcriber?: Transcriber;
 
-    /** Speech-to-text provider (batch). Required unless streamingStt is set. */
-    stt?: STTProvider;
-    /** Streaming speech-to-text provider. Optional — if set, used instead of batch `stt`. */
-    streamingStt?: StreamingSTTProvider;
-    /** Voice activity detection provider. Optional. */
-    vad?: VADProvider;
-
-    // Shared per-connection audio state manager
     #cm = new AudioConnectionManager("VoiceInput");
+    #keepAliveDispose = new Map<string, () => void>();
 
-    // Voice protocol message types handled internally
     static #VOICE_MESSAGES = new Set([
       "hello",
       "start_call",
@@ -147,10 +102,6 @@ export function withVoiceInput<TBase extends Constructor>(
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- mixin constructor must accept any args
     constructor(...args: any[]) {
       super(...args);
-
-      // Capture the consumer's lifecycle methods (defined on the subclass
-      // prototype) and wrap them so voice logic always runs first.
-      // This is the same pattern used by Agent and PartyServer.
 
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- binding consumer methods
       const _onConnect = (this as any).onConnect?.bind(this);
@@ -182,6 +133,7 @@ export function withVoiceInput<TBase extends Constructor>(
 
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- overwriting lifecycle
       (this as any).onClose = (connection: Connection, ...rest: unknown[]) => {
+        this.#releaseKeepAlive(connection.id);
         this.#cm.cleanup(connection.id);
         return _onClose?.(connection, ...rest);
       };
@@ -191,7 +143,6 @@ export function withVoiceInput<TBase extends Constructor>(
         connection: Connection,
         message: WSMessage
       ) => {
-        // Binary audio — always handled by voice, never forwarded
         if (message instanceof ArrayBuffer) {
           this.#cm.bufferAudio(connection.id, message);
           return;
@@ -201,16 +152,13 @@ export function withVoiceInput<TBase extends Constructor>(
           return _onMessage?.(connection, message);
         }
 
-        // Try to parse as voice protocol
         let parsed: { type: string };
         try {
           parsed = JSON.parse(message);
         } catch {
-          // Not JSON — forward to consumer
           return _onMessage?.(connection, message);
         }
 
-        // Voice protocol message — handle internally
         if (VoiceInputMixin.#VOICE_MESSAGES.has(parsed.type)) {
           switch (parsed.type) {
             case "hello":
@@ -222,11 +170,7 @@ export function withVoiceInput<TBase extends Constructor>(
               this.#handleEndCall(connection);
               break;
             case "start_of_speech":
-              this.#handleStartOfSpeech(connection);
-              break;
             case "end_of_speech":
-              this.#cm.clearVadRetry(connection.id);
-              this.#handleEndOfSpeech(connection);
               break;
             case "interrupt":
               this.#handleInterrupt(connection);
@@ -235,29 +179,25 @@ export function withVoiceInput<TBase extends Constructor>(
           return;
         }
 
-        // Not a voice message — forward to consumer
         return _onMessage?.(connection, message);
       };
     }
 
     // --- User-overridable hooks ---
 
-    /**
-     * Called after each utterance is transcribed.
-     * Override this to process the transcript (e.g. save to storage,
-     * trigger a search, or forward to another service).
-     *
-     * @param text - The transcribed text.
-     * @param connection - The WebSocket connection that sent the audio.
-     */
     onTranscript(
       _text: string,
       _connection: Connection
     ): void | Promise<void> {}
 
     /**
-     * Called before accepting a call. Return `false` to reject.
+     * Override to create a transcriber dynamically per connection.
+     * Return null to fall back to the `transcriber` property.
      */
+    createTranscriber(_connection: Connection): Transcriber | null {
+      return null;
+    }
+
     beforeCallStart(_connection: Connection): boolean | Promise<boolean> {
       return true;
     }
@@ -266,20 +206,6 @@ export function withVoiceInput<TBase extends Constructor>(
     onCallEnd(_connection: Connection): void | Promise<void> {}
     onInterrupt(_connection: Connection): void | Promise<void> {}
 
-    /**
-     * Hook to transform audio before STT. Return null to skip this utterance.
-     */
-    beforeTranscribe(
-      audio: ArrayBuffer,
-      _connection: Connection
-    ): ArrayBuffer | null | Promise<ArrayBuffer | null> {
-      return audio;
-    }
-
-    /**
-     * Hook to transform or filter the transcript after STT.
-     * Return null to discard this utterance.
-     */
     afterTranscribe(
       transcript: string,
       _connection: Connection
@@ -287,64 +213,39 @@ export function withVoiceInput<TBase extends Constructor>(
       return transcript;
     }
 
-    // --- Streaming STT session management ---
-
-    #handleStartOfSpeech(connection: Connection) {
-      if (!this.streamingStt) return;
-      if (this.#cm.hasSTTSession(connection.id)) return;
-      if (!this.#cm.isInCall(connection.id)) return;
-
-      // Clear EOT flag from any previous turn
-      this.#cm.clearEOT(connection.id);
-
-      // Accumulate finalized segments for the full transcript
-      let accumulated = "";
-
-      this.#cm.startSTTSession(connection.id, this.streamingStt, {
-        onFinal: (text: string) => {
-          accumulated += (accumulated ? " " : "") + text;
-          sendVoiceJSON(
-            connection,
-            {
-              type: "transcript_interim",
-              text: accumulated
-            },
-            "VoiceInput"
-          );
-        },
-        onInterim: (text: string) => {
-          const display = accumulated ? accumulated + " " + text : text;
-          sendVoiceJSON(
-            connection,
-            {
-              type: "transcript_interim",
-              text: display
-            },
-            "VoiceInput"
-          );
-        },
-        // Provider-driven end-of-turn: transcribe immediately
-        onEndOfTurn: (transcript: string) => {
-          if (this.#cm.isEOTTriggered(connection.id)) return;
-          this.#cm.setEOTTriggered(connection.id);
-
-          this.#cm.removeSTTSession(connection.id);
-          this.#cm.clearAudioBuffer(connection.id);
-          this.#cm.clearVadRetry(connection.id);
-
-          // Emit transcript and go straight back to listening
-          this.#emitTranscript(connection, transcript);
-        }
-      });
-    }
-
     // --- Internal: call lifecycle ---
 
     async #handleStartCall(connection: Connection) {
+      if (this.#cm.isInCall(connection.id)) return;
+
       const allowed = await this.beforeCallStart(connection);
       if (!allowed) return;
 
+      const provider = this.createTranscriber(connection) ?? this.transcriber;
+      if (!provider) {
+        throw new Error(
+          "No transcriber configured. Set 'transcriber' on your VoiceInput subclass or override createTranscriber()."
+        );
+      }
+
       this.#cm.initConnection(connection.id);
+
+      const dispose = await this.keepAlive();
+      this.#keepAliveDispose.set(connection.id, dispose);
+
+      this.#cm.startTranscriberSession(connection.id, provider, {
+        onInterim: (text: string) => {
+          sendVoiceJSON(
+            connection,
+            { type: "transcript_interim", text },
+            "VoiceInput"
+          );
+        },
+        onUtterance: (transcript: string) => {
+          this.#emitTranscript(connection, transcript);
+        }
+      });
+
       sendVoiceJSON(
         connection,
         { type: "status", status: "listening" },
@@ -354,238 +255,60 @@ export function withVoiceInput<TBase extends Constructor>(
       await this.onCallStart(connection);
     }
 
+    #releaseKeepAlive(connectionId: string) {
+      const dispose = this.#keepAliveDispose.get(connectionId);
+      if (dispose) {
+        dispose();
+        this.#keepAliveDispose.delete(connectionId);
+      }
+    }
+
     #handleEndCall(connection: Connection) {
       this.#cm.cleanup(connection.id);
+      this.#releaseKeepAlive(connection.id);
       sendVoiceJSON(
         connection,
         { type: "status", status: "idle" },
         "VoiceInput"
       );
-
       this.onCallEnd(connection);
     }
 
     #handleInterrupt(connection: Connection) {
       this.#cm.abortPipeline(connection.id);
-      this.#cm.abortSTTSession(connection.id);
-      this.#cm.clearVadRetry(connection.id);
-      this.#cm.clearEOT(connection.id);
       this.#cm.clearAudioBuffer(connection.id);
       sendVoiceJSON(
         connection,
         { type: "status", status: "listening" },
         "VoiceInput"
       );
-
       this.onInterrupt(connection);
     }
 
-    // --- Internal: audio pipeline ---
+    // --- Internal: transcript emission ---
 
-    async #handleEndOfSpeech(connection: Connection, skipVad = false) {
-      // If already triggered by provider-driven EOT, ignore
-      if (this.#cm.isEOTTriggered(connection.id)) {
-        this.#cm.clearEOT(connection.id);
-        return;
-      }
-
-      const audioData = this.#cm.getAndClearAudio(connection.id);
-      if (!audioData) return;
-
-      const hasStreamingSession = this.#cm.hasSTTSession(connection.id);
-
-      const minAudioBytes = opt("minAudioBytes", DEFAULT_MIN_AUDIO_BYTES);
-      if (audioData.byteLength < minAudioBytes) {
-        this.#cm.abortSTTSession(connection.id);
-        sendVoiceJSON(
-          connection,
-          { type: "status", status: "listening" },
-          "VoiceInput"
-        );
-        return;
-      }
-
-      if (this.vad && !skipVad) {
-        const vadResult = await this.vad.checkEndOfTurn(audioData);
-        const vadThreshold = opt("vadThreshold", DEFAULT_VAD_THRESHOLD);
-        const shouldProceed =
-          vadResult.isComplete || vadResult.probability > vadThreshold;
-
-        if (!shouldProceed) {
-          const pushbackSeconds = opt(
-            "vadPushbackSeconds",
-            DEFAULT_VAD_PUSHBACK_SECONDS
-          );
-          const maxPushbackBytes = pushbackSeconds * 16000 * 2;
-          const pushback =
-            audioData.byteLength > maxPushbackBytes
-              ? audioData.slice(audioData.byteLength - maxPushbackBytes)
-              : audioData;
-          this.#cm.pushbackAudio(connection.id, pushback);
-          sendVoiceJSON(
-            connection,
-            { type: "status", status: "listening" },
-            "VoiceInput"
-          );
-          this.#cm.scheduleVadRetry(
-            connection.id,
-            () => this.#handleEndOfSpeech(connection, true),
-            opt("vadRetryMs", DEFAULT_VAD_RETRY_MS) as number
-          );
-          return;
-        }
-      }
-
-      // --- STT phase ---
-
-      const signal = this.#cm.createPipelineAbort(connection.id);
+    async #emitTranscript(connection: Connection, transcript: string) {
+      const userText = await this.afterTranscribe(transcript, connection);
+      if (!userText) return;
 
       sendVoiceJSON(
         connection,
-        { type: "status", status: "thinking" },
+        { type: "transcript_interim", text: "" },
+        "VoiceInput"
+      );
+
+      sendVoiceJSON(
+        connection,
+        { type: "transcript", role: "user", text: userText },
         "VoiceInput"
       );
 
       try {
-        let userText: string | null;
-
-        if (hasStreamingSession) {
-          // Streaming STT path — flush and get final transcript
-          const rawTranscript = await this.#cm.flushSTTSession(connection.id);
-
-          if (signal.aborted) return;
-
-          if (!rawTranscript || rawTranscript.trim().length === 0) {
-            sendVoiceJSON(
-              connection,
-              {
-                type: "status",
-                status: "listening"
-              },
-              "VoiceInput"
-            );
-            return;
-          }
-
-          userText = await this.afterTranscribe(rawTranscript, connection);
-        } else {
-          // Batch STT path
-          if (!this.stt) {
-            sendVoiceJSON(
-              connection,
-              {
-                type: "status",
-                status: "listening"
-              },
-              "VoiceInput"
-            );
-            return;
-          }
-
-          const processedAudio = await this.beforeTranscribe(
-            audioData,
-            connection
-          );
-          if (!processedAudio || signal.aborted) {
-            sendVoiceJSON(
-              connection,
-              {
-                type: "status",
-                status: "listening"
-              },
-              "VoiceInput"
-            );
-            return;
-          }
-
-          const rawTranscript = await this.stt.transcribe(
-            processedAudio,
-            signal
-          );
-          if (signal.aborted) return;
-
-          if (!rawTranscript || rawTranscript.trim().length === 0) {
-            sendVoiceJSON(
-              connection,
-              {
-                type: "status",
-                status: "listening"
-              },
-              "VoiceInput"
-            );
-            return;
-          }
-
-          userText = await this.afterTranscribe(rawTranscript, connection);
-        }
-
-        if (!userText || signal.aborted) {
-          sendVoiceJSON(
-            connection,
-            { type: "status", status: "listening" },
-            "VoiceInput"
-          );
-          return;
-        }
-
-        // Emit the transcript and go straight back to listening
-        await this.#emitTranscript(connection, userText);
-      } catch (error) {
-        if (signal.aborted) return;
-        console.error("[VoiceInput] STT pipeline error:", error);
-        sendVoiceJSON(
-          connection,
-          {
-            type: "error",
-            message:
-              error instanceof Error ? error.message : "Voice input failed"
-          },
-          "VoiceInput"
-        );
-        sendVoiceJSON(
-          connection,
-          { type: "status", status: "listening" },
-          "VoiceInput"
-        );
-      } finally {
-        this.#cm.clearPipelineAbort(connection.id);
-      }
-    }
-
-    /**
-     * Send the user transcript to the client and call the onTranscript hook.
-     * Then immediately return to listening — no LLM/TTS pipeline.
-     */
-    async #emitTranscript(connection: Connection, text: string) {
-      // Clear interim transcript
-      sendVoiceJSON(
-        connection,
-        {
-          type: "transcript_interim",
-          text: ""
-        },
-        "VoiceInput"
-      );
-
-      // Send the final user transcript
-      sendVoiceJSON(
-        connection,
-        {
-          type: "transcript",
-          role: "user",
-          text
-        },
-        "VoiceInput"
-      );
-
-      // Call the user hook
-      try {
-        await this.onTranscript(text, connection);
+        await this.onTranscript(userText, connection);
       } catch (err) {
         console.error("[VoiceInput] onTranscript error:", err);
       }
 
-      // Back to listening immediately
       sendVoiceJSON(
         connection,
         { type: "status", status: "listening" },

--- a/packages/voice/src/voice-react.tsx
+++ b/packages/voice/src/voice-react.tsx
@@ -237,9 +237,14 @@ export function useVoiceAgent(
 ): UseVoiceAgentReturn {
   // Derive a stable key from the connection-identity fields.
   // When this changes, we tear down the old client and create a new one.
+  const queryString = useMemo(
+    () => (options.query ? JSON.stringify(options.query) : ""),
+    [options.query]
+  );
+
   const connectionKey = useMemo(
     () =>
-      `${options.agent}:${options.name ?? "default"}:${options.host ?? ""}:${options.silenceThreshold ?? ""}:${options.silenceDurationMs ?? ""}:${options.interruptThreshold ?? ""}:${options.interruptChunks ?? ""}`,
+      `${options.agent}:${options.name ?? "default"}:${options.host ?? ""}:${options.silenceThreshold ?? ""}:${options.silenceDurationMs ?? ""}:${options.interruptThreshold ?? ""}:${options.interruptChunks ?? ""}:${queryString}`,
     [
       options.agent,
       options.name,
@@ -247,7 +252,8 @@ export function useVoiceAgent(
       options.silenceThreshold,
       options.silenceDurationMs,
       options.interruptThreshold,
-      options.interruptChunks
+      options.interruptChunks,
+      queryString
     ]
   );
 

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -617,7 +617,10 @@ export function withVoice<TBase extends AgentLike>(
           );
 
           if (signal.aborted) return;
-          this.saveMessage("assistant", fullText);
+
+          if (fullText && fullText.trim().length > 0) {
+            this.saveMessage("assistant", fullText);
+          }
           this.#sendJSON(connection, { type: "status", status: "listening" });
         } else {
           this.#sendJSON(connection, {
@@ -637,7 +640,10 @@ export function withVoice<TBase extends AgentLike>(
             type: "transcript_end",
             text: fullText
           });
-          this.saveMessage("assistant", fullText);
+
+          if (fullText && fullText.trim().length > 0) {
+            this.saveMessage("assistant", fullText);
+          }
           this.#sendJSON(connection, { type: "status", status: "idle" });
         }
       } catch (error) {
@@ -704,6 +710,15 @@ export function withVoice<TBase extends AgentLike>(
         );
 
         if (signal.aborted) return;
+
+        if (!fullText || fullText.trim().length === 0) {
+          this.#sendJSON(connection, {
+            type: "error",
+            message: "No response generated"
+          });
+          this.#sendJSON(connection, { type: "status", status: "listening" });
+          return;
+        }
 
         const totalMs = Date.now() - pipelineStart;
 

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -515,6 +515,9 @@ export function withVoice<TBase extends AgentLike>(
 
       const provider = this.createTranscriber(connection) ?? this.transcriber;
       if (!provider) {
+        console.error(
+          "[VoiceAgent] No transcriber configured. Set 'transcriber' on your VoiceAgent subclass or override createTranscriber()."
+        );
         this.#sendJSON(connection, {
           type: "error",
           message:

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -1,33 +1,26 @@
 /**
- * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- * !! WARNING: EXPERIMENTAL — DO NOT USE IN PRODUCTION                  !!
- * !!                                                                   !!
- * !! This API is under active development and WILL break between       !!
- * !! releases. Method names, types, behavior, and the mixin signature  !!
- * !! are all subject to change without notice.                         !!
- * !!                                                                   !!
- * !! If you use this, pin your agents version and expect to rewrite    !!
- * !! your code when upgrading.                                         !!
- * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- *
- * Experimental voice pipeline mixin for the Agents SDK.
+ * Voice pipeline mixin for the Agents SDK.
  *
  * Usage:
  *   import { Agent } from "agents";
- *   import { withVoice } from "agents/experimental/voice";
+ *   import { withVoice, WorkersAIFluxSTT, WorkersAITTS } from "@cloudflare/voice";
  *
  *   const VoiceAgent = withVoice(Agent);
  *
  *   class MyAgent extends VoiceAgent<Env> {
- *     async onTurn(transcript: string, context: VoiceTurnContext) {
+ *     transcriber = new WorkersAIFluxSTT(this.env.AI);
+ *     tts = new WorkersAITTS(this.env.AI);
+ *
+ *     async onTurn(transcript, context) {
  *       const result = streamText({ ... });
  *       return result.textStream;
  *     }
  *   }
  *
- * This mixin adds the full voice pipeline: audio buffering, VAD, STT,
- * streaming TTS, interruption handling, conversation persistence, and
- * the WebSocket voice protocol.
+ * This mixin adds the full voice pipeline: continuous STT, streaming TTS,
+ * interruption handling, conversation persistence, and the WebSocket
+ * voice protocol. The transcriber session is per-call — created at
+ * start_call, closed at end_call. The model handles turn detection.
  *
  * @experimental This API is not yet stable and may change.
  */
@@ -37,27 +30,13 @@ import { SentenceChunker } from "./sentence-chunker";
 import { iterateText, type TextSource } from "./text-stream";
 import { VOICE_PROTOCOL_VERSION } from "./types";
 import type {
-  VoiceStatus,
   VoiceRole,
   VoiceAudioFormat,
-  VoiceClientMessage,
-  VoiceServerMessage,
-  VoicePipelineMetrics,
-  STTProvider,
   TTSProvider,
   StreamingTTSProvider,
-  VADProvider,
-  StreamingSTTProvider
+  Transcriber
 } from "./types";
-import {
-  AudioConnectionManager,
-  sendVoiceJSON,
-  DEFAULT_VAD_THRESHOLD,
-  DEFAULT_MIN_AUDIO_BYTES,
-  DEFAULT_VAD_PUSHBACK_SECONDS,
-  DEFAULT_VAD_RETRY_MS
-} from "./audio-pipeline";
-import type { VoiceInputAgentOptions } from "./voice-input";
+import { AudioConnectionManager, sendVoiceJSON } from "./audio-pipeline";
 
 // Re-export SentenceChunker for direct use
 export { SentenceChunker } from "./sentence-chunker";
@@ -65,7 +44,7 @@ export { SentenceChunker } from "./sentence-chunker";
 // Re-export protocol version constant
 export { VOICE_PROTOCOL_VERSION } from "./types";
 
-// Re-export shared types so existing imports from "agents/experimental/voice" still work
+// Re-export shared types
 export type {
   VoiceStatus,
   VoiceRole,
@@ -76,18 +55,15 @@ export type {
   VoiceServerMessage,
   VoicePipelineMetrics,
   TranscriptMessage,
-  STTProvider,
   TTSProvider,
   StreamingTTSProvider,
-  VADProvider,
-  StreamingSTTProvider,
-  StreamingSTTSession,
-  StreamingSTTSessionOptions
+  Transcriber,
+  TranscriberSession,
+  TranscriberSessionOptions
 } from "./types";
 
 // Re-export voice input mixin (STT-only, no TTS/LLM)
 export { withVoiceInput } from "./voice-input";
-export type { VoiceInputAgentOptions } from "./voice-input";
 
 // Re-export text stream utility
 export { iterateText, type TextSource } from "./text-stream";
@@ -108,46 +84,29 @@ export {
 } from "./sfu-utils";
 export type { SFUConfig } from "./sfu-utils";
 
-// Re-export Workers AI providers and audio utility
+// Re-export Workers AI providers
 export {
-  WorkersAISTT,
   WorkersAITTS,
-  WorkersAIVAD,
   WorkersAIFluxSTT,
-  pcmToWav
+  WorkersAINova3STT
 } from "./workers-ai-providers";
 export type {
-  WorkersAISTTOptions,
   WorkersAITTSOptions,
-  WorkersAIVADOptions,
-  WorkersAIFluxSTTOptions
+  WorkersAIFluxSTTOptions,
+  WorkersAINova3STTOptions
 } from "./workers-ai-providers";
 
 // --- Public types ---
 
-/** Result from a VAD (Voice Activity Detection) provider. */
-export interface VADResult {
-  isComplete: boolean;
-  probability: number;
-}
-
 /** Context passed to the `onTurn()` hook. */
 export interface VoiceTurnContext {
-  /**
-   * The WebSocket connection that sent the audio.
-   * Useful for sending custom JSON messages (e.g. tool progress).
-   * WARNING: sending raw binary on this connection will interleave with
-   * the TTS audio stream. Use `connection.send(JSON.stringify(...))` only.
-   */
   connection: Connection;
-  /** Conversation history from SQLite (chronological order). */
   messages: Array<{ role: VoiceRole; content: string }>;
-  /** AbortSignal — aborted if user interrupts or disconnects. */
   signal: AbortSignal;
 }
 
 /** Configuration options for the voice mixin. Passed to `withVoice()`. */
-export interface VoiceAgentOptions extends VoiceInputAgentOptions {
+export interface VoiceAgentOptions {
   /** Max conversation history messages loaded for context. @default 20 */
   historyLimit?: number;
   /** Audio format used for binary audio payloads sent to the client. @default "mp3" */
@@ -156,7 +115,7 @@ export interface VoiceAgentOptions extends VoiceInputAgentOptions {
   maxMessageCount?: number;
 }
 
-// --- Default option values (voice-specific, not in audio-pipeline) ---
+// --- Default option values ---
 
 const DEFAULT_HISTORY_LIMIT = 20;
 const DEFAULT_MAX_MESSAGE_COUNT = 1000;
@@ -167,30 +126,19 @@ const DEFAULT_MAX_MESSAGE_COUNT = 1000;
 type Constructor<T = object> = new (...args: any[]) => T;
 
 type AgentLike = Constructor<
-  Pick<
-    Agent<Cloudflare.Env>,
-    | "sql"
-    | "getConnections"
-    | "_unsafe_getConnectionFlag"
-    | "_unsafe_setConnectionFlag"
-  >
+  Pick<Agent<Cloudflare.Env>, "sql" | "getConnections" | "keepAlive">
 >;
 
 /** Public surface of the voice mixin, used as an explicit return type to satisfy TS6 declaration emit. */
 export interface VoiceAgentMixinMembers {
-  stt?: STTProvider;
-  streamingStt?: StreamingSTTProvider;
+  transcriber?: Transcriber;
   tts?: (TTSProvider & Partial<StreamingTTSProvider>) | undefined;
-  vad?: VADProvider;
   onTurn(transcript: string, context: VoiceTurnContext): Promise<TextSource>;
+  createTranscriber(connection: Connection): Transcriber | null;
   beforeCallStart(connection: Connection): boolean | Promise<boolean>;
   onCallStart(connection: Connection): void | Promise<void>;
   onCallEnd(connection: Connection): void | Promise<void>;
   onInterrupt(connection: Connection): void | Promise<void>;
-  beforeTranscribe(
-    audio: ArrayBuffer,
-    connection: Connection
-  ): ArrayBuffer | null | Promise<ArrayBuffer | null>;
   afterTranscribe(
     transcript: string,
     connection: Connection
@@ -220,7 +168,9 @@ type VoiceAgentMixinReturn<TBase extends AgentLike> = TBase &
 /**
  * Voice pipeline mixin. Adds the full voice pipeline to an Agent class.
  *
- * Subclasses must set `stt` and `tts` provider properties. VAD is optional.
+ * Subclasses must set a `transcriber` property (or override `createTranscriber`)
+ * and a `tts` provider property. The transcriber session is per-call — created
+ * at start_call and closed at end_call. The model handles turn detection.
  *
  * @param Base - The Agent class to extend (e.g. `Agent`).
  * @param voiceOptions - Optional pipeline configuration.
@@ -228,14 +178,13 @@ type VoiceAgentMixinReturn<TBase extends AgentLike> = TBase &
  * @example
  * ```typescript
  * import { Agent } from "agents";
- * import { withVoice, WorkersAISTT, WorkersAITTS, WorkersAIVAD } from "agents/experimental/voice";
+ * import { withVoice, WorkersAIFluxSTT, WorkersAITTS } from "@cloudflare/voice";
  *
  * const VoiceAgent = withVoice(Agent);
  *
  * class MyAgent extends VoiceAgent<Env> {
- *   stt = new WorkersAISTT(this.env.AI);
+ *   transcriber = new WorkersAIFluxSTT(this.env.AI);
  *   tts = new WorkersAITTS(this.env.AI);
- *   vad = new WorkersAIVAD(this.env.AI);
  *
  *   async onTurn(transcript, context) {
  *     return "Hello! I heard you say: " + transcript;
@@ -247,10 +196,6 @@ export function withVoice<TBase extends AgentLike>(
   Base: TBase,
   voiceOptions?: VoiceAgentOptions
 ): VoiceAgentMixinReturn<TBase> {
-  console.log(
-    "[@cloudflare/voice] Note: The voice API is experimental and may change between releases. Pin your version to avoid surprises."
-  );
-
   const opts = voiceOptions ?? {};
 
   function opt<K extends keyof VoiceAgentOptions>(
@@ -263,17 +208,16 @@ export function withVoice<TBase extends AgentLike>(
   class VoiceAgentMixin extends Base {
     // --- Provider properties (set by subclass) ---
 
-    /** Speech-to-text provider (batch). Required unless streamingStt is set. */
-    stt?: STTProvider;
-    /** Streaming speech-to-text provider. Optional — if set, used instead of batch `stt`. */
-    streamingStt?: StreamingSTTProvider;
+    /** Continuous transcriber provider. */
+    transcriber?: Transcriber;
     /** Text-to-speech provider. Required. May also implement StreamingTTSProvider. */
     tts?: TTSProvider & Partial<StreamingTTSProvider>;
-    /** Voice activity detection provider. Optional — if unset, every end_of_speech is treated as confirmed. */
-    vad?: VADProvider;
 
     // Shared per-connection audio state manager
     #cm = new AudioConnectionManager("VoiceAgent");
+
+    // keepAlive dispose functions per connection (prevents DO eviction during calls)
+    #keepAliveDispose = new Map<string, () => void>();
 
     // Voice protocol message types handled internally
     static #VOICE_MESSAGES = new Set([
@@ -285,31 +229,6 @@ export function withVoice<TBase extends AgentLike>(
       "interrupt",
       "text_message"
     ]);
-
-    // --- Hibernation helpers ---
-
-    #setCallState(connection: Connection, inCall: boolean) {
-      this._unsafe_setConnectionFlag(
-        connection,
-        "_cf_voiceInCall",
-        inCall || undefined
-      );
-    }
-
-    #getCallState(connection: Connection): boolean {
-      return (
-        this._unsafe_getConnectionFlag(connection, "_cf_voiceInCall") === true
-      );
-    }
-
-    /**
-     * Restore in-memory call state after hibernation wake.
-     * Called when we receive a message for a connection that the state
-     * says is in a call, but we have no in-memory buffer for it.
-     */
-    #restoreCallState(connection: Connection) {
-      this.#cm.initConnection(connection.id);
-    }
 
     // --- Agent lifecycle ---
 
@@ -331,10 +250,6 @@ export function withVoice<TBase extends AgentLike>(
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- mixin constructor must accept any args
     constructor(...args: any[]) {
       super(...args);
-
-      // Capture the consumer's lifecycle methods (defined on the subclass
-      // prototype) and wrap them so voice logic always runs first.
-      // This is the same pattern used by withVoiceInput, Agent, and PartyServer.
 
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- binding consumer methods
       const _onConnect = (this as any).onConnect?.bind(this);
@@ -358,8 +273,8 @@ export function withVoice<TBase extends AgentLike>(
 
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- overwriting lifecycle
       (this as any).onClose = (connection: Connection, ...rest: unknown[]) => {
+        this.#releaseKeepAlive(connection.id);
         this.#cm.cleanup(connection.id);
-        this.#setCallState(connection, false);
         return _onClose?.(connection, ...rest);
       };
 
@@ -368,15 +283,6 @@ export function withVoice<TBase extends AgentLike>(
         connection: Connection,
         message: WSMessage
       ) => {
-        // Restore in-memory state if DO woke from hibernation
-        if (
-          !this.#cm.isInCall(connection.id) &&
-          this.#getCallState(connection)
-        ) {
-          this.#restoreCallState(connection);
-        }
-
-        // Binary audio — always handled by voice, never forwarded
         if (message instanceof ArrayBuffer) {
           this.#cm.bufferAudio(connection.id, message);
           return;
@@ -386,20 +292,16 @@ export function withVoice<TBase extends AgentLike>(
           return _onMessage?.(connection, message);
         }
 
-        // Try to parse as voice protocol
         let parsed: { type: string };
         try {
           parsed = JSON.parse(message);
         } catch {
-          // Not JSON — forward to consumer
           return _onMessage?.(connection, message);
         }
 
-        // Voice protocol message — handle internally
         if (VoiceAgentMixin.#VOICE_MESSAGES.has(parsed.type)) {
           switch (parsed.type) {
             case "hello":
-              // Client announced its protocol version — log for diagnostics.
               break;
             case "start_call":
               this.#handleStartCall(
@@ -411,11 +313,7 @@ export function withVoice<TBase extends AgentLike>(
               this.#handleEndCall(connection);
               break;
             case "start_of_speech":
-              this.#handleStartOfSpeech(connection);
-              break;
             case "end_of_speech":
-              this.#cm.clearVadRetry(connection.id);
-              this.#handleEndOfSpeech(connection);
               break;
             case "interrupt":
               this.#handleInterrupt(connection);
@@ -431,7 +329,6 @@ export function withVoice<TBase extends AgentLike>(
           return;
         }
 
-        // Not a voice message — forward to consumer
         return _onMessage?.(connection, message);
       };
     }
@@ -447,6 +344,15 @@ export function withVoice<TBase extends AgentLike>(
       );
     }
 
+    /**
+     * Override to create a transcriber dynamically per connection.
+     * Useful for runtime model switching (e.g. Flux vs Nova 3 dropdown).
+     * Return null to fall back to the `transcriber` property.
+     */
+    createTranscriber(_connection: Connection): Transcriber | null {
+      return null;
+    }
+
     beforeCallStart(_connection: Connection): boolean | Promise<boolean> {
       return true;
     }
@@ -454,15 +360,6 @@ export function withVoice<TBase extends AgentLike>(
     onCallStart(_connection: Connection): void | Promise<void> {}
     onCallEnd(_connection: Connection): void | Promise<void> {}
     onInterrupt(_connection: Connection): void | Promise<void> {}
-
-    // --- Pipeline hooks ---
-
-    beforeTranscribe(
-      audio: ArrayBuffer,
-      _connection: Connection
-    ): ArrayBuffer | null | Promise<ArrayBuffer | null> {
-      return audio;
-    }
 
     afterTranscribe(
       transcript: string,
@@ -484,65 +381,6 @@ export function withVoice<TBase extends AgentLike>(
       _connection: Connection
     ): ArrayBuffer | null | Promise<ArrayBuffer | null> {
       return audio;
-    }
-
-    // --- Streaming STT session management ---
-
-    #handleStartOfSpeech(connection: Connection) {
-      if (!this.streamingStt) return; // no streaming provider — ignore
-      if (this.#cm.hasSTTSession(connection.id)) return; // already active
-      if (!this.#cm.isInCall(connection.id)) return; // not in a call
-
-      // Clear EOT flag from any previous turn
-      this.#cm.clearEOT(connection.id);
-
-      // Accumulate finalized segments for the full transcript
-      let accumulated = "";
-
-      this.#cm.startSTTSession(connection.id, this.streamingStt, {
-        onFinal: (text: string) => {
-          accumulated += (accumulated ? " " : "") + text;
-          // Send interim update with the accumulated final text
-          this.#sendJSON(connection, {
-            type: "transcript_interim",
-            text: accumulated
-          });
-        },
-        onInterim: (text: string) => {
-          // Show accumulated finals + current interim to the client
-          const display = accumulated ? accumulated + " " + text : text;
-          this.#sendJSON(connection, {
-            type: "transcript_interim",
-            text: display
-          });
-        },
-        // Provider-driven end-of-turn: start LLM+TTS immediately
-        // without waiting for the client to send end_of_speech.
-        onEndOfTurn: (transcript: string) => {
-          // Guard against double-fire
-          if (this.#cm.isEOTTriggered(connection.id)) return;
-          this.#cm.setEOTTriggered(connection.id);
-
-          // Remove the session — this turn is done
-          this.#cm.removeSTTSession(connection.id);
-          // Clear audio buffer — no batch STT needed
-          this.#cm.clearAudioBuffer(connection.id);
-          // Clear any pending VAD retry
-          this.#cm.clearVadRetry(connection.id);
-
-          // Start the pipeline immediately with the stable transcript
-          this.#runPipeline(connection, transcript);
-        }
-      });
-    }
-
-    #requireTTS(): TTSProvider & Partial<StreamingTTSProvider> {
-      if (!this.tts) {
-        throw new Error(
-          "No TTS provider configured. Set 'tts' on your VoiceAgent subclass."
-        );
-      }
-      return this.tts;
     }
 
     // --- Conversation persistence ---
@@ -581,14 +419,8 @@ export function withVoice<TBase extends AgentLike>(
 
     // --- Convenience methods ---
 
-    /**
-     * Programmatically end a call for a specific connection.
-     * Cleans up server-side state (audio buffers, pipelines, STT sessions,
-     * keepalives) and sends the idle status to the client.
-     * Use this to kick a speaker or enforce call limits.
-     */
     forceEndCall(connection: Connection): void {
-      if (!this.#cm.isInCall(connection.id)) return; // not in a call
+      if (!this.#cm.isInCall(connection.id)) return;
       this.#handleEndCall(connection);
     }
 
@@ -620,9 +452,7 @@ export function withVoice<TBase extends AgentLike>(
       this.saveMessage("assistant", text);
 
       const connections = [...this.getConnections()];
-      if (connections.length === 0) {
-        return;
-      }
+      if (connections.length === 0) return;
 
       for (const connection of connections) {
         const signal = this.#cm.createPipelineAbort(connection.id);
@@ -655,6 +485,15 @@ export function withVoice<TBase extends AgentLike>(
       }
     }
 
+    #requireTTS(): TTSProvider & Partial<StreamingTTSProvider> {
+      if (!this.tts) {
+        throw new Error(
+          "No TTS provider configured. Set 'tts' on your VoiceAgent subclass."
+        );
+      }
+      return this.tts;
+    }
+
     async #synthesizeWithHooks(
       text: string,
       connection: Connection,
@@ -669,38 +508,68 @@ export function withVoice<TBase extends AgentLike>(
     // --- Internal: call lifecycle ---
 
     async #handleStartCall(connection: Connection, _preferredFormat?: string) {
+      if (this.#cm.isInCall(connection.id)) return;
+
       const allowed = await this.beforeCallStart(connection);
       if (!allowed) return;
 
+      const provider = this.createTranscriber(connection) ?? this.transcriber;
+      if (!provider) {
+        throw new Error(
+          "No transcriber configured. Set 'transcriber' on your VoiceAgent subclass or override createTranscriber()."
+        );
+      }
+
       this.#cm.initConnection(connection.id);
-      this.#setCallState(connection, true);
+
+      const dispose = await this.keepAlive();
+      this.#keepAliveDispose.set(connection.id, dispose);
 
       const configuredFormat = opt("audioFormat", "mp3") as VoiceAudioFormat;
       this.#sendJSON(connection, {
         type: "audio_config",
         format: configuredFormat
       });
-      this.#sendJSON(connection, { type: "status", status: "listening" });
 
+      this.#cm.startTranscriberSession(connection.id, provider, {
+        onInterim: (text: string) => {
+          this.#sendJSON(connection, {
+            type: "transcript_interim",
+            text
+          });
+        },
+        onUtterance: (transcript: string) => {
+          this.#sendJSON(connection, {
+            type: "transcript_interim",
+            text: ""
+          });
+          this.#runPipeline(connection, transcript);
+        }
+      });
+
+      this.#sendJSON(connection, { type: "status", status: "listening" });
       await this.onCallStart(connection);
+    }
+
+    #releaseKeepAlive(connectionId: string) {
+      const dispose = this.#keepAliveDispose.get(connectionId);
+      if (dispose) {
+        dispose();
+        this.#keepAliveDispose.delete(connectionId);
+      }
     }
 
     #handleEndCall(connection: Connection) {
       this.#cm.cleanup(connection.id);
-      this.#setCallState(connection, false);
+      this.#releaseKeepAlive(connection.id);
       this.#sendJSON(connection, { type: "status", status: "idle" });
-
       this.onCallEnd(connection);
     }
 
     #handleInterrupt(connection: Connection) {
       this.#cm.abortPipeline(connection.id);
-      this.#cm.abortSTTSession(connection.id);
-      this.#cm.clearVadRetry(connection.id);
-      this.#cm.clearEOT(connection.id);
       this.#cm.clearAudioBuffer(connection.id);
       this.#sendJSON(connection, { type: "status", status: "listening" });
-
       this.onInterrupt(connection);
     }
 
@@ -710,10 +579,9 @@ export function withVoice<TBase extends AgentLike>(
       if (!text || text.trim().length === 0) return;
 
       const userText = text.trim();
-
       const signal = this.#cm.createPipelineAbort(connection.id);
-
       const pipelineStart = Date.now();
+
       this.#sendJSON(connection, { type: "status", status: "thinking" });
 
       this.saveMessage("user", userText);
@@ -789,178 +657,10 @@ export function withVoice<TBase extends AgentLike>(
       }
     }
 
-    // --- Internal: audio pipeline ---
+    // --- Internal: voice pipeline ---
 
-    async #handleEndOfSpeech(connection: Connection, skipVad = false) {
-      // If the pipeline was already triggered by provider-driven EOT,
-      // this end_of_speech from the client is late — ignore it.
-      if (this.#cm.isEOTTriggered(connection.id)) {
-        this.#cm.clearEOT(connection.id);
-        return;
-      }
-
-      const audioData = this.#cm.getAndClearAudio(connection.id);
-      if (!audioData) {
-        return;
-      }
-
-      const hasStreamingSession = this.#cm.hasSTTSession(connection.id);
-
-      const minAudioBytes = opt("minAudioBytes", DEFAULT_MIN_AUDIO_BYTES);
-      if (audioData.byteLength < minAudioBytes) {
-        // Too short — abort the streaming session if any
-        this.#cm.abortSTTSession(connection.id);
-        this.#sendJSON(connection, { type: "status", status: "listening" });
-        return;
-      }
-
-      let vadMs = 0;
-
-      if (this.vad && !skipVad) {
-        const vadStart = Date.now();
-        const vadResult = await this.vad.checkEndOfTurn(audioData);
-        vadMs = Date.now() - vadStart;
-        const vadThreshold = opt("vadThreshold", DEFAULT_VAD_THRESHOLD);
-        const shouldProceed =
-          vadResult.isComplete || vadResult.probability > vadThreshold;
-
-        if (!shouldProceed) {
-          const pushbackSeconds = opt(
-            "vadPushbackSeconds",
-            DEFAULT_VAD_PUSHBACK_SECONDS
-          );
-          const maxPushbackBytes = pushbackSeconds * 16000 * 2;
-          const pushback =
-            audioData.byteLength > maxPushbackBytes
-              ? audioData.slice(audioData.byteLength - maxPushbackBytes)
-              : audioData;
-          this.#cm.pushbackAudio(connection.id, pushback);
-          // Keep the streaming STT session alive — VAD rejected but user
-          // may still be speaking. The session continues accumulating.
-          this.#sendJSON(connection, { type: "status", status: "listening" });
-
-          // Schedule a retry that skips VAD. If the user stays silent,
-          // the client won't send another end_of_speech (its #isSpeaking
-          // is already false), so we'd deadlock without this timer.
-          this.#cm.scheduleVadRetry(
-            connection.id,
-            () => this.#handleEndOfSpeech(connection, true),
-            opt("vadRetryMs", DEFAULT_VAD_RETRY_MS) as number
-          );
-          return;
-        }
-      }
-
-      // --- STT phase ---
-
-      const signal = this.#cm.createPipelineAbort(connection.id);
-
-      const sttStart = Date.now();
-      this.#sendJSON(connection, { type: "status", status: "thinking" });
-
-      try {
-        let userText: string | null;
-        let sttMs: number;
-
-        if (hasStreamingSession) {
-          // --- Streaming STT path ---
-          // The session has been receiving audio all along.
-          // finish() flushes and returns the final transcript (~50ms).
-          // beforeTranscribe is skipped — audio was already fed incrementally.
-          const rawTranscript = await this.#cm.flushSTTSession(connection.id);
-          sttMs = Date.now() - sttStart;
-
-          if (signal.aborted) return;
-
-          if (!rawTranscript || rawTranscript.trim().length === 0) {
-            this.#sendJSON(connection, {
-              type: "status",
-              status: "listening"
-            });
-            return;
-          }
-
-          userText = await this.afterTranscribe(rawTranscript, connection);
-        } else {
-          // --- Batch STT path (original) ---
-          if (!this.stt) {
-            // No batch STT provider and no streaming session — this can
-            // happen when onEndOfTurn already consumed the session.
-            // Just return to listening.
-            this.#sendJSON(connection, {
-              type: "status",
-              status: "listening"
-            });
-            return;
-          }
-
-          const processedAudio = await this.beforeTranscribe(
-            audioData,
-            connection
-          );
-          if (!processedAudio || signal.aborted) {
-            this.#sendJSON(connection, {
-              type: "status",
-              status: "listening"
-            });
-            return;
-          }
-
-          const rawTranscript = await this.stt.transcribe(
-            processedAudio,
-            signal
-          );
-          sttMs = Date.now() - sttStart;
-
-          if (signal.aborted) return;
-
-          if (!rawTranscript || rawTranscript.trim().length === 0) {
-            this.#sendJSON(connection, {
-              type: "status",
-              status: "listening"
-            });
-            return;
-          }
-
-          userText = await this.afterTranscribe(rawTranscript, connection);
-        }
-
-        if (!userText || signal.aborted) {
-          this.#sendJSON(connection, { type: "status", status: "listening" });
-          return;
-        }
-
-        // Hand off to the shared pipeline (LLM + TTS)
-        await this.#runPipelineInner(
-          connection,
-          userText,
-          sttStart,
-          vadMs,
-          sttMs,
-          signal
-        );
-      } catch (error) {
-        if (signal.aborted) return;
-        console.error("[VoiceAgent] Pipeline error:", error);
-        this.#sendJSON(connection, {
-          type: "error",
-          message:
-            error instanceof Error ? error.message : "Voice pipeline failed"
-        });
-        this.#sendJSON(connection, { type: "status", status: "listening" });
-      } finally {
-        this.#cm.clearPipelineAbort(connection.id);
-      }
-    }
-
-    /**
-     * Start the voice pipeline from a stable transcript.
-     * Called by provider-driven EOT (onEndOfTurn callback).
-     * Handles: abort controller setup, LLM, TTS, metrics, persistence.
-     */
     async #runPipeline(connection: Connection, transcript: string) {
       const signal = this.#cm.createPipelineAbort(connection.id);
-
       const pipelineStart = Date.now();
 
       try {
@@ -970,14 +670,53 @@ export function withVoice<TBase extends AgentLike>(
           return;
         }
 
-        await this.#runPipelineInner(
+        this.saveMessage("user", userText);
+        this.#sendJSON(connection, {
+          type: "transcript",
+          role: "user",
+          text: userText
+        });
+
+        this.#sendJSON(connection, { type: "status", status: "speaking" });
+
+        const context: VoiceTurnContext = {
           connection,
-          userText,
+          messages: this.getConversationHistory(),
+          signal
+        };
+
+        const llmStart = Date.now();
+        const turnResult = await this.onTurn(userText, context);
+
+        if (signal.aborted) return;
+
+        const {
+          text: fullText,
+          llmMs,
+          ttsMs,
+          firstAudioMs
+        } = await this.#streamResponse(
+          connection,
+          turnResult,
+          llmStart,
           pipelineStart,
-          0, // vadMs — no VAD with provider-driven EOT
-          0, // sttMs — transcript was delivered instantly by EOT
           signal
         );
+
+        if (signal.aborted) return;
+
+        const totalMs = Date.now() - pipelineStart;
+
+        this.#sendJSON(connection, {
+          type: "metrics",
+          llm_ms: llmMs,
+          tts_ms: ttsMs,
+          first_audio_ms: firstAudioMs,
+          total_ms: totalMs
+        });
+
+        this.saveMessage("assistant", fullText);
+        this.#sendJSON(connection, { type: "status", status: "listening" });
       } catch (error) {
         if (signal.aborted) return;
         console.error("[VoiceAgent] Pipeline error:", error);
@@ -990,70 +729,6 @@ export function withVoice<TBase extends AgentLike>(
       } finally {
         this.#cm.clearPipelineAbort(connection.id);
       }
-    }
-
-    /**
-     * Shared inner pipeline: save transcript, run LLM, stream TTS, emit metrics.
-     * Used by both #handleEndOfSpeech (after STT) and #runPipeline (after provider EOT).
-     */
-    async #runPipelineInner(
-      connection: Connection,
-      userText: string,
-      pipelineStart: number,
-      vadMs: number,
-      sttMs: number,
-      signal: AbortSignal
-    ) {
-      this.saveMessage("user", userText);
-      this.#sendJSON(connection, {
-        type: "transcript",
-        role: "user",
-        text: userText
-      });
-
-      this.#sendJSON(connection, { type: "status", status: "speaking" });
-
-      const context: VoiceTurnContext = {
-        connection,
-        messages: this.getConversationHistory(),
-        signal
-      };
-
-      const llmStart = Date.now();
-      const turnResult = await this.onTurn(userText, context);
-
-      if (signal.aborted) return;
-
-      const {
-        text: fullText,
-        llmMs,
-        ttsMs,
-        firstAudioMs
-      } = await this.#streamResponse(
-        connection,
-        turnResult,
-        llmStart,
-        pipelineStart,
-        signal
-      );
-
-      if (signal.aborted) return;
-
-      const totalMs = Date.now() - pipelineStart;
-
-      this.#sendJSON(connection, {
-        type: "metrics",
-        vad_ms: vadMs,
-        stt_ms: sttMs,
-        llm_ms: llmMs,
-        tts_ms: ttsMs,
-        first_audio_ms: firstAudioMs,
-        total_ms: totalMs
-      });
-
-      this.saveMessage("assistant", fullText);
-
-      this.#sendJSON(connection, { type: "status", status: "listening" });
     }
 
     // --- Internal: streaming TTS pipeline ---
@@ -1164,6 +839,7 @@ export function withVoice<TBase extends AgentLike>(
               }
             }
           } catch (err) {
+            if (signal.aborted) return;
             console.error("[VoiceAgent] TTS error for sentence:", err);
             this.#sendJSON(connection, {
               type: "error",

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -662,7 +662,7 @@ export function withVoice<TBase extends AgentLike>(
           status: this.#cm.isInCall(connection.id) ? "listening" : "idle"
         });
       } finally {
-        this.#cm.clearPipelineAbort(connection.id);
+        this.#cm.clearPipelineAbort(connection.id, signal);
       }
     }
 
@@ -745,7 +745,7 @@ export function withVoice<TBase extends AgentLike>(
         });
         this.#sendJSON(connection, { type: "status", status: "listening" });
       } finally {
-        this.#cm.clearPipelineAbort(connection.id);
+        this.#cm.clearPipelineAbort(connection.id, signal);
       }
     }
 

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -515,9 +515,12 @@ export function withVoice<TBase extends AgentLike>(
 
       const provider = this.createTranscriber(connection) ?? this.transcriber;
       if (!provider) {
-        throw new Error(
-          "No transcriber configured. Set 'transcriber' on your VoiceAgent subclass or override createTranscriber()."
-        );
+        this.#sendJSON(connection, {
+          type: "error",
+          message:
+            "No transcriber configured. Set 'transcriber' on your VoiceAgent subclass or override createTranscriber()."
+        });
+        return;
       }
 
       this.#cm.initConnection(connection.id);

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -510,8 +510,15 @@ export function withVoice<TBase extends AgentLike>(
     async #handleStartCall(connection: Connection, _preferredFormat?: string) {
       if (this.#cm.isInCall(connection.id)) return;
 
+      // Mark as in-call before any await to prevent duplicate start_call
+      // from leaking keepAlive refs during the beforeCallStart window.
+      this.#cm.initConnection(connection.id);
+
       const allowed = await this.beforeCallStart(connection);
-      if (!allowed) return;
+      if (!allowed) {
+        this.#cm.cleanup(connection.id);
+        return;
+      }
 
       const provider = this.createTranscriber(connection) ?? this.transcriber;
       if (!provider) {
@@ -523,10 +530,9 @@ export function withVoice<TBase extends AgentLike>(
           message:
             "No transcriber configured. Set 'transcriber' on your VoiceAgent subclass or override createTranscriber()."
         });
+        this.#cm.cleanup(connection.id);
         return;
       }
-
-      this.#cm.initConnection(connection.id);
 
       const dispose = await this.keepAlive();
       this.#keepAliveDispose.set(connection.id, dispose);

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -444,7 +444,7 @@ export function withVoice<TBase extends AgentLike>(
           this.#sendJSON(connection, { type: "status", status: "listening" });
         }
       } finally {
-        this.#cm.clearPipelineAbort(connection.id);
+        this.#cm.clearPipelineAbort(connection.id, signal);
       }
     }
 
@@ -480,7 +480,7 @@ export function withVoice<TBase extends AgentLike>(
             });
           }
         } finally {
-          this.#cm.clearPipelineAbort(connection.id);
+          this.#cm.clearPipelineAbort(connection.id, signal);
         }
       }
     }
@@ -686,7 +686,7 @@ export function withVoice<TBase extends AgentLike>(
           text: userText
         });
 
-        this.#sendJSON(connection, { type: "status", status: "speaking" });
+        this.#sendJSON(connection, { type: "status", status: "thinking" });
 
         const context: VoiceTurnContext = {
           connection,
@@ -698,6 +698,8 @@ export function withVoice<TBase extends AgentLike>(
         const turnResult = await this.onTurn(userText, context);
 
         if (signal.aborted) return;
+
+        this.#sendJSON(connection, { type: "status", status: "speaking" });
 
         const {
           text: fullText,

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -683,7 +683,8 @@ export function withVoice<TBase extends AgentLike>(
 
       try {
         const userText = await this.afterTranscribe(transcript, connection);
-        if (!userText || signal.aborted) {
+        if (signal.aborted) return;
+        if (!userText) {
           this.#sendJSON(connection, { type: "status", status: "listening" });
           return;
         }

--- a/packages/voice/src/workers-ai-providers.ts
+++ b/packages/voice/src/workers-ai-providers.ts
@@ -2,67 +2,16 @@
  * Workers AI provider implementations for the voice pipeline.
  *
  * These are convenience classes that wrap the Workers AI binding
- * (env.AI) for STT, TTS, and VAD. They are not required — any
- * object satisfying the provider interfaces works.
+ * (env.AI) for STT and TTS. They are not required — any object
+ * satisfying the provider interfaces works.
  */
 
 import type {
-  STTProvider,
   TTSProvider,
-  VADProvider,
-  StreamingSTTProvider,
-  StreamingSTTSession,
-  StreamingSTTSessionOptions
+  Transcriber,
+  TranscriberSession,
+  TranscriberSessionOptions
 } from "./types";
-
-// --- Audio utilities ---
-
-function toStream(buffer: ArrayBuffer): ReadableStream<Uint8Array> {
-  return new ReadableStream({
-    start(controller) {
-      controller.enqueue(new Uint8Array(buffer));
-      controller.close();
-    }
-  });
-}
-
-function writeString(view: DataView, offset: number, str: string) {
-  for (let i = 0; i < str.length; i++) {
-    view.setUint8(offset + i, str.charCodeAt(i));
-  }
-}
-
-/** Convert raw PCM audio to WAV format. Exported for custom providers. */
-export function pcmToWav(
-  pcmData: ArrayBuffer,
-  sampleRate: number,
-  channels: number,
-  bitsPerSample: number
-): ArrayBuffer {
-  const byteRate = (sampleRate * channels * bitsPerSample) / 8;
-  const blockAlign = (channels * bitsPerSample) / 8;
-  const dataSize = pcmData.byteLength;
-  const headerSize = 44;
-  const buffer = new ArrayBuffer(headerSize + dataSize);
-  const view = new DataView(buffer);
-
-  writeString(view, 0, "RIFF");
-  view.setUint32(4, 36 + dataSize, true);
-  writeString(view, 8, "WAVE");
-  writeString(view, 12, "fmt ");
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);
-  view.setUint16(22, channels, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, byteRate, true);
-  view.setUint16(32, blockAlign, true);
-  view.setUint16(34, bitsPerSample, true);
-  writeString(view, 36, "data");
-  view.setUint32(40, dataSize, true);
-  new Uint8Array(buffer, headerSize).set(new Uint8Array(pcmData));
-
-  return buffer;
-}
 
 // --- Loose AI binding type ---
 
@@ -73,67 +22,6 @@ interface AiLike {
     input: Record<string, unknown>,
     options?: Record<string, unknown>
   ): Promise<unknown>;
-}
-
-// --- STT ---
-
-export interface WorkersAISTTOptions {
-  /** STT model name. @default "@cf/deepgram/nova-3" */
-  model?: string;
-  /** Language code (e.g. "en", "es", "fr"). @default "en" */
-  language?: string;
-}
-
-/**
- * Workers AI speech-to-text provider.
- *
- * @example
- * ```ts
- * class MyAgent extends VoiceAgent<Env> {
- *   stt = new WorkersAISTT(this.env.AI);
- * }
- * ```
- */
-export class WorkersAISTT implements STTProvider {
-  #ai: AiLike;
-  #model: string;
-  #language: string;
-
-  constructor(ai: AiLike, options?: WorkersAISTTOptions) {
-    this.#ai = ai;
-    this.#model = options?.model ?? "@cf/deepgram/nova-3";
-    this.#language = options?.language ?? "en";
-  }
-
-  async transcribe(
-    audioData: ArrayBuffer,
-    signal?: AbortSignal
-  ): Promise<string> {
-    const wavBuffer = pcmToWav(audioData, 16000, 1, 16);
-    const result = (await this.#ai.run(
-      this.#model,
-      {
-        audio: {
-          body: toStream(wavBuffer),
-          contentType: "audio/wav"
-        },
-        language: this.#language,
-        punctuate: true,
-        smart_format: true
-      },
-      signal ? { signal } : undefined
-    )) as {
-      results?: {
-        channels?: Array<{
-          alternatives?: Array<{
-            transcript?: string;
-          }>;
-        }>;
-      };
-    };
-
-    return result?.results?.channels?.[0]?.alternatives?.[0]?.transcript ?? "";
-  }
 }
 
 // --- TTS ---
@@ -180,7 +68,7 @@ export class WorkersAITTS implements TTSProvider {
   }
 }
 
-// --- Streaming STT (Flux) ---
+// --- Flux continuous STT ---
 
 export interface WorkersAIFluxSTTOptions {
   /** End-of-turn confidence threshold (0.5-0.9). @default 0.7 */
@@ -199,33 +87,31 @@ export interface WorkersAIFluxSTTOptions {
 }
 
 /**
- * Workers AI streaming speech-to-text provider using the Flux model.
+ * Workers AI continuous speech-to-text provider using the Flux model.
  *
  * Flux is a conversational STT model with built-in end-of-turn detection.
- * It transcribes audio incrementally via a WebSocket connection to the
- * Workers AI binding — no external API key required.
+ * A single session is created per call and receives all audio continuously.
+ * The model detects speech boundaries and fires `onUtterance` when a
+ * turn is complete — no client-side silence detection needed for STT.
  *
- * When using Flux, the separate VAD provider is optional — Flux detects
- * end-of-turn natively. Client-side silence detection still triggers the
- * pipeline, but the server-side VAD call can be skipped for lower latency.
+ * Recommended for `withVoice` (conversational voice agents).
  *
  * @example
  * ```ts
  * import { Agent } from "agents";
- * import { withVoice, WorkersAIFluxSTT, WorkersAITTS } from "agents/experimental/voice";
+ * import { withVoice, WorkersAIFluxSTT, WorkersAITTS } from "@cloudflare/voice";
  *
  * const VoiceAgent = withVoice(Agent);
  *
  * class MyAgent extends VoiceAgent<Env> {
- *   streamingStt = new WorkersAIFluxSTT(this.env.AI);
+ *   transcriber = new WorkersAIFluxSTT(this.env.AI);
  *   tts = new WorkersAITTS(this.env.AI);
- *   // No VAD needed — Flux handles turn detection
  *
  *   async onTurn(transcript, context) { ... }
  * }
  * ```
  */
-export class WorkersAIFluxSTT implements StreamingSTTProvider {
+export class WorkersAIFluxSTT implements Transcriber {
   #ai: AiLike;
   #sampleRate: number;
   #eotThreshold: number | undefined;
@@ -242,8 +128,8 @@ export class WorkersAIFluxSTT implements StreamingSTTProvider {
     this.#keyterms = options?.keyterms;
   }
 
-  createSession(options?: StreamingSTTSessionOptions): StreamingSTTSession {
-    return new FluxSTTSession(
+  createSession(options?: TranscriberSessionOptions): TranscriberSession {
+    return new FluxSession(
       this.#ai,
       {
         sampleRate: this.#sampleRate,
@@ -277,43 +163,30 @@ interface FluxEvent {
 }
 
 /**
- * A single streaming STT session backed by a Flux WebSocket via env.AI.
+ * Per-call Flux transcription session. Lives for the entire call.
  *
- * Lifecycle: created at start-of-speech, receives audio via feed(),
- * flushed via finish() at end-of-speech, or aborted on interrupt.
+ * Handles multi-turn conversations: on EndOfTurn, fires onUtterance
+ * and resets transcript state for the next turn. On StartOfTurn,
+ * clears accumulated text. The session stays alive across turns
+ * and is only closed on end_call or disconnect.
  */
-class FluxSTTSession implements StreamingSTTSession {
+class FluxSession implements TranscriberSession {
   #onInterim: ((text: string) => void) | undefined;
-  #onFinal: ((text: string) => void) | undefined;
-  #onEndOfTurn: ((text: string) => void) | undefined;
+  #onUtterance: ((text: string) => void) | undefined;
 
   #ws: WebSocket | null = null;
   #connected = false;
-  #aborted = false;
+  #closed = false;
 
-  // Audio chunks queued before the WebSocket is open
   #pendingChunks: ArrayBuffer[] = [];
-
-  // Latest transcript from Update events (may still change)
-  #latestTranscript = "";
-
-  // Transcript from EndOfTurn event (stable)
-  #endOfTurnTranscript: string | null = null;
-
-  // finish() state
-  #finishing = false;
-  #finishResolve: ((transcript: string) => void) | null = null;
-  #finishPromise: Promise<string> | null = null;
-  #finishTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     ai: AiLike,
     config: FluxSessionConfig,
-    options?: StreamingSTTSessionOptions
+    options?: TranscriberSessionOptions
   ) {
     this.#onInterim = options?.onInterim;
-    this.#onFinal = options?.onFinal;
-    this.#onEndOfTurn = options?.onEndOfTurn;
+    this.#onUtterance = options?.onUtterance;
     this.#connect(ai, config);
   }
 
@@ -335,7 +208,7 @@ class FluxSTTSession implements StreamingSTTSession {
         websocket: true
       });
 
-      if (this.#aborted) {
+      if (this.#closed) {
         const ws = (resp as { webSocket?: WebSocket }).webSocket;
         if (ws) {
           ws.accept();
@@ -347,7 +220,6 @@ class FluxSTTSession implements StreamingSTTSession {
       const ws = (resp as { webSocket?: WebSocket }).webSocket;
       if (!ws) {
         console.error("[FluxSTT] Failed to establish WebSocket connection");
-        this.#resolveFinish();
         return;
       }
 
@@ -360,86 +232,37 @@ class FluxSTTSession implements StreamingSTTSession {
       });
 
       ws.addEventListener("close", () => {
-        this.#clearFinishTimeout();
         this.#connected = false;
-        this.#resolveFinish();
       });
 
       ws.addEventListener("error", (event: Event) => {
         console.error("[FluxSTT] WebSocket error:", event);
         this.#connected = false;
-        this.#resolveFinish();
       });
 
-      // Flush any audio chunks that arrived before the WS was open
       for (const chunk of this.#pendingChunks) {
         ws.send(chunk);
       }
       this.#pendingChunks = [];
-
-      // If finish() was called while we were connecting, start the
-      // finish timeout instead of closing immediately. This gives Flux
-      // time to process the audio we just flushed.
-      if (this.#finishing) {
-        this.#startFinishTimeout();
-      }
     } catch (err) {
       console.error("[FluxSTT] Connection error:", err);
-      this.#resolveFinish();
     }
   }
 
   feed(chunk: ArrayBuffer): void {
-    if (this.#aborted || this.#finishing) return;
+    if (this.#closed) return;
 
     if (this.#connected && this.#ws) {
       this.#ws.send(chunk);
     } else {
-      // Queue until connected
       this.#pendingChunks.push(chunk);
     }
   }
 
-  async finish(): Promise<string> {
-    if (this.#aborted) return "";
-
-    this.#finishing = true;
-
-    // If we already got an EndOfTurn, return immediately
-    if (this.#endOfTurnTranscript !== null) {
-      this.#close();
-      return this.#endOfTurnTranscript;
-    }
-
-    // Create the promise that will resolve when we have the transcript
-    if (!this.#finishPromise) {
-      this.#finishPromise = new Promise<string>((resolve) => {
-        this.#finishResolve = resolve;
-      });
-    }
-
-    // Don't close the WS immediately — keep it open so Flux can finish
-    // processing buffered audio and send EndOfTurn. The timeout is a
-    // safety net: if Flux doesn't respond in time, resolve with whatever
-    // partial transcript we have.
-    if (this.#connected && this.#ws) {
-      this.#startFinishTimeout();
-    }
-    // else: #connect() will start the timeout after flushing
-
-    return this.#finishPromise;
-  }
-
-  abort(): void {
-    if (this.#aborted) return;
-    this.#aborted = true;
-    this.#clearFinishTimeout();
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
     this.#pendingChunks = [];
-    this.#close();
-    this.#resolveFinish();
-  }
-
-  #close(): void {
     if (this.#ws) {
       try {
         this.#ws.close();
@@ -451,44 +274,8 @@ class FluxSTTSession implements StreamingSTTSession {
     this.#connected = false;
   }
 
-  #closeAndResolve(): void {
-    this.#clearFinishTimeout();
-    this.#close();
-    this.#resolveFinish();
-  }
-
-  /**
-   * Start a timeout that gives Flux time to process remaining audio.
-   * If EndOfTurn arrives before the timeout, it resolves immediately
-   * (via the EndOfTurn handler). If the WS closes, the close handler
-   * resolves. The timeout is the safety net for neither happening.
-   */
-  #startFinishTimeout(): void {
-    if (this.#finishTimeout) return; // already running
-    this.#finishTimeout = setTimeout(() => {
-      this.#finishTimeout = null;
-      this.#close();
-      this.#resolveFinish();
-    }, 3000);
-  }
-
-  #clearFinishTimeout(): void {
-    if (this.#finishTimeout) {
-      clearTimeout(this.#finishTimeout);
-      this.#finishTimeout = null;
-    }
-  }
-
-  #resolveFinish(): void {
-    if (this.#finishResolve) {
-      const transcript = this.#endOfTurnTranscript ?? this.#latestTranscript;
-      this.#finishResolve(transcript.trim());
-      this.#finishResolve = null;
-    }
-  }
-
   #handleMessage(event: MessageEvent): void {
-    if (this.#aborted) return;
+    if (this.#closed) return;
 
     try {
       const data: FluxEvent =
@@ -499,43 +286,28 @@ class FluxSTTSession implements StreamingSTTSession {
       const transcript = data.transcript ?? "";
 
       switch (data.event) {
+        case "StartOfTurn":
+          break;
+
         case "Update":
           if (transcript) {
-            this.#latestTranscript = transcript;
             this.#onInterim?.(transcript);
           }
           break;
 
         case "EndOfTurn":
           if (transcript) {
-            this.#endOfTurnTranscript = transcript;
-            this.#latestTranscript = transcript;
-            this.#onFinal?.(transcript);
-            this.#onEndOfTurn?.(transcript);
-          }
-          // If finish() was already called and waiting, resolve now.
-          // Clear the timeout — we got a proper EndOfTurn.
-          if (this.#finishing) {
-            this.#clearFinishTimeout();
-            this.#closeAndResolve();
+            this.#onUtterance?.(transcript);
           }
           break;
 
         case "EagerEndOfTurn":
-          // Speculative EOT — transcript is current but may change
-          // if TurnResumed fires. Fire onInterim, not onFinal.
           if (transcript) {
-            this.#latestTranscript = transcript;
             this.#onInterim?.(transcript);
           }
           break;
 
         case "TurnResumed":
-          // User resumed speaking after EagerEndOfTurn — keep accumulating.
-          break;
-
-        case "StartOfTurn":
-          // New turn started.
           break;
       }
     } catch {
@@ -544,57 +316,253 @@ class FluxSTTSession implements StreamingSTTSession {
   }
 }
 
-// --- VAD ---
+// --- Nova 3 continuous STT ---
 
-export interface WorkersAIVADOptions {
-  /** VAD model name. @default "@cf/pipecat-ai/smart-turn-v2" */
-  model?: string;
-  /** Audio window in seconds (uses last N seconds of audio). @default 2 */
-  windowSeconds?: number;
+export interface WorkersAINova3STTOptions {
+  /** Language code. @default "en" */
+  language?: string;
+  /** Endpointing silence duration in ms. @default 300 */
+  endpointingMs?: number;
+  /** Utterance end detection timeout in ms. @default 1000 */
+  utteranceEndMs?: number;
+  /** Enable smart formatting (numbers, dates, etc.). @default true */
+  smartFormat?: boolean;
+  /** Enable punctuation. @default true */
+  punctuate?: boolean;
+  /** Keyterms to boost recognition of specialized terminology. */
+  keyterms?: string[];
+  /** Sample rate in Hz. @default 16000 */
+  sampleRate?: number;
 }
 
 /**
- * Workers AI voice activity detection provider.
+ * Workers AI continuous speech-to-text provider using Nova 3.
+ *
+ * Nova 3 is a high-accuracy STT model with streaming WebSocket support.
+ * A single session is created per call and receives all audio continuously.
+ * Server-side VAD events and endpointing handle speech boundary detection.
+ *
+ * Recommended for `withVoiceInput` (dictation / voice input UIs).
  *
  * @example
  * ```ts
- * class MyAgent extends VoiceAgent<Env> {
- *   vad = new WorkersAIVAD(this.env.AI);
+ * import { Agent } from "agents";
+ * import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
+ *
+ * const InputAgent = withVoiceInput(Agent);
+ *
+ * class MyAgent extends InputAgent<Env> {
+ *   transcriber = new WorkersAINova3STT(this.env.AI);
+ *
+ *   onTranscript(text, connection) { ... }
  * }
  * ```
  */
-export class WorkersAIVAD implements VADProvider {
+export class WorkersAINova3STT implements Transcriber {
   #ai: AiLike;
-  #model: string;
-  #windowSeconds: number;
+  #sampleRate: number;
+  #language: string;
+  #endpointingMs: number;
+  #utteranceEndMs: number;
+  #smartFormat: boolean;
+  #punctuate: boolean;
+  #keyterms: string[] | undefined;
 
-  constructor(ai: AiLike, options?: WorkersAIVADOptions) {
+  constructor(ai: AiLike, options?: WorkersAINova3STTOptions) {
     this.#ai = ai;
-    this.#model = options?.model ?? "@cf/pipecat-ai/smart-turn-v2";
-    this.#windowSeconds = options?.windowSeconds ?? 2;
+    this.#sampleRate = options?.sampleRate ?? 16000;
+    this.#language = options?.language ?? "en";
+    this.#endpointingMs = options?.endpointingMs ?? 300;
+    this.#utteranceEndMs = options?.utteranceEndMs ?? 1000;
+    this.#smartFormat = options?.smartFormat ?? true;
+    this.#punctuate = options?.punctuate ?? true;
+    this.#keyterms = options?.keyterms;
   }
 
-  async checkEndOfTurn(
-    audioData: ArrayBuffer
-  ): Promise<{ isComplete: boolean; probability: number }> {
-    const maxBytes = this.#windowSeconds * 16000 * 2;
-    const vadAudio =
-      audioData.byteLength > maxBytes
-        ? audioData.slice(audioData.byteLength - maxBytes)
-        : audioData;
+  createSession(options?: TranscriberSessionOptions): TranscriberSession {
+    return new Nova3Session(
+      this.#ai,
+      {
+        sampleRate: this.#sampleRate,
+        language: this.#language,
+        endpointingMs: this.#endpointingMs,
+        utteranceEndMs: this.#utteranceEndMs,
+        smartFormat: this.#smartFormat,
+        punctuate: this.#punctuate,
+        keyterms: this.#keyterms
+      },
+      options
+    );
+  }
+}
 
-    const wavBuffer = pcmToWav(vadAudio, 16000, 1, 16);
+interface Nova3SessionConfig {
+  sampleRate: number;
+  language: string;
+  endpointingMs: number;
+  utteranceEndMs: number;
+  smartFormat: boolean;
+  punctuate: boolean;
+  keyterms?: string[];
+}
 
-    const result = (await this.#ai.run(this.#model, {
-      audio: {
-        body: toStream(wavBuffer),
-        contentType: "application/octet-stream"
+interface Nova3Result {
+  type: string;
+  channel?: {
+    alternatives?: Array<{
+      transcript?: string;
+    }>;
+  };
+  is_final?: boolean;
+  speech_final?: boolean;
+}
+
+/**
+ * Per-call Nova 3 transcription session. Lives for the entire call.
+ *
+ * Uses Nova 3's endpointing and VAD events to detect utterance
+ * boundaries. When a result arrives with `speech_final: true`,
+ * the accumulated finalized segments are emitted as an utterance.
+ */
+class Nova3Session implements TranscriberSession {
+  #onInterim: ((text: string) => void) | undefined;
+  #onUtterance: ((text: string) => void) | undefined;
+
+  #ws: WebSocket | null = null;
+  #connected = false;
+  #closed = false;
+
+  #pendingChunks: ArrayBuffer[] = [];
+
+  #finalizedSegments: string[] = [];
+
+  constructor(
+    ai: AiLike,
+    config: Nova3SessionConfig,
+    options?: TranscriberSessionOptions
+  ) {
+    this.#onInterim = options?.onInterim;
+    this.#onUtterance = options?.onUtterance;
+    this.#connect(ai, config);
+  }
+
+  async #connect(ai: AiLike, config: Nova3SessionConfig): Promise<void> {
+    try {
+      const input: Record<string, unknown> = {
+        encoding: "linear16",
+        sample_rate: String(config.sampleRate),
+        language: config.language,
+        interim_results: "true",
+        vad_events: "true",
+        endpointing: String(config.endpointingMs),
+        utterance_end_ms: String(config.utteranceEndMs),
+        smart_format: String(config.smartFormat),
+        punctuate: String(config.punctuate)
+      };
+      if (config.keyterms?.length) input.keyterm = config.keyterms[0];
+
+      const resp = await ai.run("@cf/deepgram/nova-3", input, {
+        websocket: true
+      });
+
+      if (this.#closed) {
+        const ws = (resp as { webSocket?: WebSocket }).webSocket;
+        if (ws) {
+          ws.accept();
+          ws.close();
+        }
+        return;
       }
-    })) as { is_complete?: boolean; probability?: number };
 
-    return {
-      isComplete: result.is_complete ?? false,
-      probability: result.probability ?? 0
-    };
+      const ws = (resp as { webSocket?: WebSocket }).webSocket;
+      if (!ws) {
+        console.error("[Nova3STT] Failed to establish WebSocket connection");
+        return;
+      }
+
+      ws.accept();
+      this.#ws = ws;
+      this.#connected = true;
+
+      ws.addEventListener("message", (event: MessageEvent) => {
+        this.#handleMessage(event);
+      });
+
+      ws.addEventListener("close", () => {
+        this.#connected = false;
+      });
+
+      ws.addEventListener("error", (event: Event) => {
+        console.error("[Nova3STT] WebSocket error:", event);
+        this.#connected = false;
+      });
+
+      for (const chunk of this.#pendingChunks) {
+        ws.send(chunk);
+      }
+      this.#pendingChunks = [];
+    } catch (err) {
+      console.error("[Nova3STT] Connection error:", err);
+    }
+  }
+
+  feed(chunk: ArrayBuffer): void {
+    if (this.#closed) return;
+
+    if (this.#connected && this.#ws) {
+      this.#ws.send(chunk);
+    } else {
+      this.#pendingChunks.push(chunk);
+    }
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#pendingChunks = [];
+    if (this.#ws) {
+      try {
+        this.#ws.close();
+      } catch {
+        // ignore close errors
+      }
+      this.#ws = null;
+    }
+    this.#connected = false;
+  }
+
+  #handleMessage(event: MessageEvent): void {
+    if (this.#closed) return;
+
+    try {
+      const data: Nova3Result =
+        typeof event.data === "string" ? JSON.parse(event.data) : null;
+
+      if (!data) return;
+
+      if (data.type === "Results") {
+        const transcript = data.channel?.alternatives?.[0]?.transcript ?? "";
+
+        if (data.is_final && transcript) {
+          this.#finalizedSegments.push(transcript);
+        }
+
+        if (data.speech_final) {
+          const fullTranscript = this.#finalizedSegments.join(" ").trim();
+          this.#finalizedSegments = [];
+          if (fullTranscript) {
+            this.#onUtterance?.(fullTranscript);
+          }
+        } else if (!data.is_final && transcript) {
+          const display =
+            this.#finalizedSegments.length > 0
+              ? this.#finalizedSegments.join(" ") + " " + transcript
+              : transcript;
+          this.#onInterim?.(display);
+        }
+      }
+    } catch {
+      // Ignore non-JSON or malformed messages
+    }
   }
 }

--- a/voice-providers/deepgram/README.md
+++ b/voice-providers/deepgram/README.md
@@ -1,8 +1,8 @@
 # @cloudflare/voice-deepgram
 
-Deepgram streaming speech-to-text provider for the [Cloudflare Agents](https://github.com/cloudflare/agents) voice pipeline.
+Deepgram continuous speech-to-text provider for the [Cloudflare Agents](https://github.com/cloudflare/agents) voice pipeline.
 
-Uses Deepgram's real-time WebSocket API to transcribe audio incrementally as it arrives, producing interim and final results in real time. This eliminates STT latency from the critical path — by the time the user stops speaking, the transcript is already (nearly) ready.
+Uses Deepgram's real-time WebSocket API with server-side VAD and endpointing to transcribe audio continuously. A single session is created per call and the model handles utterance boundary detection.
 
 ## Install
 
@@ -12,22 +12,27 @@ npm install @cloudflare/voice-deepgram
 
 ## Usage
 
-Set `streamingStt` on your voice agent:
+Set `transcriber` on your voice agent:
 
 ```typescript
 import { Agent } from "agents";
-import { withVoice, type VoiceTurnContext } from "@cloudflare/voice";
-import { DeepgramStreamingSTT } from "@cloudflare/voice-deepgram";
+import {
+  withVoice,
+  WorkersAITTS,
+  type VoiceTurnContext
+} from "@cloudflare/voice";
+import { DeepgramSTT } from "@cloudflare/voice-deepgram";
 
 const VoiceAgent = withVoice(Agent);
 
 export class MyAgent extends VoiceAgent<Env> {
-  streamingStt = new DeepgramStreamingSTT({
+  transcriber = new DeepgramSTT({
     apiKey: this.env.DEEPGRAM_API_KEY
   });
+  tts = new WorkersAITTS(this.env.AI);
 
   async onTurn(transcript: string, context: VoiceTurnContext) {
-    // your LLM logic — transcript arrives with near-zero STT latency
+    // your LLM logic
   }
 }
 ```
@@ -36,27 +41,27 @@ The client receives `transcript_interim` messages in real time, which can be dis
 
 ## Options
 
-| Option        | Default      | Description                                                    |
-| ------------- | ------------ | -------------------------------------------------------------- |
-| `apiKey`      | (required)   | Deepgram API key                                               |
-| `model`       | `"nova-3"`   | Deepgram model. Nova-3 is the latest and most accurate.        |
-| `language`    | `"en"`       | Language code (e.g. `"en"`, `"es"`, `"fr"`)                    |
-| `smartFormat` | `true`       | Enable smart formatting (numbers, dates, currency)             |
-| `punctuate`   | `true`       | Enable automatic punctuation                                   |
-| `fillerWords` | `false`      | Include filler words (um, uh) in transcripts                   |
-| `encoding`    | `"linear16"` | Audio encoding. Must match the voice pipeline (16-bit PCM).    |
-| `sampleRate`  | `16000`      | Sample rate in Hz. Must match the voice pipeline (16kHz).      |
-| `channels`    | `1`          | Number of audio channels. Must match the voice pipeline (mono) |
+| Option          | Default      | Description                                                    |
+| --------------- | ------------ | -------------------------------------------------------------- |
+| `apiKey`        | (required)   | Deepgram API key                                               |
+| `model`         | `"nova-3"`   | Deepgram model                                                 |
+| `language`      | `"en"`       | Language code (e.g. `"en"`, `"es"`, `"fr"`)                    |
+| `smartFormat`   | `true`       | Enable smart formatting (numbers, dates, currency)             |
+| `punctuate`     | `true`       | Enable automatic punctuation                                   |
+| `fillerWords`   | `false`      | Include filler words (um, uh) in transcripts                   |
+| `endpointingMs` | `300`        | Silence duration in ms before finalizing an utterance          |
+| `encoding`      | `"linear16"` | Audio encoding. Must match the voice pipeline (16-bit PCM).    |
+| `sampleRate`    | `16000`      | Sample rate in Hz. Must match the voice pipeline (16kHz).      |
+| `channels`      | `1`          | Number of audio channels. Must match the voice pipeline (mono) |
 
 ## How it works
 
-1. When the user starts speaking, a WebSocket session is opened to Deepgram
-2. Audio chunks are forwarded to Deepgram in real time via `feed()`
-3. Deepgram sends back interim (unstable) and final (stable) transcript segments
-4. These are relayed to the client as `transcript_interim` messages
-5. When the user stops speaking, `finish()` sends a `CloseStream` message and returns the full transcript
-6. The transcript is passed to `onTurn()` with near-zero additional STT latency
+1. When the call starts, a WebSocket session is opened to Deepgram
+2. All audio chunks are forwarded to Deepgram continuously via `feed()`
+3. Deepgram sends back interim and final transcript segments
+4. When Deepgram detects an utterance boundary (`speech_final`), the complete transcript is emitted via `onUtterance`
+5. The pipeline runs `onTurn()` with the stable transcript
 
 ## Without a Deepgram key
 
-If you do not have a Deepgram API key, the default voice agent uses Workers AI STT (batch mode) with no external API key required. Streaming STT is opt-in.
+If you do not have a Deepgram API key, use `WorkersAIFluxSTT` or `WorkersAINova3STT` from `@cloudflare/voice` -- no external API key required.

--- a/voice-providers/deepgram/src/index.ts
+++ b/voice-providers/deepgram/src/index.ts
@@ -1,10 +1,10 @@
 import type {
-  StreamingSTTProvider,
-  StreamingSTTSession,
-  StreamingSTTSessionOptions
+  Transcriber,
+  TranscriberSession,
+  TranscriberSessionOptions
 } from "@cloudflare/voice";
 
-export interface DeepgramStreamingSTTOptions {
+export interface DeepgramSTTOptions {
   /** Deepgram API key. */
   apiKey: string;
   /** Deepgram model. @default "nova-3" */
@@ -17,6 +17,8 @@ export interface DeepgramStreamingSTTOptions {
   punctuate?: boolean;
   /** Enable filler words (um, uh). @default false */
   fillerWords?: boolean;
+  /** Endpointing silence duration in ms. @default 300 */
+  endpointingMs?: number;
   /**
    * Encoding of the audio being sent.
    * The voice pipeline sends 16-bit PCM at 16kHz mono.
@@ -32,22 +34,22 @@ export interface DeepgramStreamingSTTOptions {
 const DEEPGRAM_WS_URL = "wss://api.deepgram.com/v1/listen";
 
 /**
- * Deepgram streaming speech-to-text provider for the Agents voice pipeline.
+ * Deepgram continuous speech-to-text provider for the Agents voice pipeline.
  *
- * Creates per-utterance WebSocket sessions to Deepgram's real-time API.
- * Audio is streamed incrementally as it arrives, producing interim and
- * final transcript results in real time.
+ * Creates a per-call WebSocket session to Deepgram's real-time API.
+ * Audio is streamed continuously with server-side VAD and endpointing
+ * handling utterance boundary detection.
  *
  * @example
  * ```typescript
  * import { Agent } from "agents";
  * import { withVoice } from "@cloudflare/voice";
- * import { DeepgramStreamingSTT } from "@cloudflare/voice-deepgram";
+ * import { DeepgramSTT } from "@cloudflare/voice-deepgram";
  *
  * const VoiceAgent = withVoice(Agent);
  *
  * export class MyAgent extends VoiceAgent<Env> {
- *   streamingStt = new DeepgramStreamingSTT({
+ *   transcriber = new DeepgramSTT({
  *     apiKey: this.env.DEEPGRAM_API_KEY
  *   });
  *
@@ -55,30 +57,32 @@ const DEEPGRAM_WS_URL = "wss://api.deepgram.com/v1/listen";
  * }
  * ```
  */
-export class DeepgramStreamingSTT implements StreamingSTTProvider {
+export class DeepgramSTT implements Transcriber {
   #apiKey: string;
   #model: string;
   #language: string;
   #smartFormat: boolean;
   #punctuate: boolean;
   #fillerWords: boolean;
+  #endpointingMs: number;
   #encoding: string;
   #sampleRate: number;
   #channels: number;
 
-  constructor(options: DeepgramStreamingSTTOptions) {
+  constructor(options: DeepgramSTTOptions) {
     this.#apiKey = options.apiKey;
     this.#model = options.model ?? "nova-3";
     this.#language = options.language ?? "en";
     this.#smartFormat = options.smartFormat ?? true;
     this.#punctuate = options.punctuate ?? true;
     this.#fillerWords = options.fillerWords ?? false;
+    this.#endpointingMs = options.endpointingMs ?? 300;
     this.#encoding = options.encoding ?? "linear16";
     this.#sampleRate = options.sampleRate ?? 16000;
     this.#channels = options.channels ?? 1;
   }
 
-  createSession(options?: StreamingSTTSessionOptions): StreamingSTTSession {
+  createSession(options?: TranscriberSessionOptions): TranscriberSession {
     const params = new URLSearchParams({
       model: this.#model,
       language: options?.language ?? this.#language,
@@ -89,70 +93,45 @@ export class DeepgramStreamingSTT implements StreamingSTTProvider {
       punctuate: String(this.#punctuate),
       smart_format: String(this.#smartFormat),
       filler_words: String(this.#fillerWords),
-      // endpointing disabled — we control turn boundaries ourselves
-      endpointing: "false"
+      vad_events: "true",
+      endpointing: String(this.#endpointingMs)
     });
 
     const url = `${DEEPGRAM_WS_URL}?${params}`;
-    return new DeepgramStreamingSTTSession(url, this.#apiKey, options);
+    return new DeepgramSession(url, this.#apiKey, options);
   }
 }
 
 /**
- * A single streaming STT session backed by a Deepgram WebSocket connection.
+ * Per-call Deepgram transcription session.
  *
- * Lifecycle: created at start-of-speech, receives audio via feed(),
- * flushed via finish() at end-of-speech, or aborted on interrupt.
+ * Uses Deepgram's endpointing and VAD events for utterance detection.
+ * When a result arrives with `speech_final: true`, the accumulated
+ * finalized segments are emitted as an utterance.
  */
-class DeepgramStreamingSTTSession implements StreamingSTTSession {
+class DeepgramSession implements TranscriberSession {
   #onInterim: ((text: string) => void) | undefined;
-  #onFinal: ((text: string) => void) | undefined;
+  #onUtterance: ((text: string) => void) | undefined;
 
   #ws: WebSocket | null = null;
   #connected = false;
-  #aborted = false;
+  #closed = false;
 
-  // Audio chunks queued before the WebSocket is open
   #pendingChunks: ArrayBuffer[] = [];
-
-  // Accumulates finalized transcript segments from Deepgram
   #finalizedSegments: string[] = [];
-
-  // Resolves when Deepgram sends the final close-acknowledgement
-  // after we send CloseStream, or when we see the last is_final.
-  #finishResolve: ((transcript: string) => void) | null = null;
-  #finishPromise: Promise<string> | null = null;
-
-  // Whether finish() has been called
-  #finishing = false;
 
   constructor(
     url: string,
     apiKey: string,
-    options?: StreamingSTTSessionOptions
+    options?: TranscriberSessionOptions
   ) {
     this.#onInterim = options?.onInterim;
-    this.#onFinal = options?.onFinal;
-
-    if (options?.signal?.aborted) {
-      this.#aborted = true;
-      return;
-    }
-
-    options?.signal?.addEventListener(
-      "abort",
-      () => {
-        this.abort();
-      },
-      { once: true }
-    );
-
+    this.#onUtterance = options?.onUtterance;
     this.#connect(url, apiKey);
   }
 
   async #connect(url: string, apiKey: string): Promise<void> {
     try {
-      // Workers outbound WebSocket — use fetch with Upgrade header
       const resp = await fetch(url, {
         headers: {
           Upgrade: "websocket",
@@ -160,8 +139,7 @@ class DeepgramStreamingSTTSession implements StreamingSTTSession {
         }
       });
 
-      if (this.#aborted) {
-        // Aborted while connecting
+      if (this.#closed) {
         const ws = (resp as unknown as { webSocket?: WebSocket }).webSocket;
         if (ws) {
           ws.accept();
@@ -173,7 +151,6 @@ class DeepgramStreamingSTTSession implements StreamingSTTSession {
       const ws = (resp as unknown as { webSocket?: WebSocket }).webSocket;
       if (!ws) {
         console.error("[DeepgramSTT] Failed to establish WebSocket connection");
-        this.#resolveFinish();
         return;
       }
 
@@ -187,66 +164,44 @@ class DeepgramStreamingSTTSession implements StreamingSTTSession {
 
       ws.addEventListener("close", () => {
         this.#connected = false;
-        this.#resolveFinish();
       });
 
       ws.addEventListener("error", (event: Event) => {
         console.error("[DeepgramSTT] WebSocket error:", event);
         this.#connected = false;
-        this.#resolveFinish();
       });
 
-      // Flush any audio chunks that arrived before the WS was open
       for (const chunk of this.#pendingChunks) {
         ws.send(chunk);
       }
       this.#pendingChunks = [];
-
-      // If finish() was called while we were connecting, close now
-      if (this.#finishing) {
-        this.#sendCloseStream();
-      }
     } catch (err) {
       console.error("[DeepgramSTT] Connection error:", err);
-      this.#resolveFinish();
     }
   }
 
   feed(chunk: ArrayBuffer): void {
-    if (this.#aborted || this.#finishing) return;
+    if (this.#closed) return;
 
     if (this.#connected && this.#ws) {
       this.#ws.send(chunk);
     } else {
-      // Queue until connected
       this.#pendingChunks.push(chunk);
     }
   }
 
-  async finish(): Promise<string> {
-    if (this.#aborted) return "";
-
-    this.#finishing = true;
-
-    // Create the promise that will resolve when Deepgram closes
-    if (!this.#finishPromise) {
-      this.#finishPromise = new Promise<string>((resolve) => {
-        this.#finishResolve = resolve;
-      });
-    }
-
-    if (this.#connected && this.#ws) {
-      this.#sendCloseStream();
-    }
-    // else: #connect() will call #sendCloseStream() when it opens
-
-    return this.#finishPromise;
-  }
-
-  abort(): void {
-    if (this.#aborted) return;
-    this.#aborted = true;
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
     this.#pendingChunks = [];
+
+    if (this.#ws && this.#connected) {
+      try {
+        this.#ws.send(JSON.stringify({ type: "CloseStream" }));
+      } catch {
+        // ignore
+      }
+    }
 
     if (this.#ws) {
       try {
@@ -256,31 +211,11 @@ class DeepgramStreamingSTTSession implements StreamingSTTSession {
       }
       this.#ws = null;
     }
-
-    this.#resolveFinish();
-  }
-
-  #sendCloseStream(): void {
-    if (this.#ws && this.#connected) {
-      try {
-        this.#ws.send(JSON.stringify({ type: "CloseStream" }));
-      } catch {
-        // Connection may have dropped
-        this.#resolveFinish();
-      }
-    }
-  }
-
-  #resolveFinish(): void {
-    if (this.#finishResolve) {
-      const transcript = this.#finalizedSegments.join(" ").trim();
-      this.#finishResolve(transcript);
-      this.#finishResolve = null;
-    }
+    this.#connected = false;
   }
 
   #handleMessage(event: MessageEvent): void {
-    if (this.#aborted) return;
+    if (this.#closed) return;
 
     try {
       const data =
@@ -288,29 +223,29 @@ class DeepgramStreamingSTTSession implements StreamingSTTSession {
 
       if (!data) return;
 
-      // Deepgram response schema
       if (data.type === "Results") {
-        const alt = data.channel?.alternatives?.[0];
-        if (!alt) return;
+        const transcript: string =
+          data.channel?.alternatives?.[0]?.transcript ?? "";
 
-        const transcript: string = alt.transcript ?? "";
+        if (data.is_final && transcript) {
+          this.#finalizedSegments.push(transcript);
+        }
 
-        if (data.is_final) {
-          // Finalized segment — stable, will not change
-          if (transcript) {
-            this.#finalizedSegments.push(transcript);
-            this.#onFinal?.(transcript);
+        if (data.speech_final) {
+          const fullTranscript = this.#finalizedSegments.join(" ").trim();
+          this.#finalizedSegments = [];
+          if (fullTranscript) {
+            this.#onUtterance?.(fullTranscript);
           }
-        } else {
-          // Interim result — unstable, may change
-          if (transcript) {
-            this.#onInterim?.(transcript);
-          }
+        } else if (!data.is_final && transcript) {
+          const display =
+            this.#finalizedSegments.length > 0
+              ? this.#finalizedSegments.join(" ") + " " + transcript
+              : transcript;
+          this.#onInterim?.(display);
         }
       }
 
-      // Metadata message (connection opened) — ignore
-      // Error messages
       if (data.type === "Error") {
         console.error(
           `[DeepgramSTT] Error: ${data.description ?? data.message ?? JSON.stringify(data)}`


### PR DESCRIPTION
## Summary

Replaces per-utterance streaming STT with per-call continuous sessions. The transcriber session is created at `start_call` and lives for the entire call. The model handles turn detection — no client-side `start_of_speech`/`end_of_speech` required for STT.

**Breaking API change** to `@cloudflare/voice`.

- Single `transcriber` property replaces `stt`, `streamingStt`, and `vad`
- Two built-in providers: `WorkersAIFluxSTT` (Flux, recommended for `withVoice`) and `WorkersAINova3STT` (Nova 3, recommended for `withVoiceInput`)
- `createTranscriber(connection)` hook for runtime model switching
- `keepAlive` acquired at `start_call` to prevent DO eviction during calls
- Net deletion of ~2,700 lines; package size 322 KB → 270 KB

### Why

The old per-utterance architecture created a new STT WebSocket on every `start_of_speech` and destroyed it on `end_of_speech`. This caused the first words of each utterance to be lost — the audio arrived before the session existed. A pre-roll backfill hack partially addressed this, but it was fundamentally a workaround.

With per-call sessions, the transcriber sees ALL audio from `start_call` onward. No gap, no pre-roll, no lost words. The model (Flux `EndOfTurn`, Nova 3 `speech_final` + endpointing) handles turn detection, which is more accurate than client-side RMS-based silence detection.

### Before / After

```typescript
// Before (per-utterance, 3-4 providers)
class MyAgent extends VoiceAgent<Env> {
  stt = new WorkersAISTT(this.env.AI);
  tts = new WorkersAITTS(this.env.AI);
  vad = new WorkersAIVAD(this.env.AI);
  streamingStt = new WorkersAIFluxSTT(this.env.AI);
  async onTurn(transcript, context) { ... }
}

// After (per-call, 2 providers)
class MyAgent extends VoiceAgent<Env> {
  transcriber = new WorkersAIFluxSTT(this.env.AI);
  tts = new WorkersAITTS(this.env.AI);
  async onTurn(transcript, context) { ... }
}
```

### New features

- **`query` option on `VoiceClientOptions`** — pass query params to the WebSocket URL (e.g. `query: { model: "nova-3" }`), used by the voice-agent example for a model selection dropdown
- **`createTranscriber(connection)` hook** — override to create a transcriber dynamically per connection, enabling runtime model switching
- **Client-side playback interruption on user transcript** — when the server sends a new user transcript while audio is playing, the client clears the playback queue immediately (fixes a race condition where the model detects the utterance before the client's RMS-based interrupt fires)
- **Empty response guard** — when `onTurn` returns empty text (e.g. model hits token limit), the pipeline sends an error event, does not persist an empty assistant message, and does not emit metrics

### Removed

- `WorkersAISTT` (batch), `WorkersAIVAD`, `pcmToWav`, `concatenateBuffers`
- `STTProvider`, `VADProvider`, `StreamingSTTProvider`, `StreamingSTTSession` interfaces
- `prerollMs`, `vadThreshold`, `vadPushbackSeconds`, `vadRetryMs`, `minAudioBytes` options
- `VoiceInputAgentOptions` type, `beforeTranscribe` hook
- `vad_ms` and `stt_ms` from pipeline metrics
- Hibernation state tracking (replaced with `keepAlive`)
- Pre-roll code, EOT tracking, VAD retry timers

### Bug fixes

- Empty `onTurn` responses no longer persist as blank assistant messages or emit metrics as if the turn succeeded
- TTS abort errors (from pipeline cancellation on interrupt) silently ignored instead of logged
- Client clears playback queue when new user transcript arrives during playback
- SFU routes added to `run_worker_first` in voice-agent example (fixes 405 on POST /sfu/session)
- Duplicate metrics display fixed (was showing LLM/TTS/LLM/TTS/First audio)
- `withVoiceInput` example switched from partyserver `Server` to `Agent` (required for `keepAlive`)
- Stray `directory: "public"` removed from voice-agent wrangler.jsonc

### Provider updates

| Provider | Change |
|----------|--------|
| `WorkersAIFluxSTT` | Refactored to per-call continuous session |
| `WorkersAINova3STT` | New — per-call Nova 3 streaming with `vad_events` + `endpointing` |
| `DeepgramStreamingSTT` → `DeepgramSTT` | Ported to `Transcriber` interface |
| `ElevenLabsTTS` | No changes (TTS interface unchanged) |
| `TwilioAdapter` | No changes (adapter protocol unchanged) |

## Test plan

- [x] 78 server-side tests pass (6 test files)
- [x] Build succeeds (270 KB)
- [x] Export check passes
- [x] Manual testing: WebSocket voice agent with Flux
- [x] Manual testing: WebRTC/SFU voice agent
- [x] Manual testing: Interruption during playback (client clears queue)
- [x] Manual testing: STT model dropdown switching (Flux / Nova 3)
- [x] Empty response handling tested (error sent, no message persisted)
- [ ] CI pipeline