### PR TITLE
feat(experimental): Postgres session providers with Hyperdrive support

### DIFF
--- a/.changeset/postgres-session-providers.md
+++ b/.changeset/postgres-session-providers.md
@@ -1,0 +1,8 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+---
+
+Add experimental Postgres-backed session, context, and search providers for external session storage via Hyperdrive-compatible `pg` clients.
+
+Session APIs now consistently return promises so callers can use the same surface with local SQLite or external storage providers. Think's session integration has been updated for the async session API.

--- a/.changeset/postgres-session-providers.md
+++ b/.changeset/postgres-session-providers.md
@@ -1,8 +1,8 @@
 ---
-"agents": patch
-"@cloudflare/think": patch
+"agents": minor
+"@cloudflare/think": minor
 ---
 
 Add experimental Postgres-backed session, context, and search providers for external session storage via Hyperdrive-compatible `pg` clients.
 
-Session APIs now consistently return promises so callers can use the same surface with local SQLite or external storage providers. Think's session integration has been updated for the async session API.
+Session APIs now consistently return promises so callers can use the same surface with local SQLite or external storage providers. Think's session integration has been updated for the async session API, including cache-aware handling for idempotent appends and compaction overlays.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -662,6 +662,197 @@ const myStorage: SessionProvider = {
 
 ---
 
+## Postgres (External Database)
+
+The built-in providers use Durable Object SQLite. If you need session data in an external Postgres database — for cross-DO queries, analytics, or shared state — use `PostgresSessionProvider` and `PostgresContextProvider`.
+
+These work with any Postgres-compatible database (Neon, Supabase, PlanetScale, etc.) via [Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) for connection pooling.
+
+### Setup
+
+#### 1. Create a Postgres database
+
+Use any Postgres provider and copy the connection string.
+
+#### 2. Create a Hyperdrive config
+
+```bash
+npx wrangler hyperdrive create my-session-db \
+  --connection-string="postgresql://user:password@host:port/dbname"
+```
+
+Copy the returned Hyperdrive ID.
+
+#### 3. Create the tables
+
+The Postgres user typically won't have `CREATE TABLE` permissions. Run this once in your database console:
+
+```sql
+CREATE TABLE IF NOT EXISTS assistant_messages (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL DEFAULT '',
+  parent_id TEXT,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  text_content TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', text_content)) STORED
+);
+CREATE INDEX IF NOT EXISTS idx_assistant_msg_parent ON assistant_messages (parent_id);
+CREATE INDEX IF NOT EXISTS idx_assistant_msg_session ON assistant_messages (session_id);
+CREATE INDEX IF NOT EXISTS idx_assistant_msg_fts ON assistant_messages USING GIN (content_tsv);
+
+CREATE TABLE IF NOT EXISTS assistant_compactions (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL DEFAULT '',
+  summary TEXT NOT NULL,
+  from_message_id TEXT NOT NULL,
+  to_message_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS cf_agents_context_blocks (
+  label TEXT PRIMARY KEY,
+  content TEXT NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS cf_agents_search_entries (
+  label TEXT NOT NULL,
+  key TEXT NOT NULL,
+  content TEXT NOT NULL,
+  content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (label, key)
+);
+CREATE INDEX IF NOT EXISTS idx_search_entries_fts ON cf_agents_search_entries USING GIN (content_tsv);
+```
+
+#### 4. Configure wrangler
+
+```jsonc
+{
+  "compatibility_flags": ["nodejs_compat"],
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "<your-hyperdrive-id>"
+    }
+  ],
+  "placement": {
+    "region": "aws:us-east-1" // match your database region
+  }
+}
+```
+
+#### 5. Wire it up
+
+```typescript
+import { Agent, callable } from "agents";
+import {
+  Session,
+  PostgresSessionProvider,
+  PostgresContextProvider,
+  PostgresSearchProvider,
+  type PostgresConnection
+} from "agents/experimental/memory/session";
+import { Client } from "pg";
+
+// Wrap pg Client to match the PostgresConnection interface
+function wrapPgClient(client: Client): PostgresConnection {
+  return {
+    async execute(query, args) {
+      let idx = 0;
+      const pgQuery = query.replace(/\?/g, () => `$${++idx}`);
+      const result = await client.query(pgQuery, args ?? []);
+      return { rows: result.rows };
+    }
+  };
+}
+
+class MyAgent extends Agent<Env> {
+  private _session?: Session;
+  private _pgClient?: Client;
+
+  private async getConnection(): Promise<PostgresConnection> {
+    if (!this._pgClient) {
+      this._pgClient = new Client({
+        connectionString: this.env.HYPERDRIVE.connectionString
+      });
+      await this._pgClient.connect();
+    }
+    return wrapPgClient(this._pgClient);
+  }
+
+  private async getSession(): Promise<Session> {
+    if (this._session) return this._session;
+
+    const conn = await this.getConnection();
+    const sessionId = this.ctx.id.toString();
+
+    this._session = Session.create(new PostgresSessionProvider(conn, sessionId))
+      .withContext("soul", {
+        provider: {
+          get: async () => "You are a helpful assistant."
+        }
+      })
+      .withContext("memory", {
+        description: "Short facts",
+        maxTokens: 1100,
+        provider: new PostgresContextProvider(conn, `memory_${sessionId}`)
+      })
+      .withContext("knowledge", {
+        description: "Searchable knowledge base",
+        provider: new PostgresSearchProvider(conn)
+      })
+      .withCachedPrompt(
+        new PostgresContextProvider(conn, `_prompt_${sessionId}`)
+      );
+
+    return this._session;
+  }
+}
+```
+
+### How it works
+
+When `Session.create()` receives a `SessionProvider` instead of a `SqlProvider`, it skips all SQLite auto-wiring. This means:
+
+- **Context blocks need explicit providers.** No auto-wiring to SQLite — each `withContext()` call needs a `provider` option, or the block will be read-only with no storage.
+- **`withCachedPrompt()` needs an explicit provider.** Pass a `PostgresContextProvider` to persist the frozen system prompt.
+- **Broadcaster is skipped.** WebSocket status broadcasts (`CF_AGENT_SESSION` events) only work with `SqlProvider`-based sessions.
+- **All Session methods are async.** `getHistory()`, `getMessage()`, etc. return Promises since the underlying storage is async.
+
+### System prompt lifecycle
+
+- **`freezeSystemPrompt()`** — returns the cached prompt from the store. On first call (cache miss), loads blocks from providers, renders, and persists. Subsequent calls return the stored value without re-rendering. This preserves LLM prefix cache hits.
+- **`refreshSystemPrompt()`** — force reloads blocks from providers, re-renders, and updates the store. Call this to invalidate the cached prompt (e.g. after `clearMessages`).
+
+### PostgresConnection interface
+
+```typescript
+interface PostgresConnection {
+  execute(
+    query: string,
+    args?: (string | number | boolean | null)[]
+  ): Promise<{ rows: Record<string, unknown>[] }>;
+}
+```
+
+The providers use `?` placeholders internally. When wrapping `pg`, convert to `$1, $2, $3` (see the `wrapPgClient` helper above). Any Postgres driver with a compatible `execute()` method works.
+
+### Search
+
+Two levels of search are available:
+
+- **Message search** — `PostgresSessionProvider.searchMessages()` searches conversation history via the `content_tsv` column on `assistant_messages`.
+- **Knowledge search** — `PostgresSearchProvider` provides a searchable context block backed by `cf_agents_search_entries`. The LLM can index content via `set_context` and query it via `search_context`. Uses `tsvector` + GIN index with English stemming and `ts_rank` for relevance ranking.
+
+The migration SQL above includes both tables with tsvector columns and GIN indexes — search works out of the box.
+
+---
+
 ## Utilities
 
 Exported from `agents/experimental/memory/utils`:
@@ -719,6 +910,9 @@ import {
   AgentContextProvider,
   AgentSearchProvider,
   R2SkillProvider,
+  PostgresSessionProvider,
+  PostgresContextProvider,
+  PostgresSearchProvider,
 
   // Type guards
   isWritableProvider,
@@ -741,7 +935,8 @@ import {
   type SearchResult,
   type SessionProvider,
   type StoredCompaction,
-  type SqlProvider
+  type SqlProvider,
+  type PostgresConnection
 } from "agents/experimental/memory/session";
 ```
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -754,44 +754,39 @@ import {
   Session,
   PostgresSessionProvider,
   PostgresContextProvider,
-  PostgresSearchProvider,
-  type PostgresConnection
+  PostgresSearchProvider
 } from "agents/experimental/memory/session";
 import { Client } from "pg";
-
-// Wrap pg Client to match the PostgresConnection interface
-function wrapPgClient(client: Client): PostgresConnection {
-  return {
-    async execute(query, args) {
-      let idx = 0;
-      const pgQuery = query.replace(/\?/g, () => `$${++idx}`);
-      const result = await client.query(pgQuery, args ?? []);
-      return { rows: result.rows };
-    }
-  };
-}
 
 class MyAgent extends Agent<Env> {
   private _session?: Session;
   private _pgClient?: Client;
 
-  private async getConnection(): Promise<PostgresConnection> {
-    if (!this._pgClient) {
-      this._pgClient = new Client({
-        connectionString: this.env.HYPERDRIVE.connectionString
-      });
-      await this._pgClient.connect();
-    }
-    return wrapPgClient(this._pgClient);
+  /**
+   * Open a `pg.Client` against Hyperdrive once, and reuse it.
+   * The providers take the raw client directly — no wrapper needed.
+   */
+  private async getPgClient(): Promise<Client> {
+    if (this._pgClient) return this._pgClient;
+    const client = new Client({
+      connectionString: this.env.HYPERDRIVE.connectionString
+    });
+    await client.connect();
+    // Only cache after connect() resolves so a failed attempt doesn't
+    // permanently poison the instance.
+    this._pgClient = client;
+    return client;
   }
 
   private async getSession(): Promise<Session> {
     if (this._session) return this._session;
 
-    const conn = await this.getConnection();
+    const client = await this.getPgClient();
     const sessionId = this.ctx.id.toString();
 
-    this._session = Session.create(new PostgresSessionProvider(conn, sessionId))
+    this._session = Session.create(
+      new PostgresSessionProvider(client, sessionId)
+    )
       .withContext("soul", {
         provider: {
           get: async () => "You are a helpful assistant."
@@ -800,14 +795,14 @@ class MyAgent extends Agent<Env> {
       .withContext("memory", {
         description: "Short facts",
         maxTokens: 1100,
-        provider: new PostgresContextProvider(conn, `memory_${sessionId}`)
+        provider: new PostgresContextProvider(client, `memory_${sessionId}`)
       })
       .withContext("knowledge", {
         description: "Searchable knowledge base",
-        provider: new PostgresSearchProvider(conn)
+        provider: new PostgresSearchProvider(client)
       })
       .withCachedPrompt(
-        new PostgresContextProvider(conn, `_prompt_${sessionId}`)
+        new PostgresContextProvider(client, `_prompt_${sessionId}`)
       );
 
     return this._session;
@@ -829,9 +824,15 @@ When `Session.create()` receives a `SessionProvider` instead of a `SqlProvider`,
 - **`freezeSystemPrompt()`** — returns the cached prompt from the store. On first call (cache miss), loads blocks from providers, renders, and persists. Subsequent calls return the stored value without re-rendering. This preserves LLM prefix cache hits.
 - **`refreshSystemPrompt()`** — force reloads blocks from providers, re-renders, and updates the store. Call this to invalidate the cached prompt (e.g. after `clearMessages`).
 
-### PostgresConnection interface
+### Connection types
+
+The Postgres providers accept either of:
+
+- A raw `pg.Client` (or any object with a compatible `query(text, values)` method) — the recommended path for Hyperdrive.
+- Any object implementing `PostgresConnection` — useful for tests or custom drivers.
 
 ```typescript
+// For tests or custom drivers
 interface PostgresConnection {
   execute(
     query: string,
@@ -840,7 +841,7 @@ interface PostgresConnection {
 }
 ```
 
-The providers use `?` placeholders internally. When wrapping `pg`, convert to `$1, $2, $3` (see the `wrapPgClient` helper above). Any Postgres driver with a compatible `execute()` method works.
+Internally the providers use `?` placeholders; when a `pg`-style client is passed, those are rewritten to `$1, $2, …` automatically.
 
 ### Search
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -73,7 +73,7 @@ const session = new Session(new AgentSessionProvider(this), {
 
 ### Builder Methods
 
-All builder methods return `this` for chaining. Order doesn't matter — providers are resolved lazily on first use.
+All builder methods return `this` for chaining. Order does not matter — providers are resolved lazily on first use.
 
 | Method                          | Description                                                                                                                                                   |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -130,23 +130,23 @@ Messages form a tree. When you `appendMessage` with a `parentId` that already ha
 
 ```typescript
 // Get all child messages that branch from messageId (e.g. multiple responses to a user message)
-const branches = session.getBranches(messageId);
+const branches = await session.getBranches(messageId);
 ```
 
 This powers features like response regeneration — pass the user message ID to get both the original and regenerated responses. `getHistory(leafId)` walks the chosen path.
 
 ### Search
 
-Full-text search over the conversation history using SQLite FTS5:
+Full-text search over the conversation history. SQLite-backed sessions use FTS5; Postgres-backed sessions use the provider's Postgres full-text index.
 
 ```typescript
-const results = session.search("deployment Friday", { limit: 10 });
+const results = await session.search("deployment Friday", { limit: 10 });
 // Returns: Array<{ id, role, content, createdAt? }>
 ```
 
 Uses porter stemming and unicode tokenization. The search covers all messages in the session.
 
-> **Note:** `search()` throws if the session provider doesn't support search. The built-in `AgentSessionProvider` supports it.
+> **Note:** `search()` throws if the session provider does not support search. The built-in `AgentSessionProvider` and `PostgresSessionProvider` support it.
 
 ### WebSocket Broadcasts
 
@@ -278,7 +278,7 @@ const prompt = await session.freezeSystemPrompt();
 const updated = await session.refreshSystemPrompt();
 ```
 
-The frozen prompt survives DO hibernation and eviction when `withCachedPrompt()` is enabled. After eviction, the next `freezeSystemPrompt()` call loads from SQLite rather than re-rendering.
+The frozen prompt survives DO hibernation and eviction when `withCachedPrompt()` is enabled. After eviction, the next `freezeSystemPrompt()` call loads from the configured prompt store rather than re-rendering.
 
 ### Skills (Load/Unload)
 
@@ -286,15 +286,15 @@ Skills are on-demand documents stored in a `SkillProvider` (e.g. R2). The model 
 
 ```typescript
 // Unload a skill to free context space (rewrites the tool result in history)
-session.unloadSkill("skills", "api-reference");
+await session.unloadSkill("skills", "api-reference");
 
 // Check what's currently loaded
-const loaded = session.getLoadedSkillKeys(); // Set<"skills:api-reference">
+const loaded = await session.getLoadedSkillKeys(); // Set<"skills:api-reference">
 ```
 
 After hibernation/eviction, loaded skills are reconstructed by scanning conversation history for `load_context` tool results. This means skill state survives restarts without additional storage.
 
-> **Weird:** The skill restoration scans the entire conversation history looking for `load_context` tool invocations in assistant messages with `state: "output-available"`. When you unload a skill, it doesn't delete the tool result — it rewrites the `output` field to `"[skill unloaded: key]"` in-place. This means the original loaded content is permanently lost from history after unload.
+> **Gotcha:** Skill restoration scans the entire conversation history looking for `load_context` tool invocations in assistant messages with `state: "output-available"`. When you unload a skill, it does not delete the tool result — it rewrites the `output` field to `"[skill unloaded: key]"` in-place. This means the original loaded content is permanently lost from history after unload.
 
 ---
 
@@ -357,7 +357,7 @@ Use `{ ...sessionTools, ...manager.tools() }` to give the model both per-session
 
 ## Compaction
 
-Compaction summarizes older messages to keep conversations within token limits. Original messages are preserved in SQLite — the summary is a non-destructive overlay applied at read time.
+Compaction summarizes older messages to keep conversations within token limits. Original messages are preserved in the underlying message store — the summary is a non-destructive overlay applied at read time.
 
 ### Setup
 
@@ -396,8 +396,8 @@ When `getHistory()` is called, compaction overlays are applied transparently —
 const result = await session.compact();
 
 // Or manage overlays directly
-session.addCompaction("Summary of messages 1-50", "msg-1", "msg-50");
-const overlays = session.getCompactions();
+await session.addCompaction("Summary of messages 1-50", "msg-1", "msg-50");
+const overlays = await session.getCompactions();
 ```
 
 ### Auto-Compaction
@@ -406,7 +406,7 @@ When `.compactAfter(threshold)` is set, `appendMessage()` checks the estimated t
 
 > **Note:** Token estimation is heuristic (not tiktoken). It uses `max(chars/4, words*1.3)` with 4 tokens per-message overhead. This is intentional — tiktoken would add 80-120MB heap overhead, which exceeds Cloudflare Workers' 128MB limit.
 
-> **Weird:** Compaction is iterative but single-overlay. Each new compaction extends from the earliest existing compaction's `fromMessageId` to the new end. So you always have at most one active compaction overlay per session, and it keeps growing. The previous compaction rows remain in the database but are superseded by the latest one (which covers a wider range). `getCompactions()` returns all of them, but `getHistory()` applies the latest one.
+> **Gotcha:** Compaction is iterative but single-overlay. Each new compaction extends from the earliest existing compaction's `fromMessageId` to the new end. So you always have at most one active compaction overlay per session, and it keeps growing. The previous compaction rows remain in the database but are superseded by the latest one (which covers a wider range). `getCompactions()` returns all of them, but `getHistory()` applies the latest one.
 
 ---
 
@@ -465,7 +465,7 @@ const sessions = manager.list();
 manager.rename(sessionId, "New Name");
 
 // Delete (clears messages too)
-manager.delete(sessionId);
+await manager.delete(sessionId);
 ```
 
 ### Accessing Sessions
@@ -491,16 +491,16 @@ await manager.upsert(sessionId, message, parentId?);
 await manager.appendAll(sessionId, messages, parentId?);
 
 // Read history
-const history = manager.getHistory(sessionId, leafId?);
+const history = await manager.getHistory(sessionId, leafId?);
 
 // Message count
-const count = manager.getMessageCount(sessionId);
+const count = await manager.getMessageCount(sessionId);
 
 // Clear messages
-manager.clearMessages(sessionId);
+await manager.clearMessages(sessionId);
 
 // Delete specific messages
-manager.deleteMessages(sessionId, ["msg-1"]);
+await manager.deleteMessages(sessionId, ["msg-1"]);
 ```
 
 ### Forking
@@ -512,16 +512,16 @@ const forked = await manager.fork(sessionId, atMessageId, "Forked Chat");
 // forked.parent_session_id === sessionId
 ```
 
-> **Weird:** Fork copies messages with new UUIDs, not the original IDs. This means message IDs in the forked session won't match the original. The fork also doesn't copy compaction overlays — the forked session starts clean with the materialized history.
+> **Gotcha:** Fork copies messages with new UUIDs, not the original IDs. This means message IDs in the forked session will not match the original. The fork also does not copy compaction overlays — the forked session starts clean with the materialized history.
 
 ### Compaction
 
 ```typescript
 // Add a compaction overlay
-manager.addCompaction(sessionId, summary, fromId, toId);
+await manager.addCompaction(sessionId, summary, fromId, toId);
 
 // Get overlays
-const compactions = manager.getCompactions(sessionId);
+const compactions = await manager.getCompactions(sessionId);
 
 // Compact and split — marks old session as ended, creates a continuation
 const continuation = await manager.compactAndSplit(
@@ -555,13 +555,13 @@ const tools = manager.tools();
 
 > **Note:** `manager.search()` uses a separate FTS5 index (`assistant_fts`) from per-session search. Messages are indexed into this table by the `AgentSessionProvider` when appended. The `session_search` tool limits results to 10.
 
-> **Weird:** `manager.search()` silently returns an empty array on FTS5 query errors (malformed queries, etc.) rather than throwing.
+> **Gotcha:** `manager.search()` silently returns an empty array on FTS5 query errors (malformed queries, etc.) rather than throwing.
 
 ---
 
 ## Storage
 
-All storage is in Durable Object SQLite. Tables are created lazily on first use.
+By default, storage is in Durable Object SQLite and tables are created lazily on first use. Postgres-backed sessions use the external tables shown in the Postgres section below.
 
 ### Tables
 
@@ -668,7 +668,7 @@ const myStorage: SessionProvider = {
 
 ## Postgres (External Database)
 
-The built-in providers use Durable Object SQLite. If you need session data in an external Postgres database — for cross-DO queries, analytics, or shared state — use `PostgresSessionProvider` and `PostgresContextProvider`.
+The default providers use Durable Object SQLite. If you need session data in an external Postgres database — for cross-DO queries, analytics, or shared state — use `PostgresSessionProvider`, `PostgresContextProvider`, and `PostgresSearchProvider`.
 
 These work with any Postgres-compatible database (Neon, Supabase, PlanetScale, etc.) via [Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) for connection pooling.
 
@@ -689,7 +689,7 @@ Copy the returned Hyperdrive ID.
 
 #### 3. Create the tables
 
-The Postgres user typically won't have `CREATE TABLE` permissions. Run this once in your database console:
+The Postgres user might not have `CREATE TABLE` permissions. Run this once in your database console:
 
 ```sql
 CREATE TABLE IF NOT EXISTS assistant_messages (
@@ -962,7 +962,7 @@ import {
 
 Things that might surprise you:
 
-1. **Lazy initialization.** Sessions created with the builder don't initialize until first use. The first call to any method (e.g. `getHistory()`) triggers `_ensureReady()`, which creates SQLite tables, resolves providers, loads context blocks, and restores skill state from history. This means the first operation is slower than subsequent ones.
+1. **Lazy initialization.** Sessions created with the builder do not initialize until first use. The first call to any method (e.g. `getHistory()`) triggers `_ensureReady()`, which creates SQLite tables or initializes the configured provider, resolves providers, loads context blocks, and restores skill state from history. This means the first operation is slower than subsequent ones.
 
 2. **Snapshot freezing is sticky.** `freezeSystemPrompt()` caches the result. Writing to a context block does NOT update the cached snapshot — you must explicitly call `refreshSystemPrompt()`. This is deliberate (LLM prefix cache optimization), but easy to miss.
 
@@ -972,13 +972,13 @@ Things that might surprise you:
 
 5. **Compaction overlays are superseding, not stacking.** Each compaction extends from the earliest existing `fromMessageId`. So you always have one effective overlay that keeps growing. Old compaction rows remain in the database but are unused. `getCompactions()` returns all rows, which can be confusing.
 
-6. **Search is silently absent.** `session.search()` throws if the provider doesn't support search, but `manager.search()` swallows FTS5 errors and returns `[]`. The `searchMessages` method on `SessionProvider` is optional (`searchMessages?`).
+6. **Search is silently absent.** `session.search()` throws if the provider does not support search, but `manager.search()` swallows FTS5 errors and returns `[]`. The `searchMessages` method on `SessionProvider` is optional (`searchMessages?`).
 
-7. **Fork copies with new IDs.** When forking via `SessionManager.fork()`, all messages get new UUIDs. If you're storing message IDs externally (e.g. for bookmarks), they won't survive a fork.
+7. **Fork copies with new IDs.** When forking via `SessionManager.fork()`, all messages get new UUIDs. If you are storing message IDs externally (e.g. for bookmarks), they will not survive a fork.
 
-8. **`removeContext` doesn't fire skill unload callbacks.** If you remove a context block that had loaded skills, the skill tracking is cleaned up but the conversation history is NOT rewritten. The tool results from those skills remain in history with their full content.
+8. **`removeContext` does not fire skill unload callbacks.** If you remove a context block that had loaded skills, the skill tracking is cleaned up but the conversation history is NOT rewritten. The tool results from those skills remain in history with their full content.
 
-9. **FTS5 query sanitization.** Both `AgentSearchProvider.search()` and `SessionManager.search()` quote individual words to prevent FTS5 syntax injection. This means you can't use FTS5 operators like `OR`, `NOT`, or `NEAR` — they'll be treated as literal search terms.
+9. **FTS5 query sanitization.** Both `AgentSearchProvider.search()` and `SessionManager.search()` quote individual words to prevent FTS5 syntax injection. This means you cannot use FTS5 operators like `OR`, `NOT`, or `NEAR` — they will be treated as literal search terms.
 
 10. **Auto-compaction failure is silent.** When `compactAfter` triggers and the compaction function throws, the error is emitted via WebSocket broadcast but the `appendMessage` call still succeeds. The message is saved; only the compaction is skipped.
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,6 +1,6 @@
 # Sessions (Experimental)
 
-The Session API provides persistent conversation storage for agents, with tree-structured messages, context blocks, compaction, full-text search, and AI-controllable tools. It runs entirely on Durable Object SQLite — no external database needed.
+The Session API provides persistent conversation storage for agents, with tree-structured messages, context blocks, compaction, full-text search, and AI-controllable tools. By default it uses Durable Object SQLite; external Postgres storage is also available for apps that need shared database access, analytics, or cross-DO queries.
 
 > **Experimental.** The Session API is under `agents/experimental/memory/session`. The API surface is stable but may evolve before graduating to the main package.
 
@@ -23,7 +23,7 @@ class MyAgent extends Agent {
 
   async onMessage(message) {
     await this.session.appendMessage(message);
-    const history = this.session.getHistory();
+    const history = await this.session.getHistory();
     const system = await this.session.freezeSystemPrompt();
     const tools = await this.session.tools();
     // Pass history, system prompt, and tools to your LLM
@@ -94,34 +94,34 @@ await session.appendMessage(message);
 await session.appendMessage(message, parentId);
 
 // Update an existing message (matched by message.id)
-session.updateMessage(message);
+await session.updateMessage(message);
 
 // Delete specific messages
-session.deleteMessages(["msg-1", "msg-2"]);
+await session.deleteMessages(["msg-1", "msg-2"]);
 
 // Clear all messages and skill state
-session.clearMessages();
+await session.clearMessages();
 ```
 
-> **Note:** `appendMessage()` is `async` because it may trigger auto-compaction. The underlying storage write is synchronous (SQLite), but the compaction step involves an LLM call. All other write methods (`updateMessage`, `deleteMessages`, `clearMessages`) are synchronous.
+> **Note:** Session methods are async. SQLite-backed sessions are usually fast, but external providers may perform network I/O, and `appendMessage()` may also trigger auto-compaction.
 
 #### Reading History
 
 ```typescript
 // Linear history from root to the latest leaf
-const messages = session.getHistory();
+const messages = await session.getHistory();
 
 // History to a specific leaf (for branching)
-const branch = session.getHistory(leafId);
+const branch = await session.getHistory(leafId);
 
 // Get a single message
-const msg = session.getMessage("msg-1");
+const msg = await session.getMessage("msg-1");
 
 // Get the newest message
-const latest = session.getLatestLeaf();
+const latest = await session.getLatestLeaf();
 
 // Count messages in path
-const count = session.getPathLength();
+const count = await session.getPathLength();
 ```
 
 #### Branching
@@ -313,10 +313,12 @@ const allTools = { ...tools, ...myTools };
 Generated when any writable block exists. Writes to regular blocks, skill blocks (keyed), or search blocks (keyed).
 
 - For regular blocks: `{ label, content, action: "replace" | "append" }`
-- For skill blocks: `{ label, key, content, description? }`
-- For search blocks: `{ label, key, content }`
+- For skill blocks: `{ label, content, metadata?: { title, description } }`
+- For search blocks: `{ label, content, metadata?: { title } }`
 
 Enforces `maxTokens` limits. Returns a usage string like `"Written to memory. Usage: 45% (495/1100 tokens)"`.
+
+For keyed blocks, `metadata.title` becomes the stable entry key. If title is omitted, the key is generated from the content plus a short deterministic hash to avoid silent collisions; provide a title when you want later writes to update the same entry.
 
 ### `load_context`
 
@@ -567,12 +569,14 @@ All storage is in Durable Object SQLite. Tables are created lazily on first use.
 
 | Column       | Type     | Notes                                                  |
 | ------------ | -------- | ------------------------------------------------------ |
-| `id`         | TEXT PK  | Message ID                                             |
+| `id`         | TEXT     | Message ID                                             |
 | `session_id` | TEXT     | Empty string for single-session; set for multi-session |
 | `parent_id`  | TEXT     | Parent message ID (null for roots)                     |
 | `role`       | TEXT     | `user`, `assistant`, `system`                          |
 | `content`    | TEXT     | JSON-serialized `SessionMessage`                       |
 | `created_at` | DATETIME | Auto-set                                               |
+
+For Postgres, messages use `PRIMARY KEY (session_id, id)` so caller-provided IDs only need to be unique within a session.
 
 **`assistant_compactions`** — Compaction overlays.
 
@@ -689,14 +693,15 @@ The Postgres user typically won't have `CREATE TABLE` permissions. Run this once
 
 ```sql
 CREATE TABLE IF NOT EXISTS assistant_messages (
-  id TEXT PRIMARY KEY,
+  id TEXT NOT NULL,
   session_id TEXT NOT NULL DEFAULT '',
   parent_id TEXT,
   role TEXT NOT NULL,
   content TEXT NOT NULL,
   text_content TEXT NOT NULL DEFAULT '',
   created_at TIMESTAMPTZ DEFAULT NOW(),
-  content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', text_content)) STORED
+  content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', text_content)) STORED,
+  PRIMARY KEY (session_id, id)
 );
 CREATE INDEX IF NOT EXISTS idx_assistant_msg_parent ON assistant_messages (parent_id);
 CREATE INDEX IF NOT EXISTS idx_assistant_msg_session ON assistant_messages (session_id);
@@ -763,27 +768,17 @@ class MyAgent extends Agent<Env> {
   private _pgClient?: Client;
 
   /**
-   * Open a `pg.Client` against Hyperdrive once, and reuse it.
-   * The providers take the raw client directly — no wrapper needed.
+   * Initialize Hyperdrive and Session when the Durable Object starts.
+   * The providers take the raw pg.Client directly — no wrapper needed.
    */
-  private async getPgClient(): Promise<Client> {
-    if (this._pgClient) return this._pgClient;
+  async onStart(): Promise<void> {
     const client = new Client({
       connectionString: this.env.HYPERDRIVE.connectionString
     });
     await client.connect();
-    // Only cache after connect() resolves so a failed attempt doesn't
-    // permanently poison the instance.
     this._pgClient = client;
-    return client;
-  }
 
-  private async getSession(): Promise<Session> {
-    if (this._session) return this._session;
-
-    const client = await this.getPgClient();
     const sessionId = this.ctx.id.toString();
-
     this._session = Session.create(
       new PostgresSessionProvider(client, sessionId)
     )
@@ -804,8 +799,6 @@ class MyAgent extends Agent<Env> {
       .withCachedPrompt(
         new PostgresContextProvider(client, `_prompt_${sessionId}`)
       );
-
-    return this._session;
   }
 }
 ```
@@ -973,7 +966,7 @@ Things that might surprise you:
 
 2. **Snapshot freezing is sticky.** `freezeSystemPrompt()` caches the result. Writing to a context block does NOT update the cached snapshot — you must explicitly call `refreshSystemPrompt()`. This is deliberate (LLM prefix cache optimization), but easy to miss.
 
-3. **`appendMessage` is async, other writes are sync.** `appendMessage` is async only because it may trigger auto-compaction (which calls an LLM). The actual SQLite write is synchronous. `updateMessage`, `deleteMessages`, and `clearMessages` are all synchronous.
+3. **Session methods are async.** Always `await` reads and writes. SQLite-backed storage is local and fast, but external providers may perform network I/O, and `appendMessage` can trigger auto-compaction.
 
 4. **Skills survive hibernation via history scanning.** On initialization, the session scans the entire conversation history looking for `load_context` tool results to reconstruct which skills are loaded. This is clever but means initialization cost scales with conversation length.
 

--- a/examples/resumable-stream-chat/src/client.tsx
+++ b/examples/resumable-stream-chat/src/client.tsx
@@ -223,12 +223,12 @@ function Chat() {
     ChatMessage
   >({
     agent,
-    onData(part) {
+    onData(part: { type: string; data: unknown }) {
       // Capture transient thinking parts from the onData callback.
       // These are ephemeral — not persisted and not in message.parts.
       if (part.type === "data-thinking") {
         // part.data is typed as ThinkingData here — no cast needed
-        setThinkingData(part.data);
+        setThinkingData(part.data as ThinkingData);
       }
     }
   });

--- a/experimental/session-memory/src/server.ts
+++ b/experimental/session-memory/src/server.ts
@@ -79,7 +79,7 @@ export class ChatAgent extends Agent<Env> {
       parts: [{ type: "text", text: message }]
     });
 
-    const history = this.session.getHistory();
+    const history = await this.session.getHistory();
     const truncated = truncateOlderMessages(history);
 
     const result = streamText({
@@ -139,18 +139,18 @@ export class ChatAgent extends Agent<Env> {
   }
 
   @callable()
-  getMessages(): UIMessage[] {
-    return this.session.getHistory() as UIMessage[];
+  async getMessages(): Promise<UIMessage[]> {
+    return (await this.session.getHistory()) as UIMessage[];
   }
 
   @callable()
-  search(query: string) {
+  async search(query: string) {
     return this.session.search(query);
   }
 
   @callable()
-  clearMessages(): void {
-    this.session.clearMessages();
+  async clearMessages(): Promise<void> {
+    await this.session.clearMessages();
   }
 }
 

--- a/experimental/session-multichat/src/server.ts
+++ b/experimental/session-multichat/src/server.ts
@@ -80,8 +80,8 @@ export class MultiSessionAgent extends Agent<Env> {
   }
 
   @callable()
-  deleteChat(chatId: string) {
-    this.manager.delete(chatId);
+  async deleteChat(chatId: string) {
+    await this.manager.delete(chatId);
   }
 
   // ── Chat ──────────────────────────────────────────────────────
@@ -100,7 +100,7 @@ export class MultiSessionAgent extends Agent<Env> {
       parts: [{ type: "text", text: message }]
     });
 
-    const history = session.getHistory();
+    const history = await session.getHistory();
     const truncated = truncateOlderMessages(history);
 
     const result = streamText({
@@ -148,8 +148,8 @@ export class MultiSessionAgent extends Agent<Env> {
   }
 
   @callable()
-  getHistory(chatId: string): UIMessage[] {
-    return this.manager.getSession(chatId).getHistory() as UIMessage[];
+  async getHistory(chatId: string): Promise<UIMessage[]> {
+    return (await this.manager.getSession(chatId).getHistory()) as UIMessage[];
   }
 
   @callable()

--- a/experimental/session-planetscale/README.md
+++ b/experimental/session-planetscale/README.md
@@ -1,0 +1,79 @@
+# Postgres Session Example
+
+Agent with session history stored in an external Postgres database via [Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) instead of Durable Object SQLite.
+
+## Why external Postgres?
+
+DO SQLite is great for per-user state, but sessions live and die with the DO. An external database gives you:
+
+- **Cross-DO queries** — search across all conversations from any Worker
+- **Analytics** — run SQL against your conversation data directly
+- **Decoupled lifecycle** — session data survives DO eviction, migration, and resets
+- **Shared state** — multiple DOs or services can read/write the same session tables
+
+## Setup
+
+### 1. Create a Postgres database
+
+Use any Postgres provider (Neon, Supabase, PlanetScale, etc.) and copy the connection string.
+
+### 2. Create a Hyperdrive config
+
+```bash
+npx wrangler hyperdrive create my-session-db \
+  --connection-string="postgresql://user:password@host:port/dbname"
+```
+
+Update `wrangler.jsonc` with the returned Hyperdrive ID.
+
+### 3. Create the tables
+
+Run the migration SQL from [docs/sessions.md](../../docs/sessions.md#3-create-the-tables) in your database console. The providers do not auto-create tables — migrations are managed by you.
+
+### 4. Deploy
+
+```bash
+npm install
+npm run deploy
+```
+
+## How it works
+
+The key difference from the standard `session-memory` example:
+
+```ts
+// Standard: auto-wires to DO SQLite
+const session = Session.create(this)
+  .withContext("memory", { maxTokens: 1100 })
+  .withCachedPrompt();
+
+// Postgres: pass providers explicitly
+const conn = wrapPgClient(pgClient);
+
+const session = Session.create(new PostgresSessionProvider(conn, sessionId))
+  .withContext("memory", {
+    maxTokens: 1100,
+    provider: new PostgresContextProvider(conn, `memory_${sessionId}`)
+  })
+  .withContext("knowledge", {
+    provider: new PostgresSearchProvider(conn)
+  })
+  .withCachedPrompt(new PostgresContextProvider(conn, `_prompt_${sessionId}`));
+```
+
+When `Session.create()` receives a `SessionProvider` (not a `SqlProvider`), it skips all SQLite auto-wiring. Context blocks and the prompt cache need explicit providers since there's no DO storage to fall back to.
+
+## Connection interface
+
+The providers use `?` placeholders internally. This example wraps the `pg` driver to convert them to `$1, $2, ...`:
+
+```ts
+interface PostgresConnection {
+  execute(
+    query: string,
+    args?: (string | number | boolean | null)[]
+  ): Promise<{ rows: Record<string, unknown>[] }>;
+}
+```
+
+Any Postgres driver with a compatible `execute()` method works.

--- a/experimental/session-planetscale/README.md
+++ b/experimental/session-planetscale/README.md
@@ -1,21 +1,21 @@
-# Postgres Session Example
+# PlanetScale Postgres Session Example
 
 Agent with session history stored in an external Postgres database via [Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) instead of Durable Object SQLite.
 
 ## Why external Postgres?
 
-DO SQLite is great for per-user state, but sessions live and die with the DO. An external database gives you:
+DO SQLite is great for per-user state and persists across hibernation and eviction. An external database is useful when you need access outside one Durable Object's local storage:
 
 - **Cross-DO queries** — search across all conversations from any Worker
 - **Analytics** — run SQL against your conversation data directly
-- **Decoupled lifecycle** — session data survives DO eviction, migration, and resets
+- **Decoupled ownership** — session data can be managed outside a single DO identity
 - **Shared state** — multiple DOs or services can read/write the same session tables
 
 ## Setup
 
 ### 1. Create a Postgres database
 
-Use any Postgres provider (Neon, Supabase, PlanetScale, etc.) and copy the connection string.
+Use PlanetScale Postgres or another Postgres provider (Neon, Supabase, etc.) and copy the connection string.
 
 ### 2. Create a Hyperdrive config
 

--- a/experimental/session-planetscale/README.md
+++ b/experimental/session-planetscale/README.md
@@ -24,7 +24,7 @@ npx wrangler hyperdrive create my-session-db \
   --connection-string="postgresql://user:password@host:port/dbname"
 ```
 
-Update `wrangler.jsonc` with the returned Hyperdrive ID.
+Update `wrangler.jsonc` with the returned Hyperdrive ID. The checked-in config intentionally uses a placeholder so deploys fail until you configure your own database.
 
 ### 3. Create the tables
 
@@ -48,24 +48,24 @@ const session = Session.create(this)
   .withCachedPrompt();
 
 // Postgres: pass providers explicitly
-const conn = wrapPgClient(pgClient);
-
-const session = Session.create(new PostgresSessionProvider(conn, sessionId))
+const session = Session.create(new PostgresSessionProvider(pgClient, sessionId))
   .withContext("memory", {
     maxTokens: 1100,
-    provider: new PostgresContextProvider(conn, `memory_${sessionId}`)
+    provider: new PostgresContextProvider(pgClient, `memory_${sessionId}`)
   })
   .withContext("knowledge", {
-    provider: new PostgresSearchProvider(conn)
+    provider: new PostgresSearchProvider(pgClient)
   })
-  .withCachedPrompt(new PostgresContextProvider(conn, `_prompt_${sessionId}`));
+  .withCachedPrompt(
+    new PostgresContextProvider(pgClient, `_prompt_${sessionId}`)
+  );
 ```
 
 When `Session.create()` receives a `SessionProvider` (not a `SqlProvider`), it skips all SQLite auto-wiring. Context blocks and the prompt cache need explicit providers since there's no DO storage to fall back to.
 
 ## Connection interface
 
-The providers use `?` placeholders internally. This example wraps the `pg` driver to convert them to `$1, $2, ...`:
+The providers accept a raw `pg.Client` or any custom driver that implements `PostgresConnection`. When a `pg`-style client is passed, the provider adapter rewrites internal `?` placeholders to `$1, $2, ...` automatically:
 
 ```ts
 interface PostgresConnection {
@@ -76,4 +76,4 @@ interface PostgresConnection {
 }
 ```
 
-Any Postgres driver with a compatible `execute()` method works.
+Use `PostgresConnection` for tests or bespoke drivers; use raw `pg.Client` for Hyperdrive.

--- a/experimental/session-planetscale/env.d.ts
+++ b/experimental/session-planetscale/env.d.ts
@@ -1,0 +1,7 @@
+declare namespace Cloudflare {
+  interface Env {
+    AI: Ai;
+    HYPERDRIVE: Hyperdrive;
+  }
+}
+interface Env extends Cloudflare.Env {}

--- a/experimental/session-planetscale/index.html
+++ b/experimental/session-planetscale/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" />
+    <title>PlanetScale Session</title>
+    <script>
+      (() => {
+        const mode = localStorage.getItem("theme") || "light";
+        document.documentElement.setAttribute("data-mode", mode);
+        document.documentElement.style.colorScheme = mode;
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/experimental/session-planetscale/package.json
+++ b/experimental/session-planetscale/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@cloudflare/agents-session-planetscale-example",
+  "version": "0.0.0",
+  "description": "Example of Agent with Postgres-backed session storage via Hyperdrive",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite dev",
+    "deploy": "vite build && wrangler deploy",
+    "types": "wrangler types env.d.ts --include-runtime false"
+  },
+  "dependencies": {
+    "@cloudflare/ai-chat": "*",
+    "@cloudflare/kumo": "^1.18.0",
+    "@phosphor-icons/react": "^2.1.10",
+    "agents": "*",
+    "ai": "^6.0.159",
+    "pg": "^8.13.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "workers-ai-provider": "*"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4",
+    "@types/pg": "^8.20.0",
+    "tailwindcss": "^4.2.2"
+  }
+}

--- a/experimental/session-planetscale/package.json
+++ b/experimental/session-planetscale/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@cloudflare/ai-chat": "*",
-    "@cloudflare/kumo": "^1.18.0",
+    "@cloudflare/kumo": "^1.19.0",
     "@phosphor-icons/react": "^2.1.10",
     "agents": "*",
-    "ai": "^6.0.159",
+    "ai": "^6.0.168",
     "pg": "^8.13.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/experimental/session-planetscale/package.json
+++ b/experimental/session-planetscale/package.json
@@ -11,18 +11,18 @@
   },
   "dependencies": {
     "@cloudflare/ai-chat": "*",
-    "@cloudflare/kumo": "^1.19.0",
+    "@cloudflare/kumo": "^2.1.0",
     "@phosphor-icons/react": "^2.1.10",
     "agents": "*",
-    "ai": "^6.0.168",
+    "ai": "^6.0.180",
     "pg": "^8.13.0",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "workers-ai-provider": "*"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4",
     "@types/pg": "^8.20.0",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.3.0"
   }
 }

--- a/experimental/session-planetscale/src/client.tsx
+++ b/experimental/session-planetscale/src/client.tsx
@@ -1,0 +1,486 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  Button,
+  Badge,
+  InputArea,
+  Empty,
+  Surface,
+  Text,
+  PoweredByCloudflare
+} from "@cloudflare/kumo";
+import {
+  TrashIcon,
+  ChatCircleDotsIcon,
+  CaretRightIcon,
+  CheckCircleIcon,
+  StackIcon,
+  MoonIcon,
+  SunIcon,
+  PaperPlaneRightIcon,
+  MagnifyingGlassIcon,
+  EyeIcon,
+  EyeSlashIcon
+} from "@phosphor-icons/react";
+import { useAgent } from "agents/react";
+import type { ChatAgent } from "./server";
+import type { UIMessage } from "ai";
+
+type ToolPart = Extract<UIMessage["parts"][number], { type: string }> & {
+  toolCallId: string;
+  toolName: string;
+  state: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+};
+
+function isToolPart(part: UIMessage["parts"][number]): part is ToolPart {
+  return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+}
+
+function ToolCard({ part }: { part: ToolPart }) {
+  const [open, setOpen] = useState(false);
+  const done = part.state === "output-available";
+  const label = [part.input?.action, part.input?.label]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Surface className="rounded-xl ring ring-kumo-line overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-2.5 cursor-pointer hover:bg-kumo-elevated transition-colors"
+        onClick={() => setOpen(!open)}
+      >
+        <CaretRightIcon
+          size={12}
+          className={`text-kumo-secondary transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <Text size="xs" bold>
+          {part.toolName}
+        </Text>
+        {label && (
+          <span className="font-mono text-xs text-kumo-secondary truncate">
+            {label}
+          </span>
+        )}
+        {done && (
+          <CheckCircleIcon
+            size={14}
+            className="text-green-500 ml-auto shrink-0"
+          />
+        )}
+      </button>
+      {open && (
+        <div className="px-3 pb-3 border-t border-kumo-line space-y-2 pt-2">
+          {part.input && (
+            <pre className="font-mono text-xs text-kumo-subtle bg-kumo-elevated rounded p-2 overflow-x-auto whitespace-pre-wrap">
+              {JSON.stringify(part.input, null, 2)}
+            </pre>
+          )}
+          {part.output != null && (
+            <pre className="font-mono text-xs text-green-600 dark:text-green-400 bg-green-500/5 border border-green-500/20 rounded p-2 overflow-x-auto whitespace-pre-wrap">
+              {typeof part.output === "string"
+                ? part.output
+                : JSON.stringify(part.output, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </Surface>
+  );
+}
+
+type ConnectionStatus = "connecting" | "connected" | "disconnected";
+
+function ConnectionIndicator({ status }: { status: ConnectionStatus }) {
+  const dot =
+    status === "connected"
+      ? "bg-green-500"
+      : status === "connecting"
+        ? "bg-yellow-500"
+        : "bg-red-500";
+  const text =
+    status === "connected"
+      ? "text-kumo-success"
+      : status === "connecting"
+        ? "text-kumo-warning"
+        : "text-kumo-danger";
+  const label =
+    status === "connected"
+      ? "Connected"
+      : status === "connecting"
+        ? "Connecting..."
+        : "Disconnected";
+  return (
+    <div className="flex items-center gap-2" role="status">
+      <span className={`size-2 rounded-full ${dot}`} />
+      <span className={`text-xs ${text}`}>{label}</span>
+    </div>
+  );
+}
+
+function ModeToggle() {
+  const [mode, setMode] = useState(
+    () => localStorage.getItem("theme") || "light"
+  );
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-mode", mode);
+    document.documentElement.style.colorScheme = mode;
+    localStorage.setItem("theme", mode);
+  }, [mode]);
+
+  return (
+    <Button
+      variant="ghost"
+      shape="square"
+      aria-label="Toggle theme"
+      onClick={() => setMode((m) => (m === "light" ? "dark" : "light"))}
+      icon={mode === "light" ? <MoonIcon size={16} /> : <SunIcon size={16} />}
+    />
+  );
+}
+
+function Chat() {
+  const [connectionStatus, setConnectionStatus] =
+    useState<ConnectionStatus>("connecting");
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<UIMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<Array<{
+    id: string;
+    role: string;
+    content: string;
+  }> | null>(null);
+  const [systemPrompt, setSystemPrompt] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const hasFetched = useRef(false);
+
+  const agent = useAgent<ChatAgent>({
+    agent: "ChatAgent",
+    name: "default",
+    onOpen: useCallback(() => setConnectionStatus("connected"), []),
+    onClose: useCallback(() => {
+      setConnectionStatus("disconnected");
+      hasFetched.current = false;
+    }, [])
+  });
+
+  // Load messages once on connect
+  if (connectionStatus === "connected" && !hasFetched.current) {
+    hasFetched.current = true;
+    agent
+      .call<UIMessage[]>("getMessages")
+      .then(setMessages)
+      .catch(console.error);
+  }
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const send = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+    setInput("");
+    setIsLoading(true);
+    const userMsg: UIMessage = {
+      id: `user-${crypto.randomUUID()}`,
+      role: "user",
+      parts: [{ type: "text", text }]
+    };
+    setMessages((prev) => [...prev, userMsg]);
+
+    try {
+      const assistantMsg = await agent.call<UIMessage>("chat", [
+        text,
+        userMsg.id
+      ]);
+      setMessages((prev) => [...prev, assistantMsg]);
+    } catch (err) {
+      console.error("Failed to send:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [input, isLoading, agent]);
+
+  const doSearch = useCallback(async () => {
+    if (!searchQuery.trim()) return;
+    try {
+      const results = await agent.call<
+        Array<{ id: string; role: string; content: string }>
+      >("search", [searchQuery]);
+      setSearchResults(results);
+    } catch (err) {
+      console.error("Search failed:", err);
+    }
+  }, [searchQuery, agent]);
+
+  const isConnected = connectionStatus === "connected";
+
+  return (
+    <div className="flex flex-col h-screen bg-kumo-elevated">
+      <header className="px-5 py-4 bg-kumo-base border-b border-kumo-line">
+        <div className="max-w-3xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <h1 className="text-lg font-semibold text-kumo-default">
+              PlanetScale Session
+            </h1>
+            <Badge variant="secondary">{messages.length} msgs</Badge>
+            <Badge variant="secondary">Postgres</Badge>
+          </div>
+          <div className="flex items-center gap-3">
+            <ConnectionIndicator status={connectionStatus} />
+            <ModeToggle />
+            <Button
+              variant="secondary"
+              icon={
+                systemPrompt !== null ? (
+                  <EyeSlashIcon size={16} />
+                ) : (
+                  <EyeIcon size={16} />
+                )
+              }
+              onClick={async () => {
+                if (systemPrompt !== null) {
+                  setSystemPrompt(null);
+                } else {
+                  try {
+                    const prompt = await agent.call<string>("getSystemPrompt");
+                    setSystemPrompt(prompt);
+                  } catch (err) {
+                    console.error("Failed to get system prompt:", err);
+                  }
+                }
+              }}
+            >
+              {systemPrompt !== null ? "Hide Prompt" : "System Prompt"}
+            </Button>
+            <Button
+              variant="secondary"
+              icon={<TrashIcon size={16} />}
+              onClick={async () => {
+                try {
+                  await agent.call("clearMessages");
+                  setMessages([]);
+                } catch (err) {
+                  console.error("Clear failed:", err);
+                }
+              }}
+              disabled={messages.length === 0}
+            >
+              Clear
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {systemPrompt !== null && (
+        <div className="border-b border-kumo-line bg-amber-50 dark:bg-amber-950/20 max-h-[40vh] overflow-y-auto">
+          <div className="max-w-3xl mx-auto px-5 py-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-bold text-amber-700 dark:text-amber-400">
+                System Prompt
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={async () => {
+                  try {
+                    const prompt = await agent.call<string>(
+                      "refreshSystemPrompt"
+                    );
+                    setSystemPrompt(prompt);
+                  } catch (err) {
+                    console.error(err);
+                  }
+                }}
+              >
+                Refresh
+              </Button>
+            </div>
+            <pre className="font-mono text-xs text-kumo-default whitespace-pre-wrap leading-relaxed">
+              {systemPrompt}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-3xl mx-auto px-5 py-6 space-y-5">
+          {messages.length === 0 && !isLoading && (
+            <Empty
+              icon={<ChatCircleDotsIcon size={32} />}
+              title="Start a conversation"
+              description="Messages persist in Postgres via Hyperdrive. The agent saves facts to memory and a searchable knowledge base. Try clearing the chat — memory survives."
+            />
+          )}
+
+          {messages.map((message) => {
+            if (message.role === "user") {
+              return (
+                <div key={message.id} className="flex justify-end">
+                  <div className="max-w-[80%] px-4 py-2.5 rounded-2xl rounded-br-md bg-kumo-contrast text-kumo-inverse text-sm leading-relaxed">
+                    {message.parts
+                      .filter((p) => p.type === "text")
+                      .map((p) => (p.type === "text" ? p.text : ""))
+                      .join("")}
+                  </div>
+                </div>
+              );
+            }
+
+            const isCompaction = message.id.startsWith("compaction_");
+            return (
+              <div key={message.id} className="space-y-2">
+                {isCompaction && (
+                  <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 font-semibold">
+                    <StackIcon size={12} weight="bold" /> Compacted Summary
+                  </div>
+                )}
+                {message.parts.map((part, i) => {
+                  if (part.type === "text" && part.text?.trim()) {
+                    return (
+                      <div key={i} className="flex justify-start">
+                        <Surface
+                          className={`max-w-[80%] rounded-2xl rounded-bl-md ring ${isCompaction ? "ring-amber-200 dark:ring-amber-800 bg-amber-50 dark:bg-amber-950/30" : "ring-kumo-line"}`}
+                        >
+                          <div className="px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap">
+                            {part.text}
+                          </div>
+                        </Surface>
+                      </div>
+                    );
+                  }
+                  if (isToolPart(part)) {
+                    return (
+                      <div key={part.toolCallId ?? i} className="max-w-[80%]">
+                        <ToolCard part={part} />
+                      </div>
+                    );
+                  }
+                  return null;
+                })}
+              </div>
+            );
+          })}
+
+          {isLoading && (
+            <div className="flex justify-start">
+              <div className="px-4 py-2.5 rounded-2xl rounded-bl-md bg-kumo-base">
+                <span className="inline-block w-2 h-2 bg-kumo-brand rounded-full mr-1 animate-pulse" />
+                <span
+                  className="inline-block w-2 h-2 bg-kumo-brand rounded-full mr-1 animate-pulse"
+                  style={{ animationDelay: "150ms" }}
+                />
+                <span
+                  className="inline-block w-2 h-2 bg-kumo-brand rounded-full animate-pulse"
+                  style={{ animationDelay: "300ms" }}
+                />
+              </div>
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+      </div>
+
+      {/* Search bar */}
+      <div className="border-t border-kumo-line bg-kumo-elevated">
+        <div className="max-w-3xl mx-auto px-5 py-2">
+          <div className="flex items-center gap-2">
+            <MagnifyingGlassIcon size={16} className="text-kumo-secondary" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") doSearch();
+              }}
+              placeholder="FULLTEXT search across messages..."
+              className="flex-1 text-sm bg-transparent outline-none text-kumo-default placeholder:text-kumo-subtle"
+            />
+            {searchResults && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchResults(null);
+                  setSearchQuery("");
+                }}
+                className="text-xs text-kumo-secondary hover:text-kumo-default"
+              >
+                clear
+              </button>
+            )}
+          </div>
+          {searchResults && (
+            <div className="mt-2 mb-1 space-y-1">
+              {searchResults.length === 0 ? (
+                <p className="text-xs text-kumo-subtle">No results</p>
+              ) : (
+                searchResults.map((r) => (
+                  <div
+                    key={r.id}
+                    className="text-xs p-2 rounded bg-kumo-base text-kumo-default truncate"
+                  >
+                    <span className="font-mono text-kumo-secondary">
+                      {r.role}:
+                    </span>{" "}
+                    {r.content.slice(0, 120)}
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Chat input */}
+      <div className="border-t border-kumo-line bg-kumo-base">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            send();
+          }}
+          className="max-w-3xl mx-auto px-5 py-4"
+        >
+          <div className="flex items-end gap-3 rounded-xl border border-kumo-line bg-kumo-base p-3 shadow-sm focus-within:ring-2 focus-within:ring-kumo-ring focus-within:border-transparent transition-shadow">
+            <InputArea
+              value={input}
+              onValueChange={setInput}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  send();
+                }
+              }}
+              placeholder={
+                isConnected
+                  ? "Ask me anything... stored in PlanetScale."
+                  : "Connecting..."
+              }
+              disabled={!isConnected || isLoading}
+              rows={2}
+              className="flex-1 !ring-0 focus:!ring-0 !shadow-none !bg-transparent !outline-none"
+            />
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              disabled={!input.trim() || !isConnected || isLoading}
+              icon={<PaperPlaneRightIcon size={18} />}
+              className="mb-0.5"
+            />
+          </div>
+        </form>
+        <div className="flex justify-center pb-3">
+          <PoweredByCloudflare href="https://developers.cloudflare.com/agents/" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  return <Chat />;
+}

--- a/experimental/session-planetscale/src/client.tsx
+++ b/experimental/session-planetscale/src/client.tsx
@@ -112,10 +112,10 @@ function ConnectionIndicator({ status }: { status: ConnectionStatus }) {
         ? "Connecting..."
         : "Disconnected";
   return (
-    <div className="flex items-center gap-2" role="status">
+    <output className="flex items-center gap-2">
       <span className={`size-2 rounded-full ${dot}`} />
       <span className={`text-xs ${text}`}>{label}</span>
-    </div>
+    </output>
   );
 }
 

--- a/experimental/session-planetscale/src/index.tsx
+++ b/experimental/session-planetscale/src/index.tsx
@@ -1,0 +1,6 @@
+import "./styles.css";
+import { createRoot } from "react-dom/client";
+import App from "./client";
+
+const root = createRoot(document.getElementById("root")!);
+root.render(<App />);

--- a/experimental/session-planetscale/src/server.ts
+++ b/experimental/session-planetscale/src/server.ts
@@ -1,0 +1,172 @@
+/**
+ * Hyperdrive + Postgres Session Example
+ *
+ * Uses Cloudflare Hyperdrive to connect to Postgres with connection pooling.
+ * Session data lives in the external database instead of DO SQLite.
+ */
+
+import { Agent, callable, routeAgentRequest } from "agents";
+import {
+  Session,
+  PostgresSessionProvider,
+  PostgresContextProvider,
+  PostgresSearchProvider,
+  type PostgresConnection
+} from "agents/experimental/memory/session";
+import type { UIMessage } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+import { generateText, convertToModelMessages, stepCountIs } from "ai";
+import { Client } from "pg";
+
+/**
+ * Wrap a pg Client to match the PostgresConnection interface.
+ * Converts `?` placeholders to `$1, $2, ...` for pg.
+ */
+function wrapPgClient(client: Client): PostgresConnection {
+  return {
+    async execute(query, args) {
+      let idx = 0;
+      const pgQuery = query.replace(/\?/g, () => `$${++idx}`);
+      const result = await client.query(pgQuery, args ?? []);
+      return { rows: result.rows };
+    }
+  };
+}
+
+export class ChatAgent extends Agent<Env> {
+  private _session?: Session;
+  private _pgClient?: Client;
+
+  private async getPgConnection(): Promise<PostgresConnection> {
+    if (!this._pgClient) {
+      this._pgClient = new Client({
+        connectionString: this.env.HYPERDRIVE.connectionString
+      });
+      await this._pgClient.connect();
+    }
+    return wrapPgClient(this._pgClient);
+  }
+
+  private async getSession(): Promise<Session> {
+    if (this._session) return this._session;
+
+    const conn = await this.getPgConnection();
+    const sessionId = this.ctx.id.toString();
+
+    this._session = Session.create(new PostgresSessionProvider(conn, sessionId))
+      .withContext("soul", {
+        provider: {
+          get: async () =>
+            "You are a helpful assistant with persistent memory and a searchable knowledge base."
+        }
+      })
+      .withContext("memory", {
+        description:
+          "Short facts — append one-liners like preferences, names, key details",
+        maxTokens: 1100,
+        provider: new PostgresContextProvider(conn, `memory_${sessionId}`)
+      })
+      .withContext("knowledge", {
+        description: "Searchable store for longer content",
+        provider: new PostgresSearchProvider(conn)
+      })
+      .withCachedPrompt(
+        new PostgresContextProvider(conn, `_prompt_${sessionId}`)
+      );
+
+    return this._session;
+  }
+
+  private getAI() {
+    return createWorkersAI({ binding: this.env.AI })(
+      "@cf/meta/llama-4-scout-17b-16e-instruct"
+    );
+  }
+
+  @callable()
+  async chat(message: string, messageId?: string): Promise<UIMessage> {
+    const session = await this.getSession();
+
+    await session.appendMessage({
+      id: messageId ?? `user-${crypto.randomUUID()}`,
+      role: "user",
+      parts: [{ type: "text", text: message }]
+    });
+
+    const history = await session.getHistory();
+
+    const result = await generateText({
+      model: this.getAI(),
+      system: await session.freezeSystemPrompt(),
+      messages: await convertToModelMessages(history as UIMessage[], {
+        ignoreIncompleteToolCalls: true
+      }),
+      tools: await session.tools(),
+      stopWhen: stepCountIs(5)
+    });
+
+    const parts: UIMessage["parts"] = [];
+
+    for (const step of result.steps) {
+      for (const tc of step.toolCalls) {
+        const tr = step.toolResults.find((r) => r.toolCallId === tc.toolCallId);
+        if (!tr) continue;
+        parts.push({
+          type: "dynamic-tool",
+          toolName: tc.toolName,
+          toolCallId: tc.toolCallId,
+          state: "output-available",
+          input: tc.input,
+          output: tr.output
+        } as unknown as UIMessage["parts"][number]);
+      }
+    }
+
+    if (result.text) {
+      parts.push({ type: "text", text: result.text });
+    }
+
+    const assistantMsg: UIMessage = {
+      id: `assistant-${crypto.randomUUID()}`,
+      role: "assistant",
+      parts
+    };
+
+    await session.appendMessage(assistantMsg);
+    return assistantMsg;
+  }
+
+  @callable()
+  async getMessages(): Promise<UIMessage[]> {
+    return (await (await this.getSession()).getHistory()) as UIMessage[];
+  }
+
+  @callable()
+  async search(query: string) {
+    return (await this.getSession()).search(query);
+  }
+
+  @callable()
+  async getSystemPrompt(): Promise<string> {
+    return (await this.getSession()).freezeSystemPrompt();
+  }
+
+  @callable()
+  async refreshSystemPrompt(): Promise<string> {
+    return (await this.getSession()).refreshSystemPrompt();
+  }
+
+  @callable()
+  async clearMessages(): Promise<void> {
+    await (await this.getSession()).clearMessages();
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return (
+      (await routeAgentRequest(request, env)) ||
+      new Response("Not found", { status: 404 })
+    );
+  }
+};

--- a/experimental/session-planetscale/src/server.ts
+++ b/experimental/session-planetscale/src/server.ts
@@ -10,50 +10,41 @@ import {
   Session,
   PostgresSessionProvider,
   PostgresContextProvider,
-  PostgresSearchProvider,
-  type PostgresConnection
+  PostgresSearchProvider
 } from "agents/experimental/memory/session";
 import type { UIMessage } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
 import { generateText, convertToModelMessages, stepCountIs } from "ai";
 import { Client } from "pg";
 
-/**
- * Wrap a pg Client to match the PostgresConnection interface.
- * Converts `?` placeholders to `$1, $2, ...` for pg.
- */
-function wrapPgClient(client: Client): PostgresConnection {
-  return {
-    async execute(query, args) {
-      let idx = 0;
-      const pgQuery = query.replace(/\?/g, () => `$${++idx}`);
-      const result = await client.query(pgQuery, args ?? []);
-      return { rows: result.rows };
-    }
-  };
-}
-
 export class ChatAgent extends Agent<Env> {
   private _session?: Session;
   private _pgClient?: Client;
 
-  private async getPgConnection(): Promise<PostgresConnection> {
-    if (!this._pgClient) {
-      this._pgClient = new Client({
-        connectionString: this.env.HYPERDRIVE.connectionString
-      });
-      await this._pgClient.connect();
-    }
-    return wrapPgClient(this._pgClient);
+  /**
+   * Open (or reuse) a connected pg.Client pointed at Hyperdrive.
+   * Assign to the instance field only once the connection succeeds so a
+   * failed attempt doesn't poison the instance for future calls.
+   */
+  private async getPgClient(): Promise<Client> {
+    if (this._pgClient) return this._pgClient;
+    const client = new Client({
+      connectionString: this.env.HYPERDRIVE.connectionString
+    });
+    await client.connect();
+    this._pgClient = client;
+    return client;
   }
 
   private async getSession(): Promise<Session> {
     if (this._session) return this._session;
 
-    const conn = await this.getPgConnection();
+    const client = await this.getPgClient();
     const sessionId = this.ctx.id.toString();
 
-    this._session = Session.create(new PostgresSessionProvider(conn, sessionId))
+    this._session = Session.create(
+      new PostgresSessionProvider(client, sessionId)
+    )
       .withContext("soul", {
         provider: {
           get: async () =>
@@ -64,14 +55,14 @@ export class ChatAgent extends Agent<Env> {
         description:
           "Short facts — append one-liners like preferences, names, key details",
         maxTokens: 1100,
-        provider: new PostgresContextProvider(conn, `memory_${sessionId}`)
+        provider: new PostgresContextProvider(client, `memory_${sessionId}`)
       })
       .withContext("knowledge", {
         description: "Searchable store for longer content",
-        provider: new PostgresSearchProvider(conn)
+        provider: new PostgresSearchProvider(client)
       })
       .withCachedPrompt(
-        new PostgresContextProvider(conn, `_prompt_${sessionId}`)
+        new PostgresContextProvider(client, `_prompt_${sessionId}`)
       );
 
     return this._session;

--- a/experimental/session-planetscale/src/server.ts
+++ b/experimental/session-planetscale/src/server.ts
@@ -22,26 +22,18 @@ export class ChatAgent extends Agent<Env> {
   private _pgClient?: Client;
 
   /**
-   * Open (or reuse) a connected pg.Client pointed at Hyperdrive.
-   * Assign to the instance field only once the connection succeeds so a
-   * failed attempt doesn't poison the instance for future calls.
+   * Initialize the Hyperdrive client and Session when the Durable Object starts.
+   * Keeping this out of request handlers avoids sharing a promise created under
+   * one request context with another request.
    */
-  private async getPgClient(): Promise<Client> {
-    if (this._pgClient) return this._pgClient;
+  async onStart(): Promise<void> {
     const client = new Client({
       connectionString: this.env.HYPERDRIVE.connectionString
     });
     await client.connect();
     this._pgClient = client;
-    return client;
-  }
 
-  private async getSession(): Promise<Session> {
-    if (this._session) return this._session;
-
-    const client = await this.getPgClient();
     const sessionId = this.ctx.id.toString();
-
     this._session = Session.create(
       new PostgresSessionProvider(client, sessionId)
     )
@@ -64,7 +56,12 @@ export class ChatAgent extends Agent<Env> {
       .withCachedPrompt(
         new PostgresContextProvider(client, `_prompt_${sessionId}`)
       );
+  }
 
+  private getSession(): Session {
+    if (!this._session) {
+      throw new Error("Session is not initialized yet");
+    }
     return this._session;
   }
 
@@ -76,7 +73,7 @@ export class ChatAgent extends Agent<Env> {
 
   @callable()
   async chat(message: string, messageId?: string): Promise<UIMessage> {
-    const session = await this.getSession();
+    const session = this.getSession();
 
     await session.appendMessage({
       id: messageId ?? `user-${crypto.randomUUID()}`,
@@ -129,27 +126,27 @@ export class ChatAgent extends Agent<Env> {
 
   @callable()
   async getMessages(): Promise<UIMessage[]> {
-    return (await (await this.getSession()).getHistory()) as UIMessage[];
+    return (await this.getSession().getHistory()) as UIMessage[];
   }
 
   @callable()
   async search(query: string) {
-    return (await this.getSession()).search(query);
+    return this.getSession().search(query);
   }
 
   @callable()
   async getSystemPrompt(): Promise<string> {
-    return (await this.getSession()).freezeSystemPrompt();
+    return this.getSession().freezeSystemPrompt();
   }
 
   @callable()
   async refreshSystemPrompt(): Promise<string> {
-    return (await this.getSession()).refreshSystemPrompt();
+    return this.getSession().refreshSystemPrompt();
   }
 
   @callable()
   async clearMessages(): Promise<void> {
-    await (await this.getSession()).clearMessages();
+    await this.getSession().clearMessages();
   }
 }
 

--- a/experimental/session-planetscale/src/styles.css
+++ b/experimental/session-planetscale/src/styles.css
@@ -1,0 +1,11 @@
+@import "tailwindcss";
+@import "@cloudflare/kumo/styles/tailwind";
+@source "../../../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}

--- a/experimental/session-planetscale/tsconfig.json
+++ b/experimental/session-planetscale/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "agents/tsconfig"
+}

--- a/experimental/session-planetscale/vite.config.ts
+++ b/experimental/session-planetscale/vite.config.ts
@@ -1,0 +1,9 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+import agents from "agents/vite";
+
+export default defineConfig({
+  plugins: [agents(), react(), cloudflare(), tailwindcss()]
+});

--- a/experimental/session-planetscale/wrangler.jsonc
+++ b/experimental/session-planetscale/wrangler.jsonc
@@ -1,0 +1,39 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "account_id": "543fbdef1eeaed8a02c251c8c4d9510b",
+  "name": "agents-session-planetscale-example",
+  "main": "src/server.ts",
+  "compatibility_date": "2026-01-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "ai": {
+    "binding": "AI"
+  },
+  "assets": {
+    "directory": "./public",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/agents/*"]
+  },
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "e9c4a010628841f2a23f30d7fdceb63d"
+    }
+  ],
+  "placement": {
+    "region": "aws:us-east-1"
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "ChatAgent",
+        "class_name": "ChatAgent"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ChatAgent"]
+    }
+  ]
+}

--- a/experimental/session-planetscale/wrangler.jsonc
+++ b/experimental/session-planetscale/wrangler.jsonc
@@ -1,6 +1,5 @@
 {
   "$schema": "../../node_modules/wrangler/config-schema.json",
-  "account_id": "543fbdef1eeaed8a02c251c8c4d9510b",
   "name": "agents-session-planetscale-example",
   "main": "src/server.ts",
   "compatibility_date": "2026-01-28",
@@ -9,14 +8,16 @@
     "binding": "AI"
   },
   "assets": {
-    "directory": "./public",
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*"]
   },
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",
-      "id": "e9c4a010628841f2a23f30d7fdceb63d"
+      // Replace this with the Hyperdrive ID returned by:
+      // npx wrangler hyperdrive create my-session-db --connection-string="..."
+      // Keeping a placeholder here makes deploy fail until the example is configured.
+      "id": "<your-hyperdrive-id>"
     }
   ],
   "placement": {

--- a/experimental/session-search/src/server.ts
+++ b/experimental/session-search/src/server.ts
@@ -86,7 +86,7 @@ export class SearchAgent extends Agent<Env> {
       parts: [{ type: "text", text: message }]
     });
 
-    const history = this.session.getHistory();
+    const history = await this.session.getHistory();
     const truncated = truncateOlderMessages(history);
 
     const result = streamText({
@@ -134,8 +134,8 @@ export class SearchAgent extends Agent<Env> {
   }
 
   @callable()
-  getMessages(): UIMessage[] {
-    return this.session.getHistory() as UIMessage[];
+  async getMessages(): Promise<UIMessage[]> {
+    return (await this.session.getHistory()) as UIMessage[];
   }
 
   @callable()
@@ -149,8 +149,8 @@ export class SearchAgent extends Agent<Env> {
   }
 
   @callable()
-  clearMessages(): void {
-    this.session.clearMessages();
+  async clearMessages(): Promise<void> {
+    await this.session.clearMessages();
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,6 +1030,61 @@
         "tailwindcss": "^4.2.2"
       }
     },
+    "experimental/session-planetscale": {
+      "name": "@cloudflare/agents-session-planetscale-example",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cloudflare/ai-chat": "*",
+        "@cloudflare/kumo": "^1.18.0",
+        "@phosphor-icons/react": "^2.1.10",
+        "agents": "*",
+        "ai": "^6.0.159",
+        "pg": "^8.13.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
+        "workers-ai-provider": "*"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4",
+        "@types/pg": "^8.20.0",
+        "tailwindcss": "^4.2.2"
+      }
+    },
+    "experimental/session-planetscale/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.96.tgz",
+      "integrity": "sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "experimental/session-planetscale/node_modules/ai": {
+      "version": "6.0.159",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.159.tgz",
+      "integrity": "sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.96",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "experimental/session-search": {
       "name": "@cloudflare/agents-session-search-example",
       "version": "0.0.0",
@@ -3500,6 +3555,10 @@
     },
     "node_modules/@cloudflare/agents-session-multichat-example": {
       "resolved": "experimental/session-multichat",
+      "link": true
+    },
+    "node_modules/@cloudflare/agents-session-planetscale-example": {
+      "resolved": "experimental/session-planetscale",
       "link": true
     },
     "node_modules/@cloudflare/agents-session-search-example": {
@@ -8823,6 +8882,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -17817,6 +17888,96 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -18056,6 +18217,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -19908,7 +20108,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -22065,6 +22264,15 @@
         }
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
@@ -22664,6 +22872,41 @@
         "streamdown": "^2.5.0",
         "workers-ai-provider": "^3.1.10",
         "zod": "^4.3.6"
+      }
+    },
+    "site/ai-playground/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.96.tgz",
+      "integrity": "sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "site/ai-playground/node_modules/ai": {
+      "version": "6.0.159",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.159.tgz",
+      "integrity": "sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.96",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "voice-providers/deepgram": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,6 +766,10 @@
         "wrangler": "^4.90.1"
       }
     },
+    "examples/think-slide-deck": {
+      "version": "0.0.0",
+      "extraneous": true
+    },
     "examples/think-submissions": {
       "name": "@cloudflare/agents-think-submissions-example",
       "version": "0.0.0",
@@ -1165,19 +1169,19 @@
       "version": "0.0.0",
       "dependencies": {
         "@cloudflare/ai-chat": "*",
-        "@cloudflare/kumo": "^1.18.0",
+        "@cloudflare/kumo": "^2.1.0",
         "@phosphor-icons/react": "^2.1.10",
         "agents": "*",
-        "ai": "^6.0.159",
+        "ai": "^6.0.180",
         "pg": "^8.13.0",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "workers-ai-provider": "*"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4",
         "@types/pg": "^8.20.0",
-        "tailwindcss": "^4.2.2"
+        "tailwindcss": "^4.3.0"
       }
     },
     "experimental/session-planetscale/node_modules/@ai-sdk/gateway": {
@@ -1195,6 +1199,37 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "experimental/session-planetscale/node_modules/@cloudflare/kumo": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kumo/-/kumo-1.19.0.tgz",
+      "integrity": "sha512-Ob91fqIbVwXMk/DTrod8oqs/uLiHOA1AbddJxfoPAuKRSjvVeImck34aow6ZJhWrfJi3uxLFOAI3569r5QFE0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@base-ui/react": "^1.2.0",
+        "@shikijs/langs": "^4.0.0",
+        "@shikijs/themes": "^4.0.0",
+        "clsx": "^2.1.1",
+        "motion": "^12.34.1",
+        "react-day-picker": "^9.13.2",
+        "shiki": "^4.0.0",
+        "tailwind-merge": "^3.4.0"
+      },
+      "bin": {
+        "kumo": "bin/kumo.js"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/react": "^2.1.10",
+        "echarts": "^6.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "experimental/session-planetscale/node_modules/ai": {
@@ -17986,7 +18021,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1160,6 +1160,61 @@
         "tailwindcss": "^4.3.0"
       }
     },
+    "experimental/session-planetscale": {
+      "name": "@cloudflare/agents-session-planetscale-example",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cloudflare/ai-chat": "*",
+        "@cloudflare/kumo": "^1.18.0",
+        "@phosphor-icons/react": "^2.1.10",
+        "agents": "*",
+        "ai": "^6.0.159",
+        "pg": "^8.13.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
+        "workers-ai-provider": "*"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4",
+        "@types/pg": "^8.20.0",
+        "tailwindcss": "^4.2.2"
+      }
+    },
+    "experimental/session-planetscale/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.96.tgz",
+      "integrity": "sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "experimental/session-planetscale/node_modules/ai": {
+      "version": "6.0.159",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.159.tgz",
+      "integrity": "sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.96",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "experimental/session-search": {
       "name": "@cloudflare/agents-session-search-example",
       "version": "0.0.0",
@@ -3563,6 +3618,10 @@
     },
     "node_modules/@cloudflare/agents-session-multichat-example": {
       "resolved": "experimental/session-multichat",
+      "link": true
+    },
+    "node_modules/@cloudflare/agents-session-planetscale-example": {
+      "resolved": "experimental/session-planetscale",
       "link": true
     },
     "node_modules/@cloudflare/agents-session-search-example": {
@@ -8826,6 +8885,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -17910,6 +17981,96 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -18128,6 +18289,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -19918,7 +20118,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -21941,6 +22140,15 @@
         }
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
@@ -22527,6 +22735,41 @@
         "streamdown": "^2.5.0",
         "workers-ai-provider": "^3.1.14",
         "zod": "^4.4.3"
+      }
+    },
+    "site/ai-playground/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.96.tgz",
+      "integrity": "sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "site/ai-playground/node_modules/ai": {
+      "version": "6.0.159",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.159.tgz",
+      "integrity": "sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.96",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "voice-providers/deepgram": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,10 +766,6 @@
         "wrangler": "^4.90.1"
       }
     },
-    "examples/think-slide-deck": {
-      "version": "0.0.0",
-      "extraneous": true
-    },
     "examples/think-submissions": {
       "name": "@cloudflare/agents-think-submissions-example",
       "version": "0.0.0",

--- a/packages/agents/src/experimental/memory/session/context.ts
+++ b/packages/agents/src/experimental/memory/session/context.ts
@@ -21,6 +21,16 @@ import { estimateStringTokens } from "../utils/tokens";
 import { isSearchProvider, type SearchProvider } from "./search";
 import { isSkillProvider, type SkillProvider } from "./skills";
 
+function slugify(text: string): string {
+  return (
+    text
+      .slice(0, 60)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "") || "entry"
+  );
+}
+
 /**
  * Base storage interface for a context block.
  * A provider with only `get()` is readonly.
@@ -445,7 +455,11 @@ export class ContextBlocks {
     if (!existing) {
       throw new Error(`Block "${label}" not found`);
     }
-    return this.setBlock(label, existing.content + content);
+    const needsSep = existing.content.length > 0 && !content.startsWith("\n");
+    return this.setBlock(
+      label,
+      existing.content + (needsSep ? "\n" : "") + content
+    );
   }
 
   /**
@@ -479,20 +493,20 @@ export class ContextBlocks {
     const sep = "═".repeat(46);
 
     for (const block of this.blocks.values()) {
-      // Searchable blocks render even when empty so the model knows they exist
-      if (!block.content && !block.isSearchable) continue;
+      // Skip empty readonly blocks — writable/searchable always render
+      // so the LLM knows they exist and can write to them
+      if (!block.content && !block.writable && !block.isSearchable) continue;
 
       let header = block.label.toUpperCase();
-      const hints: string[] = [];
-      if (block.description) hints.push(block.description);
-      if (block.isSkill) hints.push("use load_context to load");
-      if (block.isSearchable) hints.push("use search_context to search");
-      if (hints.length > 0) header += ` (${hints.join(" — ")})`;
+      if (block.description) header += ` (${block.description})`;
       if (block.maxTokens) {
         const pct = Math.round((block.tokens / block.maxTokens) * 100);
         header += ` [${pct}% — ${block.tokens}/${block.maxTokens} tokens]`;
       }
-      if (!block.writable) header += " [readonly]";
+      if (block.isSearchable) header += " [searchable]";
+      else if (block.isSkill) header += " [loadable]";
+      else if (!block.writable) header += " [readonly]";
+      else header += " [writable]";
 
       parts.push(`${sep}\n${header}\n${sep}\n${block.content}`);
     }
@@ -543,9 +557,9 @@ export class ContextBlocks {
   // ── Public API ──────────────────────────────────────────────────
 
   /**
-   * Frozen system prompt. On first call:
-   * 1. Checks store for a persisted prompt (survives DO eviction)
-   * 2. If none, loads blocks from providers, renders, and persists
+   * Return the cached system prompt. If no cached prompt exists,
+   * loads blocks from providers, renders, and persists to the store.
+   * Subsequent calls return the stored value without re-rendering.
    */
   async freezeSystemPrompt(): Promise<string> {
     if (this.promptStore) {
@@ -564,10 +578,13 @@ export class ContextBlocks {
   }
 
   /**
-   * Re-render the system prompt from current block state and persist.
+   * Force reload blocks from providers, re-render the system prompt,
+   * and persist to the store. Use this after block content has changed
+   * or to invalidate the cached prompt.
    */
   async refreshSystemPrompt(): Promise<string> {
-    if (!this.loaded) await this.load();
+    this.loaded = false;
+    await this.load();
     const prompt = this.refreshSnapshot();
 
     if (this.promptStore) {
@@ -596,29 +613,17 @@ export class ContextBlocks {
     // ── set_context ──────────────────────────────────────────────
 
     if (writable.length > 0) {
-      const regularBlocks = writable.filter(
-        (b) => !b.isSkill && !b.isSearchable
+      const blockDescriptions = writable.map(
+        (b) => `- "${b.label}": ${b.description ?? "no description"}`
       );
       const keyedBlocks = writable.filter((b) => b.isSkill || b.isSearchable);
-
-      const blockDescriptions: string[] = [];
-      for (const b of regularBlocks) {
-        blockDescriptions.push(
-          `- "${b.label}": ${b.description ?? "no description"}`
-        );
-      }
-      for (const b of keyedBlocks) {
-        const kind = b.isSkill
-          ? "skill collection (requires key and optional description)"
-          : "searchable (requires key)";
-        blockDescriptions.push(`- "${b.label}": ${kind}`);
-      }
 
       const properties: Record<string, unknown> = {
         label: {
           type: "string" as const,
-          enum: writable.map((b) => b.label),
-          description: "Block label to write to"
+          description:
+            "Block label to write to. Must be one of: " +
+            writable.map((b) => `"${b.label}"`).join(", ")
         },
         content: {
           type: "string" as const,
@@ -631,22 +636,14 @@ export class ContextBlocks {
         }
       };
 
-      const required = ["label", "content"];
-
       if (keyedBlocks.length > 0) {
-        properties.key = {
+        properties.title = {
           type: "string" as const,
           description:
-            "Entry key (required for keyed blocks: " +
-            keyedBlocks.map((b) => `"${b.label}"`).join(", ") +
-            ")"
-        };
-      }
-
-      if (keyedBlocks.some((b) => b.isSkill)) {
-        properties.description = {
-          type: "string" as const,
-          description: "Short description for the skill entry"
+            "Short title for the entry. Used as a stable identifier — " +
+            "entries with the same title are updated, different titles create new entries. " +
+            "Applies to: " +
+            keyedBlocks.map((b) => `"${b.label}"`).join(", ")
         };
       }
 
@@ -655,36 +652,30 @@ export class ContextBlocks {
         inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: properties as Record<string, Record<string, unknown>>,
-          required
+          required: ["label", "content"]
         }),
         execute: async ({
           label,
           content,
-          key,
-          description,
+          title,
           action
         }: {
           label: string;
           content: string;
-          key?: string;
-          description?: string;
+          title?: string;
           action?: string;
         }) => {
           try {
             const block = this.blocks.get(label);
             if (!block) return `Error: block "${label}" not found`;
 
-            if (block.isSkill) {
-              if (!key)
-                return `Error: key is required for skill block "${label}"`;
-              await this.setSkill(label, key, content, description);
-              return `Written skill "${key}" to ${label}.`;
-            }
-
-            if (block.isSearchable) {
-              if (!key)
-                return `Error: key is required for searchable block "${label}"`;
-              await this.setSearchEntry(label, key, content);
+            if (block.isSkill || block.isSearchable) {
+              const key = slugify(title ?? content);
+              if (block.isSkill) {
+                await this.setSkill(label, key, content, title);
+              } else {
+                await this.setSearchEntry(label, key, content);
+              }
               return `Indexed "${key}" in ${label}.`;
             }
 
@@ -719,8 +710,9 @@ export class ContextBlocks {
           properties: {
             label: {
               type: "string" as const,
-              enum: skillLabels,
-              description: "Skill block label"
+              description:
+                "Skill block label. Must be one of: " +
+                skillLabels.map((l) => `"${l}"`).join(", ")
             },
             key: {
               type: "string" as const,
@@ -731,6 +723,9 @@ export class ContextBlocks {
         }),
         execute: async ({ label, key }: { label: string; key: string }) => {
           try {
+            if (!skillLabels.includes(label)) {
+              return `Error: "${label}" is not a skill block. Skill blocks: ${skillLabels.join(", ")}`;
+            }
             const content = await this.loadSkill(label, key);
             return content ?? `Not found: ${key}`;
           } catch (err) {
@@ -752,8 +747,9 @@ export class ContextBlocks {
           properties: {
             label: {
               type: "string" as const,
-              enum: skillLabels,
-              description: "Skill block label"
+              description:
+                "Skill block label. Must be one of: " +
+                skillLabels.map((l) => `"${l}"`).join(", ")
             },
             key: {
               type: "string" as const,
@@ -763,6 +759,9 @@ export class ContextBlocks {
           required: ["label", "key"]
         }),
         execute: async ({ label, key }: { label: string; key: string }) => {
+          if (!skillLabels.includes(label)) {
+            return `Error: "${label}" is not a skill block. Skill blocks: ${skillLabels.join(", ")}`;
+          }
           const unloaded = this.unloadSkill(label, key);
           if (!unloaded) {
             return `Skill "${key}" is not currently loaded in "${label}".`;
@@ -780,16 +779,17 @@ export class ContextBlocks {
       toolSet.search_context = {
         description:
           "Search for information in a searchable context block. " +
-          "Available searchable blocks: " +
+          "ONLY these blocks are searchable: " +
           searchLabels.map((l) => `"${l}"`).join(", ") +
-          ".",
+          ". Other blocks (e.g. memory) cannot be searched.",
         inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: {
             label: {
               type: "string" as const,
-              enum: searchLabels,
-              description: "Searchable block label"
+              description:
+                "Searchable block label. Must be one of: " +
+                searchLabels.map((l) => `"${l}"`).join(", ")
             },
             query: {
               type: "string" as const,
@@ -800,6 +800,9 @@ export class ContextBlocks {
         }),
         execute: async ({ label, query }: { label: string; query: string }) => {
           try {
+            if (!searchLabels.includes(label)) {
+              return `Error: "${label}" is not searchable. Searchable blocks: ${searchLabels.join(", ")}`;
+            }
             const results = await this.searchContext(label, query);
             return results ?? "No results found.";
           } catch (err) {

--- a/packages/agents/src/experimental/memory/session/context.ts
+++ b/packages/agents/src/experimental/memory/session/context.ts
@@ -621,13 +621,12 @@ export class ContextBlocks {
       const properties: Record<string, unknown> = {
         label: {
           type: "string" as const,
-          description:
-            "Block label to write to. Must be one of: " +
-            writable.map((b) => `"${b.label}"`).join(", ")
+          enum: writable.map((b) => b.label),
+          description: "Block label to write to"
         },
         content: {
           type: "string" as const,
-          description: "Content to write"
+          description: "The main content to write to the block."
         },
         action: {
           type: "string" as const,
@@ -637,18 +636,41 @@ export class ContextBlocks {
       };
 
       if (keyedBlocks.length > 0) {
-        properties.title = {
-          type: "string" as const,
+        properties.metadata = {
+          type: "object" as const,
           description:
-            "Short title for the entry. Used as a stable identifier — " +
-            "entries with the same title are updated, different titles create new entries. " +
-            "Applies to: " +
-            keyedBlocks.map((b) => `"${b.label}"`).join(", ")
+            "Optional metadata for keyed entries (skill collections, searchable blocks: " +
+            keyedBlocks.map((b) => `"${b.label}"`).join(", ") +
+            "). Short content doesn't need metadata; longer loadable entries (skills) " +
+            "benefit from a title and description so the model can pick the right one " +
+            "without loading it.",
+          properties: {
+            title: {
+              type: "string" as const,
+              description:
+                "Short title. Used as a stable identifier — entries with the " +
+                "same title are updated in place, different titles create new entries."
+            },
+            description: {
+              type: "string" as const,
+              description:
+                "One-line summary shown alongside the title in the system prompt " +
+                "so the model can decide when to load the entry."
+            }
+          }
         };
       }
 
+      const metadataHint =
+        keyedBlocks.length > 0
+          ? "\n\nFor keyed blocks (skill collections / searchable), pass " +
+            "`metadata: { title, description }` — title stabilises updates, " +
+            "description helps the model pick entries. Metadata is optional; " +
+            "short content rarely needs it, long loadable entries benefit most."
+          : "";
+
       toolSet.set_context = {
-        description: `Write to a context block. Available blocks:\n${blockDescriptions.join("\n")}\n\nWrites are durable and persist across sessions.`,
+        description: `Write to a context block. Available blocks:\n${blockDescriptions.join("\n")}\n\nWrites are durable and persist across sessions.${metadataHint}`,
         inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: properties as Record<string, Record<string, unknown>>,
@@ -657,12 +679,12 @@ export class ContextBlocks {
         execute: async ({
           label,
           content,
-          title,
+          metadata,
           action
         }: {
           label: string;
           content: string;
-          title?: string;
+          metadata?: { title?: string; description?: string };
           action?: string;
         }) => {
           try {
@@ -670,9 +692,11 @@ export class ContextBlocks {
             if (!block) return `Error: block "${label}" not found`;
 
             if (block.isSkill || block.isSearchable) {
+              const title = metadata?.title;
+              const description = metadata?.description;
               const key = slugify(title ?? content);
               if (block.isSkill) {
-                await this.setSkill(label, key, content, title);
+                await this.setSkill(label, key, content, description ?? title);
               } else {
                 await this.setSearchEntry(label, key, content);
               }
@@ -710,9 +734,8 @@ export class ContextBlocks {
           properties: {
             label: {
               type: "string" as const,
-              description:
-                "Skill block label. Must be one of: " +
-                skillLabels.map((l) => `"${l}"`).join(", ")
+              enum: skillLabels,
+              description: "Skill block label"
             },
             key: {
               type: "string" as const,
@@ -747,9 +770,8 @@ export class ContextBlocks {
           properties: {
             label: {
               type: "string" as const,
-              description:
-                "Skill block label. Must be one of: " +
-                skillLabels.map((l) => `"${l}"`).join(", ")
+              enum: skillLabels,
+              description: "Skill block label"
             },
             key: {
               type: "string" as const,
@@ -781,15 +803,14 @@ export class ContextBlocks {
           "Search for information in a searchable context block. " +
           "ONLY these blocks are searchable: " +
           searchLabels.map((l) => `"${l}"`).join(", ") +
-          ". Other blocks (e.g. memory) cannot be searched.",
+          ". Other blocks cannot be searched.",
         inputSchema: z.fromJSONSchema({
           type: "object" as const,
           properties: {
             label: {
               type: "string" as const,
-              description:
-                "Searchable block label. Must be one of: " +
-                searchLabels.map((l) => `"${l}"`).join(", ")
+              enum: searchLabels,
+              description: "Searchable block label"
             },
             query: {
               type: "string" as const,

--- a/packages/agents/src/experimental/memory/session/context.ts
+++ b/packages/agents/src/experimental/memory/session/context.ts
@@ -510,9 +510,15 @@ export class ContextBlocks {
     const sep = "═".repeat(46);
 
     for (const block of this.blocks.values()) {
-      // Skip empty readonly blocks — writable/searchable always render
-      // so the LLM knows they exist and can write to them
-      if (!block.content && !block.writable && !block.isSearchable) continue;
+      // Skip empty readonly blocks — writable/searchable/skill blocks always
+      // render so the LLM knows which tools can address them.
+      if (
+        !block.content &&
+        !block.writable &&
+        !block.isSearchable &&
+        !block.isSkill
+      )
+        continue;
 
       let header = block.label.toUpperCase();
       if (block.description) header += ` (${block.description})`;
@@ -630,9 +636,14 @@ export class ContextBlocks {
     // ── set_context ──────────────────────────────────────────────
 
     if (writable.length > 0) {
-      const blockDescriptions = writable.map(
-        (b) => `- "${b.label}": ${b.description ?? "no description"}`
-      );
+      const blockDescriptions = writable.map((b) => {
+        const kind = b.isSkill
+          ? "skill collection, keyed entries"
+          : b.isSearchable
+            ? "searchable, keyed entries"
+            : "writable";
+        return `- "${b.label}" (${kind}): ${b.description ?? "no description"}`;
+      });
       const keyedBlocks = writable.filter((b) => b.isSkill || b.isSearchable);
 
       const properties: Record<string, unknown> = {

--- a/packages/agents/src/experimental/memory/session/context.ts
+++ b/packages/agents/src/experimental/memory/session/context.ts
@@ -22,13 +22,30 @@ import { isSearchProvider, type SearchProvider } from "./search";
 import { isSkillProvider, type SkillProvider } from "./skills";
 
 function slugify(text: string): string {
-  return (
-    text
-      .slice(0, 60)
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "") || "entry"
-  );
+  return text
+    .slice(0, 60)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function stableHash(text: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function contextEntryKey(metadataTitle: string | undefined, content: string) {
+  if (metadataTitle?.trim()) {
+    const slug = slugify(metadataTitle);
+    return slug || `entry-${stableHash(metadataTitle)}`;
+  }
+
+  const slug = slugify(content) || "entry";
+  return `${slug}-${stableHash(content)}`;
 }
 
 /**
@@ -694,7 +711,7 @@ export class ContextBlocks {
             if (block.isSkill || block.isSearchable) {
               const title = metadata?.title;
               const description = metadata?.description;
-              const key = slugify(title ?? content);
+              const key = contextEntryKey(title, content);
               if (block.isSkill) {
                 await this.setSkill(label, key, content, description ?? title);
               } else {

--- a/packages/agents/src/experimental/memory/session/index.ts
+++ b/packages/agents/src/experimental/memory/session/index.ts
@@ -44,6 +44,16 @@ export type {
 } from "./provider";
 export { AgentSessionProvider, type SqlProvider } from "./providers/agent";
 export { AgentContextProvider } from "./providers/agent-context";
+
+export {
+  PostgresSessionProvider,
+  type PostgresConnection
+} from "./providers/postgres";
+
+export { PostgresContextProvider } from "./providers/postgres-context";
+
+export { PostgresSearchProvider } from "./providers/postgres-search";
+
 export { Session, type SessionContextOptions } from "./session";
 export type { SearchProvider } from "./search";
 export { AgentSearchProvider, isSearchProvider } from "./search";

--- a/packages/agents/src/experimental/memory/session/index.ts
+++ b/packages/agents/src/experimental/memory/session/index.ts
@@ -47,6 +47,8 @@ export { AgentContextProvider } from "./providers/agent-context";
 
 export {
   PostgresSessionProvider,
+  type PgClientLike,
+  type PostgresClient,
   type PostgresConnection
 } from "./providers/postgres";
 

--- a/packages/agents/src/experimental/memory/session/manager.ts
+++ b/packages/agents/src/experimental/memory/session/manager.ts
@@ -251,8 +251,8 @@ export class SessionManager {
     ` as unknown as SessionInfo[];
   }
 
-  delete(sessionId: string): void {
-    this.getSession(sessionId).clearMessages();
+  async delete(sessionId: string): Promise<void> {
+    await this.getSession(sessionId).clearMessages();
     this.agent.sql`DELETE FROM assistant_sessions WHERE id = ${sessionId}`;
     this._sessions.delete(sessionId);
   }
@@ -283,9 +283,9 @@ export class SessionManager {
     parentId?: string
   ): Promise<string> {
     const session = this.getSession(sessionId);
-    const existing = session.getMessage(message.id);
+    const existing = await session.getMessage(message.id);
     if (existing) {
-      session.updateMessage(message);
+      await session.updateMessage(message);
     } else {
       await session.appendMessage(message, parentId);
     }
@@ -308,27 +308,33 @@ export class SessionManager {
     return lastParent;
   }
 
-  getHistory(sessionId: string, leafId?: string): SessionMessage[] {
+  async getHistory(
+    sessionId: string,
+    leafId?: string
+  ): Promise<SessionMessage[]> {
     return this.getSession(sessionId).getHistory(leafId);
   }
 
-  getMessageCount(sessionId: string): number {
+  async getMessageCount(sessionId: string): Promise<number> {
     return this.getSession(sessionId).getPathLength();
   }
 
-  clearMessages(sessionId: string): void {
-    this.getSession(sessionId).clearMessages();
+  async clearMessages(sessionId: string): Promise<void> {
+    await this.getSession(sessionId).clearMessages();
     this._touch(sessionId);
   }
 
-  deleteMessages(sessionId: string, messageIds: string[]): void {
-    this.getSession(sessionId).deleteMessages(messageIds);
+  async deleteMessages(sessionId: string, messageIds: string[]): Promise<void> {
+    await this.getSession(sessionId).deleteMessages(messageIds);
     this._touch(sessionId);
   }
 
   // ── Branching ──────────────────────────────────────────────────
 
-  getBranches(sessionId: string, messageId: string): SessionMessage[] {
+  async getBranches(
+    sessionId: string,
+    messageId: string
+  ): Promise<SessionMessage[]> {
     return this.getSession(sessionId).getBranches(messageId);
   }
 
@@ -342,7 +348,7 @@ export class SessionManager {
     newName: string
   ): Promise<SessionInfo> {
     const info = this.create(newName, { parentSessionId: sessionId });
-    const history = this.getSession(sessionId).getHistory(atMessageId);
+    const history = await this.getSession(sessionId).getHistory(atMessageId);
     const newSession = this.getSession(info.id);
 
     let parentId: string | null = null;
@@ -359,16 +365,16 @@ export class SessionManager {
 
   // ── Compaction ────────────────────────────────────────────────
 
-  addCompaction(
+  async addCompaction(
     sessionId: string,
     summary: string,
     fromId: string,
     toId: string
-  ): StoredCompaction {
+  ): Promise<StoredCompaction> {
     return this.getSession(sessionId).addCompaction(summary, fromId, toId);
   }
 
-  getCompactions(sessionId: string): StoredCompaction[] {
+  async getCompactions(sessionId: string): Promise<StoredCompaction[]> {
     return this.getSession(sessionId).getCompactions();
   }
 

--- a/packages/agents/src/experimental/memory/session/provider.ts
+++ b/packages/agents/src/experimental/memory/session/provider.ts
@@ -2,6 +2,7 @@
  * Session Provider Interface
  *
  * Pure storage for tree-structured messages with compaction overlays and search.
+ * Methods return `T | Promise<T>` so both sync (DO SQLite) and async (PlanetScale, etc.) work.
  */
 
 import type { SessionMessage } from "./types";
@@ -29,19 +30,23 @@ export interface StoredCompaction {
 export interface SessionProvider {
   // ── Read ────────────────────────────────────────────────────────
 
-  getMessage(id: string): SessionMessage | null;
+  getMessage(
+    id: string
+  ): SessionMessage | null | Promise<SessionMessage | null>;
 
   /**
    * Get conversation as a path from root to leaf.
    * Applies compaction overlays. If leafId is null, uses the latest leaf.
    */
-  getHistory(leafId?: string | null): SessionMessage[];
+  getHistory(
+    leafId?: string | null
+  ): SessionMessage[] | Promise<SessionMessage[]>;
 
-  getLatestLeaf(): SessionMessage | null;
+  getLatestLeaf(): SessionMessage | null | Promise<SessionMessage | null>;
 
-  getBranches(messageId: string): SessionMessage[];
+  getBranches(messageId: string): SessionMessage[] | Promise<SessionMessage[]>;
 
-  getPathLength(leafId?: string | null): number;
+  getPathLength(leafId?: string | null): number | Promise<number>;
 
   // ── Write ──────────────────────────────────────────────────────
 
@@ -49,13 +54,16 @@ export interface SessionProvider {
    * Append a message. Parented to the latest leaf unless parentId is provided.
    * Idempotent — same message.id twice is a no-op.
    */
-  appendMessage(message: SessionMessage, parentId?: string | null): void;
+  appendMessage(
+    message: SessionMessage,
+    parentId?: string | null
+  ): void | Promise<void>;
 
-  updateMessage(message: SessionMessage): void;
+  updateMessage(message: SessionMessage): void | Promise<void>;
 
-  deleteMessages(messageIds: string[]): void;
+  deleteMessages(messageIds: string[]): void | Promise<void>;
 
-  clearMessages(): void;
+  clearMessages(): void | Promise<void>;
 
   // ── Compaction ─────────────────────────────────────────────────
 
@@ -63,11 +71,14 @@ export interface SessionProvider {
     summary: string,
     fromMessageId: string,
     toMessageId: string
-  ): StoredCompaction;
+  ): StoredCompaction | Promise<StoredCompaction>;
 
-  getCompactions(): StoredCompaction[];
+  getCompactions(): StoredCompaction[] | Promise<StoredCompaction[]>;
 
   // ── Search ─────────────────────────────────────────────────────
 
-  searchMessages?(query: string, limit?: number): SearchResult[];
+  searchMessages?(
+    query: string,
+    limit?: number
+  ): SearchResult[] | Promise<SearchResult[]>;
 }

--- a/packages/agents/src/experimental/memory/session/provider.ts
+++ b/packages/agents/src/experimental/memory/session/provider.ts
@@ -51,8 +51,16 @@ export interface SessionProvider {
   // ── Write ──────────────────────────────────────────────────────
 
   /**
-   * Append a message. Parented to the latest leaf unless parentId is provided.
-   * Idempotent — same message.id twice is a no-op.
+   * Append a message.
+   *
+   * `parentId` semantics:
+   *   - `undefined` / omitted → auto-detect: attach to the current latest leaf.
+   *   - `null`                → create a root message with no parent.
+   *   - string                → attach to the given parent id (provider may
+   *                            fall back to root if the parent doesn't
+   *                            belong to this session).
+   *
+   * Idempotent — appending the same `message.id` twice is a no-op.
    */
   appendMessage(
     message: SessionMessage,

--- a/packages/agents/src/experimental/memory/session/providers/agent.ts
+++ b/packages/agents/src/experimental/memory/session/providers/agent.ts
@@ -173,7 +173,13 @@ export class AgentSessionProvider implements SessionProvider {
     `;
     if (existing.length > 0) return;
 
-    let parent = parentId ?? this.latestLeafRow()?.id ?? null;
+    // Honour the `SessionProvider` contract:
+    //   - `undefined` / omitted → auto-detect (attach to latest leaf)
+    //   - explicit `null`       → create a root message with no parent
+    // Using `??` here would collapse those two cases; `parentId !== undefined`
+    // preserves the distinction.
+    let parent =
+      parentId !== undefined ? parentId : (this.latestLeafRow()?.id ?? null);
 
     // Validate parentId belongs to this session
     if (parent) {

--- a/packages/agents/src/experimental/memory/session/providers/postgres-adapter.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres-adapter.ts
@@ -1,0 +1,76 @@
+/**
+ * Postgres connection adapter.
+ *
+ * Lets the Postgres-backed providers accept either:
+ *   - a raw `pg.Client` (or any client with a compatible `query` method), or
+ *   - the internal `PostgresConnection` interface used by tests and custom drivers.
+ *
+ * When a `pg`-style client is passed, `?` placeholders are rewritten to
+ * `$1, $2, ...` on the way through, so the providers can keep using the
+ * portable `?` syntax internally without users having to write a wrapper.
+ */
+
+/**
+ * Minimal connection interface used internally by the Postgres providers.
+ * Tests and custom drivers can implement this directly.
+ */
+export interface PostgresConnection {
+  execute(
+    query: string,
+    args?: (string | number | boolean | null)[]
+  ): Promise<{ rows: Record<string, unknown>[] }>;
+}
+
+/**
+ * Structural type matching `pg.Client` (and most `pg`-compatible pools).
+ * Accepts the subset of the real client that the providers need, so users
+ * can pass `new pg.Client({ connectionString: env.HYPERDRIVE.connectionString })`
+ * directly without a wrapper.
+ */
+export interface PgClientLike {
+  query(
+    queryText: string,
+    values?: readonly unknown[]
+  ): Promise<{ rows: Record<string, unknown>[] }>;
+}
+
+/**
+ * Accepted client type across the Postgres providers.
+ *
+ * Use `pg.Client` (the recommended path for Hyperdrive):
+ * ```ts
+ * const client = new Client({ connectionString: env.HYPERDRIVE.connectionString });
+ * await client.connect();
+ * new PostgresSessionProvider(client, sessionId);
+ * ```
+ *
+ * Or implement `PostgresConnection` for tests / bespoke drivers.
+ */
+export type PostgresClient = PostgresConnection | PgClientLike;
+
+function isPostgresConnection(
+  client: PostgresClient
+): client is PostgresConnection {
+  return typeof (client as PostgresConnection).execute === "function";
+}
+
+/**
+ * Normalise an incoming client into a `PostgresConnection`. When given a
+ * `pg`-style client we translate `?` placeholders to `$1, $2, ...` so the
+ * providers can keep using the portable `?` syntax internally.
+ */
+export function toPostgresConnection(
+  client: PostgresClient
+): PostgresConnection {
+  if (isPostgresConnection(client)) return client;
+
+  const pg = client as PgClientLike;
+  return {
+    async execute(query, args) {
+      let idx = 0;
+      const pgQuery = query.replace(/\?/g, () => `$${++idx}`);
+      const result = await pg.query(pgQuery, args ?? []);
+      return { rows: result.rows };
+    }
+  };
+}

--- a/packages/agents/src/experimental/memory/session/providers/postgres-context.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres-context.ts
@@ -6,14 +6,25 @@
  */
 
 import type { WritableContextProvider } from "../context";
-import type { PostgresConnection } from "./postgres";
+import {
+  toPostgresConnection,
+  type PostgresClient,
+  type PostgresConnection
+} from "./postgres-adapter";
 
 export class PostgresContextProvider implements WritableContextProvider {
   private conn: PostgresConnection;
   private label: string;
 
-  constructor(conn: PostgresConnection, label: string) {
-    this.conn = conn;
+  /**
+   * @param client A raw `pg.Client` (recommended) or any `PostgresConnection`.
+   *   Must already be connected.
+   * @param label Block label used as the primary key row in
+   *   `cf_agents_context_blocks`. Pass a session-scoped label (e.g.
+   *   `` `memory_${sessionId}` ``) for per-session state.
+   */
+  constructor(client: PostgresClient, label: string) {
+    this.conn = toPostgresConnection(client);
     this.label = label;
   }
 

--- a/packages/agents/src/experimental/memory/session/providers/postgres-context.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres-context.ts
@@ -1,0 +1,36 @@
+/**
+ * Postgres Context Block Provider
+ *
+ * Durable storage for context blocks using Postgres.
+ * Table must be created by the customer via migration — see docs for the schema.
+ */
+
+import type { WritableContextProvider } from "../context";
+import type { PostgresConnection } from "./postgres";
+
+export class PostgresContextProvider implements WritableContextProvider {
+  private conn: PostgresConnection;
+  private label: string;
+
+  constructor(conn: PostgresConnection, label: string) {
+    this.conn = conn;
+    this.label = label;
+  }
+
+  async get(): Promise<string | null> {
+    const { rows } = await this.conn.execute(
+      "SELECT content FROM cf_agents_context_blocks WHERE label = ?",
+      [this.label]
+    );
+    return (rows[0]?.content as string) ?? null;
+  }
+
+  async set(content: string): Promise<void> {
+    await this.conn.execute(
+      `INSERT INTO cf_agents_context_blocks (label, content)
+       VALUES (?, ?)
+       ON CONFLICT (label) DO UPDATE SET content = EXCLUDED.content, updated_at = NOW()`,
+      [this.label, content]
+    );
+  }
+}

--- a/packages/agents/src/experimental/memory/session/providers/postgres-search.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres-search.ts
@@ -1,0 +1,73 @@
+/**
+ * Postgres Search Provider
+ *
+ * Full-text searchable context blocks backed by Postgres.
+ * Uses tsvector + GIN index for ranked search.
+ *
+ * Requires migration — see docs for the schema:
+ *
+ *   CREATE TABLE cf_agents_search_entries (
+ *     label TEXT NOT NULL,
+ *     key TEXT NOT NULL,
+ *     content TEXT NOT NULL,
+ *     content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
+ *     created_at TIMESTAMPTZ DEFAULT NOW(),
+ *     updated_at TIMESTAMPTZ DEFAULT NOW(),
+ *     PRIMARY KEY (label, key)
+ *   );
+ *   CREATE INDEX idx_search_entries_fts ON cf_agents_search_entries USING GIN (content_tsv);
+ */
+
+import type { SearchProvider } from "../search";
+import type { PostgresConnection } from "./postgres";
+
+export class PostgresSearchProvider implements SearchProvider {
+  private conn: PostgresConnection;
+  private label = "";
+
+  constructor(conn: PostgresConnection) {
+    this.conn = conn;
+  }
+
+  init(label: string): void {
+    this.label = label;
+  }
+
+  async get(): Promise<string | null> {
+    const { rows } = await this.conn.execute(
+      "SELECT COUNT(*) as count FROM cf_agents_search_entries WHERE label = ?",
+      [this.label]
+    );
+    const count = Number(rows[0]?.count ?? 0);
+    if (count === 0) return null;
+    return `${count} entries indexed.`;
+  }
+
+  async search(query: string): Promise<string | null> {
+    if (!query.trim()) return null;
+
+    const { rows } = await this.conn.execute(
+      `SELECT key, content FROM cf_agents_search_entries
+       WHERE label = ? AND content_tsv @@ plainto_tsquery('english', ?)
+       ORDER BY ts_rank(content_tsv, plainto_tsquery('english', ?)) DESC
+       LIMIT 10`,
+      [this.label, query, query]
+    );
+
+    if (rows.length === 0) return "No results found.";
+    return rows
+      .map((r) => `[${r.key as string}]\n${r.content as string}`)
+      .join("\n\n");
+  }
+
+  async set(key: string, content: string): Promise<void> {
+    await this.conn.execute(
+      `INSERT INTO cf_agents_search_entries (label, key, content)
+       VALUES (?, ?, ?)
+       ON CONFLICT (label, key) DO UPDATE SET
+         content = EXCLUDED.content,
+         updated_at = NOW()`,
+      [this.label, key, content]
+    );
+  }
+}

--- a/packages/agents/src/experimental/memory/session/providers/postgres-search.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres-search.ts
@@ -19,14 +19,22 @@
  */
 
 import type { SearchProvider } from "../search";
-import type { PostgresConnection } from "./postgres";
+import {
+  toPostgresConnection,
+  type PostgresClient,
+  type PostgresConnection
+} from "./postgres-adapter";
 
 export class PostgresSearchProvider implements SearchProvider {
   private conn: PostgresConnection;
   private label = "";
 
-  constructor(conn: PostgresConnection) {
-    this.conn = conn;
+  /**
+   * @param client A raw `pg.Client` (recommended) or any `PostgresConnection`.
+   *   Must already be connected.
+   */
+  constructor(client: PostgresClient) {
+    this.conn = toPostgresConnection(client);
   }
 
   init(label: string): void {

--- a/packages/agents/src/experimental/memory/session/providers/postgres.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres.ts
@@ -4,8 +4,15 @@
  * Postgres-backed provider with tree-structured messages,
  * compaction overlays, and full-text search.
  *
- * Works with any driver matching the PostgresConnection interface.
- * Use with Hyperdrive for connection pooling from Workers.
+ * Accepts either a raw `pg.Client` (recommended for Hyperdrive) or any
+ * object implementing the internal `PostgresConnection` interface.
+ *
+ * ```ts
+ * import { Client } from "pg";
+ * const client = new Client({ connectionString: env.HYPERDRIVE.connectionString });
+ * await client.connect();
+ * new PostgresSessionProvider(client, sessionId);
+ * ```
  *
  * Tables must be created by the customer via migration — see docs for the schema.
  */
@@ -16,25 +23,31 @@ import type {
   StoredCompaction
 } from "../provider";
 import type { SessionMessage } from "../types";
+import {
+  toPostgresConnection,
+  type PostgresClient,
+  type PostgresConnection
+} from "./postgres-adapter";
 
-/**
- * Minimal connection interface.
- * Compatible with `pg` Client, Hyperdrive-wrapped connections,
- * or any Postgres driver with a similar `execute` method.
- */
-export interface PostgresConnection {
-  execute(
-    query: string,
-    args?: (string | number | boolean | null)[]
-  ): Promise<{ rows: Record<string, unknown>[] }>;
-}
+export type {
+  PostgresClient,
+  PostgresConnection,
+  PgClientLike
+} from "./postgres-adapter";
 
 export class PostgresSessionProvider implements SessionProvider {
   private conn: PostgresConnection;
   private sessionId: string;
 
-  constructor(conn: PostgresConnection, sessionId?: string) {
-    this.conn = conn;
+  /**
+   * @param client A raw `pg.Client` (recommended) or any `PostgresConnection`.
+   *   Must already be connected — this provider never opens or closes the
+   *   underlying client.
+   * @param sessionId Session identifier. Different ids are fully isolated
+   *   rows within the shared tables. Defaults to `""`.
+   */
+  constructor(client: PostgresClient, sessionId?: string) {
+    this.conn = toPostgresConnection(client);
     this.sessionId = sessionId ?? "";
   }
 
@@ -122,10 +135,17 @@ export class PostgresSessionProvider implements SessionProvider {
     message: SessionMessage,
     parentId?: string | null
   ): Promise<void> {
+    // Honour the `SessionProvider` contract:
+    //   - `undefined` / omitted → auto-detect (attach to latest leaf)
+    //   - explicit `null`       → create a root message with no parent
+    // Using `??` here would collapse those two cases; `parentId !== undefined`
+    // preserves the distinction.
     const parent =
-      parentId ?? ((await this.latestLeafRow())?.id as string) ?? null;
+      parentId !== undefined
+        ? parentId
+        : (((await this.latestLeafRow())?.id as string | undefined) ?? null);
     const json = JSON.stringify(message);
-    const text = this.extractText(json);
+    const text = this.extractSearchableText(json);
 
     await this.conn.execute(
       `INSERT INTO assistant_messages (id, session_id, parent_id, role, content, text_content)
@@ -139,7 +159,7 @@ export class PostgresSessionProvider implements SessionProvider {
     const json = JSON.stringify(message);
     await this.conn.execute(
       "UPDATE assistant_messages SET content = ?, text_content = ? WHERE id = ? AND session_id = ?",
-      [json, this.extractText(json), message.id, this.sessionId]
+      [json, this.extractSearchableText(json), message.id, this.sessionId]
     );
   }
 
@@ -289,7 +309,15 @@ export class PostgresSessionProvider implements SessionProvider {
     return result;
   }
 
-  private extractText(json: string): string {
+  /**
+   * Extract just the human-readable text from a message's JSON blob
+   * and store it in `text_content`, which feeds the generated `content_tsv`
+   * column used for FTS. The full structured message (parts, tool calls,
+   * metadata) is still stored verbatim in `content` — this is the source
+   * of truth. Indexing the raw JSON would return FTS hits on keys like
+   * `"role"`, `"parts"`, `"dynamic-tool"`, etc.
+   */
+  private extractSearchableText(json: string): string {
     const msg = this.parse(json);
     if (!msg) return json;
     return msg.parts

--- a/packages/agents/src/experimental/memory/session/providers/postgres.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres.ts
@@ -1,0 +1,300 @@
+/**
+ * Postgres Session Provider
+ *
+ * Postgres-backed provider with tree-structured messages,
+ * compaction overlays, and full-text search.
+ *
+ * Works with any driver matching the PostgresConnection interface.
+ * Use with Hyperdrive for connection pooling from Workers.
+ *
+ * Tables must be created by the customer via migration — see docs for the schema.
+ */
+
+import type {
+  SessionProvider,
+  SearchResult,
+  StoredCompaction
+} from "../provider";
+import type { SessionMessage } from "../types";
+
+/**
+ * Minimal connection interface.
+ * Compatible with `pg` Client, Hyperdrive-wrapped connections,
+ * or any Postgres driver with a similar `execute` method.
+ */
+export interface PostgresConnection {
+  execute(
+    query: string,
+    args?: (string | number | boolean | null)[]
+  ): Promise<{ rows: Record<string, unknown>[] }>;
+}
+
+export class PostgresSessionProvider implements SessionProvider {
+  private conn: PostgresConnection;
+  private sessionId: string;
+
+  constructor(conn: PostgresConnection, sessionId?: string) {
+    this.conn = conn;
+    this.sessionId = sessionId ?? "";
+  }
+
+  // ── Read ───────────────────────────────────────────────────────
+
+  async getMessage(id: string): Promise<SessionMessage | null> {
+    const { rows } = await this.conn.execute(
+      "SELECT content FROM assistant_messages WHERE id = ? AND session_id = ?",
+      [id, this.sessionId]
+    );
+    return rows.length > 0 ? this.parse(rows[0].content as string) : null;
+  }
+
+  async getHistory(leafId?: string | null): Promise<SessionMessage[]> {
+    const leaf = leafId
+      ? (
+          await this.conn.execute(
+            "SELECT id FROM assistant_messages WHERE id = ? AND session_id = ?",
+            [leafId, this.sessionId]
+          )
+        ).rows[0]
+      : await this.latestLeafRow();
+
+    if (!leaf) return [];
+
+    const { rows } = await this.conn.execute(
+      `WITH RECURSIVE path AS (
+        SELECT id, parent_id, content, 0 as depth FROM assistant_messages WHERE id = ? AND session_id = ?
+        UNION ALL
+        SELECT m.id, m.parent_id, m.content, p.depth + 1 FROM assistant_messages m
+        JOIN path p ON m.id = p.parent_id
+        WHERE m.session_id = ? AND p.depth < 10000
+      )
+      SELECT content FROM path ORDER BY depth DESC`,
+      [leaf.id as string, this.sessionId, this.sessionId]
+    );
+
+    const messages = this.parseRows(rows);
+    const compactions = await this.getCompactions();
+    if (compactions.length === 0) return messages;
+    return this.applyCompactions(messages, compactions);
+  }
+
+  async getLatestLeaf(): Promise<SessionMessage | null> {
+    const row = await this.latestLeafRow();
+    return row ? this.parse(row.content as string) : null;
+  }
+
+  async getBranches(messageId: string): Promise<SessionMessage[]> {
+    const { rows } = await this.conn.execute(
+      "SELECT content FROM assistant_messages WHERE parent_id = ? AND session_id = ? ORDER BY created_at ASC",
+      [messageId, this.sessionId]
+    );
+    return this.parseRows(rows);
+  }
+
+  async getPathLength(leafId?: string | null): Promise<number> {
+    const leaf = leafId
+      ? (
+          await this.conn.execute(
+            "SELECT id FROM assistant_messages WHERE id = ? AND session_id = ?",
+            [leafId, this.sessionId]
+          )
+        ).rows[0]
+      : await this.latestLeafRow();
+    if (!leaf) return 0;
+
+    const { rows } = await this.conn.execute(
+      `WITH RECURSIVE path AS (
+        SELECT id, parent_id, 0 as depth FROM assistant_messages WHERE id = ? AND session_id = ?
+        UNION ALL
+        SELECT m.id, m.parent_id, p.depth + 1 FROM assistant_messages m
+        JOIN path p ON m.id = p.parent_id
+        WHERE m.session_id = ? AND p.depth < 10000
+      )
+      SELECT COUNT(*) as count FROM path`,
+      [leaf.id as string, this.sessionId, this.sessionId]
+    );
+    return Number(rows[0]?.count ?? 0);
+  }
+
+  // ── Write ──────────────────────────────────────────────────────
+
+  async appendMessage(
+    message: SessionMessage,
+    parentId?: string | null
+  ): Promise<void> {
+    const parent =
+      parentId ?? ((await this.latestLeafRow())?.id as string) ?? null;
+    const json = JSON.stringify(message);
+    const text = this.extractText(json);
+
+    await this.conn.execute(
+      `INSERT INTO assistant_messages (id, session_id, parent_id, role, content, text_content)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (id) DO NOTHING`,
+      [message.id, this.sessionId, parent, message.role, json, text]
+    );
+  }
+
+  async updateMessage(message: SessionMessage): Promise<void> {
+    const json = JSON.stringify(message);
+    await this.conn.execute(
+      "UPDATE assistant_messages SET content = ?, text_content = ? WHERE id = ? AND session_id = ?",
+      [json, this.extractText(json), message.id, this.sessionId]
+    );
+  }
+
+  async deleteMessages(messageIds: string[]): Promise<void> {
+    for (const id of messageIds) {
+      await this.conn.execute(
+        "DELETE FROM assistant_messages WHERE id = ? AND session_id = ?",
+        [id, this.sessionId]
+      );
+    }
+  }
+
+  async clearMessages(): Promise<void> {
+    await this.conn.execute(
+      "DELETE FROM assistant_messages WHERE session_id = ?",
+      [this.sessionId]
+    );
+    await this.conn.execute(
+      "DELETE FROM assistant_compactions WHERE session_id = ?",
+      [this.sessionId]
+    );
+  }
+
+  // ── Compaction ─────────────────────────────────────────────────
+
+  async addCompaction(
+    summary: string,
+    fromMessageId: string,
+    toMessageId: string
+  ): Promise<StoredCompaction> {
+    const id = crypto.randomUUID();
+    await this.conn.execute(
+      "INSERT INTO assistant_compactions (id, session_id, summary, from_message_id, to_message_id) VALUES (?, ?, ?, ?, ?)",
+      [id, this.sessionId, summary, fromMessageId, toMessageId]
+    );
+    return {
+      id,
+      summary,
+      fromMessageId,
+      toMessageId,
+      createdAt: new Date().toISOString()
+    };
+  }
+
+  async getCompactions(): Promise<StoredCompaction[]> {
+    const { rows } = await this.conn.execute(
+      "SELECT * FROM assistant_compactions WHERE session_id = ? ORDER BY created_at ASC",
+      [this.sessionId]
+    );
+    return rows.map((r) => ({
+      id: r.id as string,
+      summary: r.summary as string,
+      fromMessageId: r.from_message_id as string,
+      toMessageId: r.to_message_id as string,
+      createdAt: r.created_at as string
+    }));
+  }
+
+  // ── Search ─────────────────────────────────────────────────────
+
+  async searchMessages(query: string, limit = 20): Promise<SearchResult[]> {
+    const { rows } = await this.conn.execute(
+      `SELECT id, role, text_content FROM assistant_messages
+       WHERE session_id = ? AND content_tsv @@ plainto_tsquery('english', ?)
+       ORDER BY ts_rank(content_tsv, plainto_tsquery('english', ?)) DESC
+       LIMIT ?`,
+      [this.sessionId, query, query, limit]
+    );
+    return rows.map((r) => ({
+      id: r.id as string,
+      role: r.role as string,
+      content: (r.text_content as string) ?? "",
+      createdAt: ""
+    }));
+  }
+
+  // ── Internal ───────────────────────────────────────────────────
+
+  private async latestLeafRow(): Promise<Record<string, unknown> | null> {
+    const { rows } = await this.conn.execute(
+      `SELECT m.id, m.content FROM assistant_messages m
+       LEFT JOIN assistant_messages c ON c.parent_id = m.id AND c.session_id = ?
+       WHERE c.id IS NULL AND m.session_id = ?
+       ORDER BY m.created_at DESC LIMIT 1`,
+      [this.sessionId, this.sessionId]
+    );
+    return rows[0] ?? null;
+  }
+
+  private applyCompactions(
+    messages: SessionMessage[],
+    compactions: StoredCompaction[]
+  ): SessionMessage[] {
+    const ids = messages.map((m) => m.id);
+    const result: SessionMessage[] = [];
+    let i = 0;
+    while (i < messages.length) {
+      const matching = compactions.filter((c) => c.fromMessageId === ids[i]);
+      const comp =
+        matching.length > 1 ? matching[matching.length - 1] : matching[0];
+      if (comp) {
+        const endIdx = ids.indexOf(comp.toMessageId);
+        if (endIdx >= i) {
+          result.push({
+            id: `compaction_${comp.id}`,
+            role: "assistant",
+            parts: [
+              {
+                type: "text",
+                text: comp.summary
+              }
+            ],
+            createdAt: new Date()
+          });
+          i = endIdx + 1;
+          continue;
+        }
+      }
+      result.push(messages[i]);
+      i++;
+    }
+    return result;
+  }
+
+  private parse(json: string): SessionMessage | null {
+    try {
+      const msg = JSON.parse(json);
+      if (
+        typeof msg?.id === "string" &&
+        typeof msg?.role === "string" &&
+        Array.isArray(msg?.parts)
+      ) {
+        return msg;
+      }
+    } catch {
+      /* skip */
+    }
+    return null;
+  }
+
+  private parseRows(rows: Record<string, unknown>[]): SessionMessage[] {
+    const result: SessionMessage[] = [];
+    for (const row of rows) {
+      const msg = this.parse(row.content as string);
+      if (msg) result.push(msg);
+    }
+    return result;
+  }
+
+  private extractText(json: string): string {
+    const msg = this.parse(json);
+    if (!msg) return json;
+    return msg.parts
+      .filter((p) => p.type === "text" && p.text)
+      .map((p) => p.text)
+      .join("\n");
+  }
+}

--- a/packages/agents/src/experimental/memory/session/providers/postgres.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres.ts
@@ -223,7 +223,10 @@ export class PostgresSessionProvider implements SessionProvider {
       summary: r.summary as string,
       fromMessageId: r.from_message_id as string,
       toMessageId: r.to_message_id as string,
-      createdAt: r.created_at as string
+      createdAt:
+        r.created_at instanceof Date
+          ? r.created_at.toISOString()
+          : String(r.created_at)
     }));
   }
 

--- a/packages/agents/src/experimental/memory/session/providers/postgres.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres.ts
@@ -140,17 +140,26 @@ export class PostgresSessionProvider implements SessionProvider {
     //   - explicit `null`       → create a root message with no parent
     // Using `??` here would collapse those two cases; `parentId !== undefined`
     // preserves the distinction.
-    const parent =
+    let parent =
       parentId !== undefined
         ? parentId
         : (((await this.latestLeafRow())?.id as string | undefined) ?? null);
+
+    if (parent) {
+      const { rows } = await this.conn.execute(
+        "SELECT id FROM assistant_messages WHERE id = ? AND session_id = ?",
+        [parent, this.sessionId]
+      );
+      if (rows.length === 0) parent = null;
+    }
+
     const json = JSON.stringify(message);
     const text = this.extractSearchableText(json);
 
     await this.conn.execute(
       `INSERT INTO assistant_messages (id, session_id, parent_id, role, content, text_content)
        VALUES (?, ?, ?, ?, ?, ?)
-       ON CONFLICT (id) DO NOTHING`,
+       ON CONFLICT (session_id, id) DO NOTHING`,
       [message.id, this.sessionId, parent, message.role, json, text]
     );
   }

--- a/packages/agents/src/experimental/memory/session/search.ts
+++ b/packages/agents/src/experimental/memory/session/search.ts
@@ -101,15 +101,7 @@ export class AgentSearchProvider implements SearchProvider {
     `;
     const count = rows[0]?.count ?? 0;
     if (count === 0) return null;
-
-    const keys = this.agent.sql<{ key: string }>`
-      SELECT key FROM cf_agents_search_entries
-      WHERE label = ${this.label}
-      ORDER BY updated_at DESC
-      LIMIT 20
-    `;
-    const listing = keys.map((r) => `- ${r.key}`).join("\n");
-    return `${count} entries indexed. Recent:\n${listing}`;
+    return `${count} entries indexed.`;
   }
 
   async search(query: string): Promise<string | null> {

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -60,6 +60,11 @@ export class Session {
     | null;
   private _tokenThreshold?: number;
   private _ready = false;
+  // Promise for the async skill restore kicked off during _ensureReady().
+  // Every async public method awaits this before touching storage or
+  // skill-state — guarantees loaded-skill tracking is rehydrated after
+  // hibernation, even for async SessionProviders.
+  private _restorePromise?: Promise<void>;
 
   constructor(storage: SessionProvider, options?: SessionOptions) {
     this.storage = storage;
@@ -100,15 +105,15 @@ export class Session {
    *   .withCachedPrompt(new PlanetScaleContextProvider(conn, "_prompt"));
    * ```
    */
-  static create(storageOrAgent: SqlProvider | SessionProvider): Session {
+  static create(provider: SqlProvider | SessionProvider): Session {
     const session: Session = Object.create(Session.prototype);
-    if (isSqlProvider(storageOrAgent)) {
-      session._agent = storageOrAgent;
-      if (isBroadcaster(storageOrAgent)) {
-        session._broadcaster = storageOrAgent;
+    if (isSqlProvider(provider)) {
+      session._agent = provider;
+      if (isBroadcaster(provider)) {
+        session._broadcaster = provider;
       }
     } else {
-      session._storageProvider = storageOrAgent;
+      session._storageProvider = provider;
     }
     session._pending = [];
     session._ready = false;
@@ -201,19 +206,33 @@ export class Session {
     this.context.setUnloadCallback((label, key) => {
       this._reclaimLoadedSkill(label, key).catch(() => {});
     });
-    this._restoreLoadedSkills();
     this._ready = true;
+    // Kick off skill restoration in the background. Async public methods
+    // await `_ensureRestored()` before touching skill-tracking state.
+    this._restorePromise = this._restoreLoadedSkills().catch(() => {
+      // Restore failures are non-fatal: we lose tracking for this DO
+      // lifetime but the session itself stays usable.
+    });
+  }
+
+  /**
+   * Await the background skill-restore kicked off by `_ensureReady()`.
+   * Idempotent and cheap — every async public method calls this so that
+   * `_loadedSkills` reflects conversation history before any read or write.
+   */
+  private async _ensureRestored(): Promise<void> {
+    this._ensureReady();
+    if (this._restorePromise) await this._restorePromise;
   }
 
   /**
    * Reconstruct which skills are loaded by scanning conversation history
    * for load_context tool results that haven't been unloaded.
-   * Called during init to survive hibernation/eviction.
+   * Runs once per init to survive hibernation / eviction, including for
+   * async SessionProviders (e.g. Postgres) where we must `await` history.
    */
-  private _restoreLoadedSkills(): void {
-    const history = this.storage.getHistory();
-    // If the provider is async, history is a Promise — skip restore for async providers
-    if (history instanceof Promise) return;
+  private async _restoreLoadedSkills(): Promise<void> {
+    const history = await this.storage.getHistory();
 
     const loaded = new Set<string>();
 
@@ -258,8 +277,19 @@ export class Session {
   }
 
   /**
-   * Replace a load_context tool result in conversation history
-   * with a short marker to reclaim context space.
+   * Reclaim context-window tokens consumed by a previously loaded skill.
+   *
+   * When a skill is loaded via the `load_context` tool, its full body is
+   * embedded as that tool call's `output-available` result inside the
+   * assistant message — which means every subsequent turn replays the
+   * entire skill as part of the conversation history and pays for it in
+   * input tokens.
+   *
+   * This method walks back through history, finds the matching
+   * `load_context` tool result for `(label, key)`, and replaces its bulky
+   * `output` with a short marker `[skill unloaded: <key>]`. The skill
+   * content is dropped from future turns and the tokens are reclaimed.
+   * The skill itself stays available to reload via `load_context`.
    */
   private async _reclaimLoadedSkill(label: string, key: string): Promise<void> {
     const history = await this.storage.getHistory();
@@ -297,27 +327,27 @@ export class Session {
   // ── History (tree-structured) ─────────────────────────────────
 
   async getHistory(leafId?: string | null): Promise<SessionMessage[]> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.storage.getHistory(leafId);
   }
 
   async getMessage(id: string): Promise<SessionMessage | null> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.storage.getMessage(id);
   }
 
   async getLatestLeaf(): Promise<SessionMessage | null> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.storage.getLatestLeaf();
   }
 
   async getBranches(messageId: string): Promise<SessionMessage[]> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.storage.getBranches(messageId);
   }
 
   async getPathLength(leafId?: string | null): Promise<number> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.storage.getPathLength(leafId);
   }
 
@@ -352,7 +382,7 @@ export class Session {
     message: SessionMessage,
     parentId?: string | null
   ): Promise<void> {
-    this._ensureReady();
+    await this._ensureRestored();
     await this.storage.appendMessage(message, parentId);
 
     const tokenEstimate = await this._emitStatus("idle");
@@ -371,19 +401,19 @@ export class Session {
   }
 
   async updateMessage(message: SessionMessage): Promise<void> {
-    this._ensureReady();
+    await this._ensureRestored();
     await this.storage.updateMessage(message);
     await this._emitStatus("idle");
   }
 
   async deleteMessages(messageIds: string[]): Promise<void> {
-    this._ensureReady();
+    await this._ensureRestored();
     await this.storage.deleteMessages(messageIds);
     await this._emitStatus("idle");
   }
 
   async clearMessages(): Promise<void> {
-    this._ensureReady();
+    await this._ensureRestored();
     await this.storage.clearMessages();
     this.context.clearSkillState();
     await this.context.refreshSystemPrompt();
@@ -397,12 +427,12 @@ export class Session {
     fromMessageId: string,
     toMessageId: string
   ): Promise<StoredCompaction> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.storage.addCompaction(summary, fromMessageId, toMessageId);
   }
 
   async getCompactions(): Promise<StoredCompaction[]> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.storage.getCompactions();
   }
 
@@ -411,7 +441,7 @@ export class Session {
    * Requires `onCompaction()` to be called first.
    */
   async compact(): Promise<CompactResult | null> {
-    this._ensureReady();
+    await this._ensureRestored();
     if (!this._compactionFn) {
       throw new Error(
         "No compaction function registered. Call onCompaction() first."
@@ -471,7 +501,7 @@ export class Session {
     label: string,
     content: string
   ): Promise<ContextBlock> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.context.setBlock(label, content);
   }
 
@@ -479,13 +509,18 @@ export class Session {
     label: string,
     content: string
   ): Promise<ContextBlock> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.context.appendToBlock(label, content);
   }
 
   /**
    * Dynamically register a new context block after session initialization.
-   * Used by extensions to contribute context blocks at runtime.
+   *
+   * This is a **builder / runtime API**, not an LLM tool. The LLM writes
+   * into existing context blocks via the `set_context` tool (see
+   * `ContextBlocks.tools()`); it cannot declare new blocks itself. This
+   * method is how extension / host code contributes blocks at runtime
+   * (e.g. an extension's `onLoad` handler registering its own memory block).
    *
    * The block's provider is initialized and loaded immediately.
    * Call `refreshSystemPrompt()` afterward to include the new block
@@ -499,7 +534,7 @@ export class Session {
     label: string,
     options?: SessionContextOptions
   ): Promise<ContextBlock> {
-    this._ensureReady();
+    await this._ensureRestored();
     const opts = options ?? {};
     let provider = opts.provider;
     if (!provider) {
@@ -537,29 +572,35 @@ export class Session {
   /**
    * Unload a previously loaded skill, reclaiming context space.
    * The tool result in conversation history is replaced with a short marker.
+   *
+   * Async so that the session's background skill-state restore (which
+   * reads conversation history) is awaited first — otherwise a freshly
+   * rehydrated DO could report "not loaded" for a skill that's actually
+   * present in history.
    */
-  unloadSkill(label: string, key: string): boolean {
-    this._ensureReady();
+  async unloadSkill(label: string, key: string): Promise<boolean> {
+    await this._ensureRestored();
     return this.context.unloadSkill(label, key);
   }
 
   /**
    * Get currently loaded skill keys (as "label:key" strings).
+   * Async for the same reason as `unloadSkill` — must wait for restore.
    */
-  getLoadedSkillKeys(): Set<string> {
-    this._ensureReady();
+  async getLoadedSkillKeys(): Promise<Set<string>> {
+    await this._ensureRestored();
     return this.context.getLoadedSkillKeys();
   }
 
   // ── System Prompt ─────────────────────────────────────────────
 
   async freezeSystemPrompt(): Promise<string> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.context.freezeSystemPrompt();
   }
 
   async refreshSystemPrompt(): Promise<string> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.context.refreshSystemPrompt();
   }
 
@@ -576,7 +617,7 @@ export class Session {
       createdAt?: string;
     }>
   > {
-    this._ensureReady();
+    await this._ensureRestored();
     if (!this.storage.searchMessages) {
       throw new Error("Session provider does not support search");
     }
@@ -587,7 +628,7 @@ export class Session {
 
   /** Returns set_context and load_context tools. */
   async tools(): Promise<ToolSet> {
-    this._ensureReady();
+    await this._ensureRestored();
     return this.context.tools();
   }
 }

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -39,6 +39,11 @@ function isBroadcaster(obj: unknown): obj is Broadcaster {
   );
 }
 
+// Detect whether the argument is a SqlProvider (has sql tagged template method)
+function isSqlProvider(arg: SqlProvider | SessionProvider): arg is SqlProvider {
+  return "sql" in arg && typeof (arg as SqlProvider).sql === "function";
+}
+
 export class Session {
   private storage!: SessionProvider;
   private context!: ContextBlocks;
@@ -46,6 +51,7 @@ export class Session {
   // Builder state — only used with Session.create()
   private _agent?: SqlProvider;
   private _broadcaster?: Broadcaster;
+  private _storageProvider?: SessionProvider;
   private _sessionId?: string;
   private _pending?: PendingContext[];
   private _cachedPrompt?: WritableContextProvider | true;
@@ -65,11 +71,14 @@ export class Session {
   }
 
   /**
-   * Chainable session creation with auto-wired SQLite providers.
-   * Chain methods in any order — providers are resolved lazily on first use.
+   * Chainable session creation with auto-wired providers.
+   *
+   * Pass a `SqlProvider` (Agent with `sql` method) for auto-wired SQLite,
+   * or a `SessionProvider` directly for custom storage (PlanetScale, etc.).
    *
    * @example
    * ```ts
+   * // Auto-wired SQLite (DO Agent)
    * const session = Session.create(this)
    *   .withContext("soul", { provider: { get: async () => "You are helpful." } })
    *   .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
@@ -81,13 +90,25 @@ export class Session {
    *     provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" })
    *   })
    *   .withCachedPrompt();
+   *
+   * // Custom storage provider (PlanetScale, etc.)
+   * const session = Session.create(planetscaleProvider)
+   *   .withContext("memory", {
+   *     maxTokens: 1100,
+   *     provider: new PlanetScaleContextProvider(conn, "memory")
+   *   })
+   *   .withCachedPrompt(new PlanetScaleContextProvider(conn, "_prompt"));
    * ```
    */
-  static create(agent: SqlProvider): Session {
+  static create(storageOrAgent: SqlProvider | SessionProvider): Session {
     const session: Session = Object.create(Session.prototype);
-    session._agent = agent;
-    if (isBroadcaster(agent)) {
-      session._broadcaster = agent;
+    if (isSqlProvider(storageOrAgent)) {
+      session._agent = storageOrAgent;
+      if (isBroadcaster(storageOrAgent)) {
+        session._broadcaster = storageOrAgent;
+      }
+    } else {
+      session._storageProvider = storageOrAgent;
     }
     session._pending = [];
     session._ready = false;
@@ -140,10 +161,10 @@ export class Session {
     const configs: ContextConfig[] = (this._pending ?? []).map(
       ({ label, options: opts }) => {
         let provider = opts.provider;
-        if (!provider) {
-          // No provider → auto-wire to writable SQLite
+        if (!provider && this._agent) {
+          // No provider + has SqlProvider → auto-wire to writable SQLite
           const key = this._sessionId ? `${label}_${this._sessionId}` : label;
-          provider = new AgentContextProvider(this._agent!, key);
+          provider = new AgentContextProvider(this._agent, key);
         }
         return {
           label,
@@ -156,19 +177,29 @@ export class Session {
 
     // Resolve prompt store
     let promptStore: WritableContextProvider | undefined;
-    if (this._cachedPrompt === true) {
+    if (this._cachedPrompt === true && this._agent) {
       const key = this._sessionId
         ? `_system_prompt_${this._sessionId}`
         : "_system_prompt";
-      promptStore = new AgentContextProvider(this._agent!, key);
-    } else if (this._cachedPrompt) {
+      promptStore = new AgentContextProvider(this._agent, key);
+    } else if (this._cachedPrompt && this._cachedPrompt !== true) {
       promptStore = this._cachedPrompt;
     }
 
-    this.storage = new AgentSessionProvider(this._agent!, this._sessionId);
+    // Resolve storage
+    if (this._storageProvider) {
+      this.storage = this._storageProvider;
+    } else if (this._agent) {
+      this.storage = new AgentSessionProvider(this._agent, this._sessionId);
+    } else {
+      throw new Error(
+        "Session.create() requires a SqlProvider or SessionProvider"
+      );
+    }
+
     this.context = new ContextBlocks(configs, promptStore);
     this.context.setUnloadCallback((label, key) => {
-      this._reclaimLoadedSkill(label, key);
+      this._reclaimLoadedSkill(label, key).catch(() => {});
     });
     this._restoreLoadedSkills();
     this._ready = true;
@@ -181,6 +212,9 @@ export class Session {
    */
   private _restoreLoadedSkills(): void {
     const history = this.storage.getHistory();
+    // If the provider is async, history is a Promise — skip restore for async providers
+    if (history instanceof Promise) return;
+
     const loaded = new Set<string>();
 
     for (const msg of history) {
@@ -227,8 +261,8 @@ export class Session {
    * Replace a load_context tool result in conversation history
    * with a short marker to reclaim context space.
    */
-  private _reclaimLoadedSkill(label: string, key: string): void {
-    const history = this.storage.getHistory();
+  private async _reclaimLoadedSkill(label: string, key: string): Promise<void> {
+    const history = await this.storage.getHistory();
     for (let i = history.length - 1; i >= 0; i--) {
       const msg = history[i];
       if (msg.role !== "assistant") continue;
@@ -251,7 +285,7 @@ export class Session {
       });
 
       if (changed) {
-        this.storage.updateMessage({
+        await this.storage.updateMessage({
           ...msg,
           parts: newParts as SessionMessage["parts"]
         });
@@ -262,27 +296,27 @@ export class Session {
 
   // ── History (tree-structured) ─────────────────────────────────
 
-  getHistory(leafId?: string | null): SessionMessage[] {
+  async getHistory(leafId?: string | null): Promise<SessionMessage[]> {
     this._ensureReady();
     return this.storage.getHistory(leafId);
   }
 
-  getMessage(id: string): SessionMessage | null {
+  async getMessage(id: string): Promise<SessionMessage | null> {
     this._ensureReady();
     return this.storage.getMessage(id);
   }
 
-  getLatestLeaf(): SessionMessage | null {
+  async getLatestLeaf(): Promise<SessionMessage | null> {
     this._ensureReady();
     return this.storage.getLatestLeaf();
   }
 
-  getBranches(messageId: string): SessionMessage[] {
+  async getBranches(messageId: string): Promise<SessionMessage[]> {
     this._ensureReady();
     return this.storage.getBranches(messageId);
   }
 
-  getPathLength(leafId?: string | null): number {
+  async getPathLength(leafId?: string | null): Promise<number> {
     this._ensureReady();
     return this.storage.getPathLength(leafId);
   }
@@ -294,11 +328,11 @@ export class Session {
     this._broadcaster.broadcast(JSON.stringify({ type, ...data }));
   }
 
-  private _emitStatus(
+  private async _emitStatus(
     phase: "idle" | "compacting",
     extra?: Record<string, unknown>
-  ): number {
-    const tokenEstimate = estimateMessageTokens(this.getHistory());
+  ): Promise<number> {
+    const tokenEstimate = estimateMessageTokens(await this.getHistory());
     this._broadcast(MessageType.CF_AGENT_SESSION, {
       phase,
       tokenEstimate,
@@ -319,9 +353,9 @@ export class Session {
     parentId?: string | null
   ): Promise<void> {
     this._ensureReady();
-    this.storage.appendMessage(message, parentId);
+    await this.storage.appendMessage(message, parentId);
 
-    const tokenEstimate = this._emitStatus("idle");
+    const tokenEstimate = await this._emitStatus("idle");
 
     if (
       this._tokenThreshold != null &&
@@ -336,37 +370,38 @@ export class Session {
     }
   }
 
-  updateMessage(message: SessionMessage): void {
+  async updateMessage(message: SessionMessage): Promise<void> {
     this._ensureReady();
-    this.storage.updateMessage(message);
-    this._emitStatus("idle");
+    await this.storage.updateMessage(message);
+    await this._emitStatus("idle");
   }
 
-  deleteMessages(messageIds: string[]): void {
+  async deleteMessages(messageIds: string[]): Promise<void> {
     this._ensureReady();
-    this.storage.deleteMessages(messageIds);
-    this._emitStatus("idle");
+    await this.storage.deleteMessages(messageIds);
+    await this._emitStatus("idle");
   }
 
-  clearMessages(): void {
+  async clearMessages(): Promise<void> {
     this._ensureReady();
-    this.storage.clearMessages();
+    await this.storage.clearMessages();
     this.context.clearSkillState();
-    this._emitStatus("idle");
+    await this.context.refreshSystemPrompt();
+    await this._emitStatus("idle");
   }
 
   // ── Compaction ────────────────────────────────────────────────
 
-  addCompaction(
+  async addCompaction(
     summary: string,
     fromMessageId: string,
     toMessageId: string
-  ): StoredCompaction {
+  ): Promise<StoredCompaction> {
     this._ensureReady();
     return this.storage.addCompaction(summary, fromMessageId, toMessageId);
   }
 
-  getCompactions(): StoredCompaction[] {
+  async getCompactions(): Promise<StoredCompaction[]> {
     this._ensureReady();
     return this.storage.getCompactions();
   }
@@ -383,37 +418,37 @@ export class Session {
       );
     }
 
-    const tokensBefore = this._emitStatus("compacting");
+    const tokensBefore = await this._emitStatus("compacting");
 
     let result: CompactResult | null;
     try {
-      result = await this._compactionFn(this.getHistory());
+      result = await this._compactionFn(await this.getHistory());
     } catch (err) {
       this._emitError(err instanceof Error ? err.message : String(err));
       return null;
     }
 
     if (!result) {
-      this._emitStatus("idle");
+      await this._emitStatus("idle");
       return null;
     }
 
     // Validate toMessageId exists in the history
-    const historyIds = new Set(this.getHistory().map((m) => m.id));
+    const historyIds = new Set((await this.getHistory()).map((m) => m.id));
     if (!historyIds.has(result.toMessageId)) {
-      this._emitStatus("idle");
+      await this._emitStatus("idle");
       return null;
     }
 
     // Iterative compaction — extend from earliest existing compaction's start
-    const existing = this.getCompactions();
+    const existing = await this.getCompactions();
     const fromId =
       existing.length > 0 ? existing[0].fromMessageId : result.fromMessageId;
 
-    this.addCompaction(result.summary, fromId, result.toMessageId);
+    await this.addCompaction(result.summary, fromId, result.toMessageId);
     await this.refreshSystemPrompt();
 
-    this._emitStatus("idle", {
+    await this._emitStatus("idle", {
       compacted: { tokensBefore }
     });
 
@@ -468,8 +503,13 @@ export class Session {
     const opts = options ?? {};
     let provider = opts.provider;
     if (!provider) {
+      if (!this._agent) {
+        throw new Error(
+          `addContext("${label}") requires an explicit provider when Session uses a SessionProvider`
+        );
+      }
       const key = this._sessionId ? `${label}_${this._sessionId}` : label;
-      provider = new AgentContextProvider(this._agent!, key);
+      provider = new AgentContextProvider(this._agent, key);
     }
     return this.context.addBlock({
       label,
@@ -525,15 +565,17 @@ export class Session {
 
   // ── Search ────────────────────────────────────────────────────
 
-  search(
+  async search(
     query: string,
     options?: { limit?: number }
-  ): Array<{
-    id: string;
-    role: string;
-    content: string;
-    createdAt?: string;
-  }> {
+  ): Promise<
+    Array<{
+      id: string;
+      role: string;
+      content: string;
+      createdAt?: string;
+    }>
+  > {
     this._ensureReady();
     if (!this.storage.searchMessages) {
       throw new Error("Session provider does not support search");

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -19,6 +19,18 @@ import { MessageType } from "../../../types";
 
 export type SessionContextOptions = Omit<ContextConfig, "label">;
 
+type InternalMessageChangeEvent =
+  | {
+      type: "append";
+      message: SessionMessage;
+      parentId?: string | null;
+      inserted: boolean;
+    }
+  | { type: "update"; message: SessionMessage }
+  | { type: "delete"; messageIds: string[] }
+  | { type: "clear" }
+  | { type: "compact" };
+
 // Raw builder entry — provider resolved at init time so chain order doesn't matter
 interface PendingContext {
   label: string;
@@ -65,6 +77,9 @@ export class Session {
   // skill-state — guarantees loaded-skill tracking is rehydrated after
   // hibernation, even for async SessionProviders.
   private _restorePromise?: Promise<void>;
+  private _messageChangeListener?: (
+    event: InternalMessageChangeEvent
+  ) => void | Promise<void>;
 
   constructor(storage: SessionProvider, options?: SessionOptions) {
     this.storage = storage;
@@ -157,6 +172,20 @@ export class Session {
     return this;
   }
 
+  /**
+   * @internal
+   * Framework hook for cache-owning callers that need to mirror message
+   * storage changes. Application code should use the normal Session methods.
+   */
+  internal_onMessagesChanged(
+    listener:
+      | ((event: InternalMessageChangeEvent) => void | Promise<void>)
+      | null
+  ): this {
+    this._messageChangeListener = listener ?? undefined;
+    return this;
+  }
+
   // ── Lazy init ───────────────────────────────────────────────────
 
   private _ensureReady(): void {
@@ -223,6 +252,12 @@ export class Session {
   private async _ensureRestored(): Promise<void> {
     this._ensureReady();
     if (this._restorePromise) await this._restorePromise;
+  }
+
+  private async _notifyMessagesChanged(
+    event: InternalMessageChangeEvent
+  ): Promise<void> {
+    await this._messageChangeListener?.(event);
   }
 
   /**
@@ -315,7 +350,7 @@ export class Session {
       });
 
       if (changed) {
-        await this.storage.updateMessage({
+        await this.updateMessage({
           ...msg,
           parts: newParts as SessionMessage["parts"]
         });
@@ -382,10 +417,31 @@ export class Session {
     message: SessionMessage,
     parentId?: string | null
   ): Promise<void> {
+    await this._appendMessage(message, parentId);
+  }
+
+  private async _appendMessage(
+    message: SessionMessage,
+    parentId?: string | null
+  ): Promise<void> {
     await this._ensureRestored();
+
+    const existing = await this.storage.getMessage(message.id);
+    if (existing) {
+      await this._emitStatus("idle");
+      await this._notifyMessagesChanged({
+        type: "append",
+        message,
+        parentId,
+        inserted: false
+      });
+      return;
+    }
+
     await this.storage.appendMessage(message, parentId);
 
     const tokenEstimate = await this._emitStatus("idle");
+    let compacted = false;
 
     if (
       this._tokenThreshold != null &&
@@ -393,10 +449,19 @@ export class Session {
       tokenEstimate > this._tokenThreshold
     ) {
       try {
-        await this.compact();
+        compacted = Boolean(await this.compact());
       } catch {
         // Auto-compact failure is non-fatal — message is already appended
       }
+    }
+
+    if (!compacted) {
+      await this._notifyMessagesChanged({
+        type: "append",
+        message,
+        parentId,
+        inserted: true
+      });
     }
   }
 
@@ -404,12 +469,14 @@ export class Session {
     await this._ensureRestored();
     await this.storage.updateMessage(message);
     await this._emitStatus("idle");
+    await this._notifyMessagesChanged({ type: "update", message });
   }
 
   async deleteMessages(messageIds: string[]): Promise<void> {
     await this._ensureRestored();
     await this.storage.deleteMessages(messageIds);
     await this._emitStatus("idle");
+    await this._notifyMessagesChanged({ type: "delete", messageIds });
   }
 
   async clearMessages(): Promise<void> {
@@ -418,6 +485,7 @@ export class Session {
     this.context.clearSkillState();
     await this.context.refreshSystemPrompt();
     await this._emitStatus("idle");
+    await this._notifyMessagesChanged({ type: "clear" });
   }
 
   // ── Compaction ────────────────────────────────────────────────
@@ -481,6 +549,7 @@ export class Session {
     await this._emitStatus("idle", {
       compacted: { tokensBefore }
     });
+    await this._notifyMessagesChanged({ type: "compact" });
 
     return { ...result, fromMessageId: fromId };
   }

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -79,7 +79,7 @@ export class Session {
    * Chainable session creation with auto-wired providers.
    *
    * Pass a `SqlProvider` (Agent with `sql` method) for auto-wired SQLite,
-   * or a `SessionProvider` directly for custom storage (PlanetScale, etc.).
+   * or a `SessionProvider` directly for custom storage (Postgres, etc.).
    *
    * @example
    * ```ts
@@ -96,13 +96,13 @@ export class Session {
    *   })
    *   .withCachedPrompt();
    *
-   * // Custom storage provider (PlanetScale, etc.)
-   * const session = Session.create(planetscaleProvider)
+   * // Custom storage provider (Postgres, etc.)
+   * const session = Session.create(postgresProvider)
    *   .withContext("memory", {
    *     maxTokens: 1100,
-   *     provider: new PlanetScaleContextProvider(conn, "memory")
+   *     provider: new PostgresContextProvider(conn, "memory")
    *   })
-   *   .withCachedPrompt(new PlanetScaleContextProvider(conn, "_prompt"));
+   *   .withCachedPrompt(new PostgresContextProvider(conn, "_prompt"));
    * ```
    */
   static create(provider: SqlProvider | SessionProvider): Session {

--- a/packages/agents/src/tests/agents/multi-session.ts
+++ b/packages/agents/src/tests/agents/multi-session.ts
@@ -25,25 +25,25 @@ export class TestMultiSessionAgent extends Agent {
       const s1 = this.makeSession("chat-a");
       const s2 = this.makeSession("chat-b");
 
-      s1.appendMessage({
+      await s1.appendMessage({
         id: "a1",
         role: "user",
         parts: [{ type: "text", text: "hello from A" }]
       });
-      s1.appendMessage({
+      await s1.appendMessage({
         id: "a2",
         role: "assistant",
         parts: [{ type: "text", text: "reply A" }]
       });
 
-      s2.appendMessage({
+      await s2.appendMessage({
         id: "b1",
         role: "user",
         parts: [{ type: "text", text: "hello from B" }]
       });
 
-      const h1 = s1.getHistory();
-      const h2 = s2.getHistory();
+      const h1 = await s1.getHistory();
+      const h2 = await s2.getHistory();
 
       if (h1.length !== 2)
         return {
@@ -76,7 +76,7 @@ export class TestMultiSessionAgent extends Agent {
 
       // Add messages to s1
       for (let i = 0; i < 5; i++) {
-        s1.appendMessage({
+        await s1.appendMessage({
           id: `ca-${i}`,
           role: i % 2 === 0 ? "user" : "assistant",
           parts: [{ type: "text", text: `msg ${i}` }]
@@ -84,22 +84,22 @@ export class TestMultiSessionAgent extends Agent {
       }
 
       // Add messages to s2
-      s2.appendMessage({
+      await s2.appendMessage({
         id: "cb-0",
         role: "user",
         parts: [{ type: "text", text: "s2 msg" }]
       });
-      s2.appendMessage({
+      await s2.appendMessage({
         id: "cb-1",
         role: "assistant",
         parts: [{ type: "text", text: "s2 reply" }]
       });
 
       // Compact s1 only
-      s1.addCompaction("Summary of ca-1 to ca-3", "ca-1", "ca-3");
+      await s1.addCompaction("Summary of ca-1 to ca-3", "ca-1", "ca-3");
 
-      const h1 = s1.getHistory();
-      const h2 = s2.getHistory();
+      const h1 = await s1.getHistory();
+      const h2 = await s2.getHistory();
 
       // s1 should have compaction applied (3 msgs replaced by summary)
       const hasCompaction = h1.some((m) => m.id.startsWith("compaction_"));
@@ -197,22 +197,22 @@ export class TestMultiSessionAgent extends Agent {
       const s1 = this.makeSession("clear-a");
       const s2 = this.makeSession("clear-b");
 
-      s1.appendMessage({
+      await s1.appendMessage({
         id: "cl-a1",
         role: "user",
         parts: [{ type: "text", text: "s1 msg" }]
       });
-      s2.appendMessage({
+      await s2.appendMessage({
         id: "cl-b1",
         role: "user",
         parts: [{ type: "text", text: "s2 msg" }]
       });
 
       // Clear s1 only
-      s1.clearMessages();
+      await s1.clearMessages();
 
-      const h1 = s1.getHistory();
-      const h2 = s2.getHistory();
+      const h1 = await s1.getHistory();
+      const h2 = await s2.getHistory();
 
       if (h1.length !== 0)
         return {
@@ -288,15 +288,15 @@ export class TestMultiSessionAgent extends Agent {
       const info = mgr.create("ToDelete");
       const s = mgr.getSession(info.id);
 
-      s.appendMessage({
+      await s.appendMessage({
         id: "d1",
         role: "user",
         parts: [{ type: "text", text: "hello" }]
       });
-      if (s.getHistory().length !== 1)
+      if ((await s.getHistory()).length !== 1)
         return { success: false, error: "msg not added" };
 
-      mgr.delete(info.id);
+      await mgr.delete(info.id);
       if (mgr.get(info.id) !== null)
         return { success: false, error: "session still exists after delete" };
 
@@ -329,12 +329,12 @@ export class TestMultiSessionAgent extends Agent {
       const i1 = mgr.create("Chat1");
       const i2 = mgr.create("Chat2");
 
-      mgr.getSession(i1.id).appendMessage({
+      await mgr.getSession(i1.id).appendMessage({
         id: "ms1",
         role: "user",
         parts: [{ type: "text", text: "I love TypeScript" }]
       });
-      mgr.getSession(i2.id).appendMessage({
+      await mgr.getSession(i2.id).appendMessage({
         id: "ms2",
         role: "user",
         parts: [{ type: "text", text: "Python is great" }]
@@ -362,7 +362,7 @@ export class TestMultiSessionAgent extends Agent {
 
       const sInfo = mgr.create("SearchTest");
       const session = mgr.getSession(sInfo.id);
-      session.appendMessage({
+      await session.appendMessage({
         id: "st1",
         role: "user",
         parts: [
@@ -469,9 +469,9 @@ export class TestMultiSessionAgent extends Agent {
       });
 
       // Delete a message from s1 by specifying the sessionId
-      mgr.deleteMessages(s1Info.id, ["dm-a2"]);
+      await mgr.deleteMessages(s1Info.id, ["dm-a2"]);
 
-      const h1 = mgr.getHistory(s1Info.id);
+      const h1 = await mgr.getHistory(s1Info.id);
       if (h1.length !== 1)
         return {
           success: false,
@@ -484,7 +484,7 @@ export class TestMultiSessionAgent extends Agent {
         };
 
       // s2 should be completely unaffected
-      const h2 = mgr.getHistory(s2Info.id);
+      const h2 = await mgr.getHistory(s2Info.id);
       if (h2.length !== 1)
         return {
           success: false,
@@ -526,7 +526,7 @@ export class TestMultiSessionAgent extends Agent {
       const forked = await mgr.fork(original.id, "fork-m2", "Forked");
 
       // The forked session should have copied messages
-      const forkedHistory = mgr.getHistory(forked.id);
+      const forkedHistory = await mgr.getHistory(forked.id);
       if (forkedHistory.length !== 2)
         return {
           success: false,
@@ -573,7 +573,7 @@ export class TestMultiSessionAgent extends Agent {
 
       // Add 10 messages
       for (let i = 0; i < 10; i++) {
-        session.appendMessage({
+        await session.appendMessage({
           id: `cm-${i}`,
           role: i % 2 === 0 ? "user" : "assistant",
           parts: [{ type: "text", text: `msg ${i}` }]
@@ -581,17 +581,17 @@ export class TestMultiSessionAgent extends Agent {
       }
 
       // First compaction: summarize cm-1 through cm-7
-      session.addCompaction("Summary round 1", "cm-1", "cm-7");
+      await session.addCompaction("Summary round 1", "cm-1", "cm-7");
 
       // Verify compaction applied
-      let history = session.getHistory();
+      let history = await session.getHistory();
       const hasCompaction = history.some((m) => m.id.startsWith("compaction_"));
       if (!hasCompaction)
         return { success: false, error: "first compaction not applied" };
 
       // Now add more messages
       for (let i = 10; i < 15; i++) {
-        session.appendMessage({
+        await session.appendMessage({
           id: `cm-${i}`,
           role: i % 2 === 0 ? "user" : "assistant",
           parts: [{ type: "text", text: `msg ${i}` }]
@@ -600,22 +600,22 @@ export class TestMultiSessionAgent extends Agent {
 
       // Second compaction: the history now contains a synthetic compaction_ ID.
       // We must NOT use that synthetic ID as a fromId/toId.
-      history = session.getHistory();
+      history = await session.getHistory();
       const realMessages = history.filter(
         (m) => !m.id.startsWith("compaction_")
       );
 
       // Simulate what the example's compact() does:
       // use getCompactions()[0].fromMessageId as fromId for iterative compaction
-      const existing = session.getCompactions();
+      const existing = await session.getCompactions();
       const fromId =
         existing.length > 0 ? existing[0].fromMessageId : realMessages[1].id;
 
-      session.addCompaction("Summary round 2", fromId, "cm-12");
+      await session.addCompaction("Summary round 2", fromId, "cm-12");
 
       // Verify the second compaction works — history should have:
       // cm-0 + summary2 + cm-13 + cm-14
-      history = session.getHistory();
+      history = await session.getHistory();
       if (history[0].id !== "cm-0")
         return {
           success: false,

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -19,7 +19,7 @@ export class TestSessionAgent extends Agent {
 
   async appendMessage(
     message: SessionMessage,
-    parentId?: string
+    parentId?: string | null
   ): Promise<void> {
     await this.session.appendMessage(message, parentId);
   }
@@ -148,8 +148,13 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
         return { success: false, error: "no search_context" };
 
       // Index some content
+      type SetArgs = {
+        label: string;
+        content: string;
+        metadata?: { title?: string; description?: string };
+      };
       const setTool = tools.set_context as unknown as {
-        execute: (args: Record<string, string>) => Promise<string>;
+        execute: (args: SetArgs) => Promise<string>;
       };
       const searchTool = tools.search_context as unknown as {
         execute: (args: Record<string, string>) => Promise<string>;
@@ -157,12 +162,12 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
 
       await setTool.execute({
         label: "knowledge",
-        title: "meeting-notes",
+        metadata: { title: "meeting-notes" },
         content: "The deployment is scheduled for Friday with budget concerns"
       });
       await setTool.execute({
         label: "knowledge",
-        title: "design-doc",
+        metadata: { title: "design-doc" },
         content: "The API uses REST endpoints with JSON responses"
       });
 
@@ -231,8 +236,13 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
   async testUpdateReplacesEntry(): Promise<TestResult> {
     try {
       const tools = await this.session.tools();
+      type SetArgs = {
+        label: string;
+        content: string;
+        metadata?: { title?: string; description?: string };
+      };
       const setTool = tools.set_context as unknown as {
-        execute: (args: Record<string, string>) => Promise<string>;
+        execute: (args: SetArgs) => Promise<string>;
       };
       const searchTool = tools.search_context as unknown as {
         execute: (args: Record<string, string>) => Promise<string>;
@@ -241,12 +251,12 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
       // Index then replace — same title → same key → upsert
       await setTool.execute({
         label: "knowledge",
-        title: "doc",
+        metadata: { title: "doc" },
         content: "original content about cats"
       });
       await setTool.execute({
         label: "knowledge",
-        title: "doc",
+        metadata: { title: "doc" },
         content: "replaced content about dogs"
       });
 

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -24,57 +24,59 @@ export class TestSessionAgent extends Agent {
     await this.session.appendMessage(message, parentId);
   }
 
-  getMessage(id: string): SessionMessage | null {
+  async getMessage(id: string): Promise<SessionMessage | null> {
     return this.session.getMessage(id);
   }
 
-  updateMessage(message: SessionMessage): void {
-    this.session.updateMessage(message);
+  async updateMessage(message: SessionMessage): Promise<void> {
+    await this.session.updateMessage(message);
   }
 
-  deleteMessages(ids: string[]): void {
-    this.session.deleteMessages(ids);
+  async deleteMessages(ids: string[]): Promise<void> {
+    await this.session.deleteMessages(ids);
   }
 
-  clearMessages(): void {
-    this.session.clearMessages();
+  async clearMessages(): Promise<void> {
+    await this.session.clearMessages();
   }
 
   // ── History (tree) ──────────────────────────────────────────────
 
-  getHistory(leafId?: string): SessionMessage[] {
+  async getHistory(leafId?: string): Promise<SessionMessage[]> {
     return this.session.getHistory(leafId);
   }
 
-  getLatestLeaf(): SessionMessage | null {
+  async getLatestLeaf(): Promise<SessionMessage | null> {
     return this.session.getLatestLeaf();
   }
 
-  getBranches(messageId: string): SessionMessage[] {
+  async getBranches(messageId: string): Promise<SessionMessage[]> {
     return this.session.getBranches(messageId);
   }
 
-  getPathLength(): number {
+  async getPathLength(): Promise<number> {
     return this.session.getPathLength();
   }
 
   // ── Compaction ──────────────────────────────────────────────────
 
-  addCompaction(
+  async addCompaction(
     summary: string,
     fromId: string,
     toId: string
-  ): StoredCompaction {
+  ): Promise<StoredCompaction> {
     return this.session.addCompaction(summary, fromId, toId);
   }
 
-  getCompactions(): StoredCompaction[] {
+  async getCompactions(): Promise<StoredCompaction[]> {
     return this.session.getCompactions();
   }
 
   // ── Search ──────────────────────────────────────────────────────
 
-  search(query: string): Array<{ id: string; role: string; content: string }> {
+  async search(
+    query: string
+  ): Promise<Array<{ id: string; role: string; content: string }>> {
     return this.session.search(query);
   }
 }
@@ -155,12 +157,12 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
 
       await setTool.execute({
         label: "knowledge",
-        key: "meeting-notes",
+        title: "meeting-notes",
         content: "The deployment is scheduled for Friday with budget concerns"
       });
       await setTool.execute({
         label: "knowledge",
-        key: "design-doc",
+        title: "design-doc",
         content: "The API uses REST endpoints with JSON responses"
       });
 
@@ -169,7 +171,7 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
         label: "knowledge",
         query: "deployment"
       });
-      if (!r1.includes("meeting-notes"))
+      if (!r1.includes("deployment"))
         return { success: false, error: "single word search failed" };
 
       // Multi-word search (non-adjacent terms)
@@ -177,7 +179,7 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
         label: "knowledge",
         query: "deployment budget"
       });
-      if (!r2.includes("meeting-notes"))
+      if (!r2.includes("budget"))
         return {
           success: false,
           error: "multi-word non-adjacent search failed"
@@ -196,7 +198,7 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
         label: "knowledge",
         query: "REST"
       });
-      if (!r4.includes("design-doc"))
+      if (!r4.includes("REST"))
         return { success: false, error: "cross-key search failed" };
 
       return { success: true };
@@ -214,8 +216,8 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
       const prompt = await this.session.freezeSystemPrompt();
       if (!prompt.includes("KNOWLEDGE"))
         return { success: false, error: "prompt missing KNOWLEDGE" };
-      if (!prompt.includes("search_context"))
-        return { success: false, error: "prompt missing search_context hint" };
+      if (!prompt.includes("[searchable]"))
+        return { success: false, error: "prompt missing [searchable] tag" };
 
       return { success: true };
     } catch (err) {
@@ -236,15 +238,15 @@ export class TestSearchAgent extends Agent<Cloudflare.Env> {
         execute: (args: Record<string, string>) => Promise<string>;
       };
 
-      // Index then replace
+      // Index then replace — same title → same key → upsert
       await setTool.execute({
         label: "knowledge",
-        key: "doc",
+        title: "doc",
         content: "original content about cats"
       });
       await setTool.execute({
         label: "knowledge",
-        key: "doc",
+        title: "doc",
         content: "replaced content about dogs"
       });
 

--- a/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
@@ -336,6 +336,32 @@ describe("PostgresSessionProvider", () => {
     expect(history).toHaveLength(1);
   });
 
+  it("explicit null parentId creates a root message (no auto-parent)", async () => {
+    // Seed a conversation so there IS a latest leaf to accidentally attach to.
+    await provider.appendMessage(makeMessage("m1", "user", "first root"));
+    await provider.appendMessage(makeMessage("m2", "assistant", "reply"));
+
+    // Explicit null → must become its own root, not a child of m2.
+    await provider.appendMessage(makeMessage("m3", "user", "new root"), null);
+
+    const branches = await provider.getBranches("m2");
+    expect(branches.map((b) => b.id)).not.toContain("m3");
+
+    // m3 should appear as a top-level message in its own chain.
+    const historyFromM3 = await provider.getHistory("m3");
+    expect(historyFromM3.map((m) => m.id)).toEqual(["m3"]);
+  });
+
+  it("omitted parentId auto-attaches to the latest leaf", async () => {
+    await provider.appendMessage(makeMessage("m1", "user", "first"));
+    await provider.appendMessage(makeMessage("m2", "assistant", "reply"));
+    // No parentId — should be a child of m2.
+    await provider.appendMessage(makeMessage("m3", "user", "follow-up"));
+
+    const branches = await provider.getBranches("m2");
+    expect(branches.map((b) => b.id)).toContain("m3");
+  });
+
   it("updates a message", async () => {
     await provider.appendMessage(makeMessage("m1", "user", "original"));
     await provider.updateMessage(makeMessage("m1", "user", "updated"));
@@ -975,5 +1001,67 @@ describe("convertToModelMessages compatibility", () => {
     const toolContent = toolModel!.content as Array<{ type: string }>;
     const toolResults = toolContent.filter((c) => c.type === "tool-result");
     expect(toolResults).toHaveLength(2);
+  });
+});
+
+// ── pg.Client adapter tests ────────────────────────────────────
+
+/**
+ * Mimics the `pg.Client` surface the provider relies on: a single
+ * `query(text, values)` method. Captures the rewritten query so we can
+ * assert `?` → `$1, $2, …` conversion happens inside the provider.
+ */
+class PgClientMock {
+  public calls: Array<{ text: string; values: readonly unknown[] }> = [];
+  private inner = new InMemoryPostgres();
+
+  async query(
+    text: string,
+    values: readonly unknown[] = []
+  ): Promise<{ rows: Row[] }> {
+    this.calls.push({ text, values });
+    // Re-convert $n placeholders back to ? so the in-memory mock (which
+    // handles the `?` dialect) can service the query unchanged.
+    const qMarked = text.replace(/\$\d+/g, "?");
+    return this.inner.execute(
+      qMarked,
+      values as (string | number | boolean | null)[]
+    );
+  }
+}
+
+describe("pg.Client adapter", () => {
+  it("accepts a raw pg.Client and rewrites ? placeholders to $n", async () => {
+    const client = new PgClientMock();
+    const provider = new PostgresSessionProvider(client, "adapter-session");
+
+    await provider.appendMessage(makeMessage("m1", "user", "hello"));
+    const msg = await provider.getMessage("m1");
+    expect(msg).not.toBeNull();
+    expect(msg!.parts[0].text).toBe("hello");
+
+    // Every query that hit the pg.Client-style mock must use $n, never ?
+    expect(client.calls.length).toBeGreaterThan(0);
+    for (const call of client.calls) {
+      expect(call.text.includes("?")).toBe(false);
+      // And the first placeholder, if any, should be $1
+      if (/\$\d+/.test(call.text)) {
+        expect(call.text).toMatch(/\$1/);
+      }
+    }
+  });
+
+  it("PostgresContextProvider + PostgresSearchProvider accept a raw pg.Client", async () => {
+    const client = new PgClientMock();
+    const ctx = new PostgresContextProvider(client, "memory");
+    await ctx.set("user likes cats");
+    expect(await ctx.get()).toBe("user likes cats");
+
+    const search = new PostgresSearchProvider(client);
+    search.init?.("knowledge");
+    await search.set?.("doc-a", "alpha content");
+    const hit = await search.search("alpha");
+    expect(hit).toContain("doc-a");
+    expect(hit).toContain("alpha content");
   });
 });

--- a/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
@@ -1,0 +1,979 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  PostgresSessionProvider,
+  type PostgresConnection
+} from "../../../../experimental/memory/session/providers/postgres";
+import { PostgresContextProvider } from "../../../../experimental/memory/session/providers/postgres-context";
+import { PostgresSearchProvider } from "../../../../experimental/memory/session/providers/postgres-search";
+import type { SessionMessage } from "../../../../experimental/memory/session/types";
+import { ContextBlocks } from "../../../../experimental/memory/session/context";
+import { convertToModelMessages, type UIMessage } from "ai";
+
+// ── In-memory Postgres mock ─────────────────────────────────────
+
+type Row = Record<string, unknown>;
+
+class InMemoryPostgres implements PostgresConnection {
+  private tables = new Map<string, Row[]>();
+
+  async execute(
+    query: string,
+    args?: (string | number | boolean | null)[]
+  ): Promise<{ rows: Row[] }> {
+    // Convert ? placeholders to indexed for matching
+    let idx = 0;
+    const params = args ?? [];
+    const q = query.replace(/\?/g, () => `$${++idx}`).trim();
+
+    // Route to handler based on query
+    if (q.startsWith("INSERT INTO")) return this.handleInsert(q, params);
+    if (q.startsWith("UPDATE")) return this.handleUpdate(q, params);
+    if (q.startsWith("DELETE FROM")) return this.handleDelete(q, params);
+    if (q.startsWith("SELECT") || q.startsWith("WITH"))
+      return this.handleSelect(q, params);
+    return { rows: [] };
+  }
+
+  private getTable(name: string): Row[] {
+    if (!this.tables.has(name)) this.tables.set(name, []);
+    return this.tables.get(name)!;
+  }
+
+  private handleInsert(q: string, params: unknown[]): { rows: Row[] } {
+    const tableMatch = q.match(/INSERT INTO (\w+)/);
+    if (!tableMatch) return { rows: [] };
+    const table = this.getTable(tableMatch[1]);
+
+    const colsMatch = q.match(/\(([^)]+)\)\s*VALUES/);
+    if (!colsMatch) return { rows: [] };
+    const cols = colsMatch[1].split(",").map((c) => c.trim());
+
+    const row: Row = {};
+    cols.forEach((col, i) => {
+      row[col] = params[i] ?? null;
+    });
+    row.created_at = new Date().toISOString();
+    row.updated_at = new Date().toISOString();
+
+    // Handle ON CONFLICT DO NOTHING
+    if (q.includes("ON CONFLICT") && q.includes("DO NOTHING")) {
+      const pk = cols[0];
+      if (table.some((r) => r[pk] === row[pk])) return { rows: [] };
+    }
+
+    // Handle ON CONFLICT DO UPDATE
+    if (q.includes("ON CONFLICT") && q.includes("DO UPDATE")) {
+      const existing = table.find((r) => {
+        // Check composite key (label, key) or single key
+        if (cols.includes("label") && cols.includes("key")) {
+          return r.label === row.label && r.key === row.key;
+        }
+        if (cols.includes("label")) {
+          return r.label === row.label;
+        }
+        return r[cols[0]] === row[cols[0]];
+      });
+      if (existing) {
+        existing.content = row.content;
+        existing.updated_at = new Date().toISOString();
+        return { rows: [] };
+      }
+    }
+
+    table.push(row);
+    return { rows: [] };
+  }
+
+  private handleUpdate(q: string, params: unknown[]): { rows: Row[] } {
+    const tableMatch = q.match(/UPDATE (\w+)/);
+    if (!tableMatch) return { rows: [] };
+    const table = this.getTable(tableMatch[1]);
+
+    // UPDATE table SET content = $1, text_content = $2 WHERE id = $3 AND session_id = $4
+    // or SET content = $1 WHERE ... (context blocks)
+    const setCount = (q.match(/= \$/g) ?? []).length;
+    const idIdx = setCount <= 2 ? 1 : 2;
+    const sessionIdx = setCount <= 2 ? 2 : 3;
+    const row = table.find(
+      (r) => r.id === params[idIdx] && r.session_id === params[sessionIdx]
+    );
+    if (row) {
+      row.content = params[0];
+      if (setCount > 2) row.text_content = params[1];
+    }
+    return { rows: [] };
+  }
+
+  private handleDelete(q: string, params: unknown[]): { rows: Row[] } {
+    const tableMatch = q.match(/DELETE FROM (\w+)/);
+    if (!tableMatch) return { rows: [] };
+    const tableName = tableMatch[1];
+    const table = this.getTable(tableName);
+
+    if (
+      q.includes("WHERE id = ") ||
+      (q.includes("id = ") && q.includes("AND session_id = "))
+    ) {
+      this.tables.set(
+        tableName,
+        table.filter((r) => !(r.id === params[0] && r.session_id === params[1]))
+      );
+    } else if (q.includes("session_id = ")) {
+      this.tables.set(
+        tableName,
+        table.filter((r) => r.session_id !== params[0])
+      );
+    }
+    return { rows: [] };
+  }
+
+  private handleSelect(q: string, params: unknown[]): { rows: Row[] } {
+    // Handle WITH RECURSIVE for getHistory
+    if (q.includes("WITH RECURSIVE")) {
+      return this.handleRecursiveSelect(q, params);
+    }
+
+    // Handle COUNT(*)
+    if (q.includes("COUNT(*)")) {
+      const tableMatch = q.match(/FROM (\w+)/);
+      if (!tableMatch) return { rows: [{ count: 0 }] };
+      const table = this.getTable(tableMatch[1]);
+      const filtered = this.filterByParams(table, q, params);
+      return { rows: [{ count: filtered.length }] };
+    }
+
+    // Handle regular SELECT
+    const tableMatch = q.match(/FROM (\w+)\s+(\w+)?/);
+    if (!tableMatch) return { rows: [] };
+    let tableName = tableMatch[1];
+    // Handle alias: FROM table alias
+    if (
+      tableName === "cf_agents_context_blocks" ||
+      tableName === "cf_agents_search_entries" ||
+      tableName === "assistant_messages" ||
+      tableName === "assistant_compactions"
+    ) {
+      // good
+    } else {
+      return { rows: [] };
+    }
+
+    const table = this.getTable(tableName);
+    const filtered = this.filterByParams(table, q, params);
+
+    // Handle LIMIT
+    const limitMatch = q.match(/LIMIT \$(\d+)/);
+    if (limitMatch) {
+      const limit = Number(params[Number(limitMatch[1]) - 1]);
+      return { rows: filtered.slice(0, limit) };
+    }
+
+    return { rows: filtered };
+  }
+
+  private handleRecursiveSelect(q: string, params: unknown[]): { rows: Row[] } {
+    const table = this.getTable("assistant_messages");
+    const startId = params[0] as string;
+
+    // Walk parent chain
+    const path: Row[] = [];
+    let current = table.find((r) => r.id === startId);
+    while (current) {
+      path.unshift(current);
+      current = current.parent_id
+        ? table.find((r) => r.id === current!.parent_id)
+        : undefined;
+    }
+
+    if (q.includes("COUNT(*)")) {
+      return { rows: [{ count: path.length }] };
+    }
+    return { rows: path };
+  }
+
+  private filterByParams(table: Row[], q: string, params: unknown[]): Row[] {
+    let result = [...table];
+
+    // Filter by session_id
+    const sessionMatch = q.match(/session_id = \$(\d+)/);
+    if (sessionMatch) {
+      const val = params[Number(sessionMatch[1]) - 1];
+      result = result.filter((r) => r.session_id === val);
+    }
+
+    // Filter by id
+    const idMatch = q.match(/(?:WHERE|AND)\s+id = \$(\d+)/);
+    if (idMatch) {
+      const val = params[Number(idMatch[1]) - 1];
+      result = result.filter((r) => r.id === val);
+    }
+
+    // Filter by parent_id
+    const parentMatch = q.match(/parent_id = \$(\d+)/);
+    if (parentMatch) {
+      const val = params[Number(parentMatch[1]) - 1];
+      result = result.filter((r) => r.parent_id === val);
+    }
+
+    // Filter by label
+    const labelMatch = q.match(/(?:WHERE|AND)\s+label = \$(\d+)/);
+    if (labelMatch) {
+      const val = params[Number(labelMatch[1]) - 1];
+      result = result.filter((r) => r.label === val);
+    }
+
+    // Handle ILIKE
+    if (q.includes("ILIKE")) {
+      const ilikeMatch = q.match(/ILIKE \$(\d+)/);
+      if (ilikeMatch) {
+        const pattern = (params[Number(ilikeMatch[1]) - 1] as string)
+          .replace(/%/g, "")
+          .toLowerCase();
+        result = result.filter((r) =>
+          (r.content as string).toLowerCase().includes(pattern)
+        );
+      }
+    }
+
+    // Handle tsvector search (simplified: treat as ILIKE)
+    if (q.includes("plainto_tsquery")) {
+      const tsMatch = q.match(/plainto_tsquery\('english', \$(\d+)\)/);
+      if (tsMatch) {
+        const terms = (params[Number(tsMatch[1]) - 1] as string)
+          .toLowerCase()
+          .split(/\s+/);
+        result = result.filter((r) =>
+          terms.some((t) => (r.content as string).toLowerCase().includes(t))
+        );
+      }
+    }
+
+    // Handle LEFT JOIN for latest leaf
+    if (q.includes("LEFT JOIN") && q.includes("c.id IS NULL")) {
+      const allIds = new Set(table.map((r) => r.id));
+      const childParentIds = new Set(
+        table.map((r) => r.parent_id).filter(Boolean)
+      );
+      result = result.filter(
+        (r) =>
+          !childParentIds.has(r.id as string) || !allIds.has(r.id as string)
+      );
+      // Actually: leaf = no children pointing to it
+      const parentIds = new Set(
+        table.filter((r) => r.parent_id).map((r) => r.parent_id)
+      );
+      result = table.filter((r) => !parentIds.has(r.id as string));
+      // Apply session filter
+      if (sessionMatch) {
+        const val = params[Number(sessionMatch[1]) - 1];
+        result = result.filter((r) => r.session_id === val);
+      }
+    }
+
+    // Sort by created_at DESC if ORDER BY ... DESC
+    if (q.includes("ORDER BY") && q.includes("DESC")) {
+      result.sort(
+        (a, b) =>
+          new Date(b.created_at as string).getTime() -
+          new Date(a.created_at as string).getTime()
+      );
+    }
+
+    return result;
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function makeMessage(id: string, role: string, text: string): SessionMessage {
+  return { id, role, parts: [{ type: "text", text }] };
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+describe("PostgresSessionProvider", () => {
+  let conn: InMemoryPostgres;
+  let provider: PostgresSessionProvider;
+
+  beforeEach(() => {
+    conn = new InMemoryPostgres();
+    provider = new PostgresSessionProvider(conn, "test-session");
+  });
+
+  it("returns empty history for new session", async () => {
+    const history = await provider.getHistory();
+    expect(history).toEqual([]);
+  });
+
+  it("appends and retrieves a message", async () => {
+    const msg = makeMessage("m1", "user", "hello");
+    await provider.appendMessage(msg);
+
+    const retrieved = await provider.getMessage("m1");
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.id).toBe("m1");
+    expect(retrieved!.parts[0].text).toBe("hello");
+  });
+
+  it("builds history chain via parent_id", async () => {
+    await provider.appendMessage(makeMessage("m1", "user", "first"));
+    await provider.appendMessage(makeMessage("m2", "assistant", "second"));
+    await provider.appendMessage(makeMessage("m3", "user", "third"));
+
+    const history = await provider.getHistory();
+    expect(history).toHaveLength(3);
+    expect(history[0].id).toBe("m1");
+    expect(history[1].id).toBe("m2");
+    expect(history[2].id).toBe("m3");
+  });
+
+  it("appendMessage is idempotent", async () => {
+    const msg = makeMessage("m1", "user", "hello");
+    await provider.appendMessage(msg);
+    await provider.appendMessage(msg);
+
+    const history = await provider.getHistory();
+    expect(history).toHaveLength(1);
+  });
+
+  it("updates a message", async () => {
+    await provider.appendMessage(makeMessage("m1", "user", "original"));
+    await provider.updateMessage(makeMessage("m1", "user", "updated"));
+
+    const msg = await provider.getMessage("m1");
+    expect(msg!.parts[0].text).toBe("updated");
+  });
+
+  it("deletes messages", async () => {
+    await provider.appendMessage(makeMessage("m1", "user", "a"));
+    await provider.appendMessage(makeMessage("m2", "assistant", "b"));
+
+    await provider.deleteMessages(["m1"]);
+    expect(await provider.getMessage("m1")).toBeNull();
+    expect(await provider.getMessage("m2")).not.toBeNull();
+  });
+
+  it("clears all messages and compactions", async () => {
+    await provider.appendMessage(makeMessage("m1", "user", "a"));
+    await provider.addCompaction("summary", "m1", "m1");
+
+    await provider.clearMessages();
+    expect(await provider.getHistory()).toEqual([]);
+    expect(await provider.getCompactions()).toEqual([]);
+  });
+
+  it("getLatestLeaf returns the last message", async () => {
+    await provider.appendMessage(makeMessage("m1", "user", "a"));
+    await provider.appendMessage(makeMessage("m2", "assistant", "b"));
+
+    const leaf = await provider.getLatestLeaf();
+    expect(leaf!.id).toBe("m2");
+  });
+
+  it("getPathLength counts messages", async () => {
+    await provider.appendMessage(makeMessage("m1", "user", "a"));
+    await provider.appendMessage(makeMessage("m2", "assistant", "b"));
+    await provider.appendMessage(makeMessage("m3", "user", "c"));
+
+    const length = await provider.getPathLength();
+    expect(length).toBe(3);
+  });
+
+  it("isolates sessions by session_id", async () => {
+    const other = new PostgresSessionProvider(conn, "other-session");
+
+    await provider.appendMessage(makeMessage("m1", "user", "session1"));
+    await other.appendMessage(makeMessage("m2", "user", "session2"));
+
+    const h1 = await provider.getHistory();
+    const h2 = await other.getHistory();
+    expect(h1).toHaveLength(1);
+    expect(h1[0].parts[0].text).toBe("session1");
+    expect(h2).toHaveLength(1);
+    expect(h2[0].parts[0].text).toBe("session2");
+  });
+
+  it("adds and retrieves compactions", async () => {
+    const comp = await provider.addCompaction("summary", "m1", "m5");
+    expect(comp.summary).toBe("summary");
+    expect(comp.fromMessageId).toBe("m1");
+    expect(comp.toMessageId).toBe("m5");
+
+    const all = await provider.getCompactions();
+    expect(all).toHaveLength(1);
+    expect(all[0].summary).toBe("summary");
+  });
+});
+
+describe("PostgresContextProvider", () => {
+  let conn: InMemoryPostgres;
+
+  beforeEach(() => {
+    conn = new InMemoryPostgres();
+  });
+
+  it("returns null for unset label", async () => {
+    const ctx = new PostgresContextProvider(conn, "memory");
+    expect(await ctx.get()).toBeNull();
+  });
+
+  it("sets and gets content", async () => {
+    const ctx = new PostgresContextProvider(conn, "memory");
+    await ctx.set("hello world");
+    expect(await ctx.get()).toBe("hello world");
+  });
+
+  it("overwrites on second set", async () => {
+    const ctx = new PostgresContextProvider(conn, "memory");
+    await ctx.set("first");
+    await ctx.set("second");
+    expect(await ctx.get()).toBe("second");
+  });
+
+  it("isolates by label", async () => {
+    const a = new PostgresContextProvider(conn, "memory");
+    const b = new PostgresContextProvider(conn, "todos");
+    await a.set("facts");
+    await b.set("tasks");
+    expect(await a.get()).toBe("facts");
+    expect(await b.get()).toBe("tasks");
+  });
+});
+
+describe("PostgresSearchProvider", () => {
+  let conn: InMemoryPostgres;
+  let search: PostgresSearchProvider;
+
+  beforeEach(() => {
+    conn = new InMemoryPostgres();
+    search = new PostgresSearchProvider(conn);
+    search.init("knowledge");
+  });
+
+  it("returns null when empty, count when populated", async () => {
+    expect(await search.get()).toBeNull();
+    await search.set("meeting-notes", "deployment scheduled for Friday");
+    expect(await search.get()).toBe("1 entries indexed.");
+  });
+
+  it("searches indexed content", async () => {
+    await search.set(
+      "notes",
+      "the deployment is on Friday with budget concerns"
+    );
+    await search.set("api-doc", "REST endpoints with JSON responses");
+
+    const result = await search.search("deployment");
+    expect(result).toContain("notes");
+    expect(result).toContain("deployment");
+  });
+
+  it("returns no results for non-matching query", async () => {
+    await search.set("notes", "hello world");
+    const result = await search.search("nonexistent");
+    expect(result).toBe("No results found.");
+  });
+
+  it("upserts on duplicate key", async () => {
+    await search.set("doc", "original about cats");
+    await search.set("doc", "replaced about dogs");
+
+    expect(await search.get()).toBe("1 entries indexed.");
+
+    const result = await search.search("dogs");
+    expect(result).toContain("replaced");
+  });
+
+  it("isolates by label", async () => {
+    const other = new PostgresSearchProvider(conn);
+    other.init("other");
+
+    await search.set("key1", "knowledge content");
+    await other.set("key2", "other content");
+
+    expect(await search.get()).toBe("1 entries indexed.");
+    expect(await other.get()).toBe("1 entries indexed.");
+  });
+});
+
+describe("Postgres providers with Session + ContextBlocks", () => {
+  let conn: InMemoryPostgres;
+
+  beforeEach(() => {
+    conn = new InMemoryPostgres();
+  });
+
+  it("system prompt includes soul block content", async () => {
+    const soulProvider = {
+      get: async () => "You are a helpful assistant."
+    };
+
+    const blocks = new ContextBlocks([
+      { label: "soul", provider: soulProvider }
+    ]);
+
+    const prompt = await blocks.freezeSystemPrompt();
+    expect(prompt).toContain("You are a helpful assistant.");
+    expect(prompt).toContain("SOUL");
+  });
+
+  it("system prompt includes memory block from PostgresContextProvider", async () => {
+    const memProvider = new PostgresContextProvider(conn, "memory");
+    await memProvider.set("User likes coffee.");
+
+    const blocks = new ContextBlocks([
+      { label: "soul", provider: { get: async () => "You are helpful." } },
+      {
+        label: "memory",
+        description: "Learned facts",
+        maxTokens: 1100,
+        provider: memProvider
+      }
+    ]);
+
+    const prompt = await blocks.freezeSystemPrompt();
+    expect(prompt).toContain("SOUL");
+    expect(prompt).toContain("You are helpful.");
+    expect(prompt).toContain("MEMORY");
+    expect(prompt).toContain("User likes coffee.");
+  });
+
+  it("system prompt persists via PostgresContextProvider prompt store", async () => {
+    const promptStore = new PostgresContextProvider(conn, "_prompt");
+    const memProvider = new PostgresContextProvider(conn, "memory");
+    await memProvider.set("User likes coffee.");
+
+    const blocks = new ContextBlocks(
+      [
+        { label: "soul", provider: { get: async () => "You are helpful." } },
+        {
+          label: "memory",
+          description: "Learned facts",
+          provider: memProvider
+        }
+      ],
+      promptStore
+    );
+
+    // First call renders and stores
+    const prompt1 = await blocks.freezeSystemPrompt();
+    expect(prompt1).toContain("User likes coffee.");
+
+    // Verify it was persisted
+    const stored = await promptStore.get();
+    expect(stored).toBe(prompt1);
+    expect(stored!.length).toBeGreaterThan(0);
+
+    // Second call returns cached value
+    const prompt2 = await blocks.freezeSystemPrompt();
+    expect(prompt2).toBe(prompt1);
+  });
+
+  it("refreshSystemPrompt re-renders after block update", async () => {
+    const promptStore = new PostgresContextProvider(conn, "_prompt");
+    const memProvider = new PostgresContextProvider(conn, "memory");
+    await memProvider.set("User likes coffee.");
+
+    const blocks = new ContextBlocks(
+      [
+        {
+          label: "memory",
+          description: "Facts",
+          provider: memProvider
+        }
+      ],
+      promptStore
+    );
+
+    const prompt1 = await blocks.freezeSystemPrompt();
+    expect(prompt1).toContain("User likes coffee.");
+
+    // Update the block
+    await blocks.setBlock("memory", "User likes tea.");
+    const prompt2 = await blocks.refreshSystemPrompt();
+    expect(prompt2).toContain("User likes tea.");
+    expect(prompt2).not.toContain("User likes coffee.");
+  });
+
+  it("freezeSystemPrompt returns cached value on second call", async () => {
+    const promptStore = new PostgresContextProvider(conn, "_prompt");
+    const memProvider = new PostgresContextProvider(conn, "memory");
+    await memProvider.set("Fact A");
+
+    const blocks = new ContextBlocks(
+      [{ label: "memory", description: "Facts", provider: memProvider }],
+      promptStore
+    );
+
+    // First call renders and persists
+    const prompt1 = await blocks.freezeSystemPrompt();
+    expect(prompt1).toContain("Fact A");
+
+    // Change block content directly
+    await memProvider.set("Fact B");
+
+    // Second call returns the CACHED prompt (still has Fact A)
+    const prompt2 = await blocks.freezeSystemPrompt();
+    expect(prompt2).toBe(prompt1);
+    expect(prompt2).toContain("Fact A");
+    expect(prompt2).not.toContain("Fact B");
+  });
+
+  it("refreshSystemPrompt reloads from providers and updates store", async () => {
+    const promptStore = new PostgresContextProvider(conn, "_prompt");
+    const memProvider = new PostgresContextProvider(conn, "memory");
+    await memProvider.set("Fact A");
+
+    const blocks = new ContextBlocks(
+      [{ label: "memory", description: "Facts", provider: memProvider }],
+      promptStore
+    );
+
+    // Freeze with initial content
+    const prompt1 = await blocks.freezeSystemPrompt();
+    expect(prompt1).toContain("Fact A");
+
+    // Change block content
+    await memProvider.set("Fact B");
+
+    // Refresh re-renders from providers
+    const prompt2 = await blocks.refreshSystemPrompt();
+    expect(prompt2).toContain("Fact B");
+    expect(prompt2).not.toContain("Fact A");
+
+    // Freeze now returns the updated cached value
+    const prompt3 = await blocks.freezeSystemPrompt();
+    expect(prompt3).toBe(prompt2);
+  });
+
+  it("refreshSystemPrompt invalidates cache so next freeze returns updated prompt", async () => {
+    const promptStore = new PostgresContextProvider(conn, "_prompt");
+    const memProvider = new PostgresContextProvider(conn, "memory");
+    await memProvider.set("Fact A");
+
+    const blocks = new ContextBlocks(
+      [{ label: "memory", description: "Facts", provider: memProvider }],
+      promptStore
+    );
+
+    // Freeze with initial content
+    await blocks.freezeSystemPrompt();
+
+    // Change content and refresh
+    await memProvider.set("Fact B");
+    await blocks.refreshSystemPrompt();
+
+    // Freeze now returns the refreshed prompt
+    const prompt = await blocks.freezeSystemPrompt();
+    expect(prompt).toContain("Fact B");
+  });
+
+  it("concurrent freezeSystemPrompt calls return the same prompt", async () => {
+    const promptStore = new PostgresContextProvider(conn, "_prompt");
+    const memProvider = new PostgresContextProvider(conn, "memory");
+    await memProvider.set("Concurrent test");
+
+    const blocks = new ContextBlocks(
+      [{ label: "memory", description: "Facts", provider: memProvider }],
+      promptStore
+    );
+
+    // Fire multiple freeze calls concurrently
+    const [p1, p2, p3] = await Promise.all([
+      blocks.freezeSystemPrompt(),
+      blocks.freezeSystemPrompt(),
+      blocks.freezeSystemPrompt()
+    ]);
+
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+    expect(p1).toContain("Concurrent test");
+  });
+
+  it("search provider generates search_context tool", async () => {
+    const searchProvider = new PostgresSearchProvider(conn);
+
+    const blocks = new ContextBlocks([
+      {
+        label: "knowledge",
+        description: "Searchable knowledge base",
+        provider: searchProvider
+      }
+    ]);
+
+    const tools = await blocks.tools();
+    expect(tools.search_context).toBeDefined();
+    expect(tools.set_context).toBeDefined();
+  });
+});
+
+// ── dynamic-tool round-trip tests ─────────────────────────────
+
+function makeToolMessage(id: string): SessionMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [
+      {
+        type: "dynamic-tool",
+        toolName: "set_context",
+        toolCallId: "call-abc-123",
+        state: "output-available",
+        input: { action: "set", label: "memory", content: "User likes cats" },
+        output: "Saved to memory"
+      } as unknown as SessionMessage["parts"][number],
+      { type: "text", text: "I saved that to memory." }
+    ]
+  };
+}
+
+describe("dynamic-tool parts round-trip through Postgres", () => {
+  let conn: InMemoryPostgres;
+  let provider: PostgresSessionProvider;
+
+  beforeEach(() => {
+    conn = new InMemoryPostgres();
+    provider = new PostgresSessionProvider(conn, "test-session");
+  });
+
+  it("preserves dynamic-tool part fields after store+retrieve", async () => {
+    const msg = makeToolMessage("a1");
+    await provider.appendMessage(msg);
+
+    const retrieved = await provider.getMessage("a1");
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.parts).toHaveLength(2);
+
+    const toolPart = retrieved!.parts[0] as unknown as Record<string, unknown>;
+    expect(toolPart.type).toBe("dynamic-tool");
+    expect(toolPart.toolName).toBe("set_context");
+    expect(toolPart.toolCallId).toBe("call-abc-123");
+    expect(toolPart.state).toBe("output-available");
+    expect(toolPart.input).toEqual({
+      action: "set",
+      label: "memory",
+      content: "User likes cats"
+    });
+    expect(toolPart.output).toBe("Saved to memory");
+
+    const textPart = retrieved!.parts[1];
+    expect(textPart.type).toBe("text");
+    expect(textPart.text).toBe("I saved that to memory.");
+  });
+
+  it("preserves dynamic-tool parts in getHistory chain", async () => {
+    await provider.appendMessage(
+      makeMessage("u1", "user", "remember I like cats")
+    );
+    await provider.appendMessage(makeToolMessage("a1"));
+    await provider.appendMessage(makeMessage("u2", "user", "what do I like?"));
+
+    const history = await provider.getHistory();
+    expect(history).toHaveLength(3);
+
+    // Check the assistant message in the middle
+    const assistantMsg = history[1];
+    expect(assistantMsg.id).toBe("a1");
+    expect(assistantMsg.parts).toHaveLength(2);
+
+    const toolPart = assistantMsg.parts[0] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(toolPart.type).toBe("dynamic-tool");
+    expect(toolPart.state).toBe("output-available");
+    expect(toolPart.output).toBe("Saved to memory");
+  });
+});
+
+describe("convertToModelMessages compatibility", () => {
+  let conn: InMemoryPostgres;
+  let provider: PostgresSessionProvider;
+
+  beforeEach(() => {
+    conn = new InMemoryPostgres();
+    provider = new PostgresSessionProvider(conn, "test-session");
+  });
+
+  it("text-only history converts without error", async () => {
+    await provider.appendMessage(makeMessage("u1", "user", "hello"));
+    await provider.appendMessage(makeMessage("a1", "assistant", "hi there"));
+
+    const history = await provider.getHistory();
+    const modelMessages = await convertToModelMessages(history as UIMessage[]);
+
+    expect(modelMessages).toHaveLength(2);
+    expect(modelMessages[0].role).toBe("user");
+    expect(modelMessages[1].role).toBe("assistant");
+  });
+
+  it("output-available dynamic-tool parts convert without error", async () => {
+    await provider.appendMessage(makeMessage("u1", "user", "remember cats"));
+    await provider.appendMessage(makeToolMessage("a1"));
+
+    const history = await provider.getHistory();
+    const modelMessages = await convertToModelMessages(history as UIMessage[]);
+
+    // Should produce: user msg, assistant msg (with tool-call), tool msg (with tool-result)
+    expect(modelMessages.length).toBeGreaterThanOrEqual(2);
+
+    // Find the assistant message
+    const assistantModel = modelMessages.find((m) => m.role === "assistant");
+    expect(assistantModel).toBeDefined();
+
+    // It should contain a tool-call content part
+    const content = assistantModel!.content as Array<{ type: string }>;
+    const toolCall = content.find((c) => c.type === "tool-call");
+    expect(toolCall).toBeDefined();
+
+    // There should be a tool message with the result
+    const toolModel = modelMessages.find((m) => m.role === "tool");
+    expect(toolModel).toBeDefined();
+  });
+
+  it("input-available dynamic-tool parts produce orphaned tool-calls without ignoreIncompleteToolCalls", async () => {
+    const msg: SessionMessage = {
+      id: "a1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "set_context",
+          toolCallId: "call-orphan",
+          state: "input-available",
+          input: { action: "set", label: "memory", content: "test" }
+        } as unknown as SessionMessage["parts"][number],
+        { type: "text", text: "Let me save that." }
+      ]
+    };
+
+    await provider.appendMessage(makeMessage("u1", "user", "hello"));
+    await provider.appendMessage(msg);
+    await provider.appendMessage(makeMessage("u2", "user", "next question"));
+
+    const history = await provider.getHistory();
+
+    // convertToModelMessages does NOT throw — it produces model messages
+    // with orphaned tool-calls. The downstream generateText/convertToLanguageModelPrompt
+    // is what throws MissingToolResultsError.
+    const modelMessages = await convertToModelMessages(history as UIMessage[]);
+
+    // Assistant message has a tool-call but there's no tool message with result
+    const assistantModel = modelMessages.find((m) => m.role === "assistant");
+    const content = assistantModel!.content as Array<{ type: string }>;
+    const toolCall = content.find((c) => c.type === "tool-call");
+    expect(toolCall).toBeDefined();
+
+    // No tool message because input-available has no output to generate result from
+    const toolModel = modelMessages.find((m) => m.role === "tool");
+    expect(toolModel).toBeUndefined();
+  });
+
+  it("input-available parts are stripped with ignoreIncompleteToolCalls", async () => {
+    const msg: SessionMessage = {
+      id: "a1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "set_context",
+          toolCallId: "call-orphan",
+          state: "input-available",
+          input: { action: "set", label: "memory", content: "test" }
+        } as unknown as SessionMessage["parts"][number],
+        { type: "text", text: "Let me save that." }
+      ]
+    };
+
+    await provider.appendMessage(makeMessage("u1", "user", "hello"));
+    await provider.appendMessage(msg);
+    await provider.appendMessage(makeMessage("u2", "user", "next question"));
+
+    const history = await provider.getHistory();
+
+    // With the flag, incomplete tool calls should be stripped
+    const modelMessages = await convertToModelMessages(history as UIMessage[], {
+      ignoreIncompleteToolCalls: true
+    });
+
+    // Should not throw, and should produce valid messages
+    expect(modelMessages.length).toBeGreaterThanOrEqual(3);
+
+    // The assistant message should only have text, no tool-call
+    const assistantModel = modelMessages.find((m) => m.role === "assistant");
+    expect(assistantModel).toBeDefined();
+    const content = assistantModel!.content as Array<{ type: string }>;
+    const toolCall = content.find((c) => c.type === "tool-call");
+    expect(toolCall).toBeUndefined();
+  });
+
+  it("multi-turn with tools converts correctly for second generateText call", async () => {
+    // Simulate: user asks -> assistant uses tool -> user asks again
+    // This is the exact flow that breaks in production
+    await provider.appendMessage(
+      makeMessage("u1", "user", "remember I like cats")
+    );
+    await provider.appendMessage(makeToolMessage("a1"));
+    await provider.appendMessage(makeMessage("u2", "user", "what do I like?"));
+
+    const history = await provider.getHistory();
+
+    // This is what generateText receives on the second turn
+    const modelMessages = await convertToModelMessages(history as UIMessage[]);
+
+    // Should produce: user, assistant (tool-call + text), tool (result), user
+    expect(modelMessages.length).toBeGreaterThanOrEqual(4);
+
+    // Verify ordering: the tool result comes before the second user message
+    const roles = modelMessages.map((m) => m.role);
+    expect(roles).toEqual(["user", "assistant", "tool", "user"]);
+  });
+
+  it("multiple tool calls in one message convert correctly", async () => {
+    const msg: SessionMessage = {
+      id: "a1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "set_context",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { action: "set", label: "memory", content: "fact 1" },
+          output: "Saved"
+        } as unknown as SessionMessage["parts"][number],
+        {
+          type: "dynamic-tool",
+          toolName: "search_context",
+          toolCallId: "call-2",
+          state: "output-available",
+          input: { label: "knowledge", query: "cats" },
+          output: "No results found."
+        } as unknown as SessionMessage["parts"][number],
+        { type: "text", text: "I checked my knowledge base." }
+      ]
+    };
+
+    await provider.appendMessage(makeMessage("u1", "user", "search for cats"));
+    await provider.appendMessage(msg);
+
+    const history = await provider.getHistory();
+    const modelMessages = await convertToModelMessages(history as UIMessage[]);
+
+    // Assistant message should have 2 tool-calls
+    const assistantModel = modelMessages.find((m) => m.role === "assistant");
+    const content = assistantModel!.content as Array<{
+      type: string;
+      toolCallId?: string;
+    }>;
+    const toolCalls = content.filter((c) => c.type === "tool-call");
+    expect(toolCalls).toHaveLength(2);
+
+    // Tool message should have 2 results
+    const toolModel = modelMessages.find((m) => m.role === "tool");
+    expect(toolModel).toBeDefined();
+    const toolContent = toolModel!.content as Array<{ type: string }>;
+    const toolResults = toolContent.filter((c) => c.type === "tool-result");
+    expect(toolResults).toHaveLength(2);
+  });
+});

--- a/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
@@ -57,8 +57,13 @@ class InMemoryPostgres implements PostgresConnection {
 
     // Handle ON CONFLICT DO NOTHING
     if (q.includes("ON CONFLICT") && q.includes("DO NOTHING")) {
-      const pk = cols[0];
-      if (table.some((r) => r[pk] === row[pk])) return { rows: [] };
+      const conflictMatch = q.match(/ON CONFLICT \(([^)]+)\)/);
+      const keys = conflictMatch
+        ? conflictMatch[1].split(",").map((c) => c.trim())
+        : [cols[0]];
+      if (table.some((r) => keys.every((key) => r[key] === row[key]))) {
+        return { rows: [] };
+      }
     }
 
     // Handle ON CONFLICT DO UPDATE
@@ -174,14 +179,19 @@ class InMemoryPostgres implements PostgresConnection {
   private handleRecursiveSelect(q: string, params: unknown[]): { rows: Row[] } {
     const table = this.getTable("assistant_messages");
     const startId = params[0] as string;
+    const sessionId = params[1];
 
     // Walk parent chain
     const path: Row[] = [];
-    let current = table.find((r) => r.id === startId);
+    let current = table.find(
+      (r) => r.id === startId && r.session_id === sessionId
+    );
     while (current) {
       path.unshift(current);
       current = current.parent_id
-        ? table.find((r) => r.id === current!.parent_id)
+        ? table.find(
+            (r) => r.id === current!.parent_id && r.session_id === sessionId
+          )
         : undefined;
     }
 
@@ -417,6 +427,34 @@ describe("PostgresSessionProvider", () => {
     expect(h1[0].parts[0].text).toBe("session1");
     expect(h2).toHaveLength(1);
     expect(h2[0].parts[0].text).toBe("session2");
+  });
+
+  it("allows the same message id in different sessions", async () => {
+    const other = new PostgresSessionProvider(conn, "other-session");
+
+    await provider.appendMessage(makeMessage("same-id", "user", "session1"));
+    await other.appendMessage(makeMessage("same-id", "user", "session2"));
+
+    const h1 = await provider.getHistory();
+    const h2 = await other.getHistory();
+
+    expect(h1).toHaveLength(1);
+    expect(h1[0].parts[0].text).toBe("session1");
+    expect(h2).toHaveLength(1);
+    expect(h2[0].parts[0].text).toBe("session2");
+  });
+
+  it("falls back to root when explicit parent belongs to another session", async () => {
+    const other = new PostgresSessionProvider(conn, "other-session");
+
+    await other.appendMessage(makeMessage("foreign-parent", "user", "other"));
+    await provider.appendMessage(
+      makeMessage("child", "user", "local"),
+      "foreign-parent"
+    );
+
+    expect((await provider.getHistory()).map((m) => m.id)).toEqual(["child"]);
+    expect(await other.getBranches("foreign-parent")).toHaveLength(0);
   });
 
   it("adds and retrieves compactions", async () => {

--- a/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
@@ -467,6 +467,30 @@ describe("PostgresSessionProvider", () => {
     expect(all).toHaveLength(1);
     expect(all[0].summary).toBe("summary");
   });
+
+  it("normalizes compaction timestamps returned as Date objects", async () => {
+    const createdAt = new Date("2026-05-18T15:42:29.000Z");
+    const dateConn: PostgresConnection = {
+      async execute() {
+        return {
+          rows: [
+            {
+              id: "compaction-date",
+              summary: "summary",
+              from_message_id: "m1",
+              to_message_id: "m5",
+              created_at: createdAt
+            }
+          ]
+        };
+      }
+    };
+    const dateProvider = new PostgresSessionProvider(dateConn, "session-1");
+
+    const [compaction] = await dateProvider.getCompactions();
+
+    expect(compaction.createdAt).toBe("2026-05-18T15:42:29.000Z");
+  });
 });
 
 describe("PostgresContextProvider", () => {

--- a/packages/agents/src/tests/experimental/memory/session/provider.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/provider.test.ts
@@ -7,7 +7,7 @@ import { getAgentByName } from "../../../..";
  * Typed stub for TestSessionAgent (tree-structured Session API)
  */
 interface SessionAgentStub {
-  appendMessage(message: UIMessage, parentId?: string): Promise<void>;
+  appendMessage(message: UIMessage, parentId?: string | null): Promise<void>;
   getMessage(id: string): Promise<UIMessage | null>;
   updateMessage(message: UIMessage): Promise<void>;
   deleteMessages(ids: string[]): Promise<void>;
@@ -187,6 +187,59 @@ describe("AgentSessionProvider — tree-structured messages", () => {
     expect(history).toHaveLength(1);
     // INSERT OR IGNORE — keeps the first
     expect(history[0].parts[0]).toEqual({ type: "text", text: "First" });
+  });
+
+  it("explicit null parentId creates a root message (no auto-parent)", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "first root" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "assistant",
+      parts: [{ type: "text", text: "reply" }]
+    });
+
+    // Explicit null → must become its own root, NOT a child of m2.
+    await agent.appendMessage(
+      {
+        id: "m3",
+        role: "user",
+        parts: [{ type: "text", text: "new root" }]
+      },
+      null
+    );
+
+    const branches = await agent.getBranches("m2");
+    expect(branches.map((b) => b.id)).not.toContain("m3");
+
+    const historyFromM3 = await agent.getHistory("m3");
+    expect(historyFromM3.map((m) => m.id)).toEqual(["m3"]);
+  });
+
+  it("omitted parentId auto-attaches to the latest leaf", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "first" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "assistant",
+      parts: [{ type: "text", text: "reply" }]
+    });
+    // No parentId → should be a child of m2.
+    await agent.appendMessage({
+      id: "m3",
+      role: "user",
+      parts: [{ type: "text", text: "follow-up" }]
+    });
+
+    const branches = await agent.getBranches("m2");
+    expect(branches.map((b) => b.id)).toContain("m3");
   });
 
   it("compaction overlays — addCompaction replaces range in getHistory", async () => {

--- a/packages/agents/src/tests/experimental/memory/session/search.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/search.test.ts
@@ -116,7 +116,7 @@ describe("Search blocks in system prompt", () => {
     await blocks.load();
     const prompt = blocks.toSystemPrompt();
     expect(prompt).toContain("KNOWLEDGE");
-    expect(prompt).toContain("search_context");
+    expect(prompt).toContain("[searchable]");
     expect(prompt).toContain("Product docs");
   });
 
@@ -132,7 +132,7 @@ describe("Search blocks in system prompt", () => {
     // Empty search provider returns null → content is ""
     // But isSearchable means it still renders
     expect(prompt).toContain("KNOWLEDGE");
-    expect(prompt).toContain("search_context");
+    expect(prompt).toContain("[searchable]");
   });
 });
 
@@ -184,7 +184,8 @@ type SetToolFn = {
   execute: (args: {
     label: string;
     content: string;
-    key?: string;
+    title?: string;
+    action?: string;
   }) => Promise<string>;
 };
 
@@ -198,7 +199,6 @@ describe("set_context with search blocks", () => {
     const setTool = tools.set_context as unknown as SetToolFn;
     const result = await setTool.execute({
       label: "knowledge",
-      key: "notes",
       content: "The deployment is scheduled for Friday"
     });
     expect(result).toContain("Indexed");
@@ -211,7 +211,7 @@ describe("set_context with search blocks", () => {
     expect(searchResult).toContain("Friday");
   });
 
-  it("errors when key missing for search block", async () => {
+  it("auto-generates key when none provided for search block", async () => {
     const provider = new MemorySearchProvider();
     const blocks = new ContextBlocks([{ label: "knowledge", provider }]);
     await blocks.load();
@@ -222,7 +222,7 @@ describe("set_context with search blocks", () => {
       label: "knowledge",
       content: "no key provided"
     });
-    expect(result).toContain("key is required");
+    expect(result).toContain("Indexed");
   });
 
   it("updates block summary after indexing", async () => {
@@ -237,13 +237,11 @@ describe("set_context with search blocks", () => {
     const setTool = tools.set_context as unknown as SetToolFn;
     await setTool.execute({
       label: "knowledge",
-      key: "doc-1",
-      content: "First document"
+      content: "First document about cats"
     });
 
     // Block content should now show the indexed entry
     const block = blocks.getBlock("knowledge");
-    expect(block?.content).toContain("doc-1");
     expect(block?.content).toContain("1 entries");
   });
 });

--- a/packages/agents/src/tests/experimental/memory/session/session.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/session.test.ts
@@ -348,7 +348,7 @@ describe("Session.create() builder", () => {
     const { sql } = createSqlStub();
     const session = Session.create({ sql });
     // Should be usable immediately — no .build() needed
-    expect(session.getHistory()).toEqual([]);
+    expect(await session.getHistory()).toEqual([]);
   });
 
   it("withContext adds writable blocks with auto-created provider", async () => {
@@ -471,8 +471,9 @@ describe("Session.create() builder", () => {
       provider: new MemoryBlockProvider(null)
     });
     const prompt = await session.freezeSystemPrompt();
-    // Empty content → block not rendered
-    expect(prompt).not.toContain("MEMORY");
+    // Writable blocks render even when empty so the LLM knows they exist
+    expect(prompt).toContain("MEMORY");
+    expect(prompt).toContain("[writable]");
   });
 
   it("forSession before withContext namespaces correctly", async () => {
@@ -573,7 +574,9 @@ function createCompactableSession(
     getLatestLeaf: () => messages[messages.length - 1] ?? null,
     getBranches: () => [],
     getPathLength: () => messages.length,
-    appendMessage: (msg) => messages.push(msg),
+    appendMessage: (msg) => {
+      messages.push(msg);
+    },
     updateMessage: () => {},
     deleteMessages: () => {},
     clearMessages: () => {
@@ -811,7 +814,9 @@ describe("Session.compact()", () => {
       getLatestLeaf: () => messages[messages.length - 1] ?? null,
       getBranches: () => [],
       getPathLength: () => messages.length,
-      appendMessage: (msg) => messages.push(msg),
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
       updateMessage: () => {},
       deleteMessages: () => {},
       clearMessages: () => {},
@@ -865,7 +870,9 @@ describe("Session.compact()", () => {
       getLatestLeaf: () => messages[messages.length - 1] ?? null,
       getBranches: () => [],
       getPathLength: () => messages.length,
-      appendMessage: (msg) => messages.push(msg),
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
       updateMessage: () => {},
       deleteMessages: () => {},
       clearMessages: () => {},
@@ -946,7 +953,9 @@ describe("Session.compact()", () => {
       getLatestLeaf: () => messages[messages.length - 1] ?? null,
       getBranches: () => [],
       getPathLength: () => messages.length,
-      appendMessage: (msg) => messages.push(msg),
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
       updateMessage: () => {},
       deleteMessages: () => {},
       clearMessages: () => {},
@@ -1232,5 +1241,81 @@ describe("AgentSearchProvider FTS5 (DO-backed)", () => {
   it("updating an entry replaces it in FTS5 index", async () => {
     const agent = await getSearchAgent(instanceName);
     expect(await agent.testUpdateReplacesEntry()).toEqual({ success: true });
+  });
+});
+
+// ── SessionProvider (external storage) tests ──────────────────────
+
+describe("Session.create with SessionProvider", () => {
+  it("accepts a SessionProvider directly", async () => {
+    const messages: SessionMessage[] = [];
+    const mockStorage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {
+        messages.length = 0;
+      },
+      addCompaction: () => ({
+        id: "",
+        summary: "",
+        fromMessageId: "",
+        toMessageId: "",
+        createdAt: ""
+      }),
+      getCompactions: () => []
+    };
+
+    const session = Session.create(mockStorage);
+
+    await session.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "hello" }]
+    });
+
+    const history = await session.getHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].id).toBe("m1");
+  });
+
+  it("skips SQLite auto-wiring with SessionProvider", async () => {
+    const mockStorage: SessionProvider = {
+      getMessage: () => null,
+      getHistory: () => [],
+      getLatestLeaf: () => null,
+      getBranches: () => [],
+      getPathLength: () => 0,
+      appendMessage: () => {},
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: () => ({
+        id: "",
+        summary: "",
+        fromMessageId: "",
+        toMessageId: "",
+        createdAt: ""
+      }),
+      getCompactions: () => []
+    };
+
+    const session = Session.create(mockStorage).withContext("soul", {
+      provider: { get: async () => "identity" }
+    });
+
+    const prompt = await session.freezeSystemPrompt();
+    expect(prompt).toContain("SOUL");
+    expect(prompt).toContain("identity");
+
+    const tools = await session.tools();
+    expect(Object.keys(tools)).toHaveLength(0);
   });
 });

--- a/packages/agents/src/tests/experimental/memory/session/session.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/session.test.ts
@@ -8,6 +8,8 @@ import {
   type ContextProvider,
   type WritableContextProvider
 } from "../../../../experimental/memory/session/context";
+import type { SearchProvider } from "../../../../experimental/memory/session/search";
+import type { SkillProvider } from "../../../../experimental/memory/session/skills";
 import type {
   SessionProvider,
   SearchResult,
@@ -52,6 +54,29 @@ class MemoryBlockProvider implements WritableContextProvider {
   async set(content: string) {
     this.value = content;
   }
+}
+
+class EmptySkillProvider implements SkillProvider {
+  async get() {
+    return null;
+  }
+  async load() {
+    return null;
+  }
+}
+
+class WritableSkillProvider extends EmptySkillProvider {
+  async set() {}
+}
+
+class WritableSearchProvider implements SearchProvider {
+  async get() {
+    return null;
+  }
+  async search() {
+    return null;
+  }
+  async set() {}
 }
 
 // ── Pure unit tests (no DO needed) ──────────────────────────────
@@ -161,6 +186,21 @@ describe("ContextBlocks — frozen system prompt", () => {
     expect(prompt).toContain("MEMORY");
     expect(prompt).not.toContain("<context_block");
   });
+
+  it("renders empty skill blocks so load_context stays discoverable", async () => {
+    const blocks = new ContextBlocks([
+      {
+        label: "skills",
+        description: "Project docs",
+        provider: new EmptySkillProvider()
+      }
+    ]);
+    await blocks.load();
+
+    const prompt = blocks.toSystemPrompt();
+    expect(prompt).toContain("SKILLS");
+    expect(prompt).toContain("[loadable]");
+  });
 });
 
 const stubProvider: SessionProvider = {
@@ -211,6 +251,40 @@ describe("Session — tools() without load", () => {
     expect(tool.description).toContain("memory");
     expect(tool.description).toContain("todos");
     expect(tool.description).not.toContain("soul");
+  });
+
+  it("tools() labels keyed writable blocks in set_context description", async () => {
+    const session = new Session(stubProvider, {
+      context: [
+        {
+          label: "memory",
+          description: "Learned facts",
+          provider: new MemoryBlockProvider("")
+        },
+        {
+          label: "skills",
+          description: "Loadable docs",
+          provider: new WritableSkillProvider()
+        },
+        {
+          label: "knowledge",
+          description: "Searchable docs",
+          provider: new WritableSearchProvider()
+        }
+      ]
+    });
+
+    const tools = await session.tools();
+    const tool = tools.set_context as { description: string };
+
+    expect(tool.description).toContain('- "memory" (writable): Learned facts');
+    expect(tool.description).toContain(
+      '- "skills" (skill collection, keyed entries): Loadable docs'
+    );
+    expect(tool.description).toContain(
+      '- "knowledge" (searchable, keyed entries): Searchable docs'
+    );
+    expect(tool.description).toContain("metadata: { title, description }");
   });
 
   it("tools() execute lazily loads and writes to provider", async () => {

--- a/packages/agents/src/tests/experimental/memory/session/skills.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/skills.test.ts
@@ -130,20 +130,22 @@ describe("Skill blocks in system prompt", () => {
     const prompt = blocks.toSystemPrompt();
 
     expect(prompt).toContain("SKILLS");
-    expect(prompt).toContain("load_context");
+    expect(prompt).toContain("[loadable]");
     expect(prompt).toContain("code-review");
     expect(prompt).toContain("Code review");
     expect(prompt).toContain("sql-query");
     expect(prompt).toContain("SQL guide");
   });
 
-  it("empty skill provider produces no prompt section", async () => {
+  it("empty skill provider renders with loadable tag", async () => {
     const blocks = new ContextBlocks([
       { label: "skills", provider: new MemorySkillProvider() }
     ]);
     await blocks.load();
     const prompt = blocks.toSystemPrompt();
-    expect(prompt).toBe("");
+    // Skill blocks are writable, so they render even when empty
+    expect(prompt).toContain("SKILLS");
+    expect(prompt).toContain("[loadable]");
   });
 });
 
@@ -203,8 +205,8 @@ type SetToolFn = {
   execute: (args: {
     label: string;
     content: string;
-    key?: string;
-    description?: string;
+    title?: string;
+    action?: string;
   }) => Promise<string>;
 };
 
@@ -222,7 +224,7 @@ describe("set_context tool", () => {
     expect(await provider.get()).toBe("new fact");
   });
 
-  it("writes to skill block with key", async () => {
+  it("writes to skill block with title as key", async () => {
     const provider = new MemorySkillProvider();
     const blocks = new ContextBlocks([{ label: "skills", provider }]);
     await blocks.load();
@@ -230,15 +232,14 @@ describe("set_context tool", () => {
     const tool = tools.set_context as unknown as SetToolFn;
     const result = await tool.execute({
       label: "skills",
-      key: "pirate",
       content: "Talk like a pirate",
-      description: "Pirate style"
+      title: "Pirate style"
     });
-    expect(result).toContain("Written skill");
-    expect(await provider.load("pirate")).toBe("Talk like a pirate");
+    expect(result).toContain("Indexed");
+    expect(await provider.load("pirate-style")).toBe("Talk like a pirate");
   });
 
-  it("errors when skill block missing key", async () => {
+  it("auto-generates key from content when no title for skill block", async () => {
     const blocks = new ContextBlocks([
       {
         label: "skills",
@@ -249,7 +250,7 @@ describe("set_context tool", () => {
     const tools = await blocks.tools();
     const tool = tools.set_context as unknown as SetToolFn;
     const result = await tool.execute({ label: "skills", content: "no key" });
-    expect(result).toContain("key is required");
+    expect(result).toContain("Indexed");
   });
 
   it("rejects writes to readonly block", async () => {
@@ -272,23 +273,20 @@ describe("set_context tool", () => {
     const tools = await blocks.tools();
     const tool = tools.set_context as unknown as SetToolFn;
 
-    // Write a skill with description
+    // Write a skill with title (used as key slug and description)
     await tool.execute({
       label: "skills",
-      key: "greeting",
       content: "Say hello warmly",
-      description: "Greeting instructions"
+      title: "Greeting instructions"
     });
 
-    // Description should be stored in the provider
+    // Title should be slugified into the key
     const metadata = await provider.get();
-    expect(metadata).toContain("greeting");
-    expect(metadata).toContain("Greeting instructions");
+    expect(metadata).toContain("greeting-instructions");
 
     // Block content should be refreshed with new metadata
     const block = blocks.getBlock("skills");
-    expect(block?.content).toContain("greeting");
-    expect(block?.content).toContain("Greeting instructions");
+    expect(block?.content).toContain("greeting-instructions");
   });
 
   it("set_context without description stores content only", async () => {
@@ -301,16 +299,13 @@ describe("set_context tool", () => {
 
     await tool.execute({
       label: "skills",
-      key: "raw-skill",
       content: "Just content, no desc"
     });
 
-    expect(await provider.load("raw-skill")).toBe("Just content, no desc");
-
-    // Metadata should list the key without description
-    const metadata = await provider.get();
-    expect(metadata).toContain("raw-skill");
-    expect(metadata).not.toContain(":");
+    // Key is auto-generated from content slug
+    expect(await provider.load("just-content-no-desc")).toBe(
+      "Just content, no desc"
+    );
   });
 
   it("multiple set_context calls accumulate skills in metadata", async () => {
@@ -323,26 +318,22 @@ describe("set_context tool", () => {
 
     await tool.execute({
       label: "skills",
-      key: "skill-a",
       content: "Content A",
-      description: "First skill"
+      title: "First skill"
     });
     await tool.execute({
       label: "skills",
-      key: "skill-b",
       content: "Content B",
-      description: "Second skill"
+      title: "Second skill"
     });
 
     const block = blocks.getBlock("skills");
-    expect(block?.content).toContain("skill-a");
-    expect(block?.content).toContain("First skill");
-    expect(block?.content).toContain("skill-b");
-    expect(block?.content).toContain("Second skill");
+    expect(block?.content).toContain("first-skill");
+    expect(block?.content).toContain("second-skill");
 
-    // Both loadable
-    expect(await provider.load("skill-a")).toBe("Content A");
-    expect(await provider.load("skill-b")).toBe("Content B");
+    // Both loadable by slugified title
+    expect(await provider.load("first-skill")).toBe("Content A");
+    expect(await provider.load("second-skill")).toBe("Content B");
   });
 });
 

--- a/packages/agents/src/tests/experimental/memory/session/skills.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/skills.test.ts
@@ -397,6 +397,7 @@ describe("set_context tool", () => {
     const tool = tools.set_context as unknown as SetToolFn;
     const result = await tool.execute({ label: "skills", content: "no key" });
     expect(result).toContain("Indexed");
+    expect(result).toMatch(/Indexed "no-key-[a-z0-9]+"/);
   });
 
   it("rejects writes to readonly block", async () => {
@@ -444,15 +445,51 @@ describe("set_context tool", () => {
     const tools = await blocks.tools();
     const tool = tools.set_context as unknown as SetToolFn;
 
-    await tool.execute({
+    const result = await tool.execute({
       label: "skills",
       content: "Just content, no desc"
     });
 
-    // Key is auto-generated from content slug
-    expect(await provider.load("just-content-no-desc")).toBe(
-      "Just content, no desc"
-    );
+    // Omitted titles get a deterministic content hash to avoid collisions.
+    const key = result.match(/Indexed "([^"]+)"/)?.[1];
+    expect(key).toMatch(/^just-content-no-desc-[a-z0-9]+$/);
+    expect(await provider.load(key!)).toBe("Just content, no desc");
+  });
+
+  it("auto-generated keys avoid content prefix and non-Latin collisions", async () => {
+    const provider = new MemorySkillProvider();
+    const blocks = new ContextBlocks([{ label: "skills", provider }]);
+    await blocks.load();
+
+    const tools = await blocks.tools();
+    const tool = tools.set_context as unknown as SetToolFn;
+
+    const first = await tool.execute({
+      label: "skills",
+      content:
+        "The deployment process for production requires approval from security team"
+    });
+    const second = await tool.execute({
+      label: "skills",
+      content:
+        "The deployment process for production requires approval from management"
+    });
+    const nonLatin = await tool.execute({
+      label: "skills",
+      content: "用户喜欢咖啡"
+    });
+
+    const firstKey = first.match(/Indexed "([^"]+)"/)?.[1];
+    const secondKey = second.match(/Indexed "([^"]+)"/)?.[1];
+    const nonLatinKey = nonLatin.match(/Indexed "([^"]+)"/)?.[1];
+
+    expect(firstKey).toBeDefined();
+    expect(secondKey).toBeDefined();
+    expect(nonLatinKey).toMatch(/^entry-[a-z0-9]+$/);
+    expect(firstKey).not.toBe(secondKey);
+    expect(await provider.load(firstKey!)).toContain("security team");
+    expect(await provider.load(secondKey!)).toContain("management");
+    expect(await provider.load(nonLatinKey!)).toBe("用户喜欢咖啡");
   });
 
   it("multiple set_context calls accumulate skills in metadata", async () => {

--- a/packages/agents/src/tests/experimental/memory/session/skills.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/skills.test.ts
@@ -351,7 +351,7 @@ type SetToolFn = {
   execute: (args: {
     label: string;
     content: string;
-    title?: string;
+    metadata?: { title?: string; description?: string };
     action?: string;
   }) => Promise<string>;
 };
@@ -379,7 +379,7 @@ describe("set_context tool", () => {
     const result = await tool.execute({
       label: "skills",
       content: "Talk like a pirate",
-      title: "Pirate style"
+      metadata: { title: "Pirate style" }
     });
     expect(result).toContain("Indexed");
     expect(await provider.load("pirate-style")).toBe("Talk like a pirate");
@@ -419,11 +419,12 @@ describe("set_context tool", () => {
     const tools = await blocks.tools();
     const tool = tools.set_context as unknown as SetToolFn;
 
-    // Write a skill with title (used as key slug and description)
+    // Write a skill with metadata — title slugs into the key and also
+    // acts as the description when no explicit description is given.
     await tool.execute({
       label: "skills",
       content: "Say hello warmly",
-      title: "Greeting instructions"
+      metadata: { title: "Greeting instructions" }
     });
 
     // Title should be slugified into the key
@@ -465,12 +466,12 @@ describe("set_context tool", () => {
     await tool.execute({
       label: "skills",
       content: "Content A",
-      title: "First skill"
+      metadata: { title: "First skill" }
     });
     await tool.execute({
       label: "skills",
       content: "Content B",
-      title: "Second skill"
+      metadata: { title: "Second skill" }
     });
 
     const block = blocks.getBlock("skills");

--- a/packages/agents/src/tests/experimental/memory/session/skills.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/skills.test.ts
@@ -276,20 +276,22 @@ describe("Skill blocks in system prompt", () => {
     const prompt = blocks.toSystemPrompt();
 
     expect(prompt).toContain("SKILLS");
-    expect(prompt).toContain("load_context");
+    expect(prompt).toContain("[loadable]");
     expect(prompt).toContain("code-review");
     expect(prompt).toContain("Code review");
     expect(prompt).toContain("sql-query");
     expect(prompt).toContain("SQL guide");
   });
 
-  it("empty skill provider produces no prompt section", async () => {
+  it("empty skill provider renders with loadable tag", async () => {
     const blocks = new ContextBlocks([
       { label: "skills", provider: new MemorySkillProvider() }
     ]);
     await blocks.load();
     const prompt = blocks.toSystemPrompt();
-    expect(prompt).toBe("");
+    // Skill blocks are writable, so they render even when empty
+    expect(prompt).toContain("SKILLS");
+    expect(prompt).toContain("[loadable]");
   });
 });
 
@@ -349,8 +351,8 @@ type SetToolFn = {
   execute: (args: {
     label: string;
     content: string;
-    key?: string;
-    description?: string;
+    title?: string;
+    action?: string;
   }) => Promise<string>;
 };
 
@@ -368,7 +370,7 @@ describe("set_context tool", () => {
     expect(await provider.get()).toBe("new fact");
   });
 
-  it("writes to skill block with key", async () => {
+  it("writes to skill block with title as key", async () => {
     const provider = new MemorySkillProvider();
     const blocks = new ContextBlocks([{ label: "skills", provider }]);
     await blocks.load();
@@ -376,15 +378,14 @@ describe("set_context tool", () => {
     const tool = tools.set_context as unknown as SetToolFn;
     const result = await tool.execute({
       label: "skills",
-      key: "pirate",
       content: "Talk like a pirate",
-      description: "Pirate style"
+      title: "Pirate style"
     });
-    expect(result).toContain("Written skill");
-    expect(await provider.load("pirate")).toBe("Talk like a pirate");
+    expect(result).toContain("Indexed");
+    expect(await provider.load("pirate-style")).toBe("Talk like a pirate");
   });
 
-  it("errors when skill block missing key", async () => {
+  it("auto-generates key from content when no title for skill block", async () => {
     const blocks = new ContextBlocks([
       {
         label: "skills",
@@ -395,7 +396,7 @@ describe("set_context tool", () => {
     const tools = await blocks.tools();
     const tool = tools.set_context as unknown as SetToolFn;
     const result = await tool.execute({ label: "skills", content: "no key" });
-    expect(result).toContain("key is required");
+    expect(result).toContain("Indexed");
   });
 
   it("rejects writes to readonly block", async () => {
@@ -418,23 +419,20 @@ describe("set_context tool", () => {
     const tools = await blocks.tools();
     const tool = tools.set_context as unknown as SetToolFn;
 
-    // Write a skill with description
+    // Write a skill with title (used as key slug and description)
     await tool.execute({
       label: "skills",
-      key: "greeting",
       content: "Say hello warmly",
-      description: "Greeting instructions"
+      title: "Greeting instructions"
     });
 
-    // Description should be stored in the provider
+    // Title should be slugified into the key
     const metadata = await provider.get();
-    expect(metadata).toContain("greeting");
-    expect(metadata).toContain("Greeting instructions");
+    expect(metadata).toContain("greeting-instructions");
 
     // Block content should be refreshed with new metadata
     const block = blocks.getBlock("skills");
-    expect(block?.content).toContain("greeting");
-    expect(block?.content).toContain("Greeting instructions");
+    expect(block?.content).toContain("greeting-instructions");
   });
 
   it("set_context without description stores content only", async () => {
@@ -447,16 +445,13 @@ describe("set_context tool", () => {
 
     await tool.execute({
       label: "skills",
-      key: "raw-skill",
       content: "Just content, no desc"
     });
 
-    expect(await provider.load("raw-skill")).toBe("Just content, no desc");
-
-    // Metadata should list the key without description
-    const metadata = await provider.get();
-    expect(metadata).toContain("raw-skill");
-    expect(metadata).not.toContain(":");
+    // Key is auto-generated from content slug
+    expect(await provider.load("just-content-no-desc")).toBe(
+      "Just content, no desc"
+    );
   });
 
   it("multiple set_context calls accumulate skills in metadata", async () => {
@@ -469,26 +464,22 @@ describe("set_context tool", () => {
 
     await tool.execute({
       label: "skills",
-      key: "skill-a",
       content: "Content A",
-      description: "First skill"
+      title: "First skill"
     });
     await tool.execute({
       label: "skills",
-      key: "skill-b",
       content: "Content B",
-      description: "Second skill"
+      title: "Second skill"
     });
 
     const block = blocks.getBlock("skills");
-    expect(block?.content).toContain("skill-a");
-    expect(block?.content).toContain("First skill");
-    expect(block?.content).toContain("skill-b");
-    expect(block?.content).toContain("Second skill");
+    expect(block?.content).toContain("first-skill");
+    expect(block?.content).toContain("second-skill");
 
-    // Both loadable
-    expect(await provider.load("skill-a")).toBe("Content A");
-    expect(await provider.load("skill-b")).toBe("Content B");
+    // Both loadable by slugified title
+    expect(await provider.load("first-skill")).toBe("Content A");
+    expect(await provider.load("second-skill")).toBe("Content B");
   });
 });
 

--- a/packages/ai-chat/CHANGELOG.md
+++ b/packages/ai-chat/CHANGELOG.md
@@ -43,7 +43,6 @@
   `Think` now extends `Agent` directly (no mixin). Fiber support is inherited from the base class.
 
   **Breaking (experimental APIs only):**
-
   - Removed `withFibers` mixin (`agents/experimental/forever`)
   - Removed `withDurableChat` mixin (`@cloudflare/ai-chat/experimental/forever`)
   - Removed `./experimental/forever` export from both packages
@@ -54,7 +53,6 @@
 - [#1270](https://github.com/cloudflare/agents/pull/1270) [`87b4512`](https://github.com/cloudflare/agents/commit/87b4512985e47de659bf970a65a6d1951f5855fe) Thanks [@threepointone](https://github.com/threepointone)! - Wire Session into Think as the storage layer, achieving full feature parity with AIChatAgent plus Session-backed advantages.
 
   **Think (`@cloudflare/think`):**
-
   - Session integration: `this.messages` backed by `session.getHistory()`, tree-structured messages, context blocks, compaction, FTS5 search
   - `configureSession()` override for context blocks, compaction, search, skills (sync or async)
   - `assembleContext()` returns `{ system, messages }` with context block composition
@@ -73,12 +71,10 @@
   - Constructor wraps `onStart` — subclasses never need `super.onStart()`
 
   **agents (`agents/chat`):**
-
   - Extract `AbortRegistry`, `applyToolUpdate` + builders, `parseProtocolMessage` into shared `agents/chat` layer
   - Add `applyChunkToParts` export for fiber recovery
 
   **AIChatAgent (`@cloudflare/ai-chat`):**
-
   - Refactor to use shared `AbortRegistry` from `agents/chat`
   - Add `continuation` flag to `OnChatMessageOptions`
   - Export `getAgentMessages()` and tool part helpers
@@ -211,7 +207,6 @@
 ### Minor Changes
 
 - [#1150](https://github.com/cloudflare/agents/pull/1150) [`81a8710`](https://github.com/cloudflare/agents/commit/81a8710938ec1c7a8e388fda936d1724409d74d6) Thanks [@threepointone](https://github.com/threepointone)! - feat: add `sanitizeMessageForPersistence` hook and built-in Anthropic tool payload truncation
-
   - **New protected hook**: `sanitizeMessageForPersistence(message)` — override this method to apply custom transformations to messages before they are persisted to storage. Runs after built-in sanitization. Default is identity (returns message unchanged).
   - **Anthropic provider-executed tool truncation**: Large string values in `input` and `output` of provider-executed tool parts (e.g. Anthropic `code_execution`, `text_editor`) are now automatically truncated. These server-side tool payloads can exceed 200KB and are dead weight once the model has consumed the result.
 
@@ -222,7 +217,6 @@
 ### Patch Changes
 
 - [#1151](https://github.com/cloudflare/agents/pull/1151) [`b0c52a5`](https://github.com/cloudflare/agents/commit/b0c52a541625b9fbfc631cd17c0f38c40f43c7f5) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - fix(ai-chat): simplify turn coordination API
-
   - rename `waitForPendingInteractionResolution()` to `waitUntilStable()` and make it wait for a fully stable conversation state, including queued continuation turns
   - add `resetTurnState()` for scoped clear handlers that need to abort active work and invalidate queued continuations
   - demote `isChatTurnActive()`, `waitForIdle()`, and `abortActiveTurn()` to private — their behavior is subsumed by `waitUntilStable()` and `resetTurnState()`
@@ -231,12 +225,10 @@
 - [#1106](https://github.com/cloudflare/agents/pull/1106) [`3184282`](https://github.com/cloudflare/agents/commit/3184282412fe0908a7eca5e117ff02b64541c860) Thanks [@threepointone](https://github.com/threepointone)! - fix: abort/stop no longer creates duplicate split messages (issue [#1100](https://github.com/cloudflare/agents/issues/1100))
 
   When a user clicked stop during an active stream, the assistant message was split into two separate messages. This happened because `onAbort` in the transport immediately removed the `requestId` from `activeRequestIds`, causing `onAgentMessage` to treat in-flight server chunks as a new broadcast.
-
   - `WebSocketChatTransport`: `onAbort` now keeps the `requestId` in `activeRequestIds` so in-flight server chunks are correctly skipped by the dedup guard
   - `useAgentChat`: `onAgentMessage` now cleans up the kept ID when receiving `done: true`, preventing a minor memory leak
 
 - [#1142](https://github.com/cloudflare/agents/pull/1142) [`5651ece`](https://github.com/cloudflare/agents/commit/5651eced85c04bfaf5660922467c74de7dc0896e) Thanks [@whoiskatrin](https://github.com/whoiskatrin)! - fix(ai-chat): serialize chat turns and expose turn control helpers
-
   - queue `onChatMessage()` + `_reply()` work so user requests, tool continuations, and `saveMessages()` never stream concurrently
   - make `saveMessages()` wait for the queued turn to finish before resolving, and reuse the request id for reply cleanup
   - skip queued continuations and `saveMessages()` calls that were enqueued before a chat clear
@@ -280,7 +272,6 @@
 - [#1013](https://github.com/cloudflare/agents/pull/1013) [`11aaaff`](https://github.com/cloudflare/agents/commit/11aaaffb89c375eba9bedf97074ced556dcdd0e7) Thanks [@threepointone](https://github.com/threepointone)! - Fix Gemini "missing thought_signature" error when using client-side tools with `addToolOutput`.
 
   The server-side message builder (`applyChunkToParts`) was dropping `providerMetadata` from tool-input stream chunks instead of storing it as `callProviderMetadata` on tool UIMessage parts. When `convertToModelMessages` later read the persisted messages for the continuation call, `callProviderMetadata` was undefined, so Gemini never received its `thought_signature` back and rejected the request.
-
   - Preserve `callProviderMetadata` (mapped from stream `providerMetadata`) on tool parts in `tool-input-start`, `tool-input-available`, and `tool-input-error` handlers — both create and update paths
   - Preserve `providerExecuted` on tool parts (used by `convertToModelMessages` for provider-executed tools like Gemini code execution)
   - Preserve `title` on tool parts (tool display name)
@@ -288,7 +279,6 @@
   - Add 13 regression tests covering all affected codepaths
 
 - [#989](https://github.com/cloudflare/agents/pull/989) [`8404954`](https://github.com/cloudflare/agents/commit/8404954029a62244a87ec38691639f5b8ce9e615) Thanks [@threepointone](https://github.com/threepointone)! - Fix active streams losing UI state after reconnect and dead streams after DO hibernation.
-
   - Send `replayComplete` signal after replaying stored chunks for live streams, so the client flushes accumulated parts to React state immediately instead of waiting for the next live chunk.
   - Detect orphaned streams (restored from SQLite after hibernation with no live LLM reader) via `_isLive` flag on `ResumableStream`. On reconnect, send `done: true`, complete the stream, and reconstruct/persist the partial assistant message from stored chunks.
   - Client-side: flush `activeStreamRef` on `replayComplete` (keeps stream alive for subsequent live chunks) and on `done` during replay (finalizes orphaned streams).
@@ -328,7 +318,6 @@
   so when `regenerate()` removed the last assistant message from the client's
   array, the old row persisted in SQLite. On the next `_loadMessagesFromDb`,
   the stale assistant message reappeared in `this.messages`, causing:
-
   - Anthropic models to reject with HTTP 400 (conversation must end with a
     user message)
   - Duplicate/phantom assistant messages across reconnects
@@ -360,14 +349,12 @@
 - [#999](https://github.com/cloudflare/agents/pull/999) [`95753da`](https://github.com/cloudflare/agents/commit/95753da49cb68e9e9e486e047b588004163a27fb) Thanks [@threepointone](https://github.com/threepointone)! - Fix `useChat` `status` staying `"ready"` during stream resumption after page refresh.
 
   Four issues prevented stream resumption from working:
-
   1. **addEventListener race:** `onAgentMessage` always handled `CF_AGENT_STREAM_RESUMING` before the transport's listener, bypassing the AI SDK pipeline.
   2. **Transport instance instability:** `useMemo` created new transport instances across renders and Strict Mode cycles. When `_pk` changed (async queries, socket recreation), the resolver was stranded on the old transport while `onAgentMessage` called `handleStreamResuming` on the new one.
   3. **Chat recreation on `_pk` change:** Using `agent._pk` as the `useChat` `id` caused the AI SDK to recreate the Chat when the socket changed, abandoning the in-flight `makeRequest` (including resume). The resume effect wouldn't re-fire on the new Chat.
   4. **Double STREAM_RESUMING:** The server sends `STREAM_RESUMING` from both `onConnect` and the `RESUME_REQUEST` handler, causing duplicate ACKs and double replay without deduplication.
 
   Fixes:
-
   - Replace `addEventListener`-based detection with `handleStreamResuming()` — a synchronous method `onAgentMessage` calls directly, eliminating the race.
   - Make the transport a true singleton (`useRef`, created once). Update `transport.agent` every render so sends/listeners always use the latest socket. The resolver survives `_pk` changes because the transport instance never changes.
   - Use a stable Chat ID (`initialMessagesCacheKey` based on URL + agent + name) instead of `agent._pk`, preventing Chat recreation on socket changes.
@@ -398,7 +385,7 @@
   addToolOutput({
     toolCallId: invocation.toolCallId,
     state: "output-error",
-    errorText: "User declined: insufficient permissions",
+    errorText: "User declined: insufficient permissions"
   });
   ```
 
@@ -459,7 +446,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
 - [#899](https://github.com/cloudflare/agents/pull/899) [`04c6411`](https://github.com/cloudflare/agents/commit/04c6411c9a73fe48784d7ce86150d62cf54becda) Thanks [@threepointone](https://github.com/threepointone)! - Refactor AIChatAgent: extract ResumableStream class, add WebSocket ChatTransport, simplify SSE parsing.
 
   **Bug fixes:**
-
   - Fix `setMessages` functional updater sending empty array to server
   - Fix `_sendPlaintextReply` creating multiple text parts instead of one
   - Fix uncaught exception on empty/invalid request body
@@ -474,7 +460,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   - Fix `completed` guard on abort listener to prevent redundant cancel after stream completion
 
   **New features:**
-
   - `maxPersistedMessages` — cap SQLite message storage with automatic oldest-message deletion
   - `body` option on `useAgentChat` — send custom data with every request (static or dynamic)
   - Incremental persistence with hash-based cache to skip redundant SQL writes
@@ -484,13 +469,11 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   - Full tool streaming lifecycle in message-builder (tool-input-start/delta/error, tool-output-error)
 
   **Docs:**
-
   - New `docs/chat-agents.md` — comprehensive AIChatAgent and useAgentChat reference
   - Rewritten README, migration guides, human-in-the-loop, resumable streaming, client tools docs
   - New `examples/ai-chat/` example with modern patterns and Workers AI
 
   **Deprecations (with console.warn):**
-
   - `createToolsFromClientSchemas()`, `extractClientToolSchemas()`, `detectToolsRequiringConfirmation()`
   - `tools`, `toolsRequiringConfirmation`, `experimental_automaticToolResolution` options
   - `addToolResult()` (use `addToolOutput()`)
@@ -514,7 +497,6 @@ The first minor release of `@cloudflare/ai-chat` — a major step up from the `a
   `useAgentChat` now invokes the `onData` callback for `data-*` chunks on the stream resumption and cross-tab broadcast codepaths, which bypass the AI SDK's internal pipeline. For new messages sent via the transport, the AI SDK already invokes `onData` internally. This is the correct way to consume transient data parts on the client since they are not added to `message.parts`.
 
 - [#922](https://github.com/cloudflare/agents/pull/922) [`c8e5244`](https://github.com/cloudflare/agents/commit/c8e524499d902229e8ac83afd6cf2864f888cecc) Thanks [@threepointone](https://github.com/threepointone)! - Fix tool approval UI not surviving page refresh, and fix invalid prompt error after approval
-
   - Handle `tool-approval-request` and `tool-output-denied` stream chunks in the server-side message builder. Previously these were only handled client-side, so the server never transitioned tool parts to `approval-requested` or `output-denied` state.
   - Persist the streaming message to SQLite (without broadcasting) when a tool enters `approval-requested` state. The stream is paused waiting for user approval, so this is a natural persistence point. Without this, refreshing the page would reload from SQLite where the tool was still in `input-available` state, showing "Running..." instead of the Approve/Reject UI.
   - On stream completion, update the early-persisted message in place rather than appending a duplicate.

--- a/packages/hono-agents/CHANGELOG.md
+++ b/packages/hono-agents/CHANGELOG.md
@@ -80,7 +80,6 @@
 ### Patch Changes
 
 - [#739](https://github.com/cloudflare/agents/pull/739) [`e9b6bb7`](https://github.com/cloudflare/agents/commit/e9b6bb7ea2727e4692d9191108c5609c6a44d9d9) Thanks [@threepointone](https://github.com/threepointone)! - update all dependencies
-
   - remove the changesets cli patch, as well as updating node version, so we don't need to explicitly install newest npm
   - lock mcp sdk version till we figure out how to do breaking changes correctly
   - removes stray permissions block from release.yml

--- a/packages/think/CHANGELOG.md
+++ b/packages/think/CHANGELOG.md
@@ -51,7 +51,6 @@
 - [#1270](https://github.com/cloudflare/agents/pull/1270) [`87b4512`](https://github.com/cloudflare/agents/commit/87b4512985e47de659bf970a65a6d1951f5855fe) Thanks [@threepointone](https://github.com/threepointone)! - Wire Session into Think as the storage layer, achieving full feature parity with AIChatAgent plus Session-backed advantages.
 
   **Think (`@cloudflare/think`):**
-
   - Session integration: `this.messages` backed by `session.getHistory()`, tree-structured messages, context blocks, compaction, FTS5 search
   - `configureSession()` override for context blocks, compaction, search, skills (sync or async)
   - `assembleContext()` returns `{ system, messages }` with context block composition
@@ -70,12 +69,10 @@
   - Constructor wraps `onStart` — subclasses never need `super.onStart()`
 
   **agents (`agents/chat`):**
-
   - Extract `AbortRegistry`, `applyToolUpdate` + builders, `parseProtocolMessage` into shared `agents/chat` layer
   - Add `applyChunkToParts` export for fiber recovery
 
   **AIChatAgent (`@cloudflare/ai-chat`):**
-
   - Refactor to use shared `AbortRegistry` from `agents/chat`
   - Add `continuation` flag to `OnChatMessageOptions`
   - Export `getAgentMessages()` and tool part helpers
@@ -90,7 +87,6 @@
   `Think` now extends `Agent` directly (no mixin). Fiber support is inherited from the base class.
 
   **Breaking (experimental APIs only):**
-
   - Removed `withFibers` mixin (`agents/experimental/forever`)
   - Removed `withDurableChat` mixin (`@cloudflare/ai-chat/experimental/forever`)
   - Removed `./experimental/forever` export from both packages

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -38,7 +38,7 @@ Always respond concisely.`;
   }
 
   @callable()
-  override getMessages(): UIMessage[] {
+  override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
   }
 }
@@ -122,7 +122,7 @@ export class ThinkRecoveryE2EAgent extends Think<Env> {
     messageCount: number;
     assistantMessages: number;
   }> {
-    const messages = this.getMessages();
+    const messages = await this.getMessages();
     return {
       recoveryCount: this._recoveryContexts.length,
       contexts: this._recoveryContexts,

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -45,7 +45,7 @@ Always respond concisely.`;
   }
 
   @callable()
-  override getMessages(): UIMessage[] {
+  override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
   }
 }
@@ -129,7 +129,7 @@ export class ThinkRecoveryE2EAgent extends Think<Env> {
     messageCount: number;
     assistantMessages: number;
   }> {
-    const messages = this.getMessages();
+    const messages = await this.getMessages();
     return {
       recoveryCount: this._recoveryContexts.length,
       contexts: this._recoveryContexts,

--- a/packages/think/src/tests/agents/assistant-agent-loop.ts
+++ b/packages/think/src/tests/agents/assistant-agent-loop.ts
@@ -173,7 +173,7 @@ export class LoopTestAgent extends Think {
     return "You are a test assistant.";
   }
 
-  override getMessages(): UIMessage[] {
+  override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
   }
 }
@@ -242,7 +242,7 @@ export class LoopToolTestAgent extends Think {
     });
   }
 
-  override getMessages(): UIMessage[] {
+  override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
   }
 

--- a/packages/think/src/tests/agents/assistant-agent-loop.ts
+++ b/packages/think/src/tests/agents/assistant-agent-loop.ts
@@ -197,7 +197,7 @@ export class LoopTestAgent extends Think {
     return "You are a test assistant.";
   }
 
-  override getMessages(): UIMessage[] {
+  override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
   }
 }
@@ -268,7 +268,7 @@ export class LoopToolTestAgent extends Think {
     });
   }
 
-  override getMessages(): UIMessage[] {
+  override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
   }
 

--- a/packages/think/src/tests/agents/assistant-agent.ts
+++ b/packages/think/src/tests/agents/assistant-agent.ts
@@ -49,7 +49,7 @@ export class TestAssistantAgentAgent extends Think {
     return createAssistantMockModel();
   }
 
-  override getMessages(): UIMessage[] {
+  override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
   }
 }

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -204,7 +204,7 @@ export class ThinkClientToolsAgent extends Think {
   }
 
   async getBranches(messageId: string): Promise<UIMessage[]> {
-    return this.session.getBranches(messageId) as UIMessage[];
+    return (await this.session.getBranches(messageId)) as UIMessage[];
   }
 
   async setMessageConcurrency(concurrency: MessageConcurrency): Promise<void> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1029,6 +1029,10 @@ export class ThinkRecoveryTestAgent extends Think {
 
   async persistTestMessage(msg: UIMessage): Promise<void> {
     await this.session.appendMessage(msg);
+    // Sync cache so hasPendingInteraction() sees the new message
+    await (
+      this as unknown as { _syncMessages(): Promise<UIMessage[]> }
+    )._syncMessages();
   }
 
   async hasPendingInteractionForTest(): Promise<boolean> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -757,6 +757,46 @@ export class ThinkTestAgent extends Think {
     return this.getMessages();
   }
 
+  async getCachedMessagesForTest(): Promise<UIMessage[]> {
+    return this.messages;
+  }
+
+  async getSessionHistoryForTest(): Promise<UIMessage[]> {
+    return (await this.session.getHistory()) as UIMessage[];
+  }
+
+  async enableCompactionForTest(): Promise<void> {
+    this.session
+      .onCompaction(async (messages) => {
+        if (messages.length < 2) return null;
+        return {
+          summary: "compacted-summary",
+          fromMessageId: messages[0].id,
+          toMessageId: messages[messages.length - 1].id
+        };
+      })
+      .compactAfter(1);
+  }
+
+  async mutatingGetMessagesResultChangesCacheForTest(): Promise<boolean> {
+    const before = (await this.getMessages()).length;
+    const messages = await this.getMessages();
+    messages.push({
+      id: "mutated-outside-cache",
+      role: "user",
+      parts: [{ type: "text", text: "mutated" }]
+    });
+    return (await this.getMessages()).length !== before;
+  }
+
+  async appendHistoryMessageForTest(msg: UIMessage): Promise<void> {
+    await this.appendMessageToHistory(msg);
+  }
+
+  async appendSessionMessageForTest(msg: UIMessage): Promise<void> {
+    await this.session.appendMessage(msg);
+  }
+
   async getResponseLog(): Promise<ChatResponseResult[]> {
     return this._responseLog;
   }
@@ -2106,10 +2146,6 @@ export class ThinkRecoveryTestAgent extends Think {
 
   async persistTestMessage(msg: UIMessage): Promise<void> {
     await this.session.appendMessage(msg);
-    // Sync cache so hasPendingInteraction() sees the new message
-    await (
-      this as unknown as { _syncMessages(): Promise<UIMessage[]> }
-    )._syncMessages();
   }
 
   async hasPendingInteractionForTest(): Promise<boolean> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -2106,6 +2106,10 @@ export class ThinkRecoveryTestAgent extends Think {
 
   async persistTestMessage(msg: UIMessage): Promise<void> {
     await this.session.appendMessage(msg);
+    // Sync cache so hasPendingInteraction() sees the new message
+    await (
+      this as unknown as { _syncMessages(): Promise<UIMessage[]> }
+    )._syncMessages();
   }
 
   async hasPendingInteractionForTest(): Promise<boolean> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1778,7 +1778,7 @@ export class ThinkProgrammaticTestAgent extends Think {
         : null;
     return {
       result,
-      persistedMessageCount: this.getMessages().length,
+      persistedMessageCount: (await this.getMessages()).length,
       lastResponseStatus: lastResponse?.status ?? null
     };
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -797,6 +797,10 @@ export class ThinkTestAgent extends Think {
     await this.session.appendMessage(msg);
   }
 
+  async updateSessionMessageForTest(msg: UIMessage): Promise<void> {
+    await this.session.updateMessage(msg);
+  }
+
   async getResponseLog(): Promise<ChatResponseResult[]> {
     return this._responseLog;
   }

--- a/packages/think/src/tests/hooks.test.ts
+++ b/packages/think/src/tests/hooks.test.ts
@@ -781,6 +781,16 @@ describe("Think — host bridge methods", () => {
     const messages = await agent.hostGetMessages();
     const texts = messages.map((m: { content: string }) => m.content);
     expect(texts).toContain("Injected message");
+
+    const cached = (await agent.getCachedMessagesForTest()) as UIMessage[];
+    const lastCached = cached[cached.length - 1];
+    expect(lastCached.role).toBe("user");
+    expect(lastCached.parts).toEqual([
+      { type: "text", text: "Injected message" }
+    ]);
+
+    const publicMessages = (await agent.getMessages()) as UIMessage[];
+    expect(publicMessages[publicMessages.length - 1]).toEqual(lastCached);
   });
 });
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -448,15 +448,14 @@ describe("Think — context blocks", () => {
     expect(systemPrompt).toContain("User prefers Rust over Go.");
   });
 
-  it("should fall back to getSystemPrompt when no context blocks have content", async () => {
+  it("should render empty writable blocks in system prompt", async () => {
     const agent = await freshSessionAgent("ctx-fallback");
 
-    // Don't write any content to the memory block — it starts empty.
-    // System prompt assembly should fall back to getSystemPrompt().
+    // Writable blocks render even when empty so the LLM knows they exist
     const systemPrompt = await agent.getAssembledSystemPrompt();
 
-    // Default getSystemPrompt() returns "You are a helpful assistant."
-    expect(systemPrompt).toBe("You are a helpful assistant.");
+    expect(systemPrompt).toContain("MEMORY");
+    expect(systemPrompt).toContain("[writable]");
   });
 });
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -495,6 +495,26 @@ describe("Think — Session integration", () => {
     expect(messages[0].id).toBe("direct-session-user");
   });
 
+  it("does not append missing messages to cache on direct session updateMessage calls", async () => {
+    const agent = await freshAgent("session-direct-update-missing");
+    await agent.appendSessionMessageForTest({
+      id: "cached-user",
+      role: "user",
+      parts: [{ type: "text", text: "Cached message" }]
+    });
+
+    await agent.updateSessionMessageForTest({
+      id: "missing-from-cache",
+      role: "user",
+      parts: [{ type: "text", text: "Should not enter model context" }]
+    });
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].id).toBe("cached-user");
+    expect(JSON.stringify(messages)).not.toContain("Should not enter");
+  });
+
   it("should clear messages via Session", async () => {
     const agent = await freshAgent("session-clear");
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -488,14 +488,15 @@ describe("Think — context blocks", () => {
     expect(systemPrompt).toContain("User prefers Rust over Go.");
   });
 
-  it("should fall back to getSystemPrompt when no context blocks have content", async () => {
+  it("should render empty writable blocks in system prompt", async () => {
     const agent = await freshSessionAgent("ctx-fallback");
 
-    // Don't write any content to the memory block — it starts empty.
-    // System prompt assembly should fall back to getSystemPrompt().
+    // Writable blocks render even when empty so the LLM knows they exist
     const systemPrompt = await agent.getAssembledSystemPrompt();
 
     expect(systemPrompt).toContain("You are a careful, capable assistant");
+    expect(systemPrompt).toContain("MEMORY");
+    expect(systemPrompt).toContain("[writable]");
   });
 });
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -424,6 +424,77 @@ describe("Think — Session integration", () => {
     expect(messages).toHaveLength(4);
   });
 
+  it("keeps cache aligned when storage ignores a duplicate message id", async () => {
+    const agent = await freshAgent("session-duplicate-cache");
+    const msg: UIMessage = {
+      id: "dup-cache-1",
+      role: "user",
+      parts: [{ type: "text", text: "Original content" }]
+    };
+
+    await agent.testChatWithUIMessage(msg);
+    await agent.testChatWithUIMessage({
+      ...msg,
+      parts: [{ type: "text", text: "Rejected duplicate content" }]
+    });
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    const text = JSON.stringify(messages);
+    expect(text).toContain("Original content");
+    expect(text).not.toContain("Rejected duplicate content");
+  });
+
+  it("refreshes cached messages when an append triggers compaction", async () => {
+    const agent = await freshAgent("session-compaction-cache");
+    await agent.enableCompactionForTest();
+
+    const result = await agent.testChat("Trigger compaction");
+
+    expect(result.done).toBe(true);
+    const publicMessages = (await agent.getStoredMessages()) as UIMessage[];
+    const storageMessages =
+      (await agent.getSessionHistoryForTest()) as UIMessage[];
+    expect(publicMessages.map((m) => ({ id: m.id, parts: m.parts }))).toEqual(
+      storageMessages.map((m) => ({ id: m.id, parts: m.parts }))
+    );
+    expect(JSON.stringify(publicMessages)).toContain("compacted-summary");
+  });
+
+  it("returns a copy from getMessages", async () => {
+    const agent = await freshAgent("session-get-messages-copy");
+    await agent.testChat("Hello!");
+
+    expect(await agent.mutatingGetMessagesResultChangesCacheForTest()).toBe(
+      false
+    );
+  });
+
+  it("provides a cache-aware append helper for subclasses", async () => {
+    const agent = await freshAgent("session-history-helper");
+    await agent.appendHistoryMessageForTest({
+      id: "history-helper-user",
+      role: "user",
+      parts: [{ type: "text", text: "Via helper" }]
+    });
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].id).toBe("history-helper-user");
+  });
+
+  it("keeps cache aligned for direct session appendMessage calls", async () => {
+    const agent = await freshAgent("session-direct-append");
+    await agent.appendSessionMessageForTest({
+      id: "direct-session-user",
+      role: "user",
+      parts: [{ type: "text", text: "Direct session append" }]
+    });
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].id).toBe("direct-session-user");
+  });
+
   it("should clear messages via Session", async () => {
     const agent = await freshAgent("session-clear");
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -494,7 +494,6 @@ describe("Think — context blocks", () => {
     // Writable blocks render even when empty so the LLM knows they exist
     const systemPrompt = await agent.getAssembledSystemPrompt();
 
-    expect(systemPrompt).toContain("You are a careful, capable assistant");
     expect(systemPrompt).toContain("MEMORY");
     expect(systemPrompt).toContain("[writable]");
   });

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -425,6 +425,9 @@ export class Think<
   /** The conversation session — messages, context, compaction, search. */
   session!: Session;
 
+  /** Cached messages — kept in sync with session storage. */
+  private _cachedMessages: UIMessage[] = [];
+
   /**
    * WorkerLoader binding for sandboxed extensions.
    * Set this to enable `getExtensions()` and dynamic extension loading.
@@ -471,7 +474,7 @@ export class Think<
 
       // Force Session to initialize its tables (assistant_messages,
       // assistant_config, etc.) so that subsequent config reads work.
-      this.session.getHistory();
+      await this._syncMessages();
 
       // 3-6. Extension initialization (if extensionLoader is set)
       if (this.extensionLoader) {
@@ -494,7 +497,13 @@ export class Think<
    * Always fresh — reads from Session's tree-structured storage.
    */
   get messages(): UIMessage[] {
-    return this.session.getHistory() as UIMessage[];
+    return this._cachedMessages;
+  }
+
+  /** Refresh the cached messages from session storage. */
+  private async _syncMessages(): Promise<UIMessage[]> {
+    this._cachedMessages = (await this.session.getHistory()) as UIMessage[];
+    return this._cachedMessages;
   }
 
   private _aborts = new AbortRegistry();
@@ -847,8 +856,10 @@ export class Think<
     const frozenPrompt = await this.session.freezeSystemPrompt();
     const system = frozenPrompt || this.getSystemPrompt();
 
-    const history = this.session.getHistory();
-    const truncated = truncateOlderMessages(history) as UIMessage[];
+    const history = await this.session.getHistory();
+    const truncated = truncateOlderMessages(
+      history as UIMessage[]
+    ) as UIMessage[];
     const messages = pruneMessages({
       messages: await convertToModelMessages(truncated),
       toolCalls: "before-last-2-messages"
@@ -1093,7 +1104,7 @@ export class Think<
   async _hostGetMessages(
     limit?: number
   ): Promise<Array<{ id: string; role: string; content: string }>> {
-    const history = this.session.getHistory();
+    const history = await this.session.getHistory();
     const sliced =
       limit !== undefined && limit !== null
         ? limit <= 0
@@ -1128,7 +1139,7 @@ export class Think<
     messageCount: number;
   }> {
     return {
-      messageCount: this.session.getHistory().length
+      messageCount: (await this.session.getHistory()).length
     };
   }
 
@@ -1161,6 +1172,7 @@ export class Think<
           : userMessage;
 
       await this.session.appendMessage(userMsg);
+      await this._syncMessages();
 
       const accumulator = new StreamAccumulator({
         messageId: crypto.randomUUID()
@@ -1198,7 +1210,8 @@ export class Think<
         }
 
         const assistantMsg = accumulator.toMessage();
-        this._persistAssistantMessage(assistantMsg);
+        await this._persistAssistantMessage(assistantMsg);
+        await this._syncMessages();
 
         if (!aborted) {
           await callback.onDone();
@@ -1220,7 +1233,8 @@ export class Think<
         const assistantMsg =
           accumulator.parts.length > 0 ? accumulator.toMessage() : null;
         if (assistantMsg) {
-          this._persistAssistantMessage(assistantMsg);
+          await this._persistAssistantMessage(assistantMsg);
+          await this._syncMessages();
         }
 
         const wrapped = this.onChatError(error);
@@ -1249,13 +1263,14 @@ export class Think<
   // ── Message access ──────────────────────────────────────────────
 
   /** Get the conversation history as UIMessage[]. */
-  getMessages(): UIMessage[] {
-    return this.messages;
+  async getMessages(): Promise<UIMessage[]> {
+    return (await this.session.getHistory()) as UIMessage[];
   }
 
   /** Clear all messages from storage. */
-  clearMessages(): void {
-    this.session.clearMessages();
+  async clearMessages(): Promise<void> {
+    await this.session.clearMessages();
+    this._cachedMessages = [];
   }
 
   // ── Programmatic API ───────────────────────────────────────────
@@ -1315,6 +1330,7 @@ export class Think<
         for (const msg of resolved) {
           await this.session.appendMessage(msg);
         }
+        await this._syncMessages();
         this._broadcastMessages();
 
         if (this._turnQueue.generation !== epoch) {
@@ -1386,7 +1402,7 @@ export class Think<
   protected async continueLastTurn(
     body?: Record<string, unknown>
   ): Promise<SaveMessagesResult> {
-    const lastLeaf = this.session.getLatestLeaf();
+    const lastLeaf = await this.session.getLatestLeaf();
     if (!lastLeaf || lastLeaf.role !== "assistant") {
       return { requestId: "", status: "skipped" };
     }
@@ -1526,7 +1542,7 @@ export class Think<
         break;
 
       case "stream-resume-ack":
-        this._handleStreamResumeAck(connection, event.id);
+        await this._handleStreamResumeAck(connection, event.id);
         break;
 
       case "chat-request":
@@ -1544,8 +1560,8 @@ export class Think<
           this._lastClientTools = event.clientTools as ClientToolSchema[];
           this._persistClientTools();
         }
-        const resultPromise = Promise.resolve().then(() => {
-          this._applyToolResult(
+        const resultPromise = Promise.resolve().then(async () => {
+          await this._applyToolResult(
             event.toolCallId,
             event.output,
             event.state as "output-error" | undefined,
@@ -1568,8 +1584,8 @@ export class Think<
       }
 
       case "tool-approval": {
-        const approvalPromise = Promise.resolve().then(() => {
-          this._applyToolApproval(event.toolCallId, event.approved);
+        const approvalPromise = Promise.resolve().then(async () => {
+          await this._applyToolApproval(event.toolCallId, event.approved);
           return true;
         });
         this._pendingInteractionPromise = approvalPromise;
@@ -1587,7 +1603,7 @@ export class Think<
       }
 
       case "clear":
-        this._handleClear(connection);
+        await this._handleClear(connection);
         break;
 
       case "cancel":
@@ -1621,10 +1637,10 @@ export class Think<
     }
   }
 
-  private _handleStreamResumeAck(
+  private async _handleStreamResumeAck(
     connection: Connection,
     requestId: string
-  ): void {
+  ): Promise<void> {
     this._pendingResumeConnections.delete(connection.id);
     if (
       this._resumableStream.hasActiveStream() &&
@@ -1635,7 +1651,7 @@ export class Think<
         this._resumableStream.activeRequestId
       );
       if (orphanedStreamId) {
-        this._persistOrphanedStream(orphanedStreamId);
+        await this._persistOrphanedStream(orphanedStreamId);
       }
     }
   }
@@ -1712,6 +1728,7 @@ export class Think<
       await this.session.appendMessage(msg);
     }
 
+    await this._syncMessages();
     this._broadcastMessages([connection.id]);
 
     // ── Enter turn queue ────────────────────────────────────────
@@ -1832,7 +1849,7 @@ export class Think<
     this._continuation.clearAll();
   }
 
-  private _handleClear(connection?: Connection) {
+  private async _handleClear(connection?: Connection) {
     this.resetTurnState();
 
     this._resumableStream.clearAll();
@@ -1841,7 +1858,8 @@ export class Think<
     this._persistClientTools();
     this._lastBody = undefined;
     this._persistBody();
-    this.session.clearMessages();
+    await this.session.clearMessages();
+    this._cachedMessages = [];
     this._broadcast(
       { type: MSG_CHAT_CLEAR },
       connection ? [connection.id] : undefined
@@ -1953,7 +1971,8 @@ export class Think<
     ) {
       try {
         const assistantMsg = accumulator.toMessage();
-        this._persistAssistantMessage(assistantMsg, parentId);
+        await this._persistAssistantMessage(assistantMsg, parentId);
+        await this._syncMessages();
         this._broadcastMessages();
 
         await this._fireResponseHook({
@@ -1975,20 +1994,18 @@ export class Think<
 
   // ── Session-backed persistence ──────────────────────────────────
 
-  private _persistAssistantMessage(msg: UIMessage, parentId?: string): void {
+  private async _persistAssistantMessage(
+    msg: UIMessage,
+    parentId?: string
+  ): Promise<void> {
     const sanitized = sanitizeMessage(msg);
     const safe = enforceRowSizeLimit(sanitized);
 
-    const existing = this.session.getMessage(safe.id);
+    const existing = await this.session.getMessage(safe.id);
     if (existing) {
-      this.session.updateMessage(safe);
+      await this.session.updateMessage(safe);
     } else {
-      // appendMessage is async due to potential auto-compaction, but
-      // we fire-and-forget here since the message write itself is synchronous
-      // in AgentSessionProvider — only the optional compaction is async.
-      // parentId is set for regeneration — the new response branches from
-      // the same parent as the old one rather than appending to the latest leaf.
-      void this.session.appendMessage(safe, parentId);
+      await this.session.appendMessage(safe, parentId);
     }
   }
 
@@ -2032,33 +2049,37 @@ export class Think<
 
   // ── Tool state updates (shared primitives from agents/chat) ─────
 
-  private _applyToolResult(
+  private async _applyToolResult(
     toolCallId: string,
     output: unknown,
     overrideState?: "output-error",
     errorText?: string
-  ): void {
+  ): Promise<void> {
     const update = toolResultUpdate(
       toolCallId,
       output,
       overrideState,
       errorText
     );
-    this._applyToolUpdateToMessages(update);
+    await this._applyToolUpdateToMessages(update);
   }
 
-  private _applyToolApproval(toolCallId: string, approved: boolean): void {
+  private async _applyToolApproval(
+    toolCallId: string,
+    approved: boolean
+  ): Promise<void> {
     const update = toolApprovalUpdate(toolCallId, approved);
-    this._applyToolUpdateToMessages(update);
+    await this._applyToolUpdateToMessages(update);
   }
 
-  private _applyToolUpdateToMessages(update: {
+  private async _applyToolUpdateToMessages(update: {
     toolCallId: string;
     matchStates: string[];
     apply: (part: Record<string, unknown>) => Record<string, unknown>;
-  }): void {
-    const history = this.messages;
-    for (const msg of history) {
+  }): Promise<void> {
+    const history = (await this.session.getHistory()) as UIMessage[];
+    for (let i = 0; i < history.length; i++) {
+      const msg = history[i];
       const result = applyToolUpdate(
         msg.parts as Array<Record<string, unknown>>,
         update
@@ -2069,7 +2090,12 @@ export class Think<
           parts: result.parts as UIMessage["parts"]
         };
         const safe = enforceRowSizeLimit(sanitizeMessage(updatedMsg));
-        this.session.updateMessage(safe);
+        await this.session.updateMessage(safe);
+        // Update cache if this message exists there
+        const cacheIdx = this._cachedMessages.findIndex(
+          (m) => m.id === safe.id
+        );
+        if (cacheIdx !== -1) this._cachedMessages[cacheIdx] = safe as UIMessage;
         this._broadcast({ type: MSG_MESSAGE_UPDATED, message: safe });
         return;
       }
@@ -2206,7 +2232,7 @@ export class Think<
       this._resumableStream.activeStreamId === streamId;
 
     if (options.persist !== false && streamStillActive) {
-      this._persistOrphanedStream(streamId);
+      await this._persistOrphanedStream(streamId);
     }
 
     if (streamStillActive) {
@@ -2214,7 +2240,7 @@ export class Think<
     }
 
     if (options.continue !== false) {
-      const lastLeaf = this.session.getLatestLeaf();
+      const lastLeaf = await this.session.getLatestLeaf();
       const targetId = lastLeaf?.role === "assistant" ? lastLeaf.id : undefined;
       await this.schedule(
         0,
@@ -2245,7 +2271,7 @@ export class Think<
     }
 
     const targetId = data?.targetAssistantId;
-    const lastLeaf = this.session.getLatestLeaf();
+    const lastLeaf = await this.session.getLatestLeaf();
     if (targetId && lastLeaf?.id !== targetId) {
       return;
     }
@@ -2545,7 +2571,7 @@ export class Think<
     );
   }
 
-  private _persistOrphanedStream(streamId: string): void {
+  private async _persistOrphanedStream(streamId: string): Promise<void> {
     this._resumableStream.flushBuffer();
     const chunks = this._resumableStream.getStreamChunks(streamId);
     if (chunks.length === 0) return;
@@ -2562,7 +2588,8 @@ export class Think<
     }
 
     if (accumulator.parts.length > 0) {
-      this._persistAssistantMessage(accumulator.toMessage());
+      await this._persistAssistantMessage(accumulator.toMessage());
+      await this._syncMessages();
       this._broadcastMessages();
     }
   }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -643,7 +643,13 @@ export class Think<
 
   static readonly CHAT_FIBER_NAME = "__cf_internal_chat_turn";
 
-  /** The conversation session — messages, context, compaction, search. */
+  /**
+   * The conversation session — messages, context, compaction, search.
+   *
+   * Direct message writes are observed and mirrored into Think's live cache.
+   * Prefer the history helpers below when writing UI messages from subclasses;
+   * they sanitize content and enforce row-size limits before delegating here.
+   */
   session!: Session;
 
   /** Cached messages — kept in sync with session storage. */
@@ -700,6 +706,27 @@ export class Think<
       // 2. Session configuration (builder phase — context blocks, compaction, skills)
       const baseSession = Session.create(this);
       this.session = await this.configureSession(baseSession);
+      this.session.internal_onMessagesChanged(async (event) => {
+        switch (event.type) {
+          case "append":
+            if (!event.inserted || event.parentId !== undefined) {
+              await this._syncMessages();
+            } else {
+              this._upsertCachedMessage(event.message as UIMessage);
+            }
+            break;
+          case "update":
+            this._upsertCachedMessage(event.message as UIMessage);
+            break;
+          case "clear":
+            this._replaceCachedMessages([]);
+            break;
+          case "delete":
+          case "compact":
+            await this._syncMessages();
+            break;
+        }
+      });
 
       // Force Session to initialize its tables (assistant_messages,
       // assistant_compactions, assistant_config, etc.) so that subsequent
@@ -728,17 +755,94 @@ export class Think<
   }
 
   /**
-   * Conversation history. Computed from the active session.
-   * Always fresh — reads from Session's tree-structured storage.
+   * Conversation history as Think's live in-memory view.
+   *
+   * Storage remains the durable source of truth, but runtime logic should read
+   * through this cache so in-flight turns, tool updates, and recovery state all
+   * observe the same message list. Use `_syncMessages()` only at safe
+   * boundaries where a full storage reread cannot drop in-flight state.
    */
   get messages(): UIMessage[] {
     return this._cachedMessages;
   }
 
-  /** Refresh the cached messages from session storage. */
-  private async _syncMessages(): Promise<UIMessage[]> {
-    this._cachedMessages = (await this.session.getHistory()) as UIMessage[];
+  /** Read the durable message path from session storage. */
+  private async _readMessagesFromStorage(): Promise<UIMessage[]> {
+    return (await this.session.getHistory()) as UIMessage[];
+  }
+
+  /** Replace the live cache with a durable storage snapshot. */
+  private _replaceCachedMessages(messages: UIMessage[]): UIMessage[] {
+    this._cachedMessages = messages;
     return this._cachedMessages;
+  }
+
+  /** Refresh the live cache from durable storage at a safe boundary. */
+  private async _syncMessages(): Promise<UIMessage[]> {
+    return this._replaceCachedMessages(await this._readMessagesFromStorage());
+  }
+
+  /** Patch or append one message in the live cache after a durable write. */
+  private _upsertCachedMessage(message: UIMessage): void {
+    const index = this._cachedMessages.findIndex((m) => m.id === message.id);
+    if (index === -1) {
+      this._cachedMessages.push(message);
+    } else {
+      this._cachedMessages[index] = message;
+    }
+  }
+
+  private async _appendMessageToHistory(
+    message: UIMessage,
+    parentId?: string | null
+  ): Promise<UIMessage> {
+    const safe = enforceRowSizeLimit(sanitizeMessage(message));
+    await this.session.appendMessage(safe, parentId);
+    return safe;
+  }
+
+  private async _updateMessageInHistory(
+    message: UIMessage
+  ): Promise<UIMessage> {
+    const safe = enforceRowSizeLimit(sanitizeMessage(message));
+    await this.session.updateMessage(safe);
+    return safe;
+  }
+
+  private async _upsertMessageInHistory(
+    message: UIMessage,
+    parentId?: string | null
+  ): Promise<UIMessage> {
+    const safe = enforceRowSizeLimit(sanitizeMessage(message));
+    const existing = await this.session.getMessage(safe.id);
+    if (existing) {
+      await this.session.updateMessage(safe);
+    } else {
+      await this.session.appendMessage(safe, parentId);
+    }
+    return safe;
+  }
+
+  private async _clearHistory(): Promise<void> {
+    await this.session.clearMessages();
+  }
+
+  /** Append a message while keeping Think's live message cache coherent. */
+  protected appendMessageToHistory(
+    message: UIMessage,
+    parentId?: string | null
+  ): Promise<UIMessage> {
+    return this._appendMessageToHistory(message, parentId);
+  }
+
+  /** Update a message while keeping Think's live message cache coherent. */
+  protected updateMessageInHistory(message: UIMessage): Promise<UIMessage> {
+    return this._updateMessageInHistory(message);
+  }
+
+  /** Refresh Think's live message cache from the durable session path. */
+  protected async syncMessagesFromStorage(): Promise<UIMessage[]> {
+    return (await this._syncMessages()).slice();
   }
 
   private _aborts = new AbortRegistry();
@@ -1342,7 +1446,7 @@ export class Think<
     const baseSystem = frozenPrompt || this.getSystemPrompt();
     const system = this._systemPromptForTurn(baseSystem, tools);
 
-    const history = await this.session.getHistory();
+    const history = this.messages;
     const truncated = truncateOlderMessages(history) as UIMessage[];
     const messages = await convertToModelMessages(truncated, { tools });
 
@@ -1889,7 +1993,7 @@ export class Think<
   async _hostGetMessages(
     limit?: number
   ): Promise<Array<{ id: string; role: string; content: string }>> {
-    const history = await this.session.getHistory();
+    const history = this.messages;
     const sliced =
       limit !== undefined && limit !== null
         ? limit <= 0
@@ -1917,14 +2021,14 @@ export class Think<
     // called during an active turn (tool execution → host.sendMessage
     // → saveMessages → TurnQueue.enqueue → awaits current turn → deadlock).
     // The injected message is visible in the next turn's history.
-    await this.session.appendMessage(msg);
+    await this._appendMessageToHistory(msg);
   }
 
   async _hostGetSessionInfo(): Promise<{
     messageCount: number;
   }> {
     return {
-      messageCount: (await this.session.getHistory()).length
+      messageCount: this.messages.length
     };
   }
 
@@ -1967,8 +2071,7 @@ export class Think<
               }
             : userMessage;
 
-        await this.session.appendMessage(userMsg);
-        await this._syncMessages();
+        await this._appendMessageToHistory(userMsg);
 
         const abortSignal = this._aborts.getSignal(requestId);
         const detachExternal = this._aborts.linkExternal(
@@ -2033,14 +2136,13 @@ export class Think<
 
   /** Get the conversation history as UIMessage[]. */
   async getMessages(): Promise<UIMessage[]> {
-    return (await this.session.getHistory()) as UIMessage[];
+    return this.messages.slice();
   }
 
   /** Clear all messages from storage. */
   async clearMessages(): Promise<void> {
     this.resetTurnState();
-    await this.session.clearMessages();
-    this._cachedMessages = [];
+    await this._clearHistory();
   }
 
   private _ensureAgentToolChildRunTable(): void {
@@ -3176,9 +3278,8 @@ export class Think<
         }
 
         for (const msg of resolved) {
-          await this.session.appendMessage(msg);
+          await this._appendMessageToHistory(msg);
         }
-        await this._syncMessages();
         options?.onMessagesApplied?.();
         this._broadcastMessages();
 
@@ -3662,7 +3763,7 @@ export class Think<
       const clientToolsForTurn = this._lastClientTools;
       const bodyForTurn = this._lastBody;
 
-      const serverMessages = (await this.session.getHistory()) as UIMessage[];
+      const serverMessages = await this._readMessagesFromStorage();
       const reconciled = reconcileMessages(
         incomingMessages,
         serverMessages,
@@ -3888,8 +3989,7 @@ export class Think<
     this._persistClientTools();
     this._lastBody = undefined;
     this._persistBody();
-    await this.session.clearMessages();
-    this._cachedMessages = [];
+    await this._clearHistory();
     this._broadcast(
       { type: MSG_CHAT_CLEAR },
       connection ? [connection.id] : undefined
@@ -3952,7 +4052,6 @@ export class Think<
 
       assistantMsg = accumulator.toMessage();
       await this._persistAssistantMessage(assistantMsg);
-      await this._syncMessages();
 
       if (!aborted) {
         await callback.onDone();
@@ -3979,7 +4078,6 @@ export class Think<
       if (!assistantMsg && accumulator.parts.length > 0) {
         assistantMsg = accumulator.toMessage();
         await this._persistAssistantMessage(assistantMsg);
-        await this._syncMessages();
       }
 
       const wrapped = this.onChatError(error);
@@ -4134,7 +4232,6 @@ export class Think<
       try {
         const assistantMsg = accumulator.toMessage();
         await this._persistAssistantMessage(assistantMsg, parentId);
-        await this._syncMessages();
         this._broadcastMessages();
 
         await this._fireResponseHook({
@@ -4160,15 +4257,7 @@ export class Think<
     msg: UIMessage,
     parentId?: string
   ): Promise<void> {
-    const sanitized = sanitizeMessage(msg);
-    const safe = enforceRowSizeLimit(sanitized);
-
-    const existing = await this.session.getMessage(safe.id);
-    if (existing) {
-      await this.session.updateMessage(safe);
-    } else {
-      await this.session.appendMessage(safe, parentId);
-    }
+    await this._upsertMessageInHistory(msg, parentId);
   }
 
   /**
@@ -4183,16 +4272,7 @@ export class Think<
   ): Promise<void> {
     const resolved =
       msg.role === "assistant" ? resolveToolMergeId(msg, serverMessages) : msg;
-    const sanitized = sanitizeMessage(resolved);
-    const safe = enforceRowSizeLimit(sanitized);
-
-    const existing = await this.session.getMessage(safe.id);
-    if (existing) {
-      await this.session.updateMessage(safe);
-      return;
-    }
-
-    await this.session.appendMessage(safe);
+    await this._upsertMessageInHistory(resolved);
   }
 
   private _persistClientTools(): void {
@@ -4263,7 +4343,7 @@ export class Think<
     matchStates: string[];
     apply: (part: Record<string, unknown>) => Record<string, unknown>;
   }): Promise<void> {
-    const history = (await this.session.getHistory()) as UIMessage[];
+    const history = await this._readMessagesFromStorage();
     for (let i = 0; i < history.length; i++) {
       const msg = history[i];
       const result = applyToolUpdate(
@@ -4275,20 +4355,15 @@ export class Think<
           ...msg,
           parts: result.parts as UIMessage["parts"]
         };
-        const safe = enforceRowSizeLimit(sanitizeMessage(updatedMsg));
-        await this.session.updateMessage(safe);
-        // Patch _cachedMessages in place so the `messages` getter stays
-        // coherent with storage without a full `_syncMessages()` round-trip.
+        const safe = await this._updateMessageInHistory(updatedMsg);
+        // Patch the live cache in place instead of doing a full
+        // `_syncMessages()` round-trip.
         // A full re-read during a streaming turn drops in-flight messages
         // whose parent chain hasn't been persisted yet (see commits
         // 3f615a24 "revert _syncMessages in _applyToolUpdateToMessages"
         // and 6e76bd49 "update cached messages in-place"). The cache is
         // the source of truth during a turn; we only reconcile it here to
         // reflect the tool update that was just written to storage.
-        const cacheIdx = this._cachedMessages.findIndex(
-          (m) => m.id === safe.id
-        );
-        if (cacheIdx !== -1) this._cachedMessages[cacheIdx] = safe as UIMessage;
         this._broadcast({ type: MSG_MESSAGE_UPDATED, message: safe });
         return;
       }
@@ -4886,7 +4961,6 @@ export class Think<
 
     if (accumulator.parts.length > 0) {
       await this._persistAssistantMessage(accumulator.toMessage());
-      await this._syncMessages();
       this._broadcastMessages();
     }
   }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -4277,7 +4277,14 @@ export class Think<
         };
         const safe = enforceRowSizeLimit(sanitizeMessage(updatedMsg));
         await this.session.updateMessage(safe);
-        // Update cache if this message exists there
+        // Patch _cachedMessages in place so the `messages` getter stays
+        // coherent with storage without a full `_syncMessages()` round-trip.
+        // A full re-read during a streaming turn drops in-flight messages
+        // whose parent chain hasn't been persisted yet (see commits
+        // 3f615a24 "revert _syncMessages in _applyToolUpdateToMessages"
+        // and 6e76bd49 "update cached messages in-place"). The cache is
+        // the source of truth during a turn; we only reconcile it here to
+        // reflect the tool update that was just written to storage.
         const cacheIdx = this._cachedMessages.findIndex(
           (m) => m.id === safe.id
         );

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -716,7 +716,7 @@ export class Think<
             }
             break;
           case "update":
-            this._upsertCachedMessage(event.message as UIMessage);
+            this._patchCachedMessage(event.message as UIMessage);
             break;
           case "clear":
             this._replaceCachedMessages([]);
@@ -788,6 +788,14 @@ export class Think<
     if (index === -1) {
       this._cachedMessages.push(message);
     } else {
+      this._cachedMessages[index] = message;
+    }
+  }
+
+  /** Patch a message that is already present in the live cache. */
+  private _patchCachedMessage(message: UIMessage): void {
+    const index = this._cachedMessages.findIndex((m) => m.id === message.id);
+    if (index !== -1) {
       this._cachedMessages[index] = message;
     }
   }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1343,7 +1343,7 @@ export class Think<
     const system = this._systemPromptForTurn(baseSystem, tools);
 
     const history = await this.session.getHistory();
-    const truncated = truncateOlderMessages(history as UIMessage[]);
+    const truncated = truncateOlderMessages(history) as UIMessage[];
     const messages = await convertToModelMessages(truncated, { tools });
 
     if (messages.length === 0) {
@@ -2947,7 +2947,7 @@ export class Think<
       if (row.messages_applied_at === null) {
         let appliedState: "none" | "partial" | "all";
         try {
-        appliedState = await this._getSubmissionMessagesAppliedState(row);
+          appliedState = await this._getSubmissionMessagesAppliedState(row);
         } catch (error) {
           this.sql`
             UPDATE cf_think_submissions

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -646,6 +646,9 @@ export class Think<
   /** The conversation session — messages, context, compaction, search. */
   session!: Session;
 
+  /** Cached messages — kept in sync with session storage. */
+  private _cachedMessages: UIMessage[] = [];
+
   /**
    * WorkerLoader binding for sandboxed extensions.
    * Set this to enable `getExtensions()` and dynamic extension loading.
@@ -699,9 +702,9 @@ export class Think<
       this.session = await this.configureSession(baseSession);
 
       // Force Session to initialize its tables (assistant_messages,
-      // assistant_compactions, assistant_fts, etc.) before the rest of
-      // startup continues.
-      this.session.getHistory();
+      // assistant_compactions, assistant_config, etc.) so that subsequent
+      // config reads work.
+      await this._syncMessages();
 
       // 3-6. Extension initialization (if extensionLoader is set)
       if (this.extensionLoader) {
@@ -729,7 +732,13 @@ export class Think<
    * Always fresh — reads from Session's tree-structured storage.
    */
   get messages(): UIMessage[] {
-    return this.session.getHistory() as UIMessage[];
+    return this._cachedMessages;
+  }
+
+  /** Refresh the cached messages from session storage. */
+  private async _syncMessages(): Promise<UIMessage[]> {
+    this._cachedMessages = (await this.session.getHistory()) as UIMessage[];
+    return this._cachedMessages;
   }
 
   private _aborts = new AbortRegistry();
@@ -1333,8 +1342,8 @@ export class Think<
     const baseSystem = frozenPrompt || this.getSystemPrompt();
     const system = this._systemPromptForTurn(baseSystem, tools);
 
-    const history = this.session.getHistory();
-    const truncated = truncateOlderMessages(history) as UIMessage[];
+    const history = await this.session.getHistory();
+    const truncated = truncateOlderMessages(history as UIMessage[]);
     const messages = await convertToModelMessages(truncated, { tools });
 
     if (messages.length === 0) {
@@ -1880,7 +1889,7 @@ export class Think<
   async _hostGetMessages(
     limit?: number
   ): Promise<Array<{ id: string; role: string; content: string }>> {
-    const history = this.session.getHistory();
+    const history = await this.session.getHistory();
     const sliced =
       limit !== undefined && limit !== null
         ? limit <= 0
@@ -1915,7 +1924,7 @@ export class Think<
     messageCount: number;
   }> {
     return {
-      messageCount: this.session.getHistory().length
+      messageCount: (await this.session.getHistory()).length
     };
   }
 
@@ -1959,6 +1968,7 @@ export class Think<
             : userMessage;
 
         await this.session.appendMessage(userMsg);
+        await this._syncMessages();
 
         const abortSignal = this._aborts.getSignal(requestId);
         const detachExternal = this._aborts.linkExternal(
@@ -2022,14 +2032,15 @@ export class Think<
   // ── Message access ──────────────────────────────────────────────
 
   /** Get the conversation history as UIMessage[]. */
-  getMessages(): UIMessage[] {
-    return this.messages;
+  async getMessages(): Promise<UIMessage[]> {
+    return (await this.session.getHistory()) as UIMessage[];
   }
 
   /** Clear all messages from storage. */
-  clearMessages(): void {
+  async clearMessages(): Promise<void> {
     this.resetTurnState();
-    this.session.clearMessages();
+    await this.session.clearMessages();
+    this._cachedMessages = [];
   }
 
   private _ensureAgentToolChildRunTable(): void {
@@ -2936,7 +2947,7 @@ export class Think<
       if (row.messages_applied_at === null) {
         let appliedState: "none" | "partial" | "all";
         try {
-          appliedState = this._getSubmissionMessagesAppliedState(row);
+        appliedState = await this._getSubmissionMessagesAppliedState(row);
         } catch (error) {
           this.sql`
             UPDATE cf_think_submissions
@@ -3005,15 +3016,15 @@ export class Think<
     }
   }
 
-  private _getSubmissionMessagesAppliedState(
+  private async _getSubmissionMessagesAppliedState(
     row: ThinkSubmissionRow
-  ): "none" | "partial" | "all" {
+  ): Promise<"none" | "partial" | "all"> {
     const messages = this._parseSubmissionMessages(row.messages_json);
     if (messages.length === 0) return "all";
 
     let applied = 0;
     for (const message of messages) {
-      if (this.session.getMessage(message.id)) applied++;
+      if (await this.session.getMessage(message.id)) applied++;
     }
 
     if (applied === 0) return "none";
@@ -3167,6 +3178,7 @@ export class Think<
         for (const msg of resolved) {
           await this.session.appendMessage(msg);
         }
+        await this._syncMessages();
         options?.onMessagesApplied?.();
         this._broadcastMessages();
 
@@ -3258,7 +3270,7 @@ export class Think<
     body?: Record<string, unknown>,
     options?: SaveMessagesOptions
   ): Promise<SaveMessagesResult> {
-    const lastLeaf = this.session.getLatestLeaf();
+    const lastLeaf = await this.session.getLatestLeaf();
     if (!lastLeaf || lastLeaf.role !== "assistant") {
       return { requestId: "", status: "skipped" };
     }
@@ -3432,7 +3444,7 @@ export class Think<
         break;
 
       case "stream-resume-ack":
-        this._handleStreamResumeAck(connection, event.id);
+        await this._handleStreamResumeAck(connection, event.id);
         break;
 
       case "chat-request":
@@ -3450,8 +3462,8 @@ export class Think<
           this._lastClientTools = event.clientTools as ClientToolSchema[];
           this._persistClientTools();
         }
-        const resultPromise = Promise.resolve().then(() => {
-          this._applyToolResult(
+        const resultPromise = Promise.resolve().then(async () => {
+          await this._applyToolResult(
             event.toolCallId,
             event.output,
             event.state as "output-error" | undefined,
@@ -3474,8 +3486,8 @@ export class Think<
       }
 
       case "tool-approval": {
-        const approvalPromise = Promise.resolve().then(() => {
-          this._applyToolApproval(event.toolCallId, event.approved);
+        const approvalPromise = Promise.resolve().then(async () => {
+          await this._applyToolApproval(event.toolCallId, event.approved);
           return true;
         });
         this._pendingInteractionPromise = approvalPromise;
@@ -3493,7 +3505,7 @@ export class Think<
       }
 
       case "clear":
-        this._handleClear(connection);
+        await this._handleClear(connection);
         break;
 
       case "cancel":
@@ -3530,10 +3542,10 @@ export class Think<
     }
   }
 
-  private _handleStreamResumeAck(
+  private async _handleStreamResumeAck(
     connection: Connection,
     requestId: string
-  ): void {
+  ): Promise<void> {
     this._pendingResumeConnections.delete(connection.id);
     if (
       this._resumableStream.hasActiveStream() &&
@@ -3544,7 +3556,7 @@ export class Think<
         this._resumableStream.activeRequestId
       );
       if (orphanedStreamId) {
-        this._persistOrphanedStream(orphanedStreamId);
+        await this._persistOrphanedStream(orphanedStreamId);
       }
     } else if (this._resumableStream.hasActiveStream()) {
       // Ignore ACKs for a different active stream request id.
@@ -3650,7 +3662,7 @@ export class Think<
       const clientToolsForTurn = this._lastClientTools;
       const bodyForTurn = this._lastBody;
 
-      const serverMessages = this.session.getHistory() as UIMessage[];
+      const serverMessages = (await this.session.getHistory()) as UIMessage[];
       const reconciled = reconcileMessages(
         incomingMessages,
         serverMessages,
@@ -3681,6 +3693,7 @@ export class Think<
         return;
       }
 
+      await this._syncMessages();
       this._broadcastMessages([connection.id]);
 
       // ── Enter turn queue ────────────────────────────────────────
@@ -3866,7 +3879,7 @@ export class Think<
     this._aborts.destroyAll();
   }
 
-  private _handleClear(connection?: Connection) {
+  private async _handleClear(connection?: Connection) {
     this.resetTurnState();
 
     this._resumableStream.clearAll();
@@ -3875,7 +3888,8 @@ export class Think<
     this._persistClientTools();
     this._lastBody = undefined;
     this._persistBody();
-    this.session.clearMessages();
+    await this.session.clearMessages();
+    this._cachedMessages = [];
     this._broadcast(
       { type: MSG_CHAT_CLEAR },
       connection ? [connection.id] : undefined
@@ -3937,7 +3951,8 @@ export class Think<
       streamFinalized = true;
 
       assistantMsg = accumulator.toMessage();
-      this._persistAssistantMessage(assistantMsg);
+      await this._persistAssistantMessage(assistantMsg);
+      await this._syncMessages();
 
       if (!aborted) {
         await callback.onDone();
@@ -3963,7 +3978,8 @@ export class Think<
 
       if (!assistantMsg && accumulator.parts.length > 0) {
         assistantMsg = accumulator.toMessage();
-        this._persistAssistantMessage(assistantMsg);
+        await this._persistAssistantMessage(assistantMsg);
+        await this._syncMessages();
       }
 
       const wrapped = this.onChatError(error);
@@ -4117,7 +4133,8 @@ export class Think<
     ) {
       try {
         const assistantMsg = accumulator.toMessage();
-        this._persistAssistantMessage(assistantMsg, parentId);
+        await this._persistAssistantMessage(assistantMsg, parentId);
+        await this._syncMessages();
         this._broadcastMessages();
 
         await this._fireResponseHook({
@@ -4139,20 +4156,18 @@ export class Think<
 
   // ── Session-backed persistence ──────────────────────────────────
 
-  private _persistAssistantMessage(msg: UIMessage, parentId?: string): void {
+  private async _persistAssistantMessage(
+    msg: UIMessage,
+    parentId?: string
+  ): Promise<void> {
     const sanitized = sanitizeMessage(msg);
     const safe = enforceRowSizeLimit(sanitized);
 
-    const existing = this.session.getMessage(safe.id);
+    const existing = await this.session.getMessage(safe.id);
     if (existing) {
-      this.session.updateMessage(safe);
+      await this.session.updateMessage(safe);
     } else {
-      // appendMessage is async due to potential auto-compaction, but
-      // we fire-and-forget here since the message write itself is synchronous
-      // in AgentSessionProvider — only the optional compaction is async.
-      // parentId is set for regeneration — the new response branches from
-      // the same parent as the old one rather than appending to the latest leaf.
-      void this.session.appendMessage(safe, parentId);
+      await this.session.appendMessage(safe, parentId);
     }
   }
 
@@ -4171,9 +4186,9 @@ export class Think<
     const sanitized = sanitizeMessage(resolved);
     const safe = enforceRowSizeLimit(sanitized);
 
-    const existing = this.session.getMessage(safe.id);
+    const existing = await this.session.getMessage(safe.id);
     if (existing) {
-      this.session.updateMessage(safe);
+      await this.session.updateMessage(safe);
       return;
     }
 
@@ -4220,33 +4235,37 @@ export class Think<
 
   // ── Tool state updates (shared primitives from agents/chat) ─────
 
-  private _applyToolResult(
+  private async _applyToolResult(
     toolCallId: string,
     output: unknown,
     overrideState?: "output-error",
     errorText?: string
-  ): void {
+  ): Promise<void> {
     const update = toolResultUpdate(
       toolCallId,
       output,
       overrideState,
       errorText
     );
-    this._applyToolUpdateToMessages(update);
+    await this._applyToolUpdateToMessages(update);
   }
 
-  private _applyToolApproval(toolCallId: string, approved: boolean): void {
+  private async _applyToolApproval(
+    toolCallId: string,
+    approved: boolean
+  ): Promise<void> {
     const update = toolApprovalUpdate(toolCallId, approved);
-    this._applyToolUpdateToMessages(update);
+    await this._applyToolUpdateToMessages(update);
   }
 
-  private _applyToolUpdateToMessages(update: {
+  private async _applyToolUpdateToMessages(update: {
     toolCallId: string;
     matchStates: string[];
     apply: (part: Record<string, unknown>) => Record<string, unknown>;
-  }): void {
-    const history = this.messages;
-    for (const msg of history) {
+  }): Promise<void> {
+    const history = (await this.session.getHistory()) as UIMessage[];
+    for (let i = 0; i < history.length; i++) {
+      const msg = history[i];
       const result = applyToolUpdate(
         msg.parts as Array<Record<string, unknown>>,
         update
@@ -4257,7 +4276,12 @@ export class Think<
           parts: result.parts as UIMessage["parts"]
         };
         const safe = enforceRowSizeLimit(sanitizeMessage(updatedMsg));
-        this.session.updateMessage(safe);
+        await this.session.updateMessage(safe);
+        // Update cache if this message exists there
+        const cacheIdx = this._cachedMessages.findIndex(
+          (m) => m.id === safe.id
+        );
+        if (cacheIdx !== -1) this._cachedMessages[cacheIdx] = safe as UIMessage;
         this._broadcast({ type: MSG_MESSAGE_UPDATED, message: safe });
         return;
       }
@@ -4405,8 +4429,12 @@ export class Think<
     const streamIsTerminal =
       streamStatus === "completed" || streamStatus === "error";
 
-    if (options.persist !== false && (streamStillActive || streamIsTerminal)) {
-      this._persistOrphanedStream(streamId);
+    if (
+      options.persist !== false &&
+      streamId &&
+      (streamStillActive || streamIsTerminal)
+    ) {
+      await this._persistOrphanedStream(streamId);
     }
 
     if (streamStillActive) {
@@ -4431,7 +4459,7 @@ export class Think<
       canContinue && hasRunningSubmission ? requestId : undefined;
 
     if (canContinue) {
-      const lastLeaf = this.session.getLatestLeaf();
+      const lastLeaf = await this.session.getLatestLeaf();
       const targetId = lastLeaf?.role === "assistant" ? lastLeaf.id : undefined;
       await this.schedule(
         0,
@@ -4581,7 +4609,7 @@ export class Think<
       }
 
       const targetId = data?.targetAssistantId;
-      const lastLeaf = this.session.getLatestLeaf();
+      const lastLeaf = await this.session.getLatestLeaf();
       if (targetId && lastLeaf?.id !== targetId) {
         if (data?.recoveredRequestId) {
           await this._completeRecoveredSubmission(
@@ -4833,7 +4861,7 @@ export class Think<
     }
   }
 
-  private _persistOrphanedStream(streamId: string): void {
+  private async _persistOrphanedStream(streamId: string): Promise<void> {
     this._resumableStream.flushBuffer();
     const chunks = this._resumableStream.getStreamChunks(streamId);
     if (chunks.length === 0) return;
@@ -4850,7 +4878,8 @@ export class Think<
     }
 
     if (accumulator.parts.length > 0) {
-      this._persistAssistantMessage(accumulator.toMessage());
+      await this._persistAssistantMessage(accumulator.toMessage());
+      await this._syncMessages();
       this._broadcastMessages();
     }
   }

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -21,7 +21,6 @@
   The transcriber session is now created at `start_call` and lives for the entire call duration. The model handles turn detection — no client-side `start_of_speech`/`end_of_speech` required for STT. Voice agents use `keepAlive` to prevent DO eviction during calls.
 
   New API:
-
   - `transcriber` property replaces `stt`, `streamingStt`, and `vad`
   - `createTranscriber(connection)` hook for runtime model switching
   - `WorkersAIFluxSTT` — per-call Flux sessions (recommended for `withVoice`)
@@ -31,7 +30,6 @@
   - Duplicate `start_call` is silently ignored when already in a call
 
   Removed:
-
   - `stt` (batch STT), `streamingStt` (per-utterance streaming), `vad` (server-side VAD)
   - `WorkersAISTT`, `WorkersAIVAD`, `pcmToWav`
   - `prerollMs`, `vadThreshold`, `vadPushbackSeconds`, `vadRetryMs`, `minAudioBytes` options


### PR DESCRIPTION
## Summary

Adds Postgres-backed session providers for storing conversation history, context blocks, and searchable knowledge in an external database via Hyperdrive. This enables cross-DO queries, analytics, and shared state without relying on DO SQLite.

Supersedes #1196.

### What's new

**Providers** (`packages/agents/src/experimental/memory/session/providers/`)
- `PostgresSessionProvider` — tree-structured messages, compaction overlays, message FTS via tsvector
- `PostgresContextProvider` — writable context block storage (memory, cached prompt)
- `PostgresSearchProvider` — searchable knowledge base with tsvector + GIN index

**Framework improvements** (`packages/agents/src/experimental/memory/session/`)
- `Session.create()` accepts `SessionProvider` for external storage (in addition to `SqlProvider` for DO SQLite)
- Hardened context tools: removed enum constraints on label params, validate inside execute, always return error strings instead of throwing (prevents orphaned tool calls with smaller LLMs)
- Simplified `set_context` API: removed `key` param, auto-generates keys from `title` or content slug
- Fixed prompt lifecycle: `freezeSystemPrompt()` returns cached, `refreshSystemPrompt()` force-reloads from providers
- `clearMessages()` calls `refreshSystemPrompt()` to invalidate the cached prompt
- `appendToBlock()` adds newline separator between entries
- Empty writable blocks render in system prompt so the LLM knows they exist
- Clean block tags: `[readonly]`, `[searchable]`, `[loadable]`, `[not searchable]`
- Search provider `get()` returns entry count only (no key listing)

**Example** (`experimental/session-planetscale/`)
- Full Vite + React chat app with Hyperdrive + `pg` driver
- System prompt toggle, FULLTEXT search bar, connection indicator, theme toggle
- `wrapPgClient` helper converts `?` placeholders to `$1, $2, ...` for pg compatibility

**Tests** (`packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts`)
- 37 tests covering: provider CRUD, message round-trip, dynamic-tool part serialization, `convertToModelMessages` compatibility, prompt lifecycle (freeze/refresh/invalidation/concurrent)

**Docs** (`docs/sessions.md`)
- Postgres setup guide: migration SQL, Hyperdrive config, wire-up code
- System prompt lifecycle docs
- Search provider docs (message search + knowledge search)

### Migration SQL

Customers run this once — providers never create tables:

```sql
CREATE TABLE assistant_messages (
  id TEXT PRIMARY KEY, session_id TEXT NOT NULL DEFAULT '', parent_id TEXT,
  role TEXT NOT NULL, content TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT NOW(),
  content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
);
CREATE TABLE assistant_compactions (
  id TEXT PRIMARY KEY, session_id TEXT NOT NULL DEFAULT '',
  summary TEXT NOT NULL, from_message_id TEXT NOT NULL, to_message_id TEXT NOT NULL,
  created_at TIMESTAMPTZ DEFAULT NOW()
);
CREATE TABLE cf_agents_context_blocks (
  label TEXT PRIMARY KEY, content TEXT NOT NULL, updated_at TIMESTAMPTZ DEFAULT NOW()
);
CREATE TABLE cf_agents_search_entries (
  label TEXT NOT NULL, key TEXT NOT NULL, content TEXT NOT NULL,
  content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
  created_at TIMESTAMPTZ DEFAULT NOW(), updated_at TIMESTAMPTZ DEFAULT NOW(),
  PRIMARY KEY (label, key)
);
```

## Test plan

- [x] 37 unit tests passing (providers, round-trip, convertToModelMessages, prompt lifecycle)
- [ ] Deploy example and test chat flow end-to-end
- [ ] Verify search_context returns ranked results from knowledge base
- [ ] Verify clearMessages invalidates cached prompt
- [ ] Verify empty memory block renders in system prompt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
