### PR TITLE
fix: preserve providerMetadata on reasoning chunks in applyChunkToParts

### DIFF
--- a/.changeset/fix-reasoning-provider-metadata.md
+++ b/.changeset/fix-reasoning-provider-metadata.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix `applyChunkToParts` dropping `providerMetadata` on `reasoning-end` and `reasoning-delta` chunks. For Anthropic models with extended/adaptive thinking, the thinking block signature arrives on `reasoning-end.providerMetadata.anthropic.signature`. Without persisting it, `convertToModelMessages` produces reasoning parts with no signature, causing `@ai-sdk/anthropic` to silently drop the thinking block on subsequent turns — effectively making extended thinking single-turn only. The reasoning handlers now merge `chunk.providerMetadata` onto the persisted part, matching the behavior of source and tool chunk handlers in the same file. Fixes #1299.

--- a/packages/agents/src/chat/__tests__/stream-accumulator.test.ts
+++ b/packages/agents/src/chat/__tests__/stream-accumulator.test.ts
@@ -77,6 +77,97 @@ describe("StreamAccumulator", () => {
       expect(a.parts).toHaveLength(1);
       expect((a.parts[0] as { text: string }).text).toBe("resumed");
     });
+
+    it("reasoning-end preserves providerMetadata (Anthropic signature)", () => {
+      const a = acc();
+      a.applyChunk({ type: "reasoning-start" } as StreamChunkData);
+      a.applyChunk({
+        type: "reasoning-delta",
+        delta: "deep thought"
+      } as StreamChunkData);
+      a.applyChunk({
+        type: "reasoning-end",
+        providerMetadata: {
+          anthropic: { signature: "sig-abc-123" }
+        }
+      } as StreamChunkData);
+
+      expect(a.parts).toHaveLength(1);
+      const part = a.parts[0] as Record<string, unknown>;
+      expect(part).toMatchObject({
+        type: "reasoning",
+        text: "deep thought",
+        state: "done"
+      });
+      expect(part.providerMetadata).toEqual({
+        anthropic: { signature: "sig-abc-123" }
+      });
+    });
+
+    it("reasoning-delta preserves providerMetadata when streamed mid-block", () => {
+      const a = acc();
+      a.applyChunk({ type: "reasoning-start" } as StreamChunkData);
+      a.applyChunk({
+        type: "reasoning-delta",
+        delta: "partial",
+        providerMetadata: { someProvider: { key: "val" } }
+      } as StreamChunkData);
+
+      const part = a.parts[0] as Record<string, unknown>;
+      expect(part.providerMetadata).toEqual({
+        someProvider: { key: "val" }
+      });
+    });
+
+    it("reasoning-end merges providerMetadata from delta and end chunks", () => {
+      const a = acc();
+      a.applyChunk({ type: "reasoning-start" } as StreamChunkData);
+      a.applyChunk({
+        type: "reasoning-delta",
+        delta: "thinking",
+        providerMetadata: { custom: { fromDelta: true } }
+      } as StreamChunkData);
+      a.applyChunk({
+        type: "reasoning-end",
+        providerMetadata: {
+          anthropic: { signature: "sig-xyz" }
+        }
+      } as StreamChunkData);
+
+      const part = a.parts[0] as Record<string, unknown>;
+      expect(part.providerMetadata).toEqual({
+        custom: { fromDelta: true },
+        anthropic: { signature: "sig-xyz" }
+      });
+    });
+
+    it("reasoning-end without providerMetadata does not add the field", () => {
+      const a = acc();
+      a.applyChunk({ type: "reasoning-start" } as StreamChunkData);
+      a.applyChunk({
+        type: "reasoning-delta",
+        delta: "thought"
+      } as StreamChunkData);
+      a.applyChunk({ type: "reasoning-end" } as StreamChunkData);
+
+      const part = a.parts[0] as Record<string, unknown>;
+      expect(part.providerMetadata).toBeUndefined();
+    });
+
+    it("reasoning-delta without start carries providerMetadata on the new part", () => {
+      const a = acc();
+      a.applyChunk({
+        type: "reasoning-delta",
+        delta: "resumed",
+        providerMetadata: { anthropic: { redactedData: "enc-data" } }
+      } as StreamChunkData);
+
+      expect(a.parts).toHaveLength(1);
+      const part = a.parts[0] as Record<string, unknown>;
+      expect(part.providerMetadata).toEqual({
+        anthropic: { redactedData: "enc-data" }
+      });
+    });
   });
 
   describe("file and source chunks", () => {

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -125,12 +125,16 @@ export function applyChunkToParts(
       const lastReasoningPart = findLastPartByType(parts, "reasoning");
       if (lastReasoningPart && lastReasoningPart.type === "reasoning") {
         (lastReasoningPart as { text: string }).text += chunk.delta ?? "";
+        mergeProviderMetadata(lastReasoningPart, chunk.providerMetadata);
       } else {
         // No reasoning-start received — create a new reasoning part (stream resumption fallback)
         parts.push({
           type: "reasoning",
           text: chunk.delta ?? "",
-          state: "streaming"
+          state: "streaming",
+          ...(chunk.providerMetadata != null
+            ? { providerMetadata: chunk.providerMetadata }
+            : {})
         } as MessagePart);
       }
       return true;
@@ -140,6 +144,7 @@ export function applyChunkToParts(
       const lastReasoningPart = findLastPartByType(parts, "reasoning");
       if (lastReasoningPart && "state" in lastReasoningPart) {
         (lastReasoningPart as { state: string }).state = "done";
+        mergeProviderMetadata(lastReasoningPart, chunk.providerMetadata);
       }
       return true;
     }
@@ -389,6 +394,24 @@ function findToolPartByCallId(
     }
   }
   return undefined;
+}
+
+/**
+ * Shallow-merges providerMetadata from a chunk onto an existing part.
+ * Preserves any metadata already on the part (e.g. from earlier deltas)
+ * while adding new keys from the chunk. This is critical for providers
+ * like Anthropic that emit the thinking block signature on reasoning-end.
+ */
+function mergeProviderMetadata(
+  part: MessagePart,
+  metadata: Record<string, unknown> | undefined
+): void {
+  if (metadata == null) return;
+  const p = part as Record<string, unknown>;
+  p.providerMetadata = {
+    ...(p.providerMetadata as Record<string, unknown> | undefined),
+    ...metadata
+  };
 }
 
 /**

--- a/packages/worker-bundler/CHANGELOG.md
+++ b/packages/worker-bundler/CHANGELOG.md
@@ -19,7 +19,6 @@
   Object KV on demand, avoiding a KV write for every individual file operation.
 
   Three concrete implementations are exported from the package:
-
   - `InMemoryFileSystem` — a `Map`-backed filesystem suitable for tests and
     in-process pipelines. Accepts an optional seed object or `Map` of initial
     files.


### PR DESCRIPTION
## Summary

- `applyChunkToParts` in `message-builder.ts` was silently dropping `chunk.providerMetadata` on `reasoning-end` and `reasoning-delta` chunks. For Anthropic models with extended/adaptive thinking, the thinking block **signature** arrives on `reasoning-end.providerMetadata.anthropic.signature` — without it, `@ai-sdk/anthropic` cannot reconstruct the thinking block on subsequent turns and silently drops it, making extended thinking effectively single-turn.
- Both reasoning handlers now merge `chunk.providerMetadata` onto the persisted part via a new `mergeProviderMetadata` helper, matching the behavior of source and tool chunk handlers in the same file.
- Added 5 test cases covering: signature preservation on `reasoning-end`, metadata on `reasoning-delta`, merge across delta+end, no-op when metadata is absent, and fallback part creation with metadata.

Fixes #1299.

## Test plan

- [x] All 937 existing workers tests pass (`npx nx run agents:test:workers`)
- [x] 5 new test cases in `stream-accumulator.test.ts` cover the fix
- [x] No lint errors, formatting clean
- [ ] Verify with a real Anthropic extended thinking flow that the signature round-trips across turns (manual)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
