### PR TITLE
feat(site): add crawler and MCP discovery metadata

### DIFF
--- a/site/agents/public/.well-known/api-catalog
+++ b/site/agents/public/.well-known/api-catalog
@@ -1,0 +1,31 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://agents.cloudflare.com/mcp",
+      "service-desc": [
+        {
+          "href": "https://agents.cloudflare.com/.well-known/mcp-openapi.json",
+          "type": "application/vnd.oai.openapi+json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+          "type": "text/html"
+        }
+      ],
+      "service-meta": [
+        {
+          "href": "https://agents.cloudflare.com/.well-known/mcp/server-card.json",
+          "type": "application/json"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://agents.cloudflare.com/status.json",
+          "type": "application/json"
+        }
+      ]
+    }
+  ]
+}

--- a/site/agents/public/.well-known/mcp-openapi.json
+++ b/site/agents/public/.well-known/mcp-openapi.json
@@ -1,0 +1,200 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Cloudflare Agents SDK Docs MCP API",
+    "version": "1.0.0",
+    "description": "Public MCP endpoint for searching the Cloudflare Agents SDK documentation."
+  },
+  "servers": [
+    {
+      "url": "https://agents.cloudflare.com"
+    }
+  ],
+  "externalDocs": {
+    "description": "Cloudflare documentation for managed MCP servers",
+    "url": "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/"
+  },
+  "paths": {
+    "/mcp": {
+      "post": {
+        "operationId": "postMcpMessage",
+        "summary": "Send MCP JSON-RPC messages",
+        "description": "Initializes or continues an MCP session using the streamable HTTP transport.",
+        "parameters": [
+          {
+            "name": "accept",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Must advertise support for both application/json and text/event-stream."
+          },
+          {
+            "name": "mcp-session-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Required after initialization. Omit on the initialize request."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "MCP response payload or event stream.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON, invalid JSON-RPC, or missing MCP session metadata."
+          },
+          "404": {
+            "description": "Session not found."
+          },
+          "406": {
+            "description": "The Accept header does not include both required content types."
+          },
+          "413": {
+            "description": "Request body exceeds the 4 MB message limit."
+          },
+          "415": {
+            "description": "The Content-Type header is not application/json."
+          },
+          "500": {
+            "description": "Internal server error."
+          }
+        }
+      },
+      "get": {
+        "operationId": "openMcpEventStream",
+        "summary": "Resume an MCP event stream",
+        "description": "Opens a server-sent event stream for an existing MCP session.",
+        "parameters": [
+          {
+            "name": "mcp-session-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The existing MCP session identifier."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server-sent event stream for the MCP session.",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The MCP session header is missing."
+          },
+          "404": {
+            "description": "Session not found."
+          },
+          "500": {
+            "description": "Internal server error."
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMcpSession",
+        "summary": "Terminate an MCP session",
+        "description": "Closes an existing MCP session.",
+        "parameters": [
+          {
+            "name": "mcp-session-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The MCP session identifier to terminate."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session terminated."
+          },
+          "400": {
+            "description": "The MCP session header is missing."
+          },
+          "404": {
+            "description": "Session not found."
+          },
+          "500": {
+            "description": "Internal server error."
+          }
+        }
+      }
+    },
+    "/status.json": {
+      "get": {
+        "operationId": "getStatus",
+        "summary": "Read service status",
+        "responses": {
+          "200": {
+            "description": "Service status payload.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status", "service", "endpoint"],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "const": "ok"
+                    },
+                    "service": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/site/agents/public/.well-known/mcp/server-card.json
+++ b/site/agents/public/.well-known/mcp/server-card.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
+  "version": "1.0",
+  "protocolVersion": "2025-06-18",
+  "serverInfo": {
+    "name": "agents-mcp",
+    "title": "Cloudflare Agents Docs MCP",
+    "version": "0.0.1"
+  },
+  "description": "MCP server for token-efficient search of the Cloudflare Agents SDK documentation.",
+  "websiteUrl": "https://agents.cloudflare.com",
+  "transport": {
+    "type": "streamable-http",
+    "endpoint": "https://agents.cloudflare.com/mcp"
+  },
+  "capabilities": {
+    "tools": {
+      "listChanged": false
+    }
+  }
+}

--- a/site/agents/public/_headers
+++ b/site/agents/public/_headers
@@ -1,4 +1,20 @@
 /
   Link: </sitemap.xml>; rel="sitemap"
-  Link: </mcp>; rel="service-desc"
-  Link: <https://developers.cloudflare.com/agents/>; rel="service-doc"
+  Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727"
+  Link: </.well-known/mcp-openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"
+  Link: <https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/>; rel="service-doc"
+  Link: </.well-known/mcp/server-card.json>; rel="service-meta"; type="application/json"
+
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"
+  Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727"
+
+/.well-known/mcp-openapi.json
+  Content-Type: application/vnd.oai.openapi+json
+
+/.well-known/mcp/server-card.json
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET
+  Access-Control-Allow-Headers: Content-Type
+  Cache-Control: public, max-age=3600

--- a/site/agents/public/robots.txt
+++ b/site/agents/public/robots.txt
@@ -1,3 +1,30 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
 User-agent: *
 Allow: /
 

--- a/site/agents/public/status.json
+++ b/site/agents/public/status.json
@@ -1,0 +1,5 @@
+{
+  "status": "ok",
+  "service": "cloudflare-agents-docs-mcp",
+  "endpoint": "https://agents.cloudflare.com/mcp"
+}


### PR DESCRIPTION
## Summary
- add explicit AI crawler entries to `site/agents/public/robots.txt` so the existing allow-all policy is stated directly for major AI bots such as `GPTBot`, `OAI-SearchBot`, `Claude-Web`, and `Google-Extended`
- publish an RFC 9727 API catalog for the existing `https://agents.cloudflare.com/mcp` service, including a linkset document, an OpenAPI description, and a simple status document
- publish an MCP Server Card for the docs MCP server at `/.well-known/mcp/server-card.json` and advertise the new machine-readable endpoints via `_headers`

## Why
- agent readiness checks expect these discovery endpoints and explicit crawler rules to exist; today the site only exposes partial metadata
- keeping the metadata focused on the existing docs MCP endpoint makes the site easier for crawlers, registries, and MCP-aware clients to discover without adding a new service surface
- the card and catalog both point back to the same `agents-mcp` server, so the published metadata stays aligned with the actual endpoint we already run

## Testing
- ran `npm run check`
- the repo still fails on a pre-existing formatting issue in `packages/agents/src/react.tsx`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
