### PR TITLE
changeset: publish ai-chat, hono-agents, voice with corrected peer dep ranges

### DIFF
--- a/.changeset/fix-peer-dep-publish-ranges.md
+++ b/.changeset/fix-peer-dep-publish-ranges.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/ai-chat": patch
+"hono-agents": patch
+"@cloudflare/voice": patch
+---
+
+Publish with correct peer dependency ranges for `agents` (wide ranges were being overwritten to tight `^0.x.y` by the pre-publish script)


### PR DESCRIPTION
Patch changeset to trigger publishes for `@cloudflare/ai-chat`, `hono-agents`, and `@cloudflare/voice` with the correct wide peer dependency ranges for `agents`. The pre-publish script fix from 6aa62123 is already on main.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
