### PR TITLE
fix(agents): sub-agent cross-DO I/O + drop "experimental" compat flag

### DIFF
--- a/.changeset/facet-cross-do-io-fix.md
+++ b/.changeset/facet-cross-do-io-fix.md
@@ -13,7 +13,7 @@ Three issues in the facet initialization path caused `"Cannot perform I/O on beh
 - The facet flag was set _after_ the first `onStart()` ran, so `broadcastMcpServers()` fired with `_isFacet === false` on the initial boot.
 - `_broadcastProtocol()`, the inherited `broadcast()`, and `_workflow_broadcast()` iterated the connection registry without an `_isFacet` guard, letting broadcasts reach into the parent DO's WebSocket registry from a child isolate.
 
-Replaces the fetch-based handshake with a new `_cf_initAsFacet(name)` RPC that runs entirely in the child isolate, sets `_isFacet` before init, and seeds partyserver's `__ps_name` key directly. Adds `_isFacet` guards to `_broadcastProtocol()` and overrides `broadcast()` to no-op on facets so downstream callers (chat-streaming paths, workflow broadcasts, user `this.broadcast(...)`) are covered. `_cf_markAsFacet()` is kept for back-compat and now marked `@deprecated`.
+Replaces the fetch-based handshake with a new `_cf_initAsFacet(name)` RPC that runs entirely in the child isolate, sets `_isFacet` before init, and seeds partyserver's `__ps_name` key directly. Adds `_isFacet` guards to `_broadcastProtocol()` and overrides `broadcast()` to no-op on facets so downstream callers (chat-streaming paths, workflow broadcasts, user `this.broadcast(...)`) are covered. Removes the previous internal `_cf_markAsFacet()` method — `_cf_initAsFacet(name)` is the correct entry point (it sets the flag before running the first `onStart()`, which `_cf_markAsFacet` did not).
 
 ### `"experimental"` compatibility flag no longer required
 

--- a/.changeset/facet-cross-do-io-fix.md
+++ b/.changeset/facet-cross-do-io-fix.md
@@ -1,8 +1,11 @@
 ---
 "agents": patch
+"@cloudflare/think": patch
 ---
 
-Fix `subAgent()` cross-DO I/O errors on first use.
+Fix `subAgent()` cross-DO I/O errors on first use and drop the `"experimental"` compatibility flag requirement.
+
+### `subAgent()` cross-DO I/O fix
 
 Three issues in the facet initialization path caused `"Cannot perform I/O on behalf of a different Durable Object"` errors when spawning sub-agents in production:
 
@@ -11,3 +14,12 @@ Three issues in the facet initialization path caused `"Cannot perform I/O on beh
 - `_broadcastProtocol()`, the inherited `broadcast()`, and `_workflow_broadcast()` iterated the connection registry without an `_isFacet` guard, letting broadcasts reach into the parent DO's WebSocket registry from a child isolate.
 
 Replaces the fetch-based handshake with a new `_cf_initAsFacet(name)` RPC that runs entirely in the child isolate, sets `_isFacet` before init, and seeds partyserver's `__ps_name` key directly. Adds `_isFacet` guards to `_broadcastProtocol()` and overrides `broadcast()` to no-op on facets so downstream callers (chat-streaming paths, workflow broadcasts, user `this.broadcast(...)`) are covered. `_cf_markAsFacet()` is kept for back-compat and now marked `@deprecated`.
+
+### `"experimental"` compatibility flag no longer required
+
+`ctx.facets`, `ctx.exports`, and `env.LOADER` (Worker Loader) have graduated out of the `"experimental"` compatibility flag in workerd. `agents` and `@cloudflare/think` no longer require it:
+
+- `subAgent()` / `abortSubAgent()` / `deleteSubAgent()` — the `@experimental` JSDoc tag and runtime error messages no longer reference the flag. The runtime guards on `ctx.facets` / `ctx.exports` stay in place and now nudge users toward updating `compatibility_date` instead.
+- `Think` — the `@experimental` JSDoc tag no longer references the flag.
+
+No code change is required; remove `"experimental"` from your `compatibility_flags` in `wrangler.jsonc` if it was only there for these features.

--- a/.changeset/facet-cross-do-io-fix.md
+++ b/.changeset/facet-cross-do-io-fix.md
@@ -1,0 +1,13 @@
+---
+"agents": patch
+---
+
+Fix `subAgent()` cross-DO I/O errors on first use.
+
+Three issues in the facet initialization path caused `"Cannot perform I/O on behalf of a different Durable Object"` errors when spawning sub-agents in production:
+
+- `subAgent()` constructed a `Request` in the parent DO and passed it to the child via `stub.fetch()`. The `Request` carried native I/O tied to the parent isolate, which the child rejected.
+- The facet flag was set _after_ the first `onStart()` ran, so `broadcastMcpServers()` fired with `_isFacet === false` on the initial boot.
+- `_broadcastProtocol()`, the inherited `broadcast()`, and `_workflow_broadcast()` iterated the connection registry without an `_isFacet` guard, letting broadcasts reach into the parent DO's WebSocket registry from a child isolate.
+
+Replaces the fetch-based handshake with a new `_cf_initAsFacet(name)` RPC that runs entirely in the child isolate, sets `_isFacet` before init, and seeds partyserver's `__ps_name` key directly. Adds `_isFacet` guards to `_broadcastProtocol()` and overrides `broadcast()` to no-op on facets so downstream callers (chat-streaming paths, workflow broadcasts, user `this.broadcast(...)`) are covered. `_cf_markAsFacet()` is kept for back-compat and now marked `@deprecated`.

--- a/design/rfc-sub-agents.md
+++ b/design/rfc-sub-agents.md
@@ -129,11 +129,11 @@ Rejected because:
 
 - **Two classes for the same thing** — `SubAgent` and `Agent` had nearly identical capabilities (both extended `Server`, both had `this.sql`, etc.). The distinction was confusing.
 - **Mixin ergonomics were poor** — `const Parent = withSubAgents(AIChatAgent); export class MyAgent extends Parent<Env, State>` is awkward compared to just `extends AIChatAgent<Env, State>`.
-- **The compat flag concern was overstated** — users who don't call `subAgent()` are unaffected by the methods existing on `Agent`. The `experimental` flag is only needed at runtime when `ctx.facets` is actually accessed.
+- **The compat flag concern was overstated** — users who don't call `subAgent()` are unaffected by the methods existing on `Agent`. (At the time of this RFC, the `experimental` flag was needed at runtime when `ctx.facets` was accessed; `ctx.facets` / `ctx.exports` have since graduated out of the `experimental` flag.)
 
 ### B. Separate entry point without `experimental/` prefix
 
-Would suggest the API is stable. It isn't — it depends on `ctx.facets` and `ctx.exports`, which are behind the `experimental` compat flag in workerd. However, since the methods now live on `Agent` directly, the stability signal comes from the `@experimental` JSDoc tag on the methods rather than an import path.
+Would suggest the API is stable. At the time of this RFC, the Agents SDK API was still stabilizing around `ctx.facets` and `ctx.exports` (which were behind the `experimental` compat flag in workerd at the time). Keeping the methods on `Agent` directly lets the stability signal come from the `@experimental` JSDoc tag on the methods rather than an import path.
 
 ### C. Use `DurableObject` directly instead of extending `Server`
 
@@ -168,7 +168,7 @@ Type-level tests in `packages/agents/src/tests-d/sub-agent-stub.test-d.ts` verif
 
 ### Graduating from `experimental`
 
-The methods are on `Agent` but marked `@experimental` in JSDoc. Graduation requires `ctx.facets` and `ctx.exports` leaving the `experimental` compat flag in workerd, plus sufficient real-world usage.
+The methods are on `Agent` but marked `@experimental` in JSDoc. The underlying workerd primitives (`ctx.facets`, `ctx.exports`) have graduated out of the `experimental` compat flag. Graduation of the Agents SDK API itself is now gated only on sufficient real-world usage.
 
 ### State sync between parent and sub-agent
 

--- a/docs/think/getting-started.md
+++ b/docs/think/getting-started.md
@@ -37,7 +37,7 @@ Create `wrangler.jsonc`:
 {
   "name": "my-think-agent",
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "ai": { "binding": "AI" },
   "assets": {
     "not_found_handling": "single-page-application",
@@ -50,8 +50,6 @@ Create `wrangler.jsonc`:
   "main": "src/server.ts"
 }
 ```
-
-The `"experimental"` compatibility flag is required for Think.
 
 Create `vite.config.ts`:
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -4,7 +4,7 @@
 
 Think works as both a **top-level agent** (WebSocket chat to browser clients via `useAgentChat`) and a **sub-agent** (RPC streaming from a parent agent via `chat()`).
 
-> **Experimental.** Think requires the `"experimental"` compatibility flag in your `wrangler.jsonc`. The API surface is stable but may evolve before graduating out of experimental.
+> **Experimental.** The API surface is stable but may evolve before graduating out of experimental.
 
 ## Quick Start
 
@@ -85,7 +85,7 @@ function Chat() {
 ```jsonc
 {
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "ai": { "binding": "AI" },
   "durable_objects": {
     "bindings": [{ "class_name": "MyAgent", "name": "MyAgent" }]

--- a/examples/assistant/wrangler.jsonc
+++ b/examples/assistant/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "ai": { "binding": "AI", "remote": true },
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*"]

--- a/examples/worker-bundler-playground/wrangler.jsonc
+++ b/examples/worker-bundler-playground/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "worker-bundler-playground",
   "main": "src/server.ts",
   "compatibility_date": "2026-03-06",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*", "/preview/*"]

--- a/experimental/gadgets-chat/wrangler.jsonc
+++ b/experimental/gadgets-chat/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "ai": { "binding": "AI", "remote": true },
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*"]

--- a/experimental/gadgets-gatekeeper/src/server.ts
+++ b/experimental/gadgets-gatekeeper/src/server.ts
@@ -9,9 +9,6 @@
  * This makes the approval queue structurally enforceable: the agent
  * literally cannot bypass it because it has no path to the customer data
  * except through the facet stub.
- *
- * Requires the "experimental" compatibility flag for ctx.facets and
- * ctx.exports.
  */
 
 import { createWorkersAI } from "workers-ai-provider";

--- a/experimental/gadgets-gatekeeper/wrangler.jsonc
+++ b/experimental/gadgets-gatekeeper/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "ai": { "binding": "AI", "remote": true },
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*"]

--- a/experimental/gadgets-sandbox/wrangler.jsonc
+++ b/experimental/gadgets-sandbox/wrangler.jsonc
@@ -2,8 +2,7 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "ai": { "binding": "AI", "remote": true },
   "compatibility_date": "2026-01-28",
-  // "experimental" enables ctx.facets, ctx.exports, and worker_loaders.
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*"]

--- a/experimental/gadgets-subagents/wrangler.jsonc
+++ b/experimental/gadgets-subagents/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "ai": { "binding": "AI", "remote": true },
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/agents/*"]

--- a/experimental/gadgets.md
+++ b/experimental/gadgets.md
@@ -14,9 +14,9 @@ The key properties:
 
 The fundamental invariant: _An agent never enables a human to do something the human couldn't do directly._
 
-## Experimental Primitives
+## Primitives
 
-These patterns depend on three experimental Cloudflare APIs (enabled via `"experimental"` compatibility flag):
+These patterns depend on three Cloudflare APIs — `ctx.facets`, `ctx.exports`, and `env.LOADER` (Worker Loader). All three are available without any compatibility flag.
 
 ### `ctx.facets` — Child Durable Objects
 
@@ -99,7 +99,7 @@ Each user gets a facet (their session). Session state isolated. Parent manages s
 
 ## Prototype Examples
 
-Four examples validate these patterns against the real Cloudflare runtime. All use `"experimental"` compat flag and work with the Vite plugin.
+Four examples validate these patterns against the real Cloudflare runtime. All work with the Vite plugin, no `"experimental"` compatibility flag required.
 
 ### [`gadgets-gatekeeper`](./gadgets-gatekeeper/) — Approval Queue + Facet Isolation
 

--- a/experimental/session-skills/wrangler.jsonc
+++ b/experimental/session-skills/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "agents-session-skills-example",
   "main": "src/server.ts",
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "ai": {
     "binding": "AI",
     "remote": true

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -3499,22 +3499,6 @@ export class Agent<
   // ── Sub-agent (facet) management ────────────────────────────────────────
 
   /**
-   * Marks this agent as running inside a facet (sub-agent). Once set,
-   * scheduling methods throw a clear error instead of crashing on
-   * `setAlarm()` (which is not supported in facets).
-   *
-   * @deprecated Kept only for back-compat with older internal callers.
-   *   Use {@link _cf_initAsFacet} — it sets the flag *before* running
-   *   the first `onStart()`, which this method does not. Scheduled for
-   *   removal in a future release.
-   * @internal
-   */
-  async _cf_markAsFacet(): Promise<void> {
-    this._isFacet = true;
-    await this.ctx.storage.put("cf_agents_is_facet", true);
-  }
-
-  /**
    * Initialize this agent as a facet in a single RPC.
    *
    * Runs entirely inside the child's isolate, so every storage write

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -3502,6 +3502,11 @@ export class Agent<
    * Marks this agent as running inside a facet (sub-agent). Once set,
    * scheduling methods throw a clear error instead of crashing on
    * `setAlarm()` (which is not supported in facets).
+   *
+   * @deprecated Kept only for back-compat with older internal callers.
+   *   Use {@link _cf_initAsFacet} — it sets the flag *before* running
+   *   the first `onStart()`, which this method does not. Scheduled for
+   *   removal in a future release.
    * @internal
    */
   async _cf_markAsFacet(): Promise<void> {
@@ -3528,11 +3533,14 @@ export class Agent<
    */
   async _cf_initAsFacet(name: string): Promise<void> {
     this._isFacet = true;
-    await this.ctx.storage.put("cf_agents_is_facet", true);
-    // Seed partyserver's name storage key so `#hydrateNameFromStorage`
-    // picks it up without a network round-trip — same key
-    // partyserver's `setName()` writes.
-    await this.ctx.storage.put("__ps_name", name);
+    // Persist the facet flag and seed partyserver's `__ps_name` key in
+    // parallel — both writes are independent and fire against the same
+    // storage. `__ps_name` is the same key `Server#setName()` writes,
+    // so `#hydrateNameFromStorage()` picks it up without a round-trip.
+    await Promise.all([
+      this.ctx.storage.put("cf_agents_is_facet", true),
+      this.ctx.storage.put("__ps_name", name)
+    ]);
     await this.__unsafe_ensureInitialized();
   }
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1578,6 +1578,11 @@ export class Agent<
    * @param excludeIds Additional connection IDs to exclude (e.g. the source)
    */
   private _broadcastProtocol(msg: string, excludeIds: string[] = []) {
+    // Facets share the parent DO's WebSocket registry: getConnections()
+    // returns parent-owned sockets, so iterating from a facet throws
+    // "Cannot perform I/O on behalf of a different Durable Object".
+    // Sub-agents are RPC-only and have no WS clients of their own.
+    if (this._isFacet) return;
     const exclude = [...excludeIds];
     for (const conn of this.getConnections()) {
       if (!this.isConnectionProtocolEnabled(conn)) {
@@ -1585,6 +1590,22 @@ export class Agent<
       }
     }
     this.broadcast(msg, exclude);
+  }
+
+  /**
+   * When running as a facet, the parent DO owns the WebSocket registry
+   * (`ctx.getWebSockets()`). Iterating from the child isolate throws
+   * "Cannot perform I/O on behalf of a different Durable Object".
+   * Downstream callers (e.g. chat-streaming paths) invoke
+   * `this.broadcast()` directly, bypassing `_broadcastProtocol`'s
+   * guard, so override at the base to catch every path.
+   */
+  override broadcast(
+    msg: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): void {
+    if (this._isFacet) return;
+    super.broadcast(msg, without);
   }
 
   private _setStateInternal(
@@ -3489,6 +3510,33 @@ export class Agent<
   }
 
   /**
+   * Initialize this agent as a facet in a single RPC.
+   *
+   * Runs entirely inside the child's isolate, so every storage write
+   * and `onStart()` I/O is owned by the child DO. This replaces the
+   * previous "construct a Request in the parent DO and `stub.fetch()`
+   * it on the child" handshake, whose native I/O was tied to the
+   * parent and triggered "Cannot perform I/O on behalf of a different
+   * Durable Object" on the child.
+   *
+   * Order matters: set `_isFacet` BEFORE triggering initialization, so
+   * the first `onStart()` run (which calls `broadcastMcpServers`) sees
+   * the flag and skips broadcasts that would touch the parent DO's
+   * WebSocket registry.
+   *
+   * @internal Called by {@link subAgent}.
+   */
+  async _cf_initAsFacet(name: string): Promise<void> {
+    this._isFacet = true;
+    await this.ctx.storage.put("cf_agents_is_facet", true);
+    // Seed partyserver's name storage key so `#hydrateNameFromStorage`
+    // picks it up without a network round-trip — same key
+    // partyserver's `setName()` writes.
+    await this.ctx.storage.put("__ps_name", name);
+    await this.__unsafe_ensureInitialized();
+  }
+
+  /**
    * Get or create a named sub-agent — a child Durable Object (facet)
    * with its own isolated SQLite storage running on the same machine.
    *
@@ -3533,19 +3581,13 @@ export class Agent<
       class: ctx.exports![cls.name] as DurableObjectClass
     }));
 
-    // Trigger Server initialization (setName → onStart) via fetch,
-    // same pattern as getAgentByName / getServerByName.
-    const req = new Request(
-      "http://dummy-example.cloudflare.com/cdn-cgi/partyserver/set-name/"
-    );
-    req.headers.set("x-partykit-room", name);
-    await stub.fetch(req).then((res) => res.text());
-
-    // Mark the child as a facet so scheduling methods throw
-    // a clear error instead of crashing on setAlarm().
+    // Initialize the child as a facet via a single RPC that runs
+    // inside the child's isolate. Avoids the cross-DO I/O error that
+    // the previous `stub.fetch(req)` path triggered by handing a
+    // parent-owned Request across the isolate boundary.
     await (
-      stub as unknown as { _cf_markAsFacet(): Promise<void> }
-    )._cf_markAsFacet();
+      stub as unknown as { _cf_initAsFacet(name: string): Promise<void> }
+    )._cf_initAsFacet(name);
 
     return stub as unknown as SubAgentStub<T>;
   }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -3552,7 +3552,7 @@ export class Agent<
    * entry point. The first call for a given name triggers the child's
    * `onStart()`. Subsequent calls return the existing instance.
    *
-   * @experimental Requires the `"experimental"` compatibility flag.
+   * @experimental The API surface may change before stabilizing.
    *
    * @param cls The Agent subclass (must be exported from the worker)
    * @param name Unique name for this child instance
@@ -3571,8 +3571,9 @@ export class Agent<
     const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
     if (!ctx.facets || !ctx.exports) {
       throw new Error(
-        'subAgent() requires the "experimental" compatibility flag. ' +
-          "Add it to your wrangler.jsonc compatibility_flags."
+        "subAgent() is not supported in this runtime — " +
+          "`ctx.facets` / `ctx.exports` are unavailable. " +
+          "Update to the latest `compatibility_date` in your wrangler.jsonc."
       );
     }
     if (!ctx.exports[cls.name]) {
@@ -3606,7 +3607,7 @@ export class Agent<
    * Pending RPC calls receive the reason as an error.
    * Transitively aborts the child's own children.
    *
-   * @experimental Requires the `"experimental"` compatibility flag.
+   * @experimental The API surface may change before stabilizing.
    *
    * @param cls The Agent subclass used when creating the child
    * @param name Name of the child to abort
@@ -3616,7 +3617,9 @@ export class Agent<
     const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
     if (!ctx.facets) {
       throw new Error(
-        'abortSubAgent() requires the "experimental" compatibility flag.'
+        "abortSubAgent() is not supported in this runtime — " +
+          "`ctx.facets` is unavailable. " +
+          "Update to the latest `compatibility_date` in your wrangler.jsonc."
       );
     }
     const facetKey = `${cls.name}\0${name}`;
@@ -3627,7 +3630,7 @@ export class Agent<
    * Delete a sub-agent: abort it if running, then permanently wipe its
    * storage. Transitively deletes the child's own children.
    *
-   * @experimental Requires the `"experimental"` compatibility flag.
+   * @experimental The API surface may change before stabilizing.
    *
    * @param cls The Agent subclass used when creating the child
    * @param name Name of the child to delete
@@ -3636,7 +3639,9 @@ export class Agent<
     const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
     if (!ctx.facets) {
       throw new Error(
-        'deleteSubAgent() requires the "experimental" compatibility flag.'
+        "deleteSubAgent() is not supported in this runtime — " +
+          "`ctx.facets` is unavailable. " +
+          "Update to the latest `compatibility_date` in your wrangler.jsonc."
       );
     }
     const facetKey = `${cls.name}\0${name}`;

--- a/packages/agents/src/tests-d/sub-agent-stub.test-d.ts
+++ b/packages/agents/src/tests-d/sub-agent-stub.test-d.ts
@@ -97,8 +97,8 @@ null! as Stub["abortSubAgent"];
 // @ts-expect-error deleteSubAgent is excluded
 null! as Stub["deleteSubAgent"];
 
-// @ts-expect-error _cf_markAsFacet is excluded
-null! as Stub["_cf_markAsFacet"];
+// @ts-expect-error _cf_initAsFacet is excluded
+null! as Stub["_cf_initAsFacet"];
 
 // ── Agent subclass with extra base methods (AIChatAgent-like) ────────
 // SubAgentStub only excludes `keyof Agent`. Methods added by a middle

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -50,5 +50,6 @@ export {
   CounterSubAgent,
   OuterSubAgent,
   InnerSubAgent,
-  CallbackSubAgent
+  CallbackSubAgent,
+  BroadcastSubAgent
 } from "./sub-agent";

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -164,6 +164,60 @@ class UnexportedSubAgent extends Agent {
   }
 }
 
+// ── SubAgent: Broadcast/state regression cases ─────────────────────
+// Exercises the broadcast paths that used to throw cross-DO I/O
+// before `_isFacet` guards were added to `_broadcastProtocol()` and
+// `broadcast()`. On a facet these calls should no-op, not throw.
+
+type BroadcastState = { count: number; lastMsg: string };
+
+export class BroadcastSubAgent extends Agent<Cloudflare.Env, BroadcastState> {
+  initialState: BroadcastState = { count: 0, lastMsg: "" };
+
+  /** Calls `this.broadcast(...)` directly from a facet RPC. */
+  tryBroadcast(msg: string): string {
+    try {
+      this.broadcast(msg);
+      return "";
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  /**
+   * Calls `this.setState(...)` from a facet RPC. `setState` drives
+   * `_broadcastProtocol()` internally, so this exercises the
+   * `_isFacet` early-return guard there.
+   */
+  trySetState(count: number, msg: string): string {
+    try {
+      this.setState({ count, lastMsg: msg });
+      return "";
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  getCount(): number {
+    return this.state.count;
+  }
+
+  getLastMsg(): string {
+    return this.state.lastMsg;
+  }
+
+  /**
+   * A dummy onStart observation: the base Agent's wrapped `onStart`
+   * calls `broadcastMcpServers()` before the user's `onStart` runs.
+   * If the `_isFacet` flag isn't set in time, that call would throw
+   * when the facet's first init fires. Reaching this method at all
+   * proves init completed cleanly.
+   */
+  initializedOk(): boolean {
+    return true;
+  }
+}
+
 // ── Parent Agent that manages sub-agents ────────────────────────────
 
 export class TestSubAgentParent extends Agent {
@@ -354,5 +408,32 @@ export class TestSubAgentParent extends Agent {
   async subAgentGetStreamLog(subAgentName: string): Promise<string[]> {
     const child = await this.subAgent(CallbackSubAgent, subAgentName);
     return child.getLog();
+  }
+
+  // ── Broadcast / setState regression tests ────────────────────────
+
+  async subAgentTryBroadcast(
+    subAgentName: string,
+    msg: string
+  ): Promise<string> {
+    const child = await this.subAgent(BroadcastSubAgent, subAgentName);
+    return child.tryBroadcast(msg);
+  }
+
+  async subAgentTrySetState(
+    subAgentName: string,
+    count: number,
+    msg: string
+  ): Promise<{ error: string; persistedCount: number; persistedMsg: string }> {
+    const child = await this.subAgent(BroadcastSubAgent, subAgentName);
+    const error = await child.trySetState(count, msg);
+    const persistedCount = await child.getCount();
+    const persistedMsg = await child.getLastMsg();
+    return { error, persistedCount, persistedMsg };
+  }
+
+  async subAgentInitOk(subAgentName: string): Promise<boolean> {
+    const child = await this.subAgent(BroadcastSubAgent, subAgentName);
+    return child.initializedOk();
   }
 }

--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -288,4 +288,51 @@ describe("SubAgent", () => {
     const error = await agent.subAgentTryScheduleAfterAbort("persist-flag");
     expect(error).toMatch(/not supported in sub-agents/);
   });
+
+  // ── Regression: cross-DO I/O on broadcast paths ─────────────────────
+  // Sub-agents share their parent's process but have their own isolate.
+  // On production, iterating the connection registry or sending through
+  // a parent-owned WebSocket from a facet throws "Cannot perform I/O on
+  // behalf of a different Durable Object". The Agent base class guards
+  // every broadcast path with `_isFacet` — these tests pin the guards
+  // in place so they cannot be regressed away.
+
+  describe("broadcast paths on facets", () => {
+    it("should initialize a facet without throwing on first onStart", async () => {
+      const name = uniqueName();
+      const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+      // The wrapped onStart calls `broadcastMcpServers()` before user
+      // code runs. If `_isFacet` is not set before that runs (ordering
+      // regression), the broadcast path can throw cross-DO I/O on
+      // production. Reaching the `initializedOk()` method at all
+      // proves init completed cleanly.
+      const ok = await agent.subAgentInitOk("init-clean");
+      expect(ok).toBe(true);
+    });
+
+    it("should no-op when a sub-agent calls this.broadcast(...)", async () => {
+      const name = uniqueName();
+      const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+      const error = await agent.subAgentTryBroadcast(
+        "broadcaster",
+        "hello from facet"
+      );
+      expect(error).toBe("");
+    });
+
+    it("should persist state but skip broadcast when setState is called in a sub-agent", async () => {
+      const name = uniqueName();
+      const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+      // setState drives `_broadcastProtocol()` under the hood. On a
+      // facet the broadcast must be skipped, but the state mutation
+      // itself must still succeed (SQL + in-memory update).
+      const result = await agent.subAgentTrySetState("stateful", 42, "ping");
+      expect(result.error).toBe("");
+      expect(result.persistedCount).toBe(42);
+      expect(result.persistedMsg).toBe("ping");
+    });
+  });
 });

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -48,6 +48,7 @@ export {
   OuterSubAgent,
   InnerSubAgent,
   CallbackSubAgent,
+  BroadcastSubAgent,
   TestConnectionUriAgent
 } from "./agents";
 export { TestRunFiberAgent } from "./agents/run-fiber";

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -2,7 +2,6 @@
   "compatibility_date": "2026-01-28",
   "compatibility_flags": [
     "nodejs_compat",
-    "experimental",
     // adding these flags since the vitest runner needs them
     "enable_nodejs_tty_module",
     "enable_nodejs_fs_module",

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -255,6 +255,7 @@
         "OuterSubAgent",
         "InnerSubAgent",
         "CallbackSubAgent",
+        "BroadcastSubAgent",
         "TestMigrationAgent",
         "TestConnectionUriAgent"
       ],

--- a/packages/shell/wrangler.jsonc
+++ b/packages/shell/wrangler.jsonc
@@ -2,7 +2,6 @@
   "compatibility_date": "2026-01-28",
   "compatibility_flags": [
     "nodejs_compat",
-    "experimental",
     "enable_nodejs_tty_module",
     "enable_nodejs_fs_module",
     "enable_nodejs_http_modules",

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -4,7 +4,7 @@ An opinionated chat agent base class for Cloudflare Workers. Handles the full ch
 
 Works as both a **top-level agent** (WebSocket chat protocol for browser clients) and a **sub-agent** (RPC streaming from a parent agent).
 
-> **Experimental** — requires the `"experimental"` compatibility flag.
+> **Experimental** — the API surface is stable but may evolve before graduating out of experimental.
 
 ## Quick start
 

--- a/packages/think/src/e2e-tests/wrangler.jsonc
+++ b/packages/think/src/e2e-tests/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "think-e2e-test",
   "main": "worker.ts",
   "compatibility_date": "2026-01-28",
-  "compatibility_flags": ["nodejs_compat", "experimental"],
+  "compatibility_flags": ["nodejs_compat"],
   "ai": { "binding": "AI", "remote": true },
   "define": {
     "__filename": "'index.ts'"

--- a/packages/think/src/extensions/host-bridge.ts
+++ b/packages/think/src/extensions/host-bridge.ts
@@ -15,7 +15,7 @@
  * export { HostBridgeLoopback } from "@cloudflare/think/extensions";
  * ```
  *
- * @experimental Requires the `"experimental"` compatibility flag.
+ * @experimental The API surface may change before stabilizing.
  */
 
 import { WorkerEntrypoint } from "cloudflare:workers";

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -2,7 +2,6 @@
   "compatibility_date": "2026-01-28",
   "compatibility_flags": [
     "nodejs_compat",
-    "experimental",
     "enable_nodejs_tty_module",
     "enable_nodejs_fs_module",
     "enable_nodejs_http_modules",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -38,7 +38,7 @@
  *   - Row size enforcement (compacts large tool outputs)
  *   - Resumable streams (replay on reconnect)
  *
- * @experimental Requires the `"experimental"` compatibility flag.
+ * @experimental The API surface may change before stabilizing.
  *
  * @example
  * ```typescript
@@ -391,7 +391,7 @@ export type ChatResponseResult = {
 /**
  * An opinionated chat agent base class.
  *
- * @experimental Requires the `"experimental"` compatibility flag.
+ * @experimental The API surface may change before stabilizing.
  */
 export class Think<
   Env extends Cloudflare.Env = Cloudflare.Env,

--- a/packages/voice/src/tests/wrangler.jsonc
+++ b/packages/voice/src/tests/wrangler.jsonc
@@ -2,7 +2,6 @@
   "compatibility_date": "2026-01-28",
   "compatibility_flags": [
     "nodejs_compat",
-    "experimental",
     "enable_nodejs_tty_module",
     "enable_nodejs_fs_module",
     "enable_nodejs_http_modules",


### PR DESCRIPTION
## Summary

Fixes [#1329](https://github.com/cloudflare/agents/issues/1329) — `subAgent()` was failing on first use in production with:

> `Cannot perform I/O on behalf of a different Durable Object. (I/O type: Native)`

Enormous thanks to **[@rawwerks](https://github.com/rawwerks)** (Raymond Weitekamp) for the precise diagnosis, root-causing all three interacting failure modes, and the working fix. The initial commit on this branch is theirs, cherry-picked with attribution preserved. This PR layers on regression tests, a changeset, a small perf tweak, removal of the now-unused `_cf_markAsFacet()` internal method, and a broader cleanup: the `"experimental"` compatibility flag is no longer required anywhere the repo uses `ctx.facets`, `ctx.exports`, or `env.LOADER`.

## The three interacting bugs

All three had to be fixed together — none works in isolation.

### 1. Cross-DO `Request` in `subAgent()`

`subAgent()` constructed a `new Request(...)` inside the parent DO's isolate and handed it to the child via `stub.fetch(req)`. In workerd, a `Request` carries native I/O state tied to its originating isolate; routing that across the DO boundary to a sibling facet trips the cross-DO I/O guard. `partyserver.getServerByName()` avoided the issue by using RPC (`stub.setName(...)`) rather than fetch, which is the pattern the fix adopts.

### 2. Flag-set-after-init ordering

The previous order was `stub.fetch()` → `setName(name)` → `#ensureInitialized()` → first `onStart()` → **then** `_cf_markAsFacet()`. The Agents-wrapped `onStart()` calls `broadcastMcpServers()` before user code runs, so on the initial boot `_isFacet` was still `false` and the broadcast path iterated the (child's view of the) connection registry.

### 3. Broadcast paths weren't `_isFacet`-guarded

The scheduling guards on `schedule()` / `keepAlive()` / `cancelSchedule()` were in place, but no broadcast path was: `_broadcastProtocol()` iterated `this.getConnections()` unconditionally, and `_workflow_broadcast()` plus user-level `this.broadcast(...)` calls (for example, AIChatAgent's streaming writes) bypassed `_broadcastProtocol()` entirely.

## The fix (commit [76f75723](https://github.com/cloudflare/agents/pull/1330/commits/76f75723) — @rawwerks)

- **New `_cf_initAsFacet(name)` RPC on `Agent`** — runs entirely inside the child's isolate. Sets `_isFacet` (in memory + storage) first, seeds partyserver's `__ps_name` key directly, then calls `__unsafe_ensureInitialized()`. Order matters: by the time the first `onStart()` runs, the flag is already `true`, so `broadcastMcpServers()` sees it.
- **`subAgent()` switches from fetch to RPC** — replaces the synthetic `Request` + `stub.fetch()` with the single new RPC. Eliminates the cross-DO I/O at the source.
- **Guard `_broadcastProtocol()`** with `if (this._isFacet) return;`. Facets have no WebSocket clients of their own, so the guard is semantically sound as well as defensive.
- **Override `broadcast()`** at the `Agent` level so any caller that bypasses `_broadcastProtocol` (chat-streaming paths, workflow broadcasts, user `this.broadcast(...)`) is also covered. Non-facet path delegates to `super.broadcast()` unchanged.

## Follow-up work

### Regression tests (commit [27e591d6](https://github.com/cloudflare/agents/pull/1330/commits/27e591d6))

The existing sub-agent suite (re-enabled in #1287) passed against the broken code because none of the test fixtures exercised a broadcast path on a facet. Added a new `BroadcastSubAgent` fixture and three regression tests in `packages/agents/src/tests/sub-agent.test.ts`:

- First-`onStart()` on a facet completes without throwing (pins the ordering fix).
- `this.broadcast(...)` from a facet RPC no-ops instead of throwing (pins the `broadcast()` override).
- `this.setState({...})` in a facet persists state **and** skips the broadcast (pins the `_broadcastProtocol` guard, and verifies the state mutation itself still works).

Also parallelized the two `ctx.storage.put` calls inside `_cf_initAsFacet` via `Promise.all` (saves one round-trip).

### Drop `"experimental"` compat flag requirement (commit [045c0043](https://github.com/cloudflare/agents/pull/1330/commits/045c0043))

`ctx.facets`, `ctx.exports`, and `env.LOADER` have graduated out of the `"experimental"` compat flag in workerd, so we no longer need it anywhere in this repo:

- Removed `"experimental"` from every `wrangler.jsonc` that had it — agents tests, gadgets-* examples, shell, think tests + e2e-tests, voice tests, worker-bundler-playground, assistant, session-skills.
- Runtime error strings on `subAgent()` / `abortSubAgent()` / `deleteSubAgent()` no longer reference the flag. The `ctx.facets` / `ctx.exports` guards stay in place and now nudge users to update their `compatibility_date` if `ctx.facets` is somehow missing.
- `@experimental` JSDoc tags on the sub-agent methods, `Think`, and `HostBridgeLoopback` dropped the "requires the experimental compat flag" phrasing. The `@experimental` tag itself stays to signal API-surface stability.
- Updated prose docs (`experimental/gadgets.md`, `docs/think/*`, `packages/think/README.md`, gadgets-gatekeeper header comment) to match.
- Surgical updates to `design/rfc-sub-agents.md` — annotated the three flag-requirement claims as "At the time of this RFC…" rather than rewriting the historical reasoning.

### Remove `_cf_markAsFacet()` (commit [5c9b42d2](https://github.com/cloudflare/agents/pull/1330/commits/5c9b42d2))

The old internal handshake method `_cf_markAsFacet()` set `_isFacet` without triggering initialization, leaving it up to the caller to also invoke `setName` (which then ran the first `onStart` with the wrong flag value — the ordering bug fixed above). The replacement `_cf_initAsFacet(name)` is the single correct entry point: flag first, init second. With `subAgent()` switched over to it, there are zero remaining callers.

Initially this PR kept `_cf_markAsFacet()` around with an `@deprecated` tag for back-compat. On reflection, keeping it is a footgun — a future caller could reach for it not realizing the ordering is wrong. Given:

- it's `@internal` / `_cf_`-prefixed (our contract that it's not public),
- has no remaining callers (runtime, test, or docs),
- shipped in only one prior release (#1088),

it's safe to drop on a patch. The type-level test in `sub-agent-stub.test-d.ts` was updated to use `_cf_initAsFacet` as its sentinel for "internal methods don't leak into `SubAgentStub<T>`".

## Why the bug didn't show up earlier

The existing tests run in `@cloudflare/vitest-pool-workers`, which has historically had looser cross-DO I/O enforcement than production. On top of that, none of the test fixtures registered MCP servers on a facet, called `setState` on a facet, or called `this.broadcast` from a facet — so the broadcast paths weren't exercised even where enforcement was tighter. @rawwerks caught it on a real deployment via `wrangler tail`, spawning four sequential + parallel sub-agents via `subAgent()` + RPC `chat()` + `getMessages()`.

## Test plan

- [x] `npx vitest run -r src/tests sub-agent.test.ts` in `packages/agents` — **25/25 pass** (22 existing + 3 new regression tests)
- [x] Full `packages/agents` suite — **954/954 pass**, 7 skipped unrelated
- [x] `nx run-many -t test` — all projects green (ai-chat 458/458, think 232/232 units, shell 212/212, voice, codemode, worker-bundler, etc.)
- [x] `npm run check` at repo root — all 73 projects typecheck; sherif, exports, oxfmt, oxlint clean
- [x] Changeset added (`agents`: patch, `@cloudflare/think`: patch) covering both the cross-DO I/O fix and the flag-requirement drop

## Companion PR

Matching docs update on developers.cloudflare.com (drop the `"experimental"` flag from the `sub-agents` and `think` wrangler snippets, plus a more precise limitations table for sub-agents): [cloudflare-docs `fix-agents-experimental` branch](https://github.com/cloudflare/cloudflare-docs/tree/fix-agents-experimental) — PR to be opened separately.

Closes #1329