### PR TITLE
feat: expose createdAt on fiber and chat recovery contexts

### DIFF
--- a/.changeset/fiber-recovery-created-at.md
+++ b/.changeset/fiber-recovery-created-at.md
@@ -1,7 +1,7 @@
 ---
-"agents": minor
-"@cloudflare/ai-chat": minor
-"@cloudflare/think": minor
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
 ---
 
 Expose `createdAt` on fiber and chat recovery contexts so apps can suppress continuations for stale, interrupted turns.

--- a/.changeset/fiber-recovery-created-at.md
+++ b/.changeset/fiber-recovery-created-at.md
@@ -1,0 +1,21 @@
+---
+"agents": minor
+"@cloudflare/ai-chat": minor
+"@cloudflare/think": minor
+---
+
+Expose `createdAt` on fiber and chat recovery contexts so apps can suppress continuations for stale, interrupted turns.
+
+- `FiberRecoveryContext` (from `agents`) gains `createdAt: number` — epoch milliseconds when `runFiber` started, read from the `cf_agents_runs` row that was already tracked internally.
+- `ChatRecoveryContext` (from `@cloudflare/ai-chat` and `@cloudflare/think`) gains the same `createdAt` field, threaded through from the underlying fiber.
+
+With this, the stale-recovery guard pattern described in [#1324](https://github.com/cloudflare/agents/issues/1324) is a short override:
+
+```typescript
+override async onChatRecovery(ctx: ChatRecoveryContext): Promise<ChatRecoveryOptions> {
+  if (Date.now() - ctx.createdAt > 2 * 60 * 1000) return { continue: false };
+  return {};
+}
+```
+
+No behavior change for existing callers. See `docs/chat-agents.md` (new "Guarding against stale recoveries" section) for the full recipe, including a loop-protection pattern using `onChatResponse`.

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -609,6 +609,7 @@ export class ChatAgent extends AIChatAgent {
 | `messages`        | `ChatMessage[]`                        | Full conversation history                                             |
 | `lastBody`        | `Record<string, unknown> \| undefined` | The original request body                                             |
 | `lastClientTools` | `ClientToolSchema[] \| undefined`      | Client tool schemas from the original request                         |
+| `createdAt`       | `number`                               | Epoch milliseconds when the underlying fiber started                  |
 
 **`ChatRecoveryOptions`:**
 
@@ -622,6 +623,55 @@ Common return values:
 - `{}` — persist partial + auto-continue (default, works with providers that support assistant prefill)
 - `{ continue: false }` — persist partial but do not auto-continue (handle continuation yourself)
 - `{ persist: false, continue: false }` — handle everything yourself (e.g., retrieve a completed response from the provider)
+
+#### Guarding against stale recoveries
+
+After a long outage (an eviction combined with a slow reactivation, or a tool/container that became unreachable mid-stream), auto-continuing can replay a turn the user has already moved on from — or worse, kick off a continuation that keeps failing in the same way and occupies the turn queue while new messages pile up behind it.
+
+Use `ctx.createdAt` to suppress continuation for turns that have been orphaned too long:
+
+```typescript
+override async onChatRecovery(
+  ctx: ChatRecoveryContext
+): Promise<ChatRecoveryOptions> {
+  const ageMs = Date.now() - ctx.createdAt;
+  if (ageMs > 2 * 60 * 1000) {
+    // Persist whatever was already streamed so the user sees it, but do not
+    // spawn a fresh inference against a potentially broken tool state.
+    return { continue: false };
+  }
+  return {};
+}
+```
+
+For loop protection (suppressing continuation after N recoveries of the same turn), pair this with a small per-assistant-message counter that `onChatResponse` clears on successful completion. The counter lives entirely in your agent — no framework support required:
+
+```typescript
+override async onChatRecovery(
+  ctx: ChatRecoveryContext
+): Promise<ChatRecoveryOptions> {
+  const target = ctx.messages.filter((m) => m.role === "assistant").at(-1);
+  if (!target) return {};
+
+  const row = this.sql<{ count: number }>`
+    SELECT count FROM my_recoveries WHERE assistant_id = ${target.id}
+  `;
+  const count = (row[0]?.count ?? 0) + 1;
+  this.sql`
+    INSERT INTO my_recoveries (assistant_id, count, last_at)
+    VALUES (${target.id}, ${count}, ${Date.now()})
+    ON CONFLICT(assistant_id) DO UPDATE SET count = excluded.count, last_at = excluded.last_at
+  `;
+  if (count >= 2) return { continue: false };
+  return {};
+}
+
+override async onChatResponse(result: ChatResponseResult): Promise<void> {
+  if (result.status === "completed") {
+    this.sql`DELETE FROM my_recoveries WHERE assistant_id = ${result.message.id}`;
+  }
+}
+```
 
 #### `continueLastTurn`
 

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -127,6 +127,7 @@ type FiberRecoveryContext = {
   id: string;
   name: string;
   snapshot: unknown | null;
+  createdAt: number;
 };
 ```
 
@@ -323,6 +324,7 @@ Called once per orphaned fiber row on agent restart. Override to implement recov
 - **`ctx.id`** — unique fiber ID
 - **`ctx.name`** — the name passed to `runFiber()`
 - **`ctx.snapshot`** — the last `stash()` data, or `null` if `stash()` was never called
+- **`ctx.createdAt`** — epoch milliseconds when `runFiber` started. Compare against `Date.now()` to gate stale recoveries (e.g. skip work that has been orphaned too long to replay safely)
 
 ### `keepAlive()`
 

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -261,16 +261,17 @@ onChatRecovery(ctx: ChatRecoveryContext): ChatRecoveryOptions | void
 
 ### ChatRecoveryContext
 
-| Field             | Type                       | Description                               |
-| ----------------- | -------------------------- | ----------------------------------------- |
-| `streamId`        | `string`                   | The stream ID of the interrupted turn     |
-| `requestId`       | `string`                   | The request ID of the interrupted turn    |
-| `partialText`     | `string`                   | Text generated before the interruption    |
-| `partialParts`    | `MessagePart[]`            | Parts accumulated before the interruption |
-| `recoveryData`    | `unknown \| null`          | Data from `this.stash()` during the turn  |
-| `messages`        | `UIMessage[]`              | Current conversation history              |
-| `lastBody`        | `Record<string, unknown>?` | Body from the interrupted turn            |
-| `lastClientTools` | `ClientToolSchema[]?`      | Client tools from the interrupted turn    |
+| Field             | Type                       | Description                                          |
+| ----------------- | -------------------------- | ---------------------------------------------------- |
+| `streamId`        | `string`                   | The stream ID of the interrupted turn                |
+| `requestId`       | `string`                   | The request ID of the interrupted turn               |
+| `partialText`     | `string`                   | Text generated before the interruption               |
+| `partialParts`    | `MessagePart[]`            | Parts accumulated before the interruption            |
+| `recoveryData`    | `unknown \| null`          | Data from `this.stash()` during the turn             |
+| `messages`        | `UIMessage[]`              | Current conversation history                         |
+| `lastBody`        | `Record<string, unknown>?` | Body from the interrupted turn                       |
+| `lastClientTools` | `ClientToolSchema[]?`      | Client tools from the interrupted turn               |
+| `createdAt`       | `number`                   | Epoch milliseconds when the underlying fiber started |
 
 ### ChatRecoveryOptions
 
@@ -302,6 +303,17 @@ export class MyAgent extends Think<Env> {
 ```
 
 With `persist: true`, the partial message is saved. With `continue: true`, Think calls `continueLastTurn()` after the agent reaches a stable state.
+
+To suppress continuation for turns that have been orphaned too long to safely replay, gate on `ctx.createdAt`:
+
+```typescript
+onChatRecovery(ctx: ChatRecoveryContext): ChatRecoveryOptions {
+  if (Date.now() - ctx.createdAt > 2 * 60 * 1000) {
+    return { continue: false };
+  }
+  return {};
+}
+```
 
 ---
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -370,6 +370,11 @@ export type FiberRecoveryContext = {
   name: string;
   /** Last checkpoint data from `stash()`, or null if never stashed. */
   snapshot: unknown | null;
+  /**
+   * Epoch milliseconds when the fiber row was inserted (when `runFiber`
+   * started). Use `Date.now() - createdAt` to gate stale recoveries.
+   */
+  createdAt: number;
   [key: string]: unknown;
 };
 
@@ -3167,7 +3172,8 @@ export class Agent<
         id: string;
         name: string;
         snapshot: string | null;
-      }>`SELECT id, name, snapshot FROM cf_agents_runs`;
+        created_at: number;
+      }>`SELECT id, name, snapshot, created_at FROM cf_agents_runs`;
 
       for (const row of rows) {
         if (this._runFiberActiveFibers.has(row.id)) continue;
@@ -3186,7 +3192,8 @@ export class Agent<
         const ctx: FiberRecoveryContext = {
           id: row.id,
           name: row.name,
-          snapshot
+          snapshot,
+          createdAt: row.created_at
         };
 
         try {

--- a/packages/agents/src/tests/run-fiber.test.ts
+++ b/packages/agents/src/tests/run-fiber.test.ts
@@ -128,6 +128,7 @@ describe("runFiber", () => {
         "recovery-basic"
       );
 
+      const before = Date.now();
       // Simulate an interrupted fiber by inserting a row directly
       await agent.insertInterruptedFiber("fiber-1", "research");
       await agent.triggerRecoveryCheck();
@@ -138,6 +139,9 @@ describe("runFiber", () => {
       expect(recovered[0].id).toBe("fiber-1");
       expect(recovered[0].name).toBe("research");
       expect(recovered[0].snapshot).toBeNull();
+      expect(typeof recovered[0].createdAt).toBe("number");
+      expect(recovered[0].createdAt).toBeGreaterThanOrEqual(before);
+      expect(recovered[0].createdAt).toBeLessThanOrEqual(Date.now());
     });
 
     it("should pass snapshot data to recovery", async () => {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -120,6 +120,12 @@ export type ChatRecoveryContext = {
   lastBody?: Record<string, unknown>;
   /** Client tool schemas from the last chat request. */
   lastClientTools?: ClientToolSchema[];
+  /**
+   * Epoch milliseconds when the underlying fiber was started. Compare against
+   * `Date.now()` to suppress continuations for turns that have been orphaned
+   * too long to safely replay.
+   */
+  createdAt: number;
 };
 
 /**
@@ -2301,7 +2307,8 @@ export class AIChatAgent<
       recoveryData: ctx.snapshot,
       messages: [...this.messages],
       lastBody: this._lastBody,
-      lastClientTools: this._lastClientTools
+      lastClientTools: this._lastClientTools,
+      createdAt: ctx.createdAt
     });
 
     // Only persist and complete if the stream is still active. The ACK

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -85,21 +85,56 @@ describe("onChatRecovery", () => {
 
     await agentStub.setRecoveryOverride({ continue: false });
 
+    const ageMs = 10 * 60 * 1000;
     await agentStub.insertInterruptedStream(
       "stream-stale",
       "req-stale",
       makeChunks(["Stale content"]),
-      10 * 60 * 1000
+      ageMs
     );
     await agentStub.triggerInterruptedStreamCheck();
 
     const contexts = (await agentStub.getRecoveryContexts()) as Array<{
       streamId: string;
       partialText: string;
+      createdAt: number;
     }>;
 
     expect(contexts).toHaveLength(1);
     expect(contexts[0].partialText).toBe("Stale content");
+    expect(typeof contexts[0].createdAt).toBe("number");
+    // createdAt reflects the back-dated stream age so apps can gate on it.
+    expect(Date.now() - contexts[0].createdAt).toBeGreaterThanOrEqual(
+      ageMs - 1000
+    );
+  });
+
+  it("should expose createdAt on the recovery context for fiber recovery", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+
+    await agentStub.setRecoveryOverride({ continue: false });
+
+    const before = Date.now();
+    await agentStub.insertInterruptedStream(
+      "stream-createdat",
+      "req-createdat",
+      makeChunks(["Hi"])
+    );
+    await agentStub.insertInterruptedFiber(
+      "__cf_internal_chat_turn:req-createdat"
+    );
+    await agentStub.triggerFiberRecovery();
+
+    const contexts = (await agentStub.getRecoveryContexts()) as Array<{
+      requestId: string;
+      createdAt: number;
+    }>;
+    const match = contexts.find((c) => c.requestId === "req-createdat");
+    expect(match).toBeDefined();
+    expect(typeof match!.createdAt).toBe("number");
+    expect(match!.createdAt).toBeGreaterThanOrEqual(before);
+    expect(match!.createdAt).toBeLessThanOrEqual(Date.now());
   });
 
   it("should persist partial by default (persist !== false)", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1299,6 +1299,11 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 
     const partial = this.getPartialText(streamId);
 
+    const metadataRows = this.sql<{ created_at: number }>`
+      select created_at from cf_ai_chat_stream_metadata where id = ${streamId}
+    `;
+    const createdAt = metadataRows[0]?.created_at ?? Date.now();
+
     const options = await this.onChatRecovery({
       streamId,
       requestId,
@@ -1307,7 +1312,8 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
       recoveryData: null,
       messages: [...this.messages],
       lastBody: this._lastBody,
-      lastClientTools: this._lastClientTools
+      lastClientTools: this._lastClientTools,
+      createdAt
     });
 
     if (options.persist !== false) {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -895,6 +895,7 @@ export class ThinkRecoveryTestAgent extends Think {
     recoveryData: unknown;
     partialText: string;
     streamId: string;
+    createdAt: number;
   }> = [];
   private _recoveryOverride: ChatRecoveryOptions = {};
   private _turnCallCount = 0;
@@ -927,7 +928,8 @@ export class ThinkRecoveryTestAgent extends Think {
     this._recoveryContexts.push({
       recoveryData: ctx.recoveryData,
       partialText: ctx.partialText,
-      streamId: ctx.streamId
+      streamId: ctx.streamId,
+      createdAt: ctx.createdAt
     });
     return this._recoveryOverride;
   }
@@ -957,7 +959,12 @@ export class ThinkRecoveryTestAgent extends Think {
   }
 
   async getRecoveryContexts(): Promise<
-    Array<{ recoveryData: unknown; partialText: string; streamId: string }>
+    Array<{
+      recoveryData: unknown;
+      partialText: string;
+      streamId: string;
+      createdAt: number;
+    }>
   > {
     return this._recoveryContexts;
   }

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -1085,6 +1085,7 @@ describe("Think — onChatRecovery", () => {
         index: 2
       }
     ]);
+    const before = Date.now();
     await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-1");
 
     await agent.triggerFiberRecovery();
@@ -1093,12 +1094,16 @@ describe("Think — onChatRecovery", () => {
       recoveryData: unknown;
       partialText: string;
       streamId: string;
+      createdAt: number;
     }>;
     expect(contexts.length).toBeGreaterThanOrEqual(1);
 
     const ctx = contexts[contexts.length - 1];
     expect(ctx.partialText).toBe("Partial text");
     expect(ctx.streamId).toBe("stream-1");
+    expect(typeof ctx.createdAt).toBe("number");
+    expect(ctx.createdAt).toBeGreaterThanOrEqual(before);
+    expect(ctx.createdAt).toBeLessThanOrEqual(Date.now());
   });
 
   it("stashed data round-trips through fiber recovery", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -179,6 +179,12 @@ export type ChatRecoveryContext = {
   messages: UIMessage[];
   lastBody?: Record<string, unknown>;
   lastClientTools?: ClientToolSchema[];
+  /**
+   * Epoch milliseconds when the underlying fiber was started. Compare against
+   * `Date.now()` to suppress continuations for turns that have been orphaned
+   * too long to safely replay.
+   */
+  createdAt: number;
 };
 
 /**
@@ -2197,7 +2203,8 @@ export class Think<
       recoveryData: ctx.snapshot,
       messages: [...this.messages],
       lastBody: this._lastBody,
-      lastClientTools: this._lastClientTools
+      lastClientTools: this._lastClientTools,
+      createdAt: ctx.createdAt
     });
 
     const streamStillActive =


### PR DESCRIPTION
## Summary

Closes #1324 (partially — see follow-ups below).

Surfaces the fiber's `createdAt` timestamp on the recovery context so apps can gate continuation on age without falling back to raw SQL against `cf_agents_runs` / `cf_ai_chat_stream_metadata`. This is the minimum mechanism that unlocks the stale-guard and loop-guard policies discussed in the issue thread; per the discussion, `reason` and `priorRecoveryCount` are intentionally left out of this PR (see [Design notes](#design-notes)).

- `FiberRecoveryContext` (from `agents`) gains `createdAt: number` — epoch milliseconds, read from the existing `cf_agents_runs.created_at` column.
- `ChatRecoveryContext` (from `@cloudflare/ai-chat` and `@cloudflare/think`) threads the same field through from the underlying fiber.
- Tests: new assertions in `run-fiber.test.ts`, `durable-chat-recovery.test.ts`, and `think-session.test.ts`.
- Docs: updates the three reference tables (`docs/durable-execution.md`, `docs/chat-agents.md`, `docs/think/sub-agents.md`) and adds a "Guarding against stale recoveries" section in `chat-agents.md` with both the age-guard and loop-guard recipes.

No behavior change for existing callers. Pure additive type change.

## Recipe this enables

```typescript
override async onChatRecovery(
  ctx: ChatRecoveryContext
): Promise<ChatRecoveryOptions> {
  if (Date.now() - ctx.createdAt > 2 * 60 * 1000) {
    // Persist the partial so the user sees it, but do not replay a turn
    // that has been orphaned long enough to be unsafe.
    return { continue: false };
  }
  return {};
}
```

## Design notes

The issue thread also proposed `reason` and `priorRecoveryCount`. Both are skipped here deliberately:

- **`reason`** — the framework genuinely cannot distinguish eviction / crash / timeout (a hard crash doesn't get to write a farewell note). Shipping a field that would always be `"unknown"` creates false expectations.
- **`priorRecoveryCount`** — the naive "counter keyed by fiber name" is always 1 for chat, because `continueLastTurn` mints a fresh `requestId` per continuation, so every recovered turn has a new fiber name. The correct lineage key (target assistant message ID vs. conversation ID) and the reset semantics (clear on completion? on new user message? TTL?) are app-specific. Better as a documented userland recipe — the stale-guard section in `chat-agents.md` includes the full loop-protection pattern using `onChatResponse` for reset.

If `priorRecoveryCount` proves necessary after real usage data, we can add a framework-level counter keyed by target assistant message ID in a follow-up PR.

## Test plan

- [x] `npm run check` — all 73 projects typecheck, lint clean, formatting clean
- [x] `npx nx run agents:test:workers` — 954 pass / 7 skipped
- [x] `npx nx run @cloudflare/ai-chat:test` — 459 pass
- [x] `npx nx run @cloudflare/think:test` — 232 pass
- [x] Changeset added (`minor` bump for `agents`, `@cloudflare/ai-chat`, `@cloudflare/think`)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
