### PR TITLE
feat(worker-bundler): expose jsx, define, loader, conditions + plugin escape hatch

### DIFF
--- a/.changeset/worker-bundler-advanced-options.md
+++ b/.changeset/worker-bundler-advanced-options.md
@@ -1,0 +1,27 @@
+---
+"@cloudflare/worker-bundler": patch
+---
+
+`createWorker` and `createApp` now accept a handful of extra esbuild knobs that previously required forking or patching the package:
+
+- `jsx` (`"transform" | "preserve" | "automatic"`)
+- `jsxImportSource`
+- `define` (compile-time constant replacement)
+- `loader` (per-extension loader overrides — e.g. `{ ".svg": "text", ".wasm": "binary" }`; built-in handling for `.ts`/`.tsx`/`.js`/`.jsx`/`.json`/`.css` is preserved unless overridden, and longer extensions match first so `".d.ts"` wins over `".ts"`). The accepted values are deliberately narrowed to the portable `BundlerLoader` set (`js`/`jsx`/`ts`/`tsx`/`json`/`css`/`text`/`binary`/`base64`/`dataurl`) — esbuild-specific loaders like `file`/`copy`/`empty`/`default` are intentionally excluded. `file`/`copy` would silently break in this bundler today (they emit secondary output files that get discarded), and anything outside the portable set should go through the plugin escape hatch instead.
+- `conditions` (package export conditions, e.g. `["workerd", "worker", "browser"]`)
+
+The first five are re-typed locally (`JsxMode`, `BundlerLoader`) so the published `.d.ts` does not import from `esbuild-wasm` — a future bundler swap is a refactor, not a breaking type change.
+
+For advanced consumers (RSC-style transforms, custom asset pipelines, codegen) there is also an explicit escape hatch:
+
+```ts
+__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired?: unknown[]
+```
+
+The deliberately unwieldy name is the API contract: this option is **not** covered by semver, can change shape or be removed in any release, and ties the caller to esbuild's plugin shape — if this package switches bundlers, plugins authored against it will break. It is typed as `unknown[]` at the public boundary (cast `Plugin[]` from `esbuild-wasm` when passing in) so the published types don't acquire a hard dependency on esbuild. User plugins run before the internal virtual-filesystem plugin, so their `onResolve`/`onLoad` claims fire first.
+
+In `createApp`, all of these options apply to both the server and client bundles.
+
+The internal `bundleWithEsbuild` signature was refactored from a long positional argument list to a single options object so future bundler knobs can be added without churning every call site. This is an internal change; no public API moved.
+
+Inspired by [#1321](https://github.com/cloudflare/agents/issues/1321) — thanks @bndkt for the draft and the RSC-on-Workers proof-of-concept that motivated it.

--- a/packages/worker-bundler/README.md
+++ b/packages/worker-bundler/README.md
@@ -107,16 +107,22 @@ Static assets are served with proper content types, ETags, and caching. Requests
 
 Bundles source files into a Worker.
 
-| Option       | Type                                   | Default                        | Description                                                       |
-| ------------ | -------------------------------------- | ------------------------------ | ----------------------------------------------------------------- |
-| `files`      | `Record<string, string> \| FileSystem` | _required_                     | Input files — plain object or any `FileSystem` implementation     |
-| `entryPoint` | `string`                               | auto-detected                  | Entry point file path                                             |
-| `bundle`     | `boolean`                              | `true`                         | Bundle all dependencies into one file                             |
-| `externals`  | `string[]`                             | `[]`                           | Modules to exclude from bundling (`cloudflare:*` always external) |
-| `target`     | `string`                               | `'es2022'`                     | Target environment                                                |
-| `minify`     | `boolean`                              | `false`                        | Minify output                                                     |
-| `sourcemap`  | `boolean`                              | `false`                        | Generate inline source maps                                       |
-| `registry`   | `string`                               | `'https://registry.npmjs.org'` | npm registry URL                                                  |
+| Option                                                   | Type                                       | Default                        | Description                                                                                                                                                        |
+| -------------------------------------------------------- | ------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `files`                                                  | `Record<string, string> \| FileSystem`     | _required_                     | Input files — plain object or any `FileSystem` implementation                                                                                                      |
+| `entryPoint`                                             | `string`                                   | auto-detected                  | Entry point file path                                                                                                                                              |
+| `bundle`                                                 | `boolean`                                  | `true`                         | Bundle all dependencies into one file                                                                                                                              |
+| `externals`                                              | `string[]`                                 | `[]`                           | Modules to exclude from bundling (`cloudflare:*` always external)                                                                                                  |
+| `target`                                                 | `string`                                   | `'es2022'`                     | Target environment                                                                                                                                                 |
+| `minify`                                                 | `boolean`                                  | `false`                        | Minify output                                                                                                                                                      |
+| `sourcemap`                                              | `boolean`                                  | `false`                        | Generate inline source maps                                                                                                                                        |
+| `registry`                                               | `string`                                   | `'https://registry.npmjs.org'` | npm registry URL                                                                                                                                                   |
+| `jsx`                                                    | `"transform" \| "preserve" \| "automatic"` | esbuild default                | JSX transform mode                                                                                                                                                 |
+| `jsxImportSource`                                        | `string`                                   | esbuild default                | JSX runtime import source (e.g. `"react"`, `"preact"`)                                                                                                             |
+| `define`                                                 | `Record<string, string>`                   | `{}`                           | Constant replacements applied at bundle time                                                                                                                       |
+| `loader`                                                 | `Record<string, BundlerLoader>`            | `{}`                           | Per-extension loader overrides (e.g. `{ ".svg": "text", ".wasm": "binary" }`). See [Advanced bundler options](#advanced-bundler-options) for the supported set.    |
+| `conditions`                                             | `string[]`                                 | esbuild default                | Package export conditions to honour during resolution                                                                                                              |
+| `__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired` | `unknown[]`                                | `[]`                           | Escape hatch: extra esbuild plugins, run before the internal virtual-fs plugin. Not covered by semver — see [Advanced bundler options](#advanced-bundler-options). |
 
 Returns:
 
@@ -133,19 +139,25 @@ Returns:
 
 Builds a full-stack app: server Worker + client bundle + static assets.
 
-| Option        | Type                                    | Default       | Description                                         |
-| ------------- | --------------------------------------- | ------------- | --------------------------------------------------- |
-| `files`       | `Record<string, string> \| FileSystem`  | _required_    | All source files — plain object or any `FileSystem` |
-| `server`      | `string`                                | auto-detected | Server entry point (Worker fetch handler)           |
-| `client`      | `string \| string[]`                    | —             | Client entry point(s) to bundle for the browser     |
-| `assets`      | `Record<string, string \| ArrayBuffer>` | —             | Static assets (pathname → content)                  |
-| `assetConfig` | `AssetConfig`                           | —             | Asset serving configuration                         |
-| `bundle`      | `boolean`                               | `true`        | Bundle server dependencies                          |
-| `externals`   | `string[]`                              | `[]`          | Modules to exclude from bundling                    |
-| `target`      | `string`                                | `'es2022'`    | Server target environment                           |
-| `minify`      | `boolean`                               | `false`       | Minify output                                       |
-| `sourcemap`   | `boolean`                               | `false`       | Generate source maps                                |
-| `registry`    | `string`                                | npm default   | npm registry URL                                    |
+| Option                                                   | Type                                       | Default         | Description                                                                                                                                  |
+| -------------------------------------------------------- | ------------------------------------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `files`                                                  | `Record<string, string> \| FileSystem`     | _required_      | All source files — plain object or any `FileSystem`                                                                                          |
+| `server`                                                 | `string`                                   | auto-detected   | Server entry point (Worker fetch handler)                                                                                                    |
+| `client`                                                 | `string \| string[]`                       | —               | Client entry point(s) to bundle for the browser                                                                                              |
+| `assets`                                                 | `Record<string, string \| ArrayBuffer>`    | —               | Static assets (pathname → content)                                                                                                           |
+| `assetConfig`                                            | `AssetConfig`                              | —               | Asset serving configuration                                                                                                                  |
+| `bundle`                                                 | `boolean`                                  | `true`          | Bundle server dependencies                                                                                                                   |
+| `externals`                                              | `string[]`                                 | `[]`            | Modules to exclude from bundling                                                                                                             |
+| `target`                                                 | `string`                                   | `'es2022'`      | Server target environment                                                                                                                    |
+| `minify`                                                 | `boolean`                                  | `false`         | Minify output                                                                                                                                |
+| `sourcemap`                                              | `boolean`                                  | `false`         | Generate source maps                                                                                                                         |
+| `registry`                                               | `string`                                   | npm default     | npm registry URL                                                                                                                             |
+| `jsx`                                                    | `"transform" \| "preserve" \| "automatic"` | esbuild default | JSX transform mode (applied to both server and client bundles)                                                                               |
+| `jsxImportSource`                                        | `string`                                   | esbuild default | JSX runtime import source (e.g. `"react"`, `"preact"`)                                                                                       |
+| `define`                                                 | `Record<string, string>`                   | `{}`            | Constant replacements applied at bundle time (both server and client)                                                                        |
+| `loader`                                                 | `Record<string, BundlerLoader>`            | `{}`            | Per-extension loader overrides (e.g. `{ ".svg": "text" }`). See [Advanced bundler options](#advanced-bundler-options) for the supported set. |
+| `conditions`                                             | `string[]`                                 | esbuild default | Package export conditions to honour during resolution                                                                                        |
+| `__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired` | `unknown[]`                                | `[]`            | Escape hatch: extra esbuild plugins. See [Advanced bundler options](#advanced-bundler-options).                                              |
 
 Returns everything from `createWorker` plus:
 
@@ -473,6 +485,117 @@ const { mainModule, modules } = await createWorker({
     /* ... */
   },
   bundle: false
+});
+```
+
+## Advanced bundler options
+
+`createWorker` and `createApp` cover the common cases (target, minify, sourcemap, externals). The options below are escape hatches for advanced consumers — RSC-style transforms, custom asset pipelines, library bundling.
+
+> **All options in this section require `bundle: true`** (the default). Transform-only mode (`bundle: false`) skips esbuild entirely and uses sucrase + naïve module resolution instead, so `define`, `loader`, `conditions`, plugins, and the JSX options have no effect there. Setting any of them with `bundle: false` adds a warning to `result.warnings` rather than failing silently.
+
+### `jsx`, `jsxImportSource`
+
+Pick a JSX runtime explicitly. With `jsx: "automatic"` you don't need to import React (or whatever runtime) in every file.
+
+```ts
+await createApp({
+  files,
+  client: "src/client.tsx",
+  jsx: "automatic",
+  jsxImportSource: "react"
+});
+```
+
+### `define`
+
+Compile-time constant replacement. Each value must be a valid JavaScript expression as a string (so wrap string values in extra quotes).
+
+```ts
+await createWorker({
+  files,
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    __DEV__: "false",
+    __VERSION__: JSON.stringify(pkg.version)
+  }
+});
+```
+
+### `loader`
+
+Tell the bundler how to interpret arbitrary file extensions. The built-in handling for `.ts` / `.tsx` / `.js` / `.jsx` / `.json` / `.css` is preserved unless you override it. Longer extensions match first, so `".d.ts"` wins over `".ts"`.
+
+```ts
+await createWorker({
+  files,
+  loader: {
+    ".svg": "text",
+    ".wasm": "binary",
+    ".sql": "text"
+  }
+});
+```
+
+The supported `BundlerLoader` values are deliberately narrowed to the portable subset that every modern bundler can express:
+
+| Loader    | Meaning                                                    |
+| --------- | ---------------------------------------------------------- |
+| `js`      | Plain JavaScript                                           |
+| `jsx`     | JSX (transformed per the `jsx` option)                     |
+| `ts`      | TypeScript                                                 |
+| `tsx`     | TypeScript + JSX                                           |
+| `json`    | Parse as JSON, expose as the default export                |
+| `css`     | Parse as CSS                                               |
+| `text`    | Embed file contents as a UTF-8 string default export       |
+| `binary`  | Embed file contents as a `Uint8Array` default export       |
+| `base64`  | Embed file contents as a base64 string default export      |
+| `dataurl` | Embed file contents as a `data:` URL string default export |
+
+esbuild's `file` / `copy` loaders are intentionally not exposed: they emit secondary output files that this bundler currently discards (only the first output is read). If you need that — or anything else esbuild-specific — reach for `__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired` instead.
+
+### `conditions`
+
+Package export conditions, in priority order. Useful when bundling libraries that ship multiple builds via `package.json#exports`.
+
+```ts
+await createWorker({
+  files,
+  conditions: ["workerd", "worker", "browser"]
+});
+```
+
+### `__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired`
+
+> **Read this before using.** This option is **not** covered by semver. The name is the API contract: it can change shape, be renamed, or be removed in any release. The runtime ties you to esbuild — if this package switches bundlers (e.g. to rolldown), plugins authored against this API will break.
+
+Pass extra esbuild plugins. They run **before** the bundler's internal virtual-filesystem plugin, so a plugin's `onResolve` / `onLoad` claims fire first (e.g. an RSC plugin claiming `"server-function:*"` before virtual-fs tries to read it from disk).
+
+The option is typed as `unknown[]` at the public boundary so the published `.d.ts` doesn't depend on `esbuild-wasm`'s types. Cast your plugin array when passing it in:
+
+```ts
+import type { Plugin } from "esbuild-wasm";
+
+const myRscPlugin: Plugin = {
+  name: "rsc",
+  setup(build) {
+    build.onResolve({ filter: /^server-function:/ }, (args) => ({
+      path: args.path,
+      namespace: "rsc"
+    }));
+    build.onLoad({ filter: /.*/, namespace: "rsc" }, (args) => ({
+      contents: generateServerFunctionStub(args.path),
+      loader: "ts"
+    }));
+  }
+};
+
+await createApp({
+  files,
+  client: "src/client.tsx",
+  __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: [
+    myRscPlugin
+  ] as unknown[]
 });
 ```
 

--- a/packages/worker-bundler/src/app.ts
+++ b/packages/worker-bundler/src/app.ts
@@ -7,13 +7,18 @@
  * and only forwards non-asset requests to the isolate.
  */
 
-import { bundleWithEsbuild } from "./bundler";
+import { bundleWithEsbuild, bundlerOnlyOptionsWarning } from "./bundler";
 import { hasNodejsCompat, parseWranglerConfig } from "./config";
 import { hasDependencies, installDependencies } from "./installer";
 import { transformAndResolve } from "./transformer";
 import type { AssetConfig, AssetManifest } from "./asset-handler";
 import { buildAssetManifest } from "./asset-handler";
-import type { CreateWorkerResult, Files } from "./types";
+import type {
+  BundlerLoader,
+  CreateWorkerResult,
+  Files,
+  JsxMode
+} from "./types";
 import {
   InMemoryFileSystem,
   isFileSystem,
@@ -90,6 +95,58 @@ export interface CreateAppOptions {
    * npm registry URL for fetching packages.
    */
   registry?: string;
+
+  /**
+   * JSX transform mode passed to esbuild. Applied to both server and client
+   * bundles.
+   */
+  jsx?: JsxMode;
+
+  /**
+   * Module to import the JSX runtime from when `jsx: "automatic"`.
+   */
+  jsxImportSource?: string;
+
+  /**
+   * Constant replacements applied at bundle time. Applied to both server and
+   * client bundles.
+   */
+  define?: Record<string, string>;
+
+  /**
+   * Per-extension loader overrides. Applied to both server and client bundles.
+   */
+  loader?: Record<string, BundlerLoader>;
+
+  /**
+   * Package export conditions to honour during resolution.
+   * Applied to both server and client bundles (the host can pass e.g.
+   * `["worker", "browser"]` for the client, but most users want a single
+   * shared set).
+   */
+  conditions?: string[];
+
+  /**
+   * Escape hatch for advanced users: extra esbuild plugins to run **before**
+   * the bundler's internal virtual-filesystem plugin. Applied to both server
+   * and client bundles.
+   *
+   * The deliberately unwieldy name is the API contract:
+   *
+   *   - This option is **not** covered by semver. It can change shape, be
+   *     renamed, or be removed in any release.
+   *   - The runtime ties you to esbuild. If this package switches bundlers
+   *     (e.g. to rolldown), plugins authored against this API will break.
+   *
+   * Typed as `unknown[]` at the public boundary to keep `esbuild-wasm` types
+   * out of the published `.d.ts`. Cast your plugin array to `unknown[]` when
+   * passing it in. Each element is validated at runtime: it must be an object
+   * with `name: string` and `setup: (build) => void`.
+   *
+   * On the server side, only applies when `bundle: true`; transform-only mode
+   * surfaces a warning instead. Always applies to client bundles.
+   */
+  __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired?: unknown[];
 }
 
 /**
@@ -142,7 +199,13 @@ export async function createApp(
     target = "es2022",
     minify = false,
     sourcemap = false,
-    registry
+    registry,
+    jsx,
+    jsxImportSource,
+    define,
+    loader,
+    conditions,
+    __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: plugins
   } = options;
 
   const fileSystem: FileSystem = isFileSystem(files)
@@ -183,15 +246,21 @@ export async function createApp(
       );
     }
 
-    const clientResult = await bundleWithEsbuild(
-      fileSystem,
-      clientEntry,
+    const clientResult = await bundleWithEsbuild({
+      files: fileSystem,
+      entryPoint: clientEntry,
       externals,
-      "es2022",
+      target: "es2022",
       minify,
       sourcemap,
-      false
-    );
+      nodejsCompat: false,
+      jsx,
+      jsxImportSource,
+      define,
+      loader,
+      conditions,
+      plugins
+    });
 
     const bundleModule = clientResult.modules["bundle.js"];
     if (typeof bundleModule === "string") {
@@ -238,21 +307,41 @@ export async function createApp(
 
   let serverResult: CreateWorkerResult;
   if (bundle) {
-    serverResult = await bundleWithEsbuild(
-      fileSystem,
-      serverEntry,
+    serverResult = await bundleWithEsbuild({
+      files: fileSystem,
+      entryPoint: serverEntry,
       externals,
       target,
       minify,
       sourcemap,
-      nodejsCompat
-    );
+      nodejsCompat,
+      jsx,
+      jsxImportSource,
+      define,
+      loader,
+      conditions,
+      plugins
+    });
   } else {
+    // Transform-only mode never invokes esbuild, so any bundler-only options
+    // are silently inactive — surface that as a warning the caller can see.
     serverResult = await transformAndResolve(
       fileSystem,
       serverEntry,
       externals
     );
+
+    const bundlerOnly = bundlerOnlyOptionsWarning({
+      jsx,
+      jsxImportSource,
+      define,
+      loader,
+      conditions,
+      plugins
+    });
+    if (bundlerOnly) {
+      serverResult.warnings = [...(serverResult.warnings ?? []), bundlerOnly];
+    }
   }
 
   const result: CreateAppResult = {

--- a/packages/worker-bundler/src/bundler.ts
+++ b/packages/worker-bundler/src/bundler.ts
@@ -10,20 +10,86 @@ import * as esbuild from "esbuild-wasm/lib/browser.js";
 import esbuildWasm from "./esbuild.wasm";
 import { resolveModule } from "./resolver";
 import type { FileSystem } from "./file-system";
-import type { CreateWorkerResult, Modules } from "./types";
+import type {
+  BundlerLoader,
+  CreateWorkerResult,
+  JsxMode,
+  Modules
+} from "./types";
+
+/**
+ * Build a single warning string listing the bundler-only options the caller
+ * set together with `bundle: false`. Returns `null` if none were set.
+ *
+ * `transformAndResolve` is sucrase + naïve module resolution — it cannot apply
+ * `define` substitution, custom `loader` overrides, package-export `conditions`,
+ * or esbuild plugins. Silently ignoring these would produce subtly wrong output
+ * (e.g. `__DEV__` left as a free identifier in the emitted bundle).
+ */
+export function bundlerOnlyOptionsWarning(opts: {
+  jsx?: unknown;
+  jsxImportSource?: unknown;
+  define?: unknown;
+  loader?: unknown;
+  conditions?: unknown;
+  plugins?: unknown;
+}): string | null {
+  const set: string[] = [];
+  if (opts.jsx !== undefined) set.push("jsx");
+  if (opts.jsxImportSource !== undefined) set.push("jsxImportSource");
+  if (opts.define !== undefined) set.push("define");
+  if (opts.loader !== undefined) set.push("loader");
+  if (opts.conditions !== undefined) set.push("conditions");
+  if (opts.plugins !== undefined) {
+    set.push("__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired");
+  }
+  if (set.length === 0) return null;
+  return `${set.join(", ")} ${set.length === 1 ? "is" : "are"} ignored when \`bundle: false\` (transform-only mode does not run esbuild). Set \`bundle: true\` (the default) to apply them.`;
+}
+
+/**
+ * Internal options for bundleWithEsbuild. Kept as an object (rather than a
+ * long positional list) so new bundler knobs can be added without churning
+ * every call site.
+ */
+export interface BundleOptions {
+  files: FileSystem;
+  entryPoint: string;
+  externals: string[];
+  target: string;
+  minify: boolean;
+  sourcemap: boolean;
+  nodejsCompat: boolean;
+  jsx?: JsxMode;
+  jsxImportSource?: string;
+  define?: Record<string, string>;
+  loader?: Record<string, BundlerLoader>;
+  conditions?: string[];
+  /** Extra esbuild plugins to run BEFORE the internal virtual-fs plugin. */
+  plugins?: unknown[];
+}
 
 /**
  * Bundle files using esbuild-wasm
  */
 export async function bundleWithEsbuild(
-  files: FileSystem,
-  entryPoint: string,
-  externals: string[],
-  target: string,
-  minify: boolean,
-  sourcemap: boolean,
-  nodejsCompat: boolean
+  options: BundleOptions
 ): Promise<CreateWorkerResult> {
+  const {
+    files,
+    entryPoint,
+    externals,
+    target,
+    minify,
+    sourcemap,
+    nodejsCompat,
+    jsx,
+    jsxImportSource,
+    define,
+    loader: loaderOverrides,
+    conditions,
+    plugins: extraPlugins = []
+  } = options;
   // Ensure esbuild is initialized (happens lazily on first use)
   await initializeEsbuild();
 
@@ -94,7 +160,7 @@ export async function bundleWithEsbuild(
           return { errors: [{ text: `File not found: ${args.path}` }] };
         }
 
-        const loader = getLoader(args.path);
+        const loader = getLoader(args.path, loaderOverrides);
         // Set resolveDir so relative imports within this file resolve correctly
         const lastSlash = args.path.lastIndexOf("/");
         const resolveDir = lastSlash >= 0 ? args.path.slice(0, lastSlash) : "";
@@ -102,6 +168,33 @@ export async function bundleWithEsbuild(
       });
     }
   };
+
+  // Validate user plugins eagerly: the public type is `unknown[]` (so the
+  // .d.ts stays free of esbuild types), which means anything can flow in.
+  // Without this, a bad value surfaces as an opaque crash from inside esbuild's
+  // own plugin machinery — point at the dangerous option name instead.
+  for (let i = 0; i < extraPlugins.length; i++) {
+    const p = extraPlugins[i] as
+      | { name?: unknown; setup?: unknown }
+      | null
+      | undefined;
+    if (
+      !p ||
+      typeof p !== "object" ||
+      typeof p.name !== "string" ||
+      typeof p.setup !== "function"
+    ) {
+      throw new TypeError(
+        `__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired[${i}] is not a valid esbuild plugin (expected an object with \`name: string\` and \`setup: (build) => void\`).`
+      );
+    }
+  }
+
+  // User plugins run BEFORE the internal virtual-fs plugin so they get first
+  // crack at onResolve / onLoad (e.g. an RSC plugin claiming "server-function:*"
+  // before virtual-fs tries to read it from disk). Don't reorder this without
+  // thinking about it.
+  const userPlugins = extraPlugins as esbuild.Plugin[];
 
   const result = await esbuild.build({
     entryPoints: [entryPoint],
@@ -112,8 +205,12 @@ export async function bundleWithEsbuild(
     target,
     minify,
     sourcemap: sourcemap ? "inline" : false,
-    plugins: [virtualFsPlugin],
-    outfile: "bundle.js"
+    plugins: [...userPlugins, virtualFsPlugin],
+    outfile: "bundle.js",
+    ...(jsx !== undefined ? { jsx } : {}),
+    ...(jsxImportSource !== undefined ? { jsxImportSource } : {}),
+    ...(define !== undefined ? { define } : {}),
+    ...(conditions !== undefined ? { conditions } : {})
   });
 
   const output = result.outputFiles?.[0];
@@ -181,7 +278,20 @@ function resolveRelativePath(
   return undefined;
 }
 
-function getLoader(path: string): esbuild.Loader {
+function getLoader(
+  path: string,
+  overrides?: Record<string, BundlerLoader>
+): esbuild.Loader {
+  if (overrides) {
+    // Match on the longest extension first so ".d.ts" wins over ".ts" if both
+    // are configured.
+    const matched = Object.keys(overrides)
+      .filter((ext) => path.endsWith(ext))
+      .sort((a, b) => b.length - a.length)[0];
+    if (matched !== undefined) {
+      return overrides[matched] as esbuild.Loader;
+    }
+  }
   if (path.endsWith(".ts") || path.endsWith(".mts")) return "ts";
   if (path.endsWith(".tsx")) return "tsx";
   if (path.endsWith(".jsx")) return "jsx";

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -4,7 +4,7 @@
  * Creates worker bundles from source files for Cloudflare's Worker Loader binding.
  */
 
-import { bundleWithEsbuild } from "./bundler";
+import { bundleWithEsbuild, bundlerOnlyOptionsWarning } from "./bundler";
 import { hasNodejsCompat, parseWranglerConfig } from "./config";
 import { hasDependencies, installDependencies } from "./installer";
 import { transformAndResolve } from "./transformer";
@@ -19,9 +19,11 @@ import {
 
 // Re-export types
 export type {
+  BundlerLoader,
   CreateWorkerOptions,
   CreateWorkerResult,
   Files,
+  JsxMode,
   Modules,
   WranglerConfig
 } from "./types";
@@ -87,7 +89,13 @@ export async function createWorker(
     target = "es2022",
     minify = false,
     sourcemap = false,
-    registry
+    registry,
+    jsx,
+    jsxImportSource,
+    define,
+    loader,
+    conditions,
+    __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: plugins
   } = options;
 
   let fileSystem: FileSystem;
@@ -130,15 +138,21 @@ export async function createWorker(
 
   if (bundle) {
     // Try bundling with esbuild-wasm
-    const result = await bundleWithEsbuild(
-      fileSystem,
+    const result = await bundleWithEsbuild({
+      files: fileSystem,
       entryPoint,
       externals,
       target,
       minify,
       sourcemap,
-      nodejsCompat
-    );
+      nodejsCompat,
+      jsx,
+      jsxImportSource,
+      define,
+      loader,
+      conditions,
+      plugins
+    });
 
     // Add wrangler config if a config file was found
     if (wranglerConfig !== undefined) {
@@ -152,9 +166,20 @@ export async function createWorker(
 
     return result;
   } else {
-    // No bundling - transform files and resolve dependencies
-    // Note: sourcemaps are not supported in transform mode (output mirrors input structure)
+    // No bundling - transform files and resolve dependencies.
+    // Sourcemaps and the esbuild-only options (jsx, jsxImportSource, define,
+    // loader, conditions, plugins) are not supported in transform mode — the
+    // output mirrors the input structure and never touches esbuild.
     const result = await transformAndResolve(fileSystem, entryPoint, externals);
+
+    const bundlerOnly = bundlerOnlyOptionsWarning({
+      jsx,
+      jsxImportSource,
+      define,
+      loader,
+      conditions,
+      plugins
+    });
 
     // Add wrangler config if a config file was found
     if (wranglerConfig !== undefined) {
@@ -162,8 +187,12 @@ export async function createWorker(
     }
 
     // Add install warnings to result
-    if (installWarnings.length > 0) {
-      result.warnings = [...(result.warnings ?? []), ...installWarnings];
+    const extraWarnings = [
+      ...installWarnings,
+      ...(bundlerOnly ? [bundlerOnly] : [])
+    ];
+    if (extraWarnings.length > 0) {
+      result.warnings = [...(result.warnings ?? []), ...extraWarnings];
     }
 
     return result;

--- a/packages/worker-bundler/src/tests/app-e2e.test.ts
+++ b/packages/worker-bundler/src/tests/app-e2e.test.ts
@@ -702,3 +702,59 @@ describe("createApp e2e — 404-page not-found handling", () => {
     expect(await res.text()).toBe("api");
   });
 });
+
+// ── Advanced bundler options thread through to BOTH server and client ──
+
+describe("createApp advanced bundler options", () => {
+  it("applies `define` to the server bundle", async () => {
+    const res = await buildAppAndFetch(
+      {
+        files: {
+          "src/index.ts": [
+            "declare const __APP_NAME__: string;",
+            "export default {",
+            "  fetch() { return new Response(__APP_NAME__); }",
+            "};"
+          ].join("\n")
+        },
+        define: {
+          __APP_NAME__: '"server-saw-define"'
+        }
+      },
+      new Request("http://app/api")
+    );
+
+    expect(await res.text()).toBe("server-saw-define");
+  });
+
+  it("applies `define` to client bundles too", async () => {
+    // Build the app, then fetch the emitted client bundle and assert the
+    // substitution happened. This catches a class of bug where someone
+    // refactors the threading and forgets one of the two bundleWithEsbuild
+    // call sites in createApp.
+    const result = await createApp({
+      files: {
+        "src/server.ts":
+          "export default { fetch() { return new Response('api'); } };",
+        "src/client.ts": [
+          "declare const __CLIENT_FLAG__: boolean;",
+          "if (__CLIENT_FLAG__) {",
+          '  document.body.textContent = "flag-on";',
+          "}"
+        ].join("\n")
+      },
+      server: "src/server.ts",
+      client: "src/client.ts",
+      define: {
+        __CLIENT_FLAG__: "true"
+      }
+    });
+
+    const clientBundle = result.assets["/client.js"];
+    expect(typeof clientBundle).toBe("string");
+    // After define + dead-code-elimination-friendly emission, the literal
+    // `true` should appear and the placeholder identifier should NOT.
+    expect(clientBundle as string).not.toContain("__CLIENT_FLAG__");
+    expect(clientBundle as string).toContain("flag-on");
+  });
+});

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -261,6 +261,209 @@ describe("createWorker transform-only mode (build + load + fetch)", () => {
   });
 });
 
+describe("createWorker advanced bundler options", () => {
+  it("applies define replacements at bundle time", async () => {
+    const response = await buildAndFetch({
+      files: {
+        "src/index.ts": [
+          "declare const __GREETING__: string;",
+          "export default {",
+          "  fetch() { return new Response(__GREETING__); }",
+          "};"
+        ].join("\n")
+      },
+      define: {
+        __GREETING__: '"hello from define"'
+      }
+    });
+
+    expect(await response.text()).toBe("hello from define");
+  });
+
+  it("respects per-extension loader overrides (.svg as text)", async () => {
+    const response = await buildAndFetch({
+      files: {
+        "src/index.ts": [
+          'import logo from "./logo.svg";',
+          "export default {",
+          "  fetch() { return new Response(logo); }",
+          "};"
+        ].join("\n"),
+        "src/logo.svg": "<svg>hello</svg>"
+      },
+      loader: {
+        ".svg": "text"
+      }
+    });
+
+    expect(await response.text()).toBe("<svg>hello</svg>");
+  });
+
+  it("longer extension wins in loader overrides", async () => {
+    // ".d.ts" should beat ".ts" — both match, but the longer one is more specific.
+    const response = await buildAndFetch({
+      files: {
+        "src/index.ts": [
+          'import doc from "./readme.d.ts";',
+          "export default {",
+          "  fetch() { return new Response(doc); }",
+          "};"
+        ].join("\n"),
+        "src/readme.d.ts": "docs-as-text"
+      },
+      loader: {
+        ".ts": "ts",
+        ".d.ts": "text"
+      }
+    });
+
+    expect(await response.text()).toBe("docs-as-text");
+  });
+
+  it("runs user esbuild plugins before the internal virtual-fs plugin", async () => {
+    // A user plugin claims `virtual:greeting` before virtual-fs ever sees it.
+    const greetingPlugin = {
+      name: "test-greeting",
+      setup(build: {
+        onResolve: (
+          opts: { filter: RegExp },
+          cb: (args: { path: string }) => unknown
+        ) => void;
+        onLoad: (
+          opts: { filter: RegExp; namespace: string },
+          cb: (args: { path: string }) => unknown
+        ) => void;
+      }) {
+        build.onResolve({ filter: /^virtual:/ }, (args) => ({
+          path: args.path,
+          namespace: "test-greeting"
+        }));
+        build.onLoad({ filter: /.*/, namespace: "test-greeting" }, (_args) => ({
+          contents: 'export const greeting = "hi from a plugin";',
+          loader: "ts"
+        }));
+      }
+    };
+
+    const response = await buildAndFetch({
+      files: {
+        "src/index.ts": [
+          'import { greeting } from "virtual:greeting";',
+          "export default {",
+          "  fetch() { return new Response(greeting); }",
+          "};"
+        ].join("\n")
+      },
+      __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: [greetingPlugin]
+    });
+
+    expect(await response.text()).toBe("hi from a plugin");
+  });
+
+  it("threads jsx + jsxImportSource through to the bundle output", async () => {
+    // We don't have React in the test fixtures, so just verify that the
+    // automatic runtime references the configured import source instead of
+    // looking for a React global.
+    const result = await createWorker({
+      files: {
+        "src/index.tsx": [
+          "export default {",
+          "  fetch() {",
+          "    const el = <div>hello</div>;",
+          "    return new Response(JSON.stringify(el));",
+          "  }",
+          "};"
+        ].join("\n")
+      },
+      // .tsx isn't in the default entry-point detection list.
+      entryPoint: "src/index.tsx",
+      jsx: "automatic",
+      jsxImportSource: "preact",
+      // The classic transform requires React in scope; with `automatic` esbuild
+      // emits an import from `${jsxImportSource}/jsx-runtime`. Mark it external
+      // so the bundle compiles without us having to actually install preact.
+      externals: ["preact"]
+    });
+
+    const bundle = result.modules["bundle.js"] as string;
+    expect(bundle).toContain("preact/jsx-runtime");
+  });
+
+  it("rejects plugin entries that aren't shaped like esbuild plugins", async () => {
+    await expect(
+      createWorker({
+        files: {
+          "src/index.ts":
+            "export default { fetch() { return new Response('ok'); } };"
+        },
+        __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: [
+          // Missing `setup`.
+          { name: "broken" } as unknown
+        ]
+      })
+    ).rejects.toThrow(
+      /__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired\[0\] is not a valid esbuild plugin/
+    );
+  });
+
+  it("rejects null / non-object plugin entries with a clear error", async () => {
+    await expect(
+      createWorker({
+        files: {
+          "src/index.ts":
+            "export default { fetch() { return new Response('ok'); } };"
+        },
+        __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: [
+          null as unknown
+        ]
+      })
+    ).rejects.toThrow(
+      /__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired\[0\]/
+    );
+  });
+
+  it("warns when bundler-only options are set with bundle: false", async () => {
+    const result = await createWorker({
+      files: {
+        "src/index.ts": [
+          "export default {",
+          "  fetch() { return new Response('hi'); }",
+          "};"
+        ].join("\n")
+      },
+      bundle: false,
+      // None of these can apply in transform-only mode.
+      define: { __X__: "1" },
+      jsx: "automatic",
+      conditions: ["workerd"]
+    });
+
+    expect(result.warnings).toBeDefined();
+    const message = result.warnings!.find((w) =>
+      w.includes("ignored when `bundle: false`")
+    );
+    expect(message).toBeDefined();
+    expect(message).toContain("define");
+    expect(message).toContain("jsx");
+    expect(message).toContain("conditions");
+  });
+
+  it("does NOT warn when bundle: false is used without bundler-only options", async () => {
+    const result = await createWorker({
+      files: {
+        "src/index.ts":
+          "export default { fetch() { return new Response('hi'); } };"
+      },
+      bundle: false
+    });
+
+    const offending = (result.warnings ?? []).find((w) =>
+      w.includes("ignored when `bundle: false`")
+    );
+    expect(offending).toBeUndefined();
+  });
+});
+
 describe("createWorker error cases", () => {
   it("throws when entry point is not found", async () => {
     await expect(

--- a/packages/worker-bundler/src/types.ts
+++ b/packages/worker-bundler/src/types.ts
@@ -23,6 +23,41 @@ export interface Module {
 export type Modules = Record<string, string | Module>;
 
 /**
+ * Loader names supported for the `loader` option.
+ *
+ * Deliberately narrowed to the portable subset that every bundler in the
+ * ecosystem (esbuild, rolldown, rspack, vite, webpack) can express:
+ *
+ *   - script flavours: `js`, `jsx`, `ts`, `tsx`, `json`, `css`
+ *   - file content embedding: `text`, `binary`, `base64`, `dataurl`
+ *
+ * esbuild's `file` and `copy` loaders are intentionally NOT exposed: they
+ * emit secondary output files that the bundler currently discards (only the
+ * first output file is read). esbuild's `default` / `empty` / `local-css` /
+ * `global-css` are also omitted because they are esbuild-internal control
+ * flow, not portable concepts.
+ *
+ * Anything outside this set should go through
+ * `__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired` instead.
+ */
+export type BundlerLoader =
+  | "js"
+  | "jsx"
+  | "ts"
+  | "tsx"
+  | "json"
+  | "css"
+  | "text"
+  | "binary"
+  | "base64"
+  | "dataurl";
+
+/**
+ * JSX transform mode passed to esbuild.
+ */
+export type JsxMode = "transform" | "preserve" | "automatic";
+
+/**
  * Options for createWorker
  */
 export interface CreateWorkerOptions {
@@ -75,6 +110,72 @@ export interface CreateWorkerOptions {
    * @default 'https://registry.npmjs.org'
    */
   registry?: string;
+
+  /**
+   * JSX transform mode passed to esbuild.
+   * `"automatic"` enables the new JSX runtime (no need to import React).
+   *
+   * Only applies when `bundle: true` (the default). In transform-only mode this
+   * option is ignored and a warning is added to the result's `warnings` array.
+   */
+  jsx?: JsxMode;
+
+  /**
+   * Module to import the JSX runtime from when `jsx: "automatic"`.
+   * @example "react", "preact", "@emotion/react"
+   *
+   * Only applies when `bundle: true`.
+   */
+  jsxImportSource?: string;
+
+  /**
+   * Constant replacements applied at bundle time. Each key is replaced with the
+   * corresponding value (which must be a JSON-serialisable JavaScript expression).
+   * @example { "process.env.NODE_ENV": '"production"', "__DEV__": "false" }
+   *
+   * Only applies when `bundle: true`. In transform-only mode this option is
+   * ignored and a warning is added to the result's `warnings` array.
+   */
+  define?: Record<string, string>;
+
+  /**
+   * Per-extension loader overrides. Extensions are matched on file paths
+   * (including the leading dot, e.g. `".svg"`). Built-in handling for
+   * `.ts`/`.tsx`/`.js`/`.jsx`/`.json`/`.css` is preserved unless overridden here.
+   *
+   * Only applies when `bundle: true`.
+   */
+  loader?: Record<string, BundlerLoader>;
+
+  /**
+   * Package export conditions to honour during resolution
+   * (e.g. `["workerd", "worker", "browser"]`).
+   * Order matters — earlier conditions take precedence.
+   *
+   * Only applies when `bundle: true`.
+   */
+  conditions?: string[];
+
+  /**
+   * Escape hatch for advanced users: extra esbuild plugins to run **before**
+   * the bundler's internal virtual-filesystem plugin.
+   *
+   * The deliberately unwieldy name is the API contract:
+   *
+   *   - This option is **not** covered by semver. It can change shape, be
+   *     renamed, or be removed in any release.
+   *   - The runtime ties you to esbuild. If this package switches bundlers
+   *     (e.g. to rolldown), plugins authored against this API will break.
+   *
+   * Typed as `unknown[]` at the public boundary to keep `esbuild-wasm` types
+   * out of the published `.d.ts`. Cast your plugin array to `unknown[]` when
+   * passing it in. Each element is validated at runtime: it must be an object
+   * with `name: string` and `setup: (build) => void`.
+   *
+   * Only applies when `bundle: true`. In transform-only mode this option is
+   * ignored and a warning is added to the result's `warnings` array.
+   */
+  __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired?: unknown[];
 }
 
 /**


### PR DESCRIPTION
Closes #1321.

## Summary

Adds the bundler knobs that previously required forking `@cloudflare/worker-bundler`:

- `jsx`, `jsxImportSource` (incl. `"automatic"` runtime)
- `define` (compile-time constant replacement)
- `loader` (per-extension overrides — e.g. `{ ".svg": "text", ".wasm": "binary" }`; longest extension wins so `.d.ts` beats `.ts`)
- `conditions` (package export conditions, e.g. `["workerd", "worker", "browser"]`)
- `__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired` (escape hatch)

In `createApp`, all of these apply to **both** the server and client bundles. User plugins run **before** the internal virtual-fs plugin so they get first crack at `onResolve` / `onLoad` (e.g. an RSC plugin claiming `server-function:*` before virtual-fs tries to read it from disk).

## Type-level coupling avoidance

The first five options are re-typed locally (`JsxMode`, `BundlerLoader`) so the published `.d.ts` does not import from `esbuild-wasm` — a future bundler swap is a refactor, not a breaking type change.

`BundlerLoader` is deliberately narrowed to the portable subset every modern bundler can express: `js | jsx | ts | tsx | json | css | text | binary | base64 | dataurl`. esbuild's `file`/`copy`/`empty`/`default` are intentionally excluded — `file`/`copy` would silently break here today (secondary outputs are discarded by the bundler), and anything outside the portable set should go through the plugin escape hatch instead.

## Plugin escape hatch

The plugin escape hatch is typed `unknown[]` at the boundary for the same reason. The deliberately unwieldy name (per @bndkt's proposal in the issue) is the API contract:

- not covered by semver — can change shape, be renamed, or be removed in any release
- ties the caller to esbuild's plugin shape — if this package ever switches bundlers (e.g. to rolldown), plugins authored against this API will break

Cast your `Plugin[]` from `esbuild-wasm` to `unknown[]` when passing it in.

## DX guardrails

- **Plugin entries are validated at runtime.** A bad value (e.g. `[null]`, `[{ name: \"x\" }]` missing `setup`) throws a `TypeError` that names the offending index and the dangerous option name, rather than crashing deep inside esbuild's own plugin machinery.
- **`bundle: false` cannot apply any of these options** — `transformAndResolve` never invokes esbuild. Setting any of them with `bundle: false` now adds a warning to `result.warnings` listing exactly which options were ignored, rather than failing silently. Documented on each option's JSDoc and at the top of the README's Advanced section.

## Internal refactor

The internal `bundleWithEsbuild` signature was refactored from a 7-arg positional list to a single `BundleOptions` object so future bundler knobs can be added without churning every call site. Internal change; no public API moved.

## Test plan

- [x] 11 new tests, 176/176 total passing:
  - 5 `createWorker advanced bundler options` (define, .svg-as-text loader, longest-extension-wins, plugin runs first, jsx + jsxImportSource)
  - 2 plugin shape validation (rejects missing `setup`, rejects `null`)
  - 2 `bundle: false` warning behaviour (warns when bundler-only options set; does NOT warn when only `bundle: false` is used)
  - 2 `createApp` regression tests for both server **and** client bundle threading (catches the \"forgot to thread through to one of the two `bundleWithEsbuild` call sites\" class of bug)
- [x] `npm run check` clean (sherif + export checks + oxfmt + oxlint + typecheck across all 73 projects)

## Acknowledgements

Inspired by #1321 — thanks @bndkt for the [draft commit](https://github.com/bndkt/agents/commit/04c6bfe2) and the RSC-on-Workers proof-of-concept that motivated this. The naming convention for the plugin escape hatch is also lifted from his issue comment.

Made with [Cursor](https://cursor.com).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
