### PR TITLE
fix(worker-bundler): clear error in Node instead of cryptic 'gojs' resolution failure

### DIFF
--- a/.changeset/worker-bundler-node-gojs-error.md
+++ b/.changeset/worker-bundler-node-gojs-error.md
@@ -1,0 +1,30 @@
+---
+"@cloudflare/worker-bundler": patch
+---
+
+Fix: don't crash with `Cannot find package 'gojs'` when imported from Node.
+
+Previously, `bundler.ts` did a top-level static `import esbuildWasm from "./esbuild.wasm"`. In the Workers runtime that resolves to a `WebAssembly.Module` natively, but in Node 22+ (e.g. Vitest on GitHub Actions CI) Node's experimental ESM-WASM loader actually parses the file and tries to resolve `esbuild-wasm`'s Go-runtime import namespace `gojs` as an npm package. That surfaced as the deeply confusing error reported in [#1306](https://github.com/cloudflare/agents/issues/1306):
+
+```
+Cannot find package 'gojs' imported from
+.../@cloudflare/worker-bundler/dist/esbuild.wasm
+```
+
+Two changes:
+
+- The `./esbuild.wasm` import is now lazy — it lives inside `initializeEsbuild()` as a dynamic `import("./esbuild.wasm")` call instead of a module-level static import. The package is now safely importable from any JavaScript runtime.
+- Before evaluating that dynamic import, the bundler checks `navigator.userAgent === "Cloudflare-Workers"`. If it's not running inside workerd, it throws an actionable error pointing the caller at `@cloudflare/vitest-pool-workers` instead of letting Node surface the cryptic `gojs` resolution failure.
+
+A side benefit: `createWorker({ bundle: false })` (transform-only mode, which never invokes esbuild) now also works in Node, because the WASM is never loaded on that code path.
+
+The README now also calls out the Workers-only requirement near the top.
+
+While in there, sharpened a handful of unhelpful error messages to include actionable context:
+
+- "Entry point/Server entry point/Client entry point ... not found" now lists the user-provided files in the bundle (skipping `node_modules/`) so it's obvious whether the path is mistyped vs. missing entirely.
+- "Could not determine entry point" now spells out the full priority list it tried (`entryPoint` option → wrangler `main` → `package.json` → defaults).
+- npm registry errors include the package name, version, registry URL, and HTTP status text — e.g. `Registry returned 404 Not Found for "hno" at https://registry.npmjs.org/hno (package not found — check the name in package.json or set the `registry` option if it lives on a private registry)`.
+- The npm fetch-timeout error names the URL and notes the registry was slow/unreachable from the Worker.
+- "Invalid package.json" includes both the path and the underlying parse error.
+- "No output generated from esbuild" now names the entry point and explains the two real-world causes (a custom plugin claiming the entry without returning contents, or the entry resolving to an externalised module).

--- a/packages/worker-bundler/README.md
+++ b/packages/worker-bundler/README.md
@@ -4,6 +4,12 @@
 
 Bundle and serve full-stack applications on Cloudflare's [Worker Loader binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/) (closed beta). Dynamically generate Workers with real npm dependencies, or build complete apps with client-side bundles and static asset serving.
 
+## Runtime requirement
+
+This package only runs **inside the Cloudflare Workers runtime (`workerd`)** — both in production and in `wrangler dev`. It bundles via an `esbuild-wasm` `WebAssembly.Module` import that only the Workers module loader can resolve.
+
+It will **not** work under plain Node.js. In particular, importing it from a Vitest/Jest test that uses the default Node pool will surface an error pointing you here. To test code that depends on `@cloudflare/worker-bundler`, run your tests with [`@cloudflare/vitest-pool-workers`](https://developers.cloudflare.com/workers/testing/vitest-integration/) so the test body executes inside `workerd`. See `packages/worker-bundler/src/tests/vitest.config.ts` in this repo for an example setup.
+
 ## Installation
 
 ```

--- a/packages/worker-bundler/src/app.ts
+++ b/packages/worker-bundler/src/app.ts
@@ -24,7 +24,11 @@ import {
   isFileSystem,
   type FileSystem
 } from "./file-system";
-import { detectEntryPoint, formatFileListForError } from "./utils";
+import {
+  DEFAULT_ENTRY_POINTS,
+  detectEntryPoint,
+  formatFileListForError
+} from "./utils";
 import { showExperimentalWarning } from "./experimental";
 
 /**
@@ -297,7 +301,7 @@ export async function createApp(
 
   if (!serverEntry) {
     throw new Error(
-      "Could not determine server entry point for createApp. Tried (in order): the `server` option, `main` in wrangler config, `exports`/`module`/`main` in package.json, and the defaults src/index.ts, src/index.js, index.ts, index.js. Pass `server` explicitly or add one of those files."
+      `Could not determine server entry point for createApp. Tried (in order): the \`server\` option, \`main\` in wrangler config, \`exports\`/\`module\`/\`main\` in package.json, and the defaults ${DEFAULT_ENTRY_POINTS.join(", ")}. Pass \`server\` explicitly or add one of those files.`
     );
   }
 

--- a/packages/worker-bundler/src/app.ts
+++ b/packages/worker-bundler/src/app.ts
@@ -24,7 +24,7 @@ import {
   isFileSystem,
   type FileSystem
 } from "./file-system";
-import { detectEntryPoint } from "./utils";
+import { detectEntryPoint, formatFileListForError } from "./utils";
 import { showExperimentalWarning } from "./experimental";
 
 /**
@@ -242,7 +242,7 @@ export async function createApp(
   for (const clientEntry of clientEntries) {
     if (fileSystem.read(clientEntry) === null) {
       throw new Error(
-        `Client entry point "${clientEntry}" not found in files.`
+        `Client entry point "${clientEntry}" was not found in \`files\`. Available files: ${formatFileListForError(fileSystem)}.`
       );
     }
 
@@ -297,12 +297,14 @@ export async function createApp(
 
   if (!serverEntry) {
     throw new Error(
-      "Could not determine server entry point. Specify the 'server' option."
+      "Could not determine server entry point for createApp. Tried (in order): the `server` option, `main` in wrangler config, `exports`/`module`/`main` in package.json, and the defaults src/index.ts, src/index.js, index.ts, index.js. Pass `server` explicitly or add one of those files."
     );
   }
 
   if (fileSystem.read(serverEntry) === null) {
-    throw new Error(`Server entry point "${serverEntry}" not found in files.`);
+    throw new Error(
+      `Server entry point "${serverEntry}" was not found in \`files\`. Available files: ${formatFileListForError(fileSystem)}.`
+    );
   }
 
   let serverResult: CreateWorkerResult;

--- a/packages/worker-bundler/src/bundler.ts
+++ b/packages/worker-bundler/src/bundler.ts
@@ -336,6 +336,32 @@ export const NOT_IN_WORKERS_ERROR =
   "See https://developers.cloudflare.com/workers/testing/vitest-integration/ for setup.";
 
 /**
+ * Pre-started promise for the esbuild WASM module load.
+ *
+ * Pre-warmed at module evaluation time when (and only when) we're inside
+ * workerd, so the wasm `Compile` cost runs in parallel with everything else
+ * the test/handler is doing — matching the implicit behaviour of the static
+ * `import esbuildWasm from "./esbuild.wasm"` we used to have. Without this,
+ * the first `bundleWithEsbuild` call paid the full wasm-compile cost
+ * serially, which was enough to flake the first test of an `app-e2e`-style
+ * file under vitest's default 5s timeout on slower CI runners.
+ *
+ * Outside Workers, we *don't* start the import — Node's ESM-WASM loader
+ * would try to resolve esbuild's Go-runtime `gojs` import namespace as an
+ * npm package and crash. `initializeEsbuild()` throws `NOT_IN_WORKERS_ERROR`
+ * before ever touching the file in that case.
+ */
+let pendingWasmImport: Promise<{ default: WebAssembly.Module }> | null = null;
+
+if (isCloudflareWorkersRuntime()) {
+  // @ts-expect-error - WASM module import resolved by the Workers loader.
+  pendingWasmImport = import("./esbuild.wasm");
+  // Suppress unhandled-rejection if `initializeEsbuild()` is never called.
+  // Errors are still surfaced when the promise is awaited there.
+  pendingWasmImport.catch(() => {});
+}
+
+/**
  * Initialize the esbuild bundler.
  * This is called automatically when needed.
  */
@@ -356,18 +382,14 @@ async function initializeEsbuild(): Promise<void> {
     // npm package and surfaces `Cannot find package 'gojs'` instead of
     // anything actionable. Fail fast with a useful message before we ever
     // touch the .wasm file.
-    if (!isCloudflareWorkersRuntime()) {
+    if (!isCloudflareWorkersRuntime() || pendingWasmImport === null) {
       throw new Error(NOT_IN_WORKERS_ERROR);
     }
 
     try {
-      // Lazy dynamic import: keeps Node from eagerly evaluating the .wasm at
-      // module load time (which would crash any consumer that even imports
-      // this package from a Node process). Within Workers, the bundler's
-      // build config marks "./esbuild.wasm" as never-bundled, so this stays
-      // a real runtime import that resolves to a `WebAssembly.Module`.
-      // @ts-expect-error - WASM module import resolved by the Workers loader.
-      const wasmModule = (await import("./esbuild.wasm")).default;
+      // Await the pre-warmed wasm import kicked off at module evaluation.
+      // In the common case (warm worker) this is already resolved.
+      const wasmModule = (await pendingWasmImport).default;
 
       await esbuild.initialize({
         wasmModule,

--- a/packages/worker-bundler/src/bundler.ts
+++ b/packages/worker-bundler/src/bundler.ts
@@ -6,8 +6,6 @@
 // wasmModule in Workers with nodejs_compat (it thinks it's Node.js).
 import * as esbuild from "esbuild-wasm/lib/browser.js";
 
-// @ts-expect-error - WASM module import
-import esbuildWasm from "./esbuild.wasm";
 import { resolveModule } from "./resolver";
 import type { FileSystem } from "./file-system";
 import type {
@@ -215,7 +213,12 @@ export async function bundleWithEsbuild(
 
   const output = result.outputFiles?.[0];
   if (!output) {
-    throw new Error("No output generated from esbuild");
+    // Almost always means a plugin claimed the entry point and produced
+    // nothing, or esbuild emitted only secondary outputs (e.g. via the
+    // `file` loader, which this bundler doesn't surface).
+    throw new Error(
+      `esbuild produced no output for entry point "${entryPoint}". This usually means a custom plugin (\`__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired\`) intercepted the entry without returning contents, or the entry resolved to an externalised module.`
+    );
   }
 
   const modules: Modules = {
@@ -305,6 +308,34 @@ let esbuildInitialized = false;
 let esbuildInitializePromise: Promise<void> | null = null;
 
 /**
+ * Detect whether we are running inside the Cloudflare Workers runtime
+ * (workerd). Both production Workers and the local dev runtime expose
+ * `navigator.userAgent === "Cloudflare-Workers"`.
+ *
+ * Exported so tests can sanity-check the guard without standing up a
+ * separate Node-only test runner.
+ */
+export function isCloudflareWorkersRuntime(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    typeof navigator.userAgent === "string" &&
+    navigator.userAgent === "Cloudflare-Workers"
+  );
+}
+
+/**
+ * Error message thrown when `createWorker` / `createApp` is called outside of
+ * the Workers runtime. Exported so tests can match against it without
+ * duplicating the wording.
+ */
+export const NOT_IN_WORKERS_ERROR =
+  "@cloudflare/worker-bundler is only supported inside the Cloudflare Workers runtime (workerd). " +
+  "It cannot run in plain Node.js — including Vitest, Jest or other Node-based test runners — " +
+  "because it bundles via a `WebAssembly.Module` import that only the Workers module loader can resolve. " +
+  "To test code that uses this package, run your tests with @cloudflare/vitest-pool-workers so they execute inside workerd. " +
+  "See https://developers.cloudflare.com/workers/testing/vitest-integration/ for setup.";
+
+/**
  * Initialize the esbuild bundler.
  * This is called automatically when needed.
  */
@@ -319,9 +350,27 @@ async function initializeEsbuild(): Promise<void> {
 
   // Start initialization
   esbuildInitializePromise = (async () => {
+    // Refuse to load esbuild.wasm outside Workers. The .wasm file is built
+    // from Go, which declares a `gojs` import namespace in its WASM-host
+    // bridge; Node's ESM-WASM loader (Node 22+) tries to resolve that as an
+    // npm package and surfaces `Cannot find package 'gojs'` instead of
+    // anything actionable. Fail fast with a useful message before we ever
+    // touch the .wasm file.
+    if (!isCloudflareWorkersRuntime()) {
+      throw new Error(NOT_IN_WORKERS_ERROR);
+    }
+
     try {
+      // Lazy dynamic import: keeps Node from eagerly evaluating the .wasm at
+      // module load time (which would crash any consumer that even imports
+      // this package from a Node process). Within Workers, the bundler's
+      // build config marks "./esbuild.wasm" as never-bundled, so this stays
+      // a real runtime import that resolves to a `WebAssembly.Module`.
+      // @ts-expect-error - WASM module import resolved by the Workers loader.
+      const wasmModule = (await import("./esbuild.wasm")).default;
+
       await esbuild.initialize({
-        wasmModule: esbuildWasm,
+        wasmModule,
         worker: false
       });
 

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -9,7 +9,11 @@ import { hasNodejsCompat, parseWranglerConfig } from "./config";
 import { hasDependencies, installDependencies } from "./installer";
 import { transformAndResolve } from "./transformer";
 import type { CreateWorkerOptions, CreateWorkerResult } from "./types";
-import { detectEntryPoint, formatFileListForError } from "./utils";
+import {
+  DEFAULT_ENTRY_POINTS,
+  detectEntryPoint,
+  formatFileListForError
+} from "./utils";
 import { showExperimentalWarning } from "./experimental";
 import {
   InMemoryFileSystem,
@@ -128,7 +132,7 @@ export async function createWorker(
 
   if (!entryPoint) {
     throw new Error(
-      "Could not determine entry point for createWorker. Tried (in order): the `entryPoint` option, `main` in wrangler config, `exports`/`module`/`main` in package.json, and the defaults src/index.ts, src/index.js, index.ts, index.js. Pass `entryPoint` explicitly or add one of those files."
+      `Could not determine entry point for createWorker. Tried (in order): the \`entryPoint\` option, \`main\` in wrangler config, \`exports\`/\`module\`/\`main\` in package.json, and the defaults ${DEFAULT_ENTRY_POINTS.join(", ")}. Pass \`entryPoint\` explicitly or add one of those files.`
     );
   }
 

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -9,7 +9,7 @@ import { hasNodejsCompat, parseWranglerConfig } from "./config";
 import { hasDependencies, installDependencies } from "./installer";
 import { transformAndResolve } from "./transformer";
 import type { CreateWorkerOptions, CreateWorkerResult } from "./types";
-import { detectEntryPoint } from "./utils";
+import { detectEntryPoint, formatFileListForError } from "./utils";
 import { showExperimentalWarning } from "./experimental";
 import {
   InMemoryFileSystem,
@@ -128,12 +128,14 @@ export async function createWorker(
 
   if (!entryPoint) {
     throw new Error(
-      "Could not determine entry point. Please specify entryPoint option."
+      "Could not determine entry point for createWorker. Tried (in order): the `entryPoint` option, `main` in wrangler config, `exports`/`module`/`main` in package.json, and the defaults src/index.ts, src/index.js, index.ts, index.js. Pass `entryPoint` explicitly or add one of those files."
     );
   }
 
   if (fileSystem.read(entryPoint) === null) {
-    throw new Error(`Entry point "${entryPoint}" not found in files.`);
+    throw new Error(
+      `Entry point "${entryPoint}" was not found in \`files\`. Available files: ${formatFileListForError(fileSystem)}.`
+    );
   }
 
   if (bundle) {

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -27,7 +27,9 @@ async function fetchWithTimeout(
     return await fetch(url, { ...options, signal: controller.signal });
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Request timed out after ${timeoutMs}ms: ${url}`);
+      throw new Error(
+        `Request to ${url} timed out after ${timeoutMs}ms (npm registry slow or unreachable from this Worker)`
+      );
     }
     throw error;
   } finally {
@@ -270,7 +272,15 @@ async function fetchPackageMetadata(
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch package metadata: ${response.status}`);
+    // 404 on the registry usually means the package name is wrong (typo,
+    // wrong scope) or the registry doesn't host it — call that out.
+    const hint =
+      response.status === 404
+        ? " (package not found — check the name in package.json or set the `registry` option if it lives on a private registry)"
+        : "";
+    throw new Error(
+      `Registry returned ${response.status} ${response.statusText} for "${name}" at ${url}${hint}`
+    );
   }
 
   return (await response.json()) as NpmPackageMetadata;
@@ -314,7 +324,9 @@ export async function fetchPackageFiles(
 ): Promise<Record<string, string>> {
   const tarballUrl = metadata.dist?.tarball;
   if (!tarballUrl) {
-    throw new Error(`No tarball URL for ${name}`);
+    throw new Error(
+      `Registry metadata for ${name}@${metadata.version} is missing \`dist.tarball\` — the registry response is likely malformed or the version was unpublished.`
+    );
   }
 
   // Fetch the tarball (use longer timeout for potentially large packages)
@@ -324,7 +336,9 @@ export async function fetchPackageFiles(
     DEFAULT_TIMEOUT_MS * 2
   );
   if (!response.ok) {
-    throw new Error(`Failed to fetch tarball: ${response.status}`);
+    throw new Error(
+      `Failed to fetch tarball for ${name}@${metadata.version}: ${response.status} ${response.statusText} (${tarballUrl})`
+    );
   }
 
   // Get the tarball as array buffer

--- a/packages/worker-bundler/src/resolver.ts
+++ b/packages/worker-bundler/src/resolver.ts
@@ -131,8 +131,11 @@ function resolvePackage(
   let pkg: Record<string, unknown>;
   try {
     pkg = JSON.parse(packageJson) as Record<string, unknown>;
-  } catch {
-    throw new Error(`Invalid package.json for ${packageName}`);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid package.json at ${packageJsonPath} (for "${packageName}"): ${detail}`
+    );
   }
 
   // Use resolve.exports to handle the exports field

--- a/packages/worker-bundler/src/tests/app-e2e.test.ts
+++ b/packages/worker-bundler/src/tests/app-e2e.test.ts
@@ -3,6 +3,7 @@ import { env } from "cloudflare:workers";
 import { createApp } from "../app";
 import type { CreateAppOptions } from "../app";
 import { handleAssetRequest, createMemoryStorage } from "../asset-handler";
+import { DEFAULT_ENTRY_POINTS } from "../utils";
 
 let testId = 0;
 
@@ -536,6 +537,22 @@ describe("createApp error cases", () => {
     ).rejects.toThrow(
       /Client entry point "src\/client.ts" was not found.*src\/index\.ts/
     );
+  });
+
+  it("'Could not determine server entry point' lists every default tried by detectEntryPoint", async () => {
+    // Sibling regression to the createWorker test in e2e.test.ts (Devin
+    // Review on #1335). createApp must keep its server-entry message in
+    // sync with `DEFAULT_ENTRY_POINTS`.
+    const error = await createApp({
+      files: { "lib/other.ts": "export const x = 1;" }
+    }).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain("Could not determine server entry point");
+    for (const entry of DEFAULT_ENTRY_POINTS) {
+      expect(message).toContain(entry);
+    }
   });
 });
 

--- a/packages/worker-bundler/src/tests/app-e2e.test.ts
+++ b/packages/worker-bundler/src/tests/app-e2e.test.ts
@@ -513,16 +513,18 @@ describe("createApp e2e — multiple assets", () => {
 // ── Error cases ─────────────────────────────────────────────────────
 
 describe("createApp error cases", () => {
-  it("throws when server entry is not found", async () => {
+  it("throws when server entry is not found and lists available files", async () => {
     await expect(
       createApp({
         files: { "src/other.ts": "export const x = 1;" },
         server: "src/index.ts"
       })
-    ).rejects.toThrow('Server entry point "src/index.ts" not found');
+    ).rejects.toThrow(
+      /Server entry point "src\/index.ts" was not found.*src\/other\.ts/
+    );
   });
 
-  it("throws when client entry is not found", async () => {
+  it("throws when client entry is not found and lists available files", async () => {
     await expect(
       createApp({
         files: {
@@ -531,7 +533,9 @@ describe("createApp error cases", () => {
         },
         client: "src/client.ts"
       })
-    ).rejects.toThrow('Client entry point "src/client.ts" not found');
+    ).rejects.toThrow(
+      /Client entry point "src\/client.ts" was not found.*src\/index\.ts/
+    );
   });
 });
 

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
 import { createWorker, installDependencies } from "../index";
+import { isCloudflareWorkersRuntime, NOT_IN_WORKERS_ERROR } from "../bundler";
 import { parseWranglerConfig, hasNodejsCompat } from "../config";
 import { detectEntryPoint } from "../utils";
 import { runInDurableObject } from "cloudflare:test";
@@ -465,13 +466,15 @@ describe("createWorker advanced bundler options", () => {
 });
 
 describe("createWorker error cases", () => {
-  it("throws when entry point is not found", async () => {
+  it("throws when entry point is not found and lists available files", async () => {
     await expect(
       createWorker({
         files: { "src/other.ts": "export const x = 1;" },
         entryPoint: "src/index.ts"
       })
-    ).rejects.toThrow('Entry point "src/index.ts" not found');
+    ).rejects.toThrow(
+      /Entry point "src\/index.ts" was not found.*src\/other\.ts/
+    );
   });
 
   it("throws when no entry point can be detected", async () => {
@@ -480,6 +483,32 @@ describe("createWorker error cases", () => {
         files: { "lib/other.ts": "export const x = 1;" }
       })
     ).rejects.toThrow("Could not determine entry point");
+  });
+});
+
+describe("non-Workers runtime guard", () => {
+  // The bundler refuses to load esbuild.wasm outside Workers because Node's
+  // ESM-WASM loader can't resolve esbuild's `gojs` import namespace
+  // (cloudflare/agents#1306). Verify the runtime guard fires before the
+  // .wasm file is ever touched, and that the error message points users at
+  // @cloudflare/vitest-pool-workers.
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("isCloudflareWorkersRuntime() reflects navigator.userAgent", () => {
+    expect(isCloudflareWorkersRuntime()).toBe(true);
+
+    vi.stubGlobal("navigator", { userAgent: "node" });
+    expect(isCloudflareWorkersRuntime()).toBe(false);
+
+    vi.stubGlobal("navigator", undefined);
+    expect(isCloudflareWorkersRuntime()).toBe(false);
+  });
+
+  it("NOT_IN_WORKERS_ERROR mentions vitest-pool-workers as the fix", () => {
+    expect(NOT_IN_WORKERS_ERROR).toMatch(/@cloudflare\/vitest-pool-workers/);
+    expect(NOT_IN_WORKERS_ERROR).toMatch(/Cloudflare Workers runtime/);
   });
 });
 

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -3,7 +3,7 @@ import { env } from "cloudflare:workers";
 import { createWorker, installDependencies } from "../index";
 import { isCloudflareWorkersRuntime, NOT_IN_WORKERS_ERROR } from "../bundler";
 import { parseWranglerConfig, hasNodejsCompat } from "../config";
-import { detectEntryPoint } from "../utils";
+import { DEFAULT_ENTRY_POINTS, detectEntryPoint } from "../utils";
 import { runInDurableObject } from "cloudflare:test";
 import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
 import type { CreateWorkerOptions } from "../types";
@@ -483,6 +483,23 @@ describe("createWorker error cases", () => {
         files: { "lib/other.ts": "export const x = 1;" }
       })
     ).rejects.toThrow("Could not determine entry point");
+  });
+
+  it("'Could not determine entry point' lists every default tried by detectEntryPoint", async () => {
+    // Regression for a Devin Review finding on #1335: the error message used
+    // to hand-roll a partial list (`src/index.ts, src/index.js, index.ts,
+    // index.js`), so a user with a perfectly valid `src/worker.ts` would be
+    // told to "add one of those files" — with their existing filename absent
+    // from the list. Bind the message to the actual array so this can't
+    // drift again.
+    const error = await createWorker({
+      files: { "lib/other.ts": "export const x = 1;" }
+    }).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    for (const entry of DEFAULT_ENTRY_POINTS) {
+      expect((error as Error).message).toContain(entry);
+    }
   });
 });
 

--- a/packages/worker-bundler/src/utils.ts
+++ b/packages/worker-bundler/src/utils.ts
@@ -92,3 +92,22 @@ function normalizeEntryPath(path: string): string {
   }
   return path;
 }
+
+/**
+ * Render the user-provided source files as a short, readable list for use in
+ * "entry point not found" errors. Skips installed `node_modules/` files
+ * (which can be tens of thousands of paths and drown out the actually
+ * relevant signal — the files the user passed in) and truncates the tail.
+ */
+export function formatFileListForError(files: FileSystem, limit = 10): string {
+  const all = files
+    .list()
+    .filter((p) => !p.startsWith("node_modules/"))
+    .sort();
+  if (all.length === 0) {
+    return "(none — `files` is empty or only contains node_modules entries)";
+  }
+  const shown = all.slice(0, limit).join(", ");
+  if (all.length <= limit) return shown;
+  return `${shown}, … (+${all.length - limit} more)`;
+}

--- a/packages/worker-bundler/src/utils.ts
+++ b/packages/worker-bundler/src/utils.ts
@@ -6,6 +6,26 @@ import type { WranglerConfig } from "./types";
 import type { FileSystem } from "./file-system";
 
 /**
+ * Default entry-point paths searched (in order) when no explicit entry has
+ * been provided and `wrangler.*` / `package.json` don't declare one.
+ *
+ * Exported so the "Could not determine entry point" error messages in
+ * `index.ts` (createWorker) and `app.ts` (createApp) can reference the same
+ * source of truth — otherwise the messages drift out of sync the first time
+ * someone adds a default and forgets to update both error strings.
+ */
+export const DEFAULT_ENTRY_POINTS = [
+  "src/index.ts",
+  "src/index.js",
+  "src/index.mts",
+  "src/index.mjs",
+  "index.ts",
+  "index.js",
+  "src/worker.ts",
+  "src/worker.js"
+] as const;
+
+/**
  * Detect entry point from wrangler config, package.json, or use defaults.
  * Priority: wrangler main > package.json exports/module/main > default paths
  */
@@ -64,19 +84,7 @@ export function detectEntryPoint(
     }
   }
 
-  // Default entry points
-  const defaultEntries = [
-    "src/index.ts",
-    "src/index.js",
-    "src/index.mts",
-    "src/index.mjs",
-    "index.ts",
-    "index.js",
-    "src/worker.ts",
-    "src/worker.js"
-  ];
-
-  for (const entry of defaultEntries) {
+  for (const entry of DEFAULT_ENTRY_POINTS) {
     if (files.read(entry) !== null) {
       return entry;
     }


### PR DESCRIPTION
Closes #1306.

## Summary

Top-level `import esbuildWasm from \"./esbuild.wasm\"` works fine in workerd (resolves to a `WebAssembly.Module`) but breaks under Node 22+, where the experimental ESM-WASM loader tries to resolve the Go runtime's `gojs` import namespace as an npm package. The reporter on #1306 was running this package from a plain Vitest setup (default Node pool) on GitHub Actions and saw an opaque \`Cannot find package 'gojs'\` error.

This package is workerd-only by design; the fix gives users a clear sentence pointing them at \`@cloudflare/vitest-pool-workers\` instead of letting Node surface the deep-loader error.

### Changes

- **Lazy WASM import.** Moved \`./esbuild.wasm\` out of module scope and into \`initializeEsbuild()\` as a dynamic \`import(\"./esbuild.wasm\")\`. Importing the package from any runtime is now safe; the wasm is only touched when bundling.
- **Runtime guard.** Before evaluating that dynamic import, check \`navigator.userAgent === \"Cloudflare-Workers\"\`. If not in workerd, throw \`NOT_IN_WORKERS_ERROR\` — a single sentence that names the requirement, mentions Vitest/Jest specifically, and links to the vitest-pool-workers docs.
- **README.** New \"Runtime requirement\" section near the top spelling out the workerd-only constraint and pointing to our own \`vitest.config.ts\` as a worked example.
- **Side benefit.** \`createWorker({ bundle: false })\` (transform-only mode, sucrase + naive resolution, no WASM) now also works under plain Node since the wasm is never loaded on that path.
- **Error-message audit while in there.** Walked every \`throw new Error\` in \`packages/worker-bundler/src\` and tightened the ones that didn't give the user anything to act on:
  - Entry-point errors (\`createWorker\`, \`createApp\` server, \`createApp\` client) now list the user-provided files in the bundle (excluding \`node_modules/\`, capped at 10) so a typo is obvious.
  - \"Could not determine entry point\" now spells out the lookup priority chain (\`entryPoint\`/\`server\` option → wrangler \`main\` → \`package.json\` → defaults).
  - npm registry errors include the package name, version, registry URL and HTTP status text. 404 specifically gets a hint about wrong package name vs. private registry.
  - \"Invalid package.json\" includes the file path and the underlying parse error.
  - \"No output generated from esbuild\" now names the entry point and explains the two real-world causes (custom plugin claimed it without returning contents, or it resolved to an externalised module).

### Why workerd-only at all?

Today \`createWorker\`/\`createApp\` use \`esbuild-wasm\` via the Workers \`WebAssembly.Module\` import path, the npm installer assumes \`fetch\` + \`DecompressionStream\`, etc. Making it run natively in Node would mean swapping to native \`esbuild\` + a different storage abstraction — that's a feature, not a bug fix. This PR just stops Node users from getting a confusing failure mode.

## Test plan

- [x] All 178 existing tests still pass under \`@cloudflare/vitest-pool-workers\` (so the lazy WASM import path works in workerd).
- [x] New tests in \`e2e.test.ts\`:
  - \`isCloudflareWorkersRuntime()\` returns \`true\` in workerd, \`false\` when \`navigator\` is stubbed otherwise.
  - \`NOT_IN_WORKERS_ERROR\` mentions \`@cloudflare/vitest-pool-workers\` and the Workers runtime.
- [x] Updated existing entry-point-not-found assertions in \`e2e.test.ts\` and \`app-e2e.test.ts\` to also assert the \"available files\" listing is included.
- [x] \`tsc --noEmit -p packages/worker-bundler/tsconfig.json\` clean.
- [x] \`npm run build\` succeeds; verified the dist output emits the runtime guard before the dynamic \`import(\"./esbuild.wasm\")\`.

### Coverage gaps (not blocking)

- No end-to-end test that \`createWorker()\` actually throws \`NOT_IN_WORKERS_ERROR\` from a real Node process — would need a second Vitest config (default Node pool) for one test. Worth doing eventually.
- Installer error wording (registry 404, missing tarball, fetch timeout) and the resolver/bundler internal errors aren't directly asserted on. The text changes are cosmetic; the failure paths are unchanged.

## Changeset

\`patch\` for \`@cloudflare/worker-bundler\`.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
