### PR TITLE
fix(agents): drop unused deps, devDeps, and peer deps

### DIFF
--- a/.changeset/trim-agents-deps.md
+++ b/.changeset/trim-agents-deps.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+---
+
+Remove unused `dependencies`, `devDependencies`, and `peerDependencies` from the `agents` package.
+
+- `dependencies`: drop `json-schema`, `json-schema-to-typescript`, and `picomatch`. None are imported by the package; `picomatch` was already pulled in transitively via `@rolldown/plugin-babel`.
+- `devDependencies`: drop `@ai-sdk/openai` (only referenced in a commented-out line) and `@cloudflare/workers-oauth-provider` (not referenced anywhere).
+- `peerDependencies` / `peerDependenciesMeta`: drop `@ai-sdk/react` and `viem`. `@ai-sdk/react` is already a peer of `@cloudflare/ai-chat` (itself an optional peer here), and `viem` is a regular dependency of `@x402/evm`, so both are supplied transitively when the relevant optional features are used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,23 +1649,6 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
-      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
-      }
-    },
     "node_modules/@astrojs/cloudflare": {
       "version": "13.1.10",
       "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-13.1.10.tgz",
@@ -5342,12 +5325,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT"
-    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -8879,12 +8856,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -14638,6 +14609,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14663,6 +14635,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -15064,44 +15037,6 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/json-schema-to-typescript": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
-      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.5.5",
-        "@types/json-schema": "^7.0.15",
-        "@types/lodash": "^4.17.7",
-        "is-glob": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "prettier": "^3.2.5",
-        "tinyglobby": "^0.2.9"
-      },
-      "bin": {
-        "json2ts": "dist/src/cli.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/json-schema-to-typescript/node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -15647,12 +15582,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -23620,22 +23549,17 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@rolldown/plugin-babel": "^0.2.3",
         "cron-schedule": "^6.0.0",
-        "json-schema": "^0.4.0",
-        "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
         "nanoid": "^5.1.9",
         "partyserver": "^0.4.1",
         "partysocket": "1.1.16",
-        "picomatch": "^4.0.4",
         "yargs": "^18.0.0"
       },
       "bin": {
         "agents": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@ai-sdk/openai": "^3.0.53",
         "@ai-sdk/react": "^3.0.170",
-        "@cloudflare/workers-oauth-provider": "^0.4.0",
         "@tanstack/ai": "^0.10.3",
         "@types/react": "^19.2.14",
         "@types/yargs": "^17.0.35",
@@ -23648,7 +23572,6 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@ai-sdk/react": "^3.0.0",
         "@cloudflare/ai-chat": ">=0.0.8 <1.0.0",
         "@cloudflare/codemode": ">=0.0.7 <1.0.0",
         "@tanstack/ai": "^0.10.2",
@@ -23656,14 +23579,10 @@
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
-        "viem": ">=2.0.0",
         "vite": ">=6.0.0 <9.0.0",
         "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
-        "@ai-sdk/react": {
-          "optional": true
-        },
         "@cloudflare/ai-chat": {
           "optional": true
         },
@@ -23677,9 +23596,6 @@
           "optional": true
         },
         "@x402/evm": {
-          "optional": true
-        },
-        "viem": {
           "optional": true
         },
         "vite": {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -29,19 +29,14 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@rolldown/plugin-babel": "^0.2.3",
     "cron-schedule": "^6.0.0",
-    "json-schema": "^0.4.0",
-    "json-schema-to-typescript": "^15.0.4",
     "mimetext": "^3.0.28",
     "nanoid": "^5.1.9",
     "partyserver": "^0.4.1",
     "partysocket": "1.1.16",
-    "picomatch": "^4.0.4",
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@ai-sdk/openai": "^3.0.53",
     "@ai-sdk/react": "^3.0.170",
-    "@cloudflare/workers-oauth-provider": "^0.4.0",
     "@tanstack/ai": "^0.10.3",
     "@types/react": "^19.2.14",
     "@types/yargs": "^17.0.35",
@@ -54,7 +49,6 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@ai-sdk/react": "^3.0.0",
     "@cloudflare/ai-chat": ">=0.0.8 <1.0.0",
     "@cloudflare/codemode": ">=0.0.7 <1.0.0",
     "@tanstack/ai": "^0.10.2",
@@ -62,14 +56,10 @@
     "@x402/evm": "^2.0.0",
     "ai": "^6.0.0",
     "react": "^19.0.0",
-    "viem": ">=2.0.0",
     "vite": ">=6.0.0 <9.0.0",
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
-    "@ai-sdk/react": {
-      "optional": true
-    },
     "@cloudflare/ai-chat": {
       "optional": true
     },
@@ -83,9 +73,6 @@
       "optional": true
     },
     "@x402/evm": {
-      "optional": true
-    },
-    "viem": {
       "optional": true
     },
     "vite": {


### PR DESCRIPTION
## Summary

Trim entries from `packages/agents/package.json` that were not imported by the package. Closes #1345 by removing `json-schema-to-typescript` (which transitively pulled in vulnerable `lodash`, GHSA-p6mc-m468-83gw) from the runtime dependency tree.

### `dependencies`
- Remove `json-schema` — not imported anywhere.
- Remove `json-schema-to-typescript` — not imported anywhere. This also drops the lodash transitive from production installs, resolving #1345.
- Remove `picomatch` — not imported directly; it's already a transitive dep of `@rolldown/plugin-babel`.

### `devDependencies`
- Remove `@ai-sdk/openai` — only appeared in a commented-out line in `evals/scheduling.eval.ts`.
- Remove `@cloudflare/workers-oauth-provider` — no references anywhere in the package.

### `peerDependencies` / `peerDependenciesMeta`
- Remove `@ai-sdk/react` — not imported directly. `@cloudflare/ai-chat` (an optional peer) already declares `@ai-sdk/react` as its own peer, so users using the chat entry points will be prompted to install it via that package.
- Remove `viem` — not imported anywhere (only a JSDoc mention). `@x402/evm` declares `viem` as a regular (non-peer) dependency, so it's installed transitively whenever x402 is used.

A patch changeset for `agents` is included.

## Test plan

- [x] `npm install` at the repo root succeeds and reconciles the lockfile.
- [x] `tsc -p packages/agents/tsconfig.json`, `packages/agents/src/tests/tsconfig.json`, and `packages/agents/src/react-tests/tsconfig.json` all pass with the removals applied.
- [x] CI (lint, typecheck, tests) passes.
- [ ] Confirm `npm ls json-schema-to-typescript` no longer shows it under `agents` after install in a downstream project.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
