### PR TITLE
fix(ai-chat): don't crash when useAgent()'s HTTP URL isn't ready yet

### DIFF
--- a/.changeset/ai-chat-pending-http-url.md
+++ b/.changeset/ai-chat-pending-http-url.md
@@ -8,6 +8,7 @@ Fix `useAgentChat()` crashing on first render when `agent.getHttpUrl()` returns 
 
 - The built-in `/get-messages` fetch is deferred until the URL is known, and applied exactly once when it resolves (empty chats only — existing messages are never overwritten).
 - Custom `getInitialMessages` callbacks continue to run and are passed `url: undefined` so they can load from other sources if they don't need the socket URL. `GetInitialMessagesOptions.url` is now `string | undefined`; callers that previously typed `url: string` should widen to `url?: string`.
+- Initial messages are cached by agent identity (class + name) rather than by URL + identity, so the URL-arrival transition no longer invalidates the cache, re-invokes the loader, or re-triggers Suspense once the chat has already been populated.
 - The underlying `useChat` instance keeps a stable `id` across the URL-arrival transition, so in-flight stream resume and chat state are preserved.
 
 No API or behavior changes for apps where the URL was already available synchronously on first render.

--- a/.changeset/ai-chat-pending-http-url.md
+++ b/.changeset/ai-chat-pending-http-url.md
@@ -1,0 +1,13 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix `useAgentChat()` crashing on first render when `agent.getHttpUrl()` returns an empty string. This happened in setups where the WebSocket handshake hadn't completed by the time React rendered — most commonly when the agent is reached through a proxy or custom-routed worker — because `@cloudflare/ai-chat` unconditionally called `new URL(agent.getHttpUrl())`. See [#1356](https://github.com/cloudflare/agents/issues/1356).
+
+`useAgentChat()` now treats a missing HTTP URL as "not ready yet":
+
+- The built-in `/get-messages` fetch is deferred until the URL is known, and applied exactly once when it resolves (empty chats only — existing messages are never overwritten).
+- Custom `getInitialMessages` callbacks continue to run and are passed `url: undefined` so they can load from other sources if they don't need the socket URL. `GetInitialMessagesOptions.url` is now `string | undefined`; callers that previously typed `url: string` should widen to `url?: string`.
+- The underlying `useChat` instance keeps a stable `id` across the URL-arrival transition, so in-flight stream resume and chat state are preserved.
+
+No API or behavior changes for apps where the URL was already available synchronously on first render.

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -294,6 +294,62 @@ describe("useAgentChat", () => {
     expect(getInitialMessages).toHaveBeenCalledTimes(1);
   });
 
+  it("should invoke custom getInitialMessages only once across the HTTP URL transition", async () => {
+    let url = "";
+    const agent = createAgent({
+      name: "thread-custom-transition",
+      url
+    });
+    agent.getHttpUrl = () =>
+      url.replace("ws://", "http://").replace("wss://", "https://");
+
+    const testMessages = [
+      {
+        id: "1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "One call only" }]
+      }
+    ];
+
+    const getInitialMessages = vi.fn(async () => testMessages);
+
+    const TestComponent = () => {
+      const chat = useAgentChat({ agent, getInitialMessages });
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("One call only");
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+
+    url = "ws://localhost:3000/agents/chat/thread-custom-transition?_pk=abc";
+    await act(async () => {
+      screen.rerender(<TestComponent />);
+      await sleep(10);
+    });
+
+    // The URL transitioned from empty → resolved, but the cache key must
+    // remain stable across that transition so the custom loader isn't
+    // re-invoked and Suspense doesn't flash.
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("One call only");
+  });
+
   it("should accept prepareSendMessagesRequest option without errors", async () => {
     const agent = createAgent({
       name: "thread-with-tools",

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -350,6 +350,65 @@ describe("useAgentChat", () => {
       .toHaveTextContent("One call only");
   });
 
+  it("should not re-hydrate initial messages when a server broadcast empties the chat", async () => {
+    const agent = createAgent({
+      name: "thread-rehydrate-test",
+      url: "ws://localhost:3000/agents/chat/thread-rehydrate-test?_pk=abc"
+    });
+
+    const testMessages = [
+      {
+        id: "msg-1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "Original message" }]
+      }
+    ];
+
+    const getInitialMessages = vi.fn(async () => testMessages);
+
+    const TestComponent = () => {
+      const chat = useAgentChat({ agent, getInitialMessages });
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("Original message");
+
+    // Simulate a server broadcast with empty messages — e.g. another tab
+    // called `setMessages([])` and the server is mirroring the new state
+    // back to us via CF_AGENT_CHAT_MESSAGES.
+    await act(async () => {
+      agent.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "cf_agent_chat_messages",
+            messages: []
+          })
+        })
+      );
+      await sleep(50);
+    });
+
+    // The chat should stay empty — it must NOT be re-hydrated from the
+    // initial-messages cache.
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("[]");
+  });
+
   it("should accept prepareSendMessagesRequest option without errors", async () => {
     const agent = createAgent({
       name: "thread-with-tools",

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -181,6 +181,119 @@ describe("useAgentChat", () => {
     );
   });
 
+  it("should wait for a valid HTTP URL before fetching initial messages", async () => {
+    let url = "";
+    const agent = createAgent({
+      name: "thread-pending-url",
+      url
+    });
+    agent.getHttpUrl = () =>
+      url.replace("ws://", "http://").replace("wss://", "https://");
+
+    const testMessages = [
+      {
+        id: "1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "Hello once ready" }]
+      }
+    ];
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(testMessages), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    const TestComponent = () => {
+      const chat = useAgentChat({ agent });
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const screen = await act(async () =>
+      render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      })
+    );
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("[]");
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    url = "ws://localhost:3000/agents/chat/thread-pending-url?_pk=abc";
+
+    await act(async () => {
+      screen.rerender(<TestComponent />);
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("Hello once ready");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:3000/agents/chat/thread-pending-url/get-messages",
+      expect.objectContaining({
+        credentials: undefined,
+        headers: undefined
+      })
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should allow custom initial message loaders before the HTTP URL is ready", async () => {
+    const agent = createAgent({
+      name: "thread-custom-pending-url",
+      url: ""
+    });
+    agent.getHttpUrl = () => "";
+
+    const testMessages = [
+      {
+        id: "1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "Loaded without URL" }]
+      }
+    ];
+
+    const getInitialMessages = vi.fn(async ({ url }: { url?: string }) => {
+      expect(url).toBeUndefined();
+      return testMessages;
+    });
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages
+      });
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("Loaded without URL");
+    expect(getInitialMessages).toHaveBeenCalledTimes(1);
+  });
+
   it("should accept prepareSendMessagesRequest option without errors", async () => {
     const agent = createAgent({
       name: "thread-with-tools",

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -973,9 +973,14 @@ export function useAgentChat<
   // was already mounted (the URL-not-ready-on-first-render case), the
   // AI SDK's `useChat({ messages })` won't re-ingest the new value.
   // This effect applies it once per cache key, and only when the chat
-  // is still empty — so subsequent runs (e.g. key transitioning from
-  // the pending identity-only form to the resolved URL+identity form)
-  // don't stomp on messages the user has since sent or received.
+  // is still empty at first observation — so subsequent emptying events
+  // (a server broadcast of CF_AGENT_CHAT_MESSAGES with `[]`, a
+  // `setMessages([])` on this tab, or an explicit `clearHistory()`)
+  // don't resurrect stale initial messages on top of the clear.
+  //
+  // Crucially, we mark the key as handled on EVERY observation — not
+  // just when we actively seed — so that later empty states for the
+  // same identity can never trip the guard into re-hydrating.
   useEffect(() => {
     if (!initialMessagesPromise) {
       return;
@@ -984,6 +989,11 @@ export function useAgentChat<
       return;
     }
     if (chatMessages.length > 0) {
+      // Something already populated the chat (most commonly `useChat`
+      // picking up the fetched `initialMessages` on first render, or a
+      // server broadcast). Record that this identity has been handled
+      // so a subsequent empty state doesn't re-hydrate.
+      markInitialMessagesSeeded();
       return;
     }
 

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -648,16 +648,28 @@ export function useAgentChat<
   }
   const agentUrlString = agentUrl?.toString() ?? null;
 
-  // Build cache key from agent identity only (origin + pathname + agent + name).
-  // Query params like auth tokens change across page loads and must NOT
-  // bust the cache — otherwise Suspense re-triggers and breaks stream resume.
-  // See https://github.com/cloudflare/agents/issues/1223
+  // Cache key for the request-dedup `requestCache` and the
+  // late-seed effect. Intentionally identity-only (agent class + name):
+  //
+  //   - Query params like auth tokens change across page loads and
+  //     must not bust the cache, or Suspense re-triggers and breaks
+  //     stream resume (see issue #1223).
+  //   - The origin+pathname portion of the socket URL can legitimately
+  //     transition from empty → resolved on the second render when
+  //     `useAgent()` finishes its handshake. Including it here would
+  //     cause `doGetInitialMessages` to miss the cache after the URL
+  //     arrives, re-invoke the loader, and re-trigger Suspense — the
+  //     exact regression #1356 reports when a custom `getInitialMessages`
+  //     is provided.
+  //
+  // `resolvedInitialMessagesCacheKey` is still computed because the
+  // `stableChatIdRef` logic below uses it to detect the URL-arrival
+  // transition separately from identity changes.
   const agentIdentityKey = `${agent.agent ?? ""}|${agent.name ?? ""}`;
   const resolvedInitialMessagesCacheKey = agentUrl
     ? `${agentUrl.origin}${agentUrl.pathname}|${agentIdentityKey}`
     : null;
-  const initialMessagesCacheKey =
-    resolvedInitialMessagesCacheKey ?? agentIdentityKey;
+  const initialMessagesCacheKey = agentIdentityKey;
 
   // Stable chat ID for `useChat({ id })`.
   //

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -279,7 +279,7 @@ export async function getAgentMessages<M extends UIMessage = UIMessage>(
 type GetInitialMessagesOptions = {
   agent: string;
   name: string;
-  url: string;
+  url?: string;
 };
 
 // v5 useChat parameters
@@ -640,16 +640,66 @@ export function useAgentChat<
   const onDataRef = useRef(onData);
   onDataRef.current = onData;
 
-  const agentUrl = new URL(agent.getHttpUrl());
+  const rawHttpUrl = agent.getHttpUrl();
+  const agentUrl = rawHttpUrl ? new URL(rawHttpUrl) : null;
 
-  agentUrl.searchParams.delete("_pk");
-  const agentUrlString = agentUrl.toString();
+  if (agentUrl) {
+    agentUrl.searchParams.delete("_pk");
+  }
+  const agentUrlString = agentUrl?.toString() ?? null;
 
   // Build cache key from agent identity only (origin + pathname + agent + name).
   // Query params like auth tokens change across page loads and must NOT
   // bust the cache — otherwise Suspense re-triggers and breaks stream resume.
   // See https://github.com/cloudflare/agents/issues/1223
-  const initialMessagesCacheKey = `${agentUrl.origin}${agentUrl.pathname}|${agent.agent ?? ""}|${agent.name ?? ""}`;
+  const agentIdentityKey = `${agent.agent ?? ""}|${agent.name ?? ""}`;
+  const resolvedInitialMessagesCacheKey = agentUrl
+    ? `${agentUrl.origin}${agentUrl.pathname}|${agentIdentityKey}`
+    : null;
+  const initialMessagesCacheKey =
+    resolvedInitialMessagesCacheKey ?? agentIdentityKey;
+
+  // Stable chat ID for `useChat({ id })`.
+  //
+  // The AI SDK recreates the underlying Chat instance when `id` changes,
+  // which aborts any in-flight resume and makes the resume effect miss.
+  // See issue #1356.
+  //
+  // There are three inputs that could move `id`:
+  //   1. `agentIdentityKey` (agent class + name) — genuine identity change,
+  //      e.g. a server-determined name arriving or the caller switching
+  //      threads via props. We DO want a new Chat here.
+  //   2. `resolvedInitialMessagesCacheKey` — adds the origin+pathname of
+  //      the live socket URL. This can legitimately go from `null` →
+  //      resolved on the second render when `useAgent()` finishes its
+  //      handshake. We do NOT want a new Chat for this transition.
+  //   3. Nothing else.
+  //
+  // Policy:
+  //   - First render, or identity changed: re-derive from the resolved
+  //     key if available, otherwise the identity-only `fallbackChatId`.
+  //   - Subsequent renders: only upgrade if we were already on a
+  //     resolved key (i.e. not the fallback). Upgrading away from
+  //     the fallback is intentionally forbidden so the arrival of the
+  //     URL does not recreate the Chat.
+  const stableChatIdRef = useRef<string | null>(null);
+  const previousChatIdentityKeyRef = useRef<string | null>(null);
+  const fallbackChatId = agentIdentityKey;
+
+  if (
+    stableChatIdRef.current === null ||
+    previousChatIdentityKeyRef.current !== agentIdentityKey
+  ) {
+    stableChatIdRef.current = resolvedInitialMessagesCacheKey ?? fallbackChatId;
+  } else if (
+    resolvedInitialMessagesCacheKey &&
+    stableChatIdRef.current !== fallbackChatId &&
+    stableChatIdRef.current !== resolvedInitialMessagesCacheKey
+  ) {
+    stableChatIdRef.current = resolvedInitialMessagesCacheKey;
+  }
+
+  previousChatIdentityKeyRef.current = agentIdentityKey;
 
   // Keep a ref to always point to the latest agent instance.
   // Updated synchronously during render (not in useEffect) so the
@@ -663,6 +713,9 @@ export function useAgentChat<
   async function defaultGetInitialMessagesFetch({
     url
   }: GetInitialMessagesOptions) {
+    if (!url) {
+      return [];
+    }
     const getMessagesUrl = new URL(url);
     getMessagesUrl.pathname += "/get-messages";
     const response = await fetch(getMessagesUrl.toString(), {
@@ -705,17 +758,22 @@ export function useAgentChat<
     return promise;
   }
 
-  const initialMessagesPromise =
+  const shouldFetchInitialMessages =
     getInitialMessages === null
-      ? null
-      : doGetInitialMessages(
-          {
-            agent: agent.agent,
-            name: agent.name,
-            url: agentUrlString
-          },
-          initialMessagesCacheKey
-        );
+      ? false
+      : getInitialMessages
+        ? true
+        : !!agentUrlString;
+  const initialMessagesPromise = !shouldFetchInitialMessages
+    ? null
+    : doGetInitialMessages(
+        {
+          agent: agent.agent,
+          name: agent.name,
+          url: agentUrlString ?? undefined
+        },
+        initialMessagesCacheKey
+      );
   const initialMessages = initialMessagesPromise
     ? use(initialMessagesPromise)
     : (optionsInitialMessages ?? []);
@@ -822,7 +880,7 @@ export function useAgentChat<
     onData,
     messages: initialMessages,
     transport: customTransport,
-    id: initialMessagesCacheKey,
+    id: stableChatIdRef.current,
     // Pass resume so useChat calls transport.reconnectToStream().
     // This lets the AI SDK track status ("streaming") during resume.
     resume
@@ -887,6 +945,45 @@ export function useAgentChat<
   // Ref to access current messages in callbacks without stale closures
   const messagesRef = useRef(chatMessages);
   messagesRef.current = chatMessages;
+  const initialMessagesRef = useRef(initialMessages);
+  initialMessagesRef.current = initialMessages;
+
+  // Tracks which `initialMessagesCacheKey` we've already applied to the
+  // underlying Chat. Used by the late-seed effect below, and flipped to
+  // the current key whenever the chat is intentionally emptied so we
+  // don't re-hydrate server history on top of a user-driven clear.
+  const seededInitialMessagesKeyRef = useRef<string | null>(null);
+  const markInitialMessagesSeeded = useCallback(() => {
+    seededInitialMessagesKeyRef.current = initialMessagesCacheKey;
+  }, [initialMessagesCacheKey]);
+
+  // Late-seed: when the initial-messages promise resolves AFTER the Chat
+  // was already mounted (the URL-not-ready-on-first-render case), the
+  // AI SDK's `useChat({ messages })` won't re-ingest the new value.
+  // This effect applies it once per cache key, and only when the chat
+  // is still empty — so subsequent runs (e.g. key transitioning from
+  // the pending identity-only form to the resolved URL+identity form)
+  // don't stomp on messages the user has since sent or received.
+  useEffect(() => {
+    if (!initialMessagesPromise) {
+      return;
+    }
+    if (seededInitialMessagesKeyRef.current === initialMessagesCacheKey) {
+      return;
+    }
+    if (chatMessages.length > 0) {
+      return;
+    }
+
+    markInitialMessagesSeeded();
+    setMessages(initialMessagesRef.current);
+  }, [
+    chatMessages.length,
+    initialMessagesCacheKey,
+    initialMessagesPromise,
+    markInitialMessagesSeeded,
+    setMessages
+  ]);
 
   const localResponseMessageIdsRef = useRef(new Map<string, string>());
   const protectedStreamingAssistantRef = useRef<{
@@ -1313,6 +1410,7 @@ export function useAgentChat<
             type: "clear"
           }).state;
           setIsServerStreaming(false);
+          markInitialMessagesSeeded();
           setMessages([]);
           break;
 
@@ -1513,6 +1611,7 @@ export function useAgentChat<
     setMessages,
     resume,
     customTransport,
+    markInitialMessagesSeeded,
     preserveProtectedStreamingAssistant,
     restoreProtectedStreamingAssistant
   ]);
@@ -1741,6 +1840,7 @@ export function useAgentChat<
      */
     addToolApprovalResponse: addToolApprovalResponseAndNotifyServer,
     clearHistory: () => {
+      markInitialMessagesSeeded();
       setMessages([]);
       setClientToolResults(new Map());
       resumingToolContinuationRef.current = false;
@@ -1764,6 +1864,9 @@ export function useAgentChat<
         resolvedMessages = messagesOrUpdater;
       }
 
+      if (resolvedMessages.length === 0) {
+        markInitialMessagesSeeded();
+      }
       setMessages(resolvedMessages);
       agent.send(
         JSON.stringify({


### PR DESCRIPTION
## Summary

Closes #1356.

`useAgentChat()` called `new URL(agent.getHttpUrl())` unconditionally during render. `useAgent()` builds `getHttpUrl()` from PartySocket internals that can legitimately still be `""` before the WebSocket connects, which happens most often when the agent is behind a proxy or reached via `basePath`/custom routing. That threw `TypeError: Failed to construct 'URL': Invalid URL` and crashed the component on first render, well before the handshake completed.

This PR treats "HTTP URL not ready yet" as a first-class state in `useAgentChat()`:

- Guards `new URL(...)` so an empty result just yields `null`.
- Defers the built-in `/get-messages` fetch until the URL is available, and the default fetcher returns `[]` if called with an empty URL.
- Keeps custom `getInitialMessages` callbacks runnable before the URL exists. `GetInitialMessagesOptions.url` is now `string | undefined`; callers that previously typed `url: string` should widen to `url?: string`.
- Stabilizes the `useChat` `id` across the URL-arrival transition so the AI SDK doesn't recreate the underlying `Chat` (and abandon in-flight resume) just because the URL materialized on render 2.
- Seeds initial messages exactly once when the load promise resolves after mount (only if the chat is empty), and marks the current cache key as seeded from `clearHistory()`, `CF_AGENT_CHAT_CLEAR`, and explicit `setMessages([])` so user-driven clears aren't re-hydrated.

No API break. Apps where `getHttpUrl()` was synchronously available on first render are unchanged.

## Test plan

- [x] Added `"should wait for a valid HTTP URL before fetching initial messages"` — starts with an empty URL, verifies no `fetch()` happens, then makes the URL available and confirms `/get-messages` is called exactly once with the normalized HTTP URL.
- [x] Added `"should allow custom initial message loaders before the HTTP URL is ready"` — verifies a user-provided `getInitialMessages` runs with `url: undefined` and seeds the chat.
- [x] `npm run test:react` in `packages/ai-chat` — 47/47 passing.
- [x] `npm run check` at the repo root — formatting, lints, exports, and all 75 typecheck projects pass.

## Changeset

A patch-level changeset for `@cloudflare/ai-chat` is included at `.changeset/ai-chat-pending-http-url.md`.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
