### PR TITLE
fix(mcp): capture tool title in MCP client

### DIFF
--- a/.changeset/stupid-coats-matter.md
+++ b/.changeset/stupid-coats-matter.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+fix(mcp): capture tool title in MCP client

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -1334,10 +1334,12 @@ export class MCPClientManager {
     for (const tool of getNamespacedData(connections, "tools")) {
       try {
         const toolKey = `tool_${tool.serverId.replace(/-/g, "")}_${tool.name}`;
+        const title = tool.title ?? tool.annotations?.title;
         entries.push([
           toolKey,
           {
             description: tool.description,
+            title,
             execute: async (args) => {
               const result = await this.callTool({
                 arguments: args,


### PR DESCRIPTION
## Summary

- Surface the MCP tool `title` on tools returned by `MCPClientManager.getAITools()`, so UIs can render the friendly title instead of the namespaced tool name.
- Prefers the top-level `tool.title` (per the [2025-06-18 MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/changelog)) and falls back to the legacy `tool.annotations?.title`.
- Mirrors the Vercel AI SDK fix in [vercel/ai#11910](https://github.com/vercel/ai/pull/11910).

Fixes #1360.

## Notes

- No type changes needed: the MCP SDK's `Tool` schema already declares both `title` and `annotations.title`, and `ToolSet[string]` in `ai` already accepts `title?: string`.

## Test plan

- [ ] Connect an MCP server that advertises a tool `title` (either top-level or via `annotations.title`) and verify `title` is present on the corresponding entry from `getAITools()`.
- [ ] Verify tools without a `title` still work (field is simply `undefined`).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
