### PR TITLE
fix(ai-chat): surface "busy" signal while onToolCall is awaiting (issue #1365)

### DIFF
--- a/.changeset/ai-chat-ontoolcall-busy-signal.md
+++ b/.changeset/ai-chat-ontoolcall-busy-signal.md
@@ -1,0 +1,21 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix `useAgentChat()` going silent while an `onToolCall` handler is running. The server's `streamText` ends the stream as soon as the model emits a client-tool call, which dropped `status` back to `ready` and `isStreaming`/`isServerStreaming` to `false` for the full duration of the client-side `tool.execute()` — often a `fetch` taking several seconds. Consumers had no single flag that covered the whole "turn in progress" window. See [#1365](https://github.com/cloudflare/agents/issues/1365).
+
+`useAgentChat()` now treats any unresolved client-side tool call on the latest assistant message as an active server-driven phase:
+
+- `isServerStreaming` is `true` from the moment the tool part appears in `input-available` (with an active handler — `onToolCall` or a deprecated `tools` entry with `execute`) until it transitions out via `addToolOutput` / `addToolResult`.
+- `isStreaming` (`status === "streaming" || isServerStreaming`) stays `true` across the whole tool round-trip, including the gap between the model emitting the call and the server pushing its continuation.
+- `status` is untouched — it still means "user-initiated submission awaiting a response." Tools waiting for explicit user confirmation are excluded from the busy signal (nothing is happening until the user acts).
+
+Consumer code simplifies to:
+
+```tsx
+const { isStreaming, status } = useAgentChat({ ... });
+const isLoading = isStreaming || status === "submitted";
+const showTypingIndicator = status === "submitted";
+```
+
+No API changes. Existing code that only looked at `status` behaves the same.

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -2994,6 +2994,167 @@ describe("useAgentChat isServerStreaming / isStreaming (issue #1226)", () => {
       .element(screen.getByTestId("isStreaming"))
       .toHaveTextContent("false");
   });
+
+  // Issue #1365: covers the gap between the model emitting a client-tool
+  // call and the client calling addToolOutput — historically this window
+  // showed status='ready' and isStreaming=false, so consumers had no way
+  // to render a busy indicator during an async tool.execute().
+  it("isServerStreaming / isStreaming stay true while onToolCall is awaiting (issue #1365)", async () => {
+    const agent = createAgent({
+      name: "ontoolcall-gap",
+      url: "ws://localhost:3000/agents/chat/ontoolcall-gap?_pk=abc",
+      send: () => {}
+    });
+
+    // Gate the callback so the test can observe the "dark gap"
+    // while the tool is still running.
+    let resolveToolExec: (() => void) | undefined;
+    const toolExecPromise = new Promise<void>((r) => {
+      resolveToolExec = r;
+    });
+
+    const initialMessages: UIMessage[] = [
+      {
+        id: "msg-gap-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-getLocation",
+            toolCallId: "tc-gap-1",
+            state: "input-available",
+            input: {}
+          }
+        ]
+      }
+    ];
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: () => Promise.resolve(initialMessages),
+        onToolCall: async ({ toolCall, addToolOutput }) => {
+          await toolExecPromise;
+          addToolOutput({
+            toolCallId: toolCall.toolCallId,
+            output: { lat: 51.5, lng: -0.1 }
+          });
+        }
+      });
+      return (
+        <div>
+          <div data-testid="isServerStreaming">
+            {String(chat.isServerStreaming)}
+          </div>
+          <div data-testid="isStreaming">{String(chat.isStreaming)}</div>
+          <div data-testid="status">{chat.status}</div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(50);
+      return screen;
+    });
+
+    // While the onToolCall async work is pending, the hook must expose
+    // "something is happening" without touching status (which is
+    // reserved for user-initiated submissions).
+    await expect
+      .element(screen.getByTestId("isServerStreaming"))
+      .toHaveTextContent("true");
+    await expect
+      .element(screen.getByTestId("isStreaming"))
+      .toHaveTextContent("true");
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("ready");
+
+    // Let the tool.execute() complete → addToolOutput fires → tool part
+    // transitions to output-available → derived flag drops.
+    await act(async () => {
+      resolveToolExec?.();
+      await sleep(20);
+    });
+
+    await expect
+      .element(screen.getByTestId("isServerStreaming"))
+      .toHaveTextContent("false");
+  });
+
+  it("isServerStreaming stays false when a tool is waiting for user confirmation (issue #1365)", async () => {
+    // Tools requiring explicit user confirmation sit in input-available
+    // but aren't auto-invoked via onToolCall — nothing is happening
+    // until the user acts, so the busy indicator must stay off.
+    const agent = createAgent({
+      name: "ontoolcall-confirm",
+      url: "ws://localhost:3000/agents/chat/ontoolcall-confirm?_pk=abc",
+      send: () => {}
+    });
+
+    const initialMessages: UIMessage[] = [
+      {
+        id: "msg-confirm-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-dangerousAction",
+            toolCallId: "tc-confirm-1",
+            state: "input-available",
+            input: { action: "delete" }
+          }
+        ]
+      }
+    ];
+
+    const tools: Record<string, AITool> = {
+      dangerousAction: {
+        // No execute function → requires confirmation
+        parameters: { type: "object" as const, properties: {} }
+      }
+    };
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: () => Promise.resolve(initialMessages),
+        tools
+      });
+      return (
+        <div>
+          <div data-testid="isServerStreaming">
+            {String(chat.isServerStreaming)}
+          </div>
+          <div data-testid="isStreaming">{String(chat.isStreaming)}</div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(50);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("isServerStreaming"))
+      .toHaveTextContent("false");
+    await expect
+      .element(screen.getByTestId("isStreaming"))
+      .toHaveTextContent("false");
+  });
 });
 
 describe("useAgentChat tool approval continuations (issue #1108)", () => {

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -569,9 +569,13 @@ export function useAgentChat<
   addToolOutput: (opts: AddToolOutputOptions) => void;
   /**
    * Whether a server-initiated stream (e.g. from `saveMessages`,
-   * auto-continuation, or another tab) is currently active.
-   * This is independent of the AI SDK's `status` which only tracks
-   * client-initiated request/response cycles.
+   * auto-continuation, or another tab) is currently active, OR a
+   * client-side tool call is awaiting resolution via `onToolCall`.
+   * Covers the full "turn-in-progress" window from the consumer's
+   * perspective, including the gap between the model emitting a
+   * client-tool call and the server pushing a continuation after
+   * `addToolOutput`. This is independent of the AI SDK's `status`
+   * which only tracks client-initiated request/response cycles.
    */
   isServerStreaming: boolean;
   /**
@@ -1837,12 +1841,51 @@ export function useAgentChat<
     [sendToolOutputToServer, addToolResult]
   );
 
-  const isStreaming = status === "streaming" || isServerStreaming;
+  // Derive whether there are unresolved client-side tool calls on the
+  // latest assistant message. The AI SDK's `streamText` on the server
+  // ends the stream as soon as it emits a tool-call the server can't
+  // execute, which drops `status` back to "ready" while the client's
+  // async `onToolCall` handler is still running. Without this signal,
+  // consumers see a blank "nothing happening" window for the full
+  // duration of `tool.execute()` — often a `fetch` taking seconds.
+  //
+  // We scope this to tool calls that have an actual handler:
+  //   - `onToolCall` is provided (new, supported path), OR
+  //   - a matching entry in the deprecated `tools` option has `execute`.
+  // Tools waiting on explicit user confirmation are excluded — nothing
+  // is happening until the user acts, so the "busy" indicator would be
+  // misleading.
+  //
+  // Derivation (not a counter / not effect-tracked) so that the flag
+  // self-heals as soon as the tool part transitions to `output-available`
+  // via `addToolOutput` → `addToolResult`, or to any other terminal
+  // state via a server-pushed message update.
+  const lastAssistantMessage =
+    messagesWithToolResults[messagesWithToolResults.length - 1];
+  const hasPendingClientToolCalls = (() => {
+    const hasOnToolCall = !!onToolCall;
+    if (!hasOnToolCall && !tools) return false;
+    if (!lastAssistantMessage || lastAssistantMessage.role !== "assistant") {
+      return false;
+    }
+    for (const part of lastAssistantMessage.parts) {
+      if (!isToolUIPart(part)) continue;
+      if (part.state !== "input-available") continue;
+      const toolName = getToolName(part);
+      if (toolsRequiringConfirmation.includes(toolName)) continue;
+      if (hasOnToolCall || tools?.[toolName]?.execute) return true;
+    }
+    return false;
+  })();
+
+  const effectiveIsServerStreaming =
+    isServerStreaming || hasPendingClientToolCalls;
+  const isStreaming = status === "streaming" || effectiveIsServerStreaming;
 
   return {
     ...useChatHelpers,
     messages: messagesWithToolResults,
-    isServerStreaming,
+    isServerStreaming: effectiveIsServerStreaming,
     isStreaming,
     sendMessage: sendMessageWithStreamingProtection,
     stop: stopWithToolContinuationAbort,


### PR DESCRIPTION
## Summary

Closes the first half of #1365 — the state gap during client-side `onToolCall` execution.

The server's `streamText` ends the stream the moment the model emits a client-tool call, which dropped `status` back to `ready` and both `isStreaming`/`isServerStreaming` to `false` for the entire duration of the client-side `tool.execute()`. For fast tools it's imperceptible; for anything doing a `fetch`, the UI goes visibly silent in the middle of what the user thinks is one continuous turn.

`useAgentChat()` now derives "pending client tool call" from the latest assistant message state:

- While a part is in `input-available` **and** has an active handler (`onToolCall`, or a deprecated `tools` entry with `execute`), `isServerStreaming` (and therefore `isStreaming`) is `true`.
- The flag self-heals as soon as `addToolOutput` → `addToolResult` transitions the tool part to `output-available` — no counter, no effect-based bookkeeping, no risk of stuck indicators.
- Tools waiting for explicit user confirmation are excluded from the busy signal (nothing is happening until the user acts).

`status` is deliberately untouched. The second half of the issue (`status === 'submitted'` conflating user-initiated submissions with server-pushed tool continuations) is a separate Option-A refactor I'll open as a follow-up.

Consumer code now reduces to:

\`\`\`tsx
const { isStreaming, status } = useAgentChat({ ... });
const isLoading = isStreaming || status === "submitted";
const showTypingIndicator = status === "submitted";
\`\`\`

## Test plan

- [x] New test: `isServerStreaming / isStreaming stay true while onToolCall is awaiting` — gates the callback on a Promise, asserts `isServerStreaming === true`, `isStreaming === true`, `status === "ready"` during the gap, then verifies drop-off after resolution.
- [x] New test: `isServerStreaming stays false when a tool is waiting for user confirmation` — guards against a false-positive busy indicator for approval-style flows.
- [x] `npx vitest --project react --run` — 51/51 pass
- [x] `npx vitest --project workers --run` — 414/414 pass
- [x] `tsc --noEmit`, `oxlint`, `oxfmt --check` all clean
- [x] Changeset included (`@cloudflare/ai-chat` patch)

Made-with: Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
