### PR TITLE
fix(think): isolate private config from session metadata

### DIFF
--- a/.changeset/think-config-session-cleanup.md
+++ b/.changeset/think-config-session-cleanup.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/think": patch
+---
+
+Remove Think's unused internal `session_id` config scaffolding and move Think's private config into a dedicated `think_config` table.
+
+Older builds wrote Think-owned config into Session's shared `assistant_config(session_id, key, value)` table even though Think never actually had top-level multi-session support and `_sessionId()` always returned the empty string. Think now stores its private config rows in `think_config(key, value)`, which better matches the shipped model of one Think Durable Object per conversation and avoids overloading Session's shared metadata table.
+
+Existing Durable Objects are migrated automatically on startup: legacy Think-owned keys stored in `assistant_config` with `session_id = ''` are copied into `think_config` before config reads and writes continue.

--- a/design/chat-improvements.md
+++ b/design/chat-improvements.md
@@ -846,7 +846,11 @@ export class RequestContextStore {
 }
 ```
 
-**Note:** For Think-on-Session, this functionality moves to `assistant_config` — but the `RequestContextStore` interface is still useful for AIChatAgent (which doesn't use Session). The store could accept `assistant_config` as the table name when Session is in play.
+**Note:** For the current Think implementation, this functionality does not
+move into Session's shared `assistant_config` table. Think now keeps its own
+private request metadata in `think_config`, but the `RequestContextStore`
+interface is still useful for AIChatAgent (which does not use Think's storage
+layout).
 
 **Effort:** Low. Self-contained utility.
 
@@ -1006,13 +1010,13 @@ These are independent, purely additive, and can be PRed in parallel:
 
 These should land before Think's Session integration PR, so Think can import from `agents/chat`:
 
-| #   | Change                                               | Effort     | Impact                                    |
-| --- | ---------------------------------------------------- | ---------- | ----------------------------------------- |
-| E2  | Extract `AbortRegistry`                              | Very low   | Think reuses, AIChatAgent simplified      |
-| E4  | Extract `RequestContextStore`                        | Low        | Think reuses (or uses `assistant_config`) |
-| E3  | Extract tool state machine (`findAndUpdateToolPart`) | Low-medium | Think reuses, AIChatAgent simplified      |
-| E1  | Extract protocol handler (or `parseProtocolMessage`) | Medium     | Largest dedup win                         |
-| E5  | Extract stream resume handler                        | Medium     | Think reuses, resume logic consolidated   |
+| #   | Change                                               | Effort     | Impact                                                              |
+| --- | ---------------------------------------------------- | ---------- | ------------------------------------------------------------------- |
+| E2  | Extract `AbortRegistry`                              | Very low   | Think reuses, AIChatAgent simplified                                |
+| E4  | Extract `RequestContextStore`                        | Low        | Think reuses the pattern, but keeps private state in `think_config` |
+| E3  | Extract tool state machine (`findAndUpdateToolPart`) | Low-medium | Think reuses, AIChatAgent simplified                                |
+| E1  | Extract protocol handler (or `parseProtocolMessage`) | Medium     | Largest dedup win                                                   |
+| E5  | Extract stream resume handler                        | Medium     | Think reuses, resume logic consolidated                             |
 
 ### Wave 4: Deprecation
 

--- a/design/think-roadmap.md
+++ b/design/think-roadmap.md
@@ -134,7 +134,7 @@ See [chat-improvements.md §Shared Code Extraction](./chat-improvements.md#share
 | System prompt composition | `assembleContext()`             | Context blocks → frozen prompt, falls back to `getSystemPrompt()` |
 | Read-time truncation      | `truncateOlderMessages()`       | Old tool outputs and long text truncated before LLM               |
 | Multi-session             | `SessionManager`                | Create, list, delete, rename, fork, usage tracking                |
-| Config storage            | `assistant_config` table        | Client tools, body, Think config — one table                      |
+| Config storage            | `think_config` table            | Think-private config (`_think_config`, client tools, body)        |
 
 ### Override points
 
@@ -272,11 +272,13 @@ This is **better** than AIChatAgent's approach: alternatives are preserved, user
 
 **What it does:** Persist the client's custom `body` fields from the chat request. Available in auto-continuations, programmatic turns, and recovery. Survives hibernation.
 
-**Implementation with Session:** Store in `assistant_config` table (same as client tools).
+**Implementation with current Think storage:** Store in `think_config` table
+(same as client tools).
 
 **Depends on:** Nothing.
 
-**Effort:** Very low. Parse `body` from request, store in `assistant_config`, restore on turn start.
+**Effort:** Very low. Parse `body` from request, store in `think_config`,
+restore on turn start.
 
 ### Gap 10: `messageConcurrency` strategies
 
@@ -384,8 +386,10 @@ See [chat-improvements.md §Shared Code Extraction](./chat-improvements.md#share
    - Replace `_clearMessages()` + `this.messages = []` + `_persistedMessageCache.clear()` with `session.clearMessages()`
 
 8. **Config and client tools:**
-   - Use Session's `assistant_config` table directly for client tools and Think config
-   - Remove `_think_config` table, `think_request_context` table, `_storageReady`, `#configTableReady`
+   - Store Think-private config in `think_config`
+   - Legacy Think-owned keys in `assistant_config(session_id, key, value)`
+     migrate into `think_config`
+   - Remove `_think_config` table and `_sessionId()` scaffolding
 
 9. **Protocol handling:**
    - Use `parseProtocolMessage` from `agents/chat` (extracted in Phase 0) for typed protocol dispatch
@@ -448,7 +452,7 @@ See [chat-improvements.md §Shared Code Extraction](./chat-improvements.md#share
 
 3. **Custom body persistence:**
    - Parse `body` from chat request (everything except `messages`, `clientTools`, `trigger`)
-   - Persist to `assistant_config` as `_lastBody`
+   - Persist to `think_config` as `_lastBody`
    - Restore on turn start, pass to `onChatMessage` as `options.body`
    - Available in auto-continuations and `continueLastTurn`
 

--- a/design/think-sessions.md
+++ b/design/think-sessions.md
@@ -200,11 +200,19 @@ The mutable `messages: UIMessage[] = []` field becomes a computed getter backed 
 
 ### Removed: `think_request_context` table
 
-Client tool persistence and other request context moves to Session's `assistant_config` table (which has `(session_id, key)` as primary key and was explicitly reserved for Think integration).
+Client tool persistence and other request context no longer use
+`think_request_context`. In the current implementation, Think stores its
+private request metadata in a dedicated `think_config` table and only uses
+Session's `assistant_config` table as a legacy migration source.
 
 ### Removed: `_think_config` table
 
-Think's dynamic configuration (`configure()` / `getConfig()`) moves to `assistant_config` with a reserved key prefix. The `Config` type parameter and `configure()` / `getConfig()` API are preserved — only the backing table changes.
+Think's dynamic configuration (`configure()` / `getConfig()`) no longer uses
+the historical `_think_config` table, but it also does not write into
+Session's shared `assistant_config` table. The current implementation stores
+Think-private config in `think_config(key, value)` and migrates older
+Think-owned keys out of `assistant_config(session_id, key, value)` when
+`session_id = ''`.
 
 ### Removed: `_storageReady` / `#configTableReady` / `#configCache`
 
@@ -597,18 +605,17 @@ private _persistClientTools(): void {
 }
 ```
 
-After (using Session's `assistant_config` table):
+After (using Think's `think_config` table):
 
 ```typescript
 private _persistClientTools(): void {
-  const sessionId = this.session._sessionId ?? "";
   if (this._lastClientTools) {
     this.sql`
-      INSERT OR REPLACE INTO assistant_config (session_id, key, value)
-      VALUES (${sessionId}, 'lastClientTools', ${JSON.stringify(this._lastClientTools)})
+      INSERT OR REPLACE INTO think_config (key, value)
+      VALUES ('lastClientTools', ${JSON.stringify(this._lastClientTools)})
     `;
   } else {
-    this.sql`DELETE FROM assistant_config WHERE session_id = ${sessionId} AND key = 'lastClientTools'`;
+    this.sql`DELETE FROM think_config WHERE key = 'lastClientTools'`;
   }
 }
 ```
@@ -624,20 +631,23 @@ configure(config: Config): void {
 }
 ```
 
-After (using `assistant_config` table):
+After (using `think_config` table):
 
 ```typescript
 configure(config: Config): void {
-  const sessionId = this.session._sessionId ?? "";
   this.sql`
-    INSERT OR REPLACE INTO assistant_config (session_id, key, value)
-    VALUES (${sessionId}, '_think_config', ${JSON.stringify(config)})
+    INSERT OR REPLACE INTO think_config (key, value)
+    VALUES ('_think_config', ${JSON.stringify(config)})
   `;
   this.#configCache = config;
 }
 ```
 
-All Think-internal state consolidates into Session's `assistant_config` table. One table instead of three (`think_request_context`, `_think_config`, and the flat `assistant_messages`).
+Think-internal config no longer consolidates into Session's
+`assistant_config` table. Session still owns `assistant_config` for
+session-scoped metadata; Think now keeps its own private config in
+`think_config`, with a legacy one-way migration from `assistant_config` for
+older deployments.
 
 ### Broadcasting messages
 
@@ -984,7 +994,7 @@ These are handled by Think or the shared `agents/chat` layer. See [chat-improvem
 | WebSocket protocol      | `agents/chat` (`parseProtocolMessage`)                   | Typed parser for protocol dispatch                                 |
 | Abort/cancel            | `agents/chat` (`AbortRegistry`)                          | Per-request `AbortController` management                           |
 | Tool state updates      | `agents/chat` (`applyToolUpdate` + builders)             | State matching + update construction                               |
-| Request context         | Session (`assistant_config` table)                       | Client tools, body, config — Think uses Session directly           |
+| Request context         | Think (`think_config` table)                             | Think-private client tools, body, and config                       |
 | Auto-continuation       | Think (`_continuation`, `_scheduleAutoContinuation`)     | 50ms coalesce, deferred queue (Think-specific)                     |
 | Stream accumulation     | `agents/chat` (`StreamAccumulator`)                      | Build assistant message from chunks                                |
 | Message sanitization    | `agents/chat` (`sanitizeMessage`, `enforceRowSizeLimit`) | Applied before Session persistence                                 |
@@ -995,15 +1005,16 @@ These are handled by Think or the shared `agents/chat` layer. See [chat-improvem
 
 ### SQLite table ownership
 
-| Table                        | Owner                            | Purpose                                              |
-| ---------------------------- | -------------------------------- | ---------------------------------------------------- |
-| `assistant_messages`         | Session (`AgentSessionProvider`) | Tree-structured messages                             |
-| `assistant_compactions`      | Session (`AgentSessionProvider`) | Compaction overlays                                  |
-| `assistant_fts`              | Session (`AgentSessionProvider`) | FTS5 full-text search index                          |
-| `assistant_config`           | Session (`AgentSessionProvider`) | Key-value config (Think config, client tools, etc.)  |
-| `assistant_sessions`         | Session (`SessionManager`)       | Multi-session metadata (only if SessionManager used) |
-| `cf_agents_context_blocks`   | Session (`AgentContextProvider`) | Context block storage                                |
-| `cf_ai_chat_stream_metadata` | Think (`ResumableStream`)        | Stream replay metadata                               |
-| `cf_ai_chat_stream_chunks`   | Think (`ResumableStream`)        | Stream replay chunks                                 |
-| `cf_agents_runs`             | Agent (inherited)                | Durable fiber state                                  |
-| `cf_agents_schedules`        | Agent (inherited)                | Scheduled tasks                                      |
+| Table                        | Owner                            | Purpose                                                    |
+| ---------------------------- | -------------------------------- | ---------------------------------------------------------- |
+| `assistant_messages`         | Session (`AgentSessionProvider`) | Tree-structured messages                                   |
+| `assistant_compactions`      | Session (`AgentSessionProvider`) | Compaction overlays                                        |
+| `assistant_fts`              | Session (`AgentSessionProvider`) | FTS5 full-text search index                                |
+| `assistant_config`           | Session (`AgentSessionProvider`) | Shared session-scoped metadata table                       |
+| `think_config`               | Think                            | Think-private config (`_think_config`, client tools, body) |
+| `assistant_sessions`         | Session (`SessionManager`)       | Multi-session metadata (only if SessionManager used)       |
+| `cf_agents_context_blocks`   | Session (`AgentContextProvider`) | Context block storage                                      |
+| `cf_ai_chat_stream_metadata` | Think (`ResumableStream`)        | Stream replay metadata                                     |
+| `cf_ai_chat_stream_chunks`   | Think (`ResumableStream`)        | Stream replay chunks                                       |
+| `cf_agents_runs`             | Agent (inherited)                | Durable fiber state                                        |
+| `cf_agents_schedules`        | Agent (inherited)                | Scheduled tasks                                            |

--- a/design/think-vs-aichat.md
+++ b/design/think-vs-aichat.md
@@ -37,16 +37,16 @@ Related:
 
 ### Storage and data model
 
-| Concept                | AIChatAgent                                           | Think                                                                                                               |
-| ---------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Messages**           | `this.messages` — mutable field, flat SQL table       | `this.messages` — getter from Session tree (always fresh from SQLite)                                               |
-| **Storage**            | Flat `cf_ai_chat_agent_messages` table                | Session: `assistant_messages` (tree with `parent_id`), `assistant_compactions`, `assistant_fts`, `assistant_config` |
-| **Regeneration**       | Destructive — `_deleteStaleRows` removes old response | Non-destructive — new response branches from same parent, old preserved                                             |
-| **Message pruning**    | `maxPersistedMessages` (deletes oldest)               | Compaction (non-destructive summaries via overlays)                                                                 |
-| **Search**             | Not available                                         | FTS5 full-text search (per-session and cross-session)                                                               |
-| **Context blocks**     | Not available                                         | `configureSession()` with writable blocks, skills, search providers                                                 |
-| **Multi-session**      | One conversation per DO                               | `SessionManager` for multiple conversations per DO                                                                  |
-| **Config persistence** | Not available                                         | `configure(config)` / `getConfig()` with generic `Config` type                                                      |
+| Concept                | AIChatAgent                                           | Think                                                                                                                                   |
+| ---------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Messages**           | `this.messages` — mutable field, flat SQL table       | `this.messages` — getter from Session tree (always fresh from SQLite)                                                                   |
+| **Storage**            | Flat `cf_ai_chat_agent_messages` table                | Session: `assistant_messages` (tree with `parent_id`), `assistant_compactions`, `assistant_fts`; Think-private config in `think_config` |
+| **Regeneration**       | Destructive — `_deleteStaleRows` removes old response | Non-destructive — new response branches from same parent, old preserved                                                                 |
+| **Message pruning**    | `maxPersistedMessages` (deletes oldest)               | Compaction (non-destructive summaries via overlays)                                                                                     |
+| **Search**             | Not available                                         | FTS5 full-text search (per-session and cross-session)                                                                                   |
+| **Context blocks**     | Not available                                         | `configureSession()` with writable blocks, skills, search providers                                                                     |
+| **Multi-session**      | One conversation per DO                               | `SessionManager` for multiple conversations per DO                                                                                      |
+| **Config persistence** | Not available                                         | `configure(config)` / `getConfig()` with generic `Config` type                                                                          |
 
 ### Turn execution
 
@@ -202,7 +202,8 @@ async onScheduled() {
 
 ### 8. You need typed dynamic configuration
 
-`configure<Config>(config)` / `getConfig()` with TypeScript generics. Persisted in Session's `assistant_config` table, survives hibernation and restarts.
+`configure<Config>(config)` / `getConfig()` with TypeScript generics.
+Persisted in Think's `think_config` table, survives hibernation and restarts.
 
 ```typescript
 class MyAgent extends Think<Env, { theme: string; model: string }> {

--- a/design/think.md
+++ b/design/think.md
@@ -278,7 +278,10 @@ export class ChatSession extends Think<Env> {
 }
 ```
 
-Configuration is stored in SQLite (`_think_config`) and cached in memory. It survives hibernation. A parent orchestrator can configure sub-agents via RPC:
+Configuration is stored in SQLite (`think_config`) and cached in memory. It
+survives hibernation. Legacy Think-owned keys written into
+`assistant_config(session_id, key, value)` are migrated into `think_config` on
+startup. A parent orchestrator can configure sub-agents via RPC:
 
 ```typescript
 const session = await this.subAgent(ChatSession, "agent-abc");
@@ -396,13 +399,15 @@ Two AI SDK tools for managing extensions at runtime:
 
 ## SQLite tables
 
-| Table                   | Owner             | Purpose                                        |
-| ----------------------- | ----------------- | ---------------------------------------------- |
-| `assistant_messages`    | Think             | Flat ordered message store (no branching)      |
-| `think_request_context` | Think             | Client tools and request context (hibernation) |
-| `_think_config`         | Think             | Dynamic configuration (key-value)              |
-| `cf_agents_runs`        | Agent (inherited) | Durable fiber state and checkpoints            |
-| `cf_agents_schedules`   | Agent (inherited) | Scheduled tasks and intervals                  |
+| Table                   | Owner             | Purpose                                                    |
+| ----------------------- | ----------------- | ---------------------------------------------------------- |
+| `assistant_messages`    | Session           | Tree-structured conversation history                       |
+| `assistant_compactions` | Session           | Compaction overlays and summaries                          |
+| `assistant_fts`         | Session           | Full-text search index for messages                        |
+| `assistant_config`      | Session           | Shared session-scoped metadata reserved by Session         |
+| `think_config`          | Think             | Think-private config (`_think_config`, client tools, body) |
+| `cf_agents_runs`        | Agent (inherited) | Durable fiber state and checkpoints                        |
+| `cf_agents_schedules`   | Agent (inherited) | Scheduled tasks and intervals                              |
 
 ## Known gaps (vs AIChatAgent)
 

--- a/packages/think/src/tests/agents/index.ts
+++ b/packages/think/src/tests/agents/index.ts
@@ -11,6 +11,7 @@ export {
   ThinkSessionTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
+  ThinkLegacyConfigMigrationAgent,
   ThinkConfigInSessionAgent,
   ThinkProgrammaticTestAgent,
   ThinkAsyncHookTestAgent,

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -637,6 +637,14 @@ export class ThinkLegacyConfigMigrationAgent extends Think<Cloudflare.Env> {
     return createMockModel("Legacy config migration response");
   }
 
+  async setTestConfig(config: TestConfig): Promise<void> {
+    this.configure<TestConfig>(config);
+  }
+
+  rerunLegacyMigrationForTest(): void {
+    this._migrateLegacyConfigToThinkTable();
+  }
+
   async getTestConfig(): Promise<TestConfig | null> {
     return this.getConfig<TestConfig>();
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -645,6 +645,15 @@ export class ThinkLegacyConfigMigrationAgent extends Think<Cloudflare.Env> {
     this._migrateLegacyConfigToThinkTable();
   }
 
+  async getRawThinkConfigForTest(): Promise<TestConfig | null> {
+    const rows = this.sql<{ value: string }>`
+      SELECT value FROM think_config
+      WHERE key = ${"_think_config"}
+    `;
+    const raw = rows[0]?.value;
+    return raw ? (JSON.parse(raw) as TestConfig) : null;
+  }
+
   async getTestConfig(): Promise<TestConfig | null> {
     return this.getConfig<TestConfig>();
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -616,9 +616,35 @@ export class ThinkConfigTestAgent extends Think<Cloudflare.Env> {
   }
 }
 
+export class ThinkLegacyConfigMigrationAgent extends Think<Cloudflare.Env> {
+  constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
+    super(ctx, env);
+    ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS assistant_config (
+        session_id TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        PRIMARY KEY (session_id, key)
+      )
+    `);
+    ctx.storage.sql.exec(`
+      INSERT OR REPLACE INTO assistant_config (session_id, key, value)
+      VALUES ('', '_think_config', '{"theme":"dark","maxTokens":4000}')
+    `);
+  }
+
+  override getModel(): LanguageModel {
+    return createMockModel("Legacy config migration response");
+  }
+
+  async getTestConfig(): Promise<TestConfig | null> {
+    return this.getConfig<TestConfig>();
+  }
+}
+
 // ── ThinkConfigInSessionAgent ────────────────────────────────
 // Reproduces GH-1309: getConfig() inside configureSession() should
-// not throw "no such table: assistant_config".
+// not throw when Think's private config table has not been initialized yet.
 
 type ConfigInSessionConfig = {
   persona: string;

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -555,7 +555,7 @@ describe("Think — dynamic configuration", () => {
     await agent.setTestConfig({ theme: "light", maxTokens: 2000 });
     await agent.rerunLegacyMigrationForTest();
 
-    const config = await agent.getTestConfig();
+    const config = await agent.getRawThinkConfigForTest();
     expect(config).not.toBeNull();
     expect(config!.theme).toBe("light");
     expect(config!.maxTokens).toBe(2000);

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -553,7 +553,7 @@ describe("Think — dynamic configuration", () => {
     );
 
     await agent.setTestConfig({ theme: "light", maxTokens: 2000 });
-    agent.rerunLegacyMigrationForTest();
+    await agent.rerunLegacyMigrationForTest();
 
     const config = await agent.getTestConfig();
     expect(config).not.toBeNull();

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -7,6 +7,7 @@ import type {
   ThinkSessionTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
+  ThinkLegacyConfigMigrationAgent,
   ThinkConfigInSessionAgent,
   ThinkProgrammaticTestAgent,
   ThinkAsyncHookTestAgent,
@@ -74,6 +75,13 @@ async function freshConfigAgent(name: string) {
 async function freshConfigInSessionAgent(name: string) {
   return getServerByName(
     env.ThinkConfigInSessionAgent as unknown as DurableObjectNamespace<ThinkConfigInSessionAgent>,
+    name
+  );
+}
+
+async function freshLegacyConfigMigrationAgent(name: string) {
+  return getServerByName(
+    env.ThinkLegacyConfigMigrationAgent as unknown as DurableObjectNamespace<ThinkLegacyConfigMigrationAgent>,
     name
   );
 }
@@ -526,6 +534,17 @@ describe("Think — dynamic configuration", () => {
     const config = await agent.getTestConfig();
     expect(config!.theme).toBe("dark");
     expect(config!.maxTokens).toBe(8000);
+  });
+
+  it("should migrate legacy Think config out of assistant_config", async () => {
+    const agent = await freshLegacyConfigMigrationAgent(
+      "config-legacy-migration"
+    );
+
+    const config = await agent.getTestConfig();
+    expect(config).not.toBeNull();
+    expect(config!.theme).toBe("dark");
+    expect(config!.maxTokens).toBe(4000);
   });
 });
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -546,6 +546,20 @@ describe("Think — dynamic configuration", () => {
     expect(config!.theme).toBe("dark");
     expect(config!.maxTokens).toBe(4000);
   });
+
+  it("should not let legacy config overwrite newer think_config values on rerun", async () => {
+    const agent = await freshLegacyConfigMigrationAgent(
+      "config-legacy-rerun-preserves-newer"
+    );
+
+    await agent.setTestConfig({ theme: "light", maxTokens: 2000 });
+    agent.rerunLegacyMigrationForTest();
+
+    const config = await agent.getTestConfig();
+    expect(config).not.toBeNull();
+    expect(config!.theme).toBe("light");
+    expect(config!.maxTokens).toBe(2000);
+  });
 });
 
 // ── getConfig() inside configureSession (GH-1309) ───────────────

--- a/packages/think/src/tests/worker.ts
+++ b/packages/think/src/tests/worker.ts
@@ -15,6 +15,7 @@ export {
   ThinkSessionTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
+  ThinkLegacyConfigMigrationAgent,
   ThinkConfigInSessionAgent,
   ThinkProgrammaticTestAgent,
   ThinkAsyncHookTestAgent,
@@ -36,6 +37,7 @@ import type {
   ThinkSessionTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
+  ThinkLegacyConfigMigrationAgent,
   ThinkConfigInSessionAgent,
   ThinkProgrammaticTestAgent,
   ThinkAsyncHookTestAgent,
@@ -57,6 +59,7 @@ export type Env = {
   ThinkSessionTestAgent: DurableObjectNamespace<ThinkSessionTestAgent>;
   ThinkAsyncConfigSessionAgent: DurableObjectNamespace<ThinkAsyncConfigSessionAgent>;
   ThinkConfigTestAgent: DurableObjectNamespace<ThinkConfigTestAgent>;
+  ThinkLegacyConfigMigrationAgent: DurableObjectNamespace<ThinkLegacyConfigMigrationAgent>;
   ThinkConfigInSessionAgent: DurableObjectNamespace<ThinkConfigInSessionAgent>;
   ThinkProgrammaticTestAgent: DurableObjectNamespace<ThinkProgrammaticTestAgent>;
   ThinkAsyncHookTestAgent: DurableObjectNamespace<ThinkAsyncHookTestAgent>;

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -60,6 +60,10 @@
         "name": "ThinkConfigTestAgent"
       },
       {
+        "class_name": "ThinkLegacyConfigMigrationAgent",
+        "name": "ThinkLegacyConfigMigrationAgent"
+      },
+      {
         "class_name": "ThinkConfigInSessionAgent",
         "name": "ThinkConfigInSessionAgent"
       },
@@ -102,6 +106,7 @@
         "ThinkSessionTestAgent",
         "ThinkAsyncConfigSessionAgent",
         "ThinkConfigTestAgent",
+        "ThinkLegacyConfigMigrationAgent",
         "ThinkConfigInSessionAgent",
         "ThinkProgrammaticTestAgent",
         "ThinkAsyncHookTestAgent",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -611,6 +611,37 @@ export class Think<
 
   #configTableReady = false;
 
+  protected _migrateLegacyConfigToThinkTable(): void {
+    const rows = this.ctx.storage.sql
+      .exec(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='assistant_config'"
+      )
+      .toArray() as Array<{ sql?: unknown }>;
+    if (rows.length === 0) return;
+
+    const ddl = String(rows[0].sql ?? "");
+    if (!ddl.includes("session_id")) return;
+
+    // Older Think builds stored private config in Session's shared
+    // `assistant_config(session_id, key, value)` table, even though
+    // Think always used the empty session id. Copy only the Think-owned
+    // keys into the dedicated `think_config` table and leave the shared
+    // Session table untouched.
+    for (const key of Think.CONFIG_KEYS) {
+      const legacyRows = this.sql<{ value: string }>`
+        SELECT value FROM assistant_config
+        WHERE session_id = '' AND key = ${key}
+      `;
+      const value = legacyRows[0]?.value;
+      if (value !== undefined) {
+        this.sql`
+          INSERT OR IGNORE INTO think_config (key, value)
+          VALUES (${key}, ${value})
+        `;
+      }
+    }
+  }
+
   private _ensureConfigTable(): void {
     if (this.#configTableReady) return;
     this.sql`
@@ -620,34 +651,7 @@ export class Think<
         PRIMARY KEY (key)
       )
     `;
-    const rows = this.ctx.storage.sql
-      .exec(
-        "SELECT sql FROM sqlite_master WHERE type='table' AND name='assistant_config'"
-      )
-      .toArray() as Array<{ sql?: unknown }>;
-    if (rows.length > 0) {
-      const ddl = String(rows[0].sql ?? "");
-      if (ddl.includes("session_id")) {
-        // Older Think builds stored private config in Session's shared
-        // `assistant_config(session_id, key, value)` table, even though
-        // Think always used the empty session id. Copy only the Think-owned
-        // keys into the dedicated `think_config` table and leave the shared
-        // Session table untouched.
-        for (const key of Think.CONFIG_KEYS) {
-          const legacyRows = this.sql<{ value: string }>`
-            SELECT value FROM assistant_config
-            WHERE session_id = '' AND key = ${key}
-          `;
-          const value = legacyRows[0]?.value;
-          if (value !== undefined) {
-            this.sql`
-              INSERT OR REPLACE INTO think_config (key, value)
-              VALUES (${key}, ${value})
-            `;
-          }
-        }
-      }
-    }
+    this._migrateLegacyConfigToThinkTable();
     this.#configTableReady = true;
   }
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -441,6 +441,11 @@ export class Think<
   State = unknown,
   Props extends Record<string, unknown> = Record<string, unknown>
 > extends Agent<Env, State, Props> {
+  private static readonly CONFIG_KEYS = [
+    "_think_config",
+    "lastClientTools",
+    "lastBody"
+  ] as const;
   /**
    * Wait for MCP server connections to be ready before the inference
    * loop. MCP tools are auto-merged into the tool set.
@@ -514,7 +519,8 @@ export class Think<
       this.session = await this.configureSession(baseSession);
 
       // Force Session to initialize its tables (assistant_messages,
-      // assistant_config, etc.) so that subsequent config reads work.
+      // assistant_compactions, assistant_fts, etc.) before the rest of
+      // startup continues.
       this.session.getHistory();
 
       // 3-6. Extension initialization (if extensionLoader is set)
@@ -564,7 +570,8 @@ export class Think<
 
   /**
    * Persist an arbitrary JSON-serializable configuration object for this
-   * agent instance. Stored in the assistant_config table — survives
+   * agent instance. Stored in the Think-private `think_config` table —
+   * survives
    * restarts and hibernation. Pass the config shape as a method generic
    * for typed call sites:
    *
@@ -600,53 +607,73 @@ export class Think<
     return null;
   }
 
-  // ── Config storage helpers (assistant_config table) ─────────────
+  // ── Config storage helpers (think_config table) ─────────────────
 
   #configTableReady = false;
 
   private _ensureConfigTable(): void {
     if (this.#configTableReady) return;
     this.sql`
-      CREATE TABLE IF NOT EXISTS assistant_config (
-        session_id TEXT NOT NULL,
+      CREATE TABLE IF NOT EXISTS think_config (
         key TEXT NOT NULL,
         value TEXT NOT NULL,
-        PRIMARY KEY (session_id, key)
+        PRIMARY KEY (key)
       )
     `;
+    const rows = this.ctx.storage.sql
+      .exec(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='assistant_config'"
+      )
+      .toArray() as Array<{ sql?: unknown }>;
+    if (rows.length > 0) {
+      const ddl = String(rows[0].sql ?? "");
+      if (ddl.includes("session_id")) {
+        // Older Think builds stored private config in Session's shared
+        // `assistant_config(session_id, key, value)` table, even though
+        // Think always used the empty session id. Copy only the Think-owned
+        // keys into the dedicated `think_config` table and leave the shared
+        // Session table untouched.
+        for (const key of Think.CONFIG_KEYS) {
+          const legacyRows = this.sql<{ value: string }>`
+            SELECT value FROM assistant_config
+            WHERE session_id = '' AND key = ${key}
+          `;
+          const value = legacyRows[0]?.value;
+          if (value !== undefined) {
+            this.sql`
+              INSERT OR REPLACE INTO think_config (key, value)
+              VALUES (${key}, ${value})
+            `;
+          }
+        }
+      }
+    }
     this.#configTableReady = true;
   }
 
   private _configSet(key: string, value: string): void {
     this._ensureConfigTable();
-    const sessionId = this._sessionId();
     this.sql`
-      INSERT OR REPLACE INTO assistant_config (session_id, key, value)
-      VALUES (${sessionId}, ${key}, ${value})
+      INSERT OR REPLACE INTO think_config (key, value)
+      VALUES (${key}, ${value})
     `;
   }
 
   private _configGet(key: string): string | undefined {
     this._ensureConfigTable();
-    const sessionId = this._sessionId();
     const rows = this.sql<{ value: string }>`
-      SELECT value FROM assistant_config
-      WHERE session_id = ${sessionId} AND key = ${key}
+      SELECT value FROM think_config
+      WHERE key = ${key}
     `;
     return rows[0]?.value;
   }
 
   private _configDelete(key: string): void {
     this._ensureConfigTable();
-    const sessionId = this._sessionId();
     this.sql`
-      DELETE FROM assistant_config
-      WHERE session_id = ${sessionId} AND key = ${key}
+      DELETE FROM think_config
+      WHERE key = ${key}
     `;
-  }
-
-  private _sessionId(): string {
-    return "";
   }
 
   // ── Configuration overrides ─────────────────────────────────────

--- a/wip/AGENTS.md
+++ b/wip/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Scope
+
+Applies to everything under `wip/`.
+
+## Purpose
+
+`wip/` is for work-in-progress notes, implementation sketches, logs, and
+temporary planning documents that are useful while a feature is actively
+evolving.
+
+This folder is intentionally different from:
+
+- `design/` — design records and RFC-style documents that aim to capture
+  stable decisions, alternatives, and architecture
+- `docs/` — user-facing documentation
+
+Use `wip/` when the right shape is still being discovered and we want a
+running record without prematurely turning it into an RFC or polished design
+doc.
+
+## What belongs here
+
+- feature worklogs
+- migration notes
+- implementation plans that may change quickly
+- experiment notes from examples or prototypes
+- punch lists and next-step breakdowns
+
+## What should not go here
+
+- finalized RFCs or design decisions that belong in `design/`
+- user-facing docs that belong in `docs/`
+- long-term product documentation
+
+## Writing guidance
+
+- Prefer clear narrative context over terse bullets. Someone opening a file
+  here should be able to understand what is happening without reading the
+  entire chat history.
+- Include enough background to explain why the work exists now, what changed,
+  and what still needs validation.
+- Be explicit about what is decided, what is still experimental, and what
+  should happen next.
+- It is fine for plans here to be opinionated and provisional.
+- Keep file names descriptive and feature-specific.
+
+## Maintenance
+
+- When a plan hardens into a real design decision, move or rewrite it into
+  `design/`.
+- When a worklog stops being useful, it can be deleted or folded into a more
+  permanent document.

--- a/wip/think-multi-session-assistant-plan.md
+++ b/wip/think-multi-session-assistant-plan.md
@@ -1,0 +1,310 @@
+# Think Multi-Session WIP Plan
+
+## Why this file exists
+
+We recently landed and merged the sub-agent routing primitive into
+`packages/agents`, and we also built `examples/multi-ai-chat` on top of it as
+the first concrete proof that the routing model works in practice.
+
+The next goal is to bring that same parent/child multi-session model to Think.
+The original design direction for this work lives in
+`design/rfc-think-multi-session.md`, but the repo has evolved since that RFC
+was written:
+
+- the routing primitive has already shipped
+- the parent-side registry now exists
+- `parentAgent(Cls)`, `useAgent({ sub })`, `onBeforeSubAgent`,
+  `hasSubAgent`, and `listSubAgents` are all available
+- `examples/multi-ai-chat` now shows the intended composition pattern in real
+  code
+
+This note captures the current working plan before we decide what, if
+anything, should later move into a library API or a more permanent design
+document.
+
+## Current understanding
+
+The current intended architecture is:
+
+1. One chat conversation lives in one child Durable Object.
+2. A parent Durable Object owns the directory/sidebar state and any
+   user-scoped shared state.
+3. Clients connect directly to the active child via nested sub-agent routing.
+4. The parent uses the shipped registry and routing hooks rather than
+   inventing its own routing layer.
+
+`examples/multi-ai-chat` proves this already works with `AIChatAgent`:
+
+- parent DO for list + metadata + shared memory
+- child DO per conversation
+- parent-side strict registry gate via `onBeforeSubAgent`
+- child reaches parent with `parentAgent(Cls)`
+- client reaches the active child using `useAgent({ sub: [...] })`
+
+That means Think does not need a new routing mechanism. The work now is to
+adapt the pattern for Think, validate the UX, and decide which pieces deserve
+to become framework primitives.
+
+## Important conclusions so far
+
+### 1. Do not redesign the routing layer
+
+The routing primitive is already shipped and should be treated as the
+foundation:
+
+- `subAgent(Cls, name)`
+- `deleteSubAgent(Cls, name)`
+- `parentAgent(Cls)`
+- `onBeforeSubAgent`
+- `hasSubAgent`
+- `listSubAgents`
+- `useAgent({ sub: [...] })`
+
+Any Think-side work should build directly on those APIs.
+
+### 2. Do not rewrite `examples/multi-ai-chat`
+
+`examples/multi-ai-chat` should remain the minimal proof of the primitive.
+It is valuable precisely because it is small and explicit.
+
+Instead, the main place to exercise the Think-side multi-session story should
+be `examples/assistant`, since it is the kitchen-sink Think example and the
+best place to stress real feature interactions.
+
+### 3. Do not ship a library `Chats` abstraction yet
+
+There was an initial instinct to promote the pattern into a reusable `Chats`
+base class immediately. Current thinking is to hold off.
+
+Why delay it:
+
+- the amount of boilerplate is not huge
+- the remaining boilerplate is mostly opinionated policy, not raw plumbing
+- we do not yet know the right long-term shape for metadata, shared memory,
+  auth, or Think-specific UX
+- the assistant example is a better place to validate the API before freezing
+  it in a package
+
+The same logic applies to `useChats()`: prototype it in the assistant example
+first, then promote it only if the shape feels obviously right.
+
+### 4. Hoisting chat React primitives into `agents` is worth exploring
+
+Today Think consumers still reach into `@cloudflare/ai-chat/react` for
+`useAgentChat`, even though the underlying wire protocol and chat primitives
+already mostly live in `agents/chat`.
+
+That package boundary feels wrong. A likely follow-up is:
+
+- move or hoist the shared React chat hook implementation into `agents`
+- keep a compatibility re-export from `@cloudflare/ai-chat/react`
+- use that as the place to add Think-oriented behavior later
+
+This is a separate concern from multi-session itself and should likely happen
+in a dedicated PR after the assistant prototype is working.
+
+### 5. Add GitHub auth to the assistant example
+
+The current assistant example is powerful but not team-friendly to deploy and
+use together. Bringing over the GitHub auth layer from `examples/auth-agent`
+would let us:
+
+- deploy the assistant and use it as a team
+- naturally scope one parent directory DO per authenticated user
+- exercise the real user-boundary story rather than relying on a demo id
+
+This change also helps validate whether the multi-session parent should really
+be user-scoped, which is the current assumption.
+
+## The proposed implementation direction
+
+The next phase should be an example-first prototype inside
+`examples/assistant`, not a library-first abstraction.
+
+### High-level shape
+
+Refactor the assistant into a parent/child structure:
+
+- `AssistantDirectory` (parent)
+  - one DO per authenticated GitHub user
+  - owns the chat list/sidebar state
+  - owns per-user shared state if we decide to keep any
+  - gates access to children with `onBeforeSubAgent`
+- `MyAssistant` (child)
+  - one Think DO per conversation
+  - keeps the existing Think-heavy features:
+    - workspace tools
+    - execute
+    - extensions
+    - compaction
+    - search
+    - config
+    - MCP
+    - recovery
+
+Client shape:
+
+- one connection to the parent for sidebar state
+- one connection to the active child using `useAgent({ sub: [...] })`
+- a local prototype of `useChats()` in the example to wrap the above
+
+### Local prototype files to add in the example
+
+Instead of shipping library APIs immediately, prototype them locally:
+
+- `examples/assistant/src/chats.ts`
+  - local helper or base class for parent directory behavior
+- `examples/assistant/src/use-chats.ts`
+  - local `useChats()` hook tuned to the assistant UI
+
+These files are explicitly exploratory. If they turn out to be a great fit, we
+can later promote them into `packages/agents` or `packages/think`.
+
+## Cleanups that still should happen
+
+These are independent of the assistant prototype and should still go through.
+
+### Remove stale Think config scaffolding
+
+`packages/think/src/think.ts` still has unused multi-session scaffolding:
+
+- `_sessionId()` returns `""`
+- Think private config is still written through the old `_sessionId()` path
+
+That scaffolding should be removed:
+
+- delete `_sessionId()`
+- move Think-owned private config into a dedicated `think_config(key, value)`
+  table
+- migrate legacy Think-owned keys (`_think_config`, `lastClientTools`,
+  `lastBody`) out of `assistant_config(session_id, key, value)` when
+  `session_id = ''`
+- update `_configGet`, `_configSet`, and `_configDelete`
+
+This is a small cleanup, but it matters because it removes the impression that
+Think already has a built-in top-level multi-session model.
+
+## Open questions to validate in the assistant prototype
+
+### 1. What should be shared across chats?
+
+The assistant currently has a `memory` context block inside each Think
+instance. Once we split into parent + child, we need to decide whether:
+
+- memory remains per-chat for now
+- some memory becomes shared across all chats under the parent
+
+The likely answer is to start simple and avoid introducing remote context
+providers until we know we need them.
+
+### 2. What happens to scheduled work?
+
+Sub-agents/facets currently do not support independent alarms in the same way
+top-level agents do. The assistant currently uses scheduled work
+(`dailySummary`), so we will need to decide whether that moves to the parent or
+is temporarily disabled in multi-session mode.
+
+Most likely answer:
+
+- move schedule ownership to the parent
+- let the parent fan out to the relevant child chat(s) if needed
+
+### 3. Do extensions work correctly in a child Think DO?
+
+The assistant uses extension loading. We need to verify that all of the
+extension machinery behaves correctly when `MyAssistant` is a sub-agent rather
+than a top-level DO.
+
+This needs real testing in the example, not just design reasoning.
+
+### 4. What should the eventual library boundary be?
+
+Still unresolved:
+
+- should a future `Chats` abstraction live in `agents` or `think`?
+- should a future `useChats()` hook live in `agents/react` or `@cloudflare/think`?
+- should the chat React hook itself move into `agents` first?
+
+The prototype should help answer these.
+
+## Proposed staged plan
+
+### PR 1: Think cleanup
+
+Goal: remove stale built-in multi-session scaffolding from Think.
+
+Scope:
+
+- update `packages/think/src/think.ts`
+- remove `_sessionId()`
+- move Think-private config to `think_config`
+- migrate legacy Think-owned rows out of `assistant_config`
+- add a changeset for `@cloudflare/think`
+
+This is intentionally small and independent.
+
+### PR 2: Assistant multi-session prototype + GitHub auth
+
+Goal: make the assistant example the real-world Think multi-session testbed.
+
+Scope:
+
+- add GitHub auth from `examples/auth-agent`
+- refactor the assistant into parent + child DOs
+- use sub-agent routing for active chat access
+- add a local `useChats()` prototype inside the example
+- optionally add a local `Chats` helper or base class inside the example
+- update the assistant UI to support multiple chats
+
+This PR is the key learning step. It should prioritize usability and learning
+over framework purity.
+
+### PR 3: Hoist chat React hook(s) into `agents`
+
+Goal: fix the current package boundary where Think consumers import the main
+chat hook from `@cloudflare/ai-chat/react`.
+
+Scope:
+
+- move the shared hook implementation into `agents`
+- keep back-compat re-exports from `@cloudflare/ai-chat/react`
+- update Think-oriented examples to import from the new home
+
+This should happen after the assistant prototype so we know what new hook
+surface we actually want.
+
+### PR 4: Decide what to promote into the library
+
+Only after the prototype settles:
+
+- decide whether to promote `Chats`
+- decide whether to promote `useChats()`
+- decide which package should own each abstraction
+- write the more permanent design/docs updates
+
+## What this plan is optimizing for
+
+This approach is deliberately opinionated:
+
+- optimize for learning from a real example before freezing APIs
+- keep the shipped routing primitive as the foundation
+- avoid inventing another routing layer
+- avoid overfitting early abstractions
+- improve the assistant example so the team can actually deploy and use it
+- clean up stale Think internals now, even if higher-level APIs come later
+
+## Current status
+
+At the time this file was written:
+
+- the routing primitive is already shipped
+- `examples/multi-ai-chat` is the proof-of-value for the primitive
+- the next target is `examples/assistant`
+- `Chats` and `useChats()` are best treated as example-local prototypes first
+- GitHub auth should be added to the assistant example
+- the Think config cleanup is underway as a standalone PR
+
+## Likely next action
+
+Start with the small Think cleanup PR, then move directly into the assistant
+prototype work.


### PR DESCRIPTION
## Summary
- Move Think-owned private config out of Session's shared `assistant_config` table into a dedicated `think_config` table.
- Add a legacy migration path that copies older Think-owned keys from `assistant_config(session_id, key, value)` when `session_id = ''`, plus regression coverage for that startup path.
- Update the current-state design docs and `wip` plan so they reflect the implementation that actually shipped in this branch.

## Test plan
- [x] `cd packages/think && npm run test -- think-session.test.ts`
- [x] `cd packages/think && npm run build`

Made with [Cursor](https://cursor.com)