### PR TITLE
feat(example): multi-session assistant — sub-agent routing, shared workspace, shared MCP

### DIFF
--- a/.changeset/shell-workspace-fs-like.md
+++ b/.changeset/shell-workspace-fs-like.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/shell": patch
+---
+
+Introduce `WorkspaceFsLike` — the minimum `Workspace` surface required by `WorkspaceFileSystem` and `createWorkspaceStateBackend`.
+
+`WorkspaceFileSystem`'s constructor and `createWorkspaceStateBackend`'s parameter both now accept any `WorkspaceFsLike` (a `Pick<Workspace, …>` of the 16 filesystem methods the adapter reaches for) rather than a concrete `Workspace`. Non-breaking — `Workspace` still satisfies `WorkspaceFsLike` so every existing call site keeps working without changes.
+
+This unlocks wrapping a real `Workspace` behind your own layer — most commonly a cross-DO proxy that forwards each call to a parent agent's workspace over RPC — and still using it as the storage for codemode's `state.*` sandbox API via `createWorkspaceStateBackend`. See `examples/assistant` for the end-to-end pattern with `SharedWorkspace`.

--- a/.changeset/think-workspace-like.md
+++ b/.changeset/think-workspace-like.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/think": patch
+---
+
+Introduce `WorkspaceLike` — type the `this.workspace` field as the minimum surface Think actually uses instead of the concrete `Workspace` class.
+
+`Think`'s `workspace` is now typed as `WorkspaceLike` (`Pick<Workspace, "readFile" | "writeFile" | "readDir" | "rm" | "glob" | "mkdir" | "stat">`) rather than `Workspace`. `createWorkspaceTools()` likewise accepts any `WorkspaceLike`. The default runtime value is unchanged — a full `Workspace` backed by the DO's SQLite — so the vast majority of consumers need no changes.
+
+This unlocks patterns like a shared workspace across multiple agents: a child agent can override `workspace` with a proxy that forwards each call to a parent DO via RPC, and the rest of Think's workspace-aware code (the builtin tools, lifecycle hooks) keeps working without cast gymnastics. See `examples/assistant` for the cross-chat shared workspace built on this.
+
+Consumers who use `createWorkspaceStateBackend(workspace)` from `@cloudflare/shell` (codemode's `state.*` API) still need a concrete `Workspace` — that helper reaches for more of the filesystem surface than `WorkspaceLike` covers.

--- a/examples/assistant/README.md
+++ b/examples/assistant/README.md
@@ -12,8 +12,13 @@ the sub-agent routing primitive from `agents`.
 - **Shared workspace across chats** — `AssistantDirectory` owns one `Workspace`
   backed by its SQLite; every `MyAssistant` child gets a `SharedWorkspace`
   proxy that forwards file I/O to the parent. A `hello.txt` written in chat A
-  is visible verbatim in chat B. The proxy swaps in via the `WorkspaceLike`
-  type exported by `@cloudflare/think` — no casts, all builtin tools still work
+  is visible verbatim in chat B. The proxy swaps in via the `WorkspaceFsLike`
+  type exported by `@cloudflare/shell` — no casts; builtin workspace tools
+  AND codemode's `state.*` sandbox API both route through it
+- **Live cross-chat file updates** — the directory's `Workspace` is wired
+  with `onChange` → `broadcast`, so every open tab's file browser updates
+  live whenever any chat writes, edits, or deletes a file. `useChats()`
+  surfaces it as a `workspaceRevision` counter for `useEffect` deps
 - **Think base class** — `getModel()`, `configureSession()`, `getTools()`, `maxSteps` for a batteries-included agent
 - **Built-in workspace** — file tools (read, write, edit, find, grep, delete) auto-wired on every turn
 - **Sandboxed code execution** — `createExecuteTool` lets the LLM write and run JavaScript in a Dynamic Worker via `@cloudflare/codemode`
@@ -188,10 +193,16 @@ external links).
 - _Serialization is per-file, not per-turn._ Two chats writing to the
   same path queue behind each other in the parent DO's single-threaded
   isolate, which is the usual semantics you'd want.
-- _Change events don't fan out across chats._ `Workspace` emits
-  change events via an `onChange` callback on the parent's isolate;
-  children don't see them. The assistant doesn't rely on change-event
-  fan-out today. Add a parent → child broadcast if you need it.
+- _Change events fan out to every client, but not to sibling chats._
+  `AssistantDirectory.workspace` is constructed with `onChange: (ev)
+=> this.broadcast(...)`, so every file mutation reaches every client
+  connected to the directory — that's every browser tab the user has
+  open, across every chat. `useChats()` translates those broadcasts
+  into a `workspaceRevision` counter that chat panes pass into their
+  file-browser effects, so a write in chat A lights up chat B's files
+  list live. The parent does _not_ RPC events into sibling child
+  facets — no server-side tool in this example reacts to another
+  chat's writes. Add a parent → child RPC if that use case shows up.
 
 ## Deploying
 

--- a/examples/assistant/README.md
+++ b/examples/assistant/README.md
@@ -1,9 +1,14 @@
 # Assistant
 
-A showcase of all Project Think features, built with `@cloudflare/think`.
+A showcase of all Project Think features, built with `@cloudflare/think` and
+the sub-agent routing primitive from `agents`.
 
 ## What this demonstrates
 
+- **Multi-session via sub-agent routing** — each user gets an `AssistantDirectory`
+  parent DO that owns the sidebar. Each chat is its own `MyAssistant` facet
+  (full Think DO — own workspace, extensions, MCP, memory). Addressed
+  transparently via `useAgent({ sub: [{ agent: "MyAssistant", name: chatId }] })`
 - **Think base class** — `getModel()`, `configureSession()`, `getTools()`, `maxSteps` for a batteries-included agent
 - **Built-in workspace** — file tools (read, write, edit, find, grep, delete) auto-wired on every turn
 - **Sandboxed code execution** — `createExecuteTool` lets the LLM write and run JavaScript in a Dynamic Worker via `@cloudflare/codemode`
@@ -15,14 +20,14 @@ A showcase of all Project Think features, built with `@cloudflare/think`.
 - **Server-side tools** — `getWeather`, `calculate` execute on the server
 - **Client-side tools** — `getUserTimezone` runs in the browser via `onToolCall`
 - **Tool approval** — `calculate` requires user approval for large numbers
-- **MCP integration** — connect external tool servers, tools appear in the chat
+- **MCP integration** — connect external tool servers, tools appear in the chat (per-chat)
 - **Lifecycle hooks** — `beforeTurn`, `beforeToolCall`, `afterToolCall`, `onStepFinish`, `onChatResponse`
 - **Durable chat recovery** — `chatRecovery` wraps turns in fibers for crash recovery
-- **Scheduled proactive turns** — daily summary via `saveMessages` from a cron schedule
+- **Parent-owned scheduled work** — daily summary scheduled from the directory (facets can't own schedules), fans out to the most recently active chat
 - **Regeneration with branch navigation** — v1/v2/v3 response versions via `getBranches`
 - **Stream resumption** — page refresh replays the active stream (built into Think)
 - **useAgentChat** — Think speaks the same CF_AGENT protocol as AIChatAgent
-- **GitHub OAuth** — users sign in with GitHub; the Worker owns the DO name, so each user gets their own `MyAssistant` instance
+- **GitHub OAuth** — users sign in with GitHub; the Worker owns all DO naming, so each user gets their own directory + isolated chats
 
 ## How to run
 
@@ -57,25 +62,53 @@ npm start
 Open the app, click **Sign in with GitHub**, approve the OAuth flow, and you
 will land in the Think assistant scoped to your GitHub login.
 
-## Auth pattern
+## Architecture
 
-The browser never chooses a Durable Object name. It connects to `/chat`, and
-the Worker reads the authenticated GitHub user from an httpOnly cookie and
-forwards the request to the matching `MyAssistant` instance:
+```
+AssistantDirectory ("alice")            ◄── one DO per authenticated GitHub user
+  ├─ MyAssistant[chat-abc]   [facet]    ◄── each chat is its own Think DO
+  ├─ MyAssistant[chat-def]   [facet]
+  └─ MyAssistant[chat-ghi]   [facet]
+```
+
+`AssistantDirectory` owns the chat list, the sidebar state, and any
+cross-chat concerns (e.g. the daily-summary schedule — facets can't
+`schedule()` so the parent does it and fans out). `MyAssistant` is a
+Think DO per conversation, with its own SQLite storage, workspace,
+extensions, MCP servers, and message history.
+
+The browser never chooses a DO name. It connects to `/chat` (the
+directory) and `/chat/sub/my-assistant/<chatId>` (a specific chat), and
+the Worker resolves the `AssistantDirectory` instance from the
+authenticated GitHub cookie:
 
 ```ts
 if (url.pathname === "/chat" || url.pathname.startsWith("/chat/")) {
   const user = await getGitHubUserFromRequest(request);
   if (!user) return createUnauthorizedResponse(request);
-  const agent = await getAgentByName(env.MyAssistant, user.login);
-  return agent.fetch(request);
+  const directory = await getAgentByName(env.AssistantDirectory, user.login);
+  return directory.fetch(request);
 }
 ```
 
-On the client, `useAgent({ agent: "MyAssistant", basePath: "chat" })` mirrors
-this — the hook hits `/chat` over WebSocket and HTTP and the Worker resolves
-the real instance server-side. See `examples/auth-agent` for the minimal
-AIChatAgent version of the same pattern.
+The directory's built-in sub-agent router picks up the
+`/sub/my-assistant/<chatId>` tail — no per-chat plumbing lives in the
+Worker. Access control lives on the parent via `onBeforeSubAgent` as a
+strict registry gate:
+
+```ts
+override async onBeforeSubAgent(_req, { className, name }) {
+  if (!this.hasSubAgent(className, name)) {
+    return new Response("Not found", { status: 404 });
+  }
+}
+```
+
+On the client, `useChats()` (a local hook in `src/use-chats.ts`) wraps
+the sidebar connection and RPCs. Each chat pane uses
+`useAgent({ agent: "AssistantDirectory", basePath: "chat", sub: [{ agent: "MyAssistant", name: chatId }] })`.
+See `examples/multi-ai-chat` for the minimal AIChatAgent version of the
+same pattern.
 
 ## Deploying
 
@@ -104,31 +137,50 @@ npm run deploy
 **Server** (`src/server.ts`):
 
 ```typescript
+export class AssistantDirectory extends Agent<Env, DirectoryState> {
+  // Strict registry gate — clients can only reach chats this
+  // directory spawned via `createChat`.
+  override async onBeforeSubAgent(_req, { className, name }) {
+    if (!this.hasSubAgent(className, name)) {
+      return new Response("Not found", { status: 404 });
+    }
+  }
+
+  @callable()
+  async createChat() {
+    const id = nanoid(10);
+    await this.subAgent(MyAssistant, id); // spawn the facet
+    /* ... persist meta, refresh sidebar ... */
+  }
+}
+
 export class MyAssistant extends Think<Env> {
   chatRecovery = true;
   extensionLoader = this.env.LOADER;
 
-  getModel() { /* model tier from config */ }
+  getModel() {
+    /* model tier from config */
+  }
   configureSession(session) {
-    return session
-      .withContext("memory", { ... })
-      .onCompaction(createCompactFunction({ ... }))
-      .compactAfter(50000)
-      .withContext("knowledge", { provider: new AgentSearchProvider(this) })
-      .withCachedPrompt();
+    /* persona, memory, compaction, knowledge */
   }
   getTools() {
-    return {
-      execute: createExecuteTool({ ... }),
-      ...createExtensionTools({ ... }),
-      getWeather: tool({ ... }),
-      calculate: tool({ needsApproval: ..., ... })
-    };
+    /* execute, extensions, getWeather, calculate, ... */
+  }
+
+  // Each turn updates the parent's sidebar preview via the
+  // typed `parentAgent(AssistantDirectory)` stub.
+  async onChatResponse(result) {
+    const directory = await this.parentAgent(AssistantDirectory);
+    await directory.recordChatTurn(this.name, extractPreview(result));
   }
 }
 ```
 
-**Client** (`src/client.tsx`) — uses `useAgentChat` from `@cloudflare/ai-chat/react`, with panels for workspace browsing, extension management, and dynamic configuration.
+**Client** (`src/client.tsx`) — `useChats()` (a local prototype in
+`src/use-chats.ts`) drives the sidebar; each chat pane uses
+`useAgentChat` from `@cloudflare/ai-chat/react` over a sub-routed
+`useAgent` connection.
 
 ## Related
 

--- a/examples/assistant/README.md
+++ b/examples/assistant/README.md
@@ -125,26 +125,50 @@ a DO RPC hop:
 
 ```ts
 class MyAssistant extends Think<Env> {
-  override workspace: WorkspaceLike = new SharedWorkspace(this);
+  override workspace: WorkspaceFsLike = new SharedWorkspace(this);
+
+  getTools() {
+    return {
+      execute: createExecuteTool({
+        tools: createWorkspaceTools(this.workspace),
+        // state.* in the sandbox also hits the shared workspace,
+        // because SharedWorkspace satisfies WorkspaceFsLike.
+        state: createWorkspaceStateBackend(this.workspace),
+        loader: this.env.LOADER
+      })
+      // ...
+    };
+  }
 }
 
-class SharedWorkspace implements WorkspaceLike {
+class SharedWorkspace implements WorkspaceFsLike {
   readFile(p) {
     return (await this.parent()).readFile(p);
   }
   writeFile(p, c) {
     return (await this.parent()).writeFile(p, c);
   }
-  // ...readDir / rm / glob / mkdir / stat
+  // ...readFileBytes / writeFileBytes / appendFile / exists / stat /
+  //    lstat / mkdir / readDir / rm / cp / mv / symlink / readlink / glob
 }
 ```
 
-The proxy satisfies `@cloudflare/think`'s `WorkspaceLike` interface, so
-all of Think's workspace-aware machinery — `createWorkspaceTools`,
-lifecycle hooks, the builtin `listWorkspaceFiles` /
-`readWorkspaceFile` RPCs — works unchanged. The parent DO and the
-child facet live on the same machine, so the RPC is in-process and
-cheap (no network, no serialization across external links).
+The proxy satisfies `@cloudflare/shell`'s `WorkspaceFsLike` interface,
+which is a strict superset of `@cloudflare/think`'s `WorkspaceLike`.
+That one type annotation unlocks two things at once:
+
+- **All of Think's workspace-aware machinery** (`createWorkspaceTools`,
+  lifecycle hooks, the builtin `listWorkspaceFiles` /
+  `readWorkspaceFile` RPCs) works unchanged against the proxy.
+- **Codemode's `state.*` sandbox API** works too, via
+  `createWorkspaceStateBackend(this.workspace)`. Multi-file operations
+  like `state.planEdits` and `state.applyEdits` run against the shared
+  workspace, so a plan composed in one chat can mutate files another
+  chat just created.
+
+The parent DO and the child facet live on the same machine, so each
+RPC hop is in-process and cheap (no network, no serialization across
+external links).
 
 **Trade-offs worth knowing:**
 
@@ -165,15 +189,9 @@ cheap (no network, no serialization across external links).
   same path queue behind each other in the parent DO's single-threaded
   isolate, which is the usual semantics you'd want.
 - _Change events don't fan out across chats._ `Workspace` emits
-  change events via a `diagnostics_channel` on the parent's isolate;
+  change events via an `onChange` callback on the parent's isolate;
   children don't see them. The assistant doesn't rely on change-event
   fan-out today. Add a parent → child broadcast if you need it.
-- _`createWorkspaceStateBackend` (codemode's `state.*`) still needs a
-  concrete `Workspace`._ That helper reaches for the full filesystem
-  surface (`readFileBytes`, `symlink`, `cp`, `mv`, etc.), which
-  `WorkspaceLike` doesn't cover. The example doesn't use it; if you
-  want it, you'd need a richer proxy or a direct handle to the
-  parent's workspace.
 
 ## Deploying
 

--- a/examples/assistant/README.md
+++ b/examples/assistant/README.md
@@ -7,8 +7,13 @@ the sub-agent routing primitive from `agents`.
 
 - **Multi-session via sub-agent routing** — each user gets an `AssistantDirectory`
   parent DO that owns the sidebar. Each chat is its own `MyAssistant` facet
-  (full Think DO — own workspace, extensions, MCP, memory). Addressed
-  transparently via `useAgent({ sub: [{ agent: "MyAssistant", name: chatId }] })`
+  (full Think DO — own extensions, MCP, memory). Addressed transparently via
+  `useAgent({ sub: [{ agent: "MyAssistant", name: chatId }] })`
+- **Shared workspace across chats** — `AssistantDirectory` owns one `Workspace`
+  backed by its SQLite; every `MyAssistant` child gets a `SharedWorkspace`
+  proxy that forwards file I/O to the parent. A `hello.txt` written in chat A
+  is visible verbatim in chat B. The proxy swaps in via the `WorkspaceLike`
+  type exported by `@cloudflare/think` — no casts, all builtin tools still work
 - **Think base class** — `getModel()`, `configureSession()`, `getTools()`, `maxSteps` for a batteries-included agent
 - **Built-in workspace** — file tools (read, write, edit, find, grep, delete) auto-wired on every turn
 - **Sandboxed code execution** — `createExecuteTool` lets the LLM write and run JavaScript in a Dynamic Worker via `@cloudflare/codemode`
@@ -71,11 +76,13 @@ AssistantDirectory ("alice")            ◄── one DO per authenticated GitHu
   └─ MyAssistant[chat-ghi]   [facet]
 ```
 
-`AssistantDirectory` owns the chat list, the sidebar state, and any
-cross-chat concerns (e.g. the daily-summary schedule — facets can't
-`schedule()` so the parent does it and fans out). `MyAssistant` is a
-Think DO per conversation, with its own SQLite storage, workspace,
-extensions, MCP servers, and message history.
+`AssistantDirectory` owns the chat list, the sidebar state, the shared
+workspace, and any cross-chat concerns (e.g. the daily-summary
+schedule — facets can't `schedule()` so the parent does it and fans
+out). `MyAssistant` is a Think DO per conversation, with its own
+SQLite storage, extensions, MCP servers, and message history — and a
+`SharedWorkspace` proxy that routes all file operations back to the
+directory's single `Workspace`.
 
 The browser never chooses a DO name. It connects to `/chat` (the
 directory) and `/chat/sub/my-assistant/<chatId>` (a specific chat), and
@@ -109,6 +116,64 @@ the sidebar connection and RPCs. Each chat pane uses
 `useAgent({ agent: "AssistantDirectory", basePath: "chat", sub: [{ agent: "MyAssistant", name: chatId }] })`.
 See `examples/multi-ai-chat` for the minimal AIChatAgent version of the
 same pattern.
+
+### Shared workspace
+
+Each `MyAssistant` overrides `this.workspace` with a `SharedWorkspace`
+proxy that forwards every call to `AssistantDirectory.workspace` over
+a DO RPC hop:
+
+```ts
+class MyAssistant extends Think<Env> {
+  override workspace: WorkspaceLike = new SharedWorkspace(this);
+}
+
+class SharedWorkspace implements WorkspaceLike {
+  readFile(p) {
+    return (await this.parent()).readFile(p);
+  }
+  writeFile(p, c) {
+    return (await this.parent()).writeFile(p, c);
+  }
+  // ...readDir / rm / glob / mkdir / stat
+}
+```
+
+The proxy satisfies `@cloudflare/think`'s `WorkspaceLike` interface, so
+all of Think's workspace-aware machinery — `createWorkspaceTools`,
+lifecycle hooks, the builtin `listWorkspaceFiles` /
+`readWorkspaceFile` RPCs — works unchanged. The parent DO and the
+child facet live on the same machine, so the RPC is in-process and
+cheap (no network, no serialization across external links).
+
+**Trade-offs worth knowing:**
+
+- _Every chat can see every chat's files._ That's the design — a
+  multi-chat assistant should remember what it wrote in previous
+  chats. If you fork this for a less-trusted surface (e.g. public
+  guests), gate access in `AssistantDirectory` instead of exposing the
+  workspace methods directly.
+- _Extensions with `workspace: "read-write"` permissions inherit the
+  same reach._ The shell-level permission model is about what _the
+  LLM_ can do inside a single chat; it doesn't distinguish between
+  "this chat's files" and "this user's files" because the underlying
+  `Workspace` doesn't either. For the assistant example this is what
+  we actually want. For other apps — e.g. a hostile-code sandbox —
+  consider giving each chat its own non-shared workspace by removing
+  the override in `MyAssistant`.
+- _Serialization is per-file, not per-turn._ Two chats writing to the
+  same path queue behind each other in the parent DO's single-threaded
+  isolate, which is the usual semantics you'd want.
+- _Change events don't fan out across chats._ `Workspace` emits
+  change events via a `diagnostics_channel` on the parent's isolate;
+  children don't see them. The assistant doesn't rely on change-event
+  fan-out today. Add a parent → child broadcast if you need it.
+- _`createWorkspaceStateBackend` (codemode's `state.*`) still needs a
+  concrete `Workspace`._ That helper reaches for the full filesystem
+  surface (`readFileBytes`, `symlink`, `cp`, `mv`, etc.), which
+  `WorkspaceLike` doesn't cover. The example doesn't use it; if you
+  want it, you'd need a richer proxy or a direct handle to the
+  parent's workspace.
 
 ## Deploying
 

--- a/examples/assistant/README.md
+++ b/examples/assistant/README.md
@@ -182,6 +182,14 @@ external links).
   chats. If you fork this for a less-trusted surface (e.g. public
   guests), gate access in `AssistantDirectory` instead of exposing the
   workspace methods directly.
+- _Extensions, MCP servers, messages, and branch history stay
+  per-chat._ Only the workspace is shared. Extensions persist to the
+  child DO's own `ctx.storage` (not the workspace), so a tool
+  authored in chat A isn't auto-available in chat B. That's a
+  sensible default for this demo — extensions are "this chat's custom
+  tools" — but if you want a fork where extensions cross chats too,
+  move their persistence into the parent directory DO alongside the
+  workspace.
 - _Extensions with `workspace: "read-write"` permissions inherit the
   same reach._ The shell-level permission model is about what _the
   LLM_ can do inside a single chat; it doesn't distinguish between

--- a/examples/assistant/README.md
+++ b/examples/assistant/README.md
@@ -7,14 +7,21 @@ the sub-agent routing primitive from `agents`.
 
 - **Multi-session via sub-agent routing** — each user gets an `AssistantDirectory`
   parent DO that owns the sidebar. Each chat is its own `MyAssistant` facet
-  (full Think DO — own extensions, MCP, memory). Addressed transparently via
-  `useAgent({ sub: [{ agent: "MyAssistant", name: chatId }] })`
+  (full Think DO — own extensions, memory, messages). Addressed transparently
+  via `useAgent({ sub: [{ agent: "MyAssistant", name: chatId }] })`
 - **Shared workspace across chats** — `AssistantDirectory` owns one `Workspace`
   backed by its SQLite; every `MyAssistant` child gets a `SharedWorkspace`
   proxy that forwards file I/O to the parent. A `hello.txt` written in chat A
   is visible verbatim in chat B. The proxy swaps in via the `WorkspaceFsLike`
   type exported by `@cloudflare/shell` — no casts; builtin workspace tools
   AND codemode's `state.*` sandbox API both route through it
+- **Shared MCP across chats** — server registry, OAuth credentials, live
+  connections, and tool descriptors all live on `AssistantDirectory`. Auth
+  to a server once (e.g. GitHub MCP) and every chat sees its tools. Each
+  child carries a `SharedMCPClient` proxy that builds per-turn MCP tool
+  sets via one DO RPC hop to the parent. `useChats()` surfaces
+  `mcpState` / `addMcpServer` / `removeMcpServer` so the MCP panel is
+  the same across chats and open tabs
 - **Live cross-chat file updates** — the directory's `Workspace` is wired
   with `onChange` → `broadcast`, so every open tab's file browser updates
   live whenever any chat writes, edits, or deletes a file. `useChats()`
@@ -30,7 +37,7 @@ the sub-agent routing primitive from `agents`.
 - **Server-side tools** — `getWeather`, `calculate` execute on the server
 - **Client-side tools** — `getUserTimezone` runs in the browser via `onToolCall`
 - **Tool approval** — `calculate` requires user approval for large numbers
-- **MCP integration** — connect external tool servers, tools appear in the chat (per-chat)
+- **MCP integration** — connect external tool servers; tools appear in every chat automatically (shared at the directory level)
 - **Lifecycle hooks** — `beforeTurn`, `beforeToolCall`, `afterToolCall`, `onStepFinish`, `onChatResponse`
 - **Durable chat recovery** — `chatRecovery` wraps turns in fibers for crash recovery
 - **Parent-owned scheduled work** — daily summary scheduled from the directory (facets can't own schedules), fans out to the most recently active chat
@@ -82,12 +89,13 @@ AssistantDirectory ("alice")            ◄── one DO per authenticated GitHu
 ```
 
 `AssistantDirectory` owns the chat list, the sidebar state, the shared
-workspace, and any cross-chat concerns (e.g. the daily-summary
+workspace, the shared MCP registry (servers, OAuth creds, live
+connections), and any cross-chat concerns (e.g. the daily-summary
 schedule — facets can't `schedule()` so the parent does it and fans
 out). `MyAssistant` is a Think DO per conversation, with its own
-SQLite storage, extensions, MCP servers, and message history — and a
-`SharedWorkspace` proxy that routes all file operations back to the
-directory's single `Workspace`.
+SQLite storage, extensions, and message history — plus a
+`SharedWorkspace` proxy and a `SharedMCPClient` proxy that route file
+operations and MCP tool invocations back to the directory.
 
 The browser never chooses a DO name. It connects to `/chat` (the
 directory) and `/chat/sub/my-assistant/<chatId>` (a specific chat), and
@@ -182,14 +190,15 @@ external links).
   chats. If you fork this for a less-trusted surface (e.g. public
   guests), gate access in `AssistantDirectory` instead of exposing the
   workspace methods directly.
-- _Extensions, MCP servers, messages, and branch history stay
-  per-chat._ Only the workspace is shared. Extensions persist to the
-  child DO's own `ctx.storage` (not the workspace), so a tool
-  authored in chat A isn't auto-available in chat B. That's a
-  sensible default for this demo — extensions are "this chat's custom
-  tools" — but if you want a fork where extensions cross chats too,
-  move their persistence into the parent directory DO alongside the
-  workspace.
+- _Extensions, messages, Think config, and branch history stay
+  per-chat._ The workspace and the MCP registry are shared; everything
+  else lives in each child DO's own storage. Extensions in particular
+  persist to `ctx.storage` (not the workspace), so a tool authored in
+  chat A isn't auto-available in chat B. That's a sensible default for
+  this demo — extensions are "this chat's custom tools" — but if you
+  want a fork where extensions cross chats too, move their persistence
+  into the parent directory DO alongside the workspace and MCP
+  registry.
 - _Extensions with `workspace: "read-write"` permissions inherit the
   same reach._ The shell-level permission model is about what _the
   LLM_ can do inside a single chat; it doesn't distinguish between
@@ -211,6 +220,74 @@ external links).
   list live. The parent does _not_ RPC events into sibling child
   facets — no server-side tool in this example reacts to another
   chat's writes. Add a parent → child RPC if that use case shows up.
+
+### Shared MCP
+
+MCP follows the same pattern as the workspace: the registry, OAuth
+credentials, live connections, and tool caches all live on
+`AssistantDirectory`. Each child carries a `SharedMCPClient` proxy
+that RPCs the parent on each turn:
+
+```ts
+class MyAssistant extends Think<Env> {
+  sharedMcp = new SharedMCPClient(this);
+
+  async beforeTurn(ctx) {
+    // Splice the directory's shared MCP tools into this turn.
+    return { tools: await this.sharedMcp.getAITools() };
+  }
+}
+
+class SharedMCPClient {
+  async getAITools(timeoutMs = 5_000): Promise<ToolSet> {
+    const parent = await this.parent();
+    // Wait up to `timeoutMs` for any in-progress connections; returns
+    // only tools from servers that are ready.
+    const descriptors = await parent.listMcpToolDescriptors(timeoutMs);
+    return buildToolSet(descriptors, (serverId, name, args) =>
+      parent.callMcpTool(serverId, name, args)
+    );
+  }
+}
+```
+
+OAuth callback URL is `/chat/mcp-callback` — one URL for every
+server across every chat. The Worker's existing `/chat*` gate
+forwards it to the directory; `Agent._onRequest` dispatches to
+`handleMcpOAuthCallback`, which uses `mcp.isCallbackRequest` to
+match on stored callback URLs. Token lives in the directory's DO
+storage via `DurableObjectOAuthClientProvider`.
+
+Browser-side, `useChats()` exposes `mcpState`, `addMcpServer`,
+`removeMcpServer`, sourced from the directory's
+`CF_AGENT_MCP_SERVERS` broadcasts. The MCP panel in each `Chat`
+reads these from props, so every tab sees the same server list in
+real time.
+
+**Trade-offs worth knowing:**
+
+- _Every chat can call every MCP tool you've connected._ Same model
+  as the workspace — this is the point of a multi-chat assistant. If
+  you need per-chat tool gating, filter in `SharedMCPClient.getAITools`
+  using the existing `getAITools(filter?)` signature on
+  `MCPClientManager` as a template.
+- _Each tool invocation is one extra DO RPC hop._ Same machine,
+  in-process, cheap. If an MCP tool call is network-bound (most are),
+  the added hop is noise.
+- _The parent's isolate is the serialization point._ Two chats
+  calling tools at the same time interleave in the parent's JS event
+  loop (single-threaded DO isolate). MCP tools usually await network,
+  so they don't block each other in practice, but the parent is
+  technically the user's MCP fan-in point.
+- _Connection count per user = server count._ The directory keeps
+  one live connection per registered server. SSE-style MCP transports
+  are lightweight but still real. Worth knowing before forking this
+  for users who register dozens of servers.
+- _OAuth callbacks on this URL require an authenticated GitHub
+  session._ Callbacks come back to the same origin in the user's
+  browser, so the GitHub session cookie is present; the Worker's
+  existing `/chat*` gate validates it before forwarding to the
+  directory. Unauthenticated probes to `/chat/mcp-callback` 401.
 
 ## Deploying
 

--- a/examples/assistant/env.d.ts
+++ b/examples/assistant/env.d.ts
@@ -3,13 +3,16 @@
 declare namespace Cloudflare {
   interface GlobalProps {
     mainModule: typeof import("./src/server");
-    durableNamespaces: "MyAssistant";
+    durableNamespaces: "AssistantDirectory" | "MyAssistant";
   }
   interface Env {
     LOADER: WorkerLoader;
     AI: Ai;
     GITHUB_CLIENT_ID: string;
     GITHUB_CLIENT_SECRET: string;
+    AssistantDirectory: DurableObjectNamespace<
+      import("./src/server").AssistantDirectory
+    >;
     MyAssistant: DurableObjectNamespace<import("./src/server").MyAssistant>;
   }
 }

--- a/examples/assistant/src/client.tsx
+++ b/examples/assistant/src/client.tsx
@@ -1741,7 +1741,7 @@ function EmptyChatView({
         <Empty
           icon={<ChatsIcon size={28} />}
           title="No chats yet"
-          description="Each chat is its own isolated workspace — extensions, MCP servers, and messages don't leak across."
+          description="Files and MCP servers are shared across every chat. Messages and extensions stay per-chat."
         />
         <Button
           variant="primary"

--- a/examples/assistant/src/client.tsx
+++ b/examples/assistant/src/client.tsx
@@ -151,6 +151,9 @@ function Chat({
   chatId,
   chatTitle,
   workspaceRevision,
+  mcpState,
+  addMcpServer,
+  removeMcpServer,
   onRequestRename,
   onRequestDelete
 }: {
@@ -162,6 +165,23 @@ function Chat({
    * live across chats and open tabs without polling.
    */
   workspaceRevision: number;
+  /**
+   * Live MCP state for the whole user. Sourced from the directory's
+   * `CF_AGENT_MCP_SERVERS` broadcasts; the same server list shows up
+   * in every chat pane.
+   */
+  mcpState: MCPServersState;
+  /**
+   * Register a new MCP server on the directory. The returned
+   * `authUrl`, if any, should be opened in a popup for the user to
+   * complete OAuth.
+   */
+  addMcpServer: (
+    name: string,
+    url: string
+  ) => Promise<{ id: string; state: string; authUrl?: string }>;
+  /** Remove an MCP server from the shared registry. */
+  removeMcpServer: (id: string) => Promise<void>;
   onRequestRename: () => void;
   onRequestDelete: () => void;
 }) {
@@ -169,12 +189,6 @@ function Chat({
     useState<ConnectionStatus>("connecting");
   const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const [mcpState, setMcpState] = useState<MCPServersState>({
-    prompts: [],
-    resources: [],
-    servers: {},
-    tools: []
-  });
   const [showMcpPanel, setShowMcpPanel] = useState(false);
   const [mcpName, setMcpName] = useState("");
   const [mcpUrl, setMcpUrl] = useState("");
@@ -210,6 +224,10 @@ function Chat({
     // The parent's `onBeforeSubAgent` strict-registry gate runs once on
     // connect; after the WebSocket upgrade, frames flow straight to the
     // child `MyAssistant` DO.
+    //
+    // MCP state (servers, tools, auth) is not received on this socket
+    // any more — MCP lives on the directory now, so `useChats()` owns
+    // the MCP broadcasts and we receive the resulting state as a prop.
     agent: "AssistantDirectory",
     basePath: "chat",
     sub: [{ agent: "MyAssistant", name: chatId }],
@@ -218,10 +236,7 @@ function Chat({
     onError: useCallback(
       (error: Event) => console.error("WebSocket error:", error),
       []
-    ),
-    onMcpUpdate: useCallback((state: MCPServersState) => {
-      setMcpState(state);
-    }, [])
+    )
   });
 
   useEffect(() => {
@@ -326,9 +341,15 @@ function Chat({
     if (!mcpName.trim() || !mcpUrl.trim()) return;
     setIsAddingServer(true);
     try {
-      await agent.call("addServer", [mcpName.trim(), mcpUrl.trim()]);
+      const result = await addMcpServer(mcpName.trim(), mcpUrl.trim());
       setMcpName("");
       setMcpUrl("");
+      // If the server needs OAuth, pop the auth URL open. Callback
+      // lands at /chat/mcp-callback on the directory; our client-side
+      // state refreshes via the directory's MCP broadcast.
+      if (result.authUrl) {
+        window.open(result.authUrl, "oauth", "width=600,height=800");
+      }
     } catch (e) {
       console.error("Failed to add MCP server:", e);
     } finally {
@@ -338,7 +359,7 @@ function Chat({
 
   const handleRemoveServer = async (serverId: string) => {
     try {
-      await agent.call("removeServer", [serverId]);
+      await removeMcpServer(serverId);
     } catch (e) {
       console.error("Failed to remove MCP server:", e);
     }
@@ -1581,9 +1602,12 @@ function MultiChatApp({
     directory,
     chats,
     workspaceRevision,
+    mcpState,
     createChat,
     renameChat,
-    deleteChat
+    deleteChat,
+    addMcpServer,
+    removeMcpServer
   } = useChats();
   const [activeId, setActiveId] = useState<string | null>(null);
 
@@ -1676,6 +1700,9 @@ function MultiChatApp({
               chatId={activeChat.id}
               chatTitle={activeChat.title}
               workspaceRevision={workspaceRevision}
+              mcpState={mcpState}
+              addMcpServer={addMcpServer}
+              removeMcpServer={removeMcpServer}
               onRequestRename={() => handleRename(activeChat)}
               onRequestDelete={() => handleDelete(activeChat)}
             />

--- a/examples/assistant/src/client.tsx
+++ b/examples/assistant/src/client.tsx
@@ -150,11 +150,18 @@ function shouldShowStreamedTextPart(part: {
 function Chat({
   chatId,
   chatTitle,
+  workspaceRevision,
   onRequestRename,
   onRequestDelete
 }: {
   chatId: string;
   chatTitle: string;
+  /**
+   * Bumps whenever another chat (or this chat) mutates the shared
+   * workspace. Used as a `useEffect` dep so the files panel stays
+   * live across chats and open tabs without polling.
+   */
+  workspaceRevision: number;
   onRequestRename: () => void;
   onRequestDelete: () => void;
 }) {
@@ -283,6 +290,17 @@ function Chat({
       setWorkspaceFiles([]);
     }
   }, [agent]);
+
+  // Live-refresh the file browser when the shared workspace changes in
+  // another chat (or this one). `workspaceRevision` is incremented by
+  // `useChats()` each time the directory broadcasts a change event. We
+  // only refetch if the panel is actually open — no point fetching just
+  // to throw the result away, and `workspaceFiles` is still seeded on
+  // panel-open via the existing click handler.
+  useEffect(() => {
+    if (!showFilesPanel) return;
+    void refreshWorkspaceFiles();
+  }, [showFilesPanel, workspaceRevision, refreshWorkspaceFiles]);
 
   const refreshExtensions = useCallback(async () => {
     try {
@@ -1559,7 +1577,14 @@ function MultiChatApp({
   user: AuthUser;
   onSignOut: () => void;
 }) {
-  const { directory, chats, createChat, renameChat, deleteChat } = useChats();
+  const {
+    directory,
+    chats,
+    workspaceRevision,
+    createChat,
+    renameChat,
+    deleteChat
+  } = useChats();
   const [activeId, setActiveId] = useState<string | null>(null);
 
   // Auto-select the most-recently-active chat when the sidebar loads or
@@ -1650,6 +1675,7 @@ function MultiChatApp({
             <Chat
               chatId={activeChat.id}
               chatTitle={activeChat.title}
+              workspaceRevision={workspaceRevision}
               onRequestRename={() => handleRename(activeChat)}
               onRequestDelete={() => handleDelete(activeChat)}
             />

--- a/examples/assistant/src/client.tsx
+++ b/examples/assistant/src/client.tsx
@@ -68,7 +68,9 @@ import {
   FolderOpenIcon,
   PuzzlePieceIcon,
   SlidersHorizontalIcon,
-  FileTextIcon
+  FileTextIcon,
+  PencilIcon,
+  ChatsIcon
 } from "@phosphor-icons/react";
 import {
   fetchCurrentUser,
@@ -76,6 +78,8 @@ import {
   startGitHubLogin,
   type AuthUser
 } from "./auth-client";
+import { useChats } from "./use-chats";
+import type { ChatSummary } from "./server";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
@@ -143,23 +147,19 @@ function shouldShowStreamedTextPart(part: {
   return part.text.length > 0 || part.state === "streaming";
 }
 
-function Chat({ user, onSignOut }: { user: AuthUser; onSignOut: () => void }) {
+function Chat({
+  chatId,
+  chatTitle,
+  onRequestRename,
+  onRequestDelete
+}: {
+  chatId: string;
+  chatTitle: string;
+  onRequestRename: () => void;
+  onRequestDelete: () => void;
+}) {
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("connecting");
-  const [isSigningOut, setIsSigningOut] = useState(false);
-  const displayName = user.name || user.login;
-
-  const handleSignOut = useCallback(async () => {
-    setIsSigningOut(true);
-    try {
-      await signOut();
-      onSignOut();
-    } catch (err) {
-      console.error("Failed to sign out:", err);
-    } finally {
-      setIsSigningOut(false);
-    }
-  }, [onSignOut]);
   const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [mcpState, setMcpState] = useState<MCPServersState>({
@@ -198,13 +198,14 @@ function Chat({ user, onSignOut }: { user: AuthUser; onSignOut: () => void }) {
   } | null>(null);
 
   const agent = useAgent({
-    agent: "MyAssistant",
-    // The browser connects to `/chat`; the Worker resolves which
-    // MyAssistant DO owns the authenticated GitHub user and forwards
-    // the request. No browser-chosen room names. `sendIdentityOnConnect`
-    // on the server side lets the client know which DO it actually ended
-    // up talking to (see MyAssistant.static options in src/server.ts).
+    // This chat lives as a facet of the user's AssistantDirectory. The
+    // `sub` option builds the nested URL tail `/sub/my-assistant/:chatId`.
+    // The parent's `onBeforeSubAgent` strict-registry gate runs once on
+    // connect; after the WebSocket upgrade, frames flow straight to the
+    // child `MyAssistant` DO.
+    agent: "AssistantDirectory",
     basePath: "chat",
+    sub: [{ agent: "MyAssistant", name: chatId }],
     onOpen: useCallback(() => setConnectionStatus("connected"), []),
     onClose: useCallback(() => setConnectionStatus("disconnected"), []),
     onError: useCallback(
@@ -436,34 +437,32 @@ function Chat({ user, onSignOut }: { user: AuthUser; onSignOut: () => void }) {
   }, [input, isStreaming, sendMessage, clearError]);
 
   return (
-    <div className="flex flex-col h-screen bg-kumo-elevated">
-      <header className="px-5 py-4 bg-kumo-base border-b border-kumo-line">
-        <div className="max-w-3xl mx-auto flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <RobotIcon size={24} className="text-kumo-brand" />
-            <h1 className="text-lg font-semibold text-kumo-default">
-              Assistant
-            </h1>
-            <Badge variant="secondary">Think</Badge>
+    <div className="flex flex-col h-full bg-kumo-elevated min-w-0">
+      <header className="px-5 py-3 bg-kumo-base border-b border-kumo-line">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <h2 className="text-base font-semibold text-kumo-default truncate">
+              {chatTitle}
+            </h2>
+            <Button
+              variant="ghost"
+              size="sm"
+              shape="square"
+              aria-label="Rename chat"
+              icon={<PencilIcon size={12} />}
+              onClick={onRequestRename}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              shape="square"
+              aria-label="Delete chat"
+              icon={<TrashIcon size={12} />}
+              onClick={onRequestDelete}
+            />
           </div>
           <div className="flex items-center gap-3">
             <ConnectionIndicator status={connectionStatus} />
-            <ModeToggle />
-            <div className="flex items-center gap-2 pl-3 ml-1 border-l border-kumo-line">
-              <GithubLogoIcon size={14} className="text-kumo-inactive" />
-              <Text size="xs" variant="secondary">
-                {displayName}
-              </Text>
-              <Button
-                variant="ghost"
-                size="sm"
-                shape="square"
-                aria-label="Sign out"
-                icon={<SignOutIcon size={14} />}
-                onClick={handleSignOut}
-                loading={isSigningOut}
-              />
-            </div>
             <div className="relative" ref={mcpPanelRef}>
               <Button
                 variant="secondary"
@@ -1412,6 +1411,297 @@ function SignInView({ error }: { error: string | null }) {
   );
 }
 
+// ── Sidebar (chat list + new-chat action) ──────────────────────────────
+
+function ChatSidebar({
+  chats,
+  activeId,
+  onSelect,
+  onCreate,
+  onRename,
+  onDelete,
+  user,
+  onSignOut
+}: {
+  chats: ChatSummary[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onCreate: () => void;
+  onRename: (chat: ChatSummary) => void;
+  onDelete: (chat: ChatSummary) => void;
+  user: AuthUser;
+  onSignOut: () => Promise<void>;
+}) {
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const displayName = user.name || user.login;
+
+  const handleSignOut = useCallback(async () => {
+    setIsSigningOut(true);
+    try {
+      await onSignOut();
+    } catch (err) {
+      console.error("Failed to sign out:", err);
+    } finally {
+      setIsSigningOut(false);
+    }
+  }, [onSignOut]);
+
+  return (
+    <aside className="flex flex-col h-full w-64 shrink-0 border-r border-kumo-line bg-kumo-base">
+      <div className="px-3 py-3 border-b border-kumo-line flex items-center gap-2">
+        <RobotIcon size={20} className="text-kumo-brand" />
+        <h1 className="text-sm font-semibold text-kumo-default">Assistant</h1>
+        <Badge variant="secondary">Think</Badge>
+      </div>
+
+      <div className="px-3 py-2 border-b border-kumo-line">
+        <Button
+          variant="primary"
+          size="sm"
+          icon={<PlusIcon size={14} />}
+          onClick={onCreate}
+          className="w-full"
+        >
+          New chat
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {chats.length === 0 ? (
+          <div className="p-4 flex flex-col items-center text-center gap-2">
+            <ChatsIcon size={24} className="text-kumo-inactive" />
+            <Text size="xs" variant="secondary">
+              No chats yet. Click <strong>New chat</strong> to start one.
+            </Text>
+          </div>
+        ) : (
+          <ul className="py-1">
+            {chats.map((chat) => {
+              const isActive = chat.id === activeId;
+              return (
+                <li key={chat.id} className="group relative">
+                  <button
+                    type="button"
+                    className={`w-full flex items-start gap-1 px-2 py-2 mx-1 rounded-md text-left ${
+                      isActive ? "bg-kumo-hover" : "hover:bg-kumo-hover/60"
+                    }`}
+                    onClick={() => onSelect(chat.id)}
+                    aria-current={isActive ? "true" : undefined}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <Text size="sm" bold>
+                        <span className="truncate block">{chat.title}</span>
+                      </Text>
+                      <span className="mt-0.5 truncate block">
+                        <Text size="xs" variant="secondary">
+                          {chat.lastMessagePreview ?? "No messages yet"}
+                        </Text>
+                      </span>
+                    </div>
+                  </button>
+                  {/* Row actions sit outside the main button so nested
+                      buttons don't get flagged as a11y violations. */}
+                  <div className="absolute right-2 top-2 flex flex-col gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      shape="square"
+                      aria-label="Rename chat"
+                      icon={<PencilIcon size={12} />}
+                      onClick={() => onRename(chat)}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      shape="square"
+                      aria-label="Delete chat"
+                      icon={<TrashIcon size={12} />}
+                      onClick={() => onDelete(chat)}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="px-3 py-3 border-t border-kumo-line flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <GithubLogoIcon size={14} className="text-kumo-inactive shrink-0" />
+          <Text size="xs" variant="secondary">
+            <span className="truncate block">{displayName}</span>
+          </Text>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <ModeToggle />
+          <Button
+            variant="ghost"
+            size="sm"
+            shape="square"
+            aria-label="Sign out"
+            icon={<SignOutIcon size={14} />}
+            onClick={handleSignOut}
+            loading={isSigningOut}
+          />
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+// ── Multi-chat shell (sidebar + active chat) ───────────────────────────
+
+function MultiChatApp({
+  user,
+  onSignOut
+}: {
+  user: AuthUser;
+  onSignOut: () => void;
+}) {
+  const { directory, chats, createChat, renameChat, deleteChat } = useChats();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  // Auto-select the most-recently-active chat when the sidebar loads or
+  // when the currently-active chat is deleted from under us. The
+  // directory's state is the source of truth — we never invent an id
+  // client-side.
+  useEffect(() => {
+    if (chats.length === 0) {
+      if (activeId !== null) setActiveId(null);
+      return;
+    }
+    if (!activeId || !chats.some((c) => c.id === activeId)) {
+      setActiveId(chats[0].id);
+    }
+  }, [chats, activeId]);
+
+  const handleCreate = useCallback(async () => {
+    try {
+      const created = await createChat();
+      setActiveId(created.id);
+    } catch (err) {
+      console.error("Failed to create chat:", err);
+    }
+  }, [createChat]);
+
+  const handleRename = useCallback(
+    async (chat: ChatSummary) => {
+      const next = window.prompt("Rename chat", chat.title);
+      if (next === null) return;
+      const trimmed = next.trim();
+      if (!trimmed || trimmed === chat.title) return;
+      try {
+        await renameChat(chat.id, trimmed);
+      } catch (err) {
+        console.error("Failed to rename chat:", err);
+      }
+    },
+    [renameChat]
+  );
+
+  const handleDelete = useCallback(
+    async (chat: ChatSummary) => {
+      if (!window.confirm(`Delete "${chat.title}"? This cannot be undone.`)) {
+        return;
+      }
+      try {
+        await deleteChat(chat.id);
+      } catch (err) {
+        console.error("Failed to delete chat:", err);
+      }
+    },
+    [deleteChat]
+  );
+
+  const activeChat =
+    activeId !== null ? chats.find((c) => c.id === activeId) : undefined;
+  const directoryReady = directory.readyState === 1;
+
+  const handleSignOut = useCallback(async () => {
+    try {
+      await signOut();
+    } finally {
+      onSignOut();
+    }
+  }, [onSignOut]);
+
+  return (
+    <div className="flex h-screen bg-kumo-elevated">
+      <ChatSidebar
+        chats={chats}
+        activeId={activeId}
+        onSelect={setActiveId}
+        onCreate={handleCreate}
+        onRename={handleRename}
+        onDelete={handleDelete}
+        user={user}
+        onSignOut={handleSignOut}
+      />
+      <div className="flex-1 min-w-0">
+        {activeChat ? (
+          // `key={activeChat.id}` forces a full remount across chat
+          // switches so the chat's local state (MCP panel, file browser,
+          // branch map, input draft) all reset cleanly.
+          <Suspense
+            key={activeChat.id}
+            fallback={<LoadingView message="Loading chat…" />}
+          >
+            <Chat
+              chatId={activeChat.id}
+              chatTitle={activeChat.title}
+              onRequestRename={() => handleRename(activeChat)}
+              onRequestDelete={() => handleDelete(activeChat)}
+            />
+          </Suspense>
+        ) : (
+          <EmptyChatView
+            ready={directoryReady}
+            onCreate={handleCreate}
+            hasChats={chats.length > 0}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyChatView({
+  ready,
+  onCreate,
+  hasChats
+}: {
+  ready: boolean;
+  onCreate: () => void;
+  hasChats: boolean;
+}) {
+  if (!ready) {
+    return <LoadingView message="Connecting…" />;
+  }
+  if (hasChats) {
+    // Transient — the sidebar auto-selects a chat on the next tick.
+    return <LoadingView message="Opening chat…" />;
+  }
+  return (
+    <div className="h-full flex items-center justify-center p-8">
+      <div className="max-w-md flex flex-col items-center gap-4">
+        <Empty
+          icon={<ChatsIcon size={28} />}
+          title="No chats yet"
+          description="Each chat is its own isolated workspace — extensions, MCP servers, and messages don't leak across."
+        />
+        <Button
+          variant="primary"
+          icon={<PlusIcon size={14} />}
+          onClick={onCreate}
+        >
+          New chat
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function AuthenticatedApp() {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1450,20 +1740,14 @@ function AuthenticatedApp() {
   }
 
   if (user) {
-    // `useAgentChat` Suspense-fires during Chat's initial render while it
-    // fetches the starting message history. Keep the same shell visible
-    // so the user does not see a different "Loading…" UI between the auth
-    // check and the chat-ready state.
     return (
-      <Suspense fallback={<LoadingView message="Loading your assistant…" />}>
-        <Chat
-          user={user}
-          onSignOut={() => {
-            setUser(null);
-            setError(null);
-          }}
-        />
-      </Suspense>
+      <MultiChatApp
+        user={user}
+        onSignOut={() => {
+          setUser(null);
+          setError(null);
+        }}
+      />
     );
   }
 

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -41,6 +41,14 @@
  *     `createWorkspaceStateBackend` — so `state.planEdits` in chat B
  *     sees and mutates the same files chat A just wrote. No casts.
  *
+ *     The directory's `Workspace` is constructed with
+ *     `onChange: (ev) => this.broadcast(...)`, so every file mutation
+ *     is fanned out to every client connected to the directory —
+ *     meaning all of the user's open tabs, regardless of which chat
+ *     is active. The client's `useChats()` hook turns each broadcast
+ *     into a `workspaceRevision` bump, which the chat pane's file
+ *     browser uses as a `useEffect` dep to stay live without polling.
+ *
  * Features demonstrated inside each `MyAssistant`:
  *   - Workspace tools (read, write, edit, find, grep, delete) — backed by the shared directory workspace, not per-chat
  *   - Sandboxed code execution via @cloudflare/codemode
@@ -62,6 +70,7 @@ import { Think, Session, Workspace } from "@cloudflare/think";
 import {
   createWorkspaceStateBackend,
   type FileInfo,
+  type WorkspaceChangeEvent,
   type WorkspaceFsLike
 } from "@cloudflare/shell";
 import {
@@ -134,6 +143,12 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
    * `SharedWorkspace` proxy below, which forwards each call to
    * `readFile` / `writeFile` / etc. here. See `SharedWorkspace`.
    *
+   * The `onChange` hook fires on every mutation (create/update/delete)
+   * regardless of which chat's tool caused it. We rebroadcast to every
+   * client connected to this directory — that's every browser tab the
+   * user has open — so live UI like the file browser refreshes across
+   * chats and tabs without polling. See `_broadcastWorkspaceChange`.
+   *
    * Security note: this means any tool running inside any chat has
    * read-write access to every file this user owns. That's the point —
    * a multi-chat assistant should remember what it did in previous
@@ -143,9 +158,26 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
    */
   workspace = new Workspace({
     sql: this.ctx.storage.sql,
-    name: () => this.name
+    name: () => this.name,
+    onChange: (event) => this._broadcastWorkspaceChange(event)
     // r2: this.env.R2 — uncomment to spill large files to R2.
   });
+
+  /**
+   * Fan-out: push workspace change events to every client connected to
+   * this directory. Each chat pane's `useAgent` connection to the
+   * directory (via `useChats()`) receives these; the client side
+   * treats them as signals to refresh workspace-backed UI.
+   *
+   * Deliberately a best-effort `broadcast` (not `setState`), so file
+   * churn doesn't trigger full `DirectoryState` re-broadcasts on every
+   * write. Does NOT notify sibling child facets — no tool in this
+   * example reacts server-side to another chat's writes. Add a
+   * parent → child RPC here if that use case shows up.
+   */
+  private _broadcastWorkspaceChange(event: WorkspaceChangeEvent): void {
+    this.broadcast(JSON.stringify({ type: "workspace-change", event }));
+  }
 
   onStart() {
     this.sql`CREATE TABLE IF NOT EXISTS chat_meta (

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -24,8 +24,23 @@
  *   `/sub/my-assistant/:chatId` tail, so we don't need any custom
  *   per-chat plumbing in the Worker.
  *
+ * Cross-chat shared workspace:
+ *
+ *     AssistantDirectory owns a single `Workspace` backed by its own
+ *     SQLite. Every chat's `this.workspace` is a `SharedWorkspace`
+ *     proxy that forwards `readFile` / `writeFile` / `readDir` / etc.
+ *     to the parent's real workspace over a DO RPC hop. A file
+ *     written in chat A is visible verbatim in chat B — the assistant
+ *     has one continuous filesystem across every chat with a given
+ *     user, not a fresh scratch space per conversation.
+ *
+ *     The directory's `Workspace` is typed as `WorkspaceLike` (an
+ *     interface shipped by `@cloudflare/think`) so the proxy can
+ *     substitute in without casts. This is built-in Think support,
+ *     not a one-off hack.
+ *
  * Features demonstrated inside each `MyAssistant`:
- *   - Workspace tools (read, write, edit, find, grep, delete) — built-in
+ *   - Workspace tools (read, write, edit, find, grep, delete) — backed by the shared directory workspace, not per-chat
  *   - Sandboxed code execution via @cloudflare/codemode
  *   - Self-authored extensions via ExtensionManager
  *   - Persistent memory via context blocks
@@ -41,7 +56,9 @@
 
 import { createWorkersAI } from "workers-ai-provider";
 import { Agent, callable, getAgentByName } from "agents";
-import { Think, Session } from "@cloudflare/think";
+import { Think, Session, Workspace } from "@cloudflare/think";
+import type { WorkspaceLike } from "@cloudflare/think";
+import type { FileInfo } from "@cloudflare/shell";
 import {
   createUnauthorizedResponse,
   getGitHubUserFromRequest,
@@ -102,6 +119,28 @@ type AgentConfig = {
 
 export class AssistantDirectory extends Agent<Env, DirectoryState> {
   initialState: DirectoryState = { chats: [] };
+
+  /**
+   * Shared workspace for every chat under this directory. Backed by the
+   * directory's own SQLite so all of a user's files live in one place —
+   * a `hello.txt` written in chat A shows up verbatim in chat B.
+   *
+   * Children (`MyAssistant` facets) see this workspace through the
+   * `SharedWorkspace` proxy below, which forwards each call to
+   * `readFile` / `writeFile` / etc. here. See `SharedWorkspace`.
+   *
+   * Security note: this means any tool running inside any chat has
+   * read-write access to every file this user owns. That's the point —
+   * a multi-chat assistant should remember what it did in previous
+   * chats — but extensions declared with `workspace: "read-write"`
+   * inherit the same reach. If you fork this example for a
+   * less-trusted extension surface, add gating here.
+   */
+  workspace = new Workspace({
+    sql: this.ctx.storage.sql,
+    name: () => this.name
+    // r2: this.env.R2 — uncomment to spill large files to R2.
+  });
 
   onStart() {
     this.sql`CREATE TABLE IF NOT EXISTS chat_meta (
@@ -264,6 +303,104 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
     const target = await this.subAgent(MyAssistant, row.id);
     await target.postDailySummaryPrompt();
   }
+
+  // ── Shared workspace RPC surface (called by SharedWorkspace) ─────
+  //
+  // Children reach the directory via `parentAgent(AssistantDirectory)`,
+  // which exposes these as typed DO RPC methods. `@callable()` is
+  // deliberately NOT used — the client has no business writing to
+  // another chat's files via the sidebar websocket; workspace I/O is
+  // LLM-tool-only. DO-to-DO RPC doesn't need the decorator.
+  //
+  // Each method is a one-line delegate. We accept whatever arg shapes
+  // the concrete `Workspace` accepts rather than re-stating the types
+  // here — `ReturnType<typeof Workspace.prototype.readFile>` etc.
+  // keeps the surface automatically in sync with `@cloudflare/shell`.
+
+  async readFile(path: string): Promise<string | null> {
+    return this.workspace.readFile(path);
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    return this.workspace.writeFile(path, content);
+  }
+
+  async readDir(
+    path: string,
+    opts?: Parameters<Workspace["readDir"]>[1]
+  ): Promise<FileInfo[]> {
+    return this.workspace.readDir(path, opts);
+  }
+
+  async rm(path: string, opts?: Parameters<Workspace["rm"]>[1]): Promise<void> {
+    return this.workspace.rm(path, opts);
+  }
+
+  async glob(pattern: string): Promise<FileInfo[]> {
+    return this.workspace.glob(pattern);
+  }
+
+  async mkdir(
+    path: string,
+    opts?: Parameters<Workspace["mkdir"]>[1]
+  ): Promise<void> {
+    return this.workspace.mkdir(path, opts);
+  }
+
+  async stat(path: string): Promise<FileInfo | null> {
+    return this.workspace.stat(path);
+  }
+}
+
+// ── SharedWorkspace — proxy used by children ─────────────────────────
+//
+// Satisfies `WorkspaceLike` by forwarding every call to the parent
+// `AssistantDirectory`'s real `Workspace`. Per-call it's one extra RPC
+// hop; because the parent and child are DO facets colocated on the same
+// machine, the hop is in-process and cheap.
+//
+// The parent stub is resolved lazily on first use and cached. Stubs
+// from `parentAgent()` are thin proxies — they don't hold connections,
+// so caching the resolved stub across the child's lifetime is safe
+// even if the parent hibernates and comes back between calls.
+
+class SharedWorkspace implements WorkspaceLike {
+  #stubPromise?: Promise<DurableObjectStub<AssistantDirectory>>;
+
+  constructor(private child: Pick<MyAssistant, "parentAgent">) {}
+
+  private parent(): Promise<DurableObjectStub<AssistantDirectory>> {
+    this.#stubPromise ??= this.child.parentAgent(AssistantDirectory);
+    return this.#stubPromise;
+  }
+
+  async readFile(path: string) {
+    return (await this.parent()).readFile(path);
+  }
+
+  async writeFile(path: string, content: string) {
+    return (await this.parent()).writeFile(path, content);
+  }
+
+  async readDir(path: string, opts?: Parameters<Workspace["readDir"]>[1]) {
+    return (await this.parent()).readDir(path, opts);
+  }
+
+  async rm(path: string, opts?: Parameters<Workspace["rm"]>[1]) {
+    return (await this.parent()).rm(path, opts);
+  }
+
+  async glob(pattern: string) {
+    return (await this.parent()).glob(pattern);
+  }
+
+  async mkdir(path: string, opts?: Parameters<Workspace["mkdir"]>[1]) {
+    return (await this.parent()).mkdir(path, opts);
+  }
+
+  async stat(path: string) {
+    return (await this.parent()).stat(path);
+  }
 }
 
 // ── MyAssistant — one Think DO per chat (a facet of the directory) ────
@@ -276,6 +413,21 @@ export class MyAssistant extends Think<Env> {
   override maxSteps = 10;
   chatRecovery = true;
   extensionLoader = this.env.LOADER;
+
+  /**
+   * Override Think's default per-chat workspace with a proxy into the
+   * shared `AssistantDirectory.workspace`. This class field runs in the
+   * subclass's synthetic constructor after `super(ctx, env)`, so by the
+   * time Think's wrapped `onStart` fires its `!this.workspace` default-
+   * init check, the shared proxy is already in place — Think never
+   * creates a per-chat `Workspace` at all.
+   *
+   * All workspace-aware code (the builtin tools from
+   * `createWorkspaceTools`, lifecycle hooks, the workspace-RPC
+   * `listWorkspaceFiles` / `readWorkspaceFile` below) routes through
+   * this proxy transparently.
+   */
+  override workspace: WorkspaceLike = new SharedWorkspace(this);
 
   getModel(): LanguageModel {
     const tier = this.getConfig<AgentConfig>()?.modelTier ?? "fast";

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -49,15 +49,29 @@
  *     into a `workspaceRevision` bump, which the chat pane's file
  *     browser uses as a `useEffect` dep to stay live without polling.
  *
+ * Cross-chat shared MCP:
+ *
+ *     MCP server registry, OAuth credentials, live connections, and
+ *     tool descriptors all live on `AssistantDirectory`. Each
+ *     `MyAssistant` child carries a `SharedMCPClient` proxy that
+ *     builds each turn's MCP tool set by RPC'ing the parent for
+ *     current tools, then routes each `execute` back through the
+ *     parent. Net effect: auth to a server once, and every chat the
+ *     user ever opens sees the tools. The OAuth redirect URL is
+ *     `chat/mcp-callback` — one URL for every chat, resolved on the
+ *     directory's authenticated Worker path. The child's own default
+ *     `this.mcp` stays in place but empty; it's never registered on
+ *     and never connects out.
+ *
  * Features demonstrated inside each `MyAssistant`:
  *   - Workspace tools (read, write, edit, find, grep, delete) — backed by the shared directory workspace, not per-chat
  *   - Sandboxed code execution via @cloudflare/codemode
- *   - Self-authored extensions via ExtensionManager
- *   - Persistent memory via context blocks
+ *   - Self-authored extensions via ExtensionManager (per-chat — lives in the child DO's own storage)
+ *   - Persistent memory via context blocks (per-chat)
  *   - Non-destructive compaction for long conversations
  *   - Full-text search across conversation history (FTS5)
- *   - Dynamic typed configuration (model tier, persona)
- *   - MCP server integration
+ *   - Dynamic typed configuration (model tier, persona) — per-chat
+ *   - MCP server integration — shared across all chats via SharedMCPClient
  *   - Client-side tools and tool approval
  *   - Lifecycle hooks (beforeToolCall logging, afterToolCall analytics)
  *   - Durable chat recovery (chatRecovery)
@@ -66,6 +80,7 @@
 
 import { createWorkersAI } from "workers-ai-provider";
 import { Agent, callable, getAgentByName } from "agents";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { Think, Session, Workspace } from "@cloudflare/think";
 import {
   createWorkspaceStateBackend,
@@ -111,6 +126,14 @@ export interface ChatSummary {
 export interface DirectoryState {
   chats: ChatSummary[];
 }
+
+/**
+ * Tool descriptor the directory returns to children over RPC. Mirrors
+ * what `MCPClientManager.listTools()` returns — an MCP SDK `Tool` plus
+ * the `serverId` annotation so the child can build a `callMcpTool`
+ * closure — and stays structured-cloneable for the DO RPC boundary.
+ */
+export type McpToolDescriptor = Tool & { serverId: string };
 
 type AgentConfig = {
   modelTier: "fast" | "capable";
@@ -193,6 +216,25 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
     // on _isFacet), so any recurring turn lives here and RPCs into the
     // most-recently-active child on fire.
     this.schedule("0 9 * * *", "dailySummary", {}, { idempotent: true });
+
+    // OAuth popup handler for MCP servers. The directory owns the MCP
+    // state, so the OAuth redirect (`/chat/mcp-callback`) lands here
+    // and the framework dispatches into `this.mcp` via
+    // `handleMcpOAuthCallback` on the base `Agent` class.
+    this.mcp.configureOAuthCallback({
+      customHandler: (result) => {
+        if (result.authSuccess) {
+          return new Response("<script>window.close();</script>", {
+            headers: { "content-type": "text/html" },
+            status: 200
+          });
+        }
+        return new Response(
+          `Authentication Failed: ${result.authError || "Unknown error"}`,
+          { headers: { "content-type": "text/plain" }, status: 400 }
+        );
+      }
+    });
   }
 
   /**
@@ -449,6 +491,92 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
   async readlink(path: string): Promise<string> {
     return this.workspace.readlink(path);
   }
+
+  // ── Shared MCP surface ───────────────────────────────────────────
+  //
+  // The directory owns the MCP state for every chat under it:
+  //   - server registry (+ OAuth client registrations) in
+  //     `cf_agents_mcp_servers`
+  //   - OAuth tokens via `DurableObjectOAuthClientProvider`
+  //   - live connections + tool/prompt/resource caches in memory
+  //
+  // Browser-callable surface (`@callable()`): `addServer` /
+  // `removeServer`. These go through the directory's WS connection
+  // (the one `useChats()` already owns) rather than the per-chat WS,
+  // so the UI talks to the same DO that holds the state.
+  //
+  // Child-callable surface (not `@callable()`): `listMcpToolDescriptors`
+  // / `callMcpTool`. These are invoked via `parentAgent(AssistantDirectory)`
+  // from `SharedMCPClient` on each chat turn.
+
+  /**
+   * Register a new MCP server for this user and kick off the initial
+   * connection. If the server requires OAuth, returns the provider's
+   * `authUrl` so the browser can open the popup.
+   *
+   * The callback URL is `/chat/mcp-callback` — resolved by the Worker
+   * to this directory instance for the authenticated user. One URL
+   * for every server for every chat.
+   */
+  @callable()
+  async addServer(
+    name: string,
+    url: string
+  ): ReturnType<AssistantDirectory["addMcpServer"]> {
+    return await this.addMcpServer(name, url, {
+      callbackPath: "chat/mcp-callback"
+    });
+  }
+
+  @callable()
+  async removeServer(id: string): Promise<void> {
+    await this.removeMcpServer(id);
+  }
+
+  /**
+   * Snapshot of currently-ready MCP tools across every server this
+   * directory has connected. Children call this once per chat turn
+   * (via `SharedMCPClient.getAITools()`) to assemble the LLM's tool
+   * set.
+   *
+   * Waits up to `timeoutMs` for in-progress connections to become
+   * ready before returning, so a chat launched right after the
+   * directory wakes from hibernation still sees tools from servers
+   * that are mid-handshake. `MCPClientManager.waitForConnections`
+   * returns eagerly if everything is already ready.
+   *
+   * Deliberately NOT `@callable()` — child→parent DO RPC doesn't
+   * need the decorator, and the browser reads MCP state via the
+   * `CF_AGENT_MCP_SERVERS` broadcast (automatic, not this path).
+   */
+  async listMcpToolDescriptors(
+    timeoutMs = 5_000
+  ): Promise<McpToolDescriptor[]> {
+    await this.mcp.waitForConnections({ timeout: timeoutMs });
+    return this.mcp.listTools() as McpToolDescriptor[];
+  }
+
+  /**
+   * Invoke an MCP tool. Returns the raw `CallToolResult` from the MCP
+   * SDK; the child is responsible for unwrapping `isError` into a
+   * thrown exception for the AI SDK's tool pipeline.
+   *
+   * Deliberately NOT `@callable()` — only intended to be reached via
+   * `SharedMCPClient.execute(...)`. A `@callable()` here would let a
+   * client invoke any MCP tool directly over the sidebar WS,
+   * bypassing the agent's `beforeToolCall`/`afterToolCall` hooks.
+   */
+  async callMcpTool(
+    serverId: string,
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<CallToolResult> {
+    return (await this.mcp.callTool({
+      arguments: args,
+      name,
+      serverId
+    })) as CallToolResult;
+  }
 }
 
 // ── SharedWorkspace — proxy used by children ─────────────────────────
@@ -557,13 +685,116 @@ class SharedWorkspace implements WorkspaceFsLike {
   }
 }
 
+// ── SharedMCPClient — child-side proxy for the directory's MCP ──────
+//
+// MCP state (server registry, OAuth tokens, live connections, tool
+// caches) lives entirely on `AssistantDirectory`. This class lets a
+// child expose those shared tools to its LLM as if they were local,
+// while every actual invocation round-trips through one parent-DO
+// RPC hop.
+//
+// Shape:
+//   - `getAITools(timeoutMs?)` — snapshot the parent's current tools
+//     and return them as an AI SDK `ToolSet`. Called once per turn
+//     from `MyAssistant.beforeTurn`; the resulting tools are merged
+//     into the turn via `TurnConfig.tools`.
+//   - Each returned tool's `execute` RPCs `parent.callMcpTool(...)`
+//     and translates the MCP-level `isError` result into a thrown
+//     exception for Think's `afterToolCall` pipeline. Mirrors what
+//     `MCPClientManager.getAITools()` does internally for a local
+//     MCP client — same tool-key format, same error semantics — so
+//     the LLM sees an identical surface whether MCP is local or
+//     proxied.
+//
+// The parent stub is resolved lazily on first call and cached, same
+// pattern as `SharedWorkspace` above.
+
+class SharedMCPClient {
+  #stubPromise?: Promise<DurableObjectStub<AssistantDirectory>>;
+
+  constructor(private child: Pick<MyAssistant, "parentAgent">) {}
+
+  private parent(): Promise<DurableObjectStub<AssistantDirectory>> {
+    this.#stubPromise ??= this.child.parentAgent(AssistantDirectory);
+    return this.#stubPromise;
+  }
+
+  /**
+   * Assemble a snapshot `ToolSet` of the currently-ready MCP tools.
+   * The returned tools are safe to splice into Think's turn toolset
+   * via `TurnConfig.tools`.
+   */
+  async getAITools(timeoutMs = 5_000): Promise<ToolSet> {
+    const parent = await this.parent();
+    const descriptors = (await parent.listMcpToolDescriptors(
+      timeoutMs
+    )) as McpToolDescriptor[];
+
+    const entries: [string, ToolSet[string]][] = [];
+    for (const descriptor of descriptors) {
+      try {
+        // Same key format MCPClientManager uses internally, so the
+        // LLM's tool vocabulary matches the local-MCP case.
+        const toolKey = `tool_${descriptor.serverId.replace(/-/g, "")}_${descriptor.name}`;
+        const { serverId, name, inputSchema, outputSchema } = descriptor;
+        const title =
+          descriptor.title ??
+          (descriptor.annotations as { title?: string } | undefined)?.title;
+
+        entries.push([
+          toolKey,
+          {
+            description: descriptor.description,
+            title,
+            inputSchema: inputSchema
+              ? z.fromJSONSchema(
+                  inputSchema as Parameters<typeof z.fromJSONSchema>[0]
+                )
+              : z.fromJSONSchema({ type: "object" }),
+            outputSchema: outputSchema
+              ? z.fromJSONSchema(
+                  outputSchema as Parameters<typeof z.fromJSONSchema>[0]
+                )
+              : undefined,
+            execute: async (args) => {
+              const stub = await this.parent();
+              const result = (await stub.callMcpTool(
+                serverId,
+                name,
+                args as Record<string, unknown>
+              )) as CallToolResult;
+              if (result.isError) {
+                const content = result.content as
+                  | Array<{ type: string; text?: string }>
+                  | undefined;
+                const firstText = content?.[0];
+                const message =
+                  firstText?.type === "text" && firstText.text
+                    ? firstText.text
+                    : "Tool call failed";
+                throw new Error(message);
+              }
+              return result;
+            }
+          }
+        ]);
+      } catch (err) {
+        console.warn(
+          `[SharedMCPClient] Skipping tool "${descriptor.name}" from "${descriptor.serverId}": ${err}`
+        );
+      }
+    }
+
+    return Object.fromEntries(entries);
+  }
+}
+
 // ── MyAssistant — one Think DO per chat (a facet of the directory) ────
 
 export class MyAssistant extends Think<Env> {
   static options = {
     sendIdentityOnConnect: true
   };
-  waitForMcpConnections = { timeout: 5000 };
   override maxSteps = 10;
   chatRecovery = true;
   extensionLoader = this.env.LOADER;
@@ -589,6 +820,23 @@ export class MyAssistant extends Think<Env> {
    * transparently.
    */
   override workspace: WorkspaceFsLike = new SharedWorkspace(this);
+
+  /**
+   * Proxy to the directory's MCP state. Used by `beforeTurn` below to
+   * splice the user's shared MCP tools into each turn's tool set.
+   *
+   * The child's own `this.mcp` (Think's default) stays around but is
+   * never registered against — it exists solely so Agent framework
+   * paths that reach for `this.mcp.*` (hibernation restore, OAuth
+   * callback routing, broadcast plumbing) don't need to care about
+   * the parallel-field arrangement. Those paths all resolve to an
+   * empty, idle MCP client.
+   *
+   * OAuth callbacks (`/chat/mcp-callback`) are routed to the parent
+   * directory by the Worker, never to a child, so child-side
+   * `isCallbackRequest` in the framework reliably returns false here.
+   */
+  sharedMcp = new SharedMCPClient(this);
 
   getModel(): LanguageModel {
     const tier = this.getConfig<AgentConfig>()?.modelTier ?? "fast";
@@ -714,10 +962,21 @@ When you learn something about the user or their project, save it to memory.`
     };
   }
 
-  beforeTurn(ctx: TurnContext): TurnConfig | void {
+  async beforeTurn(ctx: TurnContext): Promise<TurnConfig | void> {
+    // Splice the directory's shared MCP tools into this turn. Think
+    // merges `config.tools` additively on top of the base tool set, so
+    // whatever tools we return here join `workspace` / `extensions` /
+    // `execute` / builtins on every turn. The proxy waits for any
+    // in-progress MCP connections to settle (5s default) before
+    // returning, so a chat that just woke up still sees tools from
+    // servers that are mid-handshake.
+    const mcpTools = await this.sharedMcp.getAITools();
+
     console.log(
-      `Turn starting: ${Object.keys(ctx.tools).length} tools, continuation=${ctx.continuation}`
+      `Turn starting: ${Object.keys(ctx.tools).length} base tools + ${Object.keys(mcpTools).length} MCP tools, continuation=${ctx.continuation}`
     );
+
+    return { tools: mcpTools };
   }
 
   beforeToolCall(ctx: ToolCallContext): void {
@@ -766,26 +1025,10 @@ When you learn something about the user or their project, save it to memory.`
     }
   }
 
-  async onStart() {
-    // MCP OAuth popup handler. Note: we do NOT schedule from here —
-    // facets can't own schedules. The daily summary is scheduled on the
-    // parent `AssistantDirectory` and RPCs into us via
-    // `postDailySummaryPrompt()` below.
-    this.mcp.configureOAuthCallback({
-      customHandler: (result) => {
-        if (result.authSuccess) {
-          return new Response("<script>window.close();</script>", {
-            headers: { "content-type": "text/html" },
-            status: 200
-          });
-        }
-        return new Response(
-          `Authentication Failed: ${result.authError || "Unknown error"}`,
-          { headers: { "content-type": "text/plain" }, status: 400 }
-        );
-      }
-    });
-  }
+  // No `onStart` override: MCP is shared from the parent directory
+  // (see `AssistantDirectory.onStart`), schedules live on the parent,
+  // and everything per-chat (workspace, extensions, session config)
+  // is wired up by Think's own base `onStart` via class fields.
 
   /**
    * Called by `AssistantDirectory.dailySummary()` on the daily cron.
@@ -812,28 +1055,11 @@ When you learn something about the user or their project, save it to memory.`
     ]);
   }
 
-  @callable()
-  async addServer(name: string, url: string) {
-    // Route the OAuth redirect through sub-agent routing so it lands on
-    // THIS chat's DO (not the parent directory, which has no MCP state).
-    // `/chat` is the authenticated Worker entry point; `/sub/my-assistant/<chatId>`
-    // is the sub-agent routing tail the parent's `fetch()` parses and
-    // forwards to us as `/mcp-callback`. `Agent._onRequest` then passes
-    // it to `mcp.isCallbackRequest()`, which matches on origin + pathname
-    // against the URL we persisted here.
-    //
-    // See issue #1378 for the follow-up on tightening the framework's
-    // default callback URL when `sendIdentityOnConnect: true`.
-    const callbackPath = `chat/sub/my-assistant/${encodeURIComponent(
-      this.name
-    )}/mcp-callback`;
-    return await this.addMcpServer(name, url, { callbackPath });
-  }
-
-  @callable()
-  async removeServer(serverId: string) {
-    await this.removeMcpServer(serverId);
-  }
+  // `addServer` / `removeServer` used to live here as `@callable`
+  // wrappers around `this.addMcpServer` / `this.removeMcpServer`. They
+  // moved to `AssistantDirectory` so every chat shares one MCP server
+  // list. The client now calls the directory directly via `useChats()`;
+  // see `src/use-chats.ts`.
 
   @callable()
   async getResponseVersions(userMessageId: string) {

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -1,7 +1,30 @@
 /**
- * Assistant — a Think-based chat agent showcasing all Project Think features.
+ * Assistant — a Think-based multi-session chat app.
  *
- * Features demonstrated:
+ * Architecture:
+ *
+ *     AssistantDirectory ("alice")                  ◄── one DO per GitHub login
+ *       ├─ MyAssistant[chat-abc]  [facet]           ◄── one Think DO per chat
+ *       ├─ MyAssistant[chat-def]  [facet]
+ *       └─ MyAssistant[chat-ghi]  [facet]
+ *
+ * - `AssistantDirectory` is a top-level `Agent`. It owns the chat list,
+ *   the sidebar state, and any per-user cross-chat concerns (e.g. the
+ *   daily summary schedule that facets can't own themselves). It gates
+ *   child access with `onBeforeSubAgent` as a strict-registry check.
+ * - `MyAssistant` is a `Think` subclass that lives as a **facet** of
+ *   `AssistantDirectory` (`this.subAgent(MyAssistant, chatId)`). Each
+ *   chat is its own Durable Object with its own SQLite storage,
+ *   workspace, extensions, MCP servers, and message history, all
+ *   colocated with the parent on the same machine.
+ * - The Worker authenticates the GitHub session, then forwards every
+ *   `/chat*` request into the authenticated user's directory via
+ *   `getAgentByName(env.AssistantDirectory, user.login).fetch(request)`.
+ *   The built-in sub-agent router inside `Agent.fetch()` picks up the
+ *   `/sub/my-assistant/:chatId` tail, so we don't need any custom
+ *   per-chat plumbing in the Worker.
+ *
+ * Features demonstrated inside each `MyAssistant`:
  *   - Workspace tools (read, write, edit, find, grep, delete) — built-in
  *   - Sandboxed code execution via @cloudflare/codemode
  *   - Self-authored extensions via ExtensionManager
@@ -13,12 +36,11 @@
  *   - Client-side tools and tool approval
  *   - Lifecycle hooks (beforeToolCall logging, afterToolCall analytics)
  *   - Durable chat recovery (chatRecovery)
- *   - Scheduled proactive turns (daily summary)
  *   - Regeneration with branch navigation
  */
 
 import { createWorkersAI } from "workers-ai-provider";
-import { getAgentByName, callable } from "agents";
+import { Agent, callable, getAgentByName } from "agents";
 import { Think, Session } from "@cloudflare/think";
 import {
   createUnauthorizedResponse,
@@ -42,12 +64,209 @@ import type {
 } from "@cloudflare/think";
 import { tool, generateText } from "ai";
 import type { LanguageModel, ToolSet } from "ai";
+import { nanoid } from "nanoid";
 import { z } from "zod";
+
+// ── Shared types (sidebar state, RPC contracts) ───────────────────────
+
+export interface ChatSummary {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  lastMessagePreview?: string;
+}
+
+export interface DirectoryState {
+  chats: ChatSummary[];
+}
 
 type AgentConfig = {
   modelTier: "fast" | "capable";
   persona: string;
 };
+
+// ── AssistantDirectory — one DO per authenticated GitHub user ─────────
+//
+// Owns:
+//   - the chat index (titles, timestamps, previews) in `chat_meta`
+//   - access control for its child chats (strict-registry gate)
+//   - cross-chat scheduled work (daily summary)
+//
+// **Existence is framework-owned.** The authoritative set of chats is
+// `listSubAgents(MyAssistant)` — the registry `subAgent()` /
+// `deleteSubAgent()` maintain in lockstep with the actual facets. We
+// keep a separate `chat_meta` table for metadata (title, preview) keyed
+// by chat id; a row there is pure decoration. If they drift, the
+// registry wins.
+
+export class AssistantDirectory extends Agent<Env, DirectoryState> {
+  initialState: DirectoryState = { chats: [] };
+
+  onStart() {
+    this.sql`CREATE TABLE IF NOT EXISTS chat_meta (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      last_message_preview TEXT
+    )`;
+    this._refreshState();
+
+    // The directory owns cross-chat scheduled work. Facets can't
+    // schedule (see `packages/agents/src/index.ts` — schedule() throws
+    // on _isFacet), so any recurring turn lives here and RPCs into the
+    // most-recently-active child on fire.
+    this.schedule("0 9 * * *", "dailySummary", {}, { idempotent: true });
+  }
+
+  /**
+   * Only allow the Worker to reach a `MyAssistant` facet that this
+   * directory has explicitly spawned via `createChat`. `hasSubAgent`
+   * is backed by the same registry `listSubAgents` reads from, so an
+   * unknown chat id gets a 404 before any child is woken.
+   */
+  override async onBeforeSubAgent(
+    _req: Request,
+    { className, name }: { className: string; name: string }
+  ): Promise<Request | Response | void> {
+    if (!this.hasSubAgent(className, name)) {
+      return new Response(`${className} "${name}" not found`, { status: 404 });
+    }
+    // Fall through — framework forwards the request to the facet.
+  }
+
+  // ── Sidebar state ──────────────────────────────────────────────────
+
+  /**
+   * Build the sidebar from two sources:
+   *   1. `listSubAgents(MyAssistant)` — authoritative set of chats.
+   *   2. `chat_meta` — app-owned title + preview decoration.
+   *
+   * A chat present in the registry without a meta row still renders
+   * with a default title; a meta row without a registry entry is
+   * silently ignored.
+   */
+  private _refreshState() {
+    const registry = this.listSubAgents(MyAssistant);
+    const metaRows = this.sql<{
+      id: string;
+      title: string;
+      updated_at: number;
+      last_message_preview: string | null;
+    }>`SELECT id, title, updated_at, last_message_preview FROM chat_meta`;
+    const metaById = new Map(metaRows.map((row) => [row.id, row]));
+
+    const chats: ChatSummary[] = registry
+      .map((entry) => {
+        const meta = metaById.get(entry.name);
+        return {
+          id: entry.name,
+          title: meta?.title ?? defaultChatTitle(entry.createdAt),
+          createdAt: entry.createdAt,
+          updatedAt: meta?.updated_at ?? entry.createdAt,
+          lastMessagePreview: meta?.last_message_preview ?? undefined
+        };
+      })
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+
+    this.setState({ ...this.state, chats });
+  }
+
+  // ── Chat lifecycle (RPC from the sidebar) ──────────────────────────
+
+  @callable()
+  async createChat(opts?: { title?: string }): Promise<ChatSummary> {
+    const id = nanoid(10);
+    const now = Date.now();
+    const title = opts?.title?.trim() || defaultChatTitle(now);
+
+    // Spawn the facet FIRST so the registry is populated. If the
+    // metadata INSERT fails for any reason, a subsequent `deleteChat`
+    // or `_refreshState` will still find the chat via the registry.
+    await this.subAgent(MyAssistant, id);
+    this.sql`
+      INSERT INTO chat_meta (id, title, updated_at, last_message_preview)
+      VALUES (${id}, ${title}, ${now}, NULL)
+    `;
+    this._refreshState();
+    return {
+      id,
+      title,
+      createdAt: now,
+      updatedAt: now
+    };
+  }
+
+  @callable()
+  async renameChat(id: string, title: string): Promise<void> {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    this.sql`
+      INSERT INTO chat_meta (id, title, updated_at)
+      VALUES (${id}, ${trimmed}, ${Date.now()})
+      ON CONFLICT(id) DO UPDATE SET
+        title = excluded.title,
+        updated_at = excluded.updated_at
+    `;
+    this._refreshState();
+  }
+
+  @callable()
+  async deleteChat(id: string): Promise<void> {
+    // Wipe the facet (idempotent — safe if already gone), then drop
+    // its metadata. Order doesn't matter for correctness since the
+    // registry is authoritative, but we do the facet first so a crash
+    // between the two leaves no orphan meta rows visible.
+    this.deleteSubAgent(MyAssistant, id);
+    this.sql`DELETE FROM chat_meta WHERE id = ${id}`;
+    this._refreshState();
+  }
+
+  /**
+   * Called by a child `MyAssistant` after every assistant turn — see
+   * `MyAssistant.onChatResponse`. Keeps the sidebar preview and
+   * "last active" ordering in sync with the real conversations.
+   */
+  @callable()
+  async recordChatTurn(chatId: string, preview: string): Promise<void> {
+    this.sql`
+      INSERT INTO chat_meta (id, title, updated_at, last_message_preview)
+      VALUES (
+        ${chatId},
+        ${defaultChatTitle(Date.now())},
+        ${Date.now()},
+        ${preview}
+      )
+      ON CONFLICT(id) DO UPDATE SET
+        updated_at = excluded.updated_at,
+        last_message_preview = excluded.last_message_preview
+    `;
+    this._refreshState();
+  }
+
+  // ── Scheduled work (parent-owned, fans out to one child) ───────────
+
+  /**
+   * Fires daily at 09:00 UTC (from `onStart()`'s cron schedule).
+   *
+   * Design note: we post the summary into the most-recently-updated
+   * chat rather than fanning out to every chat. For a demo this keeps
+   * the behavior legible — one notification per day, attached to the
+   * conversation the user was last using. A real app might fan out, or
+   * skip chats idle beyond some threshold.
+   */
+  async dailySummary() {
+    const [row] = this.sql<{ id: string }>`
+      SELECT id FROM chat_meta ORDER BY updated_at DESC LIMIT 1
+    `;
+    if (!row) return;
+
+    const target = await this.subAgent(MyAssistant, row.id);
+    await target.postDailySummaryPrompt();
+  }
+}
+
+// ── MyAssistant — one Think DO per chat (a facet of the directory) ────
 
 export class MyAssistant extends Think<Env> {
   static options = {
@@ -208,11 +427,31 @@ When you learn something about the user or their project, save it to memory.`
     }
   }
 
-  onChatResponse(result: ChatResponseResult): void {
+  async onChatResponse(result: ChatResponseResult): Promise<void> {
     console.log(`Turn ${result.status}: ${result.message.parts.length} parts`);
+
+    // Update the sidebar preview on the parent directory. Best-effort —
+    // the chat should still function if the RPC fails.
+    const preview = result.message.parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("")
+      .slice(0, 120);
+    if (!preview) return;
+
+    try {
+      const directory = await this.parentAgent(AssistantDirectory);
+      await directory.recordChatTurn(this.name, preview);
+    } catch (err) {
+      console.warn("[MyAssistant] Failed to update directory preview:", err);
+    }
   }
 
   async onStart() {
+    // MCP OAuth popup handler. Note: we do NOT schedule from here —
+    // facets can't own schedules. The daily summary is scheduled on the
+    // parent `AssistantDirectory` and RPCs into us via
+    // `postDailySummaryPrompt()` below.
     this.mcp.configureOAuthCallback({
       customHandler: (result) => {
         if (result.authSuccess) {
@@ -227,11 +466,16 @@ When you learn something about the user or their project, save it to memory.`
         );
       }
     });
-
-    await this.schedule("0 9 * * *", "dailySummary", {}, { idempotent: true });
   }
 
-  async dailySummary() {
+  /**
+   * Called by `AssistantDirectory.dailySummary()` on the daily cron.
+   * Queues a proactive user message so the model produces a summary on
+   * the next connection/turn. Runs as an RPC from the parent — no
+   * model call happens here.
+   */
+  @callable()
+  async postDailySummaryPrompt() {
     await this.saveMessages([
       {
         id: crypto.randomUUID(),
@@ -248,14 +492,20 @@ When you learn something about the user or their project, save it to memory.`
 
   @callable()
   async addServer(name: string, url: string) {
-    // Route the OAuth redirect through `/chat/mcp-callback` so it goes via
-    // the same authenticated `/chat*` path as the rest of the app. The
-    // default callback URL (`/agents/my-assistant/<name>/callback`) is not
-    // routed to the Worker in wrangler.jsonc and would silently 200 the
-    // SPA shell, hanging the MCP server in `AUTHENTICATING` forever.
-    return await this.addMcpServer(name, url, {
-      callbackPath: "chat/mcp-callback"
-    });
+    // Route the OAuth redirect through sub-agent routing so it lands on
+    // THIS chat's DO (not the parent directory, which has no MCP state).
+    // `/chat` is the authenticated Worker entry point; `/sub/my-assistant/<chatId>`
+    // is the sub-agent routing tail the parent's `fetch()` parses and
+    // forwards to us as `/mcp-callback`. `Agent._onRequest` then passes
+    // it to `mcp.isCallbackRequest()`, which matches on origin + pathname
+    // against the URL we persisted here.
+    //
+    // See issue #1378 for the follow-up on tightening the framework's
+    // default callback URL when `sendIdentityOnConnect: true`.
+    const callbackPath = `chat/sub/my-assistant/${encodeURIComponent(
+      this.name
+    )}/mcp-callback`;
+    return await this.addMcpServer(name, url, { callbackPath });
   }
 
   @callable()
@@ -303,11 +553,29 @@ When you learn something about the user or their project, save it to memory.`
   }
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function defaultChatTitle(timestamp: number): string {
+  const date = new Date(timestamp);
+  const month = date.toLocaleString("en-US", { month: "short" });
+  const day = date.getDate();
+  return `New chat — ${month} ${day}`;
+}
+
 function createJsonResponse(body: unknown, init?: ResponseInit) {
   const headers = new Headers(init?.headers);
   headers.set("Cache-Control", "no-store");
   return Response.json(body, { ...init, headers });
 }
+
+// ── Worker ────────────────────────────────────────────────────────────
+//
+// The Worker owns exactly two things:
+//   1. the GitHub OAuth flow
+//   2. the auth gate in front of `/chat*`, forwarding to the user's
+//      AssistantDirectory. The directory's built-in sub-agent router
+//      picks up the `/sub/my-assistant/:chatId` tail on its own — no
+//      per-chat routing code lives here.
 
 export default {
   async fetch(request: Request, env: Env) {
@@ -337,16 +605,22 @@ export default {
         return createJsonResponse(user);
       }
 
-      // User-scoped chat route — the Worker, not the browser, decides which
-      // MyAssistant Durable Object instance owns this user's conversation.
+      // User-scoped chat routing. The Worker, not the browser, decides
+      // which AssistantDirectory DO owns this user's chats. Everything
+      // below `/chat` (including sub-agent routing to a specific
+      // `MyAssistant` facet) is handled by the directory's built-in
+      // `Agent.fetch()` + sub-routing logic.
       if (url.pathname === "/chat" || url.pathname.startsWith("/chat/")) {
         const user = await getGitHubUserFromRequest(request);
         if (!user) {
           return createUnauthorizedResponse(request);
         }
 
-        const agent = await getAgentByName(env.MyAssistant, user.login);
-        return agent.fetch(request);
+        const directory = await getAgentByName(
+          env.AssistantDirectory,
+          user.login
+        );
+        return directory.fetch(request);
       }
     } catch (error) {
       const message =
@@ -354,10 +628,11 @@ export default {
       return createJsonResponse({ error: message }, { status: 500 });
     }
 
-    // Any other path is intentionally unhandled. In particular we do NOT
-    // fall back to `routeAgentRequest`, because that would let a client
-    // reach `/agents/my-assistant/<login>` without going through the
-    // GitHub-authenticated `/chat*` route.
+    // Any other path is intentionally unhandled. We do NOT fall back
+    // to `routeAgentRequest` — that would let a client reach
+    // `/agents/assistant-directory/<login>` or
+    // `/agents/my-assistant/<chatId>` without going through the
+    // GitHub-authenticated `/chat*` gate.
     return new Response("Not found", { status: 404 });
   }
 } satisfies ExportedHandler<Env>;

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -34,10 +34,12 @@
  *     has one continuous filesystem across every chat with a given
  *     user, not a fresh scratch space per conversation.
  *
- *     The directory's `Workspace` is typed as `WorkspaceLike` (an
- *     interface shipped by `@cloudflare/think`) so the proxy can
- *     substitute in without casts. This is built-in Think support,
- *     not a one-off hack.
+ *     The proxy implements the `WorkspaceFsLike` interface from
+ *     `@cloudflare/shell`, which is strictly wider than the
+ *     `WorkspaceLike` Think's builtin tooling needs. That means the
+ *     same proxy also backs codemode's `state.*` sandbox API via
+ *     `createWorkspaceStateBackend` — so `state.planEdits` in chat B
+ *     sees and mutates the same files chat A just wrote. No casts.
  *
  * Features demonstrated inside each `MyAssistant`:
  *   - Workspace tools (read, write, edit, find, grep, delete) — backed by the shared directory workspace, not per-chat
@@ -57,8 +59,11 @@
 import { createWorkersAI } from "workers-ai-provider";
 import { Agent, callable, getAgentByName } from "agents";
 import { Think, Session, Workspace } from "@cloudflare/think";
-import type { WorkspaceLike } from "@cloudflare/think";
-import type { FileInfo } from "@cloudflare/shell";
+import {
+  createWorkspaceStateBackend,
+  type FileInfo,
+  type WorkspaceFsLike
+} from "@cloudflare/shell";
 import {
   createUnauthorizedResponse,
   getGitHubUserFromRequest,
@@ -312,17 +317,42 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
   // another chat's files via the sidebar websocket; workspace I/O is
   // LLM-tool-only. DO-to-DO RPC doesn't need the decorator.
   //
-  // Each method is a one-line delegate. We accept whatever arg shapes
-  // the concrete `Workspace` accepts rather than re-stating the types
-  // here — `ReturnType<typeof Workspace.prototype.readFile>` etc.
-  // keeps the surface automatically in sync with `@cloudflare/shell`.
+  // The surface covers the full `WorkspaceFsLike` interface from
+  // `@cloudflare/shell`, which is what `createWorkspaceStateBackend`
+  // needs to drive codemode's `state.*` sandbox API. That means a
+  // plan from one chat can edit files the same way as a single-chat
+  // app — the shared workspace is the single source of truth.
+  //
+  // Each method is a one-line delegate. We use
+  // `Parameters<Workspace["method"]>[n]` to stay automatically in
+  // sync with `@cloudflare/shell` rather than re-stating the types.
 
   async readFile(path: string): Promise<string | null> {
     return this.workspace.readFile(path);
   }
 
-  async writeFile(path: string, content: string): Promise<void> {
-    return this.workspace.writeFile(path, content);
+  async readFileBytes(path: string): Promise<Uint8Array | null> {
+    return this.workspace.readFileBytes(path);
+  }
+
+  async writeFile(
+    path: string,
+    content: string,
+    opts?: Parameters<Workspace["writeFile"]>[2]
+  ): Promise<void> {
+    return this.workspace.writeFile(path, content, opts);
+  }
+
+  async writeFileBytes(path: string, content: Uint8Array): Promise<void> {
+    return this.workspace.writeFileBytes(path, content);
+  }
+
+  async appendFile(path: string, content: string): Promise<void> {
+    return this.workspace.appendFile(path, content);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return this.workspace.exists(path);
   }
 
   async readDir(
@@ -350,21 +380,52 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
   async stat(path: string): Promise<FileInfo | null> {
     return this.workspace.stat(path);
   }
+
+  async lstat(path: string): Promise<FileInfo | null> {
+    return this.workspace.lstat(path);
+  }
+
+  async cp(
+    src: string,
+    dest: string,
+    opts?: Parameters<Workspace["cp"]>[2]
+  ): Promise<void> {
+    return this.workspace.cp(src, dest, opts);
+  }
+
+  async mv(src: string, dest: string): Promise<void> {
+    return this.workspace.mv(src, dest);
+  }
+
+  async symlink(target: string, linkPath: string): Promise<void> {
+    return this.workspace.symlink(target, linkPath);
+  }
+
+  async readlink(path: string): Promise<string> {
+    return this.workspace.readlink(path);
+  }
 }
 
 // ── SharedWorkspace — proxy used by children ─────────────────────────
 //
-// Satisfies `WorkspaceLike` by forwarding every call to the parent
-// `AssistantDirectory`'s real `Workspace`. Per-call it's one extra RPC
-// hop; because the parent and child are DO facets colocated on the same
-// machine, the hop is in-process and cheap.
+// Satisfies `WorkspaceFsLike` (the interface shipped by
+// `@cloudflare/shell`) by forwarding every call to the parent
+// `AssistantDirectory`'s real `Workspace`. Because `WorkspaceFsLike`
+// is a strict superset of `WorkspaceLike`, this also satisfies
+// everything Think's builtin tools need — but covering the wider
+// surface is what lets us pass the same object to
+// `createWorkspaceStateBackend` below, so codemode's `state.*` sandbox
+// API operates on the shared workspace too.
+//
+// Per-call it's one extra RPC hop; parent and child are DO facets
+// colocated on the same machine, so the hop is in-process and cheap.
 //
 // The parent stub is resolved lazily on first use and cached. Stubs
 // from `parentAgent()` are thin proxies — they don't hold connections,
 // so caching the resolved stub across the child's lifetime is safe
 // even if the parent hibernates and comes back between calls.
 
-class SharedWorkspace implements WorkspaceLike {
+class SharedWorkspace implements WorkspaceFsLike {
   #stubPromise?: Promise<DurableObjectStub<AssistantDirectory>>;
 
   constructor(private child: Pick<MyAssistant, "parentAgent">) {}
@@ -378,12 +439,32 @@ class SharedWorkspace implements WorkspaceLike {
     return (await this.parent()).readFile(path);
   }
 
-  async writeFile(path: string, content: string) {
-    return (await this.parent()).writeFile(path, content);
+  async readFileBytes(path: string) {
+    return (await this.parent()).readFileBytes(path);
   }
 
-  async readDir(path: string, opts?: Parameters<Workspace["readDir"]>[1]) {
-    return (await this.parent()).readDir(path, opts);
+  async writeFile(
+    path: string,
+    content: string,
+    opts?: Parameters<Workspace["writeFile"]>[2]
+  ) {
+    return (await this.parent()).writeFile(path, content, opts);
+  }
+
+  async writeFileBytes(path: string, content: Uint8Array) {
+    return (await this.parent()).writeFileBytes(path, content);
+  }
+
+  async appendFile(path: string, content: string) {
+    return (await this.parent()).appendFile(path, content);
+  }
+
+  async exists(path: string) {
+    return (await this.parent()).exists(path);
+  }
+
+  async readDir(path?: string, opts?: Parameters<Workspace["readDir"]>[1]) {
+    return (await this.parent()).readDir(path ?? "/", opts);
   }
 
   async rm(path: string, opts?: Parameters<Workspace["rm"]>[1]) {
@@ -400,6 +481,26 @@ class SharedWorkspace implements WorkspaceLike {
 
   async stat(path: string) {
     return (await this.parent()).stat(path);
+  }
+
+  async lstat(path: string) {
+    return (await this.parent()).lstat(path);
+  }
+
+  async cp(src: string, dest: string, opts?: Parameters<Workspace["cp"]>[2]) {
+    return (await this.parent()).cp(src, dest, opts);
+  }
+
+  async mv(src: string, dest: string) {
+    return (await this.parent()).mv(src, dest);
+  }
+
+  async symlink(target: string, linkPath: string) {
+    return (await this.parent()).symlink(target, linkPath);
+  }
+
+  async readlink(path: string) {
+    return (await this.parent()).readlink(path);
   }
 }
 
@@ -422,12 +523,19 @@ export class MyAssistant extends Think<Env> {
    * init check, the shared proxy is already in place — Think never
    * creates a per-chat `Workspace` at all.
    *
-   * All workspace-aware code (the builtin tools from
-   * `createWorkspaceTools`, lifecycle hooks, the workspace-RPC
-   * `listWorkspaceFiles` / `readWorkspaceFile` below) routes through
-   * this proxy transparently.
+   * Declared as `WorkspaceFsLike` (the wider interface from
+   * `@cloudflare/shell`) rather than Think's `WorkspaceLike` so that
+   * `createWorkspaceStateBackend(this.workspace)` in `getTools()` sees
+   * the full filesystem surface it needs. `WorkspaceFsLike` is a strict
+   * superset of `WorkspaceLike`, so Think's internals keep working.
+   *
+   * All workspace-aware code — the builtin tools from
+   * `createWorkspaceTools`, lifecycle hooks, the `listWorkspaceFiles`
+   * / `readWorkspaceFile` RPCs below, and codemode's `state.*` sandbox
+   * API via `createWorkspaceStateBackend` — routes through this proxy
+   * transparently.
    */
-  override workspace: WorkspaceLike = new SharedWorkspace(this);
+  override workspace: WorkspaceFsLike = new SharedWorkspace(this);
 
   getModel(): LanguageModel {
     const tier = this.getConfig<AgentConfig>()?.modelTier ?? "fast";
@@ -489,6 +597,12 @@ When you learn something about the user or their project, save it to memory.`
     return {
       execute: createExecuteTool({
         tools: createWorkspaceTools(this.workspace),
+        // `state.*` inside the sandbox is backed by the SHARED workspace
+        // too — `createWorkspaceStateBackend` accepts our `SharedWorkspace`
+        // proxy because it satisfies the `WorkspaceFsLike` interface from
+        // `@cloudflare/shell`. That means `state.planEdits`/`applyEdits`
+        // in chat B sees and mutates the same files chat A just wrote.
+        state: createWorkspaceStateBackend(this.workspace),
         loader: this.env.LOADER
       }),
 

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -302,8 +302,13 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
    * Called by a child `MyAssistant` after every assistant turn — see
    * `MyAssistant.onChatResponse`. Keeps the sidebar preview and
    * "last active" ordering in sync with the real conversations.
+   *
+   * Deliberately NOT `@callable()` — this is a parent-side side effect
+   * of committing a turn, not something a browser should be able to
+   * trigger directly. Child→parent DO RPC doesn't need the decorator.
+   * Marking it `@callable()` would let a client forge sidebar entries
+   * for any chat id in their own directory.
    */
-  @callable()
   async recordChatTurn(chatId: string, preview: string): Promise<void> {
     this.sql`
       INSERT INTO chat_meta (id, title, updated_at, last_message_preview)
@@ -370,17 +375,25 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
   async writeFile(
     path: string,
     content: string,
-    opts?: Parameters<Workspace["writeFile"]>[2]
+    mimeType?: Parameters<Workspace["writeFile"]>[2]
   ): Promise<void> {
-    return this.workspace.writeFile(path, content, opts);
+    return this.workspace.writeFile(path, content, mimeType);
   }
 
-  async writeFileBytes(path: string, content: Uint8Array): Promise<void> {
-    return this.workspace.writeFileBytes(path, content);
+  async writeFileBytes(
+    path: string,
+    content: Parameters<Workspace["writeFileBytes"]>[1],
+    mimeType?: Parameters<Workspace["writeFileBytes"]>[2]
+  ): Promise<void> {
+    return this.workspace.writeFileBytes(path, content, mimeType);
   }
 
-  async appendFile(path: string, content: string): Promise<void> {
-    return this.workspace.appendFile(path, content);
+  async appendFile(
+    path: string,
+    content: string,
+    mimeType?: Parameters<Workspace["appendFile"]>[2]
+  ): Promise<void> {
+    return this.workspace.appendFile(path, content, mimeType);
   }
 
   async exists(path: string): Promise<boolean> {
@@ -478,17 +491,25 @@ class SharedWorkspace implements WorkspaceFsLike {
   async writeFile(
     path: string,
     content: string,
-    opts?: Parameters<Workspace["writeFile"]>[2]
+    mimeType?: Parameters<Workspace["writeFile"]>[2]
   ) {
-    return (await this.parent()).writeFile(path, content, opts);
+    return (await this.parent()).writeFile(path, content, mimeType);
   }
 
-  async writeFileBytes(path: string, content: Uint8Array) {
-    return (await this.parent()).writeFileBytes(path, content);
+  async writeFileBytes(
+    path: string,
+    content: Parameters<Workspace["writeFileBytes"]>[1],
+    mimeType?: Parameters<Workspace["writeFileBytes"]>[2]
+  ) {
+    return (await this.parent()).writeFileBytes(path, content, mimeType);
   }
 
-  async appendFile(path: string, content: string) {
-    return (await this.parent()).appendFile(path, content);
+  async appendFile(
+    path: string,
+    content: string,
+    mimeType?: Parameters<Workspace["appendFile"]>[2]
+  ) {
+    return (await this.parent()).appendFile(path, content, mimeType);
   }
 
   async exists(path: string) {
@@ -771,8 +792,11 @@ When you learn something about the user or their project, save it to memory.`
    * Queues a proactive user message so the model produces a summary on
    * the next connection/turn. Runs as an RPC from the parent — no
    * model call happens here.
+   *
+   * Deliberately NOT `@callable()` — parent→child DO RPC doesn't need
+   * the decorator, and exposing this to browsers would let a client
+   * inject a "summarize recent work" prompt on demand.
    */
-  @callable()
   async postDailySummaryPrompt() {
     await this.saveMessages([
       {

--- a/examples/assistant/src/use-chats.ts
+++ b/examples/assistant/src/use-chats.ts
@@ -31,7 +31,22 @@
 
 import { useCallback, useState } from "react";
 import { useAgent } from "agents/react";
+import type { MCPServersState } from "agents";
 import type { ChatSummary, DirectoryState } from "./server";
+
+const EMPTY_MCP_STATE: MCPServersState = {
+  prompts: [],
+  resources: [],
+  servers: {},
+  tools: []
+};
+
+/** Result of `addMcpServer` — mirrors the framework's return shape. */
+export interface AddMcpServerResult {
+  id: string;
+  state: string;
+  authUrl?: string;
+}
 
 export interface UseChats {
   /** Live `useAgent` handle for the parent directory. */
@@ -45,12 +60,27 @@ export interface UseChats {
    * browsers, tree views, etc.).
    */
   workspaceRevision: number;
+  /**
+   * Latest MCP server state from the directory — server registry,
+   * connection states, tools, prompts, resources. Updates live
+   * whenever the directory broadcasts a `CF_AGENT_MCP_SERVERS`
+   * message (add, remove, auth completes, connection state changes).
+   */
+  mcpState: MCPServersState;
   /** Create a new chat and return it. */
   createChat: (opts?: { title?: string }) => Promise<ChatSummary>;
   /** Rename a chat. No-op if the new title is empty. */
   renameChat: (id: string, title: string) => Promise<void>;
   /** Delete a chat (idempotent — safe to call for an already-gone id). */
   deleteChat: (id: string) => Promise<void>;
+  /**
+   * Register a new MCP server on the directory. If the server needs
+   * OAuth, `authUrl` is populated and the caller should `window.open`
+   * it so the user can complete the flow.
+   */
+  addMcpServer: (name: string, url: string) => Promise<AddMcpServerResult>;
+  /** Remove a registered MCP server by id. */
+  removeMcpServer: (id: string) => Promise<void>;
 }
 
 function isWorkspaceChangeMessage(value: unknown): boolean {
@@ -65,10 +95,17 @@ function isWorkspaceChangeMessage(value: unknown): boolean {
 
 export function useChats(): UseChats {
   const [workspaceRevision, setWorkspaceRevision] = useState(0);
+  const [mcpState, setMcpState] = useState<MCPServersState>(EMPTY_MCP_STATE);
 
   const directory = useAgent<DirectoryState>({
     agent: "AssistantDirectory",
     basePath: "chat",
+    // `onMcpUpdate` fires for every `CF_AGENT_MCP_SERVERS` broadcast
+    // from the directory — which is the single source of truth for
+    // this user's MCP state (server list, auth states, tools).
+    onMcpUpdate: useCallback((state: MCPServersState) => {
+      setMcpState(state);
+    }, []),
     // The directory broadcasts `{ type: "workspace-change", event }` on
     // every shared-workspace mutation (see AssistantDirectory.workspace's
     // onChange hook). `useAgent` passes through anything it doesn't
@@ -116,12 +153,28 @@ export function useChats(): UseChats {
     [directory]
   );
 
+  const addMcpServer = useCallback(
+    async (name: string, url: string) =>
+      (await directory.call("addServer", [name, url])) as AddMcpServerResult,
+    [directory]
+  );
+
+  const removeMcpServer = useCallback(
+    async (id: string) => {
+      await directory.call("removeServer", [id]);
+    },
+    [directory]
+  );
+
   return {
     directory,
     chats,
     workspaceRevision,
+    mcpState,
     createChat,
     renameChat,
-    deleteChat
+    deleteChat,
+    addMcpServer,
+    removeMcpServer
   };
 }

--- a/examples/assistant/src/use-chats.ts
+++ b/examples/assistant/src/use-chats.ts
@@ -1,0 +1,66 @@
+/**
+ * `useChats()` — a local prototype hook on top of the sub-agent routing
+ * primitive. NOT a library export.
+ *
+ * Wraps the `useAgent` connection to a user's `AssistantDirectory` and
+ * exposes a small surface for sidebar behavior:
+ *
+ * ```tsx
+ * const { directory, chats, createChat, deleteChat, renameChat } = useChats();
+ * ```
+ *
+ * Why it lives in the example, not the library: the shape of `Chats` /
+ * `useChats` is still in flux (what should the parent class own? how do
+ * we handle permissions and cross-chat shared state?). Prototyping here
+ * keeps us free to iterate — we'll promote it into a library API once
+ * we're sure about the surface. See `wip/think-multi-session-assistant-plan.md`
+ * (PR 4) for the long-term plan.
+ */
+
+import { useCallback } from "react";
+import { useAgent } from "agents/react";
+import type { ChatSummary, DirectoryState } from "./server";
+
+export interface UseChats {
+  /** Live `useAgent` handle for the parent directory. */
+  directory: ReturnType<typeof useAgent<DirectoryState>>;
+  /** Ordered chat list, most-recently-active first. */
+  chats: ChatSummary[];
+  /** Create a new chat and return it. */
+  createChat: (opts?: { title?: string }) => Promise<ChatSummary>;
+  /** Rename a chat. No-op if the new title is empty. */
+  renameChat: (id: string, title: string) => Promise<void>;
+  /** Delete a chat (idempotent — safe to call for an already-gone id). */
+  deleteChat: (id: string) => Promise<void>;
+}
+
+export function useChats(): UseChats {
+  const directory = useAgent<DirectoryState>({
+    agent: "AssistantDirectory",
+    basePath: "chat"
+  });
+
+  const chats: ChatSummary[] = directory.state?.chats ?? [];
+
+  const createChat = useCallback(
+    async (opts?: { title?: string }) =>
+      (await directory.call("createChat", opts ? [opts] : [])) as ChatSummary,
+    [directory]
+  );
+
+  const renameChat = useCallback(
+    async (id: string, title: string) => {
+      await directory.call("renameChat", [id, title]);
+    },
+    [directory]
+  );
+
+  const deleteChat = useCallback(
+    async (id: string) => {
+      await directory.call("deleteChat", [id]);
+    },
+    [directory]
+  );
+
+  return { directory, chats, createChat, renameChat, deleteChat };
+}

--- a/examples/assistant/src/use-chats.ts
+++ b/examples/assistant/src/use-chats.ts
@@ -6,8 +6,20 @@
  * exposes a small surface for sidebar behavior:
  *
  * ```tsx
- * const { directory, chats, createChat, deleteChat, renameChat } = useChats();
+ * const {
+ *   directory,
+ *   chats,
+ *   workspaceRevision,
+ *   createChat,
+ *   deleteChat,
+ *   renameChat
+ * } = useChats();
  * ```
+ *
+ * `workspaceRevision` is a monotonically increasing counter the
+ * directory bumps every time the shared workspace changes. Use it as a
+ * `useEffect` dep to keep workspace-backed UI live across chats and
+ * open tabs without polling.
  *
  * Why it lives in the example, not the library: the shape of `Chats` /
  * `useChats` is still in flux (what should the parent class own? how do
@@ -17,8 +29,9 @@
  * (PR 4) for the long-term plan.
  */
 
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useAgent } from "agents/react";
+import type { WorkspaceChangeEvent } from "@cloudflare/shell";
 import type { ChatSummary, DirectoryState } from "./server";
 
 export interface UseChats {
@@ -26,6 +39,19 @@ export interface UseChats {
   directory: ReturnType<typeof useAgent<DirectoryState>>;
   /** Ordered chat list, most-recently-active first. */
   chats: ChatSummary[];
+  /**
+   * Ticks up every time the shared workspace changes, regardless of
+   * which chat caused the change. Consumers can pass this as a
+   * `useEffect` dependency to refresh workspace-backed UI (file
+   * browsers, tree views, etc.).
+   */
+  workspaceRevision: number;
+  /**
+   * Details of the most recent workspace change the directory
+   * broadcast, or `null` if no change has been seen this session.
+   * Stable across renders that don't bump `workspaceRevision`.
+   */
+  lastWorkspaceChange: WorkspaceChangeEvent | null;
   /** Create a new chat and return it. */
   createChat: (opts?: { title?: string }) => Promise<ChatSummary>;
   /** Rename a chat. No-op if the new title is empty. */
@@ -34,10 +60,48 @@ export interface UseChats {
   deleteChat: (id: string) => Promise<void>;
 }
 
+interface WorkspaceChangeMessage {
+  type: "workspace-change";
+  event: WorkspaceChangeEvent;
+}
+
+function isWorkspaceChangeMessage(
+  value: unknown
+): value is WorkspaceChangeMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const msg = value as Record<string, unknown>;
+  if (msg.type !== "workspace-change") return false;
+  const event = msg.event;
+  if (typeof event !== "object" || event === null) return false;
+  const ev = event as Record<string, unknown>;
+  return typeof ev.path === "string" && typeof ev.type === "string";
+}
+
 export function useChats(): UseChats {
+  const [workspaceRevision, setWorkspaceRevision] = useState(0);
+  const lastChangeRef = useRef<WorkspaceChangeEvent | null>(null);
+
   const directory = useAgent<DirectoryState>({
     agent: "AssistantDirectory",
-    basePath: "chat"
+    basePath: "chat",
+    // The directory broadcasts `{ type: "workspace-change", event }` on
+    // every shared-workspace mutation (see AssistantDirectory.workspace's
+    // onChange hook). `useAgent` passes through anything it doesn't
+    // recognize internally, so we parse here and expose a revision
+    // counter for downstream effects.
+    onMessage: (message) => {
+      if (typeof message.data !== "string") return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(message.data);
+      } catch {
+        return;
+      }
+      if (isWorkspaceChangeMessage(parsed)) {
+        lastChangeRef.current = parsed.event;
+        setWorkspaceRevision((n) => n + 1);
+      }
+    }
   });
 
   const chats: ChatSummary[] = directory.state?.chats ?? [];
@@ -62,5 +126,13 @@ export function useChats(): UseChats {
     [directory]
   );
 
-  return { directory, chats, createChat, renameChat, deleteChat };
+  return {
+    directory,
+    chats,
+    workspaceRevision,
+    lastWorkspaceChange: lastChangeRef.current,
+    createChat,
+    renameChat,
+    deleteChat
+  };
 }

--- a/examples/assistant/src/use-chats.ts
+++ b/examples/assistant/src/use-chats.ts
@@ -29,9 +29,8 @@
  * (PR 4) for the long-term plan.
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { useAgent } from "agents/react";
-import type { WorkspaceChangeEvent } from "@cloudflare/shell";
 import type { ChatSummary, DirectoryState } from "./server";
 
 export interface UseChats {
@@ -46,12 +45,6 @@ export interface UseChats {
    * browsers, tree views, etc.).
    */
   workspaceRevision: number;
-  /**
-   * Details of the most recent workspace change the directory
-   * broadcast, or `null` if no change has been seen this session.
-   * Stable across renders that don't bump `workspaceRevision`.
-   */
-  lastWorkspaceChange: WorkspaceChangeEvent | null;
   /** Create a new chat and return it. */
   createChat: (opts?: { title?: string }) => Promise<ChatSummary>;
   /** Rename a chat. No-op if the new title is empty. */
@@ -60,14 +53,7 @@ export interface UseChats {
   deleteChat: (id: string) => Promise<void>;
 }
 
-interface WorkspaceChangeMessage {
-  type: "workspace-change";
-  event: WorkspaceChangeEvent;
-}
-
-function isWorkspaceChangeMessage(
-  value: unknown
-): value is WorkspaceChangeMessage {
+function isWorkspaceChangeMessage(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
   const msg = value as Record<string, unknown>;
   if (msg.type !== "workspace-change") return false;
@@ -79,7 +65,6 @@ function isWorkspaceChangeMessage(
 
 export function useChats(): UseChats {
   const [workspaceRevision, setWorkspaceRevision] = useState(0);
-  const lastChangeRef = useRef<WorkspaceChangeEvent | null>(null);
 
   const directory = useAgent<DirectoryState>({
     agent: "AssistantDirectory",
@@ -88,7 +73,13 @@ export function useChats(): UseChats {
     // every shared-workspace mutation (see AssistantDirectory.workspace's
     // onChange hook). `useAgent` passes through anything it doesn't
     // recognize internally, so we parse here and expose a revision
-    // counter for downstream effects.
+    // counter for downstream effects to key on.
+    //
+    // We intentionally don't expose the `event` payload itself here —
+    // nothing in the example reads it yet, and routing it reactively
+    // would need a state update rather than a ref. If a future consumer
+    // needs per-event details, change this to a `useState<{ revision,
+    // event }>` and expose both fields at once.
     onMessage: (message) => {
       if (typeof message.data !== "string") return;
       let parsed: unknown;
@@ -98,7 +89,6 @@ export function useChats(): UseChats {
         return;
       }
       if (isWorkspaceChangeMessage(parsed)) {
-        lastChangeRef.current = parsed.event;
         setWorkspaceRevision((n) => n + 1);
       }
     }
@@ -130,7 +120,6 @@ export function useChats(): UseChats {
     directory,
     chats,
     workspaceRevision,
-    lastWorkspaceChange: lastChangeRef.current,
     createChat,
     renameChat,
     deleteChat

--- a/examples/assistant/wrangler.jsonc
+++ b/examples/assistant/wrangler.jsonc
@@ -15,6 +15,10 @@
   "durable_objects": {
     "bindings": [
       {
+        "class_name": "AssistantDirectory",
+        "name": "AssistantDirectory"
+      },
+      {
         "class_name": "MyAssistant",
         "name": "MyAssistant"
       }
@@ -26,6 +30,10 @@
     {
       "new_sqlite_classes": ["MyAssistant"],
       "tag": "v1"
+    },
+    {
+      "new_sqlite_classes": ["AssistantDirectory"],
+      "tag": "v2"
     }
   ],
   "name": "think-assistant",

--- a/packages/shell/src/filesystem.ts
+++ b/packages/shell/src/filesystem.ts
@@ -140,6 +140,45 @@ export type WorkspaceChangeEvent = {
   entryType: EntryType;
 };
 
+/**
+ * Minimum set of `Workspace` methods required to satisfy the
+ * `FileSystem` adapter (and therefore `createWorkspaceStateBackend`).
+ *
+ * A concrete `Workspace` trivially satisfies this. Callers who wrap a
+ * `Workspace` behind their own layer — most commonly a cross-DO proxy
+ * that forwards each call to a parent agent's real `Workspace` over
+ * RPC — can satisfy `WorkspaceFsLike` without subclassing or casting,
+ * and still pass the object to `WorkspaceFileSystem` or
+ * `createWorkspaceStateBackend`.
+ *
+ * This is a strict superset of the `WorkspaceLike` shape that
+ * `@cloudflare/think` uses for builtin tool wiring. Tooling that only
+ * reaches for the narrow surface can stick with `WorkspaceLike`;
+ * anything touching codemode's `state.*` via
+ * `createWorkspaceStateBackend` needs this.
+ *
+ * @experimental The API surface may change before stabilizing.
+ */
+export type WorkspaceFsLike = Pick<
+  Workspace,
+  | "readFile"
+  | "readFileBytes"
+  | "writeFile"
+  | "writeFileBytes"
+  | "appendFile"
+  | "exists"
+  | "stat"
+  | "lstat"
+  | "mkdir"
+  | "readDir"
+  | "rm"
+  | "cp"
+  | "mv"
+  | "symlink"
+  | "readlink"
+  | "glob"
+>;
+
 // ── Constants ────────────────────────────────────────────────────────
 
 const DEFAULT_INLINE_THRESHOLD = 1_500_000;

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -9,7 +9,8 @@ export {
   type FileInfo,
   type FileStat,
   type WorkspaceChangeEvent,
-  type WorkspaceChangeType
+  type WorkspaceChangeType,
+  type WorkspaceFsLike
 } from "./filesystem";
 
 // ── FileSystem interface + InMemoryFs ─────────────────────────────────

--- a/packages/shell/src/tests/workspace.test.ts
+++ b/packages/shell/src/tests/workspace.test.ts
@@ -1,9 +1,9 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "agents";
-import type { FileInfo, FileStat } from "../filesystem";
+import type { FileInfo, FileStat, WorkspaceFsLike } from "../filesystem";
 import { StateBatchOperationError } from "../index";
-import { createWorkspaceStateBackend } from "../workspace";
+import { createWorkspaceStateBackend, WorkspaceFileSystem } from "../workspace";
 
 // ═══════════════════════════════════════════════════════════════════
 // SqlBackend / detection / name — DO-backed tests
@@ -183,8 +183,11 @@ function createWorkspaceLike(
       }
       return null;
     },
-    async mkdir(_path: string) {},
-    async readDir(path: string) {
+    async mkdir(_path: string, _options?: { recursive?: boolean }) {},
+    async readDir(
+      path: string,
+      _options?: { limit?: number; offset?: number }
+    ) {
       const prefix = path.endsWith("/") ? path : `${path}/`;
       const directories = new Map<string, ReturnType<typeof fileInfo>>();
       const fileEntries: ReturnType<typeof fileInfo>[] = [];
@@ -230,10 +233,13 @@ function createWorkspaceLike(
     async deleteFile(path: string) {
       return files.delete(path);
     },
-    async rm(path: string) {
+    async rm(
+      path: string,
+      _options?: { recursive?: boolean; force?: boolean }
+    ) {
       files.delete(path);
     },
-    async cp(src: string, dest: string) {
+    async cp(src: string, dest: string, _options?: { recursive?: boolean }) {
       const content = files.get(src);
       if (content !== undefined) files.set(dest, content);
     },
@@ -263,9 +269,7 @@ function createWorkspaceLike(
 describe("WorkspaceStateBackend", () => {
   it("reads and writes JSON through the workspace adapter", async () => {
     const files = new Map<string, string>();
-    const backend = createWorkspaceStateBackend(
-      createWorkspaceLike(files) as never
-    );
+    const backend = createWorkspaceStateBackend(createWorkspaceLike(files));
 
     await backend.writeJson("/settings.json", {
       feature: true,
@@ -285,9 +289,7 @@ describe("WorkspaceStateBackend", () => {
     const files = new Map<string, string>([
       ["/docs.txt", "alpha beta alpha\n"]
     ]);
-    const backend = createWorkspaceStateBackend(
-      createWorkspaceLike(files) as never
-    );
+    const backend = createWorkspaceStateBackend(createWorkspaceLike(files));
 
     await expect(backend.searchText("/docs.txt", "alpha")).resolves.toEqual([
       {
@@ -319,9 +321,7 @@ describe("WorkspaceStateBackend", () => {
       ["/src/b.ts", 'export const b = "foo";\n'],
       ["/src/c.ts", 'export const c = "nope";\n']
     ]);
-    const backend = createWorkspaceStateBackend(
-      createWorkspaceLike(files) as never
-    );
+    const backend = createWorkspaceStateBackend(createWorkspaceLike(files));
 
     await expect(backend.searchFiles("/src/*.ts", "foo")).resolves.toEqual([
       {
@@ -376,9 +376,7 @@ describe("WorkspaceStateBackend", () => {
       ["/src/a.ts", 'export const a = "foo";\n'],
       ["/src/data.json", '{ "count": 1 }\n']
     ]);
-    const backend = createWorkspaceStateBackend(
-      createWorkspaceLike(files) as never
-    );
+    const backend = createWorkspaceStateBackend(createWorkspaceLike(files));
 
     const plan = await backend.planEdits([
       {
@@ -410,9 +408,7 @@ describe("WorkspaceStateBackend", () => {
       ["/src/nested/b.json", '{ "count": 1 }\n'],
       ["/src/nested/c.txt", "plain"]
     ]);
-    const backend = createWorkspaceStateBackend(
-      createWorkspaceLike(files) as never
-    );
+    const backend = createWorkspaceStateBackend(createWorkspaceLike(files));
 
     await expect(
       backend.find("/src", { type: "file", pathPattern: "/src/**/*.json" })
@@ -482,7 +478,7 @@ describe("WorkspaceStateBackend", () => {
       ["/src/b.ts", 'export const b = "foo";\n']
     ]);
     const backend = createWorkspaceStateBackend(
-      createWorkspaceLike(files, { failWritePath: "/src/b.ts" }) as never
+      createWorkspaceLike(files, { failWritePath: "/src/b.ts" })
     );
 
     await expect(
@@ -503,7 +499,7 @@ describe("WorkspaceStateBackend", () => {
       ["/src/b.ts", 'export const b = "foo";\n']
     ]);
     const backend = createWorkspaceStateBackend(
-      createWorkspaceLike(files, { failWritePath: "/src/b.ts" }) as never
+      createWorkspaceLike(files, { failWritePath: "/src/b.ts" })
     );
 
     await expect(
@@ -522,6 +518,174 @@ describe("WorkspaceStateBackend", () => {
 
     expect(files.get("/src/a.ts")).toBe('export const a = "bar";\n');
     expect(files.get("/src/b.ts")).toBe('export const b = "foo";\n');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// WorkspaceFsLike — substitutability tests
+// ═══════════════════════════════════════════════════════════════════
+//
+// These tests exercise the contract that `WorkspaceFileSystem` and
+// `createWorkspaceStateBackend` accept any `WorkspaceFsLike`, not just
+// a concrete `Workspace`. The common consumer of this is a cross-DO
+// proxy (e.g. `SharedWorkspace` in `examples/assistant`) that forwards
+// each call to a parent agent's real `Workspace` over RPC.
+
+describe("WorkspaceFsLike substitutability", () => {
+  it("a bare object satisfying WorkspaceFsLike flows through WorkspaceFileSystem without casts", async () => {
+    const files = new Map<string, string>([["/readme.md", "hello"]]);
+    // This annotation is the real test: if `createWorkspaceLike`'s shape
+    // drifted away from `WorkspaceFsLike`, tsc would reject it here at
+    // compile time. We still assert at runtime so a silent regression in
+    // method bodies also surfaces.
+    const ws: WorkspaceFsLike = createWorkspaceLike(files);
+    const fs = new WorkspaceFileSystem(ws);
+
+    await expect(fs.readFile("/readme.md")).resolves.toBe("hello");
+    await expect(fs.readFile("/missing.md")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+  });
+
+  it("createWorkspaceStateBackend drives state.* through a proxy that adds an async hop per call", async () => {
+    // Simulate the cross-DO shape: every call roundtrips through a
+    // Promise microtask (as it would through a real RPC hop). Storage
+    // is inline so the proxy genuinely stands alone — no cast to the
+    // existing mock. This is the shape `SharedWorkspace` presents in
+    // `examples/assistant`.
+    const files = new Map<string, string>([
+      ["/src/a.ts", 'export const a = "foo";\n'],
+      ["/src/b.json", '{ "count": 1 }\n']
+    ]);
+
+    // oxlint-disable-next-line no-unused-vars -- proxy only exercises a
+    // subset of WorkspaceFsLike; the rest are required for type
+    // conformance but throw if reached to prove they're not needed.
+    const notImplemented = async (method: string): Promise<never> => {
+      throw new Error(`proxy.${method} unexpectedly reached`);
+    };
+
+    const proxy: WorkspaceFsLike = {
+      async readFile(path) {
+        await Promise.resolve();
+        return files.get(path) ?? null;
+      },
+      async readFileBytes(path) {
+        await Promise.resolve();
+        const content = files.get(path);
+        return content === undefined ? null : new TextEncoder().encode(content);
+      },
+      async writeFile(path, content) {
+        await Promise.resolve();
+        files.set(path, content);
+      },
+      async writeFileBytes(path, content) {
+        await Promise.resolve();
+        files.set(path, new TextDecoder().decode(content));
+      },
+      async appendFile(path, content) {
+        await Promise.resolve();
+        const prev = files.get(path) ?? "";
+        const next =
+          typeof content === "string"
+            ? content
+            : new TextDecoder().decode(content);
+        files.set(path, prev + next);
+      },
+      async exists(path) {
+        await Promise.resolve();
+        return files.has(path);
+      },
+      async stat(path) {
+        await Promise.resolve();
+        const content = files.get(path);
+        if (content === undefined) return null;
+        return fileInfo(path, "file", content.length);
+      },
+      async lstat(path) {
+        await Promise.resolve();
+        const content = files.get(path);
+        if (content === undefined) return null;
+        return fileInfo(path, "file", content.length);
+      },
+      async mkdir() {},
+      async readDir(path = "/") {
+        await Promise.resolve();
+        const prefix = path.endsWith("/") ? path : `${path}/`;
+        const entries: FileInfo[] = [];
+        for (const [filePath, content] of files) {
+          if (!filePath.startsWith(prefix)) continue;
+          const rest = filePath.slice(prefix.length);
+          if (rest.includes("/")) continue;
+          entries.push(fileInfo(filePath, "file", content.length));
+        }
+        return entries;
+      },
+      async rm(path) {
+        await Promise.resolve();
+        files.delete(path);
+      },
+      async cp(src, dest) {
+        await Promise.resolve();
+        const content = files.get(src);
+        if (content !== undefined) files.set(dest, content);
+      },
+      async mv(src, dest) {
+        await Promise.resolve();
+        const content = files.get(src);
+        if (content !== undefined) {
+          files.set(dest, content);
+          files.delete(src);
+        }
+      },
+      async symlink() {
+        return notImplemented("symlink");
+      },
+      async readlink() {
+        return notImplemented("readlink");
+      },
+      async glob(pattern) {
+        await Promise.resolve();
+        const regex = new RegExp(
+          "^" +
+            pattern
+              .replace(/[.+^$|\\()]/g, "\\$&")
+              .replace(/\*\*\//g, "(?:.+/)?")
+              .replace(/\*/g, "[^/]*") +
+            "$"
+        );
+        const result: FileInfo[] = [];
+        for (const [filePath, content] of files) {
+          if (regex.test(filePath)) {
+            result.push(fileInfo(filePath, "file", content.length));
+          }
+        }
+        return result.sort((a, b) => a.path.localeCompare(b.path));
+      }
+    };
+
+    const backend = createWorkspaceStateBackend(proxy);
+
+    // End-to-end: a multi-file plan should still apply cleanly even
+    // though every filesystem call bounces through the async proxy.
+    const plan = await backend.planEdits([
+      {
+        kind: "replace",
+        path: "/src/a.ts",
+        search: "foo",
+        replacement: "bar"
+      },
+      {
+        kind: "writeJson",
+        path: "/src/b.json",
+        value: { count: 2 }
+      }
+    ]);
+    expect(plan.totalChanged).toBe(2);
+
+    await backend.applyEditPlan(plan);
+    expect(files.get("/src/a.ts")).toBe('export const a = "bar";\n');
+    expect(files.get("/src/b.json")).toBe('{\n  "count": 2\n}\n');
   });
 });
 

--- a/packages/shell/src/workspace.ts
+++ b/packages/shell/src/workspace.ts
@@ -1,4 +1,4 @@
-import type { Workspace } from "./filesystem";
+import type { WorkspaceFsLike } from "./filesystem";
 import type { FileSystem, FileSystemDirent, FsStat } from "./fs/interface";
 import { FileSystemStateBackend } from "./memory";
 
@@ -15,15 +15,16 @@ function enoent(path: string): Error & { code: string } {
 
 // ── WorkspaceFileSystem ───────────────────────────────────────────────
 //
-// Thin adapter that makes `Workspace` satisfy the `FileSystem` interface.
-// Handles the two main API differences:
+// Thin adapter that makes any `WorkspaceFsLike` (a concrete `Workspace`
+// or a cross-DO proxy that satisfies the interface) look like a
+// `FileSystem`. Handles the two main API differences:
 //   - Workspace.readFile / readFileBytes return null on missing;
 //     FileSystem requires ENOENT to be thrown.
 //   - Workspace.stat / lstat return Workspace-specific FileStat;
 //     FileSystem.stat / lstat return FsStat = { type, size, mtime, mode? }.
 
 export class WorkspaceFileSystem implements FileSystem {
-  constructor(private readonly ws: Workspace) {}
+  constructor(private readonly ws: WorkspaceFsLike) {}
 
   async readFile(path: string): Promise<string> {
     const content = await this.ws.readFile(path);
@@ -161,8 +162,15 @@ export class WorkspaceFileSystem implements FileSystem {
 
 // ── Factory ───────────────────────────────────────────────────────────
 
+/**
+ * Wrap a `Workspace` (or any `WorkspaceFsLike` — e.g. a cross-DO proxy
+ * forwarding each call to a parent agent's workspace over RPC) in a
+ * `FileSystemStateBackend` suitable for codemode's `state.*` sandbox
+ * API. The backend reuses `WorkspaceFileSystem` as its adapter, so
+ * every caller gets identical ENOENT and stat-normalization semantics.
+ */
 export function createWorkspaceStateBackend(
-  workspace: Workspace
+  workspace: WorkspaceFsLike
 ): FileSystemStateBackend {
   return new FileSystemStateBackend(new WorkspaceFileSystem(workspace));
 }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -141,6 +141,8 @@ import { createWorkspaceTools } from "./tools/workspace";
 export { Session } from "agents/experimental/memory/session";
 export { Workspace } from "@cloudflare/shell";
 export type { FiberContext, FiberRecoveryContext } from "agents";
+export type { WorkspaceLike } from "./tools/workspace";
+import type { WorkspaceLike } from "./tools/workspace";
 
 // ── Wire protocol constants ────────────────────────────────────────
 const MSG_CHAT_MESSAGES = CHAT_MESSAGE_TYPES.CHAT_MESSAGES;
@@ -487,19 +489,27 @@ export class Think<
   extensionManager?: import("./extensions/manager").ExtensionManager;
 
   /**
-   * Workspace filesystem backed by the DO's SQLite storage.
-   * Available in `getTools()` and lifecycle hooks.
+   * Workspace filesystem available in `getTools()` and lifecycle hooks.
+   * Defaults to a full `Workspace` backed by the DO's SQLite storage.
    *
-   * Override to add R2 spillover for large files:
+   * Typed as `WorkspaceLike` rather than `Workspace` so subclasses can
+   * replace it with anything that satisfies the interface — e.g. a proxy
+   * that forwards to a shared workspace owned by a parent DO. Override as
+   * a class field to skip the default init entirely:
+   *
    * ```typescript
+   * // Default init with R2 spillover for large files.
    * override workspace = new Workspace({
    *   sql: this.ctx.storage.sql,
    *   r2: this.env.R2,
    *   name: () => this.name
    * });
+   *
+   * // Or a custom WorkspaceLike — e.g. a parent-owned shared workspace.
+   * override workspace: WorkspaceLike = new SharedWorkspace(this);
    * ```
    */
-  workspace!: Workspace;
+  workspace!: WorkspaceLike;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);

--- a/packages/think/src/tools/workspace.ts
+++ b/packages/think/src/tools/workspace.ts
@@ -2,6 +2,26 @@ import type { Workspace, FileInfo } from "@cloudflare/shell";
 import { tool } from "ai";
 import { z } from "zod";
 
+// ── WorkspaceLike ─────────────────────────────────────────────────
+//
+// Minimum workspace surface that Think's internals rely on. Covers the
+// methods called by `createWorkspaceTools()` below plus the handful
+// Think itself uses (`readFile`/`writeFile`/`readDir`/`rm` in
+// `think.ts`). A concrete `Workspace` from `@cloudflare/shell`
+// satisfies this; so do custom implementations like the `SharedWorkspace`
+// proxy in `examples/assistant` that forwards to a parent DO.
+//
+// Consumers who reach for the fuller filesystem API (e.g.
+// `createWorkspaceStateBackend` for codemode's `state.*` in a sandbox)
+// still need a concrete `Workspace`.
+//
+// @experimental The API surface may change before stabilizing.
+
+export type WorkspaceLike = Pick<
+  Workspace,
+  "readFile" | "writeFile" | "readDir" | "rm" | "glob" | "mkdir" | "stat"
+>;
+
 // ── Operations interfaces ─────────────────────────────────────────
 // Abstractions over file I/O so the same tools can work against
 // Workspace, a local filesystem, or anything else.
@@ -46,46 +66,46 @@ export interface GrepOperations {
 
 // ── Workspace-backed operation factories ──────────────────────────
 
-function workspaceReadOps(ws: Workspace): ReadOperations {
+function workspaceReadOps(ws: WorkspaceLike): ReadOperations {
   return {
     readFile: (path) => ws.readFile(path),
     stat: (path) => ws.stat(path)
   };
 }
 
-function workspaceWriteOps(ws: Workspace): WriteOperations {
+function workspaceWriteOps(ws: WorkspaceLike): WriteOperations {
   return {
     writeFile: (path, content) => ws.writeFile(path, content),
     mkdir: (path, opts) => ws.mkdir(path, opts)
   };
 }
 
-function workspaceEditOps(ws: Workspace): EditOperations {
+function workspaceEditOps(ws: WorkspaceLike): EditOperations {
   return {
     readFile: (path) => ws.readFile(path),
     writeFile: (path, content) => ws.writeFile(path, content)
   };
 }
 
-function workspaceListOps(ws: Workspace): ListOperations {
+function workspaceListOps(ws: WorkspaceLike): ListOperations {
   return {
     readDir: (dir, opts) => ws.readDir(dir, opts)
   };
 }
 
-function workspaceFindOps(ws: Workspace): FindOperations {
+function workspaceFindOps(ws: WorkspaceLike): FindOperations {
   return {
     glob: (pattern) => ws.glob(pattern)
   };
 }
 
-function workspaceDeleteOps(ws: Workspace): DeleteOperations {
+function workspaceDeleteOps(ws: WorkspaceLike): DeleteOperations {
   return {
     rm: (path, opts) => ws.rm(path, opts)
   };
 }
 
-function workspaceGrepOps(ws: Workspace): GrepOperations {
+function workspaceGrepOps(ws: WorkspaceLike): GrepOperations {
   return {
     glob: (pattern) => ws.glob(pattern),
     readFile: (path) => ws.readFile(path)
@@ -93,7 +113,11 @@ function workspaceGrepOps(ws: Workspace): GrepOperations {
 }
 
 /**
- * Create a complete set of AI SDK tools backed by a Workspace instance.
+ * Create a complete set of AI SDK tools backed by a workspace.
+ *
+ * Accepts either a concrete `Workspace` from `@cloudflare/shell` or any
+ * `WorkspaceLike` implementation — e.g. a proxy that forwards calls to a
+ * shared workspace owned by a parent DO.
  *
  * ```ts
  * import { Workspace } from "@cloudflare/shell";
@@ -110,7 +134,7 @@ function workspaceGrepOps(ws: Workspace): GrepOperations {
  * }
  * ```
  */
-export function createWorkspaceTools(workspace: Workspace) {
+export function createWorkspaceTools(workspace: WorkspaceLike) {
   return {
     read: createReadTool({ ops: workspaceReadOps(workspace) }),
     write: createWriteTool({ ops: workspaceWriteOps(workspace) }),


### PR DESCRIPTION
## Summary

Turns `examples/assistant` from a single-chat-per-user app into a proper multi-session assistant built end-to-end on the shipped sub-agent routing primitive. Each user gets one `AssistantDirectory` parent DO that owns their chat list, their files, and their MCP servers; each chat is its own `MyAssistant` facet that proxies workspace and MCP through the parent. Net user-visible result: create as many chats as you want, files and MCP tools are reachable from all of them, OAuth happens once.

Two small library changes (`@cloudflare/think`, `@cloudflare/shell`) generalize the proxy pattern: `WorkspaceLike` and `WorkspaceFsLike` are exported types so a substitute workspace satisfies the framework without casts. Both are non-breaking; concrete `Workspace` still satisfies the wider interfaces.

## Architecture

```
AssistantDirectory ("alice")              ◄── one DO per GitHub user
  ├─ chat list + sidebar state
  ├─ shared Workspace (one SQLite for all of alice's files)
  ├─ shared MCPClientManager (one OAuth per server, one connection)
  ├─ daily-summary cron (facets can't schedule)
  └─ facets:
      ├─ MyAssistant[chat-abc]            ◄── full Think DO
      │    ├─ workspace = SharedWorkspace proxy
      │    └─ sharedMcp = SharedMCPClient proxy
      ├─ MyAssistant[chat-def]
      └─ …
```

Worker stays single-purpose: \`/auth/*\` for GitHub OAuth and \`/chat*\` for everything else (sidebar, per-chat WS, MCP OAuth callback, sub-agent routing tail). The directory's built-in \`Agent.fetch()\` handles sub-agent dispatch internally.

## Commits in this PR

The branch is structured so each concern is its own reviewable commit. The two `feat(think)` / `feat(shell)` library commits are self-contained and could be cherry-picked into separate PRs if reviewers prefer.

### Multi-session foundation

- **`feat(example): multi-session assistant via sub-agent routing`** — `AssistantDirectory` parent DO, chat CRUD via `subAgent`/`deleteSubAgent`, strict-registry `onBeforeSubAgent` gate, daily summary scheduled on the parent (facets can't `schedule()`). Client gains `useChats()` hook + sidebar UI; existing `Chat` component takes a `chatId` and uses `useAgent({ sub: [{ agent: "MyAssistant", name: chatId }] })`.

### Shared workspace

- **`feat(think): add WorkspaceLike for substitutable workspaces`** *(library, patch)* — `Think.workspace` typed as `WorkspaceLike` (`Pick<Workspace, …>` of the 7 methods Think actually uses). Subclasses can swap in any `WorkspaceLike` implementation. Default behavior unchanged; concrete `Workspace` still satisfies. Includes changeset.
- **`feat(example): shared workspace across chats via SharedWorkspace proxy`** — child's `this.workspace` is a proxy that forwards to `AssistantDirectory.workspace` over one DO RPC hop. Builtin tools, hooks, and the sidebar file-browser RPCs all work transparently.
- **`feat(shell): WorkspaceFsLike — substitutable workspace for FileSystem adapter`** *(library, patch)* — broadens `WorkspaceFileSystem` and `createWorkspaceStateBackend` to accept any `WorkspaceFsLike` (the wider 16-method interface). Drops `as never` casts in existing tests, adds two substitutability tests including an async-RPC-shaped proxy driving a multi-file `planEdits`. Includes changeset.
- **`feat(example): shared workspace now backs codemode's state.* too`** — `SharedWorkspace` widens to `WorkspaceFsLike`; `getTools()` wires `state: createWorkspaceStateBackend(this.workspace)` so codemode sandbox `state.planEdits`/`applyEdits` operate on the shared filesystem.
- **`feat(example): broadcast shared-workspace change events to clients`** — directory's `Workspace.onChange` → `this.broadcast(...)`. `useChats()` exposes `workspaceRevision` counter; the file browser stays live across chats and tabs.

### Shared MCP

- **`feat(example): hoist MCP state to AssistantDirectory (shared across chats)`** — server registry, OAuth credentials, live connections, and tool descriptors all move to the directory. Children carry a `SharedMCPClient` proxy whose `getAITools()` builds per-turn ToolSets via one DO RPC. Each tool's `execute` round-trips back to the parent. OAuth callback URL becomes `/chat/mcp-callback` (one URL across every server, every chat). Browser-callable surface (`addServer`, `removeServer`) lives on the directory; `callMcpTool` is DO-RPC-only so client-side tool invocation can't bypass `beforeToolCall` / `afterToolCall` hooks.

### Polish + docs

- **`fix(example): close auth bypass + polish assistant UX`** *(landed earlier in PR #1374)* — `wrangler.jsonc` no longer routes `/agents/*`; auth-gated `/chat*` is the only path to a DO. (Carried by an earlier merge; included here for context.)
- **`fix(example): drop stray @callable decorators, widen proxy mime signatures`** — `recordChatTurn` and `postDailySummaryPrompt` were `@callable()`, exposing server-internal RPCs to the browser. Dropped. `SharedWorkspace.writeFile/writeFileBytes/appendFile` now pass `mimeType` through; `writeFileBytes.content` widens to `Uint8Array | ArrayBuffer`. `useChats()` drops the unused (and ref-misuse-prone) `lastWorkspaceChange` field.
- **`docs(example): clarify what's shared vs per-chat in the assistant`** — the README explicitly enumerates the boundary: workspace + MCP shared; extensions, messages, Think config, and branch history per-chat.
- **`docs(example): explain shared MCP + refresh scope boundary note`** — adds a dedicated "Shared MCP" section covering the `SharedMCPClient` proxy, the OAuth callback URL, and the trade-offs (per-tool RPC hop, parent serialization point, connection-count-per-user, auth required on the callback URL).

## Changesets

- `.changeset/think-workspace-like.md` — `@cloudflare/think` patch
- `.changeset/shell-workspace-fs-like.md` — `@cloudflare/shell` patch

## Test plan

- [x] `npm run check` (sherif + check:exports + oxfmt + oxlint + 75 tsconfigs typechecked)
- [x] `npx nx test shell` — 217 passing + 1 skipped (includes 2 new `WorkspaceFsLike` substitutability tests)
- [x] `npx nx test think` — 254 passing
- [x] `npx nx test agents` — passing
- [x] Manual: GitHub OAuth sign-in → multi-chat creation/deletion → mid-stream refresh resume → MCP server add with OAuth → workspace writes visible across chats. (Earlier rounds verified by @sunilpai while iterating.)

### Manual verification when you redeploy

1. **Create + delete chats** — sidebar updates live across tabs.
2. **Mid-stream refresh** — assistant message stays visible during reload (regression of the library fixes from #1374).
3. **Shared workspace** — chat A: \`Write hello.txt\` → chat B: \`Read hello.txt\` returns the same content.
4. **codemode state.\*** — chat A creates files → chat B uses \`state.planEdits\` to mutate them.
5. **Live file-browser updates** — open files panel in two tabs, write in one, the other refreshes without reopening.
6. **Shared MCP — auth once** — add GitHub MCP in chat A, complete OAuth popup. Chat B's MCP panel already shows it as ready, no popup.
7. **Shared MCP — tool availability** — chat B can immediately call GitHub MCP tools.
8. **MCP remove propagates** — remove a server in chat B, chat A's MCP panel updates live.
9. **Cold parent wake** — wait for hibernation, then trigger a turn; tools appear within ~5s (the `listMcpToolDescriptors` wait).

## Follow-ups

- **#1378** — `addMcpServer`'s default callback URL silently breaks when callers don't set `callbackPath` + `sendIdentityOnConnect: true`. Filed during the PR #1374 review; still relevant. Small standalone PR.
- **PR 3 (later)** — hoist `useAgentChat` from `@cloudflare/ai-chat` into `agents` so Think consumers don't need to reach into ai-chat for the core hook. Independent of anything on this branch.
- **PR 4 (later)** — decide whether to promote `Chats` / `useChats` / `SharedWorkspace` / `SharedMCPClient` patterns into framework primitives. We've now built one full consumer; one more (or external feedback) before freezing the shape feels right.
- **MCP cross-child server-side fan-out** — current example doesn't need it (no server-side tool reacts to another chat's MCP/workspace events). Easy parent → child RPC if a use case shows up.
- **Per-chat MCP filter** — `SharedMCPClient.getAITools(filter?)` is a natural extension point if "this chat shouldn't see server X" becomes desired. Not in v1.

## Notes for reviewers

- The two library commits (`@cloudflare/think` patch, `@cloudflare/shell` patch) are non-breaking and self-contained. Cherry-pickable into their own PRs if that helps review velocity.
- No changes to `packages/agents`. The sub-agent routing primitive landed earlier and we're consuming it as-is.
- The `@callable()` audit catches things that look benign but expose server-internal RPCs — both `recordChatTurn` (used to be \"forge any sidebar entry\") and `postDailySummaryPrompt` (used to be \"trigger an arbitrary user prompt\") were dropped in `41b05ba3`. Worth a deliberate look in review.
- Three subtleties involving the framework that I deliberately depended on: (1) `Agent.fetch()` parses `/sub/...` anywhere in the path so the Worker doesn't need a custom router, (2) `beforeTurn` returning `{ tools }` merges additively over the base tool set so MCP tools can be injected without touching the `this.mcp.getAITools()` call site, (3) child→parent DO RPC doesn't gate on `@callable()` so private filesystem/MCP RPCs are reachable from siblings without exposing them to the browser.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
