### PR TITLE
think: add `beforeStep` hook and `TurnConfig.output` passthrough

### DIFF
--- a/.changeset/think-before-step-and-output.md
+++ b/.changeset/think-before-step-and-output.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/think": patch
+---
+
+think: add `beforeStep` lifecycle hook and `output` passthrough on `TurnConfig`.
+
+- **`beforeStep(ctx)`** — new lifecycle hook called before each AI SDK step in the agentic loop, wired to `streamText({ prepareStep })`. Receives a `PrepareStepContext` (the AI SDK's `PrepareStepFunction` parameter — `steps`, `stepNumber`, `model`, `messages`, `experimental_context`) and may return a `StepConfig` (`PrepareStepResult`) to override `model`, `toolChoice`, `activeTools`, `system`, `messages`, `experimental_context`, or `providerOptions` for the current step. Use `beforeTurn` for turn-wide assembly and `beforeStep` when the decision depends on the step number or previous step results. Resolves [#1363](https://github.com/cloudflare/agents/issues/1363).
+- **`TurnConfig.output`** — new optional field on `TurnConfig` forwarded to `streamText`. Accepts the AI SDK's structured-output spec (e.g. `Output.object({ schema })`, `Output.text()`) so a single agent can keep tools enabled on intermediate turns and return schema-validated structured output on a designated turn — without losing tools at model construction. Combine with `activeTools: []` for providers that strip tools when `responseFormat: "json"` is active (e.g. `workers-ai-provider`). Resolves [#1383](https://github.com/cloudflare/agents/issues/1383).
+- New re-exports from `@cloudflare/think`: `PrepareStepFunction`, `PrepareStepResult`, `PrepareStepContext`, `StepConfig`.
+
+`beforeStep` is available to subclasses; it is not dispatched to extensions (the AI SDK `prepareStep` boundary surfaces non-serializable inputs like `LanguageModel` instances). The AI SDK does not expose `output` or `maxSteps` per step — set those at the turn level via `TurnConfig`. All other extension hook subscriptions are unchanged.

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -237,7 +237,7 @@ Think's `this.messages` getter reads directly from Session's tree-structured sto
 ## Docs
 
 - [Getting Started](./getting-started.md) — Build a Think agent step by step
-- [Lifecycle Hooks](./lifecycle-hooks.md) — `beforeTurn`, `onStepFinish`, `onChunk`, `onChatResponse`, and more
+- [Lifecycle Hooks](./lifecycle-hooks.md) — `beforeTurn`, `beforeStep`, `onStepFinish`, `onChunk`, `onChatResponse`, and more
 - [Tools](./tools.md) — Workspace tools, code execution, extensions
 - [Client Tools](./client-tools.md) — Browser-side tools, approvals, and concurrency
 - [Sub-agents and Programmatic Turns](./sub-agents.md) — RPC streaming, `saveMessages`, recovery

--- a/docs/think/lifecycle-hooks.md
+++ b/docs/think/lifecycle-hooks.md
@@ -8,6 +8,7 @@ Think owns the `streamText` call and provides hooks at each stage of the chat tu
 | --------------------------- | --------------------------------------------- | -------------------------- | ----- |
 | `configureSession(session)` | Once during `onStart`                         | `Session`                  | yes   |
 | `beforeTurn(ctx)`           | Before `streamText`                           | `TurnConfig` or void       | yes   |
+| `beforeStep(ctx)`           | Before each model step                        | `StepConfig` or void       | yes   |
 | `beforeToolCall(ctx)`       | When model calls a tool                       | `ToolCallDecision` or void | yes   |
 | `afterToolCall(ctx)`        | After tool execution                          | void                       | yes   |
 | `onStepFinish(ctx)`         | After each step completes                     | void                       | yes   |
@@ -25,12 +26,16 @@ configureSession()          ← once at startup, not per-turn
 beforeTurn()                ← inspect assembled context, override model/tools/prompt
       │
   ┌── streamText ───────────────────────────────────┐
+  │   beforeStep()                                  │
+  │       │                                         │
   │   onChunk()  onChunk()  onChunk()  ...          │
   │       │                                         │
   │   beforeToolCall()  →  tool executes            │
   │                        afterToolCall()           │
   │       │                                         │
   │   onStepFinish()                                │
+  │       │                                         │
+  │   beforeStep()                                  │
   │       │                                         │
   │   onChunk()  onChunk()  ...                     │
   │       │                                         │
@@ -163,6 +168,124 @@ beforeTurn(ctx: TurnContext) {
   }
 }
 ```
+
+Force structured output for a turn (Vercel AI SDK `Output.object`). Combine with `activeTools: []` because some providers (e.g. `workers-ai-provider`) strip tools when `responseFormat: "json"` is active:
+
+```typescript
+import { Output } from "ai";
+import { z } from "zod";
+
+const ResultSchema = z.object({ severity: z.enum(["low", "high"]) });
+
+beforeTurn(ctx: TurnContext) {
+  // Gate however your agent decides "this is the structured-answer turn":
+  // a body flag set by the caller, an internal phase enum, or a separate
+  // sub-agent invocation. `ctx.continuation === true` means "this turn
+  // was triggered by Think's auto-continuation after tool results", which
+  // is *not* the same as "terminal turn" — don't conflate them.
+  if (ctx.body?.mode === "structured-answer") {
+    return {
+      output: Output.object({ schema: ResultSchema }),
+      activeTools: []
+    };
+  }
+}
+```
+
+> `output` is a turn-level setting only. The AI SDK's `prepareStep` does not accept an `output` override, so `beforeStep` cannot toggle structured output on a single step. If you need per-step structured output, run a separate turn (or a sub-agent call) with `output` set in `beforeTurn`.
+
+---
+
+## beforeStep
+
+Called before each AI SDK step in the agentic loop. Think forwards this hook to `streamText` as `prepareStep`, so it receives the AI SDK's full prepare-step context and can return per-step overrides. Use `beforeTurn` for turn-wide assembly and `beforeStep` when the decision depends on the step number or previous step results.
+
+```typescript
+beforeStep(ctx: PrepareStepContext): StepConfig | void | Promise<StepConfig | void>
+```
+
+`beforeStep` fires _between_ steps in the agentic loop: after the previous step's `onStepFinish` and before the next model call. For a tool-call → answer flow that means the order is:
+
+```
+beforeStep(ctx, stepNumber=0)       ← ctx.steps = []
+  → model emits tool-call → beforeToolCall → execute → afterToolCall
+onStepFinish(step 0)
+beforeStep(ctx, stepNumber=1)       ← ctx.steps = [step 0]
+  → model emits final text
+onStepFinish(step 1)
+```
+
+### PrepareStepContext
+
+`PrepareStepContext<TOOLS>` is the parameter of the AI SDK's `PrepareStepFunction<TOOLS>`.
+
+| Field                  | Type                       | Description                                    |
+| ---------------------- | -------------------------- | ---------------------------------------------- |
+| `steps`                | `Array<StepResult<TOOLS>>` | Steps that have already completed              |
+| `stepNumber`           | `number`                   | Zero-based number of the step about to run     |
+| `model`                | `LanguageModel`            | Model currently selected for this step         |
+| `messages`             | `ModelMessage[]`           | Messages that will be sent to the model        |
+| `experimental_context` | `unknown`                  | AI SDK experimental context for tool execution |
+
+### StepConfig
+
+`StepConfig<TOOLS>` is the AI SDK's `PrepareStepResult<TOOLS>`. Return only the fields to override for the current step.
+
+| Field                  | Type                                                   | Description                                                 |
+| ---------------------- | ------------------------------------------------------ | ----------------------------------------------------------- |
+| `model`                | `LanguageModel`                                        | Override the model for this step                            |
+| `toolChoice`           | `ToolChoice<TOOLS>`                                    | Force or disable tool calling for this step                 |
+| `activeTools`          | `Array<keyof TOOLS>`                                   | Limit which tools are available for this step               |
+| `system`               | `string \| SystemModelMessage \| SystemModelMessage[]` | Override the system message for this step                   |
+| `messages`             | `ModelMessage[]`                                       | Override the full message list for this step                |
+| `experimental_context` | `unknown`                                              | Override context passed to tool execution from this step on |
+| `providerOptions`      | `ProviderOptions`                                      | Provider-specific options for this step                     |
+
+### Examples
+
+Force a search tool on the first step:
+
+```typescript
+beforeStep(ctx: PrepareStepContext<typeof tools>): StepConfig<typeof tools> | void {
+  if (ctx.stepNumber === 0) {
+    return {
+      activeTools: ["search"],
+      toolChoice: { type: "tool", toolName: "search" }
+    };
+  }
+}
+```
+
+Switch to a cheaper model after tool results are available (assumes a `fastSummaryModel` field on your subclass):
+
+```typescript
+beforeStep(ctx: PrepareStepContext): StepConfig | void {
+  if (ctx.steps.some((step) => step.toolResults.length > 0)) {
+    return { model: this.fastSummaryModel };
+  }
+}
+```
+
+Trim tool-heavy messages on later steps:
+
+```typescript
+beforeStep(ctx: PrepareStepContext): StepConfig | void {
+  if (ctx.stepNumber < 2) return;
+  return {
+    messages: ctx.messages.slice(-8)
+  };
+}
+```
+
+### Limitations
+
+The following are AI SDK boundary constraints surfaced through `beforeStep`, not Think-imposed limits:
+
+- **No `abortSignal` in the context.** If `beforeStep` does remote work (e.g. fetches a model from a registry), it cannot be cancelled by turn-level abort. Keep the hook fast and synchronous when possible.
+- **`output` cannot be overridden per step.** `PrepareStepResult` doesn't include `output`. Set structured output at the turn level via `TurnConfig.output` (returned from `beforeTurn`).
+- **`maxSteps` cannot be overridden per step.** Set it at the turn level via `TurnConfig.maxSteps`.
+- **`experimental_context` is typed `unknown`.** Narrow it yourself.
+- **Subclass-only.** `beforeStep` is not dispatched to extensions — the prepareStep event surface includes a live `LanguageModel` instance which is not JSON-safe to snapshot.
 
 ---
 
@@ -510,7 +633,7 @@ onChatError(error: unknown) {
 
 ## Extension hook subscriptions
 
-Extensions can subscribe to lifecycle hooks via their manifest's `hooks` array. Think dispatches to extension-side handlers in load order, after the subclass hook has run, with a JSON-safe snapshot of the event.
+Extensions can subscribe to `beforeTurn`, `beforeToolCall`, `afterToolCall`, `onStepFinish`, and `onChunk` via their manifest's `hooks` array. Think dispatches to extension-side handlers in load order, after the subclass hook has run, with a JSON-safe snapshot of the event. `beforeStep` is available to subclasses only and is not dispatched to extensions (it runs on the AI SDK's `prepareStep` boundary, where snapshotting non-serializable inputs like `LanguageModel` instances is not meaningful).
 
 ```js
 // extension source
@@ -554,7 +677,7 @@ Snapshots are intentionally narrower than the subclass `Context` types — class
 
 ### Return values
 
-Only `beforeTurn` honors return values (it merges scalar `TurnConfig` fields back into the turn). The other four hooks are observation-only — return values are discarded. Errors thrown from extension hooks are caught and logged; they do not abort the turn.
+Only `beforeTurn` honors return values (it merges scalar `TurnConfig` fields back into the turn). The other extension hooks are observation-only — return values are discarded. Errors thrown from extension hooks are caught and logged; they do not abort the turn.
 
 ### Performance note
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -82,6 +82,7 @@ Think owns the `streamText` call. Hooks fire on every turn regardless of entry p
 | Hook                     | When it fires                               | Return                         |
 | ------------------------ | ------------------------------------------- | ------------------------------ |
 | `beforeTurn(ctx)`        | Before `streamText` — see assembled context | `TurnConfig` overrides or void |
+| `beforeStep(ctx)`        | Before each model step                      | `StepConfig` overrides or void |
 | `beforeToolCall(ctx)`    | Before tool's `execute` runs                | `ToolCallDecision` or void     |
 | `afterToolCall(ctx)`     | After tool execution (success or failure)   | void                           |
 | `onStepFinish(ctx)`      | After each step completes                   | void                           |
@@ -89,14 +90,19 @@ Think owns the `streamText` call. Hooks fire on every turn regardless of entry p
 | `onChatResponse(result)` | After turn completes + message persisted    | void                           |
 | `onChatError(error)`     | On error during a turn                      | error to propagate             |
 
-The four AI SDK–derived contexts spread the SDK's own types at the top level — no information is dropped:
+The AI SDK-derived contexts spread the SDK's own types at the top level — no information is dropped:
 
 | Context                        | Backed by                                                                                                                             |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `PrepareStepContext<TOOLS>`    | `Parameters<PrepareStepFunction<TOOLS>>[0]` (`steps`, `stepNumber`, `model`, `messages`, `experimental_context`)                      |
 | `ToolCallContext<TOOLS>`       | `TypedToolCall<TOOLS>` + per-call extras from `OnToolCallStartEvent` (`stepNumber`, `messages`, `abortSignal`)                        |
 | `ToolCallResultContext<TOOLS>` | `TypedToolCall<TOOLS>` + per-call extras (`durationMs`, `messages`, `stepNumber`) + discriminated `success`/`output`/`error` outcome  |
 | `StepContext<TOOLS>`           | `StepResult<TOOLS>` (full step incl. `reasoning`, `sources`, `files`, `usage`, `providerMetadata`, `request`, `response`, `warnings`) |
 | `ChunkContext<TOOLS>`          | `Parameters<StreamTextOnChunkCallback<TOOLS>>[0]` (discriminated `TextStreamPart`)                                                    |
+
+`beforeStep` is wired to the AI SDK's `prepareStep` callback. Return a `StepConfig` to override `model`, `toolChoice`, `activeTools`, `system`, `messages`, `experimental_context`, or `providerOptions` for the current step. The AI SDK does not expose `output` or `maxSteps` per step — set those at the turn level via `TurnConfig` (returned from `beforeTurn`). `beforeStep` is subclass-only; it is not dispatched to extensions because the prepareStep event surface includes a live `LanguageModel` instance which is not JSON-safe to snapshot.
+
+`TurnConfig` also accepts an `output` field that is forwarded to `streamText` as the AI SDK's structured-output spec. Combine with `activeTools: []` for providers (e.g. `workers-ai-provider`) that strip tools when `responseFormat: "json"` is active.
 
 Per-tool hooks are wired so `beforeToolCall` fires _before_ `execute` (Think wraps every tool's `execute`) and `afterToolCall` fires _after_ (via the AI SDK's `experimental_onToolCallFinish`) with `durationMs` and a discriminated outcome. `beforeToolCall` can return a `ToolCallDecision` to:
 
@@ -107,9 +113,23 @@ Per-tool hooks are wired so `beforeToolCall` fires _before_ `execute` (Think wra
 Pass an explicit `TOOLS` generic when you want full input typing:
 
 ```ts
-import type { StepContext, ToolCallContext, ToolCallResultContext } from "@cloudflare/think";
+import type {
+  PrepareStepContext,
+  StepContext,
+  ToolCallContext,
+  ToolCallResultContext
+} from "@cloudflare/think";
 
 const tools = { search: tool({ inputSchema: z.object({ query: z.string() }), ... }) };
+
+beforeStep(ctx: PrepareStepContext<typeof tools>) {
+  if (ctx.stepNumber === 0) {
+    return {
+      activeTools: ["search"],
+      toolChoice: { type: "tool", toolName: "search" }
+    };
+  }
+}
 
 beforeToolCall(ctx: ToolCallContext<typeof tools>) {
   if (ctx.toolName === "search") {
@@ -143,7 +163,7 @@ onStepFinish(ctx: StepContext<typeof tools>) {
 
 ### Extension hook subscriptions
 
-Extensions can subscribe to any of the five lifecycle hooks via their manifest's `hooks` array. Think dispatches to extension-side handlers in load order with a JSON-safe snapshot of the event:
+Extensions can subscribe to `beforeTurn`, `beforeToolCall`, `afterToolCall`, `onStepFinish`, and `onChunk` via their manifest's `hooks` array. Think dispatches to extension-side handlers in load order with a JSON-safe snapshot of the event. `beforeStep` is available to subclasses only and is not dispatched to extensions.
 
 ```js
 // extension source (loaded via getExtensions())
@@ -169,7 +189,7 @@ Extensions can subscribe to any of the five lifecycle hooks via their manifest's
 });
 ```
 
-The handler signature is `(snapshot, host) => void`, symmetric with tool `execute`. Errors from extension hooks are caught and logged; they do not abort the turn. Only `beforeTurn` honors return values — the other four are observation-only. See [docs/think/lifecycle-hooks.md](https://github.com/cloudflare/agents/blob/main/docs/think/lifecycle-hooks.md#extension-hook-subscriptions) for the full snapshot shapes.
+The handler signature is `(snapshot, host) => void`, symmetric with tool `execute`. Errors from extension hooks are caught and logged; they do not abort the turn. Only `beforeTurn` honors return values — the other extension hooks are observation-only. See [docs/think/lifecycle-hooks.md](https://github.com/cloudflare/agents/blob/main/docs/think/lifecycle-hooks.md#extension-hook-subscriptions) for the full snapshot shapes.
 
 #### beforeTurn example
 
@@ -303,7 +323,7 @@ For values you want broadcast to connected clients, use `state` / `setState` fro
 
 - **WebSocket protocol** — wire-compatible with `useAgentChat` from `@cloudflare/ai-chat`
 - **Built-in workspace** — every agent gets `this.workspace` with file tools auto-wired
-- **Lifecycle hooks** — `beforeTurn`, `onStepFinish`, `onChunk`, `onChatResponse` fire on every turn
+- **Lifecycle hooks** — `beforeTurn`, `beforeStep`, `onStepFinish`, `onChunk`, `onChatResponse` fire on every turn
 - **Stream resumption** — page refresh replays buffered chunks via `ResumableStream`
 - **Client tools** — accept tool schemas from clients, handle results and approvals
 - **Auto-continuation** — debounce-based continuation after tool results

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1,5 +1,5 @@
 import type { LanguageModel, UIMessage } from "ai";
-import { tool } from "ai";
+import { Output, tool } from "ai";
 import { Think } from "../../think";
 import type {
   StreamCallback,
@@ -10,6 +10,8 @@ import type {
   ChatRecoveryOptions,
   TurnContext,
   TurnConfig,
+  PrepareStepContext,
+  StepConfig,
   ToolCallContext,
   ToolCallDecision,
   ToolCallResultContext,
@@ -196,6 +198,14 @@ export class ThinkTestAgent extends Think {
   }> = [];
   private _chunkCount = 0;
   private _turnConfigOverride: TurnConfig | null = null;
+  private _stepConfigOverride: StepConfig | null = null;
+  private _beforeStepAsyncDelayMs = 0;
+  private _beforeStepLog: Array<{
+    stepNumber: number;
+    previousStepCount: number;
+    messageCount: number;
+    modelId: string;
+  }> = [];
 
   override onChatResponse(result: ChatResponseResult): void {
     this._responseLog.push(result);
@@ -213,6 +223,45 @@ export class ThinkTestAgent extends Think {
 
   async setTurnConfigOverride(config: TurnConfig | null): Promise<void> {
     this._turnConfigOverride = config;
+  }
+
+  /**
+   * Set a `TurnConfig.output` override using the AI SDK's `Output.text()`
+   * helper. The Output spec contains promises and other non-cloneable
+   * fields, so it must be constructed inside the DO process — this RPC
+   * exists so tests can opt into it without sending the spec across the
+   * DO boundary.
+   */
+  async setTurnConfigOutputText(): Promise<void> {
+    this._turnConfigOverride = { output: Output.text(), activeTools: [] };
+  }
+
+  override async beforeStep(
+    ctx: PrepareStepContext
+  ): Promise<StepConfig | void> {
+    this._beforeStepLog.push({
+      stepNumber: ctx.stepNumber,
+      previousStepCount: ctx.steps.length,
+      messageCount: ctx.messages.length,
+      modelId:
+        ((ctx.model as Record<string, unknown>).modelId as string) ?? "unknown"
+    });
+    if (this._beforeStepAsyncDelayMs > 0) {
+      await new Promise((r) => setTimeout(r, this._beforeStepAsyncDelayMs));
+    }
+    if (this._stepConfigOverride) return this._stepConfigOverride;
+  }
+
+  async setStepConfigOverride(config: StepConfig | null): Promise<void> {
+    this._stepConfigOverride = config;
+  }
+
+  async setStepModelOverride(response: string): Promise<void> {
+    this._stepConfigOverride = { model: createMockModel(response) };
+  }
+
+  async setBeforeStepAsyncDelay(ms: number): Promise<void> {
+    this._beforeStepAsyncDelayMs = ms;
   }
 
   override onStepFinish(ctx: StepContext): void {
@@ -255,6 +304,17 @@ export class ThinkTestAgent extends Think {
     }>
   > {
     return this._stepLog;
+  }
+
+  async getBeforeStepLog(): Promise<
+    Array<{
+      stepNumber: number;
+      previousStepCount: number;
+      messageCount: number;
+      modelId: string;
+    }>
+  > {
+    return this._beforeStepLog;
   }
 
   async getChunkCount(): Promise<number> {
@@ -808,6 +868,32 @@ export class ThinkToolsTestAgent extends Think {
     outputJson: string;
   }> = [];
   private _toolCallDecision: ToolCallDecision | null = null;
+  private _beforeStepLog: Array<{
+    stepNumber: number;
+    previousStepCount: number;
+    previousToolResultCount: number;
+  }> = [];
+
+  override beforeStep(ctx: PrepareStepContext): StepConfig | void {
+    this._beforeStepLog.push({
+      stepNumber: ctx.stepNumber,
+      previousStepCount: ctx.steps.length,
+      previousToolResultCount: ctx.steps.reduce(
+        (n, s) => n + s.toolResults.length,
+        0
+      )
+    });
+  }
+
+  async getBeforeStepLog(): Promise<
+    Array<{
+      stepNumber: number;
+      previousStepCount: number;
+      previousToolResultCount: number;
+    }>
+  > {
+    return this._beforeStepLog;
+  }
 
   override getModel(): LanguageModel {
     return createToolCallingMockModel();

--- a/packages/think/src/tests/hooks.test.ts
+++ b/packages/think/src/tests/hooks.test.ts
@@ -60,6 +60,66 @@ describe("Think — beforeTurn hook", () => {
   });
 });
 
+// ── beforeStep ─────────────────────────────────────────────────
+
+describe("Think — beforeStep hook", () => {
+  it("receives the AI SDK prepareStep context before each step", async () => {
+    const agent = await freshAgent("hook-bs-ctx");
+    await agent.testChat("Hello");
+
+    const log = await agent.getBeforeStepLog();
+    expect(log.length).toBeGreaterThan(0);
+    expect(log[0].stepNumber).toBe(0);
+    expect(log[0].previousStepCount).toBe(0);
+    expect(log[0].messageCount).toBeGreaterThan(0);
+    expect(log[0].modelId).toBe("mock-model");
+  });
+
+  it("can override the model for a step", async () => {
+    const agent = await freshAgent("hook-bs-model");
+    await agent.setStepModelOverride("Overridden from beforeStep");
+    await agent.testChat("Hello");
+
+    const log = await agent.getStepLog();
+    expect(log.length).toBeGreaterThan(0);
+    expect(log[0].text).toBe("Overridden from beforeStep");
+  });
+
+  it("awaits async beforeStep hooks before continuing the step", async () => {
+    // Regression for the Promise<StepConfig | void> return path. The
+    // wrapper must `await` `this.beforeStep(event)` so a delayed override
+    // still applies and the step waits on slow-to-resolve hooks.
+    const agent = await freshAgent("hook-bs-async");
+    await agent.setBeforeStepAsyncDelay(5);
+    await agent.setStepModelOverride("Async override applied");
+    await agent.testChat("Hello async");
+
+    const log = await agent.getStepLog();
+    expect(log[0].text).toBe("Async override applied");
+  });
+
+  it("fires once per step across a tool-call loop with growing previous-step state", async () => {
+    // Regression: beforeStep must fire for every model step in the
+    // agentic loop, and `ctx.steps` / `ctx.stepNumber` must reflect the
+    // accumulating history. The tool-calling agent does step 0 (emits
+    // tool-call), tool executes, then step 1 (emits final text).
+    const agent = await freshToolAgent("hook-bs-multistep");
+    await agent.testChat("Run a tool");
+
+    const log = await agent.getBeforeStepLog();
+    // Two model steps in the tool-call → answer flow.
+    expect(log.length).toBeGreaterThanOrEqual(2);
+    expect(log[0].stepNumber).toBe(0);
+    expect(log[0].previousStepCount).toBe(0);
+    expect(log[0].previousToolResultCount).toBe(0);
+    // After step 0 ran a tool, step 1's context sees one prior step
+    // and one prior tool result.
+    expect(log[1].stepNumber).toBe(1);
+    expect(log[1].previousStepCount).toBe(1);
+    expect(log[1].previousToolResultCount).toBe(1);
+  });
+});
+
 // ── onStepFinish ────────────────────────────────────────────────
 
 describe("Think — onStepFinish hook", () => {
@@ -652,6 +712,18 @@ describe("Think — beforeTurn config overrides", () => {
     const agent = await freshAgent("bt-active");
     await agent.setTurnConfigOverride({ activeTools: ["read"] });
     const result = await agent.testChat("Restricted tools");
+    expect(result.done).toBe(true);
+  });
+
+  it("output override is accepted on TurnConfig and forwarded to streamText", async () => {
+    // Regression for #1383 — TurnConfig.output should be a structurally
+    // valid field that the AI SDK accepts. We construct the Output spec
+    // inside the DO (it contains Promises that can't cross the RPC
+    // boundary) and verify the turn completes; the AI SDK will throw at
+    // the streamText boundary if the field isn't honored.
+    const agent = await freshAgent("bt-output");
+    await agent.setTurnConfigOutputText();
+    const result = await agent.testChat("Structured-output turn");
     expect(result.done).toBe(true);
   });
 });

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -18,6 +18,7 @@
  *
  * Lifecycle hooks:
  *   - beforeTurn()          — inspect/override context, tools, model before inference
+ *   - beforeStep()          — per-step callback to override model, messages, tool selection
  *   - beforeToolCall()      — intercept tool calls (block, modify args, substitute result)
  *   - afterToolCall()       — inspect tool results after execution
  *   - onStepFinish()        — per-step callback (logging, analytics)
@@ -82,6 +83,8 @@
 import type {
   LanguageModel,
   ModelMessage,
+  PrepareStepFunction,
+  PrepareStepResult,
   StreamTextOnChunkCallback,
   StreamTextOnStepFinishCallback,
   StreamTextOnToolCallFinishCallback,
@@ -101,6 +104,8 @@ import {
 // Re-export AI SDK types that appear on Think's public lifecycle hooks
 // so users can import them from a single place.
 export type {
+  PrepareStepFunction,
+  PrepareStepResult,
   StepResult,
   TextStreamPart,
   TypedToolCall,
@@ -257,7 +262,46 @@ export interface TurnConfig {
   maxSteps?: number;
   /** Provider-specific options (AI SDK providerOptions). */
   providerOptions?: Record<string, unknown>;
+  /**
+   * Optional structured-output specification (AI SDK `output`).
+   * Forwarded to `streamText` so the model's final response is parsed
+   * against the supplied schema. Use the AI SDK's `Output.object({ schema })`
+   * / `Output.text()` helpers. Combine with `activeTools: []` on the
+   * terminal turn if your provider strips tools when structured output
+   * is active (e.g. workers-ai-provider).
+   */
+  output?: Parameters<typeof streamText>[0]["output"];
 }
+
+/**
+ * Context passed to the `beforeStep` hook before each AI SDK step in
+ * the agentic loop. Backed by the AI SDK's `PrepareStepFunction<TOOLS>`
+ * parameter — exposes the previous `steps`, the zero-based `stepNumber`,
+ * the currently selected `model`, the `messages` about to be sent, and
+ * `experimental_context`.
+ *
+ * Pass an explicit `TOOLS` generic for typed previous tool calls / results.
+ *
+ * Limitations (AI SDK boundary, not Think):
+ * - No `abortSignal` is exposed in the context. If you do remote work
+ *   inside `beforeStep`, it cannot be cancelled by turn-level abort.
+ * - `experimental_context` is typed `unknown`; users must narrow it.
+ * - `output` cannot be overridden per-step — set it at the turn level
+ *   via `TurnConfig.output` (returned from `beforeTurn`).
+ */
+export type PrepareStepContext<TOOLS extends ToolSet = ToolSet> = Parameters<
+  PrepareStepFunction<TOOLS>
+>[0];
+
+/**
+ * Configuration returned by `beforeStep` to override defaults for the
+ * current AI SDK step. This is the AI SDK's `PrepareStepResult<TOOLS>` —
+ * return only the fields you want to override (`model`, `toolChoice`,
+ * `activeTools`, `system`, `messages`, `experimental_context`,
+ * `providerOptions`).
+ */
+export type StepConfig<TOOLS extends ToolSet = ToolSet> =
+  PrepareStepResult<TOOLS>;
 
 /**
  * Context passed to the `beforeToolCall` hook **before** the tool's
@@ -770,6 +814,43 @@ export class Think<
   ): TurnConfig | void | Promise<TurnConfig | void> {}
 
   /**
+   * Called before each AI SDK step in the agentic loop. Backed by
+   * `streamText({ prepareStep })`.
+   *
+   * Return `void` to accept the current step defaults, or return a
+   * `StepConfig` to override the model, tool choice, active tools,
+   * system prompt, messages, experimental context, or provider options
+   * for this step. Use `beforeTurn` for turn-wide assembly and
+   * `beforeStep` when the decision depends on the step number or
+   * previous step results.
+   *
+   * @example Force search on the first step
+   * ```typescript
+   * beforeStep(ctx: PrepareStepContext) {
+   *   if (ctx.stepNumber === 0) {
+   *     return {
+   *       activeTools: ["search"],
+   *       toolChoice: { type: "tool", toolName: "search" }
+   *     };
+   *   }
+   * }
+   * ```
+   *
+   * @example Switch to a cheaper model after tool results land
+   * ```typescript
+   * beforeStep(ctx: PrepareStepContext) {
+   *   // assumes a `fastSummaryModel` field on your Think subclass
+   *   if (ctx.steps.some((s) => s.toolResults.length > 0)) {
+   *     return { model: this.fastSummaryModel };
+   *   }
+   * }
+   * ```
+   */
+  beforeStep(
+    _ctx: PrepareStepContext
+  ): StepConfig | void | Promise<StepConfig | void> {}
+
+  /**
    * Called **before** the tool's `execute` function runs. Think wraps
    * every tool's `execute` so it can consult this hook and act on the
    * returned `ToolCallDecision`:
@@ -1041,7 +1122,30 @@ export class Think<
       providerOptions: config.providerOptions as
         | Parameters<typeof streamText>[0]["providerOptions"]
         | undefined,
+      // Forward the per-turn structured-output spec from TurnConfig so
+      // callers can use AI SDK `Output.object({ schema })` / `Output.text()`
+      // on the terminal turn without dropping tools at model construction.
+      output: config.output,
       abortSignal: input.signal,
+      // Forward the AI SDK's `prepareStep` callback unchanged so subclasses
+      // can make per-step decisions from the previous steps, current
+      // messages, model, and experimental context.
+      //
+      // Subclass-only by design: extension dispatch is intentionally not
+      // wired here. The prepareStep event includes a live `LanguageModel`
+      // instance which is not JSON-serializable, and a returned override
+      // can include the same — there's no useful "snapshot, override"
+      // contract we could give to sandboxed extensions. If we expose
+      // observation-only later it should go through a separate,
+      // serialized event surface.
+      //
+      // `beforeStep` returning `void`/`undefined`/`null` is normalized to
+      // `{}` so the AI SDK falls back to top-level settings (it accepts
+      // `undefined` per docs but the typed return is non-null).
+      prepareStep: (async (event) => {
+        const result = await this.beforeStep(event);
+        return result == null ? {} : result;
+      }) satisfies PrepareStepFunction<ToolSet>,
       onChunk: async (event) => {
         // Pass the AI SDK's chunk event through unchanged — gives users
         // access to the discriminated `TextStreamPart` chunk with all


### PR DESCRIPTION
## Summary

Resolves #1363 and #1383.

- **`beforeStep(ctx: PrepareStepContext): StepConfig | void`** — new lifecycle hook wired to the AI SDK's `streamText({ prepareStep })` so subclasses can make per-step decisions (force a tool on step 0, switch to a cheaper model after tool results land, trim tool-heavy messages on later steps). Use `beforeTurn` for turn-wide assembly and `beforeStep` when the decision depends on step number or previous step results.
- **`TurnConfig.output`** — new optional field forwarded to `streamText`. Accepts the AI SDK's structured-output spec (`Output.object({ schema })`, `Output.text()`) so a single agent can keep tools enabled on intermediate turns and return schema-validated structured output on a designated turn — without losing tools at model construction. Combine with `activeTools: []` for providers (e.g. `workers-ai-provider`) that strip tools when `responseFormat: "json"` is active.
- New re-exports from `@cloudflare/think`: `PrepareStepFunction`, `PrepareStepResult`, `PrepareStepContext`, `StepConfig`.

## Naming

`PrepareStepContext` (not `StepPrepareContext`) — matches the AI SDK's `PrepareStepFunction` / `prepareStep` and avoids a confusable collision with the existing `StepContext` (which remains the completed-step result passed to `onStepFinish`). `StepConfig` mirrors `TurnConfig`.

## Subclass-only `beforeStep` (no extension dispatch)

Intentional. The prepareStep event surface includes a live `LanguageModel` instance which is not JSON-safe to snapshot, and a returned override could include the same — there's no useful \"snapshot, override\" contract for sandboxed extensions. All other extension hook subscriptions are unchanged.

## AI SDK boundary limitations (documented in `docs/think/lifecycle-hooks.md`)

These are AI SDK constraints, not Think-imposed:

- No `abortSignal` in `PrepareStepContext`.
- `output` and `maxSteps` cannot be overridden per step — set those at the turn level via `TurnConfig`.
- `experimental_context` is typed `unknown`; users narrow it themselves.

`beforeStep` returning `void`/`undefined`/`null` is normalized to `{}` (defer to top-level settings) so subclass type-violations don't trip the AI SDK.

## Test plan

- [x] `tsc -p tsconfig.json --noEmit` (`packages/think`) — clean
- [x] `tsc -p src/tests/tsconfig.json --noEmit` (`packages/think` tests) — clean
- [x] `tsc --noEmit` in `examples/assistant` — clean
- [x] `npm test` in `packages/think` — **259/259 passing** (5 new this PR, 254 baseline preserved)

New regression coverage:

- `beforeStep` receives the prepareStep context before each step
- `beforeStep` can override the model for a step
- `beforeStep` async returns are awaited before the step continues
- `beforeStep` fires once per step across a tool-call loop with `previousStepCount` / `previousToolResultCount` accumulating across steps (verified via `ThinkToolsTestAgent`'s tool-call → answer flow)
- `TurnConfig.output` is accepted and forwarded to `streamText`

Made-with: Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
