### PR TITLE
chat: share submit concurrency controller in agents/chat

### DIFF
--- a/.changeset/smart-bears-share-turns.md
+++ b/.changeset/smart-bears-share-turns.md
@@ -1,0 +1,15 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Share submit concurrency bookkeeping through `agents/chat` and use it from both chat agents.
+
+This extracts the `latest`/`merge`/`drop`/`debounce` admission state machine into a `SubmitConcurrencyController` exported from `agents/chat`. `AIChatAgent` semantics (including merge persistence) are preserved. `Think` now picks up the same pending-enqueue protection, so an overlapping submit is still detected while an accepted request is between admission and turn queue registration.
+
+Additional fixes:
+
+- `Think` now captures the turn generation immediately after admission and threads it into `_turnQueue.enqueue`, so a clear that lands between admission and queue registration cannot run a stale turn.
+- Pending-enqueue tracking is now bound to a release function tied to the controller's reset epoch, so a release from a pre-reset submit can no longer erase a post-reset submit's marker and let a third submit slip through as non-overlapping.
+- Debounce cancellation correctly resolves all in-flight waiters instead of overwriting a single timer slot.

--- a/packages/agents/src/chat/__tests__/submit-concurrency.test.ts
+++ b/packages/agents/src/chat/__tests__/submit-concurrency.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { SubmitConcurrencyController } from "../submit-concurrency";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("SubmitConcurrencyController", () => {
+  it("treats accepted-but-not-enqueued submits as overlapping", () => {
+    const controller = new SubmitConcurrencyController({
+      defaultDebounceMs: 750
+    });
+
+    const first = controller.decide({
+      concurrency: "drop",
+      isSubmitMessage: true,
+      queuedTurns: 0
+    });
+    expect(first.action).toBe("execute");
+
+    const release = controller.beginEnqueue();
+    const second = controller.decide({
+      concurrency: "drop",
+      isSubmitMessage: true,
+      queuedTurns: 0
+    });
+    expect(second.action).toBe("drop");
+
+    release();
+    const third = controller.decide({
+      concurrency: "drop",
+      isSubmitMessage: true,
+      queuedTurns: 0
+    });
+    expect(third.action).toBe("execute");
+  });
+
+  it("ignores releases from before the most recent reset", () => {
+    const controller = new SubmitConcurrencyController({
+      defaultDebounceMs: 750
+    });
+
+    const releaseA = controller.beginEnqueue();
+    expect(controller.pendingEnqueueCount).toBe(1);
+
+    controller.reset();
+    expect(controller.pendingEnqueueCount).toBe(0);
+
+    controller.beginEnqueue();
+    expect(controller.pendingEnqueueCount).toBe(1);
+
+    // A's release fires after reset + a new submit. Without the epoch
+    // guard this would erase the new submit's pending-enqueue marker
+    // and a third submit could miss the overlap.
+    releaseA();
+    expect(controller.pendingEnqueueCount).toBe(1);
+
+    const third = controller.decide({
+      concurrency: "drop",
+      isSubmitMessage: true,
+      queuedTurns: 0
+    });
+    expect(third.action).toBe("drop");
+  });
+
+  it("release functions are idempotent", () => {
+    const controller = new SubmitConcurrencyController({
+      defaultDebounceMs: 750
+    });
+
+    const release = controller.beginEnqueue();
+    release();
+    expect(controller.pendingEnqueueCount).toBe(0);
+
+    release();
+    expect(controller.pendingEnqueueCount).toBe(0);
+  });
+
+  it("tracks superseded overlapping submits", () => {
+    const controller = new SubmitConcurrencyController({
+      defaultDebounceMs: 750
+    });
+
+    controller.beginEnqueue();
+    const second = controller.decide({
+      concurrency: "latest",
+      isSubmitMessage: true,
+      queuedTurns: 0
+    });
+    const third = controller.decide({
+      concurrency: "latest",
+      isSubmitMessage: true,
+      queuedTurns: 0
+    });
+
+    expect(controller.isSuperseded(second.submitSequence)).toBe(true);
+    expect(controller.isSuperseded(third.submitSequence)).toBe(false);
+  });
+
+  it("cancels all active debounce waiters", async () => {
+    const controller = new SubmitConcurrencyController({
+      defaultDebounceMs: 750
+    });
+    const farFuture = Date.now() + 10_000;
+
+    let firstResolved = false;
+    let secondResolved = false;
+    const first = controller.waitForTimestamp(farFuture).then(() => {
+      firstResolved = true;
+    });
+    const second = controller.waitForTimestamp(farFuture).then(() => {
+      secondResolved = true;
+    });
+
+    controller.cancelActiveDebounce();
+    await Promise.race([Promise.all([first, second]), delay(100)]);
+
+    expect(firstResolved).toBe(true);
+    expect(secondResolved).toBe(true);
+  });
+});

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -22,6 +22,12 @@ export {
 export { TurnQueue, type TurnResult, type EnqueueOptions } from "./turn-queue";
 
 export {
+  SubmitConcurrencyController,
+  type NormalizedMessageConcurrency,
+  type SubmitConcurrencyDecision
+} from "./submit-concurrency";
+
+export {
   transition as broadcastTransition,
   type BroadcastStreamState,
   type BroadcastStreamEvent,

--- a/packages/agents/src/chat/lifecycle.ts
+++ b/packages/agents/src/chat/lifecycle.ts
@@ -92,8 +92,9 @@ export type ChatRecoveryOptions = {
  * - `"latest"` — keep only the latest overlapping submit; superseded
  *   submits still persist their user messages, but do not start their
  *   own model turn.
- * - `"merge"` — like `latest`, but all overlapping user messages remain
- *   in the conversation history. The model sees them all in one turn.
+ * - `"merge"` — coalesce overlapping submits into one model turn while
+ *   preserving the submitted user content. Exact persistence depends on
+ *   the chat package's message model.
  * - `"drop"` — ignore overlapping submits entirely (messages not
  *   persisted).
  * - `{ strategy: "debounce", debounceMs? }` — trailing-edge latest with

--- a/packages/agents/src/chat/submit-concurrency.ts
+++ b/packages/agents/src/chat/submit-concurrency.ts
@@ -1,0 +1,188 @@
+import type { MessageConcurrency } from "./lifecycle";
+
+export type NormalizedMessageConcurrency =
+  | "queue"
+  | "latest"
+  | "merge"
+  | "drop"
+  | {
+      strategy: "debounce";
+      debounceMs: number;
+    };
+
+export type SubmitConcurrencyDecision = {
+  action: "execute" | "drop";
+  strategy: NormalizedMessageConcurrency | null;
+  submitSequence: number | null;
+  debounceUntilMs: number | null;
+};
+
+export class SubmitConcurrencyController {
+  private _submitSequence = 0;
+  private _latestOverlappingSubmitSequence = 0;
+  private _pendingEnqueueCount = 0;
+  private _resetEpoch = 0;
+  private _activeDebounceTimers = new Set<ReturnType<typeof setTimeout>>();
+  private _activeDebounceResolves = new Set<() => void>();
+
+  constructor(private readonly options: { defaultDebounceMs: number }) {}
+
+  get pendingEnqueueCount(): number {
+    return this._pendingEnqueueCount;
+  }
+
+  get overlappingSubmitCount(): number {
+    return this._latestOverlappingSubmitSequence;
+  }
+
+  decide(options: {
+    concurrency: MessageConcurrency;
+    isSubmitMessage: boolean;
+    queuedTurns: number;
+  }): SubmitConcurrencyDecision {
+    const queuedTurnsInCurrentEpoch =
+      options.queuedTurns + this._pendingEnqueueCount;
+
+    if (!options.isSubmitMessage || queuedTurnsInCurrentEpoch === 0) {
+      return {
+        action: "execute",
+        strategy: null,
+        submitSequence: null,
+        debounceUntilMs: null
+      };
+    }
+
+    const concurrency = this.normalize(options.concurrency);
+    if (concurrency === "drop") {
+      return {
+        action: "drop",
+        strategy: concurrency,
+        submitSequence: null,
+        debounceUntilMs: null
+      };
+    }
+
+    if (concurrency === "queue") {
+      return {
+        action: "execute",
+        strategy: concurrency,
+        submitSequence: null,
+        debounceUntilMs: null
+      };
+    }
+
+    const submitSequence = ++this._submitSequence;
+    this._latestOverlappingSubmitSequence = submitSequence;
+
+    if (concurrency === "latest" || concurrency === "merge") {
+      return {
+        action: "execute",
+        strategy: concurrency,
+        submitSequence,
+        debounceUntilMs: null
+      };
+    }
+
+    return {
+      action: "execute",
+      strategy: concurrency,
+      submitSequence,
+      debounceUntilMs: Date.now() + concurrency.debounceMs
+    };
+  }
+
+  /**
+   * Mark a submit as accepted and in-flight between admission and turn
+   * queue registration. Returns an idempotent `release()` function that
+   * must be called when the submit either reaches the turn queue or is
+   * abandoned. The returned function is bound to the controller's reset
+   * epoch — releases from before the most recent `reset()` are no-ops,
+   * so post-reset submits keep an accurate count.
+   */
+  beginEnqueue(): () => void {
+    this._pendingEnqueueCount++;
+    const epoch = this._resetEpoch;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      if (this._resetEpoch !== epoch) return;
+      this._pendingEnqueueCount = Math.max(0, this._pendingEnqueueCount - 1);
+    };
+  }
+
+  isSuperseded(submitSequence: number | null): boolean {
+    return (
+      submitSequence !== null &&
+      submitSequence < this._latestOverlappingSubmitSequence
+    );
+  }
+
+  async waitForTimestamp(timestampMs: number): Promise<void> {
+    const remainingMs = timestampMs - Date.now();
+    if (remainingMs <= 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const wrappedResolve = () => {
+        this._activeDebounceResolves.delete(wrappedResolve);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        this._activeDebounceTimers.delete(timer);
+        wrappedResolve();
+      }, remainingMs);
+
+      this._activeDebounceTimers.add(timer);
+      this._activeDebounceResolves.add(wrappedResolve);
+    });
+  }
+
+  cancelActiveDebounce(): void {
+    for (const timer of this._activeDebounceTimers) {
+      clearTimeout(timer);
+    }
+    this._activeDebounceTimers.clear();
+
+    const resolves = [...this._activeDebounceResolves];
+    this._activeDebounceResolves.clear();
+    for (const resolve of resolves) {
+      resolve();
+    }
+  }
+
+  reset(): void {
+    this._resetEpoch++;
+    this._pendingEnqueueCount = 0;
+    this.cancelActiveDebounce();
+  }
+
+  async waitForIdle(waitForQueueIdle: () => Promise<void>): Promise<void> {
+    while (true) {
+      await waitForQueueIdle();
+      if (this._pendingEnqueueCount === 0) return;
+      await new Promise<void>((resolve) => setTimeout(resolve, 5));
+    }
+  }
+
+  private normalize(
+    concurrency: MessageConcurrency
+  ): NormalizedMessageConcurrency {
+    if (typeof concurrency === "string") {
+      return concurrency;
+    }
+
+    const debounceMs = concurrency.debounceMs;
+
+    return {
+      strategy: "debounce",
+      debounceMs:
+        typeof debounceMs === "number" &&
+        Number.isFinite(debounceMs) &&
+        debounceMs >= 0
+          ? debounceMs
+          : this.options.defaultDebounceMs
+    };
+  }
+}

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -28,8 +28,10 @@ import {
   byteLength as chatByteLength,
   ROW_MAX_BYTES,
   TurnQueue,
+  SubmitConcurrencyController,
   type TurnResult,
-  type MessagePart
+  type MessagePart,
+  type SubmitConcurrencyDecision
 } from "agents/chat";
 import { ResumableStream } from "agents/chat";
 import {
@@ -120,23 +122,6 @@ function isValidMessageStructure(msg: unknown): msg is UIMessage {
 export type { ClientToolSchema } from "agents/chat";
 
 type ChatRequestTrigger = "submit-message" | "regenerate-message";
-
-type NormalizedMessageConcurrency =
-  | "queue"
-  | "latest"
-  | "merge"
-  | "drop"
-  | {
-      strategy: "debounce";
-      debounceMs: number;
-    };
-
-type SubmitConcurrencyDecision = {
-  action: "execute" | "drop";
-  submitSequence: number | null;
-  debounceUntilMs: number | null;
-  mergeQueuedMessages: boolean;
-};
 
 /**
  * Options passed to the onChatMessage handler.
@@ -267,26 +252,10 @@ export class AIChatAgent<
   /** First queued overlap message index for merge strategy, keyed by epoch. */
   private _mergeQueuedUserStartIndexByEpoch = new Map<number, number>();
 
-  /** Monotonic sequence for overlapping submit-message requests. */
-  private _submitSequence = 0;
-
-  /** Latest overlapping submit-message sequence kept for latest/debounce. */
-  private _latestOverlappingSubmitSequence = 0;
-
-  /**
-   * Tracks requests that have passed concurrency decision but haven't
-   * yet been enqueued into `_turnQueue`. Bridges the gap caused by
-   * `await persistMessages()` between the decision and the enqueue,
-   * preventing a race where a subsequent message sees `queuedCount()=0`
-   * and skips concurrency handling.
-   */
-  private _pendingEnqueueCount = 0;
-
-  /** Active debounce timer handle, cleared on resetTurnState. */
-  private _activeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  /** Resolve callback for the active debounce promise. */
-  private _activeDebounceResolve: (() => void) | null = null;
+  /** Shared admission policy state for overlapping submit-message requests. */
+  private _submitConcurrency = new SubmitConcurrencyController({
+    defaultDebounceMs: AIChatAgent.MESSAGE_DEBOUNCE_MS
+  });
 
   /**
    * Set of connection IDs that are pending stream resume.
@@ -544,7 +513,7 @@ export class AIChatAgent<
           // Track that this request is past the concurrency decision but
           // not yet enqueued in _turnQueue. Decremented synchronously
           // before _runExclusiveChatTurn (which increments queuedCount).
-          this._pendingEnqueueCount++;
+          const releasePendingEnqueue = this._submitConcurrency.beginEnqueue();
           try {
             // Persist and broadcast user messages before entering the turn
             // queue so other tabs see the new message immediately and so
@@ -562,27 +531,26 @@ export class AIChatAgent<
               _deleteStaleRows: true
             });
 
-            if (concurrencyDecision.mergeQueuedMessages) {
+            if (concurrencyDecision.strategy === "merge") {
               await this._mergeQueuedUserMessages(epoch);
             }
           } finally {
-            this._pendingEnqueueCount = Math.max(
-              0,
-              this._pendingEnqueueCount - 1
-            );
+            releasePendingEnqueue();
           }
           return this._runExclusiveChatTurn(
             chatMessageId,
             async () => {
               if (
-                this._isSupersededSubmit(concurrencyDecision.submitSequence)
+                this._submitConcurrency.isSuperseded(
+                  concurrencyDecision.submitSequence
+                )
               ) {
                 this._completeSkippedRequest(connection, chatMessageId);
                 return;
               }
 
               if (concurrencyDecision.debounceUntilMs !== null) {
-                await this._waitForTimestamp(
+                await this._submitConcurrency.waitForTimestamp(
                   concurrencyDecision.debounceUntilMs
                 );
 
@@ -592,7 +560,9 @@ export class AIChatAgent<
                 }
 
                 if (
-                  this._isSupersededSubmit(concurrencyDecision.submitSequence)
+                  this._submitConcurrency.isSuperseded(
+                    concurrencyDecision.submitSequence
+                  )
                 ) {
                   this._completeSkippedRequest(connection, chatMessageId);
                   return;
@@ -601,7 +571,7 @@ export class AIChatAgent<
 
               // Re-merge inside the lock: more overlapping submits may have
               // persisted additional user messages while this turn was queued.
-              if (concurrencyDecision.mergeQueuedMessages) {
+              if (concurrencyDecision.strategy === "merge") {
                 await this._mergeQueuedUserMessages(epoch);
 
                 if (this._turnQueue.generation !== epoch) {
@@ -610,7 +580,9 @@ export class AIChatAgent<
                 }
 
                 if (
-                  this._isSupersededSubmit(concurrencyDecision.submitSequence)
+                  this._submitConcurrency.isSuperseded(
+                    concurrencyDecision.submitSequence
+                  )
                 ) {
                   this._completeSkippedRequest(connection, chatMessageId);
                   return;
@@ -1279,81 +1251,21 @@ export class AIChatAgent<
    * `waitForIdle()` (tests, `waitUntilStable`, recovery code).
    */
   private async waitForIdle(): Promise<void> {
-    while (true) {
-      await this._turnQueue.waitForIdle();
-      if (this._pendingEnqueueCount === 0) return;
-      // Brief yield so in-flight submits can reach `_runExclusiveChatTurn`,
-      // which transfers their bookkeeping from `_pendingEnqueueCount` into
-      // the turn queue. Bounded by inbound WS messages — drains quickly.
-      await new Promise<void>((resolve) => setTimeout(resolve, 5));
-    }
-  }
-
-  private _normalizeMessageConcurrency(): NormalizedMessageConcurrency {
-    if (typeof this.messageConcurrency === "string") {
-      return this.messageConcurrency;
-    }
-
-    const debounceMs = this.messageConcurrency.debounceMs;
-
-    return {
-      strategy: "debounce",
-      debounceMs:
-        typeof debounceMs === "number" &&
-        Number.isFinite(debounceMs) &&
-        debounceMs >= 0
-          ? debounceMs
-          : AIChatAgent.MESSAGE_DEBOUNCE_MS
-    };
+    await this._submitConcurrency.waitForIdle(() =>
+      this._turnQueue.waitForIdle()
+    );
   }
 
   private _getSubmitConcurrencyDecision(
     trigger: ChatRequestTrigger
   ): SubmitConcurrencyDecision {
-    const queuedTurnsInCurrentEpoch =
-      this._turnQueue.queuedCount() + this._pendingEnqueueCount;
+    const decision = this._submitConcurrency.decide({
+      concurrency: this.messageConcurrency,
+      isSubmitMessage: trigger === "submit-message",
+      queuedTurns: this._turnQueue.queuedCount()
+    });
 
-    if (trigger !== "submit-message" || queuedTurnsInCurrentEpoch === 0) {
-      return {
-        action: "execute",
-        submitSequence: null,
-        debounceUntilMs: null,
-        mergeQueuedMessages: false
-      };
-    }
-
-    const concurrency = this._normalizeMessageConcurrency();
-    if (concurrency === "drop") {
-      return {
-        action: "drop",
-        submitSequence: null,
-        debounceUntilMs: null,
-        mergeQueuedMessages: false
-      };
-    }
-
-    if (concurrency === "queue") {
-      return {
-        action: "execute",
-        submitSequence: null,
-        debounceUntilMs: null,
-        mergeQueuedMessages: false
-      };
-    }
-
-    const submitSequence = ++this._submitSequence;
-    this._latestOverlappingSubmitSequence = submitSequence;
-
-    if (concurrency === "latest") {
-      return {
-        action: "execute",
-        submitSequence,
-        debounceUntilMs: null,
-        mergeQueuedMessages: false
-      };
-    }
-
-    if (concurrency === "merge") {
+    if (decision.strategy === "merge") {
       if (
         !this._mergeQueuedUserStartIndexByEpoch.has(this._turnQueue.generation)
       ) {
@@ -1362,55 +1274,9 @@ export class AIChatAgent<
           this.messages.length
         );
       }
-
-      return {
-        action: "execute",
-        submitSequence,
-        debounceUntilMs: null,
-        mergeQueuedMessages: true
-      };
     }
 
-    return {
-      action: "execute",
-      submitSequence,
-      debounceUntilMs: Date.now() + concurrency.debounceMs,
-      mergeQueuedMessages: false
-    };
-  }
-
-  private _isSupersededSubmit(submitSequence: number | null): boolean {
-    return (
-      submitSequence !== null &&
-      submitSequence < this._latestOverlappingSubmitSequence
-    );
-  }
-
-  private async _waitForTimestamp(timestampMs: number): Promise<void> {
-    const remainingMs = timestampMs - Date.now();
-    if (remainingMs <= 0) {
-      return;
-    }
-
-    await new Promise<void>((resolve) => {
-      this._activeDebounceResolve = resolve;
-      this._activeDebounceTimer = setTimeout(() => {
-        this._activeDebounceTimer = null;
-        this._activeDebounceResolve = null;
-        resolve();
-      }, remainingMs);
-    });
-  }
-
-  private _cancelActiveDebounce(): void {
-    if (this._activeDebounceTimer !== null) {
-      clearTimeout(this._activeDebounceTimer);
-      this._activeDebounceTimer = null;
-    }
-    if (this._activeDebounceResolve !== null) {
-      this._activeDebounceResolve();
-      this._activeDebounceResolve = null;
-    }
+    return decision;
   }
 
   private async _mergeQueuedUserMessages(
@@ -1631,7 +1497,7 @@ export class AIChatAgent<
         ) {
           return false;
         }
-        if (this._pendingEnqueueCount === 0) break;
+        if (this._submitConcurrency.pendingEnqueueCount === 0) break;
         if (
           (await this._awaitWithDeadline(
             new Promise<void>((resolve) => setTimeout(resolve, 5)),
@@ -1691,8 +1557,7 @@ export class AIChatAgent<
     this._mergeQueuedUserStartIndexByEpoch.delete(this._turnQueue.generation);
     this._turnQueue.reset();
     this._abortRegistry.destroyAll();
-    this._cancelActiveDebounce();
-    this._pendingEnqueueCount = 0;
+    this._submitConcurrency.reset();
     this._pendingInteractionPromise = null;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();

--- a/packages/ai-chat/src/tests/message-concurrency.test.ts
+++ b/packages/ai-chat/src/tests/message-concurrency.test.ts
@@ -89,6 +89,23 @@ async function waitForOverlappingSubmits(
   }, timeoutMs);
 }
 
+async function waitForActiveRequest(
+  agentStub: {
+    getStartedRequestIds(): Promise<string[]> | string[];
+    isChatTurnActiveForTest(): Promise<boolean> | boolean;
+  },
+  requestId: string,
+  timeoutMs = 4000
+) {
+  await waitUntil(async () => {
+    const [started, isActive] = await Promise.all([
+      agentStub.getStartedRequestIds(),
+      agentStub.isChatTurnActiveForTest()
+    ]);
+    return isActive && started.includes(requestId);
+  }, timeoutMs);
+}
+
 function recordMessages(ws: WebSocket): OutgoingMessage[] {
   const seen: OutgoingMessage[] = [];
   ws.addEventListener("message", (event: MessageEvent) => {
@@ -226,10 +243,10 @@ describe("AIChatAgent messageConcurrency", () => {
 
     sendChatRequest(ws, "req-drop-1", [firstUserMessage], {
       format: "plaintext",
-      chunkCount: 8,
-      chunkDelayMs: 50
+      chunkCount: 15,
+      chunkDelayMs: 100
     });
-    await delay(40);
+    await waitForActiveRequest(agentStub, "req-drop-1");
 
     sendChatRequest(ws, "req-drop-2", [firstUserMessage, secondUserMessage], {
       format: "plaintext",
@@ -767,10 +784,10 @@ describe("AIChatAgent messageConcurrency", () => {
 
     sendChatRequest(ws, "req-resp-drop-1", [firstUserMessage], {
       format: "plaintext",
-      chunkCount: 8,
-      chunkDelayMs: 50
+      chunkCount: 15,
+      chunkDelayMs: 100
     });
-    await delay(40);
+    await waitForActiveRequest(agentStub, "req-resp-drop-1");
 
     sendChatRequest(
       ws,

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -726,8 +726,11 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
    * count of overlapping submits observed so far.
    */
   getOverlappingSubmitCountForTest(): number {
-    return (this as unknown as { _latestOverlappingSubmitSequence: number })
-      ._latestOverlappingSubmitSequence;
+    return (
+      this as unknown as {
+        _submitConcurrency: { overlappingSubmitCount: number };
+      }
+    )._submitConcurrency.overlappingSubmitCount;
   }
 
   abortActiveTurnForTest(): boolean {

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -211,6 +211,23 @@ export class ThinkClientToolsAgent extends Think {
     this.messageConcurrency = concurrency;
   }
 
+  isChatTurnActiveForTest(): boolean {
+    return (this as unknown as { _turnQueue: { isActive: boolean } })._turnQueue
+      .isActive;
+  }
+
+  getOverlappingSubmitCountForTest(): number {
+    return (
+      this as unknown as {
+        _submitConcurrency: { overlappingSubmitCount: number };
+      }
+    )._submitConcurrency.overlappingSubmitCount;
+  }
+
+  waitUntilStableForTest(options?: { timeout?: number }): Promise<boolean> {
+    return this.waitUntilStable(options);
+  }
+
   async clearResponseLog(): Promise<void> {
     this._responseLog.length = 0;
   }

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -83,6 +83,38 @@ function waitForDone(
   });
 }
 
+function waitForDoneId(
+  ws: WebSocket,
+  requestId: string,
+  timeout = 10000
+): Promise<Array<Record<string, unknown>>> {
+  return new Promise((resolve, reject) => {
+    const messages: Array<Record<string, unknown>> = [];
+    const timer = setTimeout(
+      () => reject(new Error(`Timeout waiting for done: ${requestId}`)),
+      timeout
+    );
+    const handler = (e: MessageEvent) => {
+      try {
+        const msg = JSON.parse(e.data as string) as Record<string, unknown>;
+        messages.push(msg);
+        if (
+          msg.type === MSG_CHAT_RESPONSE &&
+          msg.id === requestId &&
+          msg.done === true
+        ) {
+          clearTimeout(timer);
+          ws.removeEventListener("message", handler);
+          resolve(messages);
+        }
+      } catch {
+        // ignore
+      }
+    };
+    ws.addEventListener("message", handler);
+  });
+}
+
 function waitForMessageOfType(
   ws: WebSocket,
   type: string,
@@ -160,6 +192,42 @@ function makeToolMessage(
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 4000,
+  intervalMs = 25
+) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+
+    await delay(intervalMs);
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+async function waitForActiveTurn(
+  agent: { isChatTurnActiveForTest(): Promise<boolean> | boolean },
+  timeoutMs = 4000
+) {
+  await waitUntil(() => agent.isChatTurnActiveForTest(), timeoutMs);
+}
+
+async function waitForOverlappingSubmits(
+  agent: { getOverlappingSubmitCountForTest(): Promise<number> | number },
+  expected: number,
+  timeoutMs = 4000
+) {
+  await waitUntil(async () => {
+    const observed = await agent.getOverlappingSubmitCountForTest();
+    return observed >= expected;
+  }, timeoutMs);
 }
 
 function closeWS(ws: WebSocket): Promise<void> {
@@ -1494,15 +1562,15 @@ describe("Think — messageConcurrency", () => {
     const { ws } = await connectWS(room);
     await collectMessages(ws, 3);
 
-    await agent.setSlowStreamMode(true, 30, 3);
+    await agent.setSlowStreamMode(true, 100, 15);
     await agent.setMessageConcurrency("latest");
 
-    const done1 = waitForDone(ws, 10000);
-    sendChatRequest(ws, [makeUserMessage("First")]);
-    await delay(10);
+    const request1 = sendChatRequest(ws, [makeUserMessage("First")]);
+    const done1 = waitForDoneId(ws, request1, 10000);
+    await waitForActiveTurn(agent);
     sendChatRequest(ws, [makeUserMessage("Second")]);
-    await delay(10);
     sendChatRequest(ws, [makeUserMessage("Third")]);
+    await waitForOverlappingSubmits(agent, 2);
 
     await done1;
     await waitForDone(ws, 10000);
@@ -1521,15 +1589,15 @@ describe("Think — messageConcurrency", () => {
     const { ws } = await connectWS(room);
     await collectMessages(ws, 3);
 
-    await agent.setSlowStreamMode(true, 30, 3);
+    await agent.setSlowStreamMode(true, 100, 15);
     await agent.setMessageConcurrency("drop");
 
-    const done1 = waitForDone(ws, 10000);
-    sendChatRequest(ws, [makeUserMessage("First")]);
-    await delay(10);
+    const request1 = sendChatRequest(ws, [makeUserMessage("First")]);
+    const done1 = waitForDoneId(ws, request1, 10000);
+    await waitForActiveTurn(agent);
 
-    const done2 = waitForDone(ws, 3000);
-    sendChatRequest(ws, [makeUserMessage("Second")]);
+    const request2 = sendChatRequest(ws, [makeUserMessage("Second")]);
+    const done2 = waitForDoneId(ws, request2, 3000);
     await done2;
 
     await done1;
@@ -1551,15 +1619,15 @@ describe("Think — messageConcurrency", () => {
     const { ws } = await connectWS(room);
     await collectMessages(ws, 3);
 
-    await agent.setSlowStreamMode(true, 30, 3);
+    await agent.setSlowStreamMode(true, 100, 15);
     await agent.setMessageConcurrency("merge");
 
-    const done1 = waitForDone(ws, 10000);
-    sendChatRequest(ws, [makeUserMessage("First")]);
-    await delay(10);
+    const request1 = sendChatRequest(ws, [makeUserMessage("First")]);
+    const done1 = waitForDoneId(ws, request1, 10000);
+    await waitForActiveTurn(agent);
     sendChatRequest(ws, [makeUserMessage("Second")]);
-    await delay(10);
     sendChatRequest(ws, [makeUserMessage("Third")]);
+    await waitForOverlappingSubmits(agent, 2);
 
     await done1;
     await waitForDone(ws, 10000);
@@ -1578,16 +1646,17 @@ describe("Think — messageConcurrency", () => {
     const { ws } = await connectWS(room);
     await collectMessages(ws, 3);
 
-    await agent.setSlowStreamMode(true, 10, 2);
+    await agent.setSlowStreamMode(true, 100, 10);
     await agent.setMessageConcurrency({
       strategy: "debounce",
       debounceMs: 100
     });
 
-    const done1 = waitForDone(ws, 10000);
-    sendChatRequest(ws, [makeUserMessage("First")]);
-    await delay(10);
+    const request1 = sendChatRequest(ws, [makeUserMessage("First")]);
+    const done1 = waitForDoneId(ws, request1, 10000);
+    await waitForActiveTurn(agent);
     sendChatRequest(ws, [makeUserMessage("Second")]);
+    await waitForOverlappingSubmits(agent, 1);
 
     await done1;
     await waitForDone(ws, 10000);
@@ -1633,13 +1702,13 @@ describe("Think — messageConcurrency", () => {
     const { ws } = await connectWS(room);
     await collectMessages(ws, 3);
 
-    await agent.setSlowStreamMode(true, 40, 3);
+    await agent.setSlowStreamMode(true, 100, 15);
     await agent.setMessageConcurrency("latest");
 
     sendChatRequest(ws, [makeUserMessage("First")]);
-    await delay(10);
+    await waitForActiveTurn(agent);
     sendChatRequest(ws, [makeUserMessage("Second")]);
-    await delay(10);
+    await waitForOverlappingSubmits(agent, 1);
 
     ws.send(JSON.stringify({ type: MSG_CHAT_CLEAR }));
     await delay(500);
@@ -1684,15 +1753,15 @@ describe("Think — messageConcurrency", () => {
     const { ws } = await connectWS(room);
     await collectMessages(ws, 3);
 
-    await agent.setSlowStreamMode(true, 30, 3);
+    await agent.setSlowStreamMode(true, 100, 15);
     await agent.setMessageConcurrency("latest");
 
-    const done1 = waitForDone(ws, 10000);
-    sendChatRequest(ws, [makeUserMessage("First")]);
-    await delay(10);
+    const request1 = sendChatRequest(ws, [makeUserMessage("First")]);
+    const done1 = waitForDoneId(ws, request1, 10000);
+    await waitForActiveTurn(agent);
     sendChatRequest(ws, [makeUserMessage("Second")]);
-    await delay(10);
     sendChatRequest(ws, [makeUserMessage("Third")]);
+    await waitForOverlappingSubmits(agent, 2);
 
     await done1;
     await waitForDone(ws, 10000);
@@ -1712,13 +1781,14 @@ describe("Think — messageConcurrency", () => {
     const { ws } = await connectWS(room);
     await collectMessages(ws, 3);
 
-    await agent.setSlowStreamMode(true, 30, 3);
+    await agent.setSlowStreamMode(true, 100, 15);
     await agent.setMessageConcurrency("drop");
 
-    const done1 = waitForDone(ws, 10000);
-    sendChatRequest(ws, [makeUserMessage("First")]);
-    await delay(10);
-    sendChatRequest(ws, [makeUserMessage("Second")]);
+    const request1 = sendChatRequest(ws, [makeUserMessage("First")]);
+    const done1 = waitForDoneId(ws, request1, 10000);
+    await waitForActiveTurn(agent);
+    const request2 = sendChatRequest(ws, [makeUserMessage("Second")]);
+    await waitForDoneId(ws, request2, 3000);
 
     await done1;
     await delay(500);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -125,6 +125,7 @@ import {
   TurnQueue,
   ResumableStream,
   ContinuationState,
+  SubmitConcurrencyController,
   createToolsFromClientSchemas,
   AbortRegistry,
   applyToolUpdate,
@@ -136,7 +137,8 @@ import {
 import type {
   StreamChunkData,
   ClientToolSchema,
-  MessagePart
+  MessagePart,
+  SubmitConcurrencyDecision
 } from "agents/chat";
 import { Session } from "agents/experimental/memory/session";
 import { truncateOlderMessages } from "agents/experimental/memory/utils";
@@ -464,19 +466,6 @@ export interface ExtensionConfig {
 
 const TIMED_OUT = Symbol("timed-out");
 
-type NormalizedMessageConcurrency =
-  | "queue"
-  | "latest"
-  | "merge"
-  | "drop"
-  | { strategy: "debounce"; debounceMs: number };
-
-type SubmitConcurrencyDecision = {
-  action: "execute" | "drop";
-  submitSequence: number | null;
-  debounceUntilMs: number | null;
-};
-
 /**
  * An opinionated chat agent base class.
  *
@@ -612,10 +601,9 @@ export class Think<
   private _insideResponseHook = false;
   private _insideInferenceLoop = false;
   private _pendingInteractionPromise: Promise<boolean> | null = null;
-  private _submitSequence = 0;
-  private _latestOverlappingSubmitSequence = 0;
-  private _activeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-  private _activeDebounceResolve: (() => void) | null = null;
+  private _submitConcurrency = new SubmitConcurrencyController({
+    defaultDebounceMs: Think.MESSAGE_DEBOUNCE_MS
+  });
   private static MESSAGE_DEBOUNCE_MS = 750;
 
   // ── Dynamic config ──────────────────────────────────────────────
@@ -2171,62 +2159,95 @@ export class Think<
       return;
     }
 
-    // ── Persist client tools and body (only for accepted requests) ──
-    const requestClientTools =
-      rawClientTools && rawClientTools.length > 0 ? rawClientTools : undefined;
-    if (requestClientTools) {
-      this._lastClientTools = requestClientTools;
-      this._persistClientTools();
-    } else if (rawClientTools !== undefined) {
-      this._lastClientTools = undefined;
-      this._persistClientTools();
-    }
-
-    const requestBody =
-      Object.keys(customBody).length > 0 ? customBody : undefined;
-    this._lastBody = requestBody;
-    this._persistBody();
-
-    // ── Persist and broadcast user messages ──────────────────────
-    const clientToolsForTurn = this._lastClientTools;
-    const bodyForTurn = this._lastBody;
-
-    let branchParentId: string | undefined;
-    if (isRegeneration && incomingMessages.length > 0) {
-      branchParentId = incomingMessages[incomingMessages.length - 1].id;
-    }
-
-    for (const msg of incomingMessages) {
-      await this.session.appendMessage(msg);
-    }
-
-    this._broadcastMessages([connection.id]);
-
-    // ── Enter turn queue ────────────────────────────────────────
-    const abortSignal = this._aborts.getSignal(requestId);
+    const releasePendingEnqueue = this._submitConcurrency.beginEnqueue();
+    let pendingEnqueue = true;
     const epoch = this._turnQueue.generation;
+    const releaseIfPending = () => {
+      if (!pendingEnqueue) return;
+      pendingEnqueue = false;
+      releasePendingEnqueue();
+    };
 
     try {
+      // ── Persist client tools and body (only for accepted requests) ──
+      const requestClientTools =
+        rawClientTools && rawClientTools.length > 0
+          ? rawClientTools
+          : undefined;
+      if (requestClientTools) {
+        this._lastClientTools = requestClientTools;
+        this._persistClientTools();
+      } else if (rawClientTools !== undefined) {
+        this._lastClientTools = undefined;
+        this._persistClientTools();
+      }
+
+      const requestBody =
+        Object.keys(customBody).length > 0 ? customBody : undefined;
+      this._lastBody = requestBody;
+      this._persistBody();
+
+      // ── Persist and broadcast user messages ──────────────────────
+      const clientToolsForTurn = this._lastClientTools;
+      const bodyForTurn = this._lastBody;
+
+      let branchParentId: string | undefined;
+      if (isRegeneration && incomingMessages.length > 0) {
+        branchParentId = incomingMessages[incomingMessages.length - 1].id;
+      }
+
+      if (this._turnQueue.generation !== epoch) {
+        this._completeSkippedRequest(connection, requestId);
+        return;
+      }
+
+      for (const msg of incomingMessages) {
+        if (this._turnQueue.generation !== epoch) {
+          this._completeSkippedRequest(connection, requestId);
+          return;
+        }
+
+        await this.session.appendMessage(msg);
+      }
+
+      if (this._turnQueue.generation !== epoch) {
+        this._completeSkippedRequest(connection, requestId);
+        return;
+      }
+
+      this._broadcastMessages([connection.id]);
+
+      // ── Enter turn queue ────────────────────────────────────────
+      const abortSignal = this._aborts.getSignal(requestId);
+
       await this.keepAliveWhile(async () => {
-        const turnResult = await this._turnQueue.enqueue(
+        const turnPromise = this._turnQueue.enqueue(
           requestId,
           async () => {
             // Superseded by a later overlapping submit (latest/merge/debounce)
-            if (this._isSupersededSubmit(concurrencyDecision.submitSequence)) {
+            if (
+              this._submitConcurrency.isSuperseded(
+                concurrencyDecision.submitSequence
+              )
+            ) {
               this._completeSkippedRequest(connection, requestId);
               return;
             }
 
             // Debounce: wait for quiet period
             if (concurrencyDecision.debounceUntilMs !== null) {
-              await this._waitForTimestamp(concurrencyDecision.debounceUntilMs);
+              await this._submitConcurrency.waitForTimestamp(
+                concurrencyDecision.debounceUntilMs
+              );
 
               if (this._turnQueue.generation !== epoch) {
                 this._completeSkippedRequest(connection, requestId);
                 return;
               }
               if (
-                this._isSupersededSubmit(concurrencyDecision.submitSequence)
+                this._submitConcurrency.isSuperseded(
+                  concurrencyDecision.submitSequence
+                )
               ) {
                 this._completeSkippedRequest(connection, requestId);
                 return;
@@ -2274,8 +2295,14 @@ export class Think<
             } else {
               await chatTurnBody();
             }
+          },
+          {
+            generation: epoch
           }
         );
+        releaseIfPending();
+
+        const turnResult = await turnPromise;
 
         if (turnResult.status === "stale") {
           this._broadcastChat({
@@ -2295,6 +2322,7 @@ export class Think<
         error: true
       });
     } finally {
+      releaseIfPending();
       this._aborts.remove(requestId);
     }
   }
@@ -2314,7 +2342,7 @@ export class Think<
       clearTimeout(this._continuationTimer);
       this._continuationTimer = null;
     }
-    this._cancelActiveDebounce();
+    this._submitConcurrency.reset();
     this._pendingInteractionPromise = null;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();
@@ -2583,7 +2611,9 @@ export class Think<
     while (true) {
       if (
         (await this._awaitWithDeadline(
-          this._turnQueue.waitForIdle(),
+          this._submitConcurrency.waitForIdle(() =>
+            this._turnQueue.waitForIdle()
+          ),
           deadline
         )) === TIMED_OUT
       ) {
@@ -2771,101 +2801,14 @@ export class Think<
 
   // ── Concurrency strategies ──────────────────────────────────────
 
-  private _normalizeMessageConcurrency(): NormalizedMessageConcurrency {
-    if (typeof this.messageConcurrency === "string") {
-      return this.messageConcurrency;
-    }
-    const debounceMs = this.messageConcurrency.debounceMs;
-    return {
-      strategy: "debounce",
-      debounceMs:
-        typeof debounceMs === "number" &&
-        Number.isFinite(debounceMs) &&
-        debounceMs >= 0
-          ? debounceMs
-          : Think.MESSAGE_DEBOUNCE_MS
-    };
-  }
-
   private _getSubmitConcurrencyDecision(
     isSubmitMessage: boolean
   ): SubmitConcurrencyDecision {
-    const queuedTurns = this._turnQueue.queuedCount();
-
-    if (!isSubmitMessage || queuedTurns === 0) {
-      return {
-        action: "execute",
-        submitSequence: null,
-        debounceUntilMs: null
-      };
-    }
-
-    const concurrency = this._normalizeMessageConcurrency();
-
-    if (concurrency === "queue") {
-      return {
-        action: "execute",
-        submitSequence: null,
-        debounceUntilMs: null
-      };
-    }
-
-    if (concurrency === "drop") {
-      return {
-        action: "drop",
-        submitSequence: null,
-        debounceUntilMs: null
-      };
-    }
-
-    const submitSequence = ++this._submitSequence;
-    this._latestOverlappingSubmitSequence = submitSequence;
-
-    if (concurrency === "latest" || concurrency === "merge") {
-      return {
-        action: "execute",
-        submitSequence,
-        debounceUntilMs: null
-      };
-    }
-
-    return {
-      action: "execute",
-      submitSequence,
-      debounceUntilMs: Date.now() + concurrency.debounceMs
-    };
-  }
-
-  private _isSupersededSubmit(submitSequence: number | null): boolean {
-    return (
-      submitSequence !== null &&
-      submitSequence < this._latestOverlappingSubmitSequence
-    );
-  }
-
-  private async _waitForTimestamp(timestampMs: number): Promise<void> {
-    const remainingMs = timestampMs - Date.now();
-    if (remainingMs <= 0) return;
-
-    await new Promise<void>((resolve) => {
-      this._activeDebounceResolve = resolve;
-      this._activeDebounceTimer = setTimeout(() => {
-        this._activeDebounceTimer = null;
-        this._activeDebounceResolve = null;
-        resolve();
-      }, remainingMs);
+    return this._submitConcurrency.decide({
+      concurrency: this.messageConcurrency,
+      isSubmitMessage,
+      queuedTurns: this._turnQueue.queuedCount()
     });
-  }
-
-  private _cancelActiveDebounce(): void {
-    if (this._activeDebounceTimer !== null) {
-      clearTimeout(this._activeDebounceTimer);
-      this._activeDebounceTimer = null;
-    }
-    if (this._activeDebounceResolve !== null) {
-      this._activeDebounceResolve();
-      this._activeDebounceResolve = null;
-    }
   }
 
   private _completeSkippedRequest(


### PR DESCRIPTION
## Summary

- Extract the latest/merge/drop/debounce admission state machine into a `SubmitConcurrencyController` exported from `agents/chat`. `AIChatAgent` semantics (including the merge persistence rewrite) are preserved. `Think` now uses the same controller, so an overlapping submit is still detected while an accepted request is between admission and turn queue registration.
- Fix a `Think` clear/epoch race: capture the turn generation immediately after admission and thread it into `_turnQueue.enqueue`, so a clear landing between admission and queue registration cannot run a stale turn.
- Bind pending-enqueue tracking to a release function tied to the controller's reset epoch, so a release from a pre-reset submit can no longer erase a post-reset submit's marker and let a third submit slip through as non-overlapping.
- Resolve all in-flight debounce waiters on cancel (the previous single-timer slot could be overwritten by an interleaving caller).
- Replace the brittle 40ms sleep in the `AIChatAgent` drop tests with an "active turn" barrier so the second submit is provably overlapping before assertion. Adds equivalent barriers to the `Think` concurrency tests.

## Test plan

- [x] `npx vitest --run -c src/chat/__tests__/vitest.config.ts src/chat/__tests__/submit-concurrency.test.ts` (new unit tests for controller — pending-enqueue, supersession, post-reset isolation, idempotent release, debounce cancellation)
- [x] `npx vitest --project workers --run src/tests/message-concurrency.test.ts --sequence.shuffle false` in `packages/ai-chat`
- [x] `npx vitest --run -c src/tests/vitest.config.ts src/tests/client-tools.test.ts -t "Think — messageConcurrency" --sequence.shuffle false` in `packages/think`
- [x] `npm run typecheck`
- [x] `ReadLints` clean on touched files


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
