### PR TITLE
test(example): vitest+workers harness for assistant multi-session wiring

### DIFF
--- a/examples/assistant/package.json
+++ b/examples/assistant/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "vite dev",
     "deploy": "vite build && wrangler deploy",
+    "test": "vitest --run --config src/tests/vitest.config.ts",
     "types": "wrangler types env.d.ts --include-runtime false"
   },
   "dependencies": {

--- a/examples/assistant/src/tests/daily-summary.test.ts
+++ b/examples/assistant/src/tests/daily-summary.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Daily-summary fan-out test.
+ *
+ * `AssistantDirectory.dailySummary` runs on a parent-side cron
+ * because facets can't `schedule()` (workerd limitation). It picks
+ * the most-recently-updated chat from `chat_meta` and queues a prompt
+ * into that child via
+ * `subAgent(MyAssistant, id).postDailySummaryPrompt()`.
+ *
+ * Scope note: a full round-trip test would have to invoke
+ * `postDailySummaryPrompt` to completion. That calls `saveMessages`,
+ * which in turn fires Think's auto-resume fiber → `getModel()` →
+ * `createWorkersAI({ binding: env.AI })`. We deliberately don't bind
+ * `AI` in the test wrangler (see `wrangler.jsonc` for why), so we
+ * scope these tests to the no-op path and the ordering precondition
+ * the dispatcher relies on. The framework's own Think tests cover
+ * the `saveMessages` → turn pipeline in detail.
+ */
+
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "agents";
+import { readDirectoryState, uniqueDirectoryName } from "./helpers";
+
+describe("AssistantDirectory.dailySummary", () => {
+  it("is a no-op when no chats exist", async () => {
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      uniqueDirectoryName()
+    );
+
+    // Resolves cleanly without spawning anything.
+    await directory.dailySummary();
+
+    expect((await directory.listSubAgents()).length).toBe(0);
+  });
+
+  it("ordering: chat_meta is sorted most-recently-updated first", async () => {
+    // dailySummary picks `chat_meta[0].id` after ORDER BY updated_at
+    // DESC. We verify the ordering precondition holds — the actual
+    // dispatch into the child is gated on the AI binding (see scope
+    // note above).
+    const directoryName = uniqueDirectoryName();
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      directoryName
+    );
+
+    const a = await directory.createChat({ title: "older" });
+    const b = await directory.createChat({ title: "newer" });
+
+    await directory.recordChatTurn(a.id, "first ping");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await directory.recordChatTurn(b.id, "second ping");
+
+    const state = await readDirectoryState(directoryName);
+    expect(state.chats[0].id).toBe(b.id);
+    expect(state.chats[1].id).toBe(a.id);
+  });
+});

--- a/examples/assistant/src/tests/directory.test.ts
+++ b/examples/assistant/src/tests/directory.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Directory CRUD + sidebar state tests.
+ *
+ * These exercise `AssistantDirectory` as a plain Agent over DO RPC,
+ * with no Worker / GitHub auth in the loop. They pin down the
+ * lifecycle the sidebar UI depends on:
+ *
+ *   - `createChat` spawns a `MyAssistant` facet AND inserts a
+ *     `chat_meta` row, then refreshes `state.chats`.
+ *   - `listSubAgents(MyAssistant)` is the authoritative set of chats;
+ *     `chat_meta` is decoration.
+ *   - `recordChatTurn` (intentionally not `@callable()`) updates the
+ *     sidebar preview from inside a child via DO RPC.
+ *   - `deleteChat` wipes both the facet AND the meta row, and
+ *     `_refreshState` correctly drops it from the sidebar.
+ *   - `renameChat` is title-only; it does not touch the facet.
+ *
+ * Note on state reads: the base `Agent.state` is a getter, not an RPC
+ * method, so the client reads it over the WebSocket protocol via the
+ * `cf_agent_state` frame. `readDirectoryState` in `helpers.ts`
+ * encapsulates that.
+ */
+
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "agents";
+import { readDirectoryState, uniqueDirectoryName } from "./helpers";
+import type { AssistantDirectory } from "../server";
+
+async function freshDirectory(): Promise<{
+  directory: DurableObjectStub<AssistantDirectory>;
+  name: string;
+}> {
+  const name = uniqueDirectoryName();
+  const directory = await getAgentByName(env.AssistantDirectory, name);
+  return { directory, name };
+}
+
+describe("AssistantDirectory — chat lifecycle", () => {
+  it("starts with an empty sidebar", async () => {
+    const { name } = await freshDirectory();
+    const state = await readDirectoryState(name);
+    expect(state).toEqual({ chats: [] });
+  });
+
+  it("createChat populates state.chats and listSubAgents in sync", async () => {
+    const { directory, name } = await freshDirectory();
+
+    const summary = await directory.createChat({ title: "First conversation" });
+    expect(summary.id).toBeTruthy();
+    expect(summary.title).toBe("First conversation");
+
+    const state = await readDirectoryState(name);
+    expect(state.chats).toHaveLength(1);
+    expect(state.chats[0]).toMatchObject({
+      id: summary.id,
+      title: "First conversation"
+    });
+
+    // Registry is the authoritative set; meta is decoration.
+    const registry = await directory.listSubAgents();
+    const found = registry.find((entry) => entry.name === summary.id);
+    expect(found?.className).toBe("MyAssistant");
+  });
+
+  it("createChat without an explicit title falls back to a default", async () => {
+    const { directory } = await freshDirectory();
+
+    const summary = await directory.createChat();
+    expect(summary.title).toMatch(/^New chat —/);
+  });
+
+  it("renameChat updates the title without touching the facet", async () => {
+    const { directory, name } = await freshDirectory();
+    const { id } = await directory.createChat({ title: "Original" });
+
+    await directory.renameChat(id, "Renamed");
+
+    const state = await readDirectoryState(name);
+    const renamed = state.chats.find((c) => c.id === id);
+    expect(renamed?.title).toBe("Renamed");
+
+    // Whitespace-only renames are ignored, as per the example spec.
+    await directory.renameChat(id, "   ");
+    const stateAfterNoop = await readDirectoryState(name);
+    expect(stateAfterNoop.chats.find((c) => c.id === id)?.title).toBe(
+      "Renamed"
+    );
+  });
+
+  it("deleteChat removes the chat from state, registry, and meta", async () => {
+    const { directory, name } = await freshDirectory();
+    const a = await directory.createChat({ title: "Keep" });
+    const b = await directory.createChat({ title: "Drop" });
+
+    await directory.deleteChat(b.id);
+
+    const state = await readDirectoryState(name);
+    expect(state.chats.map((c) => c.id)).toEqual([a.id]);
+
+    const registry = await directory.listSubAgents();
+    expect(registry.find((entry) => entry.name === b.id)).toBeUndefined();
+  });
+
+  it("deleteChat is idempotent for unknown ids", async () => {
+    const { directory, name } = await freshDirectory();
+
+    // Should not throw.
+    await directory.deleteChat("never-existed");
+
+    const state = await readDirectoryState(name);
+    expect(state.chats).toEqual([]);
+  });
+});
+
+describe("AssistantDirectory — recordChatTurn", () => {
+  it("updates the sidebar preview and ordering, not @callable from a client", async () => {
+    const { directory, name } = await freshDirectory();
+    const a = await directory.createChat({ title: "A" });
+    const b = await directory.createChat({ title: "B" });
+
+    // recordChatTurn is the parent-side side effect of committing a
+    // child turn — invoked via DO RPC, not exposed to the browser.
+    // (The `@callable()` decorator is deliberately omitted; this test
+    // just exercises the happy-path RPC.)
+    await directory.recordChatTurn(a.id, "Hello there");
+
+    const state = await readDirectoryState(name);
+    // `a` should now be most-recent; `b` falls behind.
+    expect(state.chats.map((c) => c.id)).toEqual([a.id, b.id]);
+    expect(state.chats[0].lastMessagePreview).toBe("Hello there");
+  });
+
+  it("inserts a meta row even for a chat id with no prior meta", async () => {
+    const { directory, name } = await freshDirectory();
+    const { id } = await directory.createChat();
+
+    // Simulate a child whose initial create raced ahead of meta —
+    // recordChatTurn should still insert a row via INSERT ... ON CONFLICT.
+    await directory.recordChatTurn(id, "first turn");
+
+    const state = await readDirectoryState(name);
+    expect(state.chats[0].lastMessagePreview).toBe("first turn");
+  });
+});

--- a/examples/assistant/src/tests/env.d.ts
+++ b/examples/assistant/src/tests/env.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+type _WorkerEnv = import("./worker").Env;
+
+declare namespace Cloudflare {
+  interface Env extends _WorkerEnv {
+    // Bindings declared in the production wrangler.jsonc that the
+    // test worker doesn't carry (auth secrets, Workers AI). Tests
+    // don't exercise the code paths that read these — auth lives in
+    // the production Worker (which the test worker replaces) and AI
+    // is only touched by `MyAssistant.getModel()` during turns
+    // (which tests don't trigger). Declared here so `src/server.ts`
+    // and `src/auth.ts` typecheck under the test tsconfig.
+    AI: Ai;
+    GITHUB_CLIENT_ID: string;
+    GITHUB_CLIENT_SECRET: string;
+  }
+  interface GlobalProps {
+    mainModule: typeof import("./worker");
+  }
+}
+
+interface Env extends Cloudflare.Env {}

--- a/examples/assistant/src/tests/helpers.ts
+++ b/examples/assistant/src/tests/helpers.ts
@@ -1,0 +1,109 @@
+import { exports } from "cloudflare:workers";
+import { expect } from "vitest";
+import type { DirectoryState } from "../server";
+
+/**
+ * Open a WebSocket against the test worker for the given path.
+ * Mirrors the helper used in `packages/agents/src/tests/state.test.ts`
+ * — `Upgrade: websocket` against `exports.default.fetch` returns a
+ * 101 with a paired `webSocket`, which we accept and hand back.
+ */
+export async function connectWS(path: string): Promise<{ ws: WebSocket }> {
+  const res = await exports.default.fetch(`http://example.com${path}`, {
+    headers: { Upgrade: "websocket" }
+  });
+  expect(res.status).toBe(101);
+  const ws = res.webSocket as WebSocket;
+  expect(ws).toBeDefined();
+  ws.accept();
+  return { ws };
+}
+
+/**
+ * Resolve when the websocket emits the next message. Times out so a
+ * test asserting "should not broadcast" can fail fast rather than
+ * hanging.
+ */
+export function nextMessage(ws: WebSocket, timeoutMs = 1500): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("Timeout waiting for WebSocket message")),
+      timeoutMs
+    );
+    ws.addEventListener(
+      "message",
+      (e: MessageEvent) => {
+        clearTimeout(timer);
+        resolve(typeof e.data === "string" ? e.data : "");
+      },
+      { once: true }
+    );
+  });
+}
+
+/**
+ * Drain WebSocket messages until `predicate` returns true, then
+ * resolve with the matching frame. Used to skip Agent's initial
+ * protocol noise (identity, state, mcp_servers) before asserting on
+ * the frame the test actually cares about.
+ */
+export async function waitForMatching<T = unknown>(
+  ws: WebSocket,
+  predicate: (msg: T) => boolean,
+  timeoutMs = 2000
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = Math.max(50, deadline - Date.now());
+    const raw = await nextMessage(ws, remaining);
+    let parsed: T;
+    try {
+      parsed = JSON.parse(raw) as T;
+    } catch {
+      continue;
+    }
+    if (predicate(parsed)) {
+      return parsed;
+    }
+  }
+  throw new Error("Timeout waiting for matching WebSocket message");
+}
+
+/**
+ * Generate a directory name unique to the test invocation so parallel
+ * tests don't collide on the same DO.
+ */
+export function uniqueDirectoryName(prefix = "alice"): string {
+  return `${prefix}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Read `AssistantDirectory.state` over the WebSocket protocol the
+ * client uses, since `state` is a getter on the base Agent class and
+ * isn't exposed through `getAgentByName` RPC. Connects, waits for
+ * the initial `cf_agent_state` frame, closes.
+ *
+ * This is a substitute for the `getState()` callable that test agents
+ * in `packages/agents/src/tests` add for convenience — we deliberately
+ * don't modify the production class.
+ */
+export async function readDirectoryState(
+  directoryName: string
+): Promise<DirectoryState> {
+  const { ws } = await connectWS(
+    `/agents/assistant-directory/${directoryName}`
+  );
+  try {
+    const frame = await waitForMatching<{ type?: string; state?: unknown }>(
+      ws,
+      (msg) =>
+        typeof msg === "object" &&
+        msg !== null &&
+        (msg as { type?: string }).type === "cf_agent_state",
+      3000
+    );
+    return frame.state as DirectoryState;
+  } finally {
+    ws.close();
+  }
+}

--- a/examples/assistant/src/tests/routing.test.ts
+++ b/examples/assistant/src/tests/routing.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Routing tests for `AssistantDirectory.onBeforeSubAgent`.
+ *
+ * The directory uses `hasSubAgent` as a strict-registry gate: any
+ * incoming `/sub/my-assistant/<id>` request for a chat id that hasn't
+ * been spawned via `createChat` must short-circuit with a 404 before
+ * the framework wakes the child. This is the example's primary
+ * defense against a client guessing chat ids inside its own directory.
+ *
+ * URL shape under test:
+ *   /agents/assistant-directory/<user>/sub/my-assistant/<chat-id>
+ */
+
+import { exports, env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "agents";
+import { uniqueDirectoryName } from "./helpers";
+
+function subAgentPath(directory: string, chatId: string): string {
+  return `/agents/assistant-directory/${directory}/sub/my-assistant/${chatId}`;
+}
+
+describe("AssistantDirectory — onBeforeSubAgent strict-registry gate", () => {
+  it("rejects a chat id that was never created", async () => {
+    const directoryName = uniqueDirectoryName();
+    // Prime the directory so `hasSubAgent` runs against its real
+    // registry rather than a freshly-spawned one.
+    await getAgentByName(env.AssistantDirectory, directoryName);
+
+    const res = await exports.default.fetch(
+      `http://example.com${subAgentPath(directoryName, "ghost-chat")}`
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain('MyAssistant "ghost-chat" not found');
+  });
+
+  it("forwards to the child when the chat was created via createChat", async () => {
+    const directoryName = uniqueDirectoryName();
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      directoryName
+    );
+    const { id } = await directory.createChat({ title: "Real chat" });
+
+    // A successful WebSocket upgrade against the sub-agent URL is the
+    // cleanest liveness probe: it round-trips through the directory's
+    // `onBeforeSubAgent` hook and into the child's connect handler.
+    // 404 from the gate would short-circuit the upgrade with an HTTP
+    // response instead of a 101.
+    const res = await exports.default.fetch(
+      `http://example.com${subAgentPath(directoryName, id)}`,
+      { headers: { Upgrade: "websocket" } }
+    );
+
+    expect(res.status).toBe(101);
+    const ws = res.webSocket;
+    if (ws) {
+      ws.accept();
+      ws.close();
+    }
+  });
+
+  it("rejects a chat id that was created and then deleted", async () => {
+    const directoryName = uniqueDirectoryName();
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      directoryName
+    );
+    const { id } = await directory.createChat();
+    await directory.deleteChat(id);
+
+    const res = await exports.default.fetch(
+      `http://example.com${subAgentPath(directoryName, id)}`
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/examples/assistant/src/tests/setup.ts
+++ b/examples/assistant/src/tests/setup.ts
@@ -1,0 +1,15 @@
+import { afterAll, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+
+// Warm up the worker module graph before tests run. The first
+// fetch through the test worker triggers Vite's module resolution
+// for the entire dependency tree (Think, ai-chat, agents/chat,
+// codemode, kumo). On a cold CI runner that can take >10s, which
+// would otherwise blow the first test's per-test timeout.
+beforeAll(async () => {
+  await exports.default.fetch("http://warmup/");
+}, 30_000);
+
+// Give DOs a moment to finish WebSocket close handlers before the
+// module is invalidated between test files.
+afterAll(() => new Promise((resolve) => setTimeout(resolve, 100)));

--- a/examples/assistant/src/tests/shared-mcp.test.ts
+++ b/examples/assistant/src/tests/shared-mcp.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared MCP tests.
+ *
+ * Scope note (read this before adding tests here):
+ *
+ * The example's MCP surface is intentionally thin. `AssistantDirectory`
+ * delegates `listMcpToolDescriptors` to `this.mcp.listTools()` and
+ * `callMcpTool` to `this.mcp.callTool()`. The framework already
+ * exercises those code paths in
+ * `packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts` (RPC
+ * transport) and the streamable-http/SSE protocol tests. There's
+ * little behavior unique to this example to test on top of that.
+ *
+ * The tests we'd want for a deep round-trip — `addServer` + tool
+ * discovery + `callMcpTool` — are blocked by two real workerd
+ * test-runtime constraints:
+ *
+ *   1. RPC-transport `addMcpServer` requires passing
+ *      `env.TestMcpStub` as an argument. From a vitest test file the
+ *      call goes vitest-runner→DO and structured-clones the args,
+ *      which fails with `DataCloneError: Could not serialize
+ *      DurableObjectNamespace`. The pattern in the framework's own
+ *      `add-rpc-mcp-server.test.ts` works around this by routing the
+ *      call through a test-side Agent that calls `this.addMcpServer`
+ *      from inside the same DO, where the binding never has to cross
+ *      a serialization boundary. Replicating that here would require
+ *      a test-only callable on the production `AssistantDirectory`,
+ *      which we don't want to ship in example code.
+ *
+ *   2. HTTP-transport `addMcpServer` requires the directory's
+ *      outbound `fetch(url)` to reach the stub MCP server in the
+ *      same worker. vitest-pool-workers does not auto-route outbound
+ *      fetches back to the same worker (no `SELF` service binding by
+ *      default), so the connection times out / 404s.
+ *
+ * What we test here:
+ *
+ *   - The empty-state path: a fresh directory's
+ *     `listMcpToolDescriptors()` returns `[]` without throwing.
+ *   - The `SharedMCPClient` proxy's empty-state path inherits
+ *     correctness from the directory side, so we don't add a
+ *     redundant child-side check.
+ *
+ * If/when we need deeper MCP coverage in this example, add a small
+ * test-only helper Agent that performs the registration from inside
+ * its own DO. The framework's `add-rpc-mcp-server.test.ts` is the
+ * canonical reference for that pattern.
+ */
+
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "agents";
+import { uniqueDirectoryName } from "./helpers";
+
+describe("AssistantDirectory MCP — empty state", () => {
+  it("listMcpToolDescriptors returns [] before any servers are registered", async () => {
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      uniqueDirectoryName()
+    );
+
+    const descriptors = await directory.listMcpToolDescriptors(500);
+    expect(descriptors).toEqual([]);
+  });
+
+  it("listMcpToolDescriptors handles the explicit timeout argument", async () => {
+    // Smoke test for the wait/listTools path — even with no servers,
+    // a 0ms timeout shouldn't throw on `waitForConnections`.
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      uniqueDirectoryName()
+    );
+
+    const descriptors = await directory.listMcpToolDescriptors(0);
+    expect(descriptors).toEqual([]);
+  });
+});

--- a/examples/assistant/src/tests/shared-workspace.test.ts
+++ b/examples/assistant/src/tests/shared-workspace.test.ts
@@ -1,0 +1,96 @@
+/**
+ * SharedWorkspace round-trip tests.
+ *
+ * This is the headline assertion of the multi-session refactor: a file
+ * written inside chat A is visible verbatim inside chat B, because
+ * both `MyAssistant` facets see the directory's single `Workspace`
+ * through the `SharedWorkspace` proxy. The proxy resolves
+ * `parentAgent(AssistantDirectory)` lazily on first call, then
+ * forwards each operation over one DO RPC hop.
+ *
+ * We exercise the proxy via `MyAssistant`'s own `@callable()` surface
+ * (`listWorkspaceFiles`, `readWorkspaceFile`) plus the directory's
+ * direct `writeFile` RPC, and use `getSubAgentByName` to address the
+ * child facets without going through HTTP/WS.
+ */
+
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName, getSubAgentByName } from "agents";
+import { uniqueDirectoryName } from "./helpers";
+import { MyAssistant } from "../server";
+
+describe("SharedWorkspace — cross-chat round-trip", () => {
+  it("file written inside chat A is visible inside chat B", async () => {
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      uniqueDirectoryName()
+    );
+    const a = await directory.createChat({ title: "A" });
+    const b = await directory.createChat({ title: "B" });
+
+    // Resolve typed stubs to both chat facets.
+    const childA = await getSubAgentByName(directory, MyAssistant, a.id);
+    const childB = await getSubAgentByName(directory, MyAssistant, b.id);
+
+    // Write through chat A's `SharedWorkspace` proxy by going via the
+    // directory's direct `writeFile` RPC (the proxy forwards to the
+    // same RPC method, so this exercises the same store).
+    await directory.writeFile("/notes/hello.txt", "hi from chat A");
+
+    // Read through chat B's `SharedWorkspace` proxy via its
+    // `readWorkspaceFile` callable.
+    const contents = await childB.readWorkspaceFile("/notes/hello.txt");
+    expect(contents).toBe("hi from chat A");
+
+    // Both chats see the same listing.
+    const filesA = await childA.listWorkspaceFiles("/notes");
+    const filesB = await childB.listWorkspaceFiles("/notes");
+    expect(filesA.map((f) => f.name)).toEqual(["hello.txt"]);
+    expect(filesB.map((f) => f.name)).toEqual(["hello.txt"]);
+  });
+
+  it("directory-level reads and child-proxy reads see the same content", async () => {
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      uniqueDirectoryName()
+    );
+    const { id } = await directory.createChat();
+    const child = await getSubAgentByName(directory, MyAssistant, id);
+
+    await directory.writeFile("/shared.md", "# shared");
+
+    const fromDirectory = await directory.readFile("/shared.md");
+    const fromChild = await child.readWorkspaceFile("/shared.md");
+
+    expect(fromDirectory).toBe("# shared");
+    expect(fromChild).toBe("# shared");
+  });
+
+  it("readWorkspaceFile returns null for a missing path (proxy doesn't throw)", async () => {
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      uniqueDirectoryName()
+    );
+    const { id } = await directory.createChat();
+    const child = await getSubAgentByName(directory, MyAssistant, id);
+
+    const result = await child.readWorkspaceFile("/never-written.txt");
+    expect(result).toBeNull();
+  });
+
+  it("listWorkspaceFiles handles errors as an empty list (proxy doesn't throw)", async () => {
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      uniqueDirectoryName()
+    );
+    const { id } = await directory.createChat();
+    const child = await getSubAgentByName(directory, MyAssistant, id);
+
+    // The example's `listWorkspaceFiles` swallows exceptions and
+    // returns []; we just want to verify the proxy round-trip doesn't
+    // surface an unexpected throw for non-existent paths.
+    const result = await child.listWorkspaceFiles("/does/not/exist");
+    expect(Array.isArray(result)).toBe(true);
+  });
+});

--- a/examples/assistant/src/tests/tsconfig.json
+++ b/examples/assistant/src/tests/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "agents/tsconfig",
+  "include": ["./**/*.ts"]
+}

--- a/examples/assistant/src/tests/vitest.config.ts
+++ b/examples/assistant/src/tests/vitest.config.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import agents from "agents/vite";
+import { defineConfig } from "vitest/config";
+
+const testsDir = import.meta.dirname;
+
+export default defineConfig({
+  plugins: [
+    agents(),
+    cloudflareTest({
+      wrangler: {
+        configPath: path.join(testsDir, "wrangler.jsonc")
+      }
+    })
+  ],
+  test: {
+    name: "assistant-example",
+    include: [path.join(testsDir, "**/*.test.ts")],
+    setupFiles: [path.join(testsDir, "setup.ts")],
+    testTimeout: 15_000,
+    deps: {
+      optimizer: {
+        ssr: {
+          // ajv ships its schema files via require('./*.json') which
+          // vitest can't resolve without an explicit hint. Same fix
+          // packages/ai-chat and packages/agents use.
+          include: ["ajv"]
+        }
+      }
+    }
+  }
+});

--- a/examples/assistant/src/tests/worker.ts
+++ b/examples/assistant/src/tests/worker.ts
@@ -1,0 +1,48 @@
+/**
+ * Test worker for the assistant example.
+ *
+ * This worker is **not** the production worker. It re-exports the
+ * production `AssistantDirectory` and `MyAssistant` classes verbatim
+ * (so the harness exercises real code, not a fork) but replaces the
+ * surrounding plumbing:
+ *
+ *   - GitHub OAuth gating is dropped entirely. The production worker's
+ *     responsibility is to authenticate the user and forward `/chat*`
+ *     into the right `AssistantDirectory`. That's a Worker concern, not
+ *     a multi-session-correctness concern, so the test worker uses a
+ *     bare `routeAgentRequest` so tests can address directories by name
+ *     directly.
+ *
+ *   - `worker_loaders` is bound (`LOADER`) because `MyAssistant` reads
+ *     `this.env.LOADER` as a class field at construction. We never
+ *     actually load extensions in tests, but the binding has to exist.
+ *
+ * No AI binding is declared. Tests deliberately don't trigger turns —
+ * `MyAssistant.getModel()` is never called. That means we don't have
+ * to mock Workers AI or worry about `kimi-k2.6` flakiness, and the
+ * harness focuses on the plumbing the example owns: directory CRUD,
+ * `SharedWorkspace` round-trips, change broadcasts, and the MCP
+ * empty-state path. See `shared-mcp.test.ts` for why the deep MCP
+ * round-trip is out of scope here.
+ */
+
+import { routeAgentRequest } from "agents";
+
+export { AssistantDirectory, MyAssistant } from "../server";
+
+import type { AssistantDirectory, MyAssistant } from "../server";
+
+export type Env = {
+  AssistantDirectory: DurableObjectNamespace<AssistantDirectory>;
+  MyAssistant: DurableObjectNamespace<MyAssistant>;
+  LOADER: WorkerLoader;
+};
+
+export default {
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
+    return (
+      (await routeAgentRequest(request, env, { cors: true })) ||
+      new Response("Not found", { status: 404 })
+    );
+  }
+} satisfies ExportedHandler<Env>;

--- a/examples/assistant/src/tests/workspace-broadcast.test.ts
+++ b/examples/assistant/src/tests/workspace-broadcast.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Workspace broadcast tests.
+ *
+ * `AssistantDirectory.workspace` is constructed with
+ * `onChange: (event) => this._broadcastWorkspaceChange(event)`, which
+ * fans every workspace mutation out to every WebSocket client of the
+ * directory as a `{ type: "workspace-change", event }` JSON frame.
+ *
+ * On the client side `useChats()` keys a `workspaceRevision` counter
+ * off these frames; the file-browser pane's `useEffect` re-pulls
+ * listings whenever the revision bumps. The frame shape is the
+ * substrate that makes the live cross-chat/cross-tab UI work, so
+ * we pin it down here.
+ *
+ * We connect a WS to the directory, write a file via direct RPC, and
+ * assert the broadcast reaches the connected client.
+ */
+
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "agents";
+import { connectWS, uniqueDirectoryName, waitForMatching } from "./helpers";
+
+interface WorkspaceChangeFrame {
+  type: "workspace-change";
+  event: {
+    type: "create" | "update" | "delete";
+    path: string;
+    [key: string]: unknown;
+  };
+}
+
+function isWorkspaceChange(msg: unknown): msg is WorkspaceChangeFrame {
+  return (
+    typeof msg === "object" &&
+    msg !== null &&
+    (msg as { type?: unknown }).type === "workspace-change"
+  );
+}
+
+describe("workspace broadcast", () => {
+  it("writeFile fires a workspace-change frame to directory clients", async () => {
+    const directoryName = uniqueDirectoryName();
+    // Prime the directory so onStart has fired and the workspace is
+    // initialized before we connect. listSubAgents is a cheap RPC
+    // that triggers wake without a state read.
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      directoryName
+    );
+    await directory.listSubAgents();
+
+    const { ws } = await connectWS(
+      `/agents/assistant-directory/${directoryName}`
+    );
+
+    try {
+      // Trigger the mutation. The frame should arrive on `ws`.
+      const writePromise = directory.writeFile(
+        "/live.txt",
+        "broadcast me",
+        "text/plain"
+      );
+
+      const frame = await waitForMatching<unknown>(ws, isWorkspaceChange, 3000);
+      // Drain the directory write before we close the socket so the DO
+      // doesn't see a teardown mid-RPC.
+      await writePromise;
+
+      expect(isWorkspaceChange(frame)).toBe(true);
+      const change = frame as WorkspaceChangeFrame;
+      expect(change.event.path).toBe("/live.txt");
+      expect(
+        change.event.type === "create" || change.event.type === "update"
+      ).toBe(true);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("rm fires a workspace-change frame too", async () => {
+    const directoryName = uniqueDirectoryName();
+    const directory = await getAgentByName(
+      env.AssistantDirectory,
+      directoryName
+    );
+    await directory.writeFile("/temp.txt", "to be removed");
+
+    const { ws } = await connectWS(
+      `/agents/assistant-directory/${directoryName}`
+    );
+
+    try {
+      const rmPromise = directory.rm("/temp.txt");
+
+      const frame = await waitForMatching<unknown>(ws, isWorkspaceChange, 3000);
+      await rmPromise;
+
+      const change = frame as WorkspaceChangeFrame;
+      expect(change.event.path).toBe("/temp.txt");
+      expect(change.event.type).toBe("delete");
+    } finally {
+      ws.close();
+    }
+  });
+});

--- a/examples/assistant/src/tests/wrangler.jsonc
+++ b/examples/assistant/src/tests/wrangler.jsonc
@@ -1,0 +1,42 @@
+{
+  "$schema": "../../../../node_modules/wrangler/config-schema.json",
+  "compatibility_date": "2026-01-28",
+  "compatibility_flags": [
+    "nodejs_compat",
+    // vitest-pool-workers needs these flags on top of nodejs_compat.
+    "enable_nodejs_tty_module",
+    "enable_nodejs_fs_module",
+    "enable_nodejs_http_modules",
+    "enable_nodejs_perf_hooks_module",
+    "enable_nodejs_v8_module",
+    "enable_nodejs_process_v2"
+  ],
+  // No AI binding declared. `MyAssistant.getModel()` is the only
+  // thing that needs it, and tests deliberately don't trigger turns
+  // (which would otherwise call `createWorkersAI({ binding: env.AI })`).
+  // The vitest-pool-workers AI binding requires a wrangler login or
+  // remote proxy, neither of which we want CI to depend on. Tests
+  // that would otherwise drive `saveMessages` → auto-turn (e.g. a
+  // full `postDailySummaryPrompt` round-trip) are intentionally
+  // out of scope; see `daily-summary.test.ts`.
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "AssistantDirectory",
+        "name": "AssistantDirectory"
+      },
+      {
+        "class_name": "MyAssistant",
+        "name": "MyAssistant"
+      }
+    ]
+  },
+  "worker_loaders": [{ "binding": "LOADER" }],
+  "main": "worker.ts",
+  "migrations": [
+    {
+      "new_sqlite_classes": ["AssistantDirectory", "MyAssistant"],
+      "tag": "v1"
+    }
+  ]
+}

--- a/examples/assistant/tsconfig.json
+++ b/examples/assistant/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "agents/tsconfig",
+  "exclude": ["src/tests/**/*.ts"],
   "compilerOptions": {
     "paths": {
       "@cloudflare/think": ["../../packages/think/src/think.ts"],

--- a/wip/think-multi-session-assistant-plan.md
+++ b/wip/think-multi-session-assistant-plan.md
@@ -248,13 +248,19 @@ Architectural decisions worth referencing later:
 
 ### Follow-ups queued from PR 2b
 
-- **Test infrastructure for the example.** `examples/assistant` has no
-  vitest setup, so none of the multi-chat wiring (parent state broadcast,
-  child proxy round-trips, OAuth callback dispatch) has automated
-  coverage. We've been leaning on the framework's own tests for the
-  primitives we use, plus manual verification. Worth standing up a
-  vitest+workers harness once we know the patterns are stable enough to
-  pin. **Still open as of the post-#1384 PRs (#1393/#1394/#1395/#1396).**
+- **Test infrastructure for the example — landed.** `examples/assistant`
+  now has a `src/tests/` vitest+workers harness covering directory
+  CRUD, sub-agent routing (`onBeforeSubAgent` strict-registry gate),
+  the `SharedWorkspace` cross-chat round-trip, the `workspace-change`
+  WebSocket broadcast, the `dailySummary` ordering precondition, and
+  the MCP empty-state path. 21 tests, ~6s wall clock against the
+  Workers test pool. The harness re-exports the production
+  `AssistantDirectory` and `MyAssistant` classes verbatim and replaces
+  only the GitHub-OAuth-gated Worker with a bare `routeAgentRequest`
+  fetch handler — auth is a Worker concern, not a multi-session
+  concern, and skipping it lets every test address directories by
+  name directly. See "Tests we still don't run" below for the
+  intentional gaps.
 - **Connection-count and isolate-serialization observations.** The shared
   MCP design puts every user's MCP connections on one DO isolate and
   serializes their tool calls through it. Fine at demo scale; if real
@@ -266,6 +272,40 @@ Architectural decisions worth referencing later:
 - **Per-chat MCP filter.** `SharedMCPClient.getAITools(filter?)` is a
   natural extension point if "this chat shouldn't see server X" becomes a
   want.
+
+### Tests we still don't run
+
+The harness leaves three gaps on purpose. None are blockers; each has
+a small, well-understood reason and a documented escape hatch:
+
+- **Deep MCP round-trip** (`addServer` → tool discovery → `callMcpTool`
+  with a real stub server). Two workerd test-runtime constraints made
+  this not worth fighting for v1: (a) the RPC transport requires
+  passing `env.TestMcpStub` as an argument, which fails with
+  `DataCloneError: Could not serialize DurableObjectNamespace` from
+  the vitest runner DO; (b) the HTTP transport requires the
+  directory's outbound `fetch()` to reach a stub MCP server in the
+  same worker, which vitest-pool-workers doesn't auto-route (no
+  `SELF` binding by default). The framework's
+  `add-rpc-mcp-server.test.ts` works around (a) by routing the
+  registration through a test-side Agent that calls `this.addMcpServer`
+  from inside its own DO. Replicating that here would mean adding a
+  test-only callable to the production `AssistantDirectory`, which we
+  don't want to ship in example code. The MCP empty-state test is in
+  scope; the rest is covered by the framework's own MCP tests.
+- **LLM turn flows.** `MyAssistant.beforeTurn`, `getModel`, and the
+  full chat lifecycle aren't exercised. We deliberately don't
+  declare an `AI` binding in the test wrangler — vitest-pool-workers
+  needs a wrangler login for it. Tests stop at the boundary where
+  Think's `saveMessages` would hand off to a turn fiber. Think's own
+  tests cover the inference loop in detail.
+- **GitHub OAuth flow and MCP OAuth callback dispatch.** Both live
+  in the production Worker that the test worker replaces. They're
+  Worker concerns, not multi-session concerns. Could be tested
+  separately if and when the auth flow itself becomes interesting.
+
+The harness is structured so each of these is a small, well-bounded
+follow-up, not a redesign.
 
 ### Post-#1384 maintenance that touched the multi-session story
 
@@ -511,8 +551,12 @@ This approach is deliberately opinionated:
 - Think gained the `beforeStep` lifecycle hook + `TurnConfig.output`
   passthrough in #1394 (adjacent to multi-session, but a useful new
   surface for `MyAssistant` per-step decisions)
-- `examples/assistant` still has no vitest harness; the test
-  infrastructure follow-up from PR 2b is unchanged
+- `examples/assistant` now has a vitest+workers harness (`src/tests/`)
+  covering directory CRUD, the `SharedWorkspace` cross-chat
+  round-trip, the workspace-change WebSocket broadcast, the
+  sub-agent routing gate, dailySummary ordering, and the MCP
+  empty-state path. 21 tests, runs in ~6s. See "Tests we still
+  don't run" for the intentional gaps.
 - issue #1378 tracks the `addMcpServer` enforcement ergonomics follow-up
 
 ## Likely next action
@@ -534,12 +578,7 @@ deserve to be promoted into framework primitives, and which package owns
 each. With one full consumer in hand and the proxy/`*Like` patterns
 proving useful at the library level, the answer should be clearer.
 
-Test infrastructure for `examples/assistant` is the open follow-up most
-likely to bite next: every cross-cutting fix that lands in the
-chat-shared-layer (the four post-#1384 PRs being the latest examples)
-has to be sanity-checked through the assistant by hand, because the
-example itself has no automated coverage of its multi-session wiring.
-A minimal vitest+workers harness covering the parent state broadcast,
-child proxy round-trips, and the OAuth callback dispatch would be
-worth standing up before PR 3 lands, so we have a fixed point to
-verify the new hook home against.
+Test infrastructure for `examples/assistant` (the open follow-up that
+was most likely to bite) has now landed. PR 3 will be able to
+verify the hoisted hook against a real assistant harness rather than
+through manual sanity-checks.


### PR DESCRIPTION
## Summary

Adds the first automated coverage of `examples/assistant`. The harness re-exports the production `AssistantDirectory` and `MyAssistant` classes verbatim and replaces only the GitHub-OAuth-gated Worker with a bare `routeAgentRequest` fetch handler — auth is a Worker concern, separate from multi-session correctness, so skipping it in tests lets every case address directories by name directly.

**21 tests, ~6s wall clock** against `@cloudflare/vitest-pool-workers`.

## What's covered

| File | Surface under test |
| --- | --- |
| `directory.test.ts` | Chat CRUD, sidebar `state.chats` ↔ `listSubAgents` consistency, `recordChatTurn` ordering, idempotent `deleteChat`. State is read via the same `cf_agent_state` WebSocket frame the real client uses, since `Agent.state` is a getter rather than an `@callable`. |
| `routing.test.ts` | `onBeforeSubAgent` strict-registry gate. 404 for unknown chat ids, 101 (WebSocket upgrade) for chats created via `createChat`, 404 again after `deleteChat`. |
| `shared-workspace.test.ts` | The headline cross-chat round-trip: a file written via the directory is read back through chat B's `SharedWorkspace` proxy, exercising `parentAgent(AssistantDirectory)` resolution and the proxy's lazy stub caching. |
| `workspace-broadcast.test.ts` | The directory's `onChange → this.broadcast(...)` pipeline. Pins the `{ type: "workspace-change", event }` frame shape that `useChats()` keys `workspaceRevision` off, for both `writeFile` and `rm`. |
| `daily-summary.test.ts` | Empty-state no-op + the most-recently-updated ordering precondition that `dailySummary` relies on. |
| `shared-mcp.test.ts` | MCP empty-state path. Deeper round-trip is scoped out for now; see below. |

## Tests we still don't run (by design)

| Gap | Why |
| --- | --- |
| **Deep MCP round-trip** (`addServer` → tool discovery → `callMcpTool` against a real stub) | Two workerd test-runtime constraints: (a) RPC transport requires passing `env.TestMcpStub` from the runner DO, which fails with `DataCloneError: Could not serialize DurableObjectNamespace`; (b) HTTP transport requires the directory's outbound `fetch()` to reach a stub MCP server in the same worker, which `vitest-pool-workers` doesn't auto-route. The framework's own `add-rpc-mcp-server.test.ts` works around (a) by routing the registration through a test-side Agent that calls `this.addMcpServer` from inside its own DO. Replicating that here would require a test-only callable on the production class. The framework's MCP tests already cover the underlying machinery. |
| **LLM turn flows** | We deliberately don't declare an `AI` binding (vitest-pool-workers needs a wrangler login for it). Tests stop at the boundary where Think's `saveMessages` would hand off to a turn fiber. Think's own tests cover the inference loop in detail. |
| **GitHub OAuth + MCP OAuth callback dispatch** | Live in the production Worker that the test worker replaces. Worker concerns, not multi-session concerns. |

`wip/think-multi-session-assistant-plan.md` documents each gap with the same context so future contributors don't have to relitigate.

## Plumbing

- `vitest.config.ts` — `cloudflareTest` plugin, `agents()` vite plugin, `ajv` SSR optimizer hint (mirrors `agents`/`ai-chat` test configs).
- `wrangler.jsonc` — DO bindings for both classes + `worker_loaders` (`MyAssistant.extensionLoader = this.env.LOADER` is a class field). No AI binding.
- `worker.ts` — re-exports prod classes, bare `routeAgentRequest`.
- `helpers.ts` — `connectWS`, `nextMessage`, `waitForMatching`, `readDirectoryState`, `uniqueDirectoryName`.
- `env.d.ts` — wires the test worker's Env into the `Cloudflare`/global ambient declarations and re-declares the prod `AI` / `GITHUB_*` keys so `src/server.ts` and `src/auth.ts` typecheck cleanly under the test tsconfig.
- `examples/assistant/package.json` gains a `test` script that nx picks up via `npm run test`.
- `examples/assistant/tsconfig.json` excludes `src/tests/**` so the parent project doesn't double-typecheck the test files.

## Test plan

- [x] `cd examples/assistant && npm run test` → 21 passed
- [x] `npx tsc -p src/tests/tsconfig.json` clean
- [x] `npx tsc -p tsconfig.json` clean
- [x] `npx tsx scripts/typecheck.ts` — all 76 projects green
- [x] `npx oxlint examples/assistant/src/tests/` clean
- [ ] CI (`npm run check && npm run test`) green on this branch


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
