### PR TITLE
fix(ai-chat): stop provider tool-call replays from regressing tool part state (#1404)

### DIFF
--- a/.changeset/agents-isreplay-chunk-helper.md
+++ b/.changeset/agents-isreplay-chunk-helper.md
@@ -1,0 +1,15 @@
+---
+"agents": patch
+---
+
+Make `applyChunkToParts` idempotent against an existing tool part with the same `toolCallId`, and add `isReplayChunk(parts, chunk)` for stream broadcasters that want to drop provider replay chunks ([#1404](https://github.com/cloudflare/agents/issues/1404)).
+
+Some providers (notably the OpenAI Responses API) re-emit a prior tool call in continuation streams. The previous `tool-input-start` handler unconditionally pushed a fresh tool part, which produced duplicate parts in the message; `tool-input-delta` and `tool-input-available` overwrote a fully resolved input/state if a chunk happened to arrive for an already-known toolCallId. The new behavior:
+
+- `tool-input-start` for a `toolCallId` that already exists in `parts` is a no-op (it does not push a duplicate or regress state).
+- `tool-input-delta` only mutates input while the existing part is still `input-streaming`.
+- `tool-input-available` only advances from `input-streaming` to `input-available`; replays against parts that have already moved past `input-streaming` (including `approval-requested`/`approval-responded` and any terminal state) are no-ops.
+
+`isReplayChunk(parts, chunk)` is exported from `agents/chat` for stream broadcasters (e.g. `AIChatAgent._streamSSEReply`) that want to detect "this chunk is a replay of an already-known tool call" and skip re-broadcasting it. AI SDK v6's `updateToolPart` on the client mutates an existing tool part in place when the toolCallId matches, so re-broadcasting these replay chunks would visibly regress an `output-available` part to `input-streaming` on connected clients. `tool-output-available` is _not_ treated as a replay because its in-place update is safe when the output already matches.
+
+Tool calls that the model genuinely wants to re-issue always carry a new toolCallId, so an existing match is never a legitimate "start over".

--- a/.changeset/ai-chat-tool-replay-regression.md
+++ b/.changeset/ai-chat-tool-replay-regression.md
@@ -1,0 +1,14 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Stop provider tool-call replays from regressing tool part state during continuation streams ([#1404](https://github.com/cloudflare/agents/issues/1404)).
+
+Some providers (notably the OpenAI Responses API) re-emit prior tool calls in continuation streams as a `tool-input-start` → `tool-input-delta` → `tool-input-available` → `tool-output-available` sequence carrying the _same_ `toolCallId` and the _same_ `output` the part already holds. The AI SDK's `updateToolPart` mutates an existing tool part in place when the toolCallId matches, so a replayed `tool-input-start` was clobbering an `output-available` part back to `input-streaming` on the client and producing the worker warn `_applyToolResult: Tool part with toolCallId X not in expected state`.
+
+Two fixes:
+
+- `_streamSSEReply` now drops replay tool-input chunks before broadcasting them to clients or storing them for resume, using the new shared `isReplayChunk` helper. The cloned server-side streaming message is never corrupted because `applyChunkToParts` is idempotent against existing toolCallIds for these chunk types (also fixed below).
+- `_applyToolResult` accepts `output-available` and `output-error` as valid starting states for _idempotent_ re-application. A duplicate `cf_agent_tool_result` (cross-tab re-run, redelivered WS frame, provider replay round-trip) is now a silent no-op rather than a warn + skipped update. The cross-message `tool-output-available`/`tool-output-error` fallback in `_streamSSEReply` gets the same tolerance.
+
+`_findAndUpdateToolPart` skips the SQLite write and `MESSAGE_UPDATED` broadcast when the apply produced no semantic change, so idempotent re-applies don't churn UI on connected tabs.

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -1,5 +1,6 @@
 export {
   applyChunkToParts,
+  isReplayChunk,
   type MessageParts,
   type MessagePart,
   type StreamChunkData

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -182,6 +182,22 @@ export function applyChunkToParts(
     }
 
     case "tool-input-start": {
+      // Idempotent against an existing tool part with the same toolCallId.
+      // Some providers (notably the OpenAI Responses API) replay prior
+      // tool calls in continuation streams as a fresh `tool-input-start`
+      // → `tool-input-delta` → `tool-input-available` →
+      // `tool-output-available` sequence carrying the original toolCallId
+      // and original output. Without this guard a replay would push a
+      // duplicate part into the streaming message *and* clobber the
+      // original part's state when the AI SDK's mutate-in-place
+      // `updateToolPart` processes the replay on the client (issue #1404).
+      // A model that genuinely wants a fresh tool call always emits a
+      // new toolCallId, so an existing match is never a legitimate
+      // "start over".
+      const existing = findToolPartByCallId(parts, chunk.toolCallId);
+      if (existing) {
+        return true;
+      }
       parts.push({
         type: `tool-${chunk.toolName}`,
         toolCallId: chunk.toolCallId,
@@ -200,8 +216,15 @@ export function applyChunkToParts(
     }
 
     case "tool-input-delta": {
+      // Only mutate input while the tool is still actively input-streaming.
+      // Deltas arriving after the tool has already advanced (input-available
+      // or any terminal state) are provider replay and must not regress
+      // a fully-formed input back to a partial one.
       const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
-      if (toolPart) {
+      if (
+        toolPart &&
+        (toolPart as Record<string, unknown>).state === "input-streaming"
+      ) {
         (toolPart as Record<string, unknown>).input = chunk.input;
       }
       return true;
@@ -211,33 +234,41 @@ export function applyChunkToParts(
       const existing = findToolPartByCallId(parts, chunk.toolCallId);
       if (existing) {
         const p = existing as Record<string, unknown>;
-        p.state = "input-available";
-        p.input = chunk.input;
-        if (chunk.providerExecuted != null) {
-          p.providerExecuted = chunk.providerExecuted;
+        // Only advance from the streaming-input phase. Once the tool is
+        // already at input-available or any terminal state
+        // (output-available, output-error, output-denied,
+        // approval-requested, approval-responded), this chunk is a
+        // provider replay and must not regress state or overwrite a
+        // resolved input/output. See the comment on tool-input-start.
+        if (p.state === "input-streaming") {
+          p.state = "input-available";
+          p.input = chunk.input;
+          if (chunk.providerExecuted != null) {
+            p.providerExecuted = chunk.providerExecuted;
+          }
+          if (chunk.providerMetadata != null) {
+            p.callProviderMetadata = chunk.providerMetadata;
+          }
+          if (chunk.title != null) {
+            p.title = chunk.title;
+          }
         }
-        if (chunk.providerMetadata != null) {
-          p.callProviderMetadata = chunk.providerMetadata;
-        }
-        if (chunk.title != null) {
-          p.title = chunk.title;
-        }
-      } else {
-        parts.push({
-          type: `tool-${chunk.toolName}`,
-          toolCallId: chunk.toolCallId,
-          toolName: chunk.toolName,
-          state: "input-available",
-          input: chunk.input,
-          ...(chunk.providerExecuted != null
-            ? { providerExecuted: chunk.providerExecuted }
-            : {}),
-          ...(chunk.providerMetadata != null
-            ? { callProviderMetadata: chunk.providerMetadata }
-            : {}),
-          ...(chunk.title != null ? { title: chunk.title } : {})
-        } as MessagePart);
+        return true;
       }
+      parts.push({
+        type: `tool-${chunk.toolName}`,
+        toolCallId: chunk.toolCallId,
+        toolName: chunk.toolName,
+        state: "input-available",
+        input: chunk.input,
+        ...(chunk.providerExecuted != null
+          ? { providerExecuted: chunk.providerExecuted }
+          : {}),
+        ...(chunk.providerMetadata != null
+          ? { callProviderMetadata: chunk.providerMetadata }
+          : {}),
+        ...(chunk.title != null ? { title: chunk.title } : {})
+      } as MessagePart);
       return true;
     }
 
@@ -245,6 +276,17 @@ export function applyChunkToParts(
       const existing = findToolPartByCallId(parts, chunk.toolCallId);
       if (existing) {
         const p = existing as Record<string, unknown>;
+        // First-write-wins: a tool that's already terminal must not be
+        // regressed (or re-decided as an error) by a later chunk. A
+        // tool-input-error here is either provider replay or a confused
+        // upstream — preserve the existing terminal state.
+        if (
+          p.state === "output-available" ||
+          p.state === "output-error" ||
+          p.state === "output-denied"
+        ) {
+          return true;
+        }
         p.state = "output-error";
         p.errorText = chunk.errorText;
         p.input = chunk.input;
@@ -360,6 +402,48 @@ export function applyChunkToParts(
       return false;
     }
   }
+}
+
+/**
+ * Returns true if `chunk` would be a no-op replay against the already-known
+ * `parts` — i.e. some upstream is re-emitting events for a tool call that
+ * the message has already advanced past.
+ *
+ * Used by stream broadcasters to suppress re-broadcasting these chunks to
+ * connected clients. AI SDK v6's `updateToolPart` mutates an existing tool
+ * part in place when a chunk arrives with a matching `toolCallId`, so a
+ * replayed `tool-input-start` would clobber an `output-available` part back
+ * to `input-streaming` on the client (issue #1404).
+ *
+ * Only returns true when re-broadcasting would *visibly regress* state on
+ * a v6 client. Safe-by-construction chunk types (e.g. `tool-output-available`
+ * carrying the same output the part already has) return false.
+ *
+ * Conditions:
+ * - `tool-input-start` for a `toolCallId` that already exists in `parts`.
+ * - `tool-input-delta` for a `toolCallId` whose existing part is no longer
+ *   `input-streaming`.
+ * - `tool-input-available` for a `toolCallId` whose existing part is no
+ *   longer `input-streaming` (i.e. has already advanced to `input-available`
+ *   or any terminal state).
+ */
+export function isReplayChunk(
+  parts: MessagePart[],
+  chunk: StreamChunkData
+): boolean {
+  if (
+    chunk.type !== "tool-input-start" &&
+    chunk.type !== "tool-input-delta" &&
+    chunk.type !== "tool-input-available"
+  ) {
+    return false;
+  }
+  if (!chunk.toolCallId) return false;
+  const existing = findToolPartByCallId(parts, chunk.toolCallId);
+  if (!existing) return false;
+  if (chunk.type === "tool-input-start") return true;
+  const state = (existing as Record<string, unknown>).state;
+  return state !== "input-streaming";
 }
 
 /**

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -24,6 +24,7 @@ import { autoTransformMessages } from "./ai-chat-v5-migration";
 import { reconcileMessages, resolveToolMergeId } from "agents/chat";
 import {
   applyChunkToParts,
+  isReplayChunk,
   sanitizeMessage,
   byteLength as chatByteLength,
   ROW_MAX_BYTES,
@@ -31,6 +32,7 @@ import {
   SubmitConcurrencyController,
   type TurnResult,
   type MessagePart,
+  type StreamChunkData,
   type SubmitConcurrencyDecision
 } from "agents/chat";
 import { ResumableStream } from "agents/chat";
@@ -2775,11 +2777,17 @@ export class AIChatAgent<
    * the AI is still streaming), then retries persisted messages with backoff
    * in case streaming completes between attempts.
    *
+   * `applyUpdate` may return its argument by reference (or `{ ...part }`
+   * with no semantic changes) to signal an idempotent no-op — this is
+   * detected via `_isToolPartUnchanged` and short-circuits the SQLite
+   * write and `MESSAGE_UPDATED` broadcast.
+   *
    * @param toolCallId - The tool call ID to find
    * @param callerName - Name for log messages (e.g. "_applyToolResult")
    * @param matchStates - Which tool part states to match
    * @param applyUpdate - Mutation to apply to the matched part (streaming: in-place, persisted: spread)
-   * @returns true if the update was applied, false if not found or state didn't match
+   * @returns true if the update was applied (or matched as an idempotent
+   *   no-op), false if no matching part was found
    */
   private async _findAndUpdateToolPart(
     toolCallId: string,
@@ -2817,7 +2825,14 @@ export class AIChatAgent<
     }
 
     const isStreamingMessage = message === this._streamingMessage;
-    let updated = false;
+    // `wasFound` tracks whether any matching part was processed (real
+    // change OR idempotent no-op). `hasRealChange` tracks whether any
+    // apply actually mutated state. Tracking both separately matters
+    // when a (legacy) message somehow contains duplicate tool parts for
+    // the same toolCallId — we must still persist if any of them
+    // produced a real change, even if another was an idempotent no-op.
+    let wasFound = false;
+    let hasRealChange = false;
 
     if (isStreamingMessage) {
       // Update in place -- the message will be persisted when streaming completes
@@ -2828,9 +2843,17 @@ export class AIChatAgent<
           "state" in part &&
           matchStates.includes(part.state as string)
         ) {
+          wasFound = true;
           const applied = applyUpdate(part as Record<string, unknown>);
-          Object.assign(part, applied);
-          updated = true;
+          if (
+            !AIChatAgent._isToolPartUnchanged(
+              part as Record<string, unknown>,
+              applied
+            )
+          ) {
+            Object.assign(part, applied);
+            hasRealChange = true;
+          }
           break;
         }
       }
@@ -2843,13 +2866,23 @@ export class AIChatAgent<
           "state" in part &&
           matchStates.includes(part.state as string)
         ) {
-          updated = true;
-          return applyUpdate(part as Record<string, unknown>);
+          wasFound = true;
+          const applied = applyUpdate(part as Record<string, unknown>);
+          if (
+            AIChatAgent._isToolPartUnchanged(
+              part as Record<string, unknown>,
+              applied
+            )
+          ) {
+            return part;
+          }
+          hasRealChange = true;
+          return applied;
         }
         return part;
       }) as UIMessage["parts"];
 
-      if (updated) {
+      if (hasRealChange) {
         const updatedMessage: UIMessage = this._sanitizeMessageForPersistence({
           ...message,
           parts: updatedParts
@@ -2869,11 +2902,19 @@ export class AIChatAgent<
       }
     }
 
-    if (!updated) {
+    if (!wasFound) {
       console.warn(
         `[AIChatAgent] ${callerName}: Tool part with toolCallId ${toolCallId} not in expected state (expected: ${matchStates.join("|")})`
       );
       return false;
+    }
+
+    // Idempotent no-op: caller asked us to apply something we'd already
+    // applied (e.g. a duplicate cf_agent_tool_result, or a cross-tab
+    // re-delivery). Skip the broadcast — clients are already in the
+    // correct state and a redundant MESSAGE_UPDATED would just churn UI.
+    if (!hasRealChange) {
+      return true;
     }
 
     // Broadcast the update to all clients.
@@ -2899,10 +2940,59 @@ export class AIChatAgent<
   }
 
   /**
+   * Returns true if `applied` is the same reference as `original`, or if
+   * the two have identical state-relevant fields. Used by
+   * `_findAndUpdateToolPart` to detect idempotent re-applies and skip
+   * SQLite writes plus `MESSAGE_UPDATED` broadcasts.
+   */
+  private static _isToolPartUnchanged(
+    original: Record<string, unknown>,
+    applied: Record<string, unknown>
+  ): boolean {
+    if (applied === original) return true;
+    if (applied.state !== original.state) return false;
+    // For terminal output states, the only fields the apply functions
+    // touch are output / errorText / preliminary. Compare via JSON so
+    // structurally equal outputs (the common idempotent case) compare
+    // equal regardless of reference identity.
+    if (
+      applied.state === "output-available" ||
+      applied.state === "output-error"
+    ) {
+      return (
+        JSON.stringify(applied.output) === JSON.stringify(original.output) &&
+        applied.errorText === original.errorText &&
+        applied.preliminary === original.preliminary
+      );
+    }
+    if (applied.state === "output-denied") {
+      return true;
+    }
+    if (
+      applied.state === "approval-responded" ||
+      applied.state === "approval-requested"
+    ) {
+      return (
+        JSON.stringify(applied.approval) === JSON.stringify(original.approval)
+      );
+    }
+    return false;
+  }
+
+  /**
    * Applies a tool result to an existing assistant message.
    * This is used when the client sends CF_AGENT_TOOL_RESULT for client-side tools.
    * The server is the source of truth, so we update the message here and broadcast
    * the update to all clients.
+   *
+   * `output-available` and `output-error` are accepted as valid starting
+   * states for *idempotent* re-application — duplicate WS frames, second
+   * tabs re-running the same tool, and provider-replay round-trips all
+   * become silent no-ops rather than a warn + skipped update. The first
+   * applied terminal result wins; subsequent results carrying *different*
+   * data are also dropped (preserving the existing "first write wins"
+   * contract — see `client-tool-duplicate-message.test.ts`). See issue
+   * #1404.
    *
    * @param toolCallId - The tool call ID this result is for
    * @param _toolName - The name of the tool (unused, kept for API compat)
@@ -2921,16 +3011,42 @@ export class AIChatAgent<
     return this._findAndUpdateToolPart(
       toolCallId,
       "_applyToolResult",
-      ["input-available", "approval-requested", "approval-responded"],
-      (part) => ({
-        ...part,
-        ...(overrideState === "output-error"
-          ? {
-              state: "output-error",
-              errorText: errorText ?? "Tool execution denied by user"
-            }
-          : { state: "output-available", output, preliminary: false })
-      })
+      [
+        "input-available",
+        "approval-requested",
+        "approval-responded",
+        // Idempotent re-apply: if the part is already terminal, the apply
+        // function below returns the part by reference. _findAndUpdateToolPart
+        // detects that and skips the persist + broadcast (and the warn).
+        "output-available",
+        "output-error",
+        "output-denied"
+      ],
+      (part) => {
+        // Once a tool part has reached a terminal state, the first applied
+        // result wins. Don't overwrite with conflicting data, and don't
+        // emit a redundant MESSAGE_UPDATED for a matching re-apply.
+        if (
+          part.state === "output-available" ||
+          part.state === "output-error" ||
+          part.state === "output-denied"
+        ) {
+          return part;
+        }
+        if (overrideState === "output-error") {
+          return {
+            ...part,
+            state: "output-error",
+            errorText: errorText ?? "Tool execution denied by user"
+          };
+        }
+        return {
+          ...part,
+          state: "output-available",
+          output,
+          preliminary: false
+        };
+      }
     );
   }
 
@@ -3037,6 +3153,32 @@ export class AIChatAgent<
               }
             }
 
+            // Drop replay chunks before applying or broadcasting them.
+            //
+            // Some providers (notably the OpenAI Responses API) re-emit
+            // prior tool calls as a fresh `tool-input-start` →
+            // `tool-input-delta` → `tool-input-available` sequence
+            // carrying the *same* `toolCallId` during continuation
+            // streams. AI SDK v6's `updateToolPart` finds an existing
+            // part by toolCallId and mutates it in place, which
+            // visibly regresses an `output-available` part back to
+            // `input-streaming`/`input-available` on the client
+            // (issue #1404).
+            //
+            // `applyChunkToParts` handles the server-side cloned
+            // streaming message safely (it's idempotent for these
+            // chunk types), but we must also stop these chunks from
+            // reaching the client-side AI SDK, where the in-place
+            // mutation would corrupt a resolved tool part.
+            //
+            // `tool-output-available` is not filtered: its in-place
+            // update sets state and output to the values the part
+            // already has when the replay matches, so it's
+            // semantically a no-op on the client too.
+            if (isReplayChunk(message.parts, data as StreamChunkData)) {
+              continue;
+            }
+
             // Delegate message building to the shared parser.
             // It handles: text, reasoning, file, source, tool lifecycle,
             // step boundaries — all the part types needed for UIMessage.
@@ -3082,6 +3224,14 @@ export class AIChatAgent<
             // Note: checked independently of `handled` — applyChunkToParts
             // returns true for recognized chunk types even when it cannot
             // find the target part, so `handled` is not a reliable signal.
+            //
+            // `output-available` and `output-error` are accepted as
+            // starting states for idempotent re-application. Some
+            // providers (notably the OpenAI Responses API) replay the
+            // entire prior tool round-trip during continuations — the
+            // replay's tool-output-available carries the same output the
+            // part already has, so the apply functions below short-circuit
+            // to a no-op via reference equality (issue #1404).
             if (
               (data.type === "tool-output-available" ||
                 data.type === "tool-output-error") &&
@@ -3099,16 +3249,31 @@ export class AIChatAgent<
                       "input-available",
                       "input-streaming",
                       "approval-responded",
-                      "approval-requested"
+                      "approval-requested",
+                      "output-available",
+                      "output-error",
+                      "output-denied"
                     ],
-                    (part) => ({
-                      ...part,
-                      state: "output-available",
-                      output: data.output,
-                      ...(data.preliminary !== undefined && {
-                        preliminary: data.preliminary
-                      })
-                    })
+                    (part) => {
+                      // First-write-wins: a chunk arriving for a tool
+                      // that's already terminal is a provider replay.
+                      // Never overwrite a resolved tool's output.
+                      if (
+                        part.state === "output-available" ||
+                        part.state === "output-error" ||
+                        part.state === "output-denied"
+                      ) {
+                        return part;
+                      }
+                      return {
+                        ...part,
+                        state: "output-available",
+                        output: data.output,
+                        ...(data.preliminary !== undefined && {
+                          preliminary: data.preliminary
+                        })
+                      };
+                    }
                   );
                 } else {
                   this._findAndUpdateToolPart(
@@ -3118,13 +3283,25 @@ export class AIChatAgent<
                       "input-available",
                       "input-streaming",
                       "approval-responded",
-                      "approval-requested"
+                      "approval-requested",
+                      "output-available",
+                      "output-error",
+                      "output-denied"
                     ],
-                    (part) => ({
-                      ...part,
-                      state: "output-error",
-                      errorText: data.errorText
-                    })
+                    (part) => {
+                      if (
+                        part.state === "output-available" ||
+                        part.state === "output-error" ||
+                        part.state === "output-denied"
+                      ) {
+                        return part;
+                      }
+                      return {
+                        ...part,
+                        state: "output-error",
+                        errorText: data.errorText
+                      };
+                    }
                   );
                 }
               }

--- a/packages/ai-chat/src/tests/message-builder.test.ts
+++ b/packages/ai-chat/src/tests/message-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   applyChunkToParts,
+  isReplayChunk,
   type MessageParts,
   type StreamChunkData
 } from "agents/chat";
@@ -1008,6 +1009,379 @@ describe("applyChunkToParts", () => {
       } as StreamChunkData);
       expect(handled).toBe(false);
       expect(parts.length).toBe(0);
+    });
+  });
+
+  // Issue #1404: providers can replay prior tool calls in continuation
+  // streams (notably the OpenAI Responses API), and AI SDK v6's
+  // updateToolPart mutates an existing tool part in place when the
+  // toolCallId matches. Without these guards a replayed tool-input-start
+  // would either push a duplicate tool part on the server or visibly
+  // regress an output-available part back to input-streaming on the
+  // client.
+  describe("tool-input-* idempotency against existing tool parts (issue #1404)", () => {
+    function makeResolvedToolPart(
+      toolCallId: string,
+      toolName: string,
+      input: unknown,
+      output: unknown
+    ): MessageParts {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId,
+        toolName
+      });
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId,
+        toolName,
+        input
+      });
+      applyChunkToParts(parts, {
+        type: "tool-output-available",
+        toolCallId,
+        output
+      });
+      return parts;
+    }
+
+    it("tool-input-start does not push a duplicate part for an existing toolCallId", () => {
+      const parts = makeResolvedToolPart(
+        "call_1",
+        "getWeather",
+        { city: "London" },
+        "Sunny, 22C"
+      );
+      const handled = applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      expect(handled).toBe(true);
+      expect(parts.length).toBe(1);
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.state).toBe("output-available");
+      expect(part.input).toEqual({ city: "London" });
+      expect(part.output).toBe("Sunny, 22C");
+    });
+
+    it("tool-input-start does not regress an in-flight tool part", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      // Provider replays the start chunk for the same toolCallId — must
+      // not regress state from input-available back to input-streaming
+      // and must not wipe the input.
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      expect(parts.length).toBe(1);
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.state).toBe("input-available");
+      expect(part.input).toEqual({ city: "London" });
+    });
+
+    it("tool-input-delta does not corrupt input on an already-resolved tool", () => {
+      const parts = makeResolvedToolPart(
+        "call_1",
+        "getWeather",
+        { city: "London" },
+        "Sunny"
+      );
+      applyChunkToParts(parts, {
+        type: "tool-input-delta",
+        toolCallId: "call_1",
+        input: {}
+      });
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.input).toEqual({ city: "London" });
+      expect(part.state).toBe("output-available");
+      expect(part.output).toBe("Sunny");
+    });
+
+    it("tool-input-delta still updates input while still streaming", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      applyChunkToParts(parts, {
+        type: "tool-input-delta",
+        toolCallId: "call_1",
+        input: { city: "Lon" }
+      });
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.input).toEqual({ city: "Lon" });
+      expect(part.state).toBe("input-streaming");
+    });
+
+    it("tool-input-available does not regress an already-resolved tool", () => {
+      const parts = makeResolvedToolPart(
+        "call_1",
+        "getWeather",
+        { city: "London" },
+        "Sunny"
+      );
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.state).toBe("output-available");
+      expect(part.input).toEqual({ city: "London" });
+      expect(part.output).toBe("Sunny");
+    });
+
+    it("tool-input-available does not regress an approval-requested part", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "deleteUser"
+      });
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "deleteUser",
+        input: { userId: "u_42" }
+      });
+      applyChunkToParts(parts, {
+        type: "tool-approval-request",
+        toolCallId: "call_1",
+        approvalId: "approval_1"
+      });
+      // Replayed tool-input-available must not flip approval-requested
+      // back to input-available and drop the approval object.
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "deleteUser",
+        input: { userId: "u_42" }
+      });
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.state).toBe("approval-requested");
+      expect(part.approval).toEqual({ id: "approval_1" });
+    });
+
+    it("full provider replay of a resolved tool call leaves the part untouched", () => {
+      const parts = makeResolvedToolPart(
+        "call_1",
+        "changeBackground",
+        { color: "green" },
+        { success: true }
+      );
+      const before = JSON.parse(JSON.stringify(parts));
+
+      // Replay the full original tool round-trip — exactly the chunk
+      // sequence observed in issue #1404.
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "changeBackground"
+      });
+      applyChunkToParts(parts, {
+        type: "tool-input-delta",
+        toolCallId: "call_1",
+        input: {}
+      });
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "changeBackground",
+        input: { color: "green" }
+      });
+      applyChunkToParts(parts, {
+        type: "tool-output-available",
+        toolCallId: "call_1",
+        output: { success: true }
+      });
+
+      expect(parts).toEqual(before);
+      expect(parts.length).toBe(1);
+    });
+
+    it("tool-input-error does not regress an already-resolved tool", () => {
+      const parts = makeResolvedToolPart(
+        "call_1",
+        "getWeather",
+        { city: "London" },
+        "Sunny"
+      );
+      applyChunkToParts(parts, {
+        type: "tool-input-error",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: '{"city": "Lond',
+        errorText: "Unexpected end of JSON input"
+      });
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.state).toBe("output-available");
+      expect(part.output).toBe("Sunny");
+      expect(part.errorText).toBeUndefined();
+      expect(part.input).toEqual({ city: "London" });
+    });
+
+    it("tool-input-error still transitions an in-flight tool to output-error", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      applyChunkToParts(parts, {
+        type: "tool-input-error",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: '{"city": "Lond',
+        errorText: "Unexpected end of JSON input"
+      });
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.state).toBe("output-error");
+      expect(part.errorText).toBe("Unexpected end of JSON input");
+    });
+  });
+
+  describe("isReplayChunk (issue #1404)", () => {
+    it("returns false for non-tool-input chunk types", () => {
+      const parts = makeParts();
+      expect(
+        isReplayChunk(parts, {
+          type: "text-start",
+          id: "t1"
+        })
+      ).toBe(false);
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-output-available",
+          toolCallId: "call_1",
+          output: "x"
+        })
+      ).toBe(false);
+    });
+
+    it("returns false for tool-input-start with a new toolCallId", () => {
+      const parts = makeParts();
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-input-start",
+          toolCallId: "call_1",
+          toolName: "getWeather"
+        })
+      ).toBe(false);
+    });
+
+    it("returns true for tool-input-start matching an existing toolCallId", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-input-start",
+          toolCallId: "call_1",
+          toolName: "getWeather"
+        })
+      ).toBe(true);
+    });
+
+    it("returns false for tool-input-delta while still input-streaming", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-input-delta",
+          toolCallId: "call_1",
+          input: { city: "Lon" }
+        })
+      ).toBe(false);
+    });
+
+    it("returns true for tool-input-delta on a resolved tool part", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      applyChunkToParts(parts, {
+        type: "tool-output-available",
+        toolCallId: "call_1",
+        output: "Sunny"
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-input-delta",
+          toolCallId: "call_1",
+          input: {}
+        })
+      ).toBe(true);
+    });
+
+    it("returns true for tool-input-available on an already-input-available part", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-input-available",
+          toolCallId: "call_1",
+          toolName: "getWeather",
+          input: { city: "London" }
+        })
+      ).toBe(true);
+    });
+
+    it("returns false for tool-input-available when no existing part matches", () => {
+      const parts = makeParts();
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-input-available",
+          toolCallId: "call_unknown",
+          toolName: "getWeather",
+          input: { city: "London" }
+        })
+      ).toBe(false);
+    });
+
+    it("returns false when toolCallId is missing", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-start",
+        toolCallId: "call_1",
+        toolName: "getWeather"
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-input-start",
+          toolName: "getWeather"
+        })
+      ).toBe(false);
     });
   });
 });

--- a/packages/ai-chat/src/tests/tool-result-replay.test.ts
+++ b/packages/ai-chat/src/tests/tool-result-replay.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Issue #1404 — provider replay of prior tool calls during continuation
+ * streams must not regress tool part state, must not warn on idempotent
+ * re-applies, and must not produce duplicate tool parts in the persisted
+ * message.
+ *
+ * Two layers are exercised:
+ *
+ * 1. The server's `_streamSSEReply` filters replay tool-input-* chunks
+ *    via `isReplayChunk` so they are neither broadcast to clients nor
+ *    persisted in the resumable-stream chunk store. (The downstream
+ *    AI SDK on the client mutates an existing tool part in place when a
+ *    chunk arrives with a matching toolCallId, which would clobber an
+ *    `output-available` part back to `input-streaming` if these chunks
+ *    were forwarded.)
+ *
+ * 2. `_applyToolResult` accepts `output-available` / `output-error` as
+ *    starting states and short-circuits to a no-op when the incoming
+ *    result matches what the part already holds. This handles duplicate
+ *    cf_agent_tool_result frames (cross-tab re-runs, WS redelivery)
+ *    without the spurious "not in expected state" warn.
+ */
+import { env } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+import { MessageType } from "../types";
+import type { UIMessage as ChatMessage } from "ai";
+import { connectChatWS } from "./test-utils";
+import { getAgentByName } from "agents";
+
+function collectMessages(ws: WebSocket): Array<Record<string, unknown>> {
+  const messages: Array<Record<string, unknown>> = [];
+  ws.addEventListener("message", (e: MessageEvent) => {
+    const data = JSON.parse(e.data as string);
+    if (typeof data === "object" && data !== null) {
+      messages.push(data as Record<string, unknown>);
+    }
+  });
+  return messages;
+}
+
+async function waitForMessage(
+  messages: Array<Record<string, unknown>>,
+  predicate: (message: Record<string, unknown>) => boolean,
+  timeoutMs = 3000
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const match = messages.find(predicate);
+    if (match) {
+      return match;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return undefined;
+}
+
+function getToolPart(
+  message: ChatMessage,
+  toolCallId: string
+): Record<string, unknown> | undefined {
+  return message.parts.find(
+    (
+      part
+    ): part is ChatMessage["parts"][number] & {
+      toolCallId: string;
+    } => "toolCallId" in part && part.toolCallId === toolCallId
+  ) as Record<string, unknown> | undefined;
+}
+
+describe("Tool result idempotency (issue #1404)", () => {
+  it("re-applying the same tool result is a silent no-op (no warn, no broadcast)", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg-idempotent",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+    const toolCallId = "call_idempotent_apply";
+    const output = { success: true, color: "green" };
+
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-idempotent",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId,
+            state: "input-available",
+            input: { color: "green" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    // First apply: legitimate transition input-available → output-available.
+    const firstApplied = await agentStub.testApplyToolResult(
+      toolCallId,
+      "changeBackgroundColor",
+      output
+    );
+    expect(firstApplied).toBe(true);
+
+    // Persisted state has the tool at output-available with the right output.
+    {
+      const persisted =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      const tool = getToolPart(
+        persisted.find((m) => m.role === "assistant") as ChatMessage,
+        toolCallId
+      );
+      expect(tool?.state).toBe("output-available");
+      expect(tool?.output).toEqual(output);
+    }
+
+    // Re-collect messages from this point so we only count broadcasts
+    // emitted by the second (idempotent) apply.
+    const broadcasts = collectMessages(ws);
+
+    // Second apply with the same output — must NOT warn, must NOT
+    // broadcast a redundant MESSAGE_UPDATED.
+    const secondApplied = await agentStub.testApplyToolResult(
+      toolCallId,
+      "changeBackgroundColor",
+      output
+    );
+    expect(secondApplied).toBe(true);
+
+    // Give any spurious broadcast a chance to arrive.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const updatedBroadcasts = broadcasts.filter(
+      (m) => m.type === MessageType.CF_AGENT_MESSAGE_UPDATED
+    );
+    expect(updatedBroadcasts).toHaveLength(0);
+
+    // State is still right.
+    {
+      const persisted =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      const tool = getToolPart(
+        persisted.find((m) => m.role === "assistant") as ChatMessage,
+        toolCallId
+      );
+      expect(tool?.state).toBe("output-available");
+      expect(tool?.output).toEqual(output);
+    }
+
+    ws.close(1000);
+  });
+
+  it("re-applying the same output-error is a silent no-op", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg-idempotent-err",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+    const toolCallId = "call_idempotent_apply_err";
+    const errorText = "user denied";
+
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-idempotent-err",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId,
+            state: "input-available",
+            input: { color: "green" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    expect(
+      await agentStub.testApplyToolResult(
+        toolCallId,
+        "changeBackgroundColor",
+        undefined,
+        "output-error",
+        errorText
+      )
+    ).toBe(true);
+
+    const broadcasts = collectMessages(ws);
+
+    expect(
+      await agentStub.testApplyToolResult(
+        toolCallId,
+        "changeBackgroundColor",
+        undefined,
+        "output-error",
+        errorText
+      )
+    ).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const updatedBroadcasts = broadcasts.filter(
+      (m) => m.type === MessageType.CF_AGENT_MESSAGE_UPDATED
+    );
+    expect(updatedBroadcasts).toHaveLength(0);
+
+    const persisted = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const tool = getToolPart(
+      persisted.find((m) => m.role === "assistant") as ChatMessage,
+      toolCallId
+    );
+    expect(tool?.state).toBe("output-error");
+    expect(tool?.errorText).toBe(errorText);
+
+    ws.close(1000);
+  });
+
+  it("legacy duplicate tool parts: real change to one part is still persisted even if another duplicate is already terminal", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg-dup",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+    const toolCallId = "call_dup";
+    const realOutput = { success: true, color: "green" };
+
+    // Seed a (legacy) message with two parts sharing the same toolCallId:
+    // one already at output-available (no-op on re-apply), one still at
+    // input-available (must transition on apply).
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-dup",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId,
+            state: "output-available",
+            input: { color: "green" },
+            output: { success: true, color: "green-old" }
+          },
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId,
+            state: "input-available",
+            input: { color: "green" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    expect(
+      await agentStub.testApplyToolResult(
+        toolCallId,
+        "changeBackgroundColor",
+        realOutput
+      )
+    ).toBe(true);
+
+    // The terminal-state duplicate must be preserved (first-write-wins),
+    // and the input-available duplicate must transition to output-available.
+    const persisted = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const assistantMessages = persisted.filter((m) => m.role === "assistant");
+    const allToolParts = assistantMessages.flatMap((m) =>
+      m.parts.filter((p) => "toolCallId" in p && p.toolCallId === toolCallId)
+    ) as Array<Record<string, unknown>>;
+
+    expect(allToolParts).toHaveLength(2);
+    // Original terminal part untouched (first-write-wins).
+    expect(allToolParts[0].state).toBe("output-available");
+    expect(allToolParts[0].output).toEqual({
+      success: true,
+      color: "green-old"
+    });
+    // Previously-non-terminal part transitioned to output-available
+    // with the new output.
+    expect(allToolParts[1].state).toBe("output-available");
+    expect(allToolParts[1].output).toEqual(realOutput);
+
+    ws.close(1000);
+  });
+
+  it("legitimate transition still broadcasts (regression guard for the no-op detection)", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg-broadcast",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+    const toolCallId = "call_first_apply_broadcast";
+    const output = { success: true };
+
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-broadcast",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId,
+            state: "input-available",
+            input: { color: "blue" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    const broadcasts = collectMessages(ws);
+
+    expect(
+      await agentStub.testApplyToolResult(
+        toolCallId,
+        "changeBackgroundColor",
+        output
+      )
+    ).toBe(true);
+
+    const update = (await waitForMessage(
+      broadcasts,
+      (m) => m.type === MessageType.CF_AGENT_MESSAGE_UPDATED
+    )) as { message: ChatMessage } | undefined;
+    expect(update).toBeDefined();
+    const tool = getToolPart(update!.message, toolCallId);
+    expect(tool?.state).toBe("output-available");
+    expect(tool?.output).toEqual(output);
+
+    ws.close(1000);
+  });
+});
+
+describe("Tool replay chunks during continuation (issue #1404)", () => {
+  it("replayed tool-input-*/tool-output-available chunks are not forwarded to clients", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    const userMessage: ChatMessage = {
+      id: "msg-replay",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    };
+    const toolCallId = "call_replay";
+    const toolName = "changeBackgroundColor";
+    const input = { color: "green" };
+    const output = { success: true };
+
+    // Drive an initial chat turn so the request body — including the
+    // replay knobs — gets persisted as the auto-continuation body.
+    {
+      let resolveInitialDone: (value: boolean) => void;
+      const initialDonePromise = new Promise<boolean>((res) => {
+        resolveInitialDone = res;
+      });
+      const initialTimeout = setTimeout(() => resolveInitialDone(false), 3000);
+      ws.addEventListener("message", function initialHandler(e: MessageEvent) {
+        const data = JSON.parse(e.data as string);
+        if (data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && data.done) {
+          clearTimeout(initialTimeout);
+          resolveInitialDone(true);
+          ws.removeEventListener("message", initialHandler);
+        }
+      });
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+          id: "req-replay",
+          init: {
+            method: "POST",
+            body: JSON.stringify({
+              messages: [userMessage],
+              replayPriorToolCall: true,
+              replayToolCallId: toolCallId,
+              replayToolName: toolName,
+              replayInput: input,
+              replayOutput: output
+            })
+          }
+        })
+      );
+      const ok = await initialDonePromise;
+      expect(ok).toBe(true);
+    }
+
+    // Seed an assistant message that already has the tool at output-available
+    // — this is what the cloned _streamingMessage will look like when the
+    // continuation begins.
+    await agentStub.persistMessages([
+      userMessage,
+      {
+        id: "assistant-replay",
+        role: "assistant",
+        parts: [
+          {
+            type: `tool-${toolName}`,
+            toolCallId,
+            state: "output-available",
+            input,
+            output
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    const receivedMessages = collectMessages(ws);
+
+    // Trigger the continuation by re-sending the (already-applied)
+    // tool result with autoContinue. The continuation will hit the
+    // replayPriorToolCall branch in onChatMessage and emit the
+    // tool-input-start → delta → available → output-available
+    // sequence. With the issue #1404 fix those replay chunks must
+    // not be forwarded as CF_AGENT_USE_CHAT_RESPONSE bodies.
+    ws.send(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_TOOL_RESULT,
+        toolCallId,
+        toolName,
+        output,
+        autoContinue: true
+      })
+    );
+
+    // Wait for the continuation stream to finish.
+    const doneMessage = await waitForMessage(
+      receivedMessages,
+      (m) =>
+        m.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+        m.done === true &&
+        m.continuation === true,
+      5000
+    );
+    expect(doneMessage).toBeDefined();
+
+    // Inspect every chunk body broadcast during the continuation.
+    const replayTypes = ["tool-input-start", "tool-input-delta"];
+    const forwardedReplayChunks = receivedMessages
+      .filter(
+        (m) =>
+          m.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+          typeof m.body === "string" &&
+          (m as { body: string }).body.length > 0
+      )
+      .map((m) => {
+        try {
+          return JSON.parse((m as { body: string }).body) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          return null;
+        }
+      })
+      .filter((chunk): chunk is Record<string, unknown> => chunk != null)
+      .filter(
+        (chunk) =>
+          replayTypes.includes(chunk.type as string) &&
+          chunk.toolCallId === toolCallId
+      );
+
+    expect(forwardedReplayChunks).toHaveLength(0);
+
+    // tool-input-available for the same toolCallId must also be filtered
+    // (it's a replay since the part is already past input-streaming).
+    const forwardedInputAvailable = receivedMessages
+      .filter(
+        (m) =>
+          m.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+          typeof m.body === "string"
+      )
+      .map((m) => {
+        try {
+          return JSON.parse((m as { body: string }).body) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          return null;
+        }
+      })
+      .filter((chunk): chunk is Record<string, unknown> => chunk != null)
+      .filter(
+        (chunk) =>
+          chunk.type === "tool-input-available" &&
+          chunk.toolCallId === toolCallId
+      );
+
+    expect(forwardedInputAvailable).toHaveLength(0);
+
+    // The persisted message must still have exactly one tool part for
+    // this toolCallId, in output-available, with the original output.
+    const persisted = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const assistantMessages = persisted.filter((m) => m.role === "assistant");
+    const allToolPartsForCall = assistantMessages.flatMap((m) =>
+      m.parts.filter((p) => "toolCallId" in p && p.toolCallId === toolCallId)
+    );
+    expect(allToolPartsForCall).toHaveLength(1);
+    const tool = allToolPartsForCall[0] as Record<string, unknown>;
+    expect(tool.state).toBe("output-available");
+    expect(tool.output).toEqual(output);
+    expect(tool.input).toEqual(input);
+
+    ws.close(1000);
+  });
+});

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -148,10 +148,69 @@ export class TestChatAgent extends AIChatAgent<Env> {
       ]);
     }
 
+    // Issue #1404: simulate the OpenAI Responses API "provider replay"
+    // pattern. When asked to continue after a tool result, some providers
+    // re-emit the prior tool call (start + delta + available) plus the
+    // result that was just supplied. Without the issue #1404 fix this
+    // would visibly regress the AI SDK's tool part state on the client.
+    if (
+      options?.body?.replayPriorToolCall === true &&
+      lastAssistant?.parts.some(
+        (part) =>
+          "toolCallId" in part &&
+          part.toolCallId === options.body?.replayToolCallId &&
+          "state" in part &&
+          part.state === "output-available"
+      )
+    ) {
+      const toolCallId = options.body.replayToolCallId as string;
+      const toolName = options.body.replayToolName as string;
+      const replayInput = options.body.replayInput;
+      const replayOutput = options.body.replayOutput;
+      return makeSSEChunkResponse([
+        { type: "start" },
+        { type: "start-step" },
+        { type: "tool-input-start", toolCallId, toolName },
+        { type: "tool-input-delta", toolCallId, input: {} },
+        {
+          type: "tool-input-available",
+          toolCallId,
+          toolName,
+          input: replayInput
+        },
+        { type: "tool-output-available", toolCallId, output: replayOutput },
+        { type: "finish-step" },
+        { type: "finish", finishReason: "tool-calls" }
+      ]);
+    }
+
     // Simple echo response for testing
     return new Response("Hello from chat agent!", {
       headers: { "Content-Type": "text/plain" }
     });
+  }
+
+  // Test helper: directly invoke the protected _applyToolResult so tests
+  // can exercise the idempotency branch without scheduling an
+  // auto-continuation (issue #1404).
+  async testApplyToolResult(
+    toolCallId: string,
+    toolName: string,
+    output: unknown,
+    overrideState?: "output-error",
+    errorText?: string
+  ): Promise<boolean> {
+    return (
+      this as unknown as {
+        _applyToolResult(
+          toolCallId: string,
+          toolName: string,
+          output: unknown,
+          overrideState?: "output-error",
+          errorText?: string
+        ): Promise<boolean>;
+      }
+    )._applyToolResult(toolCallId, toolName, output, overrideState, errorText);
   }
 
   private _getChainedContinuationRegressionResponse(): Response | undefined {


### PR DESCRIPTION
## Summary

Closes #1404. The OpenAI Responses API (and likely other providers) re-emits prior tool calls in continuation streams as a `tool-input-start` → `tool-input-delta` → `tool-input-available` → `tool-output-available` sequence carrying the **same** `toolCallId` and the **same** `output` the part already holds. AI SDK v6's `updateToolPart` mutates an existing tool part in place when the toolCallId matches, so a replayed `tool-input-start` was clobbering an `output-available` part back to `input-streaming` on the client and producing the worker warn:

```
(warn) [AIChatAgent] _applyToolResult: Tool part with toolCallId call_xxx
not in expected state (expected: input-available|approval-requested|approval-responded)
```

## What changed

### `packages/agents/src/chat/message-builder.ts`

- `applyChunkToParts` is now idempotent against an existing tool part with the same `toolCallId` for `tool-input-start`, `tool-input-delta`, `tool-input-available`, and `tool-input-error`. A replayed `tool-input-start` no longer pushes a duplicate part or regresses state; deltas/available chunks only mutate while still `input-streaming`; `tool-input-error` preserves an existing terminal state (first-write-wins).
- New exported helper `isReplayChunk(parts, chunk)` returns true when a `tool-input-*` chunk would visibly regress an AI SDK v6 client's tool part. Stream broadcasters use it to drop replay chunks before forwarding them. `tool-output-available` is intentionally not in the helper because its in-place update is safe when the data already matches.

### `packages/ai-chat/src/index.ts`

- `_streamSSEReply` calls `isReplayChunk` on each chunk and skips applying / storing / broadcasting if it's a replay. Combined with the `applyChunkToParts` idempotency, the cloned server-side streaming message stays clean and the regression-inducing chunks never reach the client.
- `_applyToolResult` accepts `output-available`, `output-error`, and `output-denied` as starting states for *idempotent* re-application. A duplicate `cf_agent_tool_result` (cross-tab re-run, redelivered WS frame, provider replay round-trip) is now a silent no-op rather than a warn + skipped update. The cross-message `tool-output-available` / `tool-output-error` fallback gets the same first-write-wins semantics.
- `_findAndUpdateToolPart` separately tracks `wasFound` (a matching part was processed) and `hasRealChange` (the apply actually mutated state). Idempotent re-applies skip the SQLite write and `MESSAGE_UPDATED` broadcast. The split also handles legacy duplicate tool parts correctly: a real change to one duplicate is still persisted even when another duplicate is already terminal.

## Why two layers

The visible regression on the client comes from the AI SDK's own `updateToolPart`, which we can't fix from this repo. So the server has to stop forwarding the regression-inducing chunks (layer 1: `isReplayChunk` filter in `_streamSSEReply`). And the worker warn comes from `_applyToolResult` not accepting an already-terminal state, which we fix by making the apply itself idempotent (layer 2). The two fixes are independent: either alone reduces the symptoms, both together kill the bug.

The pre-existing "first-write-wins" contract for terminal tool states (locked in by `client-tool-duplicate-message.test.ts`) is preserved — terminal-state re-applies always become silent no-ops, never overwrites.

## Test plan

- [x] `packages/ai-chat/src/tests/message-builder.test.ts` — new describe blocks for `tool-input-* idempotency against existing tool parts` (8 tests) and `isReplayChunk` (8 tests). Covers single-chunk regressions, the full provider replay sequence, approval-state preservation, and `tool-input-error` against terminal parts.
- [x] `packages/ai-chat/src/tests/tool-result-replay.test.ts` — new file (5 tests). Idempotent re-apply for output-available / output-error (no warn, no broadcast); regression guard that real transitions still broadcast; the full continuation-stream replay scenario verifying chunks are not forwarded; legacy duplicate-tool-part edge case.
- [x] `packages/ai-chat/src/tests/worker.ts` — adds a `replayPriorToolCall` body knob to `TestChatAgent.onChatMessage` simulating the OpenAI replay chunk pattern, and a `testApplyToolResult` helper.
- [x] `npm run check` — sherif + export checks + oxfmt + oxlint + typecheck all clean.
- [x] `packages/ai-chat` — 476/476 tests pass.
- [x] `packages/agents` — 1372/1372 tests pass (8 skipped, unchanged).
- [x] `packages/think` — 270/270 tests pass.
- [x] Two changesets included (`agents` patch + `@cloudflare/ai-chat` patch).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
