### PR TITLE
Enable alarm-backed APIs in sub-agents

### DIFF
--- a/.changeset/facet-schedules.md
+++ b/.changeset/facet-schedules.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Allow sub-agents to use alarm-backed APIs by delegating the physical Durable Object alarm to the top-level parent while executing logical work inside the owning sub-agent. This enables `schedule()`, `scheduleEvery()`, `cancelSchedule()`, `getScheduleById()`, `listSchedules()`, `keepAlive()`, `keepAliveWhile()`, `runFiber()`, and Think chat recovery inside sub-agents.
+
+Sub-agent schedules are scoped to the calling child, so sibling sub-agents cannot cancel each other's schedules by id. The deprecated synchronous `getSchedule()` and `getSchedules()` APIs now throw inside sub-agents; use the async alternatives instead. Destroying a sub-agent now delegates cleanup through the parent so parent-owned schedules and descendant fiber recovery leases are removed consistently.

--- a/design/rfc-helper-sub-agent-orchestration.md
+++ b/design/rfc-helper-sub-agent-orchestration.md
@@ -128,6 +128,13 @@ The framework-provided runner owns the protocol bridge:
 - read stored chunks, final text, and stream errors for replay/result synthesis
 - prevent concurrent framework-driven turns on one agent tool instance
 
+Sub-agent scheduling is now available through the normal `Agent` scheduling
+APIs. Facets still do not own independent physical alarm slots, but the
+top-level parent stores child-owned schedule rows with an owner path and routes
+callbacks back into the owning child when the alarm fires. This matters for
+agent-tool recovery: a child can schedule recovered continuations from inside
+the facet, and that callback runs with the child as `this`.
+
 There should not be a separate public base class for agent tools unless the
 implementation later proves it needs one. The shared base class extracted in
 `examples/agents-as-tools` is prototype structure, not proposed public API.
@@ -655,11 +662,19 @@ call as interrupted. Imperative `runAgentTool(...)` calls have a cleaner
 recovery story because application code can inspect the run later without
 reconstructing an in-flight LLM turn.
 
-Today, facets still have lifecycle limits: no independent alarms, and
-`keepAlive()` is a soft no-op inside facets. The first implementation should
-therefore guarantee durable replay and honest terminal/interrupted state, while
-designing the run metadata and observer API so `detached` and full live reattach
-can be added when facet recovery improves.
+Sub-agent schedules and delegated keepAlive remove the earlier blockers for
+child-side recovery. A facet still does not own an independent physical alarm,
+but a child can schedule logical callbacks through the top-level parent's alarm,
+hold a root-owned heartbeat ref while work is active, and register facet fibers
+in a small root-side index. Think chat recovery and `runFiber()` therefore work
+for long-lived agent-tool facets even when the child is otherwise idle: the root
+alarm routes recovery checks back into the child that owns the fiber row.
+
+The remaining V1 limitation is not "facets cannot recover"; it is "the parent
+observer may be gone." V1 should still guarantee durable replay and honest
+terminal/interrupted state. `detached` and full live reattach are observer
+features that can be added once `tailAgentToolRun` / live-tail support exists,
+without changing the public `runAgentTool` / `agentTool` surface.
 
 ### Imperative API: `runAgentTool`
 
@@ -951,10 +966,12 @@ leave an orphaned child transcript that is no longer reachable through replay or
 drill-in. If a future API allows registry-only deletion, it must make that
 orphaning behavior explicit.
 
-V1 should defer automatic TTL, count-based GC, background alarms, and
-`retain: false` on `runAgentTool`. Those are useful policy knobs, but the first
-implementation only needs the reliable primitive that applications can call from
-their own lifecycle code.
+V1 should defer automatic TTL, count-based GC, and `retain: false` on
+`runAgentTool`. Those are useful policy knobs, but the first implementation only
+needs the reliable primitive that applications can call from their own lifecycle
+code. Sub-agent scheduling means the framework is no longer blocked on a
+mechanism for future background GC; the remaining question is what retention
+policy to choose.
 
 ### Think and AIChatAgent
 
@@ -1083,7 +1100,10 @@ retaining the child facet and parent registry row. Cleanup should be explicit.
 Deferred. Time-based and count-based cleanup are useful, but they are policy
 decisions and may depend on account, workspace, or chat-history lifecycle.
 Shipping `clearAgentToolRuns(...)` first gives applications a reliable primitive
-without committing to scheduler behavior or default retention windows.
+without committing to default retention windows. Sub-agent scheduling means a
+future TTL/GC implementation can run from either the parent or a retained
+agent-tool facet, but the retention policy should still be explicit rather than
+hidden in V1 defaults.
 
 ### Ship only protocol types, no client hook
 
@@ -1151,7 +1171,7 @@ The implementation does not need to land all at once. A reasonable order is:
    docs and examples.
 4. Ergonomics: `defineAgentTool(...)` or class-level reusable contracts;
    richer error shape; structured-output convenience.
-5. Live-tail reattach when facet recovery improves; `detached` observer state;
+5. Live-tail reattach via `tailAgentToolRun`; `detached` observer state;
    tracing/cost integrations.
 
 After Phase 1 lands, `examples/agents-as-tools` should be rewritten on top of

--- a/design/sub-agent-routing.md
+++ b/design/sub-agent-routing.md
@@ -17,7 +17,11 @@ They are implemented on top of workerd facets (`ctx.facets`) and have:
 - their own WebSocket clients (once addressed through `/sub/...`)
 - colocation with the parent on the same machine
 
-They do **not** have independent alarms today — `schedule()` is unsupported on facets, and `keepAlive()` is a soft no-op.
+They do **not** have independent alarm slots today. Sub-agent `schedule()` and
+`scheduleEvery()` calls are logical child schedules stored in the top-level
+parent's scheduler table with an owner path. When the parent alarm fires, the
+SDK routes the due callback back through the facet tree and executes it inside
+the owning sub-agent.
 
 ## Addressing
 
@@ -115,9 +119,23 @@ RPC if you need parent-side side effects.
 
 ## Lifecycle caveats
 
-- `schedule()` / `scheduleEvery()` / `cancelSchedule()` are unsupported on facets.
-- `keepAlive()` is a soft no-op on facets.
-- `deleteSubAgent()` is idempotent.
+- `schedule()` / `scheduleEvery()` / `cancelSchedule()` work on facets, but the
+  top-level parent owns the physical alarm.
+- `getScheduleById()` / `listSchedules()` work on facets by delegating to the
+  top-level parent.
+- `getSchedule()` / `getSchedules()` are deprecated synchronous storage reads
+  and throw on facets.
+- `keepAlive()` and `keepAliveWhile()` work on facets by delegating their
+  heartbeat ref to the top-level parent. Facets still do not get an independent
+  physical alarm slot.
+- `runFiber()` works on facets. Fiber rows and snapshots live in the child
+  SQLite database, while the root parent keeps a small index of active facet
+  fibers so alarm housekeeping can route recovery checks back into idle
+  children.
+- Think chat recovery works on facets; recovered continuations can schedule from
+  the child and are routed through the top-level parent's alarm.
+- `deleteSubAgent()` is idempotent and removes pending schedules for that
+  descendant tree before deleting the facet.
 - Class names whose kebab-case equals `"sub"` are rejected (e.g. `Sub`, `SUB`,
   `Sub_`) because they collide with the `/sub/` URL separator.
 
@@ -126,6 +144,9 @@ RPC if you need parent-side side effects.
 - **Good:** direct child connections, low-latency parent↔child RPC, clean
   parent/index + child/leaf app structure.
 - **Good:** parent-owned registry gives us strict gating and enumeration for free.
-- **Tradeoff:** no independent alarms on facets yet.
+- **Good:** sub-agent code can use the normal scheduling API even though the
+  parent owns the runtime alarm.
+- **Tradeoff:** no independent physical alarms on facets yet; the root parent
+  multiplexes schedules for the whole facet tree.
 - **Tradeoff:** `parentAgent(Cls)` only does the one-hop case; deeper ancestor
   lookup stays explicit.

--- a/docs/agent-class.md
+++ b/docs/agent-class.md
@@ -293,7 +293,7 @@ Tasks are stored in the `cf_agents_queues` SQL table and are automatically flush
 
 ### `this.schedule` and friends
 
-Agents support scheduled execution of methods by wrapping the Durable Object's `alarm()`. The available methods are `this.schedule`, `this.getSchedule`, `this.getSchedules`, `this.cancelSchedule`. Schedules can be one-time, delayed, or recurring (using cron expressions).
+Agents support scheduled execution of methods by wrapping the Durable Object's `alarm()`. The available methods are `this.schedule`, `this.getScheduleById`, `this.listSchedules`, `this.cancelSchedule`, and the deprecated synchronous `this.getSchedule` / `this.getSchedules`. Schedules can be one-time, delayed, or recurring (using cron expressions).
 
 Since DOs only allow one alarm at a time, the `Agent` class works around this by managing multiple schedules in SQL and using a single alarm.
 
@@ -450,7 +450,7 @@ class MyAgent extends Agent {
 
 ### `this.keepAlive`
 
-`this.keepAlive()` prevents the Durable Object from being evicted due to inactivity by creating a 30-second heartbeat schedule. Returns a disposer function to stop the heartbeat. For scoped work, use `this.keepAliveWhile(fn)` which automatically cleans up when the function completes. See [Keeping the Agent Alive](./scheduling.md#keeping-the-agent-alive) for full documentation.
+`this.keepAlive()` prevents the Durable Object from being evicted due to inactivity by holding an alarm-backed heartbeat ref. Returns a disposer function to stop the heartbeat. For scoped work, use `this.keepAliveWhile(fn)` which automatically cleans up when the function completes. See [Keeping the Agent Alive](./scheduling.md#keeping-the-agent-alive) for full documentation.
 
 ### Routing
 

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -81,7 +81,7 @@ try {
 
 While any `keepAlive` ref is held, an alarm fires every 30 seconds that resets the inactivity timer. When all disposers are called, alarms stop and the DO can go idle naturally.
 
-The heartbeat is invisible to `getSchedules()` — no schedule rows are created. It does not conflict with your own schedules; the alarm system multiplexes all schedules and the keepAlive heartbeat through a single alarm slot.
+The heartbeat is invisible to `listSchedules()` — no schedule rows are created. It does not conflict with your own schedules; the alarm system multiplexes all schedules and the keepAlive heartbeat through a single alarm slot.
 
 ### Configurable interval
 
@@ -168,6 +168,14 @@ runFiber("work", fn)
 ```
 
 Both recovery paths call the same hook. The alarm path is critical for background agents that have no incoming client connections — the persisted alarm wakes the agent on its own.
+
+#### Sub-agents
+
+Fibers also work inside sub-agents. The fiber row and snapshots are stored in the sub-agent's own SQLite database, and `onFiberRecovered()` runs with the sub-agent as `this`.
+
+Sub-agents do not have independent alarm slots, so the top-level parent owns the physical heartbeat. When a sub-agent starts a fiber, the parent stores a small root-side index entry for that facet and fiber ID. Root alarm housekeeping uses that index to route recovery checks back into the owning sub-agent, even if the child has no client connection or incoming RPC.
+
+This keeps recovery local to the child while preserving the single physical alarm slot owned by the parent. A recovered continuation can use `schedule()` from inside the facet; the parent owns the physical alarm and routes the callback back to the child.
 
 #### Error during execution
 

--- a/docs/long-running-agents.md
+++ b/docs/long-running-agents.md
@@ -514,7 +514,9 @@ export class ProjectManager extends Agent<ProjectState> {
 }
 ```
 
-Sub-agents have their own state and lifecycle, but not full parity with top-level Durable Objects yet. In particular, they do **not** have their own alarms today — `schedule()` / `scheduleEvery()` are not supported on facets yet (support is coming soon). Put scheduled work on the parent and let it dispatch into children by RPC. The parent also does not need to stay awake while the child handles request-scoped work; once the child is woken it can complete the current turn independently.
+Sub-agents have their own state and lifecycle. They can schedule their own logical callbacks and run durable fibers; the top-level parent owns the physical alarm and routes scheduled work back into the child. Recovery rows live in the child's SQLite database, so `onFiberRecovered()` and Think `chatRecovery` run with the child as `this`.
+
+Sub-agents still do not have independent physical alarm slots. The root parent keeps a small index of active child fibers, and its alarm routes recovery checks back into idle children. The parent does not need to stay awake while the child handles request-scoped work; once the child is woken it can complete the current turn independently.
 
 For a full user-facing guide to the routing primitive (`subAgent`, `onBeforeSubAgent`, `useAgent({ sub })`, `parentAgent`, `hasSubAgent`, `listSubAgents`), see [Sub-agents](./sub-agents.md).
 
@@ -622,7 +624,7 @@ A long-running agent eventually completes its purpose. The project ships, the in
 export class ProjectManager extends Agent<ProjectState> {
   async completeProject() {
     // Cancel remaining schedules
-    const schedules = this.getSchedules();
+    const schedules = await this.listSchedules();
     for (const schedule of schedules) {
       await this.cancelSchedule(schedule.id);
     }

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -269,7 +269,7 @@ async syncData() {
 
 Durable Objects are evicted after a period of inactivity (typically 70-140 seconds with no incoming requests, WebSocket messages, or alarms). During long-running operations — streaming LLM responses, waiting on external APIs, running multi-step computations — the agent can be evicted mid-flight.
 
-`keepAlive()` prevents this by creating a 30-second heartbeat schedule that keeps the agent active until you are done:
+`keepAlive()` prevents this by holding an alarm-backed heartbeat ref that keeps the agent active until you are done:
 
 ```typescript
 const dispose = await this.keepAlive();
@@ -299,9 +299,11 @@ This is the recommended approach since you cannot forget to dispose the heartbea
 
 ### How it works
 
-`keepAlive()` uses an in-memory reference count and the Durable Object alarm system directly. Each call increments the count; the disposer decrements it. While the count is above zero, `_scheduleNextAlarm()` ensures an alarm fires every 30 seconds, which resets the inactivity timer. No schedule rows are created and no observability events are emitted — the heartbeat is invisible to `getSchedules()` and the `agents:schedule` diagnostics channel.
+`keepAlive()` uses an in-memory reference count and the Durable Object alarm system directly. Each call increments the count; the disposer decrements it. While the count is above zero, `_scheduleNextAlarm()` ensures an alarm fires every 30 seconds, which resets the inactivity timer. No schedule rows are created and no observability events are emitted — the heartbeat is invisible to `listSchedules()` and the `agents:schedule` diagnostics channel.
 
 The heartbeat does not conflict with your own schedules — the alarm system multiplexes all schedules and the keepAlive heartbeat through a single alarm slot.
+
+Inside sub-agents, `keepAlive()` delegates that heartbeat ref to the top-level parent because facets do not have independent alarm slots. `keepAliveWhile()` works the same way because it calls `keepAlive()` and automatically disposes the delegated ref when the scoped work completes.
 
 ### Multiple concurrent callers
 
@@ -340,7 +342,7 @@ dispose2(); // Ref count reaches 0 — agent can go idle
 Retrieve a scheduled task by its ID:
 
 ```typescript
-const schedule = await this.getSchedule(scheduleId);
+const schedule = await this.getScheduleById(scheduleId);
 
 if (schedule) {
   console.log(
@@ -359,13 +361,13 @@ Query scheduled tasks with optional filters:
 
 ```typescript
 // Get all scheduled tasks
-const allSchedules = this.getSchedules();
+const allSchedules = await this.listSchedules();
 
 // Get only cron jobs
-const cronJobs = this.getSchedules({ type: "cron" });
+const cronJobs = await this.listSchedules({ type: "cron" });
 
 // Get tasks in the next hour
-const upcoming = this.getSchedules({
+const upcoming = await this.listSchedules({
   timeRange: {
     start: new Date(),
     end: new Date(Date.now() + 60 * 60 * 1000)
@@ -373,10 +375,10 @@ const upcoming = this.getSchedules({
 });
 
 // Get a specific task by ID
-const specific = this.getSchedules({ id: "abc123" });
+const specific = await this.listSchedules({ id: "abc123" });
 
 // Combine filters
-const upcomingCronJobs = this.getSchedules({
+const upcomingCronJobs = await this.listSchedules({
   type: "cron",
   timeRange: {
     start: new Date(),
@@ -398,6 +400,8 @@ if (cancelled) {
   console.log("Schedule not found (may have already executed)");
 }
 ```
+
+`cancelSchedule(id)` only matches schedules owned by the agent it is called on. A top-level agent cannot cancel a sub-agent's schedules by id, and a sub-agent cannot reach a sibling's schedules. To clear every schedule under a sub-agent (and any of its descendants), call `parent.deleteSubAgent(Cls, name)` from the parent — that bulk-cancels the prefix and tears the sub-agent down.
 
 **Example: Cancellable reminders**
 
@@ -504,7 +508,7 @@ class PollingAgent extends Agent {
 
   async stopPolling() {
     // Cancel all polling schedules
-    const schedules = this.getSchedules({ type: "delayed" });
+    const schedules = await this.listSchedules({ type: "delayed" });
     for (const schedule of schedules) {
       if (schedule.callback === "poll") {
         await this.cancelSchedule(schedule.id);
@@ -815,13 +819,33 @@ Schedule a task to run repeatedly at a fixed interval.
 - If callback throws an error, the interval continues
 - Cancel with `cancelSchedule(id)` to stop the entire interval
 
+### getScheduleById()
+
+```typescript
+async getScheduleById(id: string): Promise<Schedule<unknown> | undefined>
+```
+
+Get a scheduled task by ID. This method works in both top-level agents and sub-agents.
+
+### listSchedules()
+
+```typescript
+async listSchedules(criteria?: {
+  id?: string;
+  type?: "scheduled" | "delayed" | "cron" | "interval";
+  timeRange?: { start?: Date; end?: Date };
+}): Promise<Schedule<unknown>[]>
+```
+
+Get scheduled tasks matching the criteria. This method works in both top-level agents and sub-agents.
+
 ### getSchedule()
 
 ```typescript
 getSchedule<T = string>(id: string): Schedule<T> | undefined
 ```
 
-Get a scheduled task by ID. This method is synchronous.
+Deprecated. Get a scheduled task by ID synchronously. This method only works in top-level agents; use `await this.getScheduleById(id)` instead.
 
 ### getSchedules()
 
@@ -833,7 +857,7 @@ getSchedules<T = string>(criteria?: {
 }): Schedule<T>[]
 ```
 
-Get scheduled tasks matching the criteria. This method is synchronous.
+Deprecated. Get scheduled tasks matching the criteria synchronously. This method only works in top-level agents; use `await this.listSchedules(criteria)` instead.
 
 ### cancelSchedule()
 
@@ -849,7 +873,7 @@ Cancel a scheduled task. Returns `true` if cancelled, `false` if not found.
 async keepAlive(): Promise<() => void>
 ```
 
-Create a 30-second heartbeat schedule that prevents the Durable Object from being evicted due to inactivity. Returns a disposer function that cancels the heartbeat when called. The disposer is idempotent — calling it multiple times is safe.
+Create an alarm-backed heartbeat that prevents the Durable Object from being evicted due to inactivity. Returns a disposer function that cancels the heartbeat when called. The disposer is idempotent — calling it multiple times is safe.
 
 See [Keeping the Agent Alive](#keeping-the-agent-alive) for usage details.
 

--- a/docs/server-driven-messages.md
+++ b/docs/server-driven-messages.md
@@ -417,7 +417,7 @@ Pre-aborted signals short-circuit before any model work runs.
 ### Limitations
 
 - **Signals cannot cross Durable Object boundaries.** `AbortSignal` is not an RPC-serializable type. Construct the controller inside the DO that calls `saveMessages`. To bridge a parent's abort intent into a child DO, return a `ReadableStream` from the child and let the parent cancel it — workerd propagates the cancel back to the source's `cancel` callback. See `examples/agents-as-tools` for the canonical helper-as-sub-agent pattern.
-- **Hibernation drops the listener.** The signal lives in memory. If the DO hibernates mid-turn and `chatRecovery` is enabled, the recovered turn calls `continueLastTurn()` internally without the original signal — an abort fired after restart has no effect on the recovered turn. Override `onChatRecovery` (Think) or set `chatRecovery = false` for callers that need stronger guarantees.
+- **Hibernation drops the listener.** The signal lives in memory. If the DO hibernates mid-turn and `chatRecovery` is enabled, the recovered turn calls `continueLastTurn()` internally without the original signal — an abort fired after restart has no effect on the recovered turn. This is true for top-level agents and sub-agents; sub-agent recovery still works, but the original caller's in-memory signal is gone. Override `onChatRecovery` (Think) or set `chatRecovery = false` for callers that need stronger guarantees.
 
 This is the integration point for helper-as-sub-agent patterns where the parent's AI SDK abort signal needs to propagate into a child DO's `saveMessages` call. See [`cloudflare/agents#1406`](https://github.com/cloudflare/agents/issues/1406) for the original use case.
 

--- a/docs/sub-agents.md
+++ b/docs/sub-agents.md
@@ -76,9 +76,34 @@ Sub-agents (also called **facets**) live on the **same machine** as their parent
 
 Each sub-agent has its own SQLite database and its own in-memory state. Writes from one sibling never leak into another. When a sub-agent is deleted with `deleteSubAgent()`, its storage is wiped.
 
-### No independent alarms (yet)
+### Scheduling
 
-Sub-agents do not currently have their own alarms: `this.schedule()`, `this.scheduleEvery()`, and `this.keepAlive()` on a sub-agent are either a no-op or throw. This is a workerd limitation and support is coming soon. For now, put scheduled work on the parent and let it dispatch into children via RPC.
+Sub-agents can schedule their own callbacks with `this.schedule()` and `this.scheduleEvery()`:
+
+```typescript
+export class Chat extends Agent {
+  async onStart() {
+    await this.scheduleEvery(60, "compactHistory");
+  }
+
+  async compactHistory() {
+    // Runs inside the Chat sub-agent.
+    // this.sql points at the Chat SQLite database.
+  }
+}
+```
+
+The top-level parent still owns the underlying Durable Object alarm because facets do not have independent alarm slots. The Agents SDK stores a logical owner path for the sub-agent schedule, wakes the parent when the alarm fires, then dispatches the callback back into the sub-agent. The callback runs with the sub-agent as `this`, so it uses the sub-agent's SQLite storage, state, `parentPath`, and `getCurrentAgent()` context.
+
+`cancelSchedule()`, `getScheduleById()`, and `listSchedules()` also work inside sub-agents. They are scoped to the calling sub-agent — a sub-agent cannot cancel or list a sibling's schedules by id. To clear every schedule under a sub-agent (and any of its descendants), call `parent.deleteSubAgent(Cls, name)` from the parent. The older synchronous `getSchedule()` and `getSchedules()` APIs throw inside sub-agents because scheduled rows are stored on the top-level parent.
+
+Calling `this.destroy()` inside a sub-agent delegates the same teardown back to the parent: it cancels the sub-agent's parent-owned schedules (and descendants), removes the sub-agent from the parent's registry, and asks the runtime to wipe the sub-agent's storage. Because the underlying `ctx.facets.delete` call aborts the sub-agent's isolate, treat `this.destroy()` as fire-and-forget — it may not return cleanly to the caller.
+
+### Durable execution and chat recovery
+
+Sub-agents can use `runFiber()` and Think's `chatRecovery` just like top-level agents. Fiber rows live in the sub-agent's own SQLite database, so recovery hooks run with the sub-agent as `this` and see the sub-agent's state, storage, `parentPath`, and `getCurrentAgent()` context.
+
+Because facets do not have independent alarm slots, the top-level parent owns the physical alarm heartbeat for sub-agent fibers. The sub-agent still stores fiber rows and snapshots in its own SQLite database, while the parent stores a small root-side index of active facet fibers. When the parent alarm fires, it checks that index and routes recovery checks back into the owning sub-agent. Think's chat recovery can schedule its recovered continuation from inside the sub-agent; the parent owns the physical alarm and routes the continuation back to the child.
 
 ### Shared identity
 
@@ -109,10 +134,10 @@ The parent class also has requirements that are implicit for normal usage but wo
 
 ### `this.deleteSubAgent(Cls, name)`
 
-Abort a running sub-agent and permanently wipe its storage. Idempotent — safe to call for a never-spawned or already-deleted child.
+Abort a running sub-agent, cancel its pending schedules, and permanently wipe its storage. Idempotent — safe to call for a never-spawned or already-deleted child.
 
 ```typescript
-this.deleteSubAgent(Chat, "chat-abc");
+await this.deleteSubAgent(Chat, "chat-abc");
 ```
 
 ### `this.abortSubAgent(Cls, name, reason?)`
@@ -285,26 +310,21 @@ When a client connects to `/agents/{parent}/{name}/sub/{child}/{childName}`:
 
 ### Deletion
 
-`deleteSubAgent(Cls, name)` aborts any running instance and deletes its storage. The registry entry is removed. Idempotent.
+`deleteSubAgent(Cls, name)` aborts any running instance, removes pending schedules for that sub-agent tree, deletes its storage, and removes its registry entry. Idempotent.
 
 ### Hibernation
 
 Sub-agents hibernate when idle, same as any Durable Object. `this.name` is restored automatically from the facet's `ctx.id` (the runtime carries it across eviction). `this.parentPath` is persisted during `_cf_initAsFacet` and restored on wake.
 
-## Scheduling in sub-agents (coming soon)
+## Scheduling and durable work in sub-agents
 
-Today, sub-agents cannot set their own alarms:
+Sub-agents can schedule their own callbacks and run durable fibers:
 
-- `this.schedule()` / `this.scheduleEvery()` / `this.cancelSchedule()` throw on a sub-agent.
-- `this.keepAlive()` is a soft no-op on a sub-agent.
+- `this.schedule()` / `this.scheduleEvery()` / `this.cancelSchedule()` work on a sub-agent.
+- `this.getScheduleById()` / `this.listSchedules()` work on a sub-agent.
+- `this.runFiber()` and Think `chatRecovery` work on a sub-agent.
 
-This is a workerd limitation and first-class support is on the way. While waiting:
-
-- **Put scheduling on the parent.** The parent can call into children on a cadence using `this.subAgent(Cls, name)` + RPC.
-- **Active Promise chains keep a facet alive.** A sub-agent processing a request stays awake naturally until the handler resolves. `keepAlive()` is mostly redundant for request-scoped work.
-- **WebSocket connections keep the whole machine alive.** A facet with an active client WS will not be evicted.
-
-When workerd enables alarms on SQLite-backed facets, these methods will simply start working without an API change.
+The top-level parent still owns the physical alarm because facets do not have independent alarm slots. The Agents SDK stores the child owner path with each schedule row, wakes the parent, and routes the callback back into the child. `keepAlive()` and `keepAliveWhile()` work in sub-agents by delegating their heartbeat ref to the top-level parent. `runFiber()` also works in sub-agents: fiber rows and snapshots live in the child's own SQLite database, and the parent keeps a small root-side index so alarm housekeeping can route recovery checks back into idle children.
 
 ## Broadcasts
 
@@ -320,7 +340,8 @@ When workerd enables alarms on SQLite-backed facets, these methods will simply s
 | You need a worker pool, scatter/gather, or ephemeral task isolation                | Often yes                                          |
 | You have a single conversation per user and no need for per-context isolation      | No — just use one agent                            |
 | The children need independent geographic placement                                 | No — top-level DOs instead                         |
-| The children need independent alarms _today_                                       | No — top-level DOs; revisit when facet alarms ship |
+| The children need their own logical scheduled callbacks or chat recovery           | Yes                                                |
+| The children need independent physical alarm slots                                 | No — top-level DOs; revisit when facet alarms ship |
 
 ## Example
 
@@ -336,7 +357,7 @@ See [`examples/multi-ai-chat`](https://github.com/cloudflare/agents/tree/main/ex
 - [Think sub-agents and programmatic turns](./think/sub-agents.md) — Think's `chat()` RPC method for streaming from a parent to a Think-based child
 - [Long-running agents](./long-running-agents.md) — how sub-agents fit alongside `schedule`, `runFiber`, and workflows
 - [Callable methods](./callable-methods.md) — `@callable` methods work unchanged on sub-agents
-- [Scheduling](./scheduling.md) — scheduling primitives (parent-only today)
+- [Scheduling](./scheduling.md) — scheduling primitives for top-level agents and sub-agents
 
 ## See also
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -141,7 +141,7 @@ Both Think and [`AIChatAgent`](../chat-agents.md) extend `Agent` and speak the s
 | `configureSession()`    | identity                         | Add context blocks, compaction, search, skills — see [Sessions](../sessions.md) |
 | `messageConcurrency`    | `"queue"`                        | How overlapping submits behave — see [Client Tools](./client-tools.md)          |
 | `waitForMcpConnections` | `false`                          | Wait for MCP servers before inference                                           |
-| `chatRecovery`          | `true`                           | Wrap turns in `runFiber` for durable execution                                  |
+| `chatRecovery`          | `true`                           | Wrap turns in `runFiber` for durable execution, including sub-agent turns       |
 
 ## Dynamic Configuration
 

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -295,13 +295,16 @@ parentSignal.addEventListener("abort", () => reader.cancel(parentSignal.reason),
 
 #### Hibernation and recovery
 
+Think chat recovery works in sub-agents. The underlying fiber is stored in the sub-agent's own SQLite database, and the top-level parent keeps a small index of active child fibers. When the parent alarm fires, it routes recovery checks into the owning sub-agent, so recovery runs with the sub-agent as `this` even if the child is otherwise idle. Recovered continuations can call `schedule()` inside the sub-agent — the top-level parent owns the physical alarm and routes the continuation back into the child.
+
 The external signal lives in memory only. If the Durable Object hibernates mid-turn and `chatRecovery` is enabled, the recovered turn runs via `continueLastTurn()` **without** the original `options.signal` — the listener was lost on eviction, and the recovery path has no way to reach back to the original caller.
 
 In practice this means:
 
 - A signal that aborts **after** the DO restarts has no effect on the recovered turn.
 - Subclasses that need the recovered turn to honor a fresh signal should override `onChatRecovery` and reject continuation (`return { continue: false }`) when the original caller is gone.
-- The `examples/agents-as-tools` helper sets `chatRecovery = false` for exactly this reason: helpers are per-turn workers driven by an active parent, and silently re-running on wake would burn an inference call on no consumer.
+- Recovery is best for long-lived chat sub-agents that have their own client reconnect path. Short-lived helper sub-agents should also define a parent-side replay or terminal-state policy for cases where the original parent RPC reader is gone.
+- The `examples/agents-as-tools` helper keeps `chatRecovery` enabled. If the parent restarts mid-helper, the helper's own Think turn can recover in the child facet, while the parent still marks the inline helper row interrupted until a future live-tail policy can reattach to recovered work.
 
 See [`cloudflare/agents#1406`](https://github.com/cloudflare/agents/issues/1406) for the original motivation, and `examples/agents-as-tools` for the helper-as-sub-agent reference implementation.
 
@@ -342,7 +345,7 @@ Both methods produce the same end state as `chat-request-cancel`: inference loop
 
 ## Chat Recovery
 
-Think can wrap chat turns in Durable Object fibers for durable execution. When a DO is evicted mid-turn, the turn can be recovered on restart.
+Think can wrap chat turns in Durable Object fibers for durable execution. When a DO is evicted mid-turn, the turn can be recovered on restart. This works for top-level agents and sub-agents; for sub-agents, the top-level parent alarm drives recovery checks back into the child facet.
 
 ### Setup
 
@@ -356,7 +359,7 @@ export class MyAgent extends Think<Env> {
 }
 ```
 
-When `chatRecovery` is `true`, all four turn paths (WebSocket, auto-continuation, `saveMessages`, `continueLastTurn`) are wrapped in `runFiber`.
+When `chatRecovery` is `true`, all four turn paths (WebSocket, sub-agent `chat()` RPC, auto-continuation, `saveMessages`, `continueLastTurn`) are wrapped in `runFiber`.
 
 ### onChatRecovery
 

--- a/examples/agents-as-tools/README.md
+++ b/examples/agents-as-tools/README.md
@@ -67,7 +67,7 @@ The `chunk` body is opaque to this protocol module so it stays AI-SDK-version-ag
   - `_runHelperTurn(cls, query, parentToolCallId, displayOrder?)` is the proto-shape of an eventual `helperTool(Cls)` framework helper, parameterized by the helper class so `research`, `plan`, and `compare` can all reuse it: insert running row → broadcast synthesized `started` → open a byte stream over RPC from `helper.runTurnAndStream` → decode NDJSON frames → broadcast each as a `chunk` event with monotonic per-run sequence → fetch the helper's final assistant text → broadcast synthesized `finished` (or `error` on failure) → update row.
   - `onConnect` runs after Think's chat-protocol setup. It walks `cf_agent_helper_runs`, resolves each row's `helper_type` to the right helper class via the `helperClassByType` registry, synthesizes a `started` event from row data, fetches the helper's stored chat chunks via DO RPC (using the row's pinned `stream_id` so drill-in follow-up turns don't shadow the original turn's chunks), forwards them as `chunk` events, and appends a synthesized `finished`/`error` lifecycle event from the row.
 
-- **`HelperAgent extends Think`** — abstract base for helper sub-agents. Carries everything the helper protocol needs: the `broadcast` tee, `runTurnAndStream`, the concurrent-call guard, `getFinalTurnText`, `getLastStreamError`, and the drill-in stream-id snapshotting that powers D1 replay isolation. Concrete helpers stay thin — pick a model, a system prompt, and a tool surface.
+- **`HelperAgent extends Think`** — abstract base for helper sub-agents. Carries everything the helper protocol needs: the `broadcast` tee, `runTurnAndStream`, the concurrent-call guard, `getFinalTurnText`, `getLastStreamError`, and the drill-in stream-id snapshotting that powers D1 replay isolation. Concrete helpers stay thin — pick a model, a system prompt, and a tool surface. Think chat recovery is enabled for helper turns; the helper stores its own fiber rows and recovered continuations run in the helper facet.
   - `runTurnAndStream(query, helperId)` returns a `ReadableStream<Uint8Array>` over DO RPC. Each NDJSON line is `{ sequence, body }` where `body` is a JSON-encoded `UIMessageChunk` — the same shape the helper's own WS clients see. The `body` field is `Uint8Array` because workerd's DO RPC stream bridge only transports byte chunks; object chunks fail with the opaque "Network connection lost" error tracked in [cloudflare/workerd#6675](https://github.com/cloudflare/workerd/issues/6675).
   - The forwarder is wired by **overriding `broadcast`**: while a `runTurnAndStream` is in flight, `MSG_CHAT_RESPONSE` chunks are tee'd into the active RPC stream. Other broadcasts (state, identity, MSG_CHAT_MESSAGES, future helper-events from any downstream) pass through untouched. The pattern preserves chunk durability (Think's `_streamResult` still calls `_resumableStream.storeChunk` first) and works for direct WS clients of the helper too — drill-in is just chat.
   - `getChatChunksForReplay(streamId?)` exposes the helper's stored chunks for the parent's `onConnect` replay path; passing the row's pinned `stream_id` returns ONLY the original turn's chunks even if a drill-in follow-up has added newer streams.
@@ -77,7 +77,7 @@ The `chunk` body is opaque to this protocol module so it stays AI-SDK-version-ag
 
 - **`Planner extends HelperAgent`** — second concrete helper class with a different system prompt (writes structured implementation plans) and a different tool (`inspect_file`). Validates that the helper protocol generalizes across diverse helper workflows, not just research-shaped ones.
 
-- The whole helper run is wrapped in `keepAliveWhile` (via `saveMessages`'s own keep-alive, plus an explicit wrapper around the Think turn) so the helper DO stays alive across the inference loop pauses.
+- `saveMessages` uses Think's normal durable-turn machinery inside the helper facet. The helper's chunks and messages are stored in the helper's own SQLite database; the parent only forwards and indexes them.
 
 ## Client (`src/client.tsx`)
 
@@ -143,7 +143,7 @@ A few things to note:
 | Parent crash mid-helper marks the run interrupted; live work is not resumed | Ring 5 (live tail subscription)             |
 | Only Think-based parent. AIChatAgent port deferred                          | Stage 5 in the wip doc                      |
 
-**Parent-crash recovery**: `Assistant.onStart` marks any `running` helper rows as `interrupted`. On the next connect, stored helper chunks replay and the parent appends a synthesized terminal error event (using the row's `interrupted` status) so the UI doesn't show a "Running" panel that never resolves. The helper's live work is not resumed; Ring 5's future "live tail subscription" is the place for that.
+**Parent-crash recovery**: `Assistant.onStart` marks any `running` helper rows as `interrupted`. On the next connect, stored helper chunks replay and the parent appends a synthesized terminal error event (using the row's `interrupted` status) so the UI doesn't show a "Running" panel that never resolves. The helper's own Think turn can still recover in the child facet; what is still out of scope is reattaching the parent-side inline live stream after the parent has lost the original RPC reader. Ring 5's future "live tail subscription" is the place for that policy.
 
 **Cancellation propagation (B4)**: `Assistant`'s tool executes thread the AI SDK's `abortSignal` (which Think hooks to its own `_aborts` registry) into `_runHelperTurn`. When the parent's chat turn aborts, the parent's RPC reader is cancelled, the helper RPC stream's `cancel` callback fires a per-turn `AbortController`, and that controller's signal is threaded into Think's `saveMessages({ signal })` so the helper's inference loop terminates immediately. The row is marked `error` with an "abort" message and a synthesized `error` event broadcasts so the panel doesn't sit on "Running…" forever.
 
@@ -151,7 +151,7 @@ Helper-side abort is **race-free**. The per-turn `AbortController` is created at
 
 ## Why Think helpers (not just AIChatAgent helpers)
 
-The design notes argue Think-first because helpers want to live inside Think's fibers / sessions / turns model. v0.2 takes the next step: the helper is itself a Think, so it can use Think's auto-resume, fiber recovery, durable chat-stream resumption, and message persistence "for free" — none of which the parent has to reinvent.
+The design notes argue Think-first because helpers want to live inside Think's fibers / sessions / turns model. v0.2 takes the next step: the helper is itself a Think, so it can use durable chat-stream resumption, message persistence, and chat recovery "for free" — none of which the parent has to reinvent. The framework also supports `runFiber()` inside sub-agent facets, so helper chat recovery works even though the root parent owns the physical alarm.
 
 The pieces that stay AIChatAgent-portable:
 

--- a/examples/agents-as-tools/src/server.ts
+++ b/examples/agents-as-tools/src/server.ts
@@ -83,9 +83,10 @@
  *     helper's inference loop terminates immediately — no race
  *     window, no early-cancel orphan calls to Workers AI.
  *   - **No "live tail" subscription.** If the parent crashes
- *     mid-helper, the run is marked `interrupted`; the helper's
- *     stored chunks still replay on parent reconnect, but there's no
- *     reconstitution of the live broadcast loop.
+ *     mid-helper, the parent row is marked `interrupted`; the helper's
+ *     own Think turn can recover in the facet and its stored chunks
+ *     still replay on parent reconnect, but there's no reconstitution
+ *     of the parent-side live broadcast loop.
  *   - **Built on Think.** AIChatAgent port deferred; the Researcher
  *     class extends `Think` and the helper-event protocol doesn't
  *     reference Think types, so the AIChatAgent port is mechanical
@@ -152,14 +153,16 @@ type HelperRunStatus = "running" | "completed" | "error" | "interrupted";
  */
 export class HelperAgent extends Think<Env> {
   /**
-   * Disable Think's chat-recovery fiber. Helpers are per-turn workers
-   * driven over RPC by the parent; recovering an in-flight turn after
-   * the helper hibernates would re-run the inference loop into a
-   * parent that is no longer listening (the parent has already
-   * marked the run `interrupted`). Default-on `chatRecovery` would
-   * silently burn another LLM call into nothing on every wake.
+   * Keep helper turns durable even though helpers are facets. The root parent
+   * owns the physical alarm, but the helper stores its own chat fiber rows and
+   * recovered continuations can schedule from inside the child.
+   *
+   * Parent-crash policy is still separate: if the parent loses the RPC reader,
+   * its inline helper row is marked `interrupted` until a future live-tail
+   * subscription can reattach. The helper's own recovered chat remains durable
+   * for replay and drill-in.
    */
-  override chatRecovery = false;
+  override chatRecovery = true;
 
   /**
    * Forwarder set for the duration of a single `runTurnAndStream`.
@@ -1424,7 +1427,7 @@ export class Assistant extends Think<Env> {
         // Resolve the right class for this row so `deleteSubAgent`
         // points at the actual facet — Researcher facets and Planner
         // facets live in different `new_sqlite_classes` namespaces.
-        this.deleteSubAgent(helperClassFor(helper_type), helper_id);
+        await this.deleteSubAgent(helperClassFor(helper_type), helper_id);
       } catch {
         // Idempotent / best-effort cleanup. The helper may already be
         // gone (e.g. local dev state was wiped between runs).

--- a/examples/assistant/src/server.ts
+++ b/examples/assistant/src/server.ts
@@ -335,7 +335,7 @@ export class AssistantDirectory extends Agent<Env, DirectoryState> {
     // its metadata. Order doesn't matter for correctness since the
     // registry is authoritative, but we do the facet first so a crash
     // between the two leaves no orphan meta rows visible.
-    this.deleteSubAgent(MyAssistant, id);
+    await this.deleteSubAgent(MyAssistant, id);
     this.sql`DELETE FROM chat_meta WHERE id = ${id}`;
     this._refreshState();
   }

--- a/examples/multi-ai-chat/README.md
+++ b/examples/multi-ai-chat/README.md
@@ -4,7 +4,9 @@ Multi-session AI chat built on the sub-agent routing primitive. A
 single `Inbox` Durable Object owns the chat list + per-user shared
 memory; each chat is a **facet** of that inbox — its own
 `AIChatAgent` DO, colocated on the same machine, with isolated
-SQLite storage.
+SQLite storage. Chat facets can use the normal Agents scheduling and
+durable-execution APIs; the parent owns the physical alarm, but
+callbacks and recovery run inside the chat facet.
 
 This is the pattern the proposed `Chats` base class in
 [`design/rfc-think-multi-session.md`](../../design/rfc-think-multi-session.md)
@@ -85,6 +87,11 @@ Key things worth looking at in `src/server.ts`:
   helper — pass the parent's class, get back a typed RPC stub
   with the right identity baked in. No hardcoded user id, no
   `getAgentByName` plumbing inside the facet.
+- Each `Chat` owns its own SQLite database, stream state, and recovery
+  state. If you build this pattern with `Think`, `chatRecovery` and
+  `runFiber()` work from inside the chat facet; the root parent's alarm
+  drives recovery checks back into idle children, and reconnecting to the
+  `/sub/chat/{chatId}` URL attaches directly to that child.
 - The worker entry is a one-liner: `routeAgentRequest(request, env)`.
   It already knows how to walk `/agents/inbox/.../sub/chat/...` — no
   custom routing needed.

--- a/examples/multi-ai-chat/src/server.ts
+++ b/examples/multi-ai-chat/src/server.ts
@@ -15,6 +15,10 @@
  *   — two chats for the same user run in parallel, each with its
  *   own SQLite storage, while all colocated on the same machine as
  *   the parent.
+ *   If this pattern is built with `Think`, each chat facet can also
+ *   use `chatRecovery` / `runFiber()`; recovery state lives in the
+ *   chat's own SQLite, and recovered continuations schedule through
+ *   the parent-owned alarm.
  * - Addressing is transparent: the client connects to an inbox at
  *   `/agents/inbox/{user}` for the sidebar and to a specific chat
  *   at `/agents/inbox/{user}/sub/chat/{chatId}` for the conversation.
@@ -192,7 +196,7 @@ export class Inbox extends Agent<Env, InboxState> {
     // drop its metadata. Order doesn't matter for correctness since
     // the registry is authoritative, but we do the facet first so
     // a crash between the two leaves no orphan meta rows visible.
-    this.deleteSubAgent(Chat, id);
+    await this.deleteSubAgent(Chat, id);
     this.sql`DELETE FROM chat_meta WHERE id = ${id}`;
     this._refreshState();
   }

--- a/examples/playground/src/demos/core/ScheduleDemo.tsx
+++ b/examples/playground/src/demos/core/ScheduleDemo.tsx
@@ -59,8 +59,8 @@ class ScheduleAgent extends Agent<Env> {
   }
 
   @callable()
-  listSchedules() {
-    return this.getSchedules();
+  async getScheduledTasks() {
+    return this.listSchedules();
   }`
   },
   {
@@ -92,7 +92,7 @@ export function ScheduleDemo() {
   const userId = useUserId();
   const { logs, addLog, clearLogs } = useLogs();
   const { toast } = useToast();
-  const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [schedules, setSchedules] = useState<Schedule<unknown>[]>([]);
   const [delaySeconds, setDelaySeconds] = useState("5");
   const [message, setMessage] = useState("Hello from schedule!");
   const [intervalSeconds, setIntervalSeconds] = useState("10");
@@ -125,7 +125,7 @@ export function ScheduleDemo() {
 
   const refreshSchedules = useCallback(async () => {
     try {
-      const result = await agent.call("listSchedules");
+      const result = await agent.call("getScheduledTasks");
       setSchedules(result);
     } catch {
       // Ignore errors during refresh

--- a/examples/playground/src/demos/core/connections-agent.ts
+++ b/examples/playground/src/demos/core/connections-agent.ts
@@ -10,8 +10,8 @@ export class ConnectionsAgent extends Agent<Env, ConnectionsAgentState> {
     messages: []
   };
 
-  onConnect(connection: Connection, ctx: ConnectionContext) {
-    super.onConnect(connection, ctx);
+  async onConnect(connection: Connection, ctx: ConnectionContext) {
+    await super.onConnect(connection, ctx);
     this.broadcast(
       JSON.stringify({
         type: "connection_count",

--- a/examples/playground/src/demos/core/schedule-agent.ts
+++ b/examples/playground/src/demos/core/schedule-agent.ts
@@ -36,8 +36,8 @@ export class ScheduleAgent extends Agent<Env, ScheduleAgentState> {
   }
 
   @callable({ description: "List all scheduled tasks" })
-  listSchedules(): Schedule[] {
-    return this.getSchedules();
+  async getScheduledTasks(): Promise<Schedule<unknown>[]> {
+    return this.listSchedules();
   }
 
   async onScheduledTask(payload: { message: string }) {

--- a/examples/playground/src/demos/mcp/mcp-server-agent.ts
+++ b/examples/playground/src/demos/mcp/mcp-server-agent.ts
@@ -21,13 +21,13 @@ export class PlaygroundMcpServer extends McpAgent<Env, State, {}> {
 
   initialState: State = { totalCalls: 0 };
 
-  private resetIdleTimer() {
-    for (const schedule of this.getSchedules()) {
+  private async resetIdleTimer() {
+    for (const schedule of await this.listSchedules()) {
       if (schedule.callback === IDLE_CALLBACK) {
-        this.cancelSchedule(schedule.id);
+        await this.cancelSchedule(schedule.id);
       }
     }
-    this.schedule(IDLE_TIMEOUT_SECONDS, IDLE_CALLBACK, {});
+    await this.schedule(IDLE_TIMEOUT_SECONDS, IDLE_CALLBACK, {});
   }
 
   async onIdleTimeout() {
@@ -45,7 +45,7 @@ export class PlaygroundMcpServer extends McpAgent<Env, State, {}> {
         }
       },
       async ({ sides, count }) => {
-        this.resetIdleTimer();
+        await this.resetIdleTimer();
         const rolls = Array.from(
           { length: count },
           () => Math.floor(Math.random() * sides) + 1
@@ -78,7 +78,7 @@ export class PlaygroundMcpServer extends McpAgent<Env, State, {}> {
         }
       },
       async ({ count }) => {
-        this.resetIdleTimer();
+        await this.resetIdleTimer();
         const uuids = Array.from({ length: count }, () => crypto.randomUUID());
         this.setState({
           totalCalls: this.state.totalCalls + 1
@@ -103,7 +103,7 @@ export class PlaygroundMcpServer extends McpAgent<Env, State, {}> {
         }
       },
       async ({ text }) => {
-        this.resetIdleTimer();
+        await this.resetIdleTimer();
         const words = text.trim().split(/\s+/).filter(Boolean).length;
         const characters = text.length;
         const lines = text.split("\n").length;
@@ -130,7 +130,7 @@ export class PlaygroundMcpServer extends McpAgent<Env, State, {}> {
         }
       },
       async ({ text }) => {
-        this.resetIdleTimer();
+        await this.resetIdleTimer();
         const encoder = new TextEncoder();
         const data = encoder.encode(text);
         const hashBuffer = await crypto.subtle.digest("SHA-256", data);

--- a/examples/playground/src/demos/multi-agent/room-agent.ts
+++ b/examples/playground/src/demos/multi-agent/room-agent.ts
@@ -37,8 +37,8 @@ export class RoomAgent extends Agent<Env, RoomState> {
   // Track WebSocket connections to user IDs
   private connectionToUser: Map<string, string> = new Map();
 
-  onConnect(connection: Connection, ctx: ConnectionContext) {
-    super.onConnect(connection, ctx);
+  async onConnect(connection: Connection, ctx: ConnectionContext) {
+    await super.onConnect(connection, ctx);
     console.log(`Connection to room: ${connection.id}`);
   }
 

--- a/examples/playground/src/shared/playground-agent.ts
+++ b/examples/playground/src/shared/playground-agent.ts
@@ -13,7 +13,7 @@ const IDLE_CALLBACK = "onIdleTimeout";
  *
  * The timer is a durable schedule (persisted in SQLite), so it survives
  * hibernation. On reconnect we look it up by callback name via
- * getSchedules() and cancel it — no in-memory state needed.
+ * listSchedules() and cancel it — no in-memory state needed.
  *
  * Agents that override onConnect/onClose must call super to preserve
  * this behavior (see ConnectionsAgent and RoomAgent).
@@ -22,10 +22,10 @@ export class PlaygroundAgent<
   E extends Cloudflare.Env = Env,
   State = unknown
 > extends Agent<E, State> {
-  onConnect(_connection: Connection, _ctx: ConnectionContext) {
-    for (const schedule of this.getSchedules()) {
+  async onConnect(_connection: Connection, _ctx: ConnectionContext) {
+    for (const schedule of await this.listSchedules()) {
       if (schedule.callback === IDLE_CALLBACK) {
-        this.cancelSchedule(schedule.id);
+        await this.cancelSchedule(schedule.id);
       }
     }
   }

--- a/examples/push-notifications/src/server.ts
+++ b/examples/push-notifications/src/server.ts
@@ -80,7 +80,7 @@ export class ReminderAgent extends Agent<Env, ReminderAgentState> {
 
   @callable()
   async cancelReminder(id: string): Promise<{ ok: boolean }> {
-    const schedules = this.getSchedules();
+    const schedules = await this.listSchedules();
     for (const schedule of schedules) {
       const payload = schedule.payload as unknown as
         | Record<string, unknown>

--- a/experimental/forever.md
+++ b/experimental/forever.md
@@ -49,7 +49,7 @@ class Agent {
 
 Ref-counted alarms. `keepAlive()` increments `_keepAliveRefs`. When the first ref is taken, `_scheduleNextAlarm()` sets an alarm via `ctx.storage.setAlarm(now + keepAliveIntervalMs)`. The alarm fires, runs scheduled work and housekeeping, then sets the next alarm if refs are still held. When all disposers are called, `_keepAliveRefs` drops to zero and alarms stop — the DO can go idle naturally.
 
-No schedule rows are created in `cf_agents_schedules`. The heartbeat is invisible to `getSchedules()`.
+No schedule rows are created in `cf_agents_schedules`. The heartbeat is invisible to `listSchedules()`.
 
 ### Alarm persistence
 

--- a/experimental/gadgets-chat/src/server.ts
+++ b/experimental/gadgets-chat/src/server.ts
@@ -402,7 +402,7 @@ export class OverseerAgent extends Agent<Env, RoomsState> {
   @callable()
   async deleteRoom(roomId: string) {
     this.sql`DELETE FROM rooms WHERE id = ${roomId}`;
-    this.deleteSubAgent(ChatRoom, `room-${roomId}`);
+    await this.deleteSubAgent(ChatRoom, `room-${roomId}`);
 
     // If the calling connection was viewing this room, clear it
     const connection = this._getConnection();

--- a/packages/agents/src/e2e-tests/fiber-eviction.test.ts
+++ b/packages/agents/src/e2e-tests/fiber-eviction.test.ts
@@ -31,7 +31,9 @@ function sleep(ms: number): Promise<void> {
 
 function killProcessOnPort(port: number): void {
   try {
-    const output = execSync(`lsof -ti tcp:${port} 2>/dev/null || true`)
+    const output = execSync(
+      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
+    )
       .toString()
       .trim();
     if (output) {
@@ -138,11 +140,12 @@ function killProcess(child: ChildProcess): Promise<void> {
 
 const RUN_FIBER_AGENT_NAME = "run-fiber-e2e";
 
-async function callRunFiberAgent(
+async function callAgentByPath(
+  path: string,
   method: string,
   args: unknown[] = []
 ): Promise<unknown> {
-  const url = `${AGENT_URL}/agents/run-fiber-test-agent/${RUN_FIBER_AGENT_NAME}`;
+  const url = `${AGENT_URL}${path}`;
 
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
@@ -179,6 +182,31 @@ async function callRunFiberAgent(
       reject(err);
     };
   });
+}
+
+async function callRunFiberAgent(
+  method: string,
+  args: unknown[] = []
+): Promise<unknown> {
+  return callAgentByPath(
+    `/agents/run-fiber-test-agent/${RUN_FIBER_AGENT_NAME}`,
+    method,
+    args
+  );
+}
+
+const SUB_AGENT_FIBER_PARENT_NAME = "sub-agent-fiber-e2e";
+const SUB_AGENT_FIBER_CHILD_NAME = "child-fiber-e2e";
+
+async function callSubAgentFiberParent(
+  method: string,
+  args: unknown[] = []
+): Promise<unknown> {
+  return callAgentByPath(
+    `/agents/sub-agent-fiber-parent/${SUB_AGENT_FIBER_PARENT_NAME}`,
+    method,
+    args
+  );
 }
 
 describe("runFiber eviction e2e (no mixin)", () => {
@@ -281,6 +309,68 @@ describe("runFiber eviction e2e (no mixin)", () => {
     }>;
     expect(recoveredFibers.length).toBeGreaterThanOrEqual(1);
     expect(recoveredFibers[0].name).toBe("slowSteps");
+    expect(recoveredFibers[0].snapshot).not.toBeNull();
+  });
+
+  it("should recover a sub-agent runFiber after process kill via the parent alarm", async () => {
+    wrangler = await startAndWait();
+
+    await callSubAgentFiberParent("startChildSlowFiber", [
+      SUB_AGENT_FIBER_CHILD_NAME,
+      8
+    ]);
+
+    await sleep(3500);
+
+    const statusBefore = (await callSubAgentFiberParent(
+      "getChildRunningFiberSnapshot",
+      [SUB_AGENT_FIBER_CHILD_NAME]
+    )) as {
+      completedSteps: Array<{ index: number }>;
+      totalSteps: number;
+    } | null;
+    expect(statusBefore).not.toBeNull();
+    expect(statusBefore!.completedSteps.length).toBeGreaterThan(0);
+    expect(statusBefore!.completedSteps.length).toBeLessThan(8);
+
+    wrangler = await killAndRestart();
+
+    let recovered = false;
+    for (let i = 0; i < 30; i++) {
+      await sleep(1000);
+      try {
+        const status = (await callSubAgentFiberParent("getChildFiberStatus", [
+          SUB_AGENT_FIBER_CHILD_NAME
+        ])) as {
+          hasRunningFibers: boolean;
+          recoveredCount: number;
+        };
+        console.log(
+          `[test] Sub-agent poll ${i + 1}: running=${status.hasRunningFibers}, recovered=${status.recoveredCount}`
+        );
+        if (status.recoveredCount > 0 && !status.hasRunningFibers) {
+          recovered = true;
+          break;
+        }
+      } catch {
+        console.log(
+          `[test] Sub-agent poll ${i + 1}: error (agent may not be ready)`
+        );
+      }
+    }
+
+    expect(recovered).toBe(true);
+
+    const recoveredFibers = (await callSubAgentFiberParent(
+      "getChildRecoveredFibers",
+      [SUB_AGENT_FIBER_CHILD_NAME]
+    )) as Array<{
+      id: string;
+      name: string;
+      snapshot: unknown;
+    }>;
+    expect(recoveredFibers.length).toBeGreaterThanOrEqual(1);
+    expect(recoveredFibers[0].name).toBe("subSlowSteps");
     expect(recoveredFibers[0].snapshot).not.toBeNull();
   });
 });

--- a/packages/agents/src/e2e-tests/worker.ts
+++ b/packages/agents/src/e2e-tests/worker.ts
@@ -9,6 +9,8 @@ import { Agent, callable, routeAgentRequest } from "agents";
 
 type Env = {
   RunFiberTestAgent: DurableObjectNamespace<RunFiberTestAgent>;
+  SubAgentFiberParent: DurableObjectNamespace<SubAgentFiberParent>;
+  SubAgentFiberChild: DurableObjectNamespace<SubAgentFiberChild>;
 };
 
 export type StepResult = {
@@ -98,6 +100,99 @@ export class RunFiberTestAgent extends Agent<Record<string, unknown>> {
     `;
     if (rows.length === 0) return null;
     return rows[0].snapshot ? JSON.parse(rows[0].snapshot) : null;
+  }
+}
+
+// ── Sub-agent runFiber recovery ───────────────────────────────────────
+
+export class SubAgentFiberChild extends Agent<Record<string, unknown>> {
+  static options = { keepAliveIntervalMs: 2_000 };
+
+  recoveredFibers: RunFiberRecoveryContext[] = [];
+
+  override async onFiberRecovered(ctx: RunFiberRecoveryContext) {
+    this.recoveredFibers.push(ctx);
+  }
+
+  async startSlowFiber(totalSteps: number): Promise<string> {
+    void this.runFiber("subSlowSteps", async (ctx) => {
+      const completedSteps: Array<{ index: number; value: string }> = [];
+
+      for (let i = 0; i < totalSteps; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        completedSteps.push({ index: i, value: `sub-step-${i}-done` });
+        ctx.stash({ completedSteps: [...completedSteps], totalSteps });
+      }
+    }).catch(console.error);
+
+    return "started";
+  }
+
+  getFiberStatus(): {
+    hasRunningFibers: boolean;
+    runCount: number;
+    recoveredCount: number;
+    recoveredSnapshots: unknown[];
+  } {
+    const rows = this.sql<{ id: string; snapshot: string | null }>`
+      SELECT id, snapshot FROM cf_agents_runs
+    `;
+    return {
+      hasRunningFibers: rows.length > 0,
+      runCount: rows.length,
+      recoveredCount: this.recoveredFibers.length,
+      recoveredSnapshots: this.recoveredFibers.map((f) => f.snapshot)
+    };
+  }
+
+  getRecoveredFibers(): RunFiberRecoveryContext[] {
+    return this.recoveredFibers;
+  }
+
+  getRunningFiberSnapshot(): unknown {
+    const rows = this.sql<{ snapshot: string | null }>`
+      SELECT snapshot FROM cf_agents_runs LIMIT 1
+    `;
+    if (rows.length === 0) return null;
+    return rows[0].snapshot ? JSON.parse(rows[0].snapshot) : null;
+  }
+}
+
+export class SubAgentFiberParent extends Agent<Record<string, unknown>> {
+  static options = { keepAliveIntervalMs: 2_000 };
+
+  @callable()
+  async startChildSlowFiber(
+    childName: string,
+    totalSteps: number
+  ): Promise<string> {
+    const child = await this.subAgent(SubAgentFiberChild, childName);
+    return child.startSlowFiber(totalSteps);
+  }
+
+  @callable()
+  async getChildRunningFiberSnapshot(childName: string): Promise<unknown> {
+    const child = await this.subAgent(SubAgentFiberChild, childName);
+    return child.getRunningFiberSnapshot();
+  }
+
+  @callable()
+  async getChildFiberStatus(childName: string): Promise<{
+    hasRunningFibers: boolean;
+    runCount: number;
+    recoveredCount: number;
+    recoveredSnapshots: unknown[];
+  }> {
+    const child = await this.subAgent(SubAgentFiberChild, childName);
+    return child.getFiberStatus();
+  }
+
+  @callable()
+  async getChildRecoveredFibers(
+    childName: string
+  ): Promise<RunFiberRecoveryContext[]> {
+    const child = await this.subAgent(SubAgentFiberChild, childName);
+    return child.getRecoveredFibers();
   }
 }
 

--- a/packages/agents/src/e2e-tests/wrangler.jsonc
+++ b/packages/agents/src/e2e-tests/wrangler.jsonc
@@ -8,13 +8,25 @@
       {
         "name": "RunFiberTestAgent",
         "class_name": "RunFiberTestAgent"
+      },
+      {
+        "name": "SubAgentFiberParent",
+        "class_name": "SubAgentFiberParent"
+      },
+      {
+        "name": "SubAgentFiberChild",
+        "class_name": "SubAgentFiberChild"
       }
     ]
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["RunFiberTestAgent"]
+      "new_sqlite_classes": [
+        "RunFiberTestAgent",
+        "SubAgentFiberParent",
+        "SubAgentFiberChild"
+      ]
     }
   ]
 }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -425,7 +425,7 @@ type RootFacetRpcSurface = {
     payload?: T,
     options?: { retry?: RetryOptions; _idempotent?: boolean }
   ): Promise<{ schedule: Schedule<T>; created: boolean }>;
-  _cf_cancelSchedulesForFacetPrefix(
+  _cf_cleanupFacetPrefix(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<void>;
   _cf_getScheduleForFacet(
@@ -2725,9 +2725,9 @@ export class Agent<
     });
   }
 
-  private async _deleteFacetRunRowsForPrefix(
+  private _deleteFacetRunRowsForPrefix(
     ownerPath: ReadonlyArray<AgentPathStep>
-  ): Promise<void> {
+  ): void {
     for (const row of this._facetRunRowsForPrefix(ownerPath)) {
       this.sql`
         DELETE FROM cf_agents_facet_runs
@@ -2735,7 +2735,6 @@ export class Agent<
           AND run_id = ${row.run_id}
       `;
     }
-    await this._scheduleNextAlarm();
   }
 
   private async _rootAlarmOwner(): Promise<RootFacetRpcSurface> {
@@ -3138,15 +3137,16 @@ export class Agent<
   }
 
   /**
-   * Bulk-cancel every schedule whose `owner_path` starts with the
-   * given prefix. Used by `deleteSubAgent` and the recursive facet
-   * destroy to clear schedules for a sub-tree of facets. Emits
-   * `schedule:cancel` on this agent (the alarm-owning root) for
-   * each row removed — the facets being torn down may not be alive
-   * to receive the events themselves.
+   * Clean root-owned bookkeeping for a sub-tree of facets. This
+   * bulk-cancels schedules whose `owner_path` starts with the given
+   * prefix and deletes root-side facet fiber recovery leases for the
+   * same sub-tree. Used by `deleteSubAgent` and recursive facet
+   * destroy. Emits `schedule:cancel` on this agent (the alarm-owning
+   * root) for each schedule row removed — the facets being torn down
+   * may not be alive to receive the events themselves.
    * @internal
    */
-  async _cf_cancelSchedulesForFacetPrefix(
+  async _cf_cleanupFacetPrefix(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<void> {
     const rows = this.sql<ScheduleStorageRow>`
@@ -3171,7 +3171,7 @@ export class Agent<
       this.sql`DELETE FROM cf_agents_schedules WHERE id = ${row.id}`;
     }
 
-    await this._deleteFacetRunRowsForPrefix(ownerPath);
+    this._deleteFacetRunRowsForPrefix(ownerPath);
     await this._scheduleNextAlarm();
   }
 
@@ -3552,7 +3552,8 @@ export class Agent<
    * sub-agent's `cancelSchedule(id)` only matches schedules it
    * created. To clear every schedule under a sub-agent (and its
    * descendants), call `parent.deleteSubAgent(Cls, name)` from the
-   * parent — that bulk-cancels via {@link _cf_cancelSchedulesForFacetPrefix}.
+   * parent — that bulk-cleans root-owned bookkeeping via
+   * {@link _cf_cleanupFacetPrefix}.
    *
    * @param id ID of the task to cancel
    * @returns true if the task was cancelled, false if the task was not found
@@ -4020,7 +4021,7 @@ export class Agent<
     // upfront so we don't have to make an extra round trip back from
     // each intermediate hop.
     if (this._parentPath.length === 0) {
-      await this._cf_cancelSchedulesForFacetPrefix(targetPath);
+      await this._cf_cleanupFacetPrefix(targetPath);
     }
 
     if (selfPath.length === targetPath.length - 1) {
@@ -4918,9 +4919,9 @@ export class Agent<
     const childPath = [...this.selfPath, { className: cls.name, name }];
     if (this._isFacet) {
       const root = await this._rootAlarmOwner();
-      await root._cf_cancelSchedulesForFacetPrefix(childPath);
+      await root._cf_cleanupFacetPrefix(childPath);
     } else {
-      await this._cf_cancelSchedulesForFacetPrefix(childPath);
+      await this._cf_cleanupFacetPrefix(childPath);
     }
 
     // Idempotent: make `ctx.facets.delete` tolerant of missing keys.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -369,6 +369,90 @@ export type Schedule<T = string> = {
     }
 );
 
+type AgentPathStep = { className: string; name: string };
+
+type ScheduleStorageRow = {
+  id: string;
+  callback: string;
+  payload: string;
+  type: "scheduled" | "delayed" | "cron" | "interval";
+  time: number;
+  delayInSeconds?: number;
+  cron?: string;
+  intervalSeconds?: number;
+  retry?: RetryOptions;
+  running?: number;
+  execution_started_at?: number | null;
+  retry_options?: string | null;
+  owner_path?: string | null;
+  owner_path_key?: string | null;
+};
+
+type FacetRunStorageRow = {
+  owner_path: string;
+  owner_path_key: string;
+  run_id: string;
+  created_at: number;
+};
+
+export type ScheduleCriteria = {
+  id?: string;
+  type?: "scheduled" | "delayed" | "cron" | "interval";
+  timeRange?: { start?: Date; end?: Date };
+};
+
+/**
+ * Internal RPC surface exposed by the root agent for facets to
+ * delegate alarm-owning operations (schedules + facet teardown).
+ * @internal
+ */
+type RootFacetRpcSurface = {
+  _cf_scheduleForFacet<T>(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    when: Date | string | number,
+    callback: string,
+    payload?: T,
+    options?: { retry?: RetryOptions; idempotent?: boolean }
+  ): Promise<{ schedule: Schedule<T>; created: boolean }>;
+  _cf_cancelScheduleForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    id: string
+  ): Promise<{ ok: boolean; callback?: string }>;
+  _cf_scheduleEveryForFacet<T>(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    intervalSeconds: number,
+    callback: string,
+    payload?: T,
+    options?: { retry?: RetryOptions; _idempotent?: boolean }
+  ): Promise<{ schedule: Schedule<T>; created: boolean }>;
+  _cf_cancelSchedulesForFacetPrefix(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<void>;
+  _cf_getScheduleForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    id: string
+  ): Promise<Schedule<unknown> | undefined>;
+  _cf_listSchedulesForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    criteria?: ScheduleCriteria
+  ): Promise<Schedule<unknown>[]>;
+  _cf_destroyDescendantFacet(
+    targetPath: ReadonlyArray<AgentPathStep>
+  ): Promise<void>;
+  _cf_acquireFacetKeepAlive(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<string>;
+  _cf_releaseFacetKeepAlive(token: string): Promise<void>;
+  _cf_registerFacetRun(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    runId: string
+  ): Promise<void>;
+  _cf_unregisterFacetRun(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    runId: string
+  ): Promise<void>;
+};
+
 /**
  * Context passed to the `runFiber` callback. Provides checkpoint
  * and identity for durable execution.
@@ -496,7 +580,7 @@ const DEFAULT_KEEP_ALIVE_INTERVAL_MS = 30_000;
  * The constructor stores this as a row in cf_agents_state and checks it
  * on wake to skip DDL on established DOs.
  */
-const CURRENT_SCHEMA_VERSION = 3;
+const CURRENT_SCHEMA_VERSION = 5;
 
 const SCHEMA_VERSION_ROW_ID = "cf_schema_version";
 const STATE_ROW_ID = "cf_state_row_id";
@@ -843,6 +927,14 @@ export class Agent<
    */
   _keepAliveRefs = 0;
 
+  /**
+   * In-memory tokens for keepAlive leases acquired by facets and held
+   * on the root alarm owner. Lost on eviction, like `_keepAliveRefs`,
+   * because the in-memory work those leases were protecting is also gone.
+   * @internal
+   */
+  private _facetKeepAliveTokens = new Set<string>();
+
   /** @internal In-memory set of fiber IDs running in this process. */
   private _runFiberActiveFibers = new Set<string>();
   /** @internal Prevents re-entrant recovery from overlapping alarm ticks. */
@@ -1086,7 +1178,9 @@ export class Agent<
           running INTEGER DEFAULT 0,
           created_at INTEGER DEFAULT (unixepoch()),
           execution_started_at INTEGER,
-          retry_options TEXT
+          retry_options TEXT,
+          owner_path TEXT,
+          owner_path_key TEXT
         )
       `;
 
@@ -1115,6 +1209,12 @@ export class Agent<
       );
       addColumnIfNotExists(
         "ALTER TABLE cf_agents_schedules ADD COLUMN retry_options TEXT"
+      );
+      addColumnIfNotExists(
+        "ALTER TABLE cf_agents_schedules ADD COLUMN owner_path TEXT"
+      );
+      addColumnIfNotExists(
+        "ALTER TABLE cf_agents_schedules ADD COLUMN owner_path_key TEXT"
       );
       addColumnIfNotExists(
         "ALTER TABLE cf_agents_queues ADD COLUMN retry_options TEXT"
@@ -1149,15 +1249,19 @@ export class Agent<
                 running INTEGER DEFAULT 0,
                 created_at INTEGER DEFAULT (unixepoch()),
                 execution_started_at INTEGER,
-                retry_options TEXT
+                retry_options TEXT,
+                owner_path TEXT,
+                owner_path_key TEXT
               )
             `);
             this.ctx.storage.sql.exec(`
               INSERT INTO cf_agents_schedules_new
                 (id, callback, payload, type, time, delayInSeconds, cron,
-                 intervalSeconds, running, created_at, execution_started_at, retry_options)
+                 intervalSeconds, running, created_at, execution_started_at, retry_options,
+                 owner_path, owner_path_key)
               SELECT id, callback, payload, type, time, delayInSeconds, cron,
-                     intervalSeconds, running, created_at, execution_started_at, retry_options
+                     intervalSeconds, running, created_at, execution_started_at, retry_options,
+                     owner_path, owner_path_key
               FROM cf_agents_schedules
             `);
             this.ctx.storage.sql.exec("DROP TABLE cf_agents_schedules");
@@ -1218,6 +1322,25 @@ export class Agent<
           snapshot TEXT,
           created_at INTEGER NOT NULL
         )
+      `;
+
+      // v5: root-side index of descendant facet fibers. The fiber's
+      // authoritative row stays in the facet's own cf_agents_runs table;
+      // this table only lets the root alarm owner know which facets need
+      // recovery checks while they are idle.
+      this.sql`
+        CREATE TABLE IF NOT EXISTS cf_agents_facet_runs (
+          owner_path TEXT NOT NULL,
+          owner_path_key TEXT NOT NULL,
+          run_id TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          PRIMARY KEY (owner_path_key, run_id)
+        )
+      `;
+
+      this.sql`
+        CREATE INDEX IF NOT EXISTS idx_facet_runs_owner_path_key
+        ON cf_agents_facet_runs(owner_path_key)
       `;
 
       // Mark schema as up-to-date
@@ -2573,6 +2696,638 @@ export class Agent<
       }));
   }
 
+  private _scheduleOwnerPathKey(
+    path: ReadonlyArray<AgentPathStep> | null
+  ): string | null {
+    if (!path) return null;
+    return path
+      .map(
+        (step) =>
+          `${encodeURIComponent(step.className)}:${encodeURIComponent(step.name)}`
+      )
+      .join("/");
+  }
+
+  private _facetRunRowsForPrefix(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): FacetRunStorageRow[] {
+    const rows = this.sql<FacetRunStorageRow>`
+      SELECT owner_path, owner_path_key, run_id, created_at
+      FROM cf_agents_facet_runs
+    `;
+    return rows.filter((row) => {
+      try {
+        const rowOwnerPath = JSON.parse(row.owner_path) as AgentPathStep[];
+        return this._isSameAgentPathPrefix(ownerPath, rowOwnerPath);
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  private async _deleteFacetRunRowsForPrefix(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<void> {
+    for (const row of this._facetRunRowsForPrefix(ownerPath)) {
+      this.sql`
+        DELETE FROM cf_agents_facet_runs
+        WHERE owner_path_key = ${row.owner_path_key}
+          AND run_id = ${row.run_id}
+      `;
+    }
+    await this._scheduleNextAlarm();
+  }
+
+  private async _rootAlarmOwner(): Promise<RootFacetRpcSurface> {
+    const root = this._parentPath[0];
+    if (!root) {
+      throw new Error("Facet scheduler delegation requires a root parent.");
+    }
+
+    const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
+    const binding = ctx.exports?.[root.className] as
+      | DurableObjectNamespace
+      | undefined;
+    if (!binding) {
+      throw new Error(
+        `Unable to resolve root scheduler "${root.className}" for sub-agent schedule delegation.`
+      );
+    }
+
+    return (await getServerByName<Cloudflare.Env, Agent>(
+      binding as DurableObjectNamespace<Agent>,
+      root.name
+    )) as unknown as RootFacetRpcSurface;
+  }
+
+  private _validateScheduleCallback(
+    when: Date | string | number,
+    callback: keyof this,
+    options?: { retry?: RetryOptions; idempotent?: boolean }
+  ): asserts callback is Extract<keyof this, string> {
+    if (typeof callback !== "string") {
+      throw new Error("Callback must be a string");
+    }
+
+    if (typeof this[callback] !== "function") {
+      throw new Error(`this.${callback} is not a function`);
+    }
+
+    if (options?.retry) {
+      validateRetryOptions(options.retry, this._resolvedOptions.retry);
+    }
+
+    if (
+      this._insideOnStart &&
+      options?.idempotent === undefined &&
+      typeof when !== "string" &&
+      !this._warnedScheduleInOnStart.has(callback)
+    ) {
+      this._warnedScheduleInOnStart.add(callback);
+      console.warn(
+        `schedule("${callback}") called inside onStart() without { idempotent: true }. ` +
+          `This creates a new row on every Durable Object restart, which can cause ` +
+          `duplicate executions. Pass { idempotent: true } to deduplicate, or use ` +
+          `scheduleEvery() for recurring tasks.`
+      );
+    }
+  }
+
+  /**
+   * Insert (or, for idempotent calls, return the existing row for) a
+   * schedule owned by either this top-level agent (`ownerPath === null`)
+   * or a descendant facet. Returns `{ schedule, created }` — `created`
+   * is `false` when an idempotent insert deduplicates onto an existing
+   * row, so callers can suppress the `schedule:create` event in that
+   * case to match historic semantics.
+   * @internal
+   */
+  private async _insertScheduleForOwner<T = string>(
+    ownerPath: ReadonlyArray<AgentPathStep> | null,
+    when: Date | string | number,
+    callback: string,
+    payload?: T,
+    options?: { retry?: RetryOptions; idempotent?: boolean }
+  ): Promise<{ schedule: Schedule<T>; created: boolean }> {
+    const ownerPathJson = ownerPath ? JSON.stringify(ownerPath) : null;
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    const retryJson = options?.retry ? JSON.stringify(options.retry) : null;
+    const payloadJson = JSON.stringify(payload);
+
+    if (when instanceof Date) {
+      const timestamp = Math.floor(when.getTime() / 1000);
+
+      if (options?.idempotent) {
+        const existing = this.sql<ScheduleStorageRow>`
+          SELECT * FROM cf_agents_schedules
+          WHERE type = 'scheduled'
+            AND callback = ${callback}
+            AND payload IS ${payloadJson}
+            AND owner_path_key IS ${ownerPathKey}
+          LIMIT 1
+        `;
+
+        if (existing.length > 0) {
+          const row = existing[0];
+          await this._scheduleNextAlarm();
+          return {
+            schedule: {
+              callback: row.callback,
+              id: row.id,
+              payload: JSON.parse(row.payload) as T,
+              retry: parseRetryOptions(
+                row as unknown as Record<string, unknown>
+              ),
+              time: row.time,
+              type: "scheduled"
+            },
+            created: false
+          };
+        }
+      }
+
+      const id = nanoid(9);
+      this.sql`
+        INSERT OR REPLACE INTO cf_agents_schedules
+          (id, callback, payload, type, time, retry_options, owner_path, owner_path_key)
+        VALUES
+          (${id}, ${callback}, ${payloadJson}, 'scheduled', ${timestamp}, ${retryJson}, ${ownerPathJson}, ${ownerPathKey})
+      `;
+
+      await this._scheduleNextAlarm();
+      return {
+        schedule: {
+          callback,
+          id,
+          payload: payload as T,
+          retry: options?.retry,
+          time: timestamp,
+          type: "scheduled"
+        },
+        created: true
+      };
+    }
+
+    if (typeof when === "number") {
+      const timestamp = Math.floor((Date.now() + when * 1000) / 1000);
+
+      if (options?.idempotent) {
+        const existing = this.sql<ScheduleStorageRow>`
+          SELECT * FROM cf_agents_schedules
+          WHERE type = 'delayed'
+            AND callback = ${callback}
+            AND payload IS ${payloadJson}
+            AND owner_path_key IS ${ownerPathKey}
+          LIMIT 1
+        `;
+
+        if (existing.length > 0) {
+          const row = existing[0];
+          await this._scheduleNextAlarm();
+          return {
+            schedule: {
+              callback: row.callback,
+              delayInSeconds: row.delayInSeconds ?? 0,
+              id: row.id,
+              payload: JSON.parse(row.payload) as T,
+              retry: parseRetryOptions(
+                row as unknown as Record<string, unknown>
+              ),
+              time: row.time,
+              type: "delayed"
+            },
+            created: false
+          };
+        }
+      }
+
+      const id = nanoid(9);
+      this.sql`
+        INSERT OR REPLACE INTO cf_agents_schedules
+          (id, callback, payload, type, delayInSeconds, time, retry_options, owner_path, owner_path_key)
+        VALUES
+          (${id}, ${callback}, ${payloadJson}, 'delayed', ${when}, ${timestamp}, ${retryJson}, ${ownerPathJson}, ${ownerPathKey})
+      `;
+
+      await this._scheduleNextAlarm();
+      return {
+        schedule: {
+          callback,
+          delayInSeconds: when,
+          id,
+          payload: payload as T,
+          retry: options?.retry,
+          time: timestamp,
+          type: "delayed"
+        },
+        created: true
+      };
+    }
+
+    if (typeof when === "string") {
+      const timestamp = Math.floor(getNextCronTime(when).getTime() / 1000);
+      const idempotent = options?.idempotent !== false;
+
+      if (idempotent) {
+        const existing = this.sql<ScheduleStorageRow>`
+          SELECT * FROM cf_agents_schedules
+          WHERE type = 'cron'
+            AND callback = ${callback}
+            AND cron = ${when}
+            AND payload IS ${payloadJson}
+            AND owner_path_key IS ${ownerPathKey}
+          LIMIT 1
+        `;
+
+        if (existing.length > 0) {
+          const row = existing[0];
+          await this._scheduleNextAlarm();
+          return {
+            schedule: {
+              callback: row.callback,
+              cron: row.cron ?? when,
+              id: row.id,
+              payload: JSON.parse(row.payload) as T,
+              retry: parseRetryOptions(
+                row as unknown as Record<string, unknown>
+              ),
+              time: row.time,
+              type: "cron"
+            },
+            created: false
+          };
+        }
+      }
+
+      const id = nanoid(9);
+      this.sql`
+        INSERT OR REPLACE INTO cf_agents_schedules
+          (id, callback, payload, type, cron, time, retry_options, owner_path, owner_path_key)
+        VALUES
+          (${id}, ${callback}, ${payloadJson}, 'cron', ${when}, ${timestamp}, ${retryJson}, ${ownerPathJson}, ${ownerPathKey})
+      `;
+
+      await this._scheduleNextAlarm();
+      return {
+        schedule: {
+          callback,
+          cron: when,
+          id,
+          payload: payload as T,
+          retry: options?.retry,
+          time: timestamp,
+          type: "cron"
+        },
+        created: true
+      };
+    }
+
+    throw new Error(
+      `Invalid schedule type: ${JSON.stringify(when)}(${typeof when}) trying to schedule ${callback}`
+    );
+  }
+
+  /**
+   * Insert a schedule row owned by a descendant facet. Called via RPC
+   * from the facet's `schedule()`. Returns `{ schedule, created }`
+   * so the originating facet can suppress `schedule:create` on
+   * idempotent dedup. This method does not emit observability
+   * events itself.
+   * @internal
+   */
+  async _cf_scheduleForFacet<T = string>(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    when: Date | string | number,
+    callback: string,
+    payload?: T,
+    options?: { retry?: RetryOptions; idempotent?: boolean }
+  ): Promise<{ schedule: Schedule<T>; created: boolean }> {
+    return this._insertScheduleForOwner(
+      ownerPath,
+      when,
+      callback,
+      payload,
+      options
+    );
+  }
+
+  /**
+   * Insert (or, for idempotent calls, return the existing row for) an
+   * interval schedule. Mirrors {@link _insertScheduleForOwner} —
+   * returns `{ schedule, created }` so callers can suppress
+   * `schedule:create` on dedup.
+   * @internal
+   */
+  private async _insertIntervalScheduleForOwner<T = string>(
+    ownerPath: ReadonlyArray<AgentPathStep> | null,
+    intervalSeconds: number,
+    callback: string,
+    payload?: T,
+    options?: { retry?: RetryOptions; _idempotent?: boolean }
+  ): Promise<{ schedule: Schedule<T>; created: boolean }> {
+    const ownerPathJson = ownerPath ? JSON.stringify(ownerPath) : null;
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    const idempotent = options?._idempotent !== false;
+    const payloadJson = JSON.stringify(payload);
+
+    if (idempotent) {
+      const existing = this.sql<ScheduleStorageRow>`
+        SELECT * FROM cf_agents_schedules
+        WHERE type = 'interval'
+          AND callback = ${callback}
+          AND intervalSeconds = ${intervalSeconds}
+          AND payload IS ${payloadJson}
+          AND owner_path_key IS ${ownerPathKey}
+        LIMIT 1
+      `;
+
+      if (existing.length > 0) {
+        const row = existing[0];
+        await this._scheduleNextAlarm();
+        return {
+          schedule: {
+            callback: row.callback,
+            id: row.id,
+            intervalSeconds: row.intervalSeconds ?? intervalSeconds,
+            payload: JSON.parse(row.payload) as T,
+            retry: parseRetryOptions(row as unknown as Record<string, unknown>),
+            time: row.time,
+            type: "interval"
+          },
+          created: false
+        };
+      }
+    }
+
+    const id = nanoid(9);
+    const timestamp = Math.floor((Date.now() + intervalSeconds * 1000) / 1000);
+    const retryJson = options?.retry ? JSON.stringify(options.retry) : null;
+
+    this.sql`
+      INSERT OR REPLACE INTO cf_agents_schedules
+        (id, callback, payload, type, intervalSeconds, time, running, retry_options, owner_path, owner_path_key)
+      VALUES
+        (${id}, ${callback}, ${payloadJson}, 'interval', ${intervalSeconds}, ${timestamp}, 0, ${retryJson}, ${ownerPathJson}, ${ownerPathKey})
+    `;
+
+    await this._scheduleNextAlarm();
+    return {
+      schedule: {
+        callback,
+        id,
+        intervalSeconds,
+        payload: payload as T,
+        retry: options?.retry,
+        time: timestamp,
+        type: "interval"
+      },
+      created: true
+    };
+  }
+
+  /**
+   * Insert an interval schedule row owned by a descendant facet.
+   * Called via RPC from the facet's `scheduleEvery()`. Returns
+   * `{ schedule, created }` so the originating facet can suppress
+   * `schedule:create` on idempotent dedup. This method does not
+   * emit observability events itself.
+   * @internal
+   */
+  async _cf_scheduleEveryForFacet<T = string>(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    intervalSeconds: number,
+    callback: string,
+    payload?: T,
+    options?: { retry?: RetryOptions; _idempotent?: boolean }
+  ): Promise<{ schedule: Schedule<T>; created: boolean }> {
+    return this._insertIntervalScheduleForOwner(
+      ownerPath,
+      intervalSeconds,
+      callback,
+      payload,
+      options
+    );
+  }
+
+  /**
+   * Cancel a schedule row owned by a descendant facet, scoped by
+   * `owner_path_key` so siblings can't reach each other's rows.
+   * Returns the canceled row's callback name so the originating
+   * facet can emit `schedule:cancel`. This method does not emit
+   * observability events itself.
+   * @internal
+   */
+  async _cf_cancelScheduleForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    id: string
+  ): Promise<{ ok: boolean; callback?: string }> {
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    const result = this.sql<ScheduleStorageRow>`
+      SELECT * FROM cf_agents_schedules
+      WHERE id = ${id} AND owner_path_key IS ${ownerPathKey}
+    `;
+    if (result.length === 0) return { ok: false };
+
+    const callback = result[0].callback;
+    this.sql`
+      DELETE FROM cf_agents_schedules
+      WHERE id = ${id} AND owner_path_key IS ${ownerPathKey}
+    `;
+    await this._scheduleNextAlarm();
+    return { ok: true, callback };
+  }
+
+  /**
+   * Bulk-cancel every schedule whose `owner_path` starts with the
+   * given prefix. Used by `deleteSubAgent` and the recursive facet
+   * destroy to clear schedules for a sub-tree of facets. Emits
+   * `schedule:cancel` on this agent (the alarm-owning root) for
+   * each row removed — the facets being torn down may not be alive
+   * to receive the events themselves.
+   * @internal
+   */
+  async _cf_cancelSchedulesForFacetPrefix(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<void> {
+    const rows = this.sql<ScheduleStorageRow>`
+      SELECT * FROM cf_agents_schedules
+      WHERE owner_path IS NOT NULL
+    `;
+    const rowsToDelete = rows.filter((row) => {
+      if (!row.owner_path) return false;
+      try {
+        const rowOwnerPath = JSON.parse(row.owner_path) as AgentPathStep[];
+        return this._isSameAgentPathPrefix(ownerPath, rowOwnerPath);
+      } catch {
+        return false;
+      }
+    });
+
+    for (const row of rowsToDelete) {
+      this._emit("schedule:cancel", {
+        callback: row.callback,
+        id: row.id
+      });
+      this.sql`DELETE FROM cf_agents_schedules WHERE id = ${row.id}`;
+    }
+
+    await this._deleteFacetRunRowsForPrefix(ownerPath);
+    await this._scheduleNextAlarm();
+  }
+
+  private _scheduleRowToSchedule<T>(row: ScheduleStorageRow): Schedule<T> {
+    return {
+      ...row,
+      payload: JSON.parse(row.payload) as T,
+      retry: parseRetryOptions(row as unknown as Record<string, unknown>)
+    } as Schedule<T>;
+  }
+
+  private _getScheduleForOwner<T = string>(
+    ownerPath: ReadonlyArray<AgentPathStep> | null,
+    id: string
+  ): Schedule<T> | undefined {
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    const result = this.sql<ScheduleStorageRow>`
+      SELECT * FROM cf_agents_schedules
+      WHERE id = ${id} AND owner_path_key IS ${ownerPathKey}
+    `;
+    if (!result || result.length === 0) {
+      return undefined;
+    }
+    return this._scheduleRowToSchedule<T>(result[0]);
+  }
+
+  private _listSchedulesForOwner<T = string>(
+    ownerPath: ReadonlyArray<AgentPathStep> | null,
+    criteria: ScheduleCriteria = {}
+  ): Schedule<T>[] {
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    let query = "SELECT * FROM cf_agents_schedules WHERE owner_path_key IS ?";
+    const params: Array<string | number | null> = [ownerPathKey];
+
+    if (criteria.id) {
+      query += " AND id = ?";
+      params.push(criteria.id);
+    }
+
+    if (criteria.type) {
+      query += " AND type = ?";
+      params.push(criteria.type);
+    }
+
+    if (criteria.timeRange) {
+      query += " AND time >= ? AND time <= ?";
+      const start = criteria.timeRange.start || new Date(0);
+      const end = criteria.timeRange.end || new Date(999999999999999);
+      params.push(
+        Math.floor(start.getTime() / 1000),
+        Math.floor(end.getTime() / 1000)
+      );
+    }
+
+    return this.ctx.storage.sql
+      .exec(query, ...params)
+      .toArray()
+      .map((row) =>
+        this._scheduleRowToSchedule<T>(row as unknown as ScheduleStorageRow)
+      );
+  }
+
+  /**
+   * Read a single schedule row owned by a descendant facet.
+   * @internal
+   */
+  async _cf_getScheduleForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    id: string
+  ): Promise<Schedule<unknown> | undefined> {
+    return this._getScheduleForOwner(ownerPath, id);
+  }
+
+  /**
+   * List schedule rows owned by a descendant facet, scoped by
+   * `owner_path_key` so siblings remain isolated from each other.
+   * @internal
+   */
+  async _cf_listSchedulesForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    criteria: ScheduleCriteria = {}
+  ): Promise<Schedule<unknown>[]> {
+    return this._listSchedulesForOwner(ownerPath, criteria);
+  }
+
+  /**
+   * Acquire a root-owned keepAlive ref on behalf of a descendant facet.
+   * Facets share the root isolate but cannot set their own physical
+   * alarm, so this lets facet work use the root alarm heartbeat.
+   * @internal
+   */
+  async _cf_acquireFacetKeepAlive(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<string> {
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    const token = `${ownerPathKey ?? "unknown"}:${nanoid(9)}`;
+    this._facetKeepAliveTokens.add(token);
+    this._keepAliveRefs++;
+    if (this._keepAliveRefs === 1) {
+      await this._scheduleNextAlarm();
+    }
+    return token;
+  }
+
+  /**
+   * Release a root-owned keepAlive ref previously acquired for a facet.
+   * Idempotent so disposer calls can safely race or run twice.
+   * @internal
+   */
+  async _cf_releaseFacetKeepAlive(token: string): Promise<void> {
+    if (!this._facetKeepAliveTokens.delete(token)) return;
+    this._keepAliveRefs = Math.max(0, this._keepAliveRefs - 1);
+    await this._scheduleNextAlarm();
+  }
+
+  /**
+   * Register a facet's durable run row in the root-side index so root
+   * alarm housekeeping can dispatch recovery checks into idle facets.
+   * The facet remains authoritative for snapshots and recovery hooks.
+   * @internal
+   */
+  async _cf_registerFacetRun(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    runId: string
+  ): Promise<void> {
+    const ownerPathJson = JSON.stringify(ownerPath);
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    if (!ownerPathKey) {
+      throw new Error("_cf_registerFacetRun requires a non-empty owner path.");
+    }
+    this.sql`
+      INSERT OR REPLACE INTO cf_agents_facet_runs
+        (owner_path, owner_path_key, run_id, created_at)
+      VALUES
+        (${ownerPathJson}, ${ownerPathKey}, ${runId}, ${Date.now()})
+    `;
+    await this._scheduleNextAlarm();
+  }
+
+  /**
+   * Remove a completed facet fiber from the root-side index.
+   * @internal
+   */
+  async _cf_unregisterFacetRun(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    runId: string
+  ): Promise<void> {
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    this.sql`
+      DELETE FROM cf_agents_facet_runs
+      WHERE owner_path_key IS ${ownerPathKey}
+        AND run_id = ${runId}
+    `;
+    await this._scheduleNextAlarm();
+  }
+
   /**
    * Schedule a task to be executed in the future
    *
@@ -2601,219 +3356,33 @@ export class Agent<
     payload?: T,
     options?: { retry?: RetryOptions; idempotent?: boolean }
   ): Promise<Schedule<T>> {
-    if (this._isFacet) {
-      throw new Error(
-        "Scheduling is not supported in sub-agents. " +
-          "Schedule from the parent agent instead."
-      );
+    this._validateScheduleCallback(when, callback, options);
+
+    const result = this._isFacet
+      ? await (
+          await this._rootAlarmOwner()
+        )._cf_scheduleForFacet<T>(
+          this.selfPath,
+          when,
+          callback,
+          payload,
+          options
+        )
+      : await this._insertScheduleForOwner(
+          null,
+          when,
+          callback,
+          payload,
+          options
+        );
+
+    if (result.created) {
+      this._emit("schedule:create", {
+        callback: result.schedule.callback,
+        id: result.schedule.id
+      });
     }
-
-    if (typeof callback !== "string") {
-      throw new Error("Callback must be a string");
-    }
-
-    if (typeof this[callback] !== "function") {
-      throw new Error(`this.${callback} is not a function`);
-    }
-
-    if (options?.retry) {
-      validateRetryOptions(options.retry, this._resolvedOptions.retry);
-    }
-
-    const retryJson = options?.retry ? JSON.stringify(options.retry) : null;
-    const payloadJson = JSON.stringify(payload);
-
-    if (
-      this._insideOnStart &&
-      options?.idempotent === undefined &&
-      typeof when !== "string" &&
-      !this._warnedScheduleInOnStart.has(callback)
-    ) {
-      this._warnedScheduleInOnStart.add(callback);
-      console.warn(
-        `schedule("${callback}") called inside onStart() without { idempotent: true }. ` +
-          `This creates a new row on every Durable Object restart, which can cause ` +
-          `duplicate executions. Pass { idempotent: true } to deduplicate, or use ` +
-          `scheduleEvery() for recurring tasks.`
-      );
-    }
-
-    if (when instanceof Date) {
-      const timestamp = Math.floor(when.getTime() / 1000);
-
-      if (options?.idempotent) {
-        const existing = this.sql<{
-          id: string;
-          callback: string;
-          payload: string;
-          type: string;
-          time: number;
-          retry_options: string | null;
-        }>`
-          SELECT * FROM cf_agents_schedules
-          WHERE type = 'scheduled'
-            AND callback = ${callback}
-            AND payload IS ${payloadJson}
-          LIMIT 1
-        `;
-
-        if (existing.length > 0) {
-          const row = existing[0];
-          await this._scheduleNextAlarm();
-          return {
-            callback: row.callback,
-            id: row.id,
-            payload: JSON.parse(row.payload) as T,
-            retry: parseRetryOptions(row as unknown as Record<string, unknown>),
-            time: row.time,
-            type: "scheduled"
-          };
-        }
-      }
-
-      const id = nanoid(9);
-      this.sql`
-        INSERT OR REPLACE INTO cf_agents_schedules (id, callback, payload, type, time, retry_options)
-        VALUES (${id}, ${callback}, ${payloadJson}, 'scheduled', ${timestamp}, ${retryJson})
-      `;
-
-      await this._scheduleNextAlarm();
-
-      const schedule: Schedule<T> = {
-        callback: callback,
-        id,
-        payload: payload as T,
-        retry: options?.retry,
-        time: timestamp,
-        type: "scheduled"
-      };
-
-      this._emit("schedule:create", { callback: callback as string, id });
-
-      return schedule;
-    }
-    if (typeof when === "number") {
-      const time = new Date(Date.now() + when * 1000);
-      const timestamp = Math.floor(time.getTime() / 1000);
-
-      if (options?.idempotent) {
-        const existing = this.sql<{
-          id: string;
-          callback: string;
-          payload: string;
-          type: string;
-          time: number;
-          delayInSeconds: number;
-          retry_options: string | null;
-        }>`
-          SELECT * FROM cf_agents_schedules
-          WHERE type = 'delayed'
-            AND callback = ${callback}
-            AND payload IS ${payloadJson}
-          LIMIT 1
-        `;
-
-        if (existing.length > 0) {
-          const row = existing[0];
-          await this._scheduleNextAlarm();
-          return {
-            callback: row.callback,
-            delayInSeconds: row.delayInSeconds,
-            id: row.id,
-            payload: JSON.parse(row.payload) as T,
-            retry: parseRetryOptions(row as unknown as Record<string, unknown>),
-            time: row.time,
-            type: "delayed"
-          };
-        }
-      }
-
-      const id = nanoid(9);
-      this.sql`
-        INSERT OR REPLACE INTO cf_agents_schedules (id, callback, payload, type, delayInSeconds, time, retry_options)
-        VALUES (${id}, ${callback}, ${payloadJson}, 'delayed', ${when}, ${timestamp}, ${retryJson})
-      `;
-
-      await this._scheduleNextAlarm();
-
-      const schedule: Schedule<T> = {
-        callback: callback,
-        delayInSeconds: when,
-        id,
-        payload: payload as T,
-        retry: options?.retry,
-        time: timestamp,
-        type: "delayed"
-      };
-
-      this._emit("schedule:create", { callback: callback as string, id });
-
-      return schedule;
-    }
-    if (typeof when === "string") {
-      const nextExecutionTime = getNextCronTime(when);
-      const timestamp = Math.floor(nextExecutionTime.getTime() / 1000);
-
-      // Cron schedules are idempotent by default
-      const idempotent = options?.idempotent !== false;
-      if (idempotent) {
-        const existing = this.sql<{
-          id: string;
-          callback: string;
-          payload: string;
-          type: string;
-          time: number;
-          cron: string;
-          retry_options: string | null;
-        }>`
-          SELECT * FROM cf_agents_schedules
-          WHERE type = 'cron'
-            AND callback = ${callback}
-            AND cron = ${when}
-            AND payload IS ${payloadJson}
-          LIMIT 1
-        `;
-
-        if (existing.length > 0) {
-          const row = existing[0];
-          await this._scheduleNextAlarm();
-          return {
-            callback: row.callback,
-            cron: row.cron,
-            id: row.id,
-            payload: JSON.parse(row.payload) as T,
-            retry: parseRetryOptions(row as unknown as Record<string, unknown>),
-            time: row.time,
-            type: "cron"
-          };
-        }
-      }
-
-      const id = nanoid(9);
-      this.sql`
-        INSERT OR REPLACE INTO cf_agents_schedules (id, callback, payload, type, cron, time, retry_options)
-        VALUES (${id}, ${callback}, ${payloadJson}, 'cron', ${when}, ${timestamp}, ${retryJson})
-      `;
-
-      await this._scheduleNextAlarm();
-
-      const schedule: Schedule<T> = {
-        callback: callback,
-        cron: when,
-        id,
-        payload: payload as T,
-        retry: options?.retry,
-        time: timestamp,
-        type: "cron"
-      };
-
-      this._emit("schedule:create", { callback: callback as string, id });
-
-      return schedule;
-    }
-    throw new Error(
-      `Invalid schedule type: ${JSON.stringify(when)}(${typeof when}) trying to schedule ${callback}`
-    );
+    return result.schedule;
   }
 
   /**
@@ -2848,12 +3417,6 @@ export class Agent<
     payload?: T,
     options?: { retry?: RetryOptions; _idempotent?: boolean }
   ): Promise<Schedule<T>> {
-    if (this._isFacet) {
-      throw new Error(
-        "Scheduling is not supported in sub-agents. " +
-          "Schedule from the parent agent instead."
-      );
-    }
     // DO alarms have a max schedule time of 30 days
     const MAX_INTERVAL_SECONDS = 30 * 24 * 60 * 60; // 30 days in seconds
 
@@ -2879,74 +3442,31 @@ export class Agent<
       validateRetryOptions(options.retry, this._resolvedOptions.retry);
     }
 
-    const idempotent = options?._idempotent !== false;
-    const payloadJson = JSON.stringify(payload);
+    const result = this._isFacet
+      ? await (
+          await this._rootAlarmOwner()
+        )._cf_scheduleEveryForFacet<T>(
+          this.selfPath,
+          intervalSeconds,
+          callback,
+          payload,
+          options
+        )
+      : await this._insertIntervalScheduleForOwner(
+          null,
+          intervalSeconds,
+          callback,
+          payload,
+          options
+        );
 
-    // Idempotency: check for an existing interval schedule with the same
-    // callback, interval, and payload. A different interval or payload is
-    // treated as a distinct schedule and gets its own row.
-    if (idempotent) {
-      const existing = this.sql<{
-        id: string;
-        callback: string;
-        payload: string;
-        type: string;
-        time: number;
-        intervalSeconds: number;
-        retry_options: string | null;
-      }>`
-        SELECT * FROM cf_agents_schedules
-        WHERE type = 'interval'
-          AND callback = ${callback}
-          AND intervalSeconds = ${intervalSeconds}
-          AND payload IS ${payloadJson}
-        LIMIT 1
-      `;
-
-      if (existing.length > 0) {
-        const row = existing[0];
-
-        await this._scheduleNextAlarm();
-
-        // Exact match — return existing schedule as-is (no-op)
-        return {
-          callback: row.callback,
-          id: row.id,
-          intervalSeconds: row.intervalSeconds,
-          payload: JSON.parse(row.payload) as T,
-          retry: parseRetryOptions(row as unknown as Record<string, unknown>),
-          time: row.time,
-          type: "interval"
-        };
-      }
+    if (result.created) {
+      this._emit("schedule:create", {
+        callback: result.schedule.callback,
+        id: result.schedule.id
+      });
     }
-
-    const id = nanoid(9);
-    const time = new Date(Date.now() + intervalSeconds * 1000);
-    const timestamp = Math.floor(time.getTime() / 1000);
-
-    const retryJson = options?.retry ? JSON.stringify(options.retry) : null;
-
-    this.sql`
-      INSERT OR REPLACE INTO cf_agents_schedules (id, callback, payload, type, intervalSeconds, time, running, retry_options)
-      VALUES (${id}, ${callback}, ${payloadJson}, 'interval', ${intervalSeconds}, ${timestamp}, 0, ${retryJson})
-    `;
-
-    await this._scheduleNextAlarm();
-
-    const schedule: Schedule<T> = {
-      callback: callback,
-      id,
-      intervalSeconds,
-      payload: payload as T,
-      retry: options?.retry,
-      time: timestamp,
-      type: "interval"
-    };
-
-    this._emit("schedule:create", { callback: callback as string, id });
-
-    return schedule;
+    return result.schedule;
   }
 
   /**
@@ -2954,20 +3474,35 @@ export class Agent<
    * @template T Type of the payload data
    * @param id ID of the scheduled task
    * @returns The Schedule object or undefined if not found
+   * @deprecated Use {@link getScheduleById}. This synchronous API cannot cross
+   * Durable Object boundaries and throws inside sub-agents.
    */
   getSchedule<T = string>(id: string): Schedule<T> | undefined {
-    const result = this.sql<Schedule<string>>`
-      SELECT * FROM cf_agents_schedules WHERE id = ${id}
-    `;
-    if (!result || result.length === 0) {
-      return undefined;
+    if (this._isFacet) {
+      throw new Error(
+        "getSchedule() is synchronous and cannot read parent-owned sub-agent schedules. " +
+          "Use await this.getScheduleById(id) instead."
+      );
     }
-    const row = result[0];
-    return {
-      ...row,
-      payload: JSON.parse(row.payload) as T,
-      retry: parseRetryOptions(row as unknown as Record<string, unknown>)
-    };
+    return this._getScheduleForOwner(null, id);
+  }
+
+  /**
+   * Get a scheduled task by ID.
+   *
+   * Unlike the deprecated synchronous {@link getSchedule}, this works inside
+   * sub-agents by delegating to the top-level parent that owns the alarm.
+   *
+   * @template T Type of the payload data
+   * @param id ID of the scheduled task
+   * @returns The Schedule object or undefined if not found
+   */
+  async getScheduleById(id: string): Promise<Schedule<unknown> | undefined> {
+    if (this._isFacet) {
+      const root = await this._rootAlarmOwner();
+      return root._cf_getScheduleForFacet(this.selfPath, id);
+    }
+    return this._getScheduleForOwner(null, id);
   }
 
   /**
@@ -2975,62 +3510,63 @@ export class Agent<
    * @template T Type of the payload data
    * @param criteria Criteria to filter schedules
    * @returns Array of matching Schedule objects
+   * @deprecated Use {@link listSchedules}. This synchronous API cannot cross
+   * Durable Object boundaries and throws inside sub-agents.
    */
-  getSchedules<T = string>(
-    criteria: {
-      id?: string;
-      type?: "scheduled" | "delayed" | "cron" | "interval";
-      timeRange?: { start?: Date; end?: Date };
-    } = {}
-  ): Schedule<T>[] {
-    let query = "SELECT * FROM cf_agents_schedules WHERE 1=1";
-    const params = [];
-
-    if (criteria.id) {
-      query += " AND id = ?";
-      params.push(criteria.id);
-    }
-
-    if (criteria.type) {
-      query += " AND type = ?";
-      params.push(criteria.type);
-    }
-
-    if (criteria.timeRange) {
-      query += " AND time >= ? AND time <= ?";
-      const start = criteria.timeRange.start || new Date(0);
-      const end = criteria.timeRange.end || new Date(999999999999999);
-      params.push(
-        Math.floor(start.getTime() / 1000),
-        Math.floor(end.getTime() / 1000)
+  getSchedules<T = string>(criteria: ScheduleCriteria = {}): Schedule<T>[] {
+    if (this._isFacet) {
+      throw new Error(
+        "getSchedules() is synchronous and cannot read parent-owned sub-agent schedules. " +
+          "Use await this.listSchedules(criteria) instead."
       );
     }
 
-    const result = this.ctx.storage.sql
-      .exec(query, ...params)
-      .toArray()
-      .map((row) => ({
-        ...row,
-        payload: JSON.parse(row.payload as string) as T,
-        retry: parseRetryOptions(row as unknown as Record<string, unknown>)
-      })) as Schedule<T>[];
-
-    return result;
+    return this._listSchedulesForOwner(null, criteria);
   }
 
   /**
-   * Cancel a scheduled task
+   * List scheduled tasks matching the given criteria.
+   *
+   * Unlike the deprecated synchronous {@link getSchedules}, this works inside
+   * sub-agents by delegating to the top-level parent that owns the alarm.
+   *
+   * @template T Type of the payload data
+   * @param criteria Criteria to filter schedules
+   * @returns Array of matching Schedule objects
+   */
+  async listSchedules(
+    criteria: ScheduleCriteria = {}
+  ): Promise<Schedule<unknown>[]> {
+    if (this._isFacet) {
+      const root = await this._rootAlarmOwner();
+      return root._cf_listSchedulesForFacet(this.selfPath, criteria);
+    }
+    return this._listSchedulesForOwner(null, criteria);
+  }
+
+  /**
+   * Cancel a scheduled task.
+   *
+   * Schedules are isolated by owner: a top-level agent's
+   * `cancelSchedule(id)` only matches its own schedules, and a
+   * sub-agent's `cancelSchedule(id)` only matches schedules it
+   * created. To clear every schedule under a sub-agent (and its
+   * descendants), call `parent.deleteSubAgent(Cls, name)` from the
+   * parent — that bulk-cancels via {@link _cf_cancelSchedulesForFacetPrefix}.
+   *
    * @param id ID of the task to cancel
    * @returns true if the task was cancelled, false if the task was not found
    */
   async cancelSchedule(id: string): Promise<boolean> {
     if (this._isFacet) {
-      throw new Error(
-        "Scheduling is not supported in sub-agents. " +
-          "Schedule from the parent agent instead."
-      );
+      const root = await this._rootAlarmOwner();
+      const result = await root._cf_cancelScheduleForFacet(this.selfPath, id);
+      if (result.ok && result.callback) {
+        this._emit("schedule:cancel", { callback: result.callback, id });
+      }
+      return result.ok;
     }
-    const schedule = this.getSchedule(id);
+    const schedule = this._getScheduleForOwner(null, id);
     if (!schedule) {
       return false;
     }
@@ -3056,11 +3592,8 @@ export class Agent<
    * alarm system, without creating schedule rows or emitting observability
    * events. Configure via `static options = { keepAliveIntervalMs: 5000 }`.
    *
-   * No-op on facets. Facets share the parent's isolate and don't
-   * need a separate alarm heartbeat — the parent's own activity,
-   * any open WebSocket to the facet, and any in-flight Promise
-   * already keep the shared machine alive for the duration of
-   * real work.
+   * In facets, delegates the physical heartbeat to the root parent
+   * because facets do not have independent alarm slots.
    *
    * @example
    * ```ts
@@ -3074,12 +3607,17 @@ export class Agent<
    */
   async keepAlive(): Promise<() => void> {
     if (this._isFacet) {
-      // Soft no-op — facets share the parent's isolate and can't
-      // set their own alarms in workerd today. Return an inert
-      // disposer so call sites that use `keepAliveWhile(...)` (e.g.
-      // AIChatAgent's streaming turn) work uniformly on both
-      // top-level DOs and facets.
-      return () => {};
+      const root = await this._rootAlarmOwner();
+      const token = await root._cf_acquireFacetKeepAlive(this.selfPath);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        const release = root._cf_releaseFacetKeepAlive(token).catch((e) => {
+          console.error("[Agent] Failed to release facet keepAlive:", e);
+        });
+        this.ctx.waitUntil(release);
+      };
     }
 
     this._keepAliveRefs++;
@@ -3147,8 +3685,17 @@ export class Agent<
     `;
     this._runFiberActiveFibers.add(id);
 
-    const dispose = await this.keepAlive();
+    let root: RootFacetRpcSurface | undefined;
+    let registeredFacetRun = false;
+    let dispose: () => void = () => {};
     try {
+      if (this._isFacet) {
+        root = await this._rootAlarmOwner();
+        await root._cf_registerFacetRun(this.selfPath, id);
+        registeredFacetRun = true;
+      }
+
+      dispose = await this.keepAlive();
       const stash = (data: unknown) => {
         this.sql`
           UPDATE cf_agents_runs SET snapshot = ${JSON.stringify(data)}
@@ -3163,6 +3710,16 @@ export class Agent<
       this._runFiberActiveFibers.delete(id);
       this.sql`DELETE FROM cf_agents_runs WHERE id = ${id}`;
       dispose();
+      if (root && registeredFacetRun) {
+        try {
+          await root._cf_unregisterFacetRun(this.selfPath, id);
+        } catch (e) {
+          // Leave the root-side lease behind if cleanup fails; root
+          // housekeeping will re-enter the facet and prune stale rows
+          // once it observes that this fiber row no longer exists.
+          console.error("[Agent] Failed to unregister facet fiber:", e);
+        }
+      }
     }
   }
 
@@ -3268,6 +3825,327 @@ export class Agent<
   /** @internal */
   async _onAlarmHousekeeping(): Promise<void> {
     await this._checkRunFibers();
+    await this._checkFacetRunFibers();
+  }
+
+  private _isSameAgentPathPrefix(
+    prefix: ReadonlyArray<AgentPathStep>,
+    path: ReadonlyArray<AgentPathStep>
+  ): boolean {
+    if (prefix.length > path.length) return false;
+    return prefix.every(
+      (step, index) =>
+        step.className === path[index].className &&
+        step.name === path[index].name
+    );
+  }
+
+  /**
+   * Root-side scan for durable fibers owned by descendant facets.
+   * `cf_agents_facet_runs` is only an index; actual snapshots and
+   * recovery hooks live in each facet's own `cf_agents_runs` table.
+   * @internal
+   */
+  private async _checkFacetRunFibers(): Promise<void> {
+    // Only the root owns the physical alarm and facet-run index.
+    if (this._parentPath.length > 0) return;
+
+    const rows = this.sql<FacetRunStorageRow>`
+      SELECT owner_path, owner_path_key, run_id, created_at
+      FROM cf_agents_facet_runs
+      ORDER BY created_at ASC
+    `;
+    const firstRowByOwner = new Map<string, FacetRunStorageRow>();
+    for (const row of rows) {
+      if (!firstRowByOwner.has(row.owner_path_key)) {
+        firstRowByOwner.set(row.owner_path_key, row);
+      }
+    }
+
+    for (const row of firstRowByOwner.values()) {
+      let ownerPath: AgentPathStep[];
+      try {
+        ownerPath = JSON.parse(row.owner_path) as AgentPathStep[];
+      } catch (e) {
+        console.warn(
+          `[Agent] Corrupted facet fiber owner path for ${row.owner_path_key}; pruning stale lease.`,
+          e
+        );
+        this.sql`
+          DELETE FROM cf_agents_facet_runs
+          WHERE owner_path_key = ${row.owner_path_key}
+        `;
+        continue;
+      }
+
+      try {
+        const remaining = await this._cf_checkRunFibersForFacet(ownerPath);
+        if (remaining === 0) {
+          this.sql`
+            DELETE FROM cf_agents_facet_runs
+            WHERE owner_path_key = ${row.owner_path_key}
+          `;
+        }
+      } catch (e) {
+        // Keep the lease so a transient failure (e.g. facet init error)
+        // gets retried on the next root heartbeat.
+        console.error(
+          `[Agent] Facet fiber recovery check failed for ${row.owner_path_key}:`,
+          e
+        );
+      }
+    }
+  }
+
+  /**
+   * Dispatch a runFiber recovery check into the facet identified by
+   * `ownerPath`. Returns the number of remaining local `cf_agents_runs`
+   * rows on the target facet after recovery.
+   * @internal
+   */
+  async _cf_checkRunFibersForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<number> {
+    const selfPath = this.selfPath;
+    if (!this._isSameAgentPathPrefix(selfPath, ownerPath)) {
+      throw new Error(
+        `Facet fiber owner path does not descend from ${JSON.stringify(selfPath)}.`
+      );
+    }
+
+    if (selfPath.length === ownerPath.length) {
+      await this._checkRunFibers();
+      const rows = this.sql<{ count: number }>`
+        SELECT COUNT(*) as count FROM cf_agents_runs
+      `;
+      return rows[0]?.count ?? 0;
+    }
+
+    const next = ownerPath[selfPath.length];
+    if (!this.hasSubAgent(next.className, next.name)) {
+      // The facet was deleted or its registry was cleared. The root
+      // should prune the root-side lease; there is no remaining child
+      // storage to recover through the public registry path.
+      return 0;
+    }
+
+    const stub = await this._cf_resolveSubAgent(next.className, next.name);
+    const handle = stub as unknown as {
+      _cf_checkRunFibersForFacet(
+        ownerPath: ReadonlyArray<AgentPathStep>
+      ): Promise<number>;
+    };
+    return handle._cf_checkRunFibersForFacet(ownerPath);
+  }
+
+  /**
+   * Dispatch a scheduled callback into the facet identified by
+   * `ownerPath`. Walks one step at a time: if `ownerPath` matches
+   * `selfPath`, executes the callback locally; otherwise resolves
+   * the next descendant facet and recurses through its own RPC.
+   *
+   * Called by the root's `alarm()` (which owns the physical alarm
+   * for facet-owned schedules) and by intermediate facets while
+   * walking down the chain.
+   * @internal
+   */
+  async _cf_dispatchScheduledCallback(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    row: ScheduleStorageRow
+  ): Promise<void> {
+    const selfPath = this.selfPath;
+    if (!this._isSameAgentPathPrefix(selfPath, ownerPath)) {
+      throw new Error(
+        `Schedule owner path does not descend from ${JSON.stringify(selfPath)}.`
+      );
+    }
+
+    if (selfPath.length === ownerPath.length) {
+      await this._executeScheduleCallback(row);
+      return;
+    }
+
+    const next = ownerPath[selfPath.length];
+    if (!this.hasSubAgent(next.className, next.name)) {
+      throw new Error(
+        `Scheduled sub-agent ${next.className} "${next.name}" no longer exists.`
+      );
+    }
+
+    const stub = await this._cf_resolveSubAgent(next.className, next.name);
+    const handle = stub as unknown as {
+      _cf_dispatchScheduledCallback(
+        ownerPath: ReadonlyArray<AgentPathStep>,
+        row: ScheduleStorageRow
+      ): Promise<void>;
+    };
+    await handle._cf_dispatchScheduledCallback(ownerPath, row);
+  }
+
+  /**
+   * Recursively destroy a descendant facet identified by
+   * `targetPath`. Walks down from `selfPath` until reaching the
+   * target's immediate parent, where it cancels the target's
+   * parent-owned schedules (and any descendants), removes the
+   * target from the registry, and calls `ctx.facets.delete` to
+   * wipe the target's storage.
+   *
+   * Called by a facet's own `destroy()` (via the root) so that
+   * `this.destroy()` inside a sub-agent results in the same
+   * cleanup as `parent.deleteSubAgent(Cls, name)` from the parent.
+   * @internal
+   */
+  async _cf_destroyDescendantFacet(
+    targetPath: ReadonlyArray<AgentPathStep>
+  ): Promise<void> {
+    const selfPath = this.selfPath;
+
+    if (targetPath.length === 0) {
+      throw new Error(
+        "_cf_destroyDescendantFacet: target path must not be empty."
+      );
+    }
+    if (selfPath.length >= targetPath.length) {
+      throw new Error(
+        "_cf_destroyDescendantFacet: target must be a strict descendant."
+      );
+    }
+    if (!this._isSameAgentPathPrefix(selfPath, targetPath)) {
+      throw new Error(
+        "_cf_destroyDescendantFacet: target path does not descend from this agent."
+      );
+    }
+
+    // The root owns every schedule row; cancel the target's prefix
+    // upfront so we don't have to make an extra round trip back from
+    // each intermediate hop.
+    if (this._parentPath.length === 0) {
+      await this._cf_cancelSchedulesForFacetPrefix(targetPath);
+    }
+
+    if (selfPath.length === targetPath.length - 1) {
+      // We are the immediate parent of the target — perform the local
+      // facet teardown the same way `deleteSubAgent` does.
+      const target = targetPath[targetPath.length - 1];
+      const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
+      if (!ctx.facets) {
+        throw new Error(
+          "destroy() (delegated from facet) is not supported in this runtime — " +
+            "`ctx.facets` is unavailable. " +
+            "Update to the latest `compatibility_date` in your wrangler.jsonc."
+        );
+      }
+      try {
+        ctx.facets.delete(`${target.className}\0${target.name}`);
+      } catch {
+        // no-op — facet wasn't registered (already deleted / never spawned)
+      }
+      this._forgetSubAgent(target.className, target.name);
+      return;
+    }
+
+    // Recurse one step deeper.
+    const next = targetPath[selfPath.length];
+    if (!this.hasSubAgent(next.className, next.name)) {
+      // Already gone — schedules are cleared, nothing more to do.
+      return;
+    }
+    const stub = await this._cf_resolveSubAgent(next.className, next.name);
+    const handle = stub as unknown as {
+      _cf_destroyDescendantFacet(
+        targetPath: ReadonlyArray<AgentPathStep>
+      ): Promise<void>;
+    };
+    await handle._cf_destroyDescendantFacet(targetPath);
+  }
+
+  private async _executeScheduleCallback(
+    row: ScheduleStorageRow
+  ): Promise<void> {
+    const callback = this[row.callback as keyof Agent<Env>];
+    if (!callback) {
+      console.error(`callback ${row.callback} not found`);
+      return;
+    }
+
+    await agentContext.run(
+      {
+        agent: this,
+        connection: undefined,
+        request: undefined,
+        email: undefined
+      },
+      async () => {
+        const retryOpts = parseRetryOptions(
+          row as unknown as Record<string, unknown>
+        );
+        const { maxAttempts, baseDelayMs, maxDelayMs } = resolveRetryConfig(
+          retryOpts,
+          this._resolvedOptions.retry
+        );
+
+        let parsedPayload: unknown;
+        try {
+          parsedPayload = JSON.parse(row.payload as string);
+        } catch (e) {
+          console.error(
+            `Failed to parse payload for schedule "${row.id}" (callback "${row.callback}")`,
+            e
+          );
+          this._emit("schedule:error", {
+            callback: row.callback,
+            id: row.id,
+            error: e instanceof Error ? e.message : String(e),
+            attempts: 0
+          });
+          return;
+        }
+
+        try {
+          this._emit("schedule:execute", {
+            callback: row.callback,
+            id: row.id
+          });
+
+          await tryN(
+            maxAttempts,
+            async (attempt) => {
+              if (attempt > 1) {
+                this._emit("schedule:retry", {
+                  callback: row.callback,
+                  id: row.id,
+                  attempt,
+                  maxAttempts
+                });
+              }
+              await (
+                callback as (
+                  payload: unknown,
+                  schedule: Schedule<unknown>
+                ) => Promise<void>
+              ).bind(this)(parsedPayload, row as unknown as Schedule<unknown>);
+            },
+            { baseDelayMs, maxDelayMs }
+          );
+        } catch (e) {
+          console.error(
+            `error executing callback "${row.callback}" after ${maxAttempts} attempts`,
+            e
+          );
+          this._emit("schedule:error", {
+            callback: row.callback,
+            id: row.id,
+            error: e instanceof Error ? e.message : String(e),
+            attempts: maxAttempts
+          });
+          try {
+            await this.onError(e);
+          } catch {
+            // swallow onError errors
+          }
+        }
+      }
+    );
   }
 
   private async _scheduleNextAlarm() {
@@ -3331,6 +4209,17 @@ export class Agent<
         nextTimeMs === null ? keepAliveMs : Math.min(nextTimeMs, keepAliveMs);
     }
 
+    const facetRuns = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_agents_facet_runs
+    `;
+    if ((facetRuns[0]?.count ?? 0) > 0) {
+      const facetRecoveryMs = nowMs + this._resolvedOptions.keepAliveIntervalMs;
+      nextTimeMs =
+        nextTimeMs === null
+          ? facetRecoveryMs
+          : Math.min(nextTimeMs, facetRecoveryMs);
+    }
+
     if (nextTimeMs !== null) {
       await this.ctx.storage.setAlarm(nextTimeMs);
     } else {
@@ -3368,9 +4257,7 @@ export class Agent<
     const now = Math.floor(Date.now() / 1000);
 
     // Get all schedules that should be executed now
-    const result = this.sql<
-      Schedule<string> & { running?: number; intervalSeconds?: number }
-    >`
+    const result = this.sql<ScheduleStorageRow>`
       SELECT * FROM cf_agents_schedules WHERE time <= ${now}
     `;
 
@@ -3408,12 +4295,8 @@ export class Agent<
         }
       }
 
-      for (const row of result) {
-        const callback = this[row.callback as keyof Agent<Env>];
-        if (!callback) {
-          console.error(`callback ${row.callback} not found`);
-          continue;
-        }
+      for (const row of result as ScheduleStorageRow[]) {
+        let executed = false;
 
         // Overlap prevention for interval schedules with hung callback detection
         if (row.type === "interval" && row.running === 1) {
@@ -3442,91 +4325,48 @@ export class Agent<
             .sql`UPDATE cf_agents_schedules SET running = 1, execution_started_at = ${now} WHERE id = ${row.id}`;
         }
 
-        await agentContext.run(
-          {
-            agent: this,
-            connection: undefined,
-            request: undefined,
-            email: undefined
-          },
-          async () => {
-            const retryOpts = parseRetryOptions(
-              row as unknown as Record<string, unknown>
+        if (row.owner_path) {
+          try {
+            const ownerPath = JSON.parse(row.owner_path) as AgentPathStep[];
+            await this._cf_dispatchScheduledCallback(ownerPath, row);
+          } catch (e) {
+            console.error(
+              `error dispatching scheduled callback "${row.callback}"`,
+              e
             );
-            const { maxAttempts, baseDelayMs, maxDelayMs } = resolveRetryConfig(
-              retryOpts,
-              this._resolvedOptions.retry
-            );
-
-            let parsedPayload: unknown;
+            this._emit("schedule:error", {
+              callback: row.callback,
+              id: row.id,
+              error: e instanceof Error ? e.message : String(e),
+              attempts: 0
+            });
             try {
-              parsedPayload = JSON.parse(row.payload as string);
-            } catch (e) {
-              console.error(
-                `Failed to parse payload for schedule "${row.id}" (callback "${row.callback}")`,
-                e
-              );
-              this._emit("schedule:error", {
-                callback: row.callback,
-                id: row.id,
-                error: e instanceof Error ? e.message : String(e),
-                attempts: 0
-              });
-              return;
+              await this.onError(e);
+            } catch {
+              // swallow onError errors
             }
-
-            try {
-              this._emit("schedule:execute", {
-                callback: row.callback,
-                id: row.id
-              });
-
-              await tryN(
-                maxAttempts,
-                async (attempt) => {
-                  if (attempt > 1) {
-                    this._emit("schedule:retry", {
-                      callback: row.callback,
-                      id: row.id,
-                      attempt,
-                      maxAttempts
-                    });
-                  }
-                  await (
-                    callback as (
-                      payload: unknown,
-                      schedule: Schedule<unknown>
-                    ) => Promise<void>
-                  ).bind(this)(parsedPayload, row);
-                },
-                { baseDelayMs, maxDelayMs }
-              );
-            } catch (e) {
-              console.error(
-                `error executing callback "${row.callback}" after ${maxAttempts} attempts`,
-                e
-              );
-              this._emit("schedule:error", {
-                callback: row.callback,
-                id: row.id,
-                error: e instanceof Error ? e.message : String(e),
-                attempts: maxAttempts
-              });
-              // Route schedule errors through onError for consistency
-              try {
-                await this.onError(e);
-              } catch {
-                // swallow onError errors
-              }
+            // Reset the in-flight flag for interval rows so the row
+            // doesn't stay stuck in `running=1` when dispatch fails
+            // (e.g. the facet's registry entry is missing). The next
+            // alarm cycle will retry.
+            if (row.type === "interval") {
+              this.sql`
+                UPDATE cf_agents_schedules SET running = 0 WHERE id = ${row.id}
+              `;
             }
+            continue;
           }
-        );
+        } else {
+          await this._executeScheduleCallback(row);
+        }
+        executed = true;
 
         if (this._destroyed) return;
+        if (!executed) continue;
 
         if (row.type === "cron") {
           // Update next execution time for cron schedules
-          const nextExecutionTime = getNextCronTime(row.cron);
+          const nextExecutionTime = getNextCronTime(row.cron ?? "");
           const nextTimestamp = Math.floor(nextExecutionTime.getTime() / 1000);
 
           this.sql`
@@ -4065,7 +4905,7 @@ export class Agent<
    * @param cls The Agent subclass used when creating the child
    * @param name Name of the child to delete
    */
-  deleteSubAgent(cls: SubAgentClass, name: string): void {
+  async deleteSubAgent(cls: SubAgentClass, name: string): Promise<void> {
     const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
     if (!ctx.facets) {
       throw new Error(
@@ -4075,6 +4915,14 @@ export class Agent<
       );
     }
     const facetKey = `${cls.name}\0${name}`;
+    const childPath = [...this.selfPath, { className: cls.name, name }];
+    if (this._isFacet) {
+      const root = await this._rootAlarmOwner();
+      await root._cf_cancelSchedulesForFacetPrefix(childPath);
+    } else {
+      await this._cf_cancelSchedulesForFacetPrefix(childPath);
+    }
+
     // Idempotent: make `ctx.facets.delete` tolerant of missing keys.
     // workerd throws an opaque "internal error" when the key isn't
     // registered; swallow that so double-delete and
@@ -4194,21 +5042,36 @@ export class Agent<
   }
 
   /**
-   * Destroy the Agent, removing all state and scheduled tasks
+   * Destroy the Agent, removing all state and scheduled tasks.
+   *
+   * On a top-level agent: drops every table, clears the alarm, and
+   * aborts the isolate.
+   *
+   * On a sub-agent (facet): delegates teardown to the immediate
+   * parent so the parent-owned schedule rows for this sub-agent
+   * (and any of its descendants) are cancelled, the parent's
+   * `cf_agents_sub_agents` registry entry is cleared, and
+   * `ctx.facets.delete` wipes the facet's own storage. The
+   * `ctx.facets.delete` call aborts this isolate, so this method
+   * may not return cleanly when invoked from inside the facet —
+   * callers should treat it as fire-and-forget.
    */
   async destroy() {
-    // drop all tables
-    this.sql`DROP TABLE IF EXISTS cf_agents_mcp_servers`;
-    this.sql`DROP TABLE IF EXISTS cf_agents_state`;
-    this.sql`DROP TABLE IF EXISTS cf_agents_schedules`;
-    this.sql`DROP TABLE IF EXISTS cf_agents_queues`;
-    this.sql`DROP TABLE IF EXISTS cf_agents_workflows`;
-    this.sql`DROP TABLE IF EXISTS cf_agents_sub_agents`;
+    if (this._isFacet) {
+      this._emit("destroy");
+      const root = await this._rootAlarmOwner();
+      // The chain: root → … → direct-parent runs ctx.facets.delete
+      // on this facet, which aborts this isolate. The await may
+      // throw an abort error or never resolve depending on timing —
+      // either is acceptable, the cleanup has already been applied.
+      await root._cf_destroyDescendantFacet(this.selfPath);
+      return;
+    }
+
+    this._dropInternalTablesForDestroy();
 
     // delete all alarms
-    if (!this._isFacet) {
-      await this.ctx.storage.deleteAlarm();
-    }
+    await this.ctx.storage.deleteAlarm();
     await this.ctx.storage.deleteAll();
 
     this._disposables.dispose();
@@ -4223,6 +5086,18 @@ export class Agent<
     }, 0);
 
     this._emit("destroy");
+  }
+
+  /** @internal Drop every internal Agents SDK table during top-level destroy. */
+  protected _dropInternalTablesForDestroy(): void {
+    this.sql`DROP TABLE IF EXISTS cf_agents_mcp_servers`;
+    this.sql`DROP TABLE IF EXISTS cf_agents_state`;
+    this.sql`DROP TABLE IF EXISTS cf_agents_schedules`;
+    this.sql`DROP TABLE IF EXISTS cf_agents_queues`;
+    this.sql`DROP TABLE IF EXISTS cf_agents_workflows`;
+    this.sql`DROP TABLE IF EXISTS cf_agents_sub_agents`;
+    this.sql`DROP TABLE IF EXISTS cf_agents_runs`;
+    this.sql`DROP TABLE IF EXISTS cf_agents_facet_runs`;
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -3176,11 +3176,42 @@ export class Agent<
   }
 
   private _scheduleRowToSchedule<T>(row: ScheduleStorageRow): Schedule<T> {
-    return {
-      ...row,
+    const base = {
+      callback: row.callback,
+      id: row.id,
       payload: JSON.parse(row.payload) as T,
       retry: parseRetryOptions(row as unknown as Record<string, unknown>)
-    } as Schedule<T>;
+    };
+
+    switch (row.type) {
+      case "scheduled":
+        return {
+          ...base,
+          time: row.time,
+          type: "scheduled"
+        };
+      case "delayed":
+        return {
+          ...base,
+          delayInSeconds: row.delayInSeconds ?? 0,
+          time: row.time,
+          type: "delayed"
+        };
+      case "cron":
+        return {
+          ...base,
+          cron: row.cron ?? "",
+          time: row.time,
+          type: "cron"
+        };
+      case "interval":
+        return {
+          ...base,
+          intervalSeconds: row.intervalSeconds ?? 0,
+          time: row.time,
+          type: "interval"
+        };
+    }
   }
 
   private _getScheduleForOwner<T = string>(

--- a/packages/agents/src/tests/agents/retry.ts
+++ b/packages/agents/src/tests/agents/retry.ts
@@ -154,7 +154,7 @@ export class TestRetryAgent extends Agent {
     const schedule = await this.schedule(3600, "testScheduleNoop", "test", {
       retry: retryOpts
     });
-    const fetched = this.getSchedule(schedule.id);
+    const fetched = await this.getScheduleById(schedule.id);
     return fetched?.retry;
   }
 

--- a/packages/agents/src/tests/agents/schedule.ts
+++ b/packages/agents/src/tests/agents/schedule.ts
@@ -1,4 +1,4 @@
-import { Agent, callable } from "../../index.ts";
+import { Agent, callable, type Schedule } from "../../index.ts";
 
 /**
  * Test agent that verifies this.name is accessible during scheduled callback
@@ -179,8 +179,10 @@ export class TestScheduleAgent extends Agent {
   }
 
   @callable()
-  async getScheduleById(id: string) {
-    return this.getSchedule(id);
+  async getStoredScheduleById(
+    id: string
+  ): Promise<Schedule<string> | undefined> {
+    return (await super.getScheduleById(id)) as Schedule<string> | undefined;
   }
 
   @callable()
@@ -244,8 +246,8 @@ export class TestScheduleAgent extends Agent {
   @callable()
   async getSchedulesByType(
     type: "scheduled" | "delayed" | "cron" | "interval"
-  ) {
-    return this.getSchedules({ type });
+  ): Promise<Schedule<string>[]> {
+    return (await this.listSchedules({ type })) as Schedule<string>[];
   }
 
   @callable()

--- a/packages/agents/src/tests/agents/state.ts
+++ b/packages/agents/src/tests/agents/state.ts
@@ -124,6 +124,10 @@ export class TestStateAgent extends Agent<Cloudflare.Env, TestState> {
     return rows[0].cnt > 0;
   }
 
+  dropInternalTablesForDestroyTest(): void {
+    this._dropInternalTablesForDestroy();
+  }
+
   // Count rows in cf_agents_state (excluding internal schema version row)
   getStateRowCount(): number {
     const rows = this.ctx.storage.sql

--- a/packages/agents/src/tests/agents/state.ts
+++ b/packages/agents/src/tests/agents/state.ts
@@ -124,8 +124,14 @@ export class TestStateAgent extends Agent<Cloudflare.Env, TestState> {
     return rows[0].cnt > 0;
   }
 
-  dropInternalTablesForDestroyTest(): void {
+  dropInternalTablesForDestroyTest(): string[] {
     this._dropInternalTablesForDestroy();
+    const rows = this.ctx.storage.sql
+      .exec(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'cf_agents_%' ORDER BY name"
+      )
+      .toArray() as { name: string }[];
+    return rows.map((r) => r.name);
   }
 
   // Count rows in cf_agents_state (excluding internal schema version row)

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -186,6 +186,14 @@ export class CounterSubAgent extends Agent {
     return this.listSchedules({ type });
   }
 
+  async getOwnScheduleKeysByType(
+    type: "scheduled" | "delayed" | "cron" | "interval"
+  ): Promise<string[][]> {
+    return (await this.listSchedules({ type })).map((schedule) =>
+      Object.keys(schedule).sort()
+    );
+  }
+
   trySyncGetSchedule(id: string): string {
     try {
       this.getSchedule(id);
@@ -955,6 +963,14 @@ export class TestSubAgentParent extends Agent {
     return (await child.getOwnSchedulesByType(type)).map(
       (schedule) => schedule.id
     );
+  }
+
+  async subAgentGetScheduleKeysByType(
+    subAgentName: string,
+    type: "scheduled" | "delayed" | "cron" | "interval"
+  ): Promise<string[][]> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.getOwnScheduleKeysByType(type);
   }
 
   async subAgentTrySyncGetSchedule(

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -1,16 +1,63 @@
-import { Agent } from "../../index.ts";
+import { Agent, getCurrentAgent } from "../../index.ts";
+import type { FiberRecoveryContext } from "../../index.ts";
 import { RpcTarget } from "cloudflare:workers";
 
 // ── SubAgent: Counter ───────────────────────────────────────────────
 // A SubAgent with its own SQLite counter table.
 
 export class CounterSubAgent extends Agent {
+  private _heldKeepAliveDisposers: Array<() => void> = [];
+
   onStart() {
     this.sql`
       CREATE TABLE IF NOT EXISTS counter (
         id TEXT PRIMARY KEY,
         value INTEGER NOT NULL DEFAULT 0
       )
+    `;
+    this.sql`
+      CREATE TABLE IF NOT EXISTS schedule_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        value TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        current_agent_name TEXT,
+        parent_class TEXT,
+        schedule_id TEXT NOT NULL,
+        callback TEXT NOT NULL
+      )
+    `;
+    this.sql`
+      CREATE TABLE IF NOT EXISTS fiber_recovery_log (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        snapshot TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `;
+  }
+
+  private _releaseHeldFiber?: () => void;
+
+  protected override async _handleInternalFiberRecovery(
+    ctx: FiberRecoveryContext
+  ): Promise<boolean> {
+    if (ctx.name !== "__test_internal_chat") return false;
+
+    await this.schedule(
+      0,
+      "scheduledCallback",
+      { value: `recovered:${ctx.id}` },
+      { idempotent: true }
+    );
+    return true;
+  }
+
+  override async onFiberRecovered(ctx: FiberRecoveryContext): Promise<void> {
+    this.sql`
+      INSERT OR REPLACE INTO fiber_recovery_log
+        (id, name, snapshot, created_at)
+      VALUES
+        (${ctx.id}, ${ctx.name}, ${JSON.stringify(ctx.snapshot)}, ${ctx.createdAt})
     `;
   }
 
@@ -38,6 +85,152 @@ export class CounterSubAgent extends Agent {
 
   ping(): string {
     return "pong";
+  }
+
+  scheduledCallback(
+    payload: { value: string },
+    schedule: { id: string; callback: string }
+  ): void {
+    const { agent } = getCurrentAgent();
+    this.sql`
+      INSERT INTO schedule_log
+        (value, agent_name, current_agent_name, parent_class, schedule_id, callback)
+      VALUES
+        (${payload.value}, ${this.name}, ${agent?.name ?? null}, ${this.parentPath.at(-1)?.className ?? ""}, ${schedule.id}, ${schedule.callback})
+    `;
+  }
+
+  async scheduleDelayedCallback(
+    delaySeconds: number,
+    value: string,
+    options?: { idempotent?: boolean }
+  ): Promise<string> {
+    const schedule = await this.schedule(
+      delaySeconds,
+      "scheduledCallback",
+      { value },
+      options
+    );
+    return schedule.id;
+  }
+
+  async scheduleIntervalCallback(
+    intervalSeconds: number,
+    value: string
+  ): Promise<string> {
+    const schedule = await this.scheduleEvery(
+      intervalSeconds,
+      "scheduledCallback",
+      { value }
+    );
+    return schedule.id;
+  }
+
+  async scheduleCronCallback(cronExpr: string, value: string): Promise<string> {
+    const schedule = await this.schedule(cronExpr, "scheduledCallback", {
+      value
+    });
+    return schedule.id;
+  }
+
+  async cancelOwnSchedule(id: string): Promise<boolean> {
+    return this.cancelSchedule(id);
+  }
+
+  async selfDestruct(): Promise<void> {
+    await this.destroy();
+  }
+
+  async scheduleSelfCancellingCallback(
+    delaySeconds: number,
+    value: string
+  ): Promise<string> {
+    const schedule = await this.schedule(
+      delaySeconds,
+      "selfCancellingCallback",
+      { value }
+    );
+    return schedule.id;
+  }
+
+  /**
+   * A scheduled callback that cancels its own (one-shot) row from
+   * inside the running callback. Tests that re-entrant
+   * cancelSchedule from within a dispatched callback does not
+   * deadlock with the alarm RPC frame.
+   */
+  async selfCancellingCallback(
+    payload: { value: string },
+    schedule: { id: string; callback: string }
+  ): Promise<void> {
+    // Cancel ourselves before recording the log entry. The row is
+    // already in the middle of being dispatched, so the cancel is a
+    // no-op for the in-flight dispatch but proves the round-trip
+    // didn't deadlock.
+    await this.cancelSchedule(schedule.id);
+    this.sql`
+      INSERT INTO schedule_log
+        (value, agent_name, current_agent_name, parent_class, schedule_id, callback)
+      VALUES
+        (${payload.value}, ${this.name}, null, ${this.parentPath.at(-1)?.className ?? ""}, ${schedule.id}, ${schedule.callback})
+    `;
+  }
+
+  async getOwnSchedule(id: string) {
+    return this.getScheduleById(id);
+  }
+
+  async getOwnSchedulesByType(
+    type: "scheduled" | "delayed" | "cron" | "interval"
+  ) {
+    return this.listSchedules({ type });
+  }
+
+  trySyncGetSchedule(id: string): string {
+    try {
+      this.getSchedule(id);
+      return "";
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  trySyncGetSchedules(): string {
+    try {
+      this.getSchedules();
+      return "";
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  getScheduleLog(): Array<{
+    value: string;
+    agentName: string;
+    currentAgentName: string | null;
+    parentClass: string;
+    scheduleId: string;
+    callback: string;
+  }> {
+    return this.sql<{
+      value: string;
+      agent_name: string;
+      current_agent_name: string | null;
+      parent_class: string;
+      schedule_id: string;
+      callback: string;
+    }>`
+      SELECT value, agent_name, current_agent_name, parent_class, schedule_id, callback
+      FROM schedule_log
+      ORDER BY id
+    `.map((row) => ({
+      value: row.value,
+      agentName: row.agent_name,
+      currentAgentName: row.current_agent_name,
+      parentClass: row.parent_class,
+      scheduleId: row.schedule_id,
+      callback: row.callback
+    }));
   }
 
   getName(): string {
@@ -129,6 +322,95 @@ export class CounterSubAgent extends Agent {
     }
   }
 
+  async tryKeepAliveWhileError(): Promise<string> {
+    try {
+      await this.keepAliveWhile(async () => {
+        throw new Error("keepalive failure");
+      });
+      return "";
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async acquireHeldKeepAlive(): Promise<void> {
+    this._heldKeepAliveDisposers.push(await this.keepAlive());
+  }
+
+  releaseHeldKeepAlives(): void {
+    const disposers = this._heldKeepAliveDisposers.splice(0);
+    for (const dispose of disposers) {
+      dispose();
+    }
+  }
+
+  async holdFiber(value: string): Promise<string> {
+    const id = await new Promise<string>((resolve) => {
+      void this.runFiber("held", async (ctx) => {
+        resolve(ctx.id);
+        this.sql`
+          INSERT INTO schedule_log
+            (value, agent_name, current_agent_name, parent_class, schedule_id, callback)
+          VALUES
+            (${value}, ${this.name}, null, ${this.parentPath.at(-1)?.className ?? ""}, ${ctx.id}, ${"holdFiber"})
+        `;
+        await new Promise<void>((r) => {
+          this._releaseHeldFiber = r;
+        });
+      }).catch(console.error);
+    });
+    return id;
+  }
+
+  async releaseHeldFiber(): Promise<void> {
+    const release = this._releaseHeldFiber;
+    this._releaseHeldFiber = undefined;
+    release?.();
+  }
+
+  async insertInterruptedFiber(
+    id: string,
+    name: string,
+    snapshot?: unknown
+  ): Promise<void> {
+    this.sql`
+      INSERT INTO cf_agents_runs (id, name, snapshot, created_at)
+      VALUES (${id}, ${name}, ${snapshot ? JSON.stringify(snapshot) : null}, ${Date.now()})
+    `;
+  }
+
+  getRecoveredFibers(): Array<{
+    id: string;
+    name: string;
+    snapshot: { value?: string } | null;
+    createdAt: number;
+  }> {
+    return this.sql<{
+      id: string;
+      name: string;
+      snapshot: string | null;
+      created_at: number;
+    }>`
+      SELECT id, name, snapshot, created_at
+      FROM fiber_recovery_log
+      ORDER BY created_at
+    `.map((row) => ({
+      id: row.id,
+      name: row.name,
+      snapshot: row.snapshot
+        ? (JSON.parse(row.snapshot) as { value?: string })
+        : null,
+      createdAt: row.created_at
+    }));
+  }
+
+  getRunningFiberCount(): number {
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_agents_runs
+    `;
+    return rows[0]?.count ?? 0;
+  }
+
   async tryCancelSchedule(): Promise<string> {
     try {
       await this.cancelSchedule("nonexistent");
@@ -136,6 +418,66 @@ export class CounterSubAgent extends Agent {
     } catch (e) {
       return e instanceof Error ? e.message : String(e);
     }
+  }
+
+  /**
+   * Install an in-memory observability recorder that persists events
+   * to the facet's own SQLite. Used by tests to assert which DO
+   * emits which observability events.
+   */
+  installObservabilityRecorder(): void {
+    this.sql`
+      CREATE TABLE IF NOT EXISTS obs_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        payload TEXT NOT NULL
+      )
+    `;
+    this.observability = {
+      emit: (event) => {
+        this.sql`
+          INSERT INTO obs_log (type, agent, agent_name, payload)
+          VALUES (
+            ${event.type},
+            ${event.agent ?? ""},
+            ${event.name ?? ""},
+            ${JSON.stringify(event.payload)}
+          )
+        `;
+      }
+    };
+  }
+
+  getObservabilityLog(): Array<{
+    type: string;
+    agent: string;
+    agentName: string;
+    payload: { callback?: string; id?: string };
+  }> {
+    this.sql`
+      CREATE TABLE IF NOT EXISTS obs_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        payload TEXT NOT NULL
+      )
+    `;
+    return this.sql<{
+      type: string;
+      agent: string;
+      agent_name: string;
+      payload: string;
+    }>`
+      SELECT type, agent, agent_name, payload FROM obs_log ORDER BY id
+    `.map((row) => ({
+      type: row.type,
+      agent: row.agent,
+      agentName: row.agent_name,
+      payload: JSON.parse(row.payload) as { callback?: string; id?: string }
+    }));
   }
 }
 
@@ -150,12 +492,78 @@ export class InnerSubAgent extends Agent {
         value TEXT NOT NULL
       )
     `;
+    this.sql`
+      CREATE TABLE IF NOT EXISTS fiber_recovery_log (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        snapshot TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `;
+  }
+
+  override async onFiberRecovered(ctx: FiberRecoveryContext): Promise<void> {
+    this.sql`
+      INSERT OR REPLACE INTO fiber_recovery_log
+        (id, name, snapshot, created_at)
+      VALUES
+        (${ctx.id}, ${ctx.name}, ${JSON.stringify(ctx.snapshot)}, ${ctx.createdAt})
+    `;
   }
 
   set(key: string, value: string): void {
     this.sql`
       INSERT OR REPLACE INTO kv (key, value) VALUES (${key}, ${value})
     `;
+  }
+
+  scheduledSet(payload: { key: string; value: string }): void {
+    this.set(payload.key, payload.value);
+  }
+
+  async scheduleSet(
+    delaySeconds: number,
+    key: string,
+    value: string
+  ): Promise<string> {
+    const schedule = await this.schedule(delaySeconds, "scheduledSet", {
+      key,
+      value
+    });
+    return schedule.id;
+  }
+
+  async insertInterruptedFiber(
+    id: string,
+    name: string,
+    snapshot?: unknown
+  ): Promise<void> {
+    this.sql`
+      INSERT INTO cf_agents_runs (id, name, snapshot, created_at)
+      VALUES (${id}, ${name}, ${snapshot ? JSON.stringify(snapshot) : null}, ${Date.now()})
+    `;
+  }
+
+  getRecoveredFibers(): Array<{
+    id: string;
+    name: string;
+    snapshot: { value?: string } | null;
+  }> {
+    return this.sql<{
+      id: string;
+      name: string;
+      snapshot: string | null;
+    }>`
+      SELECT id, name, snapshot
+      FROM fiber_recovery_log
+      ORDER BY created_at
+    `.map((row) => ({
+      id: row.id,
+      name: row.name,
+      snapshot: row.snapshot
+        ? (JSON.parse(row.snapshot) as { value?: string })
+        : null
+    }));
   }
 
   getVal(key: string): string | null {
@@ -168,6 +576,10 @@ export class InnerSubAgent extends Agent {
   /** Return the facet's own `parentPath`. Used for nested-parentPath tests. */
   getParentPath(): Array<{ className: string; name: string }> {
     return this.parentPath.map((step) => ({ ...step }));
+  }
+
+  getSelfPath(): Array<{ className: string; name: string }> {
+    return this.selfPath.map((step) => ({ ...step }));
   }
 
   /**
@@ -218,6 +630,48 @@ export class OuterSubAgent extends Agent {
   async innerTryParentAgentWithRoot(innerName: string): Promise<string> {
     const inner = await this.subAgent(InnerSubAgent, innerName);
     return inner.tryParentAgentWithRoot();
+  }
+
+  async scheduleInnerSet(
+    innerName: string,
+    delaySeconds: number,
+    key: string,
+    value: string
+  ): Promise<string> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.scheduleSet(delaySeconds, key, value);
+  }
+
+  async insertInnerInterruptedFiber(
+    innerName: string,
+    id: string,
+    name: string,
+    snapshot?: { value?: string }
+  ): Promise<Array<{ className: string; name: string }>> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    await inner.insertInterruptedFiber(id, name, snapshot);
+    return inner.getSelfPath();
+  }
+
+  async getInnerRecoveredFibers(innerName: string): Promise<
+    Array<{
+      id: string;
+      name: string;
+      snapshot: { value?: string } | null;
+    }>
+  > {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.getRecoveredFibers();
+  }
+
+  /** Have the outer facet self-destruct. Used for destroy() coverage. */
+  async selfDestruct(): Promise<void> {
+    await this.destroy();
+  }
+
+  /** Spawn the inner without scheduling anything. */
+  async spawnInner(innerName: string): Promise<void> {
+    await this.subAgent(InnerSubAgent, innerName);
   }
 
   ping(): string {
@@ -380,7 +834,271 @@ export class TestSubAgentParent extends Agent {
   }
 
   async subAgentDelete(subAgentName: string): Promise<void> {
-    this.deleteSubAgent(CounterSubAgent, subAgentName);
+    await this.deleteSubAgent(CounterSubAgent, subAgentName);
+  }
+
+  async subAgentScheduleDelayed(
+    subAgentName: string,
+    delaySeconds: number,
+    value: string,
+    options?: { idempotent?: boolean }
+  ): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.scheduleDelayedCallback(delaySeconds, value, options);
+  }
+
+  async subAgentScheduleInterval(
+    subAgentName: string,
+    intervalSeconds: number,
+    value: string
+  ): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.scheduleIntervalCallback(intervalSeconds, value);
+  }
+
+  async subAgentScheduleCron(
+    subAgentName: string,
+    cronExpr: string,
+    value: string
+  ): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.scheduleCronCallback(cronExpr, value);
+  }
+
+  async subAgentScheduleSelfCancellingCallback(
+    subAgentName: string,
+    delaySeconds: number,
+    value: string
+  ): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.scheduleSelfCancellingCallback(delaySeconds, value);
+  }
+
+  async subAgentSelfDestruct(subAgentName: string): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    try {
+      await child.selfDestruct();
+      return "";
+    } catch (e) {
+      // The selfDestruct RPC frame is killed when ctx.facets.delete
+      // aborts the facet's isolate, so the await may surface an
+      // abort error. Either is acceptable — what matters is that the
+      // teardown actually happened, asserted by the caller.
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async subAgentCancelSchedule(
+    subAgentName: string,
+    id: string
+  ): Promise<boolean> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.cancelOwnSchedule(id);
+  }
+
+  /** Try to cancel a schedule from a *different* sub-agent (sibling). */
+  async subAgentCancelSiblingSchedule(
+    subAgentName: string,
+    siblingScheduleId: string
+  ): Promise<boolean> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.cancelOwnSchedule(siblingScheduleId);
+  }
+
+  /**
+   * Cancel by id from the top-level parent. With the owner-key
+   * isolation, this should NEVER match a facet-owned row.
+   */
+  async parentCancelByIdNoFacet(id: string): Promise<boolean> {
+    return this.cancelSchedule(id);
+  }
+
+  async parentGetScheduleById(
+    id: string
+  ): Promise<{ id: string; callback: string } | null> {
+    const schedule = await this.getScheduleById(id);
+    return schedule ? { id: schedule.id, callback: schedule.callback } : null;
+  }
+
+  async parentListSchedules(): Promise<string[]> {
+    return (await this.listSchedules()).map((s) => s.id);
+  }
+
+  async subAgentScheduleLog(subAgentName: string): Promise<
+    Array<{
+      value: string;
+      agentName: string;
+      currentAgentName: string | null;
+      parentClass: string;
+      scheduleId: string;
+      callback: string;
+    }>
+  > {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.getScheduleLog();
+  }
+
+  async subAgentGetSchedule(
+    subAgentName: string,
+    id: string
+  ): Promise<{ id: string; callback: string } | null> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    const schedule = await child.getOwnSchedule(id);
+    return schedule ? { id: schedule.id, callback: schedule.callback } : null;
+  }
+
+  async subAgentGetSchedulesByType(
+    subAgentName: string,
+    type: "scheduled" | "delayed" | "cron" | "interval"
+  ): Promise<string[]> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return (await child.getOwnSchedulesByType(type)).map(
+      (schedule) => schedule.id
+    );
+  }
+
+  async subAgentTrySyncGetSchedule(
+    subAgentName: string,
+    id: string
+  ): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.trySyncGetSchedule(id);
+  }
+
+  async subAgentTrySyncGetSchedules(subAgentName: string): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.trySyncGetSchedules();
+  }
+
+  async backdateSchedule(id: string): Promise<void> {
+    const past = Math.floor(Date.now() / 1000) - 1;
+    this.sql`UPDATE cf_agents_schedules SET time = ${past} WHERE id = ${id}`;
+  }
+
+  async forgetCounterSubAgentRegistry(subAgentName: string): Promise<void> {
+    this.sql`
+      DELETE FROM cf_agents_sub_agents
+      WHERE class = ${"CounterSubAgent"} AND name = ${subAgentName}
+    `;
+  }
+
+  async rootScheduleRows(): Promise<
+    Array<{
+      id: string;
+      callback: string;
+      ownerPath: string | null;
+      ownerPathKey: string | null;
+      type: string;
+      running: number;
+    }>
+  > {
+    return this.sql<{
+      id: string;
+      callback: string;
+      owner_path: string | null;
+      owner_path_key: string | null;
+      type: string;
+      running: number | null;
+    }>`
+      SELECT id, callback, owner_path, owner_path_key, type, COALESCE(running, 0) AS running
+      FROM cf_agents_schedules
+      ORDER BY id
+    `.map((row) => ({
+      id: row.id,
+      callback: row.callback,
+      ownerPath: row.owner_path,
+      ownerPathKey: row.owner_path_key,
+      type: row.type,
+      running: row.running ?? 0
+    }));
+  }
+
+  async subAgentRegistryRows(): Promise<
+    Array<{ class: string; name: string }>
+  > {
+    return this.sql<{ class: string; name: string }>`
+      SELECT class, name FROM cf_agents_sub_agents
+      ORDER BY class, name
+    `.map((row) => ({ class: row.class, name: row.name }));
+  }
+
+  /**
+   * Install observability recorders on this top-level agent and on
+   * a named CounterSubAgent facet. Used to verify that
+   * `schedule:create` / `schedule:cancel` events fire on the facet
+   * (not on the alarm-owning root).
+   */
+  async installRecordersOn(subAgentName: string): Promise<void> {
+    this.installObservabilityRecorder();
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    child.installObservabilityRecorder();
+  }
+
+  installObservabilityRecorder(): void {
+    this.sql`
+      CREATE TABLE IF NOT EXISTS obs_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        payload TEXT NOT NULL
+      )
+    `;
+    this.observability = {
+      emit: (event) => {
+        this.sql`
+          INSERT INTO obs_log (type, agent, agent_name, payload)
+          VALUES (
+            ${event.type},
+            ${event.agent ?? ""},
+            ${event.name ?? ""},
+            ${JSON.stringify(event.payload)}
+          )
+        `;
+      }
+    };
+  }
+
+  getObservabilityLog(): Array<{
+    type: string;
+    agent: string;
+    agentName: string;
+    payload: { callback?: string; id?: string };
+  }> {
+    this.sql`
+      CREATE TABLE IF NOT EXISTS obs_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        payload TEXT NOT NULL
+      )
+    `;
+    return this.sql<{
+      type: string;
+      agent: string;
+      agent_name: string;
+      payload: string;
+    }>`
+      SELECT type, agent, agent_name, payload FROM obs_log ORDER BY id
+    `.map((row) => ({
+      type: row.type,
+      agent: row.agent,
+      agentName: row.agent_name,
+      payload: JSON.parse(row.payload) as { callback?: string; id?: string }
+    }));
+  }
+
+  async subAgentObservabilityLog(subAgentName: string): Promise<
+    Array<{
+      type: string;
+      agent: string;
+      agentName: string;
+      payload: { callback?: string; id?: string };
+    }>
+  > {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.getObservabilityLog();
   }
 
   async subAgentIncrementMultiple(
@@ -473,9 +1191,71 @@ export class TestSubAgentParent extends Agent {
     return outer.getInnerValue(innerName, key);
   }
 
+  async nestedScheduleSet(
+    outerName: string,
+    innerName: string,
+    delaySeconds: number,
+    key: string,
+    value: string
+  ): Promise<string> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.scheduleInnerSet(innerName, delaySeconds, key, value);
+  }
+
   async nestedPing(outerName: string): Promise<string> {
     const outer = await this.subAgent(OuterSubAgent, outerName);
     return outer.ping();
+  }
+
+  /**
+   * Drive the doubly-nested destroy() path: have the OUTER facet
+   * self-destruct from the inside. Validates that schedules owned
+   * by the inner descendant are cleaned up too.
+   */
+  async outerSelfDestruct(outerName: string): Promise<string> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    try {
+      await outer.selfDestruct();
+      return "";
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async ensureNested(outerName: string, innerName: string): Promise<void> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    await outer.spawnInner(innerName);
+  }
+
+  async insertNestedInterruptedFiber(
+    outerName: string,
+    innerName: string,
+    id: string,
+    name: string,
+    snapshot?: { value?: string }
+  ): Promise<void> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    const innerSelfPath = await outer.insertInnerInterruptedFiber(
+      innerName,
+      id,
+      name,
+      snapshot
+    );
+    await this._cf_registerFacetRun(innerSelfPath, id);
+  }
+
+  async nestedRecoveredFibers(
+    outerName: string,
+    innerName: string
+  ): Promise<
+    Array<{
+      id: string;
+      name: string;
+      snapshot: { value?: string } | null;
+    }>
+  > {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.getInnerRecoveredFibers(innerName);
   }
 
   // ── Scheduling guard tests ─────────────────────────────────────────
@@ -493,6 +1273,94 @@ export class TestSubAgentParent extends Agent {
   async subAgentTryKeepAliveWhile(subAgentName: string): Promise<string> {
     const child = await this.subAgent(CounterSubAgent, subAgentName);
     return child.tryKeepAliveWhile();
+  }
+
+  async subAgentTryKeepAliveWhileError(subAgentName: string): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.tryKeepAliveWhileError();
+  }
+
+  async subAgentAcquireHeldKeepAlive(subAgentName: string): Promise<void> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    await child.acquireHeldKeepAlive();
+  }
+
+  async subAgentReleaseHeldKeepAlives(subAgentName: string): Promise<void> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    child.releaseHeldKeepAlives();
+  }
+
+  getRootKeepAliveRefCount(): number {
+    return this._keepAliveRefs;
+  }
+
+  async subAgentHoldFiber(
+    subAgentName: string,
+    value: string
+  ): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.holdFiber(value);
+  }
+
+  async subAgentReleaseHeldFiber(subAgentName: string): Promise<void> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    await child.releaseHeldFiber();
+  }
+
+  async subAgentRunningFiberCount(subAgentName: string): Promise<number> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.getRunningFiberCount();
+  }
+
+  async subAgentRecoveredFibers(subAgentName: string): Promise<
+    Array<{
+      id: string;
+      name: string;
+      snapshot: { value?: string } | null;
+      createdAt: number;
+    }>
+  > {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.getRecoveredFibers();
+  }
+
+  async insertSubAgentInterruptedFiber(
+    subAgentName: string,
+    id: string,
+    name: string,
+    snapshot?: { value?: string }
+  ): Promise<void> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    await child.insertInterruptedFiber(id, name, snapshot);
+    await this._cf_registerFacetRun(await child.getSelfPath(), id);
+  }
+
+  async registerSubAgentFacetRunLeaseOnly(
+    subAgentName: string,
+    id: string
+  ): Promise<void> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    await this._cf_registerFacetRun(await child.getSelfPath(), id);
+  }
+
+  facetRunRows(): Array<{
+    ownerPath: string;
+    ownerPathKey: string;
+    runId: string;
+  }> {
+    return this.sql<{
+      owner_path: string;
+      owner_path_key: string;
+      run_id: string;
+    }>`
+      SELECT owner_path, owner_path_key, run_id
+      FROM cf_agents_facet_runs
+      ORDER BY owner_path_key, run_id
+    `.map((row) => ({
+      ownerPath: row.owner_path,
+      ownerPathKey: row.owner_path_key,
+      runId: row.run_id
+    }));
   }
 
   async subAgentTryCancelSchedule(subAgentName: string): Promise<string> {
@@ -639,7 +1507,7 @@ export class TestSubAgentParent extends Agent {
     name: string
   ): Promise<{ error: string; has: boolean }> {
     try {
-      this.deleteSubAgent(CounterSubAgent, name);
+      await this.deleteSubAgent(CounterSubAgent, name);
       return { error: "", has: this.hasSubAgent(CounterSubAgent, name) };
     } catch (e) {
       return {
@@ -655,9 +1523,9 @@ export class TestSubAgentParent extends Agent {
    */
   async doubleDeleteSubAgent(name: string): Promise<{ error: string }> {
     await this.subAgent(CounterSubAgent, name);
-    this.deleteSubAgent(CounterSubAgent, name);
+    await this.deleteSubAgent(CounterSubAgent, name);
     try {
-      this.deleteSubAgent(CounterSubAgent, name);
+      await this.deleteSubAgent(CounterSubAgent, name);
       return { error: "" };
     } catch (e) {
       return { error: e instanceof Error ? e.message : String(e) };

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -57,6 +57,26 @@ describe("schedule operations", () => {
       expect(result?.id).toBe(scheduleId);
       expect(result?.callback).toBe("testCallback");
     });
+
+    it("should not expose internal storage columns on returned schedules", async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "get-public-shape-test"
+      );
+
+      await agentStub.createSchedule(60);
+
+      const [schedule] = await agentStub.getSchedulesByType("delayed");
+      expect(Object.keys(schedule).sort()).toEqual([
+        "callback",
+        "delayInSeconds",
+        "id",
+        "payload",
+        "retry",
+        "time",
+        "type"
+      ]);
+    });
   });
 
   describe("scheduleEvery (interval scheduling)", () => {

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -39,7 +39,7 @@ describe("schedule operations", () => {
         "get-nonexistent-test"
       );
 
-      const result = await agentStub.getScheduleById("non-existent-id");
+      const result = await agentStub.getStoredScheduleById("non-existent-id");
       expect(result).toBeUndefined();
     });
 
@@ -52,7 +52,7 @@ describe("schedule operations", () => {
       // Create a schedule first (60 seconds delay)
       const scheduleId = await agentStub.createSchedule(60);
 
-      const result = await agentStub.getScheduleById(scheduleId);
+      const result = await agentStub.getStoredScheduleById(scheduleId);
       expect(result).toBeDefined();
       expect(result?.id).toBe(scheduleId);
       expect(result?.callback).toBe("testCallback");
@@ -68,7 +68,7 @@ describe("schedule operations", () => {
 
       const scheduleId = await agentStub.createIntervalSchedule(30);
 
-      const result = await agentStub.getScheduleById(scheduleId);
+      const result = await agentStub.getStoredScheduleById(scheduleId);
       expect(result).toBeDefined();
       expect(result?.type).toBe("interval");
       if (result?.type === "interval") {
@@ -89,7 +89,7 @@ describe("schedule operations", () => {
       const scheduleId = await agentStub.createIntervalSchedule(30);
 
       // Verify it exists
-      const beforeCancel = await agentStub.getScheduleById(scheduleId);
+      const beforeCancel = await agentStub.getStoredScheduleById(scheduleId);
       expect(beforeCancel).toBeDefined();
 
       // Cancel it
@@ -97,7 +97,7 @@ describe("schedule operations", () => {
       expect(cancelled).toBe(true);
 
       // Verify it's gone
-      const afterCancel = await agentStub.getScheduleById(scheduleId);
+      const afterCancel = await agentStub.getStoredScheduleById(scheduleId);
       expect(afterCancel).toBeUndefined();
     });
 
@@ -141,7 +141,7 @@ describe("schedule operations", () => {
       await runDurableObjectAlarm(agentStub);
 
       // The schedule should still exist (not deleted like one-time schedules)
-      const result = await agentStub.getScheduleById(scheduleId);
+      const result = await agentStub.getStoredScheduleById(scheduleId);
       expect(result).toBeDefined();
       expect(result?.type).toBe("interval");
 
@@ -857,14 +857,14 @@ describe("schedule operations", () => {
       expect(count).toBe(2);
 
       // The new schedule should have the new interval
-      const schedule = await agentStub.getScheduleById(secondId);
+      const schedule = await agentStub.getStoredScheduleById(secondId);
       expect(schedule).toBeDefined();
       if (schedule?.type === "interval") {
         expect(schedule.intervalSeconds).toBe(60);
       }
 
       // The original schedule should still have the old interval
-      const original = await agentStub.getScheduleById(firstId);
+      const original = await agentStub.getStoredScheduleById(firstId);
       expect(original).toBeDefined();
       if (original?.type === "interval") {
         expect(original.intervalSeconds).toBe(30);
@@ -910,11 +910,11 @@ describe("schedule operations", () => {
       expect(count).toBe(2);
 
       // Each schedule should have its own payload
-      const first = await agentStub.getScheduleById(firstId);
+      const first = await agentStub.getStoredScheduleById(firstId);
       expect(first).toBeDefined();
       expect(first?.payload).toBe("foo");
 
-      const second = await agentStub.getScheduleById(secondId);
+      const second = await agentStub.getStoredScheduleById(secondId);
       expect(second).toBeDefined();
       expect(second?.payload).toBe("bar");
 

--- a/packages/agents/src/tests/schema-and-state-optimization.test.ts
+++ b/packages/agents/src/tests/schema-and-state-optimization.test.ts
@@ -28,6 +28,13 @@ import { getAgentByName } from "..";
  *   3. Update this snapshot to match the new DDL
  */
 const EXPECTED_SCHEMA_DDL = [
+  `CREATE TABLE cf_agents_facet_runs (
+          owner_path TEXT NOT NULL,
+          owner_path_key TEXT NOT NULL,
+          run_id TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          PRIMARY KEY (owner_path_key, run_id)
+        )`,
   `CREATE TABLE cf_agents_mcp_servers (
             id TEXT PRIMARY KEY NOT NULL,
             name TEXT NOT NULL,
@@ -61,7 +68,9 @@ const EXPECTED_SCHEMA_DDL = [
           running INTEGER DEFAULT 0,
           created_at INTEGER DEFAULT (unixepoch()),
           execution_started_at INTEGER,
-          retry_options TEXT
+          retry_options TEXT,
+          owner_path TEXT,
+          owner_path_key TEXT
         )`,
   `CREATE TABLE cf_agents_state (
         id TEXT PRIMARY KEY NOT NULL,
@@ -106,7 +115,7 @@ describe("schema version gating", () => {
     );
 
     const version = await agent.getSchemaVersion();
-    expect(version).toBe(3);
+    expect(version).toBe(5);
   });
 
   it("should have all required tables after construction", async () => {
@@ -120,6 +129,26 @@ describe("schema version gating", () => {
     expect(await agent.tableExists("cf_agents_schedules")).toBe(true);
     expect(await agent.tableExists("cf_agents_workflows")).toBe(true);
     expect(await agent.tableExists("cf_agents_mcp_servers")).toBe(true);
+    expect(await agent.tableExists("cf_agents_runs")).toBe(true);
+    expect(await agent.tableExists("cf_agents_facet_runs")).toBe(true);
+  });
+
+  it("should drop every internal table during destroy cleanup", async () => {
+    const agent = await getAgentByName(
+      env.TestStateAgent,
+      `destroy-drops-tables-${crypto.randomUUID()}`
+    );
+
+    agent.dropInternalTablesForDestroyTest();
+
+    expect(await agent.tableExists("cf_agents_state")).toBe(false);
+    expect(await agent.tableExists("cf_agents_queues")).toBe(false);
+    expect(await agent.tableExists("cf_agents_schedules")).toBe(false);
+    expect(await agent.tableExists("cf_agents_workflows")).toBe(false);
+    expect(await agent.tableExists("cf_agents_mcp_servers")).toBe(false);
+    expect(await agent.tableExists("cf_agents_sub_agents")).toBe(false);
+    expect(await agent.tableExists("cf_agents_runs")).toBe(false);
+    expect(await agent.tableExists("cf_agents_facet_runs")).toBe(false);
   });
 
   it("should reset to 0 after deleting version row and restore via migration", async () => {
@@ -127,7 +156,7 @@ describe("schema version gating", () => {
 
     // Create agent — sets schema version
     const agent = await getAgentByName(env.TestStateAgent, name);
-    expect(await agent.getSchemaVersion()).toBe(3);
+    expect(await agent.getSchemaVersion()).toBe(5);
 
     // Set some state
     await agent.updateState({
@@ -142,7 +171,7 @@ describe("schema version gating", () => {
 
     // Re-run migration manually (constructor won't re-run on same DO)
     await agent.runSchemaMigration();
-    expect(await agent.getSchemaVersion()).toBe(3);
+    expect(await agent.getSchemaVersion()).toBe(5);
 
     // State should be preserved through re-migration
     const state = await agent.getState();
@@ -187,7 +216,7 @@ describe("schema version gating", () => {
     });
 
     // Verify version is set
-    expect(await agent.getSchemaVersion()).toBe(3);
+    expect(await agent.getSchemaVersion()).toBe(5);
 
     // State should still be intact
     const state = await agent.getState();
@@ -205,7 +234,7 @@ describe("schema version gating", () => {
     );
 
     const version = await agent.getSchemaVersion();
-    expect(version).toBe(3);
+    expect(version).toBe(5);
   });
 });
 

--- a/packages/agents/src/tests/schema-and-state-optimization.test.ts
+++ b/packages/agents/src/tests/schema-and-state-optimization.test.ts
@@ -139,16 +139,7 @@ describe("schema version gating", () => {
       `destroy-drops-tables-${crypto.randomUUID()}`
     );
 
-    agent.dropInternalTablesForDestroyTest();
-
-    expect(await agent.tableExists("cf_agents_state")).toBe(false);
-    expect(await agent.tableExists("cf_agents_queues")).toBe(false);
-    expect(await agent.tableExists("cf_agents_schedules")).toBe(false);
-    expect(await agent.tableExists("cf_agents_workflows")).toBe(false);
-    expect(await agent.tableExists("cf_agents_mcp_servers")).toBe(false);
-    expect(await agent.tableExists("cf_agents_sub_agents")).toBe(false);
-    expect(await agent.tableExists("cf_agents_runs")).toBe(false);
-    expect(await agent.tableExists("cf_agents_facet_runs")).toBe(false);
+    expect(await agent.dropInternalTablesForDestroyTest()).toEqual([]);
   });
 
   it("should reset to 0 after deleting version row and restore via migration", async () => {

--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -394,6 +394,19 @@ describe("SubAgent", () => {
     expect(schedules).toContain(scheduleId);
   });
 
+  it("does not expose root storage columns from sub-agent schedule APIs", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.subAgentScheduleDelayed("public-shape-child", 60, "shape");
+
+    expect(
+      await agent.subAgentGetScheduleKeysByType("public-shape-child", "delayed")
+    ).toEqual([
+      ["callback", "delayInSeconds", "id", "payload", "retry", "time", "type"]
+    ]);
+  });
+
   it("should throw from sync schedule query APIs inside a sub-agent", async () => {
     const name = uniqueName();
     const agent = await getAgentByName(env.TestSubAgentParent, name);

--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -1,4 +1,5 @@
 import { env } from "cloudflare:workers";
+import { runDurableObjectAlarm } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "../index";
 
@@ -293,23 +294,546 @@ describe("SubAgent", () => {
     });
   });
 
-  it("should throw a clear error when scheduling in a sub-agent", async () => {
+  it("should schedule delayed callbacks from a sub-agent and execute inside the child", async () => {
     const name = uniqueName();
     const agent = await getAgentByName(env.TestSubAgentParent, name);
 
-    const error = await agent.subAgentTrySchedule("sched-guard");
-    expect(error).toMatch(/not supported in sub-agents/);
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "sched-child",
+      60,
+      "hello"
+    );
+    const rows = await agent.rootScheduleRows();
+    const row = rows.find((r) => r.id === scheduleId);
+    expect(row).toMatchObject({
+      callback: "scheduledCallback",
+      type: "delayed"
+    });
+    expect(row?.ownerPath).toContain("CounterSubAgent");
+
+    await agent.backdateSchedule(scheduleId);
+    await runDurableObjectAlarm(agent);
+
+    const log = await agent.subAgentScheduleLog("sched-child");
+    expect(log).toEqual([
+      {
+        value: "hello",
+        agentName: "sched-child",
+        currentAgentName: "sched-child",
+        parentClass: "TestSubAgentParent",
+        scheduleId,
+        callback: "scheduledCallback"
+      }
+    ]);
   });
 
-  it("keepAlive() works inside a sub-agent (facets maintain their own alarm heartbeat)", async () => {
+  it("should keep sub-agent interval schedules recurring and idempotent", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const first = await agent.subAgentScheduleInterval(
+      "interval-child",
+      60,
+      "tick"
+    );
+    const second = await agent.subAgentScheduleInterval(
+      "interval-child",
+      60,
+      "tick"
+    );
+    expect(second).toBe(first);
+
+    await agent.backdateSchedule(first);
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.subAgentScheduleLog("interval-child")).toHaveLength(1);
+    const rows = await agent.rootScheduleRows();
+    expect(rows.find((r) => r.id === first)?.type).toBe("interval");
+  });
+
+  it("should cancel a sub-agent schedule from the child API", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "cancel-child",
+      60,
+      "cancelled"
+    );
+    expect(await agent.subAgentCancelSchedule("cancel-child", scheduleId)).toBe(
+      true
+    );
+
+    await agent.backdateSchedule(scheduleId);
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.subAgentScheduleLog("cancel-child")).toEqual([]);
+    expect(
+      (await agent.rootScheduleRows()).some((r) => r.id === scheduleId)
+    ).toBe(false);
+  });
+
+  it("should read sub-agent schedules through the async APIs", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "query-child",
+      60,
+      "query"
+    );
+
+    const schedule = await agent.subAgentGetSchedule("query-child", scheduleId);
+    expect(schedule?.id).toBe(scheduleId);
+    expect(schedule?.callback).toBe("scheduledCallback");
+
+    const schedules = await agent.subAgentGetSchedulesByType(
+      "query-child",
+      "delayed"
+    );
+    expect(schedules).toContain(scheduleId);
+  });
+
+  it("should throw from sync schedule query APIs inside a sub-agent", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "sync-query-child",
+      60,
+      "query"
+    );
+
+    await expect(
+      agent.subAgentTrySyncGetSchedule("sync-query-child", scheduleId)
+    ).resolves.toMatch(/getSchedule\(\) is synchronous/);
+    await expect(
+      agent.subAgentTrySyncGetSchedules("sync-query-child")
+    ).resolves.toMatch(/getSchedules\(\) is synchronous/);
+  });
+
+  it("should keep a schedule row when facet dispatch fails", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "missing-registry-child",
+      60,
+      "kept"
+    );
+    await agent.forgetCounterSubAgentRegistry("missing-registry-child");
+    await agent.backdateSchedule(scheduleId);
+
+    await runDurableObjectAlarm(agent);
+
+    const rows = await agent.rootScheduleRows();
+    expect(rows.some((r) => r.id === scheduleId)).toBe(true);
+    expect(await agent.subAgentScheduleLog("missing-registry-child")).toEqual(
+      []
+    );
+  });
+
+  it("should dispatch nested sub-agent schedules through each parent hop", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.nestedScheduleSet(
+      "outer-scheduler",
+      "inner-scheduler",
+      60,
+      "scheduled-key",
+      "scheduled-value"
+    );
+
+    await agent.backdateSchedule(scheduleId);
+    await runDurableObjectAlarm(agent);
+
+    expect(
+      await agent.nestedGetValue(
+        "outer-scheduler",
+        "inner-scheduler",
+        "scheduled-key"
+      )
+    ).toBe("scheduled-value");
+  });
+
+  it("should remove pending schedules when deleting a sub-agent", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "delete-scheduled-child",
+      60,
+      "orphan"
+    );
+    await agent.subAgentDelete("delete-scheduled-child");
+
+    expect(
+      (await agent.rootScheduleRows()).some((r) => r.id === scheduleId)
+    ).toBe(false);
+  });
+
+  it("should not treat slashes in sub-agent names as schedule path separators", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const siblingId = await agent.subAgentScheduleDelayed(
+      "slash-child/nested-looking",
+      60,
+      "kept"
+    );
+    await agent.subAgentScheduleDelayed("slash-child", 60, "deleted");
+
+    await agent.subAgentDelete("slash-child");
+
+    const rows = await agent.rootScheduleRows();
+    expect(rows.some((r) => r.id === siblingId)).toBe(true);
+  });
+
+  it("should not treat SQL LIKE wildcard characters in names as schedule path wildcards", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const siblingId = await agent.subAgentScheduleDelayed(
+      "wildXchild/nested",
+      60,
+      "kept"
+    );
+    await agent.subAgentScheduleDelayed("wild%child", 60, "deleted");
+
+    await agent.subAgentDelete("wild%child");
+
+    const rows = await agent.rootScheduleRows();
+    expect(rows.some((r) => r.id === siblingId)).toBe(true);
+  });
+
+  it("supports cron schedules from inside a sub-agent", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    // "Every minute" — written as a row, not yet executed.
+    const scheduleId = await agent.subAgentScheduleCron(
+      "cron-child",
+      "* * * * *",
+      "tick"
+    );
+
+    const rows = await agent.rootScheduleRows();
+    const row = rows.find((r) => r.id === scheduleId);
+    expect(row).toBeDefined();
+    expect(row?.type).toBe("cron");
+    expect(row?.ownerPath).toContain("CounterSubAgent");
+    expect(row?.ownerPathKey).toContain("CounterSubAgent");
+
+    // Backdate and run the alarm; the cron callback should dispatch
+    // into the facet, then the row's `time` is rescheduled forward.
+    await agent.backdateSchedule(scheduleId);
+    await runDurableObjectAlarm(agent);
+
+    const log = await agent.subAgentScheduleLog("cron-child");
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({
+      value: "tick",
+      agentName: "cron-child",
+      currentAgentName: "cron-child",
+      callback: "scheduledCallback"
+    });
+
+    // The cron row stays alive (it just rescheduled itself forward).
+    const after = await agent.rootScheduleRows();
+    expect(after.some((r) => r.id === scheduleId)).toBe(true);
+  });
+
+  it("isolates cancelSchedule(id) by owner — siblings can't cancel each other", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const idA = await agent.subAgentScheduleDelayed(
+      "isolation-a",
+      60,
+      "from-a"
+    );
+    const idB = await agent.subAgentScheduleDelayed(
+      "isolation-b",
+      60,
+      "from-b"
+    );
+    expect(idA).not.toBe(idB);
+
+    // Sibling tries to cancel A's schedule by id — must miss.
+    expect(await agent.subAgentCancelSiblingSchedule("isolation-b", idA)).toBe(
+      false
+    );
+
+    // Top-level tries to cancel A's schedule by id — must also miss
+    // (top-level only owns rows where owner_path is null).
+    expect(await agent.parentCancelByIdNoFacet(idA)).toBe(false);
+
+    // Owner can still cancel its own.
+    expect(await agent.subAgentCancelSchedule("isolation-a", idA)).toBe(true);
+
+    const rows = await agent.rootScheduleRows();
+    expect(rows.some((r) => r.id === idA)).toBe(false);
+    expect(rows.some((r) => r.id === idB)).toBe(true);
+  });
+
+  it("treats same callback+payload across sibling sub-agents as distinct schedules", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    // Idempotent insert with identical payload — but different
+    // siblings, so the owner_path_key differs and the row dedup
+    // must NOT match across siblings.
+    const idA = await agent.subAgentScheduleInterval(
+      "idemp-sib-a",
+      60,
+      "shared"
+    );
+    const idB = await agent.subAgentScheduleInterval(
+      "idemp-sib-b",
+      60,
+      "shared"
+    );
+
+    expect(idA).not.toBe(idB);
+
+    const rows = await agent.rootScheduleRows();
+    const matched = rows.filter((r) => r.id === idA || r.id === idB);
+    expect(matched).toHaveLength(2);
+  });
+
+  it("cleans up grandchild schedules when an ancestor sub-agent is deleted", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    // root → outer → inner; schedule lives on inner.
+    const grandchildId = await agent.nestedScheduleSet(
+      "deep-outer",
+      "deep-inner",
+      60,
+      "key",
+      "value"
+    );
+
+    let rows = await agent.rootScheduleRows();
+    expect(rows.some((r) => r.id === grandchildId)).toBe(true);
+
+    // Tearing down OUTER must transitively clear the inner's schedule.
+    // We exercise the destroy-from-facet path here (outerSelfDestruct
+    // calls `this.destroy()` from inside the outer facet) — the same
+    // bulk-cancel logic also runs from a parent-side
+    // `deleteSubAgent`.
+    await agent.outerSelfDestruct("deep-outer");
+
+    rows = await agent.rootScheduleRows();
+    expect(rows.some((r) => r.id === grandchildId)).toBe(false);
+  });
+
+  it("self-cancel from inside a dispatched callback completes without deadlock", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.subAgentScheduleSelfCancellingCallback(
+      "self-cancel-child",
+      60,
+      "boom"
+    );
+
+    await agent.backdateSchedule(scheduleId);
+    await runDurableObjectAlarm(agent);
+
+    // The callback ran (log entry written) and the row is gone
+    // (one-shot rows are deleted post-execute regardless).
+    const log = await agent.subAgentScheduleLog("self-cancel-child");
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({
+      value: "boom",
+      callback: "selfCancellingCallback"
+    });
+
+    const rows = await agent.rootScheduleRows();
+    expect(rows.some((r) => r.id === scheduleId)).toBe(false);
+  });
+
+  it("destroy() inside a sub-agent clears its schedules and its parent registry entry", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "self-destruct",
+      60,
+      "gone"
+    );
+
+    // Sanity: schedule + registry entry both exist.
+    expect(
+      (await agent.rootScheduleRows()).some((r) => r.id === scheduleId)
+    ).toBe(true);
+    expect(
+      (await agent.subAgentRegistryRows()).some(
+        (r) => r.class === "CounterSubAgent" && r.name === "self-destruct"
+      )
+    ).toBe(true);
+
+    // Have the sub-agent destroy itself. The RPC frame may or may
+    // not return cleanly — the helper swallows abort errors.
+    await agent.subAgentSelfDestruct("self-destruct");
+
+    // After destruction:
+    // - Parent-owned schedule rows for this facet are gone.
+    // - Parent's `cf_agents_sub_agents` registry entry is cleared.
+    expect(
+      (await agent.rootScheduleRows()).some((r) => r.id === scheduleId)
+    ).toBe(false);
+    expect(
+      (await agent.subAgentRegistryRows()).some(
+        (r) => r.class === "CounterSubAgent" && r.name === "self-destruct"
+      )
+    ).toBe(false);
+
+    // Re-accessing the same name spawns a fresh facet with empty
+    // storage. Schedule log from the previous instance must NOT
+    // survive.
+    const log = await agent.subAgentScheduleLog("self-destruct");
+    expect(log).toEqual([]);
+  });
+
+  it("deleteSubAgent clears root-side facet fiber leases for that sub-tree", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.insertSubAgentInterruptedFiber(
+      "delete-fiber-child",
+      "delete-fiber-1",
+      "delete-work"
+    );
+    expect((await agent.facetRunRows()).map((row) => row.runId)).toContain(
+      "delete-fiber-1"
+    );
+
+    await agent.subAgentDelete("delete-fiber-child");
+
+    expect(await agent.facetRunRows()).toEqual([]);
+  });
+
+  it("destroy() inside an outer sub-agent transitively cleans up inner descendants", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    // root → outer → inner with a schedule on inner.
+    const innerScheduleId = await agent.nestedScheduleSet(
+      "outer-self-destruct",
+      "inner-victim",
+      60,
+      "key",
+      "value"
+    );
+
+    expect(
+      (await agent.rootScheduleRows()).some((r) => r.id === innerScheduleId)
+    ).toBe(true);
+
+    await agent.outerSelfDestruct("outer-self-destruct");
+
+    expect(
+      (await agent.rootScheduleRows()).some((r) => r.id === innerScheduleId)
+    ).toBe(false);
+
+    // Outer's registry entry on the root is cleared.
+    expect(
+      (await agent.subAgentRegistryRows()).some(
+        (r) => r.class === "OuterSubAgent" && r.name === "outer-self-destruct"
+      )
+    ).toBe(false);
+  });
+
+  it("emits schedule:create / schedule:cancel observability on the facet, not the alarm-owning root", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.installRecordersOn("emit-source-child");
+
+    const scheduleId = await agent.subAgentScheduleDelayed(
+      "emit-source-child",
+      60,
+      "ev"
+    );
+
+    // schedule:create must fire on the FACET, not the parent.
+    const childCreate = (
+      await agent.subAgentObservabilityLog("emit-source-child")
+    ).filter((e) => e.type === "schedule:create");
+    expect(childCreate).toHaveLength(1);
+    expect(childCreate[0].agent).toBe("CounterSubAgent");
+    expect(childCreate[0].agentName).toBe("emit-source-child");
+    expect(childCreate[0].payload).toMatchObject({
+      callback: "scheduledCallback",
+      id: scheduleId
+    });
+
+    const parentCreate = (await agent.getObservabilityLog()).filter(
+      (e) => e.type === "schedule:create"
+    );
+    expect(parentCreate).toHaveLength(0);
+
+    // schedule:cancel must also fire on the FACET, not the parent.
+    expect(
+      await agent.subAgentCancelSchedule("emit-source-child", scheduleId)
+    ).toBe(true);
+
+    const childCancel = (
+      await agent.subAgentObservabilityLog("emit-source-child")
+    ).filter((e) => e.type === "schedule:cancel");
+    expect(childCancel).toHaveLength(1);
+    expect(childCancel[0].agent).toBe("CounterSubAgent");
+    expect(childCancel[0].agentName).toBe("emit-source-child");
+    expect(childCancel[0].payload).toMatchObject({
+      callback: "scheduledCallback",
+      id: scheduleId
+    });
+
+    const parentCancel = (await agent.getObservabilityLog()).filter(
+      (e) => e.type === "schedule:cancel"
+    );
+    expect(parentCancel).toHaveLength(0);
+  });
+
+  it("resets running=0 on interval rows when facet dispatch fails", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const intervalId = await agent.subAgentScheduleInterval(
+      "running-reset-child",
+      60,
+      "tick"
+    );
+
+    // Wipe the registry entry so dispatch fails on the next alarm.
+    await agent.forgetCounterSubAgentRegistry("running-reset-child");
+    await agent.backdateSchedule(intervalId);
+
+    await runDurableObjectAlarm(agent);
+
+    // The row must still be there...
+    const rows = await agent.rootScheduleRows();
+    const row = rows.find((r) => r.id === intervalId);
+    expect(row).toBeDefined();
+    // ...and `running` must be back to 0 so the next alarm cycle
+    // actually retries instead of skipping the in-flight row.
+    expect(row?.running).toBe(0);
+  });
+
+  it("keepAlive() delegates heartbeat refs from a sub-agent to the root", async () => {
     // Regression: earlier versions banned keepAlive on facets, which
     // crashed every streaming turn in an AIChatAgent facet
     // (`_reply` uses `keepAliveWhile` to guard stream commit).
     const name = uniqueName();
     const agent = await getAgentByName(env.TestSubAgentParent, name);
 
+    expect(await agent.getRootKeepAliveRefCount()).toBe(0);
     const error = await agent.subAgentTryKeepAlive("keepalive-ok");
     expect(error).toBe("");
+    expect(await agent.getRootKeepAliveRefCount()).toBe(0);
   });
 
   it("keepAliveWhile() runs to completion inside a sub-agent", async () => {
@@ -319,6 +843,185 @@ describe("SubAgent", () => {
 
     const result = await agent.subAgentTryKeepAliveWhile("keepalive-while-ok");
     expect(result).toBe("ok");
+  });
+
+  it("keepAliveWhile() releases delegated refs when a sub-agent callback throws", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const result = await agent.subAgentTryKeepAliveWhileError(
+      "keepalive-while-error"
+    );
+
+    expect(result).toBe("keepalive failure");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(await agent.getRootKeepAliveRefCount()).toBe(0);
+  });
+
+  it("tracks multiple delegated keepAlive refs across sibling sub-agents", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.subAgentAcquireHeldKeepAlive("keepalive-sibling-a");
+    await agent.subAgentAcquireHeldKeepAlive("keepalive-sibling-a");
+    await agent.subAgentAcquireHeldKeepAlive("keepalive-sibling-b");
+
+    expect(await agent.getRootKeepAliveRefCount()).toBe(3);
+
+    await agent.subAgentReleaseHeldKeepAlives("keepalive-sibling-a");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(await agent.getRootKeepAliveRefCount()).toBe(1);
+
+    await agent.subAgentReleaseHeldKeepAlives("keepalive-sibling-b");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(await agent.getRootKeepAliveRefCount()).toBe(0);
+  });
+
+  it("holds root keepAlive and root facet-run leases while a sub-agent fiber is active", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    const fiberId = await agent.subAgentHoldFiber("fiber-child", "held");
+
+    expect(await agent.getRootKeepAliveRefCount()).toBe(1);
+    expect(await agent.subAgentRunningFiberCount("fiber-child")).toBe(1);
+    expect((await agent.facetRunRows()).map((row) => row.runId)).toContain(
+      fiberId
+    );
+
+    // The root alarm may check the active fiber, but the child sees
+    // it in `_runFiberActiveFibers`, so recovery must not run.
+    await runDurableObjectAlarm(agent);
+    expect(await agent.subAgentRecoveredFibers("fiber-child")).toEqual([]);
+    expect((await agent.facetRunRows()).map((row) => row.runId)).toContain(
+      fiberId
+    );
+
+    await agent.subAgentReleaseHeldFiber("fiber-child");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(await agent.subAgentRunningFiberCount("fiber-child")).toBe(0);
+    expect(await agent.facetRunRows()).toEqual([]);
+    expect(await agent.getRootKeepAliveRefCount()).toBe(0);
+  });
+
+  it("recovers an interrupted sub-agent fiber from the root alarm", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.insertSubAgentInterruptedFiber(
+      "recover-child",
+      "fiber-recover-1",
+      "recover-work",
+      { value: "checkpoint" }
+    );
+    expect((await agent.facetRunRows()).map((row) => row.runId)).toContain(
+      "fiber-recover-1"
+    );
+
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.subAgentRunningFiberCount("recover-child")).toBe(0);
+    expect(await agent.facetRunRows()).toEqual([]);
+    expect(await agent.subAgentRecoveredFibers("recover-child")).toEqual([
+      expect.objectContaining({
+        id: "fiber-recover-1",
+        name: "recover-work",
+        snapshot: { value: "checkpoint" }
+      })
+    ]);
+  });
+
+  it("lets internal sub-agent fiber recovery schedule continuation work in the child", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.insertSubAgentInterruptedFiber(
+      "chat-recovery-child",
+      "chat-fiber-1",
+      "__test_internal_chat"
+    );
+
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.facetRunRows()).toEqual([]);
+    expect(await agent.subAgentRecoveredFibers("chat-recovery-child")).toEqual(
+      []
+    );
+
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.subAgentScheduleLog("chat-recovery-child")).toEqual([
+      expect.objectContaining({
+        value: "recovered:chat-fiber-1",
+        callback: "scheduledCallback"
+      })
+    ]);
+  });
+
+  it("recovers an interrupted nested sub-agent fiber through each parent hop", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.insertNestedInterruptedFiber(
+      "fiber-outer",
+      "fiber-inner",
+      "nested-fiber-1",
+      "nested-work",
+      { value: "nested-checkpoint" }
+    );
+
+    expect((await agent.facetRunRows()).map((row) => row.runId)).toContain(
+      "nested-fiber-1"
+    );
+
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.facetRunRows()).toEqual([]);
+    expect(
+      await agent.nestedRecoveredFibers("fiber-outer", "fiber-inner")
+    ).toEqual([
+      expect.objectContaining({
+        id: "nested-fiber-1",
+        name: "nested-work",
+        snapshot: { value: "nested-checkpoint" }
+      })
+    ]);
+  });
+
+  it("prunes stale root facet-run leases when the facet has no run rows", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.registerSubAgentFacetRunLeaseOnly(
+      "stale-fiber-child",
+      "stale-fiber-1"
+    );
+    expect((await agent.facetRunRows()).map((row) => row.runId)).toContain(
+      "stale-fiber-1"
+    );
+
+    // There is a root-side lease but no child cf_agents_runs row.
+    // Root housekeeping should dispatch into the child, observe zero
+    // remaining rows, and prune the stale root index entry.
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.facetRunRows()).toEqual([]);
+  });
+
+  it("prunes root facet-run leases when the facet registry entry is gone", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.registerSubAgentFacetRunLeaseOnly(
+      "missing-fiber-child",
+      "missing-fiber-1"
+    );
+    await agent.forgetCounterSubAgentRegistry("missing-fiber-child");
+
+    await runDurableObjectAlarm(agent);
+
+    expect(await agent.facetRunRows()).toEqual([]);
   });
 
   describe("parentAgent()", () => {
@@ -396,12 +1099,12 @@ describe("SubAgent", () => {
     });
   });
 
-  it("should throw a clear error when cancelSchedule in a sub-agent", async () => {
+  it("should allow cancelSchedule in a sub-agent", async () => {
     const name = uniqueName();
     const agent = await getAgentByName(env.TestSubAgentParent, name);
 
     const error = await agent.subAgentTryCancelSchedule("cancel-guard");
-    expect(error).toMatch(/not supported in sub-agents/);
+    expect(error).toBe("");
   });
 
   it("should preserve the facet flag after abort and re-access", async () => {
@@ -411,7 +1114,7 @@ describe("SubAgent", () => {
     // This test aborts the sub-agent (killing the instance) then
     // re-accesses it. The _isFacet flag must survive via storage.
     const error = await agent.subAgentTryScheduleAfterAbort("persist-flag");
-    expect(error).toMatch(/not supported in sub-agents/);
+    expect(error).toBe("");
   });
 
   // ── Regression: cross-DO I/O on broadcast paths ─────────────────────

--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -716,6 +716,24 @@ describe("SubAgent", () => {
     expect(await agent.facetRunRows()).toEqual([]);
   });
 
+  it("destroy() inside a sub-agent clears root-side facet fiber leases immediately", async () => {
+    const name = uniqueName();
+    const agent = await getAgentByName(env.TestSubAgentParent, name);
+
+    await agent.insertSubAgentInterruptedFiber(
+      "self-destruct-fiber-child",
+      "self-destruct-fiber-1",
+      "self-destruct-work"
+    );
+    expect((await agent.facetRunRows()).map((row) => row.runId)).toContain(
+      "self-destruct-fiber-1"
+    );
+
+    await agent.subAgentSelfDestruct("self-destruct-fiber-child");
+
+    expect(await agent.facetRunRows()).toEqual([]);
+  });
+
   it("destroy() inside an outer sub-agent transitively cleans up inner descendants", async () => {
     const name = uniqueName();
     const agent = await getAgentByName(env.TestSubAgentParent, name);

--- a/packages/ai-chat/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/ai-chat/src/e2e-tests/chat-recovery.test.ts
@@ -25,7 +25,9 @@ function sleep(ms: number): Promise<void> {
 
 function killProcessOnPort(port: number): void {
   try {
-    const output = execSync(`lsof -ti tcp:${port} 2>/dev/null || true`)
+    const output = execSync(
+      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
+    )
       .toString()
       .trim();
     if (output) {

--- a/packages/think/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/think/src/e2e-tests/chat-recovery.test.ts
@@ -18,6 +18,9 @@ const PORT = 18797;
 const AGENT_URL = `http://localhost:${PORT}`;
 const AGENT_NAME = "think-recovery-e2e";
 const AGENT_SLUG = "think-recovery-e2-e-agent";
+const HELPER_PARENT_NAME = "think-helper-recovery-e2e";
+const HELPER_PARENT_SLUG = "think-recovery-helper-parent";
+const HELPER_NAME = "helper-recovery-e2e";
 const PERSIST_DIR = path.join(__dirname, ".wrangler-think-recovery-e2e-state");
 
 function sleep(ms: number): Promise<void> {
@@ -26,7 +29,9 @@ function sleep(ms: number): Promise<void> {
 
 function killProcessOnPort(port: number): void {
   try {
-    const output = execSync(`lsof -ti tcp:${port} 2>/dev/null || true`)
+    const output = execSync(
+      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
+    )
       .toString()
       .trim();
     if (output) {
@@ -127,11 +132,12 @@ function killProcess(child: ChildProcess): Promise<void> {
   });
 }
 
-async function callAgent(
+async function callAgentByPath(
+  path: string,
   method: string,
   args: unknown[] = []
 ): Promise<unknown> {
-  const url = `${AGENT_URL}/agents/${AGENT_SLUG}/${AGENT_NAME}`;
+  const url = `${AGENT_URL}${path}`;
 
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
@@ -168,6 +174,24 @@ async function callAgent(
       reject(err);
     };
   });
+}
+
+async function callAgent(
+  method: string,
+  args: unknown[] = []
+): Promise<unknown> {
+  return callAgentByPath(`/agents/${AGENT_SLUG}/${AGENT_NAME}`, method, args);
+}
+
+async function callHelperParent(
+  method: string,
+  args: unknown[] = []
+): Promise<unknown> {
+  return callAgentByPath(
+    `/agents/${HELPER_PARENT_SLUG}/${HELPER_PARENT_NAME}`,
+    method,
+    args
+  );
 }
 
 function sendChatMessage(userMessage: string): Promise<void> {
@@ -250,7 +274,10 @@ describe("Think chat recovery e2e", () => {
     await sendChatMessage("Tell me a long story");
 
     // 3. Wait for a few chunks to stream
-    await sleep(3000);
+    // ResumableStream flushes chunks in batches. Wait long enough for the
+    // slow mock model to cross the flush threshold before killing workerd, so
+    // recovery sees a non-empty partial response instead of only a fiber row.
+    await sleep(6000);
 
     // Verify fiber row exists (stream is in progress)
     const hasFibers = (await callAgent("hasFiberRows")) as boolean;
@@ -310,6 +337,82 @@ describe("Think chat recovery e2e", () => {
 
     // Fiber rows should be cleaned up after recovery
     const fiberRowsAfter = (await callAgent("hasFiberRows")) as boolean;
+    expect(fiberRowsAfter).toBe(false);
+  });
+
+  it("should recover helper sub-agent chat after process kill via parent alarm", async () => {
+    wrangler = startWrangler();
+    await waitForReady();
+
+    await callHelperParent("startHelperTurn", [
+      HELPER_NAME,
+      "Tell me a helper story"
+    ]);
+
+    // Wait long enough for buffered helper chunks to flush to SQLite before
+    // the simulated eviction.
+    await sleep(6000);
+
+    const hasFibers = (await callHelperParent("helperHasFiberRows", [
+      HELPER_NAME
+    ])) as boolean;
+    console.log(`[test] Helper fiber rows before kill: ${hasFibers}`);
+    expect(hasFibers).toBe(true);
+
+    console.log("[test] Killing wrangler (SIGKILL)...");
+    await killProcess(wrangler);
+    wrangler = null;
+    await waitForPortFree();
+
+    console.log("[test] Restarting wrangler...");
+    wrangler = startWrangler();
+    await waitForReady();
+    console.log("[test] Wrangler restarted");
+
+    let recovered = false;
+    for (let i = 0; i < 30; i++) {
+      await sleep(1000);
+      try {
+        const status = (await callHelperParent("getHelperRecoveryStatus", [
+          HELPER_NAME
+        ])) as {
+          recoveryCount: number;
+          messageCount: number;
+          assistantMessages: number;
+        };
+        console.log(
+          `[test] Helper poll ${i + 1}: recovered=${status.recoveryCount}, messages=${status.messageCount}, assistant=${status.assistantMessages}`
+        );
+        if (status.recoveryCount > 0) {
+          recovered = true;
+          break;
+        }
+      } catch {
+        console.log(`[test] Helper poll ${i + 1}: error (agent not ready)`);
+      }
+    }
+
+    expect(recovered).toBe(true);
+
+    const status = (await callHelperParent("getHelperRecoveryStatus", [
+      HELPER_NAME
+    ])) as {
+      recoveryCount: number;
+      contexts: Array<{
+        streamId: string;
+        requestId: string;
+        partialText: string;
+      }>;
+      messageCount: number;
+      assistantMessages: number;
+    };
+
+    expect(status.recoveryCount).toBeGreaterThanOrEqual(1);
+    expect(status.contexts[0].partialText.length).toBeGreaterThan(0);
+
+    const fiberRowsAfter = (await callHelperParent("helperHasFiberRows", [
+      HELPER_NAME
+    ])) as boolean;
     expect(fiberRowsAfter).toBe(false);
   });
 });

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -4,7 +4,7 @@
  * ThinkRecoveryE2EAgent: mock slow stream with chatRecovery for kill/restart testing.
  */
 import { createWorkersAI } from "workers-ai-provider";
-import { callable, routeAgentRequest } from "agents";
+import { Agent, callable, routeAgentRequest } from "agents";
 import type { LanguageModel, UIMessage } from "ai";
 import { Think, Workspace } from "../think";
 import type { ChatRecoveryContext, ChatRecoveryOptions } from "../think";
@@ -12,6 +12,8 @@ import type { ChatRecoveryContext, ChatRecoveryOptions } from "../think";
 type Env = {
   TestAssistant: DurableObjectNamespace<TestAssistant>;
   ThinkRecoveryE2EAgent: DurableObjectNamespace<ThinkRecoveryE2EAgent>;
+  ThinkRecoveryHelperParent: DurableObjectNamespace<ThinkRecoveryHelperParent>;
+  ThinkRecoveryHelperAgent: DurableObjectNamespace<ThinkRecoveryHelperAgent>;
   AI: Ai;
   R2: R2Bucket;
 };
@@ -137,6 +139,51 @@ export class ThinkRecoveryE2EAgent extends Think<Env> {
       SELECT COUNT(*) as count FROM cf_agents_runs
     `;
     return rows[0].count > 0;
+  }
+}
+
+export class ThinkRecoveryHelperAgent extends ThinkRecoveryE2EAgent {
+  async startSlowTurn(prompt: string): Promise<string> {
+    void this.saveMessages([
+      {
+        id: crypto.randomUUID(),
+        role: "user",
+        parts: [{ type: "text", text: prompt }]
+      }
+    ]).catch(console.error);
+
+    return "started";
+  }
+}
+
+export class ThinkRecoveryHelperParent extends Agent<Env> {
+  static options = { keepAliveIntervalMs: 2_000 };
+
+  @callable()
+  async startHelperTurn(helperName: string, prompt: string): Promise<string> {
+    const helper = await this.subAgent(ThinkRecoveryHelperAgent, helperName);
+    return helper.startSlowTurn(prompt);
+  }
+
+  @callable()
+  async helperHasFiberRows(helperName: string): Promise<boolean> {
+    const helper = await this.subAgent(ThinkRecoveryHelperAgent, helperName);
+    return helper.hasFiberRows();
+  }
+
+  @callable()
+  async getHelperRecoveryStatus(helperName: string): Promise<{
+    recoveryCount: number;
+    contexts: Array<{
+      streamId: string;
+      requestId: string;
+      partialText: string;
+    }>;
+    messageCount: number;
+    assistantMessages: number;
+  }> {
+    const helper = await this.subAgent(ThinkRecoveryHelperAgent, helperName);
+    return helper.getRecoveryStatus();
   }
 }
 

--- a/packages/think/src/e2e-tests/wrangler.jsonc
+++ b/packages/think/src/e2e-tests/wrangler.jsonc
@@ -16,13 +16,26 @@
       {
         "name": "ThinkRecoveryE2EAgent",
         "class_name": "ThinkRecoveryE2EAgent"
+      },
+      {
+        "name": "ThinkRecoveryHelperParent",
+        "class_name": "ThinkRecoveryHelperParent"
+      },
+      {
+        "name": "ThinkRecoveryHelperAgent",
+        "class_name": "ThinkRecoveryHelperAgent"
       }
     ]
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["TestAssistant", "ThinkRecoveryE2EAgent"]
+      "new_sqlite_classes": [
+        "TestAssistant",
+        "ThinkRecoveryE2EAgent",
+        "ThinkRecoveryHelperParent",
+        "ThinkRecoveryHelperAgent"
+      ]
     }
   ],
   "r2_buckets": [

--- a/site/ai-playground/src/server.ts
+++ b/site/ai-playground/src/server.ts
@@ -203,7 +203,7 @@ export class Playground extends AIChatAgent<Env, PlaygroundState> {
   }
 
   async ensureDestroy() {
-    const schedules = this.getSchedules().filter(
+    const schedules = (await this.listSchedules()).filter(
       (s) => s.callback === "destroy"
     );
     if (schedules.length > 0) {

--- a/wip/inline-sub-agent-events.md
+++ b/wip/inline-sub-agent-events.md
@@ -1330,13 +1330,11 @@ What works now:
 
 What is still missing:
 
-- **Helper-side `keepAliveWhile`: shape in place.** The main Think chat
+- **Helper-side `keepAliveWhile`: implemented.** The main Think chat
   turn is wrapped in `keepAliveWhile`; helper execution now is too.
-  Today `keepAlive()` is a soft no-op on facets because workerd does
-  not support independent facet alarms yet, so the live run still
-  relies on the active RPC stream / Promise chain for liveness. Keeping
-  the wrapper documents the intended Agents-level lifecycle and should
-  become meaningful once alarms work inside facets.
+  Facets delegate heartbeat refs to the top-level parent, so helper
+  execution no longer relies only on the active RPC stream / Promise
+  chain for liveness.
 - **Helper fibers.** Main chat turns can run inside a chat-recovery
   fiber. Helper work currently does not. A helper run could become a
   child fiber of the parent turn, but that requires a design for
@@ -1488,11 +1486,11 @@ abortRequest(id)` / `abortAllRequests()`; the bracket-access
     tripped over a workerd JSRPC quirk that doesn't affect
     correctness but lights up vitest's unhandled-error detector;
     documented inline alongside where the test would have lived.
-  - **H4 — `chatRecovery = false` on `Researcher`.** Helpers are
-    per-turn workers driven over RPC; Think's default-on
-    chat-recovery fiber would silently re-run the inference loop
-    into a parent that's already marked the run `interrupted` on
-    every helper hibernate-and-wake cycle. One-line override.
+  - **H4 — helper `chatRecovery`.** Helpers now keep Think chat
+    recovery enabled. The helper can recover its own turn inside the
+    facet; the parent still marks the inline helper row `interrupted`
+    if it loses the original RPC reader, until a live-tail policy can
+    reattach to recovered work.
   - **S1 — dropped redundant `keepAliveWhile` wrap.** `saveMessages`
     already wraps its body; the outer wrap was a leftover.
   - **S2 — orphan stream cleanup.** `getChatChunksForReplay` detects
@@ -1760,8 +1758,8 @@ sub: [{ agent: "Researcher", name: helperId }] })`). The framework's
   - Extracted `HelperAgent extends Think<Env>` as the shared base.
     All helper-protocol bits (`broadcast` tee, `runTurnAndStream`,
     lifecycle accessors, `_lastTurnStreamId` / `_lastStreamError` /
-    `_preTurnAssistantIds`, `chatRecovery = false`, the
-    concurrent-call guard) live there. Concrete helpers stay thin
+    `_preTurnAssistantIds`, chat recovery policy, the concurrent-call
+    guard) live there. Concrete helpers stay thin
     — pick a model, a system prompt, and a tool surface.
   - Added `Planner extends HelperAgent` with a different system
     prompt (writes structured implementation plans) and a single


### PR DESCRIPTION
## Summary

This PR makes sub-agents/facets first-class users of alarm-backed Agents APIs while preserving the Durable Object invariant that only the top-level parent owns the physical alarm slot.

The main behavior change is that sub-agents can now call:

- `schedule()` and `scheduleEvery()`
- `cancelSchedule()`
- `getScheduleById()` and `listSchedules()`
- `keepAlive()` and `keepAliveWhile()`
- `runFiber()`
- Think chat recovery paths built on fibers

The root parent stores/runs the physical alarm bookkeeping, but callbacks and recovery hooks are routed back into the logical owner. A scheduled callback created by a child runs with the child as `this`; a recovered child fiber calls the child's `onFiberRecovered()` / internal chat recovery hook; and sub-agent storage/state remain local to the sub-agent.

## Behavior Changes

### Sub-agent scheduling

- Adds logical schedule ownership via owner paths so parent-owned schedule rows can belong to a descendant facet.
- Routes due scheduled, delayed, cron, and interval callbacks back into the owning sub-agent.
- Makes `cancelSchedule(id)`, `getScheduleById(id)`, and `listSchedules()` work inside sub-agents with caller ownership isolation.
- Keeps `cancelSchedule(id)` scoped: sibling sub-agents cannot cancel each other's schedules by id.
- Keeps idempotent schedules distinct across sibling sub-agents by including the owner path in dedupe semantics.
- Emits `schedule:create` and `schedule:cancel` observability events from the logical child owner instead of only the root parent.

### Deprecated sync schedule APIs

- The old synchronous `getSchedule()` and `getSchedules()` APIs now throw inside sub-agents because child-owned schedule rows live on the top-level parent.
- Docs and examples move toward async `getScheduleById()` and `listSchedules()`.

### Sub-agent cleanup

- Calling `destroy()` from inside a sub-agent now delegates teardown through the root parent.
- Parent-side cleanup removes schedules owned by the sub-agent and descendants, prunes descendant facet fiber leases, removes the registry entry, and asks the runtime to delete the facet storage.
- Top-level `destroy()` now drops the durable fiber tables as part of internal table cleanup.

### keepAlive / keepAliveWhile

- `keepAlive()` inside a sub-agent now acquires a root-owned heartbeat ref instead of being blocked/no-op.
- The returned disposer releases the root ref through `ctx.waitUntil()` so release RPCs remain tied to the event lifetime.
- `keepAliveWhile()` therefore works inside sub-agents, including error paths.

### runFiber and chat recovery

- Sub-agent `runFiber()` rows remain authoritative in the child facet's `cf_agents_runs` table.
- The root parent keeps a small index of active descendant facet fibers so its alarm can wake idle children for recovery checks.
- Root housekeeping dispatches recovery checks into the owning child and prunes stale root index rows if the child registry or child run rows disappear.
- Think chat recovery now works inside sub-agents because recovered internal chat fibers run in the child.

## Migration Notes

- Bumps `CURRENT_SCHEMA_VERSION` to `5`.
- Adds root-side table `cf_agents_facet_runs`:
  - `owner_path`
  - `owner_path_key`
  - `run_id`
  - `created_at`
  - primary key on `(owner_path_key, run_id)`
- Adds an index on `owner_path_key` for cleanup/recovery scans.
- The table is only an index of child fibers needing root-driven recovery checks. The actual fiber snapshot and recovery state stay in each child facet's `cf_agents_runs` table.
- Migration uses `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` and updates the schema version row after migration.
- Adds a patch changeset for `agents` describing the user-facing API expansion.

## Docs / Examples

Updated docs and examples to reflect that sub-agents now support scheduling, keepAlive, durable fibers, and Think chat recovery:

- `docs/sub-agents.md`
- `docs/scheduling.md`
- `docs/durable-execution.md`
- `docs/long-running-agents.md`
- `docs/agent-class.md`
- `docs/think/sub-agents.md`
- `docs/server-driven-messages.md`
- `examples/agents-as-tools`
- `examples/multi-ai-chat`
- playground / push-notification / AI playground schedule API call sites
- internal design and WIP notes that previously described these APIs as unsupported or reconnect-driven

Notable example behavior:

- `examples/agents-as-tools` now enables helper `chatRecovery = true`.
- The parent-side live stream reattachment policy is still separate: if the parent loses the helper RPC reader, the parent inline row may still be marked interrupted until a future live-tail policy reattaches. The helper's own Think turn can recover in the child facet.

## Reviewer Notes

Please review these areas closely:

- Owner-path isolation and prefix matching. This controls sibling schedule isolation, descendant cleanup, and stale lease pruning.
- Alarm rescheduling paths. The root now considers normal schedules, root fibers, delegated keepAlive refs, and descendant facet fiber leases.
- Interval callback failure handling. If dispatching into a facet throws, interval rows should not remain stuck as `running = 1`.
- Recursive facet RPC routing. Recovery and schedule dispatch must arrive at the correct descendant and run with the child as `this`.
- `destroy()` semantics from inside a facet. The runtime facet delete may abort the child isolate, so docs describe it as effectively fire-and-forget from the caller's perspective.
- `keepAlive()` disposer reliability. The child disposer uses `ctx.waitUntil()` for the release RPC; this avoids leaking root refs when the handler returns quickly.
- E2E timing. The process-kill recovery tests are intentionally realistic and may be the most timing-sensitive CI coverage.

## Test Coverage

Added or updated coverage for:

- Cron schedules from inside a sub-agent.
- `cancelSchedule(id)` isolation across sibling sub-agents.
- Idempotent schedules with identical callback/payload across sibling sub-agents.
- Deep descendant cleanup via sub-agent `destroy()` and parent cleanup.
- Self-cancel from inside a dispatched sub-agent callback.
- `keepAlive()` delegation from child to root.
- `keepAliveWhile()` success and throwing paths inside a child.
- Multiple held keepAlive refs across sibling sub-agents.
- Active child fiber registration with root facet-run leases.
- Internal child fiber recovery that schedules continuation work inside the child.
- Stale root facet-run pruning when child run rows are gone.
- Stale root facet-run pruning when the child registry entry is gone.
- Schema snapshot/version checks for schema version 5.
- Destroy cleanup dropping all internal tables including `cf_agents_runs` and `cf_agents_facet_runs`.
- E2E `runFiber()` recovery after real process kill for both top-level agents and sub-agents.
- E2E Think chat recovery after real process kill for both top-level agents and helper sub-agents.

## Verification

Ran locally:

- `npm --workspace agents test -- schema-and-state-optimization.test.ts`
- `npm run check`
- `npm --workspace agents run build`

`npm run check` passed with the existing non-fatal sherif warning about `experimental/sub-agent-id-ioctx/package.json` not existing.

## Risks / Follow-ups

- This is a broad core change in `packages/agents/src/index.ts`; review should prioritize correctness of owner-path routing, alarm scheduling, and cleanup invariants.
- Parent-side live-tail reattachment for recovered helper work is not implemented here. The helper's own recovered chat is durable, but the parent UI policy remains intentionally conservative.
- Existing sync schedule APIs are only partially retired. This PR preserves them for top-level callers while making sub-agent use fail loudly and documenting the async replacements.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
