### PR TITLE
Expose Think turn telemetry

### DIFF
--- a/.changeset/think-telemetry.md
+++ b/.changeset/think-telemetry.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/think": patch
+---
+
+Forward `TurnConfig.experimental_telemetry` to Think's internal AI SDK
+`streamText()` call so applications can configure per-turn LLM observability.

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -138,7 +138,7 @@ The AI SDK-derived contexts spread the SDK's own types at the top level — no i
 
 `beforeStep` is wired to the AI SDK's `prepareStep` callback. Return a `StepConfig` to override `model`, `toolChoice`, `activeTools`, `system`, `messages`, `experimental_context`, or `providerOptions` for the current step. The AI SDK does not expose `output` or `maxSteps` per step — set those at the turn level via `TurnConfig` (returned from `beforeTurn`). `beforeStep` is subclass-only; it is not dispatched to extensions because the prepareStep event surface includes a live `LanguageModel` instance which is not JSON-safe to snapshot.
 
-`TurnConfig` also accepts an `output` field that is forwarded to `streamText` as the AI SDK's structured-output spec. Combine with `activeTools: []` for providers (e.g. `workers-ai-provider`) that strip tools when `responseFormat: "json"` is active.
+`TurnConfig` also accepts an `output` field that is forwarded to `streamText` as the AI SDK's structured-output spec. Combine with `activeTools: []` for providers (e.g. `workers-ai-provider`) that strip tools when `responseFormat: "json"` is active. Use `experimental_telemetry` to pass the AI SDK's per-call telemetry settings through to `streamText`; consider disabling `recordInputs` or `recordOutputs` if prompts or outputs may contain sensitive data.
 
 Per-tool hooks are wired so `beforeToolCall` fires _before_ `execute` (Think wraps every tool's `execute`) and `afterToolCall` fires _after_ (via the AI SDK's `experimental_onToolCallFinish`) with `durationMs` and a discriminated outcome. `beforeToolCall` can return a `ToolCallDecision` to:
 

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -247,6 +247,7 @@ export class ThinkTestAgent extends Think {
   private _turnConfigOverride: TurnConfig | null = null;
   private _stepConfigOverride: StepConfig | null = null;
   private _beforeStepAsyncDelayMs = 0;
+  private _telemetryEvents: string[] = [];
   private _beforeStepLog: Array<{
     stepNumber: number;
     previousStepCount: number;
@@ -281,6 +282,29 @@ export class ThinkTestAgent extends Think {
    */
   async setTurnConfigOutputText(): Promise<void> {
     this._turnConfigOverride = { output: Output.text(), activeTools: [] };
+  }
+
+  async setTurnConfigTelemetry(): Promise<void> {
+    this._telemetryEvents = [];
+    this._turnConfigOverride = {
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: "think-test-turn",
+        metadata: { source: "think-test" },
+        integrations: {
+          onStart: (event) => {
+            this._telemetryEvents.push(
+              `start:${event.functionId}:${event.metadata?.source ?? ""}`
+            );
+          },
+          onFinish: (event) => {
+            this._telemetryEvents.push(
+              `finish:${event.functionId}:${event.metadata?.source ?? ""}`
+            );
+          }
+        }
+      }
+    };
   }
 
   override async beforeStep(
@@ -351,6 +375,10 @@ export class ThinkTestAgent extends Think {
     }>
   > {
     return this._stepLog;
+  }
+
+  async getTelemetryEvents(): Promise<string[]> {
+    return this._telemetryEvents;
   }
 
   async getBeforeStepLog(): Promise<

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -172,6 +172,19 @@ describe("Think — core", () => {
     expect(fullText).toBe("Custom response text");
   });
 
+  it("should forward turn telemetry to the AI SDK", async () => {
+    const agent = await freshAgent("chat-telemetry");
+
+    await agent.setTurnConfigTelemetry();
+    const result = await agent.testChat("Trace this turn");
+
+    expect(result.done).toBe(true);
+    await expect(agent.getTelemetryEvents()).resolves.toEqual([
+      "start:think-test-turn:think-test",
+      "finish:think-test-turn:think-test"
+    ]);
+  });
+
   it("should build assistant message with text parts", async () => {
     const agent = await freshAgent("chat-parts");
     await agent.testChat("Hello!");

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -309,6 +309,10 @@ export interface TurnConfig {
   maxSteps?: number;
   /** Provider-specific options (AI SDK providerOptions). */
   providerOptions?: Record<string, unknown>;
+  /** Optional AI SDK telemetry configuration for this turn. */
+  experimental_telemetry?: Parameters<
+    typeof streamText
+  >[0]["experimental_telemetry"];
   /**
    * Optional structured-output specification (AI SDK `output`).
    * Forwarded to `streamText` so the model's final response is parsed
@@ -1199,6 +1203,7 @@ export class Think<
       providerOptions: config.providerOptions as
         | Parameters<typeof streamText>[0]["providerOptions"]
         | undefined,
+      experimental_telemetry: config.experimental_telemetry,
       // Forward the per-turn structured-output spec from TurnConfig so
       // callers can use AI SDK `Output.object({ schema })` / `Output.text()`
       // on the terminal turn without dropping tools at model construction.


### PR DESCRIPTION
## Summary
- Add `TurnConfig.experimental_telemetry` and forward it to Think's internal AI SDK `streamText()` call.
- Document the telemetry passthrough and add a patch changeset for `@cloudflare/think`.
- Cover the passthrough with a Think worker test using AI SDK telemetry integrations.

## Test plan
- `npm run test -w @cloudflare/think -- src/tests/think-session.test.ts`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
