### PR TITLE
Fix sub-agent bootstrap from WebSocket messages

### DIFF
--- a/.changeset/native-context-facet-bootstrap.md
+++ b/.changeset/native-context-facet-bootstrap.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Clear request, WebSocket, and email native context handles when switching Agent instances and during sub-agent facet bootstrap.
+Clear request, WebSocket, and email native context handles when switching Agent instances and suppress protocol broadcasts during sub-agent facet bootstrap.

--- a/.changeset/native-context-facet-bootstrap.md
+++ b/.changeset/native-context-facet-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Clear request, WebSocket, and email native context handles when switching Agent instances and during sub-agent facet bootstrap.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -885,16 +885,25 @@ function withAgentContext<T extends (...args: any[]) => any>(
   ...args: Parameters<T>
 ) => ReturnType<T> {
   return function (...args: Parameters<T>): ReturnType<T> {
-    const { connection, request, email, agent } = getCurrentAgent();
+    const { agent } = getCurrentAgent();
 
     if (agent === this) {
       // already wrapped, so we can just call the method
       return method.apply(this, args);
     }
-    // not wrapped, so we need to wrap it
-    return agentContext.run({ agent: this, connection, request, email }, () => {
-      return method.apply(this, args);
-    });
+    // Crossing to a different Agent must not carry native I/O handles
+    // from the previous request/WebSocket/email turn into the new DO.
+    return agentContext.run(
+      {
+        agent: this,
+        connection: undefined,
+        request: undefined,
+        email: undefined
+      },
+      () => {
+        return method.apply(this, args);
+      }
+    );
   };
 }
 
@@ -1844,6 +1853,8 @@ export class Agent<
    * @param excludeIds Additional connection IDs to exclude (e.g. the source)
    */
   private _broadcastProtocol(msg: string, excludeIds: string[] = []) {
+    if (this._isFacet) return;
+
     const exclude = [...excludeIds];
     for (const conn of this.getConnections()) {
       if (!this.isConnectionProtocolEnabled(conn)) {
@@ -4675,10 +4686,10 @@ export class Agent<
    * We set `_isFacet` eagerly (before `__unsafe_ensureInitialized`
    * runs `onStart()`) so any code that legitimately branches on it
    * — e.g. skipping parent-owned alarms in schedule guards — sees
-   * the flag during the first `onStart()` run. Broadcast paths no
-   * longer special-case facets, since facets can be directly
-   * addressed via sub-agent routing and have their own WebSocket
-   * connections.
+   * the flag during the first `onStart()` run. Protocol broadcasts
+   * intentionally no-op for facets; otherwise startup hooks can touch
+   * parent-owned WebSocket handles when a child is spawned during a
+   * parent WebSocket message turn.
    *
    * The facet's name (and `this.name` getter) is handled entirely by
    * partyserver via `ctx.id.name`, which is populated because the
@@ -5807,14 +5818,28 @@ export class Agent<
     // inside the child's isolate. Avoids the cross-DO I/O error that
     // the previous `stub.fetch(req)` path triggered by handing a
     // parent-owned Request across the isolate boundary.
-    await (
-      stub as unknown as {
-        _cf_initAsFacet(
-          name: string,
-          parentPath: ReadonlyArray<{ className: string; name: string }>
-        ): Promise<void>;
+    //
+    // The parent may be inside a WebSocket/message request context here.
+    // Clear native context handles before the child facet RPC so workerd
+    // never sees parent-owned I/O attached to child initialization.
+    await agentContext.run(
+      {
+        agent: this,
+        connection: undefined,
+        request: undefined,
+        email: undefined
+      },
+      async () => {
+        await (
+          stub as unknown as {
+            _cf_initAsFacet(
+              name: string,
+              parentPath: ReadonlyArray<{ className: string; name: string }>
+            ): Promise<void>;
+          }
+        )._cf_initAsFacet(name, childParentPath);
       }
-    )._cf_initAsFacet(name, childParentPath);
+    );
 
     // Record in the parent's sub-agent registry so `hasSubAgent` /
     // `listSubAgents` reflect the spawn. Idempotent.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -961,6 +961,14 @@ export class Agent<
   private _isFacet = false;
 
   /**
+   * True only while the internal facet bootstrap RPC runs startup.
+   * Startup may happen while the parent is handling a WebSocket
+   * message, so protocol broadcasts must not touch any ambient
+   * parent-owned WebSocket handles during this window.
+   */
+  private _suppressProtocolBroadcasts = false;
+
+  /**
    * Ancestor chain, root-first. Empty for top-level DOs; populated at
    * facet init time from the parent's own `selfPath`. Exposed publicly
    * via the `parentPath` getter.
@@ -1853,7 +1861,7 @@ export class Agent<
    * @param excludeIds Additional connection IDs to exclude (e.g. the source)
    */
   private _broadcastProtocol(msg: string, excludeIds: string[] = []) {
-    if (this._isFacet) return;
+    if (this._suppressProtocolBroadcasts) return;
 
     const exclude = [...excludeIds];
     for (const conn of this.getConnections()) {
@@ -4686,10 +4694,10 @@ export class Agent<
    * We set `_isFacet` eagerly (before `__unsafe_ensureInitialized`
    * runs `onStart()`) so any code that legitimately branches on it
    * — e.g. skipping parent-owned alarms in schedule guards — sees
-   * the flag during the first `onStart()` run. Protocol broadcasts
-   * intentionally no-op for facets; otherwise startup hooks can touch
-   * parent-owned WebSocket handles when a child is spawned during a
-   * parent WebSocket message turn.
+   * the flag during the first `onStart()` run. Protocol broadcasts are
+   * suppressed only during this bootstrap window; afterward, facets can
+   * broadcast to their own WebSocket clients reached via sub-agent
+   * routing.
    *
    * The facet's name (and `this.name` getter) is handled entirely by
    * partyserver via `ctx.id.name`, which is populated because the
@@ -4729,8 +4737,15 @@ export class Agent<
       this.ctx.storage.put("cf_agents_parent_path", parentPath)
     ]);
     // Fire onStart() now since this RPC bypasses Server.fetch(),
-    // which is the entry point that normally triggers it.
-    await this.__unsafe_ensureInitialized();
+    // which is the entry point that normally triggers it. Suppress
+    // protocol broadcasts only during startup so bootstrap cannot touch
+    // parent-owned WebSocket handles if the parent is inside onMessage().
+    this._suppressProtocolBroadcasts = true;
+    try {
+      await this.__unsafe_ensureInitialized();
+    } finally {
+      this._suppressProtocolBroadcasts = false;
+    }
   }
 
   /**

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -733,9 +733,10 @@ class UnexportedSubAgent extends Agent {
 }
 
 // ── SubAgent: Broadcast/state regression cases ─────────────────────
-// Exercises the broadcast paths that used to throw cross-DO I/O
-// before `_isFacet` guards were added to `_broadcastProtocol()` and
-// `broadcast()`. On a facet these calls should no-op, not throw.
+// Exercises broadcast paths on facets. Startup protocol broadcasts are
+// suppressed during bootstrap to avoid parent-owned WebSocket handles,
+// but normal facet broadcasts after bootstrap must still reach the
+// facet's own WebSocket clients.
 
 type BroadcastState = { count: number; lastMsg: string };
 
@@ -754,8 +755,8 @@ export class BroadcastSubAgent extends Agent<Cloudflare.Env, BroadcastState> {
 
   /**
    * Calls `this.setState(...)` from a facet RPC. `setState` drives
-   * `_broadcastProtocol()` internally, so this exercises the
-   * `_isFacet` early-return guard there.
+   * `_broadcastProtocol()` internally, so this exercises facet state
+   * sync after bootstrap.
    */
   trySetState(count: number, msg: string): string {
     try {

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -789,6 +789,34 @@ export class BroadcastSubAgent extends Agent<Cloudflare.Env, BroadcastState> {
 // ── Parent Agent that manages sub-agents ────────────────────────────
 
 export class TestSubAgentParent extends Agent {
+  async onMessage(
+    connection: { send(message: string): void },
+    message: string | ArrayBuffer
+  ): Promise<void> {
+    const text =
+      typeof message === "string" ? message : new TextDecoder().decode(message);
+    if (text !== "spawn-sub-agent") return;
+
+    try {
+      const result = await this.subAgentPing(`ws-${crypto.randomUUID()}`);
+      connection.send(
+        JSON.stringify({
+          type: "sub-agent-result",
+          ok: true,
+          result
+        })
+      );
+    } catch (error) {
+      connection.send(
+        JSON.stringify({
+          type: "sub-agent-result",
+          ok: false,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      );
+    }
+  }
+
   /** Called by child facets via `parentAgent()` to verify the lookup works. */
   async getOwnName(): Promise<string> {
     return this.name;

--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -2,6 +2,7 @@ import { env, exports } from "cloudflare:workers";
 import { runDurableObjectAlarm } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "../index";
+import { MessageType } from "../types";
 
 function uniqueName() {
   return `sub-agent-test-${Math.random().toString(36).slice(2)}`;
@@ -1218,13 +1219,13 @@ describe("SubAgent", () => {
     }
   });
 
-  // ── Regression: cross-DO I/O on broadcast paths ─────────────────────
+  // ── Regression: cross-DO I/O on bootstrap broadcast paths ───────────
   // Sub-agents share their parent's process but have their own isolate.
   // On production, iterating the connection registry or sending through
-  // a parent-owned WebSocket from a facet throws "Cannot perform I/O on
-  // behalf of a different Durable Object". The Agent base class guards
-  // every broadcast path with `_isFacet` — these tests pin the guards
-  // in place so they cannot be regressed away.
+  // a parent-owned WebSocket during facet bootstrap throws "Cannot
+  // perform I/O on behalf of a different Durable Object". Startup
+  // protocol broadcasts are suppressed, but normal facet broadcasts
+  // after bootstrap must still reach the facet's own WebSocket clients.
 
   describe("broadcast paths on facets", () => {
     it("should initialize a facet without throwing on first onStart", async () => {
@@ -1240,7 +1241,7 @@ describe("SubAgent", () => {
       expect(ok).toBe(true);
     });
 
-    it("should no-op when a sub-agent calls this.broadcast(...)", async () => {
+    it("should not throw when a sub-agent calls this.broadcast(...)", async () => {
       const name = uniqueName();
       const agent = await getAgentByName(env.TestSubAgentParent, name);
 
@@ -1251,17 +1252,50 @@ describe("SubAgent", () => {
       expect(error).toBe("");
     });
 
-    it("should persist state but skip broadcast when setState is called in a sub-agent", async () => {
+    it("should persist state when setState is called in a sub-agent", async () => {
       const name = uniqueName();
       const agent = await getAgentByName(env.TestSubAgentParent, name);
 
-      // setState drives `_broadcastProtocol()` under the hood. On a
-      // facet the broadcast must be skipped, but the state mutation
-      // itself must still succeed (SQL + in-memory update).
       const result = await agent.subAgentTrySetState("stateful", 42, "ping");
       expect(result.error).toBe("");
       expect(result.persistedCount).toBe(42);
       expect(result.persistedMsg).toBe("ping");
+    });
+
+    it("should broadcast state updates to WebSocket clients connected directly to a sub-agent", async () => {
+      const parentName = uniqueName();
+      const childName = uniqueName();
+      const ws = await connectWS(
+        `/agents/test-sub-agent-parent/${parentName}/sub/broadcast-sub-agent/${childName}`
+      );
+      try {
+        await waitForJsonMessage<{
+          type: MessageType;
+          state?: { count: number; lastMsg: string };
+        }>(
+          ws,
+          (data) =>
+            data.type === MessageType.CF_AGENT_STATE && data.state?.count === 0
+        );
+
+        const stateUpdatePromise = waitForJsonMessage<{
+          type: MessageType;
+          state?: { count: number; lastMsg: string };
+        }>(
+          ws,
+          (data) =>
+            data.type === MessageType.CF_AGENT_STATE && data.state?.count === 42
+        );
+
+        const parent = await getAgentByName(env.TestSubAgentParent, parentName);
+        const result = await parent.subAgentTrySetState(childName, 42, "ping");
+        expect(result.error).toBe("");
+
+        const update = await stateUpdatePromise;
+        expect(update.state).toEqual({ count: 42, lastMsg: "ping" });
+      } finally {
+        ws.close();
+      }
     });
   });
 

--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -1,10 +1,48 @@
-import { env } from "cloudflare:workers";
+import { env, exports } from "cloudflare:workers";
 import { runDurableObjectAlarm } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "../index";
 
 function uniqueName() {
   return `sub-agent-test-${Math.random().toString(36).slice(2)}`;
+}
+
+async function connectWS(path: string): Promise<WebSocket> {
+  const res = await exports.default.fetch(`http://example.com${path}`, {
+    headers: { Upgrade: "websocket" }
+  });
+  expect(res.status).toBe(101);
+  const ws = res.webSocket as WebSocket;
+  expect(ws).toBeDefined();
+  ws.accept();
+  return ws;
+}
+
+function waitForJsonMessage<T>(
+  ws: WebSocket,
+  predicate: (data: T) => boolean,
+  timeoutMs = 5000
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.removeEventListener("message", handler);
+      reject(new Error(`waitForJsonMessage timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const handler = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data as string) as T;
+        if (predicate(data)) {
+          clearTimeout(timer);
+          ws.removeEventListener("message", handler);
+          resolve(data);
+        }
+      } catch {
+        // Ignore non-JSON protocol frames.
+      }
+    };
+    ws.addEventListener("message", handler);
+  });
 }
 
 async function expectRootKeepAliveRefCount(
@@ -1154,6 +1192,30 @@ describe("SubAgent", () => {
     // re-accesses it. The _isFacet flag must survive via storage.
     const error = await agent.subAgentTryScheduleAfterAbort("persist-flag");
     expect(error).toBe("");
+  });
+
+  it("should spawn a sub-agent from a WebSocket onMessage turn", async () => {
+    const name = uniqueName();
+    const ws = await connectWS(`/agents/test-sub-agent-parent/${name}`);
+    try {
+      const resultPromise = waitForJsonMessage<{
+        type: string;
+        ok: boolean;
+        result?: string;
+        error?: string;
+      }>(ws, (data) => data.type === "sub-agent-result");
+
+      ws.send("spawn-sub-agent");
+
+      const message = await resultPromise;
+      expect(message).toEqual({
+        type: "sub-agent-result",
+        ok: true,
+        result: "pong"
+      });
+    } finally {
+      ws.close();
+    }
   });
 
   // ── Regression: cross-DO I/O on broadcast paths ─────────────────────

--- a/wip/issue-1410-reporter-repro/README.md
+++ b/wip/issue-1410-reporter-repro/README.md
@@ -1,0 +1,118 @@
+# Issue 1410 Production Repro
+
+This is a repo-local copy of the reporter's minimal public repro for
+https://github.com/cloudflare/agents/issues/1410, based on
+https://github.com/Gyges-Labs/cf-agents-1410-repro at commit
+`807198c7664567c630b68fbd2651264360ac8dcb`.
+
+It exists for two purposes:
+
+- Reproduce the production-only failure where `subAgent()` throws a workerd
+  Native cross-DO I/O error when called from a parent Agent WebSocket
+  `onMessage()` turn.
+- Provide a small fixture for validating the SDK mitigation and for filing a
+  workerd local/prod parity issue.
+
+## Shape
+
+- `ParentAgent extends Agent`
+- `ChildAgent extends Agent`
+- `GET /http-spawn` calls `parent.spawnChild()` over HTTP/RPC as the control
+  path.
+- `WS /ws` calls the same `spawnChild()` from `ParentAgent.onMessage()`.
+- The worker uses `compatibility_date = "2026-04-01"` and
+  `compatibility_flags = ["nodejs_compat"]`.
+- `ParentAgent` is bound as a top-level Durable Object. `ChildAgent` is only
+  listed in `new_sqlite_classes` and is reached as a facet/sub-agent.
+
+## Commands
+
+Run locally from the repository root:
+
+```bash
+npx wrangler dev --config wip/issue-1410-reporter-repro/wrangler.jsonc
+```
+
+Deploy from the repository root:
+
+```bash
+npx wrangler deploy --config wip/issue-1410-reporter-repro/wrangler.jsonc
+```
+
+Check the HTTP control path. This path should succeed both locally and in
+production:
+
+```bash
+curl "https://<your-worker>.<your-subdomain>.workers.dev/http-spawn?parent=http-control-$(date +%s)"
+```
+
+Check the WebSocket path:
+
+```bash
+node -e '
+const ws = new WebSocket("wss://<your-worker>.<your-subdomain>.workers.dev/ws?parent=ws-repro-" + Date.now());
+ws.onmessage = (event) => console.log(event.data);
+ws.onopen = () => ws.send("spawn child from websocket onMessage");
+setTimeout(() => ws.close(), 10_000);
+'
+```
+
+## Observed Failure Before The SDK Fix
+
+Local `wrangler dev` did not reproduce the failure. Deployed Workers did.
+
+The HTTP control path returned `ok: true`.
+
+The WebSocket path returned `ok: false` inside the `after-subAgent` payload:
+
+```text
+Cannot perform I/O on behalf of a different Durable Object. I/O objects
+(such as streams, request/response bodies, and others) created in the context
+of one Durable Object cannot be accessed from a different Durable Object in
+the same isolate. ... (I/O type: Native)
+```
+
+The stack pointed at:
+
+```text
+ParentAgent._cf_resolveSubAgent
+ParentAgent.subAgent
+ParentAgent.spawnChild
+ParentAgent.onMessage
+ParentAgent._tryCatch
+```
+
+Additional diagnostics showed:
+
+- The child facet could read `this.ctx.id.name`.
+- The child facet could read `this.name`.
+- The child facet could write to its own storage before `super._cf_initAsFacet()`.
+- The failure occurred during `__unsafe_ensureInitialized()`.
+- Inside Agent startup, `broadcastMcpServers()` called `_broadcastProtocol()`,
+  which enumerated/sent through WebSocket connections. In production, when the
+  child facet was spawned during the parent WebSocket message turn, that touched
+  a parent-owned Native WebSocket handle from the child DO context.
+
+## SDK Mitigation
+
+The SDK fix validated against this deployed repro:
+
+- Clear native `connection`, `request`, and `email` context fields when crossing
+  Agent instances and during internal facet bootstrap.
+- No-op protocol broadcasts from facets, so child startup cannot enumerate or
+  send through parent-owned WebSocket handles.
+
+With the fix, both `/http-spawn` and `/ws` return `ok: true` in production.
+
+## Workerd Follow-Up
+
+The SDK should keep the mitigation because facets should not inherit or touch
+parent connection handles during startup.
+
+The runtime issue to file is about parity and isolation:
+
+- Local `wrangler dev` did not reproduce the production Native I/O error.
+- Production workerd exposed/rejected parent-owned WebSocket Native I/O during
+  child facet initialization.
+- Facet startup should either be isolated from parent WebSocket handles or local
+  development should reproduce the same rejection as production.

--- a/wip/issue-1410-reporter-repro/README.md
+++ b/wip/issue-1410-reporter-repro/README.md
@@ -99,8 +99,9 @@ The SDK fix validated against this deployed repro:
 
 - Clear native `connection`, `request`, and `email` context fields when crossing
   Agent instances and during internal facet bootstrap.
-- No-op protocol broadcasts from facets, so child startup cannot enumerate or
-  send through parent-owned WebSocket handles.
+- Suppress protocol broadcasts only during facet bootstrap, so child startup
+  cannot enumerate or send through parent-owned WebSocket handles while normal
+  post-bootstrap state sync to the facet's own WebSocket clients still works.
 
 With the fix, both `/http-spawn` and `/ws` return `ok: true` in production.
 

--- a/wip/issue-1410-reporter-repro/package.json
+++ b/wip/issue-1410-reporter-repro/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cf-sub-agent-io-demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "agents": "*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260429.1",
+    "typescript": "^6.0.3",
+    "wrangler": "^4.86.0"
+  }
+}

--- a/wip/issue-1410-reporter-repro/src/index.ts
+++ b/wip/issue-1410-reporter-repro/src/index.ts
@@ -1,0 +1,141 @@
+import { getAgentByName, Agent } from "agents";
+
+interface Env {
+  PARENT: DurableObjectNamespace<ParentAgent>;
+}
+
+function json(data: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(data, null, 2), {
+    ...init,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...init.headers
+    }
+  });
+}
+
+function errorPayload(error: unknown): Record<string, unknown> {
+  return {
+    name: error instanceof Error ? error.name : typeof error,
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined
+  };
+}
+
+function parentNameFrom(url: URL): string {
+  return url.searchParams.get("parent") ?? "demo-parent";
+}
+
+export class ParentAgent extends Agent<Env> {
+  async onMessage(
+    connection: { send(message: string): void },
+    message: string | ArrayBuffer
+  ): Promise<void> {
+    const task =
+      typeof message === "string" ? message : new TextDecoder().decode(message);
+
+    connection.send(
+      JSON.stringify({
+        ok: true,
+        phase: "before-subAgent",
+        parent: this.describe(),
+        task
+      })
+    );
+
+    const result = await this.spawnChild(task);
+
+    connection.send(
+      JSON.stringify({
+        ok: true,
+        phase: "after-subAgent",
+        result
+      })
+    );
+  }
+
+  async spawnChild(task = "spawn child"): Promise<unknown> {
+    const childName = `child-${crypto.randomUUID()}`;
+
+    try {
+      const child = await this.subAgent(ChildAgent, childName);
+      const childResult = await child.ping(task);
+      return {
+        ok: true,
+        parent: this.describe(),
+        childName,
+        child: childResult
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        parent: this.describe(),
+        childName,
+        error: errorPayload(error)
+      };
+    } finally {
+      try {
+        this.deleteSubAgent(ChildAgent, childName);
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+  }
+
+  describe(): Record<string, unknown> {
+    return {
+      className: this.constructor.name,
+      name: this.name,
+      idName: this.ctx.id.name,
+      parentPath: this.parentPath,
+      selfPath: this.selfPath
+    };
+  }
+}
+
+export class ChildAgent extends Agent<Env> {
+  async ping(task: string): Promise<unknown> {
+    await this.ctx.storage.put("lastPing", { task, at: Date.now() });
+    return {
+      className: this.constructor.name,
+      name: this.name,
+      idName: this.ctx.id.name,
+      parentPath: this.parentPath,
+      selfPath: this.selfPath,
+      lastPing: await this.ctx.storage.get("lastPing")
+    };
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const parent = await getAgentByName(env.PARENT, parentNameFrom(url));
+
+    if (url.pathname === "/") {
+      return json({
+        name: "cf-sub-agent-io-demo",
+        description:
+          "Minimal public repro for spawning an agents subAgent from a WebSocket message handler.",
+        routes: {
+          "GET /http-spawn":
+            "Control path: calls parent.spawnChild() over RPC.",
+          "WS /ws":
+            "Repro path: send any message; onMessage calls parent.spawnChild()."
+        }
+      });
+    }
+
+    if (url.pathname === "/http-spawn") {
+      return json(
+        await parent.spawnChild("spawned from HTTP/RPC control path")
+      );
+    }
+
+    if (url.pathname === "/ws") {
+      return parent.fetch(request);
+    }
+
+    return json({ ok: false, error: "Not found" }, { status: 404 });
+  }
+} satisfies ExportedHandler<Env>;

--- a/wip/issue-1410-reporter-repro/tsconfig.json
+++ b/wip/issue-1410-reporter-repro/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "agents/tsconfig",
+  "include": ["src/**/*.ts"]
+}

--- a/wip/issue-1410-reporter-repro/wrangler.jsonc
+++ b/wip/issue-1410-reporter-repro/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "cf-sub-agent-io-demo-1410",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-04-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+      "head_sampling_rate": 1
+    }
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "PARENT",
+        "class_name": "ParentAgent"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ParentAgent", "ChildAgent"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Prevent cross-DO native I/O during sub-agent facet startup by clearing native request/WebSocket/email context when crossing Agent instances and during facet bootstrap.
- Suppress protocol broadcasts only during facet bootstrap so startup cannot enumerate parent-owned WebSocket handles while normal post-bootstrap state sync to facet WebSocket clients still works.
- Add WebSocket regression coverage for spawning a sub-agent from `onMessage` and for state sync to clients connected directly to a sub-agent.
- Add a production repro fixture for issue #1410.

## Test plan
- `npx vitest --project workers --run src/tests/sub-agent.test.ts`
- `npx oxfmt --check packages/agents/src/index.ts packages/agents/src/tests/sub-agent.test.ts packages/agents/src/tests/agents/sub-agent.ts wip/issue-1410-reporter-repro/src/index.ts wip/issue-1410-reporter-repro/wrangler.jsonc wip/issue-1410-reporter-repro/package.json wip/issue-1410-reporter-repro/tsconfig.json wip/issue-1410-reporter-repro/README.md .changeset/native-context-facet-bootstrap.md`
- Deployed `wip/issue-1410-reporter-repro` and verified both `/http-spawn` and `/ws` return `ok: true` in production with scoped bootstrap suppression.