### PR TITLE
Add hidden Basic auth defaults for git tools

### DIFF
--- a/.changeset/gentle-git-auth.md
+++ b/.changeset/gentle-git-auth.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/shell": patch
+---
+
+Add hidden default Basic auth credentials for shell git tool providers.

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -105,7 +105,7 @@ class MyAgent extends Agent<Env> {
 
 ### Git ToolProvider for codemode
 
-`gitTools(workspace)` exposes all git commands inside sandboxed executions. Auth tokens are auto-injected into clone/fetch/pull/push — the LLM never sees secrets.
+`gitTools(workspace)` exposes all git commands inside sandboxed executions. Default auth is auto-injected into clone/fetch/pull/push — the LLM never sees secrets.
 
 ```ts
 import { stateTools } from "@cloudflare/shell/workers";
@@ -116,6 +116,24 @@ const providers = [
   resolveProvider(gitTools(this.workspace, { token: this.env.GITHUB_TOKEN }))
 ];
 ```
+
+For Git servers that require Basic auth, pass hidden default credentials:
+
+```ts
+const providers = [
+  resolveProvider(stateTools(this.workspace)),
+  resolveProvider(
+    gitTools(this.workspace, {
+      auth: {
+        username: "git",
+        password: this.env.GIT_PASSWORD
+      }
+    })
+  )
+];
+```
+
+If both `auth` and `token` are configured, `auth` is used. Direct tool-call auth, if supplied, takes precedence over either default.
 
 ## Design goals
 

--- a/packages/shell/src/git/index.ts
+++ b/packages/shell/src/git/index.ts
@@ -398,4 +398,9 @@ export function createGit(filesystem: FileSystem, defaultDir = "/") {
 export type Git = ReturnType<typeof createGit>;
 
 // ── ToolProvider for codemode sandboxes ──────────────────────────────
-export { gitTools, gitToolsFromFs } from "./provider";
+export {
+  gitTools,
+  gitToolsFromFs,
+  type GitAuthOptions,
+  type GitToolsOptions
+} from "./provider";

--- a/packages/shell/src/git/provider.ts
+++ b/packages/shell/src/git/provider.ts
@@ -11,10 +11,10 @@
  *   });
  *
  * In the sandbox:
- *   await git.clone({ url: "https://github.com/org/repo", token: "ghp_..." });
+ *   await git.clone({ url: "https://github.com/org/repo" });
  *   await git.add({ filepath: "." });
  *   await git.commit({ message: "fix: bug" });
- *   await git.push({ token: "ghp_..." });
+ *   await git.push();
  */
 
 import type { ToolProvider } from "@cloudflare/codemode";
@@ -82,9 +82,27 @@ const GIT_COMMAND_NAMES = [
 /** Commands that accept a token/username/password for auth. */
 const AUTH_COMMANDS = new Set(["clone", "fetch", "pull", "push"]);
 
-function createGitToolProvider(
+export interface GitAuthOptions {
+  username: string;
+  password: string;
+}
+
+interface GitToolProviderAuthOptions {
+  token?: string;
+  auth?: GitAuthOptions;
+}
+
+function hasExplicitAuth(opts: Record<string, unknown>) {
+  return (
+    Object.prototype.hasOwnProperty.call(opts, "token") ||
+    Object.prototype.hasOwnProperty.call(opts, "username") ||
+    Object.prototype.hasOwnProperty.call(opts, "password")
+  );
+}
+
+export function createGitToolProvider(
   gitInstance: Git,
-  defaultToken?: string
+  authOptions: GitToolProviderAuthOptions = {}
 ): ToolProvider {
   const tools: Record<
     string,
@@ -100,14 +118,16 @@ function createGitToolProvider(
       execute: (...args: unknown[]) => {
         // positionalArgs mode: args may be [] (no args), [{}], or [{ url: ... }]
         let opts = (args[0] ?? {}) as Record<string, unknown>;
-        // Auto-inject token for auth commands if not explicitly set
-        if (
-          defaultToken &&
-          AUTH_COMMANDS.has(cmd) &&
-          !opts.token &&
-          !opts.username
-        ) {
-          opts = { ...opts, token: defaultToken };
+        if (AUTH_COMMANDS.has(cmd) && !hasExplicitAuth(opts)) {
+          if (authOptions.auth) {
+            opts = {
+              ...opts,
+              username: authOptions.auth.username,
+              password: authOptions.auth.password
+            };
+          } else if (authOptions.token) {
+            opts = { ...opts, token: authOptions.token };
+          }
         }
         return fn.call(gitInstance, opts);
       }
@@ -125,6 +145,8 @@ function createGitToolProvider(
 export interface GitToolsOptions {
   /** Default directory for git operations. */
   dir?: string;
+  /** Default basic auth credentials — auto-injected into clone/fetch/pull/push. */
+  auth?: GitAuthOptions;
   /** Default auth token — auto-injected into clone/fetch/pull/push. */
   token?: string;
 }
@@ -135,10 +157,10 @@ export function gitTools(
   options?: GitToolsOptions
 ): ToolProvider {
   const fs = new WorkspaceFileSystem(workspace);
-  return createGitToolProvider(
-    createGit(fs, options?.dir ?? "/"),
-    options?.token
-  );
+  return createGitToolProvider(createGit(fs, options?.dir ?? "/"), {
+    token: options?.token,
+    auth: options?.auth
+  });
 }
 
 /** Create a git ToolProvider from a raw FileSystem. */
@@ -146,8 +168,8 @@ export function gitToolsFromFs(
   filesystem: FileSystem,
   options?: GitToolsOptions
 ): ToolProvider {
-  return createGitToolProvider(
-    createGit(filesystem, options?.dir ?? "/"),
-    options?.token
-  );
+  return createGitToolProvider(createGit(filesystem, options?.dir ?? "/"), {
+    token: options?.token,
+    auth: options?.auth
+  });
 }

--- a/packages/shell/src/tests/git.test.ts
+++ b/packages/shell/src/tests/git.test.ts
@@ -5,10 +5,243 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "agents";
+import { createGitToolProvider, type GitAuthOptions } from "../git/provider";
+import type { Git } from "../git";
 
 async function freshAgent(name: string) {
   return getAgentByName(env.TestGitAgent, name);
 }
+
+type GitCallOptions = Record<string, unknown>;
+type GitCalls = Record<string, GitCallOptions | undefined>;
+
+type ProviderTool = {
+  description?: string;
+  execute: (...args: unknown[]) => Promise<unknown>;
+};
+
+function getProviderTool(tools: unknown, command: string): ProviderTool {
+  const tool = (tools as Record<string, ProviderTool | undefined>)[command];
+  if (!tool) {
+    throw new Error(`Missing provider tool: ${command}`);
+  }
+  return tool;
+}
+
+function createFakeGit() {
+  const calls: GitCalls = {};
+  const git = {
+    clone: async (opts?: GitCallOptions) => {
+      calls.clone = opts;
+      return { cloned: "https://example.com/repo.git", dir: "/" };
+    },
+    status: async (opts?: GitCallOptions) => {
+      calls.status = opts;
+      return [];
+    },
+    add: async (opts?: GitCallOptions) => {
+      calls.add = opts;
+      return { added: opts?.filepath };
+    },
+    rm: async (opts?: GitCallOptions) => {
+      calls.rm = opts;
+      return { removed: opts?.filepath };
+    },
+    commit: async (opts?: GitCallOptions) => {
+      calls.commit = opts;
+      return { oid: "oid", message: opts?.message };
+    },
+    log: async (opts?: GitCallOptions) => {
+      calls.log = opts;
+      return [];
+    },
+    branch: async (opts?: GitCallOptions) => {
+      calls.branch = opts;
+      return {};
+    },
+    checkout: async (opts?: GitCallOptions) => {
+      calls.checkout = opts;
+      return {};
+    },
+    fetch: async (opts?: GitCallOptions) => {
+      calls.fetch = opts;
+      return { fetchHead: null, fetchHeadDescription: null };
+    },
+    pull: async (opts?: GitCallOptions) => {
+      calls.pull = opts;
+      return { pulled: true };
+    },
+    push: async (opts?: GitCallOptions) => {
+      calls.push = opts;
+      return { ok: true, refs: {} };
+    },
+    diff: async (opts?: GitCallOptions) => {
+      calls.diff = opts;
+      return [];
+    },
+    init: async (opts?: GitCallOptions) => {
+      calls.init = opts;
+      return { initialized: "/" };
+    },
+    remote: async (opts?: GitCallOptions) => {
+      calls.remote = opts;
+      return [];
+    }
+  };
+
+  return { git: git as unknown as Git, calls };
+}
+
+describe("git ToolProvider auth injection", () => {
+  it.each(["clone", "fetch", "pull", "push"] as const)(
+    "injects default basic auth into git.%s",
+    async (command) => {
+      const { git, calls } = createFakeGit();
+      const auth: GitAuthOptions = {
+        username: "default-user",
+        password: "default-password"
+      };
+      const provider = createGitToolProvider(git, { auth });
+
+      await getProviderTool(provider.tools, command).execute({});
+
+      expect(calls[command]).toMatchObject(auth);
+    }
+  );
+
+  it("keeps default token injection for backward compatibility", async () => {
+    const { git, calls } = createFakeGit();
+    const provider = createGitToolProvider(git, { token: "default-token" });
+
+    await getProviderTool(provider.tools, "push").execute({});
+
+    expect(calls.push).toMatchObject({ token: "default-token" });
+  });
+
+  it("prefers default basic auth over the default token", async () => {
+    const { git, calls } = createFakeGit();
+    const provider = createGitToolProvider(git, {
+      token: "default-token",
+      auth: {
+        username: "default-user",
+        password: "default-password"
+      }
+    });
+
+    await getProviderTool(provider.tools, "push").execute({});
+
+    expect(calls.push).toMatchObject({
+      username: "default-user",
+      password: "default-password"
+    });
+    expect(calls.push).not.toHaveProperty("token");
+  });
+
+  it("prefers explicit token auth over default basic auth", async () => {
+    const { git, calls } = createFakeGit();
+    const provider = createGitToolProvider(git, {
+      auth: {
+        username: "default-user",
+        password: "default-password"
+      }
+    });
+
+    await getProviderTool(provider.tools, "push").execute({
+      token: "explicit-token"
+    });
+
+    expect(calls.push).toEqual({ token: "explicit-token" });
+  });
+
+  it("prefers explicit username and password over default basic auth", async () => {
+    const { git, calls } = createFakeGit();
+    const provider = createGitToolProvider(git, {
+      auth: {
+        username: "default-user",
+        password: "default-password"
+      }
+    });
+
+    await getProviderTool(provider.tools, "push").execute({
+      username: "explicit-user",
+      password: "explicit-password"
+    });
+
+    expect(calls.push).toEqual({
+      username: "explicit-user",
+      password: "explicit-password"
+    });
+  });
+
+  it("treats any explicit auth field as an override", async () => {
+    const { git, calls } = createFakeGit();
+    const provider = createGitToolProvider(git, {
+      auth: {
+        username: "default-user",
+        password: "default-password"
+      }
+    });
+
+    await getProviderTool(provider.tools, "push").execute({
+      password: "explicit-password"
+    });
+
+    expect(calls.push).toEqual({ password: "explicit-password" });
+  });
+
+  it("does not inject auth into non-auth commands", async () => {
+    const { git, calls } = createFakeGit();
+    const provider = createGitToolProvider(git, {
+      auth: {
+        username: "default-user",
+        password: "default-password"
+      },
+      token: "default-token"
+    });
+
+    await getProviderTool(provider.tools, "status").execute({});
+
+    expect(calls.status).toEqual({});
+  });
+
+  it("keeps hidden auth out of provider descriptions and types", () => {
+    const { git } = createFakeGit();
+    const provider = createGitToolProvider(git, {
+      token: "hidden-token",
+      auth: {
+        username: "hidden-user",
+        password: "hidden-password"
+      }
+    });
+    const visibleSurface = [
+      provider.name,
+      provider.types,
+      ...Object.values(provider.tools as Record<string, ProviderTool>).map(
+        (tool) => tool.description
+      )
+    ].join("\n");
+
+    expect(visibleSurface).not.toContain("hidden-token");
+    expect(visibleSurface).not.toContain("hidden-user");
+    expect(visibleSurface).not.toContain("hidden-password");
+  });
+
+  it("does not echo hidden auth in provider results", async () => {
+    const { git } = createFakeGit();
+    const provider = createGitToolProvider(git, {
+      auth: {
+        username: "hidden-user",
+        password: "hidden-password"
+      }
+    });
+
+    const result = await getProviderTool(provider.tools, "push").execute({});
+    const serializedResult = JSON.stringify(result);
+
+    expect(serializedResult).not.toContain("hidden-user");
+    expect(serializedResult).not.toContain("hidden-password");
+  });
+});
 
 describe("git init", () => {
   it("initializes a repo in the workspace", async () => {


### PR DESCRIPTION
## Summary
- Adds `gitTools(workspace, { auth: { username, password } })` and `gitToolsFromFs(..., { auth })` for hidden default Basic auth credentials.
- Preserves existing hidden `token` behavior while making precedence explicit: direct tool-call auth, default Basic auth, then default token.
- Keeps injected credentials out of model-visible tool declarations/descriptions and adds regression coverage that provider results do not echo hidden credentials.
- Documents the Basic auth configuration path and adds a patch changeset for `@cloudflare/shell`.

## Test plan
- `npm run format`
- `npm run test -- src/tests/git.test.ts` from `packages/shell`
- `npm run build` from `packages/shell`
- `npm run check`

Fixes #1427

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
