### PR TITLE
Fix large MCP streamable HTTP payloads

### DIFF
--- a/.changeset/fix-mcp-large-streamable-http-payloads.md
+++ b/.changeset/fix-mcp-large-streamable-http-payloads.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix MCP streamable HTTP transport failures for large JSON-RPC request bodies by sending Worker-to-Durable Object payloads over the internal WebSocket data channel instead of encoding them into headers.

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -8,10 +8,11 @@ import type {
 import {
   JSONRPCMessageSchema,
   isJSONRPCErrorResponse,
+  isJSONRPCRequest,
   isJSONRPCResultResponse,
   type ElicitResult
 } from "@modelcontextprotocol/sdk/types.js";
-import type { Connection, ConnectionContext } from "../";
+import type { Connection, ConnectionContext, WSMessage } from "../";
 import { Agent } from "../index";
 import type { BaseTransportType, MaybePromise, ServeOptions } from "./types";
 import {
@@ -25,6 +26,14 @@ import {
 } from "./utils";
 import { McpSSETransport, StreamableHTTPServerTransport } from "./transport";
 import { RPCServerTransport, type RPCServerTransportOptions } from "./rpc";
+
+type StreamableHttpPostState = {
+  _mcpHttpMethod?: "POST";
+  _mcpRequest?: {
+    headers: Record<string, string>;
+    url: string;
+  };
+};
 
 export abstract class McpAgent<
   Env extends Cloudflare.Env = Cloudflare.Env,
@@ -205,26 +214,16 @@ export abstract class McpAgent<
         if (this._transport instanceof StreamableHTTPServerTransport) {
           switch (req.headers.get(MCP_HTTP_METHOD_HEADER)) {
             case "POST": {
-              // This returns the response directly to the client
-              const payloadHeader = req.headers.get(MCP_MESSAGE_HEADER);
-              let rawPayload: string;
+              const headers = Object.fromEntries(req.headers.entries());
+              delete headers[MCP_MESSAGE_HEADER];
 
-              if (!payloadHeader) {
-                rawPayload = "{}";
-              } else {
-                try {
-                  rawPayload = Buffer.from(payloadHeader, "base64").toString(
-                    "utf-8"
-                  );
-                } catch (_error) {
-                  throw new Error(
-                    "Internal Server Error: Failed to decode MCP message header"
-                  );
+              conn.setState({
+                _mcpHttpMethod: "POST",
+                _mcpRequest: {
+                  headers,
+                  url: req.url
                 }
-              }
-
-              const parsedBody = JSON.parse(rawPayload);
-              this._transport?.handlePostRequest(req, parsedBody);
+              });
               break;
             }
             case "GET":
@@ -232,6 +231,45 @@ export abstract class McpAgent<
               break;
           }
         }
+    }
+  }
+
+  async onMessage(
+    conn: Connection<StreamableHttpPostState>,
+    message: WSMessage
+  ): Promise<void> {
+    if (
+      this.getTransportType() !== "streamable-http" ||
+      !(this._transport instanceof StreamableHTTPServerTransport) ||
+      conn.state?._mcpHttpMethod !== "POST" ||
+      !conn.state._mcpRequest
+    ) {
+      return;
+    }
+
+    try {
+      const rawPayload =
+        typeof message === "string"
+          ? message
+          : new TextDecoder().decode(message as BufferSource);
+      const parsedBody = JSON.parse(rawPayload);
+      const rawMessages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+      const messages = rawMessages.map((msg) =>
+        JSONRPCMessageSchema.parse(msg)
+      );
+      const request = new Request(conn.state._mcpRequest.url, {
+        headers: conn.state._mcpRequest.headers,
+        method: "POST"
+      });
+
+      await this._transport.handlePostRequest(request, parsedBody);
+
+      if (!messages.some(isJSONRPCRequest)) {
+        conn.close(1000, "Accepted");
+      }
+    } catch (error) {
+      this._transport.onerror?.(error as Error);
+      conn.close(1011, "Failed to process MCP message");
     }
   }
 

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -4,6 +4,7 @@ import {
   type MessageExtraInfo,
   InitializeRequestSchema,
   isJSONRPCResultResponse,
+  isJSONRPCErrorResponse,
   isJSONRPCNotification
 } from "@modelcontextprotocol/sdk/types.js";
 import type { McpAgent } from ".";
@@ -21,8 +22,9 @@ export const MCP_HTTP_METHOD_HEADER = "cf-mcp-method";
 
 /**
  * Since we use WebSockets to bridge the client to the
- * MCP transport in the Agent, we use this header to include
- * the original request body.
+ * MCP transport in the Agent, this reserved header is stripped
+ * from forwarded request metadata. Request bodies are sent over
+ * the WebSocket data channel, not this header.
  */
 export const MCP_MESSAGE_HEADER = "cf-mcp-message";
 
@@ -231,14 +233,12 @@ export const createStreamingHttpHandler = (
         request.headers.forEach((value, key) => {
           existingHeaders[key] = value;
         });
+        delete existingHeaders[MCP_MESSAGE_HEADER];
 
         const req = new Request(request.url, {
           headers: {
             ...existingHeaders,
             [MCP_HTTP_METHOD_HEADER]: "POST",
-            [MCP_MESSAGE_HEADER]: Buffer.from(
-              JSON.stringify(messages)
-            ).toString("base64"),
             Upgrade: "websocket"
           }
         });
@@ -310,15 +310,17 @@ export const createStreamingHttpHandler = (
           onClose().catch(console.error);
         });
 
+        ws.send(JSON.stringify(messages));
+
         // If there are no requests, we send the messages to the agent and acknowledge the request with a 202
         // since we don't expect any responses back through this connection
         const hasOnlyNotificationsOrResponses = messages.every(
-          (msg) => isJSONRPCNotification(msg) || isJSONRPCResultResponse(msg)
+          (msg) =>
+            isJSONRPCNotification(msg) ||
+            isJSONRPCResultResponse(msg) ||
+            isJSONRPCErrorResponse(msg)
         );
         if (hasOnlyNotificationsOrResponses) {
-          // closing the websocket will also close the SSE connection
-          ws.close();
-
           return new Response(null, {
             headers: corsHeaders(request, options.corsOptions),
             status: 202

--- a/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
+++ b/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import { createExecutionContext } from "cloudflare:test";
 import type {
   CallToolResult,
+  JSONRPCErrorResponse,
   JSONRPCMessage,
   ListToolsResult,
   JSONRPCNotification,
@@ -20,6 +21,11 @@ import {
   parseSSEData,
   expectValidToolsList
 } from "../../shared/test-utils";
+import {
+  createStreamingHttpHandler,
+  MCP_MESSAGE_HEADER
+} from "../../../mcp/utils";
+import type { McpAgent } from "../../../mcp";
 
 // small helper to read one full SSE frame from a reader
 async function readOneFrame(
@@ -27,6 +33,20 @@ async function readOneFrame(
 ): Promise<string> {
   const { value } = await reader.read();
   return new TextDecoder().decode(value!);
+}
+
+async function readCompleteSSEFrame(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("No response body");
+
+  const decoder = new TextDecoder();
+  let frame = "";
+  while (!frame.includes("\n\n")) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    frame += decoder.decode(value, { stream: true });
+  }
+  return frame;
 }
 
 /**
@@ -261,6 +281,45 @@ describe("Streamable HTTP Transport", () => {
           result.content?.[0]?.text === `Hello, ${unicodeName}!`
       ).toBe(true);
     });
+
+    it("should handle JSON-RPC payloads larger than the Worker header limit", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+      const largeName = "a".repeat(24 * 1024);
+
+      const largeRequest: JSONRPCMessage = {
+        id: "large-payload-1",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          name: "greet",
+          arguments: {
+            name: largeName
+          }
+        }
+      };
+
+      const response = await sendPostRequest(
+        ctx,
+        baseUrl,
+        largeRequest,
+        sessionId
+      );
+
+      expect(response.status).toBe(200);
+
+      const sseText = await readCompleteSSEFrame(response);
+      const parsed = parseSSEData(sseText) as JSONRPCResultResponse;
+      expect(parsed.id).toBe("large-payload-1");
+
+      const result = parsed.result as CallToolResult;
+      const firstContent = result.content?.[0];
+      expect(firstContent?.type).toBe("text");
+      if (firstContent?.type !== "text") {
+        throw new Error("Expected text content in large payload result");
+      }
+      expect(firstContent.text).toBe(`Hello, ${largeName}!`);
+    });
   });
 
   describe("Batch Operations", () => {
@@ -303,6 +362,36 @@ describe("Streamable HTTP Transport", () => {
         ctx,
         baseUrl,
         batchNotifications,
+        sessionId
+      );
+
+      expect(response.status).toBe(202);
+    });
+
+    it("should handle batch response messages with 202 response", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+
+      const batchResponses: [JSONRPCResultResponse, JSONRPCErrorResponse] = [
+        {
+          id: "result-1",
+          jsonrpc: "2.0",
+          result: {}
+        },
+        {
+          error: {
+            code: -32000,
+            message: "cancelled"
+          },
+          id: "error-1",
+          jsonrpc: "2.0"
+        }
+      ];
+
+      const response = await sendPostRequest(
+        ctx,
+        baseUrl,
+        batchResponses,
         sessionId
       );
 
@@ -610,6 +699,94 @@ describe("Streamable HTTP Transport", () => {
   });
 
   describe("Header and Auth Handling", () => {
+    it("should send large internal POST payloads over the WebSocket frame, not a header", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = "internal-frame-session";
+      const largeName = "b".repeat(24 * 1024);
+      let upgradeRequest: Request | undefined;
+      let handlerResponse: Promise<Response> | undefined;
+
+      const framePayload = new Promise<string>((resolve) => {
+        const agent = {
+          fetch(req: Request) {
+            upgradeRequest = req;
+            const pair = new WebSocketPair();
+            const [client, server] = Object.values(pair) as [
+              WebSocket,
+              WebSocket
+            ];
+            server.accept();
+            server.addEventListener("message", (event) => {
+              resolve(String(event.data));
+              server.close();
+            });
+            return Promise.resolve(
+              new Response(null, { status: 101, webSocket: client })
+            );
+          },
+          getInitializeRequest() {
+            return Promise.resolve({ jsonrpc: "2.0" });
+          },
+          setInitializeRequest() {
+            return Promise.resolve();
+          },
+          setName() {
+            return Promise.resolve();
+          }
+        };
+
+        const namespace = {
+          get() {
+            return agent;
+          },
+          idFromName() {
+            return {};
+          },
+          newUniqueId() {
+            return { toString: () => sessionId };
+          }
+        } as unknown as DurableObjectNamespace<McpAgent>;
+
+        const handler = createStreamingHttpHandler("/mcp", namespace);
+        const request = new Request(baseUrl, {
+          body: JSON.stringify({
+            id: "large-internal-frame",
+            jsonrpc: "2.0",
+            method: "tools/call",
+            params: {
+              name: "greet",
+              arguments: {
+                name: largeName
+              }
+            }
+          }),
+          headers: {
+            Accept: "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": sessionId
+          },
+          method: "POST"
+        });
+
+        handlerResponse = handler(request, ctx);
+      });
+
+      const response = await handlerResponse;
+      expect(response?.status).toBe(200);
+      const payload = await framePayload;
+      expect(upgradeRequest?.headers.get(MCP_MESSAGE_HEADER)).toBeNull();
+      expect(upgradeRequest?.headers.get("cf-mcp-method")).toBe("POST");
+      expect(payload.length).toBeGreaterThan(16 * 1024);
+      expect(JSON.parse(payload)).toEqual([
+        expect.objectContaining({
+          id: "large-internal-frame",
+          params: expect.objectContaining({
+            arguments: { name: largeName }
+          })
+        })
+      ]);
+    });
+
     it("should pass custom headers to transport via requestInfo", async () => {
       const ctx = createExecutionContext();
       const sessionId = await initializeStreamableHTTPServer(ctx);
@@ -661,8 +838,8 @@ describe("Streamable HTTP Transport", () => {
       expect(echoedData.headers["x-request-id"]).toBe("req-456");
       expect(echoedData.headers["x-custom-header"]).toBe("custom-value");
 
-      // Verify that certain internal headers that the transport adds are NOT exposed
-      // The transport adds cf-mcp-method and cf-mcp-message internally but should filter them
+      // Verify that reserved internal transport headers are not exposed.
+      // Payloads travel over the internal WebSocket data channel, not cf-mcp-message.
       expect(echoedData.headers["cf-mcp-method"]).toBeUndefined();
       expect(echoedData.headers["cf-mcp-message"]).toBeUndefined();
       expect(echoedData.headers.upgrade).toBeUndefined();
@@ -674,6 +851,51 @@ describe("Streamable HTTP Transport", () => {
       // Verify sessionId is passed through extra data
       expect(echoedData.sessionId).toBeDefined();
       expect(echoedData.sessionId).toBe(sessionId);
+    });
+
+    it("should strip reserved internal transport headers before invoking tools", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+
+      const echoMessage: JSONRPCMessage = {
+        id: "echo-internal-headers-1",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          name: "echoRequestInfo",
+          arguments: {}
+        }
+      };
+
+      const request = new Request(baseUrl, {
+        body: JSON.stringify(echoMessage),
+        headers: {
+          Accept: "application/json, text/event-stream",
+          "Content-Type": "application/json",
+          "cf-mcp-message": "client-supplied-value",
+          "cf-mcp-method": "POST",
+          "mcp-session-id": sessionId
+        },
+        method: "POST"
+      });
+
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(200);
+
+      const sseText = await readSSEEvent(response);
+      const parsed = parseSSEData(sseText) as JSONRPCResultResponse;
+      expect(parsed.id).toBe("echo-internal-headers-1");
+
+      const result = parsed.result as CallToolResult;
+      const firstContent = result.content?.[0];
+      const contentText =
+        firstContent?.type === "text" ? firstContent.text : undefined;
+      const echoedData = JSON.parse(
+        typeof contentText === "string" ? contentText : "{}"
+      );
+
+      expect(echoedData.headers["cf-mcp-method"]).toBeUndefined();
+      expect(echoedData.headers["cf-mcp-message"]).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes https://github.com/cloudflare/agents/issues/1433.
- Stops encoding streamable HTTP JSON-RPC POST bodies into the internal `cf-mcp-message` upgrade header.
- Keeps the existing Worker-to-Durable Object WebSocket bridge so long-lived streamable HTTP sessions continue to benefit from Durable Object hibernation.
- Sends the POST payload as the first internal WebSocket data frame, then lets the DO process it through the existing `StreamableHTTPServerTransport` path.

## Why
The reported `TLS Alert: record_overflow` failure was caused by large MCP JSON-RPC payloads being base64-encoded into `cf-mcp-message` during the internal Worker-to-Durable Object WebSocket upgrade. That made the request body part of an HTTP header, where it could exceed Cloudflare's per-header limit before the Durable Object ever saw the request.

A direct HTTP forwarding path would avoid the header limit too, but it changes the lifecycle story for streamable HTTP: the current bridge uses WebSockets specifically so idle/long-lived streams can hibernate with the Durable Object runtime. This PR keeps that architecture and only moves the large data out of headers and into the WebSocket data channel, which is the smaller behavioral change for a published package bug fix.

## Details
- `cf-mcp-method` remains as the small internal routing signal for POST vs GET upgrade requests.
- `cf-mcp-message` is no longer populated with the serialized payload and is stripped from forwarded request metadata.
- POST bridge state is recorded on connect, and the first WebSocket message is parsed as the JSON-RPC body.
- Notification/result/error-only POSTs still return `202`; the internal bridge is closed after the DO receives and processes the frame.

## Test plan
- `npm run test:workers -- src/tests/mcp/transports/streamable-http.test.ts`
- `npm run typecheck`
- `npm run check`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->