### PR TITLE
Add multimodal workspace read support

### DIFF
--- a/.changeset/multimodal-workspace-read.md
+++ b/.changeset/multimodal-workspace-read.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Add multimodal-aware workspace reads for images and PDFs while keeping persisted tool results compact.

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -39,7 +39,7 @@ export default {
 } satisfies ExportedHandler<Env>;
 ```
 
-That is it. Think handles the WebSocket chat protocol, message persistence, the agentic loop, message sanitization, stream resumption, client tool support, and workspace file tools.
+That is it. Think handles the WebSocket chat protocol, message persistence, the agentic loop, message sanitization, stream resumption, client tool support, and workspace file tools. The built-in `read` tool reads text with line numbers and passes images/PDFs through to multimodal-capable models.
 
 ### Client
 

--- a/docs/think/tools.md
+++ b/docs/think/tools.md
@@ -20,7 +20,7 @@ Every Think agent gets `this.workspace` — a virtual filesystem backed by the D
 
 | Tool     | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
-| `read`   | Read a file's content                                                       |
+| `read`   | Read text with line numbers; pass images and PDFs to multimodal models      |
 | `write`  | Write content to a file (creates parent directories)                        |
 | `edit`   | Apply a find-and-replace edit to an existing file (supports fuzzy matching) |
 | `list`   | List files and directories in a path                                        |
@@ -476,6 +476,7 @@ Implement the operations interface for your storage backend:
 ```typescript
 const myReadOps: ReadOperations = {
   readFile: async (path) => fetchFromMyStorage(path),
+  readFileBytes: async (path) => fetchBytesFromMyStorage(path),
   stat: async (path) => getFileInfo(path)
 };
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -67,6 +67,8 @@ drill-in, and cleanup patterns.
 
 Every Think agent gets `this.workspace` — a virtual filesystem backed by the DO's SQLite storage. Workspace tools (`read`, `write`, `edit`, `list`, `find`, `grep`, `delete`) are automatically available to the model.
 
+The `read` tool returns line-numbered text for text files. For images and PDFs, it keeps the persisted tool result compact and passes file bytes to multimodal-capable models using AI SDK content parts.
+
 ```ts
 export class MyAgent extends Think<Env> {
   getModel() { ... }

--- a/packages/think/src/tests/agents/assistant-tools.ts
+++ b/packages/think/src/tests/agents/assistant-tools.ts
@@ -23,6 +23,18 @@ export class TestAssistantToolsAgent extends Agent {
     }
   }
 
+  async seedBytes(
+    path: string,
+    bytes: number[],
+    mimeType?: string
+  ): Promise<void> {
+    const parent = path.replace(/\/[^/]+$/, "");
+    if (parent && parent !== "/") {
+      await this.workspace.mkdir(parent, { recursive: true });
+    }
+    await this.workspace.writeFileBytes(path, new Uint8Array(bytes), mimeType);
+  }
+
   async seedDir(path: string): Promise<void> {
     await this.workspace.mkdir(path, { recursive: true });
   }
@@ -41,6 +53,29 @@ export class TestAssistantToolsAgent extends Agent {
         abortSignal: new AbortController().signal
       }
     );
+  }
+
+  async toolReadModelOutput(
+    path: string,
+    offset?: number,
+    limit?: number
+  ): Promise<unknown> {
+    const tools = this.getTools();
+    const input = { path, offset, limit };
+    type ReadModelOutputOptions = Parameters<
+      NonNullable<typeof tools.read.toModelOutput>
+    >[0];
+    const output = (await tools.read.execute!(input, {
+      toolCallId: "test",
+      messages: [],
+      abortSignal: new AbortController().signal
+    })) as ReadModelOutputOptions["output"];
+
+    return tools.read.toModelOutput?.({
+      toolCallId: "test",
+      input,
+      output
+    });
   }
 
   async toolWrite(path: string, content: string): Promise<unknown> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -280,6 +280,7 @@ export class ThinkTestAgent extends Think {
     continuation: boolean;
     body?: RpcJsonObject;
   }> = [];
+  private _beforeTurnMessagesJson: string[] = [];
   private _stepLog: Array<{
     finishReason: string;
     text: string;
@@ -313,6 +314,7 @@ export class ThinkTestAgent extends Think {
       continuation: ctx.continuation,
       body: ctx.body as RpcJsonObject | undefined
     });
+    this._beforeTurnMessagesJson.push(JSON.stringify(ctx.messages));
     if (this._turnConfigOverride) return this._turnConfigOverride;
   }
 
@@ -413,6 +415,11 @@ export class ThinkTestAgent extends Think {
     }>
   > {
     return this._beforeTurnLog;
+  }
+
+  async getLastBeforeTurnMessagesJson(): Promise<string | null> {
+    const log = this._beforeTurnMessagesJson;
+    return log.length > 0 ? log[log.length - 1] : null;
   }
 
   async getStepLog(): Promise<
@@ -521,6 +528,27 @@ export class ThinkTestAgent extends Think {
       done: cb.doneCalled,
       error: cb.errorMessage
     };
+  }
+
+  async persistTestMessage(msg: UIMessage): Promise<void> {
+    await this.session.appendMessage(msg);
+  }
+
+  async seedWorkspaceBytes(
+    path: string,
+    bytes: number[],
+    mimeType?: string
+  ): Promise<void> {
+    const parent = path.replace(/\/[^/]+$/, "");
+    const workspace = this.workspace;
+    const writeFileBytes = Reflect.get(workspace, "writeFileBytes");
+    if (typeof writeFileBytes !== "function") {
+      throw new Error("Test workspace does not support writeFileBytes");
+    }
+    if (parent && parent !== "/") {
+      await workspace.mkdir(parent, { recursive: true });
+    }
+    await writeFileBytes.call(workspace, path, new Uint8Array(bytes), mimeType);
   }
 
   async testChatWithError(errorMessage?: string): Promise<TestChatResult> {

--- a/packages/think/src/tests/assistant-tools.test.ts
+++ b/packages/think/src/tests/assistant-tools.test.ts
@@ -6,6 +6,12 @@ async function freshAgent(name: string) {
   return getAgentByName(env.TestAssistantToolsAgent, name);
 }
 
+function asciiBytes(text: string): number[] {
+  return Array.from(text, (char) => char.charCodeAt(0));
+}
+
+const PNG_BYTES = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
 // ── Read tool ─────────────────────────────────────────────────────────
 
 describe("assistant tools — read", () => {
@@ -54,6 +60,117 @@ describe("assistant tools — read", () => {
     expect(result.content).toContain("4\tline4");
     expect(result.content).not.toContain("2\tline2");
     expect(result.content).not.toContain("5\tline5");
+  });
+
+  it("returns compact image metadata and model image content", async () => {
+    const agent = await freshAgent("read-image-mime");
+    await agent.seedBytes("/screenshot", PNG_BYTES, "image/png");
+
+    const result = (await agent.toolRead("/screenshot")) as {
+      kind: string;
+      path: string;
+      name: string;
+      mediaType: string;
+      sizeBytes: number;
+      data?: string;
+      content?: string;
+    };
+    expect(result).toMatchObject({
+      kind: "image",
+      path: "/screenshot",
+      name: "screenshot",
+      mediaType: "image/png",
+      sizeBytes: PNG_BYTES.length
+    });
+    expect(result.data).toBeUndefined();
+    expect(result.content).toBeUndefined();
+
+    const modelOutput = (await agent.toolReadModelOutput("/screenshot")) as {
+      type: string;
+      value: Array<{ type: string; data?: string; mediaType?: string }>;
+    };
+    expect(modelOutput.type).toBe("content");
+    expect(modelOutput.value).toContainEqual({
+      type: "image-data",
+      data: "iVBORw0KGgo=",
+      mediaType: "image/png"
+    });
+  });
+
+  it.each([
+    ["png", PNG_BYTES, "image/png"],
+    ["jpeg", [0xff, 0xd8, 0xff, 0xe0], "image/jpeg"],
+    ["gif", asciiBytes("GIF89a"), "image/gif"],
+    [
+      "webp",
+      [...asciiBytes("RIFF"), 0x00, 0x00, 0x00, 0x00, ...asciiBytes("WEBP")],
+      "image/webp"
+    ]
+  ])(
+    "sniffs %s image bytes when MIME is generic",
+    async (name, bytes, mediaType) => {
+      const agent = await freshAgent(`read-image-sniff-${name}`);
+      await agent.seedBytes("/generic.bin", bytes, "application/octet-stream");
+
+      const result = (await agent.toolRead("/generic.bin")) as {
+        kind: string;
+        mediaType: string;
+      };
+      expect(result.kind).toBe("image");
+      expect(result.mediaType).toBe(mediaType);
+    }
+  );
+
+  it("returns file-data model output for PDFs", async () => {
+    const agent = await freshAgent("read-pdf");
+    const pdfBytes = asciiBytes("%PDF-1.4\n");
+    await agent.seedBytes("/doc", pdfBytes, "application/octet-stream");
+
+    const result = (await agent.toolRead("/doc")) as {
+      kind: string;
+      mediaType: string;
+      data?: string;
+    };
+    expect(result.kind).toBe("file");
+    expect(result.mediaType).toBe("application/pdf");
+    expect(result.data).toBeUndefined();
+
+    const modelOutput = (await agent.toolReadModelOutput("/doc")) as {
+      type: string;
+      value: Array<{
+        type: string;
+        data?: string;
+        mediaType?: string;
+        filename?: string;
+      }>;
+    };
+    expect(modelOutput.type).toBe("content");
+    expect(modelOutput.value).toContainEqual({
+      type: "file-data",
+      data: "JVBERi0xLjQK",
+      mediaType: "application/pdf",
+      filename: "doc"
+    });
+  });
+
+  it("does not line-number unknown binary files", async () => {
+    const agent = await freshAgent("read-unknown-binary");
+    await agent.seedBytes(
+      "/blob.bin",
+      [0x00, 0x9f, 0x92, 0x96],
+      "application/octet-stream"
+    );
+
+    const result = (await agent.toolRead("/blob.bin")) as {
+      kind: string;
+      unsupported: boolean;
+      content?: string;
+      mediaType: string;
+    };
+    expect(result.kind).toBe("binary");
+    expect(result.unsupported).toBe(true);
+    expect(result.mediaType).toBe("application/octet-stream");
+    expect(result.content).toBeUndefined();
   });
 });
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -841,6 +841,64 @@ describe("Think — row size enforcement", () => {
   });
 });
 
+// ── Model message conversion ─────────────────────────────────────
+
+describe("Think — model message conversion", () => {
+  it("rehydrates compact workspace image read outputs during replay", async () => {
+    const agent = await freshAgent("model-conversion-image-read");
+    const imageBytes = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    await agent.seedWorkspaceBytes("/screenshot", imageBytes, "image/png");
+
+    await agent.persistTestMessage({
+      id: "u-read-image",
+      role: "user",
+      parts: [{ type: "text", text: "Read /screenshot" }]
+    });
+    await agent.persistTestMessage({
+      id: "a-read-image",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-read",
+          toolCallId: "tc-read-image",
+          state: "output-available",
+          input: { path: "/screenshot" },
+          output: {
+            kind: "image",
+            path: "/screenshot",
+            name: "screenshot",
+            mediaType: "image/png",
+            sizeBytes: imageBytes.length
+          }
+        } as UIMessage["parts"][number]
+      ]
+    });
+
+    await agent.testChat("What is in the screenshot?");
+
+    const messagesJson = await agent.getLastBeforeTurnMessagesJson();
+    expect(messagesJson).not.toBeNull();
+    const messages = JSON.parse(messagesJson!) as Array<{
+      role: string;
+      content?: Array<{
+        output?: {
+          type: string;
+          value?: Array<{ type: string; data?: string; mediaType?: string }>;
+        };
+      }>;
+    }>;
+    const toolResult = messages
+      .find((message) => message.role === "tool")
+      ?.content?.find((part) => part.output?.type === "content")?.output;
+
+    expect(toolResult?.value).toContainEqual({
+      type: "image-data",
+      data: "iVBORw0KGgo=",
+      mediaType: "image/png"
+    });
+  });
+});
+
 // ── saveMessages ─────────────────────────────────────────────────
 
 describe("Think — saveMessages", () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1167,7 +1167,7 @@ export class Think<
     const history = this.session.getHistory();
     const truncated = truncateOlderMessages(history) as UIMessage[];
     const messages = pruneMessages({
-      messages: await convertToModelMessages(truncated),
+      messages: await convertToModelMessages(truncated, { tools }),
       toolCalls: "before-last-2-messages"
     });
 

--- a/packages/think/src/tools/workspace.ts
+++ b/packages/think/src/tools/workspace.ts
@@ -7,9 +7,11 @@ import { z } from "zod";
 // Minimum workspace surface that Think's internals rely on. Covers the
 // methods called by `createWorkspaceTools()` below plus the handful
 // Think itself uses (`readFile`/`writeFile`/`readDir`/`rm` in
-// `think.ts`). A concrete `Workspace` from `@cloudflare/shell`
-// satisfies this; so do custom implementations like the `SharedWorkspace`
-// proxy in `examples/assistant` that forwards to a parent DO.
+// `think.ts`). The read tool also needs `readFileBytes` so image/PDF
+// reads can be rehydrated as AI SDK multimodal content. A concrete
+// `Workspace` from `@cloudflare/shell` satisfies this; so do custom
+// implementations like the `SharedWorkspace` proxy in `examples/assistant`
+// that forwards to a parent DO.
 //
 // Consumers who reach for the fuller filesystem API (e.g.
 // `createWorkspaceStateBackend` for codemode's `state.*` in a sandbox)
@@ -19,7 +21,14 @@ import { z } from "zod";
 
 export type WorkspaceLike = Pick<
   Workspace,
-  "readFile" | "writeFile" | "readDir" | "rm" | "glob" | "mkdir" | "stat"
+  | "readFile"
+  | "readFileBytes"
+  | "writeFile"
+  | "readDir"
+  | "rm"
+  | "glob"
+  | "mkdir"
+  | "stat"
 >;
 
 // ── Operations interfaces ─────────────────────────────────────────
@@ -28,6 +37,7 @@ export type WorkspaceLike = Pick<
 
 export interface ReadOperations {
   readFile(path: string): Promise<string | null>;
+  readFileBytes(path: string): Promise<Uint8Array | null>;
   stat(path: string): Promise<FileInfo | null> | FileInfo | null;
 }
 
@@ -69,6 +79,7 @@ export interface GrepOperations {
 function workspaceReadOps(ws: WorkspaceLike): ReadOperations {
   return {
     readFile: (path) => ws.readFile(path),
+    readFileBytes: (path) => ws.readFileBytes(path),
     stat: (path) => ws.stat(path)
   };
 }
@@ -150,6 +161,49 @@ export function createWorkspaceTools(workspace: WorkspaceLike) {
 
 const MAX_LINES = 2000;
 const MAX_LINE_LENGTH = 2000;
+const MAX_MODEL_FILE_BYTES = 3.5 * 1024 * 1024;
+
+type TextReadToolOutput = {
+  path: string;
+  content: string;
+  totalLines: number;
+  fromLine?: number;
+  toLine?: number;
+};
+
+type ImageReadToolOutput = {
+  kind: "image";
+  path: string;
+  name: string;
+  mediaType: string;
+  sizeBytes: number;
+};
+
+type FileReadToolOutput = {
+  kind: "file";
+  path: string;
+  name: string;
+  mediaType: string;
+  sizeBytes: number;
+};
+
+type BinaryReadToolOutput = {
+  kind: "binary";
+  path: string;
+  name: string;
+  mediaType: string;
+  sizeBytes: number;
+  unsupported: true;
+};
+
+type ReadToolError = { error: string };
+
+type ReadToolOutput =
+  | TextReadToolOutput
+  | ImageReadToolOutput
+  | FileReadToolOutput
+  | BinaryReadToolOutput
+  | ReadToolError;
 
 export interface ReadToolOptions {
   ops: ReadOperations;
@@ -160,8 +214,9 @@ export function createReadTool(options: ReadToolOptions) {
 
   return tool({
     description:
-      "Read the contents of a file. Returns the file content with line numbers. " +
-      "Use offset and limit for large files. Returns null if the file does not exist.",
+      "Read a workspace file. Text files return line-numbered content. " +
+      "Images and PDFs are passed to capable models as file content. " +
+      "Use offset and limit for large text files. Returns null if the file does not exist.",
     inputSchema: z.object({
       path: z.string().describe("Absolute path to the file"),
       offset: z
@@ -177,7 +232,7 @@ export function createReadTool(options: ReadToolOptions) {
         .optional()
         .describe("Number of lines to read")
     }),
-    execute: async ({ path, offset, limit }) => {
+    execute: async ({ path, offset, limit }): Promise<ReadToolOutput> => {
       const stat = await ops.stat(path);
       if (!stat) {
         return { error: `File not found: ${path}` };
@@ -186,53 +241,279 @@ export function createReadTool(options: ReadToolOptions) {
         return { error: `${path} is a directory, not a file` };
       }
 
-      const content = await ops.readFile(path);
-      if (content === null) {
-        return { error: `Could not read file: ${path}` };
+      const mediaType = await detectWorkspaceMediaType({ ops, path, stat });
+
+      if (mediaType.startsWith("image/")) {
+        return {
+          kind: "image",
+          path,
+          name: stat.name,
+          mediaType,
+          sizeBytes: stat.size
+        };
       }
 
-      const allLines = content.split("\n");
-      const totalLines = allLines.length;
-
-      // Apply offset/limit
-      const startLine = offset ? offset - 1 : 0;
-      const endLine = limit ? startLine + limit : allLines.length;
-      const lines = allLines.slice(startLine, endLine);
-
-      // Format with line numbers, truncate long lines
-      const numbered = lines.map((line, i) => {
-        const lineNum = startLine + i + 1;
-        const truncated =
-          line.length > MAX_LINE_LENGTH
-            ? line.slice(0, MAX_LINE_LENGTH) + "... (truncated)"
-            : line;
-        return `${lineNum}\t${truncated}`;
-      });
-
-      // Truncate if too many lines
-      let output: string;
-      if (numbered.length > MAX_LINES) {
-        output =
-          numbered.slice(0, MAX_LINES).join("\n") +
-          `\n... (${numbered.length - MAX_LINES} more lines truncated)`;
-      } else {
-        output = numbered.join("\n");
+      if (mediaType === "application/pdf") {
+        return {
+          kind: "file",
+          path,
+          name: stat.name,
+          mediaType,
+          sizeBytes: stat.size
+        };
       }
 
-      const result: Record<string, unknown> = {
-        path,
-        content: output,
-        totalLines
+      if (!isTextMediaType(mediaType)) {
+        return {
+          kind: "binary",
+          path,
+          name: stat.name,
+          mediaType,
+          sizeBytes: stat.size,
+          unsupported: true
+        };
+      }
+
+      return readTextWithLineNumbers({ ops, path, offset, limit });
+    },
+    toModelOutput: async ({ input, output }) => {
+      if ("error" in output) {
+        return { type: "error-text", value: output.error };
+      }
+
+      if ("content" in output) {
+        return { type: "text", value: output.content };
+      }
+
+      if (output.kind === "binary") {
+        return {
+          type: "json",
+          value: output
+        };
+      }
+
+      const bytes = await ops.readFileBytes(input.path);
+      if (bytes === null) {
+        return {
+          type: "error-text",
+          value: `Could not read file bytes: ${input.path}`
+        };
+      }
+      if (bytes.byteLength > MAX_MODEL_FILE_BYTES) {
+        return {
+          type: "error-text",
+          value:
+            `Read ${output.path} (${output.mediaType}, ${formatSize(bytes.byteLength)}), ` +
+            `but it exceeds the ${formatSize(MAX_MODEL_FILE_BYTES)} inline model output limit.`
+        };
+      }
+
+      const data = uint8ArrayToBase64(bytes);
+      const note = `Read ${output.path} (${output.mediaType}, ${formatSize(bytes.byteLength)}).`;
+
+      if (output.kind === "image") {
+        return {
+          type: "content",
+          value: [
+            { type: "text", text: note },
+            { type: "image-data", data, mediaType: output.mediaType }
+          ]
+        };
+      }
+
+      return {
+        type: "content",
+        value: [
+          { type: "text", text: note },
+          {
+            type: "file-data",
+            data,
+            mediaType: output.mediaType,
+            filename: output.name
+          }
+        ]
       };
-
-      if (offset || limit) {
-        result.fromLine = startLine + 1;
-        result.toLine = Math.min(endLine, totalLines);
-      }
-
-      return result;
     }
   });
+}
+
+function readTextWithLineNumbers({
+  ops,
+  path,
+  offset,
+  limit
+}: {
+  ops: ReadOperations;
+  path: string;
+  offset?: number;
+  limit?: number;
+}): Promise<TextReadToolOutput | ReadToolError> {
+  return Promise.resolve(ops.readFile(path)).then((content) => {
+    if (content === null) {
+      return { error: `Could not read file: ${path}` };
+    }
+
+    const allLines = content.split("\n");
+    const totalLines = allLines.length;
+
+    // Apply offset/limit
+    const startLine = offset ? offset - 1 : 0;
+    const endLine = limit ? startLine + limit : allLines.length;
+    const lines = allLines.slice(startLine, endLine);
+
+    // Format with line numbers, truncate long lines
+    const numbered = lines.map((line, i) => {
+      const lineNum = startLine + i + 1;
+      const truncated =
+        line.length > MAX_LINE_LENGTH
+          ? line.slice(0, MAX_LINE_LENGTH) + "... (truncated)"
+          : line;
+      return `${lineNum}\t${truncated}`;
+    });
+
+    // Truncate if too many lines
+    let output: string;
+    if (numbered.length > MAX_LINES) {
+      output =
+        numbered.slice(0, MAX_LINES).join("\n") +
+        `\n... (${numbered.length - MAX_LINES} more lines truncated)`;
+    } else {
+      output = numbered.join("\n");
+    }
+
+    const result: TextReadToolOutput = {
+      path,
+      content: output,
+      totalLines
+    };
+
+    if (offset || limit) {
+      result.fromLine = startLine + 1;
+      result.toLine = Math.min(endLine, totalLines);
+    }
+
+    return result;
+  });
+}
+
+async function detectWorkspaceMediaType({
+  ops,
+  path,
+  stat
+}: {
+  ops: ReadOperations;
+  path: string;
+  stat: FileInfo;
+}): Promise<string> {
+  const statMime = normalizeMediaType(stat.mimeType);
+  if (statMime && !isGenericMediaType(statMime)) {
+    return statMime;
+  }
+
+  const bytes = await ops.readFileBytes(path);
+  if (bytes === null) {
+    return statMime || "application/octet-stream";
+  }
+
+  const sniffed = sniffMediaType(bytes);
+  if (sniffed) {
+    return sniffed;
+  }
+
+  return looksLikeText(bytes) ? "text/plain" : "application/octet-stream";
+}
+
+function normalizeMediaType(mediaType: string | undefined): string | null {
+  const normalized = mediaType?.split(";")[0]?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function isGenericMediaType(mediaType: string): boolean {
+  return (
+    mediaType === "application/octet-stream" ||
+    mediaType === "binary/octet-stream"
+  );
+}
+
+function isTextMediaType(mediaType: string): boolean {
+  return (
+    mediaType.startsWith("text/") ||
+    mediaType === "application/json" ||
+    mediaType === "application/javascript" ||
+    mediaType === "application/typescript" ||
+    mediaType === "application/xml" ||
+    mediaType === "application/x-javascript" ||
+    mediaType.endsWith("+json") ||
+    mediaType.endsWith("+xml")
+  );
+}
+
+function sniffMediaType(bytes: Uint8Array): string | null {
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) {
+    return "image/jpeg";
+  }
+  if (startsWithAscii(bytes, "GIF87a") || startsWithAscii(bytes, "GIF89a")) {
+    return "image/gif";
+  }
+  if (startsWithAscii(bytes, "RIFF") && asciiAt(bytes, 8, 12) === "WEBP") {
+    return "image/webp";
+  }
+  if (startsWithAscii(bytes, "%PDF-")) {
+    return "application/pdf";
+  }
+  if (looksLikeSvg(bytes)) {
+    return "image/svg+xml";
+  }
+  return null;
+}
+
+function startsWith(bytes: Uint8Array, prefix: number[]): boolean {
+  if (bytes.length < prefix.length) return false;
+  return prefix.every((byte, index) => bytes[index] === byte);
+}
+
+function startsWithAscii(bytes: Uint8Array, prefix: string): boolean {
+  return asciiAt(bytes, 0, prefix.length) === prefix;
+}
+
+function asciiAt(bytes: Uint8Array, start: number, end: number): string {
+  return String.fromCharCode(...bytes.subarray(start, end));
+}
+
+function looksLikeSvg(bytes: Uint8Array): boolean {
+  const prefix = new TextDecoder()
+    .decode(bytes.subarray(0, Math.min(bytes.length, 512)))
+    .trimStart()
+    .toLowerCase();
+  return prefix.startsWith("<svg") || prefix.includes("<svg");
+}
+
+function looksLikeText(bytes: Uint8Array): boolean {
+  if (bytes.length === 0) return true;
+  if (bytes.includes(0)) return false;
+
+  const text = new TextDecoder().decode(bytes.subarray(0, 4096));
+  if (text.length === 0) return true;
+
+  let replacementChars = 0;
+  for (const char of text) {
+    if (char === "\uFFFD") {
+      replacementChars++;
+    }
+  }
+  return replacementChars / text.length < 0.01;
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
 }
 
 // ── Write ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add multimodal-aware Think workspace reads for images and PDFs while preserving line-numbered text reads.
- Keep persisted read tool outputs compact and use AI SDK `toModelOutput` to rehydrate image/file bytes for model input, including replayed history.
- Cover image/PDF/binary read behavior, replay conversion, docs, and release notes.

## Test plan
- `npm run test --workspace @cloudflare/think -- assistant-tools.test.ts think-session.test.ts`
- `npm run build --workspace @cloudflare/think`
- `npm run check`


Made with [Cursor](https://cursor.com)