### PR TITLE
Fix sub-agent WebSocket forwarding

### DIFF
--- a/.changeset/clean-facets-tap.md
+++ b/.changeset/clean-facets-tap.md
@@ -1,8 +1,11 @@
 ---
 "@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
 "agents": patch
 ---
 
 Fix sub-agent WebSockets on deployed Workers by keeping the browser WebSocket owned by the parent Agent and forwarding connect/message/close events to child facets over RPC.
 
 Fix resumed chat streams so a partially hydrated assistant response is rebuilt from replay chunks instead of rendering replayed text as a second assistant text part.
+
+Fix a resume ACK race where drill-in chat connections could miss the terminal stream frame if the helper completed between the resume notification and client acknowledgement.

--- a/.changeset/clean-facets-tap.md
+++ b/.changeset/clean-facets-tap.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/ai-chat": patch
+"agents": patch
+---
+
+Fix sub-agent WebSockets on deployed Workers by keeping the browser WebSocket owned by the parent Agent and forwarding connect/message/close events to child facets over RPC.
+
+Fix resumed chat streams so a partially hydrated assistant response is rebuilt from replay chunks instead of rendering replayed text as a second assistant text part.

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -222,6 +222,16 @@ const chat = useAgent({
 
 The routed URL becomes `/agents/inbox/{userId}/sub/chat/{chatId}`.
 
+Child WebSocket clients can use the same URL shape. The parent remains the
+public address, while child agents still receive `onConnect`, `onMessage`,
+`onClose`, `broadcast()`, and `getConnections()` calls scoped to their own
+clients. Parent broadcasts do not leak to child-targeted sockets, and child
+connection tags, readonly state, and protocol-message settings are preserved
+when a connection is resumed from hibernation.
+
+Nested sub-agent URLs are supported using repeated `/sub/{agent}/{name}`
+segments, subject to the platform's current facet nesting limits.
+
 ### Agent Tools
 
 Run chat-capable sub-agents as tools from a parent chat agent. Think agents and

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -356,6 +356,51 @@ export class ResumableStream {
     return null;
   }
 
+  replayCompletedChunksByRequestId(
+    connection: Connection,
+    requestId: string
+  ): boolean {
+    this.flushBuffer();
+
+    const streams = this.sql<StreamMetadata>`
+      select * from cf_ai_chat_stream_metadata
+      where request_id = ${requestId}
+      order by created_at desc
+      limit 1
+    `;
+    const stream = streams[0];
+    if (!stream) return false;
+
+    const chunks = this.sql<StreamChunk>`
+      select * from cf_ai_chat_stream_chunks
+      where stream_id = ${stream.id}
+      order by chunk_index asc
+    `;
+
+    for (const chunk of chunks || []) {
+      connection.send(
+        JSON.stringify({
+          body: chunk.body,
+          done: false,
+          id: requestId,
+          type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
+          replay: true
+        })
+      );
+    }
+
+    connection.send(
+      JSON.stringify({
+        body: "",
+        done: true,
+        id: requestId,
+        type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
+        replay: true
+      })
+    );
+    return true;
+  }
+
   // ── Restore / cleanup ──────────────────────────────────────────────
 
   /**

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -365,6 +365,7 @@ export class ResumableStream {
     const streams = this.sql<StreamMetadata>`
       select * from cf_ai_chat_stream_metadata
       where request_id = ${requestId}
+      and status = 'completed'
       order by created_at desc
       limit 1
     `;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -286,6 +286,11 @@ type SubAgentConnectionMeta = {
   requestHeaders?: [string, string][];
 };
 
+type StoredSubAgentConnection = {
+  bridge: SubAgentConnectionBridge;
+  meta: SubAgentConnectionMeta;
+};
+
 type SubAgentWebSocketEndpoint = {
   _cf_handleSubAgentWebSocketConnect(
     bridge: SubAgentConnectionBridge,
@@ -1054,6 +1059,10 @@ export class Agent<
    */
   private _suppressProtocolBroadcasts = false;
   private _cf_currentSubAgentBridge?: SubAgentConnectionBridge;
+  private _cf_virtualSubAgentConnections = new Map<
+    string,
+    StoredSubAgentConnection
+  >();
 
   /**
    * Ancestor chain, root-first. Empty for top-level DOs; populated at
@@ -1759,7 +1768,13 @@ export class Agent<
         );
       }
       if (
-        await this._cf_forwardSubAgentWebSocketConnect(connection, ctx.request)
+        await this._cf_forwardSubAgentWebSocketConnect(
+          connection,
+          ctx.request,
+          {
+            gate: false
+          }
+        )
       ) {
         return;
       }
@@ -4674,7 +4689,9 @@ export class Agent<
 
     if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
       const acceptHeaders = new Headers(forwardReq.headers);
-      acceptHeaders.set(SUB_AGENT_OUTER_URL_HEADER, request.url);
+      const routedUrl = new URL(forwardReq.url);
+      routedUrl.pathname = new URL(request.url).pathname;
+      acceptHeaders.set(SUB_AGENT_OUTER_URL_HEADER, routedUrl.toString());
       return super.fetch(new Request(forwardReq, { headers: acceptHeaders }));
     }
 
@@ -4700,6 +4717,16 @@ export class Agent<
   override getConnection<TState = unknown>(
     id: string
   ): Connection<TState> | undefined {
+    if (this._isFacet) {
+      const stored = this._cf_virtualSubAgentConnections.get(id);
+      if (stored) {
+        return this._cf_createSubAgentBridgeConnection(
+          stored.bridge,
+          stored.meta
+        ) as Connection<TState>;
+      }
+    }
+
     const connection = super.getConnection<TState>(id);
     if (!connection || this._cf_connectionHasSubAgentTarget(connection)) {
       return undefined;
@@ -4710,6 +4737,17 @@ export class Agent<
   override *getConnections<TState = unknown>(
     tag?: string
   ): Iterable<Connection<TState>> {
+    if (this._isFacet) {
+      for (const stored of this._cf_virtualSubAgentConnections.values()) {
+        if (!tag || stored.meta.tags.includes(tag)) {
+          yield this._cf_createSubAgentBridgeConnection(
+            stored.bridge,
+            stored.meta
+          ) as Connection<TState>;
+        }
+      }
+    }
+
     for (const connection of super.getConnections<TState>(tag)) {
       if (this._cf_connectionHasSubAgentTarget(connection)) continue;
       yield connection;
@@ -4797,11 +4835,13 @@ export class Agent<
 
   private async _cf_forwardSubAgentWebSocketConnect(
     connection: Connection,
-    request: Request
+    request: Request,
+    options: { gate: boolean }
   ): Promise<boolean> {
     const routed = await this._cf_resolveSubAgentConnection(
       connection,
-      request
+      request,
+      options
     );
     if (!routed) return false;
 
@@ -4859,7 +4899,8 @@ export class Agent<
 
   private async _cf_resolveSubAgentConnection(
     connection: Connection,
-    request?: Request
+    request?: Request,
+    options: { gate: boolean } = { gate: false }
   ): Promise<{
     child: SubAgentWebSocketEndpoint;
     meta: SubAgentConnectionMeta;
@@ -4889,12 +4930,25 @@ export class Agent<
       if (!match) return null;
     }
 
+    let forwardReq = request;
+    if (request && options.gate) {
+      const decision = await this.onBeforeSubAgent(request, {
+        className: match.childClass,
+        name: match.childName
+      });
+      if (decision instanceof Response) {
+        connection.close(1008, "Sub-agent connection rejected");
+        return null;
+      }
+      forwardReq = decision instanceof Request ? decision : request;
+    }
+
     const child = (await this._cf_resolveSubAgent(
       match.childClass,
       match.childName
     )) as SubAgentWebSocketEndpoint;
 
-    const childUri = new URL(uri);
+    const childUri = new URL(forwardReq?.url ?? uri);
     childUri.pathname = match.remainingPath;
 
     return {
@@ -4903,8 +4957,8 @@ export class Agent<
         id: connection.id,
         uri: childUri.toString(),
         tags: [...connection.tags],
-        state: connection.state,
-        requestHeaders: request ? [...request.headers] : undefined
+        state: this._cf_getForwardedSubAgentState(connection),
+        requestHeaders: forwardReq ? [...forwardReq.headers] : undefined
       }
     };
   }
@@ -4918,8 +4972,19 @@ export class Agent<
       const request = new Request(meta.uri ?? "http://placeholder/", {
         headers: meta.requestHeaders
       });
-      if (await this._cf_forwardSubAgentWebSocketConnect(connection, request)) {
+      if (
+        await this._cf_forwardSubAgentWebSocketConnect(connection, request, {
+          gate: true
+        })
+      ) {
         return;
+      }
+
+      if (this.shouldConnectionBeReadonly(connection, { request })) {
+        this.setConnectionReadonly(connection, true);
+      }
+      if (!this.shouldSendProtocolMessages(connection, { request })) {
+        this._setConnectionNoProtocol(connection);
       }
 
       const childTags = await this.getConnectionTags(connection, { request });
@@ -4927,7 +4992,9 @@ export class Agent<
         connection.id,
         ...childTags.filter((tag) => tag !== connection.id)
       ];
+      this._cf_storeVirtualSubAgentConnection(bridge, connection);
       await this.onConnect(connection, { request });
+      this._cf_storeVirtualSubAgentConnection(bridge, connection);
     });
   }
 
@@ -4937,6 +5004,7 @@ export class Agent<
     meta: SubAgentConnectionMeta
   ): Promise<void> {
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
+    this._cf_storeVirtualSubAgentConnection(bridge, connection);
     await this._cf_runWithSubAgentBridge(bridge, () =>
       this.onMessage(connection, message)
     );
@@ -4950,9 +5018,11 @@ export class Agent<
     meta: SubAgentConnectionMeta
   ): Promise<void> {
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
+    this._cf_storeVirtualSubAgentConnection(bridge, connection);
     await this._cf_runWithSubAgentBridge(bridge, () =>
       this.onClose(connection, code, reason, wasClean)
     );
+    this._cf_virtualSubAgentConnections.delete(meta.id);
   }
 
   private async _cf_runWithSubAgentBridge<T>(
@@ -4972,17 +5042,26 @@ export class Agent<
     bridge: SubAgentConnectionBridge,
     meta: SubAgentConnectionMeta
   ): Connection {
-    let state = meta.state;
+    const stored = this._cf_virtualSubAgentConnections.get(meta.id);
+    const effectiveMeta = stored?.meta ?? meta;
+    let state = effectiveMeta.state;
+    const updateStoredState = (nextState: unknown) => {
+      const current = this._cf_virtualSubAgentConnections.get(effectiveMeta.id);
+      if (current) {
+        current.meta = { ...current.meta, state: nextState };
+      }
+    };
     return {
-      id: meta.id,
-      uri: meta.uri,
-      tags: meta.tags,
+      id: effectiveMeta.id,
+      uri: effectiveMeta.uri,
+      tags: effectiveMeta.tags,
       server: this.name,
       get state() {
         return state;
       },
       setState(next: unknown | ((prev: unknown) => unknown)) {
         state = typeof next === "function" ? next(state) : next;
+        updateStoredState(state);
         void bridge.setState(state);
         return state;
       },
@@ -4995,6 +5074,36 @@ export class Agent<
       addEventListener() {},
       removeEventListener() {}
     } as unknown as Connection;
+  }
+
+  private _cf_storeVirtualSubAgentConnection(
+    bridge: SubAgentConnectionBridge,
+    connection: Connection
+  ): void {
+    this._cf_virtualSubAgentConnections.set(connection.id, {
+      bridge,
+      meta: {
+        id: connection.id,
+        uri: connection.uri,
+        tags: [...connection.tags],
+        state: this._cf_getRawConnectionState(connection)
+      }
+    });
+  }
+
+  private _cf_getRawConnectionState(connection: Connection): unknown {
+    this._ensureConnectionWrapped(connection);
+    return this._rawStateAccessors.get(connection)?.getRaw() ?? null;
+  }
+
+  private _cf_getForwardedSubAgentState(connection: Connection): unknown {
+    const raw = this._cf_getRawConnectionState(connection);
+    if (raw == null || typeof raw !== "object") return raw;
+    const { [CF_SUB_AGENT_OUTER_URL_KEY]: _, ...rest } = raw as Record<
+      string,
+      unknown
+    >;
+    return Object.keys(rest).length > 0 ? rest : null;
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -286,8 +286,19 @@ type SubAgentConnectionMeta = {
   requestHeaders?: [string, string][];
 };
 
+type SubAgentConnectionBridgeLike = {
+  send(message: string | ArrayBuffer | ArrayBufferView): void;
+  close(code?: number, reason?: string): void;
+  setState(state: unknown): unknown;
+  broadcast(
+    ownerPath: ReadonlyArray<{ className: string; name: string }>,
+    message: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): void;
+};
+
 type StoredSubAgentConnection = {
-  bridge: SubAgentConnectionBridge;
+  bridge: SubAgentConnectionBridgeLike;
   meta: SubAgentConnectionMeta;
 };
 
@@ -310,7 +321,10 @@ type SubAgentWebSocketEndpoint = {
   ): Promise<void>;
 };
 
-class SubAgentConnectionBridge extends RpcTarget {
+class SubAgentConnectionBridge
+  extends RpcTarget
+  implements SubAgentConnectionBridgeLike
+{
   #connection: Connection;
   #broadcast?: (
     ownerPath: ReadonlyArray<{ className: string; name: string }>,
@@ -349,6 +363,41 @@ class SubAgentConnectionBridge extends RpcTarget {
     without?: string[]
   ): void {
     this.#broadcast?.(ownerPath, message, without);
+  }
+}
+
+class RootSubAgentConnectionBridge implements SubAgentConnectionBridgeLike {
+  #root: RootFacetRpcSurface;
+  #connectionId: string;
+
+  constructor(root: RootFacetRpcSurface, connectionId: string) {
+    this.#root = root;
+    this.#connectionId = connectionId;
+  }
+
+  send(message: string | ArrayBuffer | ArrayBufferView): void {
+    void this.#root._cf_sendToSubAgentConnection(this.#connectionId, message);
+  }
+
+  close(code?: number, reason?: string): void {
+    void this.#root._cf_closeSubAgentConnection(
+      this.#connectionId,
+      code,
+      reason
+    );
+  }
+
+  setState(state: unknown): unknown {
+    void this.#root._cf_setSubAgentConnectionState(this.#connectionId, state);
+    return state;
+  }
+
+  broadcast(
+    ownerPath: ReadonlyArray<{ className: string; name: string }>,
+    message: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): void {
+    void this.#root._cf_broadcastToSubAgent(ownerPath, message, without);
   }
 }
 
@@ -577,6 +626,22 @@ type RootFacetRpcSurface = {
     message: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
   ): Promise<void>;
+  _cf_subAgentConnectionMetas(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<SubAgentConnectionMeta[]>;
+  _cf_sendToSubAgentConnection(
+    connectionId: string,
+    message: string | ArrayBuffer | ArrayBufferView
+  ): Promise<void>;
+  _cf_closeSubAgentConnection(
+    connectionId: string,
+    code?: number,
+    reason?: string
+  ): Promise<void>;
+  _cf_setSubAgentConnectionState(
+    connectionId: string,
+    state: unknown
+  ): Promise<unknown>;
 };
 
 /**
@@ -760,6 +825,7 @@ const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
  * parent-owned.
  */
 const CF_SUB_AGENT_OUTER_URL_KEY = "_cf_subAgentOuterUrl";
+const CF_SUB_AGENT_TAGS_KEY = "_cf_subAgentTags";
 
 const SUB_AGENT_OUTER_URL_HEADER = "x-cf-agents-subagent-url";
 
@@ -771,7 +837,8 @@ const CF_INTERNAL_KEYS: ReadonlySet<string> = new Set([
   CF_READONLY_KEY,
   CF_NO_PROTOCOL_KEY,
   CF_VOICE_IN_CALL_KEY,
-  CF_SUB_AGENT_OUTER_URL_KEY
+  CF_SUB_AGENT_OUTER_URL_KEY,
+  CF_SUB_AGENT_TAGS_KEY
 ]);
 
 /** Check if a raw connection state object contains any internal keys. */
@@ -1058,7 +1125,7 @@ export class Agent<
    * parent-owned WebSocket handles during this window.
    */
   private _suppressProtocolBroadcasts = false;
-  private _cf_currentSubAgentBridge?: SubAgentConnectionBridge;
+  private _cf_currentSubAgentBridge?: SubAgentConnectionBridgeLike;
   private _cf_virtualSubAgentConnections = new Map<
     string,
     StoredSubAgentConnection
@@ -1910,6 +1977,7 @@ export class Agent<
           if (isValidParentPath(storedParentPath)) {
             this._parentPath = storedParentPath;
           }
+          await this._cf_hydrateSubAgentConnectionsFromRoot();
 
           await this._tryCatch(async () => {
             await this.mcp.restoreConnectionsFromStorage(this.name);
@@ -4785,6 +4853,100 @@ export class Agent<
     }
   }
 
+  async _cf_subAgentConnectionMetas(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<SubAgentConnectionMeta[]> {
+    const metas: SubAgentConnectionMeta[] = [];
+    for (const connection of super.getConnections()) {
+      const meta = this._cf_subAgentConnectionMetaForPath(
+        connection,
+        ownerPath
+      );
+      if (meta) metas.push(meta);
+    }
+    return metas;
+  }
+
+  async _cf_sendToSubAgentConnection(
+    connectionId: string,
+    message: string | ArrayBuffer | ArrayBufferView
+  ): Promise<void> {
+    const connection = super.getConnection(connectionId);
+    if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
+      return;
+    }
+    connection.send(message);
+  }
+
+  async _cf_closeSubAgentConnection(
+    connectionId: string,
+    code?: number,
+    reason?: string
+  ): Promise<void> {
+    const connection = super.getConnection(connectionId);
+    if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
+      return;
+    }
+    connection.close(code, reason);
+  }
+
+  async _cf_setSubAgentConnectionState(
+    connectionId: string,
+    state: unknown
+  ): Promise<unknown> {
+    const connection = super.getConnection(connectionId);
+    if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
+      return null;
+    }
+    this._ensureConnectionWrapped(connection);
+    connection.setState(state);
+    return this._cf_getForwardedSubAgentState(connection);
+  }
+
+  private _cf_subAgentConnectionMetaForPath(
+    connection: Connection,
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): SubAgentConnectionMeta | null {
+    this._ensureConnectionWrapped(connection);
+    const outerUri = this._unsafe_getConnectionFlag(
+      connection,
+      CF_SUB_AGENT_OUTER_URL_KEY
+    );
+    if (typeof outerUri !== "string") return null;
+
+    const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
+    const knownClasses = ctx.exports ? Object.keys(ctx.exports) : undefined;
+    const path: AgentPathStep[] = [...this.selfPath];
+    let currentUrl = outerUri;
+
+    while (true) {
+      const match = _parseSubAgentPath(currentUrl, { knownClasses });
+      if (!match) return null;
+
+      path.push({ className: match.childClass, name: match.childName });
+      const rewritten = new URL(currentUrl);
+      rewritten.pathname = match.remainingPath;
+      currentUrl = rewritten.toString();
+
+      if (this._isSameAgentPath(path, ownerPath)) {
+        const raw = this._cf_getRawConnectionState(connection);
+        const rawTags =
+          raw != null && typeof raw === "object"
+            ? (raw as Record<string, unknown>)[CF_SUB_AGENT_TAGS_KEY]
+            : undefined;
+        const tags = Array.isArray(rawTags)
+          ? rawTags.filter((tag): tag is string => typeof tag === "string")
+          : [...connection.tags];
+        return {
+          id: connection.id,
+          uri: currentUrl,
+          tags,
+          state: this._cf_getForwardedSubAgentState(connection)
+        };
+      }
+    }
+  }
+
   private _cf_subAgentTargetPath(
     connection: Connection
   ): ReadonlyArray<AgentPathStep> | null {
@@ -4830,6 +4992,33 @@ export class Agent<
         connection,
         CF_SUB_AGENT_OUTER_URL_KEY
       ) === "string"
+    );
+  }
+
+  protected _cf_connectionTargetsSubAgent(connection: Connection): boolean {
+    if (!connection.uri) return false;
+    const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
+    return (
+      _parseSubAgentPath(connection.uri, {
+        knownClasses: ctx.exports ? Object.keys(ctx.exports) : undefined
+      }) !== null
+    );
+  }
+
+  /**
+   * Returns true when the current request is addressed to a child facet of
+   * this agent rather than to this agent itself.
+   *
+   * Chat-style subclasses wrap `onConnect` before the base Agent forwarding
+   * wrapper runs, so they need a request-level check to avoid sending their
+   * own protocol frames on sockets that are about to be forwarded to a child.
+   */
+  protected _cf_requestTargetsSubAgent(request: Request): boolean {
+    const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
+    return (
+      _parseSubAgentPath(request.url, {
+        knownClasses: ctx.exports ? Object.keys(ctx.exports) : undefined
+      }) !== null
     );
   }
 
@@ -4950,13 +5139,21 @@ export class Agent<
 
     const childUri = new URL(forwardReq?.url ?? uri);
     childUri.pathname = match.remainingPath;
+    const raw = this._cf_getRawConnectionState(connection);
+    const rawTags =
+      raw != null && typeof raw === "object"
+        ? (raw as Record<string, unknown>)[CF_SUB_AGENT_TAGS_KEY]
+        : undefined;
+    const tags = Array.isArray(rawTags)
+      ? rawTags.filter((tag): tag is string => typeof tag === "string")
+      : [...connection.tags];
 
     return {
       child,
       meta: {
         id: connection.id,
         uri: childUri.toString(),
-        tags: [...connection.tags],
+        tags,
         state: this._cf_getForwardedSubAgentState(connection),
         requestHeaders: forwardReq ? [...forwardReq.headers] : undefined
       }
@@ -5026,7 +5223,7 @@ export class Agent<
   }
 
   private async _cf_runWithSubAgentBridge<T>(
-    bridge: SubAgentConnectionBridge,
+    bridge: SubAgentConnectionBridgeLike,
     fn: () => Promise<T> | T
   ): Promise<T> {
     const previous = this._cf_currentSubAgentBridge;
@@ -5039,7 +5236,7 @@ export class Agent<
   }
 
   private _cf_createSubAgentBridgeConnection(
-    bridge: SubAgentConnectionBridge,
+    bridge: SubAgentConnectionBridgeLike,
     meta: SubAgentConnectionMeta
   ): Connection {
     const stored = this._cf_virtualSubAgentConnections.get(meta.id);
@@ -5077,9 +5274,12 @@ export class Agent<
   }
 
   private _cf_storeVirtualSubAgentConnection(
-    bridge: SubAgentConnectionBridge,
+    bridge: SubAgentConnectionBridgeLike,
     connection: Connection
   ): void {
+    this._unsafe_setConnectionFlag(connection, CF_SUB_AGENT_TAGS_KEY, [
+      ...connection.tags
+    ]);
     this._cf_virtualSubAgentConnections.set(connection.id, {
       bridge,
       meta: {
@@ -5089,6 +5289,19 @@ export class Agent<
         state: this._cf_getRawConnectionState(connection)
       }
     });
+  }
+
+  protected async _cf_hydrateSubAgentConnectionsFromRoot(): Promise<void> {
+    if (!this._isFacet || this._parentPath.length === 0) return;
+
+    const root = await this._rootAlarmOwner();
+    const metas = await root._cf_subAgentConnectionMetas(this.selfPath);
+    for (const meta of metas) {
+      this._cf_virtualSubAgentConnections.set(meta.id, {
+        bridge: new RootSubAgentConnectionBridge(root, meta.id),
+        meta
+      });
+    }
   }
 
   private _cf_getRawConnectionState(connection: Connection): unknown {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4988,7 +4988,7 @@ export class Agent<
       }
 
       const childTags = await this.getConnectionTags(connection, { request });
-      (connection as { tags: string[] }).tags = [
+      (connection as unknown as { tags: string[] }).tags = [
         connection.id,
         ...childTags.filter((tag) => tag !== connection.id)
       ];

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -278,6 +278,75 @@ interface FacetCapableCtx {
   >;
 }
 
+type SubAgentConnectionMeta = {
+  id: string;
+  uri: string | null;
+  tags: string[];
+  state: unknown;
+  requestHeaders?: [string, string][];
+};
+
+type SubAgentWebSocketEndpoint = {
+  _cf_handleSubAgentWebSocketConnect(
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Promise<void>;
+  _cf_handleSubAgentWebSocketMessage(
+    message: WSMessage,
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Promise<void>;
+  _cf_handleSubAgentWebSocketClose(
+    code: number,
+    reason: string,
+    wasClean: boolean,
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Promise<void>;
+};
+
+class SubAgentConnectionBridge extends RpcTarget {
+  #connection: Connection;
+  #broadcast?: (
+    ownerPath: ReadonlyArray<{ className: string; name: string }>,
+    message: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ) => void;
+
+  constructor(
+    connection: Connection,
+    broadcast?: (
+      ownerPath: ReadonlyArray<{ className: string; name: string }>,
+      message: string | ArrayBuffer | ArrayBufferView,
+      without?: string[]
+    ) => void
+  ) {
+    super();
+    this.#connection = connection;
+    this.#broadcast = broadcast;
+  }
+
+  send(message: string | ArrayBuffer | ArrayBufferView): void {
+    this.#connection.send(message);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.#connection.close(code, reason);
+  }
+
+  setState(state: unknown): unknown {
+    return this.#connection.setState(state);
+  }
+
+  broadcast(
+    ownerPath: ReadonlyArray<{ className: string; name: string }>,
+    message: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): void {
+    this.#broadcast?.(ownerPath, message, without);
+  }
+}
+
 /**
  * Constructor type for a sub-agent class.
  * Used by {@link Agent.subAgent} to reference the child class
@@ -498,6 +567,11 @@ type RootFacetRpcSurface = {
     ownerPath: ReadonlyArray<AgentPathStep>,
     runId: string
   ): Promise<void>;
+  _cf_broadcastToSubAgent(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    message: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): Promise<void>;
 };
 
 /**
@@ -674,13 +748,25 @@ const CF_NO_PROTOCOL_KEY = "_cf_no_protocol";
 const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
 
 /**
+ * Internal key used to remember the outer `/sub/...` URL for a
+ * WebSocket accepted by the parent on behalf of a child facet.
+ * Hibernated events then wake the parent, which forwards frames to
+ * the child over serializable RPC while keeping native WebSocket I/O
+ * parent-owned.
+ */
+const CF_SUB_AGENT_OUTER_URL_KEY = "_cf_subAgentOuterUrl";
+
+const SUB_AGENT_OUTER_URL_HEADER = "x-cf-agents-subagent-url";
+
+/**
  * The set of all internal keys stored in connection state that must be
  * hidden from user code and preserved across setState calls.
  */
 const CF_INTERNAL_KEYS: ReadonlySet<string> = new Set([
   CF_READONLY_KEY,
   CF_NO_PROTOCOL_KEY,
-  CF_VOICE_IN_CALL_KEY
+  CF_VOICE_IN_CALL_KEY,
+  CF_SUB_AGENT_OUTER_URL_KEY
 ]);
 
 /** Check if a raw connection state object contains any internal keys. */
@@ -967,6 +1053,7 @@ export class Agent<
    * parent-owned WebSocket handles during this window.
    */
   private _suppressProtocolBroadcasts = false;
+  private _cf_currentSubAgentBridge?: SubAgentConnectionBridge;
 
   /**
    * Ancestor chain, root-first. Empty for top-level DOs; populated at
@@ -1534,6 +1621,9 @@ export class Agent<
 
     const _onMessage = this.onMessage.bind(this);
     this.onMessage = async (connection: Connection, message: WSMessage) => {
+      if (await this._cf_forwardSubAgentWebSocketMessage(connection, message)) {
+        return;
+      }
       this._ensureConnectionWrapped(connection);
       return agentContext.run(
         { agent: this, connection, request: undefined, email: undefined },
@@ -1656,8 +1746,23 @@ export class Agent<
     };
 
     const _onConnect = this.onConnect.bind(this);
-    this.onConnect = (connection: Connection, ctx: ConnectionContext) => {
+    this.onConnect = async (connection: Connection, ctx: ConnectionContext) => {
       this._ensureConnectionWrapped(connection);
+      const subAgentOuterUrl = ctx.request.headers.get(
+        SUB_AGENT_OUTER_URL_HEADER
+      );
+      if (subAgentOuterUrl) {
+        this._unsafe_setConnectionFlag(
+          connection,
+          CF_SUB_AGENT_OUTER_URL_KEY,
+          subAgentOuterUrl
+        );
+      }
+      if (
+        await this._cf_forwardSubAgentWebSocketConnect(connection, ctx.request)
+      ) {
+        return;
+      }
       // TODO: This is a hack to ensure the state is sent after the connection is established
       // must fix this
       return agentContext.run(
@@ -1739,12 +1844,22 @@ export class Agent<
     };
 
     const _onClose = this.onClose.bind(this);
-    this.onClose = (
+    this.onClose = async (
       connection: Connection,
       code: number,
       reason: string,
       wasClean: boolean
     ) => {
+      if (
+        await this._cf_forwardSubAgentWebSocketClose(
+          connection,
+          code,
+          reason,
+          wasClean
+        )
+      ) {
+        return;
+      }
       return agentContext.run(
         { agent: this, connection, request: undefined, email: undefined },
         () => {
@@ -4557,7 +4672,329 @@ export class Agent<
     if (decision instanceof Response) return decision;
     const forwardReq = decision instanceof Request ? decision : request;
 
+    if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
+      const acceptHeaders = new Headers(forwardReq.headers);
+      acceptHeaders.set(SUB_AGENT_OUTER_URL_HEADER, request.url);
+      return super.fetch(new Request(forwardReq, { headers: acceptHeaders }));
+    }
+
     return this._cf_forwardToFacet(forwardReq, match);
+  }
+
+  override broadcast(
+    msg: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): void {
+    if (this._isFacet) {
+      void this._cf_broadcastToParentSubAgent(msg, without);
+      return;
+    }
+
+    for (const connection of super.getConnections()) {
+      if (without?.includes(connection.id)) continue;
+      if (this._cf_connectionHasSubAgentTarget(connection)) continue;
+      connection.send(msg);
+    }
+  }
+
+  override getConnection<TState = unknown>(
+    id: string
+  ): Connection<TState> | undefined {
+    const connection = super.getConnection<TState>(id);
+    if (!connection || this._cf_connectionHasSubAgentTarget(connection)) {
+      return undefined;
+    }
+    return connection;
+  }
+
+  override *getConnections<TState = unknown>(
+    tag?: string
+  ): Iterable<Connection<TState>> {
+    for (const connection of super.getConnections<TState>(tag)) {
+      if (this._cf_connectionHasSubAgentTarget(connection)) continue;
+      yield connection;
+    }
+  }
+
+  private async _cf_broadcastToParentSubAgent(
+    message: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): Promise<void> {
+    if (this._cf_currentSubAgentBridge) {
+      this._cf_currentSubAgentBridge.broadcast(this.selfPath, message, without);
+      return;
+    }
+    const root = await this._rootAlarmOwner();
+    await root._cf_broadcastToSubAgent(this.selfPath, message, without);
+  }
+
+  async _cf_broadcastToSubAgent(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    message: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): Promise<void> {
+    if (this._isFacet && this._cf_currentSubAgentBridge) {
+      this._cf_currentSubAgentBridge.broadcast(ownerPath, message, without);
+      return;
+    }
+
+    for (const connection of super.getConnections()) {
+      if (without?.includes(connection.id)) continue;
+      const targetPath = this._cf_subAgentTargetPath(connection);
+      if (!targetPath) continue;
+      if (!this._isSameAgentPath(targetPath, ownerPath)) continue;
+      connection.send(message);
+    }
+  }
+
+  private _cf_subAgentTargetPath(
+    connection: Connection
+  ): ReadonlyArray<AgentPathStep> | null {
+    this._ensureConnectionWrapped(connection);
+    const outerUri = this._unsafe_getConnectionFlag(
+      connection,
+      CF_SUB_AGENT_OUTER_URL_KEY
+    );
+    if (typeof outerUri !== "string") return null;
+
+    const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
+    const knownClasses = ctx.exports ? Object.keys(ctx.exports) : undefined;
+    const path: AgentPathStep[] = [...this.selfPath];
+    let currentUrl = outerUri;
+
+    while (true) {
+      const match = _parseSubAgentPath(currentUrl, { knownClasses });
+      if (!match) break;
+      path.push({ className: match.childClass, name: match.childName });
+      const rewritten = new URL(currentUrl);
+      rewritten.pathname = match.remainingPath;
+      currentUrl = rewritten.toString();
+    }
+
+    return path.length === this.selfPath.length ? null : path;
+  }
+
+  private _isSameAgentPath(
+    a: ReadonlyArray<AgentPathStep>,
+    b: ReadonlyArray<AgentPathStep>
+  ): boolean {
+    if (a.length !== b.length) return false;
+    return a.every(
+      (step, index) =>
+        step.className === b[index]?.className && step.name === b[index]?.name
+    );
+  }
+
+  private _cf_connectionHasSubAgentTarget(connection: Connection): boolean {
+    this._ensureConnectionWrapped(connection);
+    return (
+      typeof this._unsafe_getConnectionFlag(
+        connection,
+        CF_SUB_AGENT_OUTER_URL_KEY
+      ) === "string"
+    );
+  }
+
+  private async _cf_forwardSubAgentWebSocketConnect(
+    connection: Connection,
+    request: Request
+  ): Promise<boolean> {
+    const routed = await this._cf_resolveSubAgentConnection(
+      connection,
+      request
+    );
+    if (!routed) return false;
+
+    await routed.child._cf_handleSubAgentWebSocketConnect(
+      this._cf_createSubAgentConnectionBridge(connection),
+      routed.meta
+    );
+    return true;
+  }
+
+  private _cf_createSubAgentConnectionBridge(
+    connection: Connection
+  ): SubAgentConnectionBridge {
+    return new SubAgentConnectionBridge(
+      connection,
+      (ownerPath, message, without) => {
+        void this._cf_broadcastToSubAgent(ownerPath, message, without);
+      }
+    );
+  }
+
+  private async _cf_forwardSubAgentWebSocketMessage(
+    connection: Connection,
+    message: WSMessage
+  ): Promise<boolean> {
+    const routed = await this._cf_resolveSubAgentConnection(connection);
+    if (!routed) return false;
+
+    await routed.child._cf_handleSubAgentWebSocketMessage(
+      message,
+      this._cf_createSubAgentConnectionBridge(connection),
+      routed.meta
+    );
+    return true;
+  }
+
+  private async _cf_forwardSubAgentWebSocketClose(
+    connection: Connection,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): Promise<boolean> {
+    const routed = await this._cf_resolveSubAgentConnection(connection);
+    if (!routed) return false;
+
+    await routed.child._cf_handleSubAgentWebSocketClose(
+      code,
+      reason,
+      wasClean,
+      this._cf_createSubAgentConnectionBridge(connection),
+      routed.meta
+    );
+    return true;
+  }
+
+  private async _cf_resolveSubAgentConnection(
+    connection: Connection,
+    request?: Request
+  ): Promise<{
+    child: SubAgentWebSocketEndpoint;
+    meta: SubAgentConnectionMeta;
+  } | null> {
+    this._ensureConnectionWrapped(connection);
+    const outerUri = this._unsafe_getConnectionFlag(
+      connection,
+      CF_SUB_AGENT_OUTER_URL_KEY
+    );
+    const uri = typeof outerUri === "string" ? outerUri : connection.uri;
+    if (!uri) return null;
+
+    const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
+    let match = _parseSubAgentPath(uri, {
+      knownClasses: ctx.exports ? Object.keys(ctx.exports) : undefined
+    });
+    if (!match) return null;
+    if (
+      this._ParentClass.name === match.childClass &&
+      this.name === match.childName
+    ) {
+      const tailUri = new URL(uri);
+      tailUri.pathname = match.remainingPath;
+      match = _parseSubAgentPath(tailUri.toString(), {
+        knownClasses: ctx.exports ? Object.keys(ctx.exports) : undefined
+      });
+      if (!match) return null;
+    }
+
+    const child = (await this._cf_resolveSubAgent(
+      match.childClass,
+      match.childName
+    )) as SubAgentWebSocketEndpoint;
+
+    const childUri = new URL(uri);
+    childUri.pathname = match.remainingPath;
+
+    return {
+      child,
+      meta: {
+        id: connection.id,
+        uri: childUri.toString(),
+        tags: [...connection.tags],
+        state: connection.state,
+        requestHeaders: request ? [...request.headers] : undefined
+      }
+    };
+  }
+
+  async _cf_handleSubAgentWebSocketConnect(
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Promise<void> {
+    await this._cf_runWithSubAgentBridge(bridge, async () => {
+      const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
+      const request = new Request(meta.uri ?? "http://placeholder/", {
+        headers: meta.requestHeaders
+      });
+      if (await this._cf_forwardSubAgentWebSocketConnect(connection, request)) {
+        return;
+      }
+
+      const childTags = await this.getConnectionTags(connection, { request });
+      (connection as { tags: string[] }).tags = [
+        connection.id,
+        ...childTags.filter((tag) => tag !== connection.id)
+      ];
+      await this.onConnect(connection, { request });
+    });
+  }
+
+  async _cf_handleSubAgentWebSocketMessage(
+    message: WSMessage,
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Promise<void> {
+    const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
+    await this._cf_runWithSubAgentBridge(bridge, () =>
+      this.onMessage(connection, message)
+    );
+  }
+
+  async _cf_handleSubAgentWebSocketClose(
+    code: number,
+    reason: string,
+    wasClean: boolean,
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Promise<void> {
+    const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
+    await this._cf_runWithSubAgentBridge(bridge, () =>
+      this.onClose(connection, code, reason, wasClean)
+    );
+  }
+
+  private async _cf_runWithSubAgentBridge<T>(
+    bridge: SubAgentConnectionBridge,
+    fn: () => Promise<T> | T
+  ): Promise<T> {
+    const previous = this._cf_currentSubAgentBridge;
+    this._cf_currentSubAgentBridge = bridge;
+    try {
+      return await fn();
+    } finally {
+      this._cf_currentSubAgentBridge = previous;
+    }
+  }
+
+  private _cf_createSubAgentBridgeConnection(
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Connection {
+    let state = meta.state;
+    return {
+      id: meta.id,
+      uri: meta.uri,
+      tags: meta.tags,
+      server: this.name,
+      get state() {
+        return state;
+      },
+      setState(next: unknown | ((prev: unknown) => unknown)) {
+        state = typeof next === "function" ? next(state) : next;
+        void bridge.setState(state);
+        return state;
+      },
+      send(message: string | ArrayBuffer | ArrayBufferView) {
+        void bridge.send(message);
+      },
+      close(code?: number, reason?: string) {
+        void bridge.close(code, reason);
+      },
+      addEventListener() {},
+      removeEventListener() {}
+    } as unknown as Connection;
   }
 
   /**
@@ -4648,7 +5085,18 @@ export class Agent<
     // no further /sub/... remains) or recurses into its own child.
     const rewritten = new URL(req.url);
     rewritten.pathname = match.remainingPath;
-    const forwarded = new Request(rewritten, req);
+    const forwardedHeaders = new Headers(req.headers);
+    const forwardedInit: RequestInit = {
+      method: req.method,
+      headers: forwardedHeaders
+    };
+    if (req.headers.get("Upgrade")?.toLowerCase() === "websocket") {
+      forwardedHeaders.set(SUB_AGENT_OUTER_URL_HEADER, req.url);
+    }
+    if (req.body && req.method !== "GET" && req.method !== "HEAD") {
+      forwardedInit.body = await req.arrayBuffer();
+    }
+    const forwarded = new Request(rewritten, forwardedInit);
     return fetcher.fetch(forwarded);
   }
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -300,6 +300,7 @@ type SubAgentConnectionBridgeLike = {
 type StoredSubAgentConnection = {
   bridge: SubAgentConnectionBridgeLike;
   meta: SubAgentConnectionMeta;
+  connection?: Connection;
 };
 
 type SubAgentWebSocketEndpoint = {
@@ -1977,7 +1978,14 @@ export class Agent<
           if (isValidParentPath(storedParentPath)) {
             this._parentPath = storedParentPath;
           }
-          await this._cf_hydrateSubAgentConnectionsFromRoot();
+          try {
+            await this._cf_hydrateSubAgentConnectionsFromRoot();
+          } catch (error) {
+            console.warn(
+              "[Agent] Unable to hydrate sub-agent WebSocket connections:",
+              error
+            );
+          }
 
           await this._tryCatch(async () => {
             await this.mcp.restoreConnectionsFromStorage(this.name);
@@ -4914,37 +4922,23 @@ export class Agent<
     );
     if (typeof outerUri !== "string") return null;
 
-    const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
-    const knownClasses = ctx.exports ? Object.keys(ctx.exports) : undefined;
-    const path: AgentPathStep[] = [...this.selfPath];
-    let currentUrl = outerUri;
+    const target = this._cf_subAgentPathFromOuterUri(outerUri, ownerPath);
+    if (!target) return null;
 
-    while (true) {
-      const match = _parseSubAgentPath(currentUrl, { knownClasses });
-      if (!match) return null;
-
-      path.push({ className: match.childClass, name: match.childName });
-      const rewritten = new URL(currentUrl);
-      rewritten.pathname = match.remainingPath;
-      currentUrl = rewritten.toString();
-
-      if (this._isSameAgentPath(path, ownerPath)) {
-        const raw = this._cf_getRawConnectionState(connection);
-        const rawTags =
-          raw != null && typeof raw === "object"
-            ? (raw as Record<string, unknown>)[CF_SUB_AGENT_TAGS_KEY]
-            : undefined;
-        const tags = Array.isArray(rawTags)
-          ? rawTags.filter((tag): tag is string => typeof tag === "string")
-          : [...connection.tags];
-        return {
-          id: connection.id,
-          uri: currentUrl,
-          tags,
-          state: this._cf_getForwardedSubAgentState(connection)
-        };
-      }
-    }
+    const raw = this._cf_getRawConnectionState(connection);
+    const rawTags =
+      raw != null && typeof raw === "object"
+        ? (raw as Record<string, unknown>)[CF_SUB_AGENT_TAGS_KEY]
+        : undefined;
+    const tags = Array.isArray(rawTags)
+      ? rawTags.filter((tag): tag is string => typeof tag === "string")
+      : [...connection.tags];
+    return {
+      id: connection.id,
+      uri: target.uri,
+      tags,
+      state: this._cf_getForwardedSubAgentState(connection)
+    };
   }
 
   private _cf_subAgentTargetPath(
@@ -4957,6 +4951,13 @@ export class Agent<
     );
     if (typeof outerUri !== "string") return null;
 
+    return this._cf_subAgentPathFromOuterUri(outerUri)?.path ?? null;
+  }
+
+  private _cf_subAgentPathFromOuterUri(
+    outerUri: string,
+    stopAt?: ReadonlyArray<AgentPathStep>
+  ): { path: ReadonlyArray<AgentPathStep>; uri: string } | null {
     const ctx = this.ctx as unknown as Partial<FacetCapableCtx>;
     const knownClasses = ctx.exports ? Object.keys(ctx.exports) : undefined;
     const path: AgentPathStep[] = [...this.selfPath];
@@ -4969,9 +4970,14 @@ export class Agent<
       const rewritten = new URL(currentUrl);
       rewritten.pathname = match.remainingPath;
       currentUrl = rewritten.toString();
+      if (stopAt && this._isSameAgentPath(path, stopAt)) {
+        return { path, uri: currentUrl };
+      }
     }
 
-    return path.length === this.selfPath.length ? null : path;
+    if (path.length === this.selfPath.length) return null;
+    if (stopAt) return null;
+    return { path, uri: currentUrl };
   }
 
   private _isSameAgentPath(
@@ -5239,38 +5245,67 @@ export class Agent<
     bridge: SubAgentConnectionBridgeLike,
     meta: SubAgentConnectionMeta
   ): Connection {
-    const stored = this._cf_virtualSubAgentConnections.get(meta.id);
-    const effectiveMeta = stored?.meta ?? meta;
-    let state = effectiveMeta.state;
+    let stored = this._cf_virtualSubAgentConnections.get(meta.id);
+    if (stored) {
+      stored.bridge = bridge;
+      stored.meta = meta;
+      if (stored.connection) {
+        (
+          stored.connection as unknown as {
+            uri: string | null;
+            tags: string[];
+          }
+        ).uri = meta.uri;
+        (
+          stored.connection as unknown as {
+            uri: string | null;
+            tags: string[];
+          }
+        ).tags = meta.tags;
+        return stored.connection;
+      }
+    } else {
+      stored = { bridge, meta };
+      this._cf_virtualSubAgentConnections.set(meta.id, stored);
+    }
+
+    const getStored = () =>
+      this._cf_virtualSubAgentConnections.get(meta.id) ?? stored;
     const updateStoredState = (nextState: unknown) => {
-      const current = this._cf_virtualSubAgentConnections.get(effectiveMeta.id);
+      const current = this._cf_virtualSubAgentConnections.get(meta.id);
       if (current) {
         current.meta = { ...current.meta, state: nextState };
       }
     };
-    return {
-      id: effectiveMeta.id,
-      uri: effectiveMeta.uri,
-      tags: effectiveMeta.tags,
+
+    const connection = {
+      id: meta.id,
+      uri: meta.uri,
+      tags: meta.tags,
       server: this.name,
       get state() {
-        return state;
+        return getStored().meta.state;
       },
       setState(next: unknown | ((prev: unknown) => unknown)) {
-        state = typeof next === "function" ? next(state) : next;
+        const currentState = getStored().meta.state;
+        const state = typeof next === "function" ? next(currentState) : next;
         updateStoredState(state);
-        void bridge.setState(state);
+        void getStored().bridge.setState(state);
         return state;
       },
       send(message: string | ArrayBuffer | ArrayBufferView) {
-        void bridge.send(message);
+        void getStored().bridge.send(message);
       },
       close(code?: number, reason?: string) {
-        void bridge.close(code, reason);
+        void getStored().bridge.close(code, reason);
       },
       addEventListener() {},
       removeEventListener() {}
     } as unknown as Connection;
+
+    stored.connection = connection;
+    this._ensureConnectionWrapped(connection);
+    return connection;
   }
 
   private _cf_storeVirtualSubAgentConnection(
@@ -5280,6 +5315,7 @@ export class Agent<
     this._unsafe_setConnectionFlag(connection, CF_SUB_AGENT_TAGS_KEY, [
       ...connection.tags
     ]);
+    const stored = this._cf_virtualSubAgentConnections.get(connection.id);
     this._cf_virtualSubAgentConnections.set(connection.id, {
       bridge,
       meta: {
@@ -5287,7 +5323,8 @@ export class Agent<
         uri: connection.uri,
         tags: [...connection.tags],
         state: this._cf_getRawConnectionState(connection)
-      }
+      },
+      connection: stored?.connection ?? connection
     });
   }
 

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -503,6 +503,12 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
     resetReady();
   }
 
+  const mutableAgentRef = useRef<{
+    agent: string;
+    name: string;
+    identified: boolean;
+  } | null>(null);
+
   // Combine the sub-agent chain with the user-provided `path`.
   // Order matters: `/sub/{child}/{name}/...` comes before `path` so
   // the server sees the hierarchy it expects.
@@ -548,6 +554,13 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
           const oldAgent = previousIdentityRef.current.agent;
           const newName = parsedMessage.name as string;
           const newAgent = parsedMessage.agent as string;
+
+          const currentAgent = mutableAgentRef.current;
+          if (currentAgent) {
+            currentAgent.name = newName;
+            currentAgent.agent = newAgent;
+            currentAgent.identified = true;
+          }
 
           // Update reactive state (triggers re-render)
           setIdentity({ name: newName, agent: newAgent, identified: true });
@@ -638,6 +651,9 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
     onClose: (event: CloseEvent) => {
       // Reset ready state for next connection
       resetReady();
+      if (mutableAgentRef.current) {
+        mutableAgentRef.current.identified = false;
+      }
       setIdentity((prev) => ({ ...prev, identified: false }));
 
       // Pause reconnection for async queries until fresh query params are ready
@@ -722,6 +738,7 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
   agent.identified = identity.identified;
   agent.ready = readyRef.current!.promise;
   agent.state = agentState;
+  mutableAgentRef.current = agent;
   // Memoize stub so it's referentially stable across renders
   // (call is already stable via useCallback)
   const stub = useMemo(() => createStubProxy(call), [call]);

--- a/packages/agents/src/sub-routing.ts
+++ b/packages/agents/src/sub-routing.ts
@@ -203,10 +203,18 @@ export async function routeSubAgentRequest(
   // Mirrors how `_cf_forwardToFacet` rewrites only pathname when
   // handing off to the child facet. If `fromPath` itself contains a
   // `?query` segment, that overrides the original.
-  const forwardReq =
+  const forwardUrl =
     options?.fromPath !== undefined
-      ? new Request(rewritePathname(req.url, options.fromPath), req)
-      : req;
+      ? rewritePathname(req.url, options.fromPath)
+      : req.url;
+  const forwardInit: RequestInit = {
+    method: req.method,
+    headers: new Headers(req.headers)
+  };
+  if (req.body && req.method !== "GET" && req.method !== "HEAD") {
+    forwardInit.body = await req.arrayBuffer();
+  }
+  const forwardReq = new Request(forwardUrl, forwardInit);
 
   return (parent as FetchableParent).fetch(forwardReq);
 }

--- a/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
+++ b/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
@@ -66,6 +66,42 @@ export class SpikeSubChild extends Agent {
     this.sql`DELETE FROM spike_counts`;
   }
 
+  override getConnectionTags(
+    _connection: Connection,
+    ctx: { request: Request }
+  ): string[] {
+    const tag = new URL(ctx.request.url).searchParams.get("tag");
+    return tag ? [tag] : [];
+  }
+
+  override shouldConnectionBeReadonly(
+    _connection: Connection,
+    ctx: { request: Request }
+  ): boolean {
+    return new URL(ctx.request.url).searchParams.get("readonly") === "1";
+  }
+
+  override shouldSendProtocolMessages(
+    _connection: Connection,
+    ctx: { request: Request }
+  ): boolean {
+    return new URL(ctx.request.url).searchParams.get("protocol") !== "0";
+  }
+
+  connectionSnapshot(tag?: string) {
+    const all = [...this.getConnections()].map((connection) => ({
+      id: connection.id,
+      tags: [...connection.tags],
+      state: connection.state,
+      readonly: this.isConnectionReadonly(connection),
+      protocol: this.isConnectionProtocolEnabled(connection)
+    }));
+    const tagged = tag
+      ? [...this.getConnections(tag)].map((connection) => connection.id)
+      : [];
+    return { all, tagged };
+  }
+
   async onConnect(_connection: Connection): Promise<void> {
     this.bump("connect");
   }
@@ -73,6 +109,12 @@ export class SpikeSubChild extends Agent {
   async onMessage(connection: Connection, message: WSMessage): Promise<void> {
     this.bump("message");
     if (typeof message === "string") {
+      if (message === "snapshot") {
+        connection.send(
+          `snapshot:${JSON.stringify(this.connectionSnapshot("child-tag"))}`
+        );
+        return;
+      }
       if (message.startsWith("broadcast:")) {
         // Use `this.broadcast(...)` — the path
         // `AIChatAgent._broadcastChatMessage` exercises for streaming

--- a/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
+++ b/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
@@ -38,6 +38,9 @@ import type { Connection, WSMessage } from "../../index.ts";
 // ── Child ─────────────────────────────────────────────────────────────
 
 export class SpikeSubChild extends Agent {
+  private _connectionIdentityIds = new WeakMap<Connection, number>();
+  private _nextConnectionIdentityId = 1;
+
   // Count messages received — exposed via RPC so the test can verify
   // the child really received them (and not a phantom echo from the
   // parent or some proxy).
@@ -64,6 +67,14 @@ export class SpikeSubChild extends Agent {
 
   async resetCounts(): Promise<void> {
     this.sql`DELETE FROM spike_counts`;
+  }
+
+  private identityForConnection(connection: Connection): number {
+    const existing = this._connectionIdentityIds.get(connection);
+    if (existing !== undefined) return existing;
+    const id = this._nextConnectionIdentityId++;
+    this._connectionIdentityIds.set(connection, id);
+    return id;
   }
 
   async broadcastFromChild(message: string): Promise<void> {
@@ -134,6 +145,10 @@ export class SpikeSubChild extends Agent {
         connection.send(
           `snapshot:${JSON.stringify(this.connectionSnapshot("child-tag"))}`
         );
+        return;
+      }
+      if (message === "identity") {
+        connection.send(`identity:${this.identityForConnection(connection)}`);
         return;
       }
       if (message.startsWith("broadcast:")) {

--- a/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
+++ b/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
@@ -1,8 +1,7 @@
 /**
  * Spike: prove that a facet sub-agent is reachable over WebSocket
- * via a double-hop `fetch()` chain (Worker → parent DO → facet Fetcher),
- * and that after upgrade the parent is **not** touched for subsequent
- * frames.
+ * via the public `/sub/{class}/{name}` URL while the parent owns the
+ * browser transport and forwards events to the child over RPC.
  *
  * Architecture under test:
  *
@@ -26,10 +25,8 @@
  * Success criteria:
  *   1. WS upgrade succeeds through the double hop.
  *   2. Messages sent by the client reach the child and pongs come back.
- *   3. Parent's `fetchCount` is exactly 1 per connection, no matter how
- *      many frames the client sends. Confirms the WS is terminated at
- *      the child and subsequent frames don't round-trip through the
- *      parent.
+ *   3. Parent's `onBeforeSubAgent` gate runs exactly once per connection,
+ *      no matter how many frames the client sends.
  *   4. HTTP requests forwarded the same way also work end-to-end
  *      without the parent seeing per-request round-trips after initial
  *      dispatch.
@@ -137,6 +134,10 @@ export class SpikeSubParent extends Agent {
 
   async resetCounts(): Promise<void> {
     this.sql`DELETE FROM spike_parent_counts`;
+  }
+
+  async broadcastFromParent(message: string): Promise<void> {
+    this.broadcast(`parent:${message}`);
   }
 
   async onBeforeSubAgent(): Promise<Request | Response | void> {

--- a/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
+++ b/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
@@ -106,6 +106,23 @@ export class SpikeSubChild extends Agent {
     return { all, tagged };
   }
 
+  async rehydrateConnectionSnapshotForTest(tag?: string) {
+    (
+      this as unknown as {
+        _cf_virtualSubAgentConnections: Map<string, unknown>;
+      }
+    )._cf_virtualSubAgentConnections.clear();
+    await this._cf_hydrateSubAgentConnectionsFromRoot();
+    return this.connectionSnapshot(tag);
+  }
+
+  sendToFirstConnection(message: string): boolean {
+    const [connection] = [...this.getConnections()];
+    if (!connection) return false;
+    connection.send(`direct:${this.name}:${message}`);
+    return true;
+  }
+
   async onConnect(_connection: Connection): Promise<void> {
     this.bump("connect");
   }

--- a/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
+++ b/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
@@ -66,6 +66,10 @@ export class SpikeSubChild extends Agent {
     this.sql`DELETE FROM spike_counts`;
   }
 
+  async broadcastFromChild(message: string): Promise<void> {
+    this.broadcast(`child:${this.name}:${message}`);
+  }
+
   override getConnectionTags(
     _connection: Connection,
     ctx: { request: Request }

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -121,6 +121,25 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
     ws.close();
   });
 
+  it("this.broadcast(...) from child RPC reaches child-targeted WS clients", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(parent, "spike-sub-child", child);
+    const parentStub = await getAgentByName(env.SpikeSubParent, parent);
+    const childStub = await getSubAgentByName(parentStub, SpikeSubChild, child);
+
+    await childStub.broadcastFromChild("hello");
+    const [reply] = await collectMessages(
+      ws,
+      1,
+      (data) => typeof data === "string" && data.startsWith("child:")
+    );
+    expect(reply).toBe(`child:${child}:hello`);
+
+    ws.close();
+  });
+
   it("parent broadcasts do not leak onto child-targeted sockets", async () => {
     const parent = uniqueName();
     const child = uniqueName();

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -240,10 +240,40 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
       (data) => typeof data === "string" && data.startsWith("snapshot:")
     );
     const snapshot = JSON.parse(reply.slice("snapshot:".length)) as {
-      all: Array<{ readonly: boolean; protocol: boolean }>;
+      all: Array<{
+        state: Record<string, unknown> | null;
+        readonly: boolean;
+        protocol: boolean;
+      }>;
     };
+    expect(snapshot.all[0]?.state).toBeNull();
     expect(snapshot.all[0]?.readonly).toBe(true);
     expect(snapshot.all[0]?.protocol).toBe(false);
+
+    const parentStub = await getAgentByName(env.SpikeSubParent, parent);
+    const childStub = await getSubAgentByName(parentStub, SpikeSubChild, child);
+    const rehydrated = await childStub.rehydrateConnectionSnapshotForTest();
+    expect(rehydrated.all[0]?.readonly).toBe(true);
+    expect(rehydrated.all[0]?.protocol).toBe(false);
+
+    ws.close();
+  });
+
+  it("keeps the same child connection object across forwarded messages", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(parent, "spike-sub-child", child);
+
+    ws.send("identity");
+    ws.send("identity");
+    const replies = await collectMessages(
+      ws,
+      2,
+      (data) => typeof data === "string" && data.startsWith("identity:")
+    );
+    expect(replies).toHaveLength(2);
+    expect(replies[0]).toBe(replies[1]);
 
     ws.close();
   });

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -120,7 +120,26 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
     ws.close();
   });
 
-  it("routes subsequent frames direct to the facet, not back through the parent", async () => {
+  it("parent broadcasts do not leak onto child-targeted sockets", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(parent, "spike-sub-child", child);
+    const parentStub = await getAgentByName(env.SpikeSubParent, parent);
+
+    await parentStub.broadcastFromParent("hello");
+    const leaked = await collectMessages(
+      ws,
+      1,
+      (data) => typeof data === "string" && data.startsWith("parent:"),
+      200
+    );
+    expect(leaked).toHaveLength(0);
+
+    ws.close();
+  });
+
+  it("routes subsequent frames to the child without re-running the parent gate", async () => {
     const parent = uniqueName();
     const child = uniqueName();
 
@@ -130,9 +149,9 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
 
     const ws = await openWS(parent, "spike-sub-child", child);
 
-    // Send a burst of messages. If each one round-tripped through
-    // the parent DO, `onBeforeSubAgent` would fire per message — it
-    // only fires at connect time.
+    // Send a burst of messages. The parent owns the transport, but
+    // `onBeforeSubAgent` is still a connect-time gate — it must not
+    // re-run for every frame.
     const N = 10;
     for (let i = 0; i < N; i++) {
       ws.send(`msg-${i}`);

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -6,11 +6,10 @@
  * — Worker → parent DO → facet Fetcher — for both WebSocket upgrades
  * and regular HTTP.
  *
- * Critical invariant we verify: after the initial WS upgrade, the
- * **parent's `fetch()` handler is not re-entered** for subsequent
- * frames. That's what makes this primitive usable for per-chat DOs
- * in a multi-session app: the parent gets to gatekeep at connection
- * time, then steps out of the hot path.
+ * Critical invariant we verify: the parent owns the browser
+ * WebSocket transport, but sub-agent gates still run only at
+ * connection time. Subsequent frames are forwarded to the target
+ * child over RPC without re-running the gate per message.
  */
 
 import { exports, env } from "cloudflare:workers";
@@ -30,9 +29,10 @@ function uniqueName() {
 async function connectViaSpike(
   parent: string,
   childClass: string,
-  child: string
+  child: string,
+  suffix = ""
 ) {
-  const url = `http://example.com/spike-sub/${parent}/sub/${childClass}/${child}`;
+  const url = `http://example.com/spike-sub/${parent}/sub/${childClass}/${child}${suffix}`;
   const res = await exports.default.fetch(url, {
     headers: { Upgrade: "websocket" }
   });
@@ -42,9 +42,10 @@ async function connectViaSpike(
 async function openWS(
   parent: string,
   childClass: string,
-  child: string
+  child: string,
+  suffix = ""
 ): Promise<WebSocket> {
-  const { res } = await connectViaSpike(parent, childClass, child);
+  const { res } = await connectViaSpike(parent, childClass, child, suffix);
   expect(res.status).toBe(101);
   const ws = res.webSocket as WebSocket;
   expect(ws).toBeDefined();
@@ -135,6 +136,70 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
       200
     );
     expect(leaked).toHaveLength(0);
+
+    ws.close();
+  });
+
+  it("exposes child-targeted sockets through child getConnection APIs with child tags", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(parent, "spike-sub-child", child, "?tag=child-tag");
+    ws.send("snapshot");
+    const [reply] = await collectMessages(
+      ws,
+      1,
+      (data) => typeof data === "string" && data.startsWith("snapshot:")
+    );
+    const snapshot = JSON.parse(reply.slice("snapshot:".length)) as {
+      all: Array<{ id: string; tags: string[] }>;
+      tagged: string[];
+    };
+
+    expect(snapshot.all).toHaveLength(1);
+    expect(snapshot.all[0]?.tags).toContain("child-tag");
+    expect(snapshot.tagged).toEqual([snapshot.all[0]?.id]);
+
+    const parentStub = await getAgentByName(env.SpikeSubParent, parent);
+    const childStub = await getSubAgentByName(parentStub, SpikeSubChild, child);
+    const rpcSnapshot = await childStub.connectionSnapshot("child-tag");
+    expect(rpcSnapshot.all).toHaveLength(1);
+    expect(rpcSnapshot.tagged).toEqual([snapshot.all[0]?.id]);
+
+    ws.close();
+  });
+
+  it("preserves child readonly and no-protocol flags on later forwarded messages", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(
+      parent,
+      "spike-sub-child",
+      child,
+      "?readonly=1&protocol=0"
+    );
+
+    ws.send(JSON.stringify({ type: "cf_agent_state", state: { value: 1 } }));
+    const [error] = await collectMessages(
+      ws,
+      1,
+      (data) =>
+        typeof data === "string" && data.includes("Connection is readonly")
+    );
+    expect(error).toContain("cf_agent_state_error");
+
+    ws.send("snapshot");
+    const [reply] = await collectMessages(
+      ws,
+      1,
+      (data) => typeof data === "string" && data.startsWith("snapshot:")
+    );
+    const snapshot = JSON.parse(reply.slice("snapshot:".length)) as {
+      all: Array<{ readonly: boolean; protocol: boolean }>;
+    };
+    expect(snapshot.all[0]?.readonly).toBe(true);
+    expect(snapshot.all[0]?.protocol).toBe(false);
 
     ws.close();
   });

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -188,6 +188,31 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
     ws.close();
   });
 
+  it("rehydrates child connection APIs from the root-owned WebSocket state", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(parent, "spike-sub-child", child, "?tag=child-tag");
+    const parentStub = await getAgentByName(env.SpikeSubParent, parent);
+    const childStub = await getSubAgentByName(parentStub, SpikeSubChild, child);
+
+    const snapshot =
+      await childStub.rehydrateConnectionSnapshotForTest("child-tag");
+    expect(snapshot.all).toHaveLength(1);
+    expect(snapshot.all[0]?.tags).toContain("child-tag");
+    expect(snapshot.tagged).toEqual([snapshot.all[0]?.id]);
+
+    expect(await childStub.sendToFirstConnection("after-hydrate")).toBe(true);
+    const [reply] = await collectMessages(
+      ws,
+      1,
+      (data) => typeof data === "string" && data.startsWith("direct:")
+    );
+    expect(reply).toBe(`direct:${child}:after-hydrate`);
+
+    ws.close();
+  });
+
   it("preserves child readonly and no-protocol flags on later forwarded messages", async () => {
     const parent = uniqueName();
     const child = uniqueName();

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -865,6 +865,23 @@ export class AIChatAgent<
             if (orphanedStreamId) {
               this._persistOrphanedStream(orphanedStreamId);
             }
+          } else if (this._resumableStream.hasActiveStream()) {
+            // Ignore ACKs for a different active stream request id.
+          } else if (
+            !this._resumableStream.replayCompletedChunksByRequestId(
+              connection,
+              data.id
+            )
+          ) {
+            connection.send(
+              JSON.stringify({
+                body: "",
+                done: true,
+                id: data.id,
+                type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+                replay: true
+              })
+            );
           }
           return;
         }

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -503,6 +503,10 @@ export class AIChatAgent<
     this._abortRegistry = new AbortRegistry();
     const _onConnect = this.onConnect.bind(this);
     this.onConnect = async (connection: Connection, ctx: ConnectionContext) => {
+      if (this._cf_requestTargetsSubAgent(ctx.request)) {
+        return _onConnect(connection, ctx);
+      }
+
       // Notify client about active streams that can be resumed
       if (this._resumableStream.hasActiveStream()) {
         this._notifyStreamResuming(connection);
@@ -535,6 +539,10 @@ export class AIChatAgent<
     // Wrap onMessage
     const _onMessage = this.onMessage.bind(this);
     this.onMessage = async (connection: Connection, message: WSMessage) => {
+      if (this._cf_connectionTargetsSubAgent(connection)) {
+        return _onMessage(connection, message);
+      }
+
       // Handle AIChatAgent's internal messages first
       if (typeof message === "string") {
         let data: IncomingMessage;

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -3186,6 +3186,135 @@ describe("useAgentChat stream resumption (issue #896)", () => {
       .element(screen.getByTestId("text"))
       .toHaveTextContent("replayed-and live!");
   });
+
+  it("rebuilds a partially hydrated assistant during resume instead of adding a second text part", async () => {
+    const { agent, target } = createAgentWithTarget({
+      name: "resume-with-partial-hydration",
+      url: "ws://localhost:3000/agents/chat/resume-with-partial-hydration?_pk=abc"
+    });
+    const initialMessages: UIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "tell me a long story" }]
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Once upon" }]
+      }
+    ];
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: async () => initialMessages
+      });
+      const assistantMsg = chat.messages.find(
+        (m: UIMessage) => m.role === "assistant"
+      );
+      const textParts =
+        assistantMsg?.parts.filter(
+          (p: UIMessage["parts"][number]) => p.type === "text"
+        ) ?? [];
+      return (
+        <div>
+          <div data-testid="count">{chat.messages.length}</div>
+          <div data-testid="text-part-count">{textParts.length}</div>
+          <div data-testid="text">
+            {textParts
+              .map((part) => ("text" in part ? part.text : ""))
+              .join("|")}
+          </div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect.element(screen.getByTestId("count")).toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("text"))
+      .toHaveTextContent("Once upon");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_stream_resuming",
+        id: "req-partial"
+      });
+      await sleep(10);
+    });
+
+    await expect.element(screen.getByTestId("count")).toHaveTextContent("1");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-partial",
+        body: '{"type":"start","messageId":"assistant-1"}',
+        done: false,
+        replay: true
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-partial",
+        body: '{"type":"text-start","id":"t1"}',
+        done: false,
+        replay: true
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-partial",
+        body: '{"type":"text-delta","id":"t1","delta":"Once upon"}',
+        done: false,
+        replay: true
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-partial",
+        body: "",
+        done: false,
+        replay: true,
+        replayComplete: true
+      });
+      await sleep(10);
+    });
+
+    await expect.element(screen.getByTestId("count")).toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("text-part-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("text"))
+      .toHaveTextContent("Once upon");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-partial",
+        body: '{"type":"text-delta","id":"t1","delta":" a time"}',
+        done: false
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("text-part-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("text"))
+      .toHaveTextContent("Once upon a time");
+  });
 });
 
 describe("useAgentChat isServerStreaming / isStreaming (issue #1226)", () => {

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -3367,7 +3367,7 @@ describe("useAgentChat stream resumption (issue #896)", () => {
     await expect.element(screen.getByTestId("count")).toHaveTextContent("2");
     await expect
       .element(screen.getByTestId("text-part-count"))
-      .toHaveTextContent("2");
+      .toHaveTextContent("1");
     await expect
       .element(screen.getByTestId("text"))
       .toHaveTextContent("Once upon");
@@ -3384,7 +3384,7 @@ describe("useAgentChat stream resumption (issue #896)", () => {
 
     await expect
       .element(screen.getByTestId("text-part-count"))
-      .toHaveTextContent("2");
+      .toHaveTextContent("1");
     await expect
       .element(screen.getByTestId("text"))
       .toHaveTextContent("Once upon a time");
@@ -3454,6 +3454,99 @@ describe("useAgentChat stream resumption (issue #896)", () => {
     await expect
       .element(screen.getByTestId("ids"))
       .toHaveTextContent("user-1,assistant-complete,assistant-new");
+  });
+
+  it("ignores replay hydration state when resume is disabled", async () => {
+    const { agent, target } = createAgentWithTarget({
+      name: "resume-disabled",
+      url: "ws://localhost:3000/agents/chat/resume-disabled?_pk=abc"
+    });
+    const initialMessages: UIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "first" }]
+      },
+      {
+        id: "assistant-complete",
+        role: "assistant",
+        parts: [{ type: "text", text: "Done." }]
+      }
+    ];
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: async () => initialMessages,
+        resume: false
+      });
+      const assistantMsg = chat.messages.find(
+        (m: UIMessage) => m.role === "assistant"
+      );
+      const textParts =
+        assistantMsg?.parts.filter(
+          (p: UIMessage["parts"][number]) => p.type === "text"
+        ) ?? [];
+      return (
+        <div>
+          <div data-testid="count">{chat.messages.length}</div>
+          <div data-testid="text-part-count">{textParts.length}</div>
+          <div data-testid="text">
+            {textParts
+              .map((part) => ("text" in part ? part.text : ""))
+              .join("|")}
+          </div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_stream_resuming",
+        id: "ignored-resume"
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "ignored-resume",
+        body: '{"type":"start","messageId":"assistant-complete"}',
+        done: false,
+        replay: true
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "ignored-resume",
+        body: '{"type":"text-delta","id":"t1","delta":"Done."}',
+        done: false,
+        replay: true
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "ignored-resume",
+        body: "",
+        done: false,
+        replay: true,
+        replayComplete: true
+      });
+      await sleep(10);
+    });
+
+    await expect.element(screen.getByTestId("count")).toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("text-part-count"))
+      .toHaveTextContent("1");
+    await expect.element(screen.getByTestId("text")).toHaveTextContent("Done.");
   });
 });
 

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -3315,6 +3315,72 @@ describe("useAgentChat stream resumption (issue #896)", () => {
       .element(screen.getByTestId("text"))
       .toHaveTextContent("Once upon a time");
   });
+
+  it("does not remove a completed hydrated assistant when resume belongs to a different message", async () => {
+    const { agent, target } = createAgentWithTarget({
+      name: "resume-with-different-assistant",
+      url: "ws://localhost:3000/agents/chat/resume-with-different-assistant?_pk=abc"
+    });
+    const initialMessages: UIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "first" }]
+      },
+      {
+        id: "assistant-complete",
+        role: "assistant",
+        parts: [{ type: "text", text: "Done." }]
+      }
+    ];
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: async () => initialMessages
+      });
+      return (
+        <div>
+          <div data-testid="count">{chat.messages.length}</div>
+          <div data-testid="ids">
+            {chat.messages.map((m) => m.id).join(",")}
+          </div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_stream_resuming",
+        id: "req-different"
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "req-different",
+        body: '{"type":"start","messageId":"assistant-new"}',
+        done: false,
+        replay: true
+      });
+      await sleep(10);
+    });
+
+    await expect.element(screen.getByTestId("count")).toHaveTextContent("3");
+    await expect
+      .element(screen.getByTestId("ids"))
+      .toHaveTextContent("user-1,assistant-complete,assistant-new");
+  });
 });
 
 describe("useAgentChat isServerStreaming / isStreaming (issue #1226)", () => {

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -17,10 +17,12 @@ function sleep(ms: number) {
 function createAgent({
   name,
   url,
+  path,
   send
 }: {
   name: string;
   url: string;
+  path?: ReadonlyArray<{ agent: string; name: string }>;
   send?: (data: string) => void;
 }) {
   const target = new EventTarget();
@@ -36,6 +38,7 @@ function createAgent({
     removeEventListener: target.removeEventListener.bind(target),
     send: send ?? (() => {}),
     dispatchEvent: target.dispatchEvent.bind(target),
+    path: path ?? [{ agent: "Chat", name }],
     getHttpUrl: () =>
       url.replace("ws://", "http://").replace("wss://", "https://")
   };
@@ -179,6 +182,76 @@ describe("useAgentChat", () => {
       2,
       expect.objectContaining({ name: "thread-b" })
     );
+  });
+
+  it("should separate initial message caches for identical sub-agent leaves under different parents", async () => {
+    const leaf = { agent: "Researcher", name: "shared-helper" };
+    const agentA = createAgent({
+      name: leaf.name,
+      url: "ws://localhost:3000/agents/assistant/parent-a/sub/researcher/shared-helper?_pk=abc",
+      path: [{ agent: "Assistant", name: "parent-a" }, leaf]
+    });
+    const agentB = createAgent({
+      name: leaf.name,
+      url: "ws://localhost:3000/agents/assistant/parent-b/sub/researcher/shared-helper?_pk=abc",
+      path: [{ agent: "Assistant", name: "parent-b" }, leaf]
+    });
+
+    const getInitialMessages = vi.fn(
+      async ({ url }: { url?: string }) =>
+        [
+          {
+            id: url?.includes("parent-b") ? "b" : "a",
+            role: "assistant" as const,
+            parts: [
+              {
+                type: "text" as const,
+                text: url?.includes("parent-b")
+                  ? "Hello from parent B"
+                  : "Hello from parent A"
+              }
+            ]
+          }
+        ] satisfies UIMessage[]
+    );
+
+    const TestComponent = ({
+      agent
+    }: {
+      agent: ReturnType<typeof useAgent>;
+    }) => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages
+      });
+      return <div data-testid="messages">{JSON.stringify(chat.messages)}</div>;
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent agent={agentA} />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("Hello from parent A");
+
+    await act(async () => {
+      screen.rerender(<TestComponent agent={agentB} />);
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("messages"))
+      .toHaveTextContent("Hello from parent B");
+    expect(getInitialMessages).toHaveBeenCalledTimes(2);
   });
 
   it("should wait for a valid HTTP URL before fetching initial messages", async () => {
@@ -3005,7 +3078,7 @@ describe("useAgentChat stream resumption (issue #896)", () => {
       await sleep(10);
     });
 
-    // Chunks are processed progressively by useChat — message appears immediately
+    // Chunks are processed progressively by useChat — message appears immediately.
     await expect.element(screen.getByTestId("count")).toHaveTextContent("1");
     await expect
       .element(screen.getByTestId("text"))
@@ -3255,7 +3328,8 @@ describe("useAgentChat stream resumption (issue #896)", () => {
       await sleep(10);
     });
 
-    await expect.element(screen.getByTestId("count")).toHaveTextContent("1");
+    // The hydrated assistant remains visible until a matching replay start arrives.
+    await expect.element(screen.getByTestId("count")).toHaveTextContent("2");
 
     await act(async () => {
       dispatch(target, {
@@ -3293,7 +3367,7 @@ describe("useAgentChat stream resumption (issue #896)", () => {
     await expect.element(screen.getByTestId("count")).toHaveTextContent("2");
     await expect
       .element(screen.getByTestId("text-part-count"))
-      .toHaveTextContent("1");
+      .toHaveTextContent("2");
     await expect
       .element(screen.getByTestId("text"))
       .toHaveTextContent("Once upon");
@@ -3310,7 +3384,7 @@ describe("useAgentChat stream resumption (issue #896)", () => {
 
     await expect
       .element(screen.getByTestId("text-part-count"))
-      .toHaveTextContent("1");
+      .toHaveTextContent("2");
     await expect
       .element(screen.getByTestId("text"))
       .toHaveTextContent("Once upon a time");

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -854,6 +854,10 @@ export function useAgentChat<
    * Used by onAgentMessage to skip messages already handled by the transport.
    */
   const localRequestIdsRef = useRef<Set<string>>(new Set());
+  const pendingReplayResumeRequestIdsRef = useRef<Set<string>>(new Set());
+  const pendingReplayHydratedAssistantRef = useRef<
+    Map<string, { message: ChatMessage; index: number }>
+  >(new Map());
 
   // WebSocket-based transport that speaks the CF_AGENT protocol natively.
   // Replaces the old aiFetch + DefaultChatTransport indirection.
@@ -1175,24 +1179,53 @@ export function useAgentChat<
     [setMessages]
   );
 
-  const prepareMessagesForReplayResume = useCallback(() => {
-    if (resumingToolContinuationRef.current) {
-      return;
-    }
-
-    setMessages((prevMessages: ChatMessage[]) => {
-      const lastMessage = prevMessages[prevMessages.length - 1];
-      if (!lastMessage || lastMessage.role !== "assistant") {
-        return prevMessages;
+  const prepareMessagesForReplayResume = useCallback(
+    (requestId: string) => {
+      if (resumingToolContinuationRef.current) {
+        return;
       }
 
-      // Initial message hydration can already contain the partially
-      // persisted assistant response. Replay starts from the first
-      // stream chunk, so remove that tail and let replay rebuild it;
-      // otherwise the replayed text-start becomes a second text part.
-      return prevMessages.slice(0, -1);
-    });
-  }, [setMessages]);
+      setMessages((prevMessages: ChatMessage[]) => {
+        const lastMessage = prevMessages[prevMessages.length - 1];
+        if (!lastMessage || lastMessage.role !== "assistant") {
+          return prevMessages;
+        }
+
+        // Initial message hydration can already contain the partially
+        // persisted assistant response. Replay starts from the first
+        // stream chunk, so remove that tail and let replay rebuild it;
+        // otherwise the replayed text-start becomes a second text part.
+        pendingReplayHydratedAssistantRef.current.set(requestId, {
+          message: lastMessage,
+          index: prevMessages.length - 1
+        });
+        return prevMessages.slice(0, -1);
+      });
+    },
+    [setMessages]
+  );
+
+  const restoreMismatchedReplayHydration = useCallback(
+    (requestId: string, messageId: string) => {
+      const pending = pendingReplayHydratedAssistantRef.current.get(requestId);
+      if (!pending) return;
+      pendingReplayHydratedAssistantRef.current.delete(requestId);
+
+      if (pending.message.id === messageId) {
+        return;
+      }
+
+      setMessages((prevMessages: ChatMessage[]) => {
+        if (prevMessages.some((message) => message.id === pending.message.id)) {
+          return prevMessages;
+        }
+        const next = [...prevMessages];
+        next.splice(Math.min(pending.index, next.length), 0, pending.message);
+        return next;
+      });
+    },
+    [setMessages]
+  );
 
   // Shared reset for every path that wipes chat history — keep this
   // list in sync between `clearHistory()` (local user action) and the
@@ -1208,6 +1241,8 @@ export function useAgentChat<
     resetToolContinuation();
     processedToolCalls.current.clear();
     localResponseMessageIdsRef.current.clear();
+    pendingReplayResumeRequestIdsRef.current.clear();
+    pendingReplayHydratedAssistantRef.current.clear();
     protectedStreamingAssistantRef.current = null;
   }, [markInitialMessagesSeeded, setMessages, resetToolContinuation]);
 
@@ -1618,7 +1653,8 @@ export function useAgentChat<
           // creates the ReadableStream that feeds into useChat's pipeline
           // (which correctly sets status to "streaming").
           if (customTransport.handleStreamResuming(data)) {
-            prepareMessagesForReplayResume();
+            pendingReplayResumeRequestIdsRef.current.add(data.id);
+            prepareMessagesForReplayResume(data.id);
             return;
           }
           // Skip if the transport already handled this stream's resume
@@ -1655,9 +1691,41 @@ export function useAgentChat<
                   typeof chunkData.messageId === "string"
                 ) {
                   localResponseIds.set(data.id, chunkData.messageId);
+                  if (pendingReplayResumeRequestIdsRef.current.has(data.id)) {
+                    restoreMismatchedReplayHydration(
+                      data.id,
+                      chunkData.messageId
+                    );
+                  }
                 }
               } catch {
                 // Ignore malformed local stream chunks.
+              }
+            }
+
+            if (data.done || data.replayComplete) {
+              pendingReplayResumeRequestIdsRef.current.delete(data.id);
+              const pending = pendingReplayHydratedAssistantRef.current.get(
+                data.id
+              );
+              if (pending) {
+                pendingReplayHydratedAssistantRef.current.delete(data.id);
+                setMessages((prevMessages: ChatMessage[]) => {
+                  if (
+                    prevMessages.some(
+                      (message) => message.id === pending.message.id
+                    )
+                  ) {
+                    return prevMessages;
+                  }
+                  const next = [...prevMessages];
+                  next.splice(
+                    Math.min(pending.index, next.length),
+                    0,
+                    pending.message
+                  );
+                  return next;
+                });
               }
             }
 
@@ -1745,6 +1813,7 @@ export function useAgentChat<
     customTransport,
     preserveProtectedStreamingAssistant,
     prepareMessagesForReplayResume,
+    restoreMismatchedReplayHydration,
     restoreProtectedStreamingAssistant,
     resetLocalChatState
   ]);

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -372,6 +372,7 @@ type UseAgentChatOptions<
   agent: AgentConnection & {
     agent: string;
     name: string;
+    path?: ReadonlyArray<{ agent: string; name: string }>;
     getHttpUrl: () => string;
   };
   getInitialMessages?:
@@ -669,8 +670,14 @@ export function useAgentChat<
   }
   const agentUrlString = agentUrl?.toString() ?? null;
 
-  // Cache key for the request-dedup `requestCache` and the
-  // late-seed effect. Intentionally identity-only (agent class + name):
+  const agentAddressKey = Array.isArray(agent.path)
+    ? JSON.stringify(agent.path.map((step) => [step.agent, step.name]))
+    : JSON.stringify([[agent.agent ?? "", agent.name ?? ""]]);
+
+  // Cache key for the request-dedup `requestCache` and the late-seed
+  // effect. It uses the full root-first agent address when `useAgent`
+  // provides one, so sub-agents with the same leaf class/name under
+  // different parents do not share hydrated messages.
   //
   //   - Query params like auth tokens change across page loads and
   //     must not bust the cache, or Suspense re-triggers and breaks
@@ -686,11 +693,10 @@ export function useAgentChat<
   // `resolvedInitialMessagesCacheKey` is still computed because the
   // `stableChatIdRef` logic below uses it to detect the URL-arrival
   // transition separately from identity changes.
-  const agentIdentityKey = `${agent.agent ?? ""}|${agent.name ?? ""}`;
   const resolvedInitialMessagesCacheKey = agentUrl
-    ? `${agentUrl.origin}${agentUrl.pathname}|${agentIdentityKey}`
+    ? `${agentUrl.origin}${agentUrl.pathname}|${agentAddressKey}`
     : null;
-  const initialMessagesCacheKey = agentIdentityKey;
+  const initialMessagesCacheKey = agentAddressKey;
 
   // Stable chat ID for `useChat({ id })`.
   //
@@ -724,13 +730,19 @@ export function useAgentChat<
   // unambiguous "chat switch" signal.
   const stableChatIdRef = useRef<string | null>(null);
   const previousAgentRef = useRef<typeof agent | null>(null);
-  const fallbackChatId = agentIdentityKey;
+  const previousAgentAddressKeyRef = useRef<string | null>(null);
+  const fallbackChatId = agentAddressKey;
+  const agentPathChanged =
+    Array.isArray(agent.path) &&
+    previousAgentAddressKeyRef.current !== null &&
+    previousAgentAddressKeyRef.current !== agentAddressKey;
 
   if (stableChatIdRef.current === null) {
     // First render: initialize.
     stableChatIdRef.current = resolvedInitialMessagesCacheKey ?? fallbackChatId;
-  } else if (previousAgentRef.current !== agent) {
-    // Consumer swapped in a different agent object — genuine chat switch.
+  } else if (previousAgentRef.current !== agent || agentPathChanged) {
+    // Consumer swapped in a different agent object, or the full
+    // sub-agent address changed on a `useAgent` object — genuine chat switch.
     // Recompute from current values.
     stableChatIdRef.current = resolvedInitialMessagesCacheKey ?? fallbackChatId;
   } else if (
@@ -746,6 +758,7 @@ export function useAgentChat<
   }
 
   previousAgentRef.current = agent;
+  previousAgentAddressKeyRef.current = agentAddressKey;
 
   // Keep a ref to always point to the latest agent instance.
   // Updated synchronously during render (not in useEffect) so the
@@ -855,9 +868,8 @@ export function useAgentChat<
    */
   const localRequestIdsRef = useRef<Set<string>>(new Set());
   const pendingReplayResumeRequestIdsRef = useRef<Set<string>>(new Set());
-  const pendingReplayHydratedAssistantRef = useRef<
-    Map<string, { message: ChatMessage; index: number }>
-  >(new Map());
+  const replayHydratedAssistantMessageIdsRef = useRef<Set<string>>(new Set());
+  const replayMessageIdByRequestIdRef = useRef<Map<string, string>>(new Map());
 
   // WebSocket-based transport that speaks the CF_AGENT protocol natively.
   // Replaces the old aiFetch + DefaultChatTransport indirection.
@@ -1179,49 +1191,67 @@ export function useAgentChat<
     [setMessages]
   );
 
-  const prepareMessagesForReplayResume = useCallback(
-    (requestId: string) => {
-      if (resumingToolContinuationRef.current) {
-        return;
-      }
-
+  const resetMatchingHydratedAssistantForReplay = useCallback(
+    (messageId: string) => {
       setMessages((prevMessages: ChatMessage[]) => {
         const lastMessage = prevMessages[prevMessages.length - 1];
-        if (!lastMessage || lastMessage.role !== "assistant") {
+        if (
+          !lastMessage ||
+          lastMessage.role !== "assistant" ||
+          lastMessage.id !== messageId
+        ) {
           return prevMessages;
         }
 
         // Initial message hydration can already contain the partially
-        // persisted assistant response. Replay starts from the first
-        // stream chunk, so remove that tail and let replay rebuild it;
-        // otherwise the replayed text-start becomes a second text part.
-        pendingReplayHydratedAssistantRef.current.set(requestId, {
-          message: lastMessage,
-          index: prevMessages.length - 1
-        });
-        return prevMessages.slice(0, -1);
+        // persisted assistant response. Clear that assistant only once
+        // replay proves it is rebuilding the same message; keeping the
+        // shell preserves layout while avoiding duplicate text parts.
+        replayHydratedAssistantMessageIdsRef.current.add(messageId);
+        const next = [...prevMessages];
+        next[next.length - 1] = { ...lastMessage, parts: [] };
+        return next;
       });
     },
     [setMessages]
   );
 
-  const restoreMismatchedReplayHydration = useCallback(
-    (requestId: string, messageId: string) => {
-      const pending = pendingReplayHydratedAssistantRef.current.get(requestId);
-      if (!pending) return;
-      pendingReplayHydratedAssistantRef.current.delete(requestId);
-
-      if (pending.message.id === messageId) {
-        return;
+  const normalizeHydratedReplayTextParts = useCallback(
+    (messageId: string | undefined) => {
+      if (messageId) {
+        replayHydratedAssistantMessageIdsRef.current.delete(messageId);
       }
 
-      setMessages((prevMessages: ChatMessage[]) => {
-        if (prevMessages.some((message) => message.id === pending.message.id)) {
-          return prevMessages;
-        }
-        const next = [...prevMessages];
-        next.splice(Math.min(pending.index, next.length), 0, pending.message);
-        return next;
+      queueMicrotask(() => {
+        setMessages((prevMessages: ChatMessage[]) =>
+          prevMessages.map((message) => {
+            if (
+              message.role !== "assistant" ||
+              (messageId && message.id !== messageId)
+            ) {
+              return message;
+            }
+
+            const parts = message.parts;
+            let lastTextPartIndex = -1;
+            for (let i = parts.length - 1; i >= 0; i--) {
+              if (parts[i].type === "text") {
+                lastTextPartIndex = i;
+                break;
+              }
+            }
+            if (lastTextPartIndex < 0) return message;
+
+            const nextParts = parts.filter(
+              (part, index) =>
+                part.type !== "text" || index === lastTextPartIndex
+            );
+
+            return nextParts.length === parts.length
+              ? message
+              : { ...message, parts: nextParts };
+          })
+        );
       });
     },
     [setMessages]
@@ -1242,7 +1272,8 @@ export function useAgentChat<
     processedToolCalls.current.clear();
     localResponseMessageIdsRef.current.clear();
     pendingReplayResumeRequestIdsRef.current.clear();
-    pendingReplayHydratedAssistantRef.current.clear();
+    replayHydratedAssistantMessageIdsRef.current.clear();
+    replayMessageIdByRequestIdRef.current.clear();
     protectedStreamingAssistantRef.current = null;
   }, [markInitialMessagesSeeded, setMessages, resetToolContinuation]);
 
@@ -1646,6 +1677,9 @@ export function useAgentChat<
           break;
 
         case MessageType.CF_AGENT_STREAM_RESUMING:
+          if (!resumingToolContinuationRef.current) {
+            pendingReplayResumeRequestIdsRef.current.add(data.id);
+          }
           if (!resume && !customTransport.isAwaitingResume()) return;
           // Let the transport handle it if reconnectToStream is waiting.
           // This is called synchronously — no addEventListener race.
@@ -1653,8 +1687,6 @@ export function useAgentChat<
           // creates the ReadableStream that feeds into useChat's pipeline
           // (which correctly sets status to "streaming").
           if (customTransport.handleStreamResuming(data)) {
-            pendingReplayResumeRequestIdsRef.current.add(data.id);
-            prepareMessagesForReplayResume(data.id);
             return;
           }
           // Skip if the transport already handled this stream's resume
@@ -1691,9 +1723,13 @@ export function useAgentChat<
                   typeof chunkData.messageId === "string"
                 ) {
                   localResponseIds.set(data.id, chunkData.messageId);
-                  if (pendingReplayResumeRequestIdsRef.current.has(data.id)) {
-                    restoreMismatchedReplayHydration(
+                  if (data.replay) {
+                    pendingReplayResumeRequestIdsRef.current.delete(data.id);
+                    replayMessageIdByRequestIdRef.current.set(
                       data.id,
+                      chunkData.messageId
+                    );
+                    resetMatchingHydratedAssistantForReplay(
                       chunkData.messageId
                     );
                   }
@@ -1705,28 +1741,11 @@ export function useAgentChat<
 
             if (data.done || data.replayComplete) {
               pendingReplayResumeRequestIdsRef.current.delete(data.id);
-              const pending = pendingReplayHydratedAssistantRef.current.get(
-                data.id
+              normalizeHydratedReplayTextParts(
+                localResponseIds.get(data.id) ??
+                  replayMessageIdByRequestIdRef.current.get(data.id)
               );
-              if (pending) {
-                pendingReplayHydratedAssistantRef.current.delete(data.id);
-                setMessages((prevMessages: ChatMessage[]) => {
-                  if (
-                    prevMessages.some(
-                      (message) => message.id === pending.message.id
-                    )
-                  ) {
-                    return prevMessages;
-                  }
-                  const next = [...prevMessages];
-                  next.splice(
-                    Math.min(pending.index, next.length),
-                    0,
-                    pending.message
-                  );
-                  return next;
-                });
-              }
+              replayMessageIdByRequestIdRef.current.delete(data.id);
             }
 
             if (data.done) {
@@ -1741,6 +1760,21 @@ export function useAgentChat<
           if (data.body?.trim()) {
             try {
               chunkData = JSON.parse(data.body);
+              if (
+                data.replay &&
+                typeof (chunkData as Record<string, unknown>).messageId ===
+                  "string" &&
+                (chunkData as Record<string, unknown>).type === "start"
+              ) {
+                pendingReplayResumeRequestIdsRef.current.delete(data.id);
+                replayMessageIdByRequestIdRef.current.set(
+                  data.id,
+                  (chunkData as { messageId: string }).messageId
+                );
+                resetMatchingHydratedAssistantForReplay(
+                  (chunkData as { messageId: string }).messageId
+                );
+              }
               if (
                 typeof (chunkData as Record<string, unknown>).type ===
                   "string" &&
@@ -1763,6 +1797,13 @@ export function useAgentChat<
                 data.body?.slice(0, 100)
               );
             }
+          }
+          if (data.done || data.replayComplete) {
+            pendingReplayResumeRequestIdsRef.current.delete(data.id);
+            normalizeHydratedReplayTextParts(
+              replayMessageIdByRequestIdRef.current.get(data.id)
+            );
+            replayMessageIdByRequestIdRef.current.delete(data.id);
           }
 
           const result = broadcastTransition(streamStateRef.current, {
@@ -1812,8 +1853,8 @@ export function useAgentChat<
     resume,
     customTransport,
     preserveProtectedStreamingAssistant,
-    prepareMessagesForReplayResume,
-    restoreMismatchedReplayHydration,
+    normalizeHydratedReplayTextParts,
+    resetMatchingHydratedAssistantForReplay,
     restoreProtectedStreamingAssistant,
     resetLocalChatState
   ]);

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -869,7 +869,6 @@ export function useAgentChat<
   const localRequestIdsRef = useRef<Set<string>>(new Set());
   const pendingReplayResumeRequestIdsRef = useRef<Set<string>>(new Set());
   const replayHydratedAssistantMessageIdsRef = useRef<Set<string>>(new Set());
-  const replayMessageIdByRequestIdRef = useRef<Map<string, string>>(new Map());
 
   // WebSocket-based transport that speaks the CF_AGENT protocol natively.
   // Replaces the old aiFetch + DefaultChatTransport indirection.
@@ -1216,46 +1215,69 @@ export function useAgentChat<
     [setMessages]
   );
 
-  const normalizeHydratedReplayTextParts = useCallback(
-    (messageId: string | undefined) => {
-      if (messageId) {
-        replayHydratedAssistantMessageIdsRef.current.delete(messageId);
-      }
+  const collapseHydratedReplayTextParts = useCallback(
+    (message: ChatMessage): ChatMessage => {
+      const parts = message.parts;
+      const nextParts = parts.filter((part, index) => {
+        if (part.type !== "text" || !("text" in part) || !part.text) {
+          return true;
+        }
 
-      queueMicrotask(() => {
-        setMessages((prevMessages: ChatMessage[]) =>
-          prevMessages.map((message) => {
-            if (
-              message.role !== "assistant" ||
-              (messageId && message.id !== messageId)
-            ) {
-              return message;
-            }
-
-            const parts = message.parts;
-            let lastTextPartIndex = -1;
-            for (let i = parts.length - 1; i >= 0; i--) {
-              if (parts[i].type === "text") {
-                lastTextPartIndex = i;
-                break;
-              }
-            }
-            if (lastTextPartIndex < 0) return message;
-
-            const nextParts = parts.filter(
-              (part, index) =>
-                part.type !== "text" || index === lastTextPartIndex
-            );
-
-            return nextParts.length === parts.length
-              ? message
-              : { ...message, parts: nextParts };
-          })
-        );
+        // Replayed streams rebuild from the first chunk. If the
+        // hydrated assistant already had the same prefix, replay can
+        // temporarily produce a second text part with the rebuilt text.
+        return !parts.some((candidate, candidateIndex) => {
+          if (candidateIndex <= index) return false;
+          if (
+            candidate.type !== "text" ||
+            !("text" in candidate) ||
+            !candidate.text
+          ) {
+            return false;
+          }
+          return candidate.text.startsWith(part.text);
+        });
       });
+
+      return nextParts.length === parts.length
+        ? message
+        : { ...message, parts: nextParts };
     },
-    [setMessages]
+    []
   );
+
+  useEffect(() => {
+    if (replayHydratedAssistantMessageIdsRef.current.size === 0) return;
+
+    const idsToCollapse = new Set(
+      chatMessages
+        .filter(
+          (message) =>
+            replayHydratedAssistantMessageIdsRef.current.has(message.id) &&
+            message.role === "assistant" &&
+            collapseHydratedReplayTextParts(message) !== message
+        )
+        .map((message) => message.id)
+    );
+    if (idsToCollapse.size === 0) return;
+
+    setMessages((prevMessages: ChatMessage[]) => {
+      let changed = false;
+      const nextMessages = prevMessages.map((message) => {
+        if (!idsToCollapse.has(message.id)) {
+          return message;
+        }
+
+        const nextMessage = collapseHydratedReplayTextParts(message);
+        if (nextMessage !== message) {
+          changed = true;
+        }
+        return nextMessage;
+      });
+
+      return changed ? nextMessages : prevMessages;
+    });
+  }, [chatMessages, collapseHydratedReplayTextParts, setMessages]);
 
   // Shared reset for every path that wipes chat history — keep this
   // list in sync between `clearHistory()` (local user action) and the
@@ -1273,7 +1295,6 @@ export function useAgentChat<
     localResponseMessageIdsRef.current.clear();
     pendingReplayResumeRequestIdsRef.current.clear();
     replayHydratedAssistantMessageIdsRef.current.clear();
-    replayMessageIdByRequestIdRef.current.clear();
     protectedStreamingAssistantRef.current = null;
   }, [markInitialMessagesSeeded, setMessages, resetToolContinuation]);
 
@@ -1677,10 +1698,10 @@ export function useAgentChat<
           break;
 
         case MessageType.CF_AGENT_STREAM_RESUMING:
+          if (!resume && !customTransport.isAwaitingResume()) return;
           if (!resumingToolContinuationRef.current) {
             pendingReplayResumeRequestIdsRef.current.add(data.id);
           }
-          if (!resume && !customTransport.isAwaitingResume()) return;
           // Let the transport handle it if reconnectToStream is waiting.
           // This is called synchronously — no addEventListener race.
           // The transport sends ACK, adds to activeRequestIds, and
@@ -1723,12 +1744,11 @@ export function useAgentChat<
                   typeof chunkData.messageId === "string"
                 ) {
                   localResponseIds.set(data.id, chunkData.messageId);
-                  if (data.replay) {
+                  if (
+                    data.replay &&
+                    pendingReplayResumeRequestIdsRef.current.has(data.id)
+                  ) {
                     pendingReplayResumeRequestIdsRef.current.delete(data.id);
-                    replayMessageIdByRequestIdRef.current.set(
-                      data.id,
-                      chunkData.messageId
-                    );
                     resetMatchingHydratedAssistantForReplay(
                       chunkData.messageId
                     );
@@ -1741,11 +1761,6 @@ export function useAgentChat<
 
             if (data.done || data.replayComplete) {
               pendingReplayResumeRequestIdsRef.current.delete(data.id);
-              normalizeHydratedReplayTextParts(
-                localResponseIds.get(data.id) ??
-                  replayMessageIdByRequestIdRef.current.get(data.id)
-              );
-              replayMessageIdByRequestIdRef.current.delete(data.id);
             }
 
             if (data.done) {
@@ -1757,20 +1772,24 @@ export function useAgentChat<
           }
 
           let chunkData: unknown;
+          if (
+            data.replay &&
+            streamStateRef.current.status !== "observing" &&
+            !pendingReplayResumeRequestIdsRef.current.has(data.id)
+          ) {
+            return;
+          }
           if (data.body?.trim()) {
             try {
               chunkData = JSON.parse(data.body);
               if (
                 data.replay &&
+                pendingReplayResumeRequestIdsRef.current.has(data.id) &&
                 typeof (chunkData as Record<string, unknown>).messageId ===
                   "string" &&
                 (chunkData as Record<string, unknown>).type === "start"
               ) {
                 pendingReplayResumeRequestIdsRef.current.delete(data.id);
-                replayMessageIdByRequestIdRef.current.set(
-                  data.id,
-                  (chunkData as { messageId: string }).messageId
-                );
                 resetMatchingHydratedAssistantForReplay(
                   (chunkData as { messageId: string }).messageId
                 );
@@ -1800,10 +1819,6 @@ export function useAgentChat<
           }
           if (data.done || data.replayComplete) {
             pendingReplayResumeRequestIdsRef.current.delete(data.id);
-            normalizeHydratedReplayTextParts(
-              replayMessageIdByRequestIdRef.current.get(data.id)
-            );
-            replayMessageIdByRequestIdRef.current.delete(data.id);
           }
 
           const result = broadcastTransition(streamStateRef.current, {
@@ -1853,7 +1868,6 @@ export function useAgentChat<
     resume,
     customTransport,
     preserveProtectedStreamingAssistant,
-    normalizeHydratedReplayTextParts,
     resetMatchingHydratedAssistantForReplay,
     restoreProtectedStreamingAssistant,
     resetLocalChatState

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -1175,6 +1175,25 @@ export function useAgentChat<
     [setMessages]
   );
 
+  const prepareMessagesForReplayResume = useCallback(() => {
+    if (resumingToolContinuationRef.current) {
+      return;
+    }
+
+    setMessages((prevMessages: ChatMessage[]) => {
+      const lastMessage = prevMessages[prevMessages.length - 1];
+      if (!lastMessage || lastMessage.role !== "assistant") {
+        return prevMessages;
+      }
+
+      // Initial message hydration can already contain the partially
+      // persisted assistant response. Replay starts from the first
+      // stream chunk, so remove that tail and let replay rebuild it;
+      // otherwise the replayed text-start becomes a second text part.
+      return prevMessages.slice(0, -1);
+    });
+  }, [setMessages]);
+
   // Shared reset for every path that wipes chat history — keep this
   // list in sync between `clearHistory()` (local user action) and the
   // `CF_AGENT_CHAT_CLEAR` broadcast handler (server/other-tab action).
@@ -1598,7 +1617,10 @@ export function useAgentChat<
           // The transport sends ACK, adds to activeRequestIds, and
           // creates the ReadableStream that feeds into useChat's pipeline
           // (which correctly sets status to "streaming").
-          if (customTransport.handleStreamResuming(data)) return;
+          if (customTransport.handleStreamResuming(data)) {
+            prepareMessagesForReplayResume();
+            return;
+          }
           // Skip if the transport already handled this stream's resume
           // (server sends STREAM_RESUMING from both onConnect and the
           // RESUME_REQUEST handler — the second one must not trigger
@@ -1722,6 +1744,7 @@ export function useAgentChat<
     resume,
     customTransport,
     preserveProtectedStreamingAssistant,
+    prepareMessagesForReplayResume,
     restoreProtectedStreamingAssistant,
     resetLocalChatState
   ]);

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -730,6 +730,61 @@ describe("Resumable Streaming", () => {
       ws.close(1000);
     });
 
+    it("does not replay stored chunks from an errored stream after a late ACK", async () => {
+      const room = crypto.randomUUID();
+      const requestId = "req-late-ack-error";
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+      const streamId = await agentStub.testStartStream(requestId);
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text-delta","delta":"should not replay"}'
+      );
+      await agentStub.testFlushChunkBuffer();
+
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      const messages = collectMessages(ws);
+
+      await waitFor(
+        () => messages.some((message) => isStreamResumingMessage(message)),
+        1000
+      );
+
+      await agentStub.testMarkStreamError(streamId);
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
+          id: requestId
+        })
+      );
+
+      await waitFor(
+        () =>
+          messages.some(
+            (message) =>
+              isUseChatResponseMessage(message) && message.done === true
+          ),
+        1000
+      );
+
+      const responseMessages = messages.filter(isUseChatResponseMessage);
+      expect(
+        responseMessages.some((message) =>
+          message.body?.includes("should not replay")
+        )
+      ).toBe(false);
+      expect(responseMessages).toEqual([
+        expect.objectContaining({
+          type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+          id: requestId,
+          done: true,
+          replay: true
+        })
+      ]);
+
+      ws.close(1000);
+    });
+
     it("replayed chunks have replay=true flag", async () => {
       const room = crypto.randomUUID();
 

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -658,6 +658,78 @@ describe("Resumable Streaming", () => {
       ws.close(1000);
     });
 
+    it("replays stored chunks if the stream completes before the client ACK arrives", async () => {
+      const room = crypto.randomUUID();
+      const requestId = "req-late-ack-replay";
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+      const streamId = await agentStub.testStartStream(requestId);
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text-start","id":"t1"}'
+      );
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text-delta","id":"t1","delta":"hello after ack"}'
+      );
+      await agentStub.testFlushChunkBuffer();
+
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      const messages = collectMessages(ws);
+
+      await waitFor(
+        () => messages.some((message) => isStreamResumingMessage(message)),
+        1000
+      );
+
+      await agentStub.testCompleteStream(streamId);
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
+          id: requestId
+        })
+      );
+
+      await waitFor(
+        () =>
+          messages.some(
+            (message) =>
+              isUseChatResponseMessage(message) && message.done === true
+          ),
+        1000
+      );
+
+      const responseMessages = messages.filter(isUseChatResponseMessage);
+      expect(responseMessages[0]).toEqual(
+        expect.objectContaining({
+          type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+          id: requestId,
+          body: '{"type":"text-start","id":"t1"}',
+          done: false,
+          replay: true
+        })
+      );
+      expect(responseMessages[1]).toEqual(
+        expect.objectContaining({
+          type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+          id: requestId,
+          body: '{"type":"text-delta","id":"t1","delta":"hello after ack"}',
+          done: false,
+          replay: true
+        })
+      );
+      expect(responseMessages.at(-1)).toEqual(
+        expect.objectContaining({
+          type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+          id: requestId,
+          done: true,
+          replay: true
+        })
+      );
+
+      ws.close(1000);
+    });
+
     it("replayed chunks have replay=true flag", async () => {
       const room = crypto.randomUUID();
 

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -100,6 +100,49 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(ack.id).toBe("req-42");
   });
 
+  it("attaches the resume stream listener before sending ACK", async () => {
+    const originalSend = agent.send.bind(agent);
+    agent.send = (data: string) => {
+      originalSend(data);
+      const message = JSON.parse(data) as { type?: string; id?: string };
+      if (message.type === MessageType.CF_AGENT_STREAM_RESUME_ACK) {
+        agent.dispatch({
+          type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+          id: message.id,
+          body: JSON.stringify({
+            type: "text-delta",
+            id: "text-1",
+            delta: "sync replay"
+          }),
+          done: false,
+          replay: true
+        });
+        agent.dispatch({
+          type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+          id: message.id,
+          body: "",
+          done: true,
+          replay: true
+        });
+      }
+    };
+
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+    transport.handleStreamResuming({ id: "req-sync-replay" });
+
+    const stream = (await promise) as ReadableStream<UIMessageChunk>;
+    const reader = stream.getReader();
+
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { type: "text-delta", id: "text-1", delta: "sync replay" }
+    });
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined
+    });
+  });
+
   it("adds requestId to activeRequestIds when handleStreamResuming is called", async () => {
     const promise = transport.reconnectToStream({ chatId: "chat-1" });
 

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -328,6 +328,8 @@ export class WebSocketChatTransport<
         // Track this request so onAgentMessage skips subsequent chunks
         activeIds?.add(requestId);
 
+        const stream = this._createResumeStream(requestId);
+
         // Send ACK to server via the latest agent (the socket may
         // have been replaced since reconnectToStream was called).
         this.agent.send(
@@ -338,7 +340,7 @@ export class WebSocketChatTransport<
         );
 
         // Return a ReadableStream fed by the replayed + live chunks
-        done(this._createResumeStream(requestId));
+        done(stream);
       };
 
       // Send the resume request. PartySocket queues sends when

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -505,6 +505,11 @@ export class ThinkTestAgent extends Think {
     return this._resumableStream.start(requestId);
   }
 
+  async testStoreResumableChunk(streamId: string, body: string): Promise<void> {
+    this._resumableStream.storeChunk(streamId, body);
+    this._resumableStream.flushBuffer();
+  }
+
   /** Pair with `testStartResumableStream` — clean up the simulated stream. */
   async testCompleteResumableStream(streamId: string): Promise<void> {
     this._resumableStream.complete(streamId);

--- a/packages/think/src/tests/onconnect-broadcast.test.ts
+++ b/packages/think/src/tests/onconnect-broadcast.test.ts
@@ -33,6 +33,18 @@ async function connectWS(room: string) {
   return { ws };
 }
 
+async function connectSubAgentWS(parentRoom: string, childRoom: string) {
+  const res = await exports.default.fetch(
+    `http://example.com/agents/think-test-agent/${parentRoom}/sub/think-test-agent/${childRoom}`,
+    { headers: { Upgrade: "websocket" } }
+  );
+  expect(res.status).toBe(101);
+  const ws = res.webSocket as WebSocket;
+  expect(ws).toBeDefined();
+  ws.accept();
+  return { ws };
+}
+
 function collectMessages(
   ws: WebSocket,
   timeout = 500
@@ -103,6 +115,59 @@ describe("Think — onConnect broadcast policy", () => {
 
     await closeWS(ws);
     await agent.testCompleteResumableStream(streamId);
+  });
+
+  it("does not send parent resume protocol on a sub-agent WebSocket", async () => {
+    const parentRoom = crypto.randomUUID();
+    const childRoom = crypto.randomUUID();
+    const parent = await freshAgent(parentRoom);
+
+    const streamId = await parent.testStartResumableStream("req-parent-active");
+
+    const { ws } = await connectSubAgentWS(parentRoom, childRoom);
+    const messages = await collectMessages(ws);
+    const types = messages.map((m) => m.type);
+
+    expect(types).toContain(MSG_CHAT_MESSAGES);
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        type: MSG_STREAM_RESUMING,
+        id: "req-parent-active"
+      })
+    );
+
+    await closeWS(ws);
+    await parent.testCompleteResumableStream(streamId);
+  });
+
+  it("does not handle child resume protocol messages in the parent agent", async () => {
+    const parentRoom = crypto.randomUUID();
+    const childRoom = crypto.randomUUID();
+    const parent = await freshAgent(parentRoom);
+
+    const streamId = await parent.testStartResumableStream("req-parent-active");
+
+    const { ws } = await connectSubAgentWS(parentRoom, childRoom);
+    await collectMessages(ws);
+
+    ws.send(JSON.stringify({ type: "cf_agent_stream_resume_request" }));
+    ws.send(
+      JSON.stringify({
+        type: MSG_STREAM_RESUME_ACK,
+        id: "req-parent-active"
+      })
+    );
+
+    const messages = await collectMessages(ws);
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        type: MSG_STREAM_RESUMING,
+        id: "req-parent-active"
+      })
+    );
+
+    await closeWS(ws);
+    await parent.testCompleteResumableStream(streamId);
   });
 
   it("resumes broadcasting CHAT_MESSAGES once the stream completes", async () => {

--- a/packages/think/src/tests/onconnect-broadcast.test.ts
+++ b/packages/think/src/tests/onconnect-broadcast.test.ts
@@ -10,6 +10,8 @@ import type { ThinkTestAgent } from "./agents/think-session";
 // See the onConnect block in `packages/think/src/think.ts` for details.
 
 const MSG_CHAT_MESSAGES = "cf_agent_chat_messages";
+const MSG_CHAT_RESPONSE = "cf_agent_use_chat_response";
+const MSG_STREAM_RESUME_ACK = "cf_agent_stream_resume_ack";
 const MSG_STREAM_RESUMING = "cf_agent_stream_resuming";
 
 async function freshAgent(name?: string) {
@@ -118,6 +120,48 @@ describe("Think — onConnect broadcast policy", () => {
 
     expect(types).toContain(MSG_CHAT_MESSAGES);
     expect(types).not.toContain(MSG_STREAM_RESUMING);
+
+    await closeWS(ws);
+  });
+
+  it("finalizes resume if the stream completes before the client ACK arrives", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const requestId = "req-onconnect-ack-race";
+
+    const streamId = await agent.testStartResumableStream(requestId);
+    await agent.testStoreResumableChunk(
+      streamId,
+      '{"type":"text-delta","id":"t1","delta":"late hello"}'
+    );
+    const { ws } = await connectWS(room);
+    const connectMessages = await collectMessages(ws);
+    expect(connectMessages.map((m) => m.type)).toContain(MSG_STREAM_RESUMING);
+
+    await agent.testCompleteResumableStream(streamId);
+    ws.send(JSON.stringify({ type: MSG_STREAM_RESUME_ACK, id: requestId }));
+
+    const ackMessages = await collectMessages(ws);
+    const responseMessages = ackMessages.filter(
+      (message) => message.type === MSG_CHAT_RESPONSE
+    );
+    expect(responseMessages[0]).toEqual(
+      expect.objectContaining({
+        type: MSG_CHAT_RESPONSE,
+        id: requestId,
+        body: '{"type":"text-delta","id":"t1","delta":"late hello"}',
+        done: false,
+        replay: true
+      })
+    );
+    expect(responseMessages.at(-1)).toEqual(
+      expect.objectContaining({
+        type: MSG_CHAT_RESPONSE,
+        id: requestId,
+        done: true,
+        replay: true
+      })
+    );
 
     await closeWS(ws);
   });

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2518,6 +2518,23 @@ export class Think<
       if (orphanedStreamId) {
         this._persistOrphanedStream(orphanedStreamId);
       }
+    } else if (this._resumableStream.hasActiveStream()) {
+      // Ignore ACKs for a different active stream request id.
+    } else if (
+      !this._resumableStream.replayCompletedChunksByRequestId(
+        connection,
+        requestId
+      )
+    ) {
+      connection.send(
+        JSON.stringify({
+          body: "",
+          done: true,
+          id: requestId,
+          type: MSG_CHAT_RESPONSE,
+          replay: true
+        })
+      );
     }
   }
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2330,6 +2330,13 @@ export class Think<
       connection: Connection,
       ctx: { request: Request }
     ) => {
+      const requestTargetsSubAgent = this._cf_requestTargetsSubAgent(
+        ctx.request
+      );
+      if (requestTargetsSubAgent) {
+        return _onConnect(connection, ctx);
+      }
+
       if (this._resumableStream.hasActiveStream()) {
         // A stream is still in flight. The resume flow is the
         // authoritative source of state: `_notifyStreamResuming` tells
@@ -2374,6 +2381,12 @@ export class Think<
 
     const _onMessage = this.onMessage.bind(this);
     this.onMessage = async (connection: Connection, message: WSMessage) => {
+      const connectionTargetsSubAgent =
+        this._cf_connectionTargetsSubAgent(connection);
+      if (connectionTargetsSubAgent) {
+        return _onMessage(connection, message);
+      }
+
       if (typeof message === "string") {
         const event = parseProtocolMessage(message);
         if (event) {


### PR DESCRIPTION
## Summary
- Keep sub-agent browser WebSockets owned by the parent Agent and forward child connect/message/close events over RPC.
- Preserve sub-agent real-time chat behavior while avoiding native WebSocket I/O ownership errors in deployed Workers.
- Fix resumed chat streams rendering replayed text as a second assistant text block.

## Test plan
- npm run build (packages/agents)
- npm run test:workers -- spike-sub-agent-routing.test.ts (packages/agents)
- npm run test:react -- use-agent-chat.test.tsx (packages/ai-chat)
- npm run build (packages/ai-chat)
- Deployed and browser-verified multi-ai-chat long story resume/thread switching


Made with [Cursor](https://cursor.com)