### PR TITLE
think: expose turn call settings

### DIFF
--- a/.changeset/fuzzy-turns-wave.md
+++ b/.changeset/fuzzy-turns-wave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Expose stable AI SDK `streamText` call settings on Think `TurnConfig`, including `timeout` and `maxRetries`, so `beforeTurn` can tune generation behavior per turn.

--- a/docs/think/lifecycle-hooks.md
+++ b/docs/think/lifecycle-hooks.md
@@ -116,17 +116,28 @@ beforeTurn(ctx: TurnContext): TurnConfig | void | Promise<TurnConfig | void>
 
 All fields are optional. Return only what you want to change.
 
-| Field             | Type                      | Description                          |
-| ----------------- | ------------------------- | ------------------------------------ |
-| `model`           | `LanguageModel`           | Override the model for this turn     |
-| `system`          | `string`                  | Override the system prompt           |
-| `messages`        | `ModelMessage[]`          | Override the assembled messages      |
-| `tools`           | `ToolSet`                 | Extra tools to merge (additive)      |
-| `activeTools`     | `string[]`                | Limit which tools the model can call |
-| `toolChoice`      | `ToolChoice`              | Force a specific tool call           |
-| `maxSteps`        | `number`                  | Override `maxSteps` for this turn    |
-| `sendReasoning`   | `boolean`                 | Send reasoning chunks for this turn  |
-| `providerOptions` | `Record<string, unknown>` | Provider-specific options            |
+| Field              | Type                      | Description                          |
+| ------------------ | ------------------------- | ------------------------------------ |
+| `model`            | `LanguageModel`           | Override the model for this turn     |
+| `system`           | `string`                  | Override the system prompt           |
+| `messages`         | `ModelMessage[]`          | Override the assembled messages      |
+| `tools`            | `ToolSet`                 | Extra tools to merge (additive)      |
+| `activeTools`      | `string[]`                | Limit which tools the model can call |
+| `toolChoice`       | `ToolChoice`              | Force a specific tool call           |
+| `maxSteps`         | `number`                  | Override `maxSteps` for this turn    |
+| `sendReasoning`    | `boolean`                 | Send reasoning chunks for this turn  |
+| `maxOutputTokens`  | `number`                  | Maximum tokens to generate           |
+| `temperature`      | `number`                  | Sampling temperature                 |
+| `topP`             | `number`                  | Nucleus sampling value               |
+| `topK`             | `number`                  | Top-K sampling value                 |
+| `presencePenalty`  | `number`                  | Presence penalty                     |
+| `frequencyPenalty` | `number`                  | Frequency penalty                    |
+| `stopSequences`    | `string[]`                | Stop generation sequences            |
+| `seed`             | `number`                  | Sampling seed when supported         |
+| `maxRetries`       | `number`                  | Maximum retries for this turn        |
+| `timeout`          | `TimeoutConfiguration`    | Timeout for this turn                |
+| `headers`          | `Record<string, string>`  | Additional provider request headers  |
+| `providerOptions`  | `Record<string, unknown>` | Provider-specific options            |
 
 ### Examples
 
@@ -176,6 +187,19 @@ Hide reasoning for internal continuation turns:
 beforeTurn(ctx: TurnContext) {
   if (ctx.continuation) {
     return { sendReasoning: false };
+  }
+}
+```
+
+Disable retries and apply a streaming timeout for a recovery turn:
+
+```typescript
+beforeTurn(ctx: TurnContext) {
+  if (ctx.body?.recovering) {
+    return {
+      maxRetries: 0,
+      timeout: { totalMs: 30_000, chunkMs: 5_000 }
+    };
   }
 }
 ```

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -143,6 +143,8 @@ The AI SDK-derived contexts spread the SDK's own types at the top level — no i
 
 `TurnConfig` also accepts `sendReasoning` to override whether reasoning chunks are emitted for the current UI message stream. The instance-level `sendReasoning` property defaults to `true`; return `{ sendReasoning: false }` from `beforeTurn` to hide reasoning for a single turn, for example on internal continuation turns.
 
+`TurnConfig` also accepts stable AI SDK `streamText` call settings such as `maxOutputTokens`, `temperature`, `stopSequences`, `seed`, `maxRetries`, `timeout`, and `headers`. Use them to tune model behavior per turn, for example disabling retries or adding a chunk timeout during recovery flows.
+
 `TurnConfig` also accepts an `output` field that is forwarded to `streamText` as the AI SDK's structured-output spec. Combine with `activeTools: []` for providers (e.g. `workers-ai-provider`) that strip tools when `responseFormat: "json"` is active. Use `experimental_telemetry` to pass the AI SDK's per-call telemetry settings through to `streamText`; consider disabling `recordInputs` or `recordOutputs` if prompts or outputs may contain sensitive data.
 
 Per-tool hooks are wired so `beforeToolCall` fires _before_ `execute` (Think wraps every tool's `execute`) and `afterToolCall` fires _after_ (via the AI SDK's `experimental_onToolCallFinish`) with `durationMs` and a discriminated outcome. `beforeToolCall` can return a `ToolCallDecision` to:
@@ -259,6 +261,17 @@ interface TurnConfig {
   toolChoice?: ToolChoice; // force a specific tool
   maxSteps?: number; // override maxSteps for this turn
   sendReasoning?: boolean; // send reasoning chunks for this turn
+  maxOutputTokens?: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  stopSequences?: string[];
+  seed?: number;
+  maxRetries?: number;
+  timeout?: TimeoutConfiguration;
+  headers?: Record<string, string | undefined>;
   providerOptions?: Record<string, unknown>;
   experimental_telemetry?: TelemetrySettings;
 }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -60,7 +60,46 @@ const v3Usage = (inputTokens: number, outputTokens: number) => ({
   outputTokens: { total: outputTokens, text: outputTokens, reasoning: 0 }
 });
 
-function createMockModel(response: string): LanguageModel {
+type CapturedModelCallSettings = {
+  maxOutputTokens?: unknown;
+  temperature?: unknown;
+  topP?: unknown;
+  topK?: unknown;
+  presencePenalty?: unknown;
+  frequencyPenalty?: unknown;
+  stopSequences?: unknown;
+  seed?: unknown;
+  headers?: unknown;
+  providerOptions?: unknown;
+};
+
+type MockModelOptions = {
+  onCall?: (settings: CapturedModelCallSettings) => void;
+};
+
+function captureModelCallSettings(options: unknown): CapturedModelCallSettings {
+  const record =
+    options != null && typeof options === "object"
+      ? (options as Record<string, unknown>)
+      : {};
+  return {
+    maxOutputTokens: record.maxOutputTokens,
+    temperature: record.temperature,
+    topP: record.topP,
+    topK: record.topK,
+    presencePenalty: record.presencePenalty,
+    frequencyPenalty: record.frequencyPenalty,
+    stopSequences: record.stopSequences,
+    seed: record.seed,
+    headers: record.headers,
+    providerOptions: record.providerOptions
+  };
+}
+
+function createMockModel(
+  response: string,
+  options: MockModelOptions = {}
+): LanguageModel {
   return {
     specificationVersion: "v3",
     provider: "test",
@@ -69,7 +108,8 @@ function createMockModel(response: string): LanguageModel {
     doGenerate() {
       throw new Error("doGenerate not implemented in mock");
     },
-    doStream() {
+    doStream(callOptions: unknown) {
+      options.onCall?.(captureModelCallSettings(callOptions));
       _mockCallCount++;
       const callId = _mockCallCount;
       const stream = new ReadableStream({
@@ -294,6 +334,7 @@ export class ThinkTestAgent extends Think {
   private _stepConfigOverride: StepConfig | null = null;
   private _beforeStepAsyncDelayMs = 0;
   private _telemetryEvents: string[] = [];
+  private _lastModelCallSettings: CapturedModelCallSettings | null = null;
   private _reasoningResponse: { response: string; reasoning: string } | null =
     null;
   private _beforeStepLog: Array<{
@@ -437,6 +478,10 @@ export class ThinkTestAgent extends Think {
 
   async getTelemetryEvents(): Promise<string[]> {
     return this._telemetryEvents;
+  }
+
+  async getLastModelCallSettings(): Promise<CapturedModelCallSettings | null> {
+    return this._lastModelCallSettings;
   }
 
   async getBeforeStepLog(): Promise<
@@ -627,7 +672,11 @@ export class ThinkTestAgent extends Think {
     if (this._multiChunks) {
       return createMultiChunkMockModel(this._multiChunks);
     }
-    return createMockModel(this._response);
+    return createMockModel(this._response, {
+      onCall: (settings) => {
+        this._lastModelCallSettings = settings;
+      }
+    });
   }
 
   async getChatErrorLog(): Promise<string[]> {

--- a/packages/think/src/tests/hooks.test.ts
+++ b/packages/think/src/tests/hooks.test.ts
@@ -808,6 +808,41 @@ describe("Think — beforeTurn config overrides", () => {
     expect(result.done).toBe(true);
   });
 
+  it("accepts stable AI SDK call settings from TurnConfig", async () => {
+    const agent = await freshAgent("bt-call-settings");
+    await agent.setTurnConfigOverride({
+      maxOutputTokens: 123,
+      temperature: 0.2,
+      topP: 0.8,
+      topK: 40,
+      presencePenalty: 0.1,
+      frequencyPenalty: 0.3,
+      stopSequences: ["STOP"],
+      seed: 1234,
+      maxRetries: 0,
+      timeout: { totalMs: 10_000, chunkMs: 5_000 },
+      headers: { "x-test-turn": "enabled" },
+      providerOptions: { test: { mode: "turn" } }
+    });
+
+    const result = await agent.testChat("Use call settings");
+    const settings = await agent.getLastModelCallSettings();
+
+    expect(result.done).toBe(true);
+    expect(settings).toMatchObject({
+      maxOutputTokens: 123,
+      temperature: 0.2,
+      topP: 0.8,
+      topK: 40,
+      presencePenalty: 0.1,
+      frequencyPenalty: 0.3,
+      stopSequences: ["STOP"],
+      seed: 1234,
+      headers: { "x-test-turn": "enabled" },
+      providerOptions: { test: { mode: "turn" } }
+    });
+  });
+
   it("output override is accepted on TurnConfig and forwarded to streamText", async () => {
     // Regression for #1383 — TurnConfig.output should be a structurally
     // valid field that the AI SDK accepts. We construct the Output spec

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -314,6 +314,28 @@ export interface TurnConfig {
    * for this turn. Defaults to the instance-level `sendReasoning` setting.
    */
   sendReasoning?: boolean;
+  /** Maximum number of tokens to generate for this turn. */
+  maxOutputTokens?: Parameters<typeof streamText>[0]["maxOutputTokens"];
+  /** Temperature setting for this turn. */
+  temperature?: Parameters<typeof streamText>[0]["temperature"];
+  /** Nucleus sampling setting for this turn. */
+  topP?: Parameters<typeof streamText>[0]["topP"];
+  /** Top-K sampling setting for this turn. */
+  topK?: Parameters<typeof streamText>[0]["topK"];
+  /** Presence penalty setting for this turn. */
+  presencePenalty?: Parameters<typeof streamText>[0]["presencePenalty"];
+  /** Frequency penalty setting for this turn. */
+  frequencyPenalty?: Parameters<typeof streamText>[0]["frequencyPenalty"];
+  /** Stop sequences for this turn. */
+  stopSequences?: Parameters<typeof streamText>[0]["stopSequences"];
+  /** Seed for deterministic sampling when supported by the model. */
+  seed?: Parameters<typeof streamText>[0]["seed"];
+  /** Maximum number of retries for this turn. Set to 0 to disable retries. */
+  maxRetries?: Parameters<typeof streamText>[0]["maxRetries"];
+  /** Timeout configuration for this turn. */
+  timeout?: Parameters<typeof streamText>[0]["timeout"];
+  /** Additional HTTP headers for provider requests on this turn. */
+  headers?: Parameters<typeof streamText>[0]["headers"];
   /** Provider-specific options (AI SDK providerOptions). */
   providerOptions?: Record<string, unknown>;
   /** Optional AI SDK telemetry configuration for this turn. */
@@ -1213,6 +1235,17 @@ export class Think<
       tools: finalTools,
       activeTools: config.activeTools,
       toolChoice: config.toolChoice,
+      maxOutputTokens: config.maxOutputTokens,
+      temperature: config.temperature,
+      topP: config.topP,
+      topK: config.topK,
+      presencePenalty: config.presencePenalty,
+      frequencyPenalty: config.frequencyPenalty,
+      stopSequences: config.stopSequences,
+      seed: config.seed,
+      maxRetries: config.maxRetries,
+      timeout: config.timeout,
+      headers: config.headers,
       stopWhen: stepCountIs(finalMaxSteps),
       providerOptions: config.providerOptions as
         | Parameters<typeof streamText>[0]["providerOptions"]
@@ -1357,6 +1390,32 @@ export class Think<
             accumulated.maxSteps = parsed.config.maxSteps;
           if (parsed.config.sendReasoning !== undefined)
             accumulated.sendReasoning = parsed.config.sendReasoning;
+          if (parsed.config.maxOutputTokens !== undefined)
+            accumulated.maxOutputTokens = parsed.config.maxOutputTokens;
+          if (parsed.config.temperature !== undefined)
+            accumulated.temperature = parsed.config.temperature;
+          if (parsed.config.topP !== undefined)
+            accumulated.topP = parsed.config.topP;
+          if (parsed.config.topK !== undefined)
+            accumulated.topK = parsed.config.topK;
+          if (parsed.config.presencePenalty !== undefined)
+            accumulated.presencePenalty = parsed.config.presencePenalty;
+          if (parsed.config.frequencyPenalty !== undefined)
+            accumulated.frequencyPenalty = parsed.config.frequencyPenalty;
+          if (parsed.config.stopSequences !== undefined)
+            accumulated.stopSequences = parsed.config.stopSequences;
+          if (parsed.config.seed !== undefined)
+            accumulated.seed = parsed.config.seed;
+          if (parsed.config.maxRetries !== undefined)
+            accumulated.maxRetries = parsed.config.maxRetries;
+          if (parsed.config.timeout !== undefined)
+            accumulated.timeout = parsed.config.timeout;
+          if (parsed.config.headers !== undefined) {
+            accumulated.headers = {
+              ...(accumulated.headers ?? {}),
+              ...parsed.config.headers
+            };
+          }
           if (parsed.config.providerOptions !== undefined) {
             accumulated.providerOptions = {
               ...(accumulated.providerOptions ?? {}),


### PR DESCRIPTION
## Summary
- Expose stable AI SDK `streamText` call settings on Think `TurnConfig`, including `timeout` and `maxRetries`.
- Forward those settings through Think's inference loop and merge JSON-safe values from extension `beforeTurn` hooks.
- Document the new per-turn settings and add regression coverage for provider-visible call settings.

Fixes #1446

## Test plan
- [x] `npx vitest --run -c packages/think/src/tests/vitest.config.ts packages/think/src/tests/hooks.test.ts`
- [x] `npm run build --workspace @cloudflare/think`
- [x] `ReadLints` on touched files

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
