### PR TITLE
Fix streaming callable client types

### DIFF
--- a/.changeset/streaming-callable-types.md
+++ b/.changeset/streaming-callable-types.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix typed `call` and `stub` support for streaming callable methods.

--- a/packages/agents/src/client.ts
+++ b/packages/agents/src/client.ts
@@ -5,6 +5,7 @@ import {
 } from "partysocket";
 import type { Agent, RPCRequest, RPCResponse } from "./";
 import type {
+  ClientParameters,
   Method,
   RPCMethod,
   SerializableReturnValue,
@@ -123,7 +124,7 @@ export type RPCMethods<T> = {
 };
 
 type OptionalParametersMethod<T extends RPCMethod> =
-  AllOptional<Parameters<T>> extends true ? T : never;
+  AllOptional<ClientParameters<T>> extends true ? T : never;
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- generic agent type constraint
 export type AgentMethods<T> = Omit<RPCMethods<T>, keyof Agent<any, any>>;
@@ -149,7 +150,7 @@ export type AgentPromiseReturnType<T, K extends keyof AgentMethods<T>> =
 
 export type AgentStub<T> = {
   [K in keyof AgentMethods<T>]: (
-    ...args: Parameters<AgentMethods<T>[K]>
+    ...args: ClientParameters<AgentMethods<T>[K]>
   ) => AgentPromiseReturnType<AgentMethods<T>, K>;
 };
 
@@ -163,7 +164,7 @@ type OptionalArgsAgentClientCall<AgentT> = <
   K extends keyof OptionalAgentMethods<AgentT>
 >(
   method: K,
-  args?: Parameters<OptionalAgentMethods<AgentT>[K]>,
+  args?: ClientParameters<OptionalAgentMethods<AgentT>[K]>,
   options?: CallOptions | StreamOptions
 ) => AgentPromiseReturnType<AgentT, K>;
 
@@ -171,7 +172,7 @@ type RequiredArgsAgentClientCall<AgentT> = <
   K extends keyof RequiredAgentMethods<AgentT>
 >(
   method: K,
-  args: Parameters<RequiredAgentMethods<AgentT>[K]>,
+  args: ClientParameters<RequiredAgentMethods<AgentT>[K]>,
   options?: CallOptions | StreamOptions
 ) => AgentPromiseReturnType<AgentT, K>;
 

--- a/packages/agents/src/react-tests/useAgent.test.tsx
+++ b/packages/agents/src/react-tests/useAgent.test.tsx
@@ -819,6 +819,77 @@ describe("useAgent hook", () => {
       expect(onDone).toHaveBeenCalled();
       expect(result).toBe(5); // streamNumbers ends with count
     });
+
+    it("should support streaming RPC with CallOptions", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let capturedAgent: TestAgent | null = null;
+      const chunks: unknown[] = [];
+      const onChunk = vi.fn((chunk) => chunks.push(chunk));
+      const onDone = vi.fn();
+
+      render(
+        <SuspenseWrapper>
+          <TestAgentComponent
+            options={{
+              agent: "TestCallableAgent",
+              name: "hook-test-rpc-stream-options",
+              host,
+              protocol
+            }}
+            onAgent={(agent) => {
+              capturedAgent = agent;
+            }}
+          />
+        </SuspenseWrapper>
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(capturedAgent?.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      const result = await capturedAgent!.call("streamNumbers", [5], {
+        stream: { onChunk, onDone }
+      });
+
+      expect(onChunk.mock.calls.length).toBeGreaterThan(0);
+      expect(onDone).toHaveBeenCalledWith(5);
+      expect(result).toBe(5);
+    });
+
+    it("should support RPC timeout with CallOptions", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let capturedAgent: TestAgent | null = null;
+
+      render(
+        <SuspenseWrapper>
+          <TestAgentComponent
+            options={{
+              agent: "TestCallableAgent",
+              name: "hook-test-rpc-timeout",
+              host,
+              protocol
+            }}
+            onAgent={(agent) => {
+              capturedAgent = agent;
+            }}
+          />
+        </SuspenseWrapper>
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(capturedAgent?.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      await expect(
+        capturedAgent!.call("asyncMethod", [5000], { timeout: 10 })
+      ).rejects.toThrow(/timed out/);
+    });
   });
 
   describe("query parameters", () => {

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -5,11 +5,13 @@ import type { MCPServersState, RPCRequest, RPCResponse } from "./";
 import type {
   AgentPromiseReturnType,
   AgentStub,
+  CallOptions,
   OptionalAgentMethods,
   RequiredAgentMethods,
   StreamOptions,
   UntypedAgentStub
 } from "./client";
+import type { ClientParameters } from "./serializable";
 import { createStubProxy } from "./client";
 import { camelCaseToKebabCase } from "./utils";
 import { MessageType } from "./types";
@@ -227,16 +229,16 @@ type OptionalArgsAgentMethodCall<AgentT> = <
   K extends keyof OptionalAgentMethods<AgentT>
 >(
   method: K,
-  args?: Parameters<OptionalAgentMethods<AgentT>[K]>,
-  streamOptions?: StreamOptions
+  args?: ClientParameters<OptionalAgentMethods<AgentT>[K]>,
+  options?: CallOptions | StreamOptions
 ) => AgentPromiseReturnType<AgentT, K>;
 
 type RequiredArgsAgentMethodCall<AgentT> = <
   K extends keyof RequiredAgentMethods<AgentT>
 >(
   method: K,
-  args: Parameters<RequiredAgentMethods<AgentT>[K]>,
-  streamOptions?: StreamOptions
+  args: ClientParameters<RequiredAgentMethods<AgentT>[K]>,
+  options?: CallOptions | StreamOptions
 ) => AgentPromiseReturnType<AgentT, K>;
 
 type AgentMethodCall<AgentT> = OptionalArgsAgentMethodCall<AgentT> &
@@ -245,7 +247,7 @@ type AgentMethodCall<AgentT> = OptionalArgsAgentMethodCall<AgentT> &
 type UntypedAgentMethodCall = <T = unknown>(
   method: string,
   args?: unknown[],
-  streamOptions?: StreamOptions
+  options?: CallOptions | StreamOptions
 ) => Promise<T>;
 
 /**
@@ -351,6 +353,7 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
         resolve: (value: unknown) => void;
         reject: (error: Error) => void;
         stream?: StreamOptions;
+        timeoutId?: ReturnType<typeof setTimeout>;
       }
     >()
   );
@@ -623,6 +626,7 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
           if (!pending) return;
 
           if (!response.success) {
+            if (pending.timeoutId) clearTimeout(pending.timeoutId);
             pending.reject(new Error(response.error));
             pendingCallsRef.current.delete(response.id);
             pending.stream?.onError?.(response.error);
@@ -632,6 +636,7 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
           // Handle streaming responses
           if ("done" in response) {
             if (response.done) {
+              if (pending.timeoutId) clearTimeout(pending.timeoutId);
               pending.resolve(response.result);
               pendingCallsRef.current.delete(response.id);
               pending.stream?.onDone?.(response.result);
@@ -640,6 +645,7 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
             }
           } else {
             // Non-streaming response
+            if (pending.timeoutId) clearTimeout(pending.timeoutId);
             pending.resolve(response.result);
             pendingCallsRef.current.delete(response.id);
           }
@@ -668,6 +674,7 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
       // Reject all pending calls (consistent with AgentClient behavior)
       const error = new Error("Connection closed");
       for (const pending of pendingCallsRef.current.values()) {
+        if (pending.timeoutId) clearTimeout(pending.timeoutId);
         pending.reject(error);
         pending.stream?.onError?.("Connection closed");
       }
@@ -692,14 +699,38 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
     <T = unknown,>(
       method: string,
       args: unknown[] = [],
-      streamOptions?: StreamOptions
+      options?: CallOptions | StreamOptions
     ): Promise<T> => {
       return new Promise((resolve, reject) => {
         const id = crypto.randomUUID();
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+        // Detect legacy format: { onChunk?, onDone?, onError? } vs new format: { timeout?, stream? }
+        const isLegacyFormat =
+          options &&
+          ("onChunk" in options || "onDone" in options || "onError" in options);
+        const streamOptions = isLegacyFormat
+          ? (options as StreamOptions)
+          : (options as CallOptions | undefined)?.stream;
+        const timeout = isLegacyFormat
+          ? undefined
+          : (options as CallOptions | undefined)?.timeout;
+
+        if (timeout) {
+          timeoutId = setTimeout(() => {
+            const pending = pendingCallsRef.current.get(id);
+            pendingCallsRef.current.delete(id);
+            const errorMessage = `RPC call to ${method} timed out after ${timeout}ms`;
+            pending?.stream?.onError?.(errorMessage);
+            reject(new Error(errorMessage));
+          }, timeout);
+        }
+
         pendingCallsRef.current.set(id, {
           reject,
           resolve: resolve as (value: unknown) => void,
-          stream: streamOptions
+          stream: streamOptions,
+          timeoutId
         });
 
         const request: RPCRequest = {

--- a/packages/agents/src/serializable.ts
+++ b/packages/agents/src/serializable.ts
@@ -1,3 +1,5 @@
+import type { StreamingResponse } from "./index";
+
 // Primitive types that are always serializable
 type SerializablePrimitive = undefined | null | string | number | boolean;
 
@@ -138,6 +140,14 @@ type AllSerializableValues<A> = A extends [infer First, ...infer Rest]
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- generic callable type
 export type Method = (...args: any[]) => any;
 
+export type ClientParameters<T = Method> = T extends (
+  ...args: infer A
+) => unknown
+  ? A extends [StreamingResponse, ...infer Rest]
+    ? Rest
+    : A
+  : never;
+
 // Helper to check if a type is exactly unknown
 // unknown extends T is true only if T is unknown or any
 // We also need [T] extends [unknown] to handle distribution
@@ -152,12 +162,14 @@ type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
 
 export type RPCMethod<T = Method> = T extends Method
   ? T extends (...arg: infer A) => infer R
-    ? AllSerializableValues<A> extends true
-      ? CanSerializeReturn<R> extends true
+    ? AllSerializableValues<ClientParameters<T>> extends true
+      ? A extends [StreamingResponse, ...unknown[]]
         ? T
-        : IsUnknown<UnwrapPromise<R>> extends true
+        : CanSerializeReturn<R> extends true
           ? T
-          : never
+          : IsUnknown<UnwrapPromise<R>> extends true
+            ? T
+            : never
       : never
     : never
   : never;

--- a/packages/agents/src/tests-d/agent-client-stub.test-d.ts
+++ b/packages/agents/src/tests-d/agent-client-stub.test-d.ts
@@ -1,6 +1,7 @@
 import type { env } from "cloudflare:workers";
 import { Agent, callable } from "..";
 import { AgentClient } from "../client";
+import type { StreamingResponse } from "../index";
 
 declare class A extends Agent<typeof env, {}> {
   prop: string;
@@ -10,6 +11,10 @@ declare class A extends Agent<typeof env, {}> {
   f4: (a?: string) => void;
   f5: (a: string | undefined) => void;
   f6: () => Promise<void>;
+  streamText: (stream: StreamingResponse, prompt: string) => Promise<void>;
+  streamNoArgs: (stream: StreamingResponse) => void;
+  streamOptional: (stream: StreamingResponse, prompt?: string) => void;
+  streamNonSerializableParams: (stream: StreamingResponse, date: Date) => void;
   nonSerializableParams: (a: string, b: { c: Date }) => void;
   nonSerializableReturn: (a: string) => Date;
 }
@@ -44,6 +49,15 @@ stub.f5() satisfies Promise<void>;
 stub.f5(undefined) satisfies Promise<void>;
 
 stub.f6() satisfies Promise<void>;
+
+stub.streamText("hello") satisfies Promise<void>;
+// @ts-expect-error StreamingResponse is injected server-side
+stub.streamText(undefined, "hello");
+stub.streamNoArgs() satisfies Promise<void>;
+stub.streamOptional() satisfies Promise<void>;
+stub.streamOptional("hello") satisfies Promise<void>;
+// @ts-expect-error Date parameter after StreamingResponse is not serializable
+stub.streamNonSerializableParams(new Date());
 
 // @ts-expect-error should not have base Agent methods
 stub.setState({ prop: "test" });

--- a/packages/agents/src/tests-d/typed-agent-client.test-d.ts
+++ b/packages/agents/src/tests-d/typed-agent-client.test-d.ts
@@ -1,6 +1,7 @@
 import type { env } from "cloudflare:workers";
 import { Agent } from "..";
 import { AgentClient } from "../client";
+import type { StreamingResponse } from "../index";
 
 declare class A extends Agent<typeof env, {}> {
   prop: string;
@@ -12,6 +13,10 @@ declare class A extends Agent<typeof env, {}> {
   f6: () => Promise<void>;
   f7: (a: string | undefined, b: number) => Promise<void>;
   f8: (a: string | undefined, b?: number) => Promise<void>;
+  streamText: (stream: StreamingResponse, prompt: string) => Promise<void>;
+  streamNoArgs: (stream: StreamingResponse) => void;
+  streamOptional: (stream: StreamingResponse, prompt?: string) => void;
+  streamNonSerializableParams: (stream: StreamingResponse, date: Date) => void;
   nonSerializableParams: (a: string, b: { c: Date }) => void;
   nonSerializableReturn: (a: string) => Date;
 }
@@ -57,6 +62,19 @@ client.call("f7", [undefined, 1]) satisfies Promise<void>;
 
 client.call("f8") satisfies Promise<void>;
 client.call("f8", [undefined, undefined]) satisfies Promise<void>;
+
+client.call("streamText", ["hello"], {
+  stream: { onChunk: () => {}, onDone: () => {}, onError: () => {} }
+}) satisfies Promise<void>;
+// @ts-expect-error StreamingResponse is injected server-side
+client.call("streamText", [undefined, "hello"]);
+client.call("streamNoArgs", undefined, {
+  stream: { onChunk: () => {} }
+}) satisfies Promise<void>;
+client.call("streamOptional") satisfies Promise<void>;
+client.call("streamOptional", ["hello"]) satisfies Promise<void>;
+// @ts-expect-error Date parameter after StreamingResponse is not serializable
+client.call("streamNonSerializableParams", [new Date()]);
 
 // @ts-expect-error Date parameter not serializable — excluded from typed call
 client.call("nonSerializableParams", ["test", { c: new Date() }]);

--- a/packages/agents/src/tests-d/typed-use-agent.test-d.ts
+++ b/packages/agents/src/tests-d/typed-use-agent.test-d.ts
@@ -1,6 +1,7 @@
 import type { env } from "cloudflare:workers";
 import { Agent } from "..";
 import { useAgent } from "../react";
+import type { StreamingResponse } from "../index";
 
 declare class A extends Agent<typeof env, {}> {
   prop: string;
@@ -12,6 +13,10 @@ declare class A extends Agent<typeof env, {}> {
   f6: () => Promise<void>;
   f7: (a: string | undefined, b: number) => Promise<void>;
   f8: (a: string | undefined, b?: number) => Promise<void>;
+  streamText: (stream: StreamingResponse, prompt: string) => Promise<void>;
+  streamNoArgs: (stream: StreamingResponse) => void;
+  streamOptional: (stream: StreamingResponse, prompt?: string) => void;
+  streamNonSerializableParams: (stream: StreamingResponse, date: Date) => void;
   nonSerializableParams: (a: string, b: { c: Date }) => void;
   nonSerializableReturn: (a: string) => Date;
 }
@@ -61,6 +66,19 @@ a1.call("f7", [undefined, 1]) satisfies Promise<void>;
 
 a1.call("f8") satisfies Promise<void>;
 a1.call("f8", [undefined, undefined]) satisfies Promise<void>;
+
+a1.call("streamText", ["hello"], {
+  stream: { onChunk: () => {}, onDone: () => {}, onError: () => {} }
+}) satisfies Promise<void>;
+// @ts-expect-error StreamingResponse is injected server-side
+a1.call("streamText", [undefined, "hello"]);
+a1.call("streamNoArgs", undefined, {
+  stream: { onChunk: () => {} }
+}) satisfies Promise<void>;
+a1.call("streamOptional") satisfies Promise<void>;
+a1.call("streamOptional", ["hello"]) satisfies Promise<void>;
+// @ts-expect-error Date parameter after StreamingResponse is not serializable
+a1.call("streamNonSerializableParams", [new Date()]);
 
 // @ts-expect-error Date parameter not serializable
 a1.call("nonSerializableParams", ["test", { c: new Date() }]);

--- a/packages/think/CHANGELOG.md
+++ b/packages/think/CHANGELOG.md
@@ -55,7 +55,7 @@
 
   ```typescript
   const result = await this.saveMessages(messages, {
-    signal: controller.signal,
+    signal: controller.signal
   });
   if (result.status === "aborted") {
     // Inference loop terminated mid-stream; partial chunks persisted.
@@ -63,7 +63,6 @@
   ```
 
   The signal is linked to Think's per-turn `AbortController` for the duration of the call. When it aborts:
-
   - the inference loop's signal aborts (the same path `chat-request-cancel` takes);
   - partial chunks already streamed are persisted to the resumable stream;
   - `saveMessages` resolves with `{ status: "aborted" }`;
@@ -76,7 +75,6 @@
   `SaveMessagesResult.status` now includes `"aborted"` alongside `"completed"` and `"skipped"`. Existing callers that only switch on `"completed"` are unaffected.
 
   **Limitations.**
-
   - `AbortSignal` cannot cross Durable Object RPC. Construct the controller inside the DO that calls `saveMessages`. To bridge a parent's intent into a child DO, return a `ReadableStream` from the child whose `cancel` callback aborts a per-turn controller — `examples/agents-as-tools` shows the canonical pattern.
   - The signal lives in memory only. If the DO hibernates mid-turn and `chatRecovery` is enabled, the recovered turn calls `continueLastTurn()` internally without the original signal — an abort fired after restart has no effect on the recovered turn.
 
@@ -91,13 +89,11 @@
   This extracts the `latest`/`merge`/`drop`/`debounce` admission state machine into a `SubmitConcurrencyController` exported from `agents/chat`. `AIChatAgent` semantics (including merge persistence) are preserved. `Think` now picks up the same pending-enqueue protection, so an overlapping submit is still detected while an accepted request is between admission and turn queue registration.
 
   Additional fixes:
-
   - `Think` now captures the turn generation immediately after admission and threads it into `_turnQueue.enqueue`, so a clear that lands between admission and queue registration cannot run a stale turn.
   - Pending-enqueue tracking is now bound to a release function tied to the controller's reset epoch, so a release from a pre-reset submit can no longer erase a post-reset submit's marker and let a third submit slip through as non-overlapping.
   - Debounce cancellation correctly resolves all in-flight waiters instead of overwriting a single timer slot.
 
 - [#1394](https://github.com/cloudflare/agents/pull/1394) [`a0a0d17`](https://github.com/cloudflare/agents/commit/a0a0d179a862547715b0dd2e38d37065f24eabe5) Thanks [@threepointone](https://github.com/threepointone)! - think: add `beforeStep` lifecycle hook and `output` passthrough on `TurnConfig`.
-
   - **`beforeStep(ctx)`** — new lifecycle hook called before each AI SDK step in the agentic loop, wired to `streamText({ prepareStep })`. Receives a `PrepareStepContext` (the AI SDK's `PrepareStepFunction` parameter — `steps`, `stepNumber`, `model`, `messages`, `experimental_context`) and may return a `StepConfig` (`PrepareStepResult`) to override `model`, `toolChoice`, `activeTools`, `system`, `messages`, `experimental_context`, or `providerOptions` for the current step. Use `beforeTurn` for turn-wide assembly and `beforeStep` when the decision depends on the step number or previous step results. Resolves [#1363](https://github.com/cloudflare/agents/issues/1363).
   - **`TurnConfig.output`** — new optional field on `TurnConfig` forwarded to `streamText`. Accepts the AI SDK's structured-output spec (e.g. `Output.object({ schema })`, `Output.text()`) so a single agent can keep tools enabled on intermediate turns and return schema-validated structured output on a designated turn — without losing tools at model construction. Combine with `activeTools: []` for providers that strip tools when `responseFormat: "json"` is active (e.g. `workers-ai-provider`). Resolves [#1383](https://github.com/cloudflare/agents/issues/1383).
   - New re-exports from `@cloudflare/think`: `PrepareStepFunction`, `PrepareStepResult`, `PrepareStepContext`, `StepConfig`.
@@ -195,7 +191,6 @@
   ### `subAgent()` cross-DO I/O fix
 
   Three issues in the facet initialization path caused `"Cannot perform I/O on behalf of a different Durable Object"` errors when spawning sub-agents in production:
-
   - `subAgent()` constructed a `Request` in the parent DO and passed it to the child via `stub.fetch()`. The `Request` carried native I/O tied to the parent isolate, which the child rejected.
   - The facet flag was set _after_ the first `onStart()` ran, so `broadcastMcpServers()` fired with `_isFacet === false` on the initial boot.
   - `_broadcastProtocol()`, the inherited `broadcast()`, and `_workflow_broadcast()` iterated the connection registry without an `_isFacet` guard, letting broadcasts reach into the parent DO's WebSocket registry from a child isolate.
@@ -205,14 +200,12 @@
   ### `"experimental"` compatibility flag no longer required
 
   `ctx.facets`, `ctx.exports`, and `env.LOADER` (Worker Loader) have graduated out of the `"experimental"` compatibility flag in workerd. `agents` and `@cloudflare/think` no longer require it:
-
   - `subAgent()` / `abortSubAgent()` / `deleteSubAgent()` — the `@experimental` JSDoc tag and runtime error messages no longer reference the flag. The runtime guards on `ctx.facets` / `ctx.exports` stay in place and now nudge users toward updating `compatibility_date` instead.
   - `Think` — the `@experimental` JSDoc tag no longer references the flag.
 
   No code change is required; remove `"experimental"` from your `compatibility_flags` in `wrangler.jsonc` if it was only there for these features.
 
 - [#1332](https://github.com/cloudflare/agents/pull/1332) [`7cb8acf`](https://github.com/cloudflare/agents/commit/7cb8acff8281a30bc17980e506ab5582f3cb1c72) Thanks [@threepointone](https://github.com/threepointone)! - Expose `createdAt` on fiber and chat recovery contexts so apps can suppress continuations for stale, interrupted turns.
-
   - `FiberRecoveryContext` (from `agents`) gains `createdAt: number` — epoch milliseconds when `runFiber` started, read from the `cf_agents_runs` row that was already tracked internally.
   - `ChatRecoveryContext` (from `@cloudflare/ai-chat` and `@cloudflare/think`) gains the same `createdAt` field, threaded through from the underlying fiber.
 
@@ -278,7 +271,6 @@
 - [#1270](https://github.com/cloudflare/agents/pull/1270) [`87b4512`](https://github.com/cloudflare/agents/commit/87b4512985e47de659bf970a65a6d1951f5855fe) Thanks [@threepointone](https://github.com/threepointone)! - Wire Session into Think as the storage layer, achieving full feature parity with AIChatAgent plus Session-backed advantages.
 
   **Think (`@cloudflare/think`):**
-
   - Session integration: `this.messages` backed by `session.getHistory()`, tree-structured messages, context blocks, compaction, FTS5 search
   - `configureSession()` override for context blocks, compaction, search, skills (sync or async)
   - `assembleContext()` returns `{ system, messages }` with context block composition
@@ -297,12 +289,10 @@
   - Constructor wraps `onStart` — subclasses never need `super.onStart()`
 
   **agents (`agents/chat`):**
-
   - Extract `AbortRegistry`, `applyToolUpdate` + builders, `parseProtocolMessage` into shared `agents/chat` layer
   - Add `applyChunkToParts` export for fiber recovery
 
   **AIChatAgent (`@cloudflare/ai-chat`):**
-
   - Refactor to use shared `AbortRegistry` from `agents/chat`
   - Add `continuation` flag to `OnChatMessageOptions`
   - Export `getAgentMessages()` and tool part helpers
@@ -317,7 +307,6 @@
   `Think` now extends `Agent` directly (no mixin). Fiber support is inherited from the base class.
 
   **Breaking (experimental APIs only):**
-
   - Removed `withFibers` mixin (`agents/experimental/forever`)
   - Removed `withDurableChat` mixin (`@cloudflare/ai-chat/experimental/forever`)
   - Removed `./experimental/forever` export from both packages


### PR DESCRIPTION
## Summary
- Fixes typed RPC discovery for `@callable({ streaming: true })` methods by treating a leading `StreamingResponse` parameter as server-injected.
- Applies the client-visible parameter tuple to `AgentClient.call`, `useAgent.call`, and typed stubs so callers pass only serializable user arguments.
- Aligns `useAgent.call` runtime handling with `AgentClient` for `{ stream: ... }` call options and timeout handling.

Fixes #1450.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build -w agents`
- [x] `npx vitest --project react src/react-tests/useAgent.test.tsx --run`
- [x] `npx oxfmt --check packages/agents/src/serializable.ts packages/agents/src/client.ts packages/agents/src/react.tsx packages/agents/src/tests-d/typed-use-agent.test-d.ts packages/agents/src/tests-d/typed-agent-client.test-d.ts packages/agents/src/tests-d/agent-client-stub.test-d.ts packages/agents/src/react-tests/useAgent.test.tsx .changeset/streaming-callable-types.md`
- [x] `npx oxlint packages/agents/src/serializable.ts packages/agents/src/client.ts packages/agents/src/react.tsx packages/agents/src/tests-d/typed-use-agent.test-d.ts packages/agents/src/tests-d/typed-agent-client.test-d.ts packages/agents/src/tests-d/agent-client-stub.test-d.ts packages/agents/src/react-tests/useAgent.test.tsx`
- [ ] `npm run check` currently hits unrelated existing workspace issues: a `sherif` warning for `experimental/tail-agent-tool-run-repro/package.json` and formatting in `packages/think/CHANGELOG.md`.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->