### PR TITLE
Fix Workers AI voice STT turn edge cases

### DIFF
--- a/.changeset/fix-voice-stt-turns.md
+++ b/.changeset/fix-voice-stt-turns.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/voice": patch
+---
+
+Fix Workers AI STT session edge cases for Flux and Nova 3.
+
+Flux now preserves the latest non-empty interim transcript for the active turn so an `EndOfTurn` event with an empty `transcript` can still emit the completed utterance. Nova 3 now defensively normalizes finalized segment state before reading it to avoid stale teardown messages throwing during abnormal close paths.

--- a/packages/voice/src/tests/workers-ai-providers.test.ts
+++ b/packages/voice/src/tests/workers-ai-providers.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { WorkersAIFluxSTT, WorkersAINova3STT } from "../workers-ai-providers";
+
+class MockWebSocket {
+  accepted = false;
+  closed = false;
+  sent: ArrayBuffer[] = [];
+  #listeners = new Map<string, Set<(event: { data?: unknown }) => void>>();
+
+  accept(): void {
+    this.accepted = true;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.dispatch("close", {});
+  }
+
+  send(chunk: ArrayBuffer): void {
+    this.sent.push(chunk);
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: { data?: unknown }) => void
+  ) {
+    const listeners = this.#listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.#listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, event: { data?: unknown }): void {
+    for (const listener of this.#listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  message(data: unknown): void {
+    this.dispatch("message", { data });
+  }
+}
+
+class MockAi {
+  sockets: MockWebSocket[] = [];
+  calls: Array<{
+    model: string;
+    input: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
+
+  async run(
+    model: string,
+    input: Record<string, unknown>,
+    options?: Record<string, unknown>
+  ): Promise<unknown> {
+    this.calls.push({ model, input, options });
+    const webSocket = new MockWebSocket();
+    this.sockets.push(webSocket);
+    return { webSocket: webSocket as unknown as WebSocket };
+  }
+}
+
+async function waitForConnect(ai: MockAi): Promise<MockWebSocket> {
+  await Promise.resolve();
+  await Promise.resolve();
+  const socket = ai.sockets.at(-1);
+  if (!socket) throw new Error("expected a mock websocket to be created");
+  return socket;
+}
+
+describe("WorkersAIFluxSTT", () => {
+  it("uses the latest interim transcript when EndOfTurn transcript is empty", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+    const interims: string[] = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onInterim: (text) => interims.push(text),
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(JSON.stringify({ event: "StartOfTurn" }));
+    socket.message(JSON.stringify({ event: "Update", transcript: "hello" }));
+    socket.message(
+      JSON.stringify({ event: "EagerEndOfTurn", transcript: "hello world" })
+    );
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(interims).toEqual(["hello", "hello world"]);
+    expect(utterances).toEqual(["hello world"]);
+  });
+
+  it("prefers non-empty EndOfTurn transcript and clears turn state", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(JSON.stringify({ event: "Update", transcript: "stale" }));
+    socket.message(
+      JSON.stringify({ event: "EndOfTurn", transcript: "final text" })
+    );
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(utterances).toEqual(["final text"]);
+  });
+
+  it("does not emit a stale eager transcript after TurnResumed", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(
+      JSON.stringify({ event: "EagerEndOfTurn", transcript: "not done" })
+    );
+    socket.message(JSON.stringify({ event: "TurnResumed" }));
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(utterances).toEqual([]);
+  });
+});
+
+describe("WorkersAINova3STT", () => {
+  it("combines finalized segments and interim text without changing normal behavior", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+    const interims: string[] = [];
+
+    new WorkersAINova3STT(ai).createSession({
+      onInterim: (text) => interims.push(text),
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: true,
+        speech_final: false,
+        channel: { alternatives: [{ transcript: "hello" }] }
+      })
+    );
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: false,
+        speech_final: false,
+        channel: { alternatives: [{ transcript: "world" }] }
+      })
+    );
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: true,
+        speech_final: true,
+        channel: { alternatives: [{ transcript: "world" }] }
+      })
+    );
+
+    expect(interims).toEqual(["hello world"]);
+    expect(utterances).toEqual(["hello world"]);
+  });
+
+  it("ignores malformed messages and empty speech_final results", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+
+    new WorkersAINova3STT(ai).createSession({
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message("not json");
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: false,
+        speech_final: true,
+        channel: { alternatives: [{ transcript: "" }] }
+      })
+    );
+
+    expect(utterances).toEqual([]);
+  });
+});

--- a/packages/voice/src/workers-ai-providers.ts
+++ b/packages/voice/src/workers-ai-providers.ts
@@ -179,6 +179,7 @@ class FluxSession implements TranscriberSession {
   #closed = false;
 
   #pendingChunks: ArrayBuffer[] = [];
+  #currentTranscript = "";
 
   constructor(
     ai: AiLike,
@@ -287,27 +288,34 @@ class FluxSession implements TranscriberSession {
 
       switch (data.event) {
         case "StartOfTurn":
+          this.#currentTranscript = "";
           break;
 
         case "Update":
           if (transcript) {
+            this.#currentTranscript = transcript;
             this.#onInterim?.(transcript);
           }
           break;
 
-        case "EndOfTurn":
-          if (transcript) {
-            this.#onUtterance?.(transcript);
+        case "EndOfTurn": {
+          const finalTranscript = transcript || this.#currentTranscript;
+          this.#currentTranscript = "";
+          if (finalTranscript) {
+            this.#onUtterance?.(finalTranscript);
           }
           break;
+        }
 
         case "EagerEndOfTurn":
           if (transcript) {
+            this.#currentTranscript = transcript;
             this.#onInterim?.(transcript);
           }
           break;
 
         case "TurnResumed":
+          this.#currentTranscript = "";
           break;
       }
     } catch {
@@ -541,6 +549,11 @@ class Nova3Session implements TranscriberSession {
       if (!data) return;
 
       if (data.type === "Results") {
+        // Defensive re-init: stale messages after abnormal teardown can observe
+        // this field as undefined in some runtime edge cases. Keep normal
+        // behavior unchanged while avoiding throws on late Results events.
+        if (!this.#finalizedSegments) this.#finalizedSegments = [];
+
         const transcript = data.channel?.alternatives?.[0]?.transcript ?? "";
 
         if (data.is_final && transcript) {
@@ -548,15 +561,18 @@ class Nova3Session implements TranscriberSession {
         }
 
         if (data.speech_final) {
-          const fullTranscript = this.#finalizedSegments.join(" ").trim();
+          const fullTranscript = (this.#finalizedSegments ?? [])
+            .join(" ")
+            .trim();
           this.#finalizedSegments = [];
           if (fullTranscript) {
             this.#onUtterance?.(fullTranscript);
           }
         } else if (!data.is_final && transcript) {
+          const finalizedSegments = this.#finalizedSegments ?? [];
           const display =
-            this.#finalizedSegments.length > 0
-              ? this.#finalizedSegments.join(" ") + " " + transcript
+            finalizedSegments.length > 0
+              ? finalizedSegments.join(" ") + " " + transcript
               : transcript;
           this.#onInterim?.(display);
         }


### PR DESCRIPTION
## Summary

Fixes two Workers AI STT edge cases reported in #1454 for `@cloudflare/voice`:

- Flux can send the final recognized text in `Update` / `EagerEndOfTurn`, then send `EndOfTurn` with an empty `transcript`. We now preserve the latest non-empty interim transcript for the active turn and use it as the final utterance fallback.
- Nova 3 can deliver stale `Results` messages around abnormal close/teardown. We now defensively normalize finalized segment state before reading it so late messages cannot throw while handling `Results`.

## Root cause

`FluxSession` only called `onUtterance` when the `EndOfTurn` event itself carried text. In real Flux streams, the last transcript may already have arrived via `Update` or `EagerEndOfTurn`, with `EndOfTurn.transcript === ""`, so the SDK silently dropped the user utterance and the voice pipeline never invoked `onTurn`.

`Nova3Session` assumed `#finalizedSegments` was always initialized when handling `Results`. The field is initialized in normal construction, but the reported stale-message/teardown path can observe it as unavailable, causing `.join()` / `.length` reads to throw from the message handler.

## Changes

- Track `FluxSession`'s current turn transcript from non-empty `Update` and `EagerEndOfTurn` events.
- On Flux `EndOfTurn`, emit `EndOfTurn.transcript || currentTranscript` and clear turn state.
- Clear Flux turn state on `StartOfTurn`, completed `EndOfTurn`, and `TurnResumed` to avoid stale utterances.
- Guard Nova 3 finalized segment reads with defensive re-initialization/nullish reads.
- Add focused Workers AI provider tests using mock WebSockets.
- Add a patch changeset for `@cloudflare/voice`.

## Testing

- [x] `npx vitest --run packages/voice/src/tests/workers-ai-providers.test.ts --config packages/voice/src/tests/vitest.config.ts`
- [x] `npm run build -w @cloudflare/voice`
- [x] `npx oxlint packages/voice/src/workers-ai-providers.ts packages/voice/src/tests/workers-ai-providers.test.ts`
- [x] `npx oxfmt --check packages/voice/src/workers-ai-providers.ts packages/voice/src/tests/workers-ai-providers.test.ts .changeset/fix-voice-stt-turns.md`

Also attempted `npm run check`; it fails before lint/typecheck on existing export-check issues unrelated to this PR:

- `agents` missing several `dist/*` export files
- `@cloudflare/think` missing several `dist/*` export files

Also attempted `npm test -w @cloudflare/voice`; package worker tests passed

Fixes #1454
