### PR TITLE
Add Flux Multilingual support to WorkersAIFluxSTT

### DIFF
--- a/.changeset/fuzzy-badgers-speak.md
+++ b/.changeset/fuzzy-badgers-speak.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/voice": minor
+---
+
+Add Flux Multilingual model selection and language hints to `WorkersAIFluxSTT`.

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -35,6 +35,11 @@ const VoiceAgent = withVoice(Agent);
 
 export class MyAgent extends VoiceAgent<Env> {
   transcriber = new WorkersAIFluxSTT(this.env.AI);
+  // For Flux Multilingual, use:
+  // transcriber = new WorkersAIFluxSTT(this.env.AI, {
+  //   model: "flux-general-multi",
+  //   languageHints: ["en", "es"]
+  // });
   tts = new WorkersAITTS(this.env.AI);
 
   async onTurn(transcript: string, context: VoiceTurnContext) {
@@ -153,6 +158,22 @@ All default providers use Workers AI bindings -- no API keys required:
 | `WorkersAIFluxSTT`  | Continuous STT | `@cf/deepgram/flux`   | `withVoice`      |
 | `WorkersAINova3STT` | Continuous STT | `@cf/deepgram/nova-3` | `withVoiceInput` |
 | `WorkersAITTS`      | TTS            | `@cf/deepgram/aura-1` | Both             |
+
+`WorkersAIFluxSTT` supports Flux Multilingual via the underlying Deepgram Flux model variant:
+
+```typescript
+// Multilingual auto-detect
+transcriber = new WorkersAIFluxSTT(this.env.AI, {
+  model: "flux-general-multi"
+});
+
+// Bias recognition toward expected languages
+transcriber = new WorkersAIFluxSTT(this.env.AI, {
+  languageHints: ["en", "es"]
+});
+```
+
+When `languageHints` is provided, `WorkersAIFluxSTT` automatically requests `flux-general-multi` unless you set `model` explicitly.
 
 ## Third-party providers
 

--- a/packages/voice/src/tests/workers-ai-providers.test.ts
+++ b/packages/voice/src/tests/workers-ai-providers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { WorkersAIFluxSTT } from "../workers-ai-providers";
+
+function createMockAi() {
+  const calls: Array<{
+    model: string;
+    input: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
+
+  return {
+    calls,
+    ai: {
+      async run(
+        model: string,
+        input: Record<string, unknown>,
+        options?: Record<string, unknown>
+      ) {
+        calls.push({ model, input, options });
+        const pair = new WebSocketPair();
+        return { webSocket: pair[0] };
+      }
+    }
+  };
+}
+
+async function waitForRun(calls: unknown[]) {
+  for (let i = 0; i < 10; i++) {
+    if (calls.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("WorkersAIFluxSTT", () => {
+  it("preserves the default Flux input when no multilingual options are provided", async () => {
+    const { ai, calls } = createMockAi();
+
+    const transcriber = new WorkersAIFluxSTT(ai);
+    const session = transcriber.createSession();
+    await waitForRun(calls);
+    session.close();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].model).toBe("@cf/deepgram/flux");
+    expect(calls[0].input).toEqual({
+      encoding: "linear16",
+      sample_rate: "16000"
+    });
+    expect(calls[0].options).toEqual({ websocket: true });
+  });
+
+  it("uses Flux Multilingual automatically when language hints are provided", async () => {
+    const { ai, calls } = createMockAi();
+
+    const transcriber = new WorkersAIFluxSTT(ai, {
+      languageHints: ["en", "es"]
+    });
+    const session = transcriber.createSession();
+    await waitForRun(calls);
+    session.close();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toMatchObject({
+      model: "flux-general-multi",
+      language_hint: ["en", "es"]
+    });
+  });
+
+  it("passes explicit Flux model selection for multilingual auto-detection", async () => {
+    const { ai, calls } = createMockAi();
+
+    const transcriber = new WorkersAIFluxSTT(ai, {
+      model: "flux-general-multi"
+    });
+    const session = transcriber.createSession();
+    await waitForRun(calls);
+    session.close();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toMatchObject({
+      model: "flux-general-multi"
+    });
+    expect(calls[0].input).not.toHaveProperty("language_hint");
+  });
+});

--- a/packages/voice/src/tests/workers-ai-providers.test.ts
+++ b/packages/voice/src/tests/workers-ai-providers.test.ts
@@ -1,85 +1,238 @@
 import { describe, expect, it } from "vitest";
-import { WorkersAIFluxSTT } from "../workers-ai-providers";
+import { WorkersAIFluxSTT, WorkersAINova3STT } from "../workers-ai-providers";
 
-function createMockAi() {
-  const calls: Array<{
+class MockWebSocket {
+  accepted = false;
+  closed = false;
+  sent: ArrayBuffer[] = [];
+  #listeners = new Map<string, Set<(event: { data?: unknown }) => void>>();
+
+  accept(): void {
+    this.accepted = true;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.dispatch("close", {});
+  }
+
+  send(chunk: ArrayBuffer): void {
+    this.sent.push(chunk);
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: { data?: unknown }) => void
+  ) {
+    const listeners = this.#listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.#listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, event: { data?: unknown }): void {
+    for (const listener of this.#listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  message(data: unknown): void {
+    this.dispatch("message", { data });
+  }
+}
+
+class MockAi {
+  sockets: MockWebSocket[] = [];
+  calls: Array<{
     model: string;
     input: Record<string, unknown>;
     options?: Record<string, unknown>;
   }> = [];
 
-  return {
-    calls,
-    ai: {
-      async run(
-        model: string,
-        input: Record<string, unknown>,
-        options?: Record<string, unknown>
-      ) {
-        calls.push({ model, input, options });
-        const pair = new WebSocketPair();
-        return { webSocket: pair[0] };
-      }
-    }
-  };
-}
-
-async function waitForRun(calls: unknown[]) {
-  for (let i = 0; i < 10; i++) {
-    if (calls.length > 0) return;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+  async run(
+    model: string,
+    input: Record<string, unknown>,
+    options?: Record<string, unknown>
+  ): Promise<unknown> {
+    this.calls.push({ model, input, options });
+    const webSocket = new MockWebSocket();
+    this.sockets.push(webSocket);
+    return { webSocket: webSocket as unknown as WebSocket };
   }
 }
 
+async function waitForConnect(ai: MockAi): Promise<MockWebSocket> {
+  await Promise.resolve();
+  await Promise.resolve();
+  const socket = ai.sockets.at(-1);
+  if (!socket) throw new Error("expected a mock websocket to be created");
+  return socket;
+}
+
 describe("WorkersAIFluxSTT", () => {
+  it("uses the latest interim transcript when EndOfTurn transcript is empty", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+    const interims: string[] = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onInterim: (text) => interims.push(text),
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(JSON.stringify({ event: "StartOfTurn" }));
+    socket.message(JSON.stringify({ event: "Update", transcript: "hello" }));
+    socket.message(
+      JSON.stringify({ event: "EagerEndOfTurn", transcript: "hello world" })
+    );
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(interims).toEqual(["hello", "hello world"]);
+    expect(utterances).toEqual(["hello world"]);
+  });
+
+  it("prefers non-empty EndOfTurn transcript and clears turn state", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(JSON.stringify({ event: "Update", transcript: "stale" }));
+    socket.message(
+      JSON.stringify({ event: "EndOfTurn", transcript: "final text" })
+    );
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(utterances).toEqual(["final text"]);
+  });
+
+  it("does not emit a stale eager transcript after TurnResumed", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(
+      JSON.stringify({ event: "EagerEndOfTurn", transcript: "not done" })
+    );
+    socket.message(JSON.stringify({ event: "TurnResumed" }));
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(utterances).toEqual([]);
+  });
+
   it("preserves the default Flux input when no multilingual options are provided", async () => {
-    const { ai, calls } = createMockAi();
+    const ai = new MockAi();
 
-    const transcriber = new WorkersAIFluxSTT(ai);
-    const session = transcriber.createSession();
-    await waitForRun(calls);
-    session.close();
+    new WorkersAIFluxSTT(ai).createSession();
+    await waitForConnect(ai);
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0].model).toBe("@cf/deepgram/flux");
-    expect(calls[0].input).toEqual({
+    expect(ai.calls).toHaveLength(1);
+    expect(ai.calls[0].model).toBe("@cf/deepgram/flux");
+    expect(ai.calls[0].input).toEqual({
       encoding: "linear16",
       sample_rate: "16000"
     });
-    expect(calls[0].options).toEqual({ websocket: true });
+    expect(ai.calls[0].options).toEqual({ websocket: true });
   });
 
   it("uses Flux Multilingual automatically when language hints are provided", async () => {
-    const { ai, calls } = createMockAi();
+    const ai = new MockAi();
 
-    const transcriber = new WorkersAIFluxSTT(ai, {
+    new WorkersAIFluxSTT(ai, {
       languageHints: ["en", "es"]
-    });
-    const session = transcriber.createSession();
-    await waitForRun(calls);
-    session.close();
+    }).createSession();
+    await waitForConnect(ai);
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0].input).toMatchObject({
+    expect(ai.calls).toHaveLength(1);
+    expect(ai.calls[0].input).toMatchObject({
       model: "flux-general-multi",
       language_hint: ["en", "es"]
     });
   });
 
   it("passes explicit Flux model selection for multilingual auto-detection", async () => {
-    const { ai, calls } = createMockAi();
+    const ai = new MockAi();
 
-    const transcriber = new WorkersAIFluxSTT(ai, {
+    new WorkersAIFluxSTT(ai, {
+      model: "flux-general-multi"
+    }).createSession();
+    await waitForConnect(ai);
+
+    expect(ai.calls).toHaveLength(1);
+    expect(ai.calls[0].input).toMatchObject({
       model: "flux-general-multi"
     });
-    const session = transcriber.createSession();
-    await waitForRun(calls);
-    session.close();
+    expect(ai.calls[0].input).not.toHaveProperty("language_hint");
+  });
+});
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0].input).toMatchObject({
-      model: "flux-general-multi"
+describe("WorkersAINova3STT", () => {
+  it("combines finalized segments and interim text without changing normal behavior", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+    const interims: string[] = [];
+
+    new WorkersAINova3STT(ai).createSession({
+      onInterim: (text) => interims.push(text),
+      onUtterance: (text) => utterances.push(text)
     });
-    expect(calls[0].input).not.toHaveProperty("language_hint");
+
+    const socket = await waitForConnect(ai);
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: true,
+        speech_final: false,
+        channel: { alternatives: [{ transcript: "hello" }] }
+      })
+    );
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: false,
+        speech_final: false,
+        channel: { alternatives: [{ transcript: "world" }] }
+      })
+    );
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: true,
+        speech_final: true,
+        channel: { alternatives: [{ transcript: "world" }] }
+      })
+    );
+
+    expect(interims).toEqual(["hello world"]);
+    expect(utterances).toEqual(["hello world"]);
+  });
+
+  it("ignores malformed messages and empty speech_final results", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+
+    new WorkersAINova3STT(ai).createSession({
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message("not json");
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: false,
+        speech_final: true,
+        channel: { alternatives: [{ transcript: "" }] }
+      })
+    );
+
+    expect(utterances).toEqual([]);
   });
 });

--- a/packages/voice/src/workers-ai-providers.ts
+++ b/packages/voice/src/workers-ai-providers.ts
@@ -71,6 +71,17 @@ export class WorkersAITTS implements TTSProvider {
 // --- Flux continuous STT ---
 
 export interface WorkersAIFluxSTTOptions {
+  /**
+   * Deepgram Flux model variant. Set to `"flux-general-multi"` to enable
+   * Flux Multilingual auto-detection. When `languageHints` is provided and
+   * this option is omitted, `"flux-general-multi"` is used automatically.
+   */
+  model?: "flux-general-en" | "flux-general-multi" | (string & {});
+  /**
+   * Language hints for Flux Multilingual. Values are BCP-47 language codes
+   * such as `"en"`, `"es"`, or `"fr"`.
+   */
+  languageHints?: string[];
   /** End-of-turn confidence threshold (0.5-0.9). @default 0.7 */
   eotThreshold?: number;
   /**
@@ -114,6 +125,8 @@ export interface WorkersAIFluxSTTOptions {
 export class WorkersAIFluxSTT implements Transcriber {
   #ai: AiLike;
   #sampleRate: number;
+  #model: string | undefined;
+  #languageHints: string[] | undefined;
   #eotThreshold: number | undefined;
   #eagerEotThreshold: number | undefined;
   #eotTimeoutMs: number | undefined;
@@ -122,6 +135,8 @@ export class WorkersAIFluxSTT implements Transcriber {
   constructor(ai: AiLike, options?: WorkersAIFluxSTTOptions) {
     this.#ai = ai;
     this.#sampleRate = options?.sampleRate ?? 16000;
+    this.#model = options?.model;
+    this.#languageHints = options?.languageHints;
     this.#eotThreshold = options?.eotThreshold;
     this.#eagerEotThreshold = options?.eagerEotThreshold;
     this.#eotTimeoutMs = options?.eotTimeoutMs;
@@ -133,6 +148,8 @@ export class WorkersAIFluxSTT implements Transcriber {
       this.#ai,
       {
         sampleRate: this.#sampleRate,
+        model: this.#model,
+        languageHints: this.#languageHints,
         eotThreshold: this.#eotThreshold,
         eagerEotThreshold: this.#eagerEotThreshold,
         eotTimeoutMs: this.#eotTimeoutMs,
@@ -145,6 +162,8 @@ export class WorkersAIFluxSTT implements Transcriber {
 
 interface FluxSessionConfig {
   sampleRate: number;
+  model?: string;
+  languageHints?: string[];
   eotThreshold?: number;
   eagerEotThreshold?: number;
   eotTimeoutMs?: number;
@@ -196,6 +215,11 @@ class FluxSession implements TranscriberSession {
         encoding: "linear16",
         sample_rate: String(config.sampleRate)
       };
+      if (config.model != null) input.model = config.model;
+      if (config.languageHints?.length) {
+        input.model ??= "flux-general-multi";
+        input.language_hint = config.languageHints;
+      }
       if (config.eotThreshold != null)
         input.eot_threshold = String(config.eotThreshold);
       if (config.eagerEotThreshold != null)


### PR DESCRIPTION
## Summary

Fixes #1441.

This adds `@cloudflare/voice` support for configuring Deepgram Flux multilingual transcription through `WorkersAIFluxSTT`.

Previously, `WorkersAIFluxSTT` always called `@cf/deepgram/flux` with only the default audio and end-of-turn options, so callers could not request `flux-general-multi` or pass language hints for non-English or multilingual voice agents.

## Changes

- Add `model` to `WorkersAIFluxSTTOptions` so callers can request Deepgram Flux variants such as `flux-general-multi`.
- Add `languageHints` to `WorkersAIFluxSTTOptions` to bias Flux Multilingual toward expected languages.
- Forward multilingual configuration through the Workers AI websocket input as `model` and `language_hint`.
- Automatically set `model: "flux-general-multi"` when `languageHints` are provided and no explicit model is set.
- Preserve existing default behavior when no multilingual options are provided.
- Add tests covering Workers AI Flux input construction.
- Update `packages/voice/README.md` with multilingual examples.
- Add a changeset for `@cloudflare/voice`.

## Example

```ts
// Multilingual auto-detect
transcriber = new WorkersAIFluxSTT(this.env.AI, {
  model: "flux-general-multi"
});

// Bias recognition toward expected languages
transcriber = new WorkersAIFluxSTT(this.env.AI, {
  languageHints: ["en", "es"]
});
```

When `languageHints` is provided without `model`, `WorkersAIFluxSTT` automatically requests `flux-general-multi`.

## Validation

Passed:

```sh
npm run test -w @cloudflare/voice -- src/tests/workers-ai-providers.test.ts
npm run test:workers -w @cloudflare/voice
npm run build -w @cloudflare/voice
npx oxfmt --check packages/voice/src/workers-ai-providers.ts packages/voice/src/tests/workers-ai-providers.test.ts packages/voice/README.md .changeset/fuzzy-badgers-speak.md
```

Notes:

- `npm run test -w @cloudflare/voice`
