### PR TITLE
Fix withVoice handling for AI SDK textStream

### DIFF
--- a/.changeset/quick-voices-stream.md
+++ b/.changeset/quick-voices-stream.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/voice": patch
+---
+
+Fix `withVoice` handling for AI SDK `streamText().textStream` responses by preferring their explicit async-iterator text deltas before generic `ReadableStream` parsing.

--- a/packages/voice/src/tests/text-stream.test.ts
+++ b/packages/voice/src/tests/text-stream.test.ts
@@ -44,6 +44,27 @@ describe("iterateText", () => {
     const chunks = await collect(iterateText(stream));
     expect(chunks).toEqual(["hello ", "world"]);
   });
+
+  it("prefers an explicit async iterator on dual-protocol streams", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("not valid sse or ndjson\n"));
+        controller.close();
+      }
+    }) as ReadableStream<Uint8Array> & AsyncIterable<string>;
+
+    Object.defineProperty(stream, Symbol.asyncIterator, {
+      configurable: true,
+      value: async function* () {
+        yield "hello ";
+        yield "world";
+      }
+    });
+
+    const chunks = await collect(iterateText(stream));
+    expect(chunks).toEqual(["hello ", "world"]);
+  });
 });
 
 describe("SSE parsing resilience", () => {

--- a/packages/voice/src/text-stream.ts
+++ b/packages/voice/src/text-stream.ts
@@ -26,6 +26,49 @@ interface AIStreamChunk {
   }[];
 }
 
+type AsyncIteratorCandidate = {
+  [Symbol.asyncIterator]?: unknown;
+};
+
+function getAsyncIteratorMethod(source: object): unknown {
+  return (source as AsyncIteratorCandidate)[Symbol.asyncIterator];
+}
+
+function isAsyncIterable(source: object): source is AsyncIterable<string> {
+  return typeof getAsyncIteratorMethod(source) === "function";
+}
+
+function hasExplicitAsyncIterator(
+  source: object
+): source is AsyncIterable<string> {
+  const method = getAsyncIteratorMethod(source);
+  if (typeof method !== "function") return false;
+
+  if (Object.prototype.hasOwnProperty.call(source, Symbol.asyncIterator)) {
+    return true;
+  }
+
+  if (source instanceof ReadableStream) {
+    const nativeReadableStreamIterator = getAsyncIteratorMethod(
+      ReadableStream.prototype
+    );
+    return (
+      typeof nativeReadableStreamIterator === "function" &&
+      method !== nativeReadableStreamIterator
+    );
+  }
+
+  return false;
+}
+
+async function* iterateAsyncStrings(
+  source: AsyncIterable<string>
+): AsyncGenerator<string> {
+  for await (const chunk of source) {
+    if (typeof chunk === "string" && chunk) yield chunk;
+  }
+}
+
 /**
  * Turn any {@link TextSource} into a lazy async generator of string chunks.
  *
@@ -40,6 +83,16 @@ export async function* iterateText(source: TextSource): AsyncGenerator<string> {
   // --- plain string ---
   if (typeof source === "string") {
     if (source) yield source;
+    return;
+  }
+
+  // --- Explicit AsyncIterable<string> wrappers ---
+  // AI SDK's `textStream` is both a ReadableStream and an AsyncIterable,
+  // with an own/custom async iterator that yields raw text deltas. Prefer
+  // that path before generic ReadableStream parsing. Native ReadableStreams
+  // can also be async-iterable, so do not apply this to every stream.
+  if (hasExplicitAsyncIterator(source)) {
+    yield* iterateAsyncStrings(source);
     return;
   }
 
@@ -90,10 +143,8 @@ export async function* iterateText(source: TextSource): AsyncGenerator<string> {
   }
 
   // --- AsyncIterable<string> ---
-  if (Symbol.asyncIterator in source) {
-    for await (const chunk of source as AsyncIterable<string>) {
-      if (typeof chunk === "string" && chunk) yield chunk;
-    }
+  if (isAsyncIterable(source)) {
+    yield* iterateAsyncStrings(source);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1364.

`withVoice` normalizes `onTurn()` output through `iterateText()`. AI SDK v6's `streamText().textStream` is both a `ReadableStream<string>` and an `AsyncIterable<string>`, with an explicit async iterator that yields raw text deltas. Previously, `iterateText()` checked `instanceof ReadableStream` first, so AI SDK-style dual-protocol streams could be consumed through the generic reader/NDJSON path and produce no text for the TTS pipeline.

This PR updates `iterateText()` to prefer an explicit/custom async iterator before generic `ReadableStream` handling, while preserving native `ReadableStream<string>` and `ReadableStream<Uint8Array>` behavior.

## Changes

- Add small async-iterator helpers in `packages/voice/src/text-stream.ts` without using `any`.
- Prefer sources with an own/custom `Symbol.asyncIterator` before the `ReadableStream` branch, matching AI SDK `AsyncIterableStream<string>` behavior.
- Keep native `ReadableStream<string>` chunk iteration and `ReadableStream<Uint8Array>` SSE/NDJSON parsing intact.
- Add a regression test for an AI SDK-like dual-protocol stream whose reader path would not yield valid text but whose async iterator yields text deltas.
- Add a patch changeset for `@cloudflare/voice`.

## Testing

- `npx vitest --run -c packages/voice/src/tests/vitest.config.ts packages/voice/src/tests/text-stream.test.ts`
- `npm test -w @cloudflare/voice`
- `npx oxfmt --check packages/voice/src/text-stream.ts packages/voice/src/tests/text-stream.test.ts .changeset/quick-voices-stream.md`
- `npx oxlint packages/voice/src/text-stream.ts packages/voice/src/tests/text-stream.test.ts`
- `npm run build -w @cloudflare/voice`
