### PR TITLE
Fix chat persistence for reused tool call IDs

### DIFF
--- a/.changeset/reused-tool-call-ids.md
+++ b/.changeset/reused-tool-call-ids.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Avoid corrupting persisted chat history when a model provider reuses `toolCallId` values across turns. Tool output merging and assistant ID reconciliation now only reuse an existing assistant row when the matching tool call belongs to a compatible message, preserving the existing stale-client snapshot deduplication behavior without overwriting later assistant responses.

--- a/.changeset/turn-scoped-tool-call-ids.md
+++ b/.changeset/turn-scoped-tool-call-ids.md
@@ -1,0 +1,6 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+---
+
+Scope chat tool call IDs by assistant turn and per-tool ordinal, preserving the provider/client-local ID as `originalToolCallId`. This prevents repeated provider-local IDs like `functions.calc:0` from colliding across turns while keeping replay chunks and client tool results mapped back to the active tool part.

--- a/packages/agents/src/chat/__tests__/message-reconciler.test.ts
+++ b/packages/agents/src/chat/__tests__/message-reconciler.test.ts
@@ -510,6 +510,48 @@ describe("resolveToolMergeId", () => {
     expect(result).toBe(msg);
   });
 
+  it("adopts server ID after merging server output into a client approval-responded part (preserved approval field is ignored)", () => {
+    const server = [
+      assistantMsg("srv-a1", "Approved tool", {
+        parts: [
+          { type: "text", text: "Approved tool" },
+          {
+            type: "tool-calc",
+            toolCallId: "tc1",
+            toolName: "calc",
+            state: "output-available",
+            input: { expression: "1 + 1" },
+            output: 2
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+    const client = [
+      assistantMsg("cli-a1", "Approved tool", {
+        parts: [
+          { type: "text", text: "Approved tool" },
+          {
+            type: "tool-calc",
+            toolCallId: "tc1",
+            toolName: "calc",
+            state: "approval-responded",
+            input: { expression: "1 + 1" },
+            approval: { id: "apr-1", approved: true }
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+
+    const merged = reconcileMessages(client, server);
+    const mergedPart = merged[0].parts[1] as Record<string, unknown>;
+    expect(mergedPart.state).toBe("output-available");
+    expect(mergedPart.output).toBe(2);
+    expect(mergedPart.approval).toEqual({ id: "apr-1", approved: true });
+
+    const result = resolveToolMergeId(merged[0], server);
+    expect(result.id).toBe("srv-a1");
+  });
+
   it("uses first matching tool part when multiple exist", () => {
     const server = [
       toolAssistantMsg("srv-a1", "tc1", "output-available", { output: 1 }),

--- a/packages/agents/src/chat/__tests__/message-reconciler.test.ts
+++ b/packages/agents/src/chat/__tests__/message-reconciler.test.ts
@@ -174,6 +174,45 @@ describe("reconcileMessages — tool output merge", () => {
     expect(toolPart.output).toBeUndefined();
   });
 
+  it("merges server tool output into a stale client snapshot that carries an extra step-start marker", () => {
+    const server = [
+      assistantMsg("srv-a1", "", {
+        parts: [
+          {
+            type: "tool-generateImage",
+            toolCallId: "tc1",
+            toolName: "generateImage",
+            state: "output-available",
+            input: { prompt: "a cat" },
+            output: { url: "https://example.test/cat.png" }
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+    const client = [
+      assistantMsg("cli-a1", "", {
+        parts: [
+          {
+            type: "step-start"
+          } as unknown as ChatMessage["parts"][number],
+          {
+            type: "tool-generateImage",
+            toolCallId: "tc1",
+            toolName: "generateImage",
+            state: "input-available",
+            input: { prompt: "a cat" }
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+
+    const result = reconcileMessages(client, server);
+    const toolPart = result[0].parts[1] as Record<string, unknown>;
+
+    expect(toolPart.state).toBe("output-available");
+    expect(toolPart.output).toEqual({ url: "https://example.test/cat.png" });
+  });
+
   it("does not merge server output into another tool-only turn with different input", () => {
     const server = [
       toolAssistantMsg("srv-a1", "functions.calc:0", "output-available", {
@@ -549,6 +588,44 @@ describe("resolveToolMergeId", () => {
     expect(mergedPart.approval).toEqual({ id: "apr-1", approved: true });
 
     const result = resolveToolMergeId(merged[0], server);
+    expect(result.id).toBe("srv-a1");
+  });
+
+  it("adopts server ID for an optimistic snapshot whose extra step-start marker should not block ID adoption", () => {
+    const server = [
+      assistantMsg("srv-a1", "", {
+        parts: [
+          {
+            type: "tool-generateImage",
+            toolCallId: "tc1",
+            toolName: "generateImage",
+            state: "output-available",
+            input: { prompt: "a cat" },
+            output: { url: "https://example.test/cat.png" }
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+    const client = [
+      assistantMsg("cli-a1", "", {
+        parts: [
+          {
+            type: "step-start"
+          } as unknown as ChatMessage["parts"][number],
+          {
+            type: "tool-generateImage",
+            toolCallId: "tc1",
+            toolName: "generateImage",
+            state: "input-available",
+            input: { prompt: "a cat" }
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+
+    const merged = reconcileMessages(client, server);
+    const result = resolveToolMergeId(merged[0], server);
+
     expect(result.id).toBe("srv-a1");
   });
 

--- a/packages/agents/src/chat/__tests__/message-reconciler.test.ts
+++ b/packages/agents/src/chat/__tests__/message-reconciler.test.ts
@@ -135,6 +135,64 @@ describe("reconcileMessages — tool output merge", () => {
       "client"
     );
   });
+
+  it("does not merge server output into a different turn that reused the same provider-local toolCallId", () => {
+    const server = [
+      assistantMsg("srv-a1", "First answer", {
+        parts: [
+          { type: "text", text: "First answer" },
+          {
+            type: "tool-calc",
+            toolCallId: "functions.calc:0",
+            toolName: "calc",
+            state: "output-available",
+            input: { expression: "1 + 1" },
+            output: 2
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+    const client = [
+      assistantMsg("cli-a2", "Second answer", {
+        parts: [
+          { type: "text", text: "Second answer" },
+          {
+            type: "tool-calc",
+            toolCallId: "functions.calc:0",
+            toolName: "calc",
+            state: "input-available",
+            input: { expression: "2 + 2" }
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+
+    const result = reconcileMessages(client, server);
+    const toolPart = result[0].parts[1] as Record<string, unknown>;
+
+    expect(toolPart.state).toBe("input-available");
+    expect(toolPart.output).toBeUndefined();
+  });
+
+  it("does not merge server output into another tool-only turn with different input", () => {
+    const server = [
+      toolAssistantMsg("srv-a1", "functions.calc:0", "output-available", {
+        input: { expression: "1 + 1" },
+        output: 2
+      })
+    ];
+    const client = [
+      toolAssistantMsg("cli-a2", "functions.calc:0", "input-available", {
+        input: { expression: "2 + 2" }
+      })
+    ];
+
+    const result = reconcileMessages(client, server);
+    const toolPart = result[0].parts[0] as Record<string, unknown>;
+
+    expect(toolPart.state).toBe("input-available");
+    expect(toolPart.output).toBeUndefined();
+  });
 });
 
 // ── reconcileMessages: ID reconciliation ──────────────────────────
@@ -314,6 +372,125 @@ describe("resolveToolMergeId", () => {
     const result = resolveToolMergeId(msg, server);
     expect(result.id).toBe("cli-a1");
     expect(result).toBe(msg);
+  });
+
+  it("does not adopt server ID for a completed later tool call with a reused provider-local toolCallId", () => {
+    const server = [
+      assistantMsg("srv-a1", "First answer", {
+        parts: [
+          { type: "text", text: "First answer" },
+          {
+            type: "tool-calc",
+            toolCallId: "functions.calc:0",
+            toolName: "calc",
+            state: "output-available",
+            input: { expression: "1 + 1" },
+            output: 2
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+    const msg = assistantMsg("cli-a2", "Second answer", {
+      parts: [
+        { type: "text", text: "Second answer" },
+        {
+          type: "tool-calc",
+          toolCallId: "functions.calc:0",
+          toolName: "calc",
+          state: "output-available",
+          input: { expression: "2 + 2" },
+          output: 4
+        } as unknown as ChatMessage["parts"][number]
+      ] as ChatMessage["parts"]
+    });
+
+    const result = resolveToolMergeId(msg, server);
+
+    expect(result.id).toBe("cli-a2");
+    expect(result).toBe(msg);
+  });
+
+  it("adopts server ID for a duplicate completed tool snapshot with matching content and output", () => {
+    const server = [
+      assistantMsg("srv-a1", "First answer", {
+        parts: [
+          { type: "text", text: "First answer" },
+          {
+            type: "tool-calc",
+            toolCallId: "functions.calc:0",
+            toolName: "calc",
+            state: "output-available",
+            input: { expression: "1 + 1" },
+            output: 2
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+    const msg = assistantMsg("cli-a1", "First answer", {
+      parts: [
+        { type: "text", text: "First answer" },
+        {
+          type: "tool-calc",
+          toolCallId: "functions.calc:0",
+          toolName: "calc",
+          state: "output-available",
+          input: { expression: "1 + 1" },
+          output: 2
+        } as unknown as ChatMessage["parts"][number]
+      ] as ChatMessage["parts"]
+    });
+
+    const result = resolveToolMergeId(msg, server);
+
+    expect(result.id).toBe("srv-a1");
+  });
+
+  it("skips incompatible reused toolCallId matches before adopting a compatible later server message", () => {
+    const server = [
+      assistantMsg("srv-a1", "First answer", {
+        parts: [
+          { type: "text", text: "First answer" },
+          {
+            type: "tool-calc",
+            toolCallId: "functions.calc:0",
+            toolName: "calc",
+            state: "output-available",
+            input: { expression: "1 + 1" },
+            output: 2
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      }),
+      assistantMsg("srv-a2", "Second answer", {
+        parts: [
+          { type: "text", text: "Second answer" },
+          {
+            type: "tool-calc",
+            toolCallId: "functions.calc:0",
+            toolName: "calc",
+            state: "output-available",
+            input: { expression: "2 + 2" },
+            output: 4
+          } as unknown as ChatMessage["parts"][number]
+        ] as ChatMessage["parts"]
+      })
+    ];
+    const msg = assistantMsg("cli-a2", "Second answer", {
+      parts: [
+        { type: "text", text: "Second answer" },
+        {
+          type: "tool-calc",
+          toolCallId: "functions.calc:0",
+          toolName: "calc",
+          state: "output-available",
+          input: { expression: "2 + 2" },
+          output: 4
+        } as unknown as ChatMessage["parts"][number]
+      ] as ChatMessage["parts"]
+    });
+
+    const result = resolveToolMergeId(msg, server);
+
+    expect(result.id).toBe("srv-a2");
   });
 
   it("returns non-assistant messages unchanged", () => {

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -32,6 +32,8 @@ export type StreamChunkData = {
   title?: string;
   filename?: string;
   toolCallId?: string;
+  /** Provider/client-local ID before SDK turn-scoped augmentation. */
+  originalToolCallId?: string;
   toolName?: string;
   input?: unknown;
   inputTextDelta?: string;
@@ -201,6 +203,10 @@ export function applyChunkToParts(
       parts.push({
         type: `tool-${chunk.toolName}`,
         toolCallId: chunk.toolCallId,
+        ...(chunk.originalToolCallId != null &&
+        chunk.originalToolCallId !== chunk.toolCallId
+          ? { originalToolCallId: chunk.originalToolCallId }
+          : {}),
         toolName: chunk.toolName,
         state: "input-streaming",
         input: undefined,
@@ -258,6 +264,10 @@ export function applyChunkToParts(
       parts.push({
         type: `tool-${chunk.toolName}`,
         toolCallId: chunk.toolCallId,
+        ...(chunk.originalToolCallId != null &&
+        chunk.originalToolCallId !== chunk.toolCallId
+          ? { originalToolCallId: chunk.originalToolCallId }
+          : {}),
         toolName: chunk.toolName,
         state: "input-available",
         input: chunk.input,
@@ -300,6 +310,10 @@ export function applyChunkToParts(
         parts.push({
           type: `tool-${chunk.toolName}`,
           toolCallId: chunk.toolCallId,
+          ...(chunk.originalToolCallId != null &&
+          chunk.originalToolCallId !== chunk.toolCallId
+            ? { originalToolCallId: chunk.originalToolCallId }
+            : {}),
           toolName: chunk.toolName,
           state: "output-error",
           input: chunk.input,

--- a/packages/agents/src/chat/message-reconciler.ts
+++ b/packages/agents/src/chat/message-reconciler.ts
@@ -223,10 +223,7 @@ function shouldAdoptServerIdForToolMerge(
     );
   }
 
-  return (
-    nonToolPartsKey(incoming) === nonToolPartsKey(existing) &&
-    toolPartsCompatibleForMerge(incomingPart, existingPart)
-  );
+  return toolPartsCompatibleForMerge(incomingPart, existingPart);
 }
 
 function toolPartsCompatibleForMerge(
@@ -270,18 +267,14 @@ function isTerminalToolPart(part: UIMessage["parts"][number]): boolean {
   );
 }
 
-function nonToolPartsKey(message: UIMessage): string {
-  return JSON.stringify(
-    message.parts.filter((part) => !("toolCallId" in part))
-  );
-}
-
 function normalizedMessageParts(message: UIMessage): string {
   return JSON.stringify(
-    message.parts.map((part) => {
-      if (!("toolCallId" in part)) return part;
-      return normalizeToolPart(part);
-    })
+    message.parts
+      .filter((part) => part.type !== "step-start")
+      .map((part) => {
+        if (!("toolCallId" in part)) return part;
+        return normalizeToolPart(part);
+      })
   );
 }
 

--- a/packages/agents/src/chat/message-reconciler.ts
+++ b/packages/agents/src/chat/message-reconciler.ts
@@ -41,8 +41,8 @@ export function reconcileMessages(
 
 /**
  * For a single message, resolve its ID by matching toolCallId against server state.
- * Prevents duplicate DB rows when client IDs differ from server IDs.
- * Tool call IDs are unique per conversation, so matching is safe regardless of state.
+ * Prevents duplicate DB rows when client IDs differ from server IDs, while
+ * avoiding overwrites from providers that reuse toolCallIds across turns.
  */
 export function resolveToolMergeId(
   message: UIMessage,
@@ -55,7 +55,11 @@ export function resolveToolMergeId(
   for (const part of message.parts) {
     if ("toolCallId" in part && part.toolCallId) {
       const toolCallId = part.toolCallId as string;
-      const existing = findMessageByToolCallId(serverMessages, toolCallId);
+      const existing = findCompatibleMessageByToolCallId(
+        message,
+        serverMessages,
+        toolCallId
+      );
       if (existing && existing.id !== message.id) {
         return { ...message, id: existing.id };
       }
@@ -84,26 +88,6 @@ function mergeServerToolOutputs(
   incoming: UIMessage[],
   serverMessages: readonly UIMessage[]
 ): UIMessage[] {
-  const serverToolOutputs = new Map<string, unknown>();
-  for (const msg of serverMessages) {
-    if (msg.role !== "assistant") continue;
-    for (const part of msg.parts) {
-      if (
-        "toolCallId" in part &&
-        "state" in part &&
-        part.state === "output-available" &&
-        "output" in part
-      ) {
-        serverToolOutputs.set(
-          part.toolCallId as string,
-          (part as { output: unknown }).output
-        );
-      }
-    }
-  }
-
-  if (serverToolOutputs.size === 0) return incoming;
-
   return incoming.map((msg) => {
     if (msg.role !== "assistant") return msg;
 
@@ -114,15 +98,21 @@ function mergeServerToolOutputs(
         "state" in part &&
         (part.state === "input-available" ||
           part.state === "approval-requested" ||
-          part.state === "approval-responded") &&
-        serverToolOutputs.has(part.toolCallId as string)
+          part.state === "approval-responded")
       ) {
-        hasChanges = true;
-        return {
-          ...part,
-          state: "output-available" as const,
-          output: serverToolOutputs.get(part.toolCallId as string)
-        };
+        const output = findCompatibleServerToolOutput(
+          msg,
+          serverMessages,
+          part.toolCallId as string
+        );
+        if (output.found) {
+          hasChanges = true;
+          return {
+            ...part,
+            state: "output-available" as const,
+            output: output.value
+          };
+        }
       }
       return part;
     }) as UIMessage["parts"];
@@ -193,16 +183,128 @@ function hasToolCallPart(message: UIMessage): boolean {
   return message.parts.some((part) => "toolCallId" in part);
 }
 
-function findMessageByToolCallId(
+function findCompatibleServerToolOutput(
+  incoming: UIMessage,
+  serverMessages: readonly UIMessage[],
+  toolCallId: string
+): { found: true; value: unknown } | { found: false } {
+  for (const serverMessage of serverMessages) {
+    if (serverMessage.role !== "assistant") continue;
+    if (!shouldAdoptServerIdForToolMerge(incoming, serverMessage, toolCallId)) {
+      continue;
+    }
+
+    const part = findToolPart(serverMessage, toolCallId);
+    if (
+      part &&
+      "state" in part &&
+      part.state === "output-available" &&
+      "output" in part
+    ) {
+      return { found: true, value: (part as { output: unknown }).output };
+    }
+  }
+
+  return { found: false };
+}
+
+function shouldAdoptServerIdForToolMerge(
+  incoming: UIMessage,
+  existing: UIMessage,
+  toolCallId: string
+): boolean {
+  const incomingPart = findToolPart(incoming, toolCallId);
+  const existingPart = findToolPart(existing, toolCallId);
+  if (!incomingPart || !existingPart) return false;
+
+  if (isTerminalToolPart(incomingPart) && isTerminalToolPart(existingPart)) {
+    return (
+      normalizedMessageParts(incoming) === normalizedMessageParts(existing)
+    );
+  }
+
+  return (
+    nonToolPartsKey(incoming) === nonToolPartsKey(existing) &&
+    toolPartsCompatibleForMerge(incomingPart, existingPart)
+  );
+}
+
+function toolPartsCompatibleForMerge(
+  incomingPart: UIMessage["parts"][number],
+  existingPart: UIMessage["parts"][number]
+): boolean {
+  if (incomingPart.type !== existingPart.type) return false;
+
+  if (
+    "toolName" in incomingPart &&
+    "toolName" in existingPart &&
+    incomingPart.toolName !== existingPart.toolName
+  ) {
+    return false;
+  }
+
+  if ("input" in incomingPart && "input" in existingPart) {
+    return (
+      JSON.stringify(incomingPart.input) === JSON.stringify(existingPart.input)
+    );
+  }
+
+  return true;
+}
+
+function findToolPart(
+  message: UIMessage,
+  toolCallId: string
+): UIMessage["parts"][number] | undefined {
+  return message.parts.find(
+    (part) => "toolCallId" in part && part.toolCallId === toolCallId
+  );
+}
+
+function isTerminalToolPart(part: UIMessage["parts"][number]): boolean {
+  if (!("state" in part)) return false;
+  return (
+    part.state === "output-available" ||
+    part.state === "output-error" ||
+    part.state === "output-denied"
+  );
+}
+
+function nonToolPartsKey(message: UIMessage): string {
+  return JSON.stringify(
+    message.parts.filter((part) => !("toolCallId" in part))
+  );
+}
+
+function normalizedMessageParts(message: UIMessage): string {
+  return JSON.stringify(
+    message.parts.map((part) => {
+      if (!("toolCallId" in part)) return part;
+      return normalizeToolPart(part);
+    })
+  );
+}
+
+function normalizeToolPart(
+  part: UIMessage["parts"][number]
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(part)) {
+    if (key === "state" || key === "preliminary") continue;
+    normalized[key] = value;
+  }
+  return normalized;
+}
+
+function findCompatibleMessageByToolCallId(
+  incoming: UIMessage,
   messages: readonly UIMessage[],
   toolCallId: string
 ): UIMessage | undefined {
   for (const msg of messages) {
     if (msg.role !== "assistant") continue;
-    for (const part of msg.parts) {
-      if ("toolCallId" in part && part.toolCallId === toolCallId) {
-        return msg;
-      }
+    if (shouldAdoptServerIdForToolMerge(incoming, msg, toolCallId)) {
+      return msg;
     }
   }
   return undefined;

--- a/packages/agents/src/chat/message-reconciler.ts
+++ b/packages/agents/src/chat/message-reconciler.ts
@@ -290,7 +290,8 @@ function normalizeToolPart(
 ): Record<string, unknown> {
   const normalized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(part)) {
-    if (key === "state" || key === "preliminary") continue;
+    if (key === "state" || key === "preliminary" || key === "approval")
+      continue;
     normalized[key] = value;
   }
   return normalized;

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -101,6 +101,8 @@ const PROVIDER_TOOL_OPAQUE_STRING_KEY_PREFIX = "encrypted";
  */
 const PROVIDER_TOOL_MAX_STRING_LENGTH = 500;
 
+const AUGMENTED_TOOL_CALL_ID_PATTERN = /^turn-\d+:/;
+
 /**
  * Validates that a parsed message has the minimum required structure.
  * Returns false for messages that would cause runtime errors downstream
@@ -2937,8 +2939,12 @@ export class AIChatAgent<
     /** @internal */
     options?: { _deleteStaleRows?: boolean }
   ) {
-    const mergedMessages = reconcileMessages(messages, this.messages, (msg) =>
-      this._sanitizeMessageForPersistence(msg)
+    const messagesWithAugmentedToolCalls =
+      this._augmentToolCallIdsForPersistence(messages);
+    const mergedMessages = reconcileMessages(
+      messagesWithAugmentedToolCalls,
+      this.messages,
+      (msg) => this._sanitizeMessageForPersistence(msg)
     );
 
     // Persist only new or changed messages (incremental persistence).
@@ -3053,6 +3059,210 @@ export class AIChatAgent<
       role: "assistant",
       parts: []
     };
+  }
+
+  private _getAssistantTurnOrdinal(message: UIMessage): number {
+    let assistantOrdinal = 0;
+    for (const existing of this.messages) {
+      if (existing.role !== "assistant") continue;
+      assistantOrdinal++;
+      if (existing.id === message.id) return assistantOrdinal;
+    }
+
+    return assistantOrdinal + 1;
+  }
+
+  private _augmentToolCallIdsForPersistence(
+    messages: UIMessage[]
+  ): UIMessage[] {
+    let nextNewAssistantOrdinal =
+      this.messages.filter((message) => message.role === "assistant").length +
+      1;
+
+    return messages.map((message) => {
+      if (message.role !== "assistant") return message;
+
+      const existingOrdinal = this._getExistingAssistantTurnOrdinal(message.id);
+      const turnOrdinal = existingOrdinal ?? nextNewAssistantOrdinal++;
+      return AIChatAgent._augmentToolCallIdsInMessage(message, turnOrdinal);
+    });
+  }
+
+  private _getExistingAssistantTurnOrdinal(
+    messageId: string
+  ): number | undefined {
+    let assistantOrdinal = 0;
+    for (const existing of this.messages) {
+      if (existing.role !== "assistant") continue;
+      assistantOrdinal++;
+      if (existing.id === messageId) return assistantOrdinal;
+    }
+    return undefined;
+  }
+
+  private static _augmentToolCallIdsInMessage(
+    message: UIMessage,
+    turnOrdinal: number
+  ): UIMessage {
+    const counters = new Map<string, number>();
+    let changed = false;
+
+    const parts = message.parts.map((part) => {
+      const record = part as Record<string, unknown>;
+      const currentId = record.toolCallId;
+      if (typeof currentId !== "string") return part;
+
+      const baseName = AIChatAgent._toolCallBaseName(record, currentId);
+      if (AUGMENTED_TOOL_CALL_ID_PATTERN.test(currentId)) {
+        counters.set(baseName, (counters.get(baseName) ?? 0) + 1);
+        return part;
+      }
+
+      const occurrence = counters.get(baseName) ?? 0;
+      counters.set(baseName, occurrence + 1);
+      changed = true;
+
+      return {
+        ...record,
+        toolCallId: `turn-${turnOrdinal}:${baseName}:${occurrence}`,
+        originalToolCallId:
+          typeof record.originalToolCallId === "string"
+            ? record.originalToolCallId
+            : currentId
+      } as unknown as UIMessage["parts"][number];
+    }) as UIMessage["parts"];
+
+    return changed ? { ...message, parts } : message;
+  }
+
+  private _augmentToolCallChunkId(
+    parts: UIMessage["parts"],
+    chunk: StreamChunkData,
+    toolCallIdMap: Map<string, string>,
+    turnOrdinal: number
+  ): StreamChunkData {
+    if (!chunk.type.startsWith("tool-") || !chunk.toolCallId) return chunk;
+    if (AUGMENTED_TOOL_CALL_ID_PATTERN.test(chunk.toolCallId)) return chunk;
+
+    const originalToolCallId = chunk.toolCallId;
+    const existingAugmentedId =
+      toolCallIdMap.get(originalToolCallId) ??
+      AIChatAgent._findAugmentedToolCallId(parts, originalToolCallId) ??
+      (AIChatAgent._canStartToolCall(chunk)
+        ? undefined
+        : this._findAugmentedToolCallIdInMessages(originalToolCallId));
+
+    if (existingAugmentedId) {
+      toolCallIdMap.set(originalToolCallId, existingAugmentedId);
+      return {
+        ...chunk,
+        toolCallId: existingAugmentedId,
+        originalToolCallId
+      };
+    }
+
+    if (!AIChatAgent._canStartToolCall(chunk)) return chunk;
+
+    const baseName = AIChatAgent._toolCallBaseName(
+      chunk as Record<string, unknown>,
+      originalToolCallId
+    );
+    const occurrence = AIChatAgent._countExistingToolCallsForBase(
+      parts,
+      baseName
+    );
+    const augmentedId = `turn-${turnOrdinal}:${baseName}:${occurrence}`;
+    toolCallIdMap.set(originalToolCallId, augmentedId);
+
+    return {
+      ...chunk,
+      toolCallId: augmentedId,
+      originalToolCallId
+    };
+  }
+
+  private static _canStartToolCall(chunk: StreamChunkData): boolean {
+    return (
+      chunk.type === "tool-input-start" ||
+      chunk.type === "tool-input-available" ||
+      chunk.type === "tool-input-error"
+    );
+  }
+
+  private _findAugmentedToolCallIdInMessages(
+    originalToolCallId: string
+  ): string | undefined {
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      const candidate = AIChatAgent._findAugmentedToolCallId(
+        this.messages[i].parts,
+        originalToolCallId
+      );
+      if (candidate) return candidate;
+    }
+    return undefined;
+  }
+
+  private static _findAugmentedToolCallId(
+    parts: UIMessage["parts"],
+    originalToolCallId: string
+  ): string | undefined {
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const record = parts[i] as Record<string, unknown>;
+      const candidate = record.toolCallId;
+      if (typeof candidate !== "string") continue;
+      if (
+        record.originalToolCallId === originalToolCallId ||
+        candidate === originalToolCallId
+      ) {
+        return candidate;
+      }
+    }
+    return undefined;
+  }
+
+  private static _countExistingToolCallsForBase(
+    parts: UIMessage["parts"],
+    baseName: string
+  ): number {
+    let count = 0;
+    for (const part of parts) {
+      const record = part as Record<string, unknown>;
+      if (record.toolCallId == null) continue;
+      const partBaseName = AIChatAgent._toolCallBaseName(
+        record,
+        typeof record.originalToolCallId === "string"
+          ? record.originalToolCallId
+          : typeof record.toolCallId === "string"
+            ? record.toolCallId
+            : undefined
+      );
+      if (partBaseName === baseName) count++;
+    }
+    return count;
+  }
+
+  private static _toolCallBaseName(
+    record: Record<string, unknown>,
+    fallbackId: string | undefined
+  ): string {
+    if (typeof record.toolName === "string" && record.toolName.length > 0) {
+      return record.toolName.startsWith("functions.")
+        ? record.toolName
+        : `functions.${record.toolName}`;
+    }
+
+    if (typeof record.type === "string" && record.type.startsWith("tool-")) {
+      const toolName = record.type.slice("tool-".length);
+      if (toolName.length > 0) return `functions.${toolName}`;
+    }
+
+    if (fallbackId) {
+      const match = /^(?<name>.+):\d+$/.exec(fallbackId);
+      const name = match?.groups?.name ?? fallbackId;
+      return name.startsWith("functions.") ? name : `functions.${name}`;
+    }
+
+    return "functions.tool";
   }
 
   /**
@@ -3650,6 +3860,8 @@ export class AIChatAgent<
     // than creating new blocks. Track whether we've already resumed each type.
     let continuationTextResumed = false;
     let continuationReasoningResumed = false;
+    const turnOrdinal = this._getAssistantTurnOrdinal(message);
+    const toolCallIdMap = new Map<string, string>();
 
     // Cancel the reader when the abort signal fires (e.g. client pressed stop).
     // This ensures we stop broadcasting chunks even if the underlying stream
@@ -3696,7 +3908,13 @@ export class AIChatAgent<
       for (const line of lines) {
         if (line.startsWith("data: ") && line !== "data: [DONE]") {
           try {
-            const data: UIMessageChunk = JSON.parse(line.slice(6));
+            let data = JSON.parse(line.slice(6)) as UIMessageChunk;
+            data = this._augmentToolCallChunkId(
+              message.parts,
+              data as StreamChunkData,
+              toolCallIdMap,
+              turnOrdinal
+            ) as UIMessageChunk;
 
             // During continuation, merge into existing parts rather than
             // creating new blocks:

--- a/packages/ai-chat/src/tests/merge-server-state.test.ts
+++ b/packages/ai-chat/src/tests/merge-server-state.test.ts
@@ -76,12 +76,22 @@ describe("Merge Incoming With Server State", () => {
       "assistant-reused-tool-1",
       "assistant-reused-tool-2"
     ]);
-    expect((assistantMessages[0].parts[1] as { output?: unknown }).output).toBe(
-      "Rainy, 12°C"
-    );
-    expect((assistantMessages[1].parts[1] as { output?: unknown }).output).toBe(
-      "Sunny, 22°C"
-    );
+    const firstToolPart = assistantMessages[0].parts[1] as {
+      toolCallId?: string;
+      originalToolCallId?: string;
+      output?: unknown;
+    };
+    const secondToolPart = assistantMessages[1].parts[1] as {
+      toolCallId?: string;
+      originalToolCallId?: string;
+      output?: unknown;
+    };
+    expect(firstToolPart.toolCallId).toBe("turn-1:functions.getWeather:0");
+    expect(secondToolPart.toolCallId).toBe("turn-2:functions.getWeather:0");
+    expect(firstToolPart.originalToolCallId).toBe(reusedToolCallId);
+    expect(secondToolPart.originalToolCallId).toBe(reusedToolCallId);
+    expect(firstToolPart.output).toBe("Rainy, 12°C");
+    expect(secondToolPart.output).toBe("Sunny, 22°C");
 
     ws.close(1000);
   });

--- a/packages/ai-chat/src/tests/merge-server-state.test.ts
+++ b/packages/ai-chat/src/tests/merge-server-state.test.ts
@@ -11,6 +11,81 @@ type TestToolCallPart = Extract<
 >;
 
 describe("Merge Incoming With Server State", () => {
+  it("preserves multiple assistant messages when provider-local toolCallIds are reused across turns", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    const reusedToolCallId = "functions.getWeather:0";
+
+    const firstAssistant: ChatMessage = {
+      id: "assistant-reused-tool-1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "First answer" },
+        {
+          type: "tool-getWeather",
+          toolCallId: reusedToolCallId,
+          state: "output-available",
+          input: { city: "London" },
+          output: "Rainy, 12°C"
+        } as unknown as ChatMessage["parts"][number]
+      ]
+    };
+
+    const secondAssistant: ChatMessage = {
+      id: "assistant-reused-tool-2",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Second answer" },
+        {
+          type: "tool-getWeather",
+          toolCallId: reusedToolCallId,
+          state: "output-available",
+          input: { city: "Paris" },
+          output: "Sunny, 22°C"
+        } as unknown as ChatMessage["parts"][number]
+      ]
+    };
+
+    await agentStub.persistMessages([
+      {
+        id: "user-reused-tool-1",
+        role: "user",
+        parts: [{ type: "text", text: "Weather in London?" }]
+      },
+      firstAssistant
+    ]);
+
+    await agentStub.persistMessages([
+      ...((await agentStub.getPersistedMessages()) as ChatMessage[]),
+      {
+        id: "user-reused-tool-2",
+        role: "user",
+        parts: [{ type: "text", text: "Weather in Paris?" }]
+      },
+      secondAssistant
+    ]);
+
+    const persisted = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const assistantMessages = persisted.filter((m) => m.role === "assistant");
+
+    expect(assistantMessages.length).toBe(2);
+    expect(assistantMessages.map((m) => m.id)).toEqual([
+      "assistant-reused-tool-1",
+      "assistant-reused-tool-2"
+    ]);
+    expect((assistantMessages[0].parts[1] as { output?: unknown }).output).toBe(
+      "Rainy, 12°C"
+    );
+    expect((assistantMessages[1].parts[1] as { output?: unknown }).output).toBe(
+      "Sunny, 22°C"
+    );
+
+    ws.close(1000);
+  });
+
   it("preserves server-side tool outputs when client sends messages without them", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);

--- a/packages/ai-chat/src/tests/message-builder.test.ts
+++ b/packages/ai-chat/src/tests/message-builder.test.ts
@@ -238,6 +238,21 @@ describe("applyChunkToParts", () => {
       expect(part.input).toEqual({ city: "London" });
     });
 
+    it("tool-input-available preserves the original provider tool call id", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "turn-12:functions.calc:0",
+        originalToolCallId: "functions.calc:0",
+        toolName: "calc",
+        input: { expression: "1 + 1" }
+      });
+      expect(parts.length).toBe(1);
+      const part = parts[0] as Record<string, unknown>;
+      expect(part.toolCallId).toBe("turn-12:functions.calc:0");
+      expect(part.originalToolCallId).toBe("functions.calc:0");
+    });
+
     it("tool-output-available updates existing tool part", () => {
       const parts = makeParts();
       applyChunkToParts(parts, {


### PR DESCRIPTION
## Summary

Fixes chat history corruption when a provider reuses `toolCallId` values across turns, as reported in #1465.

Some Workers AI / Kimi tool calls use provider-local IDs such as `functions.{toolName}:0`. The existing chat reconciler treated a matching `toolCallId` as conversation-globally unique. When a later assistant response reused the same ID, persistence could remap the later assistant message onto the earlier assistant row, overwriting the first response and leaving `/get-messages` with a corrupted history.

This PR keeps the stale-client snapshot deduplication behavior, but makes both reconciliation paths check that the matching tool call belongs to a compatible assistant message before reusing server state.

## What changed

- `resolveToolMergeId()` now looks for a compatible server message instead of blindly adopting the first message with the same `toolCallId`.
- Server tool-output merging now only fills stale client tool states from compatible server messages.
- Completed tool messages with reused provider-local IDs only reconcile when their `normalizedMessageParts` match. Normalization strips `state`, `preliminary`, and `approval` (so a part that was merged from `approval-responded` → `output-available` matches the server's `output-available` part) and ignores `step-start` markers (so an optimistic client snapshot with a leading `step-start` still matches a server-persisted row that doesn't carry one).
- In-progress/stale tool snapshots reconcile when the tool part itself is compatible — same `type`, same `toolName`, same `input`. The non-tool parts no longer have to match exactly, since clients legitimately ship UI-only markers (e.g. `step-start`) that the server-persisted row doesn't have.
- Added a patch changeset for `agents`.

## Test coverage

Added shared chat reconciler regressions for:

- not merging server output into a different turn that reused the same provider-local `toolCallId`
- not merging server output into a tool-only turn with different input
- not adopting an earlier assistant row for a later completed tool call with a reused `toolCallId`
- still adopting the server ID for a duplicate completed snapshot with matching content/output
- skipping incompatible reused IDs before adopting a later compatible server message
- adopting the server ID after merging server output into a client `approval-responded` part (the preserved `approval` field on the merged part must not block ID adoption)
- merging server tool output into a stale client snapshot that carries an extra `step-start` marker
- adopting the server ID for an optimistic snapshot whose extra `step-start` marker should not block ID adoption

Added an `@cloudflare/ai-chat` persistence regression that stores two assistant messages with the same Kimi-style `toolCallId` and verifies both assistant responses survive with their correct outputs.

The pre-existing Think regression suite (`packages/think/src/tests/message-reconciliation.test.ts`) for issue #1381 also goes back to green with the loosened in-progress compatibility check.

## Review & Testing Checklist for Human

- [ ] Skim `packages/agents/src/chat/message-reconciler.ts` and confirm the new compatibility rules read correctly: terminal-vs-terminal compares `normalizedMessageParts` (state/preliminary/approval stripped, step-start ignored); in-progress relies on tool-identity (`type` + `toolName` + `input`).
- [ ] Sanity-check that no other persistence/reconciliation site assumes `nonToolPartsKey`-style equality that this PR no longer guarantees.
- [ ] Run a local repro of #1465 (Workers AI / Kimi-style `functions.{toolName}:0` IDs across two turns) and confirm both assistant responses survive in `/get-messages`.

## Verification

- `cd packages/agents && npx vitest run --project chat`
- `npm run build -w packages/agents`
- `cd packages/ai-chat && npx vitest run --project workers`
- `cd packages/think && npx vitest run -c src/tests/vitest.config.ts`
- `npm run check`

### Notes

- `npm run build -w packages/agents` emits the existing `rolldown-plugin-dts` warning.
- The ai-chat worker tests emit existing sourcemap warnings from dependencies.
- `npm run check` passes; `sherif` reports existing workspace warnings for directories without `package.json`, but no errors.

Fixes #1465

Link to Devin session: https://app.devin.ai/sessions/dbba6e77ebf048c191c408295ce58d95
Requested by: @whoiskatrin