### PR TITLE
fix(codemode): resolve OpenAPI specs inside sandbox

### DIFF
--- a/.changeset/codemode-openapi-spec-sandbox.md
+++ b/.changeset/codemode-openapi-spec-sandbox.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Resolve OpenAPI specs inside the codemode sandbox to avoid Worker Loader RPC size limits for heavily-referenced specs.

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -6,6 +6,7 @@ import {
   generateTypesFromJsonSchema,
   type JsonSchemaToolDescriptors
 } from "./json-schema-types";
+import { normalizeCode } from "./normalize";
 import { sanitizeToolName } from "./utils";
 import type { Executor } from "./executor";
 
@@ -247,48 +248,6 @@ export interface OpenApiMcpServerOptions {
   description?: string;
 }
 
-/**
- * Resolve internal $ref pointers in a JSON object against the root document.
- * Only handles `#/` internal refs. External file refs are left as-is.
- */
-function resolveRefs(
-  obj: unknown,
-  root: Record<string, unknown>,
-  seen = new Set<string>()
-): unknown {
-  if (obj === null || obj === undefined) return obj;
-  if (typeof obj !== "object") return obj;
-  if (Array.isArray(obj))
-    return obj.map((item) => resolveRefs(item, root, seen));
-
-  const record = obj as Record<string, unknown>;
-
-  if ("$ref" in record && typeof record.$ref === "string") {
-    const ref = record.$ref;
-    if (seen.has(ref)) return { $circular: ref };
-    if (!ref.startsWith("#/")) return record;
-    seen.add(ref);
-
-    const parts = ref
-      .slice(2)
-      .split("/")
-      .map((s) => s.replace(/~1/g, "/").replace(/~0/g, "~"));
-    let resolved: unknown = root;
-    for (const part of parts) {
-      resolved = (resolved as Record<string, unknown>)?.[part];
-    }
-    const result = resolveRefs(resolved, root, seen);
-    seen.delete(ref);
-    return result;
-  }
-
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
-    result[key] = resolveRefs(value, root, seen);
-  }
-  return result;
-}
-
 const SPEC_TYPES = `
 // OpenAPI 3.x spec with $refs resolved inline.
 // The spec object follows the standard OpenAPI 3.x structure.
@@ -356,10 +315,67 @@ interface RequestOptions {
   rawBody?: boolean;
 }
 
+${SPEC_TYPES}
+
 declare const codemode: {
+  spec(): Promise<OpenApiSpec>;
   request(options: RequestOptions): Promise<unknown>;
 };
 `;
+
+function createOpenApiSandboxCode(
+  code: string,
+  spec: Record<string, unknown>,
+  includeRequest: boolean
+): string {
+  const normalized = normalizeCode(code);
+  const specJson = JSON.stringify(spec).replace(/</g, "\\u003c");
+  const requestFn = includeRequest
+    ? `request: async (options) => await __openapiHost.request(options)`
+    : "";
+
+  return `async () => {
+const __rawSpec = ${specJson};
+const __resolveRefs = (obj, root, seen = new Set()) => {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== "object") return obj;
+  if (Array.isArray(obj)) return obj.map((item) => __resolveRefs(item, root, seen));
+
+  if (Object.prototype.hasOwnProperty.call(obj, "$ref") && typeof obj.$ref === "string") {
+    const ref = obj.$ref;
+    if (seen.has(ref)) return { $circular: ref };
+    if (!ref.startsWith("#/")) return obj;
+    seen.add(ref);
+
+    const parts = ref
+      .slice(2)
+      .split("/")
+      .map((s) => s.replace(/~1/g, "/").replace(/~0/g, "~"));
+    let resolved = root;
+    for (const part of parts) resolved = resolved?.[part];
+    const result = __resolveRefs(resolved, root, seen);
+    seen.delete(ref);
+    return result;
+  }
+
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) result[key] = __resolveRefs(value, root, seen);
+  return result;
+};
+let __resolvedSpec;
+const __truncateResponse = (content) => {
+  const text = typeof content === "string" ? content : (JSON.stringify(content, null, 2) ?? "undefined");
+  if (text.length <= ${MAX_CHARS}) return text;
+  const truncated = text.slice(0, ${MAX_CHARS});
+  const estimatedTokens = Math.ceil(text.length / ${CHARS_PER_TOKEN});
+  return truncated + "\\n\\n--- TRUNCATED ---\\nResponse was ~" + estimatedTokens.toLocaleString() + " tokens (limit: ${MAX_TOKENS.toLocaleString()}). Use more specific queries to reduce response size.";
+};
+const codemode = {
+  spec: async () => (__resolvedSpec ??= __resolveRefs(__rawSpec, __rawSpec))${requestFn ? `,\n  ${requestFn}` : ""}
+};
+return __truncateResponse(await (${normalized})());
+}`;
+}
 
 /**
  * Create an MCP server with search + execute tools from an OpenAPI spec.
@@ -377,7 +393,7 @@ export function openApiMcpServer(options: OpenApiMcpServerOptions): McpServer {
     description
   } = options;
 
-  const resolved = resolveRefs(options.spec, options.spec);
+  const spec = options.spec;
 
   const server = new McpServer({ name, version });
 
@@ -421,9 +437,10 @@ async () => {
     },
     async ({ code }) => {
       try {
-        const result = await executor.execute(code, [
-          { name: "codemode", fns: { spec: async () => resolved } }
-        ]);
+        const result = await executor.execute(
+          createOpenApiSandboxCode(code, spec, false),
+          []
+        );
         if (result.error) {
           return {
             content: [
@@ -471,14 +488,17 @@ async () => {
     },
     async ({ code }) => {
       try {
-        const result = await executor.execute(code, [
-          {
-            name: "codemode",
-            fns: {
-              request: (args: unknown) => requestFn(args as RequestOptions)
+        const result = await executor.execute(
+          createOpenApiSandboxCode(code, spec, true),
+          [
+            {
+              name: "__openapiHost",
+              fns: {
+                request: (args: unknown) => requestFn(args as RequestOptions)
+              }
             }
-          }
-        ]);
+          ]
+        );
         if (result.error) {
           return {
             content: [

--- a/packages/codemode/src/tests/__snapshots__/mcp.test.ts.snap
+++ b/packages/codemode/src/tests/__snapshots__/mcp.test.ts.snap
@@ -53,7 +53,65 @@ interface RequestOptions {
   rawBody?: boolean;
 }
 
+
+// OpenAPI 3.x spec with $refs resolved inline.
+// The spec object follows the standard OpenAPI 3.x structure.
+
+interface OperationObject {
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  tags?: string[];
+  parameters?: Array<{
+    name: string;
+    in: "query" | "header" | "path" | "cookie";
+    required?: boolean;
+    schema?: unknown;
+    description?: string;
+  }>;
+  requestBody?: {
+    required?: boolean;
+    description?: string;
+    content?: Record<string, { schema?: unknown }>;
+  };
+  responses?: Record<string, {
+    description?: string;
+    content?: Record<string, { schema?: unknown }>;
+  }>;
+  security?: Array<Record<string, string[]>>;
+  deprecated?: boolean;
+}
+
+interface PathItem {
+  summary?: string;
+  description?: string;
+  get?: OperationObject;
+  post?: OperationObject;
+  put?: OperationObject;
+  patch?: OperationObject;
+  delete?: OperationObject;
+  head?: OperationObject;
+  options?: OperationObject;
+  trace?: OperationObject;
+  parameters?: OperationObject["parameters"];
+}
+
+interface OpenApiSpec {
+  openapi: string;
+  info: { title: string; version: string; description?: string };
+  paths: Record<string, PathItem>;
+  servers?: Array<{ url: string; description?: string }>;
+  components?: Record<string, unknown>;
+  tags?: Array<{ name: string; description?: string }>;
+}
+
 declare const codemode: {
+  spec(): Promise<OpenApiSpec>;
+};
+
+
+declare const codemode: {
+  spec(): Promise<OpenApiSpec>;
   request(options: RequestOptions): Promise<unknown>;
 };
 

--- a/packages/codemode/src/tests/mcp.test.ts
+++ b/packages/codemode/src/tests/mcp.test.ts
@@ -56,6 +56,50 @@ function callText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return (result.content as Array<{ type: string; text: string }>)[0].text;
 }
 
+function buildReferencedOpenApiSpec({
+  operations,
+  properties
+}: {
+  operations: number;
+  properties: number;
+}) {
+  const bigSchema = {
+    type: "object",
+    properties: Object.fromEntries(
+      Array.from({ length: properties }, (_, i) => [
+        `field_${i}`,
+        { type: "string", description: "x".repeat(100) }
+      ])
+    )
+  };
+
+  return {
+    openapi: "3.1.0",
+    info: { title: "Synthetic", version: "1" },
+    paths: Object.fromEntries(
+      Array.from({ length: operations }, (_, i) => [
+        `/items/${i}`,
+        {
+          get: {
+            operationId: `getItem${i}`,
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/BigSchema" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ])
+    ),
+    components: { schemas: { BigSchema: bigSchema } }
+  };
+}
+
 describe("codeMcpServer", () => {
   it("should expose a single code tool", async () => {
     const upstream = createUpstreamServer();
@@ -600,6 +644,27 @@ describe("openApiMcpServer", () => {
       type: "array",
       items: { type: "object", properties: { id: { type: "string" } } }
     });
+
+    await client.close();
+  });
+
+  it("search should resolve large specs inside the sandbox instead of crossing RPC pre-expanded", async () => {
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const server = openApiMcpServer({
+      spec: buildReferencedOpenApiSpec({ operations: 2000, properties: 200 }),
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: "async () => { const spec = await codemode.spec(); return Object.keys(spec.paths).length; }"
+      }
+    });
+
+    expect(callText(result)).toBe("2000");
 
     await client.close();
   });


### PR DESCRIPTION
## Summary

Fixes #1466.

`openApiMcpServer` previously resolved every internal OpenAPI `$ref` on the host during setup:

```ts
const resolved = resolveRefs(options.spec, options.spec);
```

That preserved a convenient LLM-facing contract — `await codemode.spec()` returned a fully inlined spec — but it also meant the fully expanded object had to cross the Worker Loader RPC boundary whenever sandbox code called `codemode.spec()`.

For heavily-referenced real-world specs, resolving refs inline can expand a compact OpenAPI document by orders of magnitude. In the issue report, a ~778 KiB Xero spec expanded to ~71 MiB JSON / ~142 MiB runtime serialization, which exceeds the Worker Loader 32 MiB argument/return value limit before the generated search code can do anything useful.

This PR keeps the simple LLM-facing API but changes where the work happens:

- embed the compact unresolved OpenAPI spec into the sandbox wrapper
- resolve `$ref`s inside the sandbox when `codemode.spec()` is called
- keep `codemode.spec()` returning a fully resolved spec, preserving existing generated-code behavior
- keep `codemode.request()` as the only host-dispatched RPC call, since API requests need host-side auth/network access
- stringify/truncate search and execute results inside the sandbox before they cross back over RPC

This hides `$ref` complexity from the LLM while avoiding the huge pre-expanded spec crossing the host → sandbox RPC boundary.

## Why this shape

We considered exposing an explicit `codemode.resolveRef(ref)` helper and returning an unresolved spec from `codemode.spec()`. That would avoid the oversized RPC payload too, but it pushes OpenAPI reference-management complexity into the generated code. Since LLM-generated code should be able to one-shot common search tasks with a simple mental model, this PR preserves the existing `codemode.spec()` behavior instead.

The remaining RPC boundary is now reserved for genuinely host-owned behavior:

```ts
await codemode.request(...)
```

Static OpenAPI data and `$ref` expansion stay local to the sandbox execution.

## Tests

Added a regression test that builds a synthetic OpenAPI spec with many operations referencing one large shared schema. Under the old eager host-side resolution this expands beyond the 32 MiB Worker Loader RPC limit. With this change, `codemode.spec()` resolves inside the sandbox and the search completes successfully.

Verified locally:

```bash
npx nx run @cloudflare/codemode:test -- mcp.test.ts -u
npm run build
npm run check
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->