### PR TITLE
Fix agent-tool recovery finalization

### DIFF
--- a/.changeset/fix-agent-tool-reconcile-finish.md
+++ b/.changeset/fix-agent-tool-reconcile-finish.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Ensure recovered agent-tool runs go through the same terminal lifecycle path as live runs. Parent recovery reconciliation now replays stored child chunks, broadcasts terminal agent-tool events, and invokes `onAgentToolFinish` after updating the parent run registry.
+Fixed a bug that could cause client state to drift from internal Durable Object state when agent tool calls spanned a Durable Object restart.

--- a/.changeset/fix-agent-tool-reconcile-finish.md
+++ b/.changeset/fix-agent-tool-reconcile-finish.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Ensure recovered agent-tool runs go through the same terminal lifecycle path as live runs. Parent recovery reconciliation now replays stored child chunks, broadcasts terminal agent-tool events, and invokes `onAgentToolFinish` after updating the parent run registry.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -5740,7 +5740,6 @@ export class Agent<
         return this._resultFromAgentToolRow<Output>(existing);
       }
       return await this._replayAndInterruptAgentToolRun<Output>(
-        cls,
         existing,
         "Agent tool run was still running, but live-tail reattachment is not supported in this runtime."
       );
@@ -5836,16 +5835,7 @@ export class Agent<
           status: "aborted",
           error: reason
         };
-        this._updateAgentToolTerminal(runId, result);
-        this._broadcastAgentToolTerminal(
-          options.parentToolCallId,
-          sequence,
-          result
-        );
-        await this.onAgentToolFinish(
-          { ...runInfo, status: "aborted", completedAt: Date.now() },
-          result
-        );
+        await this._finishAgentToolRun(runInfo, result, { sequence });
         return result;
       } else {
         parentAbortListener = () => {
@@ -5891,16 +5881,7 @@ export class Agent<
           status: "aborted",
           error: reason
         };
-        this._updateAgentToolTerminal(runId, result);
-        this._broadcastAgentToolTerminal(
-          options.parentToolCallId,
-          sequence,
-          result
-        );
-        await this.onAgentToolFinish(
-          { ...runInfo, status: "aborted", completedAt: Date.now() },
-          result
-        );
+        await this._finishAgentToolRun(runInfo, result, { sequence });
         return result;
       }
 
@@ -5910,16 +5891,10 @@ export class Agent<
         agentType,
         inspection
       );
-      this._updateAgentToolTerminal(runId, result, inspection.completedAt);
-      this._broadcastAgentToolTerminal(
-        options.parentToolCallId,
+      await this._finishAgentToolRun(runInfo, result, {
         sequence,
-        result
-      );
-      await this.onAgentToolFinish(
-        { ...runInfo, status: result.status, completedAt: Date.now() },
-        result
-      );
+        completedAt: inspection.completedAt
+      });
       return result;
     } catch (error) {
       if (options.signal?.aborted) {
@@ -5934,16 +5909,7 @@ export class Agent<
           status: "aborted",
           error: reason
         };
-        this._updateAgentToolTerminal(runId, result);
-        this._broadcastAgentToolTerminal(
-          options.parentToolCallId,
-          sequence,
-          result
-        );
-        await this.onAgentToolFinish(
-          { ...runInfo, status: "aborted", completedAt: Date.now() },
-          result
-        );
+        await this._finishAgentToolRun(runInfo, result, { sequence });
         return result;
       }
       const message = error instanceof Error ? error.message : String(error);
@@ -5953,16 +5919,7 @@ export class Agent<
         status: "error",
         error: message
       };
-      this._updateAgentToolTerminal(runId, result);
-      this._broadcastAgentToolTerminal(
-        options.parentToolCallId,
-        sequence,
-        result
-      );
-      await this.onAgentToolFinish(
-        { ...runInfo, status: "error", completedAt: Date.now() },
-        result
-      );
+      await this._finishAgentToolRun(runInfo, result, { sequence });
       return result;
     } finally {
       if (parentAbortListener && options.signal) {
@@ -6087,6 +6044,26 @@ export class Agent<
     };
   }
 
+  private _agentToolRunInfoFromRow(
+    row: AgentToolRunStorageRow,
+    status: AgentToolRunStatus = row.status,
+    completedAt = row.completed_at ?? undefined
+  ): AgentToolRunInfo {
+    return {
+      runId: row.run_id,
+      parentToolCallId: row.parent_tool_call_id ?? undefined,
+      agentType: row.agent_type,
+      inputPreview: this._parseAgentToolJson(row.input_preview),
+      status,
+      display: this._parseAgentToolJson(row.display_metadata) as
+        | AgentToolDisplayMetadata
+        | undefined,
+      displayOrder: row.display_order,
+      startedAt: row.started_at,
+      completedAt
+    };
+  }
+
   private _terminalResultFromInspection<Output>(
     agentType: string,
     inspection: AgentToolRunInspection<Output>
@@ -6114,6 +6091,26 @@ export class Agent<
       status: "error",
       error: inspection.error ?? "Agent tool run failed"
     };
+  }
+
+  private async _finishAgentToolRun<Output>(
+    run: AgentToolRunInfo,
+    result: RunAgentToolResult<Output>,
+    options?: { sequence?: number; completedAt?: number }
+  ): Promise<void> {
+    const completedAt = options?.completedAt ?? Date.now();
+    this._updateAgentToolTerminal(run.runId, result, completedAt);
+    if (options?.sequence !== undefined) {
+      this._broadcastAgentToolTerminal(
+        run.parentToolCallId,
+        options.sequence,
+        result
+      );
+    }
+    await this.onAgentToolFinish(
+      { ...run, status: result.status, completedAt },
+      result
+    );
   }
 
   private _updateAgentToolTerminal<Output>(
@@ -6205,6 +6202,28 @@ export class Agent<
       );
     }
     return next;
+  }
+
+  private async _broadcastAgentToolStoredChunks(
+    row: Pick<
+      AgentToolRunStorageRow,
+      "run_id" | "agent_type" | "parent_tool_call_id"
+    >,
+    sequence: number,
+    replay?: true,
+    connection?: Connection
+  ): Promise<number> {
+    const child = await this._cf_resolveSubAgent(row.agent_type, row.run_id);
+    const adapter = this._asAgentToolChildAdapter(child);
+    const chunks = await adapter.getAgentToolChunks(row.run_id);
+    return this._broadcastAgentToolChunks(
+      row.parent_tool_call_id ?? undefined,
+      row.run_id,
+      chunks,
+      sequence,
+      replay,
+      connection
+    );
   }
 
   private async _forwardAgentToolStream(
@@ -6377,25 +6396,12 @@ export class Agent<
   }
 
   private async _replayAndInterruptAgentToolRun<Output>(
-    cls: ChatCapableAgentClass,
     row: AgentToolRunStorageRow,
     message: string
   ): Promise<RunAgentToolResult<Output>> {
-    const parentToolCallId = row.parent_tool_call_id ?? undefined;
     let sequence = 1;
     try {
-      const child = await this.subAgent(
-        cls as SubAgentClass<Agent>,
-        row.run_id
-      );
-      const adapter = this._asAgentToolChildAdapter<unknown, Output>(child);
-      const chunks = await adapter.getAgentToolChunks(row.run_id);
-      sequence = this._broadcastAgentToolChunks(
-        parentToolCallId,
-        row.run_id,
-        chunks,
-        sequence
-      );
+      sequence = await this._broadcastAgentToolStoredChunks(row, sequence);
     } catch {
       // Interruption is still the honest parent state if replay fails.
     }
@@ -6405,8 +6411,9 @@ export class Agent<
       status: "interrupted",
       error: message
     };
-    this._updateAgentToolTerminal(row.run_id, result);
-    this._broadcastAgentToolTerminal(parentToolCallId, sequence, result);
+    await this._finishAgentToolRun(this._agentToolRunInfoFromRow(row), result, {
+      sequence
+    });
     return result;
   }
 
@@ -6450,16 +6457,8 @@ export class Agent<
       );
 
       try {
-        const child = await this.subAgent(
-          this._agentToolClassByName(row.agent_type),
-          row.run_id
-        );
-        const adapter = this._asAgentToolChildAdapter(child);
-        const chunks = await adapter.getAgentToolChunks(row.run_id);
-        sequence = this._broadcastAgentToolChunks(
-          parentToolCallId,
-          row.run_id,
-          chunks,
+        sequence = await this._broadcastAgentToolStoredChunks(
+          row,
           sequence,
           true,
           connection
@@ -6488,53 +6487,65 @@ export class Agent<
   }
 
   private async _reconcileAgentToolRuns(): Promise<void> {
-    const rows = this.sql<{ run_id: string; agent_type: string }>`
-      SELECT run_id, agent_type FROM cf_agent_tool_runs
+    const rows = this.sql<AgentToolRunStorageRow>`
+      SELECT run_id, parent_tool_call_id, agent_type, input_preview, status,
+             summary, output_json, error_message, display_metadata, display_order,
+             started_at, completed_at
+      FROM cf_agent_tool_runs
       WHERE status IN ('starting', 'running')
       ORDER BY started_at ASC
     `;
     for (const row of rows) {
+      let sequence = 1;
+      let completedAt: number | undefined;
+      let result: RunAgentToolResult;
       try {
-        const cls = this._agentToolClassByName(row.agent_type);
-        if (!this.hasSubAgent(cls, row.run_id)) {
-          this._updateAgentToolTerminal(row.run_id, {
-            runId: row.run_id,
-            agentType: row.agent_type,
-            status: "interrupted",
-            error: "Agent tool child was not found during parent recovery."
-          });
-          continue;
-        }
-        const child = await this.subAgent(cls, row.run_id);
+        const child = await this._cf_resolveSubAgent(
+          row.agent_type,
+          row.run_id
+        );
         const adapter = this._asAgentToolChildAdapter(child);
         const inspection = await adapter.inspectAgentToolRun(row.run_id);
+        try {
+          sequence = await this._broadcastAgentToolStoredChunks(row, sequence);
+        } catch {
+          // Terminal reconciliation should still complete if chunk replay fails.
+        }
         if (
           !inspection ||
           inspection.status === "running" ||
           inspection.status === "starting"
         ) {
-          this._updateAgentToolTerminal(row.run_id, {
+          result = {
             runId: row.run_id,
             agentType: row.agent_type,
             status: "interrupted",
             error:
               "Agent tool run was still running, but live-tail reattachment is not supported in this runtime."
-          });
+          };
         } else {
-          this._updateAgentToolTerminal(
-            row.run_id,
-            this._terminalResultFromInspection(row.agent_type, inspection),
-            inspection.completedAt
+          result = this._terminalResultFromInspection(
+            row.agent_type,
+            inspection
           );
+          completedAt = inspection.completedAt;
         }
       } catch {
-        this._updateAgentToolTerminal(row.run_id, {
+        result = {
           runId: row.run_id,
           agentType: row.agent_type,
           status: "interrupted",
           error: "Agent tool run could not be inspected during parent recovery."
-        });
+        };
       }
+      await this._finishAgentToolRun(
+        this._agentToolRunInfoFromRow(row),
+        result,
+        {
+          sequence,
+          completedAt
+        }
+      );
     }
   }
 

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -1,6 +1,8 @@
 import { env } from "cloudflare:workers";
 import type {
   AgentToolEventMessage,
+  AgentToolLifecycleResult,
+  AgentToolRunInfo,
   AgentToolRunInspection,
   AgentToolStoredChunk,
   RunAgentToolResult
@@ -33,6 +35,23 @@ type ParentStub = DurableObjectStub & {
     runId?: string
   ): Promise<RunAgentToolResult>;
   getEventsForTest(): Promise<AgentToolEventMessage[]>;
+  getFinishesForTest(): Promise<
+    { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[]
+  >;
+  reconcileCompletedChildForTest(
+    input: {
+      prompt: string;
+      delayMs?: number;
+      chunkDelayMs?: number;
+      structured?: boolean;
+      streamError?: string;
+    },
+    runId?: string
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    inspection: AgentToolRunInspection;
+  }>;
   inspectChild(runId: string): Promise<AgentToolRunInspection | null>;
   getChildChunks(
     runId: string,
@@ -119,6 +138,49 @@ describe("AIChatAgent as an agent-tool child", () => {
 
     const laterChunks = await parent.getChildChunks(runId, 0);
     expect(laterChunks.every((chunk) => chunk.sequence > 0)).toBe(true);
+  });
+
+  it("finalizes lifecycle hooks and terminal events during parent recovery reconciliation", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, inspection } =
+      await parent.reconcileCompletedChildForTest(
+        { prompt: "recover completed child" },
+        runId
+      );
+
+    expect(inspection).toMatchObject({
+      runId,
+      status: "completed",
+      summary: "AIChat child handled: recover completed child",
+      output: "AIChat child handled: recover completed child"
+    });
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          parentToolCallId: "test-tool-call",
+          agentType: "AIChatAgentToolChild",
+          status: "completed",
+          inputPreview: "recover completed child",
+          display: { name: "test child" }
+        }),
+        result: expect.objectContaining({
+          status: "completed",
+          summary: "AIChat child handled: recover completed child"
+        })
+      }
+    ]);
+    expect(events.map((event) => event.event.kind)).toContain("finished");
+    expect(events.at(-1)).toMatchObject({
+      parentToolCallId: "test-tool-call",
+      event: {
+        kind: "finished",
+        runId,
+        summary: "AIChat child handled: recover completed child"
+      }
+    });
   });
 
   it("returns the retained parent registry result without re-running the child", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -13,6 +13,8 @@ import { Agent, getCurrentAgent, routeAgentRequest } from "agents";
 import { MessageType, type OutgoingMessage } from "../types";
 import type {
   AgentToolEventMessage,
+  AgentToolLifecycleResult,
+  AgentToolRunInfo,
   AgentToolRunInspection,
   AgentToolStoredChunk,
   RunAgentToolResult
@@ -1878,8 +1880,14 @@ export class AIChatAgentToolChild extends AIChatAgent<Env> {
   }
 }
 
+type AgentToolFinishForTest = {
+  run: AgentToolRunInfo;
+  result: AgentToolLifecycleResult;
+};
+
 export class AIChatAgentToolParent extends Agent<Env> {
   private events: AgentToolEventMessage[] = [];
+  private finishes: AgentToolFinishForTest[] = [];
 
   override broadcast(
     msg: string | ArrayBuffer | ArrayBufferView,
@@ -1898,11 +1906,19 @@ export class AIChatAgentToolParent extends Agent<Env> {
     super.broadcast(msg, without);
   }
 
+  override async onAgentToolFinish(
+    run: AgentToolRunInfo,
+    result: AgentToolLifecycleResult
+  ): Promise<void> {
+    this.finishes.push({ run, result });
+  }
+
   async runChild(
     input: AgentToolInput,
     runId = crypto.randomUUID()
   ): Promise<RunAgentToolResult> {
     this.events = [];
+    this.finishes = [];
     return this.runAgentTool(AIChatAgentToolChild, {
       runId,
       parentToolCallId: "test-tool-call",
@@ -1937,6 +1953,60 @@ export class AIChatAgentToolParent extends Agent<Env> {
 
   getEventsForTest(): AgentToolEventMessage[] {
     return this.events;
+  }
+
+  getFinishesForTest(): AgentToolFinishForTest[] {
+    return this.finishes;
+  }
+
+  async reconcileCompletedChildForTest(
+    input: AgentToolInput,
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    inspection: AgentToolRunInspection;
+  }> {
+    const child = await this.subAgent(AIChatAgentToolChild, runId);
+    const started = await child.startAgentToolRun(input, { runId });
+    this.sql`
+      INSERT INTO cf_agent_tool_runs (
+        run_id, parent_tool_call_id, agent_type, input_preview,
+        input_redacted, status, display_metadata, display_order, started_at
+      ) VALUES (
+        ${runId}, 'test-tool-call', 'AIChatAgentToolChild',
+        ${JSON.stringify(input.prompt)}, 1, 'running',
+        ${JSON.stringify({ name: "test child" })}, 0, ${started.startedAt}
+      )
+    `;
+
+    let inspection = await child.inspectAgentToolRun(runId);
+    for (let attempt = 0; attempt < 50; attempt++) {
+      if (
+        inspection &&
+        inspection.status !== "running" &&
+        inspection.status !== "starting"
+      ) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      inspection = await child.inspectAgentToolRun(runId);
+    }
+    if (
+      !inspection ||
+      inspection.status === "running" ||
+      inspection.status === "starting"
+    ) {
+      throw new Error("Timed out waiting for child agent-tool completion");
+    }
+
+    this.events = [];
+    this.finishes = [];
+    await (
+      this as unknown as { _reconcileAgentToolRuns(): Promise<void> }
+    )._reconcileAgentToolRuns();
+
+    return { events: this.events, finishes: this.finishes, inspection };
   }
 
   async inspectChild(runId: string): Promise<AgentToolRunInspection | null> {


### PR DESCRIPTION
## Summary

Fixes #1475.

This PR makes recovered agent-tool runs go through the same terminal finalization path as live `runAgentTool()` executions.

Previously, `_reconcileAgentToolRuns()` updated `cf_agent_tool_runs` when a parent Agent woke up and found a child run had reached a terminal state, but it skipped two observable parts of the framework lifecycle:

- `onAgentToolFinish(...)`
- terminal `agent-tool-event` broadcasts via `_broadcastAgentToolTerminal(...)`

That meant application state mirrors, dashboards, structured logs, and chat UI state could silently drift from the framework’s durable run registry after parent DO eviction / hibernation.

## What changed

### Shared terminal finalization path

Added a private `_finishAgentToolRun(...)` helper that centralizes the terminal lifecycle invariant:

1. update `cf_agent_tool_runs`
2. broadcast terminal agent-tool event when a sequence is available
3. invoke `onAgentToolFinish(...)`

Live `runAgentTool()` terminal paths now use this helper too, so recovery and live execution share the same behavior.

### Reconciliation now restores observable lifecycle

`_reconcileAgentToolRuns()` now:

- selects the full stored agent-tool row, not only `run_id` / `agent_type`
- reconstructs `AgentToolRunInfo` from durable state
- resolves the child by stored `agent_type`
- inspects the child’s terminal state
- best-effort replays stored child chunks before terminal broadcast
- finalizes the run through `_finishAgentToolRun(...)`

### Stored chunk replay helper

Added `_broadcastAgentToolStoredChunks(...)` to keep chunk replay behavior local and shared between:

- recovery reconciliation
- replay to connecting clients
- interrupted replay path

This keeps sequencing behavior consistent: terminal events are emitted after any replayed stored chunks.

## Why this architecture

The bug came from terminal finalization being spread across call sites. `runAgentTool()` knew to update durable state, broadcast, and call the lifecycle hook, while `_reconcileAgentToolRuns()` only updated durable state.

This PR deepens the internal finalization module: callers provide a run and terminal result, and the implementation owns the lifecycle ordering. That improves locality and makes it less likely future recovery paths drift from live execution.

## Tests

Added regression coverage for parent recovery reconciliation using `AIChatAgentToolParent` / `AIChatAgentToolChild`.

The test simulates:

1. a parent registry row stuck in `running`
2. a child agent-tool run that has completed durably
3. parent recovery reconciliation
4. verification that:
   - `onAgentToolFinish(...)` fires
   - the terminal `finished` event is broadcast
   - reconstructed run metadata is passed to the lifecycle hook

## Verification

Ran:

```bash
cd packages/ai-chat && npm run test:workers -- src/tests/agent-tools.test.ts
npm run check
```
