### PR TITLE
Add R2SkillProvider key allowlist

### DIFF
--- a/.changeset/r2-skill-provider-keys.md
+++ b/.changeset/r2-skill-provider-keys.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Add an optional `keys` allowlist to `R2SkillProvider` for exposing and loading only selected prefix-relative R2 object keys.

--- a/.changeset/r2-skill-provider-keys.md
+++ b/.changeset/r2-skill-provider-keys.md
@@ -1,5 +1,0 @@
----
-"agents": patch
----
-
-Add an optional `keys` allowlist to `R2SkillProvider` for exposing and loading only selected prefix-relative R2 object keys.

--- a/packages/agents/src/experimental/memory/session/skills.ts
+++ b/packages/agents/src/experimental/memory/session/skills.ts
@@ -44,20 +44,29 @@ export function isSkillProvider(provider: unknown): provider is SkillProvider {
  *
  * Descriptions are pulled from R2 custom metadata (`description` key).
  * If a prefix is provided, it is prepended on storage operations and
- * stripped from keys in metadata.
+ * stripped from keys in metadata. `keys`, when provided, is matched against
+ * these prefix-relative keys.
  *
  * @example
  * ```ts
- * const skills = new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" });
+ * const skills = new R2SkillProvider(env.SKILLS_BUCKET, {
+ *   prefix: "skills/",
+ *   keys: ["code-review", "debugging"]
+ * });
  * ```
  */
 export class R2SkillProvider implements SkillProvider {
   private bucket: R2Bucket;
   private prefix: string;
+  private keys: Set<string> | null;
 
-  constructor(bucket: R2Bucket, options?: { prefix?: string }) {
+  constructor(
+    bucket: R2Bucket,
+    options?: { prefix?: string; keys?: string[] }
+  ) {
     this.bucket = bucket;
     this.prefix = options?.prefix ?? "";
+    this.keys = options?.keys?.length ? new Set(options.keys) : null;
   }
 
   async get(): Promise<string | null> {
@@ -73,6 +82,7 @@ export class R2SkillProvider implements SkillProvider {
       } as any);
       for (const obj of listed.objects) {
         const key = obj.key.slice(this.prefix.length);
+        if (!this.allowsKey(key)) continue;
         const desc = obj.customMetadata?.description;
         entries.push(`- ${key}${desc ? `: ${desc}` : ""}`);
       }
@@ -83,6 +93,7 @@ export class R2SkillProvider implements SkillProvider {
   }
 
   async load(key: string): Promise<string | null> {
+    if (!this.allowsKey(key)) return null;
     const obj = await this.bucket.get(this.prefix + key);
     if (!obj) return null;
     return obj.text();
@@ -92,5 +103,9 @@ export class R2SkillProvider implements SkillProvider {
     await this.bucket.put(this.prefix + key, content, {
       customMetadata: description ? { description } : undefined
     });
+  }
+
+  private allowsKey(key: string): boolean {
+    return this.keys === null || this.keys.has(key);
   }
 }

--- a/packages/agents/src/tests/experimental/memory/session/skills.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/skills.test.ts
@@ -4,7 +4,10 @@ import {
   type ContextProvider,
   type WritableContextProvider
 } from "../../../../experimental/memory/session/context";
-import type { SkillProvider } from "../../../../experimental/memory/session/skills";
+import {
+  R2SkillProvider,
+  type SkillProvider
+} from "../../../../experimental/memory/session/skills";
 
 // ── In-memory providers for tests ──────────────────────────────
 
@@ -25,6 +28,68 @@ class WritableProvider implements WritableContextProvider {
   }
   async set(content: string) {
     this.value = content;
+  }
+}
+
+type MockR2Object = {
+  key: string;
+  content: string;
+  customMetadata?: Record<string, string>;
+  text(): Promise<string>;
+};
+
+class MockR2Bucket {
+  gets: string[] = [];
+  puts: Array<{
+    key: string;
+    content: string;
+    options?: R2PutOptions;
+  }> = [];
+  private objects: Map<string, MockR2Object>;
+
+  constructor(
+    objects: Record<
+      string,
+      { content: string; customMetadata?: Record<string, string> }
+    > = {}
+  ) {
+    this.objects = new Map(
+      Object.entries(objects).map(([key, value]) => [
+        key,
+        {
+          key,
+          content: value.content,
+          customMetadata: value.customMetadata,
+          text: async () => value.content
+        }
+      ])
+    );
+  }
+
+  async list(options?: { prefix?: string }) {
+    const prefix = options?.prefix ?? "";
+    return {
+      objects: Array.from(this.objects.values()).filter((obj) =>
+        obj.key.startsWith(prefix)
+      ),
+      truncated: false,
+      cursor: undefined
+    };
+  }
+
+  async get(key: string) {
+    this.gets.push(key);
+    return this.objects.get(key) ?? null;
+  }
+
+  async put(key: string, content: string, options?: R2PutOptions) {
+    this.puts.push({ key, content, options });
+    this.objects.set(key, {
+      key,
+      content,
+      customMetadata: options?.customMetadata,
+      text: async () => content
+    });
   }
 }
 
@@ -53,6 +118,87 @@ class MemorySkillProvider implements SkillProvider {
     this.skills.set(key, { content, description });
   }
 }
+
+// ── R2 skill provider ──────────────────────────────────────────
+
+describe("R2SkillProvider", () => {
+  it("filters metadata to configured keys relative to prefix", async () => {
+    const bucket = new MockR2Bucket({
+      "skills/tax": {
+        content: "Tax skill",
+        customMetadata: { description: "Tax workflows" }
+      },
+      "skills/bank-reconciliation": {
+        content: "Bank skill",
+        customMetadata: { description: "Bank reconciliation" }
+      },
+      "skills/hidden": {
+        content: "Hidden skill",
+        customMetadata: { description: "Should not be listed" }
+      },
+      "other/tax": { content: "Outside prefix" }
+    });
+    const provider = new R2SkillProvider(bucket as unknown as R2Bucket, {
+      prefix: "skills/",
+      keys: ["tax", "bank-reconciliation"]
+    });
+
+    const metadata = await provider.get();
+
+    expect(metadata).toBe(
+      "- tax: Tax workflows\n- bank-reconciliation: Bank reconciliation"
+    );
+  });
+
+  it("does not fetch disallowed keys", async () => {
+    const bucket = new MockR2Bucket({
+      "skills/tax": { content: "Tax skill" },
+      "skills/hidden": { content: "Hidden skill" }
+    });
+    const provider = new R2SkillProvider(bucket as unknown as R2Bucket, {
+      prefix: "skills/",
+      keys: ["tax"]
+    });
+
+    await expect(provider.load("tax")).resolves.toBe("Tax skill");
+    await expect(provider.load("hidden")).resolves.toBeNull();
+    expect(bucket.gets).toEqual(["skills/tax"]);
+  });
+
+  it("treats omitted or empty keys as exposing all keys", async () => {
+    const bucket = new MockR2Bucket({
+      tax: { content: "Tax skill" },
+      hidden: { content: "Hidden skill" }
+    });
+
+    await expect(
+      new R2SkillProvider(bucket as unknown as R2Bucket).get()
+    ).resolves.toBe("- tax\n- hidden");
+    await expect(
+      new R2SkillProvider(bucket as unknown as R2Bucket, { keys: [] }).load(
+        "hidden"
+      )
+    ).resolves.toBe("Hidden skill");
+  });
+
+  it("keeps set unchanged when keys are configured", async () => {
+    const bucket = new MockR2Bucket();
+    const provider = new R2SkillProvider(bucket as unknown as R2Bucket, {
+      prefix: "skills/",
+      keys: ["tax"]
+    });
+
+    await provider.set("hidden", "Hidden skill", "Still writable");
+
+    expect(bucket.puts).toEqual([
+      {
+        key: "skills/hidden",
+        content: "Hidden skill",
+        options: { customMetadata: { description: "Still writable" } }
+      }
+    ]);
+  });
+});
 
 // ── Provider type detection ────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #1473 by adding an optional `keys` allowlist to the experimental `R2SkillProvider`.

- filters `get()` metadata to selected prefix-relative R2 object keys
- returns `null` from `load(key)` without fetching R2 when the key is not allowed
- preserves existing behavior when `keys` is omitted or empty
- leaves `set()` unchanged

No changeset: this API is under `experimental/memory/session`.

## Testing

- `npx vitest run packages/agents/src/tests/experimental/memory/session/skills.test.ts`
- `npm install`
- `npm run build`
- `npm run check`
