### PR TITLE
Add enabled gate to useVoiceAgent

### DIFF
--- a/.changeset/bright-voices-wait.md
+++ b/.changeset/bright-voices-wait.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/voice": minor
+---
+
+Add an `enabled` option to `useVoiceAgent` so React apps can delay creating and connecting a `VoiceClient` until async prerequisites such as capability tokens are ready.

--- a/design/voice.md
+++ b/design/voice.md
@@ -387,6 +387,8 @@ JSON message handling narrows the `try/catch` to only cover `JSON.parse`. Listen
 - `useVoiceAgent(options)` — wraps `VoiceClient` for `withVoice` agents
 - `useVoiceInput(options)` — wraps `VoiceClient` for `withVoiceInput` agents
 
+`useVoiceAgent` accepts `enabled?: boolean` as a React lifecycle gate. While disabled, the hook keeps the exposed state in the idle/disconnected shape and does not construct or connect a `VoiceClient`. Enabling the hook creates a client with the current options; disabling it tears down the active client. This keeps credential/bootstrap readiness in the React hook module instead of forcing callers to provide dormant `VoiceTransport` adapters.
+
 Both include tuning knobs (`silenceThreshold`, `silenceDurationMs`, `interruptThreshold`, `interruptChunks`) in the connection key so changing them triggers client recreation.
 
 ## Tradeoffs

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -335,9 +335,12 @@ const {
 } = useVoiceAgent({
   agent: "MyAgent", // Required: Durable Object class name
   name: "default", // Instance name (default: "default")
-  host: window.location.host // Host to connect to
+  host: window.location.host, // Host to connect to
+  enabled: true // Set false to delay connecting until prerequisites are ready
 });
 ```
+
+Use `enabled: false` when the app must wait for async connection prerequisites, such as a user-scoped capability token. While disabled, the hook does not create or connect a `VoiceClient` and returns the idle/disconnected state. When `enabled` changes to `true`, the hook connects with the current options.
 
 #### Tuning Options
 

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -133,7 +133,11 @@ function App() {
     toggleMute, // () => void
     sendText, // (text: string) => void
     sendJSON // (data: Record<string, unknown>) => void
-  } = useVoiceAgent({ agent: "my-agent" });
+  } = useVoiceAgent({
+    agent: "my-agent",
+    // Set false to delay connecting until async prerequisites are ready.
+    enabled: true
+  });
 
   return <div>Status: {status}</div>;
 }

--- a/packages/voice/src/react-tests/useVoiceAgent.test.tsx
+++ b/packages/voice/src/react-tests/useVoiceAgent.test.tsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup } from "vitest-browser-react";
 import { useEffect, act } from "react";
+import { PartySocket } from "partysocket";
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -297,6 +298,117 @@ describe("useVoiceAgent", () => {
           container.querySelector('[data-testid="error"]')?.textContent
         ).toBe("Connection lost. Reconnecting...");
       });
+    });
+
+    it("should not construct or connect a client when disabled", async () => {
+      const { container, getResult } = await renderHook({ enabled: false });
+
+      expect(vi.mocked(PartySocket)).not.toHaveBeenCalled();
+      expect(socketInstance).toBeNull();
+      expect(
+        container.querySelector('[data-testid="status"]')?.textContent
+      ).toBe("idle");
+      expect(
+        container.querySelector('[data-testid="connected"]')?.textContent
+      ).toBe("false");
+
+      await act(async () => {
+        await getResult().startCall();
+      });
+      act(() => {
+        getResult().endCall();
+        getResult().toggleMute();
+        getResult().sendText("hello");
+        getResult().sendJSON({ type: "app_message" });
+      });
+
+      expect(socketSend).not.toHaveBeenCalled();
+    });
+
+    it("should connect when enabled flips false to true without firing onReconnect", async () => {
+      const onReconnect = vi.fn();
+      let latestResult: UseVoiceAgentReturn | null = null;
+      const onResult = vi.fn((r: UseVoiceAgentReturn) => {
+        latestResult = r;
+      });
+      const getLatestResult = () => {
+        if (!latestResult) throw new Error("Hook has not rendered yet");
+        return latestResult;
+      };
+
+      const screen = await render(
+        <TestVoiceComponent
+          options={{ agent: "voice-agent", enabled: false, onReconnect }}
+          onResult={onResult}
+        />
+      );
+      await sleep(10);
+
+      expect(vi.mocked(PartySocket)).not.toHaveBeenCalled();
+
+      await act(async () => {
+        screen.rerender(
+          <TestVoiceComponent
+            options={{ agent: "voice-agent", enabled: true, onReconnect }}
+            onResult={onResult}
+          />
+        );
+        await sleep(10);
+      });
+
+      expect(vi.mocked(PartySocket)).toHaveBeenCalledTimes(1);
+      expect(onReconnect).not.toHaveBeenCalled();
+      await vi.waitFor(() => {
+        expect(getLatestResult().connected).toBe(true);
+      });
+    });
+
+    it("should disconnect and reset state when enabled flips true to false", async () => {
+      let latestResult: UseVoiceAgentReturn | null = null;
+      const onResult = vi.fn((r: UseVoiceAgentReturn) => {
+        latestResult = r;
+      });
+      const getLatestResult = () => {
+        if (!latestResult) throw new Error("Hook has not rendered yet");
+        return latestResult;
+      };
+
+      const screen = await render(
+        <TestVoiceComponent
+          options={{ agent: "voice-agent" }}
+          onResult={onResult}
+        />
+      );
+      await sleep(10);
+
+      await vi.waitFor(() => {
+        expect(getLatestResult().connected).toBe(true);
+      });
+
+      act(() => {
+        fireJSON({ type: "status", status: "listening" });
+        fireJSON({ type: "transcript", role: "user", text: "hello" });
+      });
+
+      await vi.waitFor(() => {
+        expect(getLatestResult().status).toBe("listening");
+        expect(getLatestResult().transcript).toHaveLength(1);
+      });
+
+      await act(async () => {
+        screen.rerender(
+          <TestVoiceComponent
+            options={{ agent: "voice-agent", enabled: false }}
+            onResult={onResult}
+          />
+        );
+        await sleep(10);
+      });
+
+      expect(socketClose).toHaveBeenCalledTimes(1);
+      expect(getLatestResult().status).toBe("idle");
+      expect(getLatestResult().transcript).toHaveLength(0);
+      expect(getLatestResult().connected).toBe(false);
     });
   });
 

--- a/packages/voice/src/voice-react.tsx
+++ b/packages/voice/src/voice-react.tsx
@@ -25,6 +25,12 @@ export { WebSocketVoiceTransport } from "./voice-client";
 /** Options accepted by useVoiceAgent. */
 export interface UseVoiceAgentOptions extends VoiceClientOptions {
   /**
+   * Whether the hook should create and connect a VoiceClient.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+  /**
    * Called when the hook reconnects due to option changes (e.g., agent name
    * or instance name changed). Use this to show a toast or notification.
    */
@@ -242,6 +248,8 @@ export function useVoiceAgent(
     [options.query]
   );
 
+  const enabled = options.enabled ?? true;
+
   const connectionKey = useMemo(
     () =>
       `${options.agent}:${options.name ?? "default"}:${options.host ?? ""}:${options.silenceThreshold ?? ""}:${options.silenceDurationMs ?? ""}:${options.interruptThreshold ?? ""}:${options.interruptChunks ?? ""}:${queryString}`,
@@ -257,8 +265,13 @@ export function useVoiceAgent(
     ]
   );
 
+  const effectKey = useMemo(
+    () => `${enabled ? "enabled" : "disabled"}:${connectionKey}`,
+    [enabled, connectionKey]
+  );
+
   const clientRef = useRef<VoiceClient | null>(null);
-  const prevKeyRef = useRef(connectionKey);
+  const activeKeyRef = useRef<string | null>(null);
   const onReconnectRef = useRef(options.onReconnect);
   onReconnectRef.current = options.onReconnect;
 
@@ -273,18 +286,11 @@ export function useVoiceAgent(
   const [interimTranscript, setInterimTranscript] = useState<string | null>(
     null
   );
+  const [lastCustomMessage, setLastCustomMessage] = useState<unknown>(null);
 
   // Connect on mount or when connection identity changes
   useEffect(() => {
-    const isReconnect = prevKeyRef.current !== connectionKey;
-    prevKeyRef.current = connectionKey;
-
-    // Fire reconnect callback (e.g., to show a toast)
-    if (isReconnect) {
-      onReconnectRef.current?.();
-    }
-
-    // Reset state for a fresh connection
+    // Reset state for a fresh or disabled connection
     setStatus("idle");
     setTranscript([]);
     setMetrics(null);
@@ -293,8 +299,29 @@ export function useVoiceAgent(
     setConnected(false);
     setError(null);
     setInterimTranscript(null);
+    setLastCustomMessage(null);
 
-    const client = new VoiceClient(options);
+    if (!enabled) {
+      clientRef.current = null;
+      activeKeyRef.current = null;
+      return;
+    }
+
+    const isReconnect =
+      activeKeyRef.current !== null && activeKeyRef.current !== connectionKey;
+    activeKeyRef.current = connectionKey;
+
+    // Fire reconnect callback (e.g., to show a toast)
+    if (isReconnect) {
+      onReconnectRef.current?.();
+    }
+
+    const {
+      enabled: _enabled,
+      onReconnect: _onReconnect,
+      ...clientOptions
+    } = options;
+    const client = new VoiceClient(clientOptions);
     clientRef.current = client;
     client.connect();
 
@@ -326,25 +353,29 @@ export function useVoiceAgent(
       client.removeEventListener("mutechange", onMute);
       client.removeEventListener("connectionchange", onConnection);
       client.removeEventListener("error", onError);
+      if (clientRef.current === client) {
+        clientRef.current = null;
+      }
       client.disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- reconnect when connection identity changes
-  }, [connectionKey]);
+  }, [effectKey]);
 
   // Stable action callbacks — always use the latest client
-  const startCall = useCallback(() => clientRef.current!.startCall(), []);
-  const endCall = useCallback(() => clientRef.current!.endCall(), []);
-  const toggleMute = useCallback(() => clientRef.current!.toggleMute(), []);
+  const startCall = useCallback(
+    () => clientRef.current?.startCall() ?? Promise.resolve(),
+    []
+  );
+  const endCall = useCallback(() => clientRef.current?.endCall(), []);
+  const toggleMute = useCallback(() => clientRef.current?.toggleMute(), []);
   const sendText = useCallback(
-    (text: string) => clientRef.current!.sendText(text),
+    (text: string) => clientRef.current?.sendText(text),
     []
   );
   const sendJSON = useCallback(
-    (data: Record<string, unknown>) => clientRef.current!.sendJSON(data),
+    (data: Record<string, unknown>) => clientRef.current?.sendJSON(data),
     []
   );
-
-  const [lastCustomMessage, setLastCustomMessage] = useState<unknown>(null);
 
   // Listen for custom messages — needs a separate effect since it must
   // attach to the latest client.
@@ -354,7 +385,7 @@ export function useVoiceAgent(
     const onCustom = (msg: unknown) => setLastCustomMessage(msg);
     client.addEventListener("custommessage", onCustom);
     return () => client.removeEventListener("custommessage", onCustom);
-  }, [connectionKey]);
+  }, [effectKey]);
 
   return {
     status,


### PR DESCRIPTION
## Summary

Fixes #1474 by adding an `enabled` lifecycle gate to `useVoiceAgent`.

Apps that need to wait for async connection prerequisites, such as a Turnstile-backed capability token, can now keep the hook mounted without constructing or connecting a `VoiceClient` until those prerequisites are ready.

## What changed

- Adds `enabled?: boolean` to `UseVoiceAgentOptions`, defaulting to `true` for backwards compatibility.
- Keeps `useVoiceAgent` in the idle/disconnected state while disabled.
- Avoids constructing or connecting `VoiceClient` when `enabled === false`.
- Connects with the current options when `enabled` flips from `false` to `true`.
- Disconnects and resets state when `enabled` flips from `true` to `false`.
- Makes hook action callbacks safe no-ops while disabled.
- Ensures the initial disabled mount and first enable do not fire `onReconnect`.
- Documents the new option and records the lifecycle decision in the voice design notes.
- Adds a changeset for `@cloudflare/voice`.

## Architecture note

The gate lives at the React hook seam rather than in `VoiceClient` or a new transport adapter. This keeps auth/bootstrap readiness local to the React lifecycle module, and avoids forcing users to encode “do not connect yet” with dormant `VoiceTransport` adapters.

## Tests

- `npm --workspace @cloudflare/voice run build`
- `npm --workspace @cloudflare/voice run test:react`
- `npm run check`