### PR TITLE
Fix reasoning chunks in approval continuations

### DIFF
--- a/.changeset/fix-reasoning-approval-continuation.md
+++ b/.changeset/fix-reasoning-approval-continuation.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fixed approval auto-continuation streams so reasoning chunks keep a valid `reasoning-start` before `reasoning-delta` sequence when continuing from an assistant message that already has reasoning.

--- a/.changeset/fix-reasoning-approval-continuation.md
+++ b/.changeset/fix-reasoning-approval-continuation.md
@@ -2,4 +2,4 @@
 "@cloudflare/ai-chat": patch
 ---
 
-Fixed approval auto-continuation streams so reasoning chunks keep a valid `reasoning-start` before `reasoning-delta` sequence when continuing from an assistant message that already has reasoning.
+Fixed approval auto-continuation streams so reasoning chunks keep a valid `reasoning-start` before `reasoning-delta` sequence when continuing from an assistant message that already has reasoning, and preserve the continuation reasoning in the final persisted message.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -3708,12 +3708,13 @@ export class AIChatAgent<
             //   state "streaming" (interrupted mid-generation). Parts with
             //   state "done" or no state create new blocks as usual (e.g.
             //   tool auto-continuation).
-            // - reasoning-start: suppressed only when the last reasoning part
-            //   has state "streaming" (interrupted mid-generation). Completed
-            //   reasoning blocks from earlier in the turn must not swallow new
-            //   continuation reasoning, otherwise the streamed reasoning block
-            //   disappears when the final persisted message replaces the live
-            //   stream.
+            // - reasoning-start: suppressed when resuming an interrupted
+            //   assistant turn (an existing reasoning part is still streaming,
+            //   or the message has progressed to a still-streaming text part).
+            //   Completed reasoning blocks from earlier tool-continuation steps
+            //   must not swallow new continuation reasoning, otherwise the
+            //   streamed reasoning block disappears when the final persisted
+            //   message replaces the live stream.
             let skipServerApply = false;
             if (continuation) {
               if (!continuationTextResumed && data.type === "text-start") {
@@ -3737,6 +3738,15 @@ export class AIChatAgent<
               ) {
                 for (let k = message.parts.length - 1; k >= 0; k--) {
                   const part = message.parts[k];
+                  if (part.type === "text") {
+                    if (
+                      "state" in part &&
+                      (part as { state: string }).state === "streaming"
+                    ) {
+                      continuationReasoningResumed = true;
+                    }
+                    break;
+                  }
                   if (part.type === "reasoning") {
                     if (
                       "state" in part &&
@@ -3748,8 +3758,8 @@ export class AIChatAgent<
                   }
                 }
                 // For interrupted continuations, keep appending to the cloned
-                // streaming reasoning part but still forward reasoning-start to
-                // the client. AI SDK v6 requires reasoning-start before any
+                // reasoning part but still forward reasoning-start to the
+                // client. AI SDK v6 requires reasoning-start before any
                 // reasoning-delta in the stream processor's active-part
                 // registry.
                 skipServerApply = continuationReasoningResumed;

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -3708,9 +3708,12 @@ export class AIChatAgent<
             //   state "streaming" (interrupted mid-generation). Parts with
             //   state "done" or no state create new blocks as usual (e.g.
             //   tool auto-continuation).
-            // - reasoning-start: always suppressed when an existing
-            //   reasoning part exists — re-reasoning during continuation
-            //   appends to the same block rather than creating a new one.
+            // - reasoning-start: server-side message building skips appending
+            //   a new reasoning part when one already exists, so re-reasoning
+            //   during continuation merges into the same persisted block. The
+            //   chunk is still forwarded to clients to keep the UI stream
+            //   protocol valid.
+            let skipServerApply = false;
             if (continuation) {
               if (!continuationTextResumed && data.type === "text-start") {
                 for (let k = message.parts.length - 1; k >= 0; k--) {
@@ -3737,7 +3740,13 @@ export class AIChatAgent<
                     break;
                   }
                 }
-                if (continuationReasoningResumed) continue;
+                // Keep the persisted continuation merged into the cloned
+                // reasoning part, but still forward reasoning-start to the
+                // client. AI SDK v6 requires reasoning-start before any
+                // reasoning-delta in the stream processor's active-part
+                // registry, even when the message already contains a
+                // completed reasoning part from earlier in the turn.
+                skipServerApply = continuationReasoningResumed;
               }
             }
 
@@ -3770,7 +3779,9 @@ export class AIChatAgent<
             // Delegate message building to the shared parser.
             // It handles: text, reasoning, file, source, tool lifecycle,
             // step boundaries — all the part types needed for UIMessage.
-            const handled = applyChunkToParts(message.parts, data);
+            const handled = skipServerApply
+              ? true
+              : applyChunkToParts(message.parts, data);
 
             // When a tool enters approval-requested state, the stream is
             // paused waiting for user approval. Persist the streaming message

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -3708,11 +3708,12 @@ export class AIChatAgent<
             //   state "streaming" (interrupted mid-generation). Parts with
             //   state "done" or no state create new blocks as usual (e.g.
             //   tool auto-continuation).
-            // - reasoning-start: server-side message building skips appending
-            //   a new reasoning part when one already exists, so re-reasoning
-            //   during continuation merges into the same persisted block. The
-            //   chunk is still forwarded to clients to keep the UI stream
-            //   protocol valid.
+            // - reasoning-start: suppressed only when the last reasoning part
+            //   has state "streaming" (interrupted mid-generation). Completed
+            //   reasoning blocks from earlier in the turn must not swallow new
+            //   continuation reasoning, otherwise the streamed reasoning block
+            //   disappears when the final persisted message replaces the live
+            //   stream.
             let skipServerApply = false;
             if (continuation) {
               if (!continuationTextResumed && data.type === "text-start") {
@@ -3735,17 +3736,22 @@ export class AIChatAgent<
                 data.type === "reasoning-start"
               ) {
                 for (let k = message.parts.length - 1; k >= 0; k--) {
-                  if (message.parts[k].type === "reasoning") {
-                    continuationReasoningResumed = true;
+                  const part = message.parts[k];
+                  if (part.type === "reasoning") {
+                    if (
+                      "state" in part &&
+                      (part as { state: string }).state === "streaming"
+                    ) {
+                      continuationReasoningResumed = true;
+                    }
                     break;
                   }
                 }
-                // Keep the persisted continuation merged into the cloned
-                // reasoning part, but still forward reasoning-start to the
-                // client. AI SDK v6 requires reasoning-start before any
+                // For interrupted continuations, keep appending to the cloned
+                // streaming reasoning part but still forward reasoning-start to
+                // the client. AI SDK v6 requires reasoning-start before any
                 // reasoning-delta in the stream processor's active-part
-                // registry, even when the message already contains a
-                // completed reasoning part from earlier in the turn.
+                // registry.
                 skipServerApply = continuationReasoningResumed;
               }
             }

--- a/packages/ai-chat/src/tests/client-tools-continuation.test.ts
+++ b/packages/ai-chat/src/tests/client-tools-continuation.test.ts
@@ -509,6 +509,147 @@ describe("Client tools continuation", () => {
     }
   });
 
+  it("preserves reasoning-start before reasoning-delta during approval continuation (#1480)", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+    try {
+      const userMessage: ChatMessage = {
+        id: "msg-issue-1480",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }]
+      };
+
+      let resolveInitialDone: (value: boolean) => void;
+      const initialDonePromise = new Promise<boolean>((res) => {
+        resolveInitialDone = res;
+      });
+      const initialTimeout = setTimeout(() => resolveInitialDone(false), 3000);
+
+      ws.addEventListener("message", function initialHandler(e: MessageEvent) {
+        const data = JSON.parse(e.data as string);
+        if (data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && data.done) {
+          clearTimeout(initialTimeout);
+          resolveInitialDone(true);
+          ws.removeEventListener("message", initialHandler);
+        }
+      });
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+          id: "req-issue-1480-initial",
+          init: {
+            method: "POST",
+            body: JSON.stringify({
+              messages: [userMessage],
+              reasoningContinuation: true,
+              delayContinuationChunks: true
+            })
+          }
+        })
+      );
+      expect(await initialDonePromise).toBe(true);
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+      await agentStub.persistMessages([
+        userMessage,
+        {
+          id: "assistant-issue-1480",
+          role: "assistant",
+          parts: [
+            {
+              type: "reasoning",
+              text: "initial reasoning",
+              state: "done"
+            },
+            {
+              type: "tool-changeBackgroundColor",
+              toolCallId: "call_issue_1480",
+              state: "approval-requested",
+              input: { color: "blue" },
+              approval: { id: "approval_issue_1480" }
+            }
+          ] as ChatMessage["parts"]
+        }
+      ]);
+
+      const receivedMessages = collectMessages(ws);
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_TOOL_APPROVAL,
+          toolCallId: "call_issue_1480",
+          approved: true,
+          autoContinue: true
+        })
+      );
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST
+        })
+      );
+
+      const resuming = (await waitForMessage(
+        receivedMessages,
+        (message) => message.type === MessageType.CF_AGENT_STREAM_RESUMING
+      )) as { id: string } | undefined;
+      expect(resuming).toBeDefined();
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
+          id: resuming!.id
+        })
+      );
+
+      const done = await waitForMessage(
+        receivedMessages,
+        (message) =>
+          message.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+          message.done === true
+      );
+      expect(done).toBeDefined();
+
+      const chunkTypes = receivedMessages
+        .filter(
+          (message) =>
+            message.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+            typeof message.body === "string" &&
+            message.body.length > 0
+        )
+        .map((message) => JSON.parse(message.body as string).type as string);
+
+      const reasoningStartIndex = chunkTypes.indexOf("reasoning-start");
+      const reasoningDeltaIndex = chunkTypes.indexOf("reasoning-delta");
+
+      expect(reasoningStartIndex).toBeGreaterThanOrEqual(0);
+      expect(reasoningDeltaIndex).toBeGreaterThan(reasoningStartIndex);
+
+      const persistedMessagesBroadcast = (await waitForMessage(
+        receivedMessages,
+        (message) => message.type === MessageType.CF_AGENT_CHAT_MESSAGES
+      )) as { messages: ChatMessage[] } | undefined;
+      expect(persistedMessagesBroadcast).toBeDefined();
+
+      const persistedAssistant = persistedMessagesBroadcast!.messages.find(
+        (message) => message.id === "assistant-issue-1480"
+      );
+      expect(persistedAssistant).toBeDefined();
+      const reasoningParts = persistedAssistant!.parts.filter(
+        (part) => part.type === "reasoning"
+      );
+      expect(reasoningParts).toHaveLength(1);
+      expect(reasoningParts[0]).toMatchObject({
+        text: "initial reasoningcontinuation reasoning",
+        state: "done"
+      });
+    } finally {
+      ws.close(1000);
+    }
+  });
+
   it("should send resume-none when an auto-continuation returns no body", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);

--- a/packages/ai-chat/src/tests/client-tools-continuation.test.ts
+++ b/packages/ai-chat/src/tests/client-tools-continuation.test.ts
@@ -640,9 +640,28 @@ describe("Client tools continuation", () => {
       const reasoningParts = persistedAssistant!.parts.filter(
         (part) => part.type === "reasoning"
       );
-      expect(reasoningParts).toHaveLength(1);
+      expect(reasoningParts).toHaveLength(2);
       expect(reasoningParts[0]).toMatchObject({
-        text: "initial reasoningcontinuation reasoning",
+        text: "initial reasoning",
+        state: "done"
+      });
+      expect(reasoningParts[1]).toMatchObject({
+        text: "continuation reasoning",
+        state: "done"
+      });
+
+      const persistedMessages =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      const storedAssistant = persistedMessages.find(
+        (message) => message.id === "assistant-issue-1480"
+      );
+      expect(storedAssistant).toBeDefined();
+      const storedReasoningParts = storedAssistant!.parts.filter(
+        (part) => part.type === "reasoning"
+      );
+      expect(storedReasoningParts).toHaveLength(2);
+      expect(storedReasoningParts[1]).toMatchObject({
+        text: "continuation reasoning",
         state: "done"
       });
     } finally {

--- a/packages/ai-chat/src/tests/client-tools-continuation.test.ts
+++ b/packages/ai-chat/src/tests/client-tools-continuation.test.ts
@@ -669,6 +669,112 @@ describe("Client tools continuation", () => {
     }
   });
 
+  it("persists reasoning during tool-result continuation without delayed chunks", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+    try {
+      const userMessage: ChatMessage = {
+        id: "msg-tool-result-reasoning",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }]
+      };
+
+      let resolveInitialDone: (value: boolean) => void;
+      const initialDonePromise = new Promise<boolean>((res) => {
+        resolveInitialDone = res;
+      });
+      const initialTimeout = setTimeout(() => resolveInitialDone(false), 3000);
+
+      ws.addEventListener("message", function initialHandler(e: MessageEvent) {
+        const data = JSON.parse(e.data as string);
+        if (data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && data.done) {
+          clearTimeout(initialTimeout);
+          resolveInitialDone(true);
+          ws.removeEventListener("message", initialHandler);
+        }
+      });
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+          id: "req-tool-result-reasoning-initial",
+          init: {
+            method: "POST",
+            body: JSON.stringify({
+              messages: [userMessage],
+              reasoningContinuation: true
+            })
+          }
+        })
+      );
+      expect(await initialDonePromise).toBe(true);
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+      await agentStub.persistMessages([
+        userMessage,
+        {
+          id: "assistant-tool-result-reasoning",
+          role: "assistant",
+          parts: [
+            {
+              type: "reasoning",
+              text: "initial reasoning",
+              state: "done"
+            },
+            {
+              type: "tool-changeBackgroundColor",
+              toolCallId: "call_tool_result_reasoning",
+              state: "input-available",
+              input: { color: "blue" }
+            }
+          ] as ChatMessage["parts"]
+        }
+      ]);
+
+      const receivedMessages = collectMessages(ws);
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_TOOL_RESULT,
+          toolCallId: "call_tool_result_reasoning",
+          toolName: "changeBackgroundColor",
+          output: { success: true },
+          autoContinue: true
+        })
+      );
+
+      const done = await waitForMessage(
+        receivedMessages,
+        (message) =>
+          message.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+          message.done === true
+      );
+      expect(done).toBeDefined();
+
+      const persistedMessages =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      const storedAssistant = persistedMessages.find(
+        (message) => message.id === "assistant-tool-result-reasoning"
+      );
+      expect(storedAssistant).toBeDefined();
+      const storedReasoningParts = storedAssistant!.parts.filter(
+        (part) => part.type === "reasoning"
+      );
+      expect(storedReasoningParts).toHaveLength(2);
+      expect(storedReasoningParts[0]).toMatchObject({
+        text: "initial reasoning",
+        state: "done"
+      });
+      expect(storedReasoningParts[1]).toMatchObject({
+        text: "continuation reasoning",
+        state: "done"
+      });
+    } finally {
+      ws.close(1000);
+    }
+  });
+
   it("should send resume-none when an auto-continuation returns no body", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);

--- a/packages/ai-chat/src/tests/continue-last-turn.test.ts
+++ b/packages/ai-chat/src/tests/continue-last-turn.test.ts
@@ -379,6 +379,89 @@ describe("continueLastTurn", () => {
     );
   });
 
+  it("should preserve orphaned continuation reasoning as a new part after completed reasoning", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setRecoveryOverride({ continue: false });
+
+    await agentStub.persistMessages([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Approve this" }]
+      },
+      {
+        id: "assistant-orphan-reasoning",
+        role: "assistant",
+        parts: [
+          {
+            type: "reasoning",
+            text: "Initial completed thinking.",
+            state: "done"
+          },
+          {
+            type: "tool-changeBackgroundColor",
+            toolCallId: "call-orphan-reasoning",
+            state: "output-available",
+            input: { color: "blue" },
+            output: { success: true }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ] as ChatMessage[]);
+
+    await agentStub.insertInterruptedStream("orphan-reasoning", "orphan-req", [
+      { body: JSON.stringify({ type: "start" }), index: 0 },
+      { body: JSON.stringify({ type: "reasoning-start" }), index: 1 },
+      {
+        body: JSON.stringify({
+          type: "reasoning-delta",
+          delta: "Recovered continuation thinking."
+        }),
+        index: 2
+      },
+      { body: JSON.stringify({ type: "reasoning-end" }), index: 3 },
+      { body: JSON.stringify({ type: "text-start" }), index: 4 },
+      {
+        body: JSON.stringify({
+          type: "text-delta",
+          delta: "Recovered continuation answer."
+        }),
+        index: 5
+      },
+      { body: JSON.stringify({ type: "text-end" }), index: 6 },
+      { body: JSON.stringify({ type: "finish" }), index: 7 }
+    ]);
+    await agentStub.triggerInterruptedStreamCheck();
+
+    const messages = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const assistant = messages.find(
+      (m: ChatMessage) => m.id === "assistant-orphan-reasoning"
+    )!;
+
+    const reasoningParts = assistant.parts.filter(
+      (p: ChatMessage["parts"][number]) => p.type === "reasoning"
+    );
+    expect(reasoningParts).toHaveLength(2);
+    expect(reasoningParts[0]).toMatchObject({
+      text: "Initial completed thinking.",
+      state: "done"
+    });
+    expect(reasoningParts[1]).toMatchObject({
+      text: "Recovered continuation thinking.",
+      state: "done"
+    });
+
+    const textParts = assistant.parts.filter(
+      (p: ChatMessage["parts"][number]) => p.type === "text"
+    );
+    expect(textParts).toHaveLength(1);
+    expect(textParts[0]).toMatchObject({
+      text: "Recovered continuation answer.",
+      state: "done"
+    });
+  });
+
   it("should wrap continuation in a fiber when chatRecovery is true", async () => {
     const room = crypto.randomUUID();
     const agentStub = await getTestAgent(room);

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -158,6 +158,36 @@ export class TestChatAgent extends AIChatAgent<Env> {
       ]);
     }
 
+    if (
+      options?.continuation === true &&
+      options.body?.reasoningContinuation === true
+    ) {
+      const chunks = [
+        { type: "start" },
+        { type: "reasoning-start", id: "reasoning_issue_1480" },
+        {
+          type: "reasoning-delta",
+          id: "reasoning_issue_1480",
+          delta: "continuation reasoning"
+        },
+        { type: "reasoning-end", id: "reasoning_issue_1480" },
+        { type: "text-start", id: "text_issue_1480" },
+        {
+          type: "text-delta",
+          id: "text_issue_1480",
+          delta: "continuation answer"
+        },
+        { type: "text-end", id: "text_issue_1480" },
+        { type: "finish" }
+      ];
+
+      if (options.body.delayContinuationChunks === true) {
+        return makeDelayedSSEChunkResponse(chunks, 100);
+      }
+
+      return makeSSEChunkResponse(chunks);
+    }
+
     // Issue #1404: simulate the OpenAI Responses API "provider replay"
     // pattern. When asked to continue after a tool result, some providers
     // re-emit the prior tool call (start + delta + available) plus the


### PR DESCRIPTION
## Summary

Fixes #1480.

When a `needsApproval` tool is approved with `autoContinueAfterToolResult` enabled, the auto-continuation stream can resume from an assistant message that already contains a completed reasoning part.

Two related issues were happening in that path:

1. The continuation's `reasoning-start` could be suppressed before reaching the client, so AI SDK v6 saw `reasoning-delta`/`reasoning-end` without a preceding `reasoning-start` and threw:

   ```txt
   AI_UIMessageStreamError: Received reasoning-delta for missing reasoning part
   ```

2. After forwarding `reasoning-start` to fix the stream protocol, completed prior reasoning could still cause the server-side continuation builder to merge new reasoning into the existing reasoning block. That made the live stream look correct, but the final persisted/rehydrated assistant message did not keep the continuation reasoning as its own persisted reasoning part, so the reasoning block disappeared after the response finished.

This PR keeps the client stream and persisted message in sync:

- the client stream receives a valid `reasoning-start` → `reasoning-delta` → `reasoning-end` sequence
- interrupted/streaming reasoning continuations still resume the existing reasoning part
- continuations after an already-completed reasoning block create and persist a new reasoning part, so rehydrated messages preserve the reasoning shown during streaming

## Changes

- Forward `reasoning-start` during approval continuations so AI SDK v6 receives a valid reasoning lifecycle.
- Only skip server-side `reasoning-start` application when resuming an existing `state: "streaming"` reasoning part.
- Preserve continuation reasoning in the final persisted assistant message when the previous reasoning part was already `done`.
- Extend the #1480 regression test to assert both the streamed chunk order and the final SQLite-persisted reasoning parts.
- Add/update a patch changeset for `@cloudflare/ai-chat`.

## Testing

```sh
cd packages/ai-chat && npm run test:workers -- src/tests/client-tools-continuation.test.ts -t "#1480"
cd packages/ai-chat && npm run test:workers -- src/tests/client-tools-continuation.test.ts
npm run check
```

`npm run check` completes successfully. It still prints existing `sherif` warnings for package-less workspace directories, unrelated to this change.
