### PR TITLE
Allow non-chat Think agent tools to complete

### DIFF
--- a/.changeset/fix-think-agent-tool-non-chat.md
+++ b/.changeset/fix-think-agent-tool-non-chat.md
@@ -1,5 +1,8 @@
 ---
+"@cloudflare/ai-chat": patch
 "@cloudflare/think": patch
 ---
 
 Allow Think agent-tool children to complete without emitting assistant text. Non-chat tool-step agents can now provide structured output through `getAgentToolOutput`, with summaries derived from assistant text, string output, structured output, or an empty string.
+
+Fix `useAgentChat().isServerStreaming` cleanup when a resumed stream first enters the fallback observer path and later becomes transport-owned.

--- a/.changeset/fix-think-agent-tool-non-chat.md
+++ b/.changeset/fix-think-agent-tool-non-chat.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Allow Think agent-tool children to complete without emitting assistant text. Non-chat tool-step agents can now provide structured output through `getAgentToolOutput`, with summaries derived from assistant text, string output, structured output, or an empty string.

--- a/design/agent-tools.md
+++ b/design/agent-tools.md
@@ -33,6 +33,14 @@ Durable Object RPC. If a parent restarts while a run is non-terminal, V1 replays
 stored chunks and marks the parent row `interrupted`; live-tail reattach is
 deferred.
 
+Think child completion is not tied to assistant text. Assistant text is only the
+default summary source for chat-like helper agents. Workflow-style Think
+children can complete without text chunks and can expose durable structured
+output through `getAgentToolOutput()` plus an optional `getAgentToolSummary()`
+override. This keeps execution, observation, and result synthesis separate:
+finishing the turn determines terminal status, child chunks are retained for UI
+observation, and output/summary hooks determine what the parent receives.
+
 ## Tradeoffs
 
 - Runs and facets are retained by default so refresh, drill-in, and debugging

--- a/design/agent-tools.md
+++ b/design/agent-tools.md
@@ -39,7 +39,10 @@ children can complete without text chunks and can expose durable structured
 output through `getAgentToolOutput()` plus an optional `getAgentToolSummary()`
 override. This keeps execution, observation, and result synthesis separate:
 finishing the turn determines terminal status, child chunks are retained for UI
-observation, and output/summary hooks determine what the parent receives.
+observation, and output/summary hooks determine what the parent receives. The
+output hook is evaluated immediately after the child turn resolves, so workflow
+children should commit durable output before the turn finishes and keep summaries
+small enough for display.
 
 ## Tradeoffs
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -91,6 +91,26 @@ The generated tool calls `this.runAgentTool(ChildAgent, ...)`, streams
 summary to the parent model. If the run fails, aborts, or is interrupted, the
 tool returns a structured failure instead of an empty success value.
 
+For `Think` children that do workflow-style work without user-facing assistant
+text, override `getAgentToolOutput()` and, if needed, `getAgentToolSummary()`.
+Assistant text remains the default summary when present, but a Think agent-tool
+run can complete successfully without emitting text chunks.
+
+```ts
+export class Extractor extends Think<Env> {
+  protected override getAgentToolOutput(runId: string) {
+    const rows = this.sql<{ result_json: string }>`
+      SELECT result_json FROM extraction_runs WHERE id = ${runId}
+    `;
+    return rows[0] ? JSON.parse(rows[0].result_json) : undefined;
+  }
+
+  protected override getAgentToolSummary(_runId: string, output: unknown) {
+    return output ? "Extraction complete" : "";
+  }
+}
+```
+
 ## Run an Agent tool imperatively
 
 Use `runAgentTool()` for deterministic workflows, scheduled work, HTTP

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -95,6 +95,10 @@ For `Think` children that do workflow-style work without user-facing assistant
 text, override `getAgentToolOutput()` and, if needed, `getAgentToolSummary()`.
 Assistant text remains the default summary when present, but a Think agent-tool
 run can complete successfully without emitting text chunks.
+Persist any structured output before the child turn finishes, because
+`getAgentToolOutput()` is read as soon as `saveMessages()` resolves. Keep
+`getAgentToolSummary()` concise for display; the full structured value is stored
+separately as the tool output.
 
 ```ts
 export class Extractor extends Think<Env> {

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -3899,6 +3899,85 @@ describe("useAgentChat isServerStreaming / isStreaming (issue #1226)", () => {
       .toHaveTextContent("false");
   });
 
+  it("isServerStreaming resets when a fallback-observed stream later becomes transport-owned", async () => {
+    const { agent, target } = createAgentWithTarget({
+      name: "server-stream-fallback-to-transport",
+      url: "ws://localhost:3000/agents/chat/server-stream-fallback-to-transport?_pk=abc"
+    });
+
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[]
+      });
+      chatInstance = chat;
+      return (
+        <div data-testid="isServerStreaming">
+          {String(chat.isServerStreaming)}
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await act(async () => {
+      dispatch(target, { type: "cf_agent_stream_resume_none" });
+      await sleep(10);
+    });
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_stream_resuming",
+        id: "fallback-to-transport-1"
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("isServerStreaming"))
+      .toHaveTextContent("true");
+
+    await act(async () => {
+      void chatInstance!.resumeStream();
+      await sleep(10);
+    });
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_stream_resuming",
+        id: "fallback-to-transport-1"
+      });
+      await sleep(10);
+    });
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "fallback-to-transport-1",
+        body: "",
+        done: true
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("isServerStreaming"))
+      .toHaveTextContent("false");
+  });
+
   it("isServerStreaming works with continuation broadcasts", async () => {
     const { agent, target } = createAgentWithTarget({
       name: "server-stream-continuation",

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -3968,6 +3968,36 @@ describe("useAgentChat isServerStreaming / isStreaming (issue #1226)", () => {
         type: "cf_agent_use_chat_response",
         id: "fallback-to-transport-1",
         body: "",
+        done: false,
+        replay: true,
+        replayComplete: true
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("isServerStreaming"))
+      .toHaveTextContent("true");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "fallback-to-transport-1",
+        body: '{"type":"text-delta","id":"t1","delta":"live"}',
+        done: false
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("isServerStreaming"))
+      .toHaveTextContent("true");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "fallback-to-transport-1",
+        body: "",
         done: true
       });
       await sleep(10);

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -1775,6 +1775,8 @@ export function useAgentChat<
 
             if (data.done || data.replayComplete) {
               pendingReplayResumeRequestIdsRef.current.delete(data.id);
+            }
+            if (data.done) {
               if (
                 streamStateRef.current.status === "observing" &&
                 streamStateRef.current.streamId === data.id
@@ -1782,9 +1784,6 @@ export function useAgentChat<
                 streamStateRef.current = { status: "idle" };
                 setIsServerStreaming(false);
               }
-            }
-
-            if (data.done) {
               customTransport.handleServerTurnCompleted(data.id);
               restoreProtectedStreamingAssistant(localResponseIds.get(data.id));
               localResponseIds.delete(data.id);

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -1775,6 +1775,13 @@ export function useAgentChat<
 
             if (data.done || data.replayComplete) {
               pendingReplayResumeRequestIdsRef.current.delete(data.id);
+              if (
+                streamStateRef.current.status === "observing" &&
+                streamStateRef.current.streamId === data.id
+              ) {
+                streamStateRef.current = { status: "idle" };
+                setIsServerStreaming(false);
+              }
             }
 
             if (data.done) {

--- a/packages/think/src/tests/agent-tools.test.ts
+++ b/packages/think/src/tests/agent-tools.test.ts
@@ -13,6 +13,8 @@ type ThinkAgentToolTestStub = {
   setAgentToolOutputForTest(runId: string, output: unknown): Promise<void>;
   clearAgentToolOutputForTest(runId: string): Promise<void>;
   setStripTextResponseForTest(strip: boolean): Promise<void>;
+  setBeforeStepAsyncDelay(ms: number): Promise<void>;
+  resetTurnStateForTest(): Promise<void>;
   startAgentToolRun(
     input: unknown,
     options: { runId: string }
@@ -107,6 +109,24 @@ describe("Think agent tools", () => {
       status: "completed",
       output: { ok: true, value: "workflow-result" },
       summary: '{"ok":true,"value":"workflow-result"}'
+    });
+  });
+
+  it("marks skipped agent-tool turns as errors", async () => {
+    const agent = await freshAgent();
+    const runId = crypto.randomUUID();
+
+    await agent.setBeforeStepAsyncDelay(50);
+    await agent.startAgentToolRun("skipped probe", { runId });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await agent.resetTurnStateForTest();
+
+    const inspection = await waitForAgentToolRun(agent, runId);
+
+    expect(inspection).toMatchObject({
+      runId,
+      status: "error",
+      error: "Agent tool run was skipped before the child could finish."
     });
   });
 

--- a/packages/think/src/tests/agent-tools.test.ts
+++ b/packages/think/src/tests/agent-tools.test.ts
@@ -10,6 +10,9 @@ type AgentToolInspection = Awaited<
 type ThinkAgentToolTestStub = {
   inspectAgentToolRun(runId: string): Promise<AgentToolInspection>;
   seedAgentToolLastErrorForTest(runId: string, error: string): Promise<void>;
+  setAgentToolOutputForTest(runId: string, output: unknown): Promise<void>;
+  clearAgentToolOutputForTest(runId: string): Promise<void>;
+  setStripTextResponseForTest(strip: boolean): Promise<void>;
   startAgentToolRun(
     input: unknown,
     options: { runId: string }
@@ -48,6 +51,65 @@ async function waitForAgentToolRun(
 }
 
 describe("Think agent tools", () => {
+  it("uses assistant text as the default agent-tool summary", async () => {
+    const agent = await freshAgent();
+    const runId = crypto.randomUUID();
+
+    await agent.startAgentToolRun("chat-like probe", { runId });
+    const inspection = await waitForAgentToolRun(agent, runId);
+
+    expect(inspection).toMatchObject({
+      runId,
+      status: "completed",
+      summary: "Hello from the assistant!"
+    });
+    expect(inspection?.error).toBeUndefined();
+  });
+
+  it("completes when a non-chat agent-tool run emits no assistant text", async () => {
+    const agent = await freshAgent();
+    const runId = crypto.randomUUID();
+
+    await agent.setStripTextResponseForTest(true);
+    await agent.startAgentToolRun("non-chat probe", { runId });
+    const inspection = await waitForAgentToolRun(agent, runId);
+
+    expect(inspection).toMatchObject({
+      runId,
+      status: "completed",
+      summary: ""
+    });
+    expect(inspection?.error).toBeUndefined();
+  });
+
+  it("returns structured output for a non-chat agent-tool run", async () => {
+    const agent = await freshAgent();
+    const runId = crypto.randomUUID();
+
+    await agent.setStripTextResponseForTest(true);
+    await agent.setAgentToolOutputForTest(runId, {
+      ok: true,
+      value: "workflow-result"
+    });
+    await agent.startAgentToolRun("structured non-chat probe", { runId });
+    const inspection = await waitForAgentToolRun(agent, runId);
+
+    expect(inspection).toMatchObject({
+      runId,
+      status: "completed",
+      output: { ok: true, value: "workflow-result" },
+      summary: '{"ok":true,"value":"workflow-result"}'
+    });
+
+    await agent.clearAgentToolOutputForTest(runId);
+    await expect(agent.inspectAgentToolRun(runId)).resolves.toMatchObject({
+      runId,
+      status: "completed",
+      output: { ok: true, value: "workflow-result" },
+      summary: '{"ok":true,"value":"workflow-result"}'
+    });
+  });
+
   it("cleans in-memory agent-tool bookkeeping after a run completes", async () => {
     const agent = await freshAgent();
     const runId = crypto.randomUUID();

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -435,6 +435,10 @@ export class ThinkTestAgent extends Think {
     this._beforeStepAsyncDelayMs = ms;
   }
 
+  async resetTurnStateForTest(): Promise<void> {
+    this.resetTurnState();
+  }
+
   override onStepFinish(ctx: StepContext): void {
     // Capture a few fields from the full StepResult to confirm the
     // AI SDK shape is reaching the hook (text, finishReason, real usage,

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -306,6 +306,8 @@ export class ThinkTestAgent extends Think {
     afterChunks: number;
     message: string;
   } | null = null;
+  private _stripTextResponseForTest = false;
+  private _agentToolOutputForTest = new Map<string, unknown>();
   private _responseLog: ChatResponseResult[] = [];
 
   override onChatError(error: unknown): unknown {
@@ -346,6 +348,10 @@ export class ThinkTestAgent extends Think {
 
   override onChatResponse(result: ChatResponseResult): void {
     this._responseLog.push(result);
+  }
+
+  protected override getAgentToolOutput(runId: string): unknown {
+    return this._agentToolOutputForTest.get(runId);
   }
 
   override beforeTurn(ctx: TurnContext): TurnConfig | void {
@@ -502,39 +508,60 @@ export class ThinkTestAgent extends Think {
   protected override _transformInferenceResult(
     result: StreamableResult
   ): StreamableResult {
-    if (!this._errorConfig) return result;
+    if (!this._errorConfig && !this._stripTextResponseForTest) return result;
 
     const config = this._errorConfig;
-    const originalStream = result.toUIMessageStream();
-    const reader = (originalStream as unknown as ReadableStream).getReader();
-    let chunkCount = 0;
-    let shouldThrow = false;
+    const stripText = this._stripTextResponseForTest;
 
-    const wrapped: AsyncIterable<unknown> = {
-      [Symbol.asyncIterator]() {
-        return {
-          async next() {
-            if (shouldThrow) {
-              await reader.cancel();
-              throw new SimulatedChatError(config.message);
-            }
-            const { done, value } = await reader.read();
-            if (done) return { done: true as const, value: undefined };
-            chunkCount++;
-            if (chunkCount >= config.afterChunks) {
-              shouldThrow = true;
-            }
-            return { done: false as const, value };
-          },
-          async return() {
-            await reader.cancel();
-            return { done: true as const, value: undefined };
+    return {
+      toUIMessageStream(options?: { sendReasoning?: boolean }) {
+        const originalStream = result.toUIMessageStream(options);
+        const reader = (
+          originalStream as unknown as ReadableStream<unknown>
+        ).getReader();
+        let chunkCount = 0;
+        let shouldThrow = false;
+
+        const wrapped: AsyncIterable<unknown> = {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                while (true) {
+                  if (shouldThrow && config) {
+                    await reader.cancel();
+                    throw new SimulatedChatError(config.message);
+                  }
+                  const { done, value } = await reader.read();
+                  if (done) return { done: true as const, value: undefined };
+                  chunkCount++;
+                  if (config && chunkCount >= config.afterChunks) {
+                    shouldThrow = true;
+                  }
+                  if (
+                    stripText &&
+                    value != null &&
+                    typeof value === "object" &&
+                    "type" in value &&
+                    (value.type === "text-start" ||
+                      value.type === "text-delta" ||
+                      value.type === "text-end")
+                  ) {
+                    continue;
+                  }
+                  return { done: false as const, value };
+                }
+              },
+              async return() {
+                await reader.cancel();
+                return { done: true as const, value: undefined };
+              }
+            };
           }
         };
+
+        return wrapped;
       }
     };
-
-    return { toUIMessageStream: () => wrapped };
   }
 
   // ── Test-specific public methods ───────────────────────────────
@@ -643,6 +670,21 @@ export class ThinkTestAgent extends Think {
 
   async setResponse(response: string): Promise<void> {
     this._response = response;
+  }
+
+  async setStripTextResponseForTest(strip: boolean): Promise<void> {
+    this._stripTextResponseForTest = strip;
+  }
+
+  async setAgentToolOutputForTest(
+    runId: string,
+    output: unknown
+  ): Promise<void> {
+    this._agentToolOutputForTest.set(runId, output);
+  }
+
+  async clearAgentToolOutputForTest(runId: string): Promise<void> {
+    this._agentToolOutputForTest.delete(runId);
   }
 
   private _multiChunks: string[] | null = null;

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2042,14 +2042,18 @@ export class Think<
         const output = this.getAgentToolOutput(options.runId);
         const summary = this.getAgentToolSummary(options.runId, output);
         const streamError = this._agentToolLastErrors.get(options.runId);
+        const skipped = result.status === "skipped";
         const status: AgentToolChildRunStatus =
           result.status === "aborted"
             ? "aborted"
-            : streamError
+            : skipped || streamError
               ? "error"
               : "completed";
         const error: string | null =
-          status === "error" ? (streamError ?? "Agent tool run failed.") : null;
+          status === "error"
+            ? (streamError ??
+              "Agent tool run was skipped before the child could finish.")
+            : null;
         this.sql`
           UPDATE cf_agent_tool_child_runs
           SET request_id = ${result.requestId},

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -222,6 +222,7 @@ type AgentToolChildRunRow = {
   stream_id: string | null;
   status: AgentToolChildRunStatus;
   summary: string | null;
+  output_json: string | null;
   error_message: string | null;
   started_at: number;
   completed_at: number | null;
@@ -1913,18 +1914,34 @@ export class Think<
         stream_id TEXT,
         status TEXT NOT NULL,
         summary TEXT,
+        output_json TEXT,
         error_message TEXT,
         started_at INTEGER NOT NULL,
         completed_at INTEGER
       )
     `;
+
+    this._addAgentToolChildRunColumnIfMissing(
+      "ALTER TABLE cf_agent_tool_child_runs ADD COLUMN output_json TEXT"
+    );
+  }
+
+  private _addAgentToolChildRunColumnIfMissing(sql: string): void {
+    try {
+      this.ctx.storage.sql.exec(sql);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.toLowerCase().includes("duplicate column")) {
+        throw error;
+      }
+    }
   }
 
   private _readAgentToolChildRun(runId: string): AgentToolChildRunRow | null {
     this._ensureAgentToolChildRunTable();
     const rows = this.sql<AgentToolChildRunRow>`
-      SELECT run_id, request_id, stream_id, status, summary, error_message,
-             started_at, completed_at
+      SELECT run_id, request_id, stream_id, status, summary, output_json,
+             error_message, started_at, completed_at
       FROM cf_agent_tool_child_runs
       WHERE run_id = ${runId}
       LIMIT 1
@@ -1936,12 +1953,17 @@ export class Think<
     row: AgentToolChildRunRow,
     output?: Output
   ): AgentToolRunInspection<Output> {
+    const storedOutput =
+      row.output_json === null
+        ? output
+        : (Think._parseAgentToolOutput(row.output_json) as Output);
+
     return {
       runId: row.run_id,
       status: row.status,
       requestId: row.request_id ?? undefined,
       streamId: row.stream_id ?? undefined,
-      output,
+      output: storedOutput,
       summary: row.summary ?? undefined,
       error: row.error_message ?? undefined,
       startedAt: row.started_at,
@@ -1961,6 +1983,20 @@ export class Think<
 
   protected getAgentToolOutput(_runId: string): unknown {
     return undefined;
+  }
+
+  protected getAgentToolSummary(runId: string, output: unknown): string {
+    const text = this._getAgentToolFinalText(runId);
+    if (text) return text;
+    if (typeof output === "string") return output;
+    if (output !== undefined) {
+      try {
+        return JSON.stringify(output);
+      } catch {
+        return String(output);
+      }
+    }
+    return "";
   }
 
   async startAgentToolRun(
@@ -2003,25 +2039,24 @@ export class Think<
           this._resumableStream
             .getAllStreamMetadata()
             .find((m) => m.request_id === result.requestId)?.id ?? null;
-        const summary = this._getAgentToolFinalText(options.runId);
+        const output = this.getAgentToolOutput(options.runId);
+        const summary = this.getAgentToolSummary(options.runId, output);
         const streamError = this._agentToolLastErrors.get(options.runId);
         const status: AgentToolChildRunStatus =
           result.status === "aborted"
             ? "aborted"
-            : streamError || !summary
+            : streamError
               ? "error"
               : "completed";
-        const error =
-          status === "error"
-            ? (streamError ??
-              `${this.constructor.name} finished without producing assistant text.`)
-            : null;
+        const error: string | null =
+          status === "error" ? (streamError ?? "Agent tool run failed.") : null;
         this.sql`
           UPDATE cf_agent_tool_child_runs
           SET request_id = ${result.requestId},
               stream_id = ${streamId},
               status = ${status},
               summary = ${summary},
+              output_json = ${Think._stringifyAgentToolOutput(output)},
               error_message = ${error},
               completed_at = ${Date.now()}
           WHERE run_id = ${options.runId}
@@ -2138,6 +2173,24 @@ export class Think<
       }
     });
     return stream as unknown as ReadableStream<AgentToolStoredChunk>;
+  }
+
+  private static _stringifyAgentToolOutput(output: unknown): string | null {
+    if (output === undefined) return null;
+    try {
+      return JSON.stringify(output);
+    } catch {
+      return JSON.stringify(String(output));
+    }
+  }
+
+  private static _parseAgentToolOutput(value: string | null): unknown {
+    if (value === null) return undefined;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return undefined;
+    }
   }
 
   private _getAgentToolFinalText(runId: string): string | null {


### PR DESCRIPTION
## Summary

Fixes #1482.

Think agent-tool children previously treated "completed" as "the child produced assistant text after the run started." That made chat-like helpers work, but forced workflow/tool-step agents to emit sentinel text just to avoid an error terminal state.

This PR separates the agent-tool concerns:

- **execution**: whether the Think turn completed, errored, or aborted
- **observation**: streamed child chunks retained for UI/drill-in/replay
- **result synthesis**: the output and summary returned to the parent

A Think child agent-tool run can now complete successfully without emitting assistant text. Assistant text remains the default summary for chat-like helpers, while non-chat children can provide structured output via `getAgentToolOutput()` and customize display text with `getAgentToolSummary()`.

## Follow-up: `isServerStreaming` stuck after reconnect

After the initial fix, @uuouter noted that `useAgentChat().isServerStreaming` could sometimes stay `true` after reconnect / finish.

The issue was a race between two resume paths in `useAgentChat`:

1. The client receives `cf_agent_stream_resuming` before the AI SDK transport is awaiting resume.
2. `useAgentChat` takes the fallback observer path, marks the stream as observed, and sets `isServerStreaming` to `true`.
3. The AI SDK `resumeStream()` / transport path later starts awaiting the same stream id.
4. A duplicate `cf_agent_stream_resuming` for that same id is handled by the transport, which adds the id to `localRequestIdsRef`.
5. The terminal `cf_agent_use_chat_response { done: true }` then goes through the transport-owned/local-request branch.
6. That branch cleaned up local request ids, but did not clear the earlier fallback observer state, leaving `isServerStreaming` stuck `true`.

This PR now clears fallback observer state when a terminal local-request response belongs to the same stream id.

## Changes

- Stop marking Think child agent-tool runs as `error` solely because no assistant text was emitted.
- Add `protected getAgentToolSummary(runId, output)` as the summary hook paired with existing `getAgentToolOutput(runId)`.
- Persist Think child agent-tool output in `cf_agent_tool_child_runs.output_json` so completed output survives later inspection.
- Add a migration for existing Think child agent-tool run tables.
- Add regression coverage for:
  - chat-like agent-tool summary from assistant text
  - non-chat agent-tool completion with no text chunks
  - structured output persistence after the output hook no longer returns a value
  - existing error cleanup behavior
- Fix `useAgentChat().isServerStreaming` cleanup when a stream first enters the fallback resume observer path and later becomes transport-owned.
- Add React regression coverage for that resume ownership handoff.
- Document the non-chat Think agent-tool pattern in `docs/agent-tools.md` and update the design doc.
- Add a patch changeset for `@cloudflare/think`.

## Testing

```sh
cd packages/think && npm run test -- src/tests/agent-tools.test.ts
cd packages/ai-chat && npx vitest --run --project react src/react-tests/use-agent-chat.test.tsx --testNamePattern "fallback-observed stream later becomes transport-owned"
cd packages/ai-chat && npx vitest --run --project react src/react-tests/use-agent-chat.test.tsx --testNamePattern "isServerStreaming"
npm run check
```

`npm run check` completes successfully. It still prints existing `sherif` warnings for package-less workspace directories, unrelated to this change.
