### PR TITLE
Add durable cancellation mode for useAgentChat

### DIFF
--- a/.changeset/durable-chat-cancellation.md
+++ b/.changeset/durable-chat-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": minor
+---
+
+Add `durable` and `serverTurnCancellation` options to `useAgentChat`. `durable: true` treats browser/client stream cleanup as local-only while preserving explicit `stop()` as server-side turn cancellation.

--- a/.changeset/durable-chat-cancellation.md
+++ b/.changeset/durable-chat-cancellation.md
@@ -2,4 +2,4 @@
 "@cloudflare/ai-chat": minor
 ---
 
-Add `durable` and `serverTurnCancellation` options to `useAgentChat`. `durable: true` treats browser/client stream cleanup as local-only while preserving explicit `stop()` as server-side turn cancellation.
+Add `cancelOnClientAbort` to `useAgentChat`. Generic browser/client stream cleanup is now local-only by default so server turns can continue and resume; explicit `stop()` still cancels the server turn. Set `cancelOnClientAbort: true` to make generic client aborts cancel the server turn.

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -775,18 +775,17 @@ function Chat() {
 
 ### Options
 
-| Option                        | Type                                            | Default             | Description                                                                                                                                             |
-| ----------------------------- | ----------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`                       | `ReturnType<typeof useAgent>`                   | Required            | Agent connection from `useAgent`                                                                                                                        |
-| `onToolCall`                  | `({ toolCall, addToolOutput }) => void`         | —                   | Handle client-side tool execution                                                                                                                       |
-| `autoContinueAfterToolResult` | `boolean`                                       | `true`              | Auto-continue conversation after client tool results and approvals                                                                                      |
-| `resume`                      | `boolean`                                       | `true`              | Enable automatic stream resumption on reconnect                                                                                                         |
-| `durable`                     | `boolean`                                       | `false`             | Treat the browser as a reconnectable observer: generic client stream abort/cleanup is local-only, while explicit `stop()` still cancels the server turn |
-| `serverTurnCancellation`      | `"on-client-abort" \| "explicit-only"`          | `"on-client-abort"` | Advanced cancellation policy. `durable: true` defaults this to `"explicit-only"` unless explicitly overridden                                           |
-| `body`                        | `object \| () => object`                        | —                   | Custom data sent with every request                                                                                                                     |
-| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`              | —                   | Advanced per-request customization                                                                                                                      |
-| `tools`                       | `Record<string, AITool>`                        | —                   | Dynamic client-defined tools for SDK/platform use cases. Schemas are sent to the server automatically                                                   |
-| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>` or `null` | —                   | Custom initial message loader. Set to `null` to skip the HTTP fetch entirely (useful when providing `messages` directly)                                |
+| Option                        | Type                                            | Default  | Description                                                                                                              |
+| ----------------------------- | ----------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `agent`                       | `ReturnType<typeof useAgent>`                   | Required | Agent connection from `useAgent`                                                                                         |
+| `onToolCall`                  | `({ toolCall, addToolOutput }) => void`         | —        | Handle client-side tool execution                                                                                        |
+| `autoContinueAfterToolResult` | `boolean`                                       | `true`   | Auto-continue conversation after client tool results and approvals                                                       |
+| `resume`                      | `boolean`                                       | `true`   | Enable automatic stream resumption on reconnect                                                                          |
+| `cancelOnClientAbort`         | `boolean`                                       | `false`  | Cancel the server turn when generic client stream abort/cleanup occurs. Explicit `stop()` always cancels the server turn |
+| `body`                        | `object \| () => object`                        | —        | Custom data sent with every request                                                                                      |
+| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`              | —        | Advanced per-request customization                                                                                       |
+| `tools`                       | `Record<string, AITool>`                        | —        | Dynamic client-defined tools for SDK/platform use cases. Schemas are sent to the server automatically                    |
+| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>` or `null` | —        | Custom initial message loader. Set to `null` to skip the HTTP fetch entirely (useful when providing `messages` directly) |
 
 ### Return Values
 
@@ -1171,11 +1170,15 @@ When streaming is active:
 2. If the client disconnects, the server continues streaming and buffering
 3. When the client reconnects, it receives all buffered chunks and resumes live streaming
 
-For durable sessions where the browser should be a reconnectable observer of the turn, set `durable: true`. Generic client stream abort/cleanup stays local to the browser, but an explicit `stop()` still sends server cancellation:
+Generic client stream abort/cleanup stays local to the browser by default, so the server turn keeps running and can be resumed later. An explicit `stop()` still sends server cancellation:
 
 ```tsx
-const { messages, stop } = useAgentChat({ agent, durable: true });
+const { messages, stop } = useAgentChat({ agent });
 ```
+
+If your app intentionally wants client lifecycle to own server lifecycle, set `cancelOnClientAbort: true`.
+This is useful for request-lifetime or token-saving flows; explicit `stop()` is
+always server-side cancellation regardless of this option.
 
 Disable resume with `resume: false`:
 

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -775,16 +775,18 @@ function Chat() {
 
 ### Options
 
-| Option                        | Type                                            | Default  | Description                                                                                                              |
-| ----------------------------- | ----------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `agent`                       | `ReturnType<typeof useAgent>`                   | Required | Agent connection from `useAgent`                                                                                         |
-| `onToolCall`                  | `({ toolCall, addToolOutput }) => void`         | —        | Handle client-side tool execution                                                                                        |
-| `autoContinueAfterToolResult` | `boolean`                                       | `true`   | Auto-continue conversation after client tool results and approvals                                                       |
-| `resume`                      | `boolean`                                       | `true`   | Enable automatic stream resumption on reconnect                                                                          |
-| `body`                        | `object \| () => object`                        | —        | Custom data sent with every request                                                                                      |
-| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`              | —        | Advanced per-request customization                                                                                       |
-| `tools`                       | `Record<string, AITool>`                        | —        | Dynamic client-defined tools for SDK/platform use cases. Schemas are sent to the server automatically                    |
-| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>` or `null` | —        | Custom initial message loader. Set to `null` to skip the HTTP fetch entirely (useful when providing `messages` directly) |
+| Option                        | Type                                            | Default             | Description                                                                                                                                             |
+| ----------------------------- | ----------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                       | `ReturnType<typeof useAgent>`                   | Required            | Agent connection from `useAgent`                                                                                                                        |
+| `onToolCall`                  | `({ toolCall, addToolOutput }) => void`         | —                   | Handle client-side tool execution                                                                                                                       |
+| `autoContinueAfterToolResult` | `boolean`                                       | `true`              | Auto-continue conversation after client tool results and approvals                                                                                      |
+| `resume`                      | `boolean`                                       | `true`              | Enable automatic stream resumption on reconnect                                                                                                         |
+| `durable`                     | `boolean`                                       | `false`             | Treat the browser as a reconnectable observer: generic client stream abort/cleanup is local-only, while explicit `stop()` still cancels the server turn |
+| `serverTurnCancellation`      | `"on-client-abort" \| "explicit-only"`          | `"on-client-abort"` | Advanced cancellation policy. `durable: true` defaults this to `"explicit-only"` unless explicitly overridden                                           |
+| `body`                        | `object \| () => object`                        | —                   | Custom data sent with every request                                                                                                                     |
+| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`              | —                   | Advanced per-request customization                                                                                                                      |
+| `tools`                       | `Record<string, AITool>`                        | —                   | Dynamic client-defined tools for SDK/platform use cases. Schemas are sent to the server automatically                                                   |
+| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>` or `null` | —                   | Custom initial message loader. Set to `null` to skip the HTTP fetch entirely (useful when providing `messages` directly)                                |
 
 ### Return Values
 
@@ -1169,7 +1171,13 @@ When streaming is active:
 2. If the client disconnects, the server continues streaming and buffering
 3. When the client reconnects, it receives all buffered chunks and resumes live streaming
 
-Disable with `resume: false`:
+For durable sessions where the browser should be a reconnectable observer of the turn, set `durable: true`. Generic client stream abort/cleanup stays local to the browser, but an explicit `stop()` still sends server cancellation:
+
+```tsx
+const { messages, stop } = useAgentChat({ agent, durable: true });
+```
+
+Disable resume with `resume: false`:
 
 ```tsx
 const { messages } = useAgentChat({ agent, resume: false });

--- a/docs/resumable-streaming.md
+++ b/docs/resumable-streaming.md
@@ -10,9 +10,7 @@ When you use `AIChatAgent` with `useAgentChat`:
 2. **On disconnect**: The stream continues server-side, buffering chunks
 3. **On reconnect**: Client requests a resume, receives all buffered chunks, and continues streaming
 
-No extra code is needed -- it just works.
-
-If your app treats the browser as a reconnectable observer of a long-running turn, set `durable: true` on `useAgentChat`. This keeps generic client stream abort/cleanup local to the browser while preserving explicit `stop()` as server-side cancellation.
+No extra code is needed -- it just works. Generic client stream abort/cleanup is local-only by default, so browser navigation or React cleanup does not stop the server turn. An explicit `stop()` still cancels the server turn.
 
 ## Example
 
@@ -51,10 +49,10 @@ function Chat() {
   });
 
   const { messages, sendMessage, status } = useAgentChat({
-    agent,
-    durable: true
+    agent
     // resume: true is the default - streams automatically resume on reconnect
-    // durable: true means browser cleanup does not cancel the server turn
+    // cancelOnClientAbort: false is the default - browser cleanup does not
+    // cancel the server turn
   });
 
   // ... render your chat UI
@@ -86,16 +84,25 @@ Replayed chunks include `replay: true` to distinguish them from live chunks. The
 
 ## Durable client cleanup
 
-`resume: true` controls whether the client tries to reconnect to an active stream. `durable: true` controls cancellation semantics: generic client stream abort/cleanup is local-only, while explicit `stop()` still cancels the server turn.
+`resume: true` controls whether the client tries to reconnect to an active stream. `cancelOnClientAbort: false` is the default cancellation behavior: generic client stream abort/cleanup is local-only, while explicit `stop()` still cancels the server turn.
 
 ```tsx
 const { messages, stop } = useAgentChat({
-  agent,
-  durable: true
+  agent
 });
 ```
 
-Advanced clients can set `serverTurnCancellation: "explicit-only"` directly. The default remains `"on-client-abort"` for backward compatibility.
+If your app intentionally wants client lifecycle to own server lifecycle, opt in:
+
+```tsx
+const { messages } = useAgentChat({
+  agent,
+  cancelOnClientAbort: true
+});
+```
+
+Use this for request-lifetime or token-saving flows. Explicit `stop()` is always
+server-side cancellation regardless of `cancelOnClientAbort`.
 
 ## Disabling Resume
 

--- a/docs/resumable-streaming.md
+++ b/docs/resumable-streaming.md
@@ -12,6 +12,8 @@ When you use `AIChatAgent` with `useAgentChat`:
 
 No extra code is needed -- it just works.
 
+If your app treats the browser as a reconnectable observer of a long-running turn, set `durable: true` on `useAgentChat`. This keeps generic client stream abort/cleanup local to the browser while preserving explicit `stop()` as server-side cancellation.
+
 ## Example
 
 ### Server
@@ -49,8 +51,10 @@ function Chat() {
   });
 
   const { messages, sendMessage, status } = useAgentChat({
-    agent
+    agent,
+    durable: true
     // resume: true is the default - streams automatically resume on reconnect
+    // durable: true means browser cleanup does not cancel the server turn
   });
 
   // ... render your chat UI
@@ -79,6 +83,19 @@ function Chat() {
 ### The `replay` flag
 
 Replayed chunks include `replay: true` to distinguish them from live chunks. The client uses this to batch-apply all replayed chunks before rendering, which prevents intermediate states (like reasoning "Thinking..." indicators) from flashing briefly during replay. During a live stream, chunks arrive gradually and React renders each intermediate state naturally.
+
+## Durable client cleanup
+
+`resume: true` controls whether the client tries to reconnect to an active stream. `durable: true` controls cancellation semantics: generic client stream abort/cleanup is local-only, while explicit `stop()` still cancels the server turn.
+
+```tsx
+const { messages, stop } = useAgentChat({
+  agent,
+  durable: true
+});
+```
+
+Advanced clients can set `serverTurnCancellation: "explicit-only"` directly. The default remains `"on-client-abort"` for backward compatibility.
 
 ## Disabling Resume
 

--- a/packages/ai-chat/README.md
+++ b/packages/ai-chat/README.md
@@ -248,11 +248,23 @@ Streams automatically resume on disconnect/reconnect. No configuration needed.
 
 When a client disconnects mid-stream, chunks are buffered in SQLite. On reconnect, the client receives all buffered chunks and continues receiving the live stream.
 
-For apps where the browser should be only a reconnectable observer of a long-running server turn, set `durable: true`. Generic client stream abort/cleanup becomes local-only, while an explicit `stop()` still cancels the server turn:
+Generic client stream abort/cleanup is local-only by default: the server turn continues and can be resumed later. An explicit `stop()` still cancels the server turn:
 
 ```tsx
-const { messages, stop } = useAgentChat({ agent, durable: true });
+const { messages, stop } = useAgentChat({ agent });
 ```
+
+If your app intentionally wants client lifecycle to own server lifecycle, opt in to cancellation on client abort:
+
+```tsx
+const { messages } = useAgentChat({
+  agent,
+  cancelOnClientAbort: true
+});
+```
+
+Use this for request-lifetime or token-saving flows. Explicit `stop()` is always
+server-side cancellation regardless of `cancelOnClientAbort`.
 
 Disable resume with `resume: false`:
 
@@ -435,17 +447,16 @@ React hook for chat interactions. Wraps the AI SDK's `useChat` with WebSocket tr
 
 **Options:**
 
-| Option                        | Type                                    | Description                                                                                            |
-| ----------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `agent`                       | `ReturnType<typeof useAgent>`           | Agent connection (required)                                                                            |
-| `onToolCall`                  | `({ toolCall, addToolOutput }) => void` | Handle client-side tool execution                                                                      |
-| `autoContinueAfterToolResult` | `boolean`                               | Auto-continue after client tool results. Default: `true`                                               |
-| `resume`                      | `boolean`                               | Enable stream resumption. Default: `true`                                                              |
-| `durable`                     | `boolean`                               | Treat browser cleanup as local-only; explicit `stop()` still cancels the server turn. Default: `false` |
-| `serverTurnCancellation`      | `"on-client-abort" \| "explicit-only"`  | Advanced cancellation policy. Default: `"on-client-abort"`                                             |
-| `body`                        | `object \| () => object`                | Custom data sent with every request (see below)                                                        |
-| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`      | Advanced per-request customization                                                                     |
-| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>`   | Custom initial message loader                                                                          |
+| Option                        | Type                                    | Description                                                                                                                |
+| ----------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                       | `ReturnType<typeof useAgent>`           | Agent connection (required)                                                                                                |
+| `onToolCall`                  | `({ toolCall, addToolOutput }) => void` | Handle client-side tool execution                                                                                          |
+| `autoContinueAfterToolResult` | `boolean`                               | Auto-continue after client tool results. Default: `true`                                                                   |
+| `resume`                      | `boolean`                               | Enable stream resumption. Default: `true`                                                                                  |
+| `cancelOnClientAbort`         | `boolean`                               | Cancel the server turn when generic client stream abort/cleanup occurs. Explicit `stop()` always cancels. Default: `false` |
+| `body`                        | `object \| () => object`                | Custom data sent with every request (see below)                                                                            |
+| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`      | Advanced per-request customization                                                                                         |
+| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>`   | Custom initial message loader                                                                                              |
 
 **Returns:**
 

--- a/packages/ai-chat/README.md
+++ b/packages/ai-chat/README.md
@@ -248,7 +248,13 @@ Streams automatically resume on disconnect/reconnect. No configuration needed.
 
 When a client disconnects mid-stream, chunks are buffered in SQLite. On reconnect, the client receives all buffered chunks and continues receiving the live stream.
 
-Disable with `resume: false`:
+For apps where the browser should be only a reconnectable observer of a long-running server turn, set `durable: true`. Generic client stream abort/cleanup becomes local-only, while an explicit `stop()` still cancels the server turn:
+
+```tsx
+const { messages, stop } = useAgentChat({ agent, durable: true });
+```
+
+Disable resume with `resume: false`:
 
 ```tsx
 const { messages } = useAgentChat({ agent, resume: false });
@@ -429,15 +435,17 @@ React hook for chat interactions. Wraps the AI SDK's `useChat` with WebSocket tr
 
 **Options:**
 
-| Option                        | Type                                    | Description                                              |
-| ----------------------------- | --------------------------------------- | -------------------------------------------------------- |
-| `agent`                       | `ReturnType<typeof useAgent>`           | Agent connection (required)                              |
-| `onToolCall`                  | `({ toolCall, addToolOutput }) => void` | Handle client-side tool execution                        |
-| `autoContinueAfterToolResult` | `boolean`                               | Auto-continue after client tool results. Default: `true` |
-| `resume`                      | `boolean`                               | Enable stream resumption. Default: `true`                |
-| `body`                        | `object \| () => object`                | Custom data sent with every request (see below)          |
-| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`      | Advanced per-request customization                       |
-| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>`   | Custom initial message loader                            |
+| Option                        | Type                                    | Description                                                                                            |
+| ----------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `agent`                       | `ReturnType<typeof useAgent>`           | Agent connection (required)                                                                            |
+| `onToolCall`                  | `({ toolCall, addToolOutput }) => void` | Handle client-side tool execution                                                                      |
+| `autoContinueAfterToolResult` | `boolean`                               | Auto-continue after client tool results. Default: `true`                                               |
+| `resume`                      | `boolean`                               | Enable stream resumption. Default: `true`                                                              |
+| `durable`                     | `boolean`                               | Treat browser cleanup as local-only; explicit `stop()` still cancels the server turn. Default: `false` |
+| `serverTurnCancellation`      | `"on-client-abort" \| "explicit-only"`  | Advanced cancellation policy. Default: `"on-client-abort"`                                             |
+| `body`                        | `object \| () => object`                | Custom data sent with every request (see below)                                                        |
+| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`      | Advanced per-request customization                                                                     |
+| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>`   | Custom initial message loader                                                                          |
 
 **Returns:**
 

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -4452,7 +4452,7 @@ describe("useAgentChat tool approval continuations (issue #1108)", () => {
   });
 });
 
-describe("useAgentChat durable cancellation", () => {
+describe("useAgentChat client abort cancellation", () => {
   function createAgentWithTarget({ name, url }: { name: string; url: string }) {
     const target = new EventTarget();
     const sentMessages: string[] = [];
@@ -4467,13 +4467,13 @@ describe("useAgentChat durable cancellation", () => {
     (agent as unknown as Record<string, unknown>).removeEventListener =
       target.removeEventListener.bind(target);
 
-    return { agent, sentMessages };
+    return { agent, target, sentMessages };
   }
 
-  it("durable mode keeps explicit stop() as server cancellation", async () => {
+  it("keeps explicit stop() as server cancellation by default", async () => {
     const { agent, sentMessages } = createAgentWithTarget({
-      name: "durable-explicit-stop",
-      url: "ws://localhost:3000/agents/chat/durable-explicit-stop?_pk=abc"
+      name: "explicit-stop",
+      url: "ws://localhost:3000/agents/chat/explicit-stop?_pk=abc"
     });
 
     let chatInstance: ReturnType<typeof useAgentChat> | null = null;
@@ -4481,10 +4481,8 @@ describe("useAgentChat durable cancellation", () => {
     const TestComponent = () => {
       const chat = useAgentChat({
         agent,
-        durable: true,
         getInitialMessages: null,
-        messages: [] as UIMessage[],
-        resume: false
+        messages: [] as UIMessage[]
       });
       chatInstance = chat;
       return <div data-testid="status">{chat.status}</div>;

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -4452,6 +4452,80 @@ describe("useAgentChat tool approval continuations (issue #1108)", () => {
   });
 });
 
+describe("useAgentChat durable cancellation", () => {
+  function createAgentWithTarget({ name, url }: { name: string; url: string }) {
+    const target = new EventTarget();
+    const sentMessages: string[] = [];
+    const agent = createAgent({
+      name,
+      url,
+      send: (data: string) => sentMessages.push(data)
+    });
+
+    (agent as unknown as Record<string, unknown>).addEventListener =
+      target.addEventListener.bind(target);
+    (agent as unknown as Record<string, unknown>).removeEventListener =
+      target.removeEventListener.bind(target);
+
+    return { agent, sentMessages };
+  }
+
+  it("durable mode keeps explicit stop() as server cancellation", async () => {
+    const { agent, sentMessages } = createAgentWithTarget({
+      name: "durable-explicit-stop",
+      url: "ws://localhost:3000/agents/chat/durable-explicit-stop?_pk=abc"
+    });
+
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        durable: true,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        resume: false
+      });
+      chatInstance = chat;
+      return <div data-testid="status">{chat.status}</div>;
+    };
+
+    await act(async () => {
+      render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+    });
+
+    await act(async () => {
+      void chatInstance!.sendMessage({ text: "Hello" });
+      await sleep(10);
+    });
+
+    const requestId = sentMessages
+      .map((message) => JSON.parse(message) as Record<string, unknown>)
+      .find((message) => message.type === "cf_agent_use_chat_request")?.id;
+    expect(requestId).toBeDefined();
+
+    await act(async () => {
+      await chatInstance!.stop();
+      await sleep(10);
+    });
+
+    const cancelMessage = sentMessages
+      .map((message) => JSON.parse(message) as Record<string, unknown>)
+      .find((message) => message.type === "cf_agent_chat_request_cancel");
+    expect(cancelMessage).toEqual({
+      type: "cf_agent_chat_request_cancel",
+      id: requestId
+    });
+  });
+});
+
 describe("useAgentChat overlapping submits (issue #1231)", () => {
   function createAgentWithTarget({ name, url }: { name: string; url: string }) {
     const target = new EventTarget();

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -14,7 +14,8 @@ import { MessageType } from "./types";
 import { broadcastTransition, type BroadcastStreamState } from "agents/chat";
 import {
   WebSocketChatTransport,
-  type AgentConnection
+  type AgentConnection,
+  type ServerTurnCancellationPolicy
 } from "./ws-chat-transport";
 
 /**
@@ -461,6 +462,25 @@ type UseAgentChatOptions<
    */
   resume?: boolean;
   /**
+   * Treat the browser as a reconnectable observer of a durable server turn.
+   * Generic client-side stream abort/cleanup becomes local-only, while
+   * explicit stop() still cancels the server turn.
+   *
+   * This is an intent-level alias for
+   * serverTurnCancellation: "explicit-only".
+   *
+   * @default false
+   */
+  durable?: boolean;
+  /**
+   * Controls whether generic client-side abort/cancel lifecycle propagates
+   * to the durable server turn. Use "explicit-only" when the browser should
+   * be able to detach and later resume without stopping server work.
+   *
+   * @default "on-client-abort"
+   */
+  serverTurnCancellation?: ServerTurnCancellationPolicy;
+  /**
    * Custom data to include in every chat request body.
    * Accepts a static object or a function that returns one (for dynamic values).
    * These fields are available in `onChatMessage` via `options.body`.
@@ -615,10 +635,16 @@ export function useAgentChat<
     autoContinueAfterToolResult = true, // Server auto-continues after tool results/approvals
     autoSendAfterAllConfirmationsResolved = true, // Legacy option for client-side batching
     resume = true, // Enable stream resumption by default
+    durable = false,
+    serverTurnCancellation: serverTurnCancellationOption,
     body: bodyOption,
     prepareSendMessagesRequest,
     ...rest
   } = options;
+
+  const serverTurnCancellation: ServerTurnCancellationPolicy =
+    serverTurnCancellationOption ??
+    (durable ? "explicit-only" : "on-client-abort");
 
   // Emit deprecation warnings for deprecated options (once per session)
   if (manualToolsRequiringConfirmation) {
@@ -887,6 +913,7 @@ export function useAgentChat<
     customTransportRef.current = new WebSocketChatTransport<ChatMessage>({
       agent: agentRef.current,
       activeRequestIds: localRequestIdsRef.current,
+      serverTurnCancellation,
       prepareBody: async ({ messages: msgs, trigger, messageId }) => {
         // Start with the top-level body option (static or dynamic)
         let extraBody: Record<string, unknown> = {};
@@ -928,6 +955,7 @@ export function useAgentChat<
   // Always point the transport at the latest socket so sends/listeners
   // go through the current connection after _pk changes.
   customTransportRef.current.agent = agentRef.current;
+  customTransportRef.current.setServerTurnCancellation(serverTurnCancellation);
   const customTransport = customTransportRef.current;
 
   // Use a stable Chat ID that doesn't change when _pk changes.
@@ -1020,6 +1048,7 @@ export function useAgentChat<
 
   const stopWithToolContinuationAbort: typeof stop = useCallback(async () => {
     try {
+      customTransport.cancelActiveServerTurn();
       await stop();
     } finally {
       customTransport.abortActiveToolContinuation();

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -14,8 +14,7 @@ import { MessageType } from "./types";
 import { broadcastTransition, type BroadcastStreamState } from "agents/chat";
 import {
   WebSocketChatTransport,
-  type AgentConnection,
-  type ServerTurnCancellationPolicy
+  type AgentConnection
 } from "./ws-chat-transport";
 
 /**
@@ -462,24 +461,14 @@ type UseAgentChatOptions<
    */
   resume?: boolean;
   /**
-   * Treat the browser as a reconnectable observer of a durable server turn.
-   * Generic client-side stream abort/cleanup becomes local-only, while
-   * explicit stop() still cancels the server turn.
-   *
-   * This is an intent-level alias for
-   * serverTurnCancellation: "explicit-only".
+   * Whether generic client-side stream abort/cleanup should cancel the server
+   * turn. By default, client cleanup is local-only so the server turn can
+   * continue and be resumed on reconnect. Explicit stop() always cancels the
+   * server turn.
    *
    * @default false
    */
-  durable?: boolean;
-  /**
-   * Controls whether generic client-side abort/cancel lifecycle propagates
-   * to the durable server turn. Use "explicit-only" when the browser should
-   * be able to detach and later resume without stopping server work.
-   *
-   * @default "on-client-abort"
-   */
-  serverTurnCancellation?: ServerTurnCancellationPolicy;
+  cancelOnClientAbort?: boolean;
   /**
    * Custom data to include in every chat request body.
    * Accepts a static object or a function that returns one (for dynamic values).
@@ -635,16 +624,11 @@ export function useAgentChat<
     autoContinueAfterToolResult = true, // Server auto-continues after tool results/approvals
     autoSendAfterAllConfirmationsResolved = true, // Legacy option for client-side batching
     resume = true, // Enable stream resumption by default
-    durable = false,
-    serverTurnCancellation: serverTurnCancellationOption,
+    cancelOnClientAbort = false,
     body: bodyOption,
     prepareSendMessagesRequest,
     ...rest
   } = options;
-
-  const serverTurnCancellation: ServerTurnCancellationPolicy =
-    serverTurnCancellationOption ??
-    (durable ? "explicit-only" : "on-client-abort");
 
   // Emit deprecation warnings for deprecated options (once per session)
   if (manualToolsRequiringConfirmation) {
@@ -913,7 +897,7 @@ export function useAgentChat<
     customTransportRef.current = new WebSocketChatTransport<ChatMessage>({
       agent: agentRef.current,
       activeRequestIds: localRequestIdsRef.current,
-      serverTurnCancellation,
+      cancelOnClientAbort,
       prepareBody: async ({ messages: msgs, trigger, messageId }) => {
         // Start with the top-level body option (static or dynamic)
         let extraBody: Record<string, unknown> = {};
@@ -955,7 +939,7 @@ export function useAgentChat<
   // Always point the transport at the latest socket so sends/listeners
   // go through the current connection after _pk changes.
   customTransportRef.current.agent = agentRef.current;
-  customTransportRef.current.setServerTurnCancellation(serverTurnCancellation);
+  customTransportRef.current.setCancelOnClientAbort(cancelOnClientAbort);
   const customTransport = customTransportRef.current;
 
   // Use a stable Chat ID that doesn't change when _pk changes.
@@ -1751,6 +1735,7 @@ export function useAgentChat<
             streamId: data.id,
             messageId: nanoid()
           }).state;
+          customTransport.observeServerTurn(data.id);
           setIsServerStreaming(true);
           agentRef.current.send(
             JSON.stringify({
@@ -1793,6 +1778,7 @@ export function useAgentChat<
             }
 
             if (data.done) {
+              customTransport.handleServerTurnCompleted(data.id);
               restoreProtectedStreamingAssistant(localResponseIds.get(data.id));
               localResponseIds.delete(data.id);
               localRequestIdsRef.current.delete(data.id);
@@ -1848,6 +1834,9 @@ export function useAgentChat<
           }
           if (data.done || data.replayComplete) {
             pendingReplayResumeRequestIdsRef.current.delete(data.id);
+          }
+          if (data.done) {
+            customTransport.handleServerTurnCompleted(data.id);
           }
 
           const result = broadcastTransition(streamStateRef.current, {

--- a/packages/ai-chat/src/tests/ws-transport-abort.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-abort.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { UIMessage as ChatMessage, UIMessageChunk } from "ai";
 import { connectChatWS } from "./test-utils";
 import { WebSocketChatTransport } from "../ws-chat-transport";
+import { MessageType, type OutgoingMessage } from "../types";
 
 function connectSlowStream(room: string) {
   return connectChatWS(`/agents/slow-stream-agent/${room}`);
@@ -134,7 +135,7 @@ describe("WebSocketChatTransport abort", () => {
     }
   });
 
-  it("stream.cancel() sends cancel to server and terminates", async () => {
+  it("stream.cancel() terminates the local stream", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectSlowStream(room);
     await new Promise((r) => setTimeout(r, 50));
@@ -159,15 +160,15 @@ describe("WebSocketChatTransport abort", () => {
       // Let a few chunks arrive
       await new Promise((r) => setTimeout(r, 200));
 
-      // cancel() should not hang — it sends CF_AGENT_CHAT_REQUEST_CANCEL
-      // and terminates the stream
+      // cancel() should not hang — generic stream cleanup is local-only by
+      // default, but it still terminates the client stream.
       await expect(withTimeout(stream.cancel(), 2000)).resolves.toBeUndefined();
     } finally {
       ws.close(1000);
     }
   });
 
-  it("keeps requestId in activeRequestIds after abort until server sends done", async () => {
+  it("leaves the server stream resumable after default client abort", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectSlowStream(room);
     await new Promise((r) => setTimeout(r, 50));
@@ -177,6 +178,60 @@ describe("WebSocketChatTransport abort", () => {
       const transport = new WebSocketChatTransport<ChatMessage>({
         agent: ws,
         activeRequestIds
+      });
+      ws.addEventListener("message", (event) => {
+        const data = JSON.parse(
+          event.data as string
+        ) as OutgoingMessage<ChatMessage>;
+        if (data.type === MessageType.CF_AGENT_STREAM_RESUMING) {
+          transport.handleStreamResuming(data);
+        } else if (data.type === MessageType.CF_AGENT_STREAM_RESUME_NONE) {
+          transport.handleStreamResumeNone();
+        }
+      });
+
+      const abortController = new AbortController();
+      const stream = await transport.sendMessages({
+        chatId: "chat",
+        messages: [userMessage],
+        abortSignal: abortController.signal,
+        trigger: "submit-message",
+        body: {
+          format: "plaintext",
+          chunkCount: 20,
+          chunkDelayMs: 50
+        }
+      });
+
+      const reader = stream.getReader();
+      await new Promise((r) => setTimeout(r, 200));
+      abortController.abort();
+      await readUntilDoneOrAbort(reader, 5000);
+
+      expect(activeRequestIds.size).toBe(0);
+
+      const resumed = await transport.reconnectToStream({ chatId: "chat" });
+      expect(resumed).not.toBeNull();
+      if (!resumed) throw new Error("Expected stream to resume");
+
+      const chunks = await collectChunks(resumed, 5000);
+      expect(chunks.length).toBeGreaterThan(0);
+    } finally {
+      ws.close(1000);
+    }
+  });
+
+  it("keeps requestId in activeRequestIds after abort when cancelOnClientAbort is true", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectSlowStream(room);
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      const activeRequestIds = new Set<string>();
+      const transport = new WebSocketChatTransport<ChatMessage>({
+        agent: ws,
+        activeRequestIds,
+        cancelOnClientAbort: true
       });
       const abortController = new AbortController();
 
@@ -204,8 +259,8 @@ describe("WebSocketChatTransport abort", () => {
       // Abort mid-stream
       abortController.abort();
 
-      // After abort, requestId must still be in activeRequestIds so that
-      // onAgentMessage skips in-flight server chunks (issue #1100).
+      // After server cancellation, requestId must still be in activeRequestIds
+      // so that onAgentMessage skips in-flight server chunks (issue #1100).
       expect(activeRequestIds.has(requestId)).toBe(true);
 
       // Drain the stream (it errors with AbortError)

--- a/packages/ai-chat/src/tests/ws-transport-cancellation-policy.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-cancellation-policy.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { UIMessage as ChatMessage, UIMessageChunk } from "ai";
+import { MessageType } from "../types";
+import { WebSocketChatTransport } from "../ws-chat-transport";
+
+function createMockAgent() {
+  const sent: string[] = [];
+  const listeners: Array<(event: MessageEvent) => void> = [];
+
+  return {
+    sent,
+    listeners,
+    send(data: string) {
+      sent.push(data);
+    },
+    addEventListener(
+      _type: string,
+      listener: (event: MessageEvent) => void,
+      _options?: { signal?: AbortSignal }
+    ) {
+      listeners.push(listener);
+    },
+    removeEventListener(
+      _type: string,
+      _listener: (event: MessageEvent) => void
+    ) {
+      // no-op for tests
+    }
+  };
+}
+
+const userMessage: ChatMessage = {
+  id: "msg1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }]
+};
+
+async function expectAbortError(
+  stream: ReadableStream<UIMessageChunk>
+): Promise<void> {
+  const reader = stream.getReader();
+  await expect(reader.read()).rejects.toMatchObject({ name: "AbortError" });
+}
+
+describe("WebSocketChatTransport cancellation policy", () => {
+  it("keeps current behavior by default: client abort sends server cancel", async () => {
+    const agent = createMockAgent();
+    const transport = new WebSocketChatTransport<ChatMessage>({ agent });
+    const abortController = new AbortController();
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: abortController.signal,
+      trigger: "submit-message"
+    });
+
+    abortController.abort();
+
+    expect(agent.sent).toHaveLength(2);
+    expect(JSON.parse(agent.sent[1])).toMatchObject({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL
+    });
+    await expectAbortError(stream);
+  });
+
+  it("treats client abort as local-only when server turn cancellation is explicit-only", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds,
+      serverTurnCancellation: "explicit-only"
+    });
+    const abortController = new AbortController();
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: abortController.signal,
+      trigger: "submit-message"
+    });
+
+    expect(activeRequestIds.size).toBe(1);
+    abortController.abort();
+
+    expect(agent.sent).toHaveLength(1);
+    expect(JSON.parse(agent.sent[0])).toMatchObject({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST
+    });
+    expect(activeRequestIds.size).toBe(0);
+    await expectAbortError(stream);
+  });
+
+  it("treats stream.cancel() as local-only when server turn cancellation is explicit-only", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds,
+      serverTurnCancellation: "explicit-only"
+    });
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: undefined,
+      trigger: "submit-message"
+    });
+
+    expect(activeRequestIds.size).toBe(1);
+    await expect(stream.cancel()).resolves.toBeUndefined();
+
+    expect(agent.sent).toHaveLength(1);
+    expect(JSON.parse(agent.sent[0])).toMatchObject({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST
+    });
+    expect(activeRequestIds.size).toBe(0);
+  });
+
+  it("allows explicit server turn cancellation in explicit-only mode", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds,
+      serverTurnCancellation: "explicit-only"
+    });
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: undefined,
+      trigger: "submit-message"
+    });
+
+    const [requestId] = activeRequestIds;
+    expect(transport.cancelActiveServerTurn()).toBe(true);
+
+    expect(agent.sent).toHaveLength(2);
+    expect(JSON.parse(agent.sent[1])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: requestId
+    });
+    expect(activeRequestIds.has(requestId)).toBe(true);
+    await expectAbortError(stream);
+  });
+});

--- a/packages/ai-chat/src/tests/ws-transport-cancellation-policy.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-cancellation-policy.test.ts
@@ -43,34 +43,12 @@ async function expectAbortError(
 }
 
 describe("WebSocketChatTransport cancellation policy", () => {
-  it("keeps current behavior by default: client abort sends server cancel", async () => {
-    const agent = createMockAgent();
-    const transport = new WebSocketChatTransport<ChatMessage>({ agent });
-    const abortController = new AbortController();
-
-    const stream = await transport.sendMessages({
-      chatId: "chat-1",
-      messages: [userMessage],
-      abortSignal: abortController.signal,
-      trigger: "submit-message"
-    });
-
-    abortController.abort();
-
-    expect(agent.sent).toHaveLength(2);
-    expect(JSON.parse(agent.sent[1])).toMatchObject({
-      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL
-    });
-    await expectAbortError(stream);
-  });
-
-  it("treats client abort as local-only when server turn cancellation is explicit-only", async () => {
+  it("treats client abort as local-only by default", async () => {
     const agent = createMockAgent();
     const activeRequestIds = new Set<string>();
     const transport = new WebSocketChatTransport<ChatMessage>({
       agent,
-      activeRequestIds,
-      serverTurnCancellation: "explicit-only"
+      activeRequestIds
     });
     const abortController = new AbortController();
 
@@ -92,13 +70,59 @@ describe("WebSocketChatTransport cancellation policy", () => {
     await expectAbortError(stream);
   });
 
-  it("treats stream.cancel() as local-only when server turn cancellation is explicit-only", async () => {
+  it("does not start a server turn when the client signal is already aborted", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds
+    });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: abortController.signal,
+      trigger: "submit-message"
+    });
+
+    expect(agent.sent).toHaveLength(0);
+    expect(activeRequestIds.size).toBe(0);
+    await expectAbortError(stream);
+    expect(transport.cancelActiveServerTurn()).toBe(false);
+  });
+
+  it("does not leak requestId when pre-aborted with cancelOnClientAbort enabled", async () => {
     const agent = createMockAgent();
     const activeRequestIds = new Set<string>();
     const transport = new WebSocketChatTransport<ChatMessage>({
       agent,
       activeRequestIds,
-      serverTurnCancellation: "explicit-only"
+      cancelOnClientAbort: true
+    });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: abortController.signal,
+      trigger: "submit-message"
+    });
+
+    expect(agent.sent).toHaveLength(0);
+    expect(activeRequestIds.size).toBe(0);
+    await expectAbortError(stream);
+    expect(transport.cancelActiveServerTurn()).toBe(false);
+  });
+
+  it("treats stream.cancel() as local-only by default", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds
     });
 
     const stream = await transport.sendMessages({
@@ -118,13 +142,12 @@ describe("WebSocketChatTransport cancellation policy", () => {
     expect(activeRequestIds.size).toBe(0);
   });
 
-  it("allows explicit server turn cancellation in explicit-only mode", async () => {
+  it("allows explicit server turn cancellation when client abort is local-only", async () => {
     const agent = createMockAgent();
     const activeRequestIds = new Set<string>();
     const transport = new WebSocketChatTransport<ChatMessage>({
       agent,
-      activeRequestIds,
-      serverTurnCancellation: "explicit-only"
+      activeRequestIds
     });
 
     const stream = await transport.sendMessages({
@@ -144,5 +167,104 @@ describe("WebSocketChatTransport cancellation policy", () => {
     });
     expect(activeRequestIds.has(requestId)).toBe(true);
     await expectAbortError(stream);
+  });
+
+  it("allows explicit server turn cancellation after local-only client abort", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds
+    });
+    const abortController = new AbortController();
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: abortController.signal,
+      trigger: "submit-message"
+    });
+
+    const [requestId] = activeRequestIds;
+    abortController.abort();
+    await expectAbortError(stream);
+
+    expect(agent.sent).toHaveLength(1);
+    expect(transport.cancelActiveServerTurn()).toBe(true);
+    expect(agent.sent).toHaveLength(2);
+    expect(JSON.parse(agent.sent[1])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: requestId
+    });
+  });
+
+  it("allows explicit server turn cancellation for observed fallback streams", () => {
+    const agent = createMockAgent();
+    const transport = new WebSocketChatTransport<ChatMessage>({ agent });
+
+    transport.observeServerTurn("observed-request");
+
+    expect(transport.cancelActiveServerTurn()).toBe(true);
+    expect(agent.sent).toHaveLength(1);
+    expect(JSON.parse(agent.sent[0])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: "observed-request"
+    });
+  });
+
+  it("can opt in to server cancellation on client abort", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds,
+      cancelOnClientAbort: true
+    });
+    const abortController = new AbortController();
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: abortController.signal,
+      trigger: "submit-message"
+    });
+
+    const [requestId] = activeRequestIds;
+    abortController.abort();
+
+    expect(agent.sent).toHaveLength(2);
+    expect(JSON.parse(agent.sent[1])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: requestId
+    });
+    expect(activeRequestIds.has(requestId)).toBe(true);
+    await expectAbortError(stream);
+  });
+
+  it("can opt in to server cancellation on stream.cancel()", async () => {
+    const agent = createMockAgent();
+    const activeRequestIds = new Set<string>();
+    const transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds,
+      cancelOnClientAbort: true
+    });
+
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [userMessage],
+      abortSignal: undefined,
+      trigger: "submit-message"
+    });
+
+    const [requestId] = activeRequestIds;
+    await expect(stream.cancel()).resolves.toBeUndefined();
+
+    expect(agent.sent).toHaveLength(2);
+    expect(JSON.parse(agent.sent[1])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: requestId
+    });
+    expect(activeRequestIds.has(requestId)).toBe(true);
   });
 });

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -184,6 +184,47 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(activeRequestIds.has("req-tracked")).toBe(true);
   });
 
+  it("cancelActiveServerTurn cancels a resumed stream", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+
+    transport.handleStreamResuming({ id: "req-resumed-stop" });
+    const stream = (await promise) as ReadableStream<UIMessageChunk>;
+    const reader = stream.getReader();
+
+    expect(transport.cancelActiveServerTurn()).toBe(true);
+
+    expect(agent.sent).toHaveLength(3);
+    expect(JSON.parse(agent.sent[2])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: "req-resumed-stop"
+    });
+    expect(activeRequestIds.has("req-resumed-stop")).toBe(true);
+    await expect(reader.read()).rejects.toMatchObject({
+      name: "AbortError"
+    });
+  });
+
+  it("can opt in to server cancellation when a resumed stream is cancelled", async () => {
+    transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds,
+      cancelOnClientAbort: true
+    });
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+
+    transport.handleStreamResuming({ id: "req-resumed-client-cancel" });
+    const stream = (await promise) as ReadableStream<UIMessageChunk>;
+
+    await expect(stream.cancel()).resolves.toBeUndefined();
+
+    expect(agent.sent).toHaveLength(3);
+    expect(JSON.parse(agent.sent[2])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: "req-resumed-client-cancel"
+    });
+    expect(activeRequestIds.has("req-resumed-client-cancel")).toBe(true);
+  });
+
   // ── handleStreamResumeNone basics ────────────────────────────────────
 
   it("handleStreamResumeNone returns false when no reconnectToStream is pending", () => {

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -321,6 +321,47 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     });
   });
 
+  it("tool continuation stream cancel is local-only by default", async () => {
+    transport.expectToolContinuation();
+
+    const stream = (await transport.reconnectToStream({
+      chatId: "chat-1"
+    })) as ReadableStream<UIMessageChunk>;
+
+    expect(
+      transport.handleStreamResuming({ id: "req-tool-local-cancel" })
+    ).toBe(true);
+    await expect(stream.cancel()).resolves.toBeUndefined();
+
+    expect(agent.sent).toHaveLength(2);
+    expect(activeRequestIds.has("req-tool-local-cancel")).toBe(false);
+  });
+
+  it("tool continuation stream cancel sends server cancel when cancelOnClientAbort is true", async () => {
+    transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds,
+      cancelOnClientAbort: true
+    });
+    transport.expectToolContinuation();
+
+    const stream = (await transport.reconnectToStream({
+      chatId: "chat-1"
+    })) as ReadableStream<UIMessageChunk>;
+
+    expect(
+      transport.handleStreamResuming({ id: "req-tool-client-cancel" })
+    ).toBe(true);
+    await expect(stream.cancel()).resolves.toBeUndefined();
+
+    expect(agent.sent).toHaveLength(3);
+    expect(JSON.parse(agent.sent[2])).toEqual({
+      type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL,
+      id: "req-tool-client-cancel"
+    });
+    expect(activeRequestIds.has("req-tool-client-cancel")).toBe(true);
+  });
+
   it("abortActiveToolContinuation keeps requestId in activeIds for server cleanup", async () => {
     transport.expectToolContinuation();
 

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -29,8 +29,6 @@ export interface AgentConnection {
   ) => void;
 }
 
-export type ServerTurnCancellationPolicy = "on-client-abort" | "explicit-only";
-
 export type WebSocketChatTransportOptions<
   ChatMessage extends UIMessage = UIMessage
 > = {
@@ -52,12 +50,12 @@ export type WebSocketChatTransportOptions<
    */
   activeRequestIds?: Set<string>;
   /**
-   * Controls whether generic client-side abort/cancel lifecycle should
-   * propagate to the durable server turn. Explicit cancellation via
-   * cancelActiveServerTurn() always sends CF_AGENT_CHAT_REQUEST_CANCEL.
-   * @default "on-client-abort"
+   * Whether generic client-side abort/cancel lifecycle should cancel the
+   * server turn. Explicit cancellation via cancelActiveServerTurn() always
+   * sends CF_AGENT_CHAT_REQUEST_CANCEL.
+   * @default false
    */
-  serverTurnCancellation?: ServerTurnCancellationPolicy;
+  cancelOnClientAbort?: boolean;
 };
 
 /**
@@ -71,7 +69,7 @@ export class WebSocketChatTransport<
   agent: AgentConnection;
   private prepareBody?: WebSocketChatTransportOptions<ChatMessage>["prepareBody"];
   private activeRequestIds?: Set<string>;
-  private serverTurnCancellation: ServerTurnCancellationPolicy;
+  private cancelOnClientAbort: boolean;
 
   // Pending resume resolver — set by reconnectToStream, called by
   // handleStreamResuming when onAgentMessage sees CF_AGENT_STREAM_RESUMING.
@@ -85,29 +83,66 @@ export class WebSocketChatTransport<
   // to "submitted" before the server starts streaming.
   private _expectToolContinuation = false;
   private _abortToolContinuation: (() => boolean) | null = null;
-  private _cancelActiveRequest: (() => boolean) | null = null;
+  private _activeServerTurnId: string | null = null;
+  private _cancelAttachedStream: (() => boolean) | null = null;
 
   constructor(options: WebSocketChatTransportOptions<ChatMessage>) {
     this.agent = options.agent;
     this.prepareBody = options.prepareBody;
     this.activeRequestIds = options.activeRequestIds;
-    this.serverTurnCancellation =
-      options.serverTurnCancellation ?? "on-client-abort";
+    this.cancelOnClientAbort = options.cancelOnClientAbort ?? false;
   }
 
-  setServerTurnCancellation(policy: ServerTurnCancellationPolicy) {
-    this.serverTurnCancellation = policy;
+  setCancelOnClientAbort(cancelOnClientAbort: boolean) {
+    this.cancelOnClientAbort = cancelOnClientAbort;
   }
 
   /**
-   * Explicitly cancel the active durable server turn, if any.
+   * Explicitly cancel the active server turn, if any.
    * This is separate from generic client-side abort/cancel lifecycle so
-   * durable clients can detach locally without stopping server work.
+   * clients can detach locally without stopping server work.
    */
   cancelActiveServerTurn(): boolean {
-    const cancelledRequest = this._cancelActiveRequest?.() ?? false;
+    const requestId = this._activeServerTurnId;
+    let cancelledRequest = false;
+
+    if (requestId) {
+      this.sendCancelFrame(requestId);
+      this._cancelAttachedStream?.();
+      this.clearActiveServerTurn(requestId);
+      cancelledRequest = true;
+    }
+
     const cancelledToolContinuation = this.abortActiveToolContinuation();
     return cancelledRequest || cancelledToolContinuation;
+  }
+
+  private sendCancelFrame(requestId: string) {
+    try {
+      this.agent.send(
+        JSON.stringify({
+          id: requestId,
+          type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL
+        })
+      );
+    } catch {
+      // Ignore failures (e.g. agent already disconnected)
+    }
+  }
+
+  private setActiveServerTurn(
+    requestId: string,
+    cancelAttachedStream: (() => boolean) | null
+  ) {
+    this._activeServerTurnId = requestId;
+    this._cancelAttachedStream = cancelAttachedStream;
+  }
+
+  private clearActiveServerTurn(requestId: string) {
+    if (this._activeServerTurnId === requestId) {
+      this._activeServerTurnId = null;
+      this._cancelAttachedStream = null;
+    }
   }
 
   /**
@@ -156,6 +191,23 @@ export class WebSocketChatTransport<
     return true;
   }
 
+  /**
+   * Called by the hook's shared message handler when a server turn finishes
+   * outside the currently attached transport stream, such as after local-only
+   * client cleanup.
+   */
+  handleServerTurnCompleted(requestId: string) {
+    this.clearActiveServerTurn(requestId);
+  }
+
+  /**
+   * Register a server turn that is being rendered outside a transport-owned
+   * stream, such as the hook's fallback cross-tab/resume observer path.
+   */
+  observeServerTurn(requestId: string) {
+    this.setActiveServerTurn(requestId, null);
+  }
+
   async sendMessages(options: {
     chatId: string;
     messages: ChatMessage[];
@@ -169,6 +221,7 @@ export class WebSocketChatTransport<
     const requestId = nanoid(8);
     const abortController = new AbortController();
     let completed = false;
+    let requestSent = false;
 
     // Build the request body
     let extraBody: Record<string, unknown> = {};
@@ -205,11 +258,15 @@ export class WebSocketChatTransport<
     // keepId: when true, do NOT remove requestId from activeIds. Used by
     // explicit cancellation so onAgentMessage skips in-flight chunks
     // and the server's final done:true signal until cleanup happens there.
-    const finish = (action: () => void, keepId = false) => {
+    const finish = (
+      action: () => void,
+      keepId = false,
+      clearServerTurn = true
+    ) => {
       if (completed) return;
       completed = true;
-      if (this._cancelActiveRequest === cancelActiveRequest) {
-        this._cancelActiveRequest = null;
+      if (clearServerTurn) {
+        this.clearActiveServerTurn(requestId);
       }
       try {
         action();
@@ -225,38 +282,26 @@ export class WebSocketChatTransport<
     const abortError = new Error("Aborted");
     abortError.name = "AbortError";
 
-    const sendCancelFrame = () => {
-      try {
-        agent.send(
-          JSON.stringify({
-            id: requestId,
-            type: MessageType.CF_AGENT_CHAT_REQUEST_CANCEL
-          })
-        );
-      } catch {
-        // Ignore failures (e.g. agent already disconnected)
-      }
-    };
-
     const cancelActiveRequest = () => {
       if (completed) return false;
-      sendCancelFrame();
       finish(() => streamController.error(abortError), true);
       return true;
     };
-    this._cancelActiveRequest = cancelActiveRequest;
+    this.setActiveServerTurn(requestId, cancelActiveRequest);
 
-    // Abort handler: terminate the local stream. By default this preserves
-    // existing behavior and also cancels the durable server turn. In
-    // explicit-only mode, generic AI SDK abort/cancel lifecycle is local-only;
-    // use cancelActiveServerTurn() for user/app initiated cancellation.
+    // Abort handler: terminate the local stream. By default, generic AI SDK
+    // abort/cancel lifecycle is local-only so durable server turns can continue
+    // and be resumed. Use cancelActiveServerTurn() for explicit user/app
+    // cancellation, or cancelOnClientAbort for request-lifetime semantics.
     const onAbort = () => {
       if (completed) return;
-      if (this.serverTurnCancellation === "on-client-abort") {
-        sendCancelFrame();
-        finish(() => streamController.error(abortError), true);
+      if (this.cancelOnClientAbort) {
+        if (requestSent) {
+          this.sendCancelFrame(requestId);
+        }
+        finish(() => streamController.error(abortError), requestSent);
       } else {
-        finish(() => streamController.error(abortError));
+        finish(() => streamController.error(abortError), false, !requestSent);
       }
     };
 
@@ -303,7 +348,7 @@ export class WebSocketChatTransport<
         };
 
         const onClose = () => {
-          finish(() => controller.close());
+          finish(() => controller.close(), false, false);
         };
 
         agent.addEventListener("message", onMessage, {
@@ -324,7 +369,12 @@ export class WebSocketChatTransport<
       if (options.abortSignal.aborted) onAbort();
     }
 
+    if (completed) {
+      return stream;
+    }
+
     // Send the request over WebSocket
+    requestSent = true;
     agent.send(
       JSON.stringify({
         id: requestId,
@@ -635,22 +685,45 @@ export class WebSocketChatTransport<
     const agent = this.agent;
     const activeIds = this.activeRequestIds;
     const chunkController = new AbortController();
+    const abortError = new Error("Aborted");
+    abortError.name = "AbortError";
     let completed = false;
 
-    const finish = (action: () => void) => {
+    const finish = (
+      action: () => void,
+      keepId = false,
+      clearServerTurn = true
+    ) => {
       if (completed) return;
       completed = true;
+      if (clearServerTurn) {
+        this.clearActiveServerTurn(requestId);
+      }
       try {
         action();
       } catch {
         // Stream may already be closed
       }
-      activeIds?.delete(requestId);
+      if (!keepId) {
+        activeIds?.delete(requestId);
+      }
       chunkController.abort();
     };
 
+    const cancelActiveRequest = () => {
+      if (completed) return false;
+      finish(() => streamController.error(abortError), true);
+      return true;
+    };
+    this.setActiveServerTurn(requestId, cancelActiveRequest);
+
+    let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+    const transport = this;
+
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
+        streamController = controller;
+
         const onMessage = (event: MessageEvent) => {
           try {
             const data = JSON.parse(
@@ -686,7 +759,7 @@ export class WebSocketChatTransport<
         };
 
         const onClose = () => {
-          finish(() => controller.close());
+          finish(() => controller.close(), false, false);
         };
 
         agent.addEventListener("message", onMessage, {
@@ -697,7 +770,12 @@ export class WebSocketChatTransport<
         });
       },
       cancel() {
-        finish(() => {});
+        if (transport.cancelOnClientAbort) {
+          transport.sendCancelFrame(requestId);
+          finish(() => {}, true);
+        } else {
+          finish(() => {}, false, false);
+        }
       }
     });
   }

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -29,6 +29,8 @@ export interface AgentConnection {
   ) => void;
 }
 
+export type ServerTurnCancellationPolicy = "on-client-abort" | "explicit-only";
+
 export type WebSocketChatTransportOptions<
   ChatMessage extends UIMessage = UIMessage
 > = {
@@ -49,6 +51,13 @@ export type WebSocketChatTransportOptions<
    * Used by the onAgentMessage handler to skip messages already handled by the transport.
    */
   activeRequestIds?: Set<string>;
+  /**
+   * Controls whether generic client-side abort/cancel lifecycle should
+   * propagate to the durable server turn. Explicit cancellation via
+   * cancelActiveServerTurn() always sends CF_AGENT_CHAT_REQUEST_CANCEL.
+   * @default "on-client-abort"
+   */
+  serverTurnCancellation?: ServerTurnCancellationPolicy;
 };
 
 /**
@@ -62,6 +71,7 @@ export class WebSocketChatTransport<
   agent: AgentConnection;
   private prepareBody?: WebSocketChatTransportOptions<ChatMessage>["prepareBody"];
   private activeRequestIds?: Set<string>;
+  private serverTurnCancellation: ServerTurnCancellationPolicy;
 
   // Pending resume resolver — set by reconnectToStream, called by
   // handleStreamResuming when onAgentMessage sees CF_AGENT_STREAM_RESUMING.
@@ -75,11 +85,29 @@ export class WebSocketChatTransport<
   // to "submitted" before the server starts streaming.
   private _expectToolContinuation = false;
   private _abortToolContinuation: (() => boolean) | null = null;
+  private _cancelActiveRequest: (() => boolean) | null = null;
 
   constructor(options: WebSocketChatTransportOptions<ChatMessage>) {
     this.agent = options.agent;
     this.prepareBody = options.prepareBody;
     this.activeRequestIds = options.activeRequestIds;
+    this.serverTurnCancellation =
+      options.serverTurnCancellation ?? "on-client-abort";
+  }
+
+  setServerTurnCancellation(policy: ServerTurnCancellationPolicy) {
+    this.serverTurnCancellation = policy;
+  }
+
+  /**
+   * Explicitly cancel the active durable server turn, if any.
+   * This is separate from generic client-side abort/cancel lifecycle so
+   * durable clients can detach locally without stopping server work.
+   */
+  cancelActiveServerTurn(): boolean {
+    const cancelledRequest = this._cancelActiveRequest?.() ?? false;
+    const cancelledToolContinuation = this.abortActiveToolContinuation();
+    return cancelledRequest || cancelledToolContinuation;
   }
 
   /**
@@ -175,11 +203,14 @@ export class WebSocketChatTransport<
     // Single cleanup helper — every terminal path (done, error, abort)
     // goes through here exactly once.
     // keepId: when true, do NOT remove requestId from activeIds. Used by
-    // onAbort so that onAgentMessage continues to skip in-flight chunks
-    // and the server's final done:true broadcast until cleanup happens there.
+    // explicit cancellation so onAgentMessage skips in-flight chunks
+    // and the server's final done:true signal until cleanup happens there.
     const finish = (action: () => void, keepId = false) => {
       if (completed) return;
       completed = true;
+      if (this._cancelActiveRequest === cancelActiveRequest) {
+        this._cancelActiveRequest = null;
+      }
       try {
         action();
       } catch {
@@ -194,13 +225,7 @@ export class WebSocketChatTransport<
     const abortError = new Error("Aborted");
     abortError.name = "AbortError";
 
-    // Abort handler: send cancel to server, then terminate the stream.
-    // Used by both the caller's abortSignal and stream.cancel().
-    // keepId=true: keep requestId in activeIds so onAgentMessage skips any
-    // in-flight chunks the server broadcasts before its done:true signal.
-    // The ID is removed by onAgentMessage when done:true is received.
-    const onAbort = () => {
-      if (completed) return;
+    const sendCancelFrame = () => {
       try {
         agent.send(
           JSON.stringify({
@@ -211,7 +236,28 @@ export class WebSocketChatTransport<
       } catch {
         // Ignore failures (e.g. agent already disconnected)
       }
+    };
+
+    const cancelActiveRequest = () => {
+      if (completed) return false;
+      sendCancelFrame();
       finish(() => streamController.error(abortError), true);
+      return true;
+    };
+    this._cancelActiveRequest = cancelActiveRequest;
+
+    // Abort handler: terminate the local stream. By default this preserves
+    // existing behavior and also cancels the durable server turn. In
+    // explicit-only mode, generic AI SDK abort/cancel lifecycle is local-only;
+    // use cancelActiveServerTurn() for user/app initiated cancellation.
+    const onAbort = () => {
+      if (completed) return;
+      if (this.serverTurnCancellation === "on-client-abort") {
+        sendCancelFrame();
+        finish(() => streamController.error(abortError), true);
+      } else {
+        finish(() => streamController.error(abortError));
+      }
     };
 
     // streamController is assigned synchronously by start(), so it is

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -668,7 +668,12 @@ export class WebSocketChatTransport<
         }
       },
       cancel() {
-        finish(() => {});
+        if (requestId && transport.cancelOnClientAbort) {
+          transport.sendCancelFrame(requestId);
+          finish(() => {}, onResumeRef, onResumeNoneRef, true);
+        } else {
+          finish(() => {}, onResumeRef, onResumeNoneRef);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary

Changes `useAgentChat` cancellation semantics so browser/client stream cleanup is local-only by default:

```tsx
useAgentChat({
  agent
});
```

By default, the browser is treated as a reconnectable observer of a server turn. Generic client-side stream abort/cleanup does **not** send `cf_agent_chat_request_cancel`, so the server turn can continue and be resumed later. Explicit `stop()` still sends `cf_agent_chat_request_cancel` and cancels the server turn.

For apps that intentionally want request-lifetime behavior, this adds:

```ts
cancelOnClientAbort?: boolean;
```

Set `cancelOnClientAbort: true` to make generic client abort/stream cleanup cancel the server turn.

## What the issue actually was

This is not about a raw WebSocket close directly calling server-side abort.

The problematic path is one layer higher:

1. `useAgentChat` wraps AI SDK `useChat`.
2. AI SDK `useChat` owns a local active response with an `AbortController`.
3. `WebSocketChatTransport.sendMessages()` receives that signal as `options.abortSignal`, and also exposes a `ReadableStream` whose `cancel()` method can be called by the client stream lifecycle.
4. Before this PR, both paths used the same `onAbort()` handler.
5. That handler always sent `cf_agent_chat_request_cancel`.
6. The server correctly treated that frame as real server-turn cancellation.

So the server could not distinguish these two cases:

- the user/app explicitly clicked Stop and wanted to cancel the server turn
- the client-side response/stream was aborted or disposed as part of browser/React/AI SDK lifecycle

For Durable Object backed agents, the second case should often be recoverable via stream resumption. The browser can disappear or detach while the durable server turn continues and buffers chunks for a later reconnect.

## What changed

- Added `cancelOnClientAbort?: boolean` to `useAgentChat` and `WebSocketChatTransport`.
  - Default is `false`: generic client abort/stream cancel is local-only.
  - `true` opts into request-lifetime behavior where generic client abort cancels the server turn.
- Removed the earlier `durable` / `serverTurnCancellation` API shape in favor of the clearer boolean toggle.
- Kept explicit `useAgentChat().stop()` as server-side cancellation regardless of `cancelOnClientAbort`.
- Updated docs and README for the default resumable semantics and the opt-in request-lifetime mode.

## Follow-up changes from review

- Separated "active server turn is cancellable" from "local stream is attached" inside `WebSocketChatTransport`.
- Kept detached server turns explicitly cancellable after local-only client abort.
- Made explicit cancellation work for resumed streams created by `reconnectToStream()`.
- Added support for explicitly cancelling fallback-observed server turns via `observeServerTurn()`.
- Cleared stored cancellation state when the server later sends `done` for a detached turn.
- Avoided starting a new server turn when `sendMessages()` is called with an already-aborted signal.
- Added edge-case coverage for local-only abort, explicit stop after detach, resumed-stream stop, fallback-observed stop, and `cancelOnClientAbort: true` with both abort signals and `stream.cancel()`.

## Tests

- `npm run test:workers -w @cloudflare/ai-chat -- ws-transport-abort.test.ts ws-transport-cancellation-policy.test.ts ws-transport-resume.test.ts`
- `npm run test:react -w @cloudflare/ai-chat -- use-agent-chat.test.tsx`
- `npm run check`

## Related

Fixes #1471