### PR TITLE
fix(ai-chat): close chat stream on socket disconnect

### DIFF
--- a/.changeset/fix-ai-chat-recovery-stuck-stream.md
+++ b/.changeset/fix-ai-chat-recovery-stuck-stream.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Close the original WebSocket chat transport stream when the socket disconnects before a terminal response, preventing recovered chat continuations from leaving `useAgentChat` stuck in streaming state.

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -32,6 +32,10 @@ function createMockAgent() {
       target.dispatchEvent(
         new MessageEvent("message", { data: JSON.stringify(data) })
       );
+    },
+    /** Simulate the underlying WebSocket closing */
+    close() {
+      target.dispatchEvent(new CloseEvent("close"));
     }
   };
 }
@@ -48,6 +52,34 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
       agent,
       activeRequestIds
     });
+  });
+
+  // ── sendMessages lifecycle ───────────────────────────────────────────
+
+  it("closes the original sendMessages stream when the socket closes before done", async () => {
+    const stream = await transport.sendMessages({
+      chatId: "chat-1",
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }]
+        }
+      ],
+      abortSignal: undefined,
+      trigger: "submit-message"
+    });
+    const reader = stream.getReader();
+
+    expect(activeRequestIds.size).toBe(1);
+
+    agent.close();
+
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined
+    });
+    expect(activeRequestIds.size).toBe(0);
   });
 
   // ── handleStreamResuming basics ──────────────────────────────────────

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -256,7 +256,14 @@ export class WebSocketChatTransport<
           }
         };
 
+        const onClose = () => {
+          finish(() => controller.close());
+        };
+
         agent.addEventListener("message", onMessage, {
+          signal: abortController.signal
+        });
+        agent.addEventListener("close", onClose, {
           signal: abortController.signal
         });
       },


### PR DESCRIPTION
## Summary

Fixes #1485.

When an `AIChatAgent` turn is interrupted by a Worker/socket restart, `chatRecovery` can complete the recovered continuation under a new server-generated request id. The browser-side `WebSocketChatTransport.sendMessages()` stream for the original request id was only closed by a matching `done: true` frame. If the socket closed before that terminal frame arrived, the local stream stayed pending indefinitely, leaving AI SDK `useChat` / `useAgentChat` stuck in `status === "streaming"` even after the recovered continuation finished.

This PR closes the original local `sendMessages()` stream when the underlying socket closes, cleaning up its active request id so the AI SDK is not left waiting on an impossible terminal frame.

## Changes

- Add a `close` event listener in `WebSocketChatTransport.sendMessages()` that closes and cleans up the local stream.
- Add a focused regression test for the socket-close-before-`done` lifecycle.
- Add a patch changeset for `@cloudflare/ai-chat`.

## Verification

- ✅ `cd packages/ai-chat && npx vitest --run src/tests/ws-transport-resume.test.ts`
- ✅ `npm run check` was run;

## Notes

The fix is intentionally narrow: socket close means the original local stream can no longer receive its matching terminal frame on that socket. Closing it allows the AI SDK request state to settle while recovery/resume paths continue to handle any recovered stream under the new request id.
