### PR TITLE
Add reusable Browser Run sessions

### DIFF
--- a/.changeset/fuzzy-browsers-remember.md
+++ b/.changeset/fuzzy-browsers-remember.md
@@ -1,0 +1,6 @@
+---
+"agents": minor
+"@cloudflare/think": minor
+---
+
+Add opt-in reusable Browser Run sessions for browser tools, including session lifecycle tools, Live View metadata, and Think-native durable session storage.

--- a/docs/browse-the-web.md
+++ b/docs/browse-the-web.md
@@ -5,7 +5,7 @@ Browser tools give your agents full access to the Chrome DevTools Protocol (CDP)
 Two tools are provided:
 
 - **`browser_search`** — query the CDP spec to discover commands, events, and types. The spec is fetched dynamically from the browser's CDP endpoint and cached for performance.
-- **`browser_execute`** — run CDP commands against a live browser via a `cdp` helper. Each call opens a fresh browser session, executes the code, and closes it.
+- **`browser_execute`** — run CDP commands against a live browser via a `cdp` helper. By default, each call opens a fresh browser session, executes the code, and closes it. You can opt into reusable sessions for multi-step workflows.
 
 > **Experimental** — this feature may have breaking changes in future releases.
 
@@ -56,6 +56,20 @@ const browserTools = createBrowserTools({
 ```
 
 If you need to connect to a custom CDP endpoint instead of the Browser Rendering binding, pass `cdpUrl`.
+
+To preserve tabs, cookies, local storage, and navigation state across tool calls, enable reusable sessions:
+
+```ts
+const browserTools = createBrowserTools({
+  browser: env.BROWSER,
+  loader: env.LOADER,
+  session: {
+    mode: "reuse",
+    keepAliveMs: 600_000,
+    liveView: true
+  }
+});
+```
 
 ### 3. Use with streamText
 
@@ -162,7 +176,8 @@ const stream = chat({
 ## Execution model
 
 - `browser_search` fetches the live CDP protocol from the browser's `/json/protocol` endpoint and caches it briefly.
-- `browser_execute` opens a fresh browser session for the call, exposes a small `cdp` helper API to sandboxed code, and closes the session when execution finishes.
+- In the default one-shot mode, `browser_execute` opens a fresh browser session for the call, exposes a small `cdp` helper API to sandboxed code, and closes the session when execution finishes.
+- In reusable-session mode, `browser_execute` reconnects to the configured Browser Run session for each call, then disconnects the CDP WebSocket without deleting the browser. Browser state remains available until you close/reset the session or Browser Run times it out.
 - LLM-generated code runs in a Worker sandbox. CDP traffic stays in the host worker.
 
 ## CDP helper API
@@ -203,7 +218,7 @@ Clear the debug log buffer.
 
 ### `createBrowserTools(options)`
 
-Returns AI SDK tools (`browser_search` and `browser_execute`).
+Returns AI SDK tools. In one-shot mode this includes `browser_search` and `browser_execute`. In reusable-session mode this also includes `browser_session_info`, `browser_close_session`, and `browser_reset_session`.
 
 | Option       | Type                     | Default  | Description                                            |
 | ------------ | ------------------------ | -------- | ------------------------------------------------------ |
@@ -212,8 +227,44 @@ Returns AI SDK tools (`browser_search` and `browser_execute`).
 | `cdpHeaders` | `Record<string, string>` | —        | Headers for CDP URL discovery (e.g. Cloudflare Access) |
 | `loader`     | `WorkerLoader`           | required | Worker Loader binding for sandboxed execution          |
 | `timeout`    | `number`                 | `30000`  | Execution timeout in milliseconds                      |
+| `session`    | `BrowserSessionOptions`  | one-shot | Optional browser session lifecycle                     |
 
 Either `browser` or `cdpUrl` must be provided. When both are set, `cdpUrl` takes priority.
+
+Reusable sessions require the Browser Rendering binding. `cdpUrl` points at an externally managed browser, so the SDK does not create, list, or delete Browser Run sessions for that mode.
+
+### Reusable session options
+
+```ts
+createBrowserTools({
+  browser: env.BROWSER,
+  loader: env.LOADER,
+  session: {
+    mode: "reuse",
+    key: "optional-logical-owner",
+    keepAliveMs: 600_000,
+    liveView: true,
+    onSessionInfo(info) {
+      // Broadcast or render session metadata in your UI.
+    }
+  }
+});
+```
+
+| Option          | Type                                 | Default     | Description                                                     |
+| --------------- | ------------------------------------ | ----------- | --------------------------------------------------------------- |
+| `mode`          | `"reuse"`                            | required    | Reuse one Browser Run session across `browser_execute` calls    |
+| `key`           | `string`                             | `"default"` | Logical owner key for the reusable session                      |
+| `store`         | `BrowserSessionStore`                | memory      | Storage adapter for the Browser Run session id                  |
+| `keepAliveMs`   | `number`                             | Browser Run | Browser Run inactivity timeout; Browser Run caps this at 10 min |
+| `liveView`      | `boolean`                            | `false`     | Include Live View URLs in session metadata                      |
+| `onSessionInfo` | `(info: BrowserSessionInfo) => void` | —           | Callback whenever session metadata is refreshed                 |
+
+The default memory store only persists for the lifetime of the returned tool handlers. If you create browser tools per request and want reuse across requests, provide a durable `store`. Think's `@cloudflare/think/tools/browser` wrapper provides Durable Object storage automatically.
+
+`browser_session_info` lists the active targets and returns fresh Live View URLs when `liveView` is enabled. Live View URLs expire after five minutes if they are not opened; call `browser_session_info` again to refresh them.
+
+Call `browser_close_session` when a task is done to stop browser-hour usage and clear browser state. Call `browser_reset_session` when you need a fresh browser.
 
 ### Raw access
 
@@ -249,9 +300,9 @@ Use `cdpUrl` only when you intentionally want to connect to some other CDP-compa
 
 ## Current limitations
 
-- **One session per execute call** — each `browser_execute` invocation opens a fresh browser session. Multi-step workflows must be completed within a single code block.
+- **One session per execute call by default** — each `browser_execute` invocation opens a fresh browser session unless you opt into reusable sessions.
 - **Local development depends on Wrangler support** — if Browser Rendering local mode is unavailable in your environment, upgrade Wrangler or provide `cdpUrl` explicitly.
-- **No authenticated sessions** — the browser starts without any cookies or login state. A future Browser Isolation integration could enable user-authenticated sessions.
+- **No user-authenticated browser by default** — one-shot sessions start without cookies or login state. Reusable sessions preserve cookies and storage created inside that Browser Run session, but they are not connected to the user's local browser profile.
 - Requires `@cloudflare/codemode` as a peer dependency
 - Limited to JavaScript execution in the sandbox (no TypeScript syntax)
 

--- a/docs/think/tools.md
+++ b/docs/think/tools.md
@@ -285,7 +285,39 @@ This adds two tools to your agent:
 
 Both tools use the code-mode pattern — the model writes JavaScript async arrow functions that run in a sandboxed Worker isolate. In `browser_search`, the sandbox has access to `spec.get()` which returns the full normalized CDP protocol. In `browser_execute`, the sandbox has access to `cdp.send()`, `cdp.attachToTarget()`, and debug log helpers.
 
-Each `browser_execute` call opens a fresh browser session and closes it when the code finishes. For page-scoped CDP commands (`Page.*`, `Runtime.*`, `DOM.*`), the model must create a target, attach to it, and pass the `sessionId`.
+Each `browser_execute` call opens a fresh browser session and closes it when the code finishes by default. For page-scoped CDP commands (`Page.*`, `Runtime.*`, `DOM.*`), the model must create a target, attach to it, and pass the `sessionId`.
+
+For multi-step browsing workflows, enable a reusable Browser Run session:
+
+```typescript
+getTools() {
+  return {
+    ...createBrowserTools({
+      browser: this.env.BROWSER,
+      loader: this.env.LOADER,
+      session: {
+        mode: "reuse",
+        keepAliveMs: 600_000,
+        liveView: true
+      }
+    })
+  };
+}
+```
+
+In Think, `session: { mode: "reuse" }` automatically uses this agent/chat as the session owner and stores the Browser Run session id in the agent Durable Object. The CDP WebSocket is still opened only for the tool call and disconnected afterward, so this works across hibernation and restarts while the Browser Run session remains alive.
+
+Reusable mode adds three lifecycle tools:
+
+| Tool                    | Description                                              |
+| ----------------------- | -------------------------------------------------------- |
+| `browser_session_info`  | Return active targets, URLs, titles, and Live View URLs  |
+| `browser_close_session` | Close the reusable browser and release Browser Run usage |
+| `browser_reset_session` | Close any current browser and start from a fresh session |
+
+When `liveView` is enabled, Think broadcasts browser session metadata to connected clients using a `browser-session` message so UIs can render an “Open Live View” action without requiring the model to surface the URL in chat text. Live View URLs expire after five minutes if they are not opened; call `browser_session_info` again to refresh them.
+
+Reusable sessions preserve tabs, cookies, local storage, and page state, but they also consume Browser Run time while alive. Browser Run closes idle sessions automatically, and the tools recover by creating a fresh session if the stored session has expired. Call `browser_close_session` when the browsing task is done.
 
 ### Combining with Other Tools
 

--- a/packages/agents/src/browser-tests/browser.test.ts
+++ b/packages/agents/src/browser-tests/browser.test.ts
@@ -316,6 +316,63 @@ describe("browser tools e2e", () => {
     });
   });
 
+  describe("reusable browser sessions", () => {
+    afterAll(async () => {
+      await callAgent("testCloseReuse").catch(() => undefined);
+    });
+
+    it("should preserve browser targets across execute calls", async () => {
+      const first = (await callAgent("testExecuteReuse", [
+        `async () => {
+          const { targetId } = await cdp.send("Target.createTarget", { url: "about:blank" });
+          const sessionId = await cdp.attachToTarget(targetId);
+          await cdp.send("Runtime.enable", {}, { sessionId });
+          await cdp.send("Page.navigate", { url: "data:text/html,<title>Reusable Session</title><body>persisted</body>" }, { sessionId });
+          for (let i = 0; i < 20; i++) {
+            const { result } = await cdp.send("Runtime.evaluate", { expression: "document.title" }, { sessionId });
+            if (result.value === "Reusable Session") break;
+            await new Promise(r => setTimeout(r, 50));
+          }
+          return { targetId };
+        }`
+      ])) as { text: string; isError?: boolean };
+
+      expect(first.isError).toBeFalsy();
+      const { targetId } = JSON.parse(first.text) as { targetId: string };
+
+      const second = (await callAgent("testExecuteReuse", [
+        `async () => {
+          const { targetInfos } = await cdp.send("Target.getTargets");
+          const target = targetInfos.find(t => t.targetId === ${JSON.stringify(targetId)});
+          if (!target) return { found: false };
+          const sessionId = await cdp.attachToTarget(target.targetId);
+          const { result } = await cdp.send("Runtime.evaluate", { expression: "document.title" }, { sessionId });
+          return { found: true, title: result.value };
+        }`
+      ])) as { text: string; isError?: boolean };
+
+      expect(second.isError).toBeFalsy();
+      expect(JSON.parse(second.text)).toEqual({
+        found: true,
+        title: "Reusable Session"
+      });
+
+      const info = (await callAgent("testReuseInfo")) as {
+        text: string;
+        isError?: boolean;
+      };
+      expect(info.isError).toBeFalsy();
+      const parsedInfo = JSON.parse(info.text) as {
+        sessionId?: string;
+        targets?: Array<{ id: string; devtoolsFrontendUrl?: string }>;
+      };
+      expect(parsedInfo.sessionId).toBeTruthy();
+      expect(parsedInfo.targets?.some((target) => target.id === targetId)).toBe(
+        true
+      );
+    });
+  });
+
   describe("integration scenarios", () => {
     it("should navigate to a page and get its title", async () => {
       const result = (await callAgent("testExecute", [

--- a/packages/agents/src/browser-tests/worker.ts
+++ b/packages/agents/src/browser-tests/worker.ts
@@ -8,11 +8,27 @@ type Env = {
 };
 
 export class BrowserTestAgent extends Agent<Env> {
+  #reuseHandlers?: ReturnType<typeof createBrowserToolHandlers>;
+
   #getHandlers() {
     return createBrowserToolHandlers({
       browser: this.env.BROWSER,
       loader: this.env.LOADER
     });
+  }
+
+  #getReuseHandlers() {
+    this.#reuseHandlers ??= createBrowserToolHandlers({
+      browser: this.env.BROWSER,
+      loader: this.env.LOADER,
+      session: {
+        mode: "reuse",
+        key: "browser-test",
+        liveView: true,
+        keepAliveMs: 600_000
+      }
+    });
+    return this.#reuseHandlers;
   }
 
   @callable()
@@ -23,6 +39,21 @@ export class BrowserTestAgent extends Agent<Env> {
   @callable()
   async testExecute(code: string): Promise<ToolResult> {
     return this.#getHandlers().execute(code);
+  }
+
+  @callable()
+  async testExecuteReuse(code: string): Promise<ToolResult> {
+    return this.#getReuseHandlers().execute(code);
+  }
+
+  @callable()
+  async testReuseInfo(): Promise<ToolResult> {
+    return this.#getReuseHandlers().sessionInfo();
+  }
+
+  @callable()
+  async testCloseReuse(): Promise<ToolResult> {
+    return this.#getReuseHandlers().closeSession();
   }
 }
 

--- a/packages/agents/src/browser/ai.ts
+++ b/packages/agents/src/browser/ai.ts
@@ -3,7 +3,11 @@ import type { ToolSet } from "ai";
 import { z } from "zod";
 import {
   createBrowserToolHandlers,
+  hasReusableBrowserSession,
   SEARCH_DESCRIPTION,
+  SESSION_INFO_DESCRIPTION,
+  CLOSE_SESSION_DESCRIPTION,
+  RESET_SESSION_DESCRIPTION,
   EXECUTE_DESCRIPTION,
   type BrowserToolsOptions
 } from "./shared";
@@ -36,7 +40,7 @@ export type { BrowserToolsOptions } from "./shared";
 export function createBrowserTools(options: BrowserToolsOptions): ToolSet {
   const handlers = createBrowserToolHandlers(options);
 
-  return {
+  const browserTools: ToolSet = {
     browser_search: tool({
       description: SEARCH_DESCRIPTION,
       inputSchema: z.object({
@@ -69,4 +73,44 @@ export function createBrowserTools(options: BrowserToolsOptions): ToolSet {
       }
     })
   };
+
+  if (hasReusableBrowserSession(options)) {
+    browserTools.browser_session_info = tool({
+      description: SESSION_INFO_DESCRIPTION,
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await handlers.sessionInfo();
+        if (result.isError) {
+          throw new Error(result.text);
+        }
+        return result.text;
+      }
+    });
+
+    browserTools.browser_close_session = tool({
+      description: CLOSE_SESSION_DESCRIPTION,
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await handlers.closeSession();
+        if (result.isError) {
+          throw new Error(result.text);
+        }
+        return result.text;
+      }
+    });
+
+    browserTools.browser_reset_session = tool({
+      description: RESET_SESSION_DESCRIPTION,
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await handlers.resetSession();
+        if (result.isError) {
+          throw new Error(result.text);
+        }
+        return result.text;
+      }
+    });
+  }
+
+  return browserTools;
 }

--- a/packages/agents/src/browser/browser-run.ts
+++ b/packages/agents/src/browser/browser-run.ts
@@ -1,0 +1,178 @@
+import { CdpSession } from "./cdp-session";
+
+export interface BrowserTargetInfo {
+  id: string;
+  type?: string;
+  url?: string;
+  title?: string;
+  description?: string;
+  devtoolsFrontendUrl?: string;
+  webSocketDebuggerUrl?: string;
+}
+
+export interface BrowserSessionInfo {
+  sessionId: string;
+  targets?: BrowserTargetInfo[];
+  webSocketDebuggerUrl?: string;
+}
+
+export interface ConnectBrowserOptions {
+  timeoutMs?: number;
+  keepAliveMs?: number;
+  includeTargets?: boolean;
+}
+
+function browserSessionEndpoint(
+  sessionId?: string,
+  options?: { keepAliveMs?: number; includeTargets?: boolean }
+): string {
+  const path = sessionId
+    ? `/v1/devtools/browser/${sessionId}`
+    : "/v1/devtools/browser";
+  const url = new URL(`https://localhost${path}`);
+  if (options?.keepAliveMs !== undefined) {
+    url.searchParams.set("keep_alive", String(options.keepAliveMs));
+  }
+  if (options?.includeTargets) {
+    url.searchParams.set("targets", "true");
+  }
+  return url.toString();
+}
+
+async function parseBrowserSessionInfo(
+  response: Response
+): Promise<BrowserSessionInfo> {
+  const payload = (await response.json()) as {
+    sessionId?: unknown;
+    targets?: unknown;
+    webSocketDebuggerUrl?: unknown;
+  };
+  const sessionId =
+    typeof payload.sessionId === "string" ? payload.sessionId : "";
+  if (!sessionId) {
+    throw new Error("Browser Rendering response did not include a sessionId");
+  }
+  return {
+    sessionId,
+    targets: Array.isArray(payload.targets)
+      ? (payload.targets as BrowserTargetInfo[])
+      : undefined,
+    webSocketDebuggerUrl:
+      typeof payload.webSocketDebuggerUrl === "string"
+        ? payload.webSocketDebuggerUrl
+        : undefined
+  };
+}
+
+export async function createBrowserSession(
+  browser: Fetcher,
+  options?: { keepAliveMs?: number; includeTargets?: boolean }
+): Promise<BrowserSessionInfo> {
+  const response = await browser.fetch(
+    browserSessionEndpoint(undefined, options),
+    {
+      method: "POST"
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create Browser Rendering session: ${response.status}`
+    );
+  }
+  return parseBrowserSessionInfo(response);
+}
+
+export async function listBrowserTargets(
+  browser: Fetcher,
+  sessionId: string
+): Promise<BrowserTargetInfo[]> {
+  const response = await browser.fetch(
+    `https://localhost/v1/devtools/browser/${sessionId}/json/list`
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list Browser Rendering targets for ${sessionId}: ${response.status}`
+    );
+  }
+  const payload = (await response.json()) as unknown;
+  return Array.isArray(payload) ? (payload as BrowserTargetInfo[]) : [];
+}
+
+export async function deleteBrowserSession(
+  browser: Fetcher,
+  sessionId: string
+): Promise<void> {
+  const response = await browser.fetch(
+    `https://localhost/v1/devtools/browser/${sessionId}`,
+    { method: "DELETE" }
+  );
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      `Failed to delete Browser Rendering session ${sessionId}: ${response.status}`
+    );
+  }
+}
+
+/**
+ * Connect to a browser via the Browser Rendering binding (Fetcher).
+ * Establishes a CDP WebSocket through the binding's fetch interface.
+ */
+export async function connectBrowser(
+  browser: Fetcher,
+  options?: number | ConnectBrowserOptions
+): Promise<CdpSession> {
+  const normalizedOptions =
+    typeof options === "number" ? { timeoutMs: options } : (options ?? {});
+  const endpoint = browserSessionEndpoint(undefined, {
+    keepAliveMs: normalizedOptions.keepAliveMs,
+    includeTargets: normalizedOptions.includeTargets
+  });
+  const response = await browser.fetch(endpoint, {
+    headers: { Upgrade: "websocket" }
+  });
+
+  const ws = response.webSocket;
+  if (!ws) {
+    throw new Error(
+      "Browser Rendering binding did not return a WebSocket. " +
+        "Ensure the 'browser' binding is configured in wrangler.jsonc."
+    );
+  }
+
+  const sessionId = response.headers.get("cf-browser-session-id");
+  if (!sessionId) {
+    throw new Error(
+      "Browser Rendering binding did not include a session ID when opening the CDP WebSocket"
+    );
+  }
+
+  ws.accept();
+  return new CdpSession(
+    ws,
+    normalizedOptions.timeoutMs,
+    () => {
+      void deleteBrowserSession(browser, sessionId);
+    },
+    sessionId
+  );
+}
+
+export async function connectBrowserSession(
+  browser: Fetcher,
+  sessionId: string,
+  timeoutMs?: number
+): Promise<CdpSession> {
+  const response = await browser.fetch(browserSessionEndpoint(sessionId), {
+    headers: { Upgrade: "websocket" }
+  });
+
+  const ws = response.webSocket;
+  if (!ws) {
+    throw new Error(
+      `Browser Rendering binding did not return a WebSocket for session ${sessionId}`
+    );
+  }
+
+  ws.accept();
+  return new CdpSession(ws, timeoutMs, undefined, sessionId);
+}

--- a/packages/agents/src/browser/cdp-session.ts
+++ b/packages/agents/src/browser/cdp-session.ts
@@ -39,15 +39,18 @@ export class CdpSession {
   #debugLog: DebugEntry[] = [];
   #defaultTimeoutMs: number;
   #dispose?: () => void;
+  readonly sessionId?: string;
 
   constructor(
     socket: WebSocket,
     defaultTimeoutMs = DEFAULT_TIMEOUT_MS,
-    dispose?: () => void
+    dispose?: () => void,
+    sessionId?: string
   ) {
     this.#socket = socket;
     this.#defaultTimeoutMs = defaultTimeoutMs;
     this.#dispose = dispose;
+    this.sessionId = sessionId;
 
     socket.addEventListener("message", (event) => this.#handleMessage(event));
     socket.addEventListener("error", () => {
@@ -141,13 +144,17 @@ export class CdpSession {
     this.#debugLog = [];
   }
 
-  close(): void {
-    this.#rejectAll(new Error("CDP session closed"));
+  disconnect(): void {
+    this.#rejectAll(new Error("CDP session disconnected"));
     try {
       this.#socket.close(1000, "Done");
     } catch {
       // socket may already be closed
     }
+  }
+
+  close(): void {
+    this.disconnect();
     this.#dispose?.();
   }
 
@@ -213,44 +220,6 @@ export class CdpSession {
       this.#debugLog.splice(0, this.#debugLog.length - MAX_DEBUG_ENTRIES);
     }
   }
-}
-
-/**
- * Connect to a browser via the Browser Rendering binding (Fetcher).
- * Establishes a CDP WebSocket through the binding's fetch interface.
- */
-export async function connectBrowser(
-  browser: Fetcher,
-  timeoutMs?: number
-): Promise<CdpSession> {
-  const response = await browser.fetch(
-    "https://localhost/v1/devtools/browser",
-    {
-      headers: { Upgrade: "websocket" }
-    }
-  );
-
-  const ws = response.webSocket;
-  if (!ws) {
-    throw new Error(
-      "Browser Rendering binding did not return a WebSocket. " +
-        "Ensure the 'browser' binding is configured in wrangler.jsonc."
-    );
-  }
-
-  const sessionId = response.headers.get("cf-browser-session-id");
-  if (!sessionId) {
-    throw new Error(
-      "Browser Rendering binding did not include a session ID when opening the CDP WebSocket"
-    );
-  }
-
-  ws.accept();
-  return new CdpSession(ws, timeoutMs, () => {
-    void browser.fetch(`https://localhost/v1/devtools/browser/${sessionId}`, {
-      method: "DELETE"
-    });
-  });
 }
 
 const LOCALHOST_HOSTS = new Set([

--- a/packages/agents/src/browser/index.ts
+++ b/packages/agents/src/browser/index.ts
@@ -1,15 +1,33 @@
 export {
   CdpSession,
-  connectBrowser,
   connectUrl,
   type CdpSendOptions,
   type CdpAttachOptions
 } from "./cdp-session";
 
 export {
+  connectBrowser,
+  connectBrowserSession,
+  createBrowserSession,
+  deleteBrowserSession,
+  listBrowserTargets,
+  type BrowserSessionInfo,
+  type BrowserTargetInfo,
+  type ConnectBrowserOptions
+} from "./browser-run";
+
+export {
   type BrowserToolsOptions,
+  type BrowserSessionOptions,
+  type BrowserSessionStore,
+  type ReusableBrowserSessionOptions,
+  type StoredBrowserSession,
   type ToolResult,
   createBrowserToolHandlers,
+  hasReusableBrowserSession,
   SEARCH_DESCRIPTION,
+  SESSION_INFO_DESCRIPTION,
+  CLOSE_SESSION_DESCRIPTION,
+  RESET_SESSION_DESCRIPTION,
   EXECUTE_DESCRIPTION
 } from "./shared";

--- a/packages/agents/src/browser/session-manager.ts
+++ b/packages/agents/src/browser/session-manager.ts
@@ -1,0 +1,265 @@
+import { connectUrl } from "./cdp-session";
+import {
+  connectBrowser,
+  connectBrowserSession,
+  createBrowserSession,
+  deleteBrowserSession,
+  listBrowserTargets,
+  type BrowserSessionInfo,
+  type BrowserTargetInfo
+} from "./browser-run";
+import type { CdpSession } from "./cdp-session";
+import type { BrowserToolsOptions } from "./shared";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface StoredBrowserSession {
+  sessionId: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface BrowserSessionStore {
+  get(key: string): MaybePromise<StoredBrowserSession | undefined>;
+  set(key: string, session: StoredBrowserSession): MaybePromise<void>;
+  delete(key: string): MaybePromise<void>;
+}
+
+export interface ReusableBrowserSessionOptions {
+  mode: "reuse";
+  /** Logical owner key. Think supplies this automatically. */
+  key?: string;
+  /** Durable storage for the Browser Run session id. */
+  store?: BrowserSessionStore;
+  /** Browser Run inactivity timeout. Browser Run currently caps this at 10 minutes. */
+  keepAliveMs?: number;
+  /** Include Live View URLs in session metadata callbacks and session_info. */
+  liveView?: boolean;
+  /** Called whenever session metadata is refreshed. Useful for UI broadcasts. */
+  onSessionInfo?: (info: BrowserSessionInfo) => MaybePromise<void>;
+}
+
+export type BrowserSessionOptions =
+  | { mode?: "one-shot" }
+  | ReusableBrowserSessionOptions;
+
+export interface BrowserLease {
+  session: CdpSession;
+  release(): Promise<void>;
+}
+
+export interface BrowserSessionManager {
+  acquire(): Promise<BrowserLease>;
+  info(): Promise<BrowserSessionInfo | undefined>;
+  close(): Promise<void>;
+  reset(): Promise<BrowserSessionInfo | undefined>;
+}
+
+class MemoryBrowserSessionStore implements BrowserSessionStore {
+  #sessions = new Map<string, StoredBrowserSession>();
+
+  get(key: string): StoredBrowserSession | undefined {
+    return this.#sessions.get(key);
+  }
+
+  set(key: string, session: StoredBrowserSession): void {
+    this.#sessions.set(key, session);
+  }
+
+  delete(key: string): void {
+    this.#sessions.delete(key);
+  }
+}
+
+class OneShotBrowserSessionManager implements BrowserSessionManager {
+  constructor(private readonly options: BrowserToolsOptions) {}
+
+  async acquire(): Promise<BrowserLease> {
+    let session: CdpSession;
+    if (this.options.cdpUrl) {
+      session = await connectUrl(this.options.cdpUrl, {
+        timeoutMs: this.options.timeout,
+        headers: this.options.cdpHeaders
+      });
+    } else if (this.options.browser) {
+      session = await connectBrowser(
+        this.options.browser,
+        this.options.timeout
+      );
+    } else {
+      throw new Error(
+        "Either 'browser' (Fetcher binding) or 'cdpUrl' must be provided"
+      );
+    }
+
+    return {
+      session,
+      release: async () => session.close()
+    };
+  }
+
+  async info(): Promise<BrowserSessionInfo | undefined> {
+    return undefined;
+  }
+
+  async close(): Promise<void> {}
+
+  async reset(): Promise<BrowserSessionInfo | undefined> {
+    return undefined;
+  }
+}
+
+class ReusableBrowserSessionManager implements BrowserSessionManager {
+  #queue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly browser: Fetcher,
+    private readonly options: BrowserToolsOptions,
+    private readonly sessionOptions: ReusableBrowserSessionOptions,
+    private readonly store: BrowserSessionStore
+  ) {}
+
+  async acquire(): Promise<BrowserLease> {
+    const previous = this.#queue;
+    let releaseQueue: () => void = () => undefined;
+    this.#queue = previous.then(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseQueue = resolve;
+        })
+    );
+    await previous;
+
+    try {
+      const info = await this.#ensureSession();
+      const session = await connectBrowserSession(
+        this.browser,
+        info.sessionId,
+        this.options.timeout
+      );
+      await this.#publishInfo(info.sessionId).catch(() => undefined);
+      return {
+        session,
+        release: async () => {
+          try {
+            session.disconnect();
+          } finally {
+            releaseQueue();
+          }
+        }
+      };
+    } catch (error) {
+      releaseQueue();
+      throw error;
+    }
+  }
+
+  async info(): Promise<BrowserSessionInfo | undefined> {
+    await this.#queue;
+    const stored = await this.store.get(this.#key());
+    if (!stored) return undefined;
+    try {
+      return await this.#publishInfo(stored.sessionId);
+    } catch {
+      await this.store.delete(this.#key());
+      return undefined;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.#queue;
+    const stored = await this.store.get(this.#key());
+    await this.store.delete(this.#key());
+    if (stored) {
+      await deleteBrowserSession(this.browser, stored.sessionId);
+    }
+  }
+
+  async reset(): Promise<BrowserSessionInfo> {
+    await this.#queue;
+    await this.close().catch(() => undefined);
+    const info = await this.#createAndStoreSession();
+    return this.#publishInfo(info.sessionId);
+  }
+
+  async #ensureSession(): Promise<StoredBrowserSession> {
+    const stored = await this.store.get(this.#key());
+    if (stored) {
+      try {
+        await listBrowserTargets(this.browser, stored.sessionId);
+        const refreshed = { ...stored, updatedAt: Date.now() };
+        await this.store.set(this.#key(), refreshed);
+        return refreshed;
+      } catch {
+        await this.store.delete(this.#key());
+      }
+    }
+    return this.#createAndStoreSession();
+  }
+
+  async #createAndStoreSession(): Promise<StoredBrowserSession> {
+    const info = await createBrowserSession(this.browser, {
+      keepAliveMs: this.sessionOptions.keepAliveMs,
+      includeTargets: this.sessionOptions.liveView
+    });
+    const now = Date.now();
+    const stored = {
+      sessionId: info.sessionId,
+      createdAt: now,
+      updatedAt: now
+    };
+    await this.store.set(this.#key(), stored);
+    return stored;
+  }
+
+  async #publishInfo(sessionId: string): Promise<BrowserSessionInfo> {
+    const targets = await listBrowserTargets(this.browser, sessionId);
+    const info = {
+      sessionId,
+      targets: this.sessionOptions.liveView
+        ? targets
+        : targets.map(stripLiveViewUrls)
+    };
+    await this.sessionOptions.onSessionInfo?.(info);
+    return info;
+  }
+
+  #key(): string {
+    return this.sessionOptions.key ?? "default";
+  }
+}
+
+function stripLiveViewUrls(target: BrowserTargetInfo): BrowserTargetInfo {
+  const { devtoolsFrontendUrl: _devtoolsFrontendUrl, ...rest } = target;
+  return rest;
+}
+
+export function createBrowserSessionManager(
+  options: BrowserToolsOptions
+): BrowserSessionManager {
+  if (options.session?.mode === "reuse") {
+    if (options.cdpUrl) {
+      throw new Error(
+        "Reusable browser sessions require a Browser Rendering binding, not cdpUrl"
+      );
+    }
+    if (!options.browser) {
+      throw new Error(
+        "Reusable browser sessions require a Browser Rendering binding"
+      );
+    }
+    return new ReusableBrowserSessionManager(
+      options.browser,
+      options,
+      options.session,
+      options.session.store ?? new MemoryBrowserSessionStore()
+    );
+  }
+  return new OneShotBrowserSessionManager(options);
+}
+
+export function hasReusableBrowserSession(
+  options: BrowserToolsOptions
+): boolean {
+  return options.session?.mode === "reuse";
+}

--- a/packages/agents/src/browser/shared.ts
+++ b/packages/agents/src/browser/shared.ts
@@ -1,7 +1,19 @@
 import type { ResolvedProvider } from "@cloudflare/codemode";
 import { DynamicWorkerExecutor } from "@cloudflare/codemode";
-import { CdpSession, connectBrowser, connectUrl } from "./cdp-session";
+import type { BrowserLease, BrowserSessionOptions } from "./session-manager";
+import {
+  createBrowserSessionManager,
+  hasReusableBrowserSession
+} from "./session-manager";
 import { truncateResponse } from "./truncate";
+
+export {
+  hasReusableBrowserSession,
+  type BrowserSessionOptions,
+  type BrowserSessionStore,
+  type ReusableBrowserSessionOptions,
+  type StoredBrowserSession
+} from "./session-manager";
 
 export interface BrowserToolsOptions {
   /** Browser Rendering binding (Fetcher) — used in production */
@@ -14,6 +26,8 @@ export interface BrowserToolsOptions {
   loader: WorkerLoader;
   /** Execution timeout in milliseconds (default: 30000) */
   timeout?: number;
+  /** Optional browser session lifecycle. Defaults to one fresh session per execute call. */
+  session?: BrowserSessionOptions;
 }
 
 interface RawCdpCommand {
@@ -207,6 +221,12 @@ async function fetchCdpSpecFromBrowser(
   });
 }
 
+export const SESSION_INFO_DESCRIPTION = `Return metadata for the current reusable browser session, including active targets, page URLs, titles, and Live View URLs when enabled. Use this to orient yourself before continuing a multi-step browsing task.`;
+
+export const CLOSE_SESSION_DESCRIPTION = `Close the current reusable browser session. Use this when the browsing task is complete or the user asks to close the browser. Closing releases Browser Run resources and clears browser state.`;
+
+export const RESET_SESSION_DESCRIPTION = `Reset the current reusable browser session by closing any existing browser and creating a fresh one. Use this when stale browser state is causing problems or the user asks for a fresh browser.`;
+
 export const EXECUTE_DESCRIPTION = `Execute CDP commands against a live browser session using JavaScript code.
 
 Available in your code:
@@ -274,6 +294,7 @@ export function createBrowserToolHandlers(options: BrowserToolsOptions) {
     loader: options.loader,
     timeout: options.timeout
   });
+  const sessionManager = createBrowserSessionManager(options);
 
   async function search(code: string): Promise<ToolResult> {
     try {
@@ -310,40 +331,29 @@ export function createBrowserToolHandlers(options: BrowserToolsOptions) {
   }
 
   async function execute(code: string): Promise<ToolResult> {
-    let session: CdpSession | undefined;
+    let lease: BrowserLease | undefined;
     try {
-      if (options.cdpUrl) {
-        session = await connectUrl(options.cdpUrl, {
-          timeoutMs: options.timeout,
-          headers: options.cdpHeaders
-        });
-      } else if (options.browser) {
-        session = await connectBrowser(options.browser, options.timeout);
-      } else {
-        return {
-          text: "Either 'browser' (Fetcher binding) or 'cdpUrl' must be provided",
-          isError: true
-        };
-      }
+      lease = await sessionManager.acquire();
+      const session = lease.session;
 
       const providers: ResolvedProvider[] = [
         {
           name: "cdp",
           fns: {
             send: async (method: unknown, params: unknown, opts: unknown) =>
-              session!.send(
+              session.send(
                 method as string,
                 params,
                 opts as { timeoutMs?: number; sessionId?: string }
               ),
             attachToTarget: async (targetId: unknown, opts: unknown) =>
-              session!.attachToTarget(
+              session.attachToTarget(
                 targetId as string,
                 opts as { timeoutMs?: number }
               ),
             getDebugLog: async (limit: unknown) =>
-              session!.getDebugLog(limit as number | undefined),
-            clearDebugLog: async () => session!.clearDebugLog()
+              session.getDebugLog(limit as number | undefined),
+            clearDebugLog: async () => session.clearDebugLog()
           },
           positionalArgs: true
         }
@@ -357,9 +367,36 @@ export function createBrowserToolHandlers(options: BrowserToolsOptions) {
     } catch (error) {
       return { text: formatError(error), isError: true };
     } finally {
-      session?.close();
+      await lease?.release();
     }
   }
 
-  return { search, execute };
+  async function sessionInfo(): Promise<ToolResult> {
+    try {
+      const info = await sessionManager.info();
+      return { text: truncateResponse(info ?? { status: "none" }) };
+    } catch (error) {
+      return { text: formatError(error), isError: true };
+    }
+  }
+
+  async function closeSession(): Promise<ToolResult> {
+    try {
+      await sessionManager.close();
+      return { text: JSON.stringify({ status: "closed" }) };
+    } catch (error) {
+      return { text: formatError(error), isError: true };
+    }
+  }
+
+  async function resetSession(): Promise<ToolResult> {
+    try {
+      const info = await sessionManager.reset();
+      return { text: truncateResponse(info ?? { status: "none" }) };
+    } catch (error) {
+      return { text: formatError(error), isError: true };
+    }
+  }
+
+  return { search, execute, sessionInfo, closeSession, resetSession };
 }

--- a/packages/agents/src/browser/tanstack-ai.ts
+++ b/packages/agents/src/browser/tanstack-ai.ts
@@ -3,7 +3,11 @@ import type { ServerTool } from "@tanstack/ai";
 import { z } from "zod";
 import {
   createBrowserToolHandlers,
+  hasReusableBrowserSession,
   SEARCH_DESCRIPTION,
+  SESSION_INFO_DESCRIPTION,
+  CLOSE_SESSION_DESCRIPTION,
+  RESET_SESSION_DESCRIPTION,
   EXECUTE_DESCRIPTION,
   type BrowserToolsOptions
 } from "./shared";
@@ -68,5 +72,45 @@ export function createBrowserTools(options: BrowserToolsOptions): ServerTool[] {
     return { text: result.text };
   });
 
-  return [search, execute];
+  if (!hasReusableBrowserSession(options)) {
+    return [search, execute];
+  }
+
+  const sessionInfo = toolDefinition({
+    name: "browser_session_info" as const,
+    description: SESSION_INFO_DESCRIPTION,
+    inputSchema: z.object({})
+  }).server(async () => {
+    const result = await handlers.sessionInfo();
+    if (result.isError) {
+      throw new Error(result.text);
+    }
+    return { text: result.text };
+  });
+
+  const closeSession = toolDefinition({
+    name: "browser_close_session" as const,
+    description: CLOSE_SESSION_DESCRIPTION,
+    inputSchema: z.object({})
+  }).server(async () => {
+    const result = await handlers.closeSession();
+    if (result.isError) {
+      throw new Error(result.text);
+    }
+    return { text: result.text };
+  });
+
+  const resetSession = toolDefinition({
+    name: "browser_reset_session" as const,
+    description: RESET_SESSION_DESCRIPTION,
+    inputSchema: z.object({})
+  }).server(async () => {
+    const result = await handlers.resetSession();
+    if (result.isError) {
+      throw new Error(result.text);
+    }
+    return { text: result.text };
+  });
+
+  return [search, execute, sessionInfo, closeSession, resetSession];
 }

--- a/packages/think/src/e2e-tests/browser-tools-e2e.test.ts
+++ b/packages/think/src/e2e-tests/browser-tools-e2e.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 18799;
+const BASE_URL = `http://localhost:${PORT}`;
+const AGENT_SLUG = "think-browser-e2-e-agent";
+const PERSIST_DIR = path.join(__dirname, ".wrangler-think-browser-e2e-state");
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function killProcessOnPort(port: number): void {
+  try {
+    const output = execSync(
+      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
+    )
+      .toString()
+      .trim();
+    if (output) {
+      for (const pid of output.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {
+          // Already dead
+        }
+      }
+    }
+  } catch {
+    // lsof may be unavailable
+  }
+}
+
+function startWrangler(): ChildProcess {
+  const configPath = path.join(__dirname, "wrangler.browser.jsonc");
+  const child = spawn(
+    "npx",
+    [
+      "wrangler",
+      "dev",
+      "--config",
+      configPath,
+      "--port",
+      String(PORT),
+      "--persist-to",
+      PERSIST_DIR,
+      "--inspector-port",
+      "0"
+    ],
+    {
+      cwd: __dirname,
+      stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
+      env: { ...process.env, NODE_ENV: "test" }
+    }
+  );
+
+  child.stdout?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[wrangler] ${line}`);
+  });
+  child.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[wrangler:err] ${line}`);
+  });
+
+  return child;
+}
+
+async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`${BASE_URL}/`);
+      if (res.status > 0) return;
+    } catch {
+      // Not ready
+    }
+    await sleep(delayMs);
+  }
+  throw new Error(`Wrangler did not start within ${maxAttempts * delayMs}ms`);
+}
+
+function killProcess(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (!child.pid) {
+      resolve();
+      return;
+    }
+    child.on("exit", () => resolve());
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already dead
+      }
+    }
+    setTimeout(resolve, 3000);
+  });
+}
+
+async function callAgent(
+  room: string,
+  method: string,
+  args: unknown[] = []
+): Promise<unknown> {
+  const url = `${BASE_URL}/agents/${AGENT_SLUG}/${room}`;
+
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const id = crypto.randomUUID();
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`RPC call ${method} timed out`));
+    }, 30_000);
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "rpc", id, method, args }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type?: string;
+          id?: string;
+          success?: boolean;
+          result?: unknown;
+          error?: string;
+        };
+        if (msg.type === "rpc" && msg.id === id) {
+          clearTimeout(timeout);
+          ws.close();
+          if (msg.success) {
+            resolve(msg.result);
+          } else {
+            reject(new Error(msg.error || "RPC failed"));
+          }
+        }
+      } catch {
+        // Ignore non-RPC messages
+      }
+    };
+
+    ws.onerror = (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    };
+  });
+}
+
+describe("think browser tools e2e", () => {
+  let wrangler: ChildProcess | null = null;
+
+  beforeAll(async () => {
+    killProcessOnPort(PORT);
+    wrangler = startWrangler();
+    await waitForReady();
+  }, 120_000);
+
+  afterAll(async () => {
+    if (wrangler) {
+      await killProcess(wrangler);
+      wrangler = null;
+    }
+    killProcessOnPort(PORT);
+    try {
+      fs.rmSync(PERSIST_DIR, { recursive: true, force: true });
+    } catch {
+      // OK
+    }
+  }, 30_000);
+
+  it("reuses a real Browser Run session through Think browser tools", async () => {
+    const room = `browser-e2e-${Date.now()}`;
+
+    const first = (await callAgent(room, "executeBrowserTool", [
+      `async () => {
+        const { targetId } = await cdp.send("Target.createTarget", { url: "about:blank" });
+        const sessionId = await cdp.attachToTarget(targetId);
+        await cdp.send("Runtime.enable", {}, { sessionId });
+        await cdp.send("Page.navigate", { url: "data:text/html,<title>Think Browser E2E</title><body>persisted</body>" }, { sessionId });
+        for (let i = 0; i < 20; i++) {
+          const { result } = await cdp.send("Runtime.evaluate", { expression: "document.title" }, { sessionId });
+          if (result.value === "Think Browser E2E") break;
+          await new Promise(r => setTimeout(r, 50));
+        }
+        return { targetId };
+      }`
+    ])) as string;
+
+    const { targetId } = JSON.parse(first) as { targetId: string };
+    expect(targetId).toBeTruthy();
+
+    const second = (await callAgent(room, "executeBrowserTool", [
+      `async () => {
+        const { targetInfos } = await cdp.send("Target.getTargets");
+        const target = targetInfos.find(t => t.targetId === ${JSON.stringify(targetId)});
+        if (!target) return { found: false };
+        const sessionId = await cdp.attachToTarget(target.targetId);
+        const { result } = await cdp.send("Runtime.evaluate", { expression: "document.title" }, { sessionId });
+        return { found: true, title: result.value };
+      }`
+    ])) as string;
+
+    expect(JSON.parse(second)).toEqual({
+      found: true,
+      title: "Think Browser E2E"
+    });
+
+    const info = (await callAgent(room, "browserSessionInfo")) as string;
+    const parsedInfo = JSON.parse(info) as {
+      sessionId?: string;
+      targets?: Array<{ id: string; devtoolsFrontendUrl?: string }>;
+    };
+    expect(parsedInfo.sessionId).toBeTruthy();
+    expect(parsedInfo.targets?.some((target) => target.id === targetId)).toBe(
+      true
+    );
+    expect(
+      parsedInfo.targets?.some((target) => target.devtoolsFrontendUrl)
+    ).toBe(true);
+
+    await callAgent(room, "closeBrowserSession");
+  });
+});

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -5,8 +5,9 @@
  */
 import { createWorkersAI } from "workers-ai-provider";
 import { Agent, callable, routeAgentRequest } from "agents";
-import type { LanguageModel, UIMessage } from "ai";
+import type { LanguageModel, ToolSet, UIMessage } from "ai";
 import { Think, Workspace } from "../think";
+import { createBrowserTools } from "../tools/browser";
 import type { ChatRecoveryContext, ChatRecoveryOptions } from "../think";
 
 type Env = {
@@ -14,8 +15,11 @@ type Env = {
   ThinkRecoveryE2EAgent: DurableObjectNamespace<ThinkRecoveryE2EAgent>;
   ThinkRecoveryHelperParent: DurableObjectNamespace<ThinkRecoveryHelperParent>;
   ThinkRecoveryHelperAgent: DurableObjectNamespace<ThinkRecoveryHelperAgent>;
+  ThinkBrowserE2EAgent: DurableObjectNamespace<ThinkBrowserE2EAgent>;
   AI: Ai;
   R2: R2Bucket;
+  BROWSER: Fetcher;
+  LOADER: WorkerLoader;
 };
 
 export class TestAssistant extends Think<Env> {
@@ -83,6 +87,76 @@ function createSlowE2EMockModel(): LanguageModel {
       return Promise.resolve({ stream });
     }
   } as LanguageModel;
+}
+
+type ExecutableTool<Input> = {
+  execute(input: Input): unknown | Promise<unknown>;
+};
+
+function executableTool<Input>(
+  tools: ToolSet,
+  name: string
+): ExecutableTool<Input> {
+  const candidate = tools[name] as unknown;
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    !("execute" in candidate) ||
+    typeof candidate.execute !== "function"
+  ) {
+    throw new Error(`Tool ${name} is not executable`);
+  }
+  return candidate as ExecutableTool<Input>;
+}
+
+export class ThinkBrowserE2EAgent extends Think<Env> {
+  override getModel(): LanguageModel {
+    return createSlowE2EMockModel();
+  }
+
+  override getTools(): ToolSet {
+    return {
+      ...createBrowserTools({
+        browser: this.env.BROWSER,
+        loader: this.env.LOADER,
+        session: {
+          mode: "reuse",
+          keepAliveMs: 600_000,
+          liveView: true
+        }
+      })
+    };
+  }
+
+  @callable()
+  async executeBrowserTool(code: string): Promise<string> {
+    const tool = executableTool<{ code: string }>(
+      this.getTools(),
+      "browser_execute"
+    );
+    const result = await tool.execute({ code });
+    return String(result);
+  }
+
+  @callable()
+  async browserSessionInfo(): Promise<string> {
+    const tool = executableTool<Record<string, never>>(
+      this.getTools(),
+      "browser_session_info"
+    );
+    const result = await tool.execute({});
+    return String(result);
+  }
+
+  @callable()
+  async closeBrowserSession(): Promise<string> {
+    const tool = executableTool<Record<string, never>>(
+      this.getTools(),
+      "browser_close_session"
+    );
+    const result = await tool.execute({});
+    return String(result);
+  }
 }
 
 export class ThinkRecoveryE2EAgent extends Think<Env> {

--- a/packages/think/src/e2e-tests/wrangler.browser.jsonc
+++ b/packages/think/src/e2e-tests/wrangler.browser.jsonc
@@ -1,0 +1,25 @@
+{
+  "name": "think-browser-e2e-test",
+  "main": "worker.ts",
+  "compatibility_date": "2026-01-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "browser": { "binding": "BROWSER" },
+  "worker_loaders": [{ "binding": "LOADER" }],
+  "define": {
+    "__filename": "'index.ts'"
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "ThinkBrowserE2EAgent",
+        "class_name": "ThinkBrowserE2EAgent"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ThinkBrowserE2EAgent"]
+    }
+  ]
+}

--- a/packages/think/src/tests/browser-tools.test.ts
+++ b/packages/think/src/tests/browser-tools.test.ts
@@ -56,4 +56,19 @@ describe("createBrowserTools", () => {
     expect(tools).toHaveProperty("browser_search");
     expect(tools).toHaveProperty("browser_execute");
   });
+
+  it("adds lifecycle tools for reusable sessions", () => {
+    const tools = createBrowserTools({
+      browser: {} as Fetcher,
+      loader: {} as WorkerLoader,
+      session: { mode: "reuse" }
+    });
+
+    expect(tools).toHaveProperty("browser_search");
+    expect(tools).toHaveProperty("browser_execute");
+    expect(tools).toHaveProperty("browser_session_info");
+    expect(tools).toHaveProperty("browser_close_session");
+    expect(tools).toHaveProperty("browser_reset_session");
+    expect(Object.keys(tools)).toHaveLength(5);
+  });
 });

--- a/packages/think/src/tools/browser-session.ts
+++ b/packages/think/src/tools/browser-session.ts
@@ -1,0 +1,97 @@
+import { getCurrentAgent, type Agent } from "agents";
+import type {
+  BrowserSessionInfo,
+  BrowserSessionStore,
+  BrowserToolsOptions,
+  StoredBrowserSession
+} from "agents/browser";
+
+export type ThinkBrowserToolsOptions = BrowserToolsOptions;
+
+class ThinkBrowserSessionStore implements BrowserSessionStore {
+  #ready = false;
+
+  constructor(private readonly agent: Agent) {}
+
+  get(key: string): StoredBrowserSession | undefined {
+    this.#ensureTable();
+    const rows = this.agent.sql<{
+      browser_session_id: string;
+      created_at: number;
+      updated_at: number;
+    }>`
+      SELECT browser_session_id, created_at, updated_at
+      FROM think_browser_sessions
+      WHERE key = ${key}
+    `;
+    const row = rows[0];
+    if (!row) return undefined;
+    return {
+      sessionId: row.browser_session_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+  }
+
+  set(key: string, session: StoredBrowserSession): void {
+    this.#ensureTable();
+    this.agent.sql`
+      INSERT OR REPLACE INTO think_browser_sessions
+        (key, browser_session_id, created_at, updated_at)
+      VALUES (${key}, ${session.sessionId}, ${session.createdAt}, ${session.updatedAt})
+    `;
+  }
+
+  delete(key: string): void {
+    this.#ensureTable();
+    this.agent.sql`
+      DELETE FROM think_browser_sessions
+      WHERE key = ${key}
+    `;
+  }
+
+  #ensureTable(): void {
+    if (this.#ready) return;
+    this.agent.sql`
+      CREATE TABLE IF NOT EXISTS think_browser_sessions (
+        key TEXT NOT NULL PRIMARY KEY,
+        browser_session_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `;
+    this.#ready = true;
+  }
+}
+
+export function withThinkSessionDefaults(
+  options: ThinkBrowserToolsOptions
+): BrowserToolsOptions {
+  if (options.session?.mode !== "reuse") {
+    return options;
+  }
+
+  const { agent } = getCurrentAgent<Agent>();
+  if (!agent) {
+    return options;
+  }
+
+  const userOnSessionInfo = options.session.onSessionInfo;
+  return {
+    ...options,
+    session: {
+      ...options.session,
+      key: options.session.key ?? `think:${agent.sessionAffinity}:default`,
+      store: options.session.store ?? new ThinkBrowserSessionStore(agent),
+      onSessionInfo: async (info: BrowserSessionInfo) => {
+        agent.broadcast(
+          JSON.stringify({
+            type: "browser-session",
+            session: info
+          })
+        );
+        await userOnSessionInfo?.(info);
+      }
+    }
+  };
+}

--- a/packages/think/src/tools/browser.ts
+++ b/packages/think/src/tools/browser.ts
@@ -1,11 +1,17 @@
 import type { ToolSet } from "ai";
 import {
   createBrowserToolHandlers,
+  hasReusableBrowserSession,
   SEARCH_DESCRIPTION,
-  EXECUTE_DESCRIPTION
+  SESSION_INFO_DESCRIPTION,
+  CLOSE_SESSION_DESCRIPTION,
+  RESET_SESSION_DESCRIPTION,
+  EXECUTE_DESCRIPTION,
+  type BrowserToolsOptions
 } from "agents/browser";
 import { tool } from "ai";
 import { z } from "zod";
+import { withThinkSessionDefaults } from "./browser-session";
 
 export interface CreateBrowserToolsOptions {
   /**
@@ -44,6 +50,13 @@ export interface CreateBrowserToolsOptions {
    * Execution timeout in milliseconds. Defaults to 30000 (30s).
    */
   timeout?: number;
+
+  /**
+   * Browser session lifecycle. Defaults to one fresh browser session per
+   * browser_execute call. Set `{ mode: "reuse" }` to keep one Browser Run
+   * session for this Think agent/chat across tool calls.
+   */
+  session?: BrowserToolsOptions["session"];
 }
 
 /**
@@ -86,15 +99,10 @@ export interface CreateBrowserToolsOptions {
 export function createBrowserTools(
   options: CreateBrowserToolsOptions
 ): ToolSet {
-  const handlers = createBrowserToolHandlers({
-    browser: options.browser,
-    cdpUrl: options.cdpUrl,
-    cdpHeaders: options.cdpHeaders,
-    loader: options.loader,
-    timeout: options.timeout
-  });
+  const browserOptions = withThinkSessionDefaults(options);
+  const handlers = createBrowserToolHandlers(browserOptions);
 
-  return {
+  const browserTools: ToolSet = {
     browser_search: tool({
       description: SEARCH_DESCRIPTION,
       inputSchema: z.object({
@@ -127,4 +135,44 @@ export function createBrowserTools(
       }
     })
   };
+
+  if (hasReusableBrowserSession(browserOptions)) {
+    browserTools.browser_session_info = tool({
+      description: SESSION_INFO_DESCRIPTION,
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await handlers.sessionInfo();
+        if (result.isError) {
+          throw new Error(result.text);
+        }
+        return result.text;
+      }
+    });
+
+    browserTools.browser_close_session = tool({
+      description: CLOSE_SESSION_DESCRIPTION,
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await handlers.closeSession();
+        if (result.isError) {
+          throw new Error(result.text);
+        }
+        return result.text;
+      }
+    });
+
+    browserTools.browser_reset_session = tool({
+      description: RESET_SESSION_DESCRIPTION,
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await handlers.resetSession();
+        if (result.isError) {
+          throw new Error(result.text);
+        }
+        return result.text;
+      }
+    });
+  }
+
+  return browserTools;
 }


### PR DESCRIPTION
## Summary

Adds an opt-in reusable Browser Run session mode for the Agents browser tools, while keeping the existing one-shot `browser_execute` behavior as the default.

This lets callers run multiple browser tool calls against the same underlying Browser Run session so tabs, cookies, local storage, navigation state, and page context can persist across an agent workflow.

A demo of the feature is available here: https://browser-reuse-demo.agents-b8a.workers.dev/

## What changed

- Added reusable browser session lifecycle support in `agents/browser`:
  - `session: { mode: "reuse" }`
  - configurable session key / store
  - Browser Run `keep_alive` support
  - Live View target metadata support
- Added lifecycle tools when reusable sessions are enabled:
  - `browser_session_info`
  - `browser_close_session`
  - `browser_reset_session`
- Updated CDP session handling so reusable mode disconnects the WebSocket after each tool call without deleting the Browser Run session.
- Added Browser Run session helpers for create, reconnect, target listing, and delete operations.
- Added Think integration that stores the Browser Run session id in the agent Durable Object SQLite database.
- Added Think `browser-session` broadcasts so UIs can expose Live View links without requiring the model to put them in chat text.
- Updated browser docs and Think tool docs for one-shot vs reusable mode, lifecycle expectations, Live View, limits, and cleanup.

## Testing

- `npm --workspace agents run test:browser`
- `npm --workspace @cloudflare/think run test -- src/tests/browser-tools.test.ts`
- `npm --workspace @cloudflare/think run test:e2e -- browser-tools-e2e.test.ts`

## Notes

- One-shot browser execution remains the default behavior.
- Reusable sessions require the Browser Rendering binding; `cdpUrl` remains externally managed and does not support SDK-owned reusable lifecycle operations.
- Callers should explicitly close reusable sessions when a browsing task is complete to avoid unnecessary Browser Run usage.

Fixes #1398

