### PR TITLE
Follow-up cleanups for recent chat and voice PRs

### DIFF
--- a/.changeset/calm-cups-reflect.md
+++ b/.changeset/calm-cups-reflect.md
@@ -3,4 +3,4 @@
 "@cloudflare/ai-chat": patch
 ---
 
-Avoid throwing when chat stream resume/replay races with a closed WebSocket connection.
+Avoid throwing when chat stream resume negotiation/replay races with a closed WebSocket connection.

--- a/.changeset/fix-agent-tool-reconcile-finish.md
+++ b/.changeset/fix-agent-tool-reconcile-finish.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Fixed a bug that could cause client state to drift from internal Durable Object state when agent tool calls spanned a Durable Object restart.
+Fixed a bug that could cause client state to drift from internal Durable Object state when agent tool calls spanned a Durable Object restart. Recovery now defers user finish hooks until after agent startup and isolates hook failures so one failed mirror write does not block other recovered runs from finalizing.

--- a/.changeset/fix-voice-stt-turns.md
+++ b/.changeset/fix-voice-stt-turns.md
@@ -4,4 +4,4 @@
 
 Fix Workers AI STT session edge cases for Flux and Nova 3.
 
-Flux now preserves the latest non-empty interim transcript for the active turn so an `EndOfTurn` event with an empty `transcript` can still emit the completed utterance. Nova 3 now defensively normalizes finalized segment state before reading it to avoid stale teardown messages throwing during abnormal close paths.
+Flux now preserves the latest non-empty turn transcript from turn lifecycle events so an `EndOfTurn` event with an empty `transcript` can still emit the completed utterance. Flux `StartOfTurn` also drives server-side barge-in so model-detected user speech aborts active LLM/TTS playback promptly. Nova 3 now defensively normalizes finalized segment state before reading it to avoid stale teardown messages throwing during abnormal close paths.

--- a/.changeset/think-replay-sendifopen.md
+++ b/.changeset/think-replay-sendifopen.md
@@ -2,4 +2,4 @@
 "@cloudflare/think": patch
 ---
 
-Avoid throwing when the chat stream resume ACK fallback races with a closed WebSocket connection. The `_handleStreamResumeAck` fallback that fires when `ResumableStream.replayCompletedChunksByRequestId` returns `false` now goes through a `sendIfOpen` helper that swallows the `TypeError: WebSocket send() after close` race instead of letting it propagate up through `onMessage`.
+Avoid throwing when chat stream resume negotiation/replay races with a closed WebSocket connection. Resume protocol sends and the `_handleStreamResumeAck` fallback now go through `sendIfOpen` helpers that swallow the `TypeError: WebSocket send() after close` race instead of letting it propagate up through `onMessage`.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -340,7 +340,7 @@ const {
 });
 ```
 
-Use `enabled: false` when the app must wait for async connection prerequisites, such as a user-scoped capability token. While disabled, the hook does not create or connect a `VoiceClient` and returns the idle/disconnected state. When `enabled` changes to `true`, the hook connects with the current options.
+Use `enabled: false` when the app must wait for async connection prerequisites, such as a user-scoped capability token. While disabled, the hook does not create or connect a `VoiceClient`, returns the idle/disconnected state, and action callbacks such as `startCall()`, `sendText()`, and `sendJSON()` are safe no-ops. When `enabled` changes to `true`, the hook connects with the current options. The first enable is treated as an initial connection, so `onReconnect` only fires for later connection identity changes while the hook remains enabled.
 
 #### Tuning Options
 

--- a/examples/voice-agent/README.md
+++ b/examples/voice-agent/README.md
@@ -4,16 +4,16 @@ A real-time voice agent running entirely inside a Durable Object. Talk to an AI 
 
 Uses Workers AI for all models — zero external API keys required:
 
-- **STT**: Deepgram Nova 3 (`@cf/deepgram/nova-3`)
+- **STT**: Deepgram Flux (`@cf/deepgram/flux`) by default, with a Nova 3 (`@cf/deepgram/nova-3`) option in the UI
 - **TTS**: Deepgram Aura (`@cf/deepgram/aura-1`)
-- **VAD**: Pipecat Smart Turn v2 (`@cf/pipecat-ai/smart-turn-v2`)
-- **LLM**: Kimi K2.5 (`@cf/moonshotai/kimi-k2.5`)
+- **Turn detection**: Flux `StartOfTurn` / `EndOfTurn` events
+- **LLM**: Kimi K2.6 (`@cf/moonshotai/kimi-k2.6`), GPT OSS 20B, or GLM 4.7 Flash
 
 ## Run it
 
 ```bash
 npm install
-npm run dev
+npm run start
 ```
 
 No API keys needed — all AI models run via the Workers AI binding.
@@ -25,11 +25,10 @@ Browser                          Durable Object (VoiceAgent)
 ┌──────────┐   binary WS frames   ┌──────────────────────────┐
 │ Mic PCM  │ ────────────────────► │ Audio Buffer             │
 │ (16kHz)  │                       │   ↓                      │
-│          │   JSON: end_of_speech │ VAD (smart-turn-v2)      │
-│          │ ────────────────────► │   ↓                      │
-│          │                       │ STT (nova-3)             │
+│          │                       │ STT (flux)               │
+│          │                       │   ↓                      │
 │          │   JSON: transcript    │   ↓                      │
-│          │ ◄──────────────────── │ LLM (kimi-k2.5)      │
+│          │ ◄──────────────────── │ LLM                      │
 │          │   binary: MP3 audio   │   ↓ (sentence chunking)  │
 │ Speaker  │ ◄──────────────────── │ TTS (aura-1, streaming)  │
 └──────────┘                       └──────────────────────────┘
@@ -38,17 +37,16 @@ Browser                          Durable Object (VoiceAgent)
 
 1. Browser captures mic audio via AudioWorklet, downsamples to 16kHz mono PCM
 2. PCM streams to the Agent over the existing WebSocket connection (binary frames)
-3. Client-side silence detection (500ms) triggers end-of-speech
-4. Server-side VAD (smart-turn-v2) confirms the user finished speaking
-5. Agent runs the voice pipeline: STT → LLM (with tools) → streaming TTS
-6. TTS audio streams back per-sentence as MP3 while the LLM is still generating
-7. Browser decodes and plays audio; user can interrupt at any time
+3. Flux detects speech start and turn completion server-side
+4. Agent runs the voice pipeline: STT → LLM (with tools) → streaming TTS
+5. TTS audio streams back per-sentence as MP3 while the LLM is still generating
+6. Browser decodes and plays audio; user can interrupt at any time
 
 ## Features
 
 - **Streaming TTS** — LLM output is split into sentences and synthesized concurrently, so the user hears the first sentence while the rest is still being generated.
-- **Interruption handling** — speak over the agent to cut it off mid-sentence. The client detects sustained speech during playback and aborts the server pipeline.
-- **Server-side VAD** — `smart-turn-v2` validates end-of-speech after client silence detection, reducing false triggers on mid-sentence pauses.
+- **Interruption handling** — speak over the agent to cut it off mid-sentence. Flux speech-start events abort the server pipeline and stop queued browser playback; client audio-level detection remains as a fallback.
+- **Server-side turn detection** — Flux handles speech boundaries, so the example does not need client-side end-of-speech signaling to run the voice pipeline.
 - **Conversation persistence** — all messages are stored in SQLite and survive restarts. The agent remembers previous conversations.
 - **Agent tools** — the LLM can call `get_current_time`, `set_reminder`, and `get_weather` during conversation.
 - **Proactive scheduling** — reminders set via voice fire on schedule and are spoken to connected clients (or saved to history if disconnected).

--- a/packages/agents/src/chat/__tests__/continuation-state.test.ts
+++ b/packages/agents/src/chat/__tests__/continuation-state.test.ts
@@ -132,6 +132,41 @@ describe("ContinuationState", () => {
     expect(state.awaitingConnections.size).toBe(0);
   });
 
+  it("sendResumeNone ignores connections closed during resume negotiation", () => {
+    const state = new ContinuationState();
+    const conn1 = makeConnection("c1");
+    const conn2: ContinuationConnection = {
+      id: "c2",
+      send: vi.fn(() => {
+        throw new TypeError("WebSocket send() after close");
+      })
+    };
+    state.awaitingConnections.set("c1", conn1);
+    state.awaitingConnections.set("c2", conn2);
+
+    expect(() => state.sendResumeNone()).not.toThrow();
+
+    const expected = JSON.stringify({
+      type: "cf_agent_stream_resume_none"
+    });
+    expect(conn1.send).toHaveBeenCalledWith(expected);
+    expect(conn2.send).toHaveBeenCalledWith(expected);
+    expect(state.awaitingConnections.size).toBe(0);
+  });
+
+  it("sendResumeNone rethrows non-closed WebSocket send errors", () => {
+    const state = new ContinuationState();
+    const conn: ContinuationConnection = {
+      id: "c1",
+      send: vi.fn(() => {
+        throw new TypeError("unexpected send failure");
+      })
+    };
+    state.awaitingConnections.set("c1", conn);
+
+    expect(() => state.sendResumeNone()).toThrow("unexpected send failure");
+  });
+
   it("sendResumeNone is a no-op when no connections are waiting", () => {
     const state = new ContinuationState();
     state.sendResumeNone();

--- a/packages/agents/src/chat/continuation-state.ts
+++ b/packages/agents/src/chat/continuation-state.ts
@@ -15,6 +15,26 @@ import type { ClientToolSchema } from "./client-tools";
 
 const MSG_STREAM_RESUME_NONE = CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE;
 
+function sendIfOpen(
+  connection: ContinuationConnection,
+  message: string
+): boolean {
+  try {
+    connection.send(message);
+    return true;
+  } catch (error) {
+    if (isWebSocketClosedSendError(error)) return false;
+    throw error;
+  }
+}
+
+function isWebSocketClosedSendError(error: unknown): boolean {
+  return (
+    error instanceof TypeError &&
+    error.message.includes("WebSocket send() after close")
+  );
+}
+
 /**
  * Minimal connection interface for sending WebSocket messages.
  * Matches the Connection type from agents without importing it.
@@ -77,7 +97,7 @@ export class ContinuationState {
   sendResumeNone(): void {
     const msg = JSON.stringify({ type: MSG_STREAM_RESUME_NONE });
     for (const connection of this.awaitingConnections.values()) {
-      connection.send(msg);
+      sendIfOpen(connection, msg);
     }
     this.awaitingConnections.clear();
   }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2009,6 +2009,9 @@ export class Agent<
             } finally {
               this._insideOnStart = false;
             }
+            // Recovered finish hooks run only after successful user startup.
+            // If onStart fails, durable recovery state is already finalized,
+            // but user hook side effects may depend on startup-initialized mirrors.
             await this._runDeferredAgentToolFinishHooks(
               recoveredAgentToolFinishes
             );

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -566,6 +566,8 @@ type AgentToolRunStorageRow = {
   completed_at: number | null;
 };
 
+type DeferredAgentToolFinish = () => Promise<void>;
+
 export type ScheduleCriteria = {
   id?: string;
   type?: "scheduled" | "delayed" | "cron" | "interval";
@@ -1994,15 +1996,23 @@ export class Agent<
 
             this._checkOrphanedWorkflows();
             await this._checkRunFibers();
-            await this._reconcileAgentToolRuns();
+            const recoveredAgentToolFinishes =
+              await this._reconcileAgentToolRuns({
+                deferFinishHooks: true
+              });
 
             this._insideOnStart = true;
             this._warnedScheduleInOnStart.clear();
+            let result: Awaited<ReturnType<typeof _onStart>>;
             try {
-              return await _onStart(props);
+              result = await _onStart(props);
             } finally {
               this._insideOnStart = false;
             }
+            await this._runDeferredAgentToolFinishHooks(
+              recoveredAgentToolFinishes
+            );
+            return result;
           });
         }
       );
@@ -6096,8 +6106,12 @@ export class Agent<
   private async _finishAgentToolRun<Output>(
     run: AgentToolRunInfo,
     result: RunAgentToolResult<Output>,
-    options?: { sequence?: number; completedAt?: number }
-  ): Promise<void> {
+    options?: {
+      sequence?: number;
+      completedAt?: number;
+      deferFinishHook?: boolean;
+    }
+  ): Promise<DeferredAgentToolFinish | undefined> {
     const completedAt = options?.completedAt ?? Date.now();
     this._updateAgentToolTerminal(run.runId, result, completedAt);
     if (options?.sequence !== undefined) {
@@ -6107,10 +6121,31 @@ export class Agent<
         result
       );
     }
-    await this.onAgentToolFinish(
-      { ...run, status: result.status, completedAt },
-      result
-    );
+    const finish = () =>
+      this.onAgentToolFinish(
+        { ...run, status: result.status, completedAt },
+        result
+      );
+    if (options?.deferFinishHook) return finish;
+    await finish();
+    return undefined;
+  }
+
+  private async _runDeferredAgentToolFinishHooks(
+    hooks: DeferredAgentToolFinish[]
+  ): Promise<void> {
+    for (const hook of hooks) {
+      try {
+        await hook();
+      } catch (error) {
+        try {
+          await this.onError(error);
+        } catch {
+          // Recovery hooks are best-effort; one failed mirror write should not
+          // prevent the agent from starting or other recovered runs finalizing.
+        }
+      }
+    }
   }
 
   private _updateAgentToolTerminal<Output>(
@@ -6486,7 +6521,10 @@ export class Agent<
     }
   }
 
-  private async _reconcileAgentToolRuns(): Promise<void> {
+  private async _reconcileAgentToolRuns(options?: {
+    deferFinishHooks?: boolean;
+  }): Promise<DeferredAgentToolFinish[]> {
+    const deferredFinishes: DeferredAgentToolFinish[] = [];
     const rows = this.sql<AgentToolRunStorageRow>`
       SELECT run_id, parent_tool_call_id, agent_type, input_preview, status,
              summary, output_json, error_message, display_metadata, display_order,
@@ -6538,15 +6576,20 @@ export class Agent<
           error: "Agent tool run could not be inspected during parent recovery."
         };
       }
-      await this._finishAgentToolRun(
+      const deferredFinish = await this._finishAgentToolRun(
         this._agentToolRunInfoFromRow(row),
         result,
         {
           sequence,
-          completedAt
+          completedAt,
+          deferFinishHook: options?.deferFinishHooks
         }
       );
+      if (deferredFinish) {
+        deferredFinishes.push(deferredFinish);
+      }
     }
+    return deferredFinishes;
   }
 
   /**

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -844,7 +844,8 @@ export class AIChatAgent<
               this._continuation.activeConnectionId !== null &&
               this._continuation.activeConnectionId !== connection.id
             ) {
-              connection.send(
+              sendIfOpen(
+                connection,
                 JSON.stringify({
                   type: MessageType.CF_AGENT_STREAM_RESUME_NONE
                 })
@@ -861,7 +862,8 @@ export class AIChatAgent<
               connection
             );
           } else {
-            connection.send(
+            sendIfOpen(
+              connection,
               JSON.stringify({
                 type: MessageType.CF_AGENT_STREAM_RESUME_NONE
               })
@@ -1119,17 +1121,19 @@ export class AIChatAgent<
       return;
     }
 
-    // Add connection to pending set - they'll be excluded from live broadcasts
-    // until they send ACK to receive the full stream replay
-    this._pendingResumeConnections.add(connection.id);
-
     // Notify client - they will send ACK when ready
-    connection.send(
+    const sent = sendIfOpen(
+      connection,
       JSON.stringify({
         type: MessageType.CF_AGENT_STREAM_RESUMING,
         id: this._resumableStream.activeRequestId
       })
     );
+    if (sent) {
+      // Add connection to pending set - they'll be excluded from live broadcasts
+      // until they send ACK to receive the full stream replay
+      this._pendingResumeConnections.add(connection.id);
+    }
   }
 
   // ── Delegate methods for backward compatibility with tests ─────────

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -84,6 +84,21 @@ type ParentStub = DurableObjectStub & {
     finishesBeforeDrain: number;
     lifecycleOrder: string[];
   }>;
+  reconcileCompletedChildWithFailedStartupForTest(
+    input: {
+      prompt: string;
+      delayMs?: number;
+      chunkDelayMs?: number;
+      structured?: boolean;
+      streamError?: string;
+    },
+    runId?: string
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    deferredHookCount: number;
+    lifecycleOrder: string[];
+  }>;
   reconcileCompletedChildWithReplayFailureForTest(
     input: {
       prompt: string;
@@ -316,6 +331,28 @@ describe("AIChatAgent as an agent-tool child", () => {
     });
     expect(finishes).toHaveLength(1);
     expect(lifecycleOrder).toEqual(["after-on-start", `finish:${runId}`]);
+  });
+
+  it("skips recovered finish hooks when startup fails after internal recovery", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, deferredHookCount, lifecycleOrder } =
+      await parent.reconcileCompletedChildWithFailedStartupForTest(
+        { prompt: "failed startup child" },
+        runId
+      );
+
+    expect(deferredHookCount).toBe(1);
+    expect(finishes).toHaveLength(0);
+    expect(lifecycleOrder).toEqual(["on-start-error"]);
+    expect(events.at(-1)).toMatchObject({
+      event: {
+        kind: "finished",
+        runId,
+        summary: "AIChat child handled: failed startup child"
+      }
+    });
   });
 
   it("still finalizes recovery when stored chunk replay fails", async () => {

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -52,6 +52,55 @@ type ParentStub = DurableObjectStub & {
     finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
     inspection: AgentToolRunInspection;
   }>;
+  reconcileRunningChildForTest(
+    input: {
+      prompt: string;
+      delayMs?: number;
+      chunkDelayMs?: number;
+      structured?: boolean;
+      streamError?: string;
+    },
+    runId?: string
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+  }>;
+  reconcileMissingChildForTest(runId?: string): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+  }>;
+  reconcileCompletedChildWithDeferredFinishForTest(
+    input: {
+      prompt: string;
+      delayMs?: number;
+      chunkDelayMs?: number;
+      structured?: boolean;
+      streamError?: string;
+    },
+    runId?: string
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    finishesBeforeDrain: number;
+    lifecycleOrder: string[];
+  }>;
+  reconcileCompletedChildWithReplayFailureForTest(
+    input: {
+      prompt: string;
+      delayMs?: number;
+      chunkDelayMs?: number;
+      structured?: boolean;
+      streamError?: string;
+    },
+    runId?: string
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+  }>;
+  reconcileTwoCompletedChildrenWithThrowingFinishForTest(): Promise<{
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    lifecycleOrder: string[];
+  }>;
   inspectChild(runId: string): Promise<AgentToolRunInspection | null>;
   getChildChunks(
     runId: string,
@@ -181,6 +230,137 @@ describe("AIChatAgent as an agent-tool child", () => {
         summary: "AIChat child handled: recover completed child"
       }
     });
+  });
+
+  it("marks still-running recovered children interrupted and emits lifecycle events", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes } = await parent.reconcileRunningChildForTest(
+      { prompt: "still running child" },
+      runId
+    );
+
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          parentToolCallId: "test-tool-call",
+          agentType: "AIChatAgentToolChild",
+          status: "interrupted",
+          inputPreview: "still running child"
+        }),
+        result: expect.objectContaining({
+          status: "interrupted",
+          error:
+            "Agent tool run was still running, but live-tail reattachment is not supported in this runtime."
+        })
+      }
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      parentToolCallId: "test-tool-call",
+      event: {
+        kind: "interrupted",
+        runId,
+        error:
+          "Agent tool run was still running, but live-tail reattachment is not supported in this runtime."
+      }
+    });
+  });
+
+  it("marks uninspectable recovered children interrupted and emits lifecycle events", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes } =
+      await parent.reconcileMissingChildForTest(runId);
+
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          parentToolCallId: "test-tool-call",
+          agentType: "MissingAgentToolChild",
+          status: "interrupted",
+          inputPreview: "missing child"
+        }),
+        result: expect.objectContaining({
+          status: "interrupted",
+          error: "Agent tool run could not be inspected during parent recovery."
+        })
+      }
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      parentToolCallId: "test-tool-call",
+      event: {
+        kind: "interrupted",
+        runId,
+        error: "Agent tool run could not be inspected during parent recovery."
+      }
+    });
+  });
+
+  it("defers recovered finish hooks until after startup work", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, finishesBeforeDrain, lifecycleOrder } =
+      await parent.reconcileCompletedChildWithDeferredFinishForTest(
+        { prompt: "deferred finish child" },
+        runId
+      );
+
+    expect(finishesBeforeDrain).toBe(0);
+    expect(events.at(-1)).toMatchObject({
+      event: { kind: "finished", runId }
+    });
+    expect(finishes).toHaveLength(1);
+    expect(lifecycleOrder).toEqual(["after-on-start", `finish:${runId}`]);
+  });
+
+  it("still finalizes recovery when stored chunk replay fails", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes } =
+      await parent.reconcileCompletedChildWithReplayFailureForTest(
+        { prompt: "replay failure child" },
+        runId
+      );
+
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          status: "completed",
+          inputPreview: "replay failure child"
+        }),
+        result: expect.objectContaining({
+          status: "completed",
+          summary: "AIChat child handled: replay failure child"
+        })
+      }
+    ]);
+    expect(events.map((event) => event.event.kind)).toEqual(["finished"]);
+    expect(events.at(-1)).toMatchObject({
+      event: {
+        kind: "finished",
+        runId,
+        summary: "AIChat child handled: replay failure child"
+      }
+    });
+  });
+
+  it("continues draining recovered finish hooks when one hook throws", async () => {
+    const parent = await getParent();
+
+    const { finishes, lifecycleOrder } =
+      await parent.reconcileTwoCompletedChildrenWithThrowingFinishForTest();
+
+    expect(finishes).toHaveLength(2);
+    expect(lifecycleOrder).toEqual(
+      finishes.map(({ run }) => `finish:${run.runId}`)
+    );
   });
 
   it("returns the retained parent registry result without re-running the child", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -2142,6 +2142,40 @@ export class AIChatAgentToolParent extends Agent<Env> {
     };
   }
 
+  async reconcileCompletedChildWithFailedStartupForTest(
+    input: AgentToolInput,
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    deferredHookCount: number;
+    lifecycleOrder: string[];
+  }> {
+    await this.prepareCompletedChildForRecoveryTest(input, runId);
+    this.events = [];
+    this.finishes = [];
+    this.lifecycleOrder = [];
+
+    const hooks = await this.reconcileAgentToolRunsForTest({
+      deferFinishHooks: true
+    });
+
+    try {
+      this.lifecycleOrder.push("on-start-error");
+      throw new Error("test startup failure");
+    } catch {
+      // Mirrors the Agent startup contract: recovered finish hooks are only
+      // drained after successful user startup.
+    }
+
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      deferredHookCount: hooks.length,
+      lifecycleOrder: this.lifecycleOrder
+    };
+  }
+
   async reconcileCompletedChildWithReplayFailureForTest(
     input: AgentToolInput,
     runId = crypto.randomUUID()

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1888,6 +1888,8 @@ type AgentToolFinishForTest = {
 export class AIChatAgentToolParent extends Agent<Env> {
   private events: AgentToolEventMessage[] = [];
   private finishes: AgentToolFinishForTest[] = [];
+  private finishRunIdsToThrow = new Set<string>();
+  private lifecycleOrder: string[] = [];
 
   override broadcast(
     msg: string | ArrayBuffer | ArrayBufferView,
@@ -1911,6 +1913,10 @@ export class AIChatAgentToolParent extends Agent<Env> {
     result: AgentToolLifecycleResult
   ): Promise<void> {
     this.finishes.push({ run, result });
+    this.lifecycleOrder.push(`finish:${run.runId}`);
+    if (this.finishRunIdsToThrow.has(run.runId)) {
+      throw new Error(`finish failed for ${run.runId}`);
+    }
   }
 
   async runChild(
@@ -1959,6 +1965,87 @@ export class AIChatAgentToolParent extends Agent<Env> {
     return this.finishes;
   }
 
+  private insertRecoverableParentRunForTest(
+    runId: string,
+    agentType: string,
+    inputPreview: string,
+    startedAt: number,
+    status: "starting" | "running" = "running"
+  ): void {
+    this.sql`
+      INSERT INTO cf_agent_tool_runs (
+        run_id, parent_tool_call_id, agent_type, input_preview,
+        input_redacted, status, display_metadata, display_order, started_at
+      ) VALUES (
+        ${runId}, 'test-tool-call', ${agentType},
+        ${JSON.stringify(inputPreview)}, 1, ${status},
+        ${JSON.stringify({ name: "test child" })}, 0, ${startedAt}
+      )
+    `;
+  }
+
+  private async waitForTerminalInspectionForTest(
+    child: {
+      inspectAgentToolRun(
+        runId: string
+      ): Promise<AgentToolRunInspection | null>;
+    },
+    runId: string
+  ): Promise<AgentToolRunInspection> {
+    let inspection = await child.inspectAgentToolRun(runId);
+    for (let attempt = 0; attempt < 50; attempt++) {
+      if (
+        inspection &&
+        inspection.status !== "running" &&
+        inspection.status !== "starting"
+      ) {
+        return inspection;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      inspection = await child.inspectAgentToolRun(runId);
+    }
+    throw new Error("Timed out waiting for child agent-tool completion");
+  }
+
+  private async prepareCompletedChildForRecoveryTest(
+    input: AgentToolInput,
+    runId: string
+  ): Promise<AgentToolRunInspection> {
+    const child = await this.subAgent(AIChatAgentToolChild, runId);
+    const started = await child.startAgentToolRun(input, { runId });
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "AIChatAgentToolChild",
+      input.prompt,
+      started.startedAt
+    );
+    return this.waitForTerminalInspectionForTest(child, runId);
+  }
+
+  private async reconcileAgentToolRunsForTest(options?: {
+    deferFinishHooks?: boolean;
+  }): Promise<Array<() => Promise<void>>> {
+    return (
+      this as unknown as {
+        _reconcileAgentToolRuns(options?: {
+          deferFinishHooks?: boolean;
+        }): Promise<Array<() => Promise<void>>>;
+      }
+    )._reconcileAgentToolRuns(options);
+  }
+
+  private async runDeferredAgentToolFinishHooksForTest(
+    hooks: Array<() => Promise<void>>
+  ): Promise<void> {
+    await (
+      this as unknown as {
+        _runDeferredAgentToolFinishHooks(
+          hooks: Array<() => Promise<void>>
+        ): Promise<void>;
+      }
+    )._runDeferredAgentToolFinishHooks(hooks);
+  }
+
   async reconcileCompletedChildForTest(
     input: AgentToolInput,
     runId = crypto.randomUUID()
@@ -1967,46 +2054,155 @@ export class AIChatAgentToolParent extends Agent<Env> {
     finishes: AgentToolFinishForTest[];
     inspection: AgentToolRunInspection;
   }> {
-    const child = await this.subAgent(AIChatAgentToolChild, runId);
-    const started = await child.startAgentToolRun(input, { runId });
-    this.sql`
-      INSERT INTO cf_agent_tool_runs (
-        run_id, parent_tool_call_id, agent_type, input_preview,
-        input_redacted, status, display_metadata, display_order, started_at
-      ) VALUES (
-        ${runId}, 'test-tool-call', 'AIChatAgentToolChild',
-        ${JSON.stringify(input.prompt)}, 1, 'running',
-        ${JSON.stringify({ name: "test child" })}, 0, ${started.startedAt}
-      )
-    `;
+    const inspection = await this.prepareCompletedChildForRecoveryTest(
+      input,
+      runId
+    );
+    this.events = [];
+    this.finishes = [];
+    await this.reconcileAgentToolRunsForTest();
 
-    let inspection = await child.inspectAgentToolRun(runId);
-    for (let attempt = 0; attempt < 50; attempt++) {
-      if (
-        inspection &&
-        inspection.status !== "running" &&
-        inspection.status !== "starting"
-      ) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 20));
-      inspection = await child.inspectAgentToolRun(runId);
-    }
-    if (
-      !inspection ||
-      inspection.status === "running" ||
-      inspection.status === "starting"
-    ) {
-      throw new Error("Timed out waiting for child agent-tool completion");
-    }
+    return { events: this.events, finishes: this.finishes, inspection };
+  }
+
+  async reconcileRunningChildForTest(
+    input: AgentToolInput,
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+  }> {
+    const child = await this.subAgent(AIChatAgentToolChild, runId);
+    const started = await child.startAgentToolRun(
+      { ...input, delayMs: input.delayMs ?? 10_000 },
+      { runId }
+    );
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "AIChatAgentToolChild",
+      input.prompt,
+      started.startedAt
+    );
 
     this.events = [];
     this.finishes = [];
-    await (
-      this as unknown as { _reconcileAgentToolRuns(): Promise<void> }
-    )._reconcileAgentToolRuns();
+    try {
+      await this.reconcileAgentToolRunsForTest();
+    } finally {
+      await child.cancelAgentToolRun(runId, "test cleanup");
+    }
 
-    return { events: this.events, finishes: this.finishes, inspection };
+    return { events: this.events, finishes: this.finishes };
+  }
+
+  async reconcileMissingChildForTest(runId = crypto.randomUUID()): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "MissingAgentToolChild",
+      "missing child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    await this.reconcileAgentToolRunsForTest();
+
+    return { events: this.events, finishes: this.finishes };
+  }
+
+  async reconcileCompletedChildWithDeferredFinishForTest(
+    input: AgentToolInput,
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    finishesBeforeDrain: number;
+    lifecycleOrder: string[];
+  }> {
+    await this.prepareCompletedChildForRecoveryTest(input, runId);
+    this.events = [];
+    this.finishes = [];
+    this.lifecycleOrder = [];
+
+    const hooks = await this.reconcileAgentToolRunsForTest({
+      deferFinishHooks: true
+    });
+    const finishesBeforeDrain = this.finishes.length;
+    this.lifecycleOrder.push("after-on-start");
+    await this.runDeferredAgentToolFinishHooksForTest(hooks);
+
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      finishesBeforeDrain,
+      lifecycleOrder: this.lifecycleOrder
+    };
+  }
+
+  async reconcileCompletedChildWithReplayFailureForTest(
+    input: AgentToolInput,
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+  }> {
+    await this.prepareCompletedChildForRecoveryTest(input, runId);
+    this.events = [];
+    this.finishes = [];
+
+    type BroadcastStoredChunks = (
+      row: unknown,
+      sequence: number,
+      replay?: true,
+      connection?: unknown
+    ) => Promise<number>;
+    const self = this as unknown as {
+      _broadcastAgentToolStoredChunks: BroadcastStoredChunks;
+    };
+    const original = self._broadcastAgentToolStoredChunks.bind(
+      this
+    ) as BroadcastStoredChunks;
+    self._broadcastAgentToolStoredChunks = async () => {
+      throw new Error("test replay failure");
+    };
+    try {
+      await this.reconcileAgentToolRunsForTest();
+    } finally {
+      self._broadcastAgentToolStoredChunks = original;
+    }
+
+    return { events: this.events, finishes: this.finishes };
+  }
+
+  async reconcileTwoCompletedChildrenWithThrowingFinishForTest(): Promise<{
+    finishes: AgentToolFinishForTest[];
+    lifecycleOrder: string[];
+  }> {
+    const firstRunId = crypto.randomUUID();
+    const secondRunId = crypto.randomUUID();
+    await this.prepareCompletedChildForRecoveryTest(
+      { prompt: "first recovered child" },
+      firstRunId
+    );
+    await this.prepareCompletedChildForRecoveryTest(
+      { prompt: "second recovered child" },
+      secondRunId
+    );
+
+    this.events = [];
+    this.finishes = [];
+    this.lifecycleOrder = [];
+    this.finishRunIdsToThrow = new Set([firstRunId]);
+    const hooks = await this.reconcileAgentToolRunsForTest({
+      deferFinishHooks: true
+    });
+    await this.runDeferredAgentToolFinishHooksForTest(hooks);
+    this.finishRunIdsToThrow.clear();
+
+    return { finishes: this.finishes, lifecycleOrder: this.lifecycleOrder };
   }
 
   async inspectChild(runId: string): Promise<AgentToolRunInspection | null> {

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -239,6 +239,26 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(result.done).toBe(true);
   });
 
+  it("tool continuation closes and clears resolvers when socket closes before handshake", async () => {
+    transport.expectToolContinuation();
+
+    const stream = (await transport.reconnectToStream({
+      chatId: "chat-1"
+    })) as ReadableStream<UIMessageChunk>;
+    const reader = stream.getReader();
+
+    agent.close();
+
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined
+    });
+    expect(transport.handleStreamResuming({ id: "late-tool" })).toBe(false);
+    expect(transport.handleStreamResumeNone()).toBe(false);
+    expect(transport.abortActiveToolContinuation()).toBe(false);
+    expect(activeRequestIds.size).toBe(0);
+  });
+
   it("abortActiveToolContinuation sends cancel for the continuation request", async () => {
     transport.expectToolContinuation();
 
@@ -270,6 +290,39 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
     expect(transport.abortActiveToolContinuation()).toBe(true);
     expect(activeRequestIds.has("req-keep-id")).toBe(true);
+  });
+
+  it("tool continuation closes and removes requestId when socket closes mid-stream", async () => {
+    transport.expectToolContinuation();
+
+    const stream = (await transport.reconnectToStream({
+      chatId: "chat-1"
+    })) as ReadableStream<UIMessageChunk>;
+    const reader = stream.getReader();
+
+    expect(transport.handleStreamResuming({ id: "req-tool-close" })).toBe(true);
+    expect(activeRequestIds.has("req-tool-close")).toBe(true);
+
+    agent.dispatch({
+      type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+      id: "req-tool-close",
+      body: '{"type":"text-start","id":"t1"}',
+      done: false
+    });
+
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { type: "text-start", id: "t1" }
+    });
+
+    agent.close();
+
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined
+    });
+    expect(activeRequestIds.has("req-tool-close")).toBe(false);
+    expect(transport.abortActiveToolContinuation()).toBe(false);
   });
 
   it("abortActiveToolContinuation returns false when no continuation is active", async () => {
@@ -570,6 +623,36 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     await reader.read(); // { done: true }
 
     expect(activeRequestIds.has("req-cleanup")).toBe(false);
+  });
+
+  it("removes requestId from activeRequestIds when resumed stream socket closes", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+
+    transport.handleStreamResuming({ id: "req-close-cleanup" });
+    const stream = await promise;
+    const reader = stream!.getReader();
+
+    expect(activeRequestIds.has("req-close-cleanup")).toBe(true);
+
+    agent.dispatch({
+      type: "cf_agent_use_chat_response",
+      id: "req-close-cleanup",
+      body: '{"type":"text-start","id":"t1"}',
+      done: false
+    });
+
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { type: "text-start", id: "t1" }
+    });
+
+    agent.close();
+
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined
+    });
+    expect(activeRequestIds.has("req-close-cleanup")).toBe(false);
   });
 
   it("stream ignores chunks for different request IDs", async () => {

--- a/packages/ai-chat/src/ws-chat-transport.ts
+++ b/packages/ai-chat/src/ws-chat-transport.ts
@@ -549,7 +549,15 @@ export class WebSocketChatTransport<
           }
         };
 
+        const onClose = () => {
+          if (timeout) clearTimeout(timeout);
+          finish(() => controller.close(), onResume, onResumeNone);
+        };
+
         agent.addEventListener("message", onMessage, {
+          signal: streamController.signal
+        });
+        agent.addEventListener("close", onClose, {
           signal: streamController.signal
         });
 
@@ -631,7 +639,14 @@ export class WebSocketChatTransport<
           }
         };
 
+        const onClose = () => {
+          finish(() => controller.close());
+        };
+
         agent.addEventListener("message", onMessage, {
+          signal: chunkController.signal
+        });
+        agent.addEventListener("close", onClose, {
           signal: chunkController.signal
         });
       },

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2569,7 +2569,10 @@ export class Think<
         this._continuation.activeConnectionId !== null &&
         this._continuation.activeConnectionId !== connection.id
       ) {
-        connection.send(JSON.stringify({ type: MSG_STREAM_RESUME_NONE }));
+        sendIfOpen(
+          connection,
+          JSON.stringify({ type: MSG_STREAM_RESUME_NONE })
+        );
       } else {
         this._notifyStreamResuming(connection);
       }
@@ -2579,7 +2582,7 @@ export class Think<
     ) {
       this._continuation.awaitingConnections.set(connection.id, connection);
     } else {
-      connection.send(JSON.stringify({ type: MSG_STREAM_RESUME_NONE }));
+      sendIfOpen(connection, JSON.stringify({ type: MSG_STREAM_RESUME_NONE }));
     }
   }
 
@@ -3553,13 +3556,16 @@ export class Think<
 
   private _notifyStreamResuming(connection: Connection): void {
     if (!this._resumableStream.hasActiveStream()) return;
-    this._pendingResumeConnections.add(connection.id);
-    connection.send(
+    const sent = sendIfOpen(
+      connection,
       JSON.stringify({
         type: MSG_STREAM_RESUMING,
         id: this._resumableStream.activeRequestId
       })
     );
+    if (sent) {
+      this._pendingResumeConnections.add(connection.id);
+    }
   }
 
   private _persistOrphanedStream(streamId: string): void {

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -20,7 +20,7 @@ npm install @cloudflare/voice
 
 ## Server: full voice agent (`withVoice`)
 
-Adds the complete voice pipeline: continuous STT, LLM turn handling, streaming TTS, interruption, and conversation persistence.
+Adds the complete voice pipeline: continuous STT, LLM turn handling, streaming TTS, interruption, and conversation persistence. When the transcriber reports speech start, the pipeline aborts active LLM/TTS work and tells the client to stop any queued playback so users can barge in before a final transcript is available.
 
 ```typescript
 import { Agent } from "agents";
@@ -68,15 +68,15 @@ async onTurn(transcript: string) {
 
 ### Lifecycle hooks
 
-| Method                           | Description                                                                        |
-| -------------------------------- | ---------------------------------------------------------------------------------- |
-| `onTurn(transcript, context)`    | **Required.** Handle a user utterance. Return `string` or `AsyncIterable<string>`. |
-| `createTranscriber(connection)`  | Override to create a transcriber dynamically per connection.                       |
-| `onCallStart(connection)`        | Called when a voice call begins.                                                   |
-| `onCallEnd(connection)`          | Called when a voice call ends.                                                     |
-| `onInterrupt(connection)`        | Called when user interrupts playback.                                              |
-| `beforeCallStart(connection)`    | Return `false` to reject a call.                                                   |
-| `onMessage(connection, message)` | Handle non-voice WebSocket messages (voice protocol is intercepted automatically). |
+| Method                           | Description                                                                                                    |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `onTurn(transcript, context)`    | **Required.** Handle a user utterance. Return `string` or `AsyncIterable<string>`.                             |
+| `createTranscriber(connection)`  | Override to create a transcriber dynamically per connection.                                                   |
+| `onCallStart(connection)`        | Called when a voice call begins.                                                                               |
+| `onCallEnd(connection)`          | Called when a voice call ends.                                                                                 |
+| `onInterrupt(connection)`        | Called when user interrupts playback, either from client audio-level detection or model-detected speech start. |
+| `beforeCallStart(connection)`    | Return `false` to reject a call.                                                                               |
+| `onMessage(connection, message)` | Handle non-voice WebSocket messages (voice protocol is intercepted automatically).                             |
 
 ### Pipeline hooks
 
@@ -173,6 +173,8 @@ All default providers use Workers AI bindings -- no API keys required:
 | `WorkersAIFluxSTT`  | Continuous STT | `@cf/deepgram/flux`   | `withVoice`      |
 | `WorkersAINova3STT` | Continuous STT | `@cf/deepgram/nova-3` | `withVoiceInput` |
 | `WorkersAITTS`      | TTS            | `@cf/deepgram/aura-1` | Both             |
+
+`WorkersAIFluxSTT` uses Flux `StartOfTurn` events for low-latency barge-in and `EndOfTurn` events for final utterances. Custom transcribers can provide the same behavior by calling `onSpeechStart` from `TranscriberSessionOptions` when user speech begins, then `onUtterance` when the turn is complete.
 
 ## Third-party providers
 

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -143,6 +143,8 @@ function App() {
 }
 ```
 
+When `enabled` is `false`, the hook does not create or connect a `VoiceClient`, returns the idle/disconnected state, and action callbacks such as `startCall()`, `sendText()`, and `sendJSON()` are safe no-ops. The first change from disabled to enabled connects with the current options without firing `onReconnect`; later connection identity changes while enabled do fire `onReconnect`.
+
 For voice input only:
 
 ```tsx

--- a/packages/voice/src/audio-pipeline.ts
+++ b/packages/voice/src/audio-pipeline.ts
@@ -120,9 +120,12 @@ export class AudioConnectionManager {
     return controller.signal;
   }
 
-  abortPipeline(connectionId: string): void {
-    this.#activePipeline.get(connectionId)?.abort();
+  abortPipeline(connectionId: string): boolean {
+    const controller = this.#activePipeline.get(connectionId);
+    if (!controller) return false;
+    controller.abort();
     this.#activePipeline.delete(connectionId);
+    return true;
   }
 
   /**

--- a/packages/voice/src/react-tests/useVoiceAgent.test.tsx
+++ b/packages/voice/src/react-tests/useVoiceAgent.test.tsx
@@ -15,6 +15,14 @@ function sleep(ms: number) {
 // --- Mock plumbing ---
 
 // The mock PartySocket instance (set synchronously during construction)
+type MockPartySocketOptions = {
+  party?: string;
+  room?: string;
+  host?: string;
+  prefix?: string;
+  query?: Record<string, string | null | undefined>;
+};
+
 let socketInstance: {
   readyState: number;
   send: ReturnType<typeof vi.fn>;
@@ -28,9 +36,10 @@ let socketInstance: {
 let socketSend: ReturnType<typeof vi.fn>;
 let socketReadyState: number;
 let socketClose: ReturnType<typeof vi.fn>;
+let socketOptions: MockPartySocketOptions | null = null;
 
 vi.mock("partysocket", () => ({
-  PartySocket: vi.fn(function () {
+  PartySocket: vi.fn(function (options: MockPartySocketOptions) {
     const instance = {
       get readyState() {
         return socketReadyState;
@@ -43,6 +52,7 @@ vi.mock("partysocket", () => ({
       onmessage: null as ((event: MessageEvent) => void) | null
     };
     socketInstance = instance;
+    socketOptions = options;
     queueMicrotask(() => {
       instance.onopen?.();
     });
@@ -229,6 +239,7 @@ beforeEach(() => {
   socketClose = vi.fn();
   socketReadyState = WebSocket.OPEN;
   socketInstance = null;
+  socketOptions = null;
   setupAudioMocks();
 });
 
@@ -361,6 +372,68 @@ describe("useVoiceAgent", () => {
       await vi.waitFor(() => {
         expect(getLatestResult().connected).toBe(true);
       });
+    });
+
+    it("should connect with the latest query when enabled flips false to true", async () => {
+      const screen = await render(
+        <TestVoiceComponent
+          options={{
+            agent: "voice-agent",
+            enabled: false,
+            query: { capability: undefined }
+          }}
+          onResult={vi.fn()}
+        />
+      );
+      await sleep(10);
+
+      expect(vi.mocked(PartySocket)).not.toHaveBeenCalled();
+
+      await act(async () => {
+        screen.rerender(
+          <TestVoiceComponent
+            options={{
+              agent: "voice-agent",
+              enabled: true,
+              query: { capability: "ready-token" }
+            }}
+            onResult={vi.fn()}
+          />
+        );
+        await sleep(10);
+      });
+
+      expect(vi.mocked(PartySocket)).toHaveBeenCalledTimes(1);
+      expect(socketOptions?.query).toEqual({ capability: "ready-token" });
+    });
+
+    it("should fire onReconnect when connection identity changes while enabled", async () => {
+      const onReconnect = vi.fn();
+      const screen = await render(
+        <TestVoiceComponent
+          options={{ agent: "voice-agent", name: "first", onReconnect }}
+          onResult={vi.fn()}
+        />
+      );
+      await sleep(10);
+
+      expect(vi.mocked(PartySocket)).toHaveBeenCalledTimes(1);
+      expect(onReconnect).not.toHaveBeenCalled();
+
+      await act(async () => {
+        screen.rerender(
+          <TestVoiceComponent
+            options={{ agent: "voice-agent", name: "second", onReconnect }}
+            onResult={vi.fn()}
+          />
+        );
+        await sleep(10);
+      });
+
+      expect(socketClose).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(PartySocket)).toHaveBeenCalledTimes(2);
+      expect(socketOptions?.room).toBe("second");
+      expect(onReconnect).toHaveBeenCalledTimes(1);
     });
 
     it("should disconnect and reset state when enabled flips true to false", async () => {

--- a/packages/voice/src/tests/agents/voice.ts
+++ b/packages/voice/src/tests/agents/voice.ts
@@ -28,11 +28,13 @@ class TestTranscriberSession implements TranscriberSession {
   #utteranceCount = 0;
   #closed = false;
   #onInterim: ((text: string) => void) | undefined;
+  #onSpeechStart: ((text?: string) => void) | undefined;
   #onUtterance: ((text: string) => void) | undefined;
   #utteranceThreshold: number;
 
   constructor(options?: TranscriberSessionOptions, utteranceThreshold = 20000) {
     this.#onInterim = options?.onInterim;
+    this.#onSpeechStart = options?.onSpeechStart;
     this.#onUtterance = options?.onUtterance;
     this.#utteranceThreshold = utteranceThreshold;
   }
@@ -40,6 +42,7 @@ class TestTranscriberSession implements TranscriberSession {
   feed(chunk: ArrayBuffer): void {
     if (this.#closed) return;
     this.#totalBytes += chunk.byteLength;
+    this.#onSpeechStart?.(`hearing ${this.#totalBytes} bytes`);
     this.#onInterim?.(`hearing ${this.#totalBytes} bytes`);
 
     const nextThreshold = (this.#utteranceCount + 1) * this.#utteranceThreshold;
@@ -85,11 +88,15 @@ export class TestVoiceAgent extends VoiceBase {
   #callEndCount = 0;
   #interruptCount = 0;
   #beforeCallStartResult = true;
+  #turnDelayMs = 0;
 
   async onTurn(
     transcript: string,
     _context: VoiceTurnContext
   ): Promise<string> {
+    if (this.#turnDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.#turnDelayMs));
+    }
     return `Echo: ${transcript}`;
   }
 
@@ -116,6 +123,12 @@ export class TestVoiceAgent extends VoiceBase {
       switch (parsed.type) {
         case "_set_before_call_start":
           this.#beforeCallStartResult = parsed.value;
+          connection.send(
+            JSON.stringify({ type: "_ack", command: parsed.type })
+          );
+          break;
+        case "_set_turn_delay":
+          this.#turnDelayMs = parsed.value;
           connection.send(
             JSON.stringify({ type: "_ack", command: parsed.type })
           );

--- a/packages/voice/src/tests/text-stream.test.ts
+++ b/packages/voice/src/tests/text-stream.test.ts
@@ -95,4 +95,101 @@ describe("SSE parsing resilience", () => {
     const chunks = await collect(iterateText(stream));
     expect(chunks).toEqual(["hi"]);
   });
+
+  it("handles data lines without a space after the colon", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data:{"response":"hi"}\n'));
+        controller.enqueue(encoder.encode("data:[DONE]\n"));
+        controller.enqueue(encoder.encode('data:{"response":"ignored"}\n'));
+        controller.close();
+      }
+    });
+
+    const chunks = await collect(iterateText(stream));
+    expect(chunks).toEqual(["hi"]);
+  });
+});
+
+describe("NDJSON parsing resilience", () => {
+  it("parses raw newline-delimited JSON response chunks", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"response":"hello"}\n'));
+        controller.enqueue(encoder.encode('{"response":" world"}\n'));
+        controller.close();
+      }
+    });
+
+    const chunks = await collect(iterateText(stream));
+    expect(chunks).toEqual(["hello", " world"]);
+  });
+
+  it("parses raw OpenAI-style newline-delimited JSON chunks", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            '{"choices":[{"delta":{"role":"assistant","content":"hello"}}]}\n'
+          )
+        );
+        controller.enqueue(
+          encoder.encode(
+            '{"choices":[{"delta":{"role":"assistant","content":" world"}}]}\n'
+          )
+        );
+        controller.close();
+      }
+    });
+
+    const chunks = await collect(iterateText(stream));
+    expect(chunks).toEqual(["hello", " world"]);
+  });
+
+  it("survives malformed raw JSON lines without crashing", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"response":"hello"}\n'));
+        controller.enqueue(encoder.encode("{malformed json}\n"));
+        controller.enqueue(encoder.encode('{"response":" world"}\n'));
+        controller.close();
+      }
+    });
+
+    const chunks = await collect(iterateText(stream));
+    expect(chunks).toEqual(["hello", " world"]);
+  });
+
+  it("buffers raw JSON split across byte chunks", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"response":"hel'));
+        controller.enqueue(encoder.encode('lo"}\n{"response":" wor'));
+        controller.enqueue(encoder.encode('ld"}\n'));
+        controller.close();
+      }
+    });
+
+    const chunks = await collect(iterateText(stream));
+    expect(chunks).toEqual(["hello", " world"]);
+  });
+
+  it("parses the final raw JSON line without a trailing newline", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"response":"hello"}\n'));
+        controller.enqueue(encoder.encode('{"response":" world"}'));
+        controller.close();
+      }
+    });
+
+    const chunks = await collect(iterateText(stream));
+    expect(chunks).toEqual(["hello", " world"]);
+  });
 });

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -193,4 +193,46 @@ describe("VoiceClient playback interrupt", () => {
 
     expect(audioContext.source).toBeNull();
   });
+
+  it("does not start playback if call ends while audio is decoding", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+    audioContext.deferDecode = true;
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await Promise.resolve();
+
+    expect(audioContext.pendingDecode).toBeDefined();
+    client.endCall();
+    expect(transport.sentJSON).toContainEqual({ type: "end_call" });
+
+    audioContext.pendingDecode?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(audioContext.source).toBeNull();
+  });
+
+  it("does not start playback if client disconnects while audio is decoding", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+    audioContext.deferDecode = true;
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await Promise.resolve();
+
+    expect(audioContext.pendingDecode).toBeDefined();
+    client.disconnect();
+    expect(transport.connected).toBe(false);
+
+    audioContext.pendingDecode?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(audioContext.source).toBeNull();
+  });
 });

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VoiceClient } from "../voice-client";
+import type { VoiceTransport } from "../types";
+
+class MockTransport implements VoiceTransport {
+  sentJSON: Record<string, unknown>[] = [];
+  sentBinary: ArrayBuffer[] = [];
+  connected = false;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((error?: unknown) => void) | null = null;
+  onmessage: ((data: string | ArrayBuffer | Blob) => void) | null = null;
+
+  sendJSON(data: Record<string, unknown>): void {
+    this.sentJSON.push(data);
+  }
+
+  sendBinary(data: ArrayBuffer): void {
+    this.sentBinary.push(data);
+  }
+
+  connect(): void {
+    this.connected = true;
+    this.onopen?.();
+  }
+
+  disconnect(): void {
+    this.connected = false;
+    this.onclose?.();
+  }
+
+  receive(data: string | ArrayBuffer | Blob): void {
+    this.onmessage?.(data);
+  }
+}
+
+class FakeAudioBufferSourceNode {
+  buffer: AudioBuffer | null = null;
+  onended: (() => void) | null = null;
+  stopped = false;
+  started = false;
+
+  connect(): void {}
+
+  start(): void {
+    this.started = true;
+  }
+
+  stop(): void {
+    if (this.stopped) throw new Error("source already stopped");
+    this.stopped = true;
+    this.onended?.();
+  }
+}
+
+class FakeAudioContext {
+  state: AudioContextState = "running";
+  source: FakeAudioBufferSourceNode | null = null;
+  deferDecode = false;
+  pendingDecode: (() => void) | null = null;
+  destination = {};
+
+  async resume(): Promise<void> {}
+
+  async close(): Promise<void> {}
+
+  async decodeAudioData(_audioData: ArrayBuffer): Promise<AudioBuffer> {
+    if (!this.deferDecode) return {} as AudioBuffer;
+    return new Promise((resolve) => {
+      this.pendingDecode = () => resolve({} as AudioBuffer);
+    });
+  }
+
+  createBufferSource(): AudioBufferSourceNode {
+    this.source = new FakeAudioBufferSourceNode();
+    return this.source as unknown as AudioBufferSourceNode;
+  }
+}
+
+let originalAudioContext: typeof AudioContext | undefined;
+let audioContext: FakeAudioContext;
+
+async function waitForSource(): Promise<FakeAudioBufferSourceNode> {
+  for (let i = 0; i < 10; i++) {
+    if (audioContext.source) return audioContext.source;
+    await Promise.resolve();
+  }
+  throw new Error("expected audio source to be created");
+}
+
+describe("VoiceClient playback interrupt", () => {
+  beforeEach(() => {
+    originalAudioContext = globalThis.AudioContext;
+    audioContext = new FakeAudioContext();
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: class {
+        constructor() {
+          return audioContext;
+        }
+      }
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: originalAudioContext
+    });
+  });
+
+  it("stops active playback when the server sends playback_interrupt", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    transport.receive(new ArrayBuffer(4));
+
+    const source = await waitForSource();
+    expect(source.stopped).toBe(false);
+
+    transport.receive(JSON.stringify({ type: "playback_interrupt" }));
+    expect(() =>
+      transport.receive(JSON.stringify({ type: "playback_interrupt" }))
+    ).not.toThrow();
+
+    expect(source.stopped).toBe(true);
+  });
+
+  it("does not start playback if interrupted while audio is decoding", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+    audioContext.deferDecode = true;
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await Promise.resolve();
+
+    expect(audioContext.pendingDecode).toBeDefined();
+    transport.receive(JSON.stringify({ type: "playback_interrupt" }));
+    audioContext.pendingDecode?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(audioContext.source).toBeNull();
+  });
+});

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { VoiceClient } from "../voice-client";
-import type { VoiceTransport } from "../types";
+import type { VoiceAudioInput, VoiceTransport } from "../types";
 
 class MockTransport implements VoiceTransport {
   sentJSON: Record<string, unknown>[] = [];
@@ -77,6 +77,21 @@ class FakeAudioContext {
   }
 }
 
+class FakeAudioInput implements VoiceAudioInput {
+  onAudioLevel: ((rms: number) => void) | null = null;
+  onAudioData: ((pcm: ArrayBuffer) => void) | null = null;
+  started = false;
+  stopped = false;
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  stop(): void {
+    this.stopped = true;
+  }
+}
+
 let originalAudioContext: typeof AudioContext | undefined;
 let audioContext: FakeAudioContext;
 
@@ -141,6 +156,37 @@ describe("VoiceClient playback interrupt", () => {
 
     expect(audioContext.pendingDecode).toBeDefined();
     transport.receive(JSON.stringify({ type: "playback_interrupt" }));
+    audioContext.pendingDecode?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(audioContext.source).toBeNull();
+  });
+
+  it("does not start playback if client-side interrupt fires while audio is decoding", async () => {
+    const transport = new MockTransport();
+    const audioInput = new FakeAudioInput();
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      audioInput,
+      interruptThreshold: 0.1,
+      interruptChunks: 1
+    });
+    audioContext.deferDecode = true;
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    await client.startCall();
+    expect(audioInput.started).toBe(true);
+
+    transport.receive(new ArrayBuffer(4));
+    await Promise.resolve();
+
+    expect(audioContext.pendingDecode).toBeDefined();
+    audioInput.onAudioLevel?.(0.2);
+    expect(transport.sentJSON).toContainEqual({ type: "interrupt" });
+
     audioContext.pendingDecode?.();
     await Promise.resolve();
     await Promise.resolve();

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -329,6 +329,73 @@ describe("VoiceAgent — multi-turn", () => {
 });
 
 describe("VoiceAgent — interrupt", () => {
+  it("aborts an active pipeline on model-detected speech start", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "_set_turn_delay", value: 1000 });
+    await waitForType(ws, "_ack");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    sendJSON(ws, { type: "text_message", text: "long response" });
+    await waitForStatus(ws, "thinking");
+
+    ws.send(new ArrayBuffer(5000));
+
+    const interrupt = (await waitForType(ws, "playback_interrupt")) as Record<
+      string,
+      unknown
+    >;
+    expect(interrupt).toEqual({ type: "playback_interrupt" });
+    await waitForStatus(ws, "listening");
+
+    sendJSON(ws, { type: "_get_counts" });
+    const counts = (await waitForType(ws, "_counts")) as Record<
+      string,
+      unknown
+    >;
+    expect(counts.interrupt).toBe(1);
+
+    // The transcriber session stays alive after barge-in.
+    for (let i = 0; i < 3; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const transcript = (await waitForMessageMatching(
+      ws,
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as Record<string, unknown>).type === "transcript" &&
+        (m as Record<string, unknown>).role === "user"
+    )) as Record<string, unknown>;
+    expect((transcript.text as string).includes("utterance 1")).toBe(true);
+
+    ws.close();
+  });
+
+  it("does not count model-detected speech as interrupt while already listening", async () => {
+    const { ws } = await connectWS(uniquePath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    ws.send(new ArrayBuffer(5000));
+    await waitForType(ws, "transcript_interim");
+
+    sendJSON(ws, { type: "_get_counts" });
+    const counts = (await waitForType(ws, "_counts")) as Record<
+      string,
+      unknown
+    >;
+    expect(counts.interrupt).toBe(0);
+
+    ws.close();
+  });
+
   it("aborts pipeline on interrupt but session survives for next turn", async () => {
     const { ws } = await connectWS(uniquePath());
     await waitForStatus(ws, "idle");

--- a/packages/voice/src/tests/workers-ai-providers.test.ts
+++ b/packages/voice/src/tests/workers-ai-providers.test.ts
@@ -91,6 +91,43 @@ describe("WorkersAIFluxSTT", () => {
     expect(utterances).toEqual(["hello world"]);
   });
 
+  it("uses StartOfTurn transcript when EndOfTurn transcript is empty", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+    const interims: string[] = [];
+    const speechStarts: Array<string | undefined> = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onInterim: (text) => interims.push(text),
+      onSpeechStart: (text) => speechStarts.push(text),
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(
+      JSON.stringify({ event: "StartOfTurn", transcript: "hello" })
+    );
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(interims).toEqual(["hello"]);
+    expect(speechStarts).toEqual(["hello"]);
+    expect(utterances).toEqual(["hello"]);
+  });
+
+  it("emits speech start without requiring a transcript", async () => {
+    const ai = new MockAi();
+    const speechStarts: Array<string | undefined> = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onSpeechStart: (text) => speechStarts.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(JSON.stringify({ event: "StartOfTurn" }));
+
+    expect(speechStarts).toEqual([undefined]);
+  });
+
   it("prefers non-empty EndOfTurn transcript and clears turn state", async () => {
     const ai = new MockAi();
     const utterances: string[] = [];
@@ -125,6 +162,29 @@ describe("WorkersAIFluxSTT", () => {
     socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
 
     expect(utterances).toEqual([]);
+  });
+
+  it("uses resumed transcript instead of stale eager transcript", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+    const interims: string[] = [];
+
+    new WorkersAIFluxSTT(ai).createSession({
+      onInterim: (text) => interims.push(text),
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(
+      JSON.stringify({ event: "EagerEndOfTurn", transcript: "not done" })
+    );
+    socket.message(
+      JSON.stringify({ event: "TurnResumed", transcript: "not done yet" })
+    );
+    socket.message(JSON.stringify({ event: "EndOfTurn", transcript: "" }));
+
+    expect(interims).toEqual(["not done", "not done yet"]);
+    expect(utterances).toEqual(["not done yet"]);
   });
 });
 
@@ -189,5 +249,35 @@ describe("WorkersAINova3STT", () => {
     );
 
     expect(utterances).toEqual([]);
+  });
+
+  it("handles late Results messages after websocket close", async () => {
+    const ai = new MockAi();
+    const utterances: string[] = [];
+
+    new WorkersAINova3STT(ai).createSession({
+      onUtterance: (text) => utterances.push(text)
+    });
+
+    const socket = await waitForConnect(ai);
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: true,
+        speech_final: false,
+        channel: { alternatives: [{ transcript: "late" }] }
+      })
+    );
+    socket.close();
+    socket.message(
+      JSON.stringify({
+        type: "Results",
+        is_final: true,
+        speech_final: true,
+        channel: { alternatives: [{ transcript: "message" }] }
+      })
+    );
+
+    expect(utterances).toEqual(["late message"]);
   });
 });

--- a/packages/voice/src/text-stream.ts
+++ b/packages/voice/src/text-stream.ts
@@ -177,8 +177,8 @@ function parseLine(line: string): Record<string, unknown> | "DONE" | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
 
-  if (trimmed.startsWith("data: ")) {
-    const json = trimmed.slice(6).trim();
+  if (trimmed.startsWith("data:")) {
+    const json = trimmed.slice(5).trim();
     if (json === "[DONE]") return "DONE";
     try {
       return JSON.parse(json) as Record<string, unknown>;
@@ -188,5 +188,22 @@ function parseLine(line: string): Record<string, unknown> | "DONE" | null {
     }
   }
 
-  return null;
+  if (trimmed === "[DONE]") return "DONE";
+
+  // Ignore SSE metadata/comment lines. Only `data:` carries payload.
+  if (
+    trimmed.startsWith(":") ||
+    trimmed.startsWith("event:") ||
+    trimmed.startsWith("id:") ||
+    trimmed.startsWith("retry:")
+  ) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    console.warn("[voice] Skipping malformed NDJSON line:", trimmed);
+    return null;
+  }
 }

--- a/packages/voice/src/types.ts
+++ b/packages/voice/src/types.ts
@@ -50,6 +50,7 @@ export type VoiceServerMessage =
   | { type: "transcript_delta"; text: string }
   | { type: "transcript_end"; text: string }
   | { type: "transcript_interim"; text: string }
+  | { type: "playback_interrupt" }
   | {
       type: "metrics";
       llm_ms: number;
@@ -117,6 +118,13 @@ export interface TranscriberSessionOptions {
    * This text may change as more audio arrives.
    */
   onInterim?: (text: string) => void;
+  /**
+   * Called when the model detects the start of user speech.
+   *
+   * Providers can use this for low-latency barge-in before a final
+   * utterance is available. The transcript may be omitted or unstable.
+   */
+  onSpeechStart?: (text?: string) => void;
   /**
    * Called when the model detects a complete utterance.
    * The transcript is the stable text for this turn.

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -860,10 +860,7 @@ export class VoiceClient {
     if (this.#isPlaying && rms > this.#interruptThreshold) {
       this.#interruptChunkCount++;
       if (this.#interruptChunkCount >= this.#interruptChunks) {
-        this.#activeSource?.stop();
-        this.#activeSource = null;
-        this.#playbackQueue = [];
-        this.#isPlaying = false;
+        this.#stopPlayback();
         this.#interruptChunkCount = 0;
         if (this.#transport?.connected) {
           this.#transport.sendJSON({ type: "interrupt" });

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -276,6 +276,7 @@ export class VoiceClient {
   #playbackQueue: ArrayBuffer[] = [];
   #isPlaying = false;
   #activeSource: AudioBufferSourceNode | null = null;
+  #playbackGeneration = 0;
   #interruptChunkCount = 0;
 
   // Event listeners
@@ -599,6 +600,9 @@ export class VoiceClient {
         this.#interimTranscript = msg.text as string;
         this.#emit("interimtranscript", this.#interimTranscript);
         break;
+      case "playback_interrupt":
+        this.#stopPlayback();
+        break;
       case "transcript":
         // Final transcript arrived — clear interim
         this.#interimTranscript = null;
@@ -608,12 +612,7 @@ export class VoiceClient {
         // With continuous STT, the model detects the user's speech
         // server-side, so this arrives before the client's interrupt
         // detection fires.
-        if (msg.role === "user" && this.#isPlaying) {
-          this.#activeSource?.stop();
-          this.#activeSource = null;
-          this.#playbackQueue = [];
-          this.#isPlaying = false;
-        }
+        if (msg.role === "user" && this.#isPlaying) this.#stopPlayback();
 
         this.#transcript = [
           ...this.#transcript,
@@ -707,7 +706,7 @@ export class VoiceClient {
 
   // --- Audio playback ---
 
-  async #playAudio(audioData: ArrayBuffer): Promise<void> {
+  async #playAudio(audioData: ArrayBuffer, generation: number): Promise<void> {
     try {
       const ctx = await this.#getAudioContext();
 
@@ -724,10 +723,12 @@ export class VoiceClient {
         // mp3, wav, opus — let the browser decode
         audioBuffer = await ctx.decodeAudioData(audioData.slice(0));
       }
+      if (generation !== this.#playbackGeneration) return;
 
       const source = ctx.createBufferSource();
       source.buffer = audioBuffer;
       source.connect(ctx.destination);
+      if (generation !== this.#playbackGeneration) return;
       this.#activeSource = source;
 
       return new Promise<void>((resolve) => {
@@ -747,12 +748,33 @@ export class VoiceClient {
   async #processPlaybackQueue(): Promise<void> {
     if (this.#isPlaying || this.#playbackQueue.length === 0) return;
     this.#isPlaying = true;
+    const generation = this.#playbackGeneration;
 
-    while (this.#playbackQueue.length > 0) {
+    while (
+      generation === this.#playbackGeneration &&
+      this.#playbackQueue.length > 0
+    ) {
       const audioData = this.#playbackQueue.shift()!;
-      await this.#playAudio(audioData);
+      await this.#playAudio(audioData, generation);
     }
 
+    if (generation === this.#playbackGeneration) {
+      this.#isPlaying = false;
+    }
+  }
+
+  #stopPlayback(): void {
+    const source = this.#activeSource;
+    this.#playbackGeneration++;
+    this.#activeSource = null;
+    if (source) {
+      try {
+        source.stop();
+      } catch {
+        // The source may already have ended or been stopped by another signal.
+      }
+    }
+    this.#playbackQueue = [];
     this.#isPlaying = false;
   }
 

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -491,10 +491,7 @@ export class VoiceClient {
     } else {
       this.#stopMic();
     }
-    this.#activeSource?.stop();
-    this.#activeSource = null;
-    this.#playbackQueue = [];
-    this.#isPlaying = false;
+    this.#stopPlayback();
     this.#closeAudioContext();
     this.#resetDetection();
     this.#status = "idle";

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -550,6 +550,9 @@ export function withVoice<TBase extends AgentLike>(
             text
           });
         },
+        onSpeechStart: () => {
+          this.#handleBargeIn(connection);
+        },
         onUtterance: (transcript: string) => {
           this.#sendJSON(connection, {
             type: "transcript_interim",
@@ -581,6 +584,13 @@ export function withVoice<TBase extends AgentLike>(
     #handleInterrupt(connection: Connection) {
       this.#cm.abortPipeline(connection.id);
       this.#cm.clearAudioBuffer(connection.id);
+      this.#sendJSON(connection, { type: "status", status: "listening" });
+      this.onInterrupt(connection);
+    }
+
+    #handleBargeIn(connection: Connection) {
+      if (!this.#cm.abortPipeline(connection.id)) return;
+      this.#sendJSON(connection, { type: "playback_interrupt" });
       this.#sendJSON(connection, { type: "status", status: "listening" });
       this.onInterrupt(connection);
     }

--- a/packages/voice/src/workers-ai-providers.ts
+++ b/packages/voice/src/workers-ai-providers.ts
@@ -172,6 +172,7 @@ interface FluxEvent {
  */
 class FluxSession implements TranscriberSession {
   #onInterim: ((text: string) => void) | undefined;
+  #onSpeechStart: ((text?: string) => void) | undefined;
   #onUtterance: ((text: string) => void) | undefined;
 
   #ws: WebSocket | null = null;
@@ -187,6 +188,7 @@ class FluxSession implements TranscriberSession {
     options?: TranscriberSessionOptions
   ) {
     this.#onInterim = options?.onInterim;
+    this.#onSpeechStart = options?.onSpeechStart;
     this.#onUtterance = options?.onUtterance;
     this.#connect(ai, config);
   }
@@ -289,6 +291,11 @@ class FluxSession implements TranscriberSession {
       switch (data.event) {
         case "StartOfTurn":
           this.#currentTranscript = "";
+          this.#onSpeechStart?.(transcript || undefined);
+          if (transcript) {
+            this.#currentTranscript = transcript;
+            this.#onInterim?.(transcript);
+          }
           break;
 
         case "Update":
@@ -315,7 +322,10 @@ class FluxSession implements TranscriberSession {
           break;
 
         case "TurnResumed":
-          this.#currentTranscript = "";
+          this.#currentTranscript = transcript;
+          if (transcript) {
+            this.#onInterim?.(transcript);
+          }
           break;
       }
     } catch {


### PR DESCRIPTION
Thank you @whoiskatrin for the very good PRs here. I spent some time reviewing the recent fixes in detail and I am adding a handful of cleanups on top because I am, unfortunately, a little anal about tightening the nearby edge cases once I see them. Sorry for the extra follow-up churn, but these are all meant to preserve the direction of the landed PRs while hardening the corners around them.

## Summary

- Adds follow-up robustness for the recently landed voice STT, voice streaming, `useVoiceAgent`, agent-tool recovery, chat resume negotiation, and ai-chat socket disconnect fixes.
- Keeps the fixes scoped to the reviewed behavior, with regression tests for the edge cases we found during review.
- Updates relevant changesets/docs/readmes where the behavior is user-facing.

## Commit Details

### `bd1348a4` - `fix(voice): harden Workers AI STT turn handling`

Builds on PR #1458.

This expands the Workers AI STT fix beyond the original late/empty final transcript issue:

- Tracks the current Flux transcript across `Update`, `StartOfTurn`, and `TurnResumed`, so an empty `EndOfTurn` can still emit the best known utterance.
- Uses `StartOfTurn` as a model-driven speech-start signal for server-side barge-in.
- Adds `playback_interrupt` handling so the server can tell the client to stop playback when user speech starts during assistant audio.
- Adds a playback generation guard in `VoiceClient` so a stale `decodeAudioData()` task cannot start playing after an interrupt has already arrived.
- Adds server/client regression coverage for Flux turn handling, Nova late messages, barge-in, playback interruption, and decode races.
- Updates the voice docs/readmes to describe model-driven barge-in behavior.

### `f7b1b344` - `fix(chat): harden stream resume negotiation close races`

Builds on PR #1463.

This extends the `sendIfOpen` pattern from the original replay fallback fix to the rest of the resume negotiation paths:

- Wraps bare resume protocol sends in `@cloudflare/think` and `@cloudflare/ai-chat` so `TypeError: WebSocket send() after close` does not bubble out of close races.
- Only records pending resume connections when the `STREAM_RESUMING` notification send actually succeeds.
- Applies the same close-safe behavior to `ContinuationState.sendResumeNone()` in the shared agents chat continuation path.
- Adds focused tests for closed connection handling and non-close send errors.
- Updates changesets to reflect the broader resume negotiation hardening.

### `2954bd35` - `fix(voice): parse raw NDJSON text streams`

Builds on PR #1462.

This fills the NDJSON half of the documented `iterateText()` byte-stream support:

- Parses raw newline-delimited JSON as well as SSE `data:` lines.
- Handles OpenAI-style `choices[0].delta.content`, `response`, split byte chunks, final unterminated lines, raw `[DONE]`, and malformed raw JSON lines.
- Accepts valid SSE `data:{...}` lines without requiring a space after `data:`.
- Preserves the earlier AI SDK `textStream` custom async iterator preference from PR #1462.

### `5aefa984` - `fix(agents): defer recovered agent-tool finish hooks (#1476)`

Builds on PR #1476.

This addresses recovery lifecycle gaps found during review of agent-tool finalization:

- Defers recovered `onAgentToolFinish` hooks until after the agent's user `onStart` has completed, so user startup/mirror initialization runs before recovered finish hooks execute.
- Keeps durable internal state and terminal client events finalized during recovery before user finish hooks run.
- Isolates errors from deferred finish hooks through `onError`, so one failed hook does not prevent later recovered runs from draining or agent startup from completing.
- Adds coverage for completed, still-running, uninspectable, replay-failure, deferred-hook ordering, and throwing-hook recovery scenarios.

### `527c5ba2` - `test(voice): cover useVoiceAgent enabled lifecycle (#1478)`

Builds on PR #1478.

This adds follow-up tests/docs around the new `useVoiceAgent({ enabled })` gate:

- Verifies that enabling after a disabled mount connects using the latest query/capability token.
- Verifies `onReconnect` fires for real connection identity changes while enabled, but not for first enable.
- Documents that disabled action callbacks are safe no-ops and that first enable is treated as an initial connection rather than a reconnect.

### `b1497715` - `fix(ai-chat): close resumed streams on disconnect (#1487)`

Builds on PR #1487.

PR #1487 correctly closed the original `sendMessages()` stream when the socket closes before a terminal frame. This extends the same transport-owned stream cleanup to the other WebSocket-fed paths:

- Closes tool continuation streams if the socket closes before the resume handshake completes.
- Closes and cleans request bookkeeping if the socket closes mid tool-continuation stream.
- Closes resumed replay/live streams and removes their active request ids if the socket closes before `done: true`.
- Adds focused regression tests for those disconnect paths.

## Test Plan

Ran focused verification while developing the commits:

- `npm run build -w agents`
- `npm run build -w @cloudflare/ai-chat`
- `npm --workspace @cloudflare/voice run build`
- `npm run test:workers -w @cloudflare/ai-chat -- src/tests/agent-tools.test.ts`
- `npm run test:workers -w @cloudflare/ai-chat -- src/tests/ws-transport-resume.test.ts`
- `npm run test:react -w @cloudflare/ai-chat -- use-agent-chat.test.tsx`
- `npm run test:workers -w @cloudflare/think -- agent-tools.test.ts`
- `npm --workspace @cloudflare/voice run test:react -- useVoiceAgent.test.tsx`
- `npx tsc -p packages/ai-chat/src/tests/tsconfig.json --noEmit`
- Focused `oxfmt --check` / lint checks for edited files


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->