### PR TITLE
Preserve structured tool outputs during truncation

### DIFF
--- a/.changeset/fix-structured-tool-truncation.md
+++ b/.changeset/fix-structured-tool-truncation.md
@@ -1,0 +1,8 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+---
+
+Preserve structured tool output shapes when truncating older messages or oversized persisted rows, preventing custom `toModelOutput` handlers from crashing or mis-replaying compacted results.
+
+Also harden Think's workspace `read` tool so legacy raw-string read outputs replay as text instead of stalling subsequent turns.

--- a/experimental/session-memory/README.md
+++ b/experimental/session-memory/README.md
@@ -235,7 +235,7 @@ You can pass any function to `onCompaction()`. It receives the full message hist
 
 ## Read-Time Truncation
 
-`truncateOlderMessages` truncates tool outputs and long text in older messages before sending to the LLM. Does not mutate the stored messages.
+`truncateOlderMessages` truncates tool outputs and long text in older messages before sending to the LLM. Does not mutate the stored messages. Structured tool outputs keep their container shape, with large nested fields truncated in place.
 
 ```typescript
 import { truncateOlderMessages } from "agents/experimental/memory/utils";

--- a/packages/agents/src/chat/sanitize.ts
+++ b/packages/agents/src/chat/sanitize.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ProviderMetadata, ReasoningUIPart, UIMessage } from "ai";
+import { truncateToolOutput } from "./tool-output-truncation";
 
 const textEncoder = new TextEncoder();
 
@@ -117,7 +118,7 @@ function stripOpenAIMetadata<T extends UIMessage["parts"][number]>(
  * when a serialized message exceeds the safety threshold (1.8MB).
  *
  * Compaction strategy:
- * 1. Compact tool outputs over 1KB (replace with summary)
+ * 1. Compact tool outputs over 1KB while preserving structured output shape
  * 2. If still too big, truncate text parts from oldest to newest
  */
 export function enforceRowSizeLimit(message: UIMessage): UIMessage {
@@ -136,15 +137,12 @@ export function enforceRowSizeLimit(message: UIMessage): UIMessage {
       "state" in part &&
       part.state === "output-available"
     ) {
-      const outputJson = JSON.stringify((part as { output: unknown }).output);
-      if (outputJson.length > 1000) {
+      const output = (part as { output: unknown }).output;
+      const truncated = truncateToolOutput(output, 1000);
+      if (truncated.truncated) {
         return {
           ...part,
-          output:
-            "This tool output was too large to persist in storage " +
-            `(${outputJson.length} bytes). ` +
-            "If the user asks about this data, suggest re-running the tool. " +
-            `Preview: ${outputJson.slice(0, 500)}...`
+          output: truncated.output
         };
       }
     }

--- a/packages/agents/src/chat/tool-output-truncation.ts
+++ b/packages/agents/src/chat/tool-output-truncation.ts
@@ -1,0 +1,215 @@
+export interface TruncatedToolOutput {
+  output: unknown;
+  truncated: boolean;
+  originalLength: number;
+}
+
+const DEFAULT_MAX_DEPTH = 8;
+const TRUNCATED_FLAG = "__truncated";
+const TRUNCATED_CHARS = "__truncatedChars";
+
+export function truncateToolOutput(
+  output: unknown,
+  maxChars: number
+): TruncatedToolOutput {
+  const original = stringifyForLength(output);
+  if (original.length <= maxChars) {
+    return { output, truncated: false, originalLength: original.length };
+  }
+
+  return {
+    output: truncateValue(output, maxChars, original.length, 0),
+    truncated: true,
+    originalLength: original.length
+  };
+}
+
+export function truncatedSuffix(originalLength: number): string {
+  return `... [truncated ${originalLength} chars]`;
+}
+
+function truncateValue(
+  value: unknown,
+  maxChars: number,
+  originalLength: number,
+  depth: number
+): unknown {
+  if (typeof value === "string") {
+    return truncateString(value, maxChars, value.length);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (depth >= DEFAULT_MAX_DEPTH) {
+    return `[Nested output omitted ${truncatedSuffix(originalLength)}]`;
+  }
+
+  if (Array.isArray(value)) {
+    return truncateArray(value, maxChars, originalLength, depth);
+  }
+
+  return truncateObject(
+    value as Record<string, unknown>,
+    maxChars,
+    originalLength,
+    depth
+  );
+}
+
+function truncateArray(
+  value: unknown[],
+  maxChars: number,
+  originalLength: number,
+  depth: number
+): unknown[] {
+  const childBudget = childMaxChars(maxChars, value.length);
+  const result = value.map((item) =>
+    truncateValue(item, childBudget, stringifyForLength(item).length, depth + 1)
+  );
+
+  while (result.length > 1 && stringifyForLength(result).length > maxChars) {
+    result.pop();
+  }
+
+  if (result.length < value.length) {
+    result.push(`Array output truncated ${truncatedSuffix(originalLength)}`);
+  }
+
+  if (stringifyForLength(result).length > maxChars) {
+    return compactArrayMarker(maxChars, originalLength);
+  }
+
+  return result;
+}
+
+function truncateObject(
+  value: Record<string, unknown>,
+  maxChars: number,
+  originalLength: number,
+  depth: number
+): Record<string, unknown> {
+  const entries = Object.entries(value);
+  const childBudget = childMaxChars(maxChars, entries.length);
+  const result: Record<string, unknown> = {};
+
+  for (const [key, entryValue] of entries) {
+    result[key] = truncateValue(
+      entryValue,
+      childBudget,
+      stringifyForLength(entryValue).length,
+      depth + 1
+    );
+  }
+
+  const resultLength = stringifyForLength(result).length;
+  if (resultLength <= maxChars) {
+    return result;
+  }
+
+  shrinkStringFields(result, maxChars);
+  const shrunkLength = stringifyForLength(result).length;
+  if (shrunkLength > maxChars) {
+    result[TRUNCATED_FLAG] = true;
+    result[TRUNCATED_CHARS] = resultLength;
+  }
+
+  if (stringifyForLength(result).length > maxChars) {
+    return compactObjectMarker(maxChars, originalLength);
+  }
+
+  return result;
+}
+
+function shrinkStringFields(
+  value: Record<string, unknown>,
+  maxChars: number
+): void {
+  const stringEntries = Object.entries(value)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .sort((a, b) => b[1].length - a[1].length);
+
+  for (const [key, str] of stringEntries) {
+    if (stringifyForLength(value).length <= maxChars) {
+      return;
+    }
+
+    value[key] = truncateString(
+      str,
+      Math.max(0, Math.floor(maxChars / 4)),
+      str.length
+    );
+  }
+}
+
+function truncateString(
+  value: string,
+  maxChars: number,
+  originalLength: number
+): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  const suffix = truncatedSuffix(originalLength);
+  if (maxChars <= suffix.length) {
+    return suffix.slice(0, maxChars);
+  }
+
+  return `${value.slice(0, maxChars - suffix.length)}${suffix}`;
+}
+
+function compactObjectMarker(
+  maxChars: number,
+  originalLength: number
+): Record<string, unknown> {
+  const marker = {
+    [TRUNCATED_FLAG]: true,
+    [TRUNCATED_CHARS]: originalLength,
+    note: "Tool output omitted because it was too large to preserve structurally."
+  };
+
+  if (stringifyForLength(marker).length <= maxChars) {
+    return marker;
+  }
+
+  return {
+    [TRUNCATED_FLAG]: true,
+    [TRUNCATED_CHARS]: originalLength
+  };
+}
+
+function compactArrayMarker(
+  maxChars: number,
+  originalLength: number
+): unknown[] {
+  const marker = [
+    `Array output omitted because it was too large to preserve structurally ${truncatedSuffix(originalLength)}`
+  ];
+
+  if (stringifyForLength(marker).length <= maxChars) {
+    return marker;
+  }
+
+  return [truncateString("", maxChars, originalLength)];
+}
+
+function childMaxChars(maxChars: number, childCount: number): number {
+  if (childCount <= 1) {
+    return maxChars;
+  }
+
+  return Math.max(80, Math.floor(maxChars / Math.min(childCount, 10)));
+}
+
+function stringifyForLength(value: unknown): string {
+  try {
+    if (typeof value === "string") {
+      return value;
+    }
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/agents/src/chat/tool-output-truncation.ts
+++ b/packages/agents/src/chat/tool-output-truncation.ts
@@ -184,6 +184,11 @@ function compactArrayMarker(
   maxChars: number,
   originalLength: number
 ): unknown[] {
+  const structuredMarker = compactObjectMarker(maxChars, originalLength);
+  if (stringifyForLength([structuredMarker]).length <= maxChars) {
+    return [structuredMarker];
+  }
+
   const marker = [
     `Array output omitted because it was too large to preserve structurally ${truncatedSuffix(originalLength)}`
   ];
@@ -192,7 +197,7 @@ function compactArrayMarker(
     return marker;
   }
 
-  return [truncateString("", maxChars, originalLength)];
+  return [truncatedSuffix(originalLength).slice(0, maxChars)];
 }
 
 function childMaxChars(maxChars: number, childCount: number): number {

--- a/packages/agents/src/experimental/memory/utils/compaction.ts
+++ b/packages/agents/src/experimental/memory/utils/compaction.ts
@@ -2,9 +2,12 @@
  * Read-time context truncation.
  *
  * Truncates older tool outputs and long text before sending to the LLM.
+ * Structured tool outputs keep their container shape so tool-specific
+ * `toModelOutput` handlers can safely replay older results.
  * Does NOT mutate stored messages — operates on a copy.
  */
 
+import { truncateToolOutput } from "../../../chat/tool-output-truncation";
 import type { SessionMessage } from "../session/types";
 
 export interface TruncateOptions {
@@ -21,7 +24,8 @@ export interface TruncateOptions {
  * Returns a new array — input messages are not mutated.
  *
  * Recent messages (last `keepRecent`) are left intact.
- * Older messages get tool outputs and long text truncated.
+ * Older messages get tool outputs and long text truncated. Structured tool
+ * outputs are truncated in place instead of being replaced by raw strings.
  *
  * Use in assembleContext() before sending to the LLM:
  * ```typescript
@@ -62,13 +66,12 @@ export function truncateOlderMessages(
       ) {
         const output = (part as { output?: unknown }).output;
         if (output !== undefined) {
-          const str =
-            typeof output === "string" ? output : JSON.stringify(output);
-          if (str.length > maxToolOutput) {
+          const truncated = truncateToolOutput(output, maxToolOutput);
+          if (truncated.truncated) {
             changed = true;
             return {
               ...part,
-              output: `${str.slice(0, maxToolOutput)}... [truncated ${str.length} chars]`
+              output: truncated.output
             };
           }
         }

--- a/packages/agents/src/tests/experimental/memory/utils/compaction.test.ts
+++ b/packages/agents/src/tests/experimental/memory/utils/compaction.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import {
+  byteLength,
+  enforceRowSizeLimit,
+  ROW_MAX_BYTES
+} from "../../../../chat/sanitize";
+import { truncateOlderMessages } from "../../../../experimental/memory/utils/compaction";
+import type { SessionMessage } from "../../../../experimental/memory/session/types";
+
+function textMessage(id: string, text: string): SessionMessage {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text }]
+  };
+}
+
+function toolMessage(id: string, output: unknown): SessionMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-read",
+        toolCallId: `tc-${id}`,
+        toolName: "read",
+        state: "output-available",
+        input: { path: "/large.txt" },
+        output
+      }
+    ]
+  };
+}
+
+function firstOutput(message: SessionMessage): unknown {
+  return message.parts[0].output;
+}
+
+describe("truncateOlderMessages", () => {
+  it("truncates older object tool outputs without changing their shape", () => {
+    const largeContent = "x".repeat(1000);
+    const messages = [
+      toolMessage("old-tool", {
+        path: "/large.txt",
+        content: largeContent,
+        totalLines: 1
+      }),
+      textMessage("old-user", "next"),
+      textMessage("recent-1", "recent one"),
+      textMessage("recent-2", "recent two")
+    ];
+
+    const truncated = truncateOlderMessages(messages, {
+      keepRecent: 2,
+      maxToolOutputChars: 100
+    });
+    const output = firstOutput(truncated[0]);
+
+    expect(output).toMatchObject({
+      path: "/large.txt",
+      totalLines: 1
+    });
+    expect(typeof output).toBe("object");
+    expect((output as { content: string }).content).toContain("[truncated");
+    expect((output as { content: string }).content.length).toBeLessThan(
+      largeContent.length
+    );
+    expect(firstOutput(messages[0])).toMatchObject({ content: largeContent });
+  });
+
+  it("leaves recent tool outputs intact", () => {
+    const recentOutput = {
+      path: "/recent.txt",
+      content: "y".repeat(1000),
+      totalLines: 1
+    };
+    const messages = [
+      textMessage("old-1", "old"),
+      textMessage("old-2", "old"),
+      toolMessage("recent-tool", recentOutput)
+    ];
+
+    const truncated = truncateOlderMessages(messages, {
+      keepRecent: 2,
+      maxToolOutputChars: 100
+    });
+
+    expect(firstOutput(truncated[2])).toBe(recentOutput);
+  });
+
+  it("keeps string tool outputs as strings", () => {
+    const messages = [
+      toolMessage("old-tool", "z".repeat(1000)),
+      textMessage("recent-1", "recent one"),
+      textMessage("recent-2", "recent two")
+    ];
+
+    const truncated = truncateOlderMessages(messages, {
+      keepRecent: 2,
+      maxToolOutputChars: 100
+    });
+    const output = firstOutput(truncated[0]);
+
+    expect(typeof output).toBe("string");
+    expect(output).toContain("[truncated");
+  });
+});
+
+describe("enforceRowSizeLimit", () => {
+  it("compacts oversized object tool outputs without changing their shape", () => {
+    const largeContent = "x".repeat(2_000_000);
+    const message: UIMessage = {
+      id: "tool-big",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-read",
+          toolCallId: "tc-1",
+          toolName: "read",
+          state: "output-available",
+          input: { path: "/large.txt" },
+          output: {
+            path: "/large.txt",
+            content: largeContent,
+            totalLines: 1
+          }
+        } as UIMessage["parts"][number]
+      ]
+    };
+
+    const result = enforceRowSizeLimit(message);
+    const output = result.parts[0] as { output: unknown };
+
+    expect(output.output).toMatchObject({
+      path: "/large.txt",
+      totalLines: 1
+    });
+    expect((output.output as { content: string }).content).toContain(
+      "[truncated"
+    );
+    expect((output.output as { content: string }).content.length).toBeLessThan(
+      largeContent.length
+    );
+  });
+
+  it("falls back to a compact marker when object shape is too large to preserve", () => {
+    const primitiveHeavyOutput = Object.fromEntries(
+      Array.from({ length: 140_000 }, (_, i) => [`key-${i}`, i])
+    );
+    const message: UIMessage = {
+      id: "tool-primitive-heavy",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-map",
+          toolCallId: "tc-1",
+          toolName: "map",
+          state: "output-available",
+          input: {},
+          output: primitiveHeavyOutput
+        } as UIMessage["parts"][number]
+      ]
+    };
+
+    const result = enforceRowSizeLimit(message);
+    const output = (result.parts[0] as { output: Record<string, unknown> })
+      .output;
+
+    expect(byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
+      ROW_MAX_BYTES
+    );
+    expect(output.__truncated).toBe(true);
+    expect(output.__truncatedChars).toBeGreaterThan(ROW_MAX_BYTES);
+  });
+});

--- a/packages/agents/src/tests/experimental/memory/utils/compaction.test.ts
+++ b/packages/agents/src/tests/experimental/memory/utils/compaction.test.ts
@@ -69,6 +69,37 @@ describe("truncateOlderMessages", () => {
     expect(firstOutput(messages[0])).toMatchObject({ content: largeContent });
   });
 
+  it("preserves truncation context for nested arrays with small budgets", () => {
+    const messages = [
+      toolMessage("old-tool", {
+        a: Array.from({ length: 1000 }, (_, i) => i),
+        b: Array.from({ length: 1000 }, (_, i) => i),
+        c: Array.from({ length: 1000 }, (_, i) => i),
+        d: Array.from({ length: 1000 }, (_, i) => i),
+        e: Array.from({ length: 1000 }, (_, i) => i),
+        f: Array.from({ length: 1000 }, (_, i) => i),
+        g: Array.from({ length: 1000 }, (_, i) => i)
+      }),
+      textMessage("recent-1", "recent one"),
+      textMessage("recent-2", "recent two")
+    ];
+
+    const truncated = truncateOlderMessages(messages, {
+      keepRecent: 2,
+      maxToolOutputChars: 500
+    });
+    const output = firstOutput(truncated[0]) as {
+      a: Array<Record<string, unknown> | string>;
+    };
+
+    expect(output.a).toHaveLength(1);
+    expect(output.a[0]).not.toBe("");
+    expect(output.a[0]).toMatchObject({
+      __truncated: true,
+      __truncatedChars: expect.any(Number)
+    });
+  });
+
   it("leaves recent tool outputs intact", () => {
     const recentOutput = {
       path: "/recent.txt",

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -819,7 +819,7 @@ describe("Think — row size enforcement", () => {
     const toolPart = result.parts[0] as Record<string, unknown>;
     const output = toolPart.output as string;
 
-    expect(output).toContain("too large to persist");
+    expect(output).toContain("[truncated");
     expect(output.length).toBeLessThan(hugeOutput.length);
   });
 
@@ -844,6 +844,107 @@ describe("Think — row size enforcement", () => {
 // ── Model message conversion ─────────────────────────────────────
 
 describe("Think — model message conversion", () => {
+  it("replays truncated workspace text read outputs as text", async () => {
+    const agent = await freshAgent("model-conversion-truncated-read");
+    const largeContent = "read-output ".repeat(100);
+
+    await agent.persistTestMessage({
+      id: "u-read-text",
+      role: "user",
+      parts: [{ type: "text", text: "Read /large.txt" }]
+    });
+    await agent.persistTestMessage({
+      id: "a-read-text",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-read",
+          toolCallId: "tc-read-text",
+          state: "output-available",
+          input: { path: "/large.txt" },
+          output: {
+            path: "/large.txt",
+            content: largeContent,
+            totalLines: 1
+          }
+        } as UIMessage["parts"][number]
+      ]
+    });
+    for (let i = 0; i < 4; i++) {
+      await agent.persistTestMessage({
+        id: `recent-${i}`,
+        role: "user",
+        parts: [{ type: "text", text: `recent ${i}` }]
+      });
+    }
+
+    const result = await agent.testChat("follow up");
+
+    expect(result.error).toBeUndefined();
+    const messagesJson = await agent.getLastBeforeTurnMessagesJson();
+    expect(messagesJson).not.toBeNull();
+    const messages = JSON.parse(messagesJson!) as Array<{
+      role: string;
+      content?: Array<{
+        output?: {
+          type: string;
+          value?: string;
+        };
+      }>;
+    }>;
+    const toolOutput = messages
+      .find((message) => message.role === "tool")
+      ?.content?.find((part) => part.output?.type === "text")?.output;
+
+    expect(toolOutput?.value).toContain("[truncated");
+    expect(toolOutput?.value).toContain("read-output");
+  });
+
+  it("replays legacy raw-string workspace read outputs as text", async () => {
+    const agent = await freshAgent("model-conversion-string-read");
+    const legacyOutput =
+      "This read output was truncated by an older SDK version.";
+
+    await agent.persistTestMessage({
+      id: "u-read-legacy",
+      role: "user",
+      parts: [{ type: "text", text: "Read /legacy.txt" }]
+    });
+    await agent.persistTestMessage({
+      id: "a-read-legacy",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-read",
+          toolCallId: "tc-read-legacy",
+          state: "output-available",
+          input: { path: "/legacy.txt" },
+          output: legacyOutput
+        } as UIMessage["parts"][number]
+      ]
+    });
+
+    const result = await agent.testChat("follow up");
+
+    expect(result.error).toBeUndefined();
+    const messagesJson = await agent.getLastBeforeTurnMessagesJson();
+    expect(messagesJson).not.toBeNull();
+    const messages = JSON.parse(messagesJson!) as Array<{
+      role: string;
+      content?: Array<{
+        output?: {
+          type: string;
+          value?: string;
+        };
+      }>;
+    }>;
+    const toolOutput = messages
+      .find((message) => message.role === "tool")
+      ?.content?.find((part) => part.output?.type === "text")?.output;
+
+    expect(toolOutput?.value).toBe(legacyOutput);
+  });
+
   it("rehydrates compact workspace image read outputs during replay", async () => {
     const agent = await freshAgent("model-conversion-image-read");
     const imageBytes = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];

--- a/packages/think/src/tools/workspace.ts
+++ b/packages/think/src/tools/workspace.ts
@@ -1,4 +1,5 @@
 import type { Workspace, FileInfo } from "@cloudflare/shell";
+import type { JSONValue } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
 
@@ -205,6 +206,12 @@ type ReadToolOutput =
   | BinaryReadToolOutput
   | ReadToolError;
 
+type ReadToolInput = {
+  path: string;
+  offset?: number;
+  limit?: number;
+};
+
 export interface ReadToolOptions {
   ops: ReadOperations;
 }
@@ -232,7 +239,11 @@ export function createReadTool(options: ReadToolOptions) {
         .optional()
         .describe("Number of lines to read")
     }),
-    execute: async ({ path, offset, limit }): Promise<ReadToolOutput> => {
+    execute: async ({
+      path,
+      offset,
+      limit
+    }: ReadToolInput): Promise<ReadToolOutput> => {
       const stat = await ops.stat(path);
       if (!stat) {
         return { error: `File not found: ${path}` };
@@ -276,19 +287,45 @@ export function createReadTool(options: ReadToolOptions) {
 
       return readTextWithLineNumbers({ ops, path, offset, limit });
     },
-    toModelOutput: async ({ input, output }) => {
-      if ("error" in output) {
-        return { type: "error-text", value: output.error };
+    toModelOutput: async ({
+      input,
+      output
+    }: {
+      input: unknown;
+      output: unknown;
+    }) => {
+      const replayOutput: unknown = output;
+
+      if (!isRecord(replayOutput)) {
+        return { type: "text", value: String(replayOutput) };
       }
 
-      if ("content" in output) {
-        return { type: "text", value: output.content };
+      if (typeof replayOutput.error === "string") {
+        return { type: "error-text", value: replayOutput.error };
       }
 
-      if (output.kind === "binary") {
+      if (typeof replayOutput.content === "string") {
+        return { type: "text", value: replayOutput.content };
+      }
+
+      if (replayOutput.kind === "binary") {
         return {
           type: "json",
-          value: output
+          value: toJSONValue(replayOutput)
+        };
+      }
+
+      if (!isModelFileReadOutput(replayOutput)) {
+        return {
+          type: "json",
+          value: toJSONValue(replayOutput)
+        };
+      }
+
+      if (!isReadToolInput(input)) {
+        return {
+          type: "json",
+          value: toJSONValue(replayOutput)
         };
       }
 
@@ -303,20 +340,20 @@ export function createReadTool(options: ReadToolOptions) {
         return {
           type: "error-text",
           value:
-            `Read ${output.path} (${output.mediaType}, ${formatSize(bytes.byteLength)}), ` +
+            `Read ${replayOutput.path} (${replayOutput.mediaType}, ${formatSize(bytes.byteLength)}), ` +
             `but it exceeds the ${formatSize(MAX_MODEL_FILE_BYTES)} inline model output limit.`
         };
       }
 
       const data = uint8ArrayToBase64(bytes);
-      const note = `Read ${output.path} (${output.mediaType}, ${formatSize(bytes.byteLength)}).`;
+      const note = `Read ${replayOutput.path} (${replayOutput.mediaType}, ${formatSize(bytes.byteLength)}).`;
 
-      if (output.kind === "image") {
+      if (replayOutput.kind === "image") {
         return {
           type: "content",
           value: [
             { type: "text", text: note },
-            { type: "image-data", data, mediaType: output.mediaType }
+            { type: "image-data", data, mediaType: replayOutput.mediaType }
           ]
         };
       }
@@ -328,13 +365,41 @@ export function createReadTool(options: ReadToolOptions) {
           {
             type: "file-data",
             data,
-            mediaType: output.mediaType,
-            filename: output.name
+            mediaType: replayOutput.mediaType,
+            filename: replayOutput.name
           }
         ]
       };
     }
   });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isModelFileReadOutput(
+  value: Record<string, unknown>
+): value is ImageReadToolOutput | FileReadToolOutput {
+  return (
+    (value.kind === "image" || value.kind === "file") &&
+    typeof value.path === "string" &&
+    typeof value.name === "string" &&
+    typeof value.mediaType === "string"
+  );
+}
+
+function isReadToolInput(value: unknown): value is ReadToolInput {
+  return isRecord(value) && typeof value.path === "string";
+}
+
+function toJSONValue(value: unknown): JSONValue {
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? null : (JSON.parse(json) as JSONValue);
+  } catch {
+    return String(value);
+  }
 }
 
 function readTextWithLineNumbers({


### PR DESCRIPTION
## Summary
- Preserve structured tool output shapes during read-time context truncation and row-size enforcement so custom `toModelOutput` handlers keep seeing compatible replay data.
- Add bounded fallback markers for objects/arrays that are too large to preserve structurally, keeping persisted rows under the storage safety limit.
- Harden Think's workspace `read` replay path so legacy raw-string outputs and unknown object shapes replay safely instead of stalling inference.

## Details
This fixes the failure mode from #1498 where `truncateOlderMessages()` stringified older `tool-read` outputs, then Think's `read.toModelOutput` attempted object membership checks on a string during `convertToModelMessages()`.

The new shared truncation helper keeps strings as strings, objects as objects, and arrays as arrays while recursively truncating large nested values. If an object or array remains too large because its size is spread across many keys or primitive values, it falls back to a compact truncation marker rather than returning an oversized row.

## Test plan
- [x] `npm run test:workers -w agents -- --run src/tests/experimental/memory/utils/compaction.test.ts`
- [x] `npm run test -w agents`
- [x] `npm run test:workers -w @cloudflare/think -- src/tests/think-session.test.ts`
- [x] `npm run test -w @cloudflare/think`
- [x] `npm run check`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->