### PR TITLE
Harden codemode browser executor

### DIFF
--- a/.changeset/browser-codemode-iframe.md
+++ b/.changeset/browser-codemode-iframe.md
@@ -2,4 +2,6 @@
 "@cloudflare/codemode": patch
 ---
 
-Add a browser-safe codemode export with an iframe sandbox executor and browser tool helper.
+Add a browser-safe codemode export with an iframe sandbox executor and browser
+tool helper. Harden iframe message handling with nonce-scoped messages, reject
+sanitized tool name collisions, and keep tools with `needsApproval: false`.

--- a/docs/codemode.md
+++ b/docs/codemode.md
@@ -330,8 +330,16 @@ The `Executor` interface is deliberately minimal — implement it to run code in
 interface Executor {
   execute(
     code: string,
-    fns: Record<string, (...args: unknown[]) => Promise<unknown>>
+    providersOrFns:
+      | ResolvedProvider[]
+      | Record<string, (...args: unknown[]) => Promise<unknown>>
   ): Promise<ExecuteResult>;
+}
+
+interface ResolvedProvider {
+  name: string;
+  fns: Record<string, (...args: unknown[]) => Promise<unknown>>;
+  positionalArgs?: boolean;
 }
 
 interface ExecuteResult {
@@ -365,6 +373,16 @@ Executes code in an isolated Cloudflare Worker via `WorkerLoader`.
 | `timeout`        | `number`          | `30000`  | Execution timeout in ms                                      |
 | `globalOutbound` | `Fetcher \| null` | `null`   | Network access control. `null` = blocked, `Fetcher` = routed |
 
+### `IframeSandboxExecutor`
+
+Executes code in a sandboxed browser iframe. Import it from
+`@cloudflare/codemode/browser`.
+
+| Option    | Type     | Default                                                         | Description                                                              |
+| --------- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `timeout` | `number` | `30000`                                                         | Execution timeout in ms. Cannot preempt tight synchronous browser loops. |
+| `csp`     | `string` | `default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval';` | Content Security Policy applied to the sandbox iframe document.          |
+
 ### `generateTypes(tools)`
 
 Generates TypeScript type definitions from your tools. Used internally by `createCodeTool` but exported for custom use (e.g., displaying types in a frontend).
@@ -397,10 +415,18 @@ sanitizeToolName("delete"); // "delete_"
 - Tool calls are dispatched via Workers RPC, not network requests
 - Execution has a configurable **timeout** (default 30 seconds)
 - Console output is captured separately and does not leak to the host
+- Browser iframe execution runs in a sandboxed iframe with a restrictive CSP by
+  default. It uses nonce-scoped internal messages, but its timeout cannot preempt
+  tight synchronous loops like `while (true) {}` because those block the browser
+  event loop.
 
 ## Current limitations
 
-- **Tool approval (`needsApproval`) is not supported yet.** Tools with `needsApproval: true` execute immediately inside the sandbox without pausing for approval. Support for approval flows within codemode is planned. For now, do not pass approval-required tools to `createCodeTool` — use them through standard AI SDK tool calling instead.
+- **Tool approval (`needsApproval`) is not supported yet.** Tools with
+  `needsApproval: true` or a `needsApproval` function are excluded from codemode
+  instead of pausing execution for approval. Support for approval flows within
+  codemode is planned. For now, use approval-required tools through standard AI
+  SDK tool calling instead.
 - Requires Cloudflare Workers environment for `DynamicWorkerExecutor`
 - Limited to JavaScript execution
 - The `zod-to-ts` dependency bundles the TypeScript compiler, which increases Worker size
@@ -409,3 +435,6 @@ sanitizeToolName("delete"); // "delete_"
 ## Example
 
 See [`examples/codemode/`](../examples/codemode/) for a full working example — a project management assistant that uses codemode to orchestrate tasks, sprints, and comments via SQLite.
+
+See [`examples/codemode-browser/`](../examples/codemode-browser/) for a browser
+iframe executor example with dynamic client tools.

--- a/examples/codemode-browser/README.md
+++ b/examples/codemode-browser/README.md
@@ -35,6 +35,9 @@ npm start     # from this directory
 
 Uses Workers AI through the `AI` binding.
 
+For security details and current browser iframe limitations, see
+[`docs/codemode.md`](../../docs/codemode.md#security-considerations).
+
 ## Try it
 
 - "Create a project called Alpha, add two tasks, then list all projects and tasks"

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -237,10 +237,16 @@ The `Executor` interface is deliberately minimal — implement it to run code in
 interface Executor {
   execute(
     code: string,
-    providers:
+    providersOrFns:
       | ResolvedProvider[]
       | Record<string, (...args: unknown[]) => Promise<unknown>>
   ): Promise<ExecuteResult>;
+}
+
+interface ResolvedProvider {
+  name: string;
+  fns: Record<string, (...args: unknown[]) => Promise<unknown>>;
+  positionalArgs?: boolean;
 }
 
 interface ExecuteResult {
@@ -287,6 +293,16 @@ class NodeVMExecutor implements Executor {
 | `timeout`        | `number`                 | `30000`  | Execution timeout in ms                                      |
 | `globalOutbound` | `Fetcher \| null`        | `null`   | Network access control. `null` = blocked, `Fetcher` = routed |
 | `modules`        | `Record<string, string>` | `{}`     | Extra modules importable in the sandbox                      |
+
+### IframeSandboxExecutor options
+
+Import from `@cloudflare/codemode/browser` when code should run in the browser
+against browser-owned tools.
+
+| Option    | Type     | Default                                                         | Description                                                              |
+| --------- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `timeout` | `number` | `30000`                                                         | Execution timeout in ms. Cannot preempt tight synchronous browser loops. |
+| `csp`     | `string` | `default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval';` | Content Security Policy applied to the sandbox iframe document.          |
 
 ### createCodeTool options
 
@@ -428,16 +444,19 @@ const types = generateTypes(myAiSdkTools);
 | `@cloudflare/codemode`             | None                  | `sanitizeToolName`, `normalizeCode`, `generateTypesFromJsonSchema`, `jsonSchemaToType`, `DynamicWorkerExecutor`, `ToolDispatcher`, `ToolProvider`, `resolveProvider` |
 | `@cloudflare/codemode/ai`          | `ai`, `zod`           | `createCodeTool`, `generateTypes`, `aiTools`, `resolveProvider`, `ToolDescriptor`, `ToolDescriptors`                                                                 |
 | `@cloudflare/codemode/tanstack-ai` | `@tanstack/ai`, `zod` | `createCodeTool`, `generateTypes`, `tanstackTools`, `resolveProvider`                                                                                                |
+| `@cloudflare/codemode/browser`     | None                  | `createBrowserCodeTool`, `IframeSandboxExecutor`, `Executor`, `ExecuteResult`, `ResolvedProvider`, JSON Schema tool descriptor types                                 |
 
 ## Limitations
 
-- **Tool approval (`needsApproval`) is not supported yet.** Tools with `needsApproval: true` execute immediately inside the sandbox without pausing for approval. Support for approval flows within codemode is planned. For now, do not pass approval-required tools to `createCodeTool` — use them through standard AI SDK tool calling instead.
+- **Tool approval (`needsApproval`) is not supported yet.** Tools with `needsApproval: true` or a `needsApproval` function are excluded from codemode instead of pausing execution for approval. Support for approval flows within codemode is planned. For now, use approval-required tools through standard AI SDK tool calling instead.
+- Browser iframe execution uses nonce-scoped internal messages, but its timeout cannot preempt tight synchronous loops like `while (true) {}` because those block the browser event loop.
 - Requires Cloudflare Workers environment for `DynamicWorkerExecutor`
 - Limited to JavaScript execution
 
 ## Examples
 
 - [`examples/codemode/`](../../examples/codemode/) — Full working example with task management tools
+- [`examples/codemode-browser/`](../../examples/codemode-browser/) — Browser iframe executor example with dynamic client tools
 
 ## License
 

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "build": "tsx ./scripts/build.ts",
-    "test": "vitest run",
+    "test": "vitest run && vitest run --config vitest.browser.config.ts",
     "test:e2e": "npx playwright test --config e2e/playwright.config.ts",
     "test:watch": "vitest",
     "test:browser": "vitest run --config vitest.browser.config.ts"

--- a/packages/codemode/src/browser-tool.ts
+++ b/packages/codemode/src/browser-tool.ts
@@ -121,7 +121,9 @@ function toRecord(
 }
 
 function hasNeedsApproval(tool: Record<string, unknown>): boolean {
-  return "needsApproval" in tool && tool.needsApproval != null;
+  return (
+    tool.needsApproval === true || typeof tool.needsApproval === "function"
+  );
 }
 
 /**
@@ -167,11 +169,18 @@ export function createBrowserCodeTool(
 
   // Extract execute functions, keyed by sanitized name
   const fns: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  const sanitizedNames = new Map<string, string>();
   for (const [name, tool] of Object.entries(toolMap)) {
     if (tool.execute) {
-      fns[sanitizeToolName(name)] = tool.execute as (
-        args: unknown
-      ) => Promise<unknown>;
+      const sanitizedName = sanitizeToolName(name);
+      const existingName = sanitizedNames.get(sanitizedName);
+      if (existingName && existingName !== name) {
+        throw new Error(
+          `Tool names "${existingName}" and "${name}" both sanitize to "${sanitizedName}"`
+        );
+      }
+      sanitizedNames.set(sanitizedName, name);
+      fns[sanitizedName] = tool.execute as (args: unknown) => Promise<unknown>;
     }
   }
   const resolvedProviders: ResolvedProvider[] = [{ name: "codemode", fns }];

--- a/packages/codemode/src/executor.ts
+++ b/packages/codemode/src/executor.ts
@@ -288,8 +288,20 @@ export class DynamicWorkerExecutor implements Executor {
         string,
         (...args: unknown[]) => Promise<unknown>
       > = {};
+      const sanitizedNames = new Map<string, string>();
       for (const [name, fn] of Object.entries(provider.fns)) {
-        sanitizedFns[sanitizeToolName(name)] = fn;
+        const sanitizedName = sanitizeToolName(name);
+        const existingName = sanitizedNames.get(sanitizedName);
+        if (existingName && existingName !== name) {
+          return {
+            result: undefined,
+            error:
+              `Tool names "${existingName}" and "${name}" both sanitize to ` +
+              `"${sanitizedName}" in provider "${provider.name}"`
+          };
+        }
+        sanitizedNames.set(sanitizedName, name);
+        sanitizedFns[sanitizedName] = fn;
       }
       dispatchers[provider.name] = new ToolDispatcher(
         sanitizedFns,

--- a/packages/codemode/src/iframe-executor.ts
+++ b/packages/codemode/src/iframe-executor.ts
@@ -64,6 +64,7 @@ ${runtimeScript}
 }
 
 function createToolResultMessage(
+  nonce: string,
   id: number,
   value: unknown,
   isError: boolean
@@ -71,11 +72,24 @@ function createToolResultMessage(
   if (isError) {
     return {
       type: "tool-result",
+      nonce,
       id,
       error: value instanceof Error ? value.message : String(value)
     };
   }
-  return { type: "tool-result", id, result: value };
+  return { type: "tool-result", nonce, id, result: value };
+}
+
+function createExecutionNonce(): string {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    ""
+  );
 }
 
 /**
@@ -137,27 +151,42 @@ export class IframeSandboxExecutor implements Executor {
     }
 
     const normalizedCode = normalizeCode(code);
-    const resolvedProviders = providers.map((provider) => {
+    const resolvedProviders: ResolvedProvider[] = [];
+    for (const provider of providers) {
       const sanitizedFns: Record<
         string,
         (...args: unknown[]) => Promise<unknown>
       > = {};
+      const sanitizedNames = new Map<string, string>();
       for (const [name, fn] of Object.entries(provider.fns)) {
-        sanitizedFns[sanitizeToolName(name)] = fn;
+        const sanitizedName = sanitizeToolName(name);
+        const existingName = sanitizedNames.get(sanitizedName);
+        if (existingName && existingName !== name) {
+          return {
+            result: undefined,
+            error:
+              `Tool names "${existingName}" and "${name}" both sanitize to ` +
+              `"${sanitizedName}" in provider "${provider.name}"`
+          };
+        }
+        sanitizedNames.set(sanitizedName, name);
+        sanitizedFns[sanitizedName] = fn;
       }
       const resolved: ResolvedProvider = {
         name: provider.name,
         fns: sanitizedFns
       };
       if (provider.positionalArgs) resolved.positionalArgs = true;
-      return resolved;
-    });
+      resolvedProviders.push(resolved);
+    }
     const providerMap = new Map(
       resolvedProviders.map((provider) => [provider.name, provider] as const)
     );
+    const nonce = createExecutionNonce();
 
     const executeRequest: ExecuteRequestMessage = {
       type: "execute-request",
+      nonce,
       code: normalizedCode,
       providers: resolvedProviders.map((provider) => {
         if (provider.positionalArgs) {
@@ -194,6 +223,7 @@ export class IframeSandboxExecutor implements Executor {
     return new Promise<ExecuteResult>((resolve) => {
       let settled = false;
       let ready = false;
+      const warnedInvalidNonceTypes = new Set<string>();
 
       const cleanup = () => {
         if (settled) return;
@@ -230,6 +260,14 @@ export class IframeSandboxExecutor implements Executor {
         }
       };
 
+      const warnInvalidNonce = (messageType: string) => {
+        if (warnedInvalidNonceTypes.has(messageType)) return;
+        warnedInvalidNonceTypes.add(messageType);
+        console.warn(
+          `[@cloudflare/codemode] Ignoring sandbox ${messageType} message with invalid execution nonce`
+        );
+      };
+
       const handler = async (event: MessageEvent) => {
         if (event.source !== iframe.contentWindow) return;
 
@@ -243,10 +281,15 @@ export class IframeSandboxExecutor implements Executor {
         }
 
         if (isToolCallMessage(data)) {
+          if (data.nonce !== nonce) {
+            warnInvalidNonce("tool-call");
+            return;
+          }
           const provider = providerMap.get(data.provider);
           if (!provider) {
             postToChild(
               createToolResultMessage(
+                nonce,
                 data.id,
                 `Provider "${data.provider}" not found`,
                 true
@@ -260,14 +303,18 @@ export class IframeSandboxExecutor implements Executor {
               data.args,
               data.name
             );
-            postToChild(createToolResultMessage(data.id, result, false));
+            postToChild(createToolResultMessage(nonce, data.id, result, false));
           } catch (err) {
-            postToChild(createToolResultMessage(data.id, err, true));
+            postToChild(createToolResultMessage(nonce, data.id, err, true));
           }
           return;
         }
 
         if (isExecutionResultMessage(data)) {
+          if (data.nonce !== nonce) {
+            warnInvalidNonce("execution-result");
+            return;
+          }
           cleanup();
           resolve(data.result);
         }

--- a/packages/codemode/src/iframe-runtime.ts
+++ b/packages/codemode/src/iframe-runtime.ts
@@ -29,6 +29,7 @@ function iframeSandboxRuntimeMain(): void {
     { resolve: (value: unknown) => void; reject: (reason: Error) => void }
   > = {};
   let nextId = 0;
+  let activeNonce: string | undefined;
 
   function post(message: unknown) {
     parent.postMessage(message, "*");
@@ -51,10 +52,13 @@ function iframeSandboxRuntimeMain(): void {
     logs.push("[error] " + values.join(" "));
   };
 
-  function createProviderProxy(provider: {
-    name: string;
-    positionalArgs?: boolean;
-  }) {
+  function createProviderProxy(
+    nonce: string,
+    provider: {
+      name: string;
+      positionalArgs?: boolean;
+    }
+  ) {
     return new Proxy(
       {},
       {
@@ -66,6 +70,7 @@ function iframeSandboxRuntimeMain(): void {
                 pending[id] = { resolve, reject };
                 post({
                   type: "tool-call",
+                  nonce,
                   id,
                   provider: provider.name,
                   name: String(toolName),
@@ -81,6 +86,7 @@ function iframeSandboxRuntimeMain(): void {
               pending[id] = { resolve, reject };
               post({
                 type: "tool-call",
+                nonce,
                 id,
                 provider: provider.name,
                 name: String(toolName),
@@ -95,17 +101,23 @@ function iframeSandboxRuntimeMain(): void {
 
   function isToolResultMessage(message: unknown): message is {
     type: "tool-result";
+    nonce: string;
     id: number;
     result?: unknown;
     error?: string;
   } {
     if (typeof message !== "object" || message === null) return false;
     const candidate = message as Record<string, unknown>;
-    return candidate.type === "tool-result" && typeof candidate.id === "number";
+    return (
+      candidate.type === "tool-result" &&
+      typeof candidate.nonce === "string" &&
+      typeof candidate.id === "number"
+    );
   }
 
   function isExecuteRequestMessage(message: unknown): message is {
     type: "execute-request";
+    nonce: string;
     code: string;
     providers: { name: string; positionalArgs?: boolean }[];
   } {
@@ -113,6 +125,7 @@ function iframeSandboxRuntimeMain(): void {
     const candidate = message as Record<string, unknown>;
     return (
       candidate.type === "execute-request" &&
+      typeof candidate.nonce === "string" &&
       typeof candidate.code === "string" &&
       Array.isArray(candidate.providers) &&
       candidate.providers.every(
@@ -129,15 +142,17 @@ function iframeSandboxRuntimeMain(): void {
   }
 
   function executeCode(
+    nonce: string,
     code: string,
     providers: { name: string; positionalArgs?: boolean }[]
   ) {
     try {
+      activeNonce = nonce;
       const providerNames: string[] = [];
       const providerProxies: unknown[] = [];
       for (const provider of providers) {
         providerNames.push(provider.name);
-        providerProxies.push(createProviderProxy(provider));
+        providerProxies.push(createProviderProxy(nonce, provider));
       }
 
       const fn = new Function(...providerNames, "return (" + code + ")")(
@@ -145,11 +160,12 @@ function iframeSandboxRuntimeMain(): void {
       );
       Promise.resolve(fn())
         .then((result: unknown) => {
-          post({ type: "execution-result", result: { result, logs } });
+          post({ type: "execution-result", nonce, result: { result, logs } });
         })
         .catch((err: Error) => {
           post({
             type: "execution-result",
+            nonce,
             result: {
               result: undefined,
               error: err.message || String(err),
@@ -160,6 +176,7 @@ function iframeSandboxRuntimeMain(): void {
     } catch (err) {
       post({
         type: "execution-result",
+        nonce,
         result: {
           result: undefined,
           error: err instanceof Error ? err.message : String(err),
@@ -175,6 +192,7 @@ function iframeSandboxRuntimeMain(): void {
     const message = event.data;
 
     if (isToolResultMessage(message)) {
+      if (message.nonce !== activeNonce) return;
       const request = pending[message.id];
       if (!request) return;
 
@@ -186,7 +204,7 @@ function iframeSandboxRuntimeMain(): void {
     }
 
     if (isExecuteRequestMessage(message)) {
-      executeCode(message.code, message.providers);
+      executeCode(message.nonce, message.code, message.providers);
     }
   });
 

--- a/packages/codemode/src/messages.ts
+++ b/packages/codemode/src/messages.ts
@@ -18,6 +18,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export interface ToolCallMessage {
   type: "tool-call";
+  nonce: string;
   id: number;
   provider: string;
   name: string;
@@ -26,6 +27,7 @@ export interface ToolCallMessage {
 
 export interface ExecutionResultMessage {
   type: "execution-result";
+  nonce: string;
   result: ExecuteResult;
 }
 
@@ -37,18 +39,21 @@ export interface SandboxReadyMessage {
 
 export interface ToolResultSuccessMessage {
   type: "tool-result";
+  nonce: string;
   id: number;
   result: unknown;
 }
 
 export interface ToolResultErrorMessage {
   type: "tool-result";
+  nonce: string;
   id: number;
   error: string;
 }
 
 export interface ExecuteRequestMessage {
   type: "execute-request";
+  nonce: string;
   code: string;
   providers: { name: string; positionalArgs?: boolean }[];
 }
@@ -65,6 +70,7 @@ export function isToolCallMessage(data: unknown): data is ToolCallMessage {
   return (
     isRecord(data) &&
     data.type === "tool-call" &&
+    typeof data.nonce === "string" &&
     typeof data.id === "number" &&
     typeof data.provider === "string" &&
     typeof data.name === "string"
@@ -76,6 +82,7 @@ export function isExecutionResultMessage(
 ): data is ExecutionResultMessage {
   if (!isRecord(data)) return false;
   if (data.type !== "execution-result") return false;
+  if (typeof data.nonce !== "string") return false;
   if (typeof data.result !== "object" || data.result === null) return false;
   return true;
 }
@@ -86,6 +93,7 @@ export function isExecuteRequestMessageShape(
   return (
     isRecord(data) &&
     data.type === "execute-request" &&
+    typeof data.nonce === "string" &&
     typeof data.code === "string" &&
     Array.isArray(data.providers) &&
     data.providers.every(

--- a/packages/codemode/src/resolve.ts
+++ b/packages/codemode/src/resolve.ts
@@ -14,7 +14,7 @@ import type {
 } from "./executor";
 
 function hasNeedsApproval(t: Record<string, unknown>): boolean {
-  return "needsApproval" in t && t.needsApproval != null;
+  return t.needsApproval === true || typeof t.needsApproval === "function";
 }
 
 /**

--- a/packages/codemode/src/tanstack-ai.ts
+++ b/packages/codemode/src/tanstack-ai.ts
@@ -180,7 +180,7 @@ export function tanstackTools(
   name?: string
 ): ToolProvider {
   const filtered = tools.filter(
-    (t) => !("needsApproval" in t && t.needsApproval != null)
+    (t) => t.needsApproval !== true && typeof t.needsApproval !== "function"
   );
 
   const toolRecord: SimpleToolRecord = {};

--- a/packages/codemode/src/tests/executor.test.ts
+++ b/packages/codemode/src/tests/executor.test.ts
@@ -409,6 +409,22 @@ describe("Multiple providers (namespaces)", () => {
     expect(result.error).toContain("Duplicate");
   });
 
+  it("rejects sanitized tool name collisions", async () => {
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+
+    const result = await executor.execute("async () => 1", [
+      {
+        name: "codemode",
+        fns: {
+          "foo-bar": async () => "hyphen",
+          foo_bar: async () => "underscore"
+        }
+      }
+    ]);
+
+    expect(result.error).toContain("both sanitize to");
+  });
+
   it("rejects reserved provider names", async () => {
     const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
 

--- a/packages/codemode/src/tests/iframe-executor.browser.test.ts
+++ b/packages/codemode/src/tests/iframe-executor.browser.test.ts
@@ -4,7 +4,7 @@
  * These run in a real browser via @vitest/browser + Playwright.
  * No mocks — real iframes, real postMessage, real code execution.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { IframeSandboxExecutor } from "../iframe-executor";
 import type { ResolvedProvider } from "../executor-types";
 
@@ -22,6 +22,29 @@ describe("IframeSandboxExecutor", () => {
     ]);
     expect(result.result).toBe(42);
     expect(result.error).toBeUndefined();
+  });
+
+  it("should ignore forged execution-result messages from sandbox code", async () => {
+    const executor = new IframeSandboxExecutor();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await executor.execute(
+      `async () => {
+        parent.postMessage({
+          type: "execution-result",
+          nonce: "wrong",
+          result: { result: "forged", logs: [] }
+        }, "*");
+        return "real";
+      }`,
+      [codemodeProvider({})]
+    );
+
+    expect(result.result).toBe("real");
+    expect(result.error).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      "[@cloudflare/codemode] Ignoring sandbox execution-result message with invalid execution nonce"
+    );
+    warn.mockRestore();
   });
 
   it("should return undefined for void code", async () => {
@@ -88,6 +111,18 @@ describe("IframeSandboxExecutor", () => {
     );
     expect(result.result).toEqual([{ id: 1, title: "bug" }]);
     expect(result.error).toBeUndefined();
+  });
+
+  it("should reject sanitized tool name collisions", async () => {
+    const executor = new IframeSandboxExecutor();
+    const result = await executor.execute("async () => 1", [
+      codemodeProvider({
+        "foo-bar": async () => "hyphen",
+        foo_bar: async () => "underscore"
+      })
+    ]);
+
+    expect(result.error).toContain("both sanitize to");
   });
 
   it("should handle multiple sequential tool calls", async () => {
@@ -418,6 +453,49 @@ describe("createBrowserCodeTool", () => {
     await expect(
       tool.execute({ code: "async () => await codemode.dangerousTool({})" })
     ).rejects.toThrow('Code execution failed: Tool "dangerousTool" not found');
+  });
+
+  it("should keep tools with needsApproval: false", async () => {
+    const { createBrowserCodeTool } = await import("../browser-tool");
+
+    const tool = createBrowserCodeTool({
+      tools: {
+        explicitlySafeTool: {
+          description: "Explicitly safe tool",
+          inputSchema: { type: "object" },
+          needsApproval: false,
+          execute: async () => ({ ok: true })
+        }
+      }
+    });
+
+    expect(tool.description).toContain("explicitlySafeTool");
+
+    const result = await tool.execute({
+      code: "async () => await codemode.explicitlySafeTool({})"
+    });
+    expect(result.result).toEqual({ ok: true });
+  });
+
+  it("should reject sanitized browser tool name collisions", async () => {
+    const { createBrowserCodeTool } = await import("../browser-tool");
+
+    expect(() =>
+      createBrowserCodeTool({
+        tools: {
+          "foo-bar": {
+            description: "Hyphen",
+            inputSchema: { type: "object" },
+            execute: async () => "hyphen"
+          },
+          foo_bar: {
+            description: "Underscore",
+            inputSchema: { type: "object" },
+            execute: async () => "underscore"
+          }
+        }
+      })
+    ).toThrow("both sanitize to");
   });
 
   it("should exclude approval-gated tools from array-form descriptions and execution", async () => {

--- a/packages/codemode/src/tests/resolve.test.ts
+++ b/packages/codemode/src/tests/resolve.test.ts
@@ -59,6 +59,19 @@ describe("filterTools", () => {
     expect(Object.keys(filtered)).toEqual(["safe"]);
   });
 
+  it("should keep tools with needsApproval: false", () => {
+    const tools = {
+      safe: {
+        description: "Explicitly safe tool",
+        execute: async () => ({ ok: true }),
+        needsApproval: false
+      }
+    };
+
+    const filtered = filterTools(tools);
+    expect(Object.keys(filtered)).toEqual(["safe"]);
+  });
+
   it("should keep tools with needsApproval explicitly set to undefined in the shape but not actually present", () => {
     const tools: SimpleToolRecord = {
       tool: {

--- a/packages/codemode/src/tests/tanstack-ai.test.ts
+++ b/packages/codemode/src/tests/tanstack-ai.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { tanstackTools } from "../tanstack-ai";
+import type { Tool as TanStackTool } from "@tanstack/ai";
+
+describe("tanstackTools", () => {
+  it("should keep tools with needsApproval: false", () => {
+    const provider = tanstackTools([
+      {
+        name: "explicitly_safe",
+        description: "Explicitly safe",
+        needsApproval: false,
+        execute: async () => ({ ok: true })
+      } as unknown as TanStackTool
+    ]);
+
+    expect(provider.types).toContain("explicitly_safe");
+    expect(provider.tools).toHaveProperty("explicitly_safe");
+  });
+});

--- a/packages/codemode/src/tests/tool.test.ts
+++ b/packages/codemode/src/tests/tool.test.ts
@@ -243,6 +243,37 @@ describe("createCodeTool", () => {
     expect(capturedFnNames).not.toContain("approvalFnTool");
   });
 
+  it("should keep tools with needsApproval: false", async () => {
+    const testTools = {
+      explicitlySafeTool: {
+        description: "Explicitly safe",
+        inputSchema: z.object({}),
+        execute: async () => ({ ok: true }),
+        needsApproval: false
+      }
+    };
+
+    let capturedFnNames: string[] = [];
+    const executor: Executor = {
+      execute: vi.fn(async (_code: string, p: unknown) => {
+        const providers = p as ResolvedProvider[];
+        capturedFnNames = providers.flatMap((pr) => Object.keys(pr.fns));
+        return { result: null };
+      })
+    };
+
+    const codeTool = createCodeTool({ tools: testTools, executor });
+
+    expect(codeTool.description).toContain("explicitlySafeTool");
+
+    await codeTool.execute?.(
+      { code: "async () => null" },
+      {} as unknown as Parameters<NonNullable<typeof codeTool.execute>>[1]
+    );
+
+    expect(capturedFnNames).toContain("explicitlySafeTool");
+  });
+
   it("should return { code, result } on success", async () => {
     const { executor } = createMockExecutor({ result: { answer: 42 } });
     const codeTool = createCodeTool({ tools, executor });


### PR DESCRIPTION
## Summary
- Protect browser iframe codemode execution with per-run nonces on execute, tool-call, tool-result, and execution-result messages so forged sandbox completion messages are ignored and logged once per message type.
- Fix codemode tool filtering so `needsApproval: false` remains available across AI, browser, framework-agnostic, and TanStack entry points, while approval-required tools stay excluded.
- Reject sanitized tool-name collisions, run codemode browser tests in the package test script, and update docs/README/example/changelog copy for the browser export, iframe options, and timeout limitations.

## Test plan
- `npm test` in `packages/codemode` (222 unit tests + 33 browser tests before TanStack coverage; later 223 unit tests + 33 browser tests after adding TanStack regression)
- `npm run build` in `packages/codemode`
- `npx vitest run --config vitest.browser.config.ts src/tests/iframe-executor.browser.test.ts`
- `ReadLints` on touched codemode files and docs

## Notes
- Browser iframe timeouts still cannot preempt tight synchronous loops such as `while (true) {}` because they block the browser event loop; this PR documents that limitation.
- The mirrored developers.cloudflare.com MDX update lives in the separate `cloudflare-docs` checkout and is not part of this PR.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->