### PR TITLE
fix(codemode): harden OpenAPI sandbox ref handling

### DIFF
--- a/.changeset/mean-deers-shave.md
+++ b/.changeset/mean-deers-shave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+fix(codemode): harden OpenAPI sandbox ref handling

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -17,6 +17,9 @@ import type { JSONSchema7 } from "json-schema";
 const CHARS_PER_TOKEN = 4;
 const MAX_TOKENS = 6000;
 const MAX_CHARS = MAX_TOKENS * CHARS_PER_TOKEN;
+const TRUNCATION_MARKER = "--- TRUNCATED ---";
+const TRUNCATION_FOOTER_PREFIX = `\n\n${TRUNCATION_MARKER}\nResponse was ~`;
+const MAX_SANDBOX_TRUNCATED_CHARS = MAX_CHARS + 512;
 
 function truncateResponse(content: unknown): string {
   const text =
@@ -31,7 +34,18 @@ function truncateResponse(content: unknown): string {
   const truncated = text.slice(0, MAX_CHARS);
   const estimatedTokens = Math.ceil(text.length / CHARS_PER_TOKEN);
 
-  return `${truncated}\n\n--- TRUNCATED ---\nResponse was ~${estimatedTokens.toLocaleString()} tokens (limit: ${MAX_TOKENS.toLocaleString()}). Use more specific queries to reduce response size.`;
+  return `${truncated}\n\n${TRUNCATION_MARKER}\nResponse was ~${estimatedTokens.toLocaleString()} tokens (limit: ${MAX_TOKENS.toLocaleString()}). Use more specific queries to reduce response size.`;
+}
+
+function sandboxResponseText(content: unknown): string {
+  if (
+    typeof content === "string" &&
+    content.length <= MAX_SANDBOX_TRUNCATED_CHARS &&
+    content.slice(MAX_CHARS).startsWith(TRUNCATION_FOOTER_PREFIX)
+  ) {
+    return content;
+  }
+  return truncateResponse(content);
 }
 
 function formatError(error: unknown): string {
@@ -299,7 +313,9 @@ interface OpenApiSpec {
   components?: Record<string, unknown>;
   tags?: Array<{ name: string; description?: string }>;
 }
+`;
 
+const SEARCH_TYPES = `${SPEC_TYPES}
 declare const codemode: {
   spec(): Promise<OpenApiSpec>;
 };
@@ -336,6 +352,8 @@ function createOpenApiSandboxCode(
 
   return `async () => {
 const __rawSpec = ${specJson};
+const __refCache = new Map();
+const __cloneResolvedRef = (value) => structuredClone(value);
 const __resolveRefs = (obj, root, seen = new Set()) => {
   if (obj === null || obj === undefined) return obj;
   if (typeof obj !== "object") return obj;
@@ -345,6 +363,7 @@ const __resolveRefs = (obj, root, seen = new Set()) => {
     const ref = obj.$ref;
     if (seen.has(ref)) return { $circular: ref };
     if (!ref.startsWith("#/")) return obj;
+    if (__refCache.has(ref)) return __cloneResolvedRef(__refCache.get(ref));
     seen.add(ref);
 
     const parts = ref
@@ -355,7 +374,8 @@ const __resolveRefs = (obj, root, seen = new Set()) => {
     for (const part of parts) resolved = resolved?.[part];
     const result = __resolveRefs(resolved, root, seen);
     seen.delete(ref);
-    return result;
+    __refCache.set(ref, result);
+    return __cloneResolvedRef(result);
   }
 
   const result = {};
@@ -368,7 +388,7 @@ const __truncateResponse = (content) => {
   if (text.length <= ${MAX_CHARS}) return text;
   const truncated = text.slice(0, ${MAX_CHARS});
   const estimatedTokens = Math.ceil(text.length / ${CHARS_PER_TOKEN});
-  return truncated + "\\n\\n--- TRUNCATED ---\\nResponse was ~" + estimatedTokens.toLocaleString() + " tokens (limit: ${MAX_TOKENS.toLocaleString()}). Use more specific queries to reduce response size.";
+  return truncated + "\\n\\n${TRUNCATION_MARKER}\\nResponse was ~" + estimatedTokens.toLocaleString() + " tokens (limit: ${MAX_TOKENS.toLocaleString()}). Use more specific queries to reduce response size.";
 };
 const codemode = {
   spec: async () => (__resolvedSpec ??= __resolveRefs(__rawSpec, __rawSpec))${requestFn ? `,\n  ${requestFn}` : ""}
@@ -401,10 +421,10 @@ export function openApiMcpServer(options: OpenApiMcpServerOptions): McpServer {
   server.registerTool(
     "search",
     {
-      description: `Search the OpenAPI spec. All $refs are pre-resolved inline.
+      description: `Search the OpenAPI spec. codemode.spec() returns $refs resolved inline.
 
 Types:
-${SPEC_TYPES}
+${SEARCH_TYPES}
 
 Your code must be an async arrow function that returns the result.
 
@@ -451,7 +471,7 @@ async () => {
         }
         return {
           content: [
-            { type: "text" as const, text: truncateResponse(result.result) }
+            { type: "text" as const, text: sandboxResponseText(result.result) }
           ]
         };
       } catch (error) {
@@ -509,7 +529,7 @@ async () => {
         }
         return {
           content: [
-            { type: "text" as const, text: truncateResponse(result.result) }
+            { type: "text" as const, text: sandboxResponseText(result.result) }
           ]
         };
       } catch (error) {

--- a/packages/codemode/src/tests/__snapshots__/mcp.test.ts.snap
+++ b/packages/codemode/src/tests/__snapshots__/mcp.test.ts.snap
@@ -105,10 +105,6 @@ interface OpenApiSpec {
   tags?: Array<{ name: string; description?: string }>;
 }
 
-declare const codemode: {
-  spec(): Promise<OpenApiSpec>;
-};
-
 
 declare const codemode: {
   spec(): Promise<OpenApiSpec>;
@@ -125,7 +121,7 @@ async () => {
 `;
 
 exports[`openApiMcpServer > search tool description should match snapshot 1`] = `
-"Search the OpenAPI spec. All $refs are pre-resolved inline.
+"Search the OpenAPI spec. codemode.spec() returns $refs resolved inline.
 
 Types:
 

--- a/packages/codemode/src/tests/mcp.test.ts
+++ b/packages/codemode/src/tests/mcp.test.ts
@@ -596,7 +596,7 @@ describe("openApiMcpServer", () => {
     await client.close();
   });
 
-  it("should resolve $refs before injecting spec", async () => {
+  it("should resolve $refs inside the sandbox", async () => {
     const specWithRefs = {
       openapi: "3.0.0",
       paths: {
@@ -643,6 +643,272 @@ describe("openApiMcpServer", () => {
     expect(JSON.parse(callText(result))).toEqual({
       type: "array",
       items: { type: "object", properties: { id: { type: "string" } } }
+    });
+
+    await client.close();
+  });
+
+  it("search should preserve sandbox truncation metadata", async () => {
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: "async () => 'x'.repeat(25000)"
+      }
+    });
+
+    const text = callText(result);
+    expect(text).toContain("--- TRUNCATED ---");
+    expect(text).toContain("Response was ~6,250 tokens");
+
+    await client.close();
+  });
+
+  it("search should truncate oversized string results from custom executors on the host", async () => {
+    const executor = {
+      execute: async () => ({ result: "x".repeat(25000) })
+    };
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: "async () => 'ignored'"
+      }
+    });
+
+    const text = callText(result);
+    expect(text).toContain("--- TRUNCATED ---");
+    expect(text).toContain("Response was ~6,250 tokens");
+
+    await client.close();
+  });
+
+  it("search should not trust arbitrary truncation markers from custom executors", async () => {
+    const executor = {
+      execute: async () => ({
+        result: "--- TRUNCATED ---\n" + "x".repeat(25000)
+      })
+    };
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: "async () => 'ignored'"
+      }
+    });
+
+    const text = callText(result);
+    expect(text).toContain("--- TRUNCATED ---");
+    expect(text).toContain("Response was ~6,255 tokens");
+
+    await client.close();
+  });
+
+  it("should preserve external refs and surface missing internal refs as undefined", async () => {
+    const specWithRefs = {
+      openapi: "3.0.0",
+      info: { title: "Refs", version: "1" },
+      paths: {
+        "/external": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "schemas/external.json#/Thing" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/missing": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Missing" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: { schemas: {} }
+    };
+
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const server = openApiMcpServer({
+      spec: specWithRefs,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: `async () => {
+          const spec = await codemode.spec();
+          return {
+            external: spec.paths["/external"].get.responses["200"].content["application/json"].schema,
+            missing: String(spec.paths["/missing"].get.responses["200"].content["application/json"].schema)
+          };
+        }`
+      }
+    });
+
+    expect(JSON.parse(callText(result))).toEqual({
+      external: { $ref: "schemas/external.json#/Thing" },
+      missing: "undefined"
+    });
+
+    await client.close();
+  });
+
+  it("should mark circular refs without recursing forever", async () => {
+    const specWithCycle = {
+      openapi: "3.0.0",
+      info: { title: "Cycle", version: "1" },
+      paths: {
+        "/nodes": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Node" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          Node: {
+            type: "object",
+            properties: {
+              child: { $ref: "#/components/schemas/Node" }
+            }
+          }
+        }
+      }
+    };
+
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const server = openApiMcpServer({
+      spec: specWithCycle,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: `async () => {
+          const spec = await codemode.spec();
+          return spec.paths["/nodes"].get.responses["200"].content["application/json"].schema.properties.child;
+        }`
+      }
+    });
+
+    expect(JSON.parse(callText(result))).toEqual({
+      $circular: "#/components/schemas/Node"
+    });
+
+    await client.close();
+  });
+
+  it("should reuse ref resolution work without sharing mutable objects", async () => {
+    const specWithSharedRef = {
+      openapi: "3.0.0",
+      info: { title: "Shared", version: "1" },
+      paths: {
+        "/a": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Shared" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/b": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Shared" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          Shared: {
+            type: "object",
+            properties: { id: { type: "string" } }
+          }
+        }
+      }
+    };
+
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const server = openApiMcpServer({
+      spec: specWithSharedRef,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: `async () => {
+          const spec = await codemode.spec();
+          const a = spec.paths["/a"].get.responses["200"].content["application/json"].schema;
+          const b = spec.paths["/b"].get.responses["200"].content["application/json"].schema;
+          a.properties.id.type = "number";
+          return { sameObject: a === b, bType: b.properties.id.type };
+        }`
+      }
+    });
+
+    expect(JSON.parse(callText(result))).toEqual({
+      sameObject: false,
+      bType: "string"
     });
 
     await client.close();


### PR DESCRIPTION
## Summary
- Preserve sandbox-side truncation metadata for OpenAPI search/execute results without dropping host-side truncation for custom executors.
- Cache internal OpenAPI `$ref` resolution work inside the sandbox while returning cloned resolved schemas so repeated refs do not share mutable objects.
- Clean up OpenAPI tool descriptions after lazy sandbox resolution and add regression coverage for truncation and `$ref` edge cases.

## Test plan
- `npx vitest run src/tests/mcp.test.ts`
- `npx nx run @cloudflare/codemode:test`
- `git diff --check`
- Edited-file lints clean in Cursor

## Notes
This follows up on #1470. That PR moved OpenAPI spec resolution into the sandbox to avoid Worker Loader RPC size limits for heavily referenced specs. This PR tightens the behavior around the new sandbox boundary and documents the expected edge-case behavior in tests.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->