### PR TITLE
Fix duplicate initial Agent state frames

### DIFF
--- a/.changeset/fix-agent-initial-state-sync.md
+++ b/.changeset/fix-agent-initial-state-sync.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Prevent duplicate initial state frames during Agent WebSocket connection setup so client-originated state updates are not overwritten by stale initial state messages.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1134,6 +1134,7 @@ export class Agent<
    * parent-owned WebSocket handles during this window.
    */
   private _suppressProtocolBroadcasts = false;
+  private _protocolBroadcastExcludeIds = new Set<string>();
   private _cf_currentSubAgentBridge?: SubAgentConnectionBridgeLike;
   private _cf_virtualSubAgentConnections = new Map<
     string,
@@ -1908,10 +1909,22 @@ export class Agent<
               );
             }
 
-            if (this.state) {
+            const wasExcludedFromStateInitBroadcast =
+              this._protocolBroadcastExcludeIds.has(connection.id);
+            let currentState: State | undefined;
+            this._protocolBroadcastExcludeIds.add(connection.id);
+            try {
+              currentState = this.state;
+            } finally {
+              if (!wasExcludedFromStateInitBroadcast) {
+                this._protocolBroadcastExcludeIds.delete(connection.id);
+              }
+            }
+
+            if (currentState !== undefined) {
               connection.send(
                 JSON.stringify({
-                  state: this.state,
+                  state: currentState,
                   type: MessageType.CF_AGENT_STATE
                 })
               );
@@ -2088,7 +2101,7 @@ export class Agent<
   private _broadcastProtocol(msg: string, excludeIds: string[] = []) {
     if (this._suppressProtocolBroadcasts) return;
 
-    const exclude = [...excludeIds];
+    const exclude = [...excludeIds, ...this._protocolBroadcastExcludeIds];
     for (const conn of this.getConnections()) {
       if (!this.isConnectionProtocolEnabled(conn)) {
         exclude.push(conn.id);

--- a/packages/agents/src/tests/agents/protocol-messages.ts
+++ b/packages/agents/src/tests/agents/protocol-messages.ts
@@ -18,6 +18,11 @@ export class TestProtocolMessagesAgent extends Agent<
   Cloudflare.Env,
   { count: number }
 > {
+  // Capture the DEFAULT_STATE sentinel reference for cache reset in tests.
+  // Child field initializers run after super(), at which point _state is DEFAULT_STATE.
+  // @ts-expect-error - accessing private field for testing
+  private _stateSentinel: { count: number } = this._state;
+
   initialState = { count: 0 };
   static options = { hibernate: true };
 
@@ -46,6 +51,13 @@ export class TestProtocolMessagesAgent extends Agent<
   @callable()
   async getState() {
     return this.state;
+  }
+
+  @callable()
+  async resetStateForLazyInitTest() {
+    this.sql`DELETE FROM cf_agents_state WHERE id = ${"cf_state_row_id"}`;
+    // @ts-expect-error - accessing private field for testing
+    this._state = this._stateSentinel;
   }
 
   @callable()

--- a/packages/agents/src/tests/protocol-messages.test.ts
+++ b/packages/agents/src/tests/protocol-messages.test.ts
@@ -163,6 +163,57 @@ describe("Protocol Messages", () => {
       expect(types).toContain(MessageType.CF_AGENT_MCP_SERVERS);
     }, 10000);
 
+    it("should send exactly one initial state message to protocol-enabled connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectWS(`${BASE}/${room}`);
+
+      const messages = await collectMessages(ws, 1000);
+      ws.close();
+
+      const stateMessages = messages.filter(
+        (m): m is StateMessage =>
+          typeof m === "object" &&
+          m !== null &&
+          "type" in m &&
+          (m as StateMessage).type === MessageType.CF_AGENT_STATE
+      );
+
+      expect(stateMessages).toHaveLength(1);
+      expect(stateMessages[0].state.count).toBe(0);
+    }, 10000);
+
+    it("should still broadcast lazy initial state to existing protocol connections", async () => {
+      const room = crypto.randomUUID();
+      const { ws: existing } = await connectProtocol(room);
+
+      const resetMsg = await sendRpc(existing, "resetStateForLazyInitTest");
+      expect(resetMsg.success).toBe(true);
+
+      const existingStatePromise = waitForMessage<StateMessage>(
+        existing,
+        (d) => d.type === MessageType.CF_AGENT_STATE && d.state.count === 0
+      );
+
+      const { ws: connecting } = await connectWS(`${BASE}/${room}`);
+
+      const existingStateMsg = await existingStatePromise;
+      expect(existingStateMsg.state.count).toBe(0);
+
+      const connectingMessages = await collectMessages(connecting, 1000);
+      const connectingStateMessages = connectingMessages.filter(
+        (m): m is StateMessage =>
+          typeof m === "object" &&
+          m !== null &&
+          "type" in m &&
+          (m as StateMessage).type === MessageType.CF_AGENT_STATE
+      );
+      expect(connectingStateMessages).toHaveLength(1);
+      expect(connectingStateMessages[0].state.count).toBe(0);
+
+      existing.close();
+      connecting.close();
+    }, 10000);
+
     it("should NOT send any protocol messages to no-protocol connections", async () => {
       const room = crypto.randomUUID();
       const { ws } = await connectNoProtocol(room);


### PR DESCRIPTION
## Summary
- Prevent duplicate initial `CF_AGENT_STATE` frames during Agent WebSocket connection setup by temporarily excluding only the connecting socket from lazy state-initialization broadcasts.
- Preserve lazy initialization broadcasts for any other existing protocol-enabled clients.
- Add a patch changeset for `agents` and protocol regression coverage for both the duplicate-frame case and the existing-client broadcast edge case.

## Test plan
- `npm run test:workers -w agents -- src/tests/protocol-messages.test.ts`
- `npm run test:react -w agents -- src/react-tests/useAgent.test.tsx -t "should update state property on client setState"`
- `npm run test:react -w agents -- src/react-tests/useAgent.test.tsx`
- `npx oxfmt --check packages/agents/src/index.ts packages/agents/src/tests/protocol-messages.test.ts packages/agents/src/tests/agents/protocol-messages.ts`
- `ReadLints` on edited files

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->