### PR TITLE
Fix streamable HTTP server-to-client MCP routing

### DIFF
--- a/.changeset/fix-mcp-post-elicitation-routing.md
+++ b/.changeset/fix-mcp-post-elicitation-routing.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Route streamable HTTP server-to-client requests through the originating POST stream when no standalone SSE stream is available.

--- a/packages/agents/src/mcp/transport.ts
+++ b/packages/agents/src/mcp/transport.ts
@@ -1,8 +1,10 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   type MessageExtraInfo,
   type RequestInfo,
   isJSONRPCErrorResponse,
+  isJSONRPCNotification,
   isJSONRPCRequest,
   isJSONRPCResultResponse,
   type JSONRPCMessage,
@@ -81,6 +83,10 @@ export interface StreamableHTTPServerTransportOptions {
   eventStore?: EventStore;
 }
 
+type ConnectionSource = {
+  getConnections<TState = unknown>(): Iterable<Connection<TState>>;
+};
+
 /**
  * Adapted from: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/client/streamableHttp.ts
  * - Validation and initialization are removed as they're handled in `McpAgent.serve()` handler.
@@ -98,6 +104,7 @@ export class StreamableHTTPServerTransport implements Transport {
   // I's fine that we don't persist this since it's only for backwards compatibility as clients
   // should no longer batch requests, per the spec.
   private _requestResponseMap: Map<RequestId, JSONRPCMessage> = new Map();
+  private _activeRequestId = new AsyncLocalStorage<RequestId>();
 
   sessionId: string;
   onclose?: () => void;
@@ -113,6 +120,30 @@ export class StreamableHTTPServerTransport implements Transport {
     message: JSONRPCMessage,
     extra?: MessageExtraInfo
   ) => Promise<boolean>;
+
+  private getStandaloneSseConnection(
+    agent: ConnectionSource
+  ): Connection | undefined {
+    for (const conn of agent.getConnections<{ _standaloneSse?: boolean }>()) {
+      if (conn.state?._standaloneSse) return conn;
+    }
+    return undefined;
+  }
+
+  private getOnlyActiveRequestId(
+    agent: ConnectionSource
+  ): RequestId | undefined {
+    const requestIds = new Set<RequestId>();
+
+    for (const conn of agent.getConnections<{ requestIds?: RequestId[] }>()) {
+      for (const id of conn.state?.requestIds ?? []) {
+        requestIds.add(id);
+        if (requestIds.size > 1) return undefined;
+      }
+    }
+
+    return requestIds.values().next().value;
+  }
 
   constructor(options: StreamableHTTPServerTransportOptions) {
     const { agent } = getCurrentAgent<McpAgent>();
@@ -242,20 +273,32 @@ export class StreamableHTTPServerTransport implements Transport {
     // check if it contains requests
     const hasRequests = messages.some(isJSONRPCRequest);
 
+    const dispatchMessage = async (message: JSONRPCMessage): Promise<void> => {
+      // check if message should be intercepted (i.e. elicitation responses)
+      if (this.messageInterceptor) {
+        const handled = await this.messageInterceptor(message, {
+          authInfo,
+          requestInfo
+        });
+        if (handled) {
+          return; // msg was handled by interceptor, skip onmessage
+        }
+      }
+
+      if (isJSONRPCRequest(message)) {
+        this._activeRequestId.run(message.id, () => {
+          this.onmessage?.(message, { authInfo, requestInfo });
+        });
+        return;
+      }
+
+      this.onmessage?.(message, { authInfo, requestInfo });
+    };
+
     if (!hasRequests) {
       // We process without sending anything
       for (const message of messages) {
-        // check if message should be intercepted (i.e. elicitation responses)
-        if (this.messageInterceptor) {
-          const handled = await this.messageInterceptor(message, {
-            authInfo,
-            requestInfo
-          });
-          if (handled) {
-            continue; // msg was handled by interceptor, skip onmessage
-          }
-        }
-        this.onmessage?.(message, { authInfo, requestInfo });
+        await dispatchMessage(message);
       }
     } else if (hasRequests) {
       const { connection } = getCurrentAgent();
@@ -273,16 +316,7 @@ export class StreamableHTTPServerTransport implements Transport {
 
       // handle each message
       for (const message of messages) {
-        if (this.messageInterceptor) {
-          const handled = await this.messageInterceptor(message, {
-            authInfo,
-            requestInfo
-          });
-          if (handled) {
-            continue; // Message was handled by interceptor, skip onmessage
-          }
-        }
-        this.onmessage?.(message, { authInfo, requestInfo });
+        await dispatchMessage(message);
       }
       // The server SHOULD NOT close the SSE stream before sending all JSON-RPC responses
       // This will be handled by the send() method when responses are ready
@@ -307,10 +341,30 @@ export class StreamableHTTPServerTransport implements Transport {
     const { agent } = getCurrentAgent();
     if (!agent) throw new Error("Agent was not found in send");
 
+    const contextRequestId = this._activeRequestId.getStore();
     let requestId = options?.relatedRequestId;
     if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
       // If the message is a response, use the request ID from the message
       requestId = message.id;
+    }
+
+    let standaloneConnection: Connection | undefined;
+    if (requestId === undefined) {
+      standaloneConnection = this.getStandaloneSseConnection(agent);
+
+      if (standaloneConnection === undefined) {
+        if (
+          contextRequestId !== undefined &&
+          (isJSONRPCRequest(message) || isJSONRPCNotification(message))
+        ) {
+          requestId = contextRequestId;
+        } else if (
+          isJSONRPCRequest(message) ||
+          isJSONRPCNotification(message)
+        ) {
+          requestId = this.getOnlyActiveRequestId(agent);
+        }
+      }
     }
 
     // Check if this message should be sent on the standalone SSE stream (no request ID)
@@ -324,13 +378,15 @@ export class StreamableHTTPServerTransport implements Transport {
         );
       }
 
-      let standaloneConnection: Connection | undefined;
-      for (const conn of agent.getConnections<{ _standaloneSse?: boolean }>()) {
-        if (conn.state?._standaloneSse) standaloneConnection = conn;
-      }
-
       if (standaloneConnection === undefined) {
-        // The spec says the server MAY send messages on the stream, so it's ok to discard if no stream
+        if (isJSONRPCRequest(message)) {
+          throw new Error(
+            "No connection established for server-to-client request"
+          );
+        }
+
+        // The spec says the server MAY send notifications on the stream,
+        // so it's ok to discard notifications if no stream is available.
         return;
       }
 
@@ -351,8 +407,8 @@ export class StreamableHTTPServerTransport implements Transport {
 
     // Get the response for this request
     const connection = Array.from(
-      agent.getConnections<{ requestIds?: number[] }>()
-    ).find((conn) => conn.state?.requestIds?.includes(requestId as number));
+      agent.getConnections<{ requestIds?: RequestId[] }>()
+    ).find((conn) => conn.state?.requestIds?.includes(requestId));
     if (!connection) {
       throw new Error(
         `No connection established for request ID: ${String(requestId)}`
@@ -378,6 +434,7 @@ export class StreamableHTTPServerTransport implements Transport {
         for (const id of relatedIds) {
           this._requestResponseMap.delete(id);
         }
+        connection.setState({ requestIds: [] });
       }
     }
     this.writeSSEEvent(connection, message, eventId, shouldClose);

--- a/packages/agents/src/tests/mcp/elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/elicitation.test.ts
@@ -111,6 +111,200 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
       await standaloneReader.cancel();
     });
 
+    it("should route McpAgent.elicitInput through the originating POST stream without standalone SSE", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+
+      const toolCallMsg: JSONRPCMessage = {
+        id: "custom-elicit-post-1",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "elicitNameCustom", arguments: {} }
+      };
+
+      const toolResponse = await sendPostRequest(
+        ctx,
+        baseUrl,
+        toolCallMsg,
+        sessionId
+      );
+      expect(toolResponse.status).toBe(200);
+
+      const reader = toolResponse.body?.getReader();
+      expect(reader).toBeTruthy();
+      if (!reader) throw new Error("No reader available for POST stream");
+
+      const elicitFrame = await readOneFrame(reader);
+      const elicitRequest = parseSSEData(elicitFrame) as JSONRPCRequest;
+
+      expect(elicitRequest.method).toBe("elicitation/create");
+      expect(String(elicitRequest.id).startsWith("elicit_")).toBe(true);
+
+      const elicitResponse: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: elicitRequest.id,
+        result: {
+          action: "accept",
+          content: { name: "Alice" }
+        }
+      } as unknown as JSONRPCMessage;
+
+      const responsePost = await sendPostRequest(
+        ctx,
+        baseUrl,
+        elicitResponse,
+        sessionId
+      );
+      expect(responsePost.status).toBe(202);
+
+      const toolResultFrame = await readOneFrame(reader);
+      const toolResult = parseSSEData(toolResultFrame) as JSONRPCResultResponse;
+
+      expect(toolResult.id).toBe("custom-elicit-post-1");
+      const result = toolResult.result as CallToolResult;
+      expect(result.content).toEqual([
+        { type: "text", text: "Custom elicit: Alice" }
+      ]);
+    });
+
+    it("should route SDK Server.elicitInput through the originating POST stream without standalone SSE", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+
+      const toolCallMsg: JSONRPCMessage = {
+        id: "sdk-elicit-post-1",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "elicitName", arguments: {} }
+      };
+
+      const toolResponse = await sendPostRequest(
+        ctx,
+        baseUrl,
+        toolCallMsg,
+        sessionId
+      );
+      expect(toolResponse.status).toBe(200);
+
+      const reader = toolResponse.body?.getReader();
+      expect(reader).toBeTruthy();
+      if (!reader) throw new Error("No reader available for POST stream");
+
+      const elicitFrame = await readOneFrame(reader);
+      const elicitRequest = parseSSEData(elicitFrame) as JSONRPCRequest;
+
+      expect(elicitRequest.method).toBe("elicitation/create");
+
+      const elicitResponse: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: elicitRequest.id,
+        result: {
+          action: "accept",
+          content: { name: "Alice" }
+        }
+      } as unknown as JSONRPCMessage;
+
+      const responsePost = await sendPostRequest(
+        ctx,
+        baseUrl,
+        elicitResponse,
+        sessionId
+      );
+      expect(responsePost.status).toBe(202);
+
+      const toolResultFrame = await readOneFrame(reader);
+      const toolResult = parseSSEData(toolResultFrame) as JSONRPCResultResponse;
+
+      expect(toolResult.id).toBe("sdk-elicit-post-1");
+      const result = toolResult.result as CallToolResult;
+      expect(result.content).toEqual([
+        { type: "text", text: "You said your name is: Alice" }
+      ]);
+    });
+
+    it("should keep concurrent elicitation requests on their own POST streams", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+
+      const firstToolCall: JSONRPCMessage = {
+        id: "custom-elicit-concurrent-1",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "elicitNameCustom", arguments: {} }
+      };
+      const secondToolCall: JSONRPCMessage = {
+        id: "custom-elicit-concurrent-2",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "elicitNameCustom", arguments: {} }
+      };
+
+      const [firstResponse, secondResponse] = await Promise.all([
+        sendPostRequest(ctx, baseUrl, firstToolCall, sessionId),
+        sendPostRequest(ctx, baseUrl, secondToolCall, sessionId)
+      ]);
+
+      expect(firstResponse.status).toBe(200);
+      expect(secondResponse.status).toBe(200);
+
+      const firstReader = firstResponse.body?.getReader();
+      const secondReader = secondResponse.body?.getReader();
+      expect(firstReader).toBeTruthy();
+      expect(secondReader).toBeTruthy();
+      if (!firstReader || !secondReader) {
+        throw new Error("No reader available for POST stream");
+      }
+
+      const [firstElicitFrame, secondElicitFrame] = await Promise.all([
+        readOneFrame(firstReader),
+        readOneFrame(secondReader)
+      ]);
+      const firstElicit = parseSSEData(firstElicitFrame) as JSONRPCRequest;
+      const secondElicit = parseSSEData(secondElicitFrame) as JSONRPCRequest;
+
+      expect(firstElicit.method).toBe("elicitation/create");
+      expect(secondElicit.method).toBe("elicitation/create");
+      expect(firstElicit.id).not.toBe(secondElicit.id);
+
+      const secondElicitResponse: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: secondElicit.id,
+        result: {
+          action: "accept",
+          content: { name: "Second" }
+        }
+      } as unknown as JSONRPCMessage;
+      await sendPostRequest(ctx, baseUrl, secondElicitResponse, sessionId);
+
+      const secondToolResultFrame = await readOneFrame(secondReader);
+      const secondToolResult = parseSSEData(
+        secondToolResultFrame
+      ) as JSONRPCResultResponse;
+      expect(secondToolResult.id).toBe("custom-elicit-concurrent-2");
+      expect((secondToolResult.result as CallToolResult).content).toEqual([
+        { type: "text", text: "Custom elicit: Second" }
+      ]);
+
+      const firstElicitResponse: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: firstElicit.id,
+        result: {
+          action: "accept",
+          content: { name: "First" }
+        }
+      } as unknown as JSONRPCMessage;
+      await sendPostRequest(ctx, baseUrl, firstElicitResponse, sessionId);
+
+      const firstToolResultFrame = await readOneFrame(firstReader);
+      const firstToolResult = parseSSEData(
+        firstToolResultFrame
+      ) as JSONRPCResultResponse;
+      expect(firstToolResult.id).toBe("custom-elicit-concurrent-1");
+      expect((firstToolResult.result as CallToolResult).content).toEqual([
+        { type: "text", text: "Custom elicit: First" }
+      ]);
+    });
+
     it("should handle elicitation cancel response", async () => {
       const ctx = createExecutionContext();
       const sessionId = await initializeStreamableHTTPServer(ctx);

--- a/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
+++ b/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
@@ -8,6 +8,10 @@ import type {
   JSONRPCResultResponse
 } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it } from "vitest";
+import type { Connection } from "../../../index";
+import { __DO_NOT_USE_WILL_BREAK__agentContext as agentContext } from "../../../internal_context";
+import type { McpAgent } from "../../../mcp";
+import { StreamableHTTPServerTransport } from "../../../mcp/transport";
 import worker from "../../worker";
 import {
   TEST_MESSAGES,
@@ -493,6 +497,184 @@ describe("Streamable HTTP Transport", () => {
       expect(silent).toBeNull();
 
       await standaloneReader.cancel();
+    });
+
+    it("should deliver request-scoped logging/message on the originating POST stream without standalone SSE", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+
+      const emitLogMsg = {
+        id: "emit-log-post-1",
+        jsonrpc: "2.0" as const,
+        method: "tools/call",
+        params: {
+          name: "emitLog",
+          arguments: { level: "info", message: "hello-post" }
+        }
+      };
+
+      const postRes = await sendPostRequest(
+        ctx,
+        baseUrl,
+        emitLogMsg,
+        sessionId
+      );
+      expect(postRes.status).toBe(200);
+
+      const reader = postRes.body?.getReader();
+      expect(reader).toBeTruthy();
+      if (!reader) throw new Error("No reader available for POST stream");
+
+      const pushFrame = await readOneFrame(reader);
+      const pushJson = parseSSEData(pushFrame) as JSONRPCNotification;
+      expect(pushJson).toMatchObject({
+        jsonrpc: "2.0",
+        method: "notifications/message",
+        params: expect.objectContaining({
+          level: "info",
+          data: "hello-post"
+        })
+      });
+
+      const postFrame = await readOneFrame(reader);
+      const postJson = parseSSEData(postFrame) as JSONRPCResultResponse;
+      expect(postJson.id).toBe("emit-log-post-1");
+      const result = postJson.result as CallToolResult;
+      expect(
+        result.content?.[0]?.type === "text" &&
+          result.content?.[0]?.text === "logged:info"
+      ).toBe(true);
+    });
+
+    it("should route server messages to the only active POST stream when async context is unavailable", async () => {
+      const sentMessages: string[] = [];
+      const connection = {
+        id: "post-stream-1",
+        state: { requestIds: ["req-1"] },
+        send(message: string) {
+          sentMessages.push(message);
+        }
+      } as unknown as Connection;
+      const agent = {
+        getSessionId() {
+          return "test-session";
+        },
+        getConnections() {
+          return [connection];
+        }
+      } as unknown as McpAgent;
+
+      await agentContext.run(
+        { agent, connection: undefined, request: undefined, email: undefined },
+        async () => {
+          const transport = new StreamableHTTPServerTransport({});
+          const notification: JSONRPCMessage = {
+            jsonrpc: "2.0",
+            method: "notifications/message",
+            params: { level: "info", data: "hello-fallback" }
+          };
+
+          await transport.send(notification);
+        }
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const forwarded = JSON.parse(sentMessages[0]) as {
+        event: string;
+        close?: boolean;
+      };
+      const fallbackJson = parseSSEData(forwarded.event) as JSONRPCNotification;
+      expect(forwarded.close).toBe(false);
+      expect(fallbackJson).toMatchObject({
+        jsonrpc: "2.0",
+        method: "notifications/message",
+        params: expect.objectContaining({
+          level: "info",
+          data: "hello-fallback"
+        })
+      });
+    });
+
+    it("should clear request ids when a POST stream receives all final responses", async () => {
+      const sentMessages: string[] = [];
+      const connectionState = { requestIds: ["req-1"] };
+      const connection = {
+        id: "post-stream-1",
+        state: connectionState,
+        setState(nextState: typeof connectionState) {
+          connectionState.requestIds = nextState.requestIds;
+        },
+        send(message: string) {
+          sentMessages.push(message);
+        }
+      } as unknown as Connection;
+      const agent = {
+        getSessionId() {
+          return "test-session";
+        },
+        getConnections() {
+          return [connection];
+        }
+      } as unknown as McpAgent;
+
+      await agentContext.run(
+        { agent, connection: undefined, request: undefined, email: undefined },
+        async () => {
+          const transport = new StreamableHTTPServerTransport({});
+          const response: JSONRPCMessage = {
+            id: "req-1",
+            jsonrpc: "2.0",
+            result: { content: [] }
+          };
+
+          await transport.send(response);
+        }
+      );
+
+      expect(connectionState.requestIds).toEqual([]);
+      expect(sentMessages).toHaveLength(1);
+      const forwarded = JSON.parse(sentMessages[0]) as {
+        close?: boolean;
+      };
+      expect(forwarded.close).toBe(true);
+    });
+
+    it("should reject unroutable server-to-client requests instead of silently dropping them", async () => {
+      const firstConnection = {
+        id: "post-stream-1",
+        state: { requestIds: ["req-1"] },
+        send(_message: string) {}
+      } as unknown as Connection;
+      const secondConnection = {
+        id: "post-stream-2",
+        state: { requestIds: ["req-2"] },
+        send(_message: string) {}
+      } as unknown as Connection;
+      const agent = {
+        getSessionId() {
+          return "test-session";
+        },
+        getConnections() {
+          return [firstConnection, secondConnection];
+        }
+      } as unknown as McpAgent;
+
+      await agentContext.run(
+        { agent, connection: undefined, request: undefined, email: undefined },
+        async () => {
+          const transport = new StreamableHTTPServerTransport({});
+          const request: JSONRPCMessage = {
+            id: "server-request-1",
+            jsonrpc: "2.0",
+            method: "elicitation/create",
+            params: { message: "Approve?" }
+          };
+
+          await expect(transport.send(request)).rejects.toThrow(
+            /No connection established for server-to-client request/
+          );
+        }
+      );
     });
 
     it("should emit tools list_changed on install/uninstall and reflect in tools/list", async () => {


### PR DESCRIPTION
## Summary

Fixes the Streamable HTTP routing failure described in #1510 for clients that do not keep a standalone GET/SSE stream open.

The MCP Streamable HTTP spec permits clients to rely on the originating POST response stream for related server-to-client messages. Previously, `StreamableHTTPServerTransport.send()` treated server-to-client requests and notifications without an explicit `relatedRequestId` as standalone messages. If no connection had `_standaloneSse` set, those messages were silently dropped. For request/response flows such as `elicitation/create`, the caller then waited until the MCP SDK timeout and surfaced an opaque request timeout.

This PR makes the transport route related server-to-client messages through POST when that is the only correct available channel.

## What changed

- Track the currently dispatched MCP request id with transport-local `AsyncLocalStorage` while invoking the SDK `onmessage` handler.
- When `send()` is called with no explicit `relatedRequestId` and no standalone SSE stream exists:
  - route JSON-RPC requests and notifications to the active request id when available;
  - otherwise, conservatively fall back only if there is exactly one active POST request id across live connections;
  - reject unroutable server-to-client JSON-RPC requests instead of silently dropping them.
- Preserve existing Inspector-style behavior when a standalone SSE stream is present.
- Continue treating completely unroutable notifications as best-effort, since standalone notifications are optional by spec.
- Add a patch changeset for `agents`.

## Why this approach

The full semantic fix belongs upstream in `@modelcontextprotocol/sdk`: SDK convenience APIs such as `Server.elicitInput()`, `Server.createMessage()`, `Server.listRoots()`, and notification helpers should automatically inherit `relatedRequestId` when called from inside a request handler.

This transport-side fix is still needed so `agents` works with spec-compliant Streamable HTTP clients today. It avoids unsafe “pick any POST stream” behavior by using the active request context when possible and falling back only when there is exactly one active POST request.

Follow-up tracking issue for the SDK work: #1513.

## Coverage

Added regression coverage for:

- `McpAgent.elicitInput()` over the originating POST stream without standalone SSE.
- SDK `Server.elicitInput()` over the originating POST stream without standalone SSE.
- Concurrent elicitation requests staying on their own POST streams.
- Request-scoped logging notifications delivered over POST when no standalone SSE exists.
- Lost async-context fallback to the only active POST stream.
- Ambiguous server-to-client requests rejecting instead of being silently dropped.

## Test plan

- `npm --workspace packages/agents run test:workers -- src/tests/mcp/elicitation.test.ts src/tests/mcp/transports/streamable-http.test.ts`
- `npm --workspace packages/agents run test:workers -- src/tests/mcp`

Both passed locally.

## Known remaining limitations

- If a connection is still marked `_standaloneSse` but the outer HTTP SSE writer is already dead, the transport will still prefer the standalone connection. That lifecycle race is not fully observable from `send()`.
- If async context is lost while multiple POST streams are active, the transport intentionally refuses to guess. The SDK-level `relatedRequestId` propagation tracked in #1513 is the correct fix for that case.
- Durable recovery of pending SDK-level server-to-client requests across hibernation is outside this patch and likely needs SDK design work.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->