### PR TITLE
Add durable recovery for Think chat RPC

### DIFF
--- a/.changeset/fix-think-chat-recovery.md
+++ b/.changeset/fix-think-chat-recovery.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": minor
+---
+
+Wrap `Think.chat()` RPC turns in chat recovery fibers and persist their stream chunks so interrupted sub-agent turns can recover partial output. `ChatOptions.tools` has been removed from the TypeScript API; runtime `options.tools` values passed by legacy callers are ignored with a warning. Define durable tools on the child agent or use agent tools for orchestration.

--- a/design/think-durable-submissions.md
+++ b/design/think-durable-submissions.md
@@ -3,7 +3,7 @@
 Durable programmatic chat turns for `Think`, exposed through
 `submitMessages()`.
 
-**Status:** implemented on the durable submissions branch.
+**Status:** implemented.
 
 Related:
 

--- a/design/think-roadmap.md
+++ b/design/think-roadmap.md
@@ -34,7 +34,7 @@ Think hasn't shipped yet. There are no backward compatibility constraints.
 
 **Phase 5 delivered:** `messageConcurrency` strategies (queue/latest/merge/drop/debounce) matching AIChatAgent's feature set. Think's merge is non-destructive — all individual user messages stay in the Session tree, the model sees them all in one turn. `resetTurnState()` extracted as a protected method for subclasses. Drop check happens before `session.appendMessage` so dropped messages never touch the tree.
 
-**Phase 4 delivered:** `chatRecovery` flag wraps all 4 chat turn paths (WebSocket, auto-continuation, `saveMessages`, `continueLastTurn`) in `runFiber()` for durable execution. `_handleInternalFiberRecovery` override detects interrupted chat fibers. `onChatRecovery(ctx)` hook provides `ChatRecoveryContext` with partial text, stream chunks, recovery data (from `stash()`), and current messages. `_chatRecoveryContinue` scheduler waits for stable state then calls `continueLastTurn()`. `hasPendingInteraction()` and `waitUntilStable()` for quiescence detection. `_pendingInteractionPromise` for efficient wait-on-resolve.
+**Phase 4 delivered:** `chatRecovery` flag wraps every turn entry path (WebSocket, sub-agent `chat()` RPC, auto-continuation, `saveMessages`, durable `submitMessages` execution, `continueLastTurn`) in `runFiber()` for durable execution. `_handleInternalFiberRecovery` override detects interrupted chat fibers. `onChatRecovery(ctx)` hook provides `ChatRecoveryContext` with partial text, stream chunks, recovery data (from `stash()`), and current messages. `_chatRecoveryContinue` scheduler waits for stable state then calls `continueLastTurn()`. `hasPendingInteraction()` and `waitUntilStable()` for quiescence detection. `_pendingInteractionPromise` for efficient wait-on-resolve.
 
 **All phases complete.** Think now has full feature parity with AIChatAgent plus Session-backed advantages (tree-structured messages, non-destructive regeneration, context blocks, compaction, FTS5 search).
 
@@ -379,7 +379,7 @@ See [chat-improvements.md §Shared Code Extraction](./chat-improvements.md#share
    - `onChatMessage` destructures result, passes `system` and `messages` to `streamText`
 
 6. **Tool auto-merge:**
-   - `onChatMessage` merges `getTools()` + `clientTools` + `session.tools()` + `options.tools`
+   - `onChatMessage` merges `getTools()` + `clientTools` + `session.tools()`
    - Context tools (`set_context`, `load_context`, `search_context`) auto-included when context blocks configured
 
 7. **Clear:**

--- a/design/think-sessions.md
+++ b/design/think-sessions.md
@@ -407,7 +407,7 @@ async onChatMessage(options?: ChatMessageOptions): Promise<StreamableResult> {
   const baseTools = this.getTools();
   const clientToolSet = createToolsFromClientSchemas(options?.clientTools);
   const contextTools = await this.session.tools();
-  const tools = { ...baseTools, ...clientToolSet, ...contextTools, ...options?.tools };
+  const tools = { ...baseTools, ...clientToolSet, ...contextTools };
 
   const { system, messages } = await this.assembleContext();
 

--- a/design/think.md
+++ b/design/think.md
@@ -105,7 +105,7 @@ The body contains `{ messages: UIMessage[], clientTools?: ClientToolSchema[] }`.
 **RPC path** (`chat()`):
 
 ```typescript
-await session.chat("Summarize the project", callback, { signal, tools });
+await session.chat("Summarize the project", callback, { signal });
 ```
 
 The parent agent calls `chat()` directly with a string or `UIMessage`.
@@ -125,13 +125,13 @@ streamText({
   model: this.getModel(),
   system: this.getSystemPrompt(),
   messages: await this.assembleContext(),
-  tools: { ...this.getTools(), ...clientToolSet, ...options?.tools },
+  tools: { ...this.getTools(), ...clientToolSet },
   stopWhen: stepCountIs(this.getMaxSteps()),
   abortSignal: options?.signal
 });
 ```
 
-Client tool schemas (from the browser) are merged into the tool set via `createToolsFromClientSchemas()`. RPC-provided tools are also merged.
+Client tool schemas (from the browser) are merged into the tool set via `createToolsFromClientSchemas()`. Tools for sub-agent turns are owned by the child agent through `getTools()`, extensions, MCP tools, session tools, or client tool schemas. Parent-child tool orchestration uses `agentTool()` / `runAgentTool()` rather than `chat()` options.
 
 The agentic loop runs until:
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -12,6 +12,12 @@ use server-side tools. Browser-provided client tools are not available during an
 agent-tool turn unless you model that interaction as server-side state or a
 separate parent-mediated workflow.
 
+For Think children, prefer agent tools when the parent model or workflow
+delegates work and you want retained child runs, event replay, abort bridging,
+and UI drill-in. Use raw `subAgent(...).chat()` only for lower-level streaming
+RPC where your code owns forwarding, cancellation, and replay policy. For the
+full comparison, see [Choosing a turn API](./think/index.md#choosing-a-turn-api).
+
 ## Use an Agent as an AI SDK tool
 
 Use `agentTool()` when the parent model should decide when to call the helper.

--- a/docs/server-driven-messages.md
+++ b/docs/server-driven-messages.md
@@ -51,6 +51,9 @@ return Response.json({
 
 `submitMessages()` stores pending work first and appends the messages to the conversation `Session` only when the submission starts executing. It accepts serializable `UIMessage[]` values, not the function form supported by `saveMessages((messages) => ...)`.
 
+For Think-specific guidance that also compares raw child `chat()` calls with
+agent tools, see [Choosing a turn API](./think/index.md#choosing-a-turn-api).
+
 ### When to use `saveMessages` vs `onChatResponse`
 
 **Use `saveMessages` when you control the trigger** — schedule callbacks, webhooks, email handlers, or any method where you decide when to inject a message.

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -131,6 +131,32 @@ Both Think and [`AIChatAgent`](../chat-agents.md) extend `Agent` and speak the s
 - You need proactive agents (programmatic turns from scheduled tasks or webhooks)
 - You need durable async submission for webhook/RPC callers — see [Programmatic submissions](./programmatic-submissions.md)
 
+## Choosing a Turn API
+
+Think has several ways to start or continue a turn. Choose based on who is
+driving the work and what the caller needs back.
+
+| Use case                                                       | API                                             |
+| -------------------------------------------------------------- | ----------------------------------------------- |
+| A browser user sends chat messages                             | `useAgentChat` over the WebSocket chat protocol |
+| Server code can wait for the model response                    | `saveMessages()`                                |
+| Server code needs fast durable acceptance and later status     | `submitMessages()`                              |
+| Parent code needs direct streaming RPC to a specific child     | `subAgent(...).chat()`                          |
+| A parent agent delegates work to a retained child agent        | `agentTool()` or `runAgentTool()`               |
+| Add context or messages without starting a model turn          | `persistMessages()`                             |
+| Advanced subclass or recovery code continues an assistant turn | `continueLastTurn()`                            |
+
+Use [`saveMessages()`](./sub-agents.md#programmatic-turns-with-savemessages)
+when the caller owns the trigger and can wait for the turn to finish. Use
+[`submitMessages()`](./programmatic-submissions.md) when timeout ambiguity would
+make retries unsafe.
+
+Use [`chat()`](./sub-agents.md#sub-agent-via-chat) for low-level parent-to-child
+streaming when your code owns forwarding, cancellation, and replay policy. Use
+[Agent Tools](../agent-tools.md) when a parent model or workflow delegates to a
+child agent and you want retained child runs, event replay, abort bridging, and
+UI drill-in.
+
 ## Configuration Overrides
 
 | Method / Property       | Default                          | Description                                                                     |
@@ -243,3 +269,4 @@ Think's `this.messages` getter reads directly from Session's tree-structured sto
 - [Tools](./tools.md) — Workspace tools, code execution, extensions
 - [Client Tools](./client-tools.md) — Browser-side tools, approvals, and concurrency
 - [Sub-agents and Programmatic Turns](./sub-agents.md) — RPC streaming, `saveMessages`, recovery
+- [Programmatic Submissions](./programmatic-submissions.md) — durable acceptance, idempotent retry, cancellation, and status inspection

--- a/docs/think/lifecycle-hooks.md
+++ b/docs/think/lifecycle-hooks.md
@@ -1,6 +1,6 @@
 # Lifecycle Hooks
 
-Think owns the `streamText` call and provides hooks at each stage of the chat turn. Hooks fire on every turn regardless of entry path — WebSocket chat, sub-agent `chat()`, `saveMessages`, and auto-continuation after tool results.
+Think owns the `streamText` call and provides hooks at each stage of the chat turn. Hooks fire on every turn regardless of entry path — WebSocket chat, sub-agent `chat()`, `saveMessages()`, durable `submitMessages()` execution, `continueLastTurn()`, and auto-continuation after tool results.
 
 ## Hook Summary
 
@@ -629,7 +629,7 @@ onChunk(ctx: ChunkContext) {
 
 Called after a chat turn completes and the assistant message has been persisted. The turn lock is released before this hook runs, so it is safe to call `saveMessages` or other methods from inside.
 
-Fires for all turn completion paths: WebSocket, sub-agent RPC, `saveMessages`, and auto-continuation.
+Fires for all turn completion paths that persist an assistant message: WebSocket, sub-agent RPC, `saveMessages()`, durable `submitMessages()` execution, `continueLastTurn()`, and auto-continuation.
 
 ```typescript
 onChatResponse(result: ChatResponseResult): void | Promise<void>

--- a/docs/think/programmatic-submissions.md
+++ b/docs/think/programmatic-submissions.md
@@ -6,6 +6,9 @@ quickly, retry safely, and inspect the result later.
 `saveMessages()` waits for the turn to finish. `submitMessages()` durably accepts
 the turn and returns a submission record before inference runs.
 
+For a broader comparison with `chat()`, `saveMessages()`, and agent tools, see
+[Choosing a turn API](./index.md#choosing-a-turn-api).
+
 ## Why this exists
 
 Webhook handlers, RPC callers, and parent Workers often have strict timeout

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -4,6 +4,9 @@ Think works as both a top-level agent (WebSocket to browser) and a sub-agent (RP
 
 This page focuses on Think's `chat()` RPC surface and programmatic turns. For the generic framework primitives underneath (`subAgent`, `onBeforeSubAgent`, `useAgent({ sub })`, `parentAgent`, `hasSubAgent`, `listSubAgents`, routing shape), see [Sub-agents](../sub-agents.md).
 
+For a quick comparison of `chat()`, `saveMessages()`, `submitMessages()`, and
+agent tools, see [Choosing a turn API](./index.md#choosing-a-turn-api).
+
 ## Sub-agent via chat()
 
 When used as a sub-agent, the `chat()` method runs a full turn (persist user message, run agentic loop, persist assistant response) and streams events via a callback.
@@ -37,14 +40,14 @@ interface StreamCallback {
 ```typescript
 interface ChatOptions {
   signal?: AbortSignal;
-  tools?: ToolSet;
 }
 ```
 
-| Field    | Description                                                 |
-| -------- | ----------------------------------------------------------- |
-| `signal` | `AbortSignal` to cancel the turn mid-stream                 |
-| `tools`  | Extra tools to merge for this turn (highest merge priority) |
+| Field    | Description                                 |
+| -------- | ------------------------------------------- |
+| `signal` | `AbortSignal` to cancel the turn mid-stream |
+
+Tools belong to the child agent. Define durable capabilities with the child's `getTools()`, extensions, MCP tools, or client tool schemas. Legacy callers that pass `options.tools` to `chat()` get a warning and the value is ignored.
 
 ### Example: Parent agent calling a child
 
@@ -104,22 +107,6 @@ await child.chat(
   },
   callback
 );
-```
-
-### Passing extra tools
-
-The `tools` option adds tools for this turn only, with the highest merge priority:
-
-```typescript
-await child.chat("Summarize the report", callback, {
-  tools: {
-    fetchReport: tool({
-      description: "Fetch the report data",
-      inputSchema: z.object({}),
-      execute: async () => this.getReportData()
-    })
-  }
-});
 ```
 
 ### Aborting a sub-agent turn
@@ -303,6 +290,10 @@ protected async continueLastTurn(
 
 Returns `{ requestId, status: "skipped" }` if the last message is not an assistant message.
 
+Most applications do not call this directly. Treat `continueLastTurn()` as an
+advanced subclass and recovery primitive; user-facing, server-triggered turns
+usually use `saveMessages()` or `submitMessages()` instead.
+
 The optional `body` parameter overrides the stored body for this continuation. If omitted, the last body from the previous turn is used. The optional `options.signal` accepts an external `AbortSignal` for cancellation, matching the `saveMessages` contract.
 
 ---
@@ -339,7 +330,7 @@ export class MyAgent extends Think<Env> {
 }
 ```
 
-When `chatRecovery` is `true`, all four turn paths (WebSocket, sub-agent `chat()` RPC, auto-continuation, `saveMessages`, `continueLastTurn`) are wrapped in `runFiber`.
+When `chatRecovery` is `true`, every turn entry path is wrapped in `runFiber`: WebSocket chat, sub-agent `chat()` RPC, auto-continuation, `saveMessages()`, `submitMessages()` execution, and `continueLastTurn()`.
 
 ### onChatRecovery
 

--- a/docs/think/tools.md
+++ b/docs/think/tools.md
@@ -12,7 +12,10 @@ On every turn, Think merges tools from multiple sources. Later sources override 
 4. **Extension tools** — tools from loaded extensions (prefixed by extension name)
 5. **MCP tools** — from connected MCP servers
 6. **Client tools** — from the browser (see [Client Tools](./client-tools.md))
-7. **Caller tools** — from `chat()` options when used as a sub-agent
+
+Tools belong to the agent running the turn. For parent-child orchestration,
+use [Agent Tools](../agent-tools.md) instead of passing one-off tools through
+`chat()`.
 
 ## Built-in Workspace Tools
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -113,10 +113,11 @@ export class MyAgent extends Think<Env> {
 | `configureSession()` | identity                         | Add context blocks, compaction, search, skills  |
 | `getExtensions()`    | `[]`                             | Sandboxed extension declarations (load order)   |
 | `extensionLoader`    | `undefined`                      | `WorkerLoader` binding — enables extensions     |
+| `chatRecovery`       | `true`                           | Wrap turns in `runFiber` for durable execution  |
 
 ### Lifecycle hooks
 
-Think owns the `streamText` call. Hooks fire on every turn regardless of entry path (WebSocket, `chat()`, `saveMessages`, auto-continuation).
+Think owns the `streamText` call. Hooks fire on every turn regardless of entry path (WebSocket, `chat()`, `saveMessages()`, durable `submitMessages()` execution, `continueLastTurn()`, auto-continuation).
 
 | Hook                     | When it fires                               | Return                         |
 | ------------------------ | ------------------------------------------- | ------------------------------ |
@@ -340,6 +341,22 @@ export class MyAgent extends Think<Env> {
 }
 ```
 
+### Choosing a turn API
+
+Use browser chat through `useAgentChat` when a user drives the conversation. Use
+`saveMessages()` when server code controls the trigger and can wait for the
+model response. Use `submitMessages()` when a caller needs fast durable
+acceptance, idempotent retries, cancellation, and later status inspection.
+
+Use `subAgent(...).chat()` for direct streaming RPC to a specific child when
+your code owns forwarding and replay policy. Use `agentTool()` or
+`runAgentTool()` when a parent agent delegates work to a retained child and you
+want event replay, abort bridging, and UI drill-in.
+
+See [Choosing a turn API](../../docs/think/index.md#choosing-a-turn-api) and
+[Programmatic Submissions](../../docs/think/programmatic-submissions.md) for the
+full API comparison.
+
 ### Sub-agent streaming via RPC
 
 When used as a sub-agent (via `this.subAgent()`), the `chat()` method runs a full turn and streams events via a callback:
@@ -353,10 +370,12 @@ interface StreamCallback {
 
 const agent = await this.subAgent(MyAgent, "thread-1");
 await agent.chat("Summarize the project", relay, {
-  tools: extraTools,
   signal: abortController.signal
 });
 ```
+
+Tools belong to the child agent; define them with `getTools()` or use
+`agentTool()` / `runAgentTool()` for parent-child orchestration.
 
 ### Dynamic configuration
 
@@ -382,6 +401,7 @@ For values you want broadcast to connected clients, use `state` / `setState` fro
 - **Lifecycle hooks** — `beforeTurn`, `beforeStep`, `onStepFinish`, `onChunk`, `onChatResponse` fire on every turn
 - **Stream resumption** — page refresh replays buffered chunks via `ResumableStream`
 - **Client tools** — accept tool schemas from clients, handle results and approvals
+- **Durable submissions** — accept webhook/RPC-triggered turns with idempotent retry and status inspection
 - **Auto-continuation** — debounce-based continuation after tool results
 - **MCP integration** — MCP tools auto-merged, wait for connections before inference
 - **Abort/cancel** — pass an `AbortSignal` or send a cancel message

--- a/packages/think/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/think/src/e2e-tests/chat-recovery.test.ts
@@ -344,14 +344,10 @@ describe("Think chat recovery e2e", () => {
     wrangler = startWrangler();
     await waitForReady();
 
-    await callHelperParent("startHelperTurn", [
+    await callHelperParent("startHelperChatTurn", [
       HELPER_NAME,
       "Tell me a helper story"
     ]);
-
-    // Wait long enough for buffered helper chunks to flush to SQLite before
-    // the simulated eviction.
-    await sleep(6000);
 
     const hasFibers = (await callHelperParent("helperHasFiberRows", [
       HELPER_NAME

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -5,9 +5,14 @@
  */
 import { createWorkersAI } from "workers-ai-provider";
 import { Agent, callable, routeAgentRequest } from "agents";
+import { RpcTarget } from "cloudflare:workers";
 import type { LanguageModel, UIMessage } from "ai";
 import { Think, Workspace } from "../think";
-import type { ChatRecoveryContext, ChatRecoveryOptions } from "../think";
+import type {
+  ChatRecoveryContext,
+  ChatRecoveryOptions,
+  StreamCallback
+} from "../think";
 
 type Env = {
   TestAssistant: DurableObjectNamespace<TestAssistant>;
@@ -142,27 +147,64 @@ export class ThinkRecoveryE2EAgent extends Think<Env> {
   }
 }
 
-export class ThinkRecoveryHelperAgent extends ThinkRecoveryE2EAgent {
-  async startSlowTurn(prompt: string): Promise<string> {
-    void this.saveMessages([
-      {
-        id: crypto.randomUUID(),
-        role: "user",
-        parts: [{ type: "text", text: prompt }]
-      }
-    ]).catch(console.error);
-
-    return "started";
-  }
-}
+export class ThinkRecoveryHelperAgent extends ThinkRecoveryE2EAgent {}
 
 export class ThinkRecoveryHelperParent extends Agent<Env> {
   static options = { keepAliveIntervalMs: 2_000 };
 
   @callable()
-  async startHelperTurn(helperName: string, prompt: string): Promise<string> {
+  async startHelperChatTurn(
+    helperName: string,
+    prompt: string
+  ): Promise<string> {
     const helper = await this.subAgent(ThinkRecoveryHelperAgent, helperName);
-    return helper.startSlowTurn(prompt);
+
+    let markReady: () => void = () => {};
+    const ready = new Promise<void>((resolve) => {
+      markReady = resolve;
+    });
+
+    class HelperChatCallback extends RpcTarget implements StreamCallback {
+      onEvent(json: string): void {
+        try {
+          const chunk = JSON.parse(json) as { type?: string; delta?: string };
+          if (chunk.type === "text-delta" && chunk.delta) {
+            markReady();
+          }
+        } catch {
+          // Ignore malformed test chunks.
+        }
+      }
+
+      onDone(): void {
+        markReady();
+      }
+
+      onError(error: string): void {
+        markReady();
+        console.error("[test] helper chat callback error:", error);
+      }
+    }
+
+    const callback = new HelperChatCallback();
+    void helper.chat(prompt, callback).catch(console.error);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race<void>([
+        ready,
+        new Promise<void>((_resolve, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("Timed out waiting for helper chat chunk")),
+            5_000
+          );
+        })
+      ]);
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+    }
+    return "started";
   }
 
   @callable()

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -4,6 +4,7 @@ import { Think } from "../../think";
 import type {
   StreamCallback,
   StreamableResult,
+  ChatOptions,
   ChatResponseResult,
   SaveMessagesResult,
   ChatRecoveryContext,
@@ -607,6 +608,26 @@ export class ThinkTestAgent extends Think {
   async testChatWithUIMessage(msg: UIMessage): Promise<TestChatResult> {
     const cb = new TestCollectingCallback();
     await this.chat(msg, cb);
+    return {
+      events: cb.events,
+      done: cb.doneCalled,
+      error: cb.errorMessage
+    };
+  }
+
+  async testChatWithIgnoredRuntimeTools(
+    message: string
+  ): Promise<TestChatResult> {
+    const cb = new TestCollectingCallback();
+    await this.chat(message, cb, {
+      tools: {
+        ignoredRuntimeTool: tool({
+          description: "Should not be merged into chat() turns.",
+          inputSchema: z.object({}),
+          execute: () => "ignored"
+        })
+      }
+    } as unknown as ChatOptions);
     return {
       events: cb.events,
       done: cb.doneCalled,
@@ -1975,6 +1996,54 @@ export class ThinkRecoveryTestAgent extends Think {
     return this._stashResult;
   }
 
+  async getLatestStreamSnapshot(): Promise<{
+    requestId: string;
+    status: "streaming" | "completed" | "error";
+    chunkCount: number;
+    text: string;
+  } | null> {
+    const streams = this.sql<{
+      id: string;
+      request_id: string;
+      status: "streaming" | "completed" | "error";
+    }>`
+      SELECT id, request_id, status
+      FROM cf_ai_chat_stream_metadata
+      ORDER BY created_at DESC
+      LIMIT 1
+    `;
+    const stream = streams[0];
+    if (!stream) return null;
+
+    const chunks = this.sql<{ body: string }>`
+      SELECT body
+      FROM cf_ai_chat_stream_chunks
+      WHERE stream_id = ${stream.id}
+      ORDER BY chunk_index ASC
+    `;
+
+    const text = chunks
+      .map((chunk) => {
+        try {
+          const parsed = JSON.parse(chunk.body) as {
+            type?: string;
+            delta?: string;
+          };
+          return parsed.type === "text-delta" ? (parsed.delta ?? "") : "";
+        } catch {
+          return "";
+        }
+      })
+      .join("");
+
+    return {
+      requestId: stream.request_id,
+      status: stream.status,
+      chunkCount: chunks.length,
+      text
+    };
+  }
+
   async testSaveMessages(text: string): Promise<SaveMessagesResult> {
     return this.saveMessages([
       {
@@ -1992,12 +2061,13 @@ export class ThinkRecoveryTestAgent extends Think {
   async insertInterruptedStream(
     streamId: string,
     requestId: string,
-    chunks: Array<{ body: string; index: number }>
+    chunks: Array<{ body: string; index: number }>,
+    status: "streaming" | "completed" | "error" = "streaming"
   ): Promise<void> {
     const now = Date.now();
     this.sql`
       INSERT INTO cf_ai_chat_stream_metadata (id, request_id, status, created_at)
-      VALUES (${streamId}, ${requestId}, 'active', ${now})
+      VALUES (${streamId}, ${requestId}, ${status}, ${now})
     `;
     for (const chunk of chunks) {
       const chunkId = `${streamId}-${chunk.index}`;
@@ -2006,6 +2076,15 @@ export class ThinkRecoveryTestAgent extends Think {
         VALUES (${chunkId}, ${streamId}, ${chunk.index}, ${chunk.body}, ${now})
       `;
     }
+  }
+
+  async getScheduledChatRecoveryCountForTest(): Promise<number> {
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count
+      FROM cf_agents_schedules
+      WHERE callback = '_chatRecoveryContinue'
+    `;
+    return rows[0]?.count ?? 0;
   }
 
   async insertInterruptedFiber(

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:workers";
 import { getServerByName } from "partyserver";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { UIMessage } from "ai";
 import type {
   ThinkTestAgent,
@@ -170,6 +170,25 @@ describe("Think — core", () => {
     const textParts = assistantMsg.parts.filter((p) => p.type === "text");
     const fullText = textParts.map((p) => p.text ?? "").join("");
     expect(fullText).toBe("Custom response text");
+  });
+
+  it("should ignore runtime tools passed to chat()", async () => {
+    const agent = await freshAgent("chat-ignore-runtime-tools");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const result = await agent.testChatWithIgnoredRuntimeTools("Hello");
+      expect(result.done).toBe(true);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("chat() no longer accepts options.tools")
+      );
+    } finally {
+      warn.mockRestore();
+    }
+
+    const turnLog = await agent.getBeforeTurnLog();
+    expect(turnLog).toHaveLength(1);
+    expect(turnLog[0].toolNames).not.toContain("ignoredRuntimeTool");
   });
 
   it("should forward turn telemetry to the AI SDK", async () => {
@@ -1425,6 +1444,33 @@ describe("Think — chatRecovery", () => {
     expect(fibers).toHaveLength(0);
   });
 
+  it("stash() is callable during a durable chat() turn", async () => {
+    const agent = await freshRecoveryAgent("stash-chat");
+
+    await agent.setStashData({ responseId: "resp-chat", provider: "test" });
+    await agent.testChat("Hello via durable chat");
+
+    const stashResult = await agent.getStashResult();
+    expect(stashResult).not.toBeNull();
+    expect(stashResult!.success).toBe(true);
+
+    const fibers = await agent.getActiveFibers();
+    expect(fibers).toHaveLength(0);
+  });
+
+  it("chat() records stream chunks for recovery lookup", async () => {
+    const agent = await freshRecoveryAgent("chat-stream-metadata");
+
+    const result = await agent.testChat("Record the stream");
+    expect(result.done).toBe(true);
+
+    const snapshot = await agent.getLatestStreamSnapshot();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.status).toBe("completed");
+    expect(snapshot!.chunkCount).toBeGreaterThan(0);
+    expect(snapshot!.text).toBe("Continued response.");
+  });
+
   it("saveMessages with recovery wraps in fiber and cleans up", async () => {
     const agent = await freshRecoveryAgent("save-fiber");
 
@@ -1557,6 +1603,53 @@ describe("Think — onChatRecovery", () => {
     await agent.triggerFiberRecovery();
 
     expect(await agent.getTurnCallCount()).toBe(0);
+  });
+
+  it("does not continue a recovered chat fiber whose stream already completed", async () => {
+    const agent = await freshRecoveryAgent("completed-stream-recovery");
+
+    await agent.insertInterruptedStream(
+      "stream-completed",
+      "req-completed",
+      [
+        {
+          body: JSON.stringify({
+            type: "start",
+            messageId: "a-completed"
+          }),
+          index: 0
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 1 },
+        {
+          body: JSON.stringify({
+            type: "text-delta",
+            delta: "Already done"
+          }),
+          index: 2
+        },
+        { body: JSON.stringify({ type: "text-end" }), index: 3 },
+        { body: JSON.stringify({ type: "finish" }), index: 4 }
+      ],
+      "completed"
+    );
+    await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-completed");
+
+    await agent.triggerFiberRecovery();
+
+    expect(await agent.getTurnCallCount()).toBe(0);
+    expect(await agent.getScheduledChatRecoveryCountForTest()).toBe(0);
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("assistant");
+    expect(
+      messages[0].parts
+        .filter((part): part is { type: "text"; text: string } => {
+          return part.type === "text" && "text" in part;
+        })
+        .map((part) => part.text)
+        .join("")
+    ).toBe("Already done");
   });
 
   it("{ persist: false, continue: false } skips both", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -1652,6 +1652,58 @@ describe("Think — onChatRecovery", () => {
     ).toBe("Already done");
   });
 
+  it("does not duplicate an already-persisted completed stream on recovery", async () => {
+    const agent = await freshRecoveryAgent("completed-stream-existing-message");
+
+    await agent.persistTestMessage({
+      id: "a-existing-completed",
+      role: "assistant",
+      parts: [{ type: "text", text: "Already persisted" }]
+    });
+    await agent.insertInterruptedStream(
+      "stream-existing-completed",
+      "req-existing-completed",
+      [
+        {
+          body: JSON.stringify({
+            type: "start",
+            messageId: "a-existing-completed"
+          }),
+          index: 0
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 1 },
+        {
+          body: JSON.stringify({
+            type: "text-delta",
+            delta: "Already persisted"
+          }),
+          index: 2
+        },
+        { body: JSON.stringify({ type: "text-end" }), index: 3 },
+        { body: JSON.stringify({ type: "finish" }), index: 4 }
+      ],
+      "completed"
+    );
+    await agent.insertInterruptedFiber(
+      "__cf_internal_chat_turn:req-existing-completed"
+    );
+
+    await agent.triggerFiberRecovery();
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].id).toBe("a-existing-completed");
+    expect(messages[0].role).toBe("assistant");
+    expect(
+      messages[0].parts
+        .filter((part): part is { type: "text"; text: string } => {
+          return part.type === "text" && "text" in part;
+        })
+        .map((part) => part.text)
+        .join("")
+    ).toBe("Already persisted");
+  });
+
   it("{ persist: false, continue: false } skips both", async () => {
     const agent = await freshRecoveryAgent("skip-both");
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -3856,11 +3856,11 @@ export class Think<
         this._insideInferenceLoop = false;
       }
 
-      assistantMsg = accumulator.toMessage();
-      this._persistAssistantMessage(assistantMsg);
-
       this._resumableStream.complete(streamId);
       streamFinalized = true;
+
+      assistantMsg = accumulator.toMessage();
+      this._persistAssistantMessage(assistantMsg);
 
       if (!aborted) {
         await callback.onDone();

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -206,7 +206,6 @@ export interface StreamableResult {
  */
 export interface ChatOptions {
   signal?: AbortSignal;
-  tools?: ToolSet;
 }
 
 type AgentToolChildRunStatus =
@@ -330,8 +329,6 @@ import type {
  */
 export interface TurnInput {
   signal?: AbortSignal;
-  /** Extra tools from the caller (e.g. chat() options) — highest merge priority. */
-  callerTools?: ToolSet;
   /** Client-provided tool schemas for dynamic tool registration. */
   clientTools?: ClientToolSchema[];
   /** Custom body fields from the client request. */
@@ -1258,8 +1255,7 @@ export class Think<
       ...extensionTools,
       ...contextTools,
       ...(this.mcp?.getAITools?.() ?? {}),
-      ...clientToolSet,
-      ...input.callerTools
+      ...clientToolSet
     };
 
     const frozenPrompt = await this.session.freezeSystemPrompt();
@@ -1863,100 +1859,86 @@ export class Think<
     options?: ChatOptions
   ): Promise<void> {
     const requestId = crypto.randomUUID();
+    const ignoredTools = (options as { tools?: unknown } | undefined)?.tools;
+    if (
+      ignoredTools != null &&
+      typeof ignoredTools === "object" &&
+      Object.keys(ignoredTools).length > 0
+    ) {
+      console.warn(
+        "[Think] chat() no longer accepts options.tools. Define durable tools on the child agent with getTools(), or use runAgentTool()/agentTool() for parent-child orchestration."
+      );
+    }
 
-    await this._turnQueue.enqueue(requestId, async () => {
-      const userMsg: UIMessage =
-        typeof userMessage === "string"
-          ? {
-              id: crypto.randomUUID(),
-              role: "user",
-              parts: [{ type: "text", text: userMessage }]
-            }
-          : userMessage;
+    await this.keepAliveWhile(async () => {
+      await this._turnQueue.enqueue(requestId, async () => {
+        const userMsg: UIMessage =
+          typeof userMessage === "string"
+            ? {
+                id: crypto.randomUUID(),
+                role: "user",
+                parts: [{ type: "text", text: userMessage }]
+              }
+            : userMessage;
 
-      await this.session.appendMessage(userMsg);
+        await this.session.appendMessage(userMsg);
 
-      const accumulator = new StreamAccumulator({
-        messageId: crypto.randomUUID()
-      });
-
-      try {
-        const result = await agentContext.run(
-          {
-            agent: this,
-            connection: undefined,
-            request: undefined,
-            email: undefined
-          },
-          () =>
-            this._runInferenceLoop({
-              signal: options?.signal,
-              callerTools: options?.tools,
-              continuation: false
-            })
+        const abortSignal = this._aborts.getSignal(requestId);
+        const detachExternal = this._aborts.linkExternal(
+          requestId,
+          options?.signal
         );
-
-        this._insideInferenceLoop = true;
-        let aborted = false;
         try {
-          for await (const chunk of result.toUIMessageStream()) {
-            if (options?.signal?.aborted) {
-              aborted = true;
-              break;
+          const chatBody = async () => {
+            let result: StreamableResult;
+            try {
+              result = await agentContext.run(
+                {
+                  agent: this,
+                  connection: undefined,
+                  request: undefined,
+                  email: undefined
+                },
+                () =>
+                  this._runInferenceLoop({
+                    signal: abortSignal,
+                    continuation: false
+                  })
+              );
+            } catch (error) {
+              const wrapped = this.onChatError(error);
+              const errorMessage =
+                wrapped instanceof Error ? wrapped.message : String(wrapped);
+              if (callback.onError) {
+                await callback.onError(errorMessage);
+                return;
+              }
+              throw wrapped;
             }
-            accumulator.applyChunk(chunk as unknown as StreamChunkData);
-            await callback.onEvent(JSON.stringify(chunk));
+
+            await this._streamResultToRpcCallback(
+              requestId,
+              result,
+              callback,
+              abortSignal
+            );
+          };
+
+          if (this.chatRecovery) {
+            await this.runFiber(
+              `${(this.constructor as typeof Think).CHAT_FIBER_NAME}:${requestId}`,
+              async () => {
+                await chatBody();
+              }
+            );
+          } else {
+            await chatBody();
           }
         } finally {
-          this._insideInferenceLoop = false;
+          detachExternal();
+          this._aborts.remove(requestId);
         }
-
-        const assistantMsg = accumulator.toMessage();
-        this._persistAssistantMessage(assistantMsg);
-
-        if (!aborted) {
-          await callback.onDone();
-          await this._fireResponseHook({
-            message: assistantMsg,
-            requestId,
-            continuation: false,
-            status: "completed"
-          });
-        } else {
-          await this._fireResponseHook({
-            message: assistantMsg,
-            requestId,
-            continuation: false,
-            status: "aborted"
-          });
-        }
-      } catch (error) {
-        const assistantMsg =
-          accumulator.parts.length > 0 ? accumulator.toMessage() : null;
-        if (assistantMsg) {
-          this._persistAssistantMessage(assistantMsg);
-        }
-
-        const wrapped = this.onChatError(error);
-        const errorMessage =
-          wrapped instanceof Error ? wrapped.message : String(wrapped);
-
-        if (assistantMsg) {
-          await this._fireResponseHook({
-            message: assistantMsg,
-            requestId,
-            continuation: false,
-            status: "error",
-            error: errorMessage
-          });
-        }
-
-        if (callback.onError) {
-          await callback.onError(errorMessage);
-        } else {
-          throw wrapped;
-        }
-      }
+      });
     });
   }
 
@@ -3823,6 +3805,129 @@ export class Think<
     );
   }
 
+  private async _streamResultToRpcCallback(
+    requestId: string,
+    result: StreamableResult,
+    callback: StreamCallback,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    const streamId = this._resumableStream.start(requestId);
+    const accumulator = new StreamAccumulator({
+      messageId: crypto.randomUUID()
+    });
+
+    let streamFinalized = false;
+    let assistantMsg: UIMessage | null = null;
+    let aborted = false;
+
+    try {
+      this._insideInferenceLoop = true;
+      let chunksSinceFlush = 0;
+      let hasFlushedContent = false;
+      try {
+        for await (const chunk of result.toUIMessageStream()) {
+          if (abortSignal?.aborted) {
+            aborted = true;
+            break;
+          }
+
+          // RPC callbacks receive serialized UIMessage chunks directly; unlike
+          // the WebSocket protocol, there is no wrapper frame to rewrite for
+          // accumulator actions such as `error`.
+          const streamChunk = chunk as unknown as StreamChunkData;
+          accumulator.applyChunk(streamChunk);
+          const chunkBody = JSON.stringify(chunk);
+          this._resumableStream.storeChunk(streamId, chunkBody);
+          chunksSinceFlush++;
+          if (
+            this._shouldFlushRpcStreamChunk(
+              streamChunk,
+              chunksSinceFlush,
+              hasFlushedContent
+            )
+          ) {
+            this._resumableStream.flushBuffer();
+            chunksSinceFlush = 0;
+            hasFlushedContent = true;
+          }
+          await callback.onEvent(chunkBody);
+        }
+      } finally {
+        this._insideInferenceLoop = false;
+      }
+
+      assistantMsg = accumulator.toMessage();
+      this._persistAssistantMessage(assistantMsg);
+
+      this._resumableStream.complete(streamId);
+      streamFinalized = true;
+
+      if (!aborted) {
+        await callback.onDone();
+        await this._fireResponseHook({
+          message: assistantMsg,
+          requestId,
+          continuation: false,
+          status: "completed"
+        });
+      } else {
+        await this._fireResponseHook({
+          message: assistantMsg,
+          requestId,
+          continuation: false,
+          status: "aborted"
+        });
+      }
+    } catch (error) {
+      if (!streamFinalized) {
+        this._resumableStream.markError(streamId);
+        streamFinalized = true;
+      }
+
+      if (!assistantMsg && accumulator.parts.length > 0) {
+        assistantMsg = accumulator.toMessage();
+        this._persistAssistantMessage(assistantMsg);
+      }
+
+      const wrapped = this.onChatError(error);
+      const errorMessage =
+        wrapped instanceof Error ? wrapped.message : String(wrapped);
+
+      if (assistantMsg) {
+        await this._fireResponseHook({
+          message: assistantMsg,
+          requestId,
+          continuation: false,
+          status: "error",
+          error: errorMessage
+        });
+      }
+
+      if (callback.onError) {
+        await callback.onError(errorMessage);
+      } else {
+        throw wrapped;
+      }
+    }
+  }
+
+  private _shouldFlushRpcStreamChunk(
+    chunk: StreamChunkData,
+    chunksSinceFlush: number,
+    hasFlushedContent: boolean
+  ): boolean {
+    const isRecoverableContent =
+      chunk.type === "text-delta" ||
+      chunk.type === "reasoning-delta" ||
+      chunk.type === "tool-input-available" ||
+      chunk.type === "tool-output-available" ||
+      chunk.type === "tool-output-error";
+
+    return (
+      isRecoverableContent && (!hasFlushedContent || chunksSinceFlush >= 10)
+    );
+  }
+
   private async _streamResult(
     requestId: string,
     result: StreamableResult,
@@ -4179,18 +4284,24 @@ export class Think<
     const requestId = ctx.name.slice(chatPrefix.length);
 
     let streamId = "";
+    let streamStatus: "streaming" | "completed" | "error" | undefined;
     if (requestId) {
-      const rows = this.sql<{ id: string }>`
-        SELECT id FROM cf_ai_chat_stream_metadata
+      const rows = this.sql<{
+        id: string;
+        status: "streaming" | "completed" | "error";
+      }>`
+        SELECT id, status FROM cf_ai_chat_stream_metadata
         WHERE request_id = ${requestId}
         ORDER BY created_at DESC LIMIT 1
       `;
       if (rows.length > 0) {
         streamId = rows[0].id;
+        streamStatus = rows[0].status;
       }
     }
     if (!streamId && this._resumableStream.hasActiveStream()) {
       streamId = this._resumableStream.activeStreamId ?? "";
+      streamStatus = "streaming";
     }
 
     const partial = streamId
@@ -4214,7 +4325,10 @@ export class Think<
       this._resumableStream.hasActiveStream() &&
       this._resumableStream.activeStreamId === streamId;
 
-    if (options.persist !== false && streamStillActive) {
+    const streamIsTerminal =
+      streamStatus === "completed" || streamStatus === "error";
+
+    if (options.persist !== false && (streamStillActive || streamIsTerminal)) {
       this._persistOrphanedStream(streamId);
     }
 
@@ -4222,12 +4336,24 @@ export class Think<
       this._resumableStream.complete(streamId);
     }
 
-    const recoveredRequestId =
-      options.continue !== false && this._hasRunningSubmission(requestId)
-        ? requestId
-        : undefined;
+    const canContinue = options.continue !== false && !streamIsTerminal;
+    const hasRunningSubmission = this._hasRunningSubmission(requestId);
 
-    if (options.continue !== false) {
+    if (streamIsTerminal && hasRunningSubmission) {
+      await this._completeRecoveredSubmission(
+        requestId,
+        streamStatus === "completed" ? "completed" : "error",
+        requestId,
+        streamStatus === "completed"
+          ? null
+          : "Recovered chat stream had already errored."
+      );
+    }
+
+    const recoveredRequestId =
+      canContinue && hasRunningSubmission ? requestId : undefined;
+
+    if (canContinue) {
       const lastLeaf = this.session.getLatestLeaf();
       const targetId = lastLeaf?.role === "assistant" ? lastLeaf.id : undefined;
       await this.schedule(
@@ -4239,7 +4365,7 @@ export class Think<
         },
         { idempotent: true }
       );
-    } else {
+    } else if (options.continue === false && !streamIsTerminal) {
       await this._markRecoveredSubmissionInterrupted(
         requestId,
         "Submission was interrupted and chat recovery was disabled."


### PR DESCRIPTION
## Summary

This PR makes `Think.chat()` use the same durable execution model as the other Think turn entry points. Sub-agent RPC chat turns are now queued under `keepAliveWhile()`, wired through `AbortRegistry`, wrapped in `runFiber()` when `chatRecovery` is enabled, and streamed through a dedicated RPC callback helper that stores UIMessage chunks in `ResumableStream` before forwarding them to the parent callback.

It also narrows the `chat()` API by removing typed support for `ChatOptions.tools`. Runtime callers that still pass `options.tools` get a warning, but the tools are ignored. This keeps child-agent capabilities durable and owned by the child through `getTools()`, session/context tools, extensions, MCP tools, and client tool schemas. Parent-child orchestration docs now point users to `agentTool()` / `runAgentTool()` for retained runs, abort bridging, event replay, and UI drill-in.

The recovery path now handles terminal stream metadata more carefully. If a recovered chat fiber already has a completed or errored stream row, it persists recoverable partial output and avoids scheduling another continuation. For durable submissions associated with recovered work, terminal stream recovery now finalizes the submission instead of leaving it running.

The documentation now includes a central Think turn API chooser covering:

- browser chat via `useAgentChat`
- `saveMessages()` for server-triggered turns that can wait
- `submitMessages()` for durable acceptance and later inspection
- raw `subAgent(...).chat()` for direct streaming RPC
- `agentTool()` / `runAgentTool()` for retained child-agent orchestration
- `persistMessages()` for context injection without a model turn
- `continueLastTurn()` as an advanced subclass/recovery primitive

## Notable changes

- Wrap `Think.chat()` RPC turns in chat recovery fibers.
- Persist `chat()` stream chunks for recovery lookup and partial-message persistence.
- Add `_streamResultToRpcCallback()` to keep RPC streaming behavior separate from WebSocket framing.
- Remove `callerTools` / `ChatOptions.tools` from the typed Think turn path.
- Warn and ignore legacy runtime `options.tools` passed to `chat()`.
- Avoid duplicate recovery continuation for already-terminal chat streams.
- Finalize recovered durable submissions whose stream is already terminal.
- Update e2e coverage so helper sub-agent recovery exercises the RPC `chat()` path directly.
- Add/adjust unit coverage for durable `chat()` stash usage, stream chunk persistence, terminal stream recovery, and ignored runtime tools.
- Update Think docs, README, design notes, and changeset for the new API shape and chooser guidance.

## Test plan

- [x] `npm run test --workspace @cloudflare/think -- src/tests/think-session.test.ts`
- [x] `npm run test:e2e --workspace @cloudflare/think -- src/e2e-tests/chat-recovery.test.ts`
- [x] `npm run build --workspace @cloudflare/think`
- [x] `npm run check`

## Notes

I also synced the corresponding public docs changes in the sibling `cloudflare-docs` checkout, but this PR intentionally contains only `cloudflare/agents` changes.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->