### PR TITLE
Improve Think default prompt

### DIFF
--- a/.changeset/clear-think-default-prompt.md
+++ b/.changeset/clear-think-default-prompt.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Improve Think's default system prompt and append a turn-specific capability block based on the tools exposed to the model.

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -103,17 +103,19 @@ export class MyAgent extends Think<Env> {
 
 ### Configuration
 
-| Method / Property    | Default                          | Description                                     |
-| -------------------- | -------------------------------- | ----------------------------------------------- |
-| `getModel()`         | throws                           | Return the `LanguageModel` to use               |
-| `getSystemPrompt()`  | `"You are a helpful assistant."` | System prompt (fallback when no context blocks) |
-| `getTools()`         | `{}`                             | AI SDK `ToolSet` for the agentic loop           |
-| `maxSteps`           | `10`                             | Max tool-call rounds per turn (property)        |
-| `sendReasoning`      | `true`                           | Send reasoning chunks to chat clients           |
-| `configureSession()` | identity                         | Add context blocks, compaction, search, skills  |
-| `getExtensions()`    | `[]`                             | Sandboxed extension declarations (load order)   |
-| `extensionLoader`    | `undefined`                      | `WorkerLoader` binding — enables extensions     |
-| `chatRecovery`       | `true`                           | Wrap turns in `runFiber` for durable execution  |
+| Method / Property    | Default                            | Description                                     |
+| -------------------- | ---------------------------------- | ----------------------------------------------- |
+| `getModel()`         | throws                             | Return the `LanguageModel` to use               |
+| `getSystemPrompt()`  | careful assistant operating prompt | System prompt (fallback when no context blocks) |
+| `getTools()`         | `{}`                               | AI SDK `ToolSet` for the agentic loop           |
+| `maxSteps`           | `10`                               | Max tool-call rounds per turn (property)        |
+| `sendReasoning`      | `true`                             | Send reasoning chunks to chat clients           |
+| `configureSession()` | identity                           | Add context blocks, compaction, search, skills  |
+| `getExtensions()`    | `[]`                               | Sandboxed extension declarations (load order)   |
+| `extensionLoader`    | `undefined`                        | `WorkerLoader` binding — enables extensions     |
+| `chatRecovery`       | `true`                             | Wrap turns in `runFiber` for durable execution  |
+
+On each turn, Think appends a small capability block to the assembled system prompt. The block is based on the tools available for that turn, so models learn about workspace tools, context-loading tools, extension tools, sandboxed execution, MCP/client tools, and delegated-agent tools only when they are actually exposed.
 
 ### Lifecycle hooks
 

--- a/packages/think/src/tests/hooks.test.ts
+++ b/packages/think/src/tests/hooks.test.ts
@@ -120,7 +120,9 @@ describe("Think — beforeTurn hook", () => {
 
     const log = await agent.getBeforeTurnLog();
     expect(log).toHaveLength(1);
-    expect(log[0].system).toBe("You are a helpful assistant.");
+    expect(log[0].system).toContain("You are a careful, capable assistant");
+    expect(log[0].system).toContain("You are running inside a Think agent.");
+    expect(log[0].system).toContain("agent workspace");
     expect(log[0].continuation).toBe(false);
     expect(log[0].toolNames).toContain("read");
     expect(log[0].toolNames).toContain("write");
@@ -798,7 +800,8 @@ describe("Think — beforeTurn config overrides", () => {
     await agent.testChat("With override");
 
     const log = await agent.getBeforeTurnLog();
-    expect(log[0].system).toBe("You are a helpful assistant.");
+    expect(log[0].system).toContain("You are a careful, capable assistant");
+    expect(log[0].system).toContain("You are running inside a Think agent.");
   });
 
   it("activeTools override limits tool availability", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -495,8 +495,7 @@ describe("Think — context blocks", () => {
     // System prompt assembly should fall back to getSystemPrompt().
     const systemPrompt = await agent.getAssembledSystemPrompt();
 
-    // Default getSystemPrompt() returns "You are a helpful assistant."
-    expect(systemPrompt).toBe("You are a helpful assistant.");
+    expect(systemPrompt).toContain("You are a careful, capable assistant");
   });
 });
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -928,12 +928,90 @@ export class Think<
    * Used as fallback when no context blocks are configured via `configureSession`.
    */
   getSystemPrompt(): string {
-    return "You are a helpful assistant.";
+    return [
+      "You are a careful, capable assistant helping the user complete their task.",
+      "Use available tools when they materially improve accuracy or let you act on the user's request. Before changing code, understand the relevant context: existing patterns, dependencies, tests, and nearby conventions.",
+      "Keep changes focused on the user's request. Prefer small, idiomatic edits over broad rewrites or new abstractions. Do not introduce new dependencies, secrets, destructive actions, or persistent side effects unless the user clearly asks or approves.",
+      "When the task is complex, briefly state your approach and keep the user informed with concise progress updates. If you modify code, verify with the smallest relevant test, build, typecheck, lint, or runtime check available, and report any checks you could not run.",
+      "Be direct and useful in your final response: summarize the outcome, mention important files or commands, and call out real blockers or risks."
+    ].join("\n\n");
   }
 
   /** Return the tools available to the assistant. */
   getTools(): ToolSet {
     return {};
+  }
+
+  private _systemPromptForTurn(baseSystem: string, tools: ToolSet): string {
+    if (baseSystem.includes("You are running inside a Think agent.")) {
+      return baseSystem;
+    }
+
+    return `${baseSystem.trimEnd()}\n\n${this._buildThinkCapabilityBlock(tools)}`;
+  }
+
+  private _buildThinkCapabilityBlock(tools: ToolSet): string {
+    const toolNames = new Set(Object.keys(tools));
+    const hasTools = toolNames.size > 0;
+    const hasWorkspaceTools = [
+      "read",
+      "write",
+      "edit",
+      "list",
+      "find",
+      "grep",
+      "delete"
+    ].some((toolName) => toolNames.has(toolName));
+    const hasContextTools =
+      toolNames.has("load_context") || toolNames.has("unload_context");
+    const hasExtensionTools =
+      toolNames.has("load_extension") || toolNames.has("list_extensions");
+    const hasExecuteTool = toolNames.has("execute");
+
+    const lines = [
+      "You are running inside a Think agent.",
+      "",
+      "Capabilities available in this turn:"
+    ];
+
+    if (hasWorkspaceTools) {
+      lines.push(
+        "- You can inspect and edit the agent workspace using the available file tools."
+      );
+    }
+
+    if (hasTools) {
+      lines.push(
+        "- Use the tools exposed in this turn when they materially improve accuracy or let you act on the user's request. Treat tool descriptions and schemas as the source of truth."
+      );
+      lines.push(
+        "- Some tools may call server code, browser/client code, MCP servers, extensions, or delegated agents. Use them according to their descriptions."
+      );
+    }
+
+    if (hasContextTools) {
+      lines.push(
+        "- If context-loading tools are available, use them to load relevant memory, skills, or project context before acting on incomplete information."
+      );
+    }
+
+    if (hasExtensionTools) {
+      lines.push(
+        "- If extension tools are available, use them only when loading or inspecting extensions directly helps with the task."
+      );
+    }
+
+    if (hasExecuteTool) {
+      lines.push(
+        "- If sandboxed execution is available, prefer it for safe, bounded checks or coordinated multi-step operations."
+      );
+    }
+
+    lines.push(
+      "- Do not claim access to capabilities that are not exposed as tools in this turn."
+    );
+
+    return lines.join("\n");
   }
 
   /** Maximum number of tool-call steps per turn. Override via property or per-turn via TurnConfig. */
@@ -1252,7 +1330,8 @@ export class Think<
     };
 
     const frozenPrompt = await this.session.freezeSystemPrompt();
-    const system = frozenPrompt || this.getSystemPrompt();
+    const baseSystem = frozenPrompt || this.getSystemPrompt();
+    const system = this._systemPromptForTurn(baseSystem, tools);
 
     const history = this.session.getHistory();
     const truncated = truncateOlderMessages(history) as UIMessage[];
@@ -1279,7 +1358,12 @@ export class Think<
     const config = await this._pipelineExtensionBeforeTurn(ctx, subclassConfig);
 
     const finalModel = config.model ?? model;
-    const finalSystem = config.system ?? system;
+    const finalSystem =
+      config.system ??
+      this._systemPromptForTurn(
+        baseSystem,
+        config.tools ? { ...tools, ...config.tools } : tools
+      );
     const finalMessages = config.messages ?? messages;
     const mergedTools: ToolSet = config.tools
       ? { ...tools, ...config.tools }


### PR DESCRIPTION
## Summary

- Replaces Think's one-line fallback system prompt with a clearer operating prompt for agentic software tasks.
- Appends a turn-specific Think capability block based on the tools actually exposed to the model, including workspace, context-loading, extension, sandboxed execution, MCP/client, and delegated-agent tools.
- Updates Think docs, prompt-related tests, and adds a patch changeset for `@cloudflare/think`.

## Details

The new default prompt emphasizes scoped agency, reading relevant context before edits, conservative code changes, verification after modifications, and concise final responses. The Think capability block is assembled per turn so the model gets useful Think-specific guidance without claiming unavailable capabilities.

The capability block is appended to both fallback prompts and session/context-block prompts. If a subclass or extension fully overrides `system` for the turn, that override is respected.

## Test plan

- `npm test -- src/tests/hooks.test.ts src/tests/think-session.test.ts` in `packages/think`
- `npx oxfmt --check packages/think/README.md packages/think/src/think.ts packages/think/src/tests/hooks.test.ts packages/think/src/tests/think-session.test.ts .changeset/clear-think-default-prompt.md`
- `npx oxlint packages/think/src/think.ts packages/think/src/tests/hooks.test.ts packages/think/src/tests/think-session.test.ts`
- `npm run typecheck`
- `npm run check`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->