### PR TITLE
refactor(codemode): omit source code from tool results

### DIFF
--- a/.changeset/silent-pandas-learn.md
+++ b/.changeset/silent-pandas-learn.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/codemode": minor
+"@cloudflare/codemode": patch
 ---
 
 Remove the echoed source `code` field from codemode tool results. Successful sandbox executions now return only the execution `result` and any captured `logs`.

--- a/.changeset/silent-pandas-learn.md
+++ b/.changeset/silent-pandas-learn.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": minor
+---
+
+Remove the echoed source `code` field from codemode tool results. Successful sandbox executions now return only the execution `result` and any captured `logs`.

--- a/packages/codemode/src/browser-tool.ts
+++ b/packages/codemode/src/browser-tool.ts
@@ -11,9 +11,10 @@ import {
   type JsonSchemaToolDescriptor,
   type JsonSchemaToolDescriptors
 } from "./json-schema-types";
-import { normalizeCode } from "./normalize";
+import { runCode } from "./run-code";
 import { sanitizeToolName } from "./utils";
 import type { Executor, ResolvedProvider } from "./executor-types";
+import type { CodeInput, CodeOutput } from "./shared";
 import { IframeSandboxExecutor } from "./iframe-executor";
 
 // -- Types --
@@ -53,7 +54,6 @@ export interface BrowserCodeToolDescriptor {
   outputSchema: {
     type: "object";
     properties: {
-      code: { type: "string"; description: string };
       result: { description: string };
       logs: {
         type: "array";
@@ -61,11 +61,9 @@ export interface BrowserCodeToolDescriptor {
         description: string;
       };
     };
-    required: ["code", "result"];
+    required: ["result"];
   };
-  execute: (args: {
-    code: string;
-  }) => Promise<{ code: string; result: unknown; logs?: string[] }>;
+  execute: (args: CodeInput) => Promise<CodeOutput>;
 }
 
 export interface CreateBrowserCodeToolOptions {
@@ -201,10 +199,6 @@ export function createBrowserCodeTool(
     outputSchema: {
       type: "object",
       properties: {
-        code: {
-          type: "string",
-          description: "The original code that was executed"
-        },
         result: {
           description: "The return value of the executed code"
         },
@@ -214,30 +208,9 @@ export function createBrowserCodeTool(
           description: "Console output captured during execution"
         }
       },
-      required: ["code", "result"]
+      required: ["result"]
     },
-    execute: async ({ code }) => {
-      const normalizedCode = normalizeCode(code);
-      const executeResult = await executor.execute(
-        normalizedCode,
-        resolvedProviders
-      );
-
-      if (executeResult.error) {
-        const logCtx = executeResult.logs?.length
-          ? `\n\nConsole output:\n${executeResult.logs.join("\n")}`
-          : "";
-        throw new Error(
-          `Code execution failed: ${executeResult.error}${logCtx}`
-        );
-      }
-
-      const output: { code: string; result: unknown; logs?: string[] } = {
-        code,
-        result: executeResult.result
-      };
-      if (executeResult.logs) output.logs = executeResult.logs;
-      return output;
-    }
+    execute: async ({ code }) =>
+      runCode({ code, executor, providers: resolvedProviders })
   };
 }

--- a/packages/codemode/src/run-code.ts
+++ b/packages/codemode/src/run-code.ts
@@ -20,5 +20,7 @@ export async function runCode({
     throw new Error(`Code execution failed: ${executeResult.error}${logCtx}`);
   }
 
-  return { result: executeResult.result, logs: executeResult.logs };
+  return executeResult.logs?.length
+    ? { result: executeResult.result, logs: executeResult.logs }
+    : { result: executeResult.result };
 }

--- a/packages/codemode/src/run-code.ts
+++ b/packages/codemode/src/run-code.ts
@@ -1,0 +1,24 @@
+import type { CodeOutput } from "./shared";
+import type { Executor, ResolvedProvider } from "./executor";
+import { normalizeCode } from "./normalize";
+
+export async function runCode({
+  code,
+  executor,
+  providers
+}: {
+  code: string;
+  executor: Executor;
+  providers: ResolvedProvider[];
+}): Promise<CodeOutput> {
+  const executeResult = await executor.execute(normalizeCode(code), providers);
+
+  if (executeResult.error) {
+    const logCtx = executeResult.logs?.length
+      ? `\n\nConsole output:\n${executeResult.logs.join("\n")}`
+      : "";
+    throw new Error(`Code execution failed: ${executeResult.error}${logCtx}`);
+  }
+
+  return { result: executeResult.result, logs: executeResult.logs };
+}

--- a/packages/codemode/src/shared.ts
+++ b/packages/codemode/src/shared.ts
@@ -28,7 +28,7 @@ export interface CreateCodeToolOptions {
 }
 
 export type CodeInput = { code: string };
-export type CodeOutput = { code: string; result: unknown; logs?: string[] };
+export type CodeOutput = { result: unknown; logs?: string[] };
 
 /**
  * Check if the tools option is an array of ToolProviders.

--- a/packages/codemode/src/tanstack-ai.ts
+++ b/packages/codemode/src/tanstack-ai.ts
@@ -281,7 +281,7 @@ export function createCodeTool(options: CreateCodeToolOptions): ServerTool {
       throw new Error(`Code execution failed: ${executeResult.error}${logCtx}`);
     }
 
-    const output: CodeOutput = { code, result: executeResult.result };
+    const output: CodeOutput = { result: executeResult.result };
     if (executeResult.logs) output.logs = executeResult.logs;
     return output;
   });

--- a/packages/codemode/src/tanstack-ai.ts
+++ b/packages/codemode/src/tanstack-ai.ts
@@ -281,9 +281,7 @@ export function createCodeTool(options: CreateCodeToolOptions): ServerTool {
       throw new Error(`Code execution failed: ${executeResult.error}${logCtx}`);
     }
 
-    const output: CodeOutput = { result: executeResult.result };
-    if (executeResult.logs) output.logs = executeResult.logs;
-    return output;
+    return { result: executeResult.result, logs: executeResult.logs };
   });
 }
 

--- a/packages/codemode/src/tanstack-ai.ts
+++ b/packages/codemode/src/tanstack-ai.ts
@@ -41,7 +41,6 @@ import { filterTools, extractFns } from "./resolve";
 import {
   DEFAULT_DESCRIPTION,
   type CreateCodeToolOptions,
-  type CodeOutput,
   normalizeProviders
 } from "./shared";
 import { jsonSchemaToType } from "./json-schema-types";

--- a/packages/codemode/src/tanstack-ai.ts
+++ b/packages/codemode/src/tanstack-ai.ts
@@ -36,7 +36,7 @@ import type {
   ResolvedProvider,
   SimpleToolRecord
 } from "./executor";
-import { normalizeCode } from "./normalize";
+import { runCode } from "./run-code";
 import { filterTools, extractFns } from "./resolve";
 import {
   DEFAULT_DESCRIPTION,
@@ -266,23 +266,9 @@ export function createCodeTool(options: CreateCodeToolOptions): ServerTool {
     inputSchema: codeSchema
   });
 
-  return def.server(async ({ code }) => {
-    const normalizedCode = normalizeCode(code);
-
-    const executeResult = await executor.execute(
-      normalizedCode,
-      resolvedProviders
-    );
-
-    if (executeResult.error) {
-      const logCtx = executeResult.logs?.length
-        ? `\n\nConsole output:\n${executeResult.logs.join("\n")}`
-        : "";
-      throw new Error(`Code execution failed: ${executeResult.error}${logCtx}`);
-    }
-
-    return { result: executeResult.result, logs: executeResult.logs };
-  });
+  return def.server(async ({ code }) =>
+    runCode({ code, executor, providers: resolvedProviders })
+  );
 }
 
 /**

--- a/packages/codemode/src/tests/iframe-executor.browser.test.ts
+++ b/packages/codemode/src/tests/iframe-executor.browser.test.ts
@@ -382,16 +382,14 @@ describe("createBrowserCodeTool", () => {
     expect(tool.description).toContain("AddNumbersInput");
     expect(tool.description).toContain("declare const codemode");
     expect(tool.inputSchema.required).toEqual(["code"]);
-    expect(tool.outputSchema.required).toEqual(["code", "result"]);
+    expect(tool.outputSchema.required).toEqual(["result"]);
 
     const result = await tool.execute({
       code: "async () => await codemode.addNumbers({ a: 17, b: 25 })"
     });
 
     expect(result.result).toEqual({ sum: 42 });
-    expect(result.code).toBe(
-      "async () => await codemode.addNumbers({ a: 17, b: 25 })"
-    );
+    expect(result.logs).toBeUndefined();
   });
 
   it("should accept tools as an array", async () => {

--- a/packages/codemode/src/tests/iframe-executor.browser.test.ts
+++ b/packages/codemode/src/tests/iframe-executor.browser.test.ts
@@ -389,7 +389,7 @@ describe("createBrowserCodeTool", () => {
     });
 
     expect(result.result).toEqual({ sum: 42 });
-    expect(result.logs).toEqual([]);
+    expect(result.logs).toBeUndefined();
   });
 
   it("should accept tools as an array", async () => {

--- a/packages/codemode/src/tests/iframe-executor.browser.test.ts
+++ b/packages/codemode/src/tests/iframe-executor.browser.test.ts
@@ -389,7 +389,7 @@ describe("createBrowserCodeTool", () => {
     });
 
     expect(result.result).toEqual({ sum: 42 });
-    expect(result.logs).toBeUndefined();
+    expect(result.logs).toEqual([]);
   });
 
   it("should accept tools as an array", async () => {

--- a/packages/codemode/src/tests/tool.test.ts
+++ b/packages/codemode/src/tests/tool.test.ts
@@ -274,8 +274,11 @@ describe("createCodeTool", () => {
     expect(capturedFnNames).toContain("explicitlySafeTool");
   });
 
-  it("should return { result } on success", async () => {
-    const { executor } = createMockExecutor({ result: { answer: 42 } });
+  it("should return { result, logs } on success", async () => {
+    const { executor } = createMockExecutor({
+      result: { answer: 42 },
+      logs: ["hello", "world"]
+    });
     const codeTool = createCodeTool({ tools, executor });
 
     const output = await codeTool.execute?.(
@@ -284,7 +287,8 @@ describe("createCodeTool", () => {
     );
 
     expect(output).toEqual({
-      result: { answer: 42 }
+      result: { answer: 42 },
+      logs: ["hello", "world"]
     });
   });
 

--- a/packages/codemode/src/tests/tool.test.ts
+++ b/packages/codemode/src/tests/tool.test.ts
@@ -274,7 +274,7 @@ describe("createCodeTool", () => {
     expect(capturedFnNames).toContain("explicitlySafeTool");
   });
 
-  it("should return { code, result } on success", async () => {
+  it("should return { result } on success", async () => {
     const { executor } = createMockExecutor({ result: { answer: 42 } });
     const codeTool = createCodeTool({ tools, executor });
 
@@ -284,7 +284,6 @@ describe("createCodeTool", () => {
     );
 
     expect(output).toEqual({
-      code: "async () => 42",
       result: { answer: 42 }
     });
   });

--- a/packages/codemode/src/tool.ts
+++ b/packages/codemode/src/tool.ts
@@ -136,9 +136,7 @@ export function createCodeTool(
         );
       }
 
-      const output: CodeOutput = { result: executeResult.result };
-      if (executeResult.logs) output.logs = executeResult.logs;
-      return output;
+      return { result: executeResult.result, logs: executeResult.logs };
     }
   });
 }

--- a/packages/codemode/src/tool.ts
+++ b/packages/codemode/src/tool.ts
@@ -7,7 +7,7 @@ import type {
   ToolProviderTools,
   ResolvedProvider
 } from "./executor";
-import { normalizeCode } from "./normalize";
+import { runCode } from "./run-code";
 import { filterTools } from "./resolve";
 import {
   DEFAULT_DESCRIPTION,
@@ -119,24 +119,7 @@ export function createCodeTool(
   return tool({
     description,
     inputSchema: codeSchema,
-    execute: async ({ code }) => {
-      const normalizedCode = normalizeCode(code);
-
-      const executeResult = await executor.execute(
-        normalizedCode,
-        resolvedProviders
-      );
-
-      if (executeResult.error) {
-        const logCtx = executeResult.logs?.length
-          ? `\n\nConsole output:\n${executeResult.logs.join("\n")}`
-          : "";
-        throw new Error(
-          `Code execution failed: ${executeResult.error}${logCtx}`
-        );
-      }
-
-      return { result: executeResult.result, logs: executeResult.logs };
-    }
+    execute: async ({ code }) =>
+      runCode({ code, executor, providers: resolvedProviders })
   });
 }

--- a/packages/codemode/src/tool.ts
+++ b/packages/codemode/src/tool.ts
@@ -136,7 +136,7 @@ export function createCodeTool(
         );
       }
 
-      const output: CodeOutput = { code, result: executeResult.result };
+      const output: CodeOutput = { result: executeResult.result };
       if (executeResult.logs) output.logs = executeResult.logs;
       return output;
     }


### PR DESCRIPTION
## Summary

This PR removes the echoed source `code` field from codemode tool results.

Successful sandbox executions now return only:

```ts
{
  result: unknown;
  logs?: string[];
}
```

Instead of:

```ts
{
  code: string;
  result: unknown;
  logs?: string[];
}
```

The submitted code is already present in the tool call, so echoing it back in the tool result adds hella context without providing useful information to the model.
