### PR TITLE
fix(mcp): forward relatedRequestId through McpAgent.elicitInput

### DIFF
--- a/.changeset/mcpagent-elicit-input-related-request-id.md
+++ b/.changeset/mcpagent-elicit-input-related-request-id.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+`McpAgent.elicitInput` now accepts an optional `options.relatedRequestId`, forwarded to the underlying transport so the elicitation request routes through the originating POST response stream per the Streamable HTTP spec. Callers should pass `{ relatedRequestId: extra.requestId }` from inside a tool handler.

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -3,7 +3,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type {
   JSONRPCMessage,
-  MessageExtraInfo
+  MessageExtraInfo,
+  RequestId
 } from "@modelcontextprotocol/sdk/types.js";
 import {
   JSONRPCMessageSchema,
@@ -275,10 +276,13 @@ export abstract class McpAgent<
   }
 
   /** Elicit user input with a message and schema */
-  async elicitInput(params: {
-    message: string;
-    requestedSchema: unknown;
-  }): Promise<ElicitResult> {
+  async elicitInput(
+    params: {
+      message: string;
+      requestedSchema: unknown;
+    },
+    options?: { relatedRequestId?: RequestId }
+  ): Promise<ElicitResult> {
     const requestId = `elicit_${Math.random().toString(36).substring(2, 11)}`;
 
     const elicitRequest = {
@@ -326,7 +330,7 @@ export abstract class McpAgent<
       // Send through MCP transport
       if (this._transport) {
         try {
-          await this._transport.send(elicitRequest);
+          await this._transport.send(elicitRequest, options);
         } catch (error) {
           cleanup();
           throw error;

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -138,20 +138,23 @@ export class TestMcpAgent extends McpAgent<Cloudflare.Env, unknown, Props> {
       "elicitNameCustom",
       "Test tool that elicits user input using McpAgent.elicitInput()",
       {},
-      async () => {
-        const result = await this.elicitInput({
-          message: "What is your name?",
-          requestedSchema: {
-            type: "object",
-            properties: {
-              name: {
-                type: "string",
-                description: "Your name"
-              }
-            },
-            required: ["name"]
-          }
-        });
+      async (_args, extra) => {
+        const result = await this.elicitInput(
+          {
+            message: "What is your name?",
+            requestedSchema: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                  description: "Your name"
+                }
+              },
+              required: ["name"]
+            }
+          },
+          { relatedRequestId: extra.requestId }
+        );
 
         if (result.action === "accept" && result.content?.name) {
           return {

--- a/packages/agents/src/tests/mcp/elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/elicitation.test.ts
@@ -11,8 +11,6 @@ import worker from "../worker";
 import {
   initializeStreamableHTTPServer,
   sendPostRequest,
-  openStandaloneSSE,
-  readSSEEvent,
   parseSSEData,
   establishSSEConnection,
   establishRPCConnection
@@ -42,9 +40,10 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
     it("should complete elicitation accept round-trip", async () => {
       const ctx = createExecutionContext();
       const sessionId = await initializeStreamableHTTPServer(ctx);
-      const standaloneReader = await openStandaloneSSE(ctx, sessionId, baseUrl);
 
-      // Call the custom elicitation tool (uses McpAgent.elicitInput)
+      // Call the custom elicitation tool (uses McpAgent.elicitInput).
+      // The tool passes { relatedRequestId: extra.requestId } so the elicit
+      // routes through the originating POST response stream per spec.
       const toolCallMsg: JSONRPCMessage = {
         id: "custom-elicit-1",
         jsonrpc: "2.0",
@@ -52,15 +51,18 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
         params: { name: "elicitNameCustom", arguments: {} }
       };
 
-      const toolResponsePromise = sendPostRequest(
+      const toolResponse = await sendPostRequest(
         ctx,
         baseUrl,
         toolCallMsg,
         sessionId
       );
+      expect(toolResponse.status).toBe(200);
 
-      // Read the elicitation request from the standalone SSE stream
-      const elicitFrame = await readOneFrame(standaloneReader);
+      const reader = toolResponse.body?.getReader();
+      if (!reader) throw new Error("No reader available for POST stream");
+
+      const elicitFrame = await readOneFrame(reader);
       const elicitRequest = parseSSEData(elicitFrame) as JSONRPCRequest;
 
       expect(elicitRequest.method).toBe("elicitation/create");
@@ -96,19 +98,72 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
       );
       expect(responsePost.status).toBe(202);
 
-      // Read the tool call result
-      const toolResponse = await toolResponsePromise;
-      expect(toolResponse.status).toBe(200);
-      const toolSseText = await readSSEEvent(toolResponse);
-      const toolResult = parseSSEData(toolSseText) as JSONRPCResultResponse;
+      const toolResultFrame = await readOneFrame(reader);
+      const toolResult = parseSSEData(toolResultFrame) as JSONRPCResultResponse;
 
       expect(toolResult.id).toBe("custom-elicit-1");
       const result = toolResult.result as CallToolResult;
       expect(result.content).toEqual([
         { type: "text", text: "Custom elicit: Alice" }
       ]);
+    });
 
-      await standaloneReader.cancel();
+    it("should route McpAgent.elicitInput via explicit relatedRequestId to the originating POST stream", async () => {
+      // The elicitNameCustom tool now passes `{ relatedRequestId: extra.requestId }`
+      // to this.elicitInput(...). This test asserts that the elicit JSON-RPC arrives
+      // on the originating POST stream because of that explicit option — not because
+      // of any transport-side request-id inference.
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+
+      const toolCallMsg: JSONRPCMessage = {
+        id: "custom-elicit-explicit-related-1",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "elicitNameCustom", arguments: {} }
+      };
+
+      const toolResponse = await sendPostRequest(
+        ctx,
+        baseUrl,
+        toolCallMsg,
+        sessionId
+      );
+      expect(toolResponse.status).toBe(200);
+
+      const reader = toolResponse.body?.getReader();
+      if (!reader) throw new Error("No reader available for POST stream");
+
+      const elicitFrame = await readOneFrame(reader);
+      const elicitRequest = parseSSEData(elicitFrame) as JSONRPCRequest;
+
+      expect(elicitRequest.method).toBe("elicitation/create");
+
+      const elicitResponse: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: elicitRequest.id,
+        result: {
+          action: "accept",
+          content: { name: "Bob" }
+        }
+      } as unknown as JSONRPCMessage;
+
+      const responsePost = await sendPostRequest(
+        ctx,
+        baseUrl,
+        elicitResponse,
+        sessionId
+      );
+      expect(responsePost.status).toBe(202);
+
+      const toolResultFrame = await readOneFrame(reader);
+      const toolResult = parseSSEData(toolResultFrame) as JSONRPCResultResponse;
+
+      expect(toolResult.id).toBe("custom-elicit-explicit-related-1");
+      const result = toolResult.result as CallToolResult;
+      expect(result.content).toEqual([
+        { type: "text", text: "Custom elicit: Bob" }
+      ]);
     });
 
     it("should route McpAgent.elicitInput through the originating POST stream without standalone SSE", async () => {
@@ -308,7 +363,6 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
     it("should handle elicitation cancel response", async () => {
       const ctx = createExecutionContext();
       const sessionId = await initializeStreamableHTTPServer(ctx);
-      const standaloneReader = await openStandaloneSSE(ctx, sessionId, baseUrl);
 
       const toolCallMsg: JSONRPCMessage = {
         id: "custom-cancel-1",
@@ -317,14 +371,18 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
         params: { name: "elicitNameCustom", arguments: {} }
       };
 
-      const toolResponsePromise = sendPostRequest(
+      const toolResponse = await sendPostRequest(
         ctx,
         baseUrl,
         toolCallMsg,
         sessionId
       );
+      expect(toolResponse.status).toBe(200);
 
-      const elicitFrame = await readOneFrame(standaloneReader);
+      const reader = toolResponse.body?.getReader();
+      if (!reader) throw new Error("No reader available for POST stream");
+
+      const elicitFrame = await readOneFrame(reader);
       const elicitRequest = parseSSEData(elicitFrame) as JSONRPCRequest;
 
       // Send cancel
@@ -339,24 +397,19 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
 
       await sendPostRequest(ctx, baseUrl, cancelResponse, sessionId);
 
-      const toolResponse = await toolResponsePromise;
-      expect(toolResponse.status).toBe(200);
-      const toolSseText = await readSSEEvent(toolResponse);
-      const toolResult = parseSSEData(toolSseText) as JSONRPCResultResponse;
+      const toolResultFrame = await readOneFrame(reader);
+      const toolResult = parseSSEData(toolResultFrame) as JSONRPCResultResponse;
 
       expect(toolResult.id).toBe("custom-cancel-1");
       const result = toolResult.result as CallToolResult;
       expect(result.content).toEqual([
         { type: "text", text: "Custom elicit cancelled" }
       ]);
-
-      await standaloneReader.cancel();
     });
 
     it("should handle elicitation error response", async () => {
       const ctx = createExecutionContext();
       const sessionId = await initializeStreamableHTTPServer(ctx);
-      const standaloneReader = await openStandaloneSSE(ctx, sessionId, baseUrl);
 
       const toolCallMsg: JSONRPCMessage = {
         id: "custom-error-1",
@@ -365,14 +418,18 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
         params: { name: "elicitNameCustom", arguments: {} }
       };
 
-      const toolResponsePromise = sendPostRequest(
+      const toolResponse = await sendPostRequest(
         ctx,
         baseUrl,
         toolCallMsg,
         sessionId
       );
+      expect(toolResponse.status).toBe(200);
 
-      const elicitFrame = await readOneFrame(standaloneReader);
+      const reader = toolResponse.body?.getReader();
+      if (!reader) throw new Error("No reader available for POST stream");
+
+      const elicitFrame = await readOneFrame(reader);
       const elicitRequest = parseSSEData(elicitFrame) as JSONRPCRequest;
 
       // Send JSON-RPC error response — our code converts this to cancel
@@ -387,10 +444,8 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
 
       await sendPostRequest(ctx, baseUrl, errorResponse, sessionId);
 
-      const toolResponse = await toolResponsePromise;
-      expect(toolResponse.status).toBe(200);
-      const toolSseText = await readSSEEvent(toolResponse);
-      const toolResult = parseSSEData(toolSseText) as JSONRPCResultResponse;
+      const toolResultFrame = await readOneFrame(reader);
+      const toolResult = parseSSEData(toolResultFrame) as JSONRPCResultResponse;
 
       expect(toolResult.id).toBe("custom-error-1");
       const result = toolResult.result as CallToolResult;
@@ -398,8 +453,6 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
       expect(result.content).toEqual([
         { type: "text", text: "Custom elicit cancelled" }
       ]);
-
-      await standaloneReader.cancel();
     });
   });
 


### PR DESCRIPTION
## Summary

`McpAgent.elicitInput` now accepts an optional `options.relatedRequestId` and forwards it to the underlying transport. Callers should pass `{ relatedRequestId: extra.requestId }` from inside a tool handler so the elicit message routes through the originating POST response stream per the Streamable HTTP spec, rather than relying on transport-side inference.

```ts
this.server.registerTool("increase-counter", { ... }, async (_args, extra) => {
  const result = await this.elicitInput(
    { message: "...", requestedSchema: { ... } },
    { relatedRequestId: extra.requestId }   // ← explicit
  );
  ...
});
```

This restores the explicit pattern that existed in the pre-#970 `examples/mcp-server/` / `examples/mcp-elicitation/index.ts` (deleted 2026-02-21 in #970 along with the WorkerTransport-based examples), and aligns `McpAgent.elicitInput` with the equivalent `Server.elicitInput(params, { relatedRequestId })` shape.

Context: #1510 (the underlying spec-routing bug); #1513 (tracking the upstream MCP SDK propagation work); #1514 (transport-side heuristic mitigation that this PR makes unnecessary for callers that pass `relatedRequestId` explicitly).

## What changed

- `packages/agents/src/mcp/index.ts` — `elicitInput` gains optional `options: { relatedRequestId?: RequestId }`; forwarded to `_transport.send(elicitRequest, options)`. The WebSocket fallback path is untouched (per-connection routing makes `relatedRequestId` redundant there).
- `packages/agents/src/tests/agents/mcp.ts` — the `elicitNameCustom` tool now destructures `extra` and passes `{ relatedRequestId: extra.requestId }`, demonstrating the recommended pattern.
- `packages/agents/src/tests/mcp/elicitation.test.ts` — added a dedicated test asserting the explicit-`relatedRequestId` path routes through the originating POST stream. Updated three pre-existing tests (accept/cancel/error round-trips) that previously read elicits from a standalone SSE stream: with `relatedRequestId` set, elicits arrive on the originating POST stream (spec-recommended), so those tests now read from the POST response body like the existing POST-only test in this file.
- `.changeset/mcpagent-elicit-input-related-request-id.md` — patch changeset for `agents`.

## Follow-ups (deliberately out of scope for this PR)

Once #1514 is reverted in `packages/agents/src/mcp/transport.ts` (transport-side AsyncLocalStorage of active request id, single-active-POST fallback, dispatch wrapper around `onmessage`) — i.e., the proper SDK-side fix in `@modelcontextprotocol/sdk` to auto-propagate `relatedRequestId` lands and the heuristic mitigation is no longer needed — the **"throw on unroutable JSON-RPC request"** defensive behavior should be applied equivalently to `createMcpHandler` / `WorkerTransport` users. Today server-to-client JSON-RPC requests with no routable channel can be silently dropped until the SDK request timeout fires, which surfaces as an opaque `MCP error -32001: Request timed out`. Failing fast at `send()` time is much more diagnosable.

Not doing it in this PR to avoid coupling to the in-flight #1514 revert.

## Test plan

- `npm --workspace packages/agents run test:workers -- src/tests/mcp/elicitation.test.ts` — 11/11 pass
- `npm --workspace packages/agents run test:workers -- src/tests/mcp/transports/streamable-http.test.ts` — 23/23 pass
- `npm --workspace packages/agents run test:workers -- src/tests/mcp` — 412/412 pass
- `npx oxlint` / `npx oxfmt --check` clean on touched files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->