### PR TITLE
chore(ci): use nx affected for tests + nrwl/nx-set-shas

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,17 +7,9 @@ on:
       - "design/**"
       - "*.md"
       - ".changeset/**"
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "docs/**"
-      - "design/**"
-      - "*.md"
-      - ".changeset/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
@@ -68,13 +60,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      - name: Test (affected — pull_request)
-        if: github.event_name == 'pull_request'
-        run: CI=true npx nx affected -t test
+      - run: CI=true npx nx affected -t test
 
-      - name: Test (run-many — push to main)
-        if: github.event_name == 'push'
-        run: CI=true npx nx run-many -t test
-
-      - if: github.event_name == 'pull_request'
-        run: npx pkg-pr-new publish --peerDeps ./packages/*
+      - run: npx pkg-pr-new publish --peerDeps ./packages/*

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -61,4 +61,5 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - run: CI=true npx nx affected -t test
+
       - run: npx pkg-pr-new publish --peerDeps ./packages/*

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,9 +7,17 @@ on:
       - "design/**"
       - "*.md"
       - ".changeset/**"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "design/**"
+      - "*.md"
+      - ".changeset/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -60,6 +68,13 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      - run: CI=true npx nx affected -t test
+      - name: Test (affected — pull_request)
+        if: github.event_name == 'pull_request'
+        run: CI=true npx nx affected -t test
 
-      - run: npx pkg-pr-new publish --peerDeps ./packages/*
+      - name: Test (run-many — push to main)
+        if: github.event_name == 'push'
+        run: CI=true npx nx run-many -t test
+
+      - if: github.event_name == 'pull_request'
+        run: npx pkg-pr-new publish --peerDeps ./packages/*

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -22,12 +22,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          filter: tree:0
 
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "npm"
+
+      - uses: nrwl/nx-set-shas@v5
 
       - name: Cache Nx
         uses: actions/cache@v5
@@ -57,5 +60,5 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      - run: CI=true npx nx run-many -t test
+      - run: CI=true npx nx affected -t test
       - run: npx pkg-pr-new publish --peerDeps ./packages/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     if: ${{ github.repository_owner == 'cloudflare' }}
-    timeout-minutes: 5
+    timeout-minutes: 20
     runs-on: ubuntu-24.04
 
     steps:
@@ -36,6 +36,24 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      - run: npm run check
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(jq -r '.packages["node_modules/playwright"].version' package-lock.json)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - run: CI=true npx nx run-many -t test
 
       - id: changesets
         uses: changesets/action@v1.7.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Examples, guides, and sites don't need changesets.
 
 ### Pull request process
 
-CI runs on every PR (`npm ci && npm run build && npm run check && npm run test`). All checks must pass. The workflow is in `.github/workflows/pullrequest.yml`.
+CI runs on every PR (`npm ci && npm run build && npm run check && npx nx affected -t test`) and on push to `main` (with `nx run-many -t test` instead, as a safety net against under-reported affected projects). All checks must pass. The workflow is in `.github/workflows/pullrequest.yml`.
 
 ### Generated files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Examples, guides, and sites don't need changesets.
 
 ### Pull request process
 
-CI runs on every PR (`npm ci && npm run build && npm run check && npx nx affected -t test`) and on push to `main` (with `nx run-many -t test` instead, as a safety net against under-reported affected projects). All checks must pass. The workflow is in `.github/workflows/pullrequest.yml`.
+CI runs on every PR (`npm ci && npm run build && npm run check && npx nx affected -t test`); the workflow is in `.github/workflows/pullrequest.yml`. On push to `main` the Release workflow (`.github/workflows/release.yml`) runs the same steps but uses `nx run-many -t test` as a safety net against under-reported affected projects, then publishes via changesets. All checks must pass.
 
 ### Generated files
 


### PR DESCRIPTION
## Summary
- Switch PR test step from `nx run-many -t test` to `nx affected -t test` so unchanged projects skip testing entirely.
- Add `nrwl/nx-set-shas@v5` to derive `NX_BASE`/`NX_HEAD` against the last successful main-branch run (handles PR and push-to-main correctly without explicit `--base`/`--head`).
- Bump checkout to `fetch-depth: 0` with `filter: tree:0` (blobless clone) since `nx-set-shas` walks history. `filter: tree:0` keeps it fast — full history, no blob content.

Build is intentionally left as full `npm run build` (still `nx run-many -t build`) because the trailing `pkg-pr-new publish --peerDeps ./packages/*` step requires every package's `dist/` to be present. The existing Nx cache (already keyed on `package-lock.json` + sha) keeps cache-hit packages near-instant on rebuilds, so the win on build is small anyway. The real savings are on test, the most expensive step.

This is the canonical Nx 22.x CI pattern — same shape as nrwl/nx's own `ci.yml`.

## Test plan
- [ ] CI on this PR completes successfully and `nx affected -t test` reports zero affected projects for a CI-only change (workflow YAML is not in any project's input set).
- [ ] Open a follow-up trivial PR touching a single package (e.g. `packages/agents`) and confirm only that package's tests run.
- [ ] Confirm `pkg-pr-new publish` still publishes all packages (build path unchanged).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->