### PR TITLE
chore(ci): cache node_modules to skip 2.5-min npm ci

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,29 @@
+name: Install
+description: Set up Node and install dependencies, skipping `npm ci` on a node_modules cache hit.
+
+inputs:
+  registry-url:
+    description: Registry URL for setup-node (set this when publishing).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        registry-url: ${{ inputs.registry-url }}
+        cache: npm
+
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@v5
+      with:
+        path: "**/node_modules"
+        key: ${{ runner.os }}-node-24-modules-${{ hashFiles('package-lock.json', 'patches/**') }}
+
+    - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm ci

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,5 +1,5 @@
 name: Install
-description: Set up Node and install dependencies, skipping `npm ci` on a node_modules cache hit.
+description: Set up Node and install dependencies, skipping `npm ci` on a node_modules cache hit (keyed on package-lock.json + patches/**).
 
 inputs:
   registry-url:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,12 +21,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "npm"
+      - uses: ./.github/actions/install
 
-      - run: npm ci
       - run: npm run build
 
       - name: Get Playwright version
@@ -60,12 +56,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "npm"
+      - uses: ./.github/actions/install
 
-      - run: npm ci
       - run: npm run build
 
       - name: Run think e2e tests

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -24,10 +24,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "npm"
+      - uses: ./.github/actions/install
 
       - name: Cache Nx
         uses: actions/cache@v5
@@ -38,7 +35,6 @@ jobs:
             ${{ runner.os }}-nx-${{ hashFiles('package-lock.json') }}-
             ${{ runner.os }}-nx-
 
-      - run: npm ci
       - run: npm run build
       - run: npm run check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/install
         with:
-          node-version: 24
           registry-url: "https://registry.npmjs.org"
-          cache: "npm"
 
-      - run: npm ci
       - run: npm run build
 
       - id: changesets


### PR DESCRIPTION
## Summary
- Add `.github/actions/install` composite action that runs `setup-node@v6` and caches `**/node_modules` keyed on `package-lock.json` + `patches/**`. On cache hit, `npm ci` is skipped entirely.
- Wire all four `npm ci` sites — `pullrequest.yml`, `nightly.yml` (x2 jobs), `release.yml` — to use the composite. Release passes `registry-url` for trusted publishing.

On cache miss, `npm ci` runs normally and `patch-package`'s postinstall applies patches before the cache is written, so the cached `node_modules` is always patched. The cache key includes `patches/**`, so adding/removing/editing a patch invalidates correctly. Same for any `package-lock.json` change (added dep, version bump, npm-side hoisting change).

Expected saving on cache hit: ~2.5 min per job. Lockfile-changing PRs still pay the full `npm ci` cost on first run, but subsequent runs of the same PR reuse the cache.

This is independent of #1535 (`nx affected` for tests) — they compose cleanly.

## Test plan
- [ ] First run of this PR: cache miss → `npm ci` executes (this validates the composite action runs correctly).
- [ ] Push a trivial follow-up commit to this branch (no lockfile change): expect cache hit → `npm ci` skipped → `npm ci` step shows ~0s.
- [ ] Confirm `nightly.yml`'s two jobs both reach `npm run build` / `playwright test` successfully.
- [ ] Confirm `release.yml` still has `registry-url` set (verified locally in diff; will run on next merge to main).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->