### PR TITLE
Fix parentAgent for facet-only parents

### DIFF
--- a/.changeset/sharp-trees-laugh.md
+++ b/.changeset/sharp-trees-laugh.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Allow `parentAgent()` to resolve facet-only direct parents through a root RPC bridge.

--- a/design/rfc-sub-agent-routing.md
+++ b/design/rfc-sub-agent-routing.md
@@ -2,6 +2,11 @@
 
 Status: proposed
 
+> Current behavior note: this RFC records the original routing proposal. For
+> the current `parentAgent()` implementation, including facet-only direct
+> parents and `.fetch()` limitations, see
+> [`sub-agent-routing.md`](./sub-agent-routing.md).
+
 Related:
 
 - [`rfc-think-multi-session.md`](./rfc-think-multi-session.md) — proposes a `Chats` base class + per-chat DOs; depends on this primitive.
@@ -245,7 +250,7 @@ class Chat extends Agent {
 }
 ```
 
-Takes the direct parent's class reference (not the namespace binding), verifies it matches the last entry of `parentPath` (root-first, so the direct parent lives at `parentPath.at(-1)`), and resolves the stub via the standard `env[Cls.name]` binding. This catches the "wrong binding / wrong class" mistake early instead of silently talking to the wrong DO. For grandparents and further ancestors, use `parentPath[i]` + `getAgentByName(...)` directly.
+Takes the direct parent's class reference (not the namespace binding), verifies it matches the last entry of `parentPath` (root-first, so the direct parent lives at `parentPath.at(-1)`), and resolves the stub for the recorded parent. This catches the "wrong binding / wrong class" mistake early instead of silently talking to the wrong DO. For grandparents and further ancestors, use `parentPath[i]` + `getAgentByName(...)` directly.
 
 Top-level agents (instantiated outside a facet context) have `parentPath === []`. Changing a parent's `name` after spawning a child does **not** retroactively update the child — parent names are stable DO identities, so this is fine in practice.
 

--- a/design/sub-agent-routing.md
+++ b/design/sub-agent-routing.md
@@ -97,16 +97,27 @@ helpers such as `idFromName`.
 `Agent#parentAgent(Cls)` is the one-hop inverse of `subAgent(Cls, name)`:
 
 - child → direct parent
-- typed RPC stub
+- typed parent stub
 - runtime check that `Cls.name` matches the direct parent class
-- resolves the namespace binding from `env[Cls.name]`
+- resolves a top-level parent from `env[Cls.name]` or the Worker `exports`
+  namespace
+- resolves a facet parent through a root bridge that walks the recorded facet
+  path one hop at a time
 
-For grandparents and further ancestors, use `parentPath[i]` plus
-`getAgentByName(...)` directly.
+For grandparents and further ancestors that are top-level Durable Objects, use
+`parentPath[i]` plus `getAgentByName(...)` directly. Facet ancestors are not
+individually bound in `env`, and `parentAgent()` intentionally stays a one-hop
+direct-parent helper.
 
-This API intentionally assumes the common \"binding name matches class name\"
-convention. If a binding uses a different name in `wrangler.jsonc`, use
-`getAgentByName(env.MY_BINDING, this.parentPath.at(-1)!.name)` directly.
+Top-level parent resolution prefers `env[Cls.name]` and falls back to the
+Worker `exports` namespace. This supports custom Durable Object binding names
+as long as the parent class is exported under its class name.
+
+Facet-parent stubs expose normal HTTP `.fetch()` calls through the same root
+bridge as RPC methods. These internal calls do not run `onBeforeSubAgent`.
+WebSocket upgrade requests are not supported through `parentAgent().fetch()`
+yet because WebSocket handles cannot be serialized over RPC. Use externally
+routed sub-agent URLs for WebSocket connections.
 
 ## Broadcasts and state sync
 

--- a/docs/sub-agents.md
+++ b/docs/sub-agents.md
@@ -219,7 +219,7 @@ this.selfPath;
 
 ### `this.parentAgent(Cls)`
 
-Typed RPC stub to the **immediate** parent, resolved from `parentPath`. Symmetric with `subAgent(Cls, name)`: one opens a stub parent→child, the other opens a stub child→parent.
+Typed parent stub to the **immediate** parent, resolved from `parentPath`. Symmetric with `subAgent(Cls, name)`: one opens a stub parent→child, the other opens a stub child→parent.
 
 ```typescript
 const inbox = await this.parentAgent(Inbox);
@@ -229,11 +229,20 @@ await inbox.recordTurn(this.name, "...");
 The framework:
 
 1. Verifies `Cls.name` matches the recorded direct-parent class (catches the "wrong class" mistake early).
-2. Looks up the namespace in `env[Cls.name]` and opens a stub on the recorded parent name.
+2. If the direct parent is a top-level Durable Object, opens the namespace for the exported parent class and returns a stub for the recorded parent name.
+3. If the direct parent is itself a facet, returns a proxy that routes method calls through the top-level root and then down the recorded facet path.
 
-For grandparents and further ancestors, iterate `this.parentPath` and call `getAgentByName(env.X, this.parentPath[i].name)` directly. `parentAgent` is intentionally single-hop.
+For grandparents and further ancestors that are top-level Durable Objects, iterate `this.parentPath` and call `getAgentByName(env.X, this.parentPath[i].name)` directly. Facet ancestors do not have their own `env` namespace binding; `parentAgent` is intentionally single-hop and only resolves the direct parent.
 
-If the binding name does not match the class name (for example `{ class_name: "Inbox", name: "MY_INBOX" }` in `wrangler.jsonc`), skip the helper and call `getAgentByName(env.MY_INBOX, this.parentPath.at(-1)!.name)` directly.
+When `parentAgent()` returns a facet-parent proxy, RPC methods and normal HTTP `.fetch()` calls use the same internal bridge and do not run `onBeforeSubAgent`. WebSocket upgrade requests are not supported through `parentAgent().fetch()` yet because WebSocket handles cannot be serialized over RPC. Use externally routed sub-agent URLs for WebSocket connections.
+
+| Capability              | `parentAgent(Cls)`             | External `/sub/...` routing                  |
+| ----------------------- | ------------------------------ | -------------------------------------------- |
+| Use case                | Internal child-to-parent calls | Client or worker requests into a child facet |
+| RPC methods             | Yes                            | No                                           |
+| Normal HTTP `.fetch()`  | Yes                            | Yes                                          |
+| WebSocket upgrades      | No                             | Yes                                          |
+| Runs `onBeforeSubAgent` | No                             | Yes                                          |
 
 ## Client API
 

--- a/examples/multi-ai-chat/README.md
+++ b/examples/multi-ai-chat/README.md
@@ -84,7 +84,7 @@ Key things worth looking at in `src/server.ts`:
   `this.subAgent(Chat, id)` / `this.deleteSubAgent(Chat, id)` that
   insert / remove the matching meta row.
 - `Chat.getInbox()` uses the framework's `parentAgent(Inbox)`
-  helper — pass the parent's class, get back a typed RPC stub
+  helper — pass the parent's class, get back a typed parent stub
   with the right identity baked in. No hardcoded user id, no
   `getAgentByName` plumbing inside the facet.
 - Each `Chat` owns its own SQLite database, stream state, and recovery

--- a/examples/multi-ai-chat/README.md
+++ b/examples/multi-ai-chat/README.md
@@ -24,13 +24,16 @@ npm start
 
 Open the dev URL. Click **New** to create a chat. Start chatting.
 
-The assistant has three tools it can choose to call during a turn:
+The assistant has four tools it can choose to call during a turn:
 
 - `rememberFact(fact)` — saves a fact to the user's shared memory
   (persisted on the parent `Inbox`, visible to every chat on the
   next turn). Try: _"Remember I prefer TypeScript over JavaScript."_
 - `recallMemory()` — reads the full shared memory.
 - `getCurrentTime()` — returns the server's current ISO time.
+- `askResearcher(topic)` — delegates a focused question to a nested
+  `Researcher` sub-agent under the current `Chat`. Try: _"Ask the
+  researcher to summarize the tradeoffs in this conversation."_
 
 Each tool call renders in-line as a collapsible panel with state,
 input, and output; reasoning traces (if the model emits any) show
@@ -60,6 +63,15 @@ you want to seed the assistant with context without a tool call.
   │ parentPath │ │ parentPath │ │ parentPath │
   │  → Inbox   │ │  → Inbox   │ │  → Inbox   │
   └────────────┘ └────────────┘ └────────────┘
+        │
+        │ subAgent(Researcher, "default") — nested helper facet
+        ▼
+   ┌────────────┐
+   │ Researcher │
+   │ parentPath │
+   │ → Inbox    │
+   │ → Chat abc │
+   └────────────┘
 ```
 
 URL shapes the client connects to:
@@ -87,6 +99,10 @@ Key things worth looking at in `src/server.ts`:
   helper — pass the parent's class, get back a typed parent stub
   with the right identity baked in. No hardcoded user id, no
   `getAgentByName` plumbing inside the facet.
+- `Chat` can spawn a nested `Researcher` helper with
+  `this.subAgent(Researcher, "default")`. The helper calls
+  `this.parentAgent(Chat)` to get context from its direct parent even
+  though `Chat` is itself a facet rather than a top-level binding.
 - Each `Chat` owns its own SQLite database, stream state, and recovery
   state. If you build this pattern with `Think`, `chatRecovery` and
   `runFiber()` work from inside the chat facet; the root parent's alarm

--- a/examples/multi-ai-chat/src/server.ts
+++ b/examples/multi-ai-chat/src/server.ts
@@ -5,6 +5,7 @@
  *
  *     Inbox (demo-user)                     ◄── top-level DO
  *       ├─ Chat (chat-abc)  [facet]         ◄── sub-agents, one per chat
+ *       │   └─ Researcher (default) [facet] ◄── nested helper facet
  *       ├─ Chat (chat-def)  [facet]
  *       └─ Chat (chat-ghi)  [facet]
  *
@@ -29,6 +30,8 @@
  *   child names get a 404 before any facet is woken.
  * - A `Chat` reaches its parent via `this.parentAgent(Inbox)` — no
  *   hardcoded user IDs, no separate binding lookup.
+ * - A nested `Researcher` helper reaches its direct parent via
+ *   `this.parentAgent(Chat)`, even though `Chat` is itself a facet.
  *
  * This is exactly the shape the proposed `Chats` base class in
  * `design/rfc-think-multi-session.md` will codify as sugar. Once
@@ -41,7 +44,13 @@
 
 import { Agent, callable, routeAgentRequest } from "agents";
 import { AIChatAgent, type OnChatMessageOptions } from "@cloudflare/ai-chat";
-import { convertToModelMessages, stepCountIs, streamText, tool } from "ai";
+import {
+  convertToModelMessages,
+  generateText,
+  stepCountIs,
+  streamText,
+  tool
+} from "ai";
 import { createWorkersAI } from "workers-ai-provider";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -62,6 +71,12 @@ export interface ChatSummary {
 
 export interface InboxState {
   chats: ChatSummary[];
+}
+
+export interface ResearchContext {
+  chatId: string;
+  messageCount: number;
+  recentMessages: Array<{ role: string; text: string }>;
 }
 
 // ── Inbox — the parent / directory ─────────────────────────────────
@@ -254,6 +269,23 @@ export class Chat extends AIChatAgent<Env> {
     return this.parentAgent(Inbox);
   }
 
+  async getResearchContext(): Promise<ResearchContext> {
+    return {
+      chatId: this.name,
+      messageCount: this.messages.length,
+      recentMessages: this.messages.slice(-6).map((message) => ({
+        role: message.role,
+        text: message.parts
+          .filter((part): part is { type: "text"; text: string } => {
+            return part.type === "text";
+          })
+          .map((part) => part.text)
+          .join("")
+          .slice(0, 500)
+      }))
+    };
+  }
+
   async onChatMessage(_onFinish: unknown, options?: OnChatMessageOptions) {
     // Read shared user memory from the Inbox. Fails soft — if the
     // parent is unreachable for any reason, the chat still works.
@@ -270,7 +302,7 @@ export class Chat extends AIChatAgent<Env> {
       sharedMemory
         ? `Things you already know about this user:\n${sharedMemory}`
         : null,
-      "You have three tools available:",
+      "You have four tools available:",
       "- `rememberFact`: save a fact about the user to their shared memory. " +
         "EVERY chat (this one plus every other chat in the sidebar) will " +
         "see this fact in future turns. Use it when the user shares a " +
@@ -279,7 +311,10 @@ export class Chat extends AIChatAgent<Env> {
       "- `recallMemory`: re-read the full shared memory. Useful to double-" +
         "check what you know before answering a question about the user.",
       "- `getCurrentTime`: returns the server's current time in ISO-8601. " +
-        "Use only when the user asks about the time."
+        "Use only when the user asks about the time.",
+      "- `askResearcher`: delegate a focused research question to a nested " +
+        "Researcher sub-agent. Use it when the user asks for a more careful " +
+        "second pass, tradeoff analysis, or summary grounded in this chat."
     ]
       .filter(Boolean)
       .join("\n\n");
@@ -341,6 +376,22 @@ export class Chat extends AIChatAgent<Env> {
             now: new Date().toISOString(),
             tz: "UTC"
           })
+        }),
+
+        askResearcher: tool({
+          description:
+            "Ask a nested Researcher sub-agent for a concise second-pass analysis.",
+          inputSchema: z.object({
+            topic: z
+              .string()
+              .describe(
+                "The focused question or topic the Researcher should analyze."
+              )
+          }),
+          execute: async ({ topic }) => {
+            const researcher = await this.subAgent(Researcher, "default");
+            return researcher.investigate(topic);
+          }
         })
       }
     });
@@ -365,6 +416,48 @@ export class Chat extends AIChatAgent<Env> {
     } catch (err) {
       console.warn("[Chat] Failed to update inbox preview:", err);
     }
+  }
+}
+
+// ── Researcher — a nested helper facet of Chat ──────────────────────
+
+export class Researcher extends Agent<Env> {
+  async investigate(topic: string): Promise<{
+    chatId: string;
+    finding: string;
+    messageCount: number;
+  }> {
+    // This is the nested-facet path:
+    //
+    //   Inbox (top-level) -> Chat (facet) -> Researcher (facet)
+    //
+    // `Chat` has no top-level Durable Object binding, but it is still
+    // the Researcher's direct parent, so `parentAgent(Chat)` should
+    // resolve through the recorded facet path.
+    const chat = await this.parentAgent(Chat);
+    const context = await chat.getResearchContext();
+    const workersai = createWorkersAI({ binding: this.env.AI });
+
+    const { text } = await generateText({
+      model: workersai("@cf/moonshotai/kimi-k2.5"),
+      system:
+        "You are a concise research helper. Use only the provided chat context. " +
+        "Return a short, practical answer with any uncertainty called out.",
+      prompt: [
+        `Research topic: ${topic}`,
+        `Chat id: ${context.chatId}`,
+        `Recent messages (${context.recentMessages.length}):`,
+        ...context.recentMessages.map((message) => {
+          return `${message.role}: ${message.text || "(no text)"}`;
+        })
+      ].join("\n")
+    });
+
+    return {
+      chatId: context.chatId,
+      finding: text,
+      messageCount: context.messageCount
+    };
   }
 }
 

--- a/examples/multi-ai-chat/wrangler.jsonc
+++ b/examples/multi-ai-chat/wrangler.jsonc
@@ -9,9 +9,9 @@
   },
   "durable_objects": {
     "bindings": [
-      // Only `Inbox` is bound top-level. `Chat` is addressed as a
-      // facet of an Inbox (`/agents/inbox/{user}/sub/chat/{chatId}`)
-      // and doesn't need its own binding.
+      // Only `Inbox` is bound top-level. `Chat` is a facet of Inbox,
+      // and `Researcher` is a nested facet of Chat; neither needs its
+      // own top-level binding.
       { "class_name": "Inbox", "name": "Inbox" }
     ]
   },

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -28,7 +28,7 @@ import type {
 import { parseCronExpression } from "cron-schedule";
 import { nanoid } from "nanoid";
 import { EmailMessage } from "cloudflare:email";
-import { RpcTarget } from "cloudflare:workers";
+import { RpcTarget, exports as workerExports } from "cloudflare:workers";
 import {
   type Connection,
   type ConnectionContext,
@@ -38,7 +38,7 @@ import {
   getServerByName,
   routePartykitRequest
 } from "partyserver";
-import { camelCaseToKebabCase } from "./utils";
+import { camelCaseToKebabCase, isInternalJsStubProp } from "./utils";
 import {
   type RetryOptions,
   tryN,
@@ -276,6 +276,14 @@ interface FacetCapableCtx {
     | undefined
   >;
 }
+
+type SubAgentPathInvokeEndpoint = {
+  _cf_invokeSubAgentPath(
+    path: ReadonlyArray<{ className: string; name: string }>,
+    method: string,
+    args: unknown[]
+  ): Promise<unknown>;
+};
 
 type SubAgentConnectionMeta = {
   id: string;
@@ -5507,6 +5515,64 @@ export class Agent<
     args: unknown[]
   ): Promise<unknown> {
     const stub = await this._cf_resolveSubAgent(className, name);
+    return await this._cf_invokeStubMethod(stub, className, method, args);
+  }
+
+  /**
+   * Bridge method used by `parentAgent()` when the requested parent is
+   * itself a facet (and therefore has no top-level env namespace).
+   * The root receives the full root-first target path, then each hop
+   * delegates to the next facet using that facet's own `ctx.facets`.
+   *
+   * @internal
+   */
+  async _cf_invokeSubAgentPath(
+    path: ReadonlyArray<{ className: string; name: string }>,
+    method: string,
+    args: unknown[]
+  ): Promise<unknown> {
+    const [self, next, ...rest] = path;
+    if (!self) {
+      throw new Error(`Sub-agent path invocation requires a non-empty path.`);
+    }
+
+    const ownClassName = (this.constructor as { name: string }).name;
+    if (self.className !== ownClassName || self.name !== this.name) {
+      throw new Error(
+        `Sub-agent path invocation reached ${ownClassName}("${this.name}") ` +
+          `but expected ${self.className}("${self.name}").`
+      );
+    }
+
+    if (!next) {
+      return await this._cf_invokeStubMethod(
+        this,
+        this.constructor.name,
+        method,
+        args
+      );
+    }
+
+    const child = await this._cf_resolveSubAgent(next.className, next.name);
+    if (rest.length === 0) {
+      return await this._cf_invokeStubMethod(
+        child,
+        next.className,
+        method,
+        args
+      );
+    }
+
+    const bridge = child as SubAgentPathInvokeEndpoint;
+    return await bridge._cf_invokeSubAgentPath([next, ...rest], method, args);
+  }
+
+  private async _cf_invokeStubMethod(
+    stub: unknown,
+    className: string,
+    method: string,
+    args: unknown[]
+  ): Promise<unknown> {
     // Must call `handle[method](...)` in one expression — extracting
     // via `const fn = handle[method]; fn.apply(handle, args)` breaks
     // the workerd RpcProperty binding. (Confirmed by the spike.)
@@ -5625,26 +5691,33 @@ export class Agent<
   }
 
   /**
-   * Resolve a typed RPC stub for this facet's **immediate** parent
+   * Resolve a typed parent stub for this facet's **immediate** parent
    * agent.
    *
    * Symmetric with `subAgent(Cls, name)`: while `subAgent` opens a
    * stub from parent to child, `parentAgent` opens one from child
    * to parent. Pass the direct parent's class reference — the
    * framework verifies it matches the last entry of
-   * `this.parentPath` at runtime, then looks up `env[Cls.name]` to
-   * find the namespace binding.
+   * `this.parentPath` at runtime. If the parent is a top-level
+   * Durable Object, the framework returns the normal namespace stub.
+   * If the parent is itself a facet, the framework returns a bridge
+   * proxy that routes method calls through the root/supervisor and
+   * then down the recorded facet path.
    *
    * `this.parentPath` is root-first, so the direct parent is the
    * **last** entry: `this.parentPath.at(-1)`. For grandparents and
    * further ancestors, iterate `this.parentPath` and use
    * `getAgentByName(env.X, this.parentPath[i].name)` directly.
    *
-   * Assumes the standard "binding name matches class name" convention.
-   * If your `wrangler.jsonc` binds the parent under a different name
-   * (e.g. `{ class_name: "Inbox", name: "MY_INBOX" }`), call
-   * `getAgentByName(env.MY_INBOX, this.parentPath.at(-1)!.name)`
-   * directly instead.
+   * For top-level parents, the framework first checks `env[Cls.name]`,
+   * then falls back to the Worker `exports` object. This supports
+   * custom binding names as long as the parent class is exported under
+   * its class name.
+   *
+   * Facet-parent stubs route normal HTTP `.fetch()` calls through the
+   * same root bridge as RPC methods. WebSocket upgrade requests are
+   * not supported yet because WebSocket handles cannot be serialized
+   * over RPC.
    *
    * @experimental The API surface may change before stabilizing.
    *
@@ -5652,7 +5725,8 @@ export class Agent<
    * @throws If `Cls.name` doesn't match the recorded direct-parent
    *         class (guards against accidentally reaching the wrong
    *         DO, especially in nested Root → Mid → Leaf chains).
-   * @throws If no env binding named `Cls.name` is found.
+   * @throws If no namespace is found for a top-level parent, or no
+   *         root namespace is available for a facet parent bridge.
    *
    * @example
    * ```ts
@@ -5687,18 +5761,115 @@ export class Agent<
           `whose constructor actually spawned this facet.`
       );
     }
-    const binding = (this.env as Record<string, unknown>)[cls.name] as
-      | DurableObjectNamespace<T>
-      | undefined;
+    if (this._parentPath.length > 1) {
+      return await this._cf_parentAgentFacetProxy<T>(
+        cls.name,
+        this._parentPath
+      );
+    }
+
+    const binding = this._cf_getTopLevelNamespaceByClassName<T>(cls.name);
     if (!binding) {
       throw new Error(
-        `parentAgent(${cls.name}): no top-level binding "${cls.name}" ` +
-          `found in env. If the parent is bound under a different name ` +
-          `(e.g. "MY_${cls.name.toUpperCase()}"), use ` +
-          `\`getAgentByName(env.MY_${cls.name.toUpperCase()}, this.parentPath.at(-1)!.name)\` directly.`
+        `parentAgent(${cls.name}): no top-level namespace for "${cls.name}" ` +
+          `was found in env or worker exports. Make sure the parent class is ` +
+          `exported under that class name and registered as a Durable Object binding.`
       );
     }
     return await getServerByName<Cloudflare.Env, T>(binding, parent.name);
+  }
+
+  private _cf_getTopLevelNamespaceByClassName<T extends Agent>(
+    className: string
+  ): DurableObjectNamespace<T> | undefined {
+    // Prefer explicit env bindings; fall back to worker exports so
+    // custom binding names still work when the class is exported under
+    // its constructor name.
+    return (
+      this._cf_asDurableObjectNamespace<T>(
+        (this.env as Record<string, unknown>)[className]
+      ) ??
+      this._cf_asDurableObjectNamespace<T>(
+        (workerExports as Record<string, unknown>)[className]
+      )
+    );
+  }
+
+  private _cf_asDurableObjectNamespace<T extends Agent>(
+    candidate: unknown
+  ): DurableObjectNamespace<T> | undefined {
+    const binding = candidate as DurableObjectNamespace<T> | undefined;
+    return binding?.idFromName ? binding : undefined;
+  }
+
+  private async _cf_parentAgentFacetProxy<T extends Agent>(
+    className: string,
+    parentPath: ReadonlyArray<{ className: string; name: string }>
+  ): Promise<DurableObjectStub<T>> {
+    const [root] = parentPath;
+    if (!root) {
+      throw new Error(`parentAgent(${className}): parent path is empty.`);
+    }
+
+    const rootBinding = this._cf_getTopLevelNamespaceByClassName<Agent>(
+      root.className
+    );
+    if (!rootBinding) {
+      throw new Error(
+        `parentAgent(${className}): direct parent is a facet, but no ` +
+          `top-level root namespace "${root.className}" was found in env ` +
+          `or worker exports to bridge the call.`
+      );
+    }
+
+    const rootStubPromise = getServerByName<Cloudflare.Env, Agent>(
+      rootBinding,
+      root.name
+    );
+    const targetPath = parentPath.map((step) => ({ ...step }));
+    const invokeBridge = async (method: string, args: unknown[]) => {
+      const rootStub = await rootStubPromise;
+      const bridge = rootStub as unknown as SubAgentPathInvokeEndpoint;
+      return await bridge._cf_invokeSubAgentPath(targetPath, method, args);
+    };
+    const owner = this;
+    return new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (isInternalJsStubProp(prop)) return undefined;
+          if (typeof prop !== "string") return undefined;
+          if (prop === "fetch") {
+            return async (input: RequestInfo | URL, init?: RequestInit) => {
+              if (owner._cf_isWebSocketUpgradeRequest(input, init)) {
+                throw new Error(
+                  `parentAgent(${className}).fetch() does not support WebSocket upgrade requests yet. ` +
+                    `Use externally routed sub-agent URLs for WebSocket connections.`
+                );
+              }
+
+              return await invokeBridge(prop, [input, init]);
+            };
+          }
+          return async (...args: unknown[]) => {
+            return await invokeBridge(prop, args);
+          };
+        }
+      }
+    ) as DurableObjectStub<T>;
+  }
+
+  private _cf_isWebSocketUpgradeRequest(
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): boolean {
+    const initHeaders = init?.headers ? new Headers(init.headers) : undefined;
+    const requestHeaders =
+      input instanceof Request ? new Headers(input.headers) : undefined;
+    return (
+      initHeaders?.get("Upgrade")?.toLowerCase() === "websocket" ||
+      requestHeaders?.get("Upgrade")?.toLowerCase() === "websocket"
+    );
   }
 
   /**

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -48,9 +48,11 @@ export { TestWaitConnectionsAgent } from "./wait-connections";
 export { SpikeSubParent, SpikeSubChild } from "./spike-sub-agent-routing";
 export {
   TestSubAgentParent,
+  CustomBoundSubAgentParent,
   CounterSubAgent,
   OuterSubAgent,
   InnerSubAgent,
+  LeafSubAgent,
   CallbackSubAgent,
   BroadcastSubAgent,
   HookingSubAgentParent,

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -265,6 +265,11 @@ export class CounterSubAgent extends Agent {
     return await parent.getOwnName();
   }
 
+  async callCustomBoundParentName(): Promise<string> {
+    const parent = await this.parentAgent(CustomBoundSubAgentParent);
+    return await parent.getOwnName();
+  }
+
   /**
    * Call `parentAgent()` and return the error message if the agent
    * isn't a facet. Exercises the guard on the helper.
@@ -590,6 +595,14 @@ export class InnerSubAgent extends Agent {
     return this.selfPath.map((step) => ({ ...step }));
   }
 
+  async innerPing(): Promise<string> {
+    return `inner:${this.name}`;
+  }
+
+  override async onRequest(request: Request): Promise<Response> {
+    return Response.json(await describeFacetFetch(this.name, request));
+  }
+
   /**
    * Regression: a doubly-nested facet's direct parent is the last
    * entry of `parentPath`, not the first.
@@ -611,9 +624,64 @@ export class InnerSubAgent extends Agent {
       return e instanceof Error ? e.message : String(e);
     }
   }
+
+  // parentAgent() fixture methods: Inner -> Outer.
+  async callFacetParentPing(): Promise<string> {
+    const parent = await this.parentAgent(OuterSubAgent);
+    return await parent.outerPing();
+  }
+
+  async fetchFacetParent(path: string): Promise<FacetFetchDescription> {
+    const parent = await this.parentAgent(OuterSubAgent);
+    const response = await parent.fetch(`https://example.com${path}`, {
+      body: "hello from inner",
+      headers: { "x-parent-agent-test": "yes" },
+      method: "POST"
+    });
+    return (await response.json()) as FacetFetchDescription;
+  }
+
+  async fetchFacetParentWithRequest(
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const parent = await this.parentAgent(OuterSubAgent);
+    const request = new Request(`https://example.com${path}`, {
+      body: "hello from request",
+      headers: { "x-parent-agent-test": "request" },
+      method: "POST"
+    });
+    const response = await parent.fetch(request);
+    return (await response.json()) as FacetFetchDescription;
+  }
+
+  async callDeepFacetParentPing(leafName: string): Promise<string> {
+    const leaf = await this.subAgent(LeafSubAgent, leafName);
+    return leaf.callFacetParentPing();
+  }
+
+  async fetchDeepFacetParent(
+    leafName: string,
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const leaf = await this.subAgent(LeafSubAgent, leafName);
+    return leaf.fetchFacetParent(path);
+  }
+
+  async tryFetchDeepFacetParentWebSocket(leafName: string): Promise<string> {
+    const leaf = await this.subAgent(LeafSubAgent, leafName);
+    return leaf.tryFetchFacetParentWebSocket();
+  }
 }
 
 export class OuterSubAgent extends Agent {
+  async outerPing(): Promise<string> {
+    return `outer:${this.name}`;
+  }
+
+  override async onRequest(request: Request): Promise<Response> {
+    return Response.json(await describeFacetFetch(this.name, request));
+  }
+
   async spawnInnerWithOwnNamespaceHelperHidden(
     innerName: string
   ): Promise<string> {
@@ -666,6 +734,53 @@ export class OuterSubAgent extends Agent {
     return inner.tryParentAgentWithRoot();
   }
 
+  // parentAgent() fixture methods: delegate from Outer into Inner/Leaf.
+  async innerCallFacetParentPing(innerName: string): Promise<string> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.callFacetParentPing();
+  }
+
+  async innerFetchFacetParent(
+    innerName: string,
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.fetchFacetParent(path);
+  }
+
+  async innerFetchFacetParentWithRequest(
+    innerName: string,
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.fetchFacetParentWithRequest(path);
+  }
+
+  async innerCallDeepFacetParent(
+    innerName: string,
+    leafName: string
+  ): Promise<string> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.callDeepFacetParentPing(leafName);
+  }
+
+  async innerFetchDeepFacetParent(
+    innerName: string,
+    leafName: string,
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.fetchDeepFacetParent(leafName, path);
+  }
+
+  async innerTryFetchDeepFacetParentWebSocket(
+    innerName: string,
+    leafName: string
+  ): Promise<string> {
+    const inner = await this.subAgent(InnerSubAgent, innerName);
+    return inner.tryFetchDeepFacetParentWebSocket(leafName);
+  }
+
   async scheduleInnerSet(
     innerName: string,
     delaySeconds: number,
@@ -710,6 +825,63 @@ export class OuterSubAgent extends Agent {
 
   ping(): string {
     return "outer-pong";
+  }
+}
+
+type FacetFetchDescription = {
+  agentName: string;
+  body: string;
+  header: string | null;
+  method: string;
+  path: string;
+  search: string;
+};
+
+async function describeFacetFetch(
+  agentName: string,
+  request: Request
+): Promise<FacetFetchDescription> {
+  const url = new URL(request.url);
+  const body =
+    request.method === "GET" || request.method === "HEAD"
+      ? ""
+      : await request.text();
+  return {
+    agentName,
+    body,
+    header: request.headers.get("x-parent-agent-test"),
+    method: request.method,
+    path: url.pathname,
+    search: url.search
+  };
+}
+
+export class LeafSubAgent extends Agent {
+  async callFacetParentPing(): Promise<string> {
+    const parent = await this.parentAgent(InnerSubAgent);
+    return parent.innerPing();
+  }
+
+  async fetchFacetParent(path: string): Promise<FacetFetchDescription> {
+    const parent = await this.parentAgent(InnerSubAgent);
+    const response = await parent.fetch(`https://example.com${path}`, {
+      body: "hello from leaf",
+      headers: { "x-parent-agent-test": "yes" },
+      method: "POST"
+    });
+    return (await response.json()) as FacetFetchDescription;
+  }
+
+  async tryFetchFacetParentWebSocket(): Promise<string> {
+    try {
+      const parent = await this.parentAgent(InnerSubAgent);
+      await parent.fetch("https://example.com/ws-from-leaf", {
+        headers: { Upgrade: "websocket" }
+      });
+      return "";
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
   }
 }
 
@@ -810,6 +982,17 @@ export class BroadcastSubAgent extends Agent<Cloudflare.Env, BroadcastState> {
    */
   initializedOk(): boolean {
     return true;
+  }
+}
+
+export class CustomBoundSubAgentParent extends Agent {
+  async getOwnName(): Promise<string> {
+    return this.name;
+  }
+
+  async subAgentCallParentName(subAgentName: string): Promise<string> {
+    const child = await this.subAgent(CounterSubAgent, subAgentName);
+    return child.callCustomBoundParentName();
   }
 }
 
@@ -1555,6 +1738,61 @@ export class TestSubAgentParent extends Agent {
   ): Promise<string> {
     const outer = await this.subAgent(OuterSubAgent, outerName);
     return outer.innerTryParentAgentWithRoot(innerName);
+  }
+
+  // parentAgent() regression fixtures exposed from the root test parent.
+  async subAgentNestedCallFacetParent(
+    outerName: string,
+    innerName: string
+  ): Promise<string> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.innerCallFacetParentPing(innerName);
+  }
+
+  async subAgentNestedFetchFacetParent(
+    outerName: string,
+    innerName: string,
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.innerFetchFacetParent(innerName, path);
+  }
+
+  async subAgentNestedFetchFacetParentWithRequest(
+    outerName: string,
+    innerName: string,
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.innerFetchFacetParentWithRequest(innerName, path);
+  }
+
+  async subAgentDeepCallFacetParent(
+    outerName: string,
+    innerName: string,
+    leafName: string
+  ): Promise<string> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.innerCallDeepFacetParent(innerName, leafName);
+  }
+
+  async subAgentDeepFetchFacetParent(
+    outerName: string,
+    innerName: string,
+    leafName: string,
+    path: string
+  ): Promise<FacetFetchDescription> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.innerFetchDeepFacetParent(innerName, leafName, path);
+  }
+
+  async subAgentDeepTryFetchFacetParentWebSocket(
+    outerName: string,
+    innerName: string,
+    leafName: string
+  ): Promise<string> {
+    const outer = await this.subAgent(OuterSubAgent, outerName);
+    return outer.innerTryFetchDeepFacetParentWebSocket(innerName, leafName);
   }
 
   has(className: string, name: string): boolean {

--- a/packages/agents/src/tests/sub-agent.test.ts
+++ b/packages/agents/src/tests/sub-agent.test.ts
@@ -1119,6 +1119,23 @@ describe("SubAgent", () => {
       expect(observed).toBe(parentName);
     });
 
+    it("resolves a top-level parent whose binding name differs from the class name", async () => {
+      const parentName = uniqueName();
+      const parent = await getAgentByName(
+        env.CUSTOM_BOUND_SUB_AGENT_PARENT,
+        parentName
+      );
+
+      // `CustomBoundSubAgentParent` is registered under the
+      // `CUSTOM_BOUND_SUB_AGENT_PARENT` binding, so `env[Cls.name]`
+      // is absent. `parentAgent(CustomBoundSubAgentParent)` should
+      // still resolve via the worker `exports` namespace.
+      const observed = await parent.subAgentCallParentName(
+        "custom-binding-parent-probe"
+      );
+      expect(observed).toBe(parentName);
+    });
+
     it("throws a clear error when called on a non-facet (top-level agent)", async () => {
       const parentName = uniqueName();
       const parent = await getAgentByName(env.TestSubAgentParent, parentName);
@@ -1179,6 +1196,122 @@ describe("SubAgent", () => {
       expect(err).toMatch(/OuterSubAgent/);
       // And the class the caller (wrongly) passed is named too.
       expect(err).toMatch(/TestSubAgentParent/);
+    });
+
+    it("resolves a facet-only direct parent through the root bridge", async () => {
+      const rootName = uniqueName();
+      const outerName = uniqueName();
+      const innerName = uniqueName();
+      const root = await getAgentByName(env.TestSubAgentParent, rootName);
+
+      const observed = await root.subAgentNestedCallFacetParent(
+        outerName,
+        innerName
+      );
+
+      expect(observed).toBe(`outer:${outerName}`);
+    });
+
+    it("fetches through a facet-parent proxy", async () => {
+      const rootName = uniqueName();
+      const outerName = uniqueName();
+      const innerName = uniqueName();
+      const root = await getAgentByName(env.TestSubAgentParent, rootName);
+
+      const observed = await root.subAgentNestedFetchFacetParent(
+        outerName,
+        innerName,
+        "/parent-path?x=1"
+      );
+
+      expect(observed).toEqual({
+        agentName: outerName,
+        body: "hello from inner",
+        header: "yes",
+        method: "POST",
+        path: "/parent-path",
+        search: "?x=1"
+      });
+    });
+
+    it("fetches through a facet-parent proxy with a Request object", async () => {
+      const rootName = uniqueName();
+      const outerName = uniqueName();
+      const innerName = uniqueName();
+      const root = await getAgentByName(env.TestSubAgentParent, rootName);
+
+      const observed = await root.subAgentNestedFetchFacetParentWithRequest(
+        outerName,
+        innerName,
+        "/request-object?source=request"
+      );
+
+      expect(observed).toEqual({
+        agentName: outerName,
+        body: "hello from request",
+        header: "request",
+        method: "POST",
+        path: "/request-object",
+        search: "?source=request"
+      });
+    });
+
+    it("resolves a deeper facet-only parent through the recursive bridge", async () => {
+      const rootName = uniqueName();
+      const outerName = uniqueName();
+      const innerName = uniqueName();
+      const leafName = uniqueName();
+      const root = await getAgentByName(env.TestSubAgentParent, rootName);
+
+      const observed = await root.subAgentDeepCallFacetParent(
+        outerName,
+        innerName,
+        leafName
+      );
+
+      expect(observed).toBe(`inner:${innerName}`);
+    });
+
+    it("fetches through a deeper facet-parent proxy", async () => {
+      const rootName = uniqueName();
+      const outerName = uniqueName();
+      const innerName = uniqueName();
+      const leafName = uniqueName();
+      const root = await getAgentByName(env.TestSubAgentParent, rootName);
+
+      const observed = await root.subAgentDeepFetchFacetParent(
+        outerName,
+        innerName,
+        leafName,
+        "/deep-parent?mode=recursive"
+      );
+
+      expect(observed).toEqual({
+        agentName: innerName,
+        body: "hello from leaf",
+        header: "yes",
+        method: "POST",
+        path: "/deep-parent",
+        search: "?mode=recursive"
+      });
+    });
+
+    it("throws a clear error for facet-parent WebSocket upgrades", async () => {
+      const rootName = uniqueName();
+      const outerName = uniqueName();
+      const innerName = uniqueName();
+      const leafName = uniqueName();
+      const root = await getAgentByName(env.TestSubAgentParent, rootName);
+
+      const observed = await root.subAgentDeepTryFetchFacetParentWebSocket(
+        outerName,
+        innerName,
+        leafName
+      );
+
+      expect(observed).toMatch(/parentAgent\(InnerSubAgent\)\.fetch\(\)/);
+      expect(observed).toMatch(/WebSocket upgrade requests/i);
+      expect(observed).toMatch(/externally routed sub-agent URLs/i);
     });
   });
 

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -48,9 +48,11 @@ export {
   TestMultiSessionAgent,
   TestWaitConnectionsAgent,
   TestSubAgentParent,
+  CustomBoundSubAgentParent,
   CounterSubAgent,
   OuterSubAgent,
   InnerSubAgent,
+  LeafSubAgent,
   CallbackSubAgent,
   BroadcastSubAgent,
   TestConnectionUriAgent,
@@ -121,6 +123,7 @@ import type {
   TestMultiSessionAgent,
   TestWaitConnectionsAgent,
   TestSubAgentParent,
+  CustomBoundSubAgentParent,
   TestConnectionUriAgent,
   SpikeSubParent,
   HookingSubAgentParent,
@@ -169,6 +172,7 @@ export type Env = {
   TestMultiSessionAgent: DurableObjectNamespace<TestMultiSessionAgent>;
   TestWaitConnectionsAgent: DurableObjectNamespace<TestWaitConnectionsAgent>;
   TestSubAgentParent: DurableObjectNamespace<TestSubAgentParent>;
+  CUSTOM_BOUND_SUB_AGENT_PARENT: DurableObjectNamespace<CustomBoundSubAgentParent>;
   TestUnboundParentAgent: DurableObjectNamespace<TestUnboundParentAgent>;
   TestMinifiedNameParentAgent: DurableObjectNamespace<TestMinifiedNameParentAgent>;
   SpikeSubParent: DurableObjectNamespace<SpikeSubParent>;

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -166,6 +166,10 @@
         "name": "TestSubAgentParent"
       },
       {
+        "class_name": "CustomBoundSubAgentParent",
+        "name": "CUSTOM_BOUND_SUB_AGENT_PARENT"
+      },
+      {
         "class_name": "TestMigrationAgent",
         "name": "TestMigrationAgent"
       },
@@ -270,9 +274,11 @@
         "TestMultiSessionAgent",
         "TestWaitConnectionsAgent",
         "TestSubAgentParent",
+        "CustomBoundSubAgentParent",
         "CounterSubAgent",
         "OuterSubAgent",
         "InnerSubAgent",
+        "LeafSubAgent",
         "CallbackSubAgent",
         "BroadcastSubAgent",
         "TestMigrationAgent",


### PR DESCRIPTION
## Summary

This PR fixes `Agent#parentAgent(Cls)` for nested sub-agent trees where the immediate parent is itself a Durable Object facet rather than a top-level bound Durable Object namespace.

Before this change, `parentAgent(Cls)` only knew how to resolve top-level parents through `env[Cls.name]`. That worked for simple `Root -> Child` trees, but it broke for deeper `Root -> OuterFacet -> InnerFacet` trees because `InnerFacet.parentAgent(OuterFacet)` tried to find a top-level `OuterFacet` namespace even though `OuterFacet` is intentionally facet-only.

## What changed

- `parentAgent(Cls)` still validates that `Cls.name` matches the recorded direct parent class in `parentPath`.
- Top-level parent lookup now prefers `env[Cls.name]` and falls back to the Worker `exports` namespace by exported class name.
  - This preserves the normal env-binding path.
  - It also supports custom Durable Object binding names, as long as the class is exported under its constructor name.
  - Both candidates are validated as Durable Object namespaces before use.
- Facet-only direct parents now resolve through a root bridge:
  - the child records its root-first `parentPath`
  - `parentAgent()` opens the top-level root namespace
  - internal calls walk the recorded facet path one hop at a time using each parent facet's own `ctx.facets`
- Normal HTTP `.fetch()` calls on a facet-parent stub are supported through the same internal bridge as RPC methods.
- WebSocket upgrade requests through `parentAgent().fetch()` now fail early with a clear error because WebSocket handles cannot be serialized over RPC yet. External `/sub/...` routing remains the supported WebSocket path.
- `getSubAgentByName()` now reuses the same internal method invocation helper, keeping stub method dispatch consistent.

## Docs

- Updated `docs/sub-agents.md` to explain:
  - top-level vs facet-parent `parentAgent()` resolution
  - custom binding-name support via Worker `exports`
  - normal HTTP `.fetch()` support
  - WebSocket upgrade limitation for `parentAgent().fetch()`
  - the difference between internal `parentAgent(Cls)` calls and external `/sub/...` routing
- Updated `design/sub-agent-routing.md` as the living design doc.
- Added a current-behavior note to `design/rfc-sub-agent-routing.md` so readers do not rely on the older RFC wording for current `parentAgent()` behavior.
- Updated the multi-AI-chat example README wording from “typed RPC stub” to “typed parent stub.”

## Tests

Added Workers regressions covering:

- direct top-level parent lookup still works
- top-level parent lookup works when the Durable Object binding name differs from the class name
- `parentAgent()` throws clearly when called from a top-level, non-facet agent
- wrong-class protection still catches direct-parent mismatches
- doubly nested facets resolve the direct parent, not the root
- facet-only direct parent RPC calls work
- facet-parent normal HTTP `.fetch()` works
- facet-parent `.fetch()` works with a real `Request` object
- deeper recursive facet-parent bridge calls work
- deeper facet-parent HTTP `.fetch()` works
- facet-parent WebSocket upgrade requests throw the intended clear error

## Validation

- `npm run test:workers --workspace agents -- src/tests/sub-agent.test.ts` passed: 86 tests
- `npm run check` passed
  - The command still reports the existing sherif warning about `examples/think-slide-deck/package.json` missing, but exits successfully.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->