### PR TITLE
fix(codemode): use Workers-safe MCP validator

### DIFF
--- a/.changeset/codemode-cfworker-validator.md
+++ b/.changeset/codemode-cfworker-validator.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Default `openApiMcpServer` to the MCP SDK's Workers-safe JSON schema validator so elicitation response validation does not rely on runtime code generation.

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { z } from "zod";
@@ -415,7 +416,10 @@ export function openApiMcpServer(options: OpenApiMcpServerOptions): McpServer {
 
   const spec = options.spec;
 
-  const server = new McpServer({ name, version });
+  const server = new McpServer(
+    { name, version },
+    { jsonSchemaValidator: new CfWorkerJsonSchemaValidator() }
+  );
 
   // --- search tool ---
   server.registerTool(

--- a/packages/codemode/src/tests/mcp.test.ts
+++ b/packages/codemode/src/tests/mcp.test.ts
@@ -468,6 +468,20 @@ describe("openApiMcpServer", () => {
     await client.close();
   });
 
+  it("should use the Workers-safe JSON schema validator by default", () => {
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async () => ({})
+    });
+
+    expect(
+      (server.server as unknown as { _jsonSchemaValidator: unknown })
+        ._jsonSchemaValidator?.constructor.name
+    ).toBe("CfWorkerJsonSchemaValidator");
+  });
+
   it("search tool description should match snapshot", async () => {
     const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
     const server = openApiMcpServer({


### PR DESCRIPTION
## Summary

`openApiMcpServer` currently creates its underlying MCP `McpServer` without server options, which leaves the MCP SDK on its default AJV validator. AJV compiles schemas with runtime code generation, so elicitation accept responses can fail in Cloudflare Workers with `Code generation from strings disallowed`.

This PR defaults codemode's OpenAPI MCP server to the SDK's Workers-safe `CfWorkerJsonSchemaValidator`, avoiding AJV codegen for elicitation response validation.

## Changes

- Import and use `CfWorkerJsonSchemaValidator` when constructing the underlying `McpServer` in `openApiMcpServer`.
- Add a regression test that asserts `openApiMcpServer` uses the Workers-safe validator by default.
- Add a patch changeset for `@cloudflare/codemode`.

Fixes #1491.

## Testing

- [x] `npm test --workspace @cloudflare/codemode`
- [x] `npm run build --workspace @cloudflare/codemode`
- [x] `npm run build`
- [ ] `npm run check` — currently blocked by existing missing dependency/type resolution for `@cloudflare/kumo` in `site/ai-playground/tsconfig.json`; all other check steps pass, including sherif, export validation, format, lint, and 83/84 typecheck projects.
