### PR TITLE
fix: route RPC MCP responses by request id

### DIFF
--- a/.changeset/rpc-mcp-response-routing.md
+++ b/.changeset/rpc-mcp-response-routing.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix RPC MCP response routing for overlapping requests by correlating responses to JSON-RPC request ids.

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -32,7 +32,6 @@ export abstract class McpAgent<
   State = unknown,
   Props extends Record<string, unknown> = Record<string, unknown>
 > extends Agent<Env, State, Props> {
-  private _rpcMessageQueue: Promise<void> = Promise.resolve();
   private _transport?: Transport;
   private _pendingElicitations = new Map<
     string,
@@ -420,13 +419,7 @@ export abstract class McpAgent<
       }
     }
 
-    const transport = this._transport;
-    const run = this._rpcMessageQueue.then(() => transport.handle(message));
-    this._rpcMessageQueue = run.then(
-      () => undefined,
-      () => undefined
-    );
-    return await run;
+    return await this._transport.handle(message);
   }
 
   /** Return a handler for the given path for this MCP.

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -32,6 +32,7 @@ export abstract class McpAgent<
   State = unknown,
   Props extends Record<string, unknown> = Record<string, unknown>
 > extends Agent<Env, State, Props> {
+  private _rpcMessageQueue: Promise<void> = Promise.resolve();
   private _transport?: Transport;
   private _pendingElicitations = new Map<
     string,
@@ -419,7 +420,14 @@ export abstract class McpAgent<
       }
     }
 
-    return await this._transport.handle(message);
+    const run = this._rpcMessageQueue.then(() =>
+      this._transport!.handle(message)
+    );
+    this._rpcMessageQueue = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return await run;
   }
 
   /** Return a handler for the given path for this MCP.

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -405,6 +405,10 @@ export abstract class McpAgent<
 
     const transport = this._transport;
 
+    // RPC waits are intentionally in-memory. While a request/continuation is
+    // pending, keep the object alive so hibernation does not drop the resolver
+    // maps or the suspended tool stack. Making this sleep/resume across
+    // hibernation would require a durable continuation model instead.
     return await this.keepAliveWhile(async () => {
       // Intercept elicitation responses before they reach the transport.
       // Mirrors what onSSEMcpMessage() and StreamableHTTPServerTransport's

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -420,9 +420,8 @@ export abstract class McpAgent<
       }
     }
 
-    const run = this._rpcMessageQueue.then(() =>
-      this._transport!.handle(message)
-    );
+    const transport = this._transport;
+    const run = this._rpcMessageQueue.then(() => transport.handle(message));
     this._rpcMessageQueue = run.then(
       () => undefined,
       () => undefined

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -403,23 +403,27 @@ export abstract class McpAgent<
       throw new Error("Expected RPC transport");
     }
 
-    // Intercept elicitation responses before they reach the transport.
-    // Mirrors what onSSEMcpMessage() and StreamableHTTPServerTransport's
-    // messageInterceptor already do for their respective transports.
-    if (!Array.isArray(message)) {
-      const parseResult = JSONRPCMessageSchema.safeParse(message);
-      if (
-        parseResult.success &&
-        this._handleElicitationResponse(parseResult.data)
-      ) {
-        // Resolved a pending elicitation — now wait for the tool handler
-        // to send its next message (another elicitation request or the
-        // final tool result).
-        return await this._transport._awaitPendingResponse();
-      }
-    }
+    const transport = this._transport;
 
-    return await this._transport.handle(message);
+    return await this.keepAliveWhile(async () => {
+      // Intercept elicitation responses before they reach the transport.
+      // Mirrors what onSSEMcpMessage() and StreamableHTTPServerTransport's
+      // messageInterceptor already do for their respective transports.
+      if (!Array.isArray(message)) {
+        const parseResult = JSONRPCMessageSchema.safeParse(message);
+        if (
+          parseResult.success &&
+          this._handleElicitationResponse(parseResult.data)
+        ) {
+          // Resolved a pending elicitation — now wait for the tool handler
+          // to send its next message (another elicitation request or the
+          // final tool result).
+          return await transport._awaitPendingResponse();
+        }
+      }
+
+      return await transport.handle(message);
+    });
   }
 
   /** Return a handler for the given path for this MCP.

--- a/packages/agents/src/mcp/rpc.ts
+++ b/packages/agents/src/mcp/rpc.ts
@@ -6,7 +6,11 @@ import type {
   JSONRPCMessage,
   MessageExtraInfo
 } from "@modelcontextprotocol/sdk/types.js";
-import { JSONRPCMessageSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  isJSONRPCErrorResponse,
+  isJSONRPCResultResponse,
+  JSONRPCMessageSchema
+} from "@modelcontextprotocol/sdk/types.js";
 import { getServerByName } from "partyserver";
 import type { McpAgent } from ".";
 
@@ -118,12 +122,19 @@ export interface RPCServerTransportOptions {
   timeout?: number;
 }
 
+type PendingRPCResponse = {
+  messages: JSONRPCMessage[];
+  resolve: (response: JSONRPCMessage | JSONRPCMessage[] | undefined) => void;
+  reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+};
+
 export class RPCServerTransport implements Transport {
   private _started = false;
-  private _pendingResponse: JSONRPCMessage | JSONRPCMessage[] | null = null;
-  private _responseResolver: (() => void) | null = null;
   private _protocolVersion?: string;
   private _timeout: number;
+  private _pendingRequests = new Map<string, PendingRPCResponse>();
+  private _pendingContinuations: PendingRPCResponse[] = [];
 
   sessionId?: string;
   onclose?: () => void;
@@ -152,44 +163,146 @@ export class RPCServerTransport implements Transport {
   async close(): Promise<void> {
     this._started = false;
     this.onclose?.();
-    if (this._responseResolver) {
-      this._responseResolver();
-      this._responseResolver = null;
+
+    const error = new Error("Transport closed");
+    for (const pending of this._pendingRequests.values()) {
+      clearTimeout(pending.timeoutId);
+      pending.reject(error);
     }
+    this._pendingRequests.clear();
+
+    for (const pending of this._pendingContinuations) {
+      clearTimeout(pending.timeoutId);
+      pending.reject(error);
+    }
+    this._pendingContinuations = [];
+  }
+
+  private _makeTimeout(onTimeout: () => void): ReturnType<typeof setTimeout> {
+    return setTimeout(onTimeout, this._timeout);
+  }
+
+  private _appendPending(
+    pending: PendingRPCResponse,
+    message: JSONRPCMessage
+  ): void {
+    pending.messages.push(message);
+  }
+
+  private _completePending(
+    pending: PendingRPCResponse,
+    message: JSONRPCMessage
+  ): void {
+    pending.messages.push(message);
+    clearTimeout(pending.timeoutId);
+
+    const messages = pending.messages;
+    queueMicrotask(() => {
+      pending.resolve(messages.length === 1 ? messages[0] : messages);
+    });
+  }
+
+  private _completeRequest(key: string, message: JSONRPCMessage): boolean {
+    const pending = this._pendingRequests.get(key);
+    if (!pending) return false;
+
+    this._pendingRequests.delete(key);
+    this._completePending(pending, message);
+    return true;
+  }
+
+  private _appendRequest(key: string, message: JSONRPCMessage): boolean {
+    const pending = this._pendingRequests.get(key);
+    if (!pending) return false;
+
+    this._appendPending(pending, message);
+    return true;
+  }
+
+  private _completeContinuation(message: JSONRPCMessage): boolean {
+    const pending = this._pendingContinuations.shift();
+    if (!pending) return false;
+
+    this._completePending(pending, message);
+    return true;
+  }
+
+  private _appendContinuation(message: JSONRPCMessage): boolean {
+    const pending = this._pendingContinuations[0];
+    if (!pending) return false;
+
+    this._appendPending(pending, message);
+    return true;
   }
 
   async send(
     message: JSONRPCMessage,
-    _options?: TransportSendOptions
+    options?: TransportSendOptions
   ): Promise<void> {
     if (!this._started) {
       throw new Error("Transport not started");
     }
 
-    if (!this._pendingResponse) {
-      this._pendingResponse = message;
-    } else if (Array.isArray(this._pendingResponse)) {
-      this._pendingResponse.push(message);
-    } else {
-      this._pendingResponse = [this._pendingResponse, message];
+    if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
+      const id = message.id;
+      if (id === undefined) {
+        this.onerror?.(
+          new Error(`RPC response missing id: ${JSON.stringify(message)}`)
+        );
+        return;
+      }
+
+      if (this._completeRequest(id.toString(), message)) {
+        return;
+      }
+
+      if (this._completeContinuation(message)) {
+        return;
+      }
+
+      this.onerror?.(
+        new Error(
+          `No pending RPC request found for response: ${JSON.stringify(message)}`
+        )
+      );
+      return;
     }
 
-    if (this._responseResolver) {
-      const resolver = this._responseResolver;
-      queueMicrotask(() => resolver());
+    const relatedRequestId = options?.relatedRequestId?.toString();
+    const expectsResponse = "id" in message;
+
+    if (relatedRequestId) {
+      if (expectsResponse) {
+        if (this._completeRequest(relatedRequestId, message)) return;
+      } else if (this._appendRequest(relatedRequestId, message)) {
+        return;
+      }
     }
+
+    if (expectsResponse) {
+      if (this._completeContinuation(message)) return;
+    } else if (this._appendContinuation(message)) {
+      return;
+    }
+
+    this.onerror?.(
+      new Error(
+        `No pending RPC request found for message: ${JSON.stringify(message)}`
+      )
+    );
   }
 
   /**
    * @internal Called by McpAgent.handleMcpMessage() — not for external use.
    *
-   * Wait for the next send() call and return whatever it produces.
+   * Wait for the next unmatched send() call that expects a client response or
+   * completes a resumed tool call.
    *
-   * Used after resolving an elicitation response: the tool handler is still
-   * running and will eventually call send() with either another elicitation
-   * request or the final tool result. This method captures that send() using
-   * the same _responseResolver / _pendingResponse / timeout mechanism as
-   * handle().
+   * Used after resolving an elicitation response: the original tool call has
+   * already returned the elicitation request to the RPC client, and the resumed
+   * tool handler will eventually send the final tool result. That final response
+   * has the original tool request id, so there is no active handle() waiter left
+   * for id-based routing; this continuation waiter receives it instead.
    */
   async _awaitPendingResponse(): Promise<
     JSONRPCMessage | JSONRPCMessage[] | undefined
@@ -198,41 +311,27 @@ export class RPCServerTransport implements Transport {
       throw new Error("Transport not started");
     }
 
-    this._pendingResponse = null;
-
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    const responsePromise = new Promise<void>((resolve, reject) => {
-      timeoutId = setTimeout(() => {
-        this._responseResolver = null;
-        reject(
-          new Error(
-            `Request timeout: No response received within ${this._timeout}ms`
-          )
-        );
-      }, this._timeout);
-
-      this._responseResolver = () => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = null;
-        }
-        this._responseResolver = null;
-        resolve();
-      };
-    });
-
-    try {
-      await responsePromise;
-    } catch (error) {
-      this._pendingResponse = null;
-      this._responseResolver = null;
-      throw error;
-    }
-
-    const response = this._pendingResponse;
-    this._pendingResponse = null;
-
-    return response ?? undefined;
+    return await new Promise<JSONRPCMessage | JSONRPCMessage[] | undefined>(
+      (resolve, reject) => {
+        const pending: PendingRPCResponse = {
+          messages: [],
+          resolve,
+          reject,
+          timeoutId: this._makeTimeout(() => {
+            const index = this._pendingContinuations.indexOf(pending);
+            if (index !== -1) {
+              this._pendingContinuations.splice(index, 1);
+            }
+            reject(
+              new Error(
+                `Request timeout: No response received within ${this._timeout}ms`
+              )
+            );
+          })
+        };
+        this._pendingContinuations.push(pending);
+      }
+    );
   }
 
   async handle(
@@ -245,19 +344,15 @@ export class RPCServerTransport implements Transport {
     if (Array.isArray(message)) {
       validateBatch(message);
 
-      const responses: JSONRPCMessage[] = [];
-      for (const msg of message) {
-        const response = await this.handle(msg);
-        if (response !== undefined) {
-          if (Array.isArray(response)) {
-            responses.push(...response);
-          } else {
-            responses.push(response);
-          }
-        }
-      }
+      const responses = await Promise.all(
+        message.map((msg) => this.handle(msg))
+      );
+      const flattened = responses.flatMap((response) => {
+        if (response === undefined) return [];
+        return Array.isArray(response) ? response : [response];
+      });
 
-      return responses.length === 0 ? undefined : responses;
+      return flattened.length === 0 ? undefined : flattened;
     }
 
     try {
@@ -270,48 +365,43 @@ export class RPCServerTransport implements Transport {
       return makeInvalidRequestError(id);
     }
 
-    this._pendingResponse = null;
-
     const isNotification = !("id" in message);
     if (isNotification) {
       this.onmessage?.(message);
       return undefined;
     }
 
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    const responsePromise = new Promise<void>((resolve, reject) => {
-      timeoutId = setTimeout(() => {
-        this._responseResolver = null;
-        reject(
-          new Error(
-            `Request timeout: No response received within ${this._timeout}ms`
-          )
-        );
-      }, this._timeout);
+    const id = message.id?.toString();
+    if (!id) {
+      return makeInvalidRequestError(message.id);
+    }
 
-      this._responseResolver = () => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = null;
-        }
-        this._responseResolver = null;
-        resolve();
+    if (this._pendingRequests.has(id)) {
+      throw new Error(`Duplicate pending RPC request id: ${id}`);
+    }
+
+    const responsePromise = new Promise<
+      JSONRPCMessage | JSONRPCMessage[] | undefined
+    >((resolve, reject) => {
+      const pending: PendingRPCResponse = {
+        messages: [],
+        resolve,
+        reject,
+        timeoutId: this._makeTimeout(() => {
+          this._pendingRequests.delete(id);
+          reject(
+            new Error(
+              `Request timeout: No response received within ${this._timeout}ms`
+            )
+          );
+        })
       };
+
+      this._pendingRequests.set(id, pending);
     });
 
     this.onmessage?.(message);
 
-    try {
-      await responsePromise;
-    } catch (error) {
-      this._pendingResponse = null;
-      this._responseResolver = null;
-      throw error;
-    }
-
-    const response = this._pendingResponse;
-    this._pendingResponse = null;
-
-    return response ?? undefined;
+    return await responsePromise;
   }
 }

--- a/packages/agents/src/tests/mcp/elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/elicitation.test.ts
@@ -331,6 +331,33 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
   });
 
   describe("RPC Transport", () => {
+    it("should keep a normal concurrent tool call separate from an eliciting tool call via RPC", async () => {
+      const { connection } = await establishRPCConnection();
+
+      connection.handleElicitationRequest = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { action: "accept", content: { name: "Alice" } };
+      };
+
+      const [elicitResult, greetResult] = await Promise.all([
+        connection.client.callTool({
+          name: "elicitNameCustom",
+          arguments: {}
+        }),
+        connection.client.callTool({
+          name: "greet",
+          arguments: { name: "Concurrent" }
+        })
+      ]);
+
+      expect(elicitResult.content).toEqual([
+        { type: "text", text: "Custom elicit: Alice" }
+      ]);
+      expect(greetResult.content).toEqual([
+        { type: "text", text: "Hello, Concurrent!" }
+      ]);
+    });
+
     it("should complete elicitation accept round-trip via RPC", async () => {
       const { connection } = await establishRPCConnection();
 

--- a/packages/agents/src/tests/mcp/transports/rpc.test.ts
+++ b/packages/agents/src/tests/mcp/transports/rpc.test.ts
@@ -356,14 +356,41 @@ describe("RPC Transport", () => {
       const transport = new RPCServerTransport();
       await transport.start();
 
+      const firstResponse: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: "elicit_abc",
+        method: "elicitation/create",
+        params: { message: "Approve?" }
+      };
+
       const finalResponse: JSONRPCMessage = {
         jsonrpc: "2.0",
-        id: 2,
+        id: 1,
         result: { content: [{ type: "text", text: "done" }] }
       };
 
+      // Simulate: onmessage dispatches async tool handler that sends
+      // an intermediate server-to-client request first. In the MCP SDK this
+      // is sent with relatedRequestId so it routes to the originating request.
+      transport.onmessage = (msg) => {
+        const req = msg as JSONRPCRequest;
+        void transport.send(firstResponse, { relatedRequestId: req.id });
+      };
+
+      // handle() returns the intermediate elicitation request
+      const handleResult = await transport.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "test" }
+      });
+
+      expect(handleResult).toEqual(firstResponse);
+
+      // Now await the next send() — simulates waiting for the resumed tool result
       const pendingPromise = transport._awaitPendingResponse();
 
+      // Tool handler resumes and sends the final result for the original request id
       await transport.send(finalResponse);
 
       const result = await pendingPromise;

--- a/packages/agents/src/tests/mcp/transports/rpc.test.ts
+++ b/packages/agents/src/tests/mcp/transports/rpc.test.ts
@@ -177,6 +177,51 @@ describe("RPC Transport", () => {
       expect(result).toEqual(expectedResponse);
     });
 
+    it("should not resolve a request with another request's earlier response", async () => {
+      const transport = new RPCServerTransport();
+      await transport.start();
+
+      transport.onmessage = (msg) => {
+        const req = msg as JSONRPCRequest;
+        if (req.id === 1) return;
+        void transport.send({
+          jsonrpc: "2.0",
+          id: req.id,
+          result: { method: req.method }
+        });
+      };
+
+      const first = transport.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "first",
+        params: {}
+      });
+      const second = transport.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "second",
+        params: {}
+      });
+
+      await expect(second).resolves.toEqual({
+        jsonrpc: "2.0",
+        id: 2,
+        result: { method: "second" }
+      });
+
+      await transport.send({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { method: "first" }
+      });
+      await expect(first).resolves.toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { method: "first" }
+      });
+    });
+
     it("should route overlapping responses by request id", async () => {
       const transport = new RPCServerTransport();
       await transport.start();
@@ -397,7 +442,7 @@ describe("RPC Transport", () => {
       expect(result).toEqual(finalResponse);
     });
 
-    it("should not steal an id-routed response while _awaitPendingResponse is pending", async () => {
+    it("should keep an id-routed response from completing a continuation", async () => {
       const transport = new RPCServerTransport();
       await transport.start();
 
@@ -430,6 +475,33 @@ describe("RPC Transport", () => {
         id: 2,
         result: { continuation: true }
       });
+    });
+
+    it("should reject all pending request waiters on close", async () => {
+      const transport = new RPCServerTransport();
+      await transport.start();
+
+      const first = expect(
+        transport.handle({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "slow-one",
+          params: {}
+        })
+      ).rejects.toThrow("Transport closed");
+      const second = expect(
+        transport.handle({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "slow-two",
+          params: {}
+        })
+      ).rejects.toThrow("Transport closed");
+
+      await transport.close();
+
+      await first;
+      await second;
     });
 
     it("should reject pending waiters on close", async () => {
@@ -547,6 +619,38 @@ describe("RPC Transport", () => {
         id: "tools-1",
         result
       });
+    });
+
+    it("should invoke concurrent tools via RPC", async () => {
+      const { connection } = await establishRPCConnection();
+
+      const [first, second] = await Promise.all([
+        connection.client.callTool({
+          name: "greet",
+          arguments: { name: "Concurrent One" }
+        }),
+        connection.client.callTool({
+          name: "greet",
+          arguments: { name: "Concurrent Two" }
+        })
+      ]);
+
+      expectValidGreetResult(
+        {
+          jsonrpc: "2.0",
+          id: "concurrent-1",
+          result: first
+        },
+        "Concurrent One"
+      );
+      expectValidGreetResult(
+        {
+          jsonrpc: "2.0",
+          id: "concurrent-2",
+          result: second
+        },
+        "Concurrent Two"
+      );
     });
 
     it("should invoke greet tool via RPC", async () => {

--- a/packages/agents/src/tests/mcp/transports/rpc.test.ts
+++ b/packages/agents/src/tests/mcp/transports/rpc.test.ts
@@ -518,6 +518,37 @@ describe("RPC Transport", () => {
       expect(response).toHaveProperty("result");
     });
 
+    it("should serialize overlapping handleMcpMessage calls", async () => {
+      const doName = `rpc:overlap-${crypto.randomUUID()}`;
+      const id = env.MCP_OBJECT.idFromName(doName);
+      const stub = env.MCP_OBJECT.get(id) as DurableObjectStub<McpAgent>;
+
+      await seedStorageForColdWake(stub, doName);
+      await stub.handleMcpMessage(TEST_MESSAGES.initialize);
+
+      const first = stub.handleMcpMessage({
+        jsonrpc: "2.0",
+        id: "overlap-1",
+        method: "tools/call",
+        params: { name: "greet", arguments: { name: "First" } }
+      });
+      const second = stub.handleMcpMessage({
+        jsonrpc: "2.0",
+        id: "overlap-2",
+        method: "tools/call",
+        params: { name: "greet", arguments: { name: "Second" } }
+      });
+
+      await expect(first).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: "overlap-1"
+      });
+      await expect(second).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: "overlap-2"
+      });
+    });
+
     it("should handle tool calls after cold wake via handleMcpMessage", async () => {
       const doName = "rpc:cold-wake-tools";
       const id = env.MCP_OBJECT.idFromName(doName);

--- a/packages/agents/src/tests/mcp/transports/rpc.test.ts
+++ b/packages/agents/src/tests/mcp/transports/rpc.test.ts
@@ -177,65 +177,104 @@ describe("RPC Transport", () => {
       expect(result).toEqual(expectedResponse);
     });
 
-    it("should handle request and return multiple responses", async () => {
+    it("should route overlapping responses by request id", async () => {
       const transport = new RPCServerTransport();
       await transport.start();
-
-      const expectedResponses: JSONRPCMessage[] = [
-        {
-          jsonrpc: "2.0",
-          id: 1,
-          result: { success: true }
-        },
-        {
-          jsonrpc: "2.0",
-          method: "notification",
-          params: {}
-        }
-      ];
 
       transport.onmessage = (msg) => {
         const req = msg as JSONRPCRequest;
-        expect(req.id).toBe(1);
+        setTimeout(
+          () => {
+            void transport.send({
+              jsonrpc: "2.0",
+              id: req.id,
+              result: { method: req.method }
+            });
+          },
+          req.method === "first" ? 20 : 0
+        );
       };
 
-      const handlePromise = transport.handle({
+      const first = transport.handle({
         jsonrpc: "2.0",
         id: 1,
-        method: "test",
+        method: "first",
+        params: {}
+      });
+      const second = transport.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "second",
         params: {}
       });
 
-      for (const response of expectedResponses) {
-        await transport.send(response);
-      }
-
-      const result = await handlePromise;
-      expect(result).toEqual(expectedResponses);
+      await expect(second).resolves.toEqual({
+        jsonrpc: "2.0",
+        id: 2,
+        result: { method: "second" }
+      });
+      await expect(first).resolves.toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { method: "first" }
+      });
     });
 
-    it("should handle concurrent sends within the same request", async () => {
+    it("should route related server requests to the originating request", async () => {
       const transport = new RPCServerTransport();
       await transport.start();
 
-      const expectedResponses: JSONRPCMessage[] = [
-        { jsonrpc: "2.0", id: 1, result: { first: true } },
-        { jsonrpc: "2.0", id: 1, result: { second: true } }
-      ];
-
-      transport.onmessage = () => {
-        transport.send(expectedResponses[0]);
-        transport.send(expectedResponses[1]);
+      const elicitationRequest: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: "elicit_1",
+        method: "elicitation/create",
+        params: { message: "Approve?" }
       };
 
-      const result = await transport.handle({
+      transport.onmessage = (msg) => {
+        const req = msg as JSONRPCRequest;
+        void transport.send(elicitationRequest, { relatedRequestId: req.id });
+      };
+
+      await expect(
+        transport.handle({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {}
+        })
+      ).resolves.toEqual(elicitationRequest);
+    });
+
+    it("should include related notifications before the final response", async () => {
+      const transport = new RPCServerTransport();
+      await transport.start();
+
+      const notification: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        method: "notifications/message",
+        params: { level: "info", data: "hello" }
+      };
+      const finalResponse: JSONRPCMessage = {
         jsonrpc: "2.0",
         id: 1,
-        method: "test",
-        params: {}
-      });
+        result: { ok: true }
+      };
 
-      expect(result).toEqual(expectedResponses);
+      transport.onmessage = (msg) => {
+        const req = msg as JSONRPCRequest;
+        void transport.send(notification, { relatedRequestId: req.id });
+        void transport.send(finalResponse);
+      };
+
+      await expect(
+        transport.handle({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {}
+        })
+      ).resolves.toEqual([notification, finalResponse]);
     });
 
     it("should handle notification without waiting for response", async () => {
@@ -317,44 +356,75 @@ describe("RPC Transport", () => {
       const transport = new RPCServerTransport();
       await transport.start();
 
-      const firstResponse: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        id: "elicit_abc",
-        method: "elicitation/create",
-        params: { message: "Approve?" }
-      };
-
       const finalResponse: JSONRPCMessage = {
         jsonrpc: "2.0",
-        id: 1,
+        id: 2,
         result: { content: [{ type: "text", text: "done" }] }
       };
 
-      // Simulate: onmessage dispatches async tool handler that sends
-      // an intermediate message first, then later sends the final result
-      transport.onmessage = () => {
-        // Tool handler sends elicitation request (intermediate)
-        transport.send(firstResponse);
-      };
-
-      // handle() returns the intermediate elicitation request
-      const handleResult = await transport.handle({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: { name: "test" }
-      });
-
-      expect(handleResult).toEqual(firstResponse);
-
-      // Now await the next send() — simulates waiting for the tool result
       const pendingPromise = transport._awaitPendingResponse();
 
-      // Tool handler resumes and sends the final result
       await transport.send(finalResponse);
 
       const result = await pendingPromise;
       expect(result).toEqual(finalResponse);
+    });
+
+    it("should not steal an id-routed response while _awaitPendingResponse is pending", async () => {
+      const transport = new RPCServerTransport();
+      await transport.start();
+
+      const continuation = transport._awaitPendingResponse();
+      const request = transport.handle({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {}
+      });
+
+      await transport.send({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { routed: true }
+      });
+      await expect(request).resolves.toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { routed: true }
+      });
+
+      await transport.send({
+        jsonrpc: "2.0",
+        id: 2,
+        result: { continuation: true }
+      });
+      await expect(continuation).resolves.toEqual({
+        jsonrpc: "2.0",
+        id: 2,
+        result: { continuation: true }
+      });
+    });
+
+    it("should reject pending waiters on close", async () => {
+      const transport = new RPCServerTransport();
+      await transport.start();
+
+      const request = expect(
+        transport.handle({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "slow",
+          params: {}
+        })
+      ).rejects.toThrow("Transport closed");
+      const continuation = expect(
+        transport._awaitPendingResponse()
+      ).rejects.toThrow("Transport closed");
+
+      await transport.close();
+
+      await request;
+      await continuation;
     });
 
     it("should timeout _awaitPendingResponse when no send() arrives", async () => {
@@ -518,7 +588,7 @@ describe("RPC Transport", () => {
       expect(response).toHaveProperty("result");
     });
 
-    it("should serialize overlapping handleMcpMessage calls", async () => {
+    it("should route overlapping handleMcpMessage calls by request id", async () => {
       const doName = `rpc:overlap-${crypto.randomUUID()}`;
       const id = env.MCP_OBJECT.idFromName(doName);
       const stub = env.MCP_OBJECT.get(id) as DurableObjectStub<McpAgent>;


### PR DESCRIPTION
## Summary

Fixes #1540 by making `RPCServerTransport` correlate in-flight RPC MCP responses by JSON-RPC request id instead of using one shared pending response/resolver slot.

This preserves concurrent `tools/call` support for the same RPC-backed `McpAgent` instance: overlapping calls can now complete out of order and still resolve to the correct caller.

The transport now tracks:

- pending request waiters keyed by JSON-RPC request id for normal result/error responses
- related server-to-client requests/notifications via `TransportSendOptions.relatedRequestId`
- continuation waiters for elicitation responses where the original tool-call waiter already returned the server elicitation request
- close/timeout cleanup for all pending waiters

This replaces the earlier serialization approach. Serializing was safer than the old single-slot transport, but it would have reduced parallel tool-call capability below what MCP/JSON-RPC and the TypeScript SDK support.

## Testing

- `cd packages/agents && npx vitest run src/tests/mcp/transports/rpc.test.ts src/tests/mcp/elicitation.test.ts`
- `npm run check`
- Deployed `examples/mcp-elicitation` to `https://mcp-elicitation-demo.agents-b8a.workers.dev` and verified the full initialize → tools/call → elicitation/create → elicitation response → final tool result flow with curl.
