### PR TITLE
think: expose additive TurnConfig stopWhen conditions

### DIFF
--- a/.changeset/brave-tools-stop.md
+++ b/.changeset/brave-tools-stop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Expose additive `TurnConfig.stopWhen` conditions so Think subclasses can end an agentic loop early, for example after a designated tool call, while retaining the existing `maxSteps` safety bound.

--- a/docs/think/lifecycle-hooks.md
+++ b/docs/think/lifecycle-hooks.md
@@ -116,28 +116,29 @@ beforeTurn(ctx: TurnContext): TurnConfig | void | Promise<TurnConfig | void>
 
 All fields are optional. Return only what you want to change.
 
-| Field              | Type                      | Description                          |
-| ------------------ | ------------------------- | ------------------------------------ |
-| `model`            | `LanguageModel`           | Override the model for this turn     |
-| `system`           | `string`                  | Override the system prompt           |
-| `messages`         | `ModelMessage[]`          | Override the assembled messages      |
-| `tools`            | `ToolSet`                 | Extra tools to merge (additive)      |
-| `activeTools`      | `string[]`                | Limit which tools the model can call |
-| `toolChoice`       | `ToolChoice`              | Force a specific tool call           |
-| `maxSteps`         | `number`                  | Override `maxSteps` for this turn    |
-| `sendReasoning`    | `boolean`                 | Send reasoning chunks for this turn  |
-| `maxOutputTokens`  | `number`                  | Maximum tokens to generate           |
-| `temperature`      | `number`                  | Sampling temperature                 |
-| `topP`             | `number`                  | Nucleus sampling value               |
-| `topK`             | `number`                  | Top-K sampling value                 |
-| `presencePenalty`  | `number`                  | Presence penalty                     |
-| `frequencyPenalty` | `number`                  | Frequency penalty                    |
-| `stopSequences`    | `string[]`                | Stop generation sequences            |
-| `seed`             | `number`                  | Sampling seed when supported         |
-| `maxRetries`       | `number`                  | Maximum retries for this turn        |
-| `timeout`          | `TimeoutConfiguration`    | Timeout for this turn                |
-| `headers`          | `Record<string, string>`  | Additional provider request headers  |
-| `providerOptions`  | `Record<string, unknown>` | Provider-specific options            |
+| Field              | Type                               | Description                          |
+| ------------------ | ---------------------------------- | ------------------------------------ |
+| `model`            | `LanguageModel`                    | Override the model for this turn     |
+| `system`           | `string`                           | Override the system prompt           |
+| `messages`         | `ModelMessage[]`                   | Override the assembled messages      |
+| `tools`            | `ToolSet`                          | Extra tools to merge (additive)      |
+| `activeTools`      | `string[]`                         | Limit which tools the model can call |
+| `toolChoice`       | `ToolChoice`                       | Force a specific tool call           |
+| `maxSteps`         | `number`                           | Override `maxSteps` for this turn    |
+| `stopWhen`         | `StopCondition \| StopCondition[]` | Additional early-exit conditions     |
+| `sendReasoning`    | `boolean`                          | Send reasoning chunks for this turn  |
+| `maxOutputTokens`  | `number`                           | Maximum tokens to generate           |
+| `temperature`      | `number`                           | Sampling temperature                 |
+| `topP`             | `number`                           | Nucleus sampling value               |
+| `topK`             | `number`                           | Top-K sampling value                 |
+| `presencePenalty`  | `number`                           | Presence penalty                     |
+| `frequencyPenalty` | `number`                           | Frequency penalty                    |
+| `stopSequences`    | `string[]`                         | Stop generation sequences            |
+| `seed`             | `number`                           | Sampling seed when supported         |
+| `maxRetries`       | `number`                           | Maximum retries for this turn        |
+| `timeout`          | `TimeoutConfiguration`             | Timeout for this turn                |
+| `headers`          | `Record<string, string>`           | Additional provider request headers  |
+| `providerOptions`  | `Record<string, unknown>`          | Provider-specific options            |
 
 ### Examples
 
@@ -180,6 +181,18 @@ beforeTurn(ctx: TurnContext) {
   }
 }
 ```
+
+Stop early when a designated tool is called while retaining Think's `maxSteps` safety bound:
+
+```typescript
+import { hasToolCall } from "ai";
+
+beforeTurn() {
+  return { stopWhen: hasToolCall("finalAnswer") };
+}
+```
+
+`stopWhen` is additive: Think sends both `stepCountIs(maxSteps)` and your condition(s) to the AI SDK, so the loop ends when either one matches. Stop conditions are functions, so they can be returned from a Think subclass's `beforeTurn`, but not from sandboxed extension `beforeTurn` hooks over RPC.
 
 Prune older tool calls from the model context with the AI SDK's [`pruneMessages`](https://ai-sdk.dev/):
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -148,6 +148,8 @@ The AI SDK-derived contexts spread the SDK's own types at the top level — no i
 
 `TurnConfig` also accepts stable AI SDK `streamText` call settings such as `maxOutputTokens`, `temperature`, `stopSequences`, `seed`, `maxRetries`, `timeout`, and `headers`. Use them to tune model behavior per turn, for example disabling retries or adding a chunk timeout during recovery flows.
 
+`TurnConfig.stopWhen` accepts AI SDK stop conditions such as `hasToolCall("finalAnswer")` for ending a turn early. Think composes these with its own `maxSteps` bound, so a custom condition can stop before the cap without removing the safety limit. Because stop conditions are functions, return `stopWhen` from a Think subclass's `beforeTurn`; sandboxed extension hooks cannot provide it over RPC.
+
 `TurnConfig` also accepts an `output` field that is forwarded to `streamText` as the AI SDK's structured-output spec. Combine with `activeTools: []` for providers (e.g. `workers-ai-provider`) that strip tools when `responseFormat: "json"` is active. Use `experimental_telemetry` to pass the AI SDK's per-call telemetry settings through to `streamText`; consider disabling `recordInputs` or `recordOutputs` if prompts or outputs may contain sensitive data.
 
 Per-tool hooks are wired so `beforeToolCall` fires _before_ `execute` (Think wraps every tool's `execute`) and `afterToolCall` fires _after_ (via the AI SDK's `experimental_onToolCallFinish`) with `durationMs` and a discriminated outcome. `beforeToolCall` can return a `ToolCallDecision` to:
@@ -263,6 +265,7 @@ interface TurnConfig {
   activeTools?: string[]; // limit which tools the model can call
   toolChoice?: ToolChoice; // force a specific tool
   maxSteps?: number; // override maxSteps for this turn
+  stopWhen?: StopCondition | StopCondition[]; // additional early-exit conditions
   sendReasoning?: boolean; // send reasoning chunks for this turn
   maxOutputTokens?: number;
   temperature?: number;

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1,5 +1,5 @@
 import type { LanguageModel, UIMessage } from "ai";
-import { Output, tool } from "ai";
+import { hasToolCall, Output, tool } from "ai";
 import { Think } from "../../think";
 import type {
   StreamCallback,
@@ -1311,6 +1311,18 @@ export class ThinkToolsTestAgent extends Think {
     mode: "default" | "async-iterable" | "sync-iterable"
   ): Promise<void> {
     this._echoExecuteMode = mode;
+  }
+
+  async stopAfterEchoToolCall(): Promise<void> {
+    this._turnStopCondition = hasToolCall("echo");
+  }
+
+  private _turnStopCondition: TurnConfig["stopWhen"];
+
+  override beforeTurn(): TurnConfig | void {
+    if (this._turnStopCondition) {
+      return { stopWhen: this._turnStopCondition };
+    }
   }
 
   private _beforeToolCallThrowMessage: string | null = null;

--- a/packages/think/src/tests/hooks.test.ts
+++ b/packages/think/src/tests/hooks.test.ts
@@ -527,6 +527,16 @@ describe("Think — maxSteps property", () => {
     expect(result.done).toBe(true);
   });
 
+  it("composes TurnConfig stopWhen with the maxSteps bound", async () => {
+    const agent = await freshToolAgent("hook-stop-when-tool-call");
+    await agent.stopAfterEchoToolCall();
+    const result = await agent.testChat("Call echo");
+
+    expect(result.done).toBe(true);
+    expect(await agent.getBeforeStepLog()).toHaveLength(1);
+    expect(await agent.getAfterToolCallLog()).toHaveLength(1);
+  });
+
   it("works with tool-calling loop agent", async () => {
     const agent = await freshLoopToolAgent("hook-loop-ms");
     const messages = agent.getMessages();

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -88,6 +88,7 @@ import type {
   StreamTextOnChunkCallback,
   StreamTextOnStepFinishCallback,
   StreamTextOnToolCallFinishCallback,
+  StopCondition,
   ToolSet,
   TypedToolCall,
   UIMessage
@@ -100,6 +101,7 @@ export type {
   PrepareStepFunction,
   PrepareStepResult,
   StepResult,
+  StopCondition,
   TextStreamPart,
   TypedToolCall,
   TypedToolResult
@@ -368,6 +370,11 @@ export interface TurnConfig {
   toolChoice?: Parameters<typeof streamText>[0]["toolChoice"];
   /** Override maxSteps for this turn. */
   maxSteps?: number;
+  /**
+   * Additional AI SDK stop conditions for ending the turn early.
+   * Think always keeps its `maxSteps` stop condition as a safety bound.
+   */
+  stopWhen?: StopCondition<ToolSet> | Array<StopCondition<ToolSet>>;
   /**
    * Controls whether reasoning chunks are included in the UI message stream
    * for this turn. Defaults to the instance-level `sendReasoning` setting.
@@ -1497,6 +1504,14 @@ export class Think<
     const finalTools: ToolSet = this._wrapToolsWithDecision(mergedTools);
     const finalMaxSteps = config.maxSteps ?? this.maxSteps;
     const finalSendReasoning = config.sendReasoning ?? this.sendReasoning;
+    const finalStopWhen = [
+      stepCountIs(finalMaxSteps),
+      ...(Array.isArray(config.stopWhen)
+        ? config.stopWhen
+        : config.stopWhen
+          ? [config.stopWhen]
+          : [])
+    ];
 
     const result = streamText({
       model: finalModel,
@@ -1516,7 +1531,7 @@ export class Think<
       maxRetries: config.maxRetries,
       timeout: config.timeout,
       headers: config.headers,
-      stopWhen: stepCountIs(finalMaxSteps),
+      stopWhen: finalStopWhen,
       providerOptions: config.providerOptions as
         | Parameters<typeof streamText>[0]["providerOptions"]
         | undefined,


### PR DESCRIPTION
## Summary

Expose additive AI SDK `stopWhen` conditions through Think's `TurnConfig`.

Think already owns the `streamText()` call and maps `maxSteps` to:

```ts
stopWhen: stepCountIs(maxSteps)
```

That covers step-count limits, but it leaves no way for Think subclasses to express other AI SDK stop conditions such as:

```ts
hasToolCall("finalAnswer")
```

This PR adds:

```ts
beforeTurn() {
  return {
    stopWhen: hasToolCall("finalAnswer")
  };
}
```

## Behavior

Custom `stopWhen` conditions are **additive**.

Think now sends both:

- its existing `stepCountIs(maxSteps)` safety bound
- any custom `TurnConfig.stopWhen` condition(s)

to the AI SDK, so the loop ends when either matches.

That means callers can stop early after a designated tool call without silently removing Think's existing runaway-loop guardrail.

## API

```ts
interface TurnConfig {
  maxSteps?: number;
  stopWhen?: StopCondition | StopCondition[];
}
```

Example:

```ts
import { hasToolCall } from "ai";

beforeTurn() {
  return {
    stopWhen: hasToolCall("finalAnswer")
  };
}
```

`StopCondition` is also re-exported from `@cloudflare/think` alongside the other AI SDK lifecycle-facing types.

## Notes on extensions

`stopWhen` is function-valued, so it is supported from a Think subclass's `beforeTurn()` hook, but not from sandboxed extension `beforeTurn` hooks over RPC.

The docs call this out explicitly.

## Tests

Added regression coverage verifying that:

- a Think turn can return `stopWhen: hasToolCall("echo")`
- the tool executes
- Think does **not** start the follow-up continuation model step after that matching tool call

## Documentation

Updated:

- `packages/think/README.md`
- `docs/think/lifecycle-hooks.md`

to document:

- `TurnConfig.stopWhen`
- composition with `maxSteps`
- `hasToolCall(...)` usage
- subclass-only support for function-valued stop conditions

## Validation

Passed:

```bash
npm run build --workspace @cloudflare/think
npm run build --workspace agents
npx vitest --run -c packages/think/src/tests/vitest.config.ts packages/think/src/tests/hooks.test.ts
```

Focused Think hook suite:

```text
66 passed
```

Also ran:

```bash
npm run check
```

Formatting, exports, and lint passed. Repo-wide typecheck could not complete in this environment because `tsgo` is unavailable:

```text
/bin/sh: tsgo: command not found
```
