### PR TITLE
fix: fire chat responses for errors returned before parts are returned

### DIFF
--- a/.changeset/fix-think-inband-stream-error-hooks.md
+++ b/.changeset/fix-think-inband-stream-error-hooks.md
@@ -1,5 +1,7 @@
 ---
+"agents": patch
+"@cloudflare/ai-chat": patch
 "@cloudflare/think": patch
 ---
 
-Fire `onChatResponse` for in-band stream errors that arrive before any response parts.
+Return error statuses for in-band stream errors across programmatic chat turns.

--- a/.changeset/fix-think-inband-stream-error-hooks.md
+++ b/.changeset/fix-think-inband-stream-error-hooks.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Fire `onChatResponse` for in-band stream errors that arrive before any response parts.

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -334,9 +334,11 @@ messages against the latest persisted transcript when the turn actually starts.
 This avoids stale baselines when multiple `saveMessages()` calls queue up
 behind active work.
 
-`saveMessages()` returns `{ requestId, status }`. The `status` is `"completed"`
-when the turn ran, `"skipped"` when it was invalidated (chat cleared mid-flight),
-or `"aborted"` when an external `AbortSignal` cancelled it before completion.
+`saveMessages()` returns `{ requestId, status, error? }`. The `status` is
+`"completed"` when the turn ran, `"error"` when the stream reported an error,
+`"skipped"` when it was invalidated (chat cleared mid-flight), or `"aborted"`
+when an external `AbortSignal` cancelled it before completion. When `status` is
+`"error"`, `error` contains the stream error message when available.
 
 Pass `options.signal` to cancel the turn from outside. Useful for forwarding
 an upstream `AbortSignal` (e.g. an AI SDK tool `execute`'s `abortSignal` on a
@@ -361,7 +363,7 @@ retained, streaming tools.
 
 ### `onChatResponse`
 
-Called after a chat turn completes and the assistant message has been persisted. Override this to react when the agent finishes responding — broadcast state, process queued work, track analytics, or trigger follow-up messages.
+Called after a chat turn reaches a terminal state. Override this to react when the agent finishes responding — broadcast state, process queued work, track analytics, or trigger follow-up messages. Successful turns and errors that produced partial assistant chunks persist the assistant message before the hook runs; errors that occur before any assistant chunks still fire the hook with an empty assistant message and `status: "error"`.
 
 ```typescript
 import { AIChatAgent, type ChatResponseResult } from "@cloudflare/ai-chat";
@@ -395,13 +397,13 @@ Responses triggered from inside `onChatResponse` do not fire the hook concurrent
 
 **`ChatResponseResult` fields:**
 
-| Field          | Type                                  | Description                                          |
-| -------------- | ------------------------------------- | ---------------------------------------------------- |
-| `message`      | `UIMessage`                           | The finalized assistant message from this turn       |
-| `requestId`    | `string`                              | The request ID associated with this turn             |
-| `continuation` | `boolean`                             | Whether this turn was a continuation (auto-continue) |
-| `status`       | `"completed" \| "error" \| "aborted"` | How the turn ended                                   |
-| `error`        | `string \| undefined`                 | Error message when `status` is `"error"`             |
+| Field          | Type                                  | Description                                                                                                                    |
+| -------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `message`      | `UIMessage`                           | The finalized assistant message from this turn. Error turns can provide an empty assistant message if no chunks were produced. |
+| `requestId`    | `string`                              | The request ID associated with this turn                                                                                       |
+| `continuation` | `boolean`                             | Whether this turn was a continuation (auto-continue)                                                                           |
+| `status`       | `"completed" \| "error" \| "aborted"` | How the turn ended                                                                                                             |
+| `error`        | `string \| undefined`                 | Error message when `status` is `"error"`                                                                                       |
 
 `onChatResponse` fires for all turn completion paths: WebSocket chat requests, `saveMessages`, and auto-continuation after tool results or approvals.
 

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -170,11 +170,12 @@ async saveMessages(
 ): Promise<SaveMessagesResult>
 ```
 
-Returns `{ requestId, status }` where `status` is `"completed"`, `"skipped"`, or `"aborted"`.
+Returns `{ requestId, status, error? }` where `status` is `"completed"`, `"error"`, `"skipped"`, or `"aborted"`.
 
 | `status`      | When                                                                                                                      |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `"completed"` | Turn ran to completion.                                                                                                   |
+| `"error"`     | Turn started but the stream reported an error. `error` contains the stream error message when available.                  |
 | `"skipped"`   | Turn invalidated mid-flight (e.g. by `chat-clear`); user message persisted, no model run.                                 |
 | `"aborted"`   | Turn cancelled before completion via `options.signal` or `chat-request-cancel`. Partial assistant chunks still persisted. |
 

--- a/packages/agents/src/chat/lifecycle.ts
+++ b/packages/agents/src/chat/lifecycle.ts
@@ -69,12 +69,16 @@ export type SaveMessagesOptions = {
  *   completion, either by `MSG_CHAT_CANCEL` over the chat WebSocket or
  *   by an external `AbortSignal` passed via {@link SaveMessagesOptions}.
  *   Partial chunks streamed before the abort are still persisted.
+ * - `"error"` — the turn ran but ended with a stream error. Partial chunks
+ *   streamed before the error are still persisted.
  */
 export type SaveMessagesResult = {
   /** Server-generated request ID for the chat turn. */
   requestId: string;
-  /** Whether the turn ran, was skipped, or was aborted. */
-  status: "completed" | "skipped" | "aborted";
+  /** Whether the turn completed, errored, was skipped, or was aborted. */
+  status: "completed" | "error" | "skipped" | "aborted";
+  /** Error message when `status` is `"error"`. */
+  error?: string;
 };
 
 /**

--- a/packages/agents/src/tests-d/save-messages-options.test-d.ts
+++ b/packages/agents/src/tests-d/save-messages-options.test-d.ts
@@ -66,6 +66,8 @@ function describe(status: SaveMessagesResult["status"]): string {
       return "skipped";
     case "aborted":
       return "aborted";
+    case "error":
+      return "error";
     default: {
       const exhaustive: never = status;
       return exhaustive;

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -1242,8 +1242,13 @@ export class AIChatAgent<
 
   /** @internal Delegate to _resumableStream */
   protected _markStreamError(streamId: string) {
+    const erroredRequestId = this._resumableStream.activeRequestId;
     this._resumableStream.markError(streamId);
     this._pendingResumeConnections.clear();
+    if (erroredRequestId === this._continuation.activeRequestId) {
+      this._continuation.activeRequestId = null;
+      this._continuation.activeConnectionId = null;
+    }
   }
 
   /**
@@ -2030,10 +2035,19 @@ export class AIChatAgent<
                     );
 
                     if (response) {
-                      await this._reply(requestId, response, [], {
-                        continuation: true,
-                        chatMessageId: requestId
-                      });
+                      const replyResult = await this._reply(
+                        requestId,
+                        response,
+                        [],
+                        {
+                          continuation: true,
+                          chatMessageId: requestId
+                        }
+                      );
+                      if (replyResult.status === "error") {
+                        this._clearAllAutoContinuationState(true);
+                        return;
+                      }
                       this._activateDeferredAutoContinuation();
                     } else {
                       this._clearPendingAutoContinuation(true);

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -87,6 +87,11 @@ type ChatRecoveryContinueData = {
   lastClientTools?: ClientToolSchema[] | null;
 };
 
+type StreamResultStatus = {
+  status: Exclude<SaveMessagesResult["status"], "skipped">;
+  error?: string;
+};
+
 function sendIfOpen(connection: Connection, message: string): boolean {
   try {
     connection.send(message);
@@ -2069,19 +2074,17 @@ export class AIChatAgent<
   }
 
   /**
-   * @returns `true` if the registry's controller for `requestId` was
-   *   aborted during the turn (so the caller can surface
-   *   `status: "aborted"` to the public API). Returns `false` for
-   *   successful or errored completion.
+   * @returns Terminal status for the turn.
    */
   private async _runProgrammaticChatTurn(
     requestId: string,
     clientTools?: ClientToolSchema[],
     body?: Record<string, unknown>,
     externalSignal?: AbortSignal
-  ): Promise<boolean> {
+  ): Promise<StreamResultStatus> {
     this._setRequestContext(clientTools, body);
     let wasAborted = false;
+    let status: StreamResultStatus = { status: "completed" };
 
     await this._tryCatchChat(async () => {
       return agentContext.run(
@@ -2113,7 +2116,7 @@ export class AIChatAgent<
               });
 
               if (response) {
-                await this._reply(requestId, response, [], {
+                status = await this._reply(requestId, response, [], {
                   chatMessageId: requestId
                 });
               }
@@ -2137,7 +2140,10 @@ export class AIChatAgent<
       );
     });
 
-    return wasAborted;
+    if (status.status === "completed" && wasAborted) {
+      return { status: "aborted" };
+    }
+    return status;
   }
 
   /**
@@ -2355,12 +2361,15 @@ export class AIChatAgent<
           return;
         }
 
-        const streamError = this._agentToolLastErrors.get(options.runId);
-        if (streamError) {
+        const streamError =
+          result.error ?? this._agentToolLastErrors.get(options.runId);
+        if (result.status === "error" || streamError) {
+          const errorMessage =
+            streamError ?? "Agent tool run failed during streaming.";
           this.sql`
             update cf_ai_chat_agent_tool_runs
             set request_id = ${requestId}, status = 'error',
-                error_message = ${streamError}, completed_at = ${Date.now()}
+                error_message = ${errorMessage}, completed_at = ${Date.now()}
             where run_id = ${options.runId}
           `;
           return;
@@ -2667,9 +2676,10 @@ export class AIChatAgent<
    * loop's signal aborts and the result reports `status: "aborted"`.
    * Pre-aborted signals short-circuit before any model work runs.
    *
-   * Returns `{ requestId, status }` where `status` is `"completed"` when
-   * the turn ran, `"skipped"` when the chat was cleared, or `"aborted"`
-   * when an external signal cancelled it mid-stream.
+   * Returns `{ requestId, status, error? }` where `status` is `"completed"`
+   * when the turn ran, `"error"` when the stream reported an error,
+   * `"skipped"` when the chat was cleared, or `"aborted"` when an external
+   * signal cancelled it mid-stream.
    */
   async saveMessages(
     messages:
@@ -2684,7 +2694,7 @@ export class AIChatAgent<
     const body = this._lastBody;
     const epoch = this._turnQueue.generation;
     let status: SaveMessagesResult["status"] = "completed";
-    let wasAborted = false;
+    let error: string | undefined;
 
     await this._runExclusiveChatTurn(
       requestId,
@@ -2706,23 +2716,23 @@ export class AIChatAgent<
           return;
         }
 
-        wasAborted = await this._runProgrammaticChatTurn(
+        const turnResult = await this._runProgrammaticChatTurn(
           requestId,
           clientTools,
           body,
           options?.signal
         );
+        status = turnResult.status;
+        error = turnResult.error;
       },
       { epoch }
     );
 
     if (this._turnQueue.generation !== epoch && status === "completed") {
       status = "skipped";
-    } else if (wasAborted && status === "completed") {
-      status = "aborted";
     }
 
-    return { requestId, status };
+    return { requestId, status, ...(error !== undefined && { error }) };
   }
 
   /**
@@ -2753,6 +2763,7 @@ export class AIChatAgent<
     const resolvedBody = body ?? this._lastBody;
     const epoch = this._turnQueue.generation;
     let status: SaveMessagesResult["status"] = "completed";
+    let error: string | undefined;
     let wasAborted = false;
 
     await this._runExclusiveChatTurn(
@@ -2790,10 +2801,17 @@ export class AIChatAgent<
                   });
 
                   if (response) {
-                    await this._reply(requestId, response, [], {
-                      continuation: true,
-                      chatMessageId: requestId
-                    });
+                    const replyResult = await this._reply(
+                      requestId,
+                      response,
+                      [],
+                      {
+                        continuation: true,
+                        chatMessageId: requestId
+                      }
+                    );
+                    status = replyResult.status;
+                    error = replyResult.error;
                   }
                 } finally {
                   if (abortSignal?.aborted) wasAborted = true;
@@ -2820,7 +2838,7 @@ export class AIChatAgent<
       status = "aborted";
     }
 
-    return { requestId, status };
+    return { requestId, status, ...(error !== undefined && { error }) };
   }
 
   private async _retryLastUserTurn(
@@ -2837,7 +2855,7 @@ export class AIChatAgent<
     const requestId = nanoid();
     const epoch = this._turnQueue.generation;
     let status: SaveMessagesResult["status"] = "completed";
-    let wasAborted = false;
+    let error: string | undefined;
 
     await this._runExclusiveChatTurn(
       requestId,
@@ -2847,23 +2865,23 @@ export class AIChatAgent<
           return;
         }
 
-        wasAborted = await this._runProgrammaticChatTurn(
+        const turnResult = await this._runProgrammaticChatTurn(
           requestId,
           clientTools,
           body,
           options?.signal
         );
+        status = turnResult.status;
+        error = turnResult.error;
       },
       { epoch }
     );
 
     if (this._turnQueue.generation !== epoch && status === "completed") {
       status = "skipped";
-    } else if (wasAborted && status === "completed") {
-      status = "aborted";
     }
 
-    return { requestId, status };
+    return { requestId, status, ...(error !== undefined && { error }) };
   }
 
   // ── Chat recovery via fibers ──────────────────────────────────────
@@ -3831,7 +3849,7 @@ export class AIChatAgent<
     streamCompleted: { value: boolean },
     continuation = false,
     abortSignal?: AbortSignal
-  ): Promise<"completed" | "aborted"> {
+  ): Promise<StreamResultStatus> {
     streamCompleted.value = false;
 
     // During continuation, the first text-start and reasoning-start from the
@@ -3876,7 +3894,7 @@ export class AIChatAgent<
           type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
           ...(continuation && { continuation: true })
         });
-        return "completed";
+        return { status: "completed" };
       }
 
       const chunk = decoder.decode(value);
@@ -4135,14 +4153,28 @@ export class AIChatAgent<
                   break;
                 }
                 case "error": {
+                  const error =
+                    data.errorText ?? JSON.stringify({ type: data.type });
                   this._broadcastChatMessage({
                     error: true,
-                    body: data.errorText ?? JSON.stringify(data),
+                    body: error,
                     done: false,
                     id,
-                    type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
+                    type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+                    ...(continuation && { continuation: true })
                   });
-                  break;
+                  this._markStreamError(streamId);
+                  this._emit("message:error", { error });
+                  await reader.cancel().catch(() => {});
+                  streamCompleted.value = true;
+                  this._broadcastChatMessage({
+                    body: "",
+                    done: true,
+                    id,
+                    type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+                    ...(continuation && { continuation: true })
+                  });
+                  return { status: "error", error };
                 }
               }
             }
@@ -4200,10 +4232,10 @@ export class AIChatAgent<
         type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
         ...(continuation && { continuation: true })
       });
-      return "aborted";
+      return { status: "aborted" };
     }
 
-    return "completed";
+    return { status: "completed" };
   }
 
   // Handle plain text responses (e.g., from generateText)
@@ -4215,7 +4247,7 @@ export class AIChatAgent<
     streamCompleted: { value: boolean },
     continuation = false,
     abortSignal?: AbortSignal
-  ): Promise<"completed" | "aborted"> {
+  ): Promise<StreamResultStatus> {
     // During continuation, if the last text part was still streaming
     // (interrupted mid-generation), reuse it so the resumed content
     // stays in the same block.
@@ -4294,7 +4326,7 @@ export class AIChatAgent<
           type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
           ...(continuation && { continuation: true })
         });
-        return "completed";
+        return { status: "completed" };
       }
 
       const chunk = decoder.decode(value);
@@ -4327,10 +4359,10 @@ export class AIChatAgent<
         type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
         ...(continuation && { continuation: true })
       });
-      return "aborted";
+      return { status: "aborted" };
     }
 
-    return "completed";
+    return { status: "completed" };
   }
 
   /**
@@ -4372,7 +4404,7 @@ export class AIChatAgent<
     response: Response,
     excludeBroadcastIds: string[] = [],
     options: { continuation?: boolean; chatMessageId?: string } = {}
-  ) {
+  ): Promise<StreamResultStatus> {
     const { continuation = false, chatMessageId } = options;
     // Look up the abort signal for this request so we can cancel the reader
     // loop if the client sends a cancel message. This is a safety net —
@@ -4395,7 +4427,7 @@ export class AIChatAgent<
             ...(continuation && { continuation: true })
           });
           this._activateDeferredAutoContinuation();
-          return;
+          return { status: "completed" };
         }
 
         // Start tracking this stream for resumability
@@ -4413,7 +4445,7 @@ export class AIChatAgent<
         const contentType = response.headers.get("content-type") || "";
         const isSSE = contentType.includes("text/event-stream"); // AI SDK v5 SSE format
         const streamCompleted = { value: false };
-        let streamEndStatus: "completed" | "aborted" | "error" = "completed";
+        let streamResult: StreamResultStatus = { status: "completed" };
         // Capture before try so it's available after finally.
         // _approvalPersistedMessageId is set inside _streamSSEReply when a
         // tool enters approval-requested state and the message is persisted early.
@@ -4422,7 +4454,7 @@ export class AIChatAgent<
         try {
           if (isSSE) {
             // AI SDK v5 SSE format
-            streamEndStatus = await this._streamSSEReply(
+            streamResult = await this._streamSSEReply(
               id,
               streamId,
               reader,
@@ -4432,7 +4464,7 @@ export class AIChatAgent<
               abortSignal
             );
           } else {
-            streamEndStatus = await this._sendPlaintextReply(
+            streamResult = await this._sendPlaintextReply(
               id,
               streamId,
               reader,
@@ -4443,31 +4475,24 @@ export class AIChatAgent<
             );
           }
         } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          streamResult = { status: "error", error: errorMessage };
           // Mark stream as error if not already completed
           if (!streamCompleted.value) {
             this._markStreamError(streamId);
             // Notify clients of the error
             this._broadcastChatMessage({
-              body: error instanceof Error ? error.message : "Stream error",
+              body: errorMessage,
               done: true,
               error: true,
               id,
               type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
               ...(continuation && { continuation: true })
             });
-            this._emit("message:error", {
-              error: error instanceof Error ? error.message : String(error)
-            });
-
-            this._pendingChatResponseResults.push({
-              message,
-              requestId: id,
-              continuation,
-              status: "error",
-              error: error instanceof Error ? error.message : String(error)
-            });
+            this._emit("message:error", { error: errorMessage });
+            streamCompleted.value = true;
           }
-          throw error;
         } finally {
           reader.releaseLock();
 
@@ -4482,7 +4507,7 @@ export class AIChatAgent<
           // Only emit observability on success (not on error path).
           if (chatMessageId) {
             this._abortRegistry.remove(chatMessageId);
-            if (streamCompleted.value) {
+            if (streamCompleted.value && streamResult.status !== "error") {
               this._emit("message:response");
             }
           }
@@ -4535,8 +4560,10 @@ export class AIChatAgent<
           message,
           requestId: id,
           continuation,
-          status: streamEndStatus
+          status: streamResult.status,
+          ...(streamResult.error !== undefined && { error: streamResult.error })
         });
+        return streamResult;
       })
     );
   }

--- a/packages/ai-chat/src/tests/client-tools-continuation.test.ts
+++ b/packages/ai-chat/src/tests/client-tools-continuation.test.ts
@@ -888,6 +888,94 @@ describe("Client tools continuation", () => {
     ws.close(1000);
   });
 
+  it("clears queued auto-continuation state after a continuation stream error", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    try {
+      await agentStub.setTestBody({
+        continuationStreamError: "Continuation stream failed",
+        continuationStreamErrorDelayMs: 250
+      });
+
+      await agentStub.persistMessages([
+        {
+          id: "user-stream-error",
+          role: "user",
+          parts: [{ type: "text", text: "Run tools" }]
+        },
+        {
+          id: "assistant-stream-error",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-firstTool",
+              toolCallId: "call_first_stream_error",
+              state: "input-available",
+              input: {}
+            },
+            {
+              type: "tool-secondTool",
+              toolCallId: "call_second_stream_error",
+              state: "input-available",
+              input: {}
+            }
+          ] as ChatMessage["parts"]
+        }
+      ]);
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_TOOL_RESULT,
+          toolCallId: "call_first_stream_error",
+          toolName: "firstTool",
+          output: { ok: true },
+          autoContinue: true
+        })
+      );
+
+      let activeContinuation:
+        | Awaited<ReturnType<typeof agentStub.getContinuationStateForTest>>
+        | undefined;
+      const start = Date.now();
+      while (Date.now() - start < 3000) {
+        const state = await agentStub.getContinuationStateForTest();
+        if (state.activeRequestId !== null) {
+          activeContinuation = state;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(activeContinuation).toBeDefined();
+
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_TOOL_RESULT,
+          toolCallId: "call_second_stream_error",
+          toolName: "secondTool",
+          output: { ok: true },
+          autoContinue: true
+        })
+      );
+
+      await agentStub.waitForIdleForTest();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await agentStub.waitForIdleForTest();
+
+      expect(await agentStub.getLatestStreamStatusForTest()).toBe("error");
+      expect(await agentStub.getChatMessageCallCountForTest()).toBe(1);
+      expect(await agentStub.getContinuationStateForTest()).toEqual({
+        hasPending: false,
+        hasDeferred: false,
+        activeRequestId: null,
+        activeConnectionId: null
+      });
+    } finally {
+      ws.close(1000);
+    }
+  });
+
   it("should clear stored client tools when chat is cleared", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);

--- a/packages/ai-chat/src/tests/on-stream-end.test.ts
+++ b/packages/ai-chat/src/tests/on-stream-end.test.ts
@@ -5,6 +5,7 @@ import type { UIMessage as ChatMessage } from "ai";
 import type { ChatResponseResult } from "../";
 import { connectChatWS, isUseChatResponseMessage } from "./test-utils";
 import { getAgentByName } from "agents";
+import { subscribe } from "agents/observability";
 
 function connectResponseAgent(room: string) {
   return connectChatWS(`/agents/response-agent/${room}`);
@@ -116,6 +117,42 @@ describe("onChatResponse hook", () => {
     expect(results[0].status).toBe("completed");
 
     ws.close(1000);
+  });
+
+  it("fires with status=error for in-band SSE error chunks", async () => {
+    const room = crypto.randomUUID();
+    const observedTypes: string[] = [];
+    const unsubscribe = subscribe("message", (event) => {
+      if (event.agent === "ResponseAgent" && event.name === room) {
+        observedTypes.push(event.type);
+      }
+    });
+    const { ws } = await connectResponseAgent(room);
+    const done = waitForDone(ws, "req-sse-error");
+
+    try {
+      sendChatRequest(ws, "req-sse-error", [userMessage], {
+        format: "sse",
+        streamError: "SSE in-band failure"
+      });
+
+      expect(await done).toBe(true);
+      await new Promise((r) => setTimeout(r, 100));
+
+      const agentStub = await getAgentByName(env.ResponseAgent, room);
+      const results =
+        (await agentStub.getChatResponseResults()) as ChatResponseResult[];
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("error");
+      expect(results[0].error).toBe("SSE in-band failure");
+      expect(results[0].requestId).toBe("req-sse-error");
+      expect(observedTypes).toContain("message:error");
+      expect(observedTypes).not.toContain("message:response");
+    } finally {
+      unsubscribe();
+      ws.close(1000);
+    }
   });
 
   it("fires with status=error when the stream throws", async () => {
@@ -467,7 +504,7 @@ describe("onChatResponse error resilience", () => {
 });
 
 describe("Reader error propagation", () => {
-  it("client receives error:true and message is NOT persisted on stream error", async () => {
+  it("client receives error:true and partial message is persisted on stream error", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectResponseAgent(room);
 
@@ -497,12 +534,17 @@ describe("Reader error propagation", () => {
     expect(errorDone).toBeDefined();
     expect(errorDone!.error).toBe(true);
 
-    // The errored assistant message should NOT be persisted
+    // Partial chunks before the stream error should be persisted.
     const agentStub = await getAgentByName(env.ResponseAgent, room);
     await agentStub.waitForIdleForTest();
     const persisted = (await agentStub.getPersistedMessages()) as ChatMessage[];
     const assistantMessages = persisted.filter((m) => m.role === "assistant");
-    expect(assistantMessages).toHaveLength(0);
+    expect(assistantMessages).toHaveLength(1);
+    expect(
+      assistantMessages[0].parts.some(
+        (part) => part.type === "text" && part.text.includes("chunk-0")
+      )
+    ).toBe(true);
 
     ws.close(1000);
   });

--- a/packages/ai-chat/src/tests/programmatic-turns.test.ts
+++ b/packages/ai-chat/src/tests/programmatic-turns.test.ts
@@ -122,6 +122,38 @@ describe("AIChatAgent programmatic turns via saveMessages", () => {
     ]);
   });
 
+  it("returns error status for in-band stream errors", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    const result = await agentStub.enqueueSyntheticUserMessage("Fails", {
+      body: {
+        format: "sse",
+        streamError: "programmatic in-band failure"
+      }
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("programmatic in-band failure");
+  });
+
+  it("returns error status when programmatic streams throw", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    const result = await agentStub.enqueueSyntheticUserMessage("Throws", {
+      body: {
+        format: "plaintext",
+        chunkCount: 6,
+        chunkDelayMs: 10,
+        throwError: true
+      }
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("Simulated stream error");
+  });
+
   it("marks queued programmatic turns as skipped after chat clear", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectSlowStream(room);

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -97,11 +97,13 @@ export class TestChatAgent extends AIChatAgent<Env> {
   private _capturedClientTools: ClientToolSchema[] | undefined = undefined;
   // Store captured requestId from onChatMessage options for testing
   private _capturedRequestId: string | undefined = undefined;
+  private _chatMessageCallCount = 0;
 
   async onChatMessage(
     _onFinish: StreamTextOnFinishCallback<ToolSet>,
     options?: OnChatMessageOptions
   ) {
+    this._chatMessageCallCount++;
     // Capture the body, clientTools, and requestId from options for testing
     this._capturedBody = options?.body;
     this._capturedClientTools = options?.clientTools;
@@ -156,6 +158,22 @@ export class TestChatAgent extends AIChatAgent<Env> {
         { type: "text-end", id: "sse-t" },
         { type: "finish" }
       ]);
+    }
+
+    const continuationStreamError = options?.body?.continuationStreamError;
+    if (options?.continuation && typeof continuationStreamError === "string") {
+      const delayMs =
+        typeof options.body?.continuationStreamErrorDelayMs === "number"
+          ? options.body.continuationStreamErrorDelayMs
+          : 25;
+      return makeDelayedSSEChunkResponse(
+        [
+          { type: "start" },
+          { type: "error", errorText: continuationStreamError }
+        ],
+        delayMs,
+        options.abortSignal
+      );
     }
 
     if (
@@ -387,6 +405,14 @@ export class TestChatAgent extends AIChatAgent<Env> {
     return this.waitUntilStable(options);
   }
 
+  setTestBody(body: Record<string, unknown>): void {
+    (this as unknown as { _lastBody: Record<string, unknown> })._lastBody =
+      body;
+    (
+      this as unknown as { _persistRequestContext(): void }
+    )._persistRequestContext();
+  }
+
   resetTurnStateForTest(): void {
     this.resetTurnState();
   }
@@ -399,6 +425,45 @@ export class TestChatAgent extends AIChatAgent<Env> {
 
   async waitForIdleForTest(): Promise<void> {
     await (this as unknown as { waitForIdle(): Promise<void> }).waitForIdle();
+  }
+
+  getChatMessageCallCountForTest(): number {
+    return this._chatMessageCallCount;
+  }
+
+  getContinuationStateForTest(): {
+    hasPending: boolean;
+    hasDeferred: boolean;
+    activeRequestId: string | null;
+    activeConnectionId: string | null;
+  } {
+    const continuation = (
+      this as unknown as {
+        _continuation: {
+          pending: unknown;
+          deferred: unknown;
+          activeRequestId: string | null;
+          activeConnectionId: string | null;
+        };
+      }
+    )._continuation;
+
+    return {
+      hasPending: continuation.pending !== null,
+      hasDeferred: continuation.deferred !== null,
+      activeRequestId: continuation.activeRequestId,
+      activeConnectionId: continuation.activeConnectionId
+    };
+  }
+
+  getLatestStreamStatusForTest(): string | null {
+    const rows = this.sql<{ status: string }>`
+      select status
+      from cf_ai_chat_stream_metadata
+      order by created_at desc
+      limit 1
+    `;
+    return rows[0]?.status ?? null;
   }
 
   getPersistedMessages(): ChatMessage[] {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -715,6 +715,8 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
           responseDelayMs?: number;
           chunkCount?: number;
           chunkDelayMs?: number;
+          streamError?: string;
+          throwError?: boolean;
         }
       | undefined;
     const format = body?.format ?? "plaintext";
@@ -722,6 +724,8 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
     const responseDelayMs = body?.responseDelayMs ?? 0;
     const chunkCount = body?.chunkCount ?? 20;
     const chunkDelayMs = body?.chunkDelayMs ?? 50;
+    const streamError = body?.streamError;
+    const throwError = body?.throwError ?? false;
     const abortSignal = useAbortSignal ? options?.abortSignal : undefined;
 
     if (responseDelayMs > 0) {
@@ -731,6 +735,15 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async pull(controller) {
+        if (format === "sse" && streamError) {
+          const chunk = JSON.stringify({
+            type: "error",
+            errorText: streamError
+          });
+          controller.enqueue(encoder.encode(`data: ${chunk}\n\n`));
+          controller.close();
+          return;
+        }
         for (let i = 0; i < chunkCount; i++) {
           if (abortSignal?.aborted) {
             controller.close();
@@ -740,6 +753,9 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
           if (abortSignal?.aborted) {
             controller.close();
             return;
+          }
+          if (throwError && i === Math.floor(chunkCount / 2)) {
+            throw new Error("Simulated stream error");
           }
           if (format === "sse") {
             const chunk = JSON.stringify({
@@ -1044,6 +1060,7 @@ export class ResponseAgent extends AIChatAgent<Env> {
           chunkCount?: number;
           chunkDelayMs?: number;
           throwError?: boolean;
+          streamError?: string;
           useAbortSignal?: boolean;
         }
       | undefined;
@@ -1052,12 +1069,22 @@ export class ResponseAgent extends AIChatAgent<Env> {
     const chunkCount = body?.chunkCount ?? 3;
     const chunkDelayMs = body?.chunkDelayMs ?? 10;
     const throwError = body?.throwError ?? false;
+    const streamError = body?.streamError;
     const useAbortSignal = body?.useAbortSignal ?? false;
     const abortSignal = useAbortSignal ? options?.abortSignal : undefined;
 
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async pull(controller) {
+        if (format === "sse" && streamError) {
+          const chunk = JSON.stringify({
+            type: "error",
+            errorText: streamError
+          });
+          controller.enqueue(encoder.encode(`data: ${chunk}\n\n`));
+          controller.close();
+          return;
+        }
         for (let i = 0; i < chunkCount; i++) {
           if (abortSignal?.aborted) {
             controller.close();

--- a/packages/think/src/tests/agent-tools.test.ts
+++ b/packages/think/src/tests/agent-tools.test.ts
@@ -19,6 +19,10 @@ type ThinkAgentToolTestStub = {
     input: unknown,
     options: { runId: string }
   ): ReturnType<ThinkTestAgent["startAgentToolRun"]>;
+  cancelAgentToolRun(
+    runId: string,
+    reason?: unknown
+  ): ReturnType<ThinkTestAgent["cancelAgentToolRun"]>;
   getAgentToolCleanupMapSizesForTest(): Promise<{
     lastErrors: number;
     preTurnAssistantIds: number;
@@ -127,6 +131,30 @@ describe("Think agent tools", () => {
       runId,
       status: "error",
       error: "Agent tool run was skipped before the child could finish."
+    });
+  });
+
+  it("preserves explicit agent-tool cancellation as aborted", async () => {
+    const agent = await freshAgent();
+    const runId = crypto.randomUUID();
+
+    await agent.setBeforeStepAsyncDelay(50);
+    await agent.startAgentToolRun("cancelled probe", { runId });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await agent.cancelAgentToolRun(runId, "stop");
+
+    const inspection = await waitForAgentToolRun(agent, runId);
+    expect(inspection).toMatchObject({
+      runId,
+      status: "aborted",
+      error: "stop"
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await expect(agent.inspectAgentToolRun(runId)).resolves.toMatchObject({
+      runId,
+      status: "aborted",
+      error: "stop"
     });
   });
 

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -692,6 +692,16 @@ export class ThinkTestAgent extends Think {
     this._resumableStream.complete(streamId);
   }
 
+  async getLatestStreamStatusForTest(): Promise<string | null> {
+    const streams = this.sql<{ status: string }>`
+      SELECT status
+      FROM cf_ai_chat_stream_metadata
+      ORDER BY created_at DESC
+      LIMIT 1
+    `;
+    return streams[0]?.status ?? null;
+  }
+
   async testChat(message: string): Promise<TestChatResult> {
     const cb = new TestCollectingCallback();
     await this.chat(message, cb);

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -310,6 +310,22 @@ function createInBandErrorStreamResult(
   };
 }
 
+function createEmptyStreamResult(): StreamableResult {
+  return {
+    toUIMessageStream() {
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              return { done: true as const, value: undefined };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
 /**
  * Mock model that emits multiple text-delta chunks with a configurable
  * delay between each. Lets tests reliably reach the read loop in
@@ -855,6 +871,40 @@ export class ThinkTestAgent extends Think {
       crypto.randomUUID(),
       createInBandErrorStreamResult(errorText, [], ["ignored response"])
     );
+  }
+
+  async runEmptyStreamForTest(): Promise<void> {
+    await (
+      this as unknown as {
+        _streamResult: (
+          requestId: string,
+          result: StreamableResult
+        ) => Promise<void>;
+      }
+    )._streamResult(crypto.randomUUID(), createEmptyStreamResult());
+  }
+
+  async runEmptyRpcStreamForTest(): Promise<{ doneCalled: boolean }> {
+    let doneCalled = false;
+    await (
+      this as unknown as {
+        _streamResultToRpcCallback: (
+          requestId: string,
+          result: StreamableResult,
+          callback: StreamCallback
+        ) => Promise<void>;
+      }
+    )._streamResultToRpcCallback(
+      crypto.randomUUID(),
+      createEmptyStreamResult(),
+      {
+        onEvent() {},
+        onDone() {
+          doneCalled = true;
+        }
+      }
+    );
+    return { doneCalled };
   }
 
   async testChatWithAbort(

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -223,6 +223,93 @@ function createMultiChunkMockModel(chunks: string[]): LanguageModel {
   } as LanguageModel;
 }
 
+function createInBandErrorMockModel(
+  errorText: string,
+  textChunks: string[] = []
+): LanguageModel {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-in-band-error",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented in mock");
+    },
+    doStream() {
+      _mockCallCount++;
+      const callId = _mockCallCount;
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          if (textChunks.length > 0) {
+            controller.enqueue({ type: "text-start", id: `t-${callId}` });
+            for (const chunk of textChunks) {
+              controller.enqueue({
+                type: "text-delta",
+                id: `t-${callId}`,
+                delta: chunk
+              });
+            }
+          }
+          controller.enqueue({ type: "error", error: new Error(errorText) });
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
+function createInBandErrorStreamResult(
+  errorText: string,
+  textChunks: string[] = [],
+  afterErrorTextChunks: string[] = []
+): StreamableResult {
+  return {
+    toUIMessageStream() {
+      return {
+        [Symbol.asyncIterator]() {
+          let index = 0;
+          const chunks: unknown[] = [];
+          if (textChunks.length > 0) {
+            chunks.push({ type: "text-start", id: "t-inband" });
+            for (const chunk of textChunks) {
+              chunks.push({
+                type: "text-delta",
+                id: "t-inband",
+                delta: chunk
+              });
+            }
+          }
+          chunks.push({ type: "error", errorText });
+          if (afterErrorTextChunks.length > 0) {
+            chunks.push({ type: "text-start", id: "t-after-error" });
+            for (const chunk of afterErrorTextChunks) {
+              chunks.push({
+                type: "text-delta",
+                id: "t-after-error",
+                delta: chunk
+              });
+            }
+          }
+
+          return {
+            async next() {
+              if (index < chunks.length) {
+                return {
+                  done: false as const,
+                  value: chunks[index++]
+                };
+              }
+              return { done: true as const, value: undefined };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
 /**
  * Mock model that emits multiple text-delta chunks with a configurable
  * delay between each. Lets tests reliably reach the read loop in
@@ -349,6 +436,10 @@ export class ThinkTestAgent extends Think {
   private _lastModelCallSettings: CapturedModelCallSettings | null = null;
   private _reasoningResponse: { response: string; reasoning: string } | null =
     null;
+  private _inBandErrorResponse: {
+    errorText: string;
+    textChunks: string[];
+  } | null = null;
   private _beforeStepLog: Array<{
     stepNumber: number;
     previousStepCount: number;
@@ -611,6 +702,35 @@ export class ThinkTestAgent extends Think {
     };
   }
 
+  async testChatWithoutErrorCallback(message: string): Promise<string> {
+    const cb: StreamCallback = {
+      onEvent() {},
+      onDone() {}
+    };
+    try {
+      await this.chat(message, cb);
+      return "";
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  async testChatWithThrowingErrorCallback(message: string): Promise<string> {
+    const cb: StreamCallback = {
+      onEvent() {},
+      onDone() {},
+      onError() {
+        throw new Error("callback failed");
+      }
+    };
+    try {
+      await this.chat(message, cb);
+      return "";
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  }
+
   async testChatWithUIMessage(msg: UIMessage): Promise<TestChatResult> {
     const cb = new TestCollectingCallback();
     await this.chat(msg, cb);
@@ -674,29 +794,18 @@ export class ThinkTestAgent extends Think {
     }
   }
 
-  async runInBandStreamErrorForTest(errorText: string): Promise<void> {
-    const result: StreamableResult = {
-      toUIMessageStream() {
-        return {
-          [Symbol.asyncIterator]() {
-            let emitted = false;
-            return {
-              async next() {
-                if (!emitted) {
-                  emitted = true;
-                  return {
-                    done: false as const,
-                    value: { type: "error", errorText }
-                  };
-                }
-                return { done: true as const, value: undefined };
-              }
-            };
-          }
-        };
-      }
-    };
+  async setInBandErrorResponse(
+    errorText: string,
+    textChunks: string[] = []
+  ): Promise<void> {
+    this._inBandErrorResponse = { errorText, textChunks };
+  }
 
+  async clearInBandErrorResponse(): Promise<void> {
+    this._inBandErrorResponse = null;
+  }
+
+  async runInBandStreamErrorForTest(errorText: string): Promise<void> {
     await (
       this as unknown as {
         _streamResult: (
@@ -704,7 +813,38 @@ export class ThinkTestAgent extends Think {
           result: StreamableResult
         ) => Promise<void>;
       }
-    )._streamResult(crypto.randomUUID(), result);
+    )._streamResult(
+      crypto.randomUUID(),
+      createInBandErrorStreamResult(errorText)
+    );
+  }
+
+  async runPartialInBandStreamErrorForTest(errorText: string): Promise<void> {
+    await (
+      this as unknown as {
+        _streamResult: (
+          requestId: string,
+          result: StreamableResult
+        ) => Promise<void>;
+      }
+    )._streamResult(
+      crypto.randomUUID(),
+      createInBandErrorStreamResult(errorText, ["partial response"])
+    );
+  }
+
+  async runInBandStreamErrorThenTextForTest(errorText: string): Promise<void> {
+    await (
+      this as unknown as {
+        _streamResult: (
+          requestId: string,
+          result: StreamableResult
+        ) => Promise<void>;
+      }
+    )._streamResult(
+      crypto.randomUUID(),
+      createInBandErrorStreamResult(errorText, [], ["ignored response"])
+    );
   }
 
   async testChatWithAbort(
@@ -803,6 +943,12 @@ export class ThinkTestAgent extends Think {
   }
 
   override getModel(): LanguageModel {
+    if (this._inBandErrorResponse) {
+      return createInBandErrorMockModel(
+        this._inBandErrorResponse.errorText,
+        this._inBandErrorResponse.textChunks
+      );
+    }
     if (this._reasoningResponse) {
       return createReasoningMockModel(
         this._reasoningResponse.response,
@@ -1485,8 +1631,18 @@ export class ThinkProgrammaticTestAgent extends Think {
   private _delayedChunks: { chunks: string[]; delayMs: number } | null = null;
   private _throwBeforeTurnError: string | null = null;
   private _submissionStatusDelayMs = 0;
+  private _inBandErrorResponse: {
+    errorText: string;
+    textChunks: string[];
+  } | null = null;
 
   override getModel(): LanguageModel {
+    if (this._inBandErrorResponse) {
+      return createInBandErrorMockModel(
+        this._inBandErrorResponse.errorText,
+        this._inBandErrorResponse.textChunks
+      );
+    }
     if (this._delayedChunks) {
       return createDelayedMultiChunkMockModel(
         this._delayedChunks.chunks,
@@ -1530,6 +1686,17 @@ export class ThinkProgrammaticTestAgent extends Think {
 
   async clearDelayedChunkResponse(): Promise<void> {
     this._delayedChunks = null;
+  }
+
+  async setInBandStreamErrorResponse(
+    errorText: string,
+    textChunks: string[] = []
+  ): Promise<void> {
+    this._inBandErrorResponse = { errorText, textChunks };
+  }
+
+  async clearInBandStreamErrorResponse(): Promise<void> {
+    this._inBandErrorResponse = null;
   }
 
   async setThrowingStreamError(message: string | null): Promise<void> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -674,6 +674,39 @@ export class ThinkTestAgent extends Think {
     }
   }
 
+  async runInBandStreamErrorForTest(errorText: string): Promise<void> {
+    const result: StreamableResult = {
+      toUIMessageStream() {
+        return {
+          [Symbol.asyncIterator]() {
+            let emitted = false;
+            return {
+              async next() {
+                if (!emitted) {
+                  emitted = true;
+                  return {
+                    done: false as const,
+                    value: { type: "error", errorText }
+                  };
+                }
+                return { done: true as const, value: undefined };
+              }
+            };
+          }
+        };
+      }
+    };
+
+    await (
+      this as unknown as {
+        _streamResult: (
+          requestId: string,
+          result: StreamableResult
+        ) => Promise<void>;
+      }
+    )._streamResult(crypto.randomUUID(), result);
+  }
+
   async testChatWithAbort(
     message: string,
     abortAfterEvents: number

--- a/packages/think/src/tests/hooks.test.ts
+++ b/packages/think/src/tests/hooks.test.ts
@@ -436,7 +436,9 @@ describe("Think — extension observation hooks", () => {
     // beforeToolCall/afterToolCall/onStepFinish/onChunk but Think only
     // ever fired beforeTurn. The extension records each hook into a
     // workspace marker file via the host bridge.
-    const agent = await freshExtensionHookAgent("ext-before-tc");
+    const agent = await freshExtensionHookAgent(
+      `ext-before-tc-${crypto.randomUUID()}`
+    );
     await agent.testChat("ping");
 
     const files = await agent.listExtLogFiles();

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -11,10 +11,15 @@ import type {
 type ThinkSubmissionTestStub = {
   setDelayedChunkResponse(chunks: string[], delayMs: number): Promise<void>;
   clearDelayedChunkResponse(): Promise<void>;
+  setInBandStreamErrorResponse(
+    errorText: string,
+    textChunks?: string[]
+  ): Promise<void>;
+  clearInBandStreamErrorResponse(): Promise<void>;
   setThrowingStreamError(message: string | null): Promise<void>;
   getProgrammaticStreamErrorCountForTest(): Promise<number>;
   getSubmissionFinalStatusForTest(
-    resultStatus: "completed" | "skipped" | "aborted",
+    resultStatus: "completed" | "error" | "skipped" | "aborted",
     streamError?: string
   ): Promise<ThinkSubmissionStatus>;
   runNonSubmissionStreamFailureForTest(requestId: string): Promise<void>;
@@ -542,6 +547,36 @@ describe("Think durable submissions", () => {
     });
   });
 
+  it("preserves stream error text from recovered continuations", async () => {
+    const agent = await freshAgent();
+    await agent.setDelayedChunkResponse(["seed"], 1);
+    const seed = await agent.testSubmitMessages("seed conversation", {
+      submissionId: "sub-recovered-error-seed"
+    });
+    await waitForSubmission(
+      agent,
+      seed.submissionId,
+      (submission) => submission.status === "completed"
+    );
+
+    await agent.setInBandStreamErrorResponse("recovered in-band failure");
+    await agent.insertSubmissionForTest({
+      submissionId: "sub-recovered-inband-error",
+      requestId: "sub-recovered-inband-error",
+      status: "running",
+      messagesAppliedAt: Date.now()
+    });
+
+    await agent.continueRecoveredChatForTest("sub-recovered-inband-error");
+
+    await expect(
+      agent.inspectSubmissionForTest("sub-recovered-inband-error")
+    ).resolves.toMatchObject({
+      status: "error",
+      error: "recovered in-band failure"
+    });
+  });
+
   it("aborts an active recovered continuation without a late overwrite", async () => {
     const agent = await freshAgent();
     await agent.setDelayedChunkResponse(["seed"], 1);
@@ -636,6 +671,23 @@ describe("Think durable submissions", () => {
     );
 
     expect(failed.error).toBe("boom");
+  });
+
+  it("stores error status and message when an in-band stream error occurs", async () => {
+    const agent = await freshAgent();
+    await agent.setInBandStreamErrorResponse("submission in-band failure");
+
+    const accepted = await agent.testSubmitMessages("in-band failure", {
+      submissionId: "sub-inband-error"
+    });
+
+    const failed = await waitForSubmission(
+      agent,
+      accepted.submissionId,
+      (submission) => submission.status === "error"
+    );
+
+    expect(failed.error).toBe("submission in-band failure");
   });
 
   it("does not retain stream error records for non-submission callers", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2063,7 +2063,9 @@ describe("Think — onChatRecovery", () => {
   });
 
   it("retries a pre-stream interrupted user turn by default without duplicating the user message", async () => {
-    const agent = await freshRecoveryAgent("pre-stream-retry");
+    const agent = await freshRecoveryAgent(
+      `pre-stream-retry-${crypto.randomUUID()}`
+    );
 
     await agent.persistTestMessage({
       id: "u-retry",

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2,6 +2,7 @@ import { env, exports } from "cloudflare:workers";
 import { getServerByName } from "partyserver";
 import { describe, expect, it, vi } from "vitest";
 import type { UIMessage } from "ai";
+import { subscribe } from "agents/observability";
 import type {
   ThinkTestAgent,
   ThinkSessionTestAgent,
@@ -911,6 +912,37 @@ describe("Think — onChatResponse", () => {
     expect(log[0].requestId).toBeTruthy();
   });
 
+  it("should fire onChatResponse for empty successful streams", async () => {
+    const agent = await freshAgent("hook-empty-stream");
+
+    await agent.runEmptyStreamForTest();
+
+    const history = await agent.getStoredMessages();
+    expect(history).toHaveLength(0);
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("completed");
+    expect(log[0].message.role).toBe("assistant");
+    expect(log[0].message.parts).toHaveLength(0);
+  });
+
+  it("should fire onChatResponse and onDone for empty successful RPC streams", async () => {
+    const agent = await freshAgent("hook-empty-rpc-stream");
+
+    const result = await agent.runEmptyRpcStreamForTest();
+
+    expect(result.doneCalled).toBe(true);
+    const history = await agent.getStoredMessages();
+    expect(history).toHaveLength(0);
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("completed");
+    expect(log[0].message.role).toBe("assistant");
+    expect(log[0].message.parts).toHaveLength(0);
+  });
+
   it("should fire onChatResponse with error status on failure", async () => {
     const agent = await freshAgent("hook-error");
 
@@ -923,15 +955,27 @@ describe("Think — onChatResponse", () => {
   });
 
   it("should fire onChatResponse with error status when in-band error arrives before any parts", async () => {
-    const agent = await freshAgent("hook-inband-error");
+    const room = "hook-inband-error";
+    const observedTypes: string[] = [];
+    const unsubscribe = subscribe("message", (event) => {
+      if (event.agent === "ThinkTestAgent" && event.name === room) {
+        observedTypes.push(event.type);
+      }
+    });
+    const agent = await freshAgent(room);
 
-    await agent.runInBandStreamErrorForTest("Early in-band error");
+    try {
+      await agent.runInBandStreamErrorForTest("Early in-band error");
 
-    const log = (await agent.getResponseLog()) as ChatResponseResult[];
-    expect(log).toHaveLength(1);
-    expect(log[0].status).toBe("error");
-    expect(log[0].error).toContain("Early in-band error");
-    await expect(agent.getLatestStreamStatusForTest()).resolves.toBe("error");
+      const log = (await agent.getResponseLog()) as ChatResponseResult[];
+      expect(log).toHaveLength(1);
+      expect(log[0].status).toBe("error");
+      expect(log[0].error).toContain("Early in-band error");
+      expect(observedTypes).toContain("message:error");
+      await expect(agent.getLatestStreamStatusForTest()).resolves.toBe("error");
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("should persist partial parts and fire error status for in-band errors", async () => {
@@ -973,19 +1017,31 @@ describe("Think — onChatResponse", () => {
   });
 
   it("should report in-band stream errors through RPC chat onError", async () => {
-    const agent = await freshAgent("hook-rpc-inband-error");
+    const room = "hook-rpc-inband-error";
+    const observedTypes: string[] = [];
+    const unsubscribe = subscribe("message", (event) => {
+      if (event.agent === "ThinkTestAgent" && event.name === room) {
+        observedTypes.push(event.type);
+      }
+    });
+    const agent = await freshAgent(room);
 
-    await agent.setInBandErrorResponse("RPC in-band error");
-    const result = await agent.testChat("trigger rpc in-band error");
+    try {
+      await agent.setInBandErrorResponse("RPC in-band error");
+      const result = await agent.testChat("trigger rpc in-band error");
 
-    expect(result.done).toBe(false);
-    expect(result.error).toContain("RPC in-band error");
+      expect(result.done).toBe(false);
+      expect(result.error).toContain("RPC in-band error");
 
-    const log = (await agent.getResponseLog()) as ChatResponseResult[];
-    expect(log).toHaveLength(1);
-    expect(log[0].status).toBe("error");
-    expect(log[0].error).toContain("RPC in-band error");
-    await expect(agent.getLatestStreamStatusForTest()).resolves.toBe("error");
+      const log = (await agent.getResponseLog()) as ChatResponseResult[];
+      expect(log).toHaveLength(1);
+      expect(log[0].status).toBe("error");
+      expect(log[0].error).toContain("RPC in-band error");
+      expect(observedTypes).toContain("message:error");
+      await expect(agent.getLatestStreamStatusForTest()).resolves.toBe("error");
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("should throw RPC in-band stream errors when no onError callback exists", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2112,7 +2112,9 @@ describe("Think — onChatRecovery", () => {
   });
 
   it("continues a partial stream with request context from the recovered snapshot", async () => {
-    const agent = await freshRecoveryAgent("partial-continue-context");
+    const agent = await freshRecoveryAgent(
+      `partial-continue-context-${crypto.randomUUID()}`
+    );
 
     await agent.persistTestMessage({
       id: "u-continue",

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -931,6 +931,7 @@ describe("Think — onChatResponse", () => {
     expect(log).toHaveLength(1);
     expect(log[0].status).toBe("error");
     expect(log[0].error).toContain("Early in-band error");
+    await expect(agent.getLatestStreamStatusForTest()).resolves.toBe("error");
   });
 
   it("should persist partial parts and fire error status for in-band errors", async () => {
@@ -954,6 +955,7 @@ describe("Think — onChatResponse", () => {
     expect(log).toHaveLength(1);
     expect(log[0].status).toBe("error");
     expect(log[0].error).toContain("Late in-band error");
+    await expect(agent.getLatestStreamStatusForTest()).resolves.toBe("error");
   });
 
   it("should treat in-band errors as terminal stream events", async () => {
@@ -983,6 +985,7 @@ describe("Think — onChatResponse", () => {
     expect(log).toHaveLength(1);
     expect(log[0].status).toBe("error");
     expect(log[0].error).toContain("RPC in-band error");
+    await expect(agent.getLatestStreamStatusForTest()).resolves.toBe("error");
   });
 
   it("should throw RPC in-band stream errors when no onError callback exists", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -922,6 +922,17 @@ describe("Think — onChatResponse", () => {
     expect(log[0].error).toContain("Boom");
   });
 
+  it("should fire onChatResponse with error status when in-band error arrives before any parts", async () => {
+    const agent = await freshAgent("hook-inband-error");
+
+    await agent.runInBandStreamErrorForTest("Early in-band error");
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("error");
+    expect(log[0].error).toContain("Early in-band error");
+  });
+
   it("should fire onChatResponse with aborted status on abort", async () => {
     const agent = await freshAgent("hook-abort");
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -933,6 +933,90 @@ describe("Think — onChatResponse", () => {
     expect(log[0].error).toContain("Early in-band error");
   });
 
+  it("should persist partial parts and fire error status for in-band errors", async () => {
+    const agent = await freshAgent("hook-partial-inband-error");
+
+    await agent.runPartialInBandStreamErrorForTest("Late in-band error");
+
+    const history = await agent.getStoredMessages();
+    expect(history).toHaveLength(1);
+    const assistantMsg = history[0] as {
+      role: string;
+      parts: Array<{ type: string; text?: string }>;
+    };
+    expect(assistantMsg.role).toBe("assistant");
+    expect(assistantMsg.parts[0]).toMatchObject({
+      type: "text",
+      text: "partial response"
+    });
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("error");
+    expect(log[0].error).toContain("Late in-band error");
+  });
+
+  it("should treat in-band errors as terminal stream events", async () => {
+    const agent = await freshAgent("hook-terminal-inband-error");
+
+    await agent.runInBandStreamErrorThenTextForTest("Terminal in-band error");
+
+    const history = await agent.getStoredMessages();
+    expect(history).toHaveLength(0);
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("error");
+    expect(log[0].error).toContain("Terminal in-band error");
+  });
+
+  it("should report in-band stream errors through RPC chat onError", async () => {
+    const agent = await freshAgent("hook-rpc-inband-error");
+
+    await agent.setInBandErrorResponse("RPC in-band error");
+    const result = await agent.testChat("trigger rpc in-band error");
+
+    expect(result.done).toBe(false);
+    expect(result.error).toContain("RPC in-band error");
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("error");
+    expect(log[0].error).toContain("RPC in-band error");
+  });
+
+  it("should throw RPC in-band stream errors when no onError callback exists", async () => {
+    const agent = await freshAgent("hook-rpc-inband-error-no-callback");
+
+    await agent.setInBandErrorResponse("RPC missing callback error");
+    const error = await agent.testChatWithoutErrorCallback(
+      "trigger rpc in-band error"
+    );
+
+    expect(error).toContain("RPC missing callback error");
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("error");
+    expect(log[0].error).toContain("RPC missing callback error");
+  });
+
+  it("should not fire duplicate response hooks when RPC onError throws", async () => {
+    const agent = await freshAgent("hook-rpc-inband-error-callback-throws");
+
+    await agent.setInBandErrorResponse("RPC callback throws source error");
+    const error = await agent.testChatWithThrowingErrorCallback(
+      "trigger rpc in-band error"
+    );
+
+    expect(error).toBe("callback failed");
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("error");
+    expect(log[0].error).toContain("RPC callback throws source error");
+  });
+
   it("should fire onChatResponse with aborted status on abort", async () => {
     const agent = await freshAgent("hook-abort");
 
@@ -1391,6 +1475,26 @@ describe("Think — saveMessages", () => {
     expect(log).toHaveLength(1);
     expect(log[0].status).toBe("completed");
     expect(log[0].continuation).toBe(false);
+  });
+
+  it("should return error status for in-band stream errors", async () => {
+    const agent = await freshProgrammaticAgent("save-inband-error");
+    await agent.setInBandStreamErrorResponse("saveMessages in-band failure");
+
+    const result = (await agent.testSaveMessages([
+      {
+        id: crypto.randomUUID(),
+        role: "user",
+        parts: [{ type: "text", text: "Trigger in-band error" }]
+      }
+    ])) as SaveMessagesResult;
+
+    expect(result.status).toBe("error");
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe("error");
+    expect(log[0].error).toContain("saveMessages in-band failure");
   });
 
   it("should broadcast to connected clients", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -178,6 +178,17 @@ function isWebSocketClosedSendError(error: unknown): boolean {
   );
 }
 
+function shouldMarkSkippedAfterGenerationChange(
+  status: SaveMessagesResult["status"]
+): boolean {
+  return status === "completed";
+}
+
+type StreamResultStatus = {
+  status: Exclude<SaveMessagesResult["status"], "skipped">;
+  error?: string;
+};
+
 type ChatRecoveryRetryData = {
   targetUserId?: string;
   originalRequestId?: string;
@@ -2355,12 +2366,13 @@ export class Think<
             .find((m) => m.request_id === result.requestId)?.id ?? null;
         const output = this.getAgentToolOutput(options.runId);
         const summary = this.getAgentToolSummary(options.runId, output);
-        const streamError = this._agentToolLastErrors.get(options.runId);
+        const streamError =
+          result.error ?? this._agentToolLastErrors.get(options.runId);
         const skipped = result.status === "skipped";
         const status: AgentToolChildRunStatus =
           result.status === "aborted"
             ? "aborted"
-            : skipped || streamError
+            : result.status === "error" || skipped || streamError
               ? "error"
               : "completed";
         const error: string | null =
@@ -3041,14 +3053,15 @@ export class Think<
       const streamError = this._programmaticStreamErrors.get(result.requestId);
       const finalStatus = this._getSubmissionFinalStatus(
         result.status,
-        streamError
+        result.error ?? streamError
       );
+      const errorMessage = result.error ?? streamError ?? null;
       this.sql`
         UPDATE cf_think_submissions
         SET status = ${finalStatus},
             request_id = ${result.requestId},
             stream_id = ${streamId},
-            error_message = ${finalStatus === "error" ? (streamError ?? null) : null},
+            error_message = ${finalStatus === "error" ? errorMessage : null},
             completed_at = ${Date.now()}
         WHERE submission_id = ${row.submission_id}
           AND status = 'running'
@@ -3338,6 +3351,7 @@ export class Think<
     const body = this._lastBody;
     const epoch = this._turnQueue.generation;
     let status: SaveMessagesResult["status"] = "completed";
+    let error: string | undefined;
     let wasAborted = false;
 
     await this.keepAliveWhile(async () => {
@@ -3391,10 +3405,17 @@ export class Think<
             );
 
             if (result) {
-              await this._streamResult(requestId, result, abortSignal, {
-                captureProgrammaticStreamError:
-                  options?.captureProgrammaticStreamError
-              });
+              const streamResult = await this._streamResult(
+                requestId,
+                result,
+                abortSignal,
+                {
+                  captureProgrammaticStreamError:
+                    options?.captureProgrammaticStreamError
+                }
+              );
+              status = streamResult.status;
+              error = streamResult.error;
             }
           };
 
@@ -3415,13 +3436,16 @@ export class Think<
       });
     });
 
-    if (this._turnQueue.generation !== epoch && status === "completed") {
+    if (
+      this._turnQueue.generation !== epoch &&
+      shouldMarkSkippedAfterGenerationChange(status)
+    ) {
       status = "skipped";
     } else if (wasAborted && status === "completed") {
       status = "aborted";
     }
 
-    return { requestId, status };
+    return { requestId, status, ...(error !== undefined && { error }) };
   }
 
   /**
@@ -3455,6 +3479,7 @@ export class Think<
     const resolvedBody = body ?? this._lastBody;
     const epoch = this._turnQueue.generation;
     let status: SaveMessagesResult["status"] = "completed";
+    let error: string | undefined;
     let wasAborted = false;
 
     await this.keepAliveWhile(async () => {
@@ -3488,9 +3513,16 @@ export class Think<
             );
 
             if (result) {
-              await this._streamResult(requestId, result, abortSignal, {
-                continuation: true
-              });
+              const streamResult = await this._streamResult(
+                requestId,
+                result,
+                abortSignal,
+                {
+                  continuation: true
+                }
+              );
+              status = streamResult.status;
+              error = streamResult.error;
             }
           };
 
@@ -3507,13 +3539,16 @@ export class Think<
       });
     });
 
-    if (this._turnQueue.generation !== epoch && status === "completed") {
+    if (
+      this._turnQueue.generation !== epoch &&
+      shouldMarkSkippedAfterGenerationChange(status)
+    ) {
       status = "skipped";
     } else if (wasAborted && status === "completed") {
       status = "aborted";
     }
 
-    return { requestId, status };
+    return { requestId, status, ...(error !== undefined && { error }) };
   }
 
   private async _retryLastUserTurn(
@@ -3529,6 +3564,7 @@ export class Think<
     const requestId = crypto.randomUUID();
     const epoch = this._turnQueue.generation;
     let status: SaveMessagesResult["status"] = "completed";
+    let error: string | undefined;
     let wasAborted = false;
 
     await this.keepAliveWhile(async () => {
@@ -3562,7 +3598,13 @@ export class Think<
             );
 
             if (result) {
-              await this._streamResult(requestId, result, abortSignal);
+              const streamResult = await this._streamResult(
+                requestId,
+                result,
+                abortSignal
+              );
+              status = streamResult.status;
+              error = streamResult.error;
             }
           };
 
@@ -3579,13 +3621,16 @@ export class Think<
       });
     });
 
-    if (this._turnQueue.generation !== epoch && status === "completed") {
+    if (
+      this._turnQueue.generation !== epoch &&
+      shouldMarkSkippedAfterGenerationChange(status)
+    ) {
       status = "skipped";
     } else if (wasAborted && status === "completed") {
       status = "aborted";
     }
 
-    return { requestId, status };
+    return { requestId, status, ...(error !== undefined && { error }) };
   }
 
   // ── WebSocket protocol ──────────────────────────────────────────
@@ -4154,6 +4199,8 @@ export class Think<
     let assistantMsg: UIMessage | null = null;
     let aborted = false;
     let doneSent = false;
+    let streamError: string | undefined;
+    let pendingRpcError: string | undefined;
 
     try {
       this._insideInferenceLoop = true;
@@ -4173,6 +4220,7 @@ export class Think<
           const { action } = accumulator.applyChunk(streamChunk);
 
           if (action?.type === "error") {
+            streamError = action.error;
             this._broadcastChat({
               type: MSG_CHAT_RESPONSE,
               id: requestId,
@@ -4180,7 +4228,7 @@ export class Think<
               done: false,
               error: true
             });
-            continue;
+            break;
           }
 
           const chunkBody = JSON.stringify(chunk);
@@ -4220,17 +4268,30 @@ export class Think<
       doneSent = true;
 
       assistantMsg = accumulator.toMessage();
-      await this._persistAssistantMessage(assistantMsg);
-      this._broadcastMessages();
+      if (accumulator.parts.length > 0) {
+        await this._persistAssistantMessage(assistantMsg);
+        this._broadcastMessages();
+      }
 
-      if (!aborted) {
-        await callback.onDone();
+      if (streamError) {
         await this._fireResponseHook({
           message: assistantMsg,
           requestId,
           continuation: false,
-          status: "completed"
+          status: "error",
+          error: streamError
         });
+        pendingRpcError = streamError;
+      } else if (!aborted) {
+        await callback.onDone();
+        if (accumulator.parts.length > 0) {
+          await this._fireResponseHook({
+            message: assistantMsg,
+            requestId,
+            continuation: false,
+            status: "completed"
+          });
+        }
       } else {
         await this._fireResponseHook({
           message: assistantMsg,
@@ -4283,6 +4344,14 @@ export class Think<
         throw wrapped;
       }
     }
+
+    if (pendingRpcError) {
+      if (callback.onError) {
+        await callback.onError(pendingRpcError);
+      } else {
+        throw new Error(pendingRpcError);
+      }
+    }
   }
 
   private _shouldFlushRpcStreamChunk(
@@ -4311,7 +4380,7 @@ export class Think<
       parentId?: string;
       captureProgrammaticStreamError?: boolean;
     }
-  ) {
+  ): Promise<StreamResultStatus> {
     const clearGen = this._turnQueue.generation;
     const streamId = this._resumableStream.start(requestId);
     const continuation = options?.continuation ?? false;
@@ -4347,6 +4416,9 @@ export class Think<
 
           if (action?.type === "error") {
             streamError = action.error;
+            if (options?.captureProgrammaticStreamError) {
+              this._programmaticStreamErrors.set(requestId, streamError);
+            }
             this._broadcastChat({
               type: MSG_CHAT_RESPONSE,
               id: requestId,
@@ -4354,7 +4426,7 @@ export class Think<
               done: false,
               error: true
             });
-            continue;
+            break;
           }
 
           const chunkBody = JSON.stringify(chunk);
@@ -4409,7 +4481,10 @@ export class Think<
       }
     }
 
-    if (this._turnQueue.generation === clearGen) {
+    if (
+      this._turnQueue.generation === clearGen &&
+      (accumulator.parts.length > 0 || streamError || streamAborted)
+    ) {
       try {
         const assistantMsg = accumulator.toMessage();
 
@@ -4422,10 +4497,10 @@ export class Think<
           message: assistantMsg,
           requestId,
           continuation,
-          status: streamAborted
-            ? "aborted"
-            : streamError
-              ? "error"
+          status: streamError
+            ? "error"
+            : streamAborted
+              ? "aborted"
               : "completed",
           error: streamError
         });
@@ -4433,6 +4508,10 @@ export class Think<
         console.error("Failed to persist assistant message:", e);
       }
     }
+
+    return streamError
+      ? { status: "error", error: streamError }
+      : { status: streamAborted ? "aborted" : "completed" };
   }
 
   // ── Session-backed persistence ──────────────────────────────────
@@ -4877,7 +4956,7 @@ export class Think<
           result.requestId || null,
           result.status === "completed"
             ? null
-            : `Recovery retry ${result.status}.`
+            : (result.error ?? `Recovery retry ${result.status}.`)
         );
       }
     } catch (error) {
@@ -5048,7 +5127,9 @@ export class Think<
           data.recoveredRequestId,
           result.status,
           result.requestId || null,
-          result.status === "completed" ? null : `Recovery ${result.status}.`
+          result.status === "completed"
+            ? null
+            : (result.error ?? `Recovery ${result.status}.`)
         );
       }
     } catch (error) {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -4226,6 +4226,7 @@ export class Think<
 
           if (action?.type === "error") {
             streamError = action.error;
+            this._emit("message:error", { error: streamError });
             this._broadcastChat({
               type: MSG_CHAT_RESPONSE,
               id: requestId,
@@ -4293,14 +4294,12 @@ export class Think<
         pendingRpcError = streamError;
       } else if (!aborted) {
         await callback.onDone();
-        if (accumulator.parts.length > 0) {
-          await this._fireResponseHook({
-            message: assistantMsg,
-            requestId,
-            continuation: false,
-            status: "completed"
-          });
-        }
+        await this._fireResponseHook({
+          message: assistantMsg,
+          requestId,
+          continuation: false,
+          status: "completed"
+        });
       } else {
         await this._fireResponseHook({
           message: assistantMsg,
@@ -4428,6 +4427,7 @@ export class Think<
             if (options?.captureProgrammaticStreamError) {
               this._programmaticStreamErrors.set(requestId, streamError);
             }
+            this._emit("message:error", { error: streamError });
             this._broadcastChat({
               type: MSG_CHAT_RESPONSE,
               id: requestId,
@@ -4494,10 +4494,7 @@ export class Think<
       }
     }
 
-    if (
-      this._turnQueue.generation === clearGen &&
-      (accumulator.parts.length > 0 || streamError || streamAborted)
-    ) {
+    if (this._turnQueue.generation === clearGen) {
       try {
         const assistantMsg = accumulator.toMessage();
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2347,6 +2347,7 @@ export class Think<
       )
     );
 
+    const epoch = this._turnQueue.generation;
     void this.keepAliveWhile(async () => {
       try {
         this.sql`
@@ -2368,12 +2369,14 @@ export class Think<
         const summary = this.getAgentToolSummary(options.runId, output);
         const streamError =
           result.error ?? this._agentToolLastErrors.get(options.runId);
-        const skipped = result.status === "skipped";
+        const skipped =
+          result.status === "skipped" ||
+          (result.status === "aborted" && this._turnQueue.generation !== epoch);
         const status: AgentToolChildRunStatus =
-          result.status === "aborted"
-            ? "aborted"
-            : result.status === "error" || skipped || streamError
-              ? "error"
+          result.status === "error" || skipped || streamError
+            ? "error"
+            : result.status === "aborted"
+              ? "aborted"
               : "completed";
         const error: string | null =
           status === "error"
@@ -2390,6 +2393,7 @@ export class Think<
               error_message = ${error},
               completed_at = ${Date.now()}
           WHERE run_id = ${options.runId}
+            AND completed_at IS NULL
         `;
       } catch (error) {
         this.sql`
@@ -2398,6 +2402,7 @@ export class Think<
               error_message = ${error instanceof Error ? error.message : String(error)},
               completed_at = ${Date.now()}
           WHERE run_id = ${options.runId}
+            AND completed_at IS NULL
         `;
       } finally {
         this._agentToolAbortControllers.delete(options.runId);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -4257,7 +4257,11 @@ export class Think<
         this._insideInferenceLoop = false;
       }
 
-      this._resumableStream.complete(streamId);
+      if (streamError) {
+        this._resumableStream.markError(streamId);
+      } else {
+        this._resumableStream.complete(streamId);
+      }
       streamFinalized = true;
       this._broadcastChat({
         type: MSG_CHAT_RESPONSE,
@@ -4442,7 +4446,11 @@ export class Think<
         this._insideInferenceLoop = false;
       }
 
-      this._resumableStream.complete(streamId);
+      if (streamError) {
+        this._resumableStream.markError(streamId);
+      } else {
+        this._resumableStream.complete(streamId);
+      }
       this._pendingResumeConnections.clear();
       this._broadcastChat({
         type: MSG_CHAT_RESPONSE,

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -4346,6 +4346,7 @@ export class Think<
           );
 
           if (action?.type === "error") {
+            streamError = action.error;
             this._broadcastChat({
               type: MSG_CHAT_RESPONSE,
               id: requestId,
@@ -4408,14 +4409,14 @@ export class Think<
       }
     }
 
-    if (
-      accumulator.parts.length > 0 &&
-      this._turnQueue.generation === clearGen
-    ) {
+    if (this._turnQueue.generation === clearGen) {
       try {
         const assistantMsg = accumulator.toMessage();
-        await this._persistAssistantMessage(assistantMsg, parentId);
-        this._broadcastMessages();
+
+        if (accumulator.parts.length > 0) {
+          await this._persistAssistantMessage(assistantMsg, parentId);
+          this._broadcastMessages();
+        }
 
         await this._fireResponseHook({
           message: assistantMsg,


### PR DESCRIPTION
Improves error handling in `@cloudflare/think by ensuring that the `onChatResponse` hook is fired when an in-band stream error occurs before any response parts are emitted. Also tests.

Fixes #1527 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->