### PR TITLE
fix: defer voice transcript_start events until first non-empty token

### DIFF
--- a/.changeset/lazy-voices-listen.md
+++ b/.changeset/lazy-voices-listen.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/voice": patch
+---
+
+Avoid emitting empty assistant transcript entries when a voice turn produces no response text.

--- a/packages/voice/src/tests/agents/voice.ts
+++ b/packages/voice/src/tests/agents/voice.ts
@@ -178,11 +178,16 @@ export class TestEmptyResponseVoiceAgent extends VoiceBase {
 
   transcriber = new TestTranscriber();
   tts = new TestTTS();
+  #responseMode: "empty_string" | "empty_stream" = "empty_string";
 
   async onTurn(
     _transcript: string,
     _context: VoiceTurnContext
-  ): Promise<string> {
+  ): Promise<string | AsyncIterable<string>> {
+    if (this.#responseMode === "empty_stream") {
+      return (async function* () {})();
+    }
+
     return "";
   }
 
@@ -190,13 +195,26 @@ export class TestEmptyResponseVoiceAgent extends VoiceBase {
     if (typeof message !== "string") return;
     try {
       const parsed = JSON.parse(message);
-      if (parsed.type === "_get_message_count") {
-        connection.send(
-          JSON.stringify({
-            type: "_message_count",
-            count: this.getMessageCount()
-          })
-        );
+      switch (parsed.type) {
+        case "_set_response_mode":
+          if (
+            parsed.value === "empty_string" ||
+            parsed.value === "empty_stream"
+          ) {
+            this.#responseMode = parsed.value;
+          }
+          connection.send(
+            JSON.stringify({ type: "_ack", command: parsed.type })
+          );
+          break;
+        case "_get_message_count":
+          connection.send(
+            JSON.stringify({
+              type: "_message_count",
+              count: this.getMessageCount()
+            })
+          );
+          break;
       }
     } catch {
       // ignore

--- a/packages/voice/src/tests/agents/voice.ts
+++ b/packages/voice/src/tests/agents/voice.ts
@@ -178,7 +178,11 @@ export class TestEmptyResponseVoiceAgent extends VoiceBase {
 
   transcriber = new TestTranscriber();
   tts = new TestTTS();
-  #responseMode: "empty_string" | "empty_stream" = "empty_string";
+  #responseMode:
+    | "empty_string"
+    | "empty_stream"
+    | "whitespace_stream"
+    | "leading_whitespace_stream" = "empty_string";
 
   async onTurn(
     _transcript: string,
@@ -186,6 +190,18 @@ export class TestEmptyResponseVoiceAgent extends VoiceBase {
   ): Promise<string | AsyncIterable<string>> {
     if (this.#responseMode === "empty_stream") {
       return (async function* () {})();
+    }
+    if (this.#responseMode === "whitespace_stream") {
+      return (async function* () {
+        yield "   ";
+      })();
+    }
+    if (this.#responseMode === "leading_whitespace_stream") {
+      return (async function* () {
+        yield "   ";
+        yield "Hello";
+        yield " world.";
+      })();
     }
 
     return "";
@@ -199,7 +215,9 @@ export class TestEmptyResponseVoiceAgent extends VoiceBase {
         case "_set_response_mode":
           if (
             parsed.value === "empty_string" ||
-            parsed.value === "empty_stream"
+            parsed.value === "empty_stream" ||
+            parsed.value === "whitespace_stream" ||
+            parsed.value === "leading_whitespace_stream"
           ) {
             this.#responseMode = parsed.value;
           }

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -679,15 +679,111 @@ describe("VoiceAgent — empty response handling", () => {
 
     const messages = await collectMessagesUntil(
       ws,
-      (msg) => msg.type === "error"
+      (msg) => msg.type === "status" && msg.status === "listening"
     );
 
     expect(messages).toContainEqual({
       type: "error",
       message: "No response generated"
     });
-    expect(messages.map((m) => m.type)).not.toContain("transcript_start");
-    expect(messages.map((m) => m.type)).not.toContain("transcript_end");
+    const types = messages.map((m) => m.type);
+    expect(types).not.toContain("transcript_start");
+    expect(types).not.toContain("transcript_end");
+    expect(types).not.toContain("metrics");
+
+    sendJSON(ws, { type: "_get_message_count" });
+    const count = (await waitForType(ws, "_message_count")) as Record<
+      string,
+      unknown
+    >;
+    expect(count.count).toBe(1);
+
+    ws.close();
+  });
+
+  it("does not emit assistant transcript events for whitespace-only stream", async () => {
+    const { ws } = await connectEmptyWS(uniqueEmptyPath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, {
+      type: "_set_response_mode",
+      value: "whitespace_stream"
+    });
+    await waitForType(ws, "_ack");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const messages = await collectMessagesUntil(
+      ws,
+      (msg) => msg.type === "status" && msg.status === "listening"
+    );
+
+    expect(messages).toContainEqual({
+      type: "error",
+      message: "No response generated"
+    });
+    const types = messages.map((m) => m.type);
+    expect(types).not.toContain("transcript_start");
+    expect(types).not.toContain("transcript_end");
+    expect(types).not.toContain("metrics");
+
+    sendJSON(ws, { type: "_get_message_count" });
+    const count = (await waitForType(ws, "_message_count")) as Record<
+      string,
+      unknown
+    >;
+    expect(count.count).toBe(1);
+
+    ws.close();
+  });
+
+  it("defers assistant transcript start until streamed text is non-empty", async () => {
+    const { ws } = await connectEmptyWS(uniqueEmptyPath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, {
+      type: "_set_response_mode",
+      value: "leading_whitespace_stream"
+    });
+    await waitForType(ws, "_ack");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const messages = await collectMessagesUntil(
+      ws,
+      (msg) => msg.type === "transcript_end"
+    );
+    const assistantMessages = messages.filter((msg) =>
+      ["transcript_start", "transcript_delta", "transcript_end"].includes(
+        msg.type as string
+      )
+    );
+
+    expect(assistantMessages).toEqual([
+      { type: "transcript_start", role: "assistant" },
+      { type: "transcript_delta", text: "   Hello" },
+      { type: "transcript_delta", text: " world." },
+      { type: "transcript_end", text: "   Hello world." }
+    ]);
+
+    await waitForStatus(ws, "listening");
+
+    sendJSON(ws, { type: "_get_message_count" });
+    const count = (await waitForType(ws, "_message_count")) as Record<
+      string,
+      unknown
+    >;
+    expect(count.count).toBe(2);
 
     ws.close();
   });

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -77,6 +77,32 @@ function waitForType(ws: WebSocket, type: string) {
   );
 }
 
+function collectMessagesUntil(
+  ws: WebSocket,
+  predicate: (msg: Record<string, unknown>) => boolean,
+  timeout = 5000
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    const messages: Record<string, unknown>[] = [];
+    const timer = setTimeout(
+      () => reject(new Error("Timeout collecting messages")),
+      timeout
+    );
+    const handler = (e: MessageEvent) => {
+      if (typeof e.data !== "string") return;
+
+      const msg = JSON.parse(e.data) as Record<string, unknown>;
+      messages.push(msg);
+      if (predicate(msg)) {
+        clearTimeout(timer);
+        ws.removeEventListener("message", handler);
+        resolve(messages);
+      }
+    };
+    ws.addEventListener("message", handler);
+  });
+}
+
 // --- Tests ---
 
 describe("VoiceAgent — protocol", () => {
@@ -634,6 +660,38 @@ async function connectEmptyWS(path: string) {
 }
 
 describe("VoiceAgent — empty response handling", () => {
+  it("does not emit assistant transcript events for an empty stream", async () => {
+    const { ws } = await connectEmptyWS(uniqueEmptyPath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, {
+      type: "_set_response_mode",
+      value: "empty_stream"
+    });
+    await waitForType(ws, "_ack");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const messages = await collectMessagesUntil(
+      ws,
+      (msg) => msg.type === "error"
+    );
+
+    expect(messages).toContainEqual({
+      type: "error",
+      message: "No response generated"
+    });
+    expect(messages.map((m) => m.type)).not.toContain("transcript_start");
+    expect(messages.map((m) => m.type)).not.toContain("transcript_end");
+
+    ws.close();
+  });
+
   it("sends error and does not save message when onTurn returns empty string", async () => {
     const { ws } = await connectEmptyWS(uniqueEmptyPath());
     await waitForStatus(ws, "idle");
@@ -646,9 +704,18 @@ describe("VoiceAgent — empty response handling", () => {
       ws.send(new ArrayBuffer(5000));
     }
 
-    // Should get an error message about empty response
-    const error = (await waitForType(ws, "error")) as Record<string, unknown>;
-    expect(error.message).toBe("No response generated");
+    // Should get an error message about empty response without creating an
+    // assistant transcript entry.
+    const messages = await collectMessagesUntil(
+      ws,
+      (msg) => msg.type === "error"
+    );
+    expect(messages).toContainEqual({
+      type: "error",
+      message: "No response generated"
+    });
+    expect(messages.map((m) => m.type)).not.toContain("transcript_start");
+    expect(messages.map((m) => m.type)).not.toContain("transcript_end");
 
     // Should go back to listening
     await waitForStatus(ws, "listening");
@@ -677,25 +744,10 @@ describe("VoiceAgent — empty response handling", () => {
     }
 
     // Collect all messages until we get back to listening
-    const messages: Record<string, unknown>[] = [];
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error("Timeout collecting messages")),
-        5000
-      );
-      const handler = (e: MessageEvent) => {
-        if (typeof e.data === "string") {
-          const msg = JSON.parse(e.data);
-          messages.push(msg);
-          if (msg.type === "status" && msg.status === "listening") {
-            clearTimeout(timer);
-            ws.removeEventListener("message", handler);
-            resolve();
-          }
-        }
-      };
-      ws.addEventListener("message", handler);
-    });
+    const messages = await collectMessagesUntil(
+      ws,
+      (msg) => msg.type === "status" && msg.status === "listening"
+    );
 
     // Should NOT have received metrics
     const types = messages.map((m) => m.type);

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -645,25 +645,43 @@ export function withVoice<TBase extends AgentLike>(
           }
           this.#sendJSON(connection, { type: "status", status: "listening" });
         } else {
-          this.#sendJSON(connection, {
-            type: "transcript_start",
-            role: "assistant"
-          });
           let fullText = "";
-          for await (const token of iterateText(turnResult)) {
-            if (signal.aborted) break;
-            fullText += token;
+          let pendingText = "";
+          let transcriptStarted = false;
+
+          const sendAssistantDelta = (token: string) => {
+            if (!transcriptStarted) {
+              pendingText += token;
+              if (pendingText.trim().length === 0) return;
+
+              this.#sendJSON(connection, {
+                type: "transcript_start",
+                role: "assistant"
+              });
+              transcriptStarted = true;
+              token = pendingText;
+              pendingText = "";
+            }
+
             this.#sendJSON(connection, {
               type: "transcript_delta",
               text: token
             });
+          };
+
+          for await (const token of iterateText(turnResult)) {
+            if (signal.aborted) break;
+            fullText += token;
+            sendAssistantDelta(token);
           }
-          this.#sendJSON(connection, {
-            type: "transcript_end",
-            text: fullText
-          });
 
           if (fullText && fullText.trim().length > 0) {
+            if (transcriptStarted) {
+              this.#sendJSON(connection, {
+                type: "transcript_end",
+                text: fullText
+              });
+            }
             this.saveMessage("assistant", fullText);
           }
           this.#sendJSON(connection, { type: "status", status: "idle" });
@@ -788,6 +806,10 @@ export function withVoice<TBase extends AgentLike>(
       if (typeof response === "string") {
         const llmMs = Date.now() - llmStart;
 
+        if (response.trim().length === 0) {
+          return { text: response, llmMs, ttsMs: 0, firstAudioMs: 0 };
+        }
+
         this.#sendJSON(connection, {
           type: "transcript_start",
           role: "assistant"
@@ -833,6 +855,8 @@ export function withVoice<TBase extends AgentLike>(
       const chunker = new SentenceChunker();
       const ttsQueue: AsyncIterable<ArrayBuffer>[] = [];
       let fullText = "";
+      let pendingTranscriptText = "";
+      let transcriptStarted = false;
       let firstAudioSentAt: number | null = null;
       let cumulativeTtsMs = 0;
 
@@ -929,16 +953,28 @@ export function withVoice<TBase extends AgentLike>(
         notifyDrain();
       };
 
-      this.#sendJSON(connection, {
-        type: "transcript_start",
-        role: "assistant"
-      });
+      const sendAssistantDelta = (token: string) => {
+        if (!transcriptStarted) {
+          pendingTranscriptText += token;
+          if (pendingTranscriptText.trim().length === 0) return;
+
+          this.#sendJSON(connection, {
+            type: "transcript_start",
+            role: "assistant"
+          });
+          transcriptStarted = true;
+          token = pendingTranscriptText;
+          pendingTranscriptText = "";
+        }
+
+        this.#sendJSON(connection, { type: "transcript_delta", text: token });
+      };
 
       for await (const token of tokenStream) {
         if (signal.aborted) break;
 
         fullText += token;
-        this.#sendJSON(connection, { type: "transcript_delta", text: token });
+        sendAssistantDelta(token);
 
         const sentences = chunker.add(token);
         for (const sentence of sentences) {
@@ -955,7 +991,9 @@ export function withVoice<TBase extends AgentLike>(
 
       streamComplete = true;
       notifyDrain();
-      this.#sendJSON(connection, { type: "transcript_end", text: fullText });
+      if (transcriptStarted) {
+        this.#sendJSON(connection, { type: "transcript_end", text: fullText });
+      }
 
       await drainPromise;
 


### PR DESCRIPTION
Handles cases where the assistant produces no response text, ensuring that empty transcript events are not emitted and errors are reported correctly. Also tests.

Follows the implementation direction from and fixes #1293.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->