### PR TITLE
Fix generated workflow instance IDs

### DIFF
--- a/.changeset/fix-run-workflow-default-id.md
+++ b/.changeset/fix-run-workflow-default-id.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Ensure Agent-generated workflow instance IDs always satisfy the Workflows runtime ID validator.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -8091,8 +8091,8 @@ export class Agent<
       );
     }
 
-    // Generate workflow ID if not provided
-    const workflowId = options?.id ?? nanoid();
+    // Workflows instance IDs must start with [a-zA-Z0-9_].
+    const workflowId = options?.id ?? `wf_${nanoid()}`;
 
     // Inject agent identity and workflow name into params
     const augmentedParams = {

--- a/packages/agents/src/tests/agents/workflow.ts
+++ b/packages/agents/src/tests/agents/workflow.ts
@@ -230,6 +230,13 @@ export class TestWorkflowAgent extends Agent {
     });
   }
 
+  // Start a simple workflow using the Agent's generated default ID
+  async runSimpleWorkflowTestWithDefaultId(params: {
+    value: string;
+  }): Promise<string> {
+    return this.runWorkflow("SIMPLE_WORKFLOW", params);
+  }
+
   // Send an event to a workflow
   async sendApprovalEvent(
     workflowId: string,

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -260,6 +260,16 @@ describe("workflow operations", () => {
       );
     });
 
+    it("should generate valid default workflow IDs", async () => {
+      const agentStub = await getTestAgent("workflow-default-id-test");
+
+      const workflowId = await agentStub.runSimpleWorkflowTestWithDefaultId({
+        value: "default-id"
+      });
+
+      expect(workflowId).toMatch(/^wf_[a-zA-Z0-9_-]+$/);
+    });
+
     it("should migrate workflow binding names", async () => {
       const agentStub = await getTestAgent("workflow-migrate-test");
 


### PR DESCRIPTION
## Summary

- Prefix Agent-generated `runWorkflow()` instance IDs with `wf_` so the default ID path always starts with a character accepted by the Workflows runtime validator.
- Preserve backwards compatibility for callers that pass `options.id`; explicit workflow IDs are still sent through unchanged.
- Add regression coverage that starts a workflow without an explicit ID and asserts the generated ID matches the valid Workflows ID shape.
- Add a patch changeset for the published `agents` package.

Fixes #1542.

## Test plan

- `npm run test:workers -- src/tests/workflow.test.ts` from `packages/agents`
- `npm run check` from the repository root

## Notes

The bug came from `nanoid()` using an alphabet that includes `-`. Since Workflows rejects instance IDs whose first character is `-`, the old default path could fail nondeterministically for callers that did not provide an explicit workflow ID.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->