### PR TITLE
Fix session auto-compaction token estimates

### DIFF
--- a/.changeset/bright-timers-compact.md
+++ b/.changeset/bright-timers-compact.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Improve session auto-compaction estimates by including the Session-managed frozen system prompt, support custom token counters, and expose an auto-compaction error callback.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -75,14 +75,15 @@ const session = new Session(new AgentSessionProvider(this), {
 
 All builder methods return `this` for chaining. Order does not matter — providers are resolved lazily on first use.
 
-| Method                          | Description                                                                                                                                                   |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Session.create(agent)`         | Static factory. `agent` is any object with a `sql` tagged template method (i.e. your Agent/DO).                                                               |
-| `.forSession(sessionId)`        | Namespace this session by ID. Required for multi-session isolation when not using SessionManager. Context provider keys and storage are scoped to this ID.    |
-| `.withContext(label, options?)` | Add a context block. See [Context Blocks](#context-blocks).                                                                                                   |
-| `.withCachedPrompt(provider?)`  | Enable system prompt persistence. The prompt is frozen on first use and survives DO hibernation/eviction. Without an explicit provider, auto-wires to SQLite. |
-| `.onCompaction(fn)`             | Register a compaction function. See [Compaction](#compaction).                                                                                                |
-| `.compactAfter(tokenThreshold)` | Auto-compact when estimated token count exceeds the threshold. Checked after each `appendMessage()`. Requires `.onCompaction()`.                              |
+| Method                                    | Description                                                                                                                                                   |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Session.create(agent)`                   | Static factory. `agent` is any object with a `sql` tagged template method (i.e. your Agent/DO).                                                               |
+| `.forSession(sessionId)`                  | Namespace this session by ID. Required for multi-session isolation when not using SessionManager. Context provider keys and storage are scoped to this ID.    |
+| `.withContext(label, options?)`           | Add a context block. See [Context Blocks](#context-blocks).                                                                                                   |
+| `.withCachedPrompt(provider?)`            | Enable system prompt persistence. The prompt is frozen on first use and survives DO hibernation/eviction. Without an explicit provider, auto-wires to SQLite. |
+| `.onCompaction(fn)`                       | Register a compaction function. See [Compaction](#compaction).                                                                                                |
+| `.compactAfter(tokenThreshold, options?)` | Auto-compact when estimated token count exceeds the threshold. Checked after each `appendMessage()`. Requires `.onCompaction()`.                              |
+| `.onCompactionError(handler)`             | Handle errors from automatic compaction. Handler failures are swallowed so message writes remain non-fatal.                                                   |
 
 ### Messages
 
@@ -404,7 +405,28 @@ const overlays = await session.getCompactions();
 
 When `.compactAfter(threshold)` is set, `appendMessage()` checks the estimated token count after each write. If it exceeds the threshold, `compact()` is called automatically. Auto-compaction failure is non-fatal — the message is already saved.
 
-> **Note:** Token estimation is heuristic (not tiktoken). It uses `max(chars/4, words*1.3)` with 4 tokens per-message overhead. This is intentional — tiktoken would add 80-120MB heap overhead, which exceeds Cloudflare Workers' 128MB limit.
+By default, the estimate includes stored message parts plus the Session-managed frozen system prompt. That means context blocks and cached prompts managed by `Session` contribute to the threshold. The estimate does not include framework-specific prompt additions or tool schema serialization that happen outside `Session`, such as Think's final capability prompt and tool catalog.
+
+Use `tokenCounter` when you have model-reported usage or your own tokenizer:
+
+```typescript
+const session = Session.create(this)
+  .onCompaction(myCompactFn)
+  .compactAfter(100_000, {
+    tokenCounter: async ({ messages, systemPrompt, contextBlocks }) => {
+      return estimateWithYourTokenizer({
+        messages,
+        systemPrompt,
+        contextBlocks
+      });
+    }
+  })
+  .onCompactionError((err) => {
+    console.warn("Auto-compaction failed", err);
+  });
+```
+
+> **Note:** The default token estimation is heuristic (not tiktoken). It uses `max(chars/4, words*1.3)` with 4 tokens per-message overhead, and also applies the string heuristic to the Session-managed system prompt. This is intentional — tiktoken would add 80-120MB heap overhead, which exceeds Cloudflare Workers' 128MB limit.
 
 > **Gotcha:** Compaction is iterative but single-overlay. Each new compaction extends from the earliest existing compaction's `fromMessageId` to the new end. So you always have at most one active compaction overlay per session, and it keeps growing. The previous compaction rows remain in the database but are superseded by the latest one (which covers a wider range). `getCompactions()` returns all of them, but `getHistory()` applies the latest one.
 
@@ -432,14 +454,15 @@ Context blocks, prompt caching, and compaction settings are propagated to all se
 
 ### Builder Methods
 
-| Method                          | Description                                                                                                              |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `SessionManager.create(agent)`  | Static factory.                                                                                                          |
-| `.withContext(label, options?)` | Add context block template for all sessions.                                                                             |
-| `.withCachedPrompt(provider?)`  | Enable prompt persistence for all sessions.                                                                              |
-| `.onCompaction(fn)`             | Register compaction function for all sessions.                                                                           |
-| `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions.                                                                                 |
-| `.withSearchableHistory(label)` | Add a cross-session searchable history block to every session. The model can search past conversations from any session. |
+| Method                                    | Description                                                                                                              |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `SessionManager.create(agent)`            | Static factory.                                                                                                          |
+| `.withContext(label, options?)`           | Add context block template for all sessions.                                                                             |
+| `.withCachedPrompt(provider?)`            | Enable prompt persistence for all sessions.                                                                              |
+| `.onCompaction(fn)`                       | Register compaction function for all sessions.                                                                           |
+| `.compactAfter(tokenThreshold, options?)` | Auto-compact threshold for all sessions. Supports the same `tokenCounter` option as `Session`.                           |
+| `.onCompactionError(handler)`             | Handle automatic compaction errors for managed sessions.                                                                 |
+| `.withSearchableHistory(label)`           | Add a cross-session searchable history block to every session. The model can search past conversations from any session. |
 
 ### Session Lifecycle
 

--- a/packages/agents/src/experimental/memory/session/context.ts
+++ b/packages/agents/src/experimental/memory/session/context.ts
@@ -505,7 +505,7 @@ export class ContextBlocks {
     return this.captureSnapshot();
   }
 
-  private captureSnapshot(): string {
+  private renderPrompt(): string {
     const parts: string[] = [];
     const sep = "═".repeat(46);
 
@@ -534,7 +534,11 @@ export class ContextBlocks {
       parts.push(`${sep}\n${header}\n${sep}\n${block.content}`);
     }
 
-    this.snapshot = parts.join("\n\n");
+    return parts.join("\n\n");
+  }
+
+  private captureSnapshot(): string {
+    this.snapshot = this.renderPrompt();
     return this.snapshot;
   }
 
@@ -598,6 +602,28 @@ export class ContextBlocks {
     }
 
     return prompt;
+  }
+
+  /**
+   * Return the prompt text used for token estimation without persisting a new
+   * frozen prompt to the prompt store.
+   *
+   * This still reads an existing cached prompt when present, so estimates match
+   * the prompt that inference would reuse. If no cached prompt exists, it loads
+   * providers and renders the current blocks without freezing the snapshot.
+   */
+  async getSystemPromptForEstimate(): Promise<string> {
+    if (this.snapshot !== null) {
+      return this.snapshot;
+    }
+
+    if (this.promptStore) {
+      const stored = await this.promptStore.get();
+      if (stored !== null) return stored;
+    }
+
+    if (!this.loaded) await this.load();
+    return this.renderPrompt();
   }
 
   /**

--- a/packages/agents/src/experimental/memory/session/index.ts
+++ b/packages/agents/src/experimental/memory/session/index.ts
@@ -62,7 +62,11 @@ export { AgentSearchProvider, isSearchProvider } from "./search";
 export type { SkillProvider } from "./skills";
 export { isSkillProvider, R2SkillProvider } from "./skills";
 export type {
+  CompactAfterOptions,
+  CompactionErrorHandler,
   SessionMessage,
   SessionMessagePart,
-  SessionOptions
+  SessionOptions,
+  SessionTokenCounter,
+  SessionTokenCounterInput
 } from "./types";

--- a/packages/agents/src/experimental/memory/session/manager.ts
+++ b/packages/agents/src/experimental/memory/session/manager.ts
@@ -14,7 +14,12 @@ import type { StoredCompaction } from "./provider";
 import type { SqlProvider } from "./providers/agent";
 import type { SearchProvider } from "./search";
 import { Session, type SessionContextOptions } from "./session";
-import type { SessionMessage } from "./types";
+import type {
+  CompactAfterOptions,
+  CompactionErrorHandler,
+  SessionMessage,
+  SessionTokenCounter
+} from "./types";
 
 export interface SessionInfo {
   id: string;
@@ -46,6 +51,8 @@ export class SessionManager {
     | ((messages: SessionMessage[]) => Promise<CompactResult | null>)
     | null;
   private _tokenThreshold?: number;
+  private _tokenCounter?: SessionTokenCounter;
+  private _compactionErrorHandler?: CompactionErrorHandler;
   private _sessions = new Map<string, Session>();
   private _historyLabel?: string;
   private _tableReady = false;
@@ -80,6 +87,8 @@ export class SessionManager {
     mgr._pending = [];
     mgr._compactionFn = null;
     mgr._tokenThreshold = undefined;
+    mgr._tokenCounter = undefined;
+    mgr._compactionErrorHandler = undefined;
     mgr._sessions = new Map();
     mgr._tableReady = false;
     mgr._ready = false;
@@ -113,8 +122,19 @@ export class SessionManager {
    * Auto-compact when estimated token count exceeds the threshold.
    * Propagated to all sessions. Requires `onCompaction()`.
    */
-  compactAfter(tokenThreshold: number): this {
+  compactAfter(tokenThreshold: number, options?: CompactAfterOptions): this {
     this._tokenThreshold = tokenThreshold;
+    if (options?.tokenCounter) {
+      this._tokenCounter = options.tokenCounter;
+    }
+    return this;
+  }
+
+  /**
+   * Handle failures from automatic compaction in managed sessions.
+   */
+  onCompactionError(handler: CompactionErrorHandler): this {
+    this._compactionErrorHandler = handler;
     return this;
   }
 
@@ -213,7 +233,12 @@ export class SessionManager {
         s.onCompaction(this._compactionFn);
       }
       if (this._tokenThreshold != null) {
-        s.compactAfter(this._tokenThreshold);
+        s.compactAfter(this._tokenThreshold, {
+          tokenCounter: this._tokenCounter
+        });
+      }
+      if (this._compactionErrorHandler) {
+        s.onCompactionError(this._compactionErrorHandler);
       }
       session = s;
       this._sessions.set(sessionId, session);

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -4,7 +4,13 @@
 
 import type { ToolSet } from "ai";
 import type { SessionProvider, StoredCompaction } from "./provider";
-import type { SessionMessage, SessionOptions } from "./types";
+import type {
+  CompactAfterOptions,
+  CompactionErrorHandler,
+  SessionMessage,
+  SessionOptions,
+  SessionTokenCounter
+} from "./types";
 import {
   ContextBlocks,
   type ContextBlock,
@@ -14,7 +20,7 @@ import {
 import { AgentSessionProvider, type SqlProvider } from "./providers/agent";
 import { AgentContextProvider } from "./providers/agent-context";
 import type { CompactResult } from "../utils/compaction-helpers";
-import { estimateMessageTokens } from "../utils/tokens";
+import { estimateMessageTokens, estimateStringTokens } from "../utils/tokens";
 import { MessageType } from "../../../types";
 
 export type SessionContextOptions = Omit<ContextConfig, "label">;
@@ -71,6 +77,8 @@ export class Session {
     | ((messages: SessionMessage[]) => Promise<CompactResult | null>)
     | null;
   private _tokenThreshold?: number;
+  private _tokenCounter?: SessionTokenCounter;
+  private _compactionErrorHandler?: CompactionErrorHandler;
   private _ready = false;
   // Promise for the async skill restore kicked off during _ensureReady().
   // Every async public method awaits this before touching storage or
@@ -87,6 +95,8 @@ export class Session {
       options?.context ?? [],
       options?.promptStore
     );
+    this._tokenCounter = options?.tokenCounter;
+    this._compactionErrorHandler = options?.onCompactionError;
     this._ready = true;
   }
 
@@ -166,9 +176,27 @@ export class Session {
   /**
    * Auto-compact when estimated token count exceeds the threshold.
    * Checked after each `appendMessage`. Requires `onCompaction()`.
+   *
+   * By default this uses a Workers-safe heuristic over stored messages plus
+   * the Session-managed frozen system prompt. Provide `tokenCounter` when you
+   * have model-reported usage or a tokenizer and need a stricter budget.
    */
-  compactAfter(tokenThreshold: number): this {
+  compactAfter(tokenThreshold: number, options?: CompactAfterOptions): this {
     this._tokenThreshold = tokenThreshold;
+    if (options?.tokenCounter) {
+      this._tokenCounter = options.tokenCounter;
+    }
+    return this;
+  }
+
+  /**
+   * Handle failures from the automatic `compactAfter()` trigger.
+   *
+   * Manual `compact()` still reports errors through the existing session error
+   * broadcast path.
+   */
+  onCompactionError(handler: CompactionErrorHandler): this {
+    this._compactionErrorHandler = handler;
     return this;
   }
 
@@ -393,11 +421,64 @@ export class Session {
     this._broadcaster.broadcast(JSON.stringify({ type, ...data }));
   }
 
+  private _shouldEstimateTokens(): boolean {
+    return Boolean(
+      this._broadcaster || (this._tokenThreshold != null && this._compactionFn)
+    );
+  }
+
+  private async _estimateTokenCount(): Promise<number> {
+    const messages = await this.getHistory();
+    const systemPrompt = await this.context.getSystemPromptForEstimate();
+    const contextBlocks = this.context.getBlocks();
+
+    if (this._tokenCounter) {
+      const estimate = await this._tokenCounter({
+        messages,
+        systemPrompt,
+        contextBlocks
+      });
+      return Number.isFinite(estimate) ? Math.max(0, Math.ceil(estimate)) : 0;
+    }
+
+    return estimateMessageTokens(messages) + estimateStringTokens(systemPrompt);
+  }
+
+  private async _handleAutoCompactionError(error: unknown): Promise<void> {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (this._compactionErrorHandler) {
+      try {
+        await this._compactionErrorHandler(error);
+      } catch (handlerError) {
+        const handlerMessage =
+          handlerError instanceof Error
+            ? handlerError.message
+            : String(handlerError);
+        console.warn(
+          `Session auto-compaction error handler failed: ${handlerMessage}`
+        );
+      }
+    } else {
+      console.warn(`Session auto-compaction failed: ${message}`);
+    }
+
+    this._emitError(message);
+  }
+
   private async _emitStatus(
     phase: "idle" | "compacting",
     extra?: Record<string, unknown>
   ): Promise<number> {
-    const tokenEstimate = estimateMessageTokens(await this.getHistory());
+    let tokenEstimate = 0;
+    if (this._shouldEstimateTokens()) {
+      try {
+        tokenEstimate = await this._estimateTokenCount();
+      } catch (err) {
+        await this._handleAutoCompactionError(err);
+      }
+    }
+
     this._broadcast(MessageType.CF_AGENT_SESSION, {
       phase,
       tokenEstimate,
@@ -450,8 +531,9 @@ export class Session {
     ) {
       try {
         compacted = Boolean(await this.compact());
-      } catch {
+      } catch (err) {
         // Auto-compact failure is non-fatal — message is already appended
+        await this._handleAutoCompactionError(err);
       }
     }
 

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -430,9 +430,12 @@ export class Session {
   private async _estimateTokenCount(): Promise<number> {
     const messages = await this.getHistory();
     const systemPrompt = await this.context.getSystemPromptForEstimate();
-    const contextBlocks = this.context.getBlocks();
 
     if (this._tokenCounter) {
+      if (!this.context.isLoaded()) {
+        await this.context.load();
+      }
+      const contextBlocks = this.context.getBlocks();
       const estimate = await this._tokenCounter({
         messages,
         systemPrompt,

--- a/packages/agents/src/experimental/memory/session/types.ts
+++ b/packages/agents/src/experimental/memory/session/types.ts
@@ -2,7 +2,11 @@
  * Session Types
  */
 
-import type { ContextConfig, WritableContextProvider } from "./context";
+import type {
+  ContextBlock,
+  ContextConfig,
+  WritableContextProvider
+} from "./context";
 
 /**
  * Minimal message part shape used by Session internals.
@@ -11,6 +15,7 @@ import type { ContextConfig, WritableContextProvider } from "./context";
 export interface SessionMessagePart {
   type: string;
   text?: string;
+  reasoning?: string;
   toolCallId?: string;
   toolName?: string;
   input?: unknown;
@@ -18,6 +23,34 @@ export interface SessionMessagePart {
   state?: string;
   result?: unknown;
 }
+
+export interface SessionTokenCounterInput {
+  /** Messages returned by `session.getHistory()` for the active branch. */
+  messages: SessionMessage[];
+
+  /** Frozen system prompt managed by the Session context system. */
+  systemPrompt: string;
+
+  /** Loaded context blocks that were used to build `systemPrompt`. */
+  contextBlocks: ContextBlock[];
+}
+
+export type SessionTokenCounter = (
+  input: SessionTokenCounterInput
+) => number | Promise<number>;
+
+export interface CompactAfterOptions {
+  /**
+   * Override the token estimate used by auto-compaction and status broadcasts.
+   *
+   * The default is a Workers-safe heuristic over message parts plus the
+   * Session-managed frozen system prompt. Callers that have model-reported
+   * usage or a tokenizer can provide a more precise counter here.
+   */
+  tokenCounter?: SessionTokenCounter;
+}
+
+export type CompactionErrorHandler = (error: unknown) => void | Promise<void>;
 
 /**
  * Minimal message shape used by Session internals.
@@ -40,4 +73,10 @@ export interface SessionOptions {
 
   /** Provider for persisting the frozen system prompt. */
   promptStore?: WritableContextProvider;
+
+  /** Custom token counter for auto-compaction/status estimates. */
+  tokenCounter?: SessionTokenCounter;
+
+  /** Called when automatic compaction fails after a threshold trigger. */
+  onCompactionError?: CompactionErrorHandler;
 }

--- a/packages/agents/src/experimental/memory/utils/tokens.ts
+++ b/packages/agents/src/experimental/memory/utils/tokens.ts
@@ -49,10 +49,21 @@ export function estimateStringTokens(text: string): number {
   return Math.ceil(Math.max(charEstimate, wordEstimate));
 }
 
+function estimateUnknownTokens(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "string") return estimateStringTokens(value);
+
+  try {
+    return estimateStringTokens(JSON.stringify(value));
+  } catch {
+    return estimateStringTokens(String(value));
+  }
+}
+
 /**
  * Estimate total token count for an array of UIMessages.
  *
- * Walks each message's parts (text, tool invocations, tool results)
+ * Walks each message's parts (text, reasoning, tool invocations, tool results)
  * and applies per-message overhead.
  *
  * This is a heuristic. Do not use where exact counts are required.
@@ -62,21 +73,18 @@ export function estimateMessageTokens(messages: SessionMessage[]): number {
   for (const msg of messages) {
     tokens += TOKENS_PER_MESSAGE;
     for (const part of msg.parts) {
-      if (part.type === "text") {
-        tokens += estimateStringTokens(
-          (part as { type: "text"; text: string }).text
-        );
+      if (part.type === "text" || part.type === "reasoning") {
+        tokens += estimateUnknownTokens(part.text ?? part.reasoning);
       } else if (
         part.type.startsWith("tool-") ||
         part.type === "dynamic-tool"
       ) {
-        const toolPart = part as { input?: unknown; output?: unknown };
-        if (toolPart.input) {
-          tokens += estimateStringTokens(JSON.stringify(toolPart.input));
-        }
-        if (toolPart.output) {
-          tokens += estimateStringTokens(JSON.stringify(toolPart.output));
-        }
+        tokens += estimateUnknownTokens(part.input);
+        tokens += estimateUnknownTokens(part.output ?? part.result);
+      } else if (part.text !== undefined) {
+        tokens += estimateUnknownTokens(part.text);
+      } else if (part.result !== undefined) {
+        tokens += estimateUnknownTokens(part.result);
       }
     }
   }

--- a/packages/agents/src/tests/experimental/memory/session/session.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/session.test.ts
@@ -20,6 +20,7 @@ import {
   createCompactFunction,
   type CompactResult
 } from "../../../../experimental/memory/utils/compaction-helpers";
+import { estimateMessageTokens } from "../../../../experimental/memory/utils/tokens";
 
 // ── Test helpers ────────────────────────────────────────────────
 
@@ -916,6 +917,384 @@ describe("Session.compact()", () => {
     });
 
     expect(messages).toHaveLength(1);
+  });
+
+  it("appendMessage includes session system prompt in auto-compaction estimate", async () => {
+    let compactCalled = false;
+    const messages: SessionMessage[] = [];
+    const compactions: StoredCompaction[] = [];
+    const storage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: (summary, fromMessageId, toMessageId) => {
+        const compaction = {
+          id: "c1",
+          summary,
+          fromMessageId,
+          toMessageId,
+          createdAt: ""
+        };
+        compactions.push(compaction);
+        return compaction;
+      },
+      getCompactions: () => compactions
+    };
+    const session = new Session(storage, {
+      context: [
+        {
+          label: "big",
+          provider: new ReadonlyBlockProvider("x".repeat(400))
+        }
+      ]
+    })
+      .onCompaction(async () => {
+        compactCalled = true;
+        return {
+          fromMessageId: "m0",
+          toMessageId: "m1",
+          summary: "context-triggered"
+        };
+      })
+      .compactAfter(50);
+
+    messages.push({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "short" }]
+    });
+
+    await session.appendMessage({
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: "text", text: "ok" }]
+    });
+
+    expect(compactCalled).toBe(true);
+    expect(compactions[0].summary).toBe("context-triggered");
+  });
+
+  it("auto-compaction estimates do not persist a new cached prompt", async () => {
+    const promptStore = new MemoryBlockProvider(null);
+    const messages: SessionMessage[] = [];
+    const storage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: () => {
+        throw new Error("should not compact");
+      },
+      getCompactions: () => []
+    };
+    const session = new Session(storage, {
+      context: [
+        {
+          label: "soul",
+          provider: new ReadonlyBlockProvider("do not persist during estimate")
+        }
+      ],
+      promptStore
+    })
+      .onCompaction(async () => null)
+      .compactAfter(1000000);
+
+    await session.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "hello" }]
+    });
+
+    expect(await promptStore.get()).toBeNull();
+  });
+
+  it("auto-compaction estimates reuse an existing frozen prompt snapshot", async () => {
+    let compactCalled = false;
+    const provider = new MemoryBlockProvider("x".repeat(400));
+    const messages: SessionMessage[] = [];
+    const compactions: StoredCompaction[] = [];
+    const storage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: (summary, fromMessageId, toMessageId) => {
+        const compaction = {
+          id: "c1",
+          summary,
+          fromMessageId,
+          toMessageId,
+          createdAt: ""
+        };
+        compactions.push(compaction);
+        return compaction;
+      },
+      getCompactions: () => compactions
+    };
+    const session = new Session(storage, {
+      context: [{ label: "memory", provider }]
+    })
+      .onCompaction(async () => {
+        compactCalled = true;
+        return {
+          fromMessageId: "m0",
+          toMessageId: "m1",
+          summary: "should not trigger from unfrozen changes"
+        };
+      })
+      .compactAfter(50);
+
+    await session.freezeSystemPrompt();
+    await provider.set("short");
+
+    messages.push({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "short" }]
+    });
+
+    await session.appendMessage({
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: "text", text: "ok" }]
+    });
+
+    expect(compactCalled).toBe(true);
+  });
+
+  it("compactAfter accepts a custom token counter", async () => {
+    let compactCalled = false;
+    let counterSawPrompt = false;
+    const messages: SessionMessage[] = [];
+    const compactions: StoredCompaction[] = [];
+    const storage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: (summary, fromMessageId, toMessageId) => {
+        const compaction = {
+          id: "c1",
+          summary,
+          fromMessageId,
+          toMessageId,
+          createdAt: ""
+        };
+        compactions.push(compaction);
+        return compaction;
+      },
+      getCompactions: () => compactions
+    };
+    const session = new Session(storage, {
+      context: [
+        {
+          label: "memory",
+          provider: new ReadonlyBlockProvider("remember this")
+        }
+      ]
+    })
+      .onCompaction(async () => {
+        compactCalled = true;
+        return {
+          fromMessageId: "m0",
+          toMessageId: "m1",
+          summary: "custom-counter"
+        };
+      })
+      .compactAfter(10, {
+        tokenCounter: ({ messages: history, systemPrompt, contextBlocks }) => {
+          counterSawPrompt =
+            history.length === 2 &&
+            systemPrompt.includes("remember this") &&
+            contextBlocks[0].label === "memory";
+          return 11;
+        }
+      });
+
+    messages.push({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "short" }]
+    });
+
+    await session.appendMessage({
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: "text", text: "ok" }]
+    });
+
+    expect(counterSawPrompt).toBe(true);
+    expect(compactCalled).toBe(true);
+  });
+
+  it("treats non-finite custom token counter results as zero", async () => {
+    let compactCalled = false;
+    const { session, setTokenThreshold } = createCompactableSession(
+      async (): Promise<CompactResult> => {
+        compactCalled = true;
+        return {
+          fromMessageId: "m0",
+          toMessageId: "m0",
+          summary: "should not happen"
+        };
+      }
+    );
+
+    session.compactAfter(1, {
+      tokenCounter: () => Number.NaN
+    });
+    setTokenThreshold(1);
+
+    await session.appendMessage({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "short" }]
+    });
+
+    expect(compactCalled).toBe(false);
+  });
+
+  it("counts reasoning parts in message token estimates", () => {
+    const withReasoning = estimateMessageTokens([
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "reasoning",
+            text: "Let me think through the constraints carefully."
+          }
+        ]
+      }
+    ]);
+
+    const withoutReasoning = estimateMessageTokens([
+      { id: "m1", role: "assistant", parts: [] }
+    ]);
+
+    expect(withReasoning).toBeGreaterThan(withoutReasoning);
+  });
+
+  it("calls onCompactionError when auto-compaction fails", async () => {
+    const errors: unknown[] = [];
+    const messages: SessionMessage[] = [];
+    const storage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: () => {
+        throw new Error("storage unavailable");
+      },
+      getCompactions: () => []
+    };
+    const session = new Session(storage)
+      .onCompaction(async () => ({
+        fromMessageId: "m0",
+        toMessageId: "m1",
+        summary: "will fail"
+      }))
+      .onCompactionError((err) => {
+        errors.push(err);
+      })
+      .compactAfter(1);
+
+    messages.push({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "enough tokens to trigger" }]
+    });
+
+    await session.appendMessage({
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: "text", text: "ok" }]
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+  });
+
+  it("keeps appendMessage non-fatal when onCompactionError throws", async () => {
+    const messages: SessionMessage[] = [];
+    const storage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: () => {
+        throw new Error("storage unavailable");
+      },
+      getCompactions: () => []
+    };
+    const session = new Session(storage)
+      .onCompaction(async () => ({
+        fromMessageId: "m0",
+        toMessageId: "m1",
+        summary: "will fail"
+      }))
+      .onCompactionError(() => {
+        throw new Error("logger unavailable");
+      })
+      .compactAfter(1);
+
+    messages.push({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "enough tokens to trigger" }]
+    });
+
+    await expect(
+      session.appendMessage({
+        id: "m1",
+        role: "assistant",
+        parts: [{ type: "text", text: "ok" }]
+      })
+    ).resolves.toBeUndefined();
+    expect(messages).toHaveLength(2);
   });
 
   it("iterative compaction with overlay messages in history", async () => {

--- a/packages/agents/src/tests/experimental/memory/session/session.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/session.test.ts
@@ -1156,6 +1156,87 @@ describe("Session.compact()", () => {
     expect(compactCalled).toBe(true);
   });
 
+  it("loads context blocks for a custom counter when prompt store is cached", async () => {
+    const counterInputs: Array<{
+      historyLength: number;
+      systemPrompt: string;
+      blockLabels: string[];
+      blockContents: string[];
+    }> = [];
+    const messages: SessionMessage[] = [];
+    const compactions: StoredCompaction[] = [];
+    const storage: SessionProvider = {
+      getMessage: (id) => messages.find((m) => m.id === id) ?? null,
+      getHistory: () => messages,
+      getLatestLeaf: () => messages[messages.length - 1] ?? null,
+      getBranches: () => [],
+      getPathLength: () => messages.length,
+      appendMessage: (msg) => {
+        messages.push(msg);
+      },
+      updateMessage: () => {},
+      deleteMessages: () => {},
+      clearMessages: () => {},
+      addCompaction: (summary, fromMessageId, toMessageId) => {
+        const compaction = {
+          id: "c1",
+          summary,
+          fromMessageId,
+          toMessageId,
+          createdAt: ""
+        };
+        compactions.push(compaction);
+        return compaction;
+      },
+      getCompactions: () => compactions
+    };
+    const session = new Session(storage, {
+      context: [
+        {
+          label: "memory",
+          provider: new ReadonlyBlockProvider("current block content")
+        }
+      ],
+      promptStore: new MemoryBlockProvider("cached frozen prompt")
+    })
+      .onCompaction(async () => ({
+        fromMessageId: "m0",
+        toMessageId: "m1",
+        summary: "cached prompt counter"
+      }))
+      .compactAfter(10, {
+        tokenCounter: ({ messages: history, systemPrompt, contextBlocks }) => {
+          counterInputs.push({
+            historyLength: history.length,
+            systemPrompt,
+            blockLabels: contextBlocks.map((block) => block.label),
+            blockContents: contextBlocks.map((block) => block.content)
+          });
+          return 11;
+        }
+      });
+
+    messages.push({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "short" }]
+    });
+
+    await session.appendMessage({
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: "text", text: "ok" }]
+    });
+
+    expect(counterInputs).toContainEqual({
+      historyLength: 2,
+      systemPrompt: "cached frozen prompt",
+      blockLabels: ["memory"],
+      blockContents: ["current block content"]
+    });
+    expect(compactions[0].summary).toBe("cached prompt counter");
+  });
+
   it("treats non-finite custom token counter results as zero", async () => {
     let compactCalled = false;
     const { session, setTokenThreshold } = createCompactableSession(


### PR DESCRIPTION
## Summary
- Include the Session-managed frozen system prompt in `compactAfter()` token estimates so context blocks and cached prompts are no longer invisible to auto-compaction.
- Add `compactAfter(threshold, { tokenCounter })` and `onCompactionError(handler)` for consumers that need model-reported/tokenizer-based accounting and observable, non-fatal auto-compaction failures.
- Broaden the heuristic message counter to include reasoning parts and common result fields, document the new semantics, and add regression coverage for prompt-estimate side effects and error handling.

## Details
The previous auto-compaction trigger only estimated stored message parts via `estimateMessageTokens(await getHistory())`. That made `compactAfter()` blind to Session-managed context blocks and cached prompts even though those are part of the prompt sent by consumers such as Think.

This PR keeps the default estimator Workers-friendly, but makes it less misleading by adding the Session-managed frozen system prompt to the estimate. The estimate path deliberately avoids creating a new cached prompt: it reuses an existing in-memory snapshot first, reads an existing prompt-store value if present, and otherwise renders loaded context blocks without persisting a prompt-store entry.

For callers that need stricter accounting, `compactAfter()` now accepts a `tokenCounter` option. The callback receives `messages`, `systemPrompt`, and `contextBlocks`, so consumers can plug in model usage, a tokenizer, or a service-specific upper-bound estimate. Non-finite custom counter results are treated as zero to avoid leaking `NaN`/`Infinity` into status and threshold logic.

Automatic compaction errors are now observable through `onCompactionError()`. The handler is best-effort: errors from the handler itself are swallowed after a warning so `appendMessage()` preserves the existing non-fatal auto-compaction behavior.

## Remaining Limits
- This remains Session-level best-effort accounting. It does not include framework-level prompt additions or tool schema serialization that happen outside `Session`, such as Think's final capability prompt and tool catalog.
- A precise pre-inference budget gate should live near the final inference assembly layer, where `{ system, messages, tools }` are known.

## Test Plan
- `npm --workspace packages/agents run test:workers -- src/tests/experimental/memory/session/session.test.ts` ✅
- `npx oxfmt --check docs/sessions.md .changeset/bright-timers-compact.md packages/agents/src/experimental/memory/session/context.ts packages/agents/src/experimental/memory/session/index.ts packages/agents/src/experimental/memory/session/manager.ts packages/agents/src/experimental/memory/session/session.ts packages/agents/src/experimental/memory/session/types.ts packages/agents/src/experimental/memory/utils/tokens.ts packages/agents/src/tests/experimental/memory/session/session.test.ts` ✅
- `npm run check` ✅


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->