### PR TITLE
Add declarative scheduled tasks and handlers to Think

### DIFF
--- a/.changeset/tiny-ravens-schedule.md
+++ b/.changeset/tiny-ravens-schedule.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": minor
+---
+
+Add declarative scheduled tasks for Think agents with a typed recurring DSL, timezone-aware reconciliation, and durable idempotent submissions.

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -141,6 +141,7 @@ driving the work and what the caller needs back.
 | A browser user sends chat messages                             | `useAgentChat` over the WebSocket chat protocol |
 | Server code can wait for the model response                    | `saveMessages()`                                |
 | Server code needs fast durable acceptance and later status     | `submitMessages()`                              |
+| Code should create recurring prompt-driven turns               | `getScheduledTasks()`                           |
 | Parent code needs direct streaming RPC to a specific child     | `subAgent(...).chat()`                          |
 | A parent agent delegates work to a retained child agent        | `agentTool()` or `runAgentTool()`               |
 | Surround a turn with idempotent app-owned side effects         | `startFiber()`                                  |
@@ -178,6 +179,8 @@ with retries per step, long waits, external events, or approvals.
 | `getModel()`            | throws                           | Return the `LanguageModel` to use                                               |
 | `getSystemPrompt()`     | `"You are a helpful assistant."` | System prompt (fallback when no context blocks)                                 |
 | `getTools()`            | `{}`                             | AI SDK `ToolSet` for the agentic loop                                           |
+| `getScheduledTasks()`   | `{}`                             | Code-declared recurring prompts                                                 |
+| `getDefaultTimezone()`  | `undefined`                      | Default timezone for wall-clock scheduled tasks                                 |
 | `maxSteps`              | `10`                             | Max tool-call rounds per turn                                                   |
 | `sendReasoning`         | `true`                           | Send reasoning chunks to chat clients                                           |
 | `configureSession()`    | identity                         | Add context blocks, compaction, search, skills — see [Sessions](../sessions.md) |
@@ -227,6 +230,49 @@ export class MyAgent extends Think<Env> {
   }
 }
 ```
+
+## Scheduled Tasks
+
+Use `getScheduledTasks()` when code should create recurring Think turns. Think
+reconciles the declarations on startup, stores a durable one-shot schedule for
+the next occurrence, and submits each occurrence through `submitMessages()` with
+a stable idempotency key.
+
+```typescript
+import { Think, defineScheduledTasks } from "@cloudflare/think";
+
+export class DigestAgent extends Think<Env> {
+  getDefaultTimezone() {
+    return "Europe/London";
+  }
+
+  getScheduledTasks() {
+    return defineScheduledTasks({
+      weeklyCommitReport: {
+        schedule: "every week on monday at 09:00",
+        prompt:
+          "Compile all my GitHub commits for the last week and send a concise summary."
+      },
+      workout: {
+        schedule: "every day at 08:00 in Europe/London",
+        prompt: "Start my workout."
+      }
+    });
+  }
+}
+```
+
+The DSL supports `every <n> minutes`, `every <n> hours`,
+`every day at HH:mm`, `every weekday at HH:mm`, and
+`every week on monday,wednesday at HH:mm`. Wall-clock schedules require either
+an inline timezone, a task `timezone`, or `getDefaultTimezone()`. If an alarm is
+late, Think runs the intended occurrence once and schedules the next future
+occurrence; it does not backfill missed runs.
+
+Use `getScheduledTasks()` for recurring prompt-driven turns. If your product
+lets users edit schedules at runtime, or a scheduled occurrence should start a
+deterministic Workflow rather than submit a prompt, keep that reconciliation in
+application code for now.
 
 ## Session Integration
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -141,7 +141,7 @@ driving the work and what the caller needs back.
 | A browser user sends chat messages                             | `useAgentChat` over the WebSocket chat protocol |
 | Server code can wait for the model response                    | `saveMessages()`                                |
 | Server code needs fast durable acceptance and later status     | `submitMessages()`                              |
-| Code should create recurring prompt-driven turns               | `getScheduledTasks()`                           |
+| Code should create recurring prompt-driven turns or handlers   | `getScheduledTasks()`                           |
 | Parent code needs direct streaming RPC to a specific child     | `subAgent(...).chat()`                          |
 | A parent agent delegates work to a retained child agent        | `agentTool()` or `runAgentTool()`               |
 | Surround a turn with idempotent app-owned side effects         | `startFiber()`                                  |
@@ -179,7 +179,7 @@ with retries per step, long waits, external events, or approvals.
 | `getModel()`            | throws                           | Return the `LanguageModel` to use                                               |
 | `getSystemPrompt()`     | `"You are a helpful assistant."` | System prompt (fallback when no context blocks)                                 |
 | `getTools()`            | `{}`                             | AI SDK `ToolSet` for the agentic loop                                           |
-| `getScheduledTasks()`   | `{}`                             | Code-declared recurring prompts                                                 |
+| `getScheduledTasks()`   | `{}`                             | Code-declared recurring prompts or handlers                                     |
 | `getDefaultTimezone()`  | `undefined`                      | Default timezone for wall-clock scheduled tasks                                 |
 | `maxSteps`              | `10`                             | Max tool-call rounds per turn                                                   |
 | `sendReasoning`         | `true`                           | Send reasoning chunks to chat clients                                           |
@@ -233,10 +233,10 @@ export class MyAgent extends Think<Env> {
 
 ## Scheduled Tasks
 
-Use `getScheduledTasks()` when code should create recurring Think turns. Think
-reconciles the declarations on startup, stores a durable one-shot schedule for
-the next occurrence, and submits each occurrence through `submitMessages()` with
-a stable idempotency key.
+Use `getScheduledTasks()` when code should create recurring Think turns or
+deterministic scheduled handlers. Think reconciles the declarations on startup,
+stores a durable one-shot schedule for the next occurrence, and re-arms the next
+occurrence after each run.
 
 ```typescript
 import { Think, defineScheduledTasks } from "@cloudflare/think";
@@ -256,6 +256,23 @@ export class DigestAgent extends Think<Env> {
       workout: {
         schedule: "every day at 08:00 in Europe/London",
         prompt: "Start my workout."
+      },
+      customerDigest: {
+        schedule: "every day at 09:00",
+        timezone: "America/New_York",
+        metadata: { workflowName: "customer-digest" },
+        retry: { maxAttempts: 3 },
+        handler: async ({
+          idempotencyKey,
+          scheduledFor,
+          scheduleKind,
+          timezone
+        }) => {
+          await this.env.DIGEST_WORKFLOW.create({
+            id: idempotencyKey,
+            params: { scheduledFor, scheduleKind, timezone }
+          });
+        }
       }
     });
   }
@@ -269,10 +286,23 @@ an inline timezone, a task `timezone`, or `getDefaultTimezone()`. If an alarm is
 late, Think runs the intended occurrence once and schedules the next future
 occurrence; it does not backfill missed runs.
 
-Use `getScheduledTasks()` for recurring prompt-driven turns. If your product
-lets users edit schedules at runtime, or a scheduled occurrence should start a
-deterministic Workflow rather than submit a prompt, keep that reconciliation in
-application code for now.
+Each task must define exactly one of `prompt` or `handler`. Prompt tasks create a
+durable submission with `submitMessages()`. Handler tasks receive
+`{ taskId, scheduledFor, scheduledForDate, occurrenceKey, idempotencyKey,
+schedule, scheduleKind, timezone, metadata }` and are intended for app-owned
+work such as creating a Workflow run or writing a run ledger. Delivery is
+at-least-once; use `idempotencyKey` or `occurrenceKey` for your own durable
+idempotency.
+
+Static declarations reconcile on startup. If `getScheduledTasks()` reads
+product-owned data that can change while the Durable Object is live, call
+`internal_reconcileScheduledTasks()` after updating that data. During
+reconciliation Think records the task row before creating the underlying Agent
+schedule, so a missing `schedule_id` is only a pending reconcile state and is
+repaired on the next reconcile. The task `retry` option retries the prompt or
+handler action before the failure is logged. The next occurrence is still
+scheduled after the action succeeds or exhausts its retries, so failed
+occurrences do not block future runs.
 
 ## Session Integration
 

--- a/docs/think/programmatic-submissions.md
+++ b/docs/think/programmatic-submissions.md
@@ -9,6 +9,11 @@ the turn and returns a submission record before inference runs.
 For a broader comparison with `chat()`, `saveMessages()`, and agent tools, see
 [Choosing a turn API](./index.md#choosing-a-turn-api).
 
+Declarative scheduled prompt tasks use the same durable submission path under
+the hood. Use `getScheduledTasks()` when the trigger is recurring and
+code-declared; use `submitMessages()` directly when an external caller or
+webhook creates one-off work.
+
 ## Why this exists
 
 Webhook handlers, RPC callers, and parent Workers often have strict timeout

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -211,7 +211,7 @@ await this.saveMessages((current) => [
 
 ### Scheduled responses
 
-Trigger a turn from a cron schedule:
+Trigger a recurring prompt turn with `getScheduledTasks()`:
 
 ```typescript
 export class MyAgent extends Think<Env> {
@@ -219,14 +219,14 @@ export class MyAgent extends Think<Env> {
     /* ... */
   }
 
-  async onScheduled() {
-    await this.saveMessages([
-      {
-        id: crypto.randomUUID(),
-        role: "user",
-        parts: [{ type: "text", text: "Generate the daily report." }]
+  getScheduledTasks() {
+    return {
+      dailyReport: {
+        schedule: "every day at 09:00",
+        timezone: "UTC",
+        prompt: "Generate the daily report."
       }
-    ]);
+    };
   }
 }
 ```

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -148,11 +148,29 @@ continue after the Workflow stops waiting.
 
 ## Boundary With Other Primitives
 
-Use scheduled tasks for recurring prompts:
+Use `getScheduledTasks()` for recurring prompt submissions or deterministic
+scheduled handlers:
 
 ```typescript
-async onScheduled() {
-  await this.saveMessages([{ role: "user", parts: [{ type: "text", text: "Daily summary" }] }]);
+getScheduledTasks() {
+  return {
+    dailySummary: {
+      schedule: "every day at 09:00",
+      timezone: "UTC",
+      prompt: "Generate the daily report."
+    },
+    dailyWorkflow: {
+      schedule: "every day at 09:00",
+      timezone: "UTC",
+      retry: { maxAttempts: 3 },
+      handler: async ({ idempotencyKey, scheduledFor, timezone }) => {
+        await this.env.REPORT_WORKFLOW.create({
+          id: idempotencyKey,
+          params: { scheduledFor, timezone }
+        });
+      }
+    }
+  };
 }
 ```
 

--- a/examples/think-submissions/README.md
+++ b/examples/think-submissions/README.md
@@ -2,7 +2,8 @@
 
 A focused demo of durable programmatic Think turns. It shows how to submit a
 message turn, receive an immediate durable ACK, retry safely with an
-idempotency key, inspect status later, and cancel active work.
+idempotency key, inspect status later, cancel active work, and declare a
+recurring scheduled task.
 
 ## Run
 
@@ -18,6 +19,8 @@ Open the dev URL and use the dashboard to:
 3. Watch the submission move through `pending`, `running`, and a terminal status.
 4. Retry with the same idempotency key and confirm no duplicate turn is created.
 5. Cancel a pending or running submission.
+6. Inspect the code-declared hourly scheduled task. To watch it fire quickly
+   during local development, temporarily change it to `every 5 minutes`.
 
 ## What It Demonstrates
 
@@ -40,6 +43,26 @@ const submission = await this.submitMessages(
 The caller can return `submission.submissionId` immediately, then poll or render
 `inspectSubmission()` / `listSubmissions()` later.
 
+The same durable submission path is used by declarative scheduled tasks:
+
+```ts
+getScheduledTasks(): ThinkScheduledTasks {
+  return {
+    hourlyQueueDigest: {
+      schedule: "every 1 hour",
+      prompt:
+        "Write a concise hourly reminder that durable background task queues should be checked for stuck or failed work."
+    }
+  };
+}
+```
+
+Think reconciles this declaration on startup, schedules the next occurrence, and
+submits each run with a stable idempotency key so retries do not duplicate work.
+The example uses an hourly cadence to avoid surprising model usage; shorten it
+locally if you want to watch automatic submissions appear while the dashboard is
+open.
+
 ## Server
 
 `src/server.ts` defines `TaskAgent extends Think` and exposes callable methods:
@@ -48,6 +71,7 @@ The caller can return `submission.submissionId` immediately, then poll or render
 - `inspectTask(submissionId)` wraps `inspectSubmission()`.
 - `listTasks(status?)` wraps `listSubmissions()`.
 - `cancelTask(submissionId)` wraps `cancelSubmission()`.
+- `getScheduledTasks()` declares an hourly background digest.
 
 ## Client
 
@@ -63,5 +87,7 @@ idempotent retry, queue status, cancellation, and terminal history.
 - Use `startFiber()` around the submission when the caller also owns external
   side effects, such as accepting a webhook once, restoring provider state, and
   posting a visible reply.
+- Use `getScheduledTasks()` when the same durable Think turn should be created
+  on a recurring schedule.
 - Use Workflows when the job is a multi-step process with retries, approvals,
   or long waits beyond one Think turn.

--- a/examples/think-submissions/src/client.tsx
+++ b/examples/think-submissions/src/client.tsx
@@ -198,7 +198,10 @@ function App() {
                 <Text size="xs" variant="secondary">
                   `submitMessages()` stores pending work before the model runs.
                   Retrying with the same idempotency key returns the existing
-                  submission instead of duplicating the chat turn.
+                  submission instead of duplicating the chat turn. This example
+                  also declares an hourly scheduled task; shorten it locally if
+                  you want to watch automatic background submissions appear in
+                  the same list.
                 </Text>
               </span>
             </div>

--- a/examples/think-submissions/src/server.ts
+++ b/examples/think-submissions/src/server.ts
@@ -2,6 +2,7 @@ import { callable, routeAgentRequest } from "agents";
 import { createWorkersAI } from "workers-ai-provider";
 import { Think } from "@cloudflare/think";
 import type {
+  ThinkScheduledTasks,
   ThinkSubmissionInspection,
   ThinkSubmissionStatus
 } from "@cloudflare/think";
@@ -23,6 +24,16 @@ export class TaskAgent extends Think<Env> {
       "You are a background task assistant.",
       "Respond with a concise status update and the final answer for the submitted task."
     ].join("\n");
+  }
+
+  getScheduledTasks(): ThinkScheduledTasks {
+    return {
+      hourlyQueueDigest: {
+        schedule: "every 1 hour",
+        prompt:
+          "Write a concise hourly reminder that durable background task queues should be checked for stuck or failed work."
+      }
+    };
   }
 
   @callable()

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -103,19 +103,66 @@ export class MyAgent extends Think<Env> {
 
 ### Configuration
 
-| Method / Property    | Default                            | Description                                     |
-| -------------------- | ---------------------------------- | ----------------------------------------------- |
-| `getModel()`         | throws                             | Return the `LanguageModel` to use               |
-| `getSystemPrompt()`  | careful assistant operating prompt | System prompt (fallback when no context blocks) |
-| `getTools()`         | `{}`                               | AI SDK `ToolSet` for the agentic loop           |
-| `maxSteps`           | `10`                               | Max tool-call rounds per turn (property)        |
-| `sendReasoning`      | `true`                             | Send reasoning chunks to chat clients           |
-| `configureSession()` | identity                           | Add context blocks, compaction, search, skills  |
-| `getExtensions()`    | `[]`                               | Sandboxed extension declarations (load order)   |
-| `extensionLoader`    | `undefined`                        | `WorkerLoader` binding — enables extensions     |
-| `chatRecovery`       | `true`                             | Wrap turns in `runFiber` for durable execution  |
+| Method / Property      | Default                            | Description                                     |
+| ---------------------- | ---------------------------------- | ----------------------------------------------- |
+| `getModel()`           | throws                             | Return the `LanguageModel` to use               |
+| `getSystemPrompt()`    | careful assistant operating prompt | System prompt (fallback when no context blocks) |
+| `getTools()`           | `{}`                               | AI SDK `ToolSet` for the agentic loop           |
+| `getScheduledTasks()`  | `{}`                               | Code-declared recurring prompts                 |
+| `getDefaultTimezone()` | `undefined`                        | Default timezone for wall-clock schedules       |
+| `maxSteps`             | `10`                               | Max tool-call rounds per turn (property)        |
+| `sendReasoning`        | `true`                             | Send reasoning chunks to chat clients           |
+| `configureSession()`   | identity                           | Add context blocks, compaction, search, skills  |
+| `getExtensions()`      | `[]`                               | Sandboxed extension declarations (load order)   |
+| `extensionLoader`      | `undefined`                        | `WorkerLoader` binding — enables extensions     |
+| `chatRecovery`         | `true`                             | Wrap turns in `runFiber` for durable execution  |
 
 On each turn, Think appends a small capability block to the assembled system prompt. The block is based on the tools available for that turn, so models learn about workspace tools, context-loading tools, extension tools, sandboxed execution, MCP/client tools, and delegated-agent tools only when they are actually exposed.
+
+### Scheduled tasks
+
+Use `getScheduledTasks()` for code-declared recurring prompts. Think reconciles
+these declarations on startup, stores durable one-shot schedules for the next
+occurrence, and runs each occurrence through `submitMessages()` with an
+idempotency key.
+
+```ts
+import { Think } from "@cloudflare/think";
+import type { ThinkScheduledTasks } from "@cloudflare/think";
+
+export class Assistant extends Think<Env> {
+  getDefaultTimezone() {
+    return "Europe/London";
+  }
+
+  getScheduledTasks(): ThinkScheduledTasks {
+    return {
+      weeklyCommitReport: {
+        schedule: "every week on monday at 09:00",
+        prompt:
+          "Compile all my GitHub commits for the last week and send an email to my boss."
+      },
+      workout: {
+        schedule: "every day at 08:00 in Europe/London",
+        prompt: "Start my workout."
+      }
+    };
+  }
+}
+```
+
+The DSL is intentionally small: `every <n> minutes`, `every <n> hours`,
+`every day at HH:mm`, `every weekday at HH:mm`, and
+`every week on monday,wednesday at HH:mm`. Wall-clock schedules require either
+an inline timezone, a task `timezone`, or `getDefaultTimezone()`. If an alarm is
+late, Think runs the intended occurrence once and schedules the next future
+occurrence; it does not backfill missed runs.
+
+The return type annotation gives TypeScript literal checks for schedule strings.
+If you prefer not to annotate the method, wrap the object with
+`defineScheduledTasks(...)` to keep the same checks. Think also validates
+scheduled tasks at runtime during startup reconciliation, so dynamically built
+objects still fail before schedules are persisted.
 
 ### Lifecycle hooks
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -121,10 +121,10 @@ On each turn, Think appends a small capability block to the assembled system pro
 
 ### Scheduled tasks
 
-Use `getScheduledTasks()` for code-declared recurring prompts. Think reconciles
-these declarations on startup, stores durable one-shot schedules for the next
-occurrence, and runs each occurrence through `submitMessages()` with an
-idempotency key.
+Use `getScheduledTasks()` for code-declared recurring prompts or deterministic
+scheduled handlers. Think reconciles these declarations on startup, stores
+durable one-shot schedules for the next occurrence, and re-arms the next
+occurrence after each run.
 
 ```ts
 import { Think } from "@cloudflare/think";
@@ -140,11 +140,28 @@ export class Assistant extends Think<Env> {
       weeklyCommitReport: {
         schedule: "every week on monday at 09:00",
         prompt:
-          "Compile all my GitHub commits for the last week and send an email to my boss."
+          "Compile all my GitHub commits for the last week and write a concise summary."
       },
       workout: {
         schedule: "every day at 08:00 in Europe/London",
         prompt: "Start my workout."
+      },
+      customerDigest: {
+        schedule: "every day at 09:00",
+        timezone: "America/New_York",
+        metadata: { workflowName: "customer-digest" },
+        retry: { maxAttempts: 3 },
+        handler: async ({
+          idempotencyKey,
+          scheduledFor,
+          scheduleKind,
+          timezone
+        }) => {
+          await this.env.DIGEST_WORKFLOW.create({
+            id: idempotencyKey,
+            params: { scheduledFor, scheduleKind, timezone }
+          });
+        }
       }
     };
   }
@@ -163,6 +180,24 @@ If you prefer not to annotate the method, wrap the object with
 `defineScheduledTasks(...)` to keep the same checks. Think also validates
 scheduled tasks at runtime during startup reconciliation, so dynamically built
 objects still fail before schedules are persisted.
+
+Each task must define exactly one of `prompt` or `handler`. Prompt tasks create a
+durable submission with `submitMessages()`. Handler tasks receive
+`{ taskId, scheduledFor, scheduledForDate, occurrenceKey, idempotencyKey,
+schedule, scheduleKind, timezone, metadata }` and are intended for app-owned
+work such as creating a Workflow run or writing a run ledger. Delivery is
+at-least-once; use `idempotencyKey` or `occurrenceKey` for your own durable
+idempotency.
+
+Static declarations reconcile on startup. If `getScheduledTasks()` reads
+product-owned data that can change while the Durable Object is live, call
+`internal_reconcileScheduledTasks()` after updating that data. During
+reconciliation Think records the task row before creating the underlying Agent
+schedule, so a `schedule_id` may be temporarily empty if the object is
+interrupted mid-reconcile; the next reconcile repairs that pending row. The
+task `retry` option retries the prompt or handler action before the failure is
+logged. The next occurrence is still scheduled after the action succeeds or
+exhausts its retries, so failed occurrences do not block future runs.
 
 ### Lifecycle hooks
 
@@ -399,6 +434,8 @@ Use browser chat through `useAgentChat` when a user drives the conversation. Use
 `saveMessages()` when server code controls the trigger and can wait for the
 model response. Use `submitMessages()` when a caller needs fast durable
 acceptance, idempotent retries, cancellation, and later status inspection.
+Use `getScheduledTasks()` when code should create recurring prompt submissions
+or deterministic scheduled handlers.
 
 Use `subAgent(...).chat()` for direct streaming RPC to a specific child when
 your code owns forwarding and replay policy. Use `agentTool()` or

--- a/packages/think/src/tests/agents/index.ts
+++ b/packages/think/src/tests/agents/index.ts
@@ -14,6 +14,7 @@ export {
   ThinkLegacyConfigMigrationAgent,
   ThinkConfigInSessionAgent,
   ThinkProgrammaticTestAgent,
+  ThinkScheduledTasksTestAgent,
   ThinkAsyncHookTestAgent,
   ThinkRecoveryTestAgent,
   ThinkNonRecoveryTestAgent,

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -22,6 +22,7 @@ import type {
   ThinkSubmissionStatus,
   SubmitMessagesResult,
   ThinkScheduledTask,
+  ThinkScheduledTaskContext,
   ThinkScheduledTasks,
   TurnContext,
   TurnConfig,
@@ -2770,7 +2771,10 @@ export class ThinkProgrammaticTestAgent extends Think {
 type ScheduledTaskConfigForTest = {
   schedule: string;
   timezone?: string;
-  prompt: string;
+  prompt?: string;
+  handler?: "record" | "throw" | "throw-once";
+  retry?: ThinkScheduledTask["retry"];
+  metadata?: Record<string, unknown>;
 };
 
 type DeclaredScheduledTaskRowForTest = {
@@ -2790,6 +2794,18 @@ type DeclaredScheduledTaskPayloadForTest = {
   scheduledFor: number;
 };
 
+type ScheduledTaskHandlerEventForTest = {
+  taskId: string;
+  scheduledFor: number;
+  scheduledForIso: string;
+  occurrenceKey: string;
+  idempotencyKey: string;
+  schedule: string;
+  scheduleKind: string;
+  timezone: string | null;
+  metadataJson: string | null;
+};
+
 export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
   override async getDefaultTimezone(): Promise<string | undefined> {
     return this.ctx.storage.get<string>("scheduledTasksDefaultTimezone");
@@ -2802,15 +2818,53 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
       )) ?? {};
     const tasks: ThinkScheduledTasks = {};
     for (const [taskId, task] of Object.entries(config)) {
+      const base = {
+        schedule: task.schedule as ThinkScheduledTask["schedule"],
+        ...(task.timezone !== undefined && { timezone: task.timezone }),
+        ...(task.retry !== undefined && { retry: task.retry }),
+        ...(task.metadata !== undefined && { metadata: task.metadata })
+      };
+      if (task.handler) {
+        tasks[taskId] = {
+          ...base,
+          handler: async (ctx: ThinkScheduledTaskContext) => {
+            const events =
+              (await this.ctx.storage.get<ScheduledTaskHandlerEventForTest[]>(
+                "scheduledTaskHandlerEvents"
+              )) ?? [];
+            events.push({
+              taskId: ctx.taskId,
+              scheduledFor: ctx.scheduledFor,
+              scheduledForIso: ctx.scheduledForDate.toISOString(),
+              occurrenceKey: ctx.occurrenceKey,
+              idempotencyKey: ctx.idempotencyKey,
+              schedule: ctx.schedule,
+              scheduleKind: ctx.scheduleKind,
+              timezone: ctx.timezone ?? null,
+              metadataJson:
+                ctx.metadata === undefined ? null : JSON.stringify(ctx.metadata)
+            });
+            await this.ctx.storage.put("scheduledTaskHandlerEvents", events);
+            if (
+              task.handler === "throw" ||
+              (task.handler === "throw-once" &&
+                events.filter((event) => event.taskId === ctx.taskId).length ===
+                  1)
+            ) {
+              throw new Error("scheduled handler failed");
+            }
+          }
+        } as ThinkScheduledTask;
+        continue;
+      }
       const prompt: ThinkScheduledTask["prompt"] =
         task.prompt === "__throw__"
           ? () => {
               throw new Error("scheduled prompt failed");
             }
-          : task.prompt;
+          : (task.prompt ?? "");
       tasks[taskId] = {
-        schedule: task.schedule as ThinkScheduledTask["schedule"],
-        ...(task.timezone !== undefined && { timezone: task.timezone }),
+        ...base,
         prompt
       } as ThinkScheduledTask;
     }
@@ -2832,11 +2886,7 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
   }
 
   async reconcileScheduledTasksForTest(): Promise<void> {
-    await (
-      this as unknown as {
-        _reconcileDeclaredScheduledTasks: () => Promise<void>;
-      }
-    )._reconcileDeclaredScheduledTasks();
+    await this.internal_reconcileScheduledTasks();
   }
 
   async reconcileScheduledTasksErrorForTest(): Promise<string> {
@@ -2914,6 +2964,34 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
 
   async listSchedulesForTest(): Promise<Schedule<unknown>[]> {
     return this.listSchedules();
+  }
+
+  async listScheduledTaskHandlerEventsForTest(): Promise<
+    ScheduledTaskHandlerEventForTest[]
+  > {
+    return (
+      (await this.ctx.storage.get<ScheduledTaskHandlerEventForTest[]>(
+        "scheduledTaskHandlerEvents"
+      )) ?? []
+    );
+  }
+
+  async clearDeclaredScheduleIdForTest(taskId: string): Promise<void> {
+    const row = (
+      this as unknown as {
+        _readDeclaredScheduledTaskRow(
+          taskId: string
+        ): DeclaredScheduledTaskRowForTest | null;
+      }
+    )._readDeclaredScheduledTaskRow(taskId);
+    if (!row) throw new Error("No declared schedule row");
+    if (row.schedule_id) await this.cancelSchedule(row.schedule_id);
+    this.sql`
+      UPDATE cf_think_scheduled_tasks
+      SET schedule_id = NULL
+      WHERE owner_key = ${row.owner_key}
+        AND task_id = ${taskId}
+    `;
   }
 
   async createUnrelatedScheduleForTest(): Promise<string> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel, UIMessage } from "ai";
 import { hasToolCall, Output, tool } from "ai";
-import { Think } from "../../think";
+import { defineScheduledTasks, Think } from "../../think";
 import { Agent } from "agents";
 import type {
   AgentToolEventMessage,
@@ -21,6 +21,8 @@ import type {
   ThinkSubmissionInspection,
   ThinkSubmissionStatus,
   SubmitMessagesResult,
+  ThinkScheduledTask,
+  ThinkScheduledTasks,
   TurnContext,
   TurnConfig,
   PrepareStepContext,
@@ -33,6 +35,7 @@ import type {
 } from "../../think";
 import { sanitizeMessage, enforceRowSizeLimit } from "agents/chat";
 import type { ClientToolSchema } from "agents/chat";
+import type { Schedule } from "agents";
 import { Session } from "agents/experimental/memory/session";
 import { z } from "zod";
 
@@ -2761,6 +2764,221 @@ export class ThinkProgrammaticTestAgent extends Think {
       done: cb.doneCalled,
       error: cb.errorMessage
     };
+  }
+}
+
+type ScheduledTaskConfigForTest = {
+  schedule: string;
+  timezone?: string;
+  prompt: string;
+};
+
+type DeclaredScheduledTaskRowForTest = {
+  task_id: string;
+  schedule_hash: string;
+  task_hash: string;
+  schedule_id: string | null;
+  next_run_at: number | null;
+  created_at: number;
+  updated_at: number;
+};
+
+type DeclaredScheduledTaskPayloadForTest = {
+  taskId: string;
+  scheduleHash: string;
+  scheduledFor: number;
+};
+
+export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
+  override async getDefaultTimezone(): Promise<string | undefined> {
+    return this.ctx.storage.get<string>("scheduledTasksDefaultTimezone");
+  }
+
+  override async getScheduledTasks(): Promise<ThinkScheduledTasks> {
+    const config =
+      (await this.ctx.storage.get<Record<string, ScheduledTaskConfigForTest>>(
+        "scheduledTasksConfig"
+      )) ?? {};
+    const tasks: ThinkScheduledTasks = {};
+    for (const [taskId, task] of Object.entries(config)) {
+      const prompt: ThinkScheduledTask["prompt"] =
+        task.prompt === "__throw__"
+          ? () => {
+              throw new Error("scheduled prompt failed");
+            }
+          : task.prompt;
+      tasks[taskId] = {
+        schedule: task.schedule as ThinkScheduledTask["schedule"],
+        ...(task.timezone !== undefined && { timezone: task.timezone }),
+        prompt
+      } as ThinkScheduledTask;
+    }
+    return defineScheduledTasks(tasks);
+  }
+
+  async setScheduledTasksForTest(
+    config: Record<string, ScheduledTaskConfigForTest>
+  ): Promise<void> {
+    await this.ctx.storage.put("scheduledTasksConfig", config);
+  }
+
+  async setDefaultTimezoneForTest(timezone?: string): Promise<void> {
+    if (timezone === undefined) {
+      await this.ctx.storage.delete("scheduledTasksDefaultTimezone");
+      return;
+    }
+    await this.ctx.storage.put("scheduledTasksDefaultTimezone", timezone);
+  }
+
+  async reconcileScheduledTasksForTest(): Promise<void> {
+    await (
+      this as unknown as {
+        _reconcileDeclaredScheduledTasks: () => Promise<void>;
+      }
+    )._reconcileDeclaredScheduledTasks();
+  }
+
+  async reconcileScheduledTasksErrorForTest(): Promise<string> {
+    try {
+      await this.reconcileScheduledTasksForTest();
+      return "";
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  async validateScheduleForTest(
+    schedule: string,
+    options: { timezone?: string; defaultTimezone?: string } = {}
+  ): Promise<string | null> {
+    return (
+      this as unknown as {
+        _declaredScheduleValidationError: (
+          schedule: string,
+          timezone?: string,
+          defaultTimezone?: string
+        ) => string | null;
+      }
+    )._declaredScheduleValidationError(
+      schedule,
+      options.timezone,
+      options.defaultTimezone
+    );
+  }
+
+  async nextScheduleTimeForTest(
+    schedule: string,
+    nowIso: string,
+    options: {
+      timezone?: string;
+      defaultTimezone?: string;
+      previousScheduledFor?: number;
+    } = {}
+  ): Promise<number> {
+    return (
+      this as unknown as {
+        _nextDeclaredScheduleTimeForConfig: (
+          schedule: string,
+          now: Date,
+          options?: {
+            taskTimezone?: string;
+            defaultTimezone?: string;
+            previousScheduledFor?: number;
+          }
+        ) => Date;
+      }
+    )
+      ._nextDeclaredScheduleTimeForConfig(schedule, new Date(nowIso), {
+        taskTimezone: options.timezone,
+        defaultTimezone: options.defaultTimezone,
+        previousScheduledFor: options.previousScheduledFor
+      })
+      .getTime();
+  }
+
+  async listDeclaredScheduledTaskRowsForTest(): Promise<
+    DeclaredScheduledTaskRowForTest[]
+  > {
+    return this.sql<DeclaredScheduledTaskRowForTest>`
+      SELECT task_id, schedule_hash, task_hash, schedule_id,
+             next_run_at, created_at, updated_at
+      FROM cf_think_scheduled_tasks
+      ORDER BY task_id ASC
+    `;
+  }
+
+  async listSchedulesForTest(): Promise<Schedule<unknown>[]> {
+    return this.listSchedules();
+  }
+
+  async createUnrelatedScheduleForTest(): Promise<string> {
+    const schedule = await this.schedule(
+      new Date(Date.now() + 60 * 60_000),
+      "noopScheduledTaskForTest",
+      { source: "unrelated" },
+      { idempotent: true }
+    );
+    return schedule.id;
+  }
+
+  async noopScheduledTaskForTest(): Promise<void> {}
+
+  async getFirstDeclaredPayloadForTest(): Promise<DeclaredScheduledTaskPayloadForTest> {
+    const [row] = await this.listDeclaredScheduledTaskRowsForTest();
+    if (!row?.schedule_id) throw new Error("No declared schedule row");
+    const schedule = await this.getScheduleById(row.schedule_id);
+    if (!schedule) throw new Error("Declared schedule row has no schedule");
+    return schedule.payload as DeclaredScheduledTaskPayloadForTest;
+  }
+
+  async runDeclaredPayloadForTest(
+    payload: DeclaredScheduledTaskPayloadForTest
+  ): Promise<void> {
+    await this._runDeclaredScheduledTask(payload);
+  }
+
+  async runDeclaredPayloadErrorForTest(
+    payload: DeclaredScheduledTaskPayloadForTest
+  ): Promise<string> {
+    try {
+      await this.runDeclaredPayloadForTest(payload);
+      return "";
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  async setChildScheduledTasksForTest(
+    name: string,
+    config: Record<string, ScheduledTaskConfigForTest>
+  ): Promise<void> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    await child.setScheduledTasksForTest(config);
+  }
+
+  async setChildDefaultTimezoneForTest(
+    name: string,
+    timezone?: string
+  ): Promise<void> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    await child.setDefaultTimezoneForTest(timezone);
+  }
+
+  async reconcileChildScheduledTasksForTest(name: string): Promise<void> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    await child.reconcileScheduledTasksForTest();
+  }
+
+  async listChildDeclaredScheduledTaskRowsForTest(
+    name: string
+  ): Promise<DeclaredScheduledTaskRowForTest[]> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    return child.listDeclaredScheduledTaskRowsForTest();
+  }
+
+  async listChildSchedulesForTest(name: string): Promise<Schedule<unknown>[]> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    return child.listSchedulesForTest();
   }
 }
 

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -2774,6 +2774,7 @@ type ScheduledTaskConfigForTest = {
 };
 
 type DeclaredScheduledTaskRowForTest = {
+  owner_key: string;
   task_id: string;
   schedule_hash: string;
   task_hash: string;
@@ -2899,10 +2900,14 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
   async listDeclaredScheduledTaskRowsForTest(): Promise<
     DeclaredScheduledTaskRowForTest[]
   > {
+    const ownerKey = (
+      this as unknown as { _declaredScheduleOwnerKey(): string }
+    )._declaredScheduleOwnerKey();
     return this.sql<DeclaredScheduledTaskRowForTest>`
-      SELECT task_id, schedule_hash, task_hash, schedule_id,
+      SELECT owner_key, task_id, schedule_hash, task_hash, schedule_id,
              next_run_at, created_at, updated_at
       FROM cf_think_scheduled_tasks
+      WHERE owner_key = ${ownerKey}
       ORDER BY task_id ASC
     `;
   }

--- a/packages/think/src/tests/scheduled-tasks-types.ts
+++ b/packages/think/src/tests/scheduled-tasks-types.ts
@@ -17,6 +17,19 @@ const validScheduledTasks = defineScheduledTasks({
   wallClockInlineTimezone: {
     schedule: "every weekday at 09:00 in Europe/London",
     prompt: "Run inline timezone task"
+  },
+  handler: {
+    schedule: "every 1 hour",
+    handler: (ctx) => {
+      const idempotencyKey: string = ctx.idempotencyKey;
+      const scheduledFor: number = ctx.scheduledFor;
+      const scheduleKind: "interval" | "wall-clock" = ctx.scheduleKind;
+      const timezone: string | undefined = ctx.timezone;
+      void idempotencyKey;
+      void scheduledFor;
+      void scheduleKind;
+      void timezone;
+    }
   }
 });
 
@@ -37,5 +50,14 @@ defineScheduledTasks({
     schedule: "every 5 minutes",
     timezone: "UTC",
     prompt: "Interval with timezone"
+  }
+});
+
+defineScheduledTasks({
+  // @ts-expect-error scheduled tasks must define prompt or handler, not both
+  promptAndHandler: {
+    schedule: "every 5 minutes",
+    prompt: "Run prompt",
+    handler: () => {}
   }
 });

--- a/packages/think/src/tests/scheduled-tasks-types.ts
+++ b/packages/think/src/tests/scheduled-tasks-types.ts
@@ -1,0 +1,41 @@
+import { defineScheduledTasks } from "../think";
+
+const validScheduledTasks = defineScheduledTasks({
+  interval: {
+    schedule: "every 5 minutes",
+    prompt: "Run interval task"
+  },
+  wallClockWithTimezone: {
+    schedule: "every day at 09:00",
+    timezone: "UTC",
+    prompt: "Run wall-clock task"
+  },
+  wallClockWithDefaultTimezone: {
+    schedule: "every day at 10:00",
+    prompt: "Valid when getDefaultTimezone() is provided by the agent"
+  },
+  wallClockInlineTimezone: {
+    schedule: "every weekday at 09:00 in Europe/London",
+    prompt: "Run inline timezone task"
+  }
+});
+
+void validScheduledTasks;
+
+defineScheduledTasks({
+  invalidTime: {
+    // @ts-expect-error obvious invalid literal times are rejected
+    schedule: "every day at 25:00",
+    timezone: "UTC",
+    prompt: "Invalid time"
+  }
+});
+
+defineScheduledTasks({
+  // @ts-expect-error intervals do not accept timezone
+  intervalWithTimezone: {
+    schedule: "every 5 minutes",
+    timezone: "UTC",
+    prompt: "Interval with timezone"
+  }
+});

--- a/packages/think/src/tests/scheduled-tasks.test.ts
+++ b/packages/think/src/tests/scheduled-tasks.test.ts
@@ -303,4 +303,60 @@ describe("Think scheduled tasks", () => {
     const childSchedules = await parent.listChildSchedulesForTest("child");
     expect(childSchedules).toHaveLength(1);
   });
+
+  it("keeps declared task ledgers isolated across parents and sub-agents", async () => {
+    const parent = await freshAgent();
+    await parent.setScheduledTasksForTest({
+      shared: {
+        schedule: "every 1 minute",
+        prompt: "Parent task"
+      }
+    });
+    await parent.setChildScheduledTasksForTest("alpha", {
+      shared: {
+        schedule: "every 1 minute",
+        prompt: "Alpha child task"
+      }
+    });
+    await parent.setChildScheduledTasksForTest("beta", {
+      shared: {
+        schedule: "every 1 minute",
+        prompt: "Beta child task"
+      }
+    });
+
+    await parent.reconcileScheduledTasksForTest();
+    await parent.reconcileChildScheduledTasksForTest("alpha");
+    await parent.reconcileChildScheduledTasksForTest("beta");
+
+    const parentRows = await parent.listDeclaredScheduledTaskRowsForTest();
+    const alphaRows =
+      await parent.listChildDeclaredScheduledTaskRowsForTest("alpha");
+    const betaRows =
+      await parent.listChildDeclaredScheduledTaskRowsForTest("beta");
+
+    expect(parentRows).toHaveLength(1);
+    expect(alphaRows).toHaveLength(1);
+    expect(betaRows).toHaveLength(1);
+    expect(parentRows[0].task_id).toBe("shared");
+    expect(alphaRows[0].task_id).toBe("shared");
+    expect(betaRows[0].task_id).toBe("shared");
+    const scheduleIds = new Set([
+      parentRows[0].schedule_id,
+      alphaRows[0].schedule_id,
+      betaRows[0].schedule_id
+    ]);
+    expect(scheduleIds.size).toBe(3);
+
+    await parent.setChildScheduledTasksForTest("alpha", {});
+    await parent.reconcileChildScheduledTasksForTest("alpha");
+
+    expect(await parent.listDeclaredScheduledTaskRowsForTest()).toHaveLength(1);
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("alpha")
+    ).toHaveLength(0);
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("beta")
+    ).toHaveLength(1);
+  });
 });

--- a/packages/think/src/tests/scheduled-tasks.test.ts
+++ b/packages/think/src/tests/scheduled-tasks.test.ts
@@ -1,0 +1,306 @@
+import { env } from "cloudflare:workers";
+import { getServerByName } from "partyserver";
+import { describe, expect, it } from "vitest";
+import type { ThinkScheduledTasksTestAgent } from "./agents/think-session";
+import type { ThinkSubmissionInspection } from "../think";
+
+type ScheduledTaskConfigForTest = {
+  schedule: string;
+  timezone?: string;
+  prompt: string;
+};
+
+type DeclaredScheduledTaskRowForTest = {
+  task_id: string;
+  schedule_hash: string;
+  task_hash: string;
+  schedule_id: string | null;
+  next_run_at: number | null;
+};
+
+type DeclaredScheduledTaskPayloadForTest = {
+  taskId: string;
+  scheduleHash: string;
+  scheduledFor: number;
+};
+
+type ThinkScheduledTasksTestStub = {
+  setScheduledTasksForTest(
+    config: Record<string, ScheduledTaskConfigForTest>
+  ): Promise<void>;
+  setDefaultTimezoneForTest(timezone?: string): Promise<void>;
+  reconcileScheduledTasksForTest(): Promise<void>;
+  reconcileScheduledTasksErrorForTest(): Promise<string>;
+  validateScheduleForTest(
+    schedule: string,
+    options?: { timezone?: string; defaultTimezone?: string }
+  ): Promise<string | null>;
+  nextScheduleTimeForTest(
+    schedule: string,
+    nowIso: string,
+    options?: {
+      timezone?: string;
+      defaultTimezone?: string;
+      previousScheduledFor?: number;
+    }
+  ): Promise<number>;
+  listDeclaredScheduledTaskRowsForTest(): Promise<
+    DeclaredScheduledTaskRowForTest[]
+  >;
+  listSchedulesForTest(): Promise<Array<{ id: string; payload: unknown }>>;
+  createUnrelatedScheduleForTest(): Promise<string>;
+  getFirstDeclaredPayloadForTest(): Promise<DeclaredScheduledTaskPayloadForTest>;
+  runDeclaredPayloadForTest(
+    payload: DeclaredScheduledTaskPayloadForTest
+  ): Promise<void>;
+  runDeclaredPayloadErrorForTest(
+    payload: DeclaredScheduledTaskPayloadForTest
+  ): Promise<string>;
+  listSubmissionsForTest(options?: {
+    limit?: number;
+  }): Promise<ThinkSubmissionInspection[]>;
+  getStoredMessages(): Promise<Array<{ role: string; parts?: unknown[] }>>;
+  setChildScheduledTasksForTest(
+    name: string,
+    config: Record<string, ScheduledTaskConfigForTest>
+  ): Promise<void>;
+  setChildDefaultTimezoneForTest(
+    name: string,
+    timezone?: string
+  ): Promise<void>;
+  reconcileChildScheduledTasksForTest(name: string): Promise<void>;
+  listChildDeclaredScheduledTaskRowsForTest(
+    name: string
+  ): Promise<DeclaredScheduledTaskRowForTest[]>;
+  listChildSchedulesForTest(
+    name: string
+  ): Promise<Array<{ id: string; payload: unknown }>>;
+};
+
+async function freshAgent(
+  name = crypto.randomUUID()
+): Promise<ThinkScheduledTasksTestStub> {
+  return getServerByName(
+    env.ThinkScheduledTasksTestAgent as unknown as DurableObjectNamespace<ThinkScheduledTasksTestAgent>,
+    name
+  ) as unknown as Promise<ThinkScheduledTasksTestStub>;
+}
+
+async function waitForSubmissionCount(
+  agent: ThinkScheduledTasksTestStub,
+  count: number
+): Promise<ThinkSubmissionInspection[]> {
+  for (let attempt = 0; attempt < 80; attempt++) {
+    const submissions = await agent.listSubmissionsForTest({ limit: 10 });
+    if (submissions.length >= count) return submissions;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return agent.listSubmissionsForTest({ limit: 10 });
+}
+
+describe("Think scheduled tasks", () => {
+  it("creates, updates, and removes declared schedule rows without touching unrelated schedules", async () => {
+    const agent = await freshAgent();
+    await agent.setDefaultTimezoneForTest("Europe/London");
+    await agent.setScheduledTasksForTest({
+      report: {
+        schedule: "every day at 09:00",
+        prompt: "Daily report"
+      }
+    });
+
+    await agent.reconcileScheduledTasksForTest();
+    const [initial] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(initial).toMatchObject({ task_id: "report" });
+    expect(initial.schedule_id).toBeTruthy();
+
+    await agent.setScheduledTasksForTest({
+      report: {
+        schedule: "every day at 09:00",
+        prompt: "Updated report prompt"
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const [promptOnly] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(promptOnly.schedule_id).toBe(initial.schedule_id);
+    expect(promptOnly.task_hash).not.toBe(initial.task_hash);
+
+    await agent.setScheduledTasksForTest({
+      report: {
+        schedule: "every day at 10:00",
+        prompt: "Updated report prompt"
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const [scheduleChanged] =
+      await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(scheduleChanged.schedule_id).not.toBe(initial.schedule_id);
+    expect(scheduleChanged.schedule_hash).not.toBe(initial.schedule_hash);
+
+    const unrelatedId = await agent.createUnrelatedScheduleForTest();
+    await agent.setScheduledTasksForTest({});
+    await agent.reconcileScheduledTasksForTest();
+
+    expect(await agent.listDeclaredScheduledTaskRowsForTest()).toHaveLength(0);
+    const schedules = await agent.listSchedulesForTest();
+    expect(schedules.map((schedule) => schedule.id)).toContain(unrelatedId);
+    expect(schedules.map((schedule) => schedule.id)).not.toContain(
+      scheduleChanged.schedule_id
+    );
+  });
+
+  it("replaces wall-clock schedules when the default timezone changes", async () => {
+    const agent = await freshAgent();
+    await agent.setDefaultTimezoneForTest("UTC");
+    await agent.setScheduledTasksForTest({
+      reminder: {
+        schedule: "every day at 09:00",
+        prompt: "Reminder"
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const [initial] = await agent.listDeclaredScheduledTaskRowsForTest();
+
+    await agent.setDefaultTimezoneForTest("America/New_York");
+    await agent.reconcileScheduledTasksForTest();
+    const [updated] = await agent.listDeclaredScheduledTaskRowsForTest();
+
+    expect(updated.schedule_hash).not.toBe(initial.schedule_hash);
+    expect(updated.schedule_id).not.toBe(initial.schedule_id);
+  });
+
+  it("validates runtime DSL and timezone edge cases", async () => {
+    const agent = await freshAgent();
+
+    await expect(
+      agent.validateScheduleForTest("every day at 25:00", { timezone: "UTC" })
+    ).resolves.toMatch(/Unsupported schedule DSL|Invalid schedule time/);
+    await expect(
+      agent.validateScheduleForTest("every weekday at 09:00")
+    ).resolves.toMatch(/requires a timezone/);
+    await expect(
+      agent.validateScheduleForTest("every 1 minutes")
+    ).resolves.toMatch(/singular/);
+    await expect(
+      agent.validateScheduleForTest("every day at 09:00", {
+        timezone: "Not/A_Zone"
+      })
+    ).resolves.toMatch(/Invalid timezone/);
+    await expect(
+      agent.validateScheduleForTest("every day at 09:00 in UTC", {
+        timezone: "Europe/London"
+      })
+    ).resolves.toMatch(/does not match/);
+    await expect(
+      agent.validateScheduleForTest("every 2 hours", { timezone: "UTC" })
+    ).resolves.toMatch(/Interval schedules cannot specify a timezone/);
+    await expect(
+      agent.validateScheduleForTest("every week on monday,monday at 09:00", {
+        timezone: "UTC"
+      })
+    ).resolves.toMatch(/Duplicate schedule day/);
+  });
+
+  it("computes late interval and DST wall-clock occurrences", async () => {
+    const agent = await freshAgent();
+
+    const lateInterval = await agent.nextScheduleTimeForTest(
+      "every 1 hour",
+      "2026-01-01T10:30:00.000Z",
+      { previousScheduledFor: Date.parse("2026-01-01T08:00:00.000Z") }
+    );
+    expect(new Date(lateInterval).toISOString()).toBe(
+      "2026-01-01T11:00:00.000Z"
+    );
+
+    const springForward = await agent.nextScheduleTimeForTest(
+      "every day at 01:30",
+      "2026-03-28T23:00:00.000Z",
+      { timezone: "Europe/London" }
+    );
+    expect(new Date(springForward).toISOString()).toBe(
+      "2026-03-29T01:00:00.000Z"
+    );
+
+    const fallBack = await agent.nextScheduleTimeForTest(
+      "every day at 01:30",
+      "2026-10-24T23:00:00.000Z",
+      { timezone: "Europe/London" }
+    );
+    expect(new Date(fallBack).toISOString()).toBe("2026-10-25T00:30:00.000Z");
+  });
+
+  it("submits scheduled work idempotently and schedules the next occurrence", async () => {
+    const agent = await freshAgent();
+    await agent.setScheduledTasksForTest({
+      workout: {
+        schedule: "every 1 minute",
+        prompt: "Start my workout"
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const payload = await agent.getFirstDeclaredPayloadForTest();
+
+    await agent.runDeclaredPayloadForTest(payload);
+    await agent.runDeclaredPayloadForTest(payload);
+
+    const submissions = await waitForSubmissionCount(agent, 1);
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].idempotencyKey).toContain(
+      `workout:${payload.scheduledFor}`
+    );
+    expect(submissions[0].metadata).toMatchObject({
+      source: "scheduled-task",
+      taskId: "workout",
+      scheduledFor: payload.scheduledFor,
+      schedule: "every 1 minute"
+    });
+
+    const messages = await agent.getStoredMessages();
+    expect(messages.filter((message) => message.role === "user")).toHaveLength(
+      1
+    );
+    const [row] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(row.next_run_at).toBeGreaterThan(payload.scheduledFor);
+  });
+
+  it("leaves the current occurrence in place when prompt resolution fails", async () => {
+    const agent = await freshAgent();
+    await agent.setScheduledTasksForTest({
+      broken: {
+        schedule: "every 1 minute",
+        prompt: "__throw__"
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const before = await agent.getFirstDeclaredPayloadForTest();
+
+    await expect(agent.runDeclaredPayloadErrorForTest(before)).resolves.toMatch(
+      /scheduled prompt failed/
+    );
+
+    const [row] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(row.next_run_at).toBe(before.scheduledFor);
+    expect(await agent.listSubmissionsForTest({ limit: 10 })).toHaveLength(0);
+  });
+
+  it("supports declared scheduled tasks in sub-agents", async () => {
+    const parent = await freshAgent();
+    await parent.setChildDefaultTimezoneForTest("child", "UTC");
+    await parent.setChildScheduledTasksForTest("child", {
+      childTask: {
+        schedule: "every weekday at 09:00",
+        prompt: "Child task"
+      }
+    });
+
+    await parent.reconcileChildScheduledTasksForTest("child");
+
+    const rows =
+      await parent.listChildDeclaredScheduledTaskRowsForTest("child");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ task_id: "childTask" });
+    const childSchedules = await parent.listChildSchedulesForTest("child");
+    expect(childSchedules).toHaveLength(1);
+  });
+});

--- a/packages/think/src/tests/scheduled-tasks.test.ts
+++ b/packages/think/src/tests/scheduled-tasks.test.ts
@@ -7,7 +7,10 @@ import type { ThinkSubmissionInspection } from "../think";
 type ScheduledTaskConfigForTest = {
   schedule: string;
   timezone?: string;
-  prompt: string;
+  prompt?: string;
+  handler?: "record" | "throw" | "throw-once";
+  retry?: { maxAttempts?: number; baseDelayMs?: number; maxDelayMs?: number };
+  metadata?: Record<string, unknown>;
 };
 
 type DeclaredScheduledTaskRowForTest = {
@@ -22,6 +25,18 @@ type DeclaredScheduledTaskPayloadForTest = {
   taskId: string;
   scheduleHash: string;
   scheduledFor: number;
+};
+
+type ScheduledTaskHandlerEventForTest = {
+  taskId: string;
+  scheduledFor: number;
+  scheduledForIso: string;
+  occurrenceKey: string;
+  idempotencyKey: string;
+  schedule: string;
+  scheduleKind: string;
+  timezone: string | null;
+  metadataJson: string | null;
 };
 
 type ThinkScheduledTasksTestStub = {
@@ -48,6 +63,10 @@ type ThinkScheduledTasksTestStub = {
     DeclaredScheduledTaskRowForTest[]
   >;
   listSchedulesForTest(): Promise<Array<{ id: string; payload: unknown }>>;
+  listScheduledTaskHandlerEventsForTest(): Promise<
+    ScheduledTaskHandlerEventForTest[]
+  >;
+  clearDeclaredScheduleIdForTest(taskId: string): Promise<void>;
   createUnrelatedScheduleForTest(): Promise<string>;
   getFirstDeclaredPayloadForTest(): Promise<DeclaredScheduledTaskPayloadForTest>;
   runDeclaredPayloadForTest(
@@ -96,6 +115,20 @@ async function waitForSubmissionCount(
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   return agent.listSubmissionsForTest({ limit: 10 });
+}
+
+function declaredTaskScheduleIds(
+  schedules: Array<{ id: string; payload: unknown }>
+): string[] {
+  return schedules
+    .filter(
+      (schedule): schedule is { id: string; payload: { taskId: string } } =>
+        schedule.payload != null &&
+        typeof schedule.payload === "object" &&
+        "taskId" in schedule.payload
+    )
+    .map((schedule) => schedule.id)
+    .sort();
 }
 
 describe("Think scheduled tasks", () => {
@@ -242,6 +275,9 @@ describe("Think scheduled tasks", () => {
     const payload = await agent.getFirstDeclaredPayloadForTest();
 
     await agent.runDeclaredPayloadForTest(payload);
+    const schedulesAfterFirst = declaredTaskScheduleIds(
+      await agent.listSchedulesForTest()
+    );
     await agent.runDeclaredPayloadForTest(payload);
 
     const submissions = await waitForSubmissionCount(agent, 1);
@@ -262,9 +298,12 @@ describe("Think scheduled tasks", () => {
     );
     const [row] = await agent.listDeclaredScheduledTaskRowsForTest();
     expect(row.next_run_at).toBeGreaterThan(payload.scheduledFor);
+    expect(declaredTaskScheduleIds(await agent.listSchedulesForTest())).toEqual(
+      schedulesAfterFirst
+    );
   });
 
-  it("leaves the current occurrence in place when prompt resolution fails", async () => {
+  it("re-arms the next occurrence when prompt resolution fails", async () => {
     const agent = await freshAgent();
     await agent.setScheduledTasksForTest({
       broken: {
@@ -275,13 +314,94 @@ describe("Think scheduled tasks", () => {
     await agent.reconcileScheduledTasksForTest();
     const before = await agent.getFirstDeclaredPayloadForTest();
 
-    await expect(agent.runDeclaredPayloadErrorForTest(before)).resolves.toMatch(
-      /scheduled prompt failed/
+    await expect(agent.runDeclaredPayloadErrorForTest(before)).resolves.toBe(
+      ""
     );
 
     const [row] = await agent.listDeclaredScheduledTaskRowsForTest();
-    expect(row.next_run_at).toBe(before.scheduledFor);
+    expect(row.next_run_at).toBeGreaterThan(before.scheduledFor);
     expect(await agent.listSubmissionsForTest({ limit: 10 })).toHaveLength(0);
+  });
+
+  it("runs scheduled task handlers with stable occurrence context", async () => {
+    const agent = await freshAgent();
+    await agent.setScheduledTasksForTest({
+      workflow: {
+        schedule: "every 1 minute",
+        handler: "record",
+        metadata: { workflowName: "daily-digest" }
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const payload = await agent.getFirstDeclaredPayloadForTest();
+
+    await agent.runDeclaredPayloadForTest(payload);
+
+    const events = await agent.listScheduledTaskHandlerEventsForTest();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "workflow",
+      scheduledFor: payload.scheduledFor,
+      scheduledForIso: new Date(payload.scheduledFor).toISOString(),
+      occurrenceKey: `workflow:${payload.scheduledFor}`,
+      schedule: "every 1 minute",
+      scheduleKind: "interval",
+      timezone: null,
+      metadataJson: JSON.stringify({ workflowName: "daily-digest" })
+    });
+    expect(events[0].idempotencyKey).toContain(
+      `workflow:${payload.scheduledFor}`
+    );
+    expect(await agent.listSubmissionsForTest({ limit: 10 })).toHaveLength(0);
+
+    const [row] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(row.next_run_at).toBeGreaterThan(payload.scheduledFor);
+  });
+
+  it("retries scheduled task handlers before recording failure", async () => {
+    const agent = await freshAgent();
+    await agent.setScheduledTasksForTest({
+      workflow: {
+        schedule: "every day at 09:00",
+        timezone: "UTC",
+        handler: "throw-once",
+        retry: { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 1 }
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const payload = await agent.getFirstDeclaredPayloadForTest();
+
+    await agent.runDeclaredPayloadForTest(payload);
+
+    const events = await agent.listScheduledTaskHandlerEventsForTest();
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      scheduleKind: "wall-clock",
+      timezone: "UTC"
+    });
+    const [row] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(row.next_run_at).toBeGreaterThanOrEqual(payload.scheduledFor);
+  });
+
+  it("re-arms the next occurrence when scheduled task handlers fail", async () => {
+    const agent = await freshAgent();
+    await agent.setScheduledTasksForTest({
+      workflow: {
+        schedule: "every 1 minute",
+        handler: "throw"
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const payload = await agent.getFirstDeclaredPayloadForTest();
+
+    await expect(agent.runDeclaredPayloadErrorForTest(payload)).resolves.toBe(
+      ""
+    );
+
+    const events = await agent.listScheduledTaskHandlerEventsForTest();
+    expect(events).toHaveLength(3);
+    const [row] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(row.next_run_at).toBeGreaterThan(payload.scheduledFor);
   });
 
   it("supports declared scheduled tasks in sub-agents", async () => {
@@ -302,6 +422,47 @@ describe("Think scheduled tasks", () => {
     expect(rows[0]).toMatchObject({ task_id: "childTask" });
     const childSchedules = await parent.listChildSchedulesForTest("child");
     expect(childSchedules).toHaveLength(1);
+  });
+
+  it("supports scheduled task handlers in sub-agents", async () => {
+    const parent = await freshAgent();
+    await parent.setChildScheduledTasksForTest("child", {
+      childHandler: {
+        schedule: "every 1 minute",
+        handler: "record"
+      }
+    });
+
+    await parent.reconcileChildScheduledTasksForTest("child");
+
+    const rows =
+      await parent.listChildDeclaredScheduledTaskRowsForTest("child");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ task_id: "childHandler" });
+    const childSchedules = await parent.listChildSchedulesForTest("child");
+    expect(childSchedules).toHaveLength(1);
+  });
+
+  it("reconciles pending declared rows without duplicate task rows", async () => {
+    const agent = await freshAgent();
+    await agent.setScheduledTasksForTest({
+      pending: {
+        schedule: "every 1 minute",
+        prompt: "Pending schedule"
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const [before] = await agent.listDeclaredScheduledTaskRowsForTest();
+    await agent.clearDeclaredScheduleIdForTest("pending");
+
+    await agent.reconcileScheduledTasksForTest();
+
+    const rows = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ task_id: "pending" });
+    expect(rows[0].schedule_id).toBeTruthy();
+    expect(rows[0].next_run_at).toBe(before.next_run_at);
+    expect(await agent.listSchedulesForTest()).toHaveLength(1);
   });
 
   it("keeps declared task ledgers isolated across parents and sub-agents", async () => {

--- a/packages/think/src/tests/worker.ts
+++ b/packages/think/src/tests/worker.ts
@@ -18,6 +18,7 @@ export {
   ThinkLegacyConfigMigrationAgent,
   ThinkConfigInSessionAgent,
   ThinkProgrammaticTestAgent,
+  ThinkScheduledTasksTestAgent,
   ThinkAsyncHookTestAgent,
   ThinkRecoveryTestAgent,
   ThinkNonRecoveryTestAgent,
@@ -42,6 +43,7 @@ import type {
   ThinkLegacyConfigMigrationAgent,
   ThinkConfigInSessionAgent,
   ThinkProgrammaticTestAgent,
+  ThinkScheduledTasksTestAgent,
   ThinkAsyncHookTestAgent,
   ThinkRecoveryTestAgent,
   ThinkNonRecoveryTestAgent,
@@ -66,6 +68,7 @@ export type Env = {
   ThinkLegacyConfigMigrationAgent: DurableObjectNamespace<ThinkLegacyConfigMigrationAgent>;
   ThinkConfigInSessionAgent: DurableObjectNamespace<ThinkConfigInSessionAgent>;
   ThinkProgrammaticTestAgent: DurableObjectNamespace<ThinkProgrammaticTestAgent>;
+  ThinkScheduledTasksTestAgent: DurableObjectNamespace<ThinkScheduledTasksTestAgent>;
   ThinkAsyncHookTestAgent: DurableObjectNamespace<ThinkAsyncHookTestAgent>;
   ThinkRecoveryTestAgent: DurableObjectNamespace<ThinkRecoveryTestAgent>;
   ThinkNonRecoveryTestAgent: DurableObjectNamespace<ThinkNonRecoveryTestAgent>;

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -72,6 +72,10 @@
         "name": "ThinkProgrammaticTestAgent"
       },
       {
+        "class_name": "ThinkScheduledTasksTestAgent",
+        "name": "ThinkScheduledTasksTestAgent"
+      },
+      {
         "class_name": "ThinkAsyncHookTestAgent",
         "name": "ThinkAsyncHookTestAgent"
       },
@@ -117,6 +121,7 @@
         "ThinkLegacyConfigMigrationAgent",
         "ThinkConfigInSessionAgent",
         "ThinkProgrammaticTestAgent",
+        "ThinkScheduledTasksTestAgent",
         "ThinkAsyncHookTestAgent",
         "ThinkRecoveryTestAgent",
         "ThinkNonRecoveryTestAgent",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -118,7 +118,12 @@ import {
 } from "agents";
 
 const agentToolChunkEncoder = new TextEncoder();
-import type { Connection, FiberRecoveryContext, WSMessage } from "agents";
+import type {
+  Connection,
+  FiberRecoveryContext,
+  RetryOptions,
+  WSMessage
+} from "agents";
 import {
   sanitizeMessage,
   enforceRowSizeLimit,
@@ -188,6 +193,348 @@ function shouldMarkSkippedAfterGenerationChange(
   status: SaveMessagesResult["status"]
 ): boolean {
   return status === "completed";
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(",")}}`;
+}
+
+function stableHash(value: unknown): string {
+  const input = stableStringify(value);
+  let h1 = 1779033703;
+  let h2 = 3144134277;
+  let h3 = 1013904242;
+  let h4 = 2773480762;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    h1 = h2 ^ Math.imul(h1 ^ code, 597399067);
+    h2 = h3 ^ Math.imul(h2 ^ code, 2869860233);
+    h3 = h4 ^ Math.imul(h3 ^ code, 951274213);
+    h4 = h1 ^ Math.imul(h4 ^ code, 2716044179);
+  }
+  h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067);
+  h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233);
+  h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213);
+  h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179);
+  return [h1, h2, h3, h4]
+    .map((part) => (part >>> 0).toString(16).padStart(8, "0"))
+    .join("");
+}
+
+function validateTimezone(timezone: string): string {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return formatter.resolvedOptions().timeZone;
+  } catch {
+    throw new Error(`Invalid timezone "${timezone}"`);
+  }
+}
+
+function parseTime(value: string): { hour: number; minute: number } {
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value);
+  if (!match) {
+    throw new Error(`Invalid schedule time "${value}"; expected HH:mm`);
+  }
+  return { hour: Number(match[1]), minute: Number(match[2]) };
+}
+
+const declaredScheduleDayNumbers: Record<string, number> = {
+  sun: 0,
+  sunday: 0,
+  mon: 1,
+  monday: 1,
+  tue: 2,
+  tuesday: 2,
+  wed: 3,
+  wednesday: 3,
+  thu: 4,
+  thursday: 4,
+  fri: 5,
+  friday: 5,
+  sat: 6,
+  saturday: 6
+};
+
+function parseDeclaredTaskSchedule(
+  rawSchedule: string,
+  taskTimezone: string | undefined,
+  defaultTimezone: string | undefined
+): ParsedDeclaredSchedule {
+  const result = tryParseDeclaredTaskSchedule(
+    rawSchedule,
+    taskTimezone,
+    defaultTimezone
+  );
+  if (!result.ok) throw new Error(result.error);
+  return result.schedule;
+}
+
+function tryParseDeclaredTaskSchedule(
+  rawSchedule: string,
+  taskTimezone: string | undefined,
+  defaultTimezone: string | undefined
+): ParseDeclaredScheduleResult {
+  try {
+    return {
+      ok: true,
+      schedule: parseDeclaredTaskScheduleUnchecked(
+        rawSchedule,
+        taskTimezone,
+        defaultTimezone
+      )
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+function parseDeclaredTaskScheduleUnchecked(
+  rawSchedule: string,
+  taskTimezone: string | undefined,
+  defaultTimezone: string | undefined
+): ParsedDeclaredSchedule {
+  const trimmed = rawSchedule.trim().replace(/\s+/g, " ").toLowerCase();
+  const inlineTimezoneMatch = /^(.*) in ([A-Za-z_][A-Za-z0-9_+\-/]*)$/.exec(
+    trimmed
+  );
+  const schedule = inlineTimezoneMatch?.[1] ?? trimmed;
+  const inlineTimezone = inlineTimezoneMatch?.[2];
+  if (
+    inlineTimezone &&
+    taskTimezone &&
+    validateTimezone(inlineTimezone) !== validateTimezone(taskTimezone)
+  ) {
+    throw new Error(
+      `Schedule timezone "${inlineTimezone}" does not match task timezone "${taskTimezone}"`
+    );
+  }
+
+  const intervalMatch = /^every ([1-9]\d*) (minute|minutes|hour|hours)$/.exec(
+    schedule
+  );
+  if (intervalMatch) {
+    if (inlineTimezone || taskTimezone) {
+      throw new Error("Interval schedules cannot specify a timezone");
+    }
+    const count = Number(intervalMatch[1]);
+    const unit = intervalMatch[2];
+    if (count === 1 && unit.endsWith("s")) {
+      throw new Error(`Use singular unit for "${rawSchedule}"`);
+    }
+    if (count !== 1 && !unit.endsWith("s")) {
+      throw new Error(`Use plural unit for "${rawSchedule}"`);
+    }
+    return {
+      kind: "interval",
+      intervalMs: count * (unit.startsWith("hour") ? 60 * 60_000 : 60_000),
+      normalizedSchedule: `every ${count} ${unit}`
+    };
+  }
+
+  const timezone = inlineTimezone ?? taskTimezone ?? defaultTimezone;
+  if (!timezone) {
+    throw new Error(
+      `Wall-clock schedule "${rawSchedule}" requires a timezone or getDefaultTimezone()`
+    );
+  }
+  const resolvedTimezone = validateTimezone(timezone);
+
+  const dailyMatch = /^every day at ([0-2]\d:[0-5]\d)$/.exec(schedule);
+  if (dailyMatch) {
+    const { hour, minute } = parseTime(dailyMatch[1]);
+    return {
+      kind: "wall-clock",
+      normalizedSchedule: `every day at ${dailyMatch[1]}`,
+      timezone: resolvedTimezone,
+      hour,
+      minute,
+      days: "daily"
+    };
+  }
+
+  const weekdayMatch = /^every weekday at ([0-2]\d:[0-5]\d)$/.exec(schedule);
+  if (weekdayMatch) {
+    const { hour, minute } = parseTime(weekdayMatch[1]);
+    return {
+      kind: "wall-clock",
+      normalizedSchedule: `every weekday at ${weekdayMatch[1]}`,
+      timezone: resolvedTimezone,
+      hour,
+      minute,
+      days: "weekday"
+    };
+  }
+
+  const weeklyMatch = /^every week on ([a-z,\s]+) at ([0-2]\d:[0-5]\d)$/.exec(
+    schedule
+  );
+  if (weeklyMatch) {
+    const seen = new Set<number>();
+    const days = weeklyMatch[1].split(",").map((day) => {
+      const normalized = day.trim();
+      const dayNumber = declaredScheduleDayNumbers[normalized];
+      if (dayNumber === undefined) {
+        throw new Error(`Invalid schedule day "${normalized}"`);
+      }
+      if (seen.has(dayNumber)) {
+        throw new Error(`Duplicate schedule day "${normalized}"`);
+      }
+      seen.add(dayNumber);
+      return dayNumber;
+    });
+    if (days.length === 0) {
+      throw new Error("Weekly schedule requires at least one day");
+    }
+    const { hour, minute } = parseTime(weeklyMatch[2]);
+    return {
+      kind: "wall-clock",
+      normalizedSchedule: `every week on ${weeklyMatch[1]
+        .split(",")
+        .map((day) => day.trim())
+        .join(",")} at ${weeklyMatch[2]}`,
+      timezone: resolvedTimezone,
+      hour,
+      minute,
+      days
+    };
+  }
+
+  throw new Error(`Unsupported schedule DSL "${rawSchedule}"`);
+}
+
+function getZonedParts(date: Date, timezone: string): ZonedParts {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    calendar: "iso8601",
+    numberingSystem: "latn",
+    weekday: "short",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23"
+  }).formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((entry) => entry.type === type)?.value ?? "";
+  return {
+    year: Number(part("year")),
+    month: Number(part("month")),
+    day: Number(part("day")),
+    hour: Number(part("hour")),
+    minute: Number(part("minute")),
+    second: Number(part("second")),
+    weekday: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].indexOf(
+      part("weekday")
+    )
+  };
+}
+
+function compareLocalParts(
+  left: Pick<ZonedParts, "year" | "month" | "day" | "hour" | "minute">,
+  right: Pick<ZonedParts, "year" | "month" | "day" | "hour" | "minute">
+): number {
+  const fields = ["year", "month", "day", "hour", "minute"] as const;
+  for (const field of fields) {
+    const diff = left[field] - right[field];
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function findZonedInstant(
+  target: Pick<ZonedParts, "year" | "month" | "day" | "hour" | "minute">,
+  timezone: string
+): Date {
+  const approximate = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+    target.minute
+  );
+  const start = approximate - 14 * 60 * 60_000;
+  const end = approximate + 14 * 60 * 60_000;
+  for (let time = start; time <= end; time += 60_000) {
+    const candidate = new Date(time);
+    const parts = getZonedParts(candidate, timezone);
+    if (compareLocalParts(parts, target) === 0) return candidate;
+  }
+  for (let time = start; time <= end; time += 60_000) {
+    const candidate = new Date(time);
+    const parts = getZonedParts(candidate, timezone);
+    if (compareLocalParts(parts, target) > 0) return candidate;
+  }
+  throw new Error(`Unable to resolve local time in timezone "${timezone}"`);
+}
+
+function addLocalDays(
+  parts: Pick<ZonedParts, "year" | "month" | "day">,
+  days: number
+): Pick<ZonedParts, "year" | "month" | "day"> {
+  const date = new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day + days)
+  );
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate()
+  };
+}
+
+function isAllowedWallClockDay(
+  weekday: number,
+  days: ParsedDeclaredSchedule & { kind: "wall-clock" }
+): boolean {
+  if (days.days === "daily") return true;
+  if (days.days === "weekday") return weekday >= 1 && weekday <= 5;
+  return days.days.includes(weekday);
+}
+
+function nextDeclaredScheduleTime(
+  schedule: ParsedDeclaredSchedule,
+  now: Date,
+  previousScheduledFor?: number
+): Date {
+  if (schedule.kind === "interval") {
+    let next =
+      previousScheduledFor === undefined
+        ? now.getTime() + schedule.intervalMs
+        : previousScheduledFor + schedule.intervalMs;
+    while (next <= now.getTime()) next += schedule.intervalMs;
+    return new Date(next);
+  }
+
+  const nowParts = getZonedParts(now, schedule.timezone);
+  for (let offset = 0; offset < 370; offset++) {
+    const localDate = addLocalDays(nowParts, offset);
+    const candidate = findZonedInstant(
+      {
+        ...localDate,
+        hour: schedule.hour,
+        minute: schedule.minute
+      },
+      schedule.timezone
+    );
+    const weekday = getZonedParts(candidate, schedule.timezone).weekday;
+    if (!isAllowedWallClockDay(weekday, schedule)) continue;
+    if (candidate.getTime() > now.getTime()) return candidate;
+  }
+  throw new Error("Unable to compute next scheduled task occurrence");
 }
 
 type StreamResultStatus = {
@@ -280,6 +627,105 @@ type AgentToolRunInspection<Output = unknown> = {
   error?: string;
   startedAt: number;
   completedAt?: number;
+};
+
+type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type Hour = `0${Digit}` | `1${Digit}` | "20" | "21" | "22" | "23";
+type Minute = `${"0" | "1" | "2" | "3" | "4" | "5"}${Digit}`;
+export type ThinkTime = `${Hour}:${Minute}`;
+export type ThinkIntervalSchedule =
+  | `every ${number} minute${"" | "s"}`
+  | `every ${number} hour${"" | "s"}`;
+export type ThinkWallClockSchedule =
+  | `every day at ${ThinkTime}`
+  | `every weekday at ${ThinkTime}`
+  | `every week on ${string} at ${ThinkTime}`;
+export type ThinkScheduledTaskSchedule =
+  | ThinkIntervalSchedule
+  | ThinkWallClockSchedule
+  | `${ThinkWallClockSchedule} in ${string}`;
+
+type ThinkScheduledTaskBase = {
+  prompt: string | (() => string | Promise<string>);
+  retry?: RetryOptions;
+  metadata?: Record<string, unknown>;
+};
+
+export type ThinkScheduledTask =
+  | (ThinkScheduledTaskBase & {
+      schedule: ThinkIntervalSchedule;
+      timezone?: never;
+    })
+  | (ThinkScheduledTaskBase & {
+      schedule: ThinkWallClockSchedule;
+      timezone?: string;
+    })
+  | (ThinkScheduledTaskBase & {
+      schedule: `${ThinkWallClockSchedule} in ${string}`;
+      timezone?: string;
+    });
+
+export type ThinkScheduledTasks = Record<string, ThinkScheduledTask>;
+
+export function defineScheduledTasks<const T extends ThinkScheduledTasks>(
+  tasks: T
+): T {
+  return tasks;
+}
+
+type ParsedDeclaredSchedule =
+  | {
+      kind: "interval";
+      intervalMs: number;
+      normalizedSchedule: string;
+    }
+  | {
+      kind: "wall-clock";
+      normalizedSchedule: string;
+      timezone: string;
+      hour: number;
+      minute: number;
+      days: "daily" | "weekday" | number[];
+    };
+
+type ParseDeclaredScheduleResult =
+  | { ok: true; schedule: ParsedDeclaredSchedule }
+  | { ok: false; error: string };
+
+type NormalizedDeclaredTask = {
+  taskId: string;
+  prompt: ThinkScheduledTask["prompt"];
+  schedule: ParsedDeclaredSchedule;
+  retry?: RetryOptions;
+  metadata?: Record<string, unknown>;
+  scheduleHash: string;
+  taskHash: string;
+};
+
+type DeclaredScheduledTaskRow = {
+  task_id: string;
+  schedule_hash: string;
+  task_hash: string;
+  schedule_id: string | null;
+  next_run_at: number | null;
+  created_at: number;
+  updated_at: number;
+};
+
+type DeclaredScheduledTaskPayload = {
+  taskId: string;
+  scheduleHash: string;
+  scheduledFor: number;
+};
+
+type ZonedParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  weekday: number;
 };
 
 type AgentToolStoredChunk = {
@@ -833,7 +1279,11 @@ export class Think<
       // 8. User's onStart
       await _onStart();
 
-      // 9. Durable submissions may run user-defined model/hooks, so start them
+      // 9. Declarative scheduled tasks are code-defined and should reconcile
+      // before draining any recovered programmatic work they may enqueue.
+      await this._reconcileDeclaredScheduledTasks();
+
+      // 10. Durable submissions may run user-defined model/hooks, so start them
       // after subclass initialization has completed.
       await this._recoverSubmissionsOnStart();
       this._recoverWorkflowNotifications();
@@ -967,6 +1417,7 @@ export class Think<
   private _agentToolLiveSequences = new Map<string, number>();
   private _submissionTableEnsured = false;
   private _workflowNotificationTableEnsured = false;
+  private _declaredScheduledTasksTableEnsured = false;
   private _drainingSubmissions = false;
   private _drainingWorkflowNotifications = false;
   private _submissionAbortControllers = new Map<string, AbortController>();
@@ -1156,6 +1607,19 @@ export class Think<
   /** Return the tools available to the assistant. */
   getTools(): ToolSet {
     return {};
+  }
+
+  /** Return code-declared scheduled tasks for this agent. */
+  getScheduledTasks(): ThinkScheduledTasks | Promise<ThinkScheduledTasks> {
+    return {};
+  }
+
+  /**
+   * Return the default timezone for wall-clock scheduled tasks.
+   * Task-local timezone declarations take precedence.
+   */
+  getDefaultTimezone(): string | undefined | Promise<string | undefined> {
+    return undefined;
   }
 
   private async _runChatRecoveryFiber<T>(
@@ -2606,6 +3070,314 @@ export class Think<
       if (text.length > 0) return text;
     }
     return null;
+  }
+
+  // ── Declarative scheduled tasks ─────────────────────────────────
+
+  private _ensureDeclaredScheduledTasksTable(): void {
+    if (this._declaredScheduledTasksTableEnsured) return;
+    this.sql`
+      CREATE TABLE IF NOT EXISTS cf_think_scheduled_tasks (
+        task_id TEXT PRIMARY KEY,
+        schedule_hash TEXT NOT NULL,
+        task_hash TEXT NOT NULL,
+        schedule_id TEXT,
+        next_run_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `;
+    this._declaredScheduledTasksTableEnsured = true;
+  }
+
+  private _readDeclaredScheduledTaskRow(
+    taskId: string
+  ): DeclaredScheduledTaskRow | null {
+    this._ensureDeclaredScheduledTasksTable();
+    const rows = this.sql<DeclaredScheduledTaskRow>`
+      SELECT task_id, schedule_hash, task_hash, schedule_id,
+             next_run_at, created_at, updated_at
+      FROM cf_think_scheduled_tasks
+      WHERE task_id = ${taskId}
+      LIMIT 1
+    `;
+    return rows[0] ?? null;
+  }
+
+  private _listDeclaredScheduledTaskRows(): DeclaredScheduledTaskRow[] {
+    this._ensureDeclaredScheduledTasksTable();
+    return this.sql<DeclaredScheduledTaskRow>`
+      SELECT task_id, schedule_hash, task_hash, schedule_id,
+             next_run_at, created_at, updated_at
+      FROM cf_think_scheduled_tasks
+      ORDER BY task_id ASC
+    `;
+  }
+
+  private async _normalizeDeclaredScheduledTasks(
+    tasks: ThinkScheduledTasks,
+    defaultTimezone: string | undefined
+  ): Promise<Map<string, NormalizedDeclaredTask>> {
+    const normalized = new Map<string, NormalizedDeclaredTask>();
+    for (const [taskId, task] of Object.entries(tasks)) {
+      if (!/^[A-Za-z0-9_-]+$/.test(taskId)) {
+        throw new Error(
+          `Invalid scheduled task id "${taskId}"; use letters, numbers, "_" or "-"`
+        );
+      }
+      const schedule = parseDeclaredTaskSchedule(
+        task.schedule,
+        task.timezone,
+        defaultTimezone
+      );
+      const scheduleHash = stableHash({
+        schedule,
+        retry: task.retry
+      });
+      const taskHash = stableHash({
+        scheduleHash,
+        prompt: typeof task.prompt === "string" ? task.prompt : "<function>",
+        metadata: task.metadata
+      });
+      normalized.set(taskId, {
+        taskId,
+        prompt: task.prompt,
+        schedule,
+        retry: task.retry,
+        metadata: task.metadata,
+        scheduleHash,
+        taskHash
+      });
+    }
+    return normalized;
+  }
+
+  private async _declaredScheduledTasksForNow(): Promise<
+    Map<string, NormalizedDeclaredTask>
+  > {
+    const defaultTimezone = await this.getDefaultTimezone();
+    const resolvedDefaultTimezone =
+      defaultTimezone === undefined
+        ? undefined
+        : validateTimezone(defaultTimezone);
+    return this._normalizeDeclaredScheduledTasks(
+      await this.getScheduledTasks(),
+      resolvedDefaultTimezone
+    );
+  }
+
+  private _declaredScheduleOwnerKey(): string {
+    return stableHash(this.selfPath);
+  }
+
+  private _declaredScheduleValidationError(
+    rawSchedule: string,
+    taskTimezone?: string,
+    defaultTimezone?: string
+  ): string | null {
+    const resolvedDefaultTimezone =
+      defaultTimezone === undefined
+        ? undefined
+        : validateTimezone(defaultTimezone);
+    const result = tryParseDeclaredTaskSchedule(
+      rawSchedule,
+      taskTimezone,
+      resolvedDefaultTimezone
+    );
+    return result.ok ? null : result.error;
+  }
+
+  private _nextDeclaredScheduleTimeForConfig(
+    rawSchedule: string,
+    now: Date,
+    options: {
+      taskTimezone?: string;
+      defaultTimezone?: string;
+      previousScheduledFor?: number;
+    } = {}
+  ): Date {
+    const resolvedDefaultTimezone =
+      options.defaultTimezone === undefined
+        ? undefined
+        : validateTimezone(options.defaultTimezone);
+    return nextDeclaredScheduleTime(
+      parseDeclaredTaskSchedule(
+        rawSchedule,
+        options.taskTimezone,
+        resolvedDefaultTimezone
+      ),
+      now,
+      options.previousScheduledFor
+    );
+  }
+
+  private async _reconcileDeclaredScheduledTasks(): Promise<void> {
+    const tasks = await this._declaredScheduledTasksForNow();
+    this._ensureDeclaredScheduledTasksTable();
+    const now = Date.now();
+    const existing = this._listDeclaredScheduledTaskRows();
+    const seen = new Set<string>();
+
+    for (const [taskId, task] of tasks) {
+      seen.add(taskId);
+      const row = existing.find((candidate) => candidate.task_id === taskId);
+      if (!row) {
+        const scheduled = await this._scheduleDeclaredTaskOccurrence(
+          task,
+          new Date(now)
+        );
+        this.sql`
+          INSERT INTO cf_think_scheduled_tasks (
+            task_id, schedule_hash, task_hash, schedule_id,
+            next_run_at, created_at, updated_at
+          )
+          VALUES (
+            ${taskId}, ${task.scheduleHash}, ${task.taskHash},
+            ${scheduled.scheduleId}, ${scheduled.scheduledFor},
+            ${now}, ${now}
+          )
+        `;
+        continue;
+      }
+
+      if (row.schedule_hash !== task.scheduleHash) {
+        if (row.schedule_id) await this.cancelSchedule(row.schedule_id);
+        const scheduled = await this._scheduleDeclaredTaskOccurrence(
+          task,
+          new Date(now)
+        );
+        this.sql`
+          UPDATE cf_think_scheduled_tasks
+          SET schedule_hash = ${task.scheduleHash},
+              task_hash = ${task.taskHash},
+              schedule_id = ${scheduled.scheduleId},
+              next_run_at = ${scheduled.scheduledFor},
+              updated_at = ${now}
+          WHERE task_id = ${taskId}
+        `;
+        continue;
+      }
+
+      if (row.schedule_id) {
+        const schedule = await this.getScheduleById(row.schedule_id);
+        if (!schedule) {
+          const scheduled = await this._scheduleDeclaredTaskOccurrence(
+            task,
+            new Date(now),
+            row.next_run_at ?? undefined
+          );
+          this.sql`
+            UPDATE cf_think_scheduled_tasks
+            SET task_hash = ${task.taskHash},
+                schedule_id = ${scheduled.scheduleId},
+                next_run_at = ${scheduled.scheduledFor},
+                updated_at = ${now}
+            WHERE task_id = ${taskId}
+          `;
+          continue;
+        }
+      }
+
+      if (row.task_hash !== task.taskHash) {
+        this.sql`
+          UPDATE cf_think_scheduled_tasks
+          SET task_hash = ${task.taskHash}, updated_at = ${now}
+          WHERE task_id = ${taskId}
+        `;
+      }
+    }
+
+    for (const row of existing) {
+      if (seen.has(row.task_id)) continue;
+      if (row.schedule_id) await this.cancelSchedule(row.schedule_id);
+      this.sql`
+        DELETE FROM cf_think_scheduled_tasks
+        WHERE task_id = ${row.task_id}
+      `;
+    }
+  }
+
+  private async _scheduleDeclaredTaskOccurrence(
+    task: NormalizedDeclaredTask,
+    now: Date,
+    previousScheduledFor?: number
+  ): Promise<{ scheduleId: string; scheduledFor: number }> {
+    const next = nextDeclaredScheduleTime(
+      task.schedule,
+      now,
+      previousScheduledFor
+    );
+    const scheduledFor = next.getTime();
+    const schedule = await this.schedule<DeclaredScheduledTaskPayload>(
+      next,
+      "_runDeclaredScheduledTask",
+      {
+        taskId: task.taskId,
+        scheduleHash: task.scheduleHash,
+        scheduledFor
+      },
+      { retry: task.retry, idempotent: true }
+    );
+    return { scheduleId: schedule.id, scheduledFor };
+  }
+
+  async _runDeclaredScheduledTask(
+    payload: DeclaredScheduledTaskPayload
+  ): Promise<void> {
+    if (
+      !payload ||
+      typeof payload.taskId !== "string" ||
+      typeof payload.scheduleHash !== "string" ||
+      typeof payload.scheduledFor !== "number"
+    ) {
+      throw new Error("Invalid declared scheduled task payload");
+    }
+
+    const row = this._readDeclaredScheduledTaskRow(payload.taskId);
+    if (!row || row.schedule_hash !== payload.scheduleHash) return;
+
+    const tasks = await this._declaredScheduledTasksForNow();
+    const task = tasks.get(payload.taskId);
+    if (!task || task.scheduleHash !== payload.scheduleHash) return;
+
+    const prompt =
+      typeof task.prompt === "function" ? await task.prompt() : task.prompt;
+    const ownerKey = this._declaredScheduleOwnerKey();
+    await this.submitMessages(
+      [
+        {
+          id: crypto.randomUUID(),
+          role: "user",
+          parts: [{ type: "text", text: prompt }]
+        }
+      ],
+      {
+        idempotencyKey: `think-schedule:${ownerKey}:${payload.taskId}:${payload.scheduledFor}`,
+        metadata: {
+          ...task.metadata,
+          source: "scheduled-task",
+          ownerKey,
+          taskId: payload.taskId,
+          scheduledFor: payload.scheduledFor,
+          schedule: task.schedule.normalizedSchedule
+        }
+      }
+    );
+
+    const scheduled = await this._scheduleDeclaredTaskOccurrence(
+      task,
+      new Date(),
+      payload.scheduledFor
+    );
+    this.sql`
+      UPDATE cf_think_scheduled_tasks
+      SET schedule_id = ${scheduled.scheduleId},
+          next_run_at = ${scheduled.scheduledFor},
+          task_hash = ${task.taskHash},
+          updated_at = ${Date.now()}
+      WHERE task_id = ${payload.taskId}
+        AND schedule_hash = ${payload.scheduleHash}
+    `;
   }
 
   // ── Durable programmatic submissions ───────────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -703,6 +703,7 @@ type NormalizedDeclaredTask = {
 };
 
 type DeclaredScheduledTaskRow = {
+  owner_key: string;
   task_id: string;
   schedule_hash: string;
   task_hash: string;
@@ -3078,13 +3079,15 @@ export class Think<
     if (this._declaredScheduledTasksTableEnsured) return;
     this.sql`
       CREATE TABLE IF NOT EXISTS cf_think_scheduled_tasks (
-        task_id TEXT PRIMARY KEY,
+        owner_key TEXT NOT NULL,
+        task_id TEXT NOT NULL,
         schedule_hash TEXT NOT NULL,
         task_hash TEXT NOT NULL,
         schedule_id TEXT,
         next_run_at INTEGER,
         created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (owner_key, task_id)
       )
     `;
     this._declaredScheduledTasksTableEnsured = true;
@@ -3094,11 +3097,13 @@ export class Think<
     taskId: string
   ): DeclaredScheduledTaskRow | null {
     this._ensureDeclaredScheduledTasksTable();
+    const ownerKey = this._declaredScheduleOwnerKey();
     const rows = this.sql<DeclaredScheduledTaskRow>`
-      SELECT task_id, schedule_hash, task_hash, schedule_id,
+      SELECT owner_key, task_id, schedule_hash, task_hash, schedule_id,
              next_run_at, created_at, updated_at
       FROM cf_think_scheduled_tasks
       WHERE task_id = ${taskId}
+        AND owner_key = ${ownerKey}
       LIMIT 1
     `;
     return rows[0] ?? null;
@@ -3106,10 +3111,12 @@ export class Think<
 
   private _listDeclaredScheduledTaskRows(): DeclaredScheduledTaskRow[] {
     this._ensureDeclaredScheduledTasksTable();
+    const ownerKey = this._declaredScheduleOwnerKey();
     return this.sql<DeclaredScheduledTaskRow>`
-      SELECT task_id, schedule_hash, task_hash, schedule_id,
+      SELECT owner_key, task_id, schedule_hash, task_hash, schedule_id,
              next_run_at, created_at, updated_at
       FROM cf_think_scheduled_tasks
+      WHERE owner_key = ${ownerKey}
       ORDER BY task_id ASC
     `;
   }
@@ -3214,6 +3221,7 @@ export class Think<
   private async _reconcileDeclaredScheduledTasks(): Promise<void> {
     const tasks = await this._declaredScheduledTasksForNow();
     this._ensureDeclaredScheduledTasksTable();
+    const ownerKey = this._declaredScheduleOwnerKey();
     const now = Date.now();
     const existing = this._listDeclaredScheduledTaskRows();
     const seen = new Set<string>();
@@ -3228,11 +3236,11 @@ export class Think<
         );
         this.sql`
           INSERT INTO cf_think_scheduled_tasks (
-            task_id, schedule_hash, task_hash, schedule_id,
+            owner_key, task_id, schedule_hash, task_hash, schedule_id,
             next_run_at, created_at, updated_at
           )
           VALUES (
-            ${taskId}, ${task.scheduleHash}, ${task.taskHash},
+            ${ownerKey}, ${taskId}, ${task.scheduleHash}, ${task.taskHash},
             ${scheduled.scheduleId}, ${scheduled.scheduledFor},
             ${now}, ${now}
           )
@@ -3253,7 +3261,8 @@ export class Think<
               schedule_id = ${scheduled.scheduleId},
               next_run_at = ${scheduled.scheduledFor},
               updated_at = ${now}
-          WHERE task_id = ${taskId}
+          WHERE owner_key = ${ownerKey}
+            AND task_id = ${taskId}
         `;
         continue;
       }
@@ -3272,7 +3281,8 @@ export class Think<
                 schedule_id = ${scheduled.scheduleId},
                 next_run_at = ${scheduled.scheduledFor},
                 updated_at = ${now}
-            WHERE task_id = ${taskId}
+            WHERE owner_key = ${ownerKey}
+              AND task_id = ${taskId}
           `;
           continue;
         }
@@ -3282,7 +3292,8 @@ export class Think<
         this.sql`
           UPDATE cf_think_scheduled_tasks
           SET task_hash = ${task.taskHash}, updated_at = ${now}
-          WHERE task_id = ${taskId}
+          WHERE owner_key = ${ownerKey}
+            AND task_id = ${taskId}
         `;
       }
     }
@@ -3292,7 +3303,8 @@ export class Think<
       if (row.schedule_id) await this.cancelSchedule(row.schedule_id);
       this.sql`
         DELETE FROM cf_think_scheduled_tasks
-        WHERE task_id = ${row.task_id}
+        WHERE owner_key = ${ownerKey}
+          AND task_id = ${row.task_id}
       `;
     }
   }
@@ -3375,7 +3387,8 @@ export class Think<
           next_run_at = ${scheduled.scheduledFor},
           task_hash = ${task.taskHash},
           updated_at = ${Date.now()}
-      WHERE task_id = ${payload.taskId}
+      WHERE owner_key = ${ownerKey}
+        AND task_id = ${payload.taskId}
         AND schedule_hash = ${payload.scheduleHash}
     `;
   }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -645,8 +645,32 @@ export type ThinkScheduledTaskSchedule =
   | ThinkWallClockSchedule
   | `${ThinkWallClockSchedule} in ${string}`;
 
-type ThinkScheduledTaskBase = {
+export type ThinkScheduledTaskContext = {
+  taskId: string;
+  scheduledFor: number;
+  scheduledForDate: Date;
+  occurrenceKey: string;
+  idempotencyKey: string;
+  schedule: string;
+  scheduleKind: "interval" | "wall-clock";
+  timezone?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type ThinkScheduledTaskPromptAction = {
   prompt: string | (() => string | Promise<string>);
+  handler?: never;
+};
+
+type ThinkScheduledTaskHandlerAction = {
+  handler: (ctx: ThinkScheduledTaskContext) => void | Promise<void>;
+  prompt?: never;
+};
+
+type ThinkScheduledTaskBase = (
+  | ThinkScheduledTaskPromptAction
+  | ThinkScheduledTaskHandlerAction
+) & {
   retry?: RetryOptions;
   metadata?: Record<string, unknown>;
 };
@@ -694,7 +718,8 @@ type ParseDeclaredScheduleResult =
 
 type NormalizedDeclaredTask = {
   taskId: string;
-  prompt: ThinkScheduledTask["prompt"];
+  prompt?: ThinkScheduledTaskPromptAction["prompt"];
+  handler?: ThinkScheduledTaskHandlerAction["handler"];
   schedule: ParsedDeclaredSchedule;
   retry?: RetryOptions;
   metadata?: Record<string, unknown>;
@@ -1613,6 +1638,15 @@ export class Think<
   /** Return code-declared scheduled tasks for this agent. */
   getScheduledTasks(): ThinkScheduledTasks | Promise<ThinkScheduledTasks> {
     return {};
+  }
+
+  /**
+   * Reconcile code-declared scheduled tasks immediately.
+   * Static declarations are reconciled on startup automatically; call this
+   * after changing app-owned data that `getScheduledTasks()` reads.
+   */
+  async internal_reconcileScheduledTasks(): Promise<void> {
+    await this._reconcileDeclaredScheduledTasks();
   }
 
   /**
@@ -3121,6 +3155,24 @@ export class Think<
     `;
   }
 
+  private _updateDeclaredScheduledTaskSchedule(
+    task: NormalizedDeclaredTask,
+    ownerKey: string,
+    scheduled: { scheduleId: string; scheduledFor: number },
+    updatedAt = Date.now()
+  ): void {
+    this.sql`
+      UPDATE cf_think_scheduled_tasks
+      SET schedule_hash = ${task.scheduleHash},
+          task_hash = ${task.taskHash},
+          schedule_id = ${scheduled.scheduleId},
+          next_run_at = ${scheduled.scheduledFor},
+          updated_at = ${updatedAt}
+      WHERE owner_key = ${ownerKey}
+        AND task_id = ${task.taskId}
+    `;
+  }
+
   private async _normalizeDeclaredScheduledTasks(
     tasks: ThinkScheduledTasks,
     defaultTimezone: string | undefined
@@ -3137,18 +3189,32 @@ export class Think<
         task.timezone,
         defaultTimezone
       );
+      const hasPrompt = "prompt" in task && task.prompt !== undefined;
+      const hasHandler = "handler" in task && task.handler !== undefined;
+      if (hasPrompt === hasHandler) {
+        throw new Error(
+          `Scheduled task "${taskId}" must define exactly one of prompt or handler`
+        );
+      }
       const scheduleHash = stableHash({
         schedule,
         retry: task.retry
       });
+      const actionHash = hasPrompt
+        ? {
+            type: "prompt",
+            value: typeof task.prompt === "string" ? task.prompt : "<function>"
+          }
+        : { type: "handler" };
       const taskHash = stableHash({
         scheduleHash,
-        prompt: typeof task.prompt === "string" ? task.prompt : "<function>",
+        action: actionHash,
         metadata: task.metadata
       });
       normalized.set(taskId, {
         taskId,
-        prompt: task.prompt,
+        ...(hasPrompt ? { prompt: task.prompt } : {}),
+        ...(hasHandler ? { handler: task.handler } : {}),
         schedule,
         retry: task.retry,
         metadata: task.metadata,
@@ -3230,10 +3296,6 @@ export class Think<
       seen.add(taskId);
       const row = existing.find((candidate) => candidate.task_id === taskId);
       if (!row) {
-        const scheduled = await this._scheduleDeclaredTaskOccurrence(
-          task,
-          new Date(now)
-        );
         this.sql`
           INSERT INTO cf_think_scheduled_tasks (
             owner_key, task_id, schedule_hash, task_hash, schedule_id,
@@ -3241,49 +3303,80 @@ export class Think<
           )
           VALUES (
             ${ownerKey}, ${taskId}, ${task.scheduleHash}, ${task.taskHash},
-            ${scheduled.scheduleId}, ${scheduled.scheduledFor},
-            ${now}, ${now}
+            NULL, NULL, ${now}, ${now}
           )
         `;
+        const scheduled = await this._scheduleDeclaredTaskOccurrence(
+          task,
+          new Date(now)
+        );
+        this._updateDeclaredScheduledTaskSchedule(
+          task,
+          ownerKey,
+          scheduled,
+          now
+        );
         continue;
       }
 
       if (row.schedule_hash !== task.scheduleHash) {
         if (row.schedule_id) await this.cancelSchedule(row.schedule_id);
-        const scheduled = await this._scheduleDeclaredTaskOccurrence(
-          task,
-          new Date(now)
-        );
         this.sql`
           UPDATE cf_think_scheduled_tasks
           SET schedule_hash = ${task.scheduleHash},
               task_hash = ${task.taskHash},
-              schedule_id = ${scheduled.scheduleId},
-              next_run_at = ${scheduled.scheduledFor},
+              schedule_id = NULL,
+              next_run_at = NULL,
               updated_at = ${now}
           WHERE owner_key = ${ownerKey}
             AND task_id = ${taskId}
         `;
+        const scheduled = await this._scheduleDeclaredTaskOccurrence(
+          task,
+          new Date(now)
+        );
+        this._updateDeclaredScheduledTaskSchedule(
+          task,
+          ownerKey,
+          scheduled,
+          now
+        );
+        continue;
+      }
+
+      if (!row.schedule_id) {
+        const scheduled =
+          row.next_run_at === null
+            ? await this._scheduleDeclaredTaskOccurrence(task, new Date(now))
+            : await this._scheduleDeclaredTaskOccurrenceAt(
+                task,
+                row.next_run_at
+              );
+        this._updateDeclaredScheduledTaskSchedule(
+          task,
+          ownerKey,
+          scheduled,
+          now
+        );
         continue;
       }
 
       if (row.schedule_id) {
         const schedule = await this.getScheduleById(row.schedule_id);
         if (!schedule) {
-          const scheduled = await this._scheduleDeclaredTaskOccurrence(
+          const scheduled =
+            row.next_run_at === null
+              ? await this._scheduleDeclaredTaskOccurrence(task, new Date(now))
+              : await this._scheduleDeclaredTaskOccurrenceAt(
+                  task,
+                  row.next_run_at
+                );
+          this._updateDeclaredScheduledTaskSchedule(
             task,
-            new Date(now),
-            row.next_run_at ?? undefined
+            ownerKey,
+            scheduled,
+            now
           );
-          this.sql`
-            UPDATE cf_think_scheduled_tasks
-            SET task_hash = ${task.taskHash},
-                schedule_id = ${scheduled.scheduleId},
-                next_run_at = ${scheduled.scheduledFor},
-                updated_at = ${now}
-            WHERE owner_key = ${ownerKey}
-              AND task_id = ${taskId}
-          `;
           continue;
         }
       }
@@ -3319,18 +3412,58 @@ export class Think<
       now,
       previousScheduledFor
     );
-    const scheduledFor = next.getTime();
+    return this._scheduleDeclaredTaskOccurrenceAt(task, next.getTime());
+  }
+
+  private async _scheduleDeclaredTaskOccurrenceAt(
+    task: NormalizedDeclaredTask,
+    scheduledFor: number
+  ): Promise<{ scheduleId: string; scheduledFor: number }> {
     const schedule = await this.schedule<DeclaredScheduledTaskPayload>(
-      next,
+      new Date(scheduledFor),
       "_runDeclaredScheduledTask",
       {
         taskId: task.taskId,
         scheduleHash: task.scheduleHash,
         scheduledFor
       },
-      { retry: task.retry, idempotent: true }
+      { idempotent: true }
     );
     return { scheduleId: schedule.id, scheduledFor };
+  }
+
+  private async _advanceDeclaredScheduledTask(
+    task: NormalizedDeclaredTask,
+    payload: DeclaredScheduledTaskPayload,
+    ownerKey: string
+  ): Promise<void> {
+    const scheduled = await this._scheduleDeclaredTaskOccurrence(
+      task,
+      new Date(),
+      payload.scheduledFor
+    );
+    this._updateDeclaredScheduledTaskSchedule(task, ownerKey, scheduled);
+  }
+
+  private _declaredScheduledTaskContext(
+    task: NormalizedDeclaredTask,
+    payload: DeclaredScheduledTaskPayload,
+    ownerKey: string
+  ): ThinkScheduledTaskContext {
+    const occurrenceKey = `${payload.taskId}:${payload.scheduledFor}`;
+    return {
+      taskId: payload.taskId,
+      scheduledFor: payload.scheduledFor,
+      scheduledForDate: new Date(payload.scheduledFor),
+      occurrenceKey,
+      idempotencyKey: `think-schedule:${ownerKey}:${occurrenceKey}`,
+      schedule: task.schedule.normalizedSchedule,
+      scheduleKind: task.schedule.kind,
+      ...(task.schedule.kind === "wall-clock" && {
+        timezone: task.schedule.timezone
+      }),
+      ...(task.metadata !== undefined && { metadata: task.metadata })
+    };
   }
 
   async _runDeclaredScheduledTask(
@@ -3347,50 +3480,66 @@ export class Think<
 
     const row = this._readDeclaredScheduledTaskRow(payload.taskId);
     if (!row || row.schedule_hash !== payload.scheduleHash) return;
+    if (row.next_run_at !== null && row.next_run_at > payload.scheduledFor) {
+      return;
+    }
 
     const tasks = await this._declaredScheduledTasksForNow();
     const task = tasks.get(payload.taskId);
     if (!task || task.scheduleHash !== payload.scheduleHash) return;
 
-    const prompt =
-      typeof task.prompt === "function" ? await task.prompt() : task.prompt;
     const ownerKey = this._declaredScheduleOwnerKey();
-    await this.submitMessages(
-      [
-        {
-          id: crypto.randomUUID(),
-          role: "user",
-          parts: [{ type: "text", text: prompt }]
-        }
-      ],
-      {
-        idempotencyKey: `think-schedule:${ownerKey}:${payload.taskId}:${payload.scheduledFor}`,
-        metadata: {
-          ...task.metadata,
-          source: "scheduled-task",
-          ownerKey,
-          taskId: payload.taskId,
-          scheduledFor: payload.scheduledFor,
-          schedule: task.schedule.normalizedSchedule
-        }
-      }
-    );
+    const context = this._declaredScheduledTaskContext(task, payload, ownerKey);
 
-    const scheduled = await this._scheduleDeclaredTaskOccurrence(
-      task,
-      new Date(),
-      payload.scheduledFor
-    );
-    this.sql`
-      UPDATE cf_think_scheduled_tasks
-      SET schedule_id = ${scheduled.scheduleId},
-          next_run_at = ${scheduled.scheduledFor},
-          task_hash = ${task.taskHash},
-          updated_at = ${Date.now()}
-      WHERE owner_key = ${ownerKey}
-        AND task_id = ${payload.taskId}
-        AND schedule_hash = ${payload.scheduleHash}
-    `;
+    let actionError: unknown;
+    try {
+      await this.retry(async () => {
+        if (task.prompt !== undefined) {
+          const prompt =
+            typeof task.prompt === "function"
+              ? await task.prompt()
+              : task.prompt;
+          await this.submitMessages(
+            [
+              {
+                id: crypto.randomUUID(),
+                role: "user",
+                parts: [{ type: "text", text: prompt }]
+              }
+            ],
+            {
+              idempotencyKey: context.idempotencyKey,
+              metadata: {
+                ...task.metadata,
+                source: "scheduled-task",
+                ownerKey,
+                taskId: payload.taskId,
+                scheduledFor: payload.scheduledFor,
+                schedule: task.schedule.normalizedSchedule
+              }
+            }
+          );
+        } else {
+          await task.handler?.(context);
+        }
+      }, task.retry);
+    } catch (error) {
+      actionError = error;
+    } finally {
+      await this._advanceDeclaredScheduledTask(task, payload, ownerKey);
+    }
+
+    if (actionError !== undefined) {
+      console.error(
+        `[Think] Scheduled task "${payload.taskId}" failed; next occurrence was still scheduled`,
+        actionError
+      );
+      try {
+        await this.onError(actionError);
+      } catch {
+        // Preserve recurrence even if user error handling fails.
+      }
+    }
   }
 
   // ── Durable programmatic submissions ───────────────────────────


### PR DESCRIPTION
## Summary

This PR adds declarative scheduled tasks to `@cloudflare/think`: a `getScheduledTasks()` API that lets Think agents declare recurring prompt submissions or deterministic scheduled handlers in code, with durable scheduling, startup reconciliation, and stable idempotency context built in.

The goal is to make proactive agent work feel native to Think. Instead of manually calling `schedule()` in `onStart()` and wiring callback methods by hand, a Think subclass can now declare durable recurring work:

```ts
getScheduledTasks(): ThinkScheduledTasks {
  return {
    hourlyQueueDigest: {
      schedule: "every 1 hour",
      prompt:
        "Write a concise hourly reminder that durable background task queues should be checked for stuck or failed work."
    },
    dailyWorkflow: {
      schedule: "every day at 09:00",
      timezone: "UTC",
      retry: { maxAttempts: 3 },
      handler: async ({ idempotencyKey, scheduledFor, timezone }) => {
        await this.env.REPORT_WORKFLOW.create({
          id: idempotencyKey,
          params: { scheduledFor, timezone }
        });
      }
    }
  };
}
```

## What This Adds

- Adds `getScheduledTasks()` to `Think` for code-declared recurring prompts and handlers.
- Adds `getDefaultTimezone()` for app/user-level wall-clock timezone context.
- Adds exported scheduled-task types and `defineScheduledTasks()` for optional literal inference without method return annotations.
- Adds mutually exclusive `prompt` and `handler` task actions.
- Gives handlers stable occurrence context: `taskId`, `scheduledFor`, `scheduledForDate`, `occurrenceKey`, `idempotencyKey`, `schedule`, `scheduleKind`, `timezone`, and `metadata`.
- Adds a small deterministic recurring DSL:
  - `every <n> minutes`
  - `every <n> hours`
  - `every day at HH:mm`
  - `every weekday at HH:mm`
  - `every week on <day>[,<day>...] at HH:mm`
- Adds runtime validation for task IDs, DSL shape, timezone sources, pluralization, invalid/duplicate days, and interval/timezone mismatches.
- Adds timezone-aware wall-clock scheduling using `Intl.DateTimeFormat`, including explicit DST gap/overlap semantics.
- Reconciles declared tasks into owner-scoped one-shot Agent schedules and tracks them in `cf_think_scheduled_tasks`.
- Preserves schedule rows for action-only changes, replaces rows when timing semantics change, removes rows when tasks are removed, and repairs missing/pending schedule rows.
- Runs prompt occurrences through durable `submitMessages()` using stable owner/task/occurrence idempotency keys.
- Runs handler occurrences directly for app-owned deterministic work such as starting Workflows or writing ledgers.
- Supports sub-agents through the existing root scheduler delegation and owner-scoped schedule APIs.

## Why This Matters

Scheduled work is a core agent use case: daily summaries, recurring check-ins, background reports, routine reminders, health digests, and deterministic app jobs like Workflow starts. Before this PR, developers needed to reason about scheduler rows, callback names, idempotent `schedule()` calls in `onStart()`, payload stability, and duplicate execution safety themselves.

This API lifts that into Think's mental model:

- `getTools()` defines what the agent can do.
- `configureSession()` defines what the agent remembers.
- `getScheduledTasks()` defines what the agent should proactively do over time.

Prompt tasks are normal durable Think turns, so existing hooks, storage, submission inspection, recovery behavior, and idempotency semantics continue to apply. Handler tasks are for deterministic app-owned work and are delivered at least once, so callers should use the provided `idempotencyKey` or `occurrenceKey` for external side effects.

## Deploy/Reconciliation Semantics

Declared schedules are reconciled on startup after Think session/protocol setup and before recovered submissions drain. If `getScheduledTasks()` reads product-owned data that can change while the Durable Object is live, app code can call `internal_reconcileScheduledTasks()` after updating that data.

The reconciler:

- Validates the current declaration set.
- Normalizes each schedule and resolved timezone.
- Computes separate schedule/task hashes.
- Creates schedule rows for new tasks.
- Leaves the existing schedule row in place for prompt/handler/metadata-only changes.
- Cancels/replaces schedule rows when schedule, timezone, or retry semantics change.
- Cancels/deletes owned rows when tasks are removed from code.
- Repairs pending rows where the Think ledger exists but `schedule_id` has not been written yet.
- Recreates rows whose underlying Agent schedule is missing.
- Ignores stale callback payloads after task changes.
- Never scans or cancels unrelated user-created schedules.

## Retry, Failure, And Delivery Semantics

The task `retry` option applies to the scheduled action itself: prompt generation/submission for prompt tasks, or handler execution for handler tasks. After the action succeeds or exhausts its retries, Think still schedules the next occurrence so one bad run does not stall the recurrence chain.

Delivery remains at least once. If the Durable Object or scheduler retries after a partial failure, the same occurrence may be delivered again. Prompt tasks use stable `submitMessages()` idempotency keys; handler tasks receive stable keys and should use them when creating Workflows or performing external side effects.

## Timezone And Timing Behavior

Wall-clock schedules require one of:

- inline DSL timezone, e.g. `every day at 08:00 in Europe/London`
- task-local `timezone`
- `getDefaultTimezone()`

Interval schedules intentionally do not accept timezone because they are duration based.

The runtime uses one-shot `Date` schedules for declared tasks instead of cron rows, which gives Think control over timezone behavior, late alarms, and interval drift.

Defined behavior:

- Nonexistent local time during DST spring-forward runs at the next valid local time after the gap.
- Repeated local time during DST fall-back runs once, at the first occurrence.
- Late alarms run the intended occurrence once and schedule the next future occurrence.
- Missed occurrences are not backfilled.
- Different intended occurrence timestamps may queue separately if previous work is still active.

## Example And Docs

This PR updates `examples/think-submissions` to show scheduled prompt tasks alongside manual durable submissions. The example keeps an hourly cadence to avoid surprising model usage, and the README explains how to shorten the interval locally for a quick demo.

The Think README and docs now cover:

- `getScheduledTasks()`
- prompt vs handler tasks
- handler context and idempotency expectations
- `getDefaultTimezone()`
- the supported DSL
- runtime validation
- no-backfill behavior
- optional `defineScheduledTasks()` usage
- dynamic reconciliation with `internal_reconcileScheduledTasks()`
- scheduled handler usage for Workflow starts

## Test Coverage

Adds coverage for:

- Runtime DSL validation and timezone validation.
- Type-level literal schedule checks.
- Prompt vs handler type exclusivity.
- Startup reconciliation.
- Action-only changes preserving schedule rows.
- Schedule/timezone changes replacing schedule rows.
- Removed tasks cancelling owned rows.
- Unrelated user-created schedules being preserved.
- Default timezone changes affecting wall-clock schedules.
- Late interval/no-backfill behavior.
- DST spring-forward and fall-back behavior.
- Idempotent scheduled execution through `submitMessages()`.
- Prompt and handler failures still re-arming future occurrences.
- Action-level retries for scheduled handlers.
- Pending `schedule_id` repair without duplicate task rows.
- Sub-agent scheduled task ownership and handler support.

## Test Plan

- `npx vitest run packages/think/src/tests/scheduled-tasks.test.ts --config packages/think/src/tests/vitest.config.ts`
- `npm run check`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->