### PR TITLE
feat(mcp): support caller-supplied stable ids in addMcpServer

### DIFF
--- a/.changeset/stable-mcp-server-ids.md
+++ b/.changeset/stable-mcp-server-ids.md
@@ -10,7 +10,7 @@ The supplied id is normalized via the exported `normalizeServerId` helper so tha
 
 **Fully additive — no user code breaks.** If you add `{ id: "github" }` to an existing `addMcpServer` call for a server that's already registered under an auto-generated nanoid, the SDK transparently migrates the existing storage row, in-memory connection, and OAuth-related DO storage keys to the new stable id. No `removeMcpServer` step required, no stale rows, no broken hibernation restore.
 
-`addMcpServer` only throws on a genuinely ambiguous collision: the same stable id already belongs to a *different* `(name, url)` server.
+`addMcpServer` only throws on a genuinely ambiguous collision: the same stable id already belongs to a _different_ `(name, url)` server.
 
 ```ts
 await this.addMcpServer("GitHub", env.MCP_SESSION, {

--- a/.changeset/stable-mcp-server-ids.md
+++ b/.changeset/stable-mcp-server-ids.md
@@ -1,0 +1,19 @@
+---
+"agents": minor
+---
+
+Support stable, caller-supplied server ids in `addMcpServer` for connector-style integrations.
+
+Both the HTTP and RPC overloads of `addMcpServer` now accept an optional `id` field on their options object. When provided, this id replaces the generated `nanoid(8)` as the server's id in storage, restore, `listServers()`, `listTools()`, `getAITools()` (so tool keys become e.g. `tool_github_create_pull_request` instead of opaque connection ids), and OAuth state.
+
+The supplied id is normalized via the exported `normalizeServerId` helper so that values like `"GitHub MCP!"` become `"github-mcp"` — guaranteeing the id is safe to embed in AI SDK tool names and storage keys. If a caller-supplied id already maps to a server with a different name or url, `addMcpServer` now throws instead of silently overwriting the existing row.
+
+```ts
+await this.addMcpServer("GitHub", env.MCP_SESSION, {
+  id: "github",
+  props: { token: "..." }
+});
+// tools surface as `tool_github_<name>`
+```
+
+Closes #1564.

--- a/.changeset/stable-mcp-server-ids.md
+++ b/.changeset/stable-mcp-server-ids.md
@@ -1,5 +1,5 @@
 ---
-"agents": minor
+"agents": patch
 ---
 
 Support stable, caller-supplied server ids in `addMcpServer` for connector-style integrations.

--- a/.changeset/stable-mcp-server-ids.md
+++ b/.changeset/stable-mcp-server-ids.md
@@ -8,10 +8,9 @@ Both the HTTP and RPC overloads of `addMcpServer` now accept an optional `id` fi
 
 The supplied id is normalized via the exported `normalizeServerId` helper so that values like `"GitHub MCP!"` become `"github-mcp"` — guaranteeing the id is safe to embed in AI SDK tool names and storage keys.
 
-`addMcpServer` now throws explicitly when a stable id would conflict with existing storage:
+**Fully additive — no user code breaks.** If you add `{ id: "github" }` to an existing `addMcpServer` call for a server that's already registered under an auto-generated nanoid, the SDK transparently migrates the existing storage row, in-memory connection, and OAuth-related DO storage keys to the new stable id. No `removeMcpServer` step required, no stale rows, no broken hibernation restore.
 
-- the supplied id already belongs to a different `(name, url)` server, or
-- the same `(name, url)` is already registered under a different id (e.g. an auto-generated nanoid from a previous call). The error message points the caller at `removeMcpServer(oldId)` to migrate. This avoids silently returning the old id or leaving a stale storage row after `INSERT OR REPLACE`.
+`addMcpServer` only throws on a genuinely ambiguous collision: the same stable id already belongs to a *different* `(name, url)` server.
 
 ```ts
 await this.addMcpServer("GitHub", env.MCP_SESSION, {

--- a/.changeset/stable-mcp-server-ids.md
+++ b/.changeset/stable-mcp-server-ids.md
@@ -6,7 +6,12 @@ Support stable, caller-supplied server ids in `addMcpServer` for connector-style
 
 Both the HTTP and RPC overloads of `addMcpServer` now accept an optional `id` field on their options object. When provided, this id replaces the generated `nanoid(8)` as the server's id in storage, restore, `listServers()`, `listTools()`, `getAITools()` (so tool keys become e.g. `tool_github_create_pull_request` instead of opaque connection ids), and OAuth state.
 
-The supplied id is normalized via the exported `normalizeServerId` helper so that values like `"GitHub MCP!"` become `"github-mcp"` — guaranteeing the id is safe to embed in AI SDK tool names and storage keys. If a caller-supplied id already maps to a server with a different name or url, `addMcpServer` now throws instead of silently overwriting the existing row.
+The supplied id is normalized via the exported `normalizeServerId` helper so that values like `"GitHub MCP!"` become `"github-mcp"` — guaranteeing the id is safe to embed in AI SDK tool names and storage keys.
+
+`addMcpServer` now throws explicitly when a stable id would conflict with existing storage:
+
+- the supplied id already belongs to a different `(name, url)` server, or
+- the same `(name, url)` is already registered under a different id (e.g. an auto-generated nanoid from a previous call). The error message points the caller at `removeMcpServer(oldId)` to migrate. This avoids silently returning the old id or leaving a stale storage row after `INSERT OR REPLACE`.
 
 ```ts
 await this.addMcpServer("GitHub", env.MCP_SESSION, {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -9434,11 +9434,17 @@ export class Agent<
 
     const allServers = this.mcp.listServers();
 
-    // Collision check: a caller-supplied id may only re-resolve to an existing
-    // server when the (name, url) also matches. Otherwise this would silently
-    // overwrite the existing row (storage uses INSERT OR REPLACE on id).
+    const existingServer = allServers.find(
+      (s) =>
+        s.name === serverName &&
+        (!isHttpTransport || new URL(s.server_url).href === normalizedUrl)
+    );
+
     if (requestedId) {
-      const conflict = allServers.find((s) => {
+      // Collision check 1: a caller-supplied id may only re-resolve to an
+      // existing server when the (name, url) also matches. Otherwise storage
+      // (INSERT OR REPLACE on id) would silently overwrite the existing row.
+      const idConflict = allServers.find((s) => {
         if (s.id !== requestedId) return false;
         if (s.name !== serverName) return true;
         if (isHttpTransport) {
@@ -9446,19 +9452,28 @@ export class Agent<
         }
         return false;
       });
-      if (conflict) {
+      if (idConflict) {
         throw new Error(
-          `MCP server id "${requestedId}" is already in use by server "${conflict.name}" (${conflict.server_url}). ` +
+          `MCP server id "${requestedId}" is already in use by server "${idConflict.name}" (${idConflict.server_url}). ` +
             `Stable ids must be unique per (name, url).`
+        );
+      }
+
+      // Collision check 2: the same (name, url) is already registered under a
+      // different id (typically an auto-generated nanoid from a previous call
+      // that didn't supply `id`). Honouring `requestedId` here would either
+      // silently return the old id (violating the caller's contract) or leave
+      // a stale row in storage after INSERT OR REPLACE on the new id. Require
+      // an explicit migration via removeMcpServer().
+      if (existingServer && existingServer.id !== requestedId) {
+        throw new Error(
+          `MCP server "${serverName}" is already registered with id "${existingServer.id}", ` +
+            `cannot re-register with stable id "${requestedId}". ` +
+            `Call removeMcpServer("${existingServer.id}") first to migrate to a stable id.`
         );
       }
     }
 
-    const existingServer = allServers.find(
-      (s) =>
-        s.name === serverName &&
-        (!isHttpTransport || new URL(s.server_url).href === normalizedUrl)
-    );
     if (existingServer && this.mcp.mcpConnections[existingServer.id]) {
       const conn = this.mcp.mcpConnections[existingServer.id];
       if (

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -45,7 +45,11 @@ import {
   isErrorRetryable,
   validateRetryOptions
 } from "./retries";
-import { MCPClientManager, type MCPClientOAuthResult } from "./mcp/client";
+import {
+  MCPClientManager,
+  normalizeServerId,
+  type MCPClientOAuthResult
+} from "./mcp/client";
 import type {
   WorkflowCallback,
   WorkflowTrackingRow,
@@ -796,6 +800,7 @@ function getNextCronTime(cron: string) {
 
 export type { TransportType } from "./mcp/types";
 export type { RetryOptions } from "./retries";
+export { normalizeServerId, MCP_SERVER_ID_MAX_LENGTH } from "./mcp/client";
 export {
   DurableObjectOAuthClientProvider,
   type AgentMcpOAuthProvider,
@@ -838,6 +843,17 @@ export type MCPServer = {
  * Options for adding an MCP server
  */
 export type AddMcpServerOptions = {
+  /**
+   * Optional caller-supplied stable server id. When provided, this id is used
+   * for storage, restore, and tool-name namespacing instead of a generated
+   * `nanoid`. The value is normalized via {@link normalizeServerId} — for
+   * connector-style integrations this lets `addMcpServer` keep producing
+   * keys like `tool_github_create_pull_request`.
+   *
+   * Throws if an existing server already uses the same (normalized) id but a
+   * different name or url.
+   */
+  id?: string;
   /** OAuth callback host (auto-derived from request if omitted) */
   callbackHost?: string;
   /**
@@ -867,6 +883,15 @@ export type AddMcpServerOptions = {
  * Options for adding an MCP server via RPC (Durable Object binding)
  */
 export type AddRpcMcpServerOptions = {
+  /**
+   * Optional caller-supplied stable server id. When provided, this id is used
+   * for storage, restore, and tool-name namespacing instead of a generated
+   * `nanoid`. The value is normalized via {@link normalizeServerId}.
+   *
+   * Throws if an existing server already uses the same (normalized) id but a
+   * different name or url.
+   */
+  id?: string;
   /** Props to pass to the McpAgent instance */
   props?: Record<string, unknown>;
 };
@@ -9394,13 +9419,46 @@ export class Agent<
     const normalizedUrl = isHttpTransport
       ? new URL(urlOrBinding).href
       : undefined;
-    const existingServer = this.mcp
-      .listServers()
-      .find(
-        (s) =>
-          s.name === serverName &&
-          (!isHttpTransport || new URL(s.server_url).href === normalizedUrl)
-      );
+
+    // Extract and normalize a caller-supplied stable id, if any. The same
+    // option field is accepted on both the HTTP and RPC option shapes.
+    let requestedId: string | undefined;
+    if (
+      typeof callbackHostOrOptions === "object" &&
+      callbackHostOrOptions !== null &&
+      typeof (callbackHostOrOptions as { id?: unknown }).id === "string"
+    ) {
+      const rawId = (callbackHostOrOptions as { id: string }).id;
+      requestedId = normalizeServerId(rawId);
+    }
+
+    const allServers = this.mcp.listServers();
+
+    // Collision check: a caller-supplied id may only re-resolve to an existing
+    // server when the (name, url) also matches. Otherwise this would silently
+    // overwrite the existing row (storage uses INSERT OR REPLACE on id).
+    if (requestedId) {
+      const conflict = allServers.find((s) => {
+        if (s.id !== requestedId) return false;
+        if (s.name !== serverName) return true;
+        if (isHttpTransport) {
+          return new URL(s.server_url).href !== normalizedUrl;
+        }
+        return false;
+      });
+      if (conflict) {
+        throw new Error(
+          `MCP server id "${requestedId}" is already in use by server "${conflict.name}" (${conflict.server_url}). ` +
+            `Stable ids must be unique per (name, url).`
+        );
+      }
+    }
+
+    const existingServer = allServers.find(
+      (s) =>
+        s.name === serverName &&
+        (!isHttpTransport || new URL(s.server_url).href === normalizedUrl)
+    );
     if (existingServer && this.mcp.mcpConnections[existingServer.id]) {
       const conn = this.mcp.mcpConnections[existingServer.id];
       if (
@@ -9429,7 +9487,9 @@ export class Agent<
 
       const normalizedName = serverName.toLowerCase().replace(/\s+/g, "-");
 
-      const reconnectId = existingServer?.id;
+      // Prefer the caller-supplied stable id, falling back to the existing
+      // server's id (for restore-through-addMcpServer), then to a generated id.
+      const reconnectId = requestedId ?? existingServer?.id;
       const { id } = await this.mcp.connect(
         `${RPC_DO_PREFIX}${normalizedName}`,
         {
@@ -9544,7 +9604,7 @@ export class Agent<
         : `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
     }
 
-    const id = nanoid(8);
+    const id = requestedId ?? nanoid(8);
 
     // Only create authProvider if we have a callbackUrl (needed for OAuth servers)
     let authProvider:

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -9459,18 +9459,20 @@ export class Agent<
         );
       }
 
-      // Collision check 2: the same (name, url) is already registered under a
-      // different id (typically an auto-generated nanoid from a previous call
-      // that didn't supply `id`). Honouring `requestedId` here would either
-      // silently return the old id (violating the caller's contract) or leave
-      // a stale row in storage after INSERT OR REPLACE on the new id. Require
-      // an explicit migration via removeMcpServer().
+      // JIT-migrate: the same (name, url) is already registered under a
+      // different id (typically an auto-generated nanoid from a previous
+      // call that didn't supply `id`). This is the natural upgrade path —
+      // a user adds `{ id: "github" }` to an existing `addMcpServer` call.
+      // Rename the existing row + connection + OAuth keys to the new id in
+      // place so the caller's contract ("the id I get back is the id I
+      // asked for") holds and no stale storage rows are left behind.
       if (existingServer && existingServer.id !== requestedId) {
-        throw new Error(
-          `MCP server "${serverName}" is already registered with id "${existingServer.id}", ` +
-            `cannot re-register with stable id "${requestedId}". ` +
-            `Call removeMcpServer("${existingServer.id}") first to migrate to a stable id.`
+        await this.mcp.migrateServerId(
+          existingServer.id,
+          requestedId,
+          this.name
         );
+        existingServer.id = requestedId;
       }
     }
 

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -34,6 +34,55 @@ const defaultClientOptions: ConstructorParameters<typeof Client>[1] = {
   jsonSchemaValidator: new CfWorkerJsonSchemaValidator()
 };
 
+/** Maximum length of a normalized MCP server id. */
+export const MCP_SERVER_ID_MAX_LENGTH = 64;
+
+/**
+ * Normalize a caller-supplied MCP server id into a stable, storage- and
+ * tool-name-safe form.
+ *
+ * The id is surfaced in several places where the character set matters:
+ *  - as the primary key in the `cf_agents_mcp_servers` SQLite table
+ *  - embedded in AI SDK tool names as `` `tool_${id.replace(/-/g, "")}_${tool}` ``
+ *    (tool names must match `/^[A-Za-z0-9_]+$/`)
+ *  - as a key on the `mcpConnections` map and OAuth provider storage
+ *
+ * Rules:
+ *  1. Lowercase.
+ *  2. Replace any run of disallowed characters with a single `-`.
+ *  3. Collapse repeated `-` and trim leading/trailing `-`/`_`.
+ *  4. Prefix with `id-` if the result is empty or doesn't start with a letter.
+ *  5. Truncate to {@link MCP_SERVER_ID_MAX_LENGTH} characters.
+ *
+ * @example
+ * normalizeServerId("my-supplied-id");  // "my-supplied-id"
+ * normalizeServerId("GitHub MCP!");     // "github-mcp"
+ * normalizeServerId("42-things");       // "id-42-things"
+ */
+export function normalizeServerId(input: string): string {
+  if (typeof input !== "string") {
+    throw new TypeError(
+      `normalizeServerId: expected string, got ${typeof input}`
+    );
+  }
+
+  let id = input
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "");
+
+  if (id.length === 0 || !/^[a-z]/.test(id)) {
+    id = `id-${id}`.replace(/-+$/g, "");
+  }
+
+  if (id.length > MCP_SERVER_ID_MAX_LENGTH) {
+    id = id.slice(0, MCP_SERVER_ID_MAX_LENGTH).replace(/-+$/g, "");
+  }
+
+  return id;
+}
+
 /**
  * Blocked hostname patterns for SSRF protection.
  * Prevents MCP client from connecting to internal/private network addresses

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -385,6 +385,113 @@ export class MCPClientManager {
     this.sql("DELETE FROM cf_agents_mcp_servers WHERE id = ?", serverId);
   }
 
+  /**
+   * Rename a server's id, in-place, across every place the id is used as a
+   * key. Used to JIT-migrate servers that were originally registered under an
+   * auto-generated nanoid to a caller-supplied stable id (see
+   * `Agent.addMcpServer`'s `{ id }` option).
+   *
+   * Migrates:
+   *  - the `cf_agents_mcp_servers` row (primary key)
+   *  - the in-memory `mcpConnections` map key
+   *  - the connection disposables map key
+   *  - the attached `authProvider.serverId`, if any
+   *  - OAuth-related storage keys under `/{clientName}/{oldId}/...`
+   *
+   * Safe to call when no OAuth keys exist (RPC / bearer-token HTTP servers).
+   * If `oldId === newId` this is a no-op. If a row already exists under
+   * `newId`, throws — the caller is expected to have verified uniqueness.
+   *
+   * @internal Exposed for `Agent.addMcpServer` JIT-migration.
+   */
+  async migrateServerId(
+    oldId: string,
+    newId: string,
+    clientName: string
+  ): Promise<void> {
+    if (oldId === newId) return;
+
+    const existing = this.sql<MCPServerRow>(
+      "SELECT id FROM cf_agents_mcp_servers WHERE id = ?",
+      oldId
+    );
+    if (existing.length === 0) {
+      // Nothing in storage to rename; just rename the in-memory connection if any.
+      this._renameInMemoryConnection(oldId, newId);
+      return;
+    }
+
+    const collision = this.sql<MCPServerRow>(
+      "SELECT id FROM cf_agents_mcp_servers WHERE id = ?",
+      newId
+    );
+    if (collision.length > 0) {
+      throw new Error(
+        `Cannot migrate MCP server id "${oldId}" → "${newId}": new id is already in use.`
+      );
+    }
+
+    // 1. Storage: rename the SQL row.
+    this.sql(
+      "UPDATE cf_agents_mcp_servers SET id = ? WHERE id = ?",
+      newId,
+      oldId
+    );
+
+    // 2. OAuth-related storage keys. The DurableObjectOAuthClientProvider
+    //    keys everything under `/{clientName}/{serverId}/...`. Other servers
+    //    won't have any keys with this prefix, so the list will be empty and
+    //    this is a no-op for them.
+    const oldPrefix = `/${clientName}/${oldId}/`;
+    const newPrefix = `/${clientName}/${newId}/`;
+    try {
+      const keys = await this._storage.list({ prefix: oldPrefix });
+      if (keys.size > 0) {
+        const writes: Record<string, unknown> = {};
+        const deletes: string[] = [];
+        for (const [oldKey, value] of keys) {
+          const newKey = newPrefix + oldKey.slice(oldPrefix.length);
+          writes[newKey] = value;
+          deletes.push(oldKey);
+        }
+        await this._storage.put(writes);
+        await this._storage.delete(deletes);
+      }
+    } catch (error) {
+      // Best-effort: storage rename failures shouldn't break the SQL-level
+      // rename that already succeeded. Log and continue.
+      console.warn(
+        `[MCPClientManager] OAuth key migration ${oldPrefix} → ${newPrefix} failed:`,
+        error
+      );
+    }
+
+    // 3. In-memory connection + disposables + authProvider.
+    this._renameInMemoryConnection(oldId, newId);
+
+    this._onServerStateChanged.fire();
+  }
+
+  private _renameInMemoryConnection(oldId: string, newId: string): void {
+    if (oldId === newId) return;
+
+    const conn = this.mcpConnections[oldId];
+    if (conn) {
+      this.mcpConnections[newId] = conn;
+      delete this.mcpConnections[oldId];
+      const authProvider = conn.options.transport.authProvider;
+      if (authProvider) {
+        authProvider.serverId = newId;
+      }
+    }
+
+    const disposables = this._connectionDisposables.get(oldId);
+    if (disposables) {
+      this._connectionDisposables.set(newId, disposables);
+      this._connectionDisposables.delete(oldId);
+    }
+  }
+
   private getServersFromStorage(): MCPServerRow[] {
     return this.sql<MCPServerRow>(
       "SELECT id, name, server_url, client_id, auth_url, callback_url, server_options FROM cf_agents_mcp_servers"

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -544,6 +544,8 @@ export type {
   MCPDiscoverResult
 } from "./client";
 
+export { normalizeServerId, MCP_SERVER_ID_MAX_LENGTH } from "./client";
+
 export type { McpClientOptions } from "./types";
 
 export {

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -571,6 +571,81 @@ export class TestRpcMcpClientAgent extends Agent {
     }
   }
 
+  async testRpcSuppliedIdRejectsExistingNanoid() {
+    try {
+      // First call: no supplied id — gets an auto-generated nanoid.
+      const first = await this.addMcpServer(
+        "rpc-migrate-test",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        { props: { testValue: "first" } }
+      );
+
+      // Second call: same (name, url) but now supplying a stable id should
+      // throw and tell the caller how to migrate, NOT silently return the old
+      // id and NOT leave a stale row in storage.
+      let threw = false;
+      let message = "";
+      try {
+        await this.addMcpServer(
+          "rpc-migrate-test",
+          this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+          { id: "migrated", props: { testValue: "second" } }
+        );
+      } catch (e) {
+        threw = true;
+        message = e instanceof Error ? e.message : String(e);
+      }
+
+      // After throwing, only the original row should exist.
+      const storedIds = this.mcp
+        .getRpcServersFromStorage()
+        .filter((s) => s.name === "rpc-migrate-test")
+        .map((s) => s.id);
+
+      return {
+        success: true,
+        firstId: first.id,
+        threw,
+        message,
+        storedIds
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  async testRpcSuppliedIdDedupsOnRepeat() {
+    try {
+      const first = await this.addMcpServer(
+        "rpc-dedup-stable",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        { id: "stable", props: { testValue: "first" } }
+      );
+
+      // Calling again with the same id + (name, url) should dedup, not throw.
+      const second = await this.addMcpServer(
+        "rpc-dedup-stable",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        { id: "stable", props: { testValue: "second" } }
+      );
+
+      return {
+        success: true,
+        firstId: first.id,
+        secondId: second.id,
+        sameId: first.id === second.id
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
   async testRemoveRpcMcpServer() {
     try {
       const { id } = await this.addMcpServer(

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -571,7 +571,7 @@ export class TestRpcMcpClientAgent extends Agent {
     }
   }
 
-  async testRpcSuppliedIdRejectsExistingNanoid() {
+  async testRpcSuppliedIdMigratesExistingNanoid() {
     try {
       // First call: no supplied id — gets an auto-generated nanoid.
       const first = await this.addMcpServer(
@@ -580,34 +580,46 @@ export class TestRpcMcpClientAgent extends Agent {
         { props: { testValue: "first" } }
       );
 
-      // Second call: same (name, url) but now supplying a stable id should
-      // throw and tell the caller how to migrate, NOT silently return the old
-      // id and NOT leave a stale row in storage.
-      let threw = false;
-      let message = "";
-      try {
-        await this.addMcpServer(
-          "rpc-migrate-test",
-          this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
-          { id: "migrated", props: { testValue: "second" } }
-        );
-      } catch (e) {
-        threw = true;
-        message = e instanceof Error ? e.message : String(e);
-      }
+      const connectionsBefore = Object.keys(this.mcp.mcpConnections).length;
 
-      // After throwing, only the original row should exist.
+      // Second call: same (name, url) but now supplying a stable id. This is
+      // the natural upgrade path (user adds `{ id }` to existing code) — the
+      // existing row + connection should be migrated in place, NOT thrown.
+      const second = await this.addMcpServer(
+        "rpc-migrate-test",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        { id: "migrated", props: { testValue: "second" } }
+      );
+
+      // After migration: only the new stable id should exist in storage.
       const storedIds = this.mcp
         .getRpcServersFromStorage()
         .filter((s) => s.name === "rpc-migrate-test")
         .map((s) => s.id);
 
+      const connectionsAfter = Object.keys(this.mcp.mcpConnections).length;
+      const stableConnectionExists =
+        this.mcp.mcpConnections[second.id] !== undefined;
+      const nanoidConnectionGone =
+        this.mcp.mcpConnections[first.id] === undefined;
+
+      // Tool calls should still work against the migrated id.
+      const callResult = await this.mcp.callTool({
+        serverId: second.id,
+        name: "greet",
+        arguments: { name: "Migrated User" }
+      });
+
       return {
         success: true,
         firstId: first.id,
-        threw,
-        message,
-        storedIds
+        secondId: second.id,
+        storedIds,
+        connectionsBefore,
+        connectionsAfter,
+        stableConnectionExists,
+        nanoidConnectionGone,
+        callOk: !callResult.isError
       };
     } catch (error) {
       return {
@@ -863,6 +875,66 @@ export class TestHttpMcpDedupAgent extends Agent {
       seededId,
       returnedId: result.id,
       deduped: result.id === seededId
+    };
+  }
+
+  // Test: a server first registered without `id` (under a nanoid) gets
+  // migrated in place when the caller adds `{ id }` on the next call.
+  async testHttpSuppliedIdMigratesNanoid() {
+    // Seed an existing server under a nanoid-ish id, exactly as if the user
+    // had called addMcpServer(name, url) previously without { id }.
+    const oldId = await this._seedServer(
+      "http-migrate-server",
+      "https://mcp.example.com/migrate",
+      "old-nanoid-aaaa"
+    );
+
+    // Drop fake OAuth-style keys under the old prefix to verify the manager
+    // also migrates DO-storage-backed OAuth state, not just the SQL row.
+    const ctx = (this as unknown as { ctx: { storage: DurableObjectStorage } })
+      .ctx;
+    await ctx.storage.put(`/${this.name}/${oldId}/test-client/client_info/`, {
+      client_id: "abc"
+    });
+    await ctx.storage.put(`/${this.name}/${oldId}/test-client/token`, {
+      access_token: "t"
+    });
+
+    let resultId: string | null = null;
+    try {
+      const r = await this.addMcpServer(
+        "http-migrate-server",
+        "https://mcp.example.com/migrate",
+        { id: "stable-migrated" }
+      );
+      resultId = r.id;
+    } catch (_e) {
+      // The mocked connectToServer always fails; that's expected. What we
+      // care about is the storage-level migration that ran before connect.
+      const servers = this.mcp.listServers();
+      resultId =
+        servers.find((s) => s.name === "http-migrate-server")?.id ?? null;
+    }
+
+    const storedIds = this.mcp
+      .listServers()
+      .filter((s) => s.name === "http-migrate-server")
+      .map((s) => s.id);
+
+    // OAuth keys should have moved from old prefix to new prefix.
+    const oldKeys = await ctx.storage.list({
+      prefix: `/${this.name}/${oldId}/`
+    });
+    const newKeys = await ctx.storage.list({
+      prefix: `/${this.name}/stable-migrated/`
+    });
+
+    return {
+      oldId,
+      resultId,
+      storedIds,
+      oldKeyCount: oldKeys.size,
+      newKeyCount: newKeys.size
     };
   }
 

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -486,6 +486,91 @@ export class TestRpcMcpClientAgent extends Agent {
     }
   }
 
+  async testRpcStableSuppliedId() {
+    try {
+      const { id } = await this.addMcpServer(
+        "rpc-stable-id-test",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        {
+          id: "my-supplied-id",
+          props: { testValue: "stable-id" }
+        }
+      );
+
+      const toolNames = this.mcp.listTools().map((t) => t.name);
+      const saved = this.mcp
+        .getRpcServersFromStorage()
+        .find((s) => s.id === id);
+
+      return {
+        success: true,
+        id,
+        savedId: saved?.id ?? null,
+        toolNames
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  async testRpcNormalizesSuppliedId() {
+    try {
+      const { id } = await this.addMcpServer(
+        "rpc-normalize-id-test",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        {
+          id: "GitHub MCP!",
+          props: { testValue: "normalized" }
+        }
+      );
+      return { success: true, id };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  async testRpcSuppliedIdCollision() {
+    try {
+      const first = await this.addMcpServer(
+        "rpc-collide-a",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        {
+          id: "collide",
+          props: { testValue: "a" }
+        }
+      );
+
+      let threw = false;
+      let message = "";
+      try {
+        await this.addMcpServer(
+          "rpc-collide-b",
+          this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+          {
+            id: "collide",
+            props: { testValue: "b" }
+          }
+        );
+      } catch (e) {
+        threw = true;
+        message = e instanceof Error ? e.message : String(e);
+      }
+
+      return { success: true, firstId: first.id, threw, message };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
   async testRemoveRpcMcpServer() {
     try {
       const { id } = await this.addMcpServer(
@@ -620,8 +705,12 @@ export class TestHttpMcpDedupAgent extends Agent {
   }
 
   // Set up a fake "ready" server so the dedup check has something to find
-  private async _seedServer(name: string, url: string): Promise<string> {
-    const id = `test-${name}-${Date.now()}`;
+  private async _seedServer(
+    name: string,
+    url: string,
+    overrideId?: string
+  ): Promise<string> {
+    const id = overrideId ?? `test-${name}-${Date.now()}`;
 
     // Register in storage
     await this.mcp.registerServer(id, {
@@ -700,6 +789,49 @@ export class TestHttpMcpDedupAgent extends Agent {
       returnedId: result.id,
       deduped: result.id === seededId
     };
+  }
+
+  // Test: caller-supplied id is normalized and used for the new server
+  async testHttpSuppliedIdIsUsed() {
+    try {
+      const result = await this.addMcpServer(
+        "http-stable",
+        "https://mcp.example.com/stable",
+        { id: "GitHub MCP!" }
+      );
+      return { ok: true, id: result.id };
+    } catch (e) {
+      // connectToServer is mocked to fail. The registered server still gets
+      // the requested id; we can read it back from storage.
+      const servers = this.mcp.listServers();
+      const server = servers.find((s) => s.name === "http-stable") ?? null;
+      return {
+        ok: false,
+        id: server?.id ?? null,
+        error: e instanceof Error ? e.message : String(e)
+      };
+    }
+  }
+
+  // Test: caller-supplied id colliding with a different (name,url) throws
+  async testHttpSuppliedIdCollision() {
+    const seededId = await this._seedServer(
+      "http-collide-a",
+      "https://mcp.example.com/a",
+      "collide"
+    );
+
+    let threw = false;
+    let message = "";
+    try {
+      await this.addMcpServer("http-collide-b", "https://mcp.example.com/b", {
+        id: "collide"
+      });
+    } catch (e) {
+      threw = true;
+      message = e instanceof Error ? e.message : String(e);
+    }
+    return { seededId, threw, message };
   }
 
   // Test: different name + same URL should NOT dedup

--- a/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
+++ b/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
@@ -44,18 +44,22 @@ describe("addMcpServer with RPC binding — stable supplied ids", () => {
     expect(result.id).toBe("github-mcp");
   });
 
-  it("throws when re-registering an existing (name,url) under a new stable id", async () => {
+  it("JIT-migrates an existing (name,url) row to a newly supplied stable id", async () => {
     const agentStub = await getAgentByName(
       env.TestRpcMcpClientAgent,
       "test-rpc-migrate-id"
     );
     const result =
-      (await agentStub.testRpcSuppliedIdRejectsExistingNanoid()) as unknown as {
+      (await agentStub.testRpcSuppliedIdMigratesExistingNanoid()) as unknown as {
         success: boolean;
         firstId?: string;
-        threw?: boolean;
-        message?: string;
+        secondId?: string;
         storedIds?: string[];
+        connectionsBefore?: number;
+        connectionsAfter?: number;
+        stableConnectionExists?: boolean;
+        nanoidConnectionGone?: boolean;
+        callOk?: boolean;
         error?: string;
       };
 
@@ -63,11 +67,20 @@ describe("addMcpServer with RPC binding — stable supplied ids", () => {
       throw new Error(`Test failed: ${result.error}`);
     }
 
-    expect(result.threw).toBe(true);
-    expect(result.message).toContain("already registered with id");
-    expect(result.message).toContain("removeMcpServer");
-    // Crucially: no stale row created under the new stable id.
-    expect(result.storedIds).toEqual([result.firstId]);
+    // Original call got a nanoid; second call asked for "migrated".
+    expect(result.secondId).toBe("migrated");
+    expect(result.firstId).not.toBe("migrated");
+
+    // Exactly one row remains — the migrated one. No stale nanoid row.
+    expect(result.storedIds).toEqual(["migrated"]);
+
+    // Connection count unchanged; in-memory map renamed from nanoid → stable.
+    expect(result.connectionsBefore).toBe(result.connectionsAfter);
+    expect(result.stableConnectionExists).toBe(true);
+    expect(result.nanoidConnectionGone).toBe(true);
+
+    // Tool calls still route correctly post-migration.
+    expect(result.callOk).toBe(true);
   });
 
   it("dedups when the same stable id is re-supplied for the same (name,url)", async () => {

--- a/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
+++ b/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
@@ -2,6 +2,72 @@ import { describe, it, expect } from "vitest";
 import { env } from "cloudflare:workers";
 import { getAgentByName } from "../..";
 
+describe("addMcpServer with RPC binding — stable supplied ids", () => {
+  it("uses a caller-supplied stable id as the server id", async () => {
+    const agentStub = await getAgentByName(
+      env.TestRpcMcpClientAgent,
+      "test-rpc-stable-id"
+    );
+    const result = (await agentStub.testRpcStableSuppliedId()) as unknown as {
+      success: boolean;
+      id?: string;
+      savedId?: string | null;
+      toolNames?: string[];
+      error?: string;
+    };
+
+    if (!result.success) {
+      throw new Error(`Test failed: ${result.error}`);
+    }
+
+    expect(result.id).toBe("my-supplied-id");
+    expect(result.savedId).toBe("my-supplied-id");
+    expect(result.toolNames!.length).toBeGreaterThan(0);
+  });
+
+  it("normalizes a caller-supplied id (e.g. 'GitHub MCP!' → 'github-mcp')", async () => {
+    const agentStub = await getAgentByName(
+      env.TestRpcMcpClientAgent,
+      "test-rpc-normalize-id"
+    );
+    const result =
+      (await agentStub.testRpcNormalizesSuppliedId()) as unknown as {
+        success: boolean;
+        id?: string;
+        error?: string;
+      };
+
+    if (!result.success) {
+      throw new Error(`Test failed: ${result.error}`);
+    }
+
+    expect(result.id).toBe("github-mcp");
+  });
+
+  it("throws when a caller-supplied id collides with a different server", async () => {
+    const agentStub = await getAgentByName(
+      env.TestRpcMcpClientAgent,
+      "test-rpc-collide-id"
+    );
+    const result =
+      (await agentStub.testRpcSuppliedIdCollision()) as unknown as {
+        success: boolean;
+        firstId?: string;
+        threw?: boolean;
+        message?: string;
+        error?: string;
+      };
+
+    if (!result.success) {
+      throw new Error(`Test failed: ${result.error}`);
+    }
+
+    expect(result.firstId).toBe("collide");
+    expect(result.threw).toBe(true);
+    expect(result.message).toContain("already in use");
+  });
+});
+
 describe("addMcpServer with RPC binding", () => {
   it("should connect to McpAgent via RPC and discover tools", async () => {
     const agentStub = await getAgentByName(

--- a/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
+++ b/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
@@ -44,6 +44,54 @@ describe("addMcpServer with RPC binding — stable supplied ids", () => {
     expect(result.id).toBe("github-mcp");
   });
 
+  it("throws when re-registering an existing (name,url) under a new stable id", async () => {
+    const agentStub = await getAgentByName(
+      env.TestRpcMcpClientAgent,
+      "test-rpc-migrate-id"
+    );
+    const result =
+      (await agentStub.testRpcSuppliedIdRejectsExistingNanoid()) as unknown as {
+        success: boolean;
+        firstId?: string;
+        threw?: boolean;
+        message?: string;
+        storedIds?: string[];
+        error?: string;
+      };
+
+    if (!result.success) {
+      throw new Error(`Test failed: ${result.error}`);
+    }
+
+    expect(result.threw).toBe(true);
+    expect(result.message).toContain("already registered with id");
+    expect(result.message).toContain("removeMcpServer");
+    // Crucially: no stale row created under the new stable id.
+    expect(result.storedIds).toEqual([result.firstId]);
+  });
+
+  it("dedups when the same stable id is re-supplied for the same (name,url)", async () => {
+    const agentStub = await getAgentByName(
+      env.TestRpcMcpClientAgent,
+      "test-rpc-dedup-stable"
+    );
+    const result =
+      (await agentStub.testRpcSuppliedIdDedupsOnRepeat()) as unknown as {
+        success: boolean;
+        firstId?: string;
+        secondId?: string;
+        sameId?: boolean;
+        error?: string;
+      };
+
+    if (!result.success) {
+      throw new Error(`Test failed: ${result.error}`);
+    }
+
+    expect(result.firstId).toBe("stable");
+    expect(result.sameId).toBe(true);
+  });
+
   it("throws when a caller-supplied id collides with a different server", async () => {
     const agentStub = await getAgentByName(
       env.TestRpcMcpClientAgent,

--- a/packages/agents/src/tests/mcp/http-dedup.test.ts
+++ b/packages/agents/src/tests/mcp/http-dedup.test.ts
@@ -63,3 +63,38 @@ describe("addMcpServer HTTP dedup (name + URL)", () => {
     expect(result.deduped).toBe(false);
   });
 });
+
+describe("addMcpServer HTTP — stable supplied ids", () => {
+  it("normalizes a caller-supplied id and uses it as the new server id", async () => {
+    const agentStub = await getAgentByName(
+      env.TestHttpMcpDedupAgent,
+      "test-http-stable-id"
+    );
+    const result = (await agentStub.testHttpSuppliedIdIsUsed()) as unknown as {
+      ok: boolean;
+      id: string | null;
+      error?: string;
+    };
+
+    // connectToServer is mocked to fail, but we still expect the row to be
+    // registered with the normalized id.
+    expect(result.id).toBe("github-mcp");
+  });
+
+  it("throws when a caller-supplied id collides with a different (name,url)", async () => {
+    const agentStub = await getAgentByName(
+      env.TestHttpMcpDedupAgent,
+      "test-http-collide-id"
+    );
+    const result =
+      (await agentStub.testHttpSuppliedIdCollision()) as unknown as {
+        seededId: string;
+        threw: boolean;
+        message: string;
+      };
+
+    expect(result.seededId).toBe("collide");
+    expect(result.threw).toBe(true);
+    expect(result.message).toContain("already in use");
+  });
+});

--- a/packages/agents/src/tests/mcp/http-dedup.test.ts
+++ b/packages/agents/src/tests/mcp/http-dedup.test.ts
@@ -65,6 +65,29 @@ describe("addMcpServer HTTP dedup (name + URL)", () => {
 });
 
 describe("addMcpServer HTTP — stable supplied ids", () => {
+  it("JIT-migrates an existing nanoid row + OAuth keys to the supplied stable id", async () => {
+    const agentStub = await getAgentByName(
+      env.TestHttpMcpDedupAgent,
+      "test-http-migrate-id"
+    );
+    const result =
+      (await agentStub.testHttpSuppliedIdMigratesNanoid()) as unknown as {
+        oldId: string;
+        resultId: string | null;
+        storedIds: string[];
+        oldKeyCount: number;
+        newKeyCount: number;
+      };
+
+    // The server row is now keyed under the stable id, not the old nanoid.
+    expect(result.resultId).toBe("stable-migrated");
+    expect(result.storedIds).toEqual(["stable-migrated"]);
+
+    // OAuth-style storage keys have been moved off the old prefix.
+    expect(result.oldKeyCount).toBe(0);
+    expect(result.newKeyCount).toBe(2);
+  });
+
   it("normalizes a caller-supplied id and uses it as the new server id", async () => {
     const agentStub = await getAgentByName(
       env.TestHttpMcpDedupAgent,

--- a/packages/agents/src/tests/mcp/normalize-server-id.test.ts
+++ b/packages/agents/src/tests/mcp/normalize-server-id.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { normalizeServerId, MCP_SERVER_ID_MAX_LENGTH } from "../../mcp/client";
+
+describe("normalizeServerId", () => {
+  it("passes already-valid ids through unchanged", () => {
+    expect(normalizeServerId("my-supplied-id")).toBe("my-supplied-id");
+    expect(normalizeServerId("github")).toBe("github");
+    expect(normalizeServerId("slack_v2")).toBe("slack_v2");
+    expect(normalizeServerId("a")).toBe("a");
+  });
+
+  it("lowercases the input", () => {
+    expect(normalizeServerId("GitHub")).toBe("github");
+    expect(normalizeServerId("My-Supplied-ID")).toBe("my-supplied-id");
+  });
+
+  it("replaces disallowed characters with a single hyphen", () => {
+    expect(normalizeServerId("GitHub MCP!")).toBe("github-mcp");
+    expect(normalizeServerId("foo/bar.baz")).toBe("foo-bar-baz");
+    expect(normalizeServerId("a   b")).toBe("a-b");
+    expect(normalizeServerId("a@@@b")).toBe("a-b");
+  });
+
+  it("collapses repeated hyphens", () => {
+    expect(normalizeServerId("foo---bar")).toBe("foo-bar");
+    expect(normalizeServerId("foo - - bar")).toBe("foo-bar");
+  });
+
+  it("trims leading and trailing hyphens and underscores", () => {
+    expect(normalizeServerId("---github---")).toBe("github");
+    expect(normalizeServerId("__slack__")).toBe("slack");
+    expect(normalizeServerId("-_foo_-")).toBe("foo");
+  });
+
+  it("prefixes with id- when the result doesn't start with a letter", () => {
+    expect(normalizeServerId("42-things")).toBe("id-42-things");
+    expect(normalizeServerId("123")).toBe("id-123");
+    expect(normalizeServerId("_underscore_first")).toBe("underscore_first");
+    expect(normalizeServerId("-leading-hyphen")).toBe("leading-hyphen");
+  });
+
+  it("prefixes with id- when the input is empty after stripping", () => {
+    expect(normalizeServerId("")).toBe("id");
+    expect(normalizeServerId("!!!")).toBe("id");
+    expect(normalizeServerId("   ")).toBe("id");
+  });
+
+  it("truncates to MCP_SERVER_ID_MAX_LENGTH", () => {
+    const long = "a".repeat(MCP_SERVER_ID_MAX_LENGTH + 50);
+    const out = normalizeServerId(long);
+    expect(out.length).toBe(MCP_SERVER_ID_MAX_LENGTH);
+    expect(out).toBe("a".repeat(MCP_SERVER_ID_MAX_LENGTH));
+  });
+
+  it("does not leave trailing hyphens after truncation", () => {
+    // Build an id whose 64th char would be a hyphen
+    const input = `${"a".repeat(MCP_SERVER_ID_MAX_LENGTH - 1)}-tail`;
+    const out = normalizeServerId(input);
+    expect(out.endsWith("-")).toBe(false);
+    expect(out.length).toBeLessThanOrEqual(MCP_SERVER_ID_MAX_LENGTH);
+  });
+
+  it("normalizes inputs idempotently", () => {
+    const samples = [
+      "my-supplied-id",
+      "GitHub MCP!",
+      "42-things",
+      "---foo---",
+      "!!!",
+      "a".repeat(200)
+    ];
+    for (const s of samples) {
+      const once = normalizeServerId(s);
+      const twice = normalizeServerId(once);
+      expect(twice).toBe(once);
+    }
+  });
+
+  it("produces ids that match the AI SDK tool-name character set when hyphens are stripped", () => {
+    // mcp/client.ts builds tool keys as `tool_${id.replace(/-/g, "")}_${name}`
+    // which must match /^[A-Za-z0-9_]+$/.
+    const samples = [
+      "my-supplied-id",
+      "GitHub MCP!",
+      "42-things",
+      "foo/bar.baz",
+      "---weird---",
+      "a@@@b"
+    ];
+    for (const s of samples) {
+      const id = normalizeServerId(s);
+      const toolKey = `tool_${id.replace(/-/g, "")}_test`;
+      expect(toolKey).toMatch(/^[A-Za-z0-9_]+$/);
+    }
+  });
+
+  it("throws on non-string input", () => {
+    expect(() => normalizeServerId(undefined as unknown as string)).toThrow(
+      TypeError
+    );
+    expect(() => normalizeServerId(123 as unknown as string)).toThrow(
+      TypeError
+    );
+  });
+});


### PR DESCRIPTION
Closes #1564.

## What

`addMcpServer` now accepts an optional stable `id` so connector-style apps can register MCP servers under predictable keys (`github`, `slack`, `gmail`) instead of opaque `nanoid(8)` connection ids.

```ts
await this.addMcpServer("GitHub", env.MCP_SESSION, {
  id: "github",
  props: { token: "..." }
});

// AI SDK tool keys become `tool_github_create_pull_request`
// instead of `tool_<random8chars>_create_pull_request`.
```

The supplied id flows through every place the SDK surfaces it: storage primary key, restore-after-hibernation, `listServers()` / `listTools()` / `getAITools()` tool-name namespacing, the `mcpConnections` map, and the OAuth `authProvider.serverId`.

Available on both overloads:

```ts
// HTTP
addMcpServer(name: string, url: string, options?: AddMcpServerOptions)
// RPC (Durable Object binding)
addMcpServer(name: string, binding: DurableObjectNamespace, options?: AddRpcMcpServerOptions)
```

If `id` is omitted, behaviour is unchanged (generated `nanoid(8)`).

## Normalization

Stable ids must be safe to use as a SQLite primary key **and** as part of an AI SDK tool name (which must match `/^[A-Za-z0-9_]+$/` after the SDK strips hyphens). Rather than make the caller think about both, the SDK normalizes the supplied id through a new exported `normalizeServerId` helper:

```ts
normalizeServerId("my-supplied-id");  // "my-supplied-id" (unchanged)
normalizeServerId("GitHub MCP!");     // "github-mcp"
normalizeServerId("42-things");       // "id-42-things"  (must start with a letter)
normalizeServerId("");                // "id"            (must be non-empty)
```

Rules: lowercase → replace runs of disallowed chars with `-` → collapse `-` → trim leading/trailing `-`/`_` → ensure leading letter → truncate to 64 chars. The function is idempotent and exported from `agents` and `agents/mcp` for callers that want to pre-compute the id (e.g. for `removeMcpServer`).

## Fully additive — no user code breaks

Adopting stable ids on an already-deployed agent must not require an explicit migration step. A user who upgrades:

```diff
- await this.addMcpServer("GitHub", env.MCP_SESSION);
+ await this.addMcpServer("GitHub", env.MCP_SESSION, { id: "github" });
```

…should not have to call `removeMcpServer` first, re-authenticate with OAuth, or lose tool-call state. So when the same `(name, url)` is already registered under a different id (typically an auto-generated nanoid from a previous call), `addMcpServer` calls a new `MCPClientManager.migrateServerId(oldId, newId, clientName)` which atomically renames the id across every place it's used as a key:

- the `cf_agents_mcp_servers` SQL row
- the in-memory `mcpConnections` map key
- the connection-disposables map key
- `authProvider.serverId` on the live connection
- OAuth-related Durable Object storage keys under `/${clientName}/${oldId}/...` (PKCE verifier, client info, tokens, state) — listed under the old prefix, re-put under the new prefix, then deleted from the old prefix in one batched `put` + one batched `delete`

The contract "the id you get back is the id you asked for" holds from the very first call, with no stale storage rows and no broken hibernation restore.

## When does it still throw?

Only on a genuinely ambiguous collision: the supplied stable id already belongs to a *different* `(name, url)` server. This is unrecoverable without the caller telling us which server they meant.

```
MCP server id "github" is already in use by server "GitHub Enterprise" (https://ghe.example.com/mcp). Stable ids must be unique per (name, url).
```

## Tests

- `packages/agents/src/tests/mcp/normalize-server-id.test.ts` — 12 unit tests covering happy path, normalization rules, idempotency, AI-SDK-tool-name safety after hyphen-strip, and truncation.
- `packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts` — new RPC integration tests:
  - stable id round-trips through storage
  - `"GitHub MCP!"` normalizes to `"github-mcp"`
  - JIT-migration: round-trips a real tool call through the migrated id and asserts no stale storage row remains, connection count unchanged
  - re-supplying the same stable id for the same `(name, url)` dedups (no regression on existing dedup)
  - collision against a different server throws
- `packages/agents/src/tests/mcp/http-dedup.test.ts` — new HTTP integration tests:
  - supplied id is used for the new server row
  - JIT-migration moves OAuth-style storage keys from `/${clientName}/${oldId}/...` to `/${clientName}/${newId}/...`
  - collision throws

All 433 MCP tests pass; `npm run check` clean.

## Out of scope

The lower-level `MCPClientManager.connect` / `registerServer` APIs already accept arbitrary ids; this PR only changes the high-level `addMcpServer` lifecycle.
