### PR TITLE
Add Think workflow prompt integration

### DIFF
--- a/.changeset/thin-owls-prompt.md
+++ b/.changeset/thin-owls-prompt.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/think": minor
+"agents": minor
+---
+
+Add `ThinkAgentWorkflow` with durable `step.prompt()` support for Workflow-owned Think reasoning steps.

--- a/.changeset/thin-owls-prompt.md
+++ b/.changeset/thin-owls-prompt.md
@@ -3,4 +3,4 @@
 "agents": minor
 ---
 
-Add `ThinkAgentWorkflow` with durable `step.prompt()` support for Workflow-owned Think reasoning steps.
+Add `ThinkWorkflow` with durable `step.prompt()` support for Workflow-owned Think reasoning steps.

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -265,7 +265,7 @@ Think's `this.messages` getter reads directly from Session's tree-structured sto
 | `@cloudflare/think/tools/execute`    | `createExecuteTool()` — sandboxed code execution via codemode |
 | `@cloudflare/think/tools/extensions` | `createExtensionTools()` — LLM-driven extension loading       |
 | `@cloudflare/think/extensions`       | `ExtensionManager`, `HostBridgeLoopback` — extension runtime  |
-| `@cloudflare/think/workflows`        | `ThinkAgentWorkflow`, `step.prompt()` — Workflow prompts      |
+| `@cloudflare/think/workflows`        | `ThinkWorkflow`, `step.prompt()` — Workflow prompts           |
 
 ## Peer Dependencies
 
@@ -285,4 +285,4 @@ Think's `this.messages` getter reads directly from Session's tree-structured sto
 - [Client Tools](./client-tools.md) — Browser-side tools, approvals, and concurrency
 - [Sub-agents and Programmatic Turns](./sub-agents.md) — RPC streaming, `saveMessages`, recovery
 - [Programmatic Submissions](./programmatic-submissions.md) — durable acceptance, idempotent retry, cancellation, and status inspection
-- [Workflows](./workflows.md) — `ThinkAgentWorkflow`, `step.prompt()`, structured output, and long-running workflow steps
+- [Workflows](./workflows.md) — `ThinkWorkflow`, `step.prompt()`, structured output, and long-running workflow steps

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -265,6 +265,7 @@ Think's `this.messages` getter reads directly from Session's tree-structured sto
 | `@cloudflare/think/tools/execute`    | `createExecuteTool()` — sandboxed code execution via codemode |
 | `@cloudflare/think/tools/extensions` | `createExtensionTools()` — LLM-driven extension loading       |
 | `@cloudflare/think/extensions`       | `ExtensionManager`, `HostBridgeLoopback` — extension runtime  |
+| `@cloudflare/think/workflows`        | `ThinkAgentWorkflow`, `step.prompt()` — Workflow prompts      |
 
 ## Peer Dependencies
 
@@ -284,3 +285,4 @@ Think's `this.messages` getter reads directly from Session's tree-structured sto
 - [Client Tools](./client-tools.md) — Browser-side tools, approvals, and concurrency
 - [Sub-agents and Programmatic Turns](./sub-agents.md) — RPC streaming, `saveMessages`, recovery
 - [Programmatic Submissions](./programmatic-submissions.md) — durable acceptance, idempotent retry, cancellation, and status inspection
+- [Workflows](./workflows.md) — `ThinkAgentWorkflow`, `step.prompt()`, structured output, and long-running workflow steps

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -104,8 +104,8 @@ Object RPC open.
 2. Think runs the submitted turn through the normal submission queue.
 3. When the submission reaches `completed`, `error`, `aborted`, or `skipped`,
    Think records a pending workflow notification.
-4. Think drains the notification outbox with `retry()` and Durable Object
-   alarms until `sendWorkflowEvent()` succeeds.
+4. Think drains the notification outbox with `sendWorkflowEvent()` and Durable
+   Object alarms until delivery succeeds.
 5. `step.waitForEvent("<name>:wait", ...)` resumes the Workflow.
 6. `step.prompt()` validates the structured output or throws a typed error.
 

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -1,0 +1,167 @@
+# Think Workflows
+
+`ThinkAgentWorkflow` connects Think to Cloudflare Workflows when a durable job
+needs one model-driven reasoning step.
+
+Use it when the Workflow owns the process:
+
+- durable multi-step orchestration
+- approval gates or long waits
+- retryable deterministic side effects
+- a Think turn that should produce typed structured output
+
+Keep recurring prompts as scheduled tasks, and keep simple one-off background
+turns on `submitMessages()`. Workflows are for jobs where the steps matter.
+
+## API
+
+Import from `@cloudflare/think/workflows`:
+
+```typescript
+import { ThinkAgentWorkflow } from "@cloudflare/think/workflows";
+```
+
+Extend `ThinkAgentWorkflow` and call `step.prompt()` inside `run()`:
+
+```typescript
+import { z } from "zod";
+import { ThinkAgentWorkflow } from "@cloudflare/think/workflows";
+import type { ThinkAgentWorkflowStep } from "@cloudflare/think/workflows";
+import type { AgentWorkflowEvent } from "agents/workflows";
+
+const draftSchema = z.object({
+  title: z.string(),
+  summary: z.string(),
+  labels: z.array(z.string())
+});
+
+export class TriageWorkflow extends ThinkAgentWorkflow<TriageAgent, Params> {
+  async run(event: AgentWorkflowEvent<Params>, step: ThinkAgentWorkflowStep) {
+    const draft = await step.prompt("triage-issue", {
+      prompt: `Triage issue #${event.payload.issueNumber}`,
+      output: draftSchema,
+      timeout: "3 days"
+    });
+
+    await step.do("apply-labels", async () => {
+      await this.agent.applyLabels(draft.labels);
+    });
+  }
+}
+```
+
+Start the Workflow from inside your Think Agent with `runWorkflow()`:
+
+```typescript
+export class TriageAgent extends Think<Env> {
+  async triageIssue(issueNumber: number): Promise<string> {
+    return this.runWorkflow(
+      "TRIAGE_WORKFLOW",
+      { issueNumber },
+      { metadata: { issueNumber } }
+    );
+  }
+}
+```
+
+`runWorkflow()` creates the Workflow instance and injects the Agent identity that
+`ThinkAgentWorkflow` needs to reconnect to `this.agent` inside `run()`. Prefer it
+over calling the Workflows binding directly:
+
+```typescript
+// Avoid this for Agent workflows. It does not include Agent context.
+await this.env.TRIAGE_WORKFLOW.create({ params: { issueNumber } });
+```
+
+Use `sendWorkflowEvent()` from the Agent when a waiting Workflow needs an
+external signal, such as human approval:
+
+```typescript
+await this.sendWorkflowEvent("TRIAGE_WORKFLOW", workflowId, {
+  type: "approval",
+  payload: { approved: true }
+});
+```
+
+`step.prompt()` accepts a prompt string and a Zod object schema. The schema is
+converted to JSON Schema before the Workflow calls the Agent, then Think
+reconstructs the AI SDK structured output configuration for the turn. When the
+Workflow resumes, the payload is validated again with the original Zod schema
+before the typed value is returned.
+
+Unsupported Zod features that cannot be represented as JSON Schema fail while
+creating the prompt step. Think does not silently repair invalid model output.
+If the model or provider cannot produce valid output, the submission reaches a
+terminal error state and `step.prompt()` throws.
+
+## How It Runs
+
+The call reads like a blocking step, but it does not hold a long-lived Durable
+Object RPC open.
+
+1. `step.do("<name>:submit", ...)` creates or finds an idempotent Think
+   submission.
+2. Think runs the submitted turn through the normal submission queue.
+3. When the submission reaches `completed`, `error`, `aborted`, or `skipped`,
+   Think records a pending workflow notification.
+4. Think drains the notification outbox with `retry()` and Durable Object
+   alarms until `sendWorkflowEvent()` succeeds.
+5. `step.waitForEvent("<name>:wait", ...)` resumes the Workflow.
+6. `step.prompt()` validates the structured output or throws a typed error.
+
+The machine-readable output is carried in the pending notification and Workflow
+event payload. Think does not store a separate `output_json` column on the
+submission ledger, and clears the notification payload after delivery. After
+delivery, the Workflow owns the durable result.
+
+## Idempotency
+
+By default, `step.prompt()` infers the idempotency key from Workflow identity and
+step name:
+
+```text
+think-workflow:<workflowName>:<workflowId>:<stepName>
+```
+
+For loops, pass a string `key` to distinguish repeated uses of the same step
+name:
+
+```typescript
+await step.prompt("summarize-file", {
+  key: file.path,
+  prompt: `Summarize ${file.path}`,
+  output: summarySchema
+});
+```
+
+Prompt text is not part of the inferred key, but Think stores workflow metadata
+and a prompt/config fingerprint for diagnostics.
+
+## Timeouts
+
+Pass `timeout` to control how long the Workflow waits for the terminal event.
+If the wait times out, `step.prompt()` cancels the Think submission by default
+and throws `ThinkPromptTimeoutError`.
+
+Set `cancelOnTimeout: false` when you intentionally want the Think submission to
+continue after the Workflow stops waiting.
+
+## Boundary With Other Primitives
+
+Use scheduled tasks for recurring prompts:
+
+```typescript
+async onScheduled() {
+  await this.saveMessages([{ role: "user", parts: [{ type: "text", text: "Daily summary" }] }]);
+}
+```
+
+Use `submitMessages()` for durable one-off turns where the caller can inspect
+submission status later.
+
+Use `startFiber()` for app-owned idempotent Agent jobs that need recovery inside
+the Agent. Think's workflow notification delivery does not use fibers; it uses a
+private outbox because it needs to store an event until delivery succeeds.
+
+Use Workflows when the process has multiple deterministic steps, long waits, or
+human approval.

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -1,6 +1,6 @@
 # Think Workflows
 
-`ThinkAgentWorkflow` connects Think to Cloudflare Workflows when a durable job
+`ThinkWorkflow` connects Think to Cloudflare Workflows when a durable job
 needs one model-driven reasoning step.
 
 Use it when the Workflow owns the process:
@@ -18,15 +18,15 @@ turns on `submitMessages()`. Workflows are for jobs where the steps matter.
 Import from `@cloudflare/think/workflows`:
 
 ```typescript
-import { ThinkAgentWorkflow } from "@cloudflare/think/workflows";
+import { ThinkWorkflow } from "@cloudflare/think/workflows";
 ```
 
-Extend `ThinkAgentWorkflow` and call `step.prompt()` inside `run()`:
+Extend `ThinkWorkflow` and call `step.prompt()` inside `run()`:
 
 ```typescript
 import { z } from "zod";
-import { ThinkAgentWorkflow } from "@cloudflare/think/workflows";
-import type { ThinkAgentWorkflowStep } from "@cloudflare/think/workflows";
+import { ThinkWorkflow } from "@cloudflare/think/workflows";
+import type { ThinkWorkflowStep } from "@cloudflare/think/workflows";
 import type { AgentWorkflowEvent } from "agents/workflows";
 
 const draftSchema = z.object({
@@ -35,8 +35,8 @@ const draftSchema = z.object({
   labels: z.array(z.string())
 });
 
-export class TriageWorkflow extends ThinkAgentWorkflow<TriageAgent, Params> {
-  async run(event: AgentWorkflowEvent<Params>, step: ThinkAgentWorkflowStep) {
+export class TriageWorkflow extends ThinkWorkflow<TriageAgent, Params> {
+  async run(event: AgentWorkflowEvent<Params>, step: ThinkWorkflowStep) {
     const draft = await step.prompt("triage-issue", {
       prompt: `Triage issue #${event.payload.issueNumber}`,
       output: draftSchema,
@@ -65,7 +65,7 @@ export class TriageAgent extends Think<Env> {
 ```
 
 `runWorkflow()` creates the Workflow instance and injects the Agent identity that
-`ThinkAgentWorkflow` needs to reconnect to `this.agent` inside `run()`. Prefer it
+`ThinkWorkflow` needs to reconnect to `this.agent` inside `run()`. Prefer it
 over calling the Workflows binding directly:
 
 ```typescript

--- a/examples/think-workflows/README.md
+++ b/examples/think-workflows/README.md
@@ -1,6 +1,6 @@
 # Think Workflows
 
-This example shows how `ThinkAgentWorkflow` lets a Workflow run one durable
+This example shows how `ThinkWorkflow` lets a Workflow run one durable
 Think reasoning step, wait for human approval, then apply a deterministic side
 effect.
 

--- a/examples/think-workflows/README.md
+++ b/examples/think-workflows/README.md
@@ -1,0 +1,98 @@
+# Think Workflows
+
+This example shows how `ThinkAgentWorkflow` lets a Workflow run one durable
+Think reasoning step, wait for human approval, then apply a deterministic side
+effect.
+
+## Run
+
+```bash
+npm install
+npm run dev
+```
+
+Start a report workflow. The response includes both `workflowId` and `reportId`:
+
+```bash
+curl -X POST http://localhost:8787/reports \
+  -H "Content-Type: application/json" \
+  -d '{"topic":"weekly incident trends"}'
+```
+
+Approve the waiting workflow with the returned `workflowId`:
+
+```bash
+curl -X POST http://localhost:8787/reports/<workflowId>/approval \
+  -H "Content-Type: application/json" \
+  -d '{"approved":true,"notes":"Looks good"}'
+```
+
+Reject the workflow instead:
+
+```bash
+curl -X POST http://localhost:8787/reports/<workflowId>/approval \
+  -H "Content-Type: application/json" \
+  -d '{"approved":false,"notes":"Needs more detail"}'
+```
+
+Fetch the saved draft, approval, or rejection with the returned `reportId`:
+
+```bash
+curl http://localhost:8787/reports/<reportId>
+```
+
+## Key Pattern
+
+Start the Workflow from an Agent method with `runWorkflow()`:
+
+```typescript
+async startReport(topic: string) {
+  const reportId = crypto.randomUUID();
+  const workflowId = await this.runWorkflow(
+    "REPORT_WORKFLOW",
+    { reportId, topic },
+    { metadata: { reportId, topic } }
+  );
+  return { reportId, workflowId };
+}
+```
+
+Then the Workflow can call back into the originating Agent and use
+`step.prompt()`:
+
+```typescript
+const draft = await step.prompt("draft-report", {
+  prompt: `Draft an operational report about: ${event.payload.topic}`,
+  output: reportDraftSchema,
+  timeout: "3 days"
+});
+
+const approvalEvent = await step.waitForEvent("wait-for-approval", {
+  type: "approval",
+  timeout: "7 days"
+});
+const approval = approvalEvent.payload as {
+  approved: boolean;
+  reason?: string;
+  metadata?: { notes?: string };
+};
+
+if (!approval.approved) {
+  await step.do("store-rejection", async () => {
+    await this.agent.saveReport({ draft, status: "rejected" });
+  });
+  return;
+}
+
+await step.do("publish-or-reject", async () => {
+  await this.agent.saveReport({
+    draft,
+    status: "approved",
+    approvalNotes: approval.metadata?.notes
+  });
+});
+```
+
+`step.prompt()` submits the Think turn, waits for a Workflow event, validates the
+structured output, and returns the typed result. The Workflow still owns the
+multi-step process and all deterministic side effects.

--- a/examples/think-workflows/package.json
+++ b/examples/think-workflows/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@cloudflare/agents-think-workflows-example",
+  "description": "ThinkAgentWorkflow example with durable prompts, approval, and deterministic side effects",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "types": "wrangler types env.d.ts --include-runtime false"
+  },
+  "dependencies": {
+    "@cloudflare/think": "*",
+    "agents": "*",
+    "ai": "^6.0.185",
+    "workers-ai-provider": "^3.1.14",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260519.1",
+    "typescript": "^6.0.3",
+    "wrangler": "^4.93.0"
+  }
+}

--- a/examples/think-workflows/package.json
+++ b/examples/think-workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/agents-think-workflows-example",
-  "description": "ThinkAgentWorkflow example with durable prompts, approval, and deterministic side effects",
+  "description": "ThinkWorkflow example with durable prompts, approval, and deterministic side effects",
   "private": true,
   "type": "module",
   "version": "0.0.0",

--- a/examples/think-workflows/src/index.ts
+++ b/examples/think-workflows/src/index.ts
@@ -1,0 +1,216 @@
+import { getAgentByName, routeAgentRequest } from "agents";
+import { createWorkersAI } from "workers-ai-provider";
+import { z } from "zod";
+import { Think } from "@cloudflare/think";
+import { ThinkAgentWorkflow } from "@cloudflare/think/workflows";
+import type { ThinkAgentWorkflowStep } from "@cloudflare/think/workflows";
+import type { AgentWorkflowEvent } from "agents/workflows";
+
+type Env = {
+  AI: Ai;
+  ReportAgent: DurableObjectNamespace<ReportAgent>;
+};
+
+type ReportParams = {
+  reportId: string;
+  topic: string;
+};
+
+type ReportRecord = {
+  reportId: string;
+  topic: string;
+  status: "drafted" | "approved" | "rejected";
+  draft?: z.infer<typeof reportDraftSchema>;
+  approvalNotes?: string;
+  updatedAt: string;
+};
+
+const reportDraftSchema = z.object({
+  title: z.string(),
+  summary: z.string(),
+  recommendations: z.array(z.string()).min(1)
+});
+
+export class ReportAgent extends Think<Env> {
+  getModel() {
+    return createWorkersAI({ binding: this.env.AI })(
+      "@cf/moonshotai/kimi-k2.6"
+    );
+  }
+
+  getSystemPrompt() {
+    return [
+      "You draft concise operational reports.",
+      "Return practical recommendations that can be reviewed by a human."
+    ].join("\n");
+  }
+
+  async startReport(
+    topic: string
+  ): Promise<{ reportId: string; workflowId: string }> {
+    const reportId = crypto.randomUUID();
+    const workflowId = await this.runWorkflow(
+      "REPORT_WORKFLOW",
+      { reportId, topic },
+      { metadata: { reportId, topic } }
+    );
+    return { reportId, workflowId };
+  }
+
+  async approveReport(
+    workflowId: string,
+    approved: boolean,
+    notes?: string
+  ): Promise<void> {
+    await this.sendWorkflowEvent("REPORT_WORKFLOW", workflowId, {
+      type: "approval",
+      payload: {
+        approved,
+        reason: approved ? undefined : notes,
+        metadata: { notes }
+      }
+    });
+  }
+
+  async saveReport(record: ReportRecord): Promise<void> {
+    this.sql`
+      CREATE TABLE IF NOT EXISTS example_reports (
+        report_id TEXT PRIMARY KEY,
+        record_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `;
+    this.sql`
+      INSERT OR REPLACE INTO example_reports (report_id, record_json, updated_at)
+      VALUES (${record.reportId}, ${JSON.stringify(record)}, ${record.updatedAt})
+    `;
+  }
+
+  async getReport(reportId: string): Promise<ReportRecord | null> {
+    const rows = this.sql<{ record_json: string }>`
+      SELECT record_json
+      FROM example_reports
+      WHERE report_id = ${reportId}
+      LIMIT 1
+    `;
+    return rows[0] ? (JSON.parse(rows[0].record_json) as ReportRecord) : null;
+  }
+}
+
+export class ReportWorkflow extends ThinkAgentWorkflow<
+  ReportAgent,
+  ReportParams
+> {
+  async run(
+    event: AgentWorkflowEvent<ReportParams>,
+    step: ThinkAgentWorkflowStep
+  ): Promise<void> {
+    const draft = await step.prompt("draft-report", {
+      prompt: `Draft an operational report about: ${event.payload.topic}`,
+      output: reportDraftSchema,
+      timeout: "3 days"
+    });
+
+    await step.do("store-draft", async () => {
+      await this.agent.saveReport({
+        reportId: event.payload.reportId,
+        topic: event.payload.topic,
+        status: "drafted",
+        draft,
+        updatedAt: new Date().toISOString()
+      });
+    });
+
+    const approvalEvent = await step.waitForEvent("wait-for-approval", {
+      type: "approval",
+      timeout: "7 days"
+    });
+    const approval = approvalEvent.payload as {
+      approved: boolean;
+      reason?: string;
+      metadata?: { notes?: string };
+    };
+
+    if (!approval.approved) {
+      await step.do("store-rejection", async () => {
+        await this.agent.saveReport({
+          reportId: event.payload.reportId,
+          topic: event.payload.topic,
+          status: "rejected",
+          draft,
+          approvalNotes: approval.reason ?? approval.metadata?.notes,
+          updatedAt: new Date().toISOString()
+        });
+      });
+      return;
+    }
+
+    await step.do("publish-or-reject", async () => {
+      await this.agent.saveReport({
+        reportId: event.payload.reportId,
+        topic: event.payload.topic,
+        status: "approved",
+        draft,
+        approvalNotes: approval.metadata?.notes,
+        updatedAt: new Date().toISOString()
+      });
+    });
+  }
+}
+
+async function getDefaultAgent(env: Env) {
+  return getAgentByName(env.ReportAgent, "default");
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const agentResponse = await routeAgentRequest(request, env);
+    if (agentResponse) return agentResponse;
+
+    const url = new URL(request.url);
+    const agent = await getDefaultAgent(env);
+
+    if (request.method === "POST" && url.pathname === "/reports") {
+      const body = (await request.json()) as { topic?: unknown };
+      if (typeof body.topic !== "string" || body.topic.trim() === "") {
+        return Response.json(
+          { error: "Expected JSON body with topic" },
+          {
+            status: 400
+          }
+        );
+      }
+      return Response.json(await agent.startReport(body.topic));
+    }
+
+    const approvalMatch = url.pathname.match(/^\/reports\/([^/]+)\/approval$/);
+    if (request.method === "POST" && approvalMatch) {
+      const body = (await request.json()) as {
+        approved?: unknown;
+        notes?: unknown;
+      };
+      await agent.approveReport(
+        approvalMatch[1],
+        body.approved === true,
+        typeof body.notes === "string" ? body.notes : undefined
+      );
+      return Response.json({ ok: true });
+    }
+
+    const reportMatch = url.pathname.match(/^\/reports\/([^/]+)$/);
+    if (request.method === "GET" && reportMatch) {
+      return Response.json(await agent.getReport(reportMatch[1]));
+    }
+
+    return Response.json(
+      {
+        routes: [
+          "POST /reports { topic }",
+          "POST /reports/:workflowId/approval { approved, notes }",
+          "GET /reports/:reportId"
+        ]
+      },
+      { status: 404 }
+    );
+  }
+};

--- a/examples/think-workflows/src/index.ts
+++ b/examples/think-workflows/src/index.ts
@@ -2,8 +2,8 @@ import { getAgentByName, routeAgentRequest } from "agents";
 import { createWorkersAI } from "workers-ai-provider";
 import { z } from "zod";
 import { Think } from "@cloudflare/think";
-import { ThinkAgentWorkflow } from "@cloudflare/think/workflows";
-import type { ThinkAgentWorkflowStep } from "@cloudflare/think/workflows";
+import { ThinkWorkflow } from "@cloudflare/think/workflows";
+import type { ThinkWorkflowStep } from "@cloudflare/think/workflows";
 import type { AgentWorkflowEvent } from "agents/workflows";
 
 type Env = {
@@ -97,13 +97,10 @@ export class ReportAgent extends Think<Env> {
   }
 }
 
-export class ReportWorkflow extends ThinkAgentWorkflow<
-  ReportAgent,
-  ReportParams
-> {
+export class ReportWorkflow extends ThinkWorkflow<ReportAgent, ReportParams> {
   async run(
     event: AgentWorkflowEvent<ReportParams>,
-    step: ThinkAgentWorkflowStep
+    step: ThinkWorkflowStep
   ): Promise<void> {
     const draft = await step.prompt("draft-report", {
       prompt: `Draft an operational report about: ${event.payload.topic}`,

--- a/examples/think-workflows/tsconfig.json
+++ b/examples/think-workflows/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "agents/tsconfig"
+}

--- a/examples/think-workflows/wrangler.jsonc
+++ b/examples/think-workflows/wrangler.jsonc
@@ -1,0 +1,29 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "think-workflows-example",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "ai": { "binding": "AI", "remote": true },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "ReportAgent",
+        "class_name": "ReportAgent"
+      }
+    ]
+  },
+  "workflows": [
+    {
+      "name": "report-workflow",
+      "binding": "REPORT_WORKFLOW",
+      "class_name": "ReportWorkflow"
+    }
+  ],
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ReportAgent"]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -850,6 +850,22 @@
         "wrangler": "^4.93.0"
       }
     },
+    "examples/think-workflows": {
+      "name": "@cloudflare/agents-think-workflows-example",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cloudflare/think": "*",
+        "agents": "*",
+        "ai": "^6.0.185",
+        "workers-ai-provider": "^3.1.14",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260519.1",
+        "typescript": "^6.0.3",
+        "wrangler": "^4.93.0"
+      }
+    },
     "examples/tictactoe": {
       "name": "@cloudflare/agents-tictactoe",
       "version": "0.0.0",
@@ -3703,6 +3719,10 @@
     },
     "node_modules/@cloudflare/agents-think-submissions-example": {
       "resolved": "examples/think-submissions",
+      "link": true
+    },
+    "node_modules/@cloudflare/agents-think-workflows-example": {
+      "resolved": "examples/think-workflows",
       "link": true
     },
     "node_modules/@cloudflare/agents-tictactoe": {

--- a/packages/agents/src/tests/workflow-prototype.test.ts
+++ b/packages/agents/src/tests/workflow-prototype.test.ts
@@ -115,6 +115,33 @@ describe("AgentWorkflow prototype wrapping", () => {
       const proto = AgentWorkflow.prototype;
       expect(Object.hasOwn(proto, "_initAgent")).toBe(true);
       expect(Object.hasOwn(proto, "_wrapStep")).toBe(true);
+      expect(Object.hasOwn(proto, "extendStep")).toBe(true);
+    });
+
+    it("allows subclasses to extend wrapped steps", () => {
+      class ExtendingWorkflow extends AgentWorkflow {
+        protected override extendStep(
+          step: AgentWorkflowStep
+        ): AgentWorkflowStep {
+          return Object.assign(step, { customPrompt: true });
+        }
+      }
+
+      const proto = ExtendingWorkflow.prototype as unknown as {
+        extendStep(
+          step: AgentWorkflowStep,
+          event: AgentWorkflowEvent<unknown>
+        ): AgentWorkflowStep & { customPrompt?: boolean };
+      };
+
+      const step = {} as AgentWorkflowStep;
+      const extended = proto.extendStep(step, {
+        payload: {},
+        instanceId: "workflow-test"
+      } as AgentWorkflowEvent<unknown>);
+
+      expect(extended).toBe(step);
+      expect(extended.customPrompt).toBe(true);
     });
   });
 

--- a/packages/agents/src/workflows.ts
+++ b/packages/agents/src/workflows.ts
@@ -138,7 +138,10 @@ export class AgentWorkflow<
             payload: userParams as Params
           } as WorkflowEvent<Params>;
 
-          const wrappedStep = this._wrapStep(step);
+          const wrappedStep = this.extendStep(
+            this._wrapStep(step),
+            cleanedEvent
+          );
 
           try {
             return await originalRun.call(this, cleanedEvent, wrappedStep);
@@ -278,6 +281,19 @@ export class AgentWorkflow<
     };
 
     return wrappedStep;
+  }
+
+  /**
+   * Extend the Agent-aware workflow step before user code receives it.
+   *
+   * Subclasses can override this to add framework-specific step helpers while
+   * preserving the underlying WorkflowStep object identity.
+   */
+  protected extendStep(
+    step: AgentWorkflowStep,
+    _event: WorkflowEvent<Params>
+  ): AgentWorkflowStep {
+    return step;
   }
 
   /**

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -46,6 +46,10 @@
       "types": "./dist/extensions/index.d.ts",
       "import": "./dist/extensions/index.js"
     },
+    "./workflows": {
+      "types": "./dist/workflows.d.ts",
+      "import": "./dist/workflows.js"
+    },
     "./tools/workspace": {
       "types": "./dist/tools/workspace.d.ts",
       "import": "./dist/tools/workspace.js"

--- a/packages/think/scripts/build.ts
+++ b/packages/think/scripts/build.ts
@@ -8,6 +8,7 @@ async function main() {
     target: "es2021",
     entry: [
       "src/think.ts",
+      "src/workflows.ts",
       "src/extensions/index.ts",
       "src/tools/workspace.ts",
       "src/tools/execute.ts",

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1697,6 +1697,7 @@ export class ThinkProgrammaticTestAgent extends Think {
   private _delayedChunks: { chunks: string[]; delayMs: number } | null = null;
   private _throwBeforeTurnError: string | null = null;
   private _submissionStatusDelayMs = 0;
+  private _programmaticResponse = "Programmatic response";
   private _inBandErrorResponse: {
     errorText: string;
     textChunks: string[];
@@ -1715,7 +1716,7 @@ export class ThinkProgrammaticTestAgent extends Think {
         this._delayedChunks.delayMs
       );
     }
-    return createMockModel("Programmatic response");
+    return createMockModel(this._programmaticResponse);
   }
 
   override onChatResponse(result: ChatResponseResult): void {
@@ -1827,6 +1828,10 @@ export class ThinkProgrammaticTestAgent extends Think {
 
   async setSubmissionStatusDelayForTest(delayMs: number): Promise<void> {
     this._submissionStatusDelayMs = delayMs;
+  }
+
+  async setProgrammaticResponseForTest(response: string): Promise<void> {
+    this._programmaticResponse = response;
   }
 
   async setWorkflowEventFailuresForTest(count: number): Promise<void> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1834,6 +1834,12 @@ export class ThinkProgrammaticTestAgent extends Think {
     this._programmaticResponse = response;
   }
 
+  async setLastBodyForTest(body: Record<string, unknown>): Promise<void> {
+    (
+      this as unknown as { _lastBody: Record<string, unknown> | undefined }
+    )._lastBody = body;
+  }
+
   async setWorkflowEventFailuresForTest(count: number): Promise<void> {
     this._workflowEventFailuresRemaining = count;
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1684,6 +1684,12 @@ export class ThinkProgrammaticTestAgent extends Think {
 
   private _responseLog: ChatResponseResult[] = [];
   private _submissionLog: ThinkSubmissionInspection[] = [];
+  private _workflowEventLog: Array<{
+    workflowName: string;
+    workflowId: string;
+    event: { type: string; payload?: unknown };
+  }> = [];
+  private _workflowEventFailuresRemaining = 0;
   private _capturedTurnContexts: Array<{
     continuation?: boolean;
     body?: RpcJsonObject;
@@ -1714,6 +1720,18 @@ export class ThinkProgrammaticTestAgent extends Think {
 
   override onChatResponse(result: ChatResponseResult): void {
     this._responseLog.push(result);
+  }
+
+  override async sendWorkflowEvent(
+    workflowName: string & {},
+    workflowId: string,
+    event: { type: string; payload?: unknown }
+  ): Promise<void> {
+    if (this._workflowEventFailuresRemaining > 0) {
+      this._workflowEventFailuresRemaining--;
+      throw new Error("simulated workflow event failure");
+    }
+    this._workflowEventLog.push({ workflowName, workflowId, event });
   }
 
   override async onSubmissionStatus(
@@ -1809,6 +1827,20 @@ export class ThinkProgrammaticTestAgent extends Think {
 
   async setSubmissionStatusDelayForTest(delayMs: number): Promise<void> {
     this._submissionStatusDelayMs = delayMs;
+  }
+
+  async setWorkflowEventFailuresForTest(count: number): Promise<void> {
+    this._workflowEventFailuresRemaining = count;
+  }
+
+  async getWorkflowEventsForTest(): Promise<
+    Array<{
+      workflowName: string;
+      workflowId: string;
+      event: { type: string; payload?: unknown };
+    }>
+  > {
+    return this._workflowEventLog;
   }
 
   async setSubmissionRecoveryStaleMsForTest(ms: number): Promise<void> {
@@ -1959,6 +1991,8 @@ export class ThinkProgrammaticTestAgent extends Think {
     submissionId: string;
     status?: ThinkSubmissionStatus;
     requestId?: string;
+    metadata?: Record<string, unknown>;
+    errorMessage?: string | null;
     messagesAppliedAt?: number | null;
     completedAt?: number | null;
     createdAt?: number;
@@ -1977,6 +2011,10 @@ export class ThinkProgrammaticTestAgent extends Think {
     const startedAt = status === "running" ? now : null;
     const completedAt =
       options.completedAt === undefined ? null : options.completedAt;
+    const metadataJson =
+      options.metadata === undefined ? null : JSON.stringify(options.metadata);
+    const errorMessage =
+      options.errorMessage === undefined ? null : options.errorMessage;
     const messageIds = options.messageIds ?? [crypto.randomUUID()];
     const messagesJson = JSON.stringify(
       messageIds.map((id) => ({
@@ -1993,10 +2031,99 @@ export class ThinkProgrammaticTestAgent extends Think {
       )
       VALUES (
         ${options.submissionId}, NULL, ${requestId}, NULL, ${status},
-        ${messagesJson}, NULL, NULL, ${now}, ${messagesAppliedAt},
+        ${messagesJson}, ${metadataJson}, ${errorMessage}, ${now}, ${messagesAppliedAt},
         ${startedAt}, ${completedAt}
       )
     `;
+  }
+
+  async recoverWorkflowNotificationsForTest(): Promise<void> {
+    (
+      this as unknown as { _recoverWorkflowNotifications: () => void }
+    )._recoverWorkflowNotifications();
+  }
+
+  async drainWorkflowNotificationsForTest(): Promise<void> {
+    await (
+      this as unknown as { _drainWorkflowNotifications: () => Promise<void> }
+    )._drainWorkflowNotifications();
+  }
+
+  async insertWorkflowNotificationForTest(options: {
+    notificationId: string;
+    submissionId: string;
+    workflowName?: string;
+    workflowId?: string;
+    eventType?: string;
+    payload?: unknown;
+  }): Promise<void> {
+    (
+      this as unknown as { _ensureWorkflowNotificationTable: () => void }
+    )._ensureWorkflowNotificationTable();
+    const now = Date.now();
+    this.sql`
+      INSERT INTO cf_think_workflow_notifications (
+        notification_id, submission_id, workflow_name, workflow_id, event_type,
+        payload_json, attempts, last_error, created_at, updated_at, delivered_at
+      )
+      VALUES (
+        ${options.notificationId},
+        ${options.submissionId},
+        ${options.workflowName ?? "TEST_WORKFLOW"},
+        ${options.workflowId ?? "workflow-1"},
+        ${options.eventType ?? "think-prompt-test"},
+        ${JSON.stringify(options.payload ?? { submissionId: options.submissionId, status: "error" })},
+        0,
+        NULL,
+        ${now},
+        ${now},
+        NULL
+      )
+    `;
+  }
+
+  async listWorkflowNotificationsForTest(): Promise<
+    Array<{
+      notificationId: string;
+      submissionId: string;
+      workflowName: string;
+      workflowId: string;
+      eventType: string;
+      payloadJson: string;
+      attempts: number;
+      lastError: string | null;
+      deliveredAt: number | null;
+    }>
+  > {
+    (
+      this as unknown as { _ensureWorkflowNotificationTable: () => void }
+    )._ensureWorkflowNotificationTable();
+    return this.sql<{
+      notification_id: string;
+      submission_id: string;
+      workflow_name: string;
+      workflow_id: string;
+      event_type: string;
+      payload_json: string;
+      attempts: number;
+      last_error: string | null;
+      delivered_at: number | null;
+    }>`
+      SELECT notification_id, submission_id, workflow_name, workflow_id,
+             event_type, payload_json, attempts, last_error, delivered_at
+      FROM cf_think_workflow_notifications
+      ORDER BY created_at ASC, notification_id ASC
+    `.map((row) => ({
+      notificationId: row.notification_id,
+      submissionId: row.submission_id,
+      workflowName: row.workflow_name,
+      workflowId: row.workflow_id,
+      eventType: row.event_type,
+      payloadJson: row.payload_json,
+      attempts: row.attempts,
+      lastError: row.last_error,
+      deliveredAt: row.delivered_at
+    }));
   }
 
   async insertMalformedSubmissionForTest(options: {

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -25,6 +25,14 @@ type ThinkSubmissionTestStub = {
   runNonSubmissionStreamFailureForTest(requestId: string): Promise<void>;
   setSubmissionStatusDelayForTest(delayMs: number): Promise<void>;
   setSubmissionRecoveryStaleMsForTest(ms: number): Promise<void>;
+  setWorkflowEventFailuresForTest(count: number): Promise<void>;
+  getWorkflowEventsForTest(): Promise<
+    Array<{
+      workflowName: string;
+      workflowId: string;
+      event: { type: string; payload?: unknown };
+    }>
+  >;
   testSubmitMessages(
     text: string,
     options?: {
@@ -70,6 +78,8 @@ type ThinkSubmissionTestStub = {
     submissionId: string;
     status?: ThinkSubmissionStatus;
     requestId?: string;
+    metadata?: Record<string, unknown>;
+    errorMessage?: string | null;
     messagesAppliedAt?: number | null;
     completedAt?: number | null;
     createdAt?: number;
@@ -83,6 +93,29 @@ type ThinkSubmissionTestStub = {
     requestId: string,
     createdAt: number
   ): Promise<void>;
+  recoverWorkflowNotificationsForTest(): Promise<void>;
+  drainWorkflowNotificationsForTest(): Promise<void>;
+  insertWorkflowNotificationForTest(options: {
+    notificationId: string;
+    submissionId: string;
+    workflowName?: string;
+    workflowId?: string;
+    eventType?: string;
+    payload?: unknown;
+  }): Promise<void>;
+  listWorkflowNotificationsForTest(): Promise<
+    Array<{
+      notificationId: string;
+      submissionId: string;
+      workflowName: string;
+      workflowId: string;
+      eventType: string;
+      payloadJson: string;
+      attempts: number;
+      lastError: string | null;
+      deliveredAt: number | null;
+    }>
+  >;
   getStoredMessages(): Promise<
     Array<{ id: string; role: string; parts?: unknown[] }>
   >;
@@ -323,6 +356,125 @@ describe("Think durable submissions", () => {
       error: "not needed"
     });
     await expect(agent.getStoredMessages()).resolves.toHaveLength(0);
+  });
+
+  it("recovers terminal workflow submissions into workflow notifications", async () => {
+    const agent = await freshAgent();
+    await agent.insertSubmissionForTest({
+      submissionId: "sub-workflow-error",
+      status: "error",
+      completedAt: Date.now(),
+      errorMessage: "model failed",
+      metadata: {
+        workflow: {
+          name: "TEST_WORKFLOW",
+          id: "workflow-recover",
+          stepName: "draft-report",
+          eventType: "think-prompt-recover"
+        },
+        workflowPrompt: {
+          output: { schema: { type: "object" } },
+          fingerprint: "fingerprint"
+        }
+      }
+    });
+
+    await agent.recoverWorkflowNotificationsForTest();
+    const notifications = await agent.listWorkflowNotificationsForTest();
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      notificationId: "sub-workflow-error:think-prompt-recover",
+      submissionId: "sub-workflow-error",
+      workflowName: "TEST_WORKFLOW",
+      workflowId: "workflow-recover",
+      eventType: "think-prompt-recover",
+      attempts: 0,
+      payloadJson: "{}"
+    });
+    expect(notifications[0].deliveredAt).toBeTypeOf("number");
+    await expect(agent.getWorkflowEventsForTest()).resolves.toEqual([
+      {
+        workflowName: "TEST_WORKFLOW",
+        workflowId: "workflow-recover",
+        event: {
+          type: "think-prompt-recover",
+          payload: {
+            submissionId: "sub-workflow-error",
+            status: "error",
+            error: "model failed"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("drains workflow notifications and clears delivered payloads", async () => {
+    const agent = await freshAgent();
+    await agent.insertWorkflowNotificationForTest({
+      notificationId: "notification-deliver",
+      submissionId: "sub-deliver",
+      workflowName: "TEST_WORKFLOW",
+      workflowId: "workflow-deliver",
+      eventType: "think-prompt-deliver",
+      payload: {
+        submissionId: "sub-deliver",
+        status: "completed",
+        output: { title: "Done" }
+      }
+    });
+
+    await agent.drainWorkflowNotificationsForTest();
+
+    await expect(agent.getWorkflowEventsForTest()).resolves.toEqual([
+      {
+        workflowName: "TEST_WORKFLOW",
+        workflowId: "workflow-deliver",
+        event: {
+          type: "think-prompt-deliver",
+          payload: {
+            submissionId: "sub-deliver",
+            status: "completed",
+            output: { title: "Done" }
+          }
+        }
+      }
+    ]);
+    const notifications = await agent.listWorkflowNotificationsForTest();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      notificationId: "notification-deliver",
+      attempts: 0,
+      lastError: null,
+      payloadJson: "{}"
+    });
+    expect(notifications[0].deliveredAt).toBeTypeOf("number");
+  });
+
+  it("keeps workflow notifications pending when delivery fails", async () => {
+    const agent = await freshAgent();
+    await agent.insertWorkflowNotificationForTest({
+      notificationId: "notification-retry",
+      submissionId: "sub-retry",
+      workflowName: "TEST_WORKFLOW",
+      workflowId: "workflow-retry",
+      eventType: "think-prompt-retry"
+    });
+    await agent.setWorkflowEventFailuresForTest(5);
+
+    await agent.drainWorkflowNotificationsForTest();
+
+    const notifications = await agent.listWorkflowNotificationsForTest();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      notificationId: "notification-retry",
+      attempts: 1,
+      deliveredAt: null
+    });
+    expect(notifications[0].lastError).toContain(
+      "simulated workflow event failure"
+    );
+    await expect(agent.getWorkflowEventsForTest()).resolves.toEqual([]);
   });
 
   it("runs durable pending rows through the scheduled drain callback path", async () => {

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -25,6 +25,7 @@ type ThinkSubmissionTestStub = {
   runNonSubmissionStreamFailureForTest(requestId: string): Promise<void>;
   setSubmissionStatusDelayForTest(delayMs: number): Promise<void>;
   setProgrammaticResponseForTest(response: string): Promise<void>;
+  setLastBodyForTest(body: Record<string, unknown>): Promise<void>;
   setSubmissionRecoveryStaleMsForTest(ms: number): Promise<void>;
   setWorkflowEventFailuresForTest(count: number): Promise<void>;
   getWorkflowEventsForTest(): Promise<
@@ -331,6 +332,44 @@ describe("Think durable submissions", () => {
     ).resolves.toBe(
       "submissionId and idempotencyKey refer to different submissions"
     );
+  });
+
+  it("does not treat client body workflow-shaped data as workflow configuration", async () => {
+    const agent = await freshAgent();
+    await agent.setProgrammaticResponseForTest("plain text response");
+    await agent.setLastBodyForTest({
+      workflow: {
+        name: "TEST_WORKFLOW",
+        id: "client-controlled",
+        stepName: "not-a-workflow-step",
+        eventType: "think-prompt-client-body"
+      },
+      workflowPrompt: {
+        output: {
+          schema: {
+            type: "object",
+            properties: {
+              title: { type: "string" }
+            },
+            required: ["title"],
+            additionalProperties: false
+          }
+        },
+        fingerprint: "client-body"
+      }
+    });
+
+    const accepted = await agent.testSubmitMessages("normal body", {
+      submissionId: "sub-client-body-workflow-shape"
+    });
+    const completed = await waitForSubmission(
+      agent,
+      accepted.submissionId,
+      (submission) => terminalStatuses.has(submission.status)
+    );
+
+    expect(completed.status).toBe("completed");
+    await expect(agent.getWorkflowEventsForTest()).resolves.toEqual([]);
   });
 
   it("aborts a running submission without letting late completion overwrite it", async () => {

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -24,6 +24,7 @@ type ThinkSubmissionTestStub = {
   ): Promise<ThinkSubmissionStatus>;
   runNonSubmissionStreamFailureForTest(requestId: string): Promise<void>;
   setSubmissionStatusDelayForTest(delayMs: number): Promise<void>;
+  setProgrammaticResponseForTest(response: string): Promise<void>;
   setSubmissionRecoveryStaleMsForTest(ms: number): Promise<void>;
   setWorkflowEventFailuresForTest(count: number): Promise<void>;
   getWorkflowEventsForTest(): Promise<
@@ -154,6 +155,26 @@ async function waitForSubmission(
     throw new Error(`Submission ${submissionId} was not found`);
   }
   return submission;
+}
+
+async function waitForWorkflowEvent(
+  agent: ThinkSubmissionTestStub,
+  predicate: (
+    event: Awaited<
+      ReturnType<ThinkSubmissionTestStub["getWorkflowEventsForTest"]>
+    >[number]
+  ) => boolean
+): Promise<
+  Awaited<
+    ReturnType<ThinkSubmissionTestStub["getWorkflowEventsForTest"]>
+  >[number]
+> {
+  for (let attempt = 0; attempt < 80; attempt++) {
+    const event = (await agent.getWorkflowEventsForTest()).find(predicate);
+    if (event) return event;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("Workflow event was not delivered");
 }
 
 describe("Think durable submissions", () => {
@@ -407,6 +428,71 @@ describe("Think durable submissions", () => {
         }
       }
     ]);
+  });
+
+  it("captures workflow structured output in terminal notifications", async () => {
+    const agent = await freshAgent();
+    await agent.setProgrammaticResponseForTest(
+      JSON.stringify({
+        title: "Workflow output",
+        labels: ["ops", "review"]
+      })
+    );
+
+    const accepted = await agent.testSubmitMessages("produce workflow output", {
+      submissionId: "sub-workflow-output",
+      metadata: {
+        workflow: {
+          name: "TEST_WORKFLOW",
+          id: "workflow-output",
+          stepName: "draft-report",
+          eventType: "think-prompt-output"
+        },
+        workflowPrompt: {
+          output: {
+            schema: {
+              type: "object",
+              properties: {
+                title: { type: "string" },
+                labels: {
+                  type: "array",
+                  items: { type: "string" }
+                }
+              },
+              required: ["title", "labels"],
+              additionalProperties: false
+            }
+          },
+          fingerprint: "fingerprint"
+        }
+      }
+    });
+
+    await waitForSubmission(
+      agent,
+      accepted.submissionId,
+      (submission) => submission.status === "completed"
+    );
+    const event = await waitForWorkflowEvent(
+      agent,
+      (entry) => entry.event.type === "think-prompt-output"
+    );
+
+    expect(event).toEqual({
+      workflowName: "TEST_WORKFLOW",
+      workflowId: "workflow-output",
+      event: {
+        type: "think-prompt-output",
+        payload: {
+          submissionId: "sub-workflow-output",
+          status: "completed",
+          output: {
+            title: "Workflow output",
+            labels: ["ops", "review"]
+          }
+        }
+      }
+    });
   });
 
   it("drains workflow notifications and clears delivered payloads", async () => {

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -140,6 +140,7 @@ const terminalStatuses = new Set<ThinkSubmissionStatus>([
   "skipped",
   "error"
 ]);
+const workflowPromptMetadataKey = "__thinkWorkflowPrompt";
 
 async function waitForSubmission(
   agent: ThinkSubmissionTestStub,
@@ -372,6 +373,44 @@ describe("Think durable submissions", () => {
     await expect(agent.getWorkflowEventsForTest()).resolves.toEqual([]);
   });
 
+  it("does not treat public workflow-shaped metadata as workflow configuration", async () => {
+    const agent = await freshAgent();
+    await agent.setProgrammaticResponseForTest("plain text response");
+
+    const accepted = await agent.testSubmitMessages("normal metadata", {
+      submissionId: "sub-public-metadata-workflow-shape",
+      metadata: {
+        workflow: {
+          name: "TEST_WORKFLOW",
+          id: "metadata-controlled",
+          stepName: "not-a-workflow-step",
+          eventType: "think-prompt-metadata"
+        },
+        workflowPrompt: {
+          output: {
+            schema: {
+              type: "object",
+              properties: {
+                title: { type: "string" }
+              },
+              required: ["title"],
+              additionalProperties: false
+            }
+          },
+          fingerprint: "metadata"
+        }
+      }
+    });
+    const completed = await waitForSubmission(
+      agent,
+      accepted.submissionId,
+      (submission) => terminalStatuses.has(submission.status)
+    );
+
+    expect(completed.status).toBe("completed");
+    await expect(agent.getWorkflowEventsForTest()).resolves.toEqual([]);
+  });
+
   it("aborts a running submission without letting late completion overwrite it", async () => {
     const agent = await freshAgent();
     await agent.setDelayedChunkResponse(["a ", "b ", "c ", "d "], 50);
@@ -426,13 +465,13 @@ describe("Think durable submissions", () => {
       completedAt: Date.now(),
       errorMessage: "model failed",
       metadata: {
-        workflow: {
-          name: "TEST_WORKFLOW",
-          id: "workflow-recover",
-          stepName: "draft-report",
-          eventType: "think-prompt-recover"
-        },
-        workflowPrompt: {
+        [workflowPromptMetadataKey]: {
+          workflow: {
+            name: "TEST_WORKFLOW",
+            id: "workflow-recover",
+            stepName: "draft-report",
+            eventType: "think-prompt-recover"
+          },
           output: { schema: { type: "object" } },
           fingerprint: "fingerprint"
         }
@@ -481,13 +520,13 @@ describe("Think durable submissions", () => {
     const accepted = await agent.testSubmitMessages("produce workflow output", {
       submissionId: "sub-workflow-output",
       metadata: {
-        workflow: {
-          name: "TEST_WORKFLOW",
-          id: "workflow-output",
-          stepName: "draft-report",
-          eventType: "think-prompt-output"
-        },
-        workflowPrompt: {
+        [workflowPromptMetadataKey]: {
+          workflow: {
+            name: "TEST_WORKFLOW",
+            id: "workflow-output",
+            stepName: "draft-report",
+            eventType: "think-prompt-output"
+          },
           output: {
             schema: {
               type: "object",

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -585,7 +585,7 @@ describe("Think durable submissions", () => {
       workflowId: "workflow-retry",
       eventType: "think-prompt-retry"
     });
-    await agent.setWorkflowEventFailuresForTest(5);
+    await agent.setWorkflowEventFailuresForTest(1);
 
     await agent.drainWorkflowNotificationsForTest();
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -403,6 +403,8 @@ export interface TurnInput {
   clientTools?: ClientToolSchema[];
   /** Custom body fields from the client request. */
   body?: Record<string, unknown>;
+  /** Internal workflow prompt configuration, never sourced from client body. */
+  workflowPrompt?: ThinkWorkflowPromptContext;
   /** Whether this is a continuation turn (auto-continue after tool result, recovery). */
   continuation: boolean;
 }
@@ -1597,7 +1599,7 @@ export class Think<
 
     const subclassConfig = (await this.beforeTurn(ctx)) ?? {};
     const config = await this._pipelineExtensionBeforeTurn(ctx, subclassConfig);
-    const workflowPrompt = this._readWorkflowPromptContext(input.body ?? null);
+    const workflowPrompt = input.workflowPrompt;
     const workflowOutput = workflowPrompt?.output
       ? Output.object({
           schema: jsonSchema(workflowPrompt.output.schema as never)
@@ -3367,7 +3369,7 @@ export class Think<
           signal: controller.signal,
           captureProgrammaticStreamError: true,
           captureOutput: Boolean(workflowPrompt?.output),
-          body: workflowPrompt ? (metadata ?? undefined) : undefined,
+          workflowPrompt: workflowPrompt ?? undefined,
           onMessagesApplied: () => {
             this.sql`
               UPDATE cf_think_submissions
@@ -3707,6 +3709,7 @@ export class Think<
       captureProgrammaticStreamError?: boolean;
       captureOutput?: boolean;
       body?: Record<string, unknown>;
+      workflowPrompt?: ThinkWorkflowPromptContext;
     }
   ): Promise<ProgrammaticMessagesResult> {
     const clientTools = this._lastClientTools;
@@ -3763,6 +3766,7 @@ export class Think<
                   signal: abortSignal,
                   clientTools,
                   body,
+                  workflowPrompt: options?.workflowPrompt,
                   continuation: false
                 })
             );

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -93,7 +93,13 @@ import type {
   TypedToolCall,
   UIMessage
 } from "ai";
-import { convertToModelMessages, stepCountIs, streamText } from "ai";
+import {
+  convertToModelMessages,
+  jsonSchema,
+  Output,
+  stepCountIs,
+  streamText
+} from "ai";
 
 // Re-export AI SDK types that appear on Think's public lifecycle hooks
 // so users can import them from a single place.
@@ -187,6 +193,11 @@ function shouldMarkSkippedAfterGenerationChange(
 type StreamResultStatus = {
   status: Exclude<SaveMessagesResult["status"], "skipped">;
   error?: string;
+  output?: unknown;
+};
+
+type ProgrammaticMessagesResult = SaveMessagesResult & {
+  output?: unknown;
 };
 
 type ChatRecoveryRetryData = {
@@ -230,6 +241,7 @@ export interface StreamableResult {
   toUIMessageStream(options?: {
     sendReasoning?: boolean;
   }): AsyncIterable<unknown>;
+  output?: PromiseLike<unknown>;
 }
 
 /**
@@ -289,6 +301,19 @@ export type SubmitMessagesOptions = {
   metadata?: Record<string, unknown>;
 };
 
+type ThinkWorkflowPromptContext = {
+  workflow: {
+    name: string;
+    id: string;
+    stepName: string;
+    eventType: string;
+  };
+  output?: {
+    schema: unknown;
+  };
+  fingerprint?: string;
+};
+
 export type ThinkSubmissionInspection = {
   submissionId: string;
   idempotencyKey?: string;
@@ -329,6 +354,20 @@ type ThinkSubmissionRow = {
   messages_applied_at: number | null;
   started_at: number | null;
   completed_at: number | null;
+};
+
+type ThinkWorkflowNotificationRow = {
+  notification_id: string;
+  submission_id: string;
+  workflow_name: string;
+  workflow_id: string;
+  event_type: string;
+  payload_json: string;
+  attempts: number;
+  last_error: string | null;
+  created_at: number;
+  updated_at: number;
+  delivered_at: number | null;
 };
 
 // Lifecycle / result types are shared with `@cloudflare/ai-chat` via
@@ -793,7 +832,9 @@ export class Think<
       // 9. Durable submissions may run user-defined model/hooks, so start them
       // after subclass initialization has completed.
       await this._recoverSubmissionsOnStart();
+      this._recoverWorkflowNotifications();
       this._startSubmissionDrain();
+      this._startWorkflowNotificationDrain();
     };
   }
 
@@ -921,7 +962,9 @@ export class Think<
   private _agentToolPreTurnAssistantIds = new Map<string, Set<string>>();
   private _agentToolLiveSequences = new Map<string, number>();
   private _submissionTableEnsured = false;
+  private _workflowNotificationTableEnsured = false;
   private _drainingSubmissions = false;
+  private _drainingWorkflowNotifications = false;
   private _submissionAbortControllers = new Map<string, AbortController>();
   private _programmaticStreamErrors = new Map<string, string>();
   protected static submissionRecoveryStaleMs = 15 * 60 * 1000;
@@ -959,6 +1002,11 @@ export class Think<
       }
     }
     super.broadcast(msg, without);
+  }
+
+  override async alarm(): Promise<void> {
+    await super.alarm();
+    this._startWorkflowNotificationDrain();
   }
 
   // ── Dynamic config ──────────────────────────────────────────────
@@ -1549,6 +1597,12 @@ export class Think<
 
     const subclassConfig = (await this.beforeTurn(ctx)) ?? {};
     const config = await this._pipelineExtensionBeforeTurn(ctx, subclassConfig);
+    const workflowPrompt = this._readWorkflowPromptContext(input.body ?? null);
+    const workflowOutput = workflowPrompt?.output
+      ? Output.object({
+          schema: jsonSchema(workflowPrompt.output.schema as never)
+        })
+      : undefined;
 
     const finalModel = config.model ?? model;
     const finalSystem =
@@ -1604,7 +1658,7 @@ export class Think<
       // Forward the per-turn structured-output spec from TurnConfig so
       // callers can use AI SDK `Output.object({ schema })` / `Output.text()`
       // on the terminal turn without dropping tools at model construction.
-      output: config.output,
+      output: workflowOutput ?? config.output,
       abortSignal: input.signal,
       // Forward the AI SDK's `prepareStep` callback unchanged so subclasses
       // can make per-step decisions from the previous steps, current
@@ -2577,6 +2631,40 @@ export class Think<
     this._submissionTableEnsured = true;
   }
 
+  private _ensureWorkflowNotificationTable(): void {
+    if (this._workflowNotificationTableEnsured) return;
+    this.sql`
+      CREATE TABLE IF NOT EXISTS cf_think_workflow_notifications (
+        notification_id TEXT PRIMARY KEY,
+        submission_id TEXT NOT NULL,
+        workflow_name TEXT NOT NULL,
+        workflow_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        delivered_at INTEGER
+      )
+    `;
+    try {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE cf_think_workflow_notifications ADD COLUMN delivered_at INTEGER"
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.toLowerCase().includes("duplicate column")) {
+        throw error;
+      }
+    }
+    this.sql`
+      CREATE INDEX IF NOT EXISTS cf_think_workflow_notifications_created_idx
+      ON cf_think_workflow_notifications (delivered_at, created_at, notification_id)
+    `;
+    this._workflowNotificationTableEnsured = true;
+  }
+
   private _readSubmission(submissionId: string): ThinkSubmissionRow | null {
     this._ensureSubmissionTable();
     const rows = this.sql<ThinkSubmissionRow>`
@@ -2711,7 +2799,60 @@ export class Think<
     return metadata === undefined ? null : JSON.stringify(metadata);
   }
 
-  private async _emitSubmissionStatus(row: ThinkSubmissionRow): Promise<void> {
+  private _readWorkflowPromptContext(
+    metadata: Record<string, unknown> | null
+  ): ThinkWorkflowPromptContext | null {
+    const workflowPromptValue = metadata?.workflowPrompt;
+    const workflowValue = metadata?.workflow;
+    if (
+      workflowPromptValue === null ||
+      typeof workflowPromptValue !== "object" ||
+      Array.isArray(workflowPromptValue) ||
+      workflowValue === null ||
+      typeof workflowValue !== "object" ||
+      Array.isArray(workflowValue)
+    ) {
+      return null;
+    }
+    const workflowPrompt = workflowPromptValue as Record<string, unknown>;
+    const workflowRecord = workflowValue as Record<string, unknown>;
+    if (
+      typeof workflowRecord.name !== "string" ||
+      typeof workflowRecord.id !== "string" ||
+      typeof workflowRecord.stepName !== "string" ||
+      typeof workflowRecord.eventType !== "string"
+    ) {
+      return null;
+    }
+    const output = workflowPrompt.output;
+    const outputRecord =
+      output !== null && typeof output === "object" && !Array.isArray(output)
+        ? (output as Record<string, unknown>)
+        : null;
+    return {
+      workflow: {
+        name: workflowRecord.name,
+        id: workflowRecord.id,
+        stepName: workflowRecord.stepName,
+        eventType: workflowRecord.eventType
+      },
+      ...(outputRecord
+        ? {
+            output: {
+              schema: outputRecord.schema
+            }
+          }
+        : {}),
+      ...(typeof workflowPrompt.fingerprint === "string" && {
+        fingerprint: workflowPrompt.fingerprint
+      })
+    };
+  }
+
+  private async _emitSubmissionStatus(
+    row: ThinkSubmissionRow,
+    output?: unknown
+  ): Promise<void> {
     const inspection = this._inspectionFromSubmissionRow(row);
     this._emit("submission:status", {
       submissionId: inspection.submissionId,
@@ -2725,6 +2866,9 @@ export class Think<
         error: inspection.error
       });
     }
+    if (this._isTerminalSubmissionStatus(inspection.status)) {
+      await this._enqueueWorkflowNotification(inspection, output);
+    }
     await this.keepAliveWhile(async () => {
       try {
         await this.onSubmissionStatus(inspection);
@@ -2737,6 +2881,175 @@ export class Think<
   protected onSubmissionStatus(
     _submission: ThinkSubmissionInspection
   ): void | Promise<void> {}
+
+  private async _enqueueWorkflowNotification(
+    submission: ThinkSubmissionInspection,
+    output?: unknown
+  ): Promise<void> {
+    this._insertWorkflowNotification(submission, output);
+    this._startWorkflowNotificationDrain();
+  }
+
+  private _insertWorkflowNotification(
+    submission: ThinkSubmissionInspection,
+    output?: unknown,
+    override?: { status: ThinkSubmissionStatus; error: string }
+  ): boolean {
+    const workflowPrompt = this._readWorkflowPromptContext(
+      submission.metadata ?? null
+    );
+    if (!workflowPrompt) return false;
+
+    this._ensureWorkflowNotificationTable();
+    const now = Date.now();
+    const status = override?.status ?? submission.status;
+    const error = override?.error ?? submission.error;
+    const payload = {
+      submissionId: submission.submissionId,
+      status,
+      ...(status === "completed" && { output }),
+      ...(error && { error })
+    };
+    this.sql`
+      INSERT OR IGNORE INTO cf_think_workflow_notifications (
+        notification_id, submission_id, workflow_name, workflow_id, event_type,
+        payload_json, attempts, last_error, created_at, updated_at, delivered_at
+      )
+      VALUES (
+        ${`${submission.submissionId}:${workflowPrompt.workflow.eventType}`},
+        ${submission.submissionId},
+        ${workflowPrompt.workflow.name},
+        ${workflowPrompt.workflow.id},
+        ${workflowPrompt.workflow.eventType},
+        ${JSON.stringify(payload)},
+        0,
+        NULL,
+        ${now},
+        ${now},
+        NULL
+      )
+    `;
+    return true;
+  }
+
+  private _recoverWorkflowNotifications(): void {
+    this._ensureSubmissionTable();
+    this._ensureWorkflowNotificationTable();
+    const terminalRows = this.sql<ThinkSubmissionRow>`
+      SELECT submission_id, idempotency_key, request_id, stream_id, status,
+             messages_json, metadata_json, error_message, created_at,
+             messages_applied_at, started_at, completed_at
+      FROM cf_think_submissions
+      WHERE status IN ('aborted', 'skipped', 'error')
+      ORDER BY completed_at DESC, created_at DESC
+      LIMIT 100
+    `;
+
+    let recovered = false;
+    for (const row of terminalRows) {
+      const inspection = this._inspectionFromSubmissionRow(row);
+      const workflowPrompt = this._readWorkflowPromptContext(
+        inspection.metadata ?? null
+      );
+      if (!workflowPrompt) continue;
+      const notificationId = `${inspection.submissionId}:${workflowPrompt.workflow.eventType}`;
+      const existing = this.sql<{ notification_id: string }>`
+        SELECT notification_id
+        FROM cf_think_workflow_notifications
+        WHERE notification_id = ${notificationId}
+        LIMIT 1
+      `;
+      if (existing[0]) continue;
+
+      recovered = this._insertWorkflowNotification(inspection) || recovered;
+    }
+    if (recovered) this._startWorkflowNotificationDrain();
+  }
+
+  private _startWorkflowNotificationDrain(): void {
+    void this.keepAliveWhile(() => this._drainWorkflowNotifications()).catch(
+      (error) => {
+        console.error("[Think] Failed to drain workflow notifications", error);
+        void this._scheduleWorkflowNotificationAlarm();
+      }
+    );
+  }
+
+  private async _drainWorkflowNotifications(): Promise<void> {
+    if (this._drainingWorkflowNotifications) return;
+    this._ensureWorkflowNotificationTable();
+    this._drainingWorkflowNotifications = true;
+    try {
+      const rows = this.sql<ThinkWorkflowNotificationRow>`
+        SELECT notification_id, submission_id, workflow_name, workflow_id,
+               event_type, payload_json, attempts, last_error, created_at,
+               updated_at, delivered_at
+        FROM cf_think_workflow_notifications
+        WHERE delivered_at IS NULL
+        ORDER BY created_at ASC, notification_id ASC
+        LIMIT 25
+      `;
+      for (const row of rows) {
+        try {
+          const payload = JSON.parse(row.payload_json) as unknown;
+          await this.retry(
+            async () => {
+              await this.sendWorkflowEvent(
+                row.workflow_name as string & {},
+                row.workflow_id,
+                {
+                  type: row.event_type,
+                  payload
+                }
+              );
+            },
+            { maxAttempts: 5 }
+          );
+          this.sql`
+            UPDATE cf_think_workflow_notifications
+            SET payload_json = '{}',
+                last_error = NULL,
+                updated_at = ${Date.now()},
+                delivered_at = ${Date.now()}
+            WHERE notification_id = ${row.notification_id}
+              AND delivered_at IS NULL
+          `;
+        } catch (error) {
+          this.sql`
+            UPDATE cf_think_workflow_notifications
+            SET attempts = attempts + 1,
+                last_error = ${error instanceof Error ? error.message : String(error)},
+                updated_at = ${Date.now()}
+            WHERE notification_id = ${row.notification_id}
+          `;
+        }
+      }
+    } finally {
+      this._drainingWorkflowNotifications = false;
+    }
+    await this._scheduleWorkflowNotificationAlarm();
+  }
+
+  private async _scheduleWorkflowNotificationAlarm(): Promise<void> {
+    this._ensureWorkflowNotificationTable();
+    const pending = this.sql<{ attempts: number }>`
+      SELECT attempts
+      FROM cf_think_workflow_notifications
+      WHERE delivered_at IS NULL
+      ORDER BY created_at ASC, notification_id ASC
+      LIMIT 1
+    `;
+    if (!pending[0]) return;
+    const delayMs = Math.min(
+      5 * 60 * 1000,
+      1000 * 2 ** Math.min(pending[0].attempts, 8)
+    );
+    const nextAlarm = Date.now() + delayMs;
+    const existingAlarm = await this.ctx.storage.getAlarm();
+    if (existingAlarm === null || existingAlarm > nextAlarm) {
+      await this.ctx.storage.setAlarm(nextAlarm);
+    }
+  }
 
   async inspectSubmission(
     submissionId: string
@@ -3031,14 +3344,24 @@ export class Think<
 
     const controller = new AbortController();
     this._submissionAbortControllers.set(row.submission_id, controller);
+    let output: unknown;
     try {
       const messages = this._parseSubmissionMessages(row.messages_json);
+      const workflowPrompt = this._readWorkflowPromptContext(
+        this._parseJsonObject(row.metadata_json)
+      );
       const result = await this._runProgrammaticMessagesTurn(
         requestId,
         messages,
         {
           signal: controller.signal,
           captureProgrammaticStreamError: true,
+          captureOutput: Boolean(workflowPrompt?.output),
+          body: workflowPrompt
+            ? {
+                workflowPrompt
+              }
+            : undefined,
           onMessagesApplied: () => {
             this.sql`
               UPDATE cf_think_submissions
@@ -3050,6 +3373,7 @@ export class Think<
           }
         }
       );
+      output = result.output;
       const streamId =
         this._resumableStream
           .getAllStreamMetadata()
@@ -3061,31 +3385,56 @@ export class Think<
         result.error ?? streamError
       );
       const errorMessage = result.error ?? streamError ?? null;
-      this.sql`
-        UPDATE cf_think_submissions
-        SET status = ${finalStatus},
-            request_id = ${result.requestId},
-            stream_id = ${streamId},
-            error_message = ${finalStatus === "error" ? errorMessage : null},
-            completed_at = ${Date.now()}
-        WHERE submission_id = ${row.submission_id}
-          AND status = 'running'
-      `;
+      const completedAt = Date.now();
+      this.ctx.storage.transactionSync(() => {
+        this.sql`
+          UPDATE cf_think_submissions
+          SET status = ${finalStatus},
+              request_id = ${result.requestId},
+              stream_id = ${streamId},
+              error_message = ${finalStatus === "error" ? errorMessage : null},
+              completed_at = ${completedAt}
+          WHERE submission_id = ${row.submission_id}
+            AND status = 'running'
+        `;
+        this._insertWorkflowNotification(
+          {
+            ...this._inspectionFromSubmissionRow(claimed),
+            requestId: result.requestId,
+            status: finalStatus,
+            error:
+              finalStatus === "error" ? (errorMessage ?? undefined) : undefined,
+            completedAt
+          },
+          output
+        );
+      });
     } catch (error) {
-      this.sql`
-        UPDATE cf_think_submissions
-        SET status = 'error',
-            error_message = ${error instanceof Error ? error.message : String(error)},
-            completed_at = ${Date.now()}
-        WHERE submission_id = ${row.submission_id}
-          AND status = 'running'
-      `;
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const completedAt = Date.now();
+      this.ctx.storage.transactionSync(() => {
+        this.sql`
+          UPDATE cf_think_submissions
+          SET status = 'error',
+              error_message = ${errorMessage},
+              completed_at = ${completedAt}
+          WHERE submission_id = ${row.submission_id}
+            AND status = 'running'
+        `;
+        this._insertWorkflowNotification({
+          ...this._inspectionFromSubmissionRow(claimed),
+          status: "error",
+          error: errorMessage,
+          completedAt
+        });
+      });
     } finally {
       this._programmaticStreamErrors.delete(requestId);
       this._submissionAbortControllers.delete(row.submission_id);
       const updated = this._readSubmission(row.submission_id);
       if (updated && this._isTerminalSubmissionStatus(updated.status)) {
-        await this._emitSubmissionStatus(updated);
+        await this._emitSubmissionStatus(updated, output);
       }
     }
   }
@@ -3350,13 +3699,16 @@ export class Think<
     options?: SaveMessagesOptions & {
       onMessagesApplied?: () => void;
       captureProgrammaticStreamError?: boolean;
+      captureOutput?: boolean;
+      body?: Record<string, unknown>;
     }
-  ): Promise<SaveMessagesResult> {
+  ): Promise<ProgrammaticMessagesResult> {
     const clientTools = this._lastClientTools;
-    const body = this._lastBody;
+    const body = options?.body ?? this._lastBody;
     const epoch = this._turnQueue.generation;
     let status: SaveMessagesResult["status"] = "completed";
     let error: string | undefined;
+    let output: unknown;
     let wasAborted = false;
 
     await this.keepAliveWhile(async () => {
@@ -3416,11 +3768,13 @@ export class Think<
                 abortSignal,
                 {
                   captureProgrammaticStreamError:
-                    options?.captureProgrammaticStreamError
+                    options?.captureProgrammaticStreamError,
+                  captureOutput: options?.captureOutput
                 }
               );
               status = streamResult.status;
               error = streamResult.error;
+              output = streamResult.output;
             }
           };
 
@@ -3450,7 +3804,12 @@ export class Think<
       status = "aborted";
     }
 
-    return { requestId, status, ...(error !== undefined && { error }) };
+    return {
+      requestId,
+      status,
+      ...(error !== undefined && { error }),
+      ...(output !== undefined && { output })
+    };
   }
 
   /**
@@ -4387,6 +4746,7 @@ export class Think<
       continuation?: boolean;
       parentId?: string;
       captureProgrammaticStreamError?: boolean;
+      captureOutput?: boolean;
     }
   ): Promise<StreamResultStatus> {
     const clearGen = this._turnQueue.generation;
@@ -4408,6 +4768,7 @@ export class Think<
     let doneSent = false;
     let streamAborted = false;
     let streamError: string | undefined;
+    let output: unknown;
 
     try {
       this._insideInferenceLoop = true;
@@ -4494,6 +4855,23 @@ export class Think<
       }
     }
 
+    if (
+      options?.captureOutput &&
+      result.output &&
+      !streamError &&
+      !streamAborted
+    ) {
+      try {
+        output = await result.output;
+      } catch (error) {
+        streamError =
+          error instanceof Error ? error.message : "Structured output error";
+        if (options.captureProgrammaticStreamError) {
+          this._programmaticStreamErrors.set(requestId, streamError);
+        }
+      }
+    }
+
     if (this._turnQueue.generation === clearGen) {
       try {
         const assistantMsg = accumulator.toMessage();
@@ -4521,7 +4899,10 @@ export class Think<
 
     return streamError
       ? { status: "error", error: streamError }
-      : { status: streamAborted ? "aborted" : "completed" };
+      : {
+          status: streamAborted ? "aborted" : "completed",
+          ...(output !== undefined && { output })
+        };
   }
 
   // ── Session-backed persistence ──────────────────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -3005,18 +3005,13 @@ export class Think<
       for (const row of rows) {
         try {
           const payload = JSON.parse(row.payload_json) as unknown;
-          await this.retry(
-            async () => {
-              await this.sendWorkflowEvent(
-                row.workflow_name as string & {},
-                row.workflow_id,
-                {
-                  type: row.event_type,
-                  payload
-                }
-              );
-            },
-            { maxAttempts: 5 }
+          await this.sendWorkflowEvent(
+            row.workflow_name as string & {},
+            row.workflow_id,
+            {
+              type: row.event_type,
+              payload
+            }
           );
           this.sql`
             UPDATE cf_think_workflow_notifications

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -314,6 +314,8 @@ type ThinkWorkflowPromptContext = {
   fingerprint?: string;
 };
 
+const THINK_WORKFLOW_PROMPT_METADATA_KEY = "__thinkWorkflowPrompt";
+
 export type ThinkSubmissionInspection = {
   submissionId: string;
   idempotencyKey?: string;
@@ -2815,19 +2817,23 @@ export class Think<
   private _readWorkflowPromptContext(
     metadata: Record<string, unknown> | null
   ): ThinkWorkflowPromptContext | null {
-    const workflowPromptValue = metadata?.workflowPrompt;
-    const workflowValue = metadata?.workflow;
+    const workflowPromptValue = metadata?.[THINK_WORKFLOW_PROMPT_METADATA_KEY];
     if (
       workflowPromptValue === null ||
       typeof workflowPromptValue !== "object" ||
-      Array.isArray(workflowPromptValue) ||
+      Array.isArray(workflowPromptValue)
+    ) {
+      return null;
+    }
+    const workflowPrompt = workflowPromptValue as Record<string, unknown>;
+    const workflowValue = workflowPrompt.workflow;
+    if (
       workflowValue === null ||
       typeof workflowValue !== "object" ||
       Array.isArray(workflowValue)
     ) {
       return null;
     }
-    const workflowPrompt = workflowPromptValue as Record<string, unknown>;
     const workflowRecord = workflowValue as Record<string, unknown>;
     if (
       typeof workflowRecord.name !== "string" ||

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1623,6 +1623,7 @@ export class Think<
     const finalTools: ToolSet = this._wrapToolsWithDecision(mergedTools);
     const finalMaxSteps = config.maxSteps ?? this.maxSteps;
     const finalSendReasoning = config.sendReasoning ?? this.sendReasoning;
+    const finalOutput = workflowOutput ?? config.output;
     const finalStopWhen = [
       stepCountIs(finalMaxSteps),
       ...(Array.isArray(config.stopWhen)
@@ -1658,7 +1659,7 @@ export class Think<
       // Forward the per-turn structured-output spec from TurnConfig so
       // callers can use AI SDK `Output.object({ schema })` / `Output.text()`
       // on the terminal turn without dropping tools at model construction.
-      output: workflowOutput ?? config.output,
+      output: finalOutput,
       abortSignal: input.signal,
       // Forward the AI SDK's `prepareStep` callback unchanged so subclasses
       // can make per-step decisions from the previous steps, current
@@ -1717,9 +1718,19 @@ export class Think<
       }) satisfies StreamTextOnToolCallFinishCallback<ToolSet>
     });
 
+    const outputPromise =
+      finalOutput && result.output ? Promise.resolve(result.output) : undefined;
+    if (outputPromise) {
+      // Attach a rejection observer immediately. `_streamResult()` will still
+      // await this promise when captureOutput is enabled, but aborted streams can
+      // reject before the stream consumer reaches that point.
+      void outputPromise.catch(() => {});
+    }
+
     const streamResult = {
       toUIMessageStream: () =>
-        result.toUIMessageStream({ sendReasoning: finalSendReasoning })
+        result.toUIMessageStream({ sendReasoning: finalSendReasoning }),
+      output: outputPromise
     } satisfies StreamableResult;
 
     return this._transformInferenceResult(streamResult);
@@ -3347,9 +3358,8 @@ export class Think<
     let output: unknown;
     try {
       const messages = this._parseSubmissionMessages(row.messages_json);
-      const workflowPrompt = this._readWorkflowPromptContext(
-        this._parseJsonObject(row.metadata_json)
-      );
+      const metadata = this._parseJsonObject(row.metadata_json);
+      const workflowPrompt = this._readWorkflowPromptContext(metadata);
       const result = await this._runProgrammaticMessagesTurn(
         requestId,
         messages,
@@ -3357,11 +3367,7 @@ export class Think<
           signal: controller.signal,
           captureProgrammaticStreamError: true,
           captureOutput: Boolean(workflowPrompt?.output),
-          body: workflowPrompt
-            ? {
-                workflowPrompt
-              }
-            : undefined,
+          body: workflowPrompt ? (metadata ?? undefined) : undefined,
           onMessagesApplied: () => {
             this.sql`
               UPDATE cf_think_submissions

--- a/packages/think/src/workflows.ts
+++ b/packages/think/src/workflows.ts
@@ -161,10 +161,14 @@ export class ThinkWorkflow<
       eventPayload = event.payload as ThinkPromptEventPayload;
     } catch (error) {
       if (options.cancelOnTimeout !== false) {
-        await this.agent.cancelSubmission(
-          submission.submissionId,
-          "Workflow prompt wait timed out"
-        );
+        try {
+          await this.agent.cancelSubmission(
+            submission.submissionId,
+            "Workflow prompt wait timed out"
+          );
+        } catch {
+          // Cancellation is best-effort cleanup; preserve the timeout error.
+        }
       }
       throw new ThinkPromptTimeoutError(submission.submissionId, error);
     }

--- a/packages/think/src/workflows.ts
+++ b/packages/think/src/workflows.ts
@@ -32,7 +32,7 @@ export type ThinkPromptOptions<Schema extends ZodObject> = {
   cancelOnTimeout?: boolean;
 };
 
-export interface ThinkAgentWorkflowStep extends AgentWorkflowStep {
+export interface ThinkWorkflowStep extends AgentWorkflowStep {
   prompt<Schema extends ZodObject>(
     name: string,
     options: ThinkPromptOptions<Schema>
@@ -84,7 +84,7 @@ export class ThinkPromptValidationError extends ThinkPromptError {
   }
 }
 
-export class ThinkAgentWorkflow<
+export class ThinkWorkflow<
   AgentType extends Think = Think,
   Params = unknown,
   ProgressType = DefaultProgress,
@@ -93,8 +93,8 @@ export class ThinkAgentWorkflow<
   protected extendStep(
     step: AgentWorkflowStep,
     event: WorkflowEvent<Params>
-  ): ThinkAgentWorkflowStep {
-    const workflowStep = step as ThinkAgentWorkflowStep;
+  ): ThinkWorkflowStep {
+    const workflowStep = step as ThinkWorkflowStep;
     workflowStep.prompt = async <Schema extends ZodObject>(
       name: string,
       options: ThinkPromptOptions<Schema>

--- a/packages/think/src/workflows.ts
+++ b/packages/think/src/workflows.ts
@@ -24,6 +24,8 @@ type ThinkPromptEventPayload = {
   error?: string;
 };
 
+const THINK_WORKFLOW_PROMPT_METADATA_KEY = "__thinkWorkflowPrompt";
+
 export type ThinkPromptOptions<Schema extends ZodObject> = {
   prompt: string;
   output: Schema;
@@ -135,13 +137,13 @@ export class ThinkWorkflow<
         {
           idempotencyKey,
           metadata: {
-            workflow: {
-              name: this.workflowName,
-              id: this.workflowId,
-              stepName,
-              eventType
-            },
-            workflowPrompt: {
+            [THINK_WORKFLOW_PROMPT_METADATA_KEY]: {
+              workflow: {
+                name: this.workflowName,
+                id: this.workflowId,
+                stepName,
+                eventType
+              },
               output: {
                 schema: outputSchema
               },

--- a/packages/think/src/workflows.ts
+++ b/packages/think/src/workflows.ts
@@ -1,0 +1,236 @@
+import type { WorkflowEvent, WorkflowSleepDuration } from "cloudflare:workers";
+import {
+  AgentWorkflow,
+  type AgentWorkflowStep,
+  type DefaultProgress
+} from "agents/workflows";
+import type { UIMessage } from "ai";
+import { toJSONSchema, type ZodObject, type z } from "zod";
+import type {
+  SubmitMessagesResult,
+  Think,
+  ThinkSubmissionStatus
+} from "./think";
+
+type ThinkPromptTerminalStatus = Exclude<
+  ThinkSubmissionStatus,
+  "pending" | "running"
+>;
+
+type ThinkPromptEventPayload = {
+  submissionId: string;
+  status: ThinkPromptTerminalStatus;
+  output?: unknown;
+  error?: string;
+};
+
+export type ThinkPromptOptions<Schema extends ZodObject> = {
+  prompt: string;
+  output: Schema;
+  timeout?: WorkflowSleepDuration;
+  key?: string;
+  cancelOnTimeout?: boolean;
+};
+
+export interface ThinkAgentWorkflowStep extends AgentWorkflowStep {
+  prompt<Schema extends ZodObject>(
+    name: string,
+    options: ThinkPromptOptions<Schema>
+  ): Promise<z.infer<Schema>>;
+}
+
+export class ThinkPromptError extends Error {
+  constructor(
+    message: string,
+    readonly submissionId: string,
+    readonly status: ThinkPromptTerminalStatus,
+    readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "ThinkPromptError";
+  }
+}
+
+export class ThinkPromptAbortedError extends ThinkPromptError {
+  constructor(submissionId: string, message = "Think prompt was aborted") {
+    super(message, submissionId, "aborted");
+    this.name = "ThinkPromptAbortedError";
+  }
+}
+
+export class ThinkPromptSkippedError extends ThinkPromptError {
+  constructor(submissionId: string, message = "Think prompt was skipped") {
+    super(message, submissionId, "skipped");
+    this.name = "ThinkPromptSkippedError";
+  }
+}
+
+export class ThinkPromptTimeoutError extends ThinkPromptError {
+  constructor(submissionId: string, cause: unknown) {
+    super("Timed out waiting for Think prompt", submissionId, "error", cause);
+    this.name = "ThinkPromptTimeoutError";
+  }
+}
+
+export class ThinkPromptValidationError extends ThinkPromptError {
+  constructor(submissionId: string, cause: unknown) {
+    super(
+      "Think prompt returned invalid structured output",
+      submissionId,
+      "error",
+      cause
+    );
+    this.name = "ThinkPromptValidationError";
+  }
+}
+
+export class ThinkAgentWorkflow<
+  AgentType extends Think = Think,
+  Params = unknown,
+  ProgressType = DefaultProgress,
+  Env extends Cloudflare.Env = Cloudflare.Env
+> extends AgentWorkflow<AgentType, Params, ProgressType, Env> {
+  protected extendStep(
+    step: AgentWorkflowStep,
+    event: WorkflowEvent<Params>
+  ): ThinkAgentWorkflowStep {
+    const workflowStep = step as ThinkAgentWorkflowStep;
+    workflowStep.prompt = async <Schema extends ZodObject>(
+      name: string,
+      options: ThinkPromptOptions<Schema>
+    ): Promise<z.infer<Schema>> => {
+      return this._promptStep(name, options, step, event);
+    };
+    return workflowStep;
+  }
+
+  private async _promptStep<Schema extends ZodObject>(
+    stepName: string,
+    options: ThinkPromptOptions<Schema>,
+    step: AgentWorkflowStep,
+    _event: WorkflowEvent<Params>
+  ): Promise<z.infer<Schema>> {
+    const outputSchema = toJSONSchema(options.output);
+    const eventType = await this._eventTypeForPrompt(stepName, options.key);
+    const idempotencyKey = await this._idempotencyKeyForPrompt(
+      stepName,
+      options.key
+    );
+    const fingerprint = await this._hashString(
+      JSON.stringify({
+        prompt: options.prompt,
+        output: outputSchema
+      })
+    );
+
+    const submission = (await step.do(`${stepName}:submit`, async () => {
+      return this.agent.submitMessages(
+        [
+          {
+            id: crypto.randomUUID(),
+            role: "user",
+            parts: [{ type: "text", text: options.prompt }]
+          } satisfies UIMessage
+        ],
+        {
+          idempotencyKey,
+          metadata: {
+            workflow: {
+              name: this.workflowName,
+              id: this.workflowId,
+              stepName,
+              eventType
+            },
+            workflowPrompt: {
+              output: {
+                schema: outputSchema
+              },
+              fingerprint
+            }
+          }
+        }
+      );
+    })) as SubmitMessagesResult;
+
+    let eventPayload: ThinkPromptEventPayload;
+    try {
+      const event = await step.waitForEvent(`${stepName}:wait`, {
+        type: eventType,
+        timeout: options.timeout
+      });
+      eventPayload = event.payload as ThinkPromptEventPayload;
+    } catch (error) {
+      if (options.cancelOnTimeout !== false) {
+        await this.agent.cancelSubmission(
+          submission.submissionId,
+          "Workflow prompt wait timed out"
+        );
+      }
+      throw new ThinkPromptTimeoutError(submission.submissionId, error);
+    }
+
+    if (eventPayload.status !== "completed") {
+      throw this._terminalPromptError(eventPayload);
+    }
+
+    const parsed = options.output.safeParse(eventPayload.output);
+    if (!parsed.success) {
+      throw new ThinkPromptValidationError(
+        eventPayload.submissionId,
+        parsed.error
+      );
+    }
+    return parsed.data;
+  }
+
+  private _terminalPromptError(
+    payload: ThinkPromptEventPayload
+  ): ThinkPromptError {
+    if (payload.status === "aborted") {
+      return new ThinkPromptAbortedError(payload.submissionId, payload.error);
+    }
+    if (payload.status === "skipped") {
+      return new ThinkPromptSkippedError(payload.submissionId, payload.error);
+    }
+    return new ThinkPromptError(
+      payload.error ?? `Think prompt ended with status ${payload.status}`,
+      payload.submissionId,
+      payload.status
+    );
+  }
+
+  private async _idempotencyKeyForPrompt(
+    stepName: string,
+    key: string | undefined
+  ): Promise<string> {
+    const base = `think-workflow:${this.workflowName}:${this.workflowId}:${stepName}`;
+    if (key === undefined) return base;
+    return `${base}:${await this._hashString(key)}`;
+  }
+
+  private async _eventTypeForPrompt(
+    stepName: string,
+    key: string | undefined
+  ): Promise<string> {
+    return `think-prompt-${await this._hashString(
+      `${this.workflowName}:${this.workflowId}:${stepName}:${key ?? ""}`
+    )}`;
+  }
+
+  private async _hashString(value: string): Promise<string> {
+    const bytes = new TextEncoder().encode(value);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return base64Url(digest).slice(0, 22);
+  }
+}
+
+function base64Url(buffer: ArrayBuffer): string {
+  let binary = "";
+  for (const byte of new Uint8Array(buffer)) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}


### PR DESCRIPTION
## Summary

This adds a first-class Think integration for Cloudflare Workflows via `@cloudflare/think/workflows`.

The main new API is `ThinkWorkflow` plus `step.prompt()`, which lets a Workflow run a single durable Think reasoning turn and resume with typed structured output:

```ts
const draft = await step.prompt("draft-report", {
  prompt: `Draft an operational report about: ${event.payload.topic}`,
  output: reportDraftSchema,
  timeout: "3 days"
});
```

The call reads like a blocking Workflow step, but it is implemented as an event-driven submit-and-resume flow so it does not hold a long-lived Durable Object RPC open.

## What Changed

- Added `@cloudflare/think/workflows` with `ThinkWorkflow`, `ThinkWorkflowStep`, `ThinkPromptOptions`, and typed prompt errors.
- Added `AgentWorkflow.extendStep()` so framework-specific workflow integrations can add helpers to the wrapped Workflow step without duplicating the base Agent workflow machinery.
- Added `step.prompt(name, options)` for Think workflows:
  - accepts `prompt: string` and a Zod object `output` schema
  - converts the schema to JSON Schema for the submitted Think turn
  - re-validates the returned output with the original Zod schema when the Workflow resumes
  - infers submission idempotency from workflow name, workflow id, step name, and optional string `key`
  - supports Workflow wait timeouts and cancels the Think submission by default on timeout
- Updated Think programmatic submissions to capture AI SDK structured output when invoked by a Workflow prompt.
- Kept workflow prompt configuration on an internal inference-loop field so client/app `body` data cannot accidentally trigger workflow structured-output mode.
- Namespaced workflow prompt control data under a private metadata envelope so public `workflow`/`workflowPrompt` metadata remains ordinary caller metadata.
- Added a private durable workflow notification outbox in Think:
  - terminal workflow submissions enqueue a notification row
  - notification delivery calls `sendWorkflowEvent()` once per drain pass and relies on its built-in transient retry plus outbox alarm retry
  - Durable Object alarms continue draining pending notifications after failures
  - delivered rows are retained but have their payload cleared
  - terminal `aborted`, `skipped`, and `error` submissions can be recovered into missing notifications on startup
- Added a server-side `examples/think-workflows` example showing:
  - starting a Workflow from an Agent with `runWorkflow()`
  - using `step.prompt()` for a report draft
  - waiting for approval with `step.waitForEvent()`
  - saving deterministic side effects through the originating Agent
- Added Think docs covering:
  - when to use Workflows versus scheduled tasks, submissions, or fibers
  - how to start a Workflow from inside a Think Agent
  - why Agent workflows should use `runWorkflow()` rather than direct `env.WORKFLOW.create()`
  - idempotency, timeout, structured output, and notification delivery behavior
- Added a changeset for `@cloudflare/think` and `agents`.

## API Shape

New import:

```ts
import { ThinkWorkflow } from "@cloudflare/think/workflows";
import type { ThinkWorkflowStep } from "@cloudflare/think/workflows";
```

Workflow definition:

```ts
export class ReportWorkflow extends ThinkWorkflow<ReportAgent, ReportParams> {
  async run(event: AgentWorkflowEvent<ReportParams>, step: ThinkWorkflowStep) {
    const draft = await step.prompt("draft-report", {
      prompt: `Draft an operational report about: ${event.payload.topic}`,
      output: reportDraftSchema,
      timeout: "3 days"
    });

    await step.do("store-draft", async () => {
      await this.agent.saveReport({ draft, status: "drafted" });
    });
  }
}
```

Agent entry point:

```ts
async startReport(topic: string) {
  const reportId = crypto.randomUUID();
  const workflowId = await this.runWorkflow(
    "REPORT_WORKFLOW",
    { reportId, topic },
    { metadata: { reportId, topic } }
  );
  return { reportId, workflowId };
}
```

## Design Notes

The important design choice is that `step.prompt()` does not synchronously wait on the Agent RPC. It submits a durable Think submission inside `step.do()`, then waits for a Workflow event. Think sends that event from a private notification outbox when the submission reaches a terminal state.

This gives the API a simple blocking shape while preserving the durable execution model:

1. Workflow submits or reuses an idempotent Think submission.
2. Think processes the turn through its existing durable submission queue.
3. Terminal submission state enqueues a Workflow notification.
4. Think retries notification delivery until `sendWorkflowEvent()` succeeds.
5. Workflow resumes from `step.waitForEvent()`.
6. `step.prompt()` validates structured output or throws a typed error.

## Tests

- `npm run test -w @cloudflare/think -- submissions.test.ts`
- `npx vitest --run -c packages/agents/src/tests/vitest.config.ts packages/agents/src/tests/workflow-prototype.test.ts`
- `npx nx run @cloudflare/think:build`
- `npx nx run agents:build`
- `npm run check`
- After the rename: `npx nx run @cloudflare/think:build`
- After the rename: `npm run typecheck -- examples/think-workflows/tsconfig.json packages/think/tsconfig.json packages/think/src/tests/tsconfig.json`
- After the structured output fix: `npm run test -w @cloudflare/think -- submissions.test.ts`
- After the structured output fix: `npx nx run @cloudflare/think:build`
- After the structured output fix: `npm run typecheck -- packages/think/tsconfig.json packages/think/src/tests/tsconfig.json examples/think-workflows/tsconfig.json`
- After internalizing workflow prompt config: `npm run test -w @cloudflare/think -- submissions.test.ts`
- After internalizing workflow prompt config: `npx nx run @cloudflare/think:build`
- After internalizing workflow prompt config: `npm run typecheck -- packages/think/tsconfig.json packages/think/src/tests/tsconfig.json examples/think-workflows/tsconfig.json`
- After the timeout cancellation fix: `npx nx run @cloudflare/think:build`
- After the timeout cancellation fix: `npm run typecheck -- packages/think/tsconfig.json examples/think-workflows/tsconfig.json`
- After simplifying notification delivery retries: `npm run test -w @cloudflare/think -- submissions.test.ts`
- After simplifying notification delivery retries: `npx nx run @cloudflare/think:build`
- After simplifying notification delivery retries: `npm run typecheck -- packages/think/tsconfig.json packages/think/src/tests/tsconfig.json examples/think-workflows/tsconfig.json`
- After reserving workflow prompt metadata: `npm run test -w @cloudflare/think -- submissions.test.ts`
- After reserving workflow prompt metadata: `npx nx run @cloudflare/think:build`
- After reserving workflow prompt metadata: `npm run typecheck -- packages/think/tsconfig.json packages/think/src/tests/tsconfig.json examples/think-workflows/tsconfig.json`

The original full `npm run check` passed before the rename, with only the repo's existing sherif warnings. After the rename, `@cloudflare/think` builds and the new `examples/think-workflows` project typechecks; a full `npm run check` rerun reached typecheck and failed in unrelated `examples/mcp-rpc-transport` because TypeScript could not resolve `workers-ai-provider` from that example.

## Remaining Follow-Up

There is not yet a true end-to-end Workflows runtime test that drives `step.prompt()` through an actual `waitForEvent()` resume. The focused tests cover the risky durable pieces added here: the base step-extension hook, workflow notification recovery, successful delivery, payload clearing, retry state after failed delivery, structured output capture in terminal workflow notifications, and isolation from workflow-shaped client body/metadata data.


