### PR TITLE
Fix Think RPC callbacks and e2e harness stability

### DIFF
--- a/.changeset/fixed-stream-callbacks.md
+++ b/.changeset/fixed-stream-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Require fixed StreamCallback RPC handlers so sub-agent chat callbacks do not probe missing remote methods.

--- a/design/think.md
+++ b/design/think.md
@@ -296,9 +296,10 @@ When used as a sub-agent, the `chat()` method runs a full turn and streams event
 
 ```typescript
 interface StreamCallback {
+  onStart(event: { requestId: string }): void | Promise<void>;
   onEvent(json: string): void | Promise<void>;
   onDone(): void | Promise<void>;
-  onError?(error: string): void | Promise<void>;
+  onError(error: string): void | Promise<void>;
 }
 ```
 

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -23,10 +23,10 @@ async chat(
 
 ```typescript
 interface StreamCallback {
-  onStart?(event: { requestId: string }): void | Promise<void>;
+  onStart(event: { requestId: string }): void | Promise<void>;
   onEvent(json: string): void | Promise<void>;
   onDone(): void | Promise<void>;
-  onError?(error: string): void | Promise<void>;
+  onError(error: string): void | Promise<void>;
 }
 ```
 
@@ -35,7 +35,7 @@ interface StreamCallback {
 | `onStart(event)` | Before work starts; exposes the request id for cancellation     |
 | `onEvent(json)`  | For each streaming chunk (JSON-serialized UIMessageChunk)       |
 | `onDone()`       | After the turn completes and the assistant message is persisted |
-| `onError(error)` | On error during the turn (if not provided, the error is thrown) |
+| `onError(error)` | On error during the turn                                        |
 
 ### ChatOptions
 
@@ -67,6 +67,9 @@ export class ParentAgent extends Think<Env> {
 
     const chunks: string[] = [];
     await child.chat(task, {
+      onStart: (event) => {
+        console.log("Child started:", event.requestId);
+      },
       onEvent: (json) => {
         chunks.push(json);
         // Optionally forward to a connected client

--- a/examples/agents-as-tools/e2e/helpers.ts
+++ b/examples/agents-as-tools/e2e/helpers.ts
@@ -119,11 +119,11 @@ export async function waitForHelperOfType(
  *
  * Helper turns (the helper's OWN inference loop, separate from the
  * parent's tool-selection loop) can take a while — especially when
- * the helper has its own internal tool calls to make. 90s.
+ * the helper has its own internal tool calls to make. 150s.
  */
 export async function waitForHelperTerminal(panel: Locator): Promise<void> {
   await expect(panel).toHaveAttribute("data-helper-status", /^(done|error)$/, {
-    timeout: 90_000
+    timeout: 150_000
   });
 }
 

--- a/examples/agents-as-tools/playwright.config.ts
+++ b/examples/agents-as-tools/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
   // tool runs two helpers in parallel which doubles that. 180s
   // gives a comfortable margin without being so long that a real
   // hang waits forever.
-  timeout: 180_000,
+  timeout: 240_000,
   expect: {
     // Long enough to wait through a slow first-token latency on
     // Workers AI without wedging on a real-but-flaked test.
@@ -78,7 +78,7 @@ export default defineConfig({
   // into a workerd-running dev server with the real `ai` binding
   // (`remote: true` in wrangler.jsonc).
   webServer: {
-    command: "npm start",
+    command: "rm -rf .wrangler/state .wrangler/tmp && npm start",
     url: `http://localhost:${PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "check": "sherif && npm run check:exports && oxfmt --check . && oxlint . && npm run typecheck",
     "test": "nx run-many -t test",
     "ci": "oxfmt --write . && nx run-many -t build test && npm run check",
-    "test:e2e": "nx run-many -t test:e2e",
+    "test:e2e": "nx run-many -t test:e2e --parallel=1",
     "test:react": "npm run test:react -w agents",
     "postinstall": "patch-package",
     "prepare:playwright": "playwright install --with-deps chromium",

--- a/packages/agents/src/e2e-tests/fiber-eviction.test.ts
+++ b/packages/agents/src/e2e-tests/fiber-eviction.test.ts
@@ -52,6 +52,28 @@ function killProcessOnPort(port: number): void {
   }
 }
 
+function killProcessTree(pid: number): void {
+  let children: number[] = [];
+  try {
+    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    // pgrep may be unavailable; killing the parent is still useful.
+  }
+  for (const childPid of children) {
+    killProcessTree(childPid);
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // Already dead
+  }
+}
+
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -64,12 +86,13 @@ function startWrangler(): ChildProcess {
       "--port",
       String(PORT),
       "--persist-to",
-      PERSIST_DIR
+      PERSIST_DIR,
+      "--inspector-port",
+      "0"
     ],
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
-      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -90,6 +113,7 @@ async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const res = await fetch(`${AGENT_URL}/`);
+      await res.body?.cancel();
       if (res.status > 0) return;
     } catch {
       // Not ready yet
@@ -102,7 +126,8 @@ async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
 async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
-      await fetch(`${AGENT_URL}/`);
+      const res = await fetch(`${AGENT_URL}/`);
+      await res.body?.cancel();
     } catch {
       return;
     }
@@ -124,15 +149,7 @@ function killProcess(child: ChildProcess): Promise<void> {
       clearTimeout(fallback);
       resolve();
     });
-    try {
-      process.kill(-child.pid, "SIGKILL");
-    } catch {
-      try {
-        process.kill(child.pid, "SIGKILL");
-      } catch {
-        // Already dead
-      }
-    }
+    killProcessTree(child.pid);
   });
 }
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -374,10 +374,10 @@ When used as a sub-agent (via `this.subAgent()`), the `chat()` method runs a ful
 
 ```ts
 interface StreamCallback {
-  onStart?(event: { requestId: string }): void | Promise<void>;
+  onStart(event: { requestId: string }): void | Promise<void>;
   onEvent(json: string): void | Promise<void>;
   onDone(): void | Promise<void>;
-  onError?(error: string): void | Promise<void>;
+  onError(error: string): void | Promise<void>;
 }
 
 const agent = await this.subAgent(MyAgent, "thread-1");

--- a/packages/think/src/e2e-tests/assistant-e2e.test.ts
+++ b/packages/think/src/e2e-tests/assistant-e2e.test.ts
@@ -49,6 +49,28 @@ function killProcessOnPort(port: number): void {
   }
 }
 
+function killProcessTree(pid: number): void {
+  let children: number[] = [];
+  try {
+    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    // pgrep may be unavailable; killing the parent is still useful.
+  }
+  for (const childPid of children) {
+    killProcessTree(childPid);
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // Already dead
+  }
+}
+
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -68,7 +90,6 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
-      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -89,6 +110,7 @@ async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const res = await fetch(`${BASE_URL}/`);
+      await res.body?.cancel();
       if (res.status > 0) return;
     } catch {
       // Not ready yet
@@ -105,15 +127,7 @@ function killProcess(child: ChildProcess): Promise<void> {
       return;
     }
     child.on("exit", () => resolve());
-    try {
-      process.kill(-child.pid, "SIGKILL");
-    } catch {
-      try {
-        process.kill(child.pid, "SIGKILL");
-      } catch {
-        // Already dead
-      }
-    }
+    killProcessTree(child.pid);
     setTimeout(resolve, 3000);
   });
 }

--- a/packages/think/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/think/src/e2e-tests/chat-recovery.test.ts
@@ -48,6 +48,28 @@ function killProcessOnPort(port: number): void {
   }
 }
 
+function killProcessTree(pid: number): void {
+  let children: number[] = [];
+  try {
+    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    // pgrep may be unavailable; killing the parent is still useful.
+  }
+  for (const childPid of children) {
+    killProcessTree(childPid);
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // Already dead
+  }
+}
+
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -67,7 +89,6 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
-      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -88,6 +109,7 @@ async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const res = await fetch(`${AGENT_URL}/`);
+      await res.body?.cancel();
       if (res.status > 0) return;
     } catch {
       // Not ready
@@ -100,7 +122,8 @@ async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
 async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
-      await fetch(`${AGENT_URL}/`);
+      const res = await fetch(`${AGENT_URL}/`);
+      await res.body?.cancel();
     } catch {
       return;
     }
@@ -120,15 +143,7 @@ function killProcess(child: ChildProcess): Promise<void> {
       clearTimeout(fallback);
       resolve();
     });
-    try {
-      process.kill(-child.pid, "SIGKILL");
-    } catch {
-      try {
-        process.kill(child.pid, "SIGKILL");
-      } catch {
-        // Already dead
-      }
-    }
+    killProcessTree(child.pid);
   });
 }
 

--- a/packages/think/src/e2e-tests/vitest.config.ts
+++ b/packages/think/src/e2e-tests/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     // Run in Node.js — we spawn wrangler as a child process
     testTimeout: 120_000,
     hookTimeout: 60_000,
+    fileParallelism: false,
     include: ["src/e2e-tests/**/*.test.ts"]
   }
 });

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -165,6 +165,10 @@ export class ThinkRecoveryHelperParent extends Agent<Env> {
     });
 
     class HelperChatCallback extends RpcTarget implements StreamCallback {
+      onStart(): void {
+        // The RPC callback surface is fixed; this test only waits for chunks.
+      }
+
       onEvent(json: string): void {
         try {
           const chunk = JSON.parse(json) as { type?: string; delta?: string };

--- a/packages/think/src/tests/agents/assistant-agent-loop.ts
+++ b/packages/think/src/tests/agents/assistant-agent-loop.ts
@@ -27,6 +27,7 @@ class TestCollectingCallback implements StreamCallback {
   events: string[] = [];
   doneCalled = false;
   errorMessage?: string;
+  onStart(): void {}
   onEvent(json: string): void {
     this.events.push(json);
   }

--- a/packages/think/src/tests/agents/extension-hooks.ts
+++ b/packages/think/src/tests/agents/extension-hooks.ts
@@ -32,6 +32,7 @@ class TestCollectingCallback implements StreamCallback {
   events: string[] = [];
   doneCalled = false;
   errorMessage?: string;
+  onStart(): void {}
   onEvent(json: string): void {
     this.events.push(json);
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -728,10 +728,14 @@ export class ThinkTestAgent extends Think {
     };
   }
 
-  async testChatWithoutErrorCallback(message: string): Promise<string> {
+  async testChatWithRethrowingErrorCallback(message: string): Promise<string> {
     const cb: StreamCallback = {
+      onStart() {},
       onEvent() {},
-      onDone() {}
+      onDone() {},
+      onError(error: string) {
+        throw new Error(error);
+      }
     };
     try {
       await this.chat(message, cb);
@@ -743,6 +747,7 @@ export class ThinkTestAgent extends Think {
 
   async testChatWithThrowingErrorCallback(message: string): Promise<string> {
     const cb: StreamCallback = {
+      onStart() {},
       onEvent() {},
       onDone() {},
       onError() {
@@ -898,9 +903,13 @@ export class ThinkTestAgent extends Think {
       crypto.randomUUID(),
       createEmptyStreamResult(),
       {
+        onStart() {},
         onEvent() {},
         onDone() {
           doneCalled = true;
+        },
+        onError(error: string) {
+          throw new Error(error);
         }
       }
     );
@@ -916,6 +925,7 @@ export class ThinkTestAgent extends Think {
     const controller = new AbortController();
 
     const cb: StreamCallback = {
+      onStart() {},
       onEvent(json: string) {
         events.push(json);
         if (events.length >= abortAfterEvents) {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -1044,11 +1044,11 @@ describe("Think — onChatResponse", () => {
     }
   });
 
-  it("should throw RPC in-band stream errors when no onError callback exists", async () => {
-    const agent = await freshAgent("hook-rpc-inband-error-no-callback");
+  it("should propagate RPC in-band stream errors when onError rethrows", async () => {
+    const agent = await freshAgent("hook-rpc-inband-error-rethrow");
 
     await agent.setInBandErrorResponse("RPC missing callback error");
-    const error = await agent.testChatWithoutErrorCallback(
+    const error = await agent.testChatWithRethrowingErrorCallback(
       "trigger rpc in-band error"
     );
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -227,10 +227,10 @@ export interface ChatStartEvent {
 }
 
 export interface StreamCallback {
-  onStart?(event: ChatStartEvent): void | Promise<void>;
+  onStart(event: ChatStartEvent): void | Promise<void>;
   onEvent(json: string): void | Promise<void>;
   onDone(): void | Promise<void>;
-  onError?(error: string): void | Promise<void>;
+  onError(error: string): void | Promise<void>;
 }
 
 /**
@@ -2223,7 +2223,7 @@ export class Think<
     }
 
     try {
-      await callback.onStart?.({ requestId });
+      await callback.onStart({ requestId });
       await this.keepAliveWhile(async () => {
         await this._turnQueue.enqueue(requestId, async () => {
           const userMsg: UIMessage =
@@ -2258,11 +2258,8 @@ export class Think<
               const wrapped = this.onChatError(error);
               const errorMessage =
                 wrapped instanceof Error ? wrapped.message : String(wrapped);
-              if (callback.onError) {
-                await callback.onError(errorMessage);
-                return;
-              }
-              throw wrapped;
+              await callback.onError(errorMessage);
+              return;
             }
 
             await this._streamResultToRpcCallback(
@@ -4716,19 +4713,11 @@ export class Think<
         });
       }
 
-      if (callback.onError) {
-        await callback.onError(errorMessage);
-      } else {
-        throw wrapped;
-      }
+      await callback.onError(errorMessage);
     }
 
     if (pendingRpcError) {
-      if (callback.onError) {
-        await callback.onError(pendingRpcError);
-      } else {
-        throw new Error(pendingRpcError);
-      }
+      await callback.onError(pendingRpcError);
     }
   }
 


### PR DESCRIPTION
## Summary
- Make `@cloudflare/think`'s `StreamCallback` RPC surface fixed by requiring `onStart` and `onError`, avoiding Workers RPC calls to missing optional methods.
- Update Think callback tests/e2e helpers to implement the fixed callback contract and preserve error propagation semantics.
- Stabilize local e2e harnesses by avoiding detached process-group kills, using ephemeral Wrangler inspector ports, draining readiness probes, clearing stale agents-as-tools Wrangler state, widening real-LLM helper waits, and running root e2e targets serially.

## Why
Nightly/local e2e runs were failing in two ways:
- `Think.chat()` called `callback.onStart?.(...)`, but optional method probing is unsafe across Workers RPC; callback receivers without `onStart` threw `The RPC receiver does not implement the method "onStart"`.
- Full `npm run test:e2e` ran remote-AI/dev-server e2e targets concurrently, which made tests contend for local runtimes/remote AI and left helper panels stuck in `running` or Vitest workers unable to terminate.

## Test plan
- `npm run test` in `packages/think`
- `npm run build` in `packages/think`
- `npm run test:e2e` in `packages/think` on Node 25
- `npm run test:e2e` in `packages/agents` on Node 25
- `E2E_NO_RETRY=1 npx playwright test e2e/refresh-replay.e2e.ts --grep "two completed runs"` in `examples/agents-as-tools` on Node 25
- `npx nx run-many -t test:e2e --parallel=1`
- `npm run check`

## Notes
- `npm run check` still reports the existing Sherif warnings for example directories without `package.json`; no errors were introduced.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->