### PR TITLE
Fix agent-tool recovery startup wedges

### DIFF
--- a/.changeset/quiet-tools-recover.md
+++ b/.changeset/quiet-tools-recover.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Recover stale agent-tool runs after startup and bound child inspection so wedged child facets cannot prevent a parent Agent from booting.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -7856,7 +7856,7 @@ export class Agent<
     runId: string,
     timeoutMs?: number
   ): Promise<AgentToolStoredChunk[] | undefined> {
-    const chunks = adapter.getAgentToolChunks(runId);
+    const chunks = adapter.getAgentToolChunks(runId).catch(() => undefined);
     if (timeoutMs === undefined || timeoutMs <= 0) return chunks;
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -897,6 +897,7 @@ export type AddRpcMcpServerOptions = {
 };
 
 const DEFAULT_KEEP_ALIVE_INTERVAL_MS = 30_000;
+const DEFAULT_AGENT_TOOL_RECOVERY_TIMEOUT_MS = 2_000;
 const SUB_AGENT_IDENTITY_VERSION_LEGACY = "legacy";
 const SUB_AGENT_IDENTITY_VERSION_PATH_V2 = "path-v2";
 const SUB_AGENT_IDENTITY_PATH_V2_PREFIX = "cf-agents:v2:";
@@ -904,6 +905,15 @@ const SUB_AGENT_IDENTITY_PATH_V2_PREFIX = "cf-agents:v2:";
 type SubAgentIdentityVersion =
   | typeof SUB_AGENT_IDENTITY_VERSION_LEGACY
   | typeof SUB_AGENT_IDENTITY_VERSION_PATH_V2;
+
+type AgentToolRecoveryInspection =
+  | {
+      status: "inspected";
+      adapter: AgentToolChildAdapter;
+      inspection: AgentToolRunInspection | null;
+    }
+  | { status: "failed" }
+  | { status: "timed-out" };
 
 /**
  * Schema version for the Agent's internal SQLite tables.
@@ -1348,6 +1358,8 @@ export class Agent<
   private _managedFiberTerminalWaiters = new Map<string, Set<() => void>>();
   /** @internal Prevents re-entrant recovery from overlapping alarm ticks. */
   private _runFiberRecoveryInProgress = false;
+  /** @internal Single-flight background recovery for parent agent-tool rows. */
+  private _agentToolRunRecoveryPromise: Promise<void> | undefined;
 
   private _ParentClass: typeof Agent<Env, State> =
     Object.getPrototypeOf(this).constructor;
@@ -2226,10 +2238,7 @@ export class Agent<
 
             this._checkOrphanedWorkflows();
             await this._checkRunFibers();
-            const recoveredAgentToolFinishes =
-              await this._reconcileAgentToolRuns({
-                deferFinishHooks: true
-              });
+            const startupAgentToolRunIds = this._agentToolRunRecoveryRunIds();
 
             this._insideOnStart = true;
             this._warnedScheduleInOnStart.clear();
@@ -2239,12 +2248,9 @@ export class Agent<
             } finally {
               this._insideOnStart = false;
             }
-            // Recovered finish hooks run only after successful user startup.
-            // If onStart fails, durable recovery state is already finalized,
-            // but user hook side effects may depend on startup-initialized mirrors.
-            await this._runDeferredAgentToolFinishHooks(
-              recoveredAgentToolFinishes
-            );
+            this._scheduleAgentToolRunRecovery({
+              runIds: startupAgentToolRunIds
+            });
             return result;
           });
         }
@@ -7389,7 +7395,29 @@ export class Agent<
   ): Promise<number> {
     const child = await this._cf_resolveSubAgent(row.agent_type, row.run_id);
     const adapter = this._asAgentToolChildAdapter(child);
-    const chunks = await adapter.getAgentToolChunks(row.run_id);
+    return this._broadcastAgentToolStoredChunksFromAdapter(
+      adapter,
+      row,
+      sequence,
+      replay,
+      connection
+    );
+  }
+
+  private async _broadcastAgentToolStoredChunksFromAdapter(
+    adapter: AgentToolChildAdapter,
+    row: Pick<AgentToolRunStorageRow, "run_id" | "parent_tool_call_id">,
+    sequence: number,
+    replay?: true,
+    connection?: Connection,
+    timeoutMs?: number
+  ): Promise<number> {
+    const chunks = await this._getAgentToolChunksForRecovery(
+      adapter,
+      row.run_id,
+      timeoutMs
+    );
+    if (!chunks) return sequence;
     return this._broadcastAgentToolChunks(
       row.parent_tool_call_id ?? undefined,
       row.run_id,
@@ -7662,6 +7690,8 @@ export class Agent<
 
   private async _reconcileAgentToolRuns(options?: {
     deferFinishHooks?: boolean;
+    childInspectionTimeoutMs?: number;
+    runIds?: readonly string[];
   }): Promise<DeferredAgentToolFinish[]> {
     const deferredFinishes: DeferredAgentToolFinish[] = [];
     const rows = this.sql<AgentToolRunStorageRow>`
@@ -7672,19 +7702,30 @@ export class Agent<
       WHERE status IN ('starting', 'running')
       ORDER BY started_at ASC
     `;
+    const runIds =
+      options?.runIds !== undefined ? new Set(options.runIds) : undefined;
     for (const row of rows) {
+      if (runIds && !runIds.has(row.run_id)) continue;
       let sequence = 1;
       let completedAt: number | undefined;
       let result: RunAgentToolResult;
-      try {
-        const child = await this._cf_resolveSubAgent(
-          row.agent_type,
-          row.run_id
-        );
-        const adapter = this._asAgentToolChildAdapter(child);
-        const inspection = await adapter.inspectAgentToolRun(row.run_id);
+      const recovery = await this._inspectAgentToolRunForRecovery(
+        row,
+        sequence,
+        options?.childInspectionTimeoutMs
+      );
+      if (recovery.status === "inspected") {
+        const inspection = recovery.inspection;
         try {
-          sequence = await this._broadcastAgentToolStoredChunks(row, sequence);
+          sequence = await this._broadcastAgentToolStoredChunksFromAdapter(
+            recovery.adapter,
+            row,
+            sequence,
+            undefined,
+            undefined,
+            options?.childInspectionTimeoutMs ??
+              DEFAULT_AGENT_TOOL_RECOVERY_TIMEOUT_MS
+          );
         } catch {
           // Terminal reconciliation should still complete if chunk replay fails.
         }
@@ -7707,7 +7748,14 @@ export class Agent<
           );
           completedAt = inspection.completedAt;
         }
-      } catch {
+      } else if (recovery.status === "timed-out") {
+        result = {
+          runId: row.run_id,
+          agentType: row.agent_type,
+          status: "interrupted",
+          error: "Agent tool run inspection timed out during parent recovery."
+        };
+      } else {
         result = {
           runId: row.run_id,
           agentType: row.agent_type,
@@ -7729,6 +7777,95 @@ export class Agent<
       }
     }
     return deferredFinishes;
+  }
+
+  private async _inspectAgentToolRunForRecovery(
+    row: AgentToolRunStorageRow,
+    _sequence: number,
+    timeoutMs = DEFAULT_AGENT_TOOL_RECOVERY_TIMEOUT_MS
+  ): Promise<AgentToolRecoveryInspection> {
+    const inspect = (async (): Promise<AgentToolRecoveryInspection> => {
+      const child = await this._cf_resolveSubAgent(row.agent_type, row.run_id);
+      const adapter = this._asAgentToolChildAdapter(child);
+      const inspection = await adapter.inspectAgentToolRun(row.run_id);
+      return { status: "inspected", adapter, inspection };
+    })().catch((): AgentToolRecoveryInspection => ({ status: "failed" }));
+
+    if (timeoutMs <= 0) return inspect;
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<AgentToolRecoveryInspection>((resolve) => {
+      timeoutId = setTimeout(() => {
+        resolve({ status: "timed-out" });
+      }, timeoutMs);
+    });
+
+    const result = await Promise.race([inspect, timeout]);
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    return result;
+  }
+
+  private _scheduleAgentToolRunRecovery(options?: {
+    childInspectionTimeoutMs?: number;
+    runIds?: readonly string[];
+  }): Promise<void> {
+    if (this._agentToolRunRecoveryPromise) {
+      return this._agentToolRunRecoveryPromise;
+    }
+
+    if (options?.runIds && options.runIds.length === 0) {
+      return Promise.resolve();
+    }
+
+    const recovery = (async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const recoveredAgentToolFinishes = await this._reconcileAgentToolRuns({
+        deferFinishHooks: true,
+        childInspectionTimeoutMs: options?.childInspectionTimeoutMs,
+        runIds: options?.runIds
+      });
+      await this._runDeferredAgentToolFinishHooks(recoveredAgentToolFinishes);
+    })()
+      .catch(async (error) => {
+        try {
+          await this.onError(error);
+        } catch {
+          // Background recovery must never make a started agent unreachable.
+        }
+      })
+      .finally(() => {
+        this._agentToolRunRecoveryPromise = undefined;
+      });
+
+    this._agentToolRunRecoveryPromise = recovery;
+    this.ctx.waitUntil(recovery);
+    return recovery;
+  }
+
+  private _agentToolRunRecoveryRunIds(): string[] {
+    return this.sql<{ run_id: string }>`
+      SELECT run_id
+      FROM cf_agent_tool_runs
+      WHERE status IN ('starting', 'running')
+      ORDER BY started_at ASC
+    `.map((row) => row.run_id);
+  }
+
+  private async _getAgentToolChunksForRecovery(
+    adapter: AgentToolChildAdapter,
+    runId: string,
+    timeoutMs?: number
+  ): Promise<AgentToolStoredChunk[] | undefined> {
+    const chunks = adapter.getAgentToolChunks(runId);
+    if (timeoutMs === undefined || timeoutMs <= 0) return chunks;
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<undefined>((resolve) => {
+      timeoutId = setTimeout(() => resolve(undefined), timeoutMs);
+    });
+    const result = await Promise.race([chunks, timeout]);
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    return result;
   }
 
   /**

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -69,6 +69,22 @@ type ParentStub = DurableObjectStub & {
     events: AgentToolEventMessage[];
     finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
   }>;
+  reconcileStuckChildWithTimeoutForTest(runId?: string): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    elapsedMs: number;
+    status: string | null;
+  }>;
+  scheduleStuckChildRecoveryForTest(runId?: string): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    status: string | null;
+  }>;
+  scheduleStuckChildRecoveryTwiceForTest(runId?: string): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    status: string | null;
+  }>;
   reconcileCompletedChildWithDeferredFinishForTest(
     input: {
       prompt: string;
@@ -313,6 +329,79 @@ describe("AIChatAgent as an agent-tool child", () => {
         error: "Agent tool run could not be inspected during parent recovery."
       }
     });
+  });
+
+  it("bounds recovery when child facet startup never completes", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, elapsedMs, status } =
+      await parent.reconcileStuckChildWithTimeoutForTest(runId);
+
+    expect(elapsedMs).toBeLessThan(1000);
+    expect(status).toBe("interrupted");
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          parentToolCallId: "test-tool-call",
+          agentType: "StuckAgentToolChild",
+          status: "interrupted",
+          inputPreview: "stuck child"
+        }),
+        result: expect.objectContaining({
+          status: "interrupted",
+          error: "Agent tool run inspection timed out during parent recovery."
+        })
+      }
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      parentToolCallId: "test-tool-call",
+      event: {
+        kind: "interrupted",
+        runId,
+        error: "Agent tool run inspection timed out during parent recovery."
+      }
+    });
+  });
+
+  it("runs scheduled startup recovery in the background and finalizes stale rows", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, status } =
+      await parent.scheduleStuckChildRecoveryForTest(runId);
+
+    expect(status).toBe("interrupted");
+    expect(finishes).toHaveLength(1);
+    expect(finishes[0]).toMatchObject({
+      run: expect.objectContaining({
+        runId,
+        agentType: "StuckAgentToolChild",
+        status: "interrupted"
+      }),
+      result: expect.objectContaining({
+        status: "interrupted",
+        error: "Agent tool run inspection timed out during parent recovery."
+      })
+    });
+    expect(events.at(-1)).toMatchObject({
+      event: { kind: "interrupted", runId }
+    });
+  });
+
+  it("keeps scheduled startup recovery single-flight", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, status } =
+      await parent.scheduleStuckChildRecoveryTwiceForTest(runId);
+
+    expect(status).toBe("interrupted");
+    expect(finishes).toHaveLength(1);
+    expect(
+      events.filter((event) => event.event.kind === "interrupted")
+    ).toHaveLength(1);
   });
 
   it("defers recovered finish hooks until after startup work", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -76,6 +76,7 @@ export type Env = {
   RecoverySlowStreamAgent: DurableObjectNamespace<RecoverySlowStreamAgent>;
   AIChatAgentToolParent: DurableObjectNamespace<AIChatAgentToolParent>;
   AIChatAgentToolChild: DurableObjectNamespace<AIChatAgentToolChild>;
+  StuckAgentToolChild: DurableObjectNamespace<StuckAgentToolChild>;
 };
 
 export class TestChatAgent extends AIChatAgent<Env> {
@@ -2089,6 +2090,32 @@ export class AIChatAgentToolChild extends AIChatAgent<Env> {
   }
 }
 
+export class StuckAgentToolChild extends Agent<Env> {
+  override async _cf_initAsFacet(
+    _name: string,
+    _parentPath: ReadonlyArray<{ className: string; name: string }> = [],
+    _identityName = _name
+  ): Promise<void> {
+    await new Promise<void>(() => {
+      // Intentionally never resolves: simulates a child facet wedged in startup.
+    });
+  }
+
+  async startAgentToolRun(): Promise<AgentToolRunInspection> {
+    throw new Error("stuck child should never start");
+  }
+
+  async cancelAgentToolRun(): Promise<void> {}
+
+  async inspectAgentToolRun(): Promise<AgentToolRunInspection | null> {
+    throw new Error("stuck child should never be inspected");
+  }
+
+  async getAgentToolChunks(): Promise<AgentToolStoredChunk[]> {
+    return [];
+  }
+}
+
 type AgentToolFinishForTest = {
   run: AgentToolRunInfo;
   result: AgentToolLifecycleResult;
@@ -2233,14 +2260,28 @@ export class AIChatAgentToolParent extends Agent<Env> {
 
   private async reconcileAgentToolRunsForTest(options?: {
     deferFinishHooks?: boolean;
+    childInspectionTimeoutMs?: number;
   }): Promise<Array<() => Promise<void>>> {
     return (
       this as unknown as {
         _reconcileAgentToolRuns(options?: {
           deferFinishHooks?: boolean;
+          childInspectionTimeoutMs?: number;
         }): Promise<Array<() => Promise<void>>>;
       }
     )._reconcileAgentToolRuns(options);
+  }
+
+  private async scheduleAgentToolRunRecoveryForTest(options?: {
+    childInspectionTimeoutMs?: number;
+  }): Promise<void> {
+    await (
+      this as unknown as {
+        _scheduleAgentToolRunRecovery(options?: {
+          childInspectionTimeoutMs?: number;
+        }): Promise<void>;
+      }
+    )._scheduleAgentToolRunRecovery(options);
   }
 
   private async runDeferredAgentToolFinishHooksForTest(
@@ -2322,6 +2363,96 @@ export class AIChatAgentToolParent extends Agent<Env> {
     return { events: this.events, finishes: this.finishes };
   }
 
+  async reconcileStuckChildWithTimeoutForTest(
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    elapsedMs: number;
+    status: string | null;
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "StuckAgentToolChild",
+      "stuck child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    const startedAt = Date.now();
+    await this.reconcileAgentToolRunsForTest({ childInspectionTimeoutMs: 10 });
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      elapsedMs: Date.now() - startedAt,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  async scheduleStuckChildRecoveryForTest(
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    status: string | null;
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "StuckAgentToolChild",
+      "scheduled stuck child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    await this.scheduleAgentToolRunRecoveryForTest({
+      childInspectionTimeoutMs: 10
+    });
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  async scheduleStuckChildRecoveryTwiceForTest(
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    status: string | null;
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "StuckAgentToolChild",
+      "single flight stuck child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    const first = this.scheduleAgentToolRunRecoveryForTest({
+      childInspectionTimeoutMs: 10
+    });
+    const second = this.scheduleAgentToolRunRecoveryForTest({
+      childInspectionTimeoutMs: 10
+    });
+    await Promise.all([first, second]);
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  getParentAgentToolStatusForTest(runId: string): string | null {
+    const rows = this.sql<{ status: string }>`
+      SELECT status FROM cf_agent_tool_runs WHERE run_id = ${runId} LIMIT 1
+    `;
+    return rows[0]?.status ?? null;
+  }
+
   async reconcileCompletedChildWithDeferredFinishForTest(
     input: AgentToolInput,
     runId = crypto.randomUUID()
@@ -2396,25 +2527,26 @@ export class AIChatAgentToolParent extends Agent<Env> {
     this.events = [];
     this.finishes = [];
 
-    type BroadcastStoredChunks = (
+    type BroadcastStoredChunksFromAdapter = (
+      adapter: unknown,
       row: unknown,
       sequence: number,
       replay?: true,
       connection?: unknown
     ) => Promise<number>;
     const self = this as unknown as {
-      _broadcastAgentToolStoredChunks: BroadcastStoredChunks;
+      _broadcastAgentToolStoredChunksFromAdapter: BroadcastStoredChunksFromAdapter;
     };
-    const original = self._broadcastAgentToolStoredChunks.bind(
+    const original = self._broadcastAgentToolStoredChunksFromAdapter.bind(
       this
-    ) as BroadcastStoredChunks;
-    self._broadcastAgentToolStoredChunks = async () => {
+    ) as BroadcastStoredChunksFromAdapter;
+    self._broadcastAgentToolStoredChunksFromAdapter = async () => {
       throw new Error("test replay failure");
     };
     try {
       await this.reconcileAgentToolRunsForTest();
     } finally {
-      self._broadcastAgentToolStoredChunks = original;
+      self._broadcastAgentToolStoredChunksFromAdapter = original;
     }
 
     return { events: this.events, finishes: this.finishes };

--- a/packages/ai-chat/src/tests/wrangler.jsonc
+++ b/packages/ai-chat/src/tests/wrangler.jsonc
@@ -109,9 +109,13 @@
       {
         "class_name": "AIChatAgentToolChild",
         "name": "AIChatAgentToolChild"
+      },
+      {
+        "class_name": "StuckAgentToolChild",
+        "name": "StuckAgentToolChild"
       }
-      // `AIChatAgentToolChild` is addressed as a facet of
-      // `AIChatAgentToolParent`, so it does not need a migration entry.
+      // Agent-tool children are addressed as facets of
+      // `AIChatAgentToolParent`, so they do not need migration entries.
     ]
   },
   "main": "worker.ts",

--- a/packages/think/src/tests/agent-tools.test.ts
+++ b/packages/think/src/tests/agent-tools.test.ts
@@ -1,7 +1,13 @@
 import { env } from "cloudflare:workers";
 import { getAgentByName } from "agents";
 import { describe, expect, it } from "vitest";
-import type { ThinkTestAgent } from "./agents";
+import type { ThinkAgentToolParent, ThinkTestAgent } from "./agents";
+import type {
+  AgentToolEventMessage,
+  AgentToolLifecycleResult,
+  AgentToolRunInfo,
+  RunAgentToolResult
+} from "agents";
 
 type AgentToolInspection = Awaited<
   ReturnType<ThinkTestAgent["inspectAgentToolRun"]>
@@ -29,6 +35,57 @@ type ThinkAgentToolTestStub = {
   }>;
 };
 
+type ThinkAgentToolParentStub = DurableObjectStub & {
+  runThinkChild(input: string, runId?: string): Promise<RunAgentToolResult>;
+  reconcileCompletedThinkChildForTest(
+    input: string,
+    runId?: string
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    inspection: NonNullable<AgentToolInspection>;
+    status: string | null;
+  }>;
+  reconcileRunningThinkChildForTest(
+    input: string,
+    runId?: string
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    status: string | null;
+  }>;
+  reconcileStuckThinkChildWithTimeoutForTest(runId?: string): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    elapsedMs: number;
+    status: string | null;
+  }>;
+  scheduleStuckThinkChildRecoveryForTest(runId?: string): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    status: string | null;
+  }>;
+  scheduleStuckThinkChildRecoveryTwiceForTest(runId?: string): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    status: string | null;
+  }>;
+  startupDefersStaleThinkRecoveryForTest(runId?: string): Promise<{
+    statusesDuringStartup: string[];
+    statusAfterStartup: string | null;
+    finalStatus: string | null;
+    startupElapsedMs: number;
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    events: AgentToolEventMessage[];
+  }>;
+  startupRecoveryIgnoresRunsCreatedDuringOnStartForTest(): Promise<{
+    staleStatus: string | null;
+    onStartRunStatus: string | null;
+    finishes: { run: AgentToolRunInfo; result: AgentToolLifecycleResult }[];
+    events: AgentToolEventMessage[];
+  }>;
+};
+
 async function freshAgent(
   name = crypto.randomUUID()
 ): Promise<ThinkAgentToolTestStub> {
@@ -36,6 +93,15 @@ async function freshAgent(
     env.ThinkTestAgent as unknown as DurableObjectNamespace<ThinkTestAgent>,
     name
   ) as unknown as Promise<ThinkAgentToolTestStub>;
+}
+
+async function freshParent(
+  name = crypto.randomUUID()
+): Promise<ThinkAgentToolParentStub> {
+  return getAgentByName(
+    env.ThinkAgentToolParent as unknown as DurableObjectNamespace<ThinkAgentToolParent>,
+    name
+  ) as unknown as Promise<ThinkAgentToolParentStub>;
 }
 
 async function waitForAgentToolRun(
@@ -171,5 +237,218 @@ describe("Think agent tools", () => {
       lastErrors: 0,
       preTurnAssistantIds: 0
     });
+  });
+
+  it("runs a Think child through the parent agent-tool API", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    const result = await parent.runThinkChild("parent Think probe", runId);
+
+    expect(result).toMatchObject({
+      runId,
+      agentType: "ThinkTestAgent",
+      status: "completed",
+      summary: "Hello from the assistant!"
+    });
+  });
+
+  it("recovers completed Think child runs into terminal parent rows", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, inspection, status } =
+      await parent.reconcileCompletedThinkChildForTest(
+        "recover completed Think child",
+        runId
+      );
+
+    expect(status).toBe("completed");
+    expect(inspection).toMatchObject({
+      runId,
+      status: "completed",
+      summary: "Hello from the assistant!"
+    });
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          parentToolCallId: "think-tool-call",
+          agentType: "ThinkTestAgent",
+          status: "completed",
+          inputPreview: "recover completed Think child"
+        }),
+        result: expect.objectContaining({
+          status: "completed",
+          summary: "Hello from the assistant!"
+        })
+      }
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      parentToolCallId: "think-tool-call",
+      event: {
+        kind: "finished",
+        runId,
+        summary: "Hello from the assistant!"
+      }
+    });
+  });
+
+  it("recovers still-running Think child rows as interrupted", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, status } =
+      await parent.reconcileRunningThinkChildForTest(
+        "still running Think child",
+        runId
+      );
+
+    expect(status).toBe("interrupted");
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          parentToolCallId: "think-tool-call",
+          agentType: "ThinkTestAgent",
+          status: "interrupted",
+          inputPreview: "still running Think child"
+        }),
+        result: expect.objectContaining({
+          status: "interrupted",
+          error:
+            "Agent tool run was still running, but live-tail reattachment is not supported in this runtime."
+        })
+      }
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      event: {
+        kind: "interrupted",
+        runId,
+        error:
+          "Agent tool run was still running, but live-tail reattachment is not supported in this runtime."
+      }
+    });
+  });
+
+  it("bounds Think recovery when child facet startup never completes", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, elapsedMs, status } =
+      await parent.reconcileStuckThinkChildWithTimeoutForTest(runId);
+
+    expect(elapsedMs).toBeLessThan(1000);
+    expect(status).toBe("interrupted");
+    expect(finishes).toEqual([
+      {
+        run: expect.objectContaining({
+          runId,
+          parentToolCallId: "think-tool-call",
+          agentType: "StuckThinkAgentToolChild",
+          status: "interrupted",
+          inputPreview: "stuck Think child"
+        }),
+        result: expect.objectContaining({
+          status: "interrupted",
+          error: "Agent tool run inspection timed out during parent recovery."
+        })
+      }
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      event: {
+        kind: "interrupted",
+        runId,
+        error: "Agent tool run inspection timed out during parent recovery."
+      }
+    });
+  });
+
+  it("runs scheduled Think startup recovery and finalizes stale rows", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, status } =
+      await parent.scheduleStuckThinkChildRecoveryForTest(runId);
+
+    expect(status).toBe("interrupted");
+    expect(finishes).toHaveLength(1);
+    expect(finishes[0]).toMatchObject({
+      run: expect.objectContaining({
+        runId,
+        agentType: "StuckThinkAgentToolChild",
+        status: "interrupted"
+      }),
+      result: expect.objectContaining({
+        status: "interrupted",
+        error: "Agent tool run inspection timed out during parent recovery."
+      })
+    });
+    expect(events.at(-1)).toMatchObject({
+      event: { kind: "interrupted", runId }
+    });
+  });
+
+  it("keeps scheduled Think startup recovery single-flight", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    const { events, finishes, status } =
+      await parent.scheduleStuckThinkChildRecoveryTwiceForTest(runId);
+
+    expect(status).toBe("interrupted");
+    expect(finishes).toHaveLength(1);
+    expect(
+      events.filter((event) => event.event.kind === "interrupted")
+    ).toHaveLength(1);
+  });
+
+  it("lets Think startup return before stale child recovery finalizes", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    const {
+      statusesDuringStartup,
+      statusAfterStartup,
+      finalStatus,
+      startupElapsedMs,
+      finishes,
+      events
+    } = await parent.startupDefersStaleThinkRecoveryForTest(runId);
+
+    expect(startupElapsedMs).toBeLessThan(1000);
+    expect(statusesDuringStartup).toContain("running");
+    expect(statusAfterStartup).toBe("running");
+    expect(finalStatus).toBe("interrupted");
+    expect(finishes).toHaveLength(1);
+    expect(finishes[0]).toMatchObject({
+      run: expect.objectContaining({
+        runId,
+        agentType: "StuckThinkAgentToolChild",
+        status: "interrupted"
+      }),
+      result: expect.objectContaining({
+        status: "interrupted",
+        error: "Agent tool run inspection timed out during parent recovery."
+      })
+    });
+    expect(events.at(-1)).toMatchObject({
+      event: { kind: "interrupted", runId }
+    });
+  });
+
+  it("only recovers rows that were stale before Think startup began", async () => {
+    const parent = await freshParent();
+
+    const { staleStatus, onStartRunStatus, finishes, events } =
+      await parent.startupRecoveryIgnoresRunsCreatedDuringOnStartForTest();
+
+    expect(staleStatus).toBe("interrupted");
+    expect(onStartRunStatus).toBe("running");
+    expect(finishes).toHaveLength(1);
+    expect(finishes[0]?.run.inputPreview).toBe("startup snapshot stale child");
+    expect(
+      events.filter((event) => event.event.kind === "interrupted")
+    ).toHaveLength(1);
   });
 });

--- a/packages/think/src/tests/agents/index.ts
+++ b/packages/think/src/tests/agents/index.ts
@@ -16,7 +16,9 @@ export {
   ThinkProgrammaticTestAgent,
   ThinkAsyncHookTestAgent,
   ThinkRecoveryTestAgent,
-  ThinkNonRecoveryTestAgent
+  ThinkNonRecoveryTestAgent,
+  ThinkAgentToolParent,
+  StuckThinkAgentToolChild
 } from "./think-session";
 export { ThinkFiberTestAgent } from "./fiber";
 export { ThinkClientToolsAgent } from "./client-tools";

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1,6 +1,15 @@
 import type { LanguageModel, UIMessage } from "ai";
 import { hasToolCall, Output, tool } from "ai";
 import { Think } from "../../think";
+import { Agent } from "agents";
+import type {
+  AgentToolEventMessage,
+  AgentToolLifecycleResult,
+  AgentToolRunInfo,
+  AgentToolRunInspection,
+  AgentToolStoredChunk,
+  RunAgentToolResult
+} from "agents";
 import type {
   StreamCallback,
   StreamableResult,
@@ -1160,6 +1169,402 @@ export class ThinkTestAgent extends Think {
   async getLastBeforeTurnSystem(): Promise<string | null> {
     const log = this._beforeTurnLog;
     return log.length > 0 ? log[log.length - 1].system : null;
+  }
+}
+
+type AgentToolFinishForTest = {
+  run: AgentToolRunInfo;
+  result: AgentToolLifecycleResult;
+};
+
+export class StuckThinkAgentToolChild extends Agent {
+  override async _cf_initAsFacet(
+    _name: string,
+    _parentPath: ReadonlyArray<{ className: string; name: string }> = [],
+    _identityName = _name
+  ): Promise<void> {
+    await new Promise<void>(() => {
+      // Intentionally never resolves: simulates a child facet wedged in startup.
+    });
+  }
+
+  async startAgentToolRun(): Promise<AgentToolRunInspection> {
+    throw new Error("stuck Think child should never start");
+  }
+
+  async cancelAgentToolRun(): Promise<void> {}
+
+  async inspectAgentToolRun(): Promise<AgentToolRunInspection | null> {
+    throw new Error("stuck Think child should never be inspected");
+  }
+
+  async getAgentToolChunks(): Promise<AgentToolStoredChunk[]> {
+    return [];
+  }
+}
+
+export class ThinkAgentToolParent extends Agent {
+  private events: AgentToolEventMessage[] = [];
+  private finishes: AgentToolFinishForTest[] = [];
+  private startupObservedStatuses: string[][] = [];
+  private insertRunDuringOnStartId: string | null = null;
+
+  override broadcast(
+    msg: string | ArrayBuffer | ArrayBufferView,
+    without?: string[]
+  ): void {
+    if (typeof msg === "string") {
+      try {
+        const parsed = JSON.parse(msg) as AgentToolEventMessage;
+        if (parsed.type === "agent-tool-event") {
+          this.events.push(parsed);
+        }
+      } catch {
+        // Ignore non-agent-tool frames.
+      }
+    }
+    super.broadcast(msg, without);
+  }
+
+  override async onAgentToolFinish(
+    run: AgentToolRunInfo,
+    result: AgentToolLifecycleResult
+  ): Promise<void> {
+    this.finishes.push({ run, result });
+  }
+
+  override onStart(): void {
+    const rows = this.sql<{ status: string }>`
+      SELECT status FROM cf_agent_tool_runs ORDER BY started_at ASC
+    `;
+    this.startupObservedStatuses.push(rows.map((row) => row.status));
+    if (this.insertRunDuringOnStartId) {
+      this.insertRecoverableParentRunForTest(
+        this.insertRunDuringOnStartId,
+        "StuckThinkAgentToolChild",
+        "created during onStart",
+        Date.now()
+      );
+    }
+  }
+
+  async runThinkChild(
+    input: string,
+    runId = crypto.randomUUID()
+  ): Promise<RunAgentToolResult> {
+    this.events = [];
+    this.finishes = [];
+    return this.runAgentTool(ThinkTestAgent, {
+      runId,
+      parentToolCallId: "think-tool-call",
+      input,
+      inputPreview: input
+    });
+  }
+
+  private insertRecoverableParentRunForTest(
+    runId: string,
+    agentType: string,
+    inputPreview: string,
+    startedAt: number,
+    status: "starting" | "running" = "running"
+  ): void {
+    this.sql`
+      INSERT INTO cf_agent_tool_runs (
+        run_id, parent_tool_call_id, agent_type, input_preview,
+        input_redacted, status, display_metadata, display_order, started_at
+      ) VALUES (
+        ${runId}, 'think-tool-call', ${agentType},
+        ${JSON.stringify(inputPreview)}, 1, ${status},
+        ${JSON.stringify({ name: "think child" })}, 0, ${startedAt}
+      )
+    `;
+  }
+
+  private async waitForTerminalInspectionForTest(
+    child: {
+      inspectAgentToolRun(
+        runId: string
+      ): Promise<AgentToolRunInspection | null>;
+    },
+    runId: string
+  ): Promise<AgentToolRunInspection> {
+    let inspection = await child.inspectAgentToolRun(runId);
+    for (let attempt = 0; attempt < 50; attempt++) {
+      if (
+        inspection &&
+        inspection.status !== "running" &&
+        inspection.status !== "starting"
+      ) {
+        return inspection;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      inspection = await child.inspectAgentToolRun(runId);
+    }
+    throw new Error("Timed out waiting for Think child completion");
+  }
+
+  private async reconcileAgentToolRunsForTest(options?: {
+    deferFinishHooks?: boolean;
+    childInspectionTimeoutMs?: number;
+  }): Promise<Array<() => Promise<void>>> {
+    return (
+      this as unknown as {
+        _reconcileAgentToolRuns(options?: {
+          deferFinishHooks?: boolean;
+          childInspectionTimeoutMs?: number;
+        }): Promise<Array<() => Promise<void>>>;
+      }
+    )._reconcileAgentToolRuns(options);
+  }
+
+  private async scheduleAgentToolRunRecoveryForTest(options?: {
+    childInspectionTimeoutMs?: number;
+  }): Promise<void> {
+    await (
+      this as unknown as {
+        _scheduleAgentToolRunRecovery(options?: {
+          childInspectionTimeoutMs?: number;
+        }): Promise<void>;
+      }
+    )._scheduleAgentToolRunRecovery(options);
+  }
+
+  async reconcileCompletedThinkChildForTest(
+    input: string,
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    inspection: AgentToolRunInspection;
+    status: string | null;
+  }> {
+    const child = await this.subAgent(ThinkTestAgent, runId);
+    const started = await child.startAgentToolRun(input, { runId });
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "ThinkTestAgent",
+      input,
+      started.startedAt
+    );
+    const inspection = await this.waitForTerminalInspectionForTest(
+      child,
+      runId
+    );
+
+    this.events = [];
+    this.finishes = [];
+    await this.reconcileAgentToolRunsForTest();
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      inspection,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  async reconcileRunningThinkChildForTest(
+    input: string,
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    status: string | null;
+  }> {
+    const child = await this.subAgent(ThinkTestAgent, runId);
+    await child.setBeforeStepAsyncDelay(10_000);
+    const started = await child.startAgentToolRun(input, { runId });
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "ThinkTestAgent",
+      input,
+      started.startedAt
+    );
+
+    this.events = [];
+    this.finishes = [];
+    try {
+      await this.reconcileAgentToolRunsForTest();
+    } finally {
+      await child.cancelAgentToolRun(runId, "test cleanup");
+    }
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  async reconcileStuckThinkChildWithTimeoutForTest(
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    elapsedMs: number;
+    status: string | null;
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "StuckThinkAgentToolChild",
+      "stuck Think child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    const startedAt = Date.now();
+    await this.reconcileAgentToolRunsForTest({ childInspectionTimeoutMs: 10 });
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      elapsedMs: Date.now() - startedAt,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  async scheduleStuckThinkChildRecoveryForTest(
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    status: string | null;
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "StuckThinkAgentToolChild",
+      "scheduled stuck Think child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    await this.scheduleAgentToolRunRecoveryForTest({
+      childInspectionTimeoutMs: 10
+    });
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  async scheduleStuckThinkChildRecoveryTwiceForTest(
+    runId = crypto.randomUUID()
+  ): Promise<{
+    events: AgentToolEventMessage[];
+    finishes: AgentToolFinishForTest[];
+    status: string | null;
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "StuckThinkAgentToolChild",
+      "single flight stuck Think child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    const first = this.scheduleAgentToolRunRecoveryForTest({
+      childInspectionTimeoutMs: 10
+    });
+    const second = this.scheduleAgentToolRunRecoveryForTest({
+      childInspectionTimeoutMs: 10
+    });
+    await Promise.all([first, second]);
+    return {
+      events: this.events,
+      finishes: this.finishes,
+      status: this.getParentAgentToolStatusForTest(runId)
+    };
+  }
+
+  async startupDefersStaleThinkRecoveryForTest(
+    runId = crypto.randomUUID()
+  ): Promise<{
+    statusesDuringStartup: string[];
+    statusAfterStartup: string | null;
+    finalStatus: string | null;
+    startupElapsedMs: number;
+    finishes: AgentToolFinishForTest[];
+    events: AgentToolEventMessage[];
+  }> {
+    this.insertRecoverableParentRunForTest(
+      runId,
+      "StuckThinkAgentToolChild",
+      "startup stuck Think child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    this.startupObservedStatuses = [];
+    const startedAt = Date.now();
+    await this.onStart();
+    const startupElapsedMs = Date.now() - startedAt;
+    const statusAfterStartup = this.getParentAgentToolStatusForTest(runId);
+
+    for (let attempt = 0; attempt < 40; attempt++) {
+      if (this.getParentAgentToolStatusForTest(runId) === "interrupted") {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    return {
+      statusesDuringStartup: this.startupObservedStatuses[0] ?? [],
+      statusAfterStartup,
+      finalStatus: this.getParentAgentToolStatusForTest(runId),
+      startupElapsedMs,
+      finishes: this.finishes,
+      events: this.events
+    };
+  }
+
+  async startupRecoveryIgnoresRunsCreatedDuringOnStartForTest(): Promise<{
+    staleStatus: string | null;
+    onStartRunStatus: string | null;
+    finishes: AgentToolFinishForTest[];
+    events: AgentToolEventMessage[];
+  }> {
+    const staleRunId = crypto.randomUUID();
+    const onStartRunId = crypto.randomUUID();
+    this.insertRecoverableParentRunForTest(
+      staleRunId,
+      "StuckThinkAgentToolChild",
+      "startup snapshot stale child",
+      Date.now()
+    );
+
+    this.events = [];
+    this.finishes = [];
+    this.startupObservedStatuses = [];
+    this.insertRunDuringOnStartId = onStartRunId;
+    try {
+      await this.onStart();
+    } finally {
+      this.insertRunDuringOnStartId = null;
+    }
+
+    for (let attempt = 0; attempt < 40; attempt++) {
+      if (this.getParentAgentToolStatusForTest(staleRunId) === "interrupted") {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    return {
+      staleStatus: this.getParentAgentToolStatusForTest(staleRunId),
+      onStartRunStatus: this.getParentAgentToolStatusForTest(onStartRunId),
+      finishes: this.finishes,
+      events: this.events
+    };
+  }
+
+  getParentAgentToolStatusForTest(runId: string): string | null {
+    const rows = this.sql<{ status: string }>`
+      SELECT status FROM cf_agent_tool_runs WHERE run_id = ${runId} LIMIT 1
+    `;
+    return rows[0]?.status ?? null;
   }
 }
 

--- a/packages/think/src/tests/worker.ts
+++ b/packages/think/src/tests/worker.ts
@@ -21,6 +21,8 @@ export {
   ThinkAsyncHookTestAgent,
   ThinkRecoveryTestAgent,
   ThinkNonRecoveryTestAgent,
+  ThinkAgentToolParent,
+  StuckThinkAgentToolChild,
   ThinkExtensionHookAgent
 } from "./agents";
 
@@ -43,6 +45,8 @@ import type {
   ThinkAsyncHookTestAgent,
   ThinkRecoveryTestAgent,
   ThinkNonRecoveryTestAgent,
+  ThinkAgentToolParent,
+  StuckThinkAgentToolChild,
   ThinkExtensionHookAgent
 } from "./agents";
 
@@ -65,6 +69,8 @@ export type Env = {
   ThinkAsyncHookTestAgent: DurableObjectNamespace<ThinkAsyncHookTestAgent>;
   ThinkRecoveryTestAgent: DurableObjectNamespace<ThinkRecoveryTestAgent>;
   ThinkNonRecoveryTestAgent: DurableObjectNamespace<ThinkNonRecoveryTestAgent>;
+  ThinkAgentToolParent: DurableObjectNamespace<ThinkAgentToolParent>;
+  StuckThinkAgentToolChild: DurableObjectNamespace<StuckThinkAgentToolChild>;
   ThinkExtensionHookAgent: DurableObjectNamespace<ThinkExtensionHookAgent>;
   LOADER: WorkerLoader;
 };

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -84,6 +84,14 @@
         "name": "ThinkNonRecoveryTestAgent"
       },
       {
+        "class_name": "ThinkAgentToolParent",
+        "name": "ThinkAgentToolParent"
+      },
+      {
+        "class_name": "StuckThinkAgentToolChild",
+        "name": "StuckThinkAgentToolChild"
+      },
+      {
         "class_name": "ThinkExtensionHookAgent",
         "name": "ThinkExtensionHookAgent"
       }
@@ -112,6 +120,7 @@
         "ThinkAsyncHookTestAgent",
         "ThinkRecoveryTestAgent",
         "ThinkNonRecoveryTestAgent",
+        "ThinkAgentToolParent",
         "ThinkExtensionHookAgent"
       ],
       "tag": "v1"


### PR DESCRIPTION
## Summary
- Move stale agent-tool run reconciliation out of the Agent startup gate so parent Durable Objects can boot even when child facets are stuck or recursively recovering.
- Snapshot only rows that were stale before user `onStart` runs, then reconcile that snapshot in `ctx.waitUntil` with a single-flight guard.
- Bound child inspection and recovery chunk replay; timed-out or uninspectable rows are terminal-finalized as `interrupted` so future wakes do not retry the same wedged recovery cascade.
- Reuse the already-resolved child adapter for recovery chunk replay to avoid an extra child facet initialization during reconciliation.
- Add AIChat and Think coverage for completed, running, stuck, scheduled, single-flight, and Think startup-ordering recovery scenarios.

## Why
Issue #1595 reports parent Agent Durable Objects becoming permanently wedged when startup recovery encounters stale `cf_agent_tool_runs` rows. The old startup path awaited `_reconcileAgentToolRuns()` inside PartyServer's `blockConcurrencyWhile` startup gate. Reconciliation synchronously resolved child facets via `_cf_resolveSubAgent()` / `_cf_initAsFacet()`, which forces the child through its own startup and can recursively drive more recovery. If that tree exceeds the runtime startup budget, the parent resets before marking rows terminal, so the same stale rows wedge every subsequent wake.

This change keeps parent startup live by making startup recovery asynchronous and bounded. It preserves best-effort recovery of completed child results, but prioritizes liveness by interrupting rows that cannot be inspected promptly.

## Behavior changes
- `onStart()` may now observe stale agent-tool rows that recovery will finalize shortly afterward.
- Recovered `onAgentToolFinish()` hooks now run after startup, not before user `onStart()` completes.
- Clients may briefly replay a stale running tool before receiving the recovered terminal event.
- Recovery is scoped to rows that were already stale before user startup began, so tool runs created during `onStart()` or immediately after startup are not accidentally interrupted by the startup recovery task.

## Test plan
- `npx nx run agents:build`
- `cd packages/ai-chat && npm run test:workers -- src/tests/agent-tools.test.ts`
- `cd packages/think && npm run test:workers -- src/tests/agent-tools.test.ts`
- `npm run check`

Notes: `npm run check` passes. Sherif still reports the existing warnings for example workspace folders that do not have `package.json` files:
- `examples/agent-skills/package.json`
- `examples/think-tanstack-start/package.json`
- `examples/think-react-router/package.json`

## Coverage added
- AIChat parent recovery finalizes stuck child facet startup via timeout.
- AIChat scheduled recovery finalizes stale rows and remains single-flight.
- Think parent `runAgentTool(ThinkTestAgent, ...)` happy path.
- Think completed child recovery preserves completed terminal state.
- Think still-running child recovery becomes `interrupted`.
- Think stuck child facet startup times out and finalizes as `interrupted`.
- Think scheduled recovery finalizes stale rows and remains single-flight.
- Think startup-ordering test proves startup returns while stale rows are still running, then background recovery finalizes only the pre-startup snapshot.
- Think startup snapshot test proves rows created during user `onStart()` are not interrupted by startup recovery.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->