### PR TITLE
Fix ai-chat tool continuation single-flight

### DIFF
--- a/.changeset/single-flight-tool-continuations.md
+++ b/.changeset/single-flight-tool-continuations.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Serialize client-tool continuation resumes so they do not overlap the active AI SDK chat request.

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -14,6 +14,17 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function sawActiveResponseError(spy: { mock: { calls: unknown[][] } }) {
+  return spy.mock.calls.some((args) =>
+    args.some((arg) =>
+      arg instanceof Error
+        ? arg.message.includes("Cannot read properties of undefined")
+        : typeof arg === "string" &&
+          arg.includes("Cannot read properties of undefined")
+    )
+  );
+}
+
 function createAgent({
   name,
   url,
@@ -2163,6 +2174,232 @@ describe("useAgentChat tool continuation status (issue #1157)", () => {
     await expect
       .element(screen.getByTestId("status"))
       .toHaveTextContent("ready");
+  });
+
+  it("defers tool continuation resume until the active request settles", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { agent, target, sentMessages } = createAgentWithTarget({
+      name: "tool-cont-single-flight",
+      url: "ws://localhost:3000/agents/chat/tool-cont-single-flight?_pk=abc"
+    });
+
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+    let sendPromise: Promise<void> | undefined;
+
+    const sentTypes = () =>
+      sentMessages.map((message) => JSON.parse(message).type as string);
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        resume: false,
+        onToolCall: ({ toolCall, addToolOutput }) => {
+          addToolOutput({
+            toolCallId: toolCall.toolCallId,
+            output: { lat: 51.5, lng: -0.1 }
+          });
+        }
+      });
+      chatInstance = chat;
+      return <div data-testid="status">{chat.status}</div>;
+    };
+
+    await act(async () => {
+      render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+    });
+
+    await act(async () => {
+      sendPromise = chatInstance!.sendMessage({ text: "Where am I?" });
+      await sleep(10);
+    });
+
+    const request = sentMessages
+      .map((message) => JSON.parse(message))
+      .find((message) => message.type === "cf_agent_use_chat_request");
+    expect(request).toBeDefined();
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: request.id,
+        body: JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "tc-single-flight",
+          toolName: "getLocation",
+          input: { city: "London" }
+        }),
+        done: false
+      });
+      await sleep(20);
+    });
+
+    expect(sentTypes()).toContain("cf_agent_tool_result");
+    expect(sentTypes()).not.toContain("cf_agent_stream_resume_request");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: request.id,
+        body: "",
+        done: true
+      });
+      await sendPromise;
+      await sleep(20);
+    });
+
+    expect(sentTypes()).toContain("cf_agent_stream_resume_request");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_stream_resuming",
+        id: "server-cont-single-flight"
+      });
+      await sleep(5);
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "server-cont-single-flight",
+        continuation: true,
+        body: "",
+        done: true
+      });
+      await sleep(10);
+    });
+
+    expect(sawActiveResponseError(consoleErrorSpy)).toBe(false);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("uses the fallback path for early tool continuation announcements", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { agent, target, sentMessages } = createAgentWithTarget({
+      name: "tool-cont-early-resuming",
+      url: "ws://localhost:3000/agents/chat/tool-cont-early-resuming?_pk=abc"
+    });
+
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+    let sendPromise: Promise<void> | undefined;
+
+    const sentTypes = () =>
+      sentMessages.map((message) => JSON.parse(message).type as string);
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        resume: false,
+        onToolCall: ({ toolCall, addToolOutput }) => {
+          addToolOutput({
+            toolCallId: toolCall.toolCallId,
+            output: { lat: 51.5, lng: -0.1 }
+          });
+        }
+      });
+      chatInstance = chat;
+      return (
+        <div>
+          <div data-testid="status">{chat.status}</div>
+          <div data-testid="isToolContinuation">
+            {String(chat.isToolContinuation)}
+          </div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await act(async () => {
+      sendPromise = chatInstance!.sendMessage({ text: "Where am I?" });
+      await sleep(10);
+    });
+
+    const request = sentMessages
+      .map((message) => JSON.parse(message))
+      .find((message) => message.type === "cf_agent_use_chat_request");
+    expect(request).toBeDefined();
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: request.id,
+        body: JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "tc-early-resume",
+          toolName: "getLocation",
+          input: { city: "London" }
+        }),
+        done: false
+      });
+      await sleep(20);
+    });
+
+    expect(sentTypes()).toContain("cf_agent_tool_result");
+    expect(sentTypes()).not.toContain("cf_agent_stream_resume_request");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_stream_resuming",
+        id: "server-cont-early"
+      });
+      await sleep(5);
+    });
+
+    expect(sentTypes()).toContain("cf_agent_stream_resume_ack");
+    expect(sentTypes()).not.toContain("cf_agent_stream_resume_request");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: request.id,
+        body: "",
+        done: true
+      });
+      await sendPromise;
+      await sleep(20);
+    });
+
+    expect(sentTypes()).not.toContain("cf_agent_stream_resume_request");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "server-cont-early",
+        continuation: true,
+        body: "",
+        done: true
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("isToolContinuation"))
+      .toHaveTextContent("false");
+
+    expect(sawActiveResponseError(consoleErrorSpy)).toBe(false);
+    consoleErrorSpy.mockRestore();
   });
 
   it("should use transport-owned status for approval continuations", async () => {

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -996,6 +996,11 @@ export function useAgentChat<
   statusRef.current = status;
 
   const resumingToolContinuationRef = useRef(false);
+  const pendingToolContinuationRef = useRef(false);
+  const observedToolContinuationRequestIdRef = useRef<string | null>(null);
+  const continuationLaunchTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
   // Generation counter for tool continuations. Bumped on every
   // `startToolContinuation` entry and on any external reset path
   // (e.g. `clearHistory`). The `.finally()` handler captures its
@@ -1021,31 +1026,79 @@ export function useAgentChat<
   // the generation bump ensures the pending `.finally()` is a no-op.
   const resetToolContinuation = useCallback(() => {
     continuationGenerationRef.current++;
+    pendingToolContinuationRef.current = false;
     resumingToolContinuationRef.current = false;
+    observedToolContinuationRequestIdRef.current = null;
+    if (continuationLaunchTimerRef.current) {
+      clearTimeout(continuationLaunchTimerRef.current);
+      continuationLaunchTimerRef.current = null;
+    }
     setIsToolContinuation(false);
   }, []);
+
+  const scheduleToolContinuationLaunch = useCallback(() => {
+    if (
+      !pendingToolContinuationRef.current ||
+      statusRef.current !== "ready" ||
+      continuationLaunchTimerRef.current
+    ) {
+      return;
+    }
+
+    continuationLaunchTimerRef.current = setTimeout(() => {
+      continuationLaunchTimerRef.current = null;
+
+      if (
+        !pendingToolContinuationRef.current ||
+        statusRef.current !== "ready"
+      ) {
+        return;
+      }
+
+      pendingToolContinuationRef.current = false;
+      const myGeneration = continuationGenerationRef.current;
+      customTransport.expectToolContinuation();
+
+      void resumeStream()
+        .catch((error) => {
+          console.error(
+            "[useAgentChat] Tool continuation resume failed:",
+            error
+          );
+        })
+        .finally(() => {
+          // Bail if a reset (clearHistory / cross-tab clear) or a newer
+          // continuation has taken over since we started — otherwise this
+          // stale settlement would flip the flags off while a newer
+          // continuation is still in flight, and reopen the re-entry
+          // guard spuriously.
+          if (continuationGenerationRef.current !== myGeneration) return;
+          resumingToolContinuationRef.current = false;
+          setIsToolContinuation(false);
+        });
+    }, 0);
+  }, [customTransport, resumeStream]);
 
   const startToolContinuation = useCallback(() => {
     if (!autoContinueAfterToolResult || resumingToolContinuationRef.current) {
       return;
     }
 
-    const myGeneration = ++continuationGenerationRef.current;
+    ++continuationGenerationRef.current;
     resumingToolContinuationRef.current = true;
+    pendingToolContinuationRef.current = true;
     setIsToolContinuation(true);
-    customTransport.expectToolContinuation();
+    scheduleToolContinuationLaunch();
+  }, [autoContinueAfterToolResult, scheduleToolContinuationLaunch]);
 
-    void resumeStream().finally(() => {
-      // Bail if a reset (clearHistory / cross-tab clear) or a newer
-      // continuation has taken over since we started — otherwise this
-      // stale settlement would flip the flags off while a newer
-      // continuation is still in flight, and reopen the re-entry
-      // guard spuriously.
-      if (continuationGenerationRef.current !== myGeneration) return;
-      resumingToolContinuationRef.current = false;
-      setIsToolContinuation(false);
-    });
-  }, [autoContinueAfterToolResult, customTransport, resumeStream]);
+  useEffect(() => {
+    if (status === "error" && pendingToolContinuationRef.current) {
+      resetToolContinuation();
+      return;
+    }
+
+    scheduleToolContinuationLaunch();
+  }, [resetToolContinuation, scheduleToolContinuationLaunch, status]);
 
   const stopWithToolContinuationAbort: typeof stop = useCallback(async () => {
     try {
@@ -1722,8 +1775,13 @@ export function useAgentChat<
           customTransport.handleStreamResumeNone();
           break;
 
-        case MessageType.CF_AGENT_STREAM_RESUMING:
-          if (!resume && !customTransport.isAwaitingResume()) return;
+        case MessageType.CF_AGENT_STREAM_RESUMING: {
+          const isEarlyToolContinuation =
+            resumingToolContinuationRef.current &&
+            !customTransport.isAwaitingResume();
+          if (!resume && !customTransport.isAwaitingResume()) {
+            if (!isEarlyToolContinuation) return;
+          }
           if (!resumingToolContinuationRef.current) {
             pendingReplayResumeRequestIdsRef.current.add(data.id);
           }
@@ -1740,6 +1798,14 @@ export function useAgentChat<
           // RESUME_REQUEST handler — the second one must not trigger
           // a duplicate ACK / replay).
           if (localRequestIdsRef.current.has(data.id)) return;
+          if (isEarlyToolContinuation) {
+            pendingToolContinuationRef.current = false;
+            observedToolContinuationRequestIdRef.current = data.id;
+            if (continuationLaunchTimerRef.current) {
+              clearTimeout(continuationLaunchTimerRef.current);
+              continuationLaunchTimerRef.current = null;
+            }
+          }
           // Fallback for cross-tab broadcasts or cases where the
           // transport isn't expecting a resume.
           streamStateRef.current = broadcastTransition(streamStateRef.current, {
@@ -1756,6 +1822,7 @@ export function useAgentChat<
             })
           );
           break;
+        }
 
         case MessageType.CF_AGENT_USE_CHAT_RESPONSE: {
           if (localRequestIdsRef.current.has(data.id)) {
@@ -1856,6 +1923,9 @@ export function useAgentChat<
           if (data.done) {
             customTransport.handleServerTurnCompleted(data.id);
           }
+          const completedObservedToolContinuation =
+            data.done &&
+            observedToolContinuationRequestIdRef.current === data.id;
 
           const result = broadcastTransition(streamStateRef.current, {
             type: "response",
@@ -1879,6 +1949,9 @@ export function useAgentChat<
             );
           }
           setIsServerStreaming(result.isStreaming);
+          if (completedObservedToolContinuation) {
+            resetToolContinuation();
+          }
           break;
         }
       }
@@ -1904,6 +1977,7 @@ export function useAgentChat<
     resume,
     customTransport,
     preserveProtectedStreamingAssistant,
+    resetToolContinuation,
     resetMatchingHydratedAssistantForReplay,
     restoreProtectedStreamingAssistant,
     resetLocalChatState


### PR DESCRIPTION
## Summary

Fixes #1600.

This makes client-tool continuation resumes single-flight on the browser side so `@cloudflare/ai-chat` no longer drives AI SDK 6 into overlapping `makeRequest()` calls for the `submit-message` → client tool → `resume-stream` path.

The key change is that `addToolOutput` / tool approval still marks the continuation immediately for UI and re-entry protection, but the actual `resumeStream()` call is deferred until the active AI SDK request has returned to `ready`. That prevents the continuation request from clobbering the AI SDK `Chat` instance's shared `activeResponse` while the original request is still in `finally`.

This also preserves fast server continuations: if the server sends `CF_AGENT_STREAM_RESUMING` before the deferred `resumeStream()` has installed its transport resolver, the hook now accepts that announcement through the existing fallback observer path, ACKs it, cancels the pending resume launch, and clears `isToolContinuation` when the observed continuation finishes.

## Changes

- Queue client-tool continuation launches behind the current AI SDK request status.
- Clear pending continuation state on reset, stop/error paths, and fallback-observed completion.
- Allow early tool-continuation `STREAM_RESUMING` to be handled even when normal `resume: false` is configured.
- Add React regressions for both delayed continuation attachment and early server continuation announcement.
- Add a patch changeset for `@cloudflare/ai-chat`.

## Test plan

- `npm run test:react -w @cloudflare/ai-chat -- --run src/react-tests/use-agent-chat.test.tsx -t "tool continuation"`
- `npm run test -w @cloudflare/ai-chat`
- `npm run check`

Notes:

- The full ai-chat suite still logs an existing AI SDK `activeResponse` error from a separate same-tab overlapping `sendMessage()` test path. The new client-tool continuation regressions explicitly assert that this error is not emitted for the #1600 continuation scenarios.
- `npm run check` reports existing `sherif` warnings for example folders without `package.json`, but exits successfully.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->