### PR TITLE
Fix auto-continuation stream resume race

### DIFF
--- a/.changeset/early-ravens-continue.md
+++ b/.changeset/early-ravens-continue.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/think": patch
+"agents": patch
+---
+
+Fix Think auto-continuation stream resumes so immediate client-tool resume requests attach to the pending continuation instead of receiving `cf_agent_stream_resume_none`.

--- a/.changeset/early-ravens-continue.md
+++ b/.changeset/early-ravens-continue.md
@@ -1,6 +1,7 @@
 ---
 "@cloudflare/think": patch
+"@cloudflare/ai-chat": patch
 "agents": patch
 ---
 
-Fix Think auto-continuation stream resumes so immediate client-tool resume requests attach to the pending continuation instead of receiving `cf_agent_stream_resume_none`.
+Fix auto-continuation stream resumes so immediate client-tool resume requests attach to the pending continuation instead of receiving `cf_agent_stream_resume_none`.

--- a/packages/agents/src/chat/__tests__/continuation-state.test.ts
+++ b/packages/agents/src/chat/__tests__/continuation-state.test.ts
@@ -113,6 +113,49 @@ describe("ContinuationState", () => {
     expect(state.awaitingConnections.size).toBe(0);
   });
 
+  // ── releaseConnection ─────────────────────────────────────────────
+
+  it("releaseConnection clears ownership without removing pending", () => {
+    const state = new ContinuationState();
+    const conn = makeConnection("c1");
+    state.pending = {
+      connection: conn,
+      connectionId: "c1",
+      requestId: "r1",
+      errorPrefix: null,
+      prerequisite: null,
+      pastCoalesce: false
+    };
+    state.awaitingConnections.set("c1", conn);
+
+    state.releaseConnection("c1");
+
+    expect(state.pending).not.toBeNull();
+    expect(state.pending!.connection).toBe(conn);
+    expect(state.pending!.connectionId).toBeNull();
+    expect(state.awaitingConnections.size).toBe(0);
+  });
+
+  it("releaseConnection clears deferred and active ownership", () => {
+    const state = new ContinuationState();
+    const conn = makeConnection("c1");
+    state.deferred = {
+      connection: conn,
+      connectionId: "c1",
+      errorPrefix: "[test]",
+      prerequisite: null
+    };
+    state.activeRequestId = "r1";
+    state.activeConnectionId = "c1";
+
+    state.releaseConnection("c1");
+
+    expect(state.deferred).not.toBeNull();
+    expect(state.deferred!.connectionId).toBeNull();
+    expect(state.activeRequestId).toBe("r1");
+    expect(state.activeConnectionId).toBeNull();
+  });
+
   // ── sendResumeNone ────────────────────────────────────────────────
 
   it("sendResumeNone sends to all awaiting connections then clears", () => {

--- a/packages/agents/src/chat/continuation-state.ts
+++ b/packages/agents/src/chat/continuation-state.ts
@@ -46,8 +46,10 @@ export interface ContinuationConnection {
   send(message: string): void;
 }
 
-export interface ContinuationPending {
-  connection: ContinuationConnection;
+export interface ContinuationPending<
+  TConnection extends ContinuationConnection = ContinuationConnection
+> {
+  connection: TConnection;
   connectionId: string;
   requestId: string;
   clientTools?: ClientToolSchema[];
@@ -57,8 +59,10 @@ export interface ContinuationPending {
   pastCoalesce: boolean;
 }
 
-export interface ContinuationDeferred {
-  connection: ContinuationConnection;
+export interface ContinuationDeferred<
+  TConnection extends ContinuationConnection = ContinuationConnection
+> {
+  connection: TConnection;
   connectionId: string;
   clientTools?: ClientToolSchema[];
   body?: Record<string, unknown>;
@@ -66,12 +70,14 @@ export interface ContinuationDeferred {
   prerequisite: Promise<boolean> | null;
 }
 
-export class ContinuationState {
-  pending: ContinuationPending | null = null;
-  deferred: ContinuationDeferred | null = null;
+export class ContinuationState<
+  TConnection extends ContinuationConnection = ContinuationConnection
+> {
+  pending: ContinuationPending<TConnection> | null = null;
+  deferred: ContinuationDeferred<TConnection> | null = null;
   activeRequestId: string | null = null;
   activeConnectionId: string | null = null;
-  awaitingConnections: Map<string, ContinuationConnection> = new Map();
+  awaitingConnections: Map<string, TConnection> = new Map();
 
   /** Clear pending state and awaiting connections (without sending RESUME_NONE). */
   clearPending(): void {
@@ -106,9 +112,7 @@ export class ContinuationState {
    * Flush awaiting connections by notifying each one via the provided
    * callback (typically sends STREAM_RESUMING), then clear.
    */
-  flushAwaitingConnections(
-    notify: (conn: ContinuationConnection) => void
-  ): void {
+  flushAwaitingConnections(notify: (conn: TConnection) => void): void {
     for (const connection of this.awaitingConnections.values()) {
       notify(connection);
     }
@@ -136,7 +140,7 @@ export class ContinuationState {
    */
   activateDeferred(
     generateRequestId: () => string
-  ): ContinuationPending | null {
+  ): ContinuationPending<TConnection> | null {
     if (this.pending || !this.deferred) return null;
 
     const d = this.deferred;

--- a/packages/agents/src/chat/continuation-state.ts
+++ b/packages/agents/src/chat/continuation-state.ts
@@ -50,7 +50,7 @@ export interface ContinuationPending<
   TConnection extends ContinuationConnection = ContinuationConnection
 > {
   connection: TConnection;
-  connectionId: string;
+  connectionId: string | null;
   requestId: string;
   clientTools?: ClientToolSchema[];
   body?: Record<string, unknown>;
@@ -63,7 +63,7 @@ export interface ContinuationDeferred<
   TConnection extends ContinuationConnection = ContinuationConnection
 > {
   connection: TConnection;
-  connectionId: string;
+  connectionId: string | null;
   clientTools?: ClientToolSchema[];
   body?: Record<string, unknown>;
   errorPrefix: string;
@@ -94,6 +94,23 @@ export class ContinuationState<
     this.clearDeferred();
     this.activeRequestId = null;
     this.activeConnectionId = null;
+  }
+
+  /**
+   * Mark a connection as no longer available without canceling the
+   * continuation it initiated.
+   */
+  releaseConnection(connectionId: string): void {
+    this.awaitingConnections.delete(connectionId);
+    if (this.pending?.connectionId === connectionId) {
+      this.pending = { ...this.pending, connectionId: null };
+    }
+    if (this.deferred?.connectionId === connectionId) {
+      this.deferred = { ...this.deferred, connectionId: null };
+    }
+    if (this.activeConnectionId === connectionId) {
+      this.activeConnectionId = null;
+    }
   }
 
   /**
@@ -159,7 +176,9 @@ export class ContinuationState<
       pastCoalesce: false
     };
 
-    this.awaitingConnections.set(d.connectionId, d.connection);
+    if (d.connectionId !== null) {
+      this.awaitingConnections.set(d.connectionId, d.connection);
+    }
     return this.pending;
   }
 }

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -595,13 +595,7 @@ export class AIChatAgent<
     ) => {
       // Clean up pending resume state for this connection
       this._pendingResumeConnections.delete(connection.id);
-      this._continuation.awaitingConnections.delete(connection.id);
-      if (this._continuation.pending?.connectionId === connection.id) {
-        this._continuation.pending = null;
-      }
-      if (this._continuation.activeConnectionId === connection.id) {
-        this._continuation.activeConnectionId = null;
-      }
+      this._continuation.releaseConnection(connection.id);
       // Call consumer's onClose
       return _onClose(connection, code, reason, wasClean);
     };
@@ -907,7 +901,8 @@ export class AIChatAgent<
             }
           } else if (
             this._continuation.pending !== null &&
-            this._continuation.pending.connectionId === connection.id
+            (this._continuation.pending.connectionId === null ||
+              this._continuation.pending.connectionId === connection.id)
           ) {
             this._continuation.awaitingConnections.set(
               connection.id,

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -48,7 +48,6 @@ import { ResumableStream } from "agents/chat";
 import {
   ContinuationState,
   AbortRegistry,
-  type ContinuationConnection,
   type ClientToolSchema
 } from "agents/chat";
 import type {
@@ -339,7 +338,7 @@ export class AIChatAgent<
    * Continuation lifecycle state: pending, deferred, active, and
    * connections awaiting a continuation stream to start.
    */
-  private _continuation = new ContinuationState();
+  private _continuation = new ContinuationState<Connection>();
   private _agentToolForwarders = new Map<
     string,
     Set<(chunk: AgentToolStoredChunk) => void>
@@ -1101,8 +1100,8 @@ export class AIChatAgent<
       return;
     }
 
-    this._continuation.flushAwaitingConnections((c: ContinuationConnection) =>
-      this._notifyStreamResuming(c as Connection)
+    this._continuation.flushAwaitingConnections((c) =>
+      this._notifyStreamResuming(c)
     );
   }
 
@@ -1997,8 +1996,7 @@ export class AIChatAgent<
             return;
           }
 
-          const connection = this._continuation.pending
-            ?.connection as Connection | null;
+          const connection = this._continuation.pending?.connection;
           if (!connection) {
             this._clearAllAutoContinuationState(true);
             return;

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -997,6 +997,74 @@ describe("Think — tool broadcast and persistence", () => {
 // ── Resume coordination during pending continuation ──────────────
 
 describe("resume coordination during pending continuation", () => {
+  it("does not send STREAM_RESUME_NONE for an immediate resume request after tool output", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const { ws } = await connectWS(room);
+    await delay(100);
+
+    const userMsg: UIMessage = {
+      id: "msg-immediate-resume-user",
+      role: "user",
+      parts: [{ type: "text", text: "hi" }]
+    } as UIMessage;
+
+    const initialDone = waitForDone(ws, 10000);
+    ws.send(
+      JSON.stringify({
+        type: MSG_CHAT_REQUEST,
+        id: "req-immediate-resume",
+        init: {
+          method: "POST",
+          body: JSON.stringify({ messages: [userMsg] })
+        }
+      })
+    );
+    await initialDone;
+
+    await agent.persistToolCallMessage([
+      userMsg,
+      {
+        id: "assistant-immediate-resume",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-immediate-resume",
+            state: "input-available",
+            input: { action: "test" }
+          }
+        ]
+      } as unknown as UIMessage
+    ]);
+
+    const resumeResponse = Promise.race([
+      waitForMessageOfType(ws, MSG_STREAM_RESUMING, 5000).then(
+        () => "resuming" as const
+      ),
+      waitForMessageOfType(ws, MSG_STREAM_RESUME_NONE, 5000).then(
+        () => "none" as const
+      )
+    ]);
+
+    ws.send(
+      JSON.stringify({
+        type: MSG_TOOL_RESULT,
+        toolCallId: "tc-immediate-resume",
+        toolName: "client_action",
+        output: "done",
+        autoContinue: true
+      })
+    );
+    ws.send(JSON.stringify({ type: MSG_STREAM_RESUME_REQUEST }));
+
+    const result = await resumeResponse;
+    expect(result).toBe("resuming");
+
+    await waitForDone(ws, 10000);
+    await closeWS(ws);
+  });
+
   it("holds STREAM_RESUME_REQUEST while continuation is pending", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1065,6 +1065,70 @@ describe("resume coordination during pending continuation", () => {
     await closeWS(ws);
   });
 
+  it("continues when the initiating connection closes before coalescing finishes", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const { ws } = await connectWS(room);
+    await delay(100);
+
+    const userMsg: UIMessage = {
+      id: "msg-close-before-coalesce-user",
+      role: "user",
+      parts: [{ type: "text", text: "hi" }]
+    } as UIMessage;
+
+    const initialDone = waitForDone(ws, 10000);
+    ws.send(
+      JSON.stringify({
+        type: MSG_CHAT_REQUEST,
+        id: "req-close-before-coalesce",
+        init: {
+          method: "POST",
+          body: JSON.stringify({ messages: [userMsg] })
+        }
+      })
+    );
+    await initialDone;
+
+    await agent.clearResponseLog();
+    await agent.persistToolCallMessage([
+      userMsg,
+      {
+        id: "assistant-close-before-coalesce",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-close-before-coalesce",
+            state: "input-available",
+            input: { action: "test" }
+          }
+        ]
+      } as unknown as UIMessage
+    ]);
+
+    ws.send(
+      JSON.stringify({
+        type: MSG_TOOL_RESULT,
+        toolCallId: "tc-close-before-coalesce",
+        toolName: "client_action",
+        output: "done",
+        autoContinue: true
+      })
+    );
+
+    await delay(10);
+    await closeWS(ws);
+
+    await waitUntil(async () => {
+      const log = (await agent.getResponseLog()) as ChatResponseResult[];
+      return log.some((entry) => entry.continuation);
+    }, 10000);
+
+    const log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log.some((entry) => entry.continuation)).toBe(true);
+  });
+
   it("holds STREAM_RESUME_REQUEST while continuation is pending", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1423,7 +1423,7 @@ export class Think<
   private _pendingResumeConnections: Set<string> = new Set();
   private _lastClientTools: ClientToolSchema[] | undefined;
   private _lastBody: Record<string, unknown> | undefined;
-  private _continuation = new ContinuationState();
+  private _continuation = new ContinuationState<Connection>();
   private _continuationTimer: ReturnType<typeof setTimeout> | null = null;
   private _insideResponseHook = false;
   private _insideInferenceLoop = false;
@@ -6578,29 +6578,30 @@ export class Think<
     if (this._continuationTimer) {
       clearTimeout(this._continuationTimer);
     }
+    this._continuation.pending = {
+      connection,
+      connectionId: connection.id,
+      requestId: crypto.randomUUID(),
+      clientTools: this._lastClientTools,
+      body: undefined,
+      errorPrefix: "[Think] Auto-continuation failed:",
+      prerequisite: null,
+      pastCoalesce: false
+    };
+    this._continuation.awaitingConnections.set(connection.id, connection);
     this._continuationTimer = setTimeout(() => {
       this._continuationTimer = null;
-      this._fireAutoContinuation(connection);
+      const pending = this._continuation.pending;
+      if (!pending) return;
+      this._fireAutoContinuation(pending.connection);
     }, 50);
   }
 
   private _fireAutoContinuation(connection: Connection): void {
-    if (!this._continuation.pending) {
-      const requestId = crypto.randomUUID();
-      this._continuation.pending = {
-        connection,
-        connectionId: connection.id,
-        requestId,
-        clientTools: this._lastClientTools,
-        body: undefined,
-        errorPrefix: "[Think] Auto-continuation failed:",
-        prerequisite: null,
-        pastCoalesce: false
-      };
-      this._continuation.awaitingConnections.set(connection.id, connection);
-    }
+    const pending = this._continuation.pending;
+    if (!pending) return;
 
-    const { requestId, clientTools } = this._continuation.pending!;
+    const { requestId, clientTools } = pending;
     const abortSignal = this._aborts.getSignal(requestId);
 
     this.keepAliveWhile(async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -4988,6 +4988,10 @@ export class Think<
       this._pendingResumeConnections.delete(connection.id);
       this._continuation.awaitingConnections.delete(connection.id);
       if (this._continuation.pending?.connectionId === connection.id) {
+        if (this._continuationTimer) {
+          clearTimeout(this._continuationTimer);
+          this._continuationTimer = null;
+        }
         this._continuation.pending = null;
       }
       if (this._continuation.activeConnectionId === connection.id) {
@@ -5691,7 +5695,7 @@ export class Think<
     if (this._continuation.pending?.requestId === requestId) {
       this._continuation.activatePending();
       this._continuation.flushAwaitingConnections((c) =>
-        this._notifyStreamResuming(c as Connection)
+        this._notifyStreamResuming(c)
       );
     }
 
@@ -6572,12 +6576,10 @@ export class Think<
       this._continuation.pending.connectionId = connection.id;
       this._continuation.pending.clientTools = this._lastClientTools;
       this._continuation.awaitingConnections.set(connection.id, connection);
+      this._resetAutoContinuationTimer();
       return;
     }
 
-    if (this._continuationTimer) {
-      clearTimeout(this._continuationTimer);
-    }
     this._continuation.pending = {
       connection,
       connectionId: connection.id,
@@ -6589,6 +6591,13 @@ export class Think<
       pastCoalesce: false
     };
     this._continuation.awaitingConnections.set(connection.id, connection);
+    this._resetAutoContinuationTimer();
+  }
+
+  private _resetAutoContinuationTimer(): void {
+    if (this._continuationTimer) {
+      clearTimeout(this._continuationTimer);
+    }
     this._continuationTimer = setTimeout(() => {
       this._continuationTimer = null;
       const pending = this._continuation.pending;
@@ -6661,7 +6670,7 @@ export class Think<
     );
     if (!pending) return;
 
-    this._fireAutoContinuation(pending.connection as Connection);
+    this._fireAutoContinuation(pending.connection);
   }
 
   // ── Response hook ──────────────────────────────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -4986,17 +4986,7 @@ export class Think<
       wasClean: boolean
     ) => {
       this._pendingResumeConnections.delete(connection.id);
-      this._continuation.awaitingConnections.delete(connection.id);
-      if (this._continuation.pending?.connectionId === connection.id) {
-        if (this._continuationTimer) {
-          clearTimeout(this._continuationTimer);
-          this._continuationTimer = null;
-        }
-        this._continuation.pending = null;
-      }
-      if (this._continuation.activeConnectionId === connection.id) {
-        this._continuation.activeConnectionId = null;
-      }
+      this._continuation.releaseConnection(connection.id);
       return _onClose(connection, code, reason, wasClean);
     };
 
@@ -5131,7 +5121,8 @@ export class Think<
       }
     } else if (
       this._continuation.pending !== null &&
-      this._continuation.pending.connectionId === connection.id
+      (this._continuation.pending.connectionId === null ||
+        this._continuation.pending.connectionId === connection.id)
     ) {
       this._continuation.awaitingConnections.set(connection.id, connection);
     } else {


### PR DESCRIPTION
This PR fixes a race in Think auto-continuation streaming after client-side tool output.

When a client calls `addToolOutput(...)` with `autoContinue: true`, the client immediately asks to resume/attach to the continuation stream. Think was only creating `ContinuationState.pending` after the 50ms coalescing timer fired, so the immediate `cf_agent_stream_resume_request` could arrive while there was no active stream and no pending continuation. The server would reply `cf_agent_stream_resume_none`, causing the client’s deferred stream to close and leaving the user with no live assistant chunks until end-of-turn replay.

The fix keeps the existing 50ms coalescing delay for starting the continuation turn, but registers the continuation as pending synchronously:

- `pending` now exists before the coalescing timer fires, so an immediate resume request is held in `awaitingConnections` instead of getting `cf_agent_stream_resume_none`.
- The timer fires the continuation from the latest pending connection, avoiding a stale captured connection if the pending continuation is updated during the coalescing window.
- `_fireAutoContinuation` now consumes the already-registered pending state instead of creating it late.
- `ContinuationState` is now generic over the concrete connection type, so Think and AIChatAgent can store full `Connection` objects without casts while keeping the shared chat primitive decoupled from the Agents connection type.
- 
The regression test sends `cf_agent_tool_result` with `autoContinue: true` and immediately follows it with `cf_agent_stream_resume_request`. It failed before this patch, and passes now. It asserts that the server responds with `cf_agent_stream_resuming`, not `cf_agent_stream_resume_none`, which captures the broken timing from #1586.

Fixes #1586 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->