### PR TITLE
Fix second deploy-churn recovery abandonment: defer one-shot callbacks on a code-update DO reset

### DIFF
--- a/.changeset/defer-recovery-on-superseded-isolate.md
+++ b/.changeset/defer-recovery-on-superseded-isolate.md
@@ -1,0 +1,21 @@
+---
+"agents": patch
+---
+
+Scheduled callbacks no longer drop their work when an alarm fires on an isolate
+that a deploy has just superseded. In that window the first `ctx.storage` op
+throws `Durable Object reset because its code was updated.` for the entire
+invocation (code never reloads mid-invocation). Previously
+`Agent._executeScheduleCallback` burned its in-process retries (all doomed),
+swallowed the error, and `alarm()` deleted the one-shot row — permanently
+abandoning the work even though the next fresh invocation would succeed. This
+was a second deploy-churn abandonment path for chat recovery
+(`_chatRecoveryContinue` / `_chatRecoveryRetry`) that the progress-aware budget
+in `@cloudflare/think` / `@cloudflare/ai-chat` could not reach, because the
+continuation was deleted before it could be re-detected.
+
+For a one-shot schedule failing with this transient, the SDK now skips the
+doomed in-process retries and re-throws so `alarm()` rejects: the one-shot row
+survives and Cloudflare re-runs the alarm on a fresh isolate (= new code) under
+the at-least-once alarm guarantee, so the work auto-resumes once the deploy
+settles. All other callbacks and error classes keep the existing behavior.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1207,6 +1207,25 @@ function resolveRetryConfig(
   };
 }
 
+/**
+ * Whether an error is a Durable Object reset caused by a code update (deploy).
+ *
+ * This is a transient, environmental failure: the invocation started on a
+ * superseded isolate, so every `ctx.storage` op throws this for the entire
+ * life of the invocation (code never reloads mid-invocation) — but the next
+ * fresh invocation runs the new code and succeeds. workerd surfaces it as a
+ * plain `Error` with this message, so a message match is the only signal.
+ */
+function isDurableObjectCodeUpdateReset(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  return /reset because its code was updated/i.test(message);
+}
+
 export function getCurrentAgent<
   T extends Agent<Cloudflare.Env> = Agent<Cloudflare.Env>
 >(): {
@@ -5617,6 +5636,20 @@ export class Agent<
           return;
         }
 
+        // A one-shot row is deleted by `alarm()` once this returns normally.
+        // If it fails with a Durable Object code-update reset (a deploy
+        // superseded the isolate), burning in-process retries is futile (code
+        // never reloads mid-invocation) and swallowing the error would let
+        // `alarm()` delete the row — permanently abandoning the work (e.g. an
+        // interrupted chat-recovery continuation). For that transient we skip
+        // the doomed retries and re-throw so `alarm()` rejects, the one-shot
+        // row survives, and the platform re-runs it on a fresh isolate (= new
+        // code) under the at-least-once alarm guarantee.
+        const isOneShotSchedule =
+          row.type === "delayed" || row.type === "scheduled";
+        const shouldDeferReset = (error: unknown): boolean =>
+          isOneShotSchedule && isDurableObjectCodeUpdateReset(error);
+
         try {
           this._emit("schedule:execute", {
             callback: row.callback,
@@ -5641,9 +5674,19 @@ export class Agent<
                 ) => Promise<void>
               ).bind(this)(parsedPayload, row as unknown as Schedule<unknown>);
             },
-            { baseDelayMs, maxDelayMs }
+            {
+              baseDelayMs,
+              maxDelayMs,
+              shouldRetry: (error) => !shouldDeferReset(error)
+            }
           );
         } catch (e) {
+          if (shouldDeferReset(e)) {
+            console.warn(
+              `Deferring scheduled callback "${row.callback}" to a fresh invocation after a Durable Object code-update reset; the one-shot row is preserved and the alarm will re-run on new code.`
+            );
+            throw e;
+          }
           console.error(
             `error executing callback "${row.callback}" after ${maxAttempts} attempts`,
             e

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -42,6 +42,7 @@ interface ChatRecoveryTestStub {
   getRunFiberCountForTest(): Promise<number>;
   runAlarmForTest(): Promise<void>;
   setSimulateSupersededIsolateForTest(value: boolean): Promise<void>;
+  getSupersededThrowsForTest(): Promise<number>;
   setChatRecoveryConfigForTest(config: {
     maxAttempts?: number;
     terminalMessage?: string;
@@ -306,35 +307,40 @@ describe("onChatRecovery", () => {
     const room = crypto.randomUUID();
     const agentStub = await getTestAgent(room);
 
+    // Simulate a SUPERSEDED isolate before recovery schedules anything, so
+    // every run of the continuation throws the catchable "Durable Object reset
+    // because its code was updated." — no race with the real DO alarm.
+    await agentStub.setSimulateSupersededIsolateForTest(true);
+
     // Interrupted chat turn: recovery schedules the continuation and, because
     // recovery is "handled", deletes the orphaned fiber-ledger row. From here
     // the only thing that can resume the turn is the scheduled continuation.
     await agentStub.insertInterruptedFiber("__cf_internal_chat_turn:req-stale");
     await agentStub.triggerFiberRecovery();
-    expect(
-      await agentStub.getScheduleCountForCallback("_chatRecoveryContinue")
-    ).toBe(1);
     expect(await agentStub.getRunFiberCountForTest()).toBe(0);
 
-    // The continuation alarm fires on a SUPERSEDED isolate: the first storage
-    // op throws the catchable "Durable Object reset because its code was
-    // updated." for the whole invocation. `_executeScheduleCallback` burns its
-    // in-process retries, swallows the error, and `alarm()` deletes the
-    // one-shot row.
-    await agentStub.setSimulateSupersededIsolateForTest(true);
+    // Fire the continuation alarm on the superseded isolate. The first storage
+    // op throws for the whole invocation; `_executeScheduleCallback` would burn
+    // its in-process retries and (pre-fix) swallow the error, letting `alarm()`
+    // delete the one-shot row.
     await agentStub.runAlarmForTest();
-    await agentStub.setSimulateSupersededIsolateForTest(false);
+    expect(await agentStub.getSupersededThrowsForTest()).toBeGreaterThanOrEqual(
+      1
+    );
 
     // A deploy-class transient must not destroy recovery: the turn should still
     // be resumable afterward — either the one-shot continuation row survives for
     // a fresh-code re-run, or an orphaned fiber remains for the boot scan. On
-    // current main BOTH are gone, so this assertion fails — that is the bug
-    // (the turn is permanently abandoned; #1615's progress logic never re-runs).
+    // current main BOTH are gone, so this fails — that is the bug (the turn is
+    // permanently abandoned; #1615's progress logic never runs again).
     const pendingContinuations = await agentStub.getScheduleCountForCallback(
       "_chatRecoveryContinue"
     );
     const pendingFibers = await agentStub.getRunFiberCountForTest();
     expect(pendingContinuations + pendingFibers).toBeGreaterThanOrEqual(1);
+
+    // Stop simulating so any platform-retried alarm can complete cleanly.
+    await agentStub.setSimulateSupersededIsolateForTest(false);
   });
 
   it("shares one attempt budget when an incident flips between retry and continue", async () => {

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -39,6 +39,9 @@ interface ChatRecoveryTestStub {
     Array<Array<{ name: string; description?: string }> | undefined>
   >;
   getScheduleCountForCallback(callback: string): Promise<number>;
+  getRunFiberCountForTest(): Promise<number>;
+  runAlarmForTest(): Promise<void>;
+  setSimulateSupersededIsolateForTest(value: boolean): Promise<void>;
   setChatRecoveryConfigForTest(config: {
     maxAttempts?: number;
     terminalMessage?: string;
@@ -297,6 +300,41 @@ describe("onChatRecovery", () => {
       status: "exhausted",
       reason: "max_recovery_window_exceeded"
     });
+  });
+
+  it("recovers when the continuation alarm fires on a superseded isolate", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+
+    // Interrupted chat turn: recovery schedules the continuation and, because
+    // recovery is "handled", deletes the orphaned fiber-ledger row. From here
+    // the only thing that can resume the turn is the scheduled continuation.
+    await agentStub.insertInterruptedFiber("__cf_internal_chat_turn:req-stale");
+    await agentStub.triggerFiberRecovery();
+    expect(
+      await agentStub.getScheduleCountForCallback("_chatRecoveryContinue")
+    ).toBe(1);
+    expect(await agentStub.getRunFiberCountForTest()).toBe(0);
+
+    // The continuation alarm fires on a SUPERSEDED isolate: the first storage
+    // op throws the catchable "Durable Object reset because its code was
+    // updated." for the whole invocation. `_executeScheduleCallback` burns its
+    // in-process retries, swallows the error, and `alarm()` deletes the
+    // one-shot row.
+    await agentStub.setSimulateSupersededIsolateForTest(true);
+    await agentStub.runAlarmForTest();
+    await agentStub.setSimulateSupersededIsolateForTest(false);
+
+    // A deploy-class transient must not destroy recovery: the turn should still
+    // be resumable afterward — either the one-shot continuation row survives for
+    // a fresh-code re-run, or an orphaned fiber remains for the boot scan. On
+    // current main BOTH are gone, so this assertion fails — that is the bug
+    // (the turn is permanently abandoned; #1615's progress logic never re-runs).
+    const pendingContinuations = await agentStub.getScheduleCountForCallback(
+      "_chatRecoveryContinue"
+    );
+    const pendingFibers = await agentStub.getRunFiberCountForTest();
+    expect(pendingContinuations + pendingFibers).toBeGreaterThanOrEqual(1);
   });
 
   it("shares one attempt budget when an incident flips between retry and continue", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1519,6 +1519,27 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 
   recoveryShouldThrow = false;
   onExhaustedCalls = 0;
+  private _simulateSupersededIsolate = false;
+
+  /**
+   * Simulate the recovery continuation alarm firing on a SUPERSEDED isolate:
+   * the first storage op throws the catchable
+   * `Durable Object reset because its code was updated.` for the whole
+   * invocation. Used to reproduce the scheduled-callback abandonment path that
+   * #1615's `_beginChatRecoveryIncident` progress logic cannot reach.
+   */
+  override async _chatRecoveryContinue(
+    ...args: Parameters<AIChatAgent<Env>["_chatRecoveryContinue"]>
+  ): Promise<void> {
+    if (this._simulateSupersededIsolate) {
+      throw new Error("Durable Object reset because its code was updated.");
+    }
+    return super._chatRecoveryContinue(...args);
+  }
+
+  setSimulateSupersededIsolateForTest(value: boolean): void {
+    this._simulateSupersededIsolate = value;
+  }
 
   override async onChatRecovery(
     ctx: ChatRecoveryContext
@@ -1748,6 +1769,18 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
       WHERE callback = ${callback}
     `;
     return rows[0]?.count ?? 0;
+  }
+
+  getRunFiberCountForTest(): number {
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_agents_runs
+    `;
+    return rows[0]?.count ?? 0;
+  }
+
+  /** Run the real DO alarm handler (schedule dispatch + one-shot row delete). */
+  async runAlarmForTest(): Promise<void> {
+    await (this as unknown as { alarm(): Promise<void> }).alarm();
   }
 
   async waitForIdleForTest(): Promise<void> {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1528,10 +1528,13 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
    * invocation. Used to reproduce the scheduled-callback abandonment path that
    * #1615's `_beginChatRecoveryIncident` progress logic cannot reach.
    */
+  _supersededThrows = 0;
+
   override async _chatRecoveryContinue(
     ...args: Parameters<AIChatAgent<Env>["_chatRecoveryContinue"]>
   ): Promise<void> {
     if (this._simulateSupersededIsolate) {
+      this._supersededThrows += 1;
       throw new Error("Durable Object reset because its code was updated.");
     }
     return super._chatRecoveryContinue(...args);
@@ -1539,6 +1542,10 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 
   setSimulateSupersededIsolateForTest(value: boolean): void {
     this._simulateSupersededIsolate = value;
+  }
+
+  getSupersededThrowsForTest(): number {
+    return this._supersededThrows;
   }
 
   override async onChatRecovery(
@@ -1778,9 +1785,18 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     return rows[0]?.count ?? 0;
   }
 
-  /** Run the real DO alarm handler (schedule dispatch + one-shot row delete). */
+  /**
+   * Run the real DO alarm handler (schedule dispatch + one-shot row delete).
+   * Swallows a thrown alarm the way the platform does — workerd absorbs a
+   * rejected alarm and retries it later under the at-least-once guarantee — so
+   * tests can inspect the post-alarm state.
+   */
   async runAlarmForTest(): Promise<void> {
-    await (this as unknown as { alarm(): Promise<void> }).alarm();
+    try {
+      await (this as unknown as { alarm(): Promise<void> }).alarm();
+    } catch {
+      // Platform absorbs and retries; intentionally swallowed for inspection.
+    }
   }
 
   async waitForIdleForTest(): Promise<void> {


### PR DESCRIPTION
## Summary

Follow-up to #1615. There are **two distinct deploy-churn abandonment paths** for durable chat recovery, at two layers. #1615 closed the first (the progress-blind attempt budget in `_beginChatRecoveryIncident`). This PR closes the second, which lives one layer down in the `agents` base class and #1615 cannot reach.

When the scheduled recovery continuation alarm fires on an isolate a deploy has **just superseded**, the first `ctx.storage` op throws the *catchable* `Durable Object reset because its code was updated.` for the entire invocation (code never reloads mid-invocation). `Agent._executeScheduleCallback` then:

1. burns its whole in-process `tryN` retry budget — every attempt is doomed for the same reason; then
2. **swallows** the error and returns normally, so `alarm()` marks the one-shot row executed and **deletes it**.

The orphaned `cf_agents_runs` fiber row was already deleted the moment recovery was "handled" (it scheduled the continuation), so the turn rode **solely** on that one-shot schedule row. Deleting it leaves nothing for the boot-time fiber scan to re-detect — `_beginChatRecoveryIncident` (and #1615's progress logic) never runs again, and the turn is **permanently abandoned**, even though the next fresh invocation would succeed. A customer observed this firing ~35× over ~19 mid-turn redeploys.

## The fix

In `Agent._executeScheduleCallback`, for a **one-shot** row (`delayed`/`scheduled`) failing with the code-update reset transient:

- skip the doomed in-process retries (`shouldRetry`), and
- **re-throw** instead of swallowing, so `alarm()` rejects → the one-shot row is **not** deleted → Cloudflare re-runs the alarm on a **fresh isolate (= new code)** under the at-least-once alarm guarantee. The interrupted turn auto-resumes once the deploy storm settles, with no new user message.

Every other callback and error class keeps the existing swallow-and-exhaust behavior. Interval/cron schedules are untouched (they are not deleted on execution, so the bug does not apply).

The detector is a message match (`/reset because its code was updated/i`) — the only signal workerd surfaces for this reset class.

## Why this is real (not a contrived test)

The reproduction drives the **real** dispatch path — `alarm()` → `_executeScheduleCallback` → `tryN` → swallow → one-shot `DELETE` — in the Workers runtime. The only injected element is the production-observed reset error itself, thrown from `_chatRecoveryContinue` via a test-only flag (the handler can't distinguish where the reset is thrown). The test setup confirms the structural precondition live: after recovery is handled, the fiber row is gone and the turn rides solely on the schedule row.

Verified both directions:
- **Without the fix:** `expected 0 to be greater than or equal to 1` — both recovery vehicles destroyed (permanent abandonment).
- **With the fix:** green — the one-shot row survives for a fresh-code re-run.

(First commit adds the red reproduction; second commit is the fix that turns it green.)

## Trade-off worth a look in review

Re-throwing propagates out of `alarm()`, so that one alarm tick's remaining work (other due schedules, fiber housekeeping, `_scheduleNextAlarm`) is skipped. This is safe because the platform's at-least-once alarm retry re-runs the tick, and the keepAlive heartbeat re-arms `_scheduleNextAlarm` as a backstop — but it is a behavioral nuance in the core alarm path.

## Test plan

- [x] `npx nx run-many -t test --projects=agents` — 1662 pass
- [x] `npm run test -w @cloudflare/ai-chat` — 544 pass (incl. new reproduction)
- [x] `npm run test -w @cloudflare/think` — 431 pass
- [x] `npm run test:e2e -w @cloudflare/think` — 9 pass
- [x] `npm run test:e2e -w @cloudflare/ai-chat` — 2 pass
- [x] Confirmed the reproduction fails without the fix and passes with it
- [ ] CI green

## Related

- #1615 — companion fix (progress-aware recovery budget); this PR is the second, lower-layer half.

Made with [Cursor](https://cursor.com)