### PR TITLE
Fix silent/frozen interrupted turns: replay terminal status on reconnect

### DIFF
--- a/.changeset/recovery-terminal-status-hydration.md
+++ b/.changeset/recovery-terminal-status-hydration.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/think": patch
+---
+
+Interrupted/failed chat turns are no longer silently "frozen" for clients that
+reconnect after the failure. The terminal `MSG_CHAT_RESPONSE` broadcast (on a
+turn error or exhausted recovery) is transient — a client disconnected at that
+moment (e.g. during a deploy / WebSocket reconnect storm) misses it, and on
+reconnect `onConnect` previously replayed only the current messages with no
+terminal signal, so the turn appeared stuck with no completed response and no
+error. Think now persists a durable record of the last terminal turn and
+replays it on connect, so a reconnecting client learns the turn failed. The
+record is cleared when a later turn completes; benign recovery skips (e.g.
+`conversation_changed`, where a newer turn owns the UI) are intentionally not
+surfaced.

--- a/examples/deploy-churn/src/server.ts
+++ b/examples/deploy-churn/src/server.ts
@@ -240,6 +240,39 @@ function createSlowMockModel(seconds: number): LanguageModel {
   } as LanguageModel;
 }
 
+/**
+ * Streams a couple chunks then errors mid-stream — used to produce a terminal
+ * *error* turn on demand (send a message containing "fail") so the silent /
+ * frozen-after-reconnect behavior (Issue 4) can be observed in a browser.
+ */
+function createFailingModel(): LanguageModel {
+  return {
+    specificationVersion: "v3",
+    provider: "deploy-churn",
+    modelId: "mock-failing",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented");
+    },
+    doStream() {
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({ type: "text-start", id: "t" });
+          controller.enqueue({
+            type: "text-delta",
+            id: "t",
+            delta: "Working on it"
+          });
+          await new Promise((r) => setTimeout(r, 600));
+          controller.error(new Error("Simulated model failure (harness)"));
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
 export class DeployChurnAgent extends Think<Env> {
   // Wake quickly after eviction so alarm-driven recovery is observable.
   static options = { keepAliveIntervalMs: 5_000 };
@@ -279,6 +312,7 @@ export class DeployChurnAgent extends Think<Env> {
           .map((p) => p.text)
           .join(" ")
       : "";
+    if (/\bfail\b/i.test(text)) return createFailingModel();
     return createSlowMockModel(parseDurationSeconds(text));
   }
 

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3360,6 +3360,38 @@ export class ThinkRecoveryTestAgent extends Think {
     return this._lastPromptRole;
   }
 
+  /** Drive the internal terminal-status hook (what `_streamResult` calls). */
+  async fireResponseHookForTest(result: {
+    requestId: string;
+    status: "completed" | "error" | "aborted";
+    error?: string;
+  }): Promise<void> {
+    const self = this as unknown as {
+      _fireResponseHook(r: unknown): Promise<void>;
+    };
+    await self._fireResponseHook({
+      message: {
+        id: `m-${result.requestId}`,
+        role: "assistant",
+        parts: [{ type: "text", text: "" }]
+      },
+      requestId: result.requestId,
+      continuation: false,
+      status: result.status,
+      ...(result.error !== undefined ? { error: result.error } : {})
+    });
+  }
+
+  /** What `onConnect` replays to a reconnecting client (no active stream). */
+  async getIdleConnectMessagesForTest(): Promise<
+    Array<Record<string, unknown>>
+  > {
+    const self = this as unknown as {
+      _buildIdleConnectMessages(): Promise<Array<Record<string, unknown>>>;
+    };
+    return self._buildIdleConnectMessages();
+  }
+
   async setRecoveryShouldThrowForTest(shouldThrow: boolean): Promise<void> {
     this._recoveryShouldThrow = shouldThrow;
   }

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2068,6 +2068,40 @@ describe("Think — onChatRecovery", () => {
     expect(result.status).toBe("completed");
   });
 
+  it("replays a terminal error to a reconnecting client (hydration)", async () => {
+    const agent = await freshRecoveryAgent("terminal-hydration");
+
+    // A turn that errored. The live error broadcast is transient — a client
+    // disconnected at that moment (e.g. during a WS reconnect storm) misses it.
+    await agent.fireResponseHookForTest({
+      requestId: "r-fail",
+      status: "error",
+      error: "boom"
+    });
+
+    // On (re)connect, the client must learn the turn failed instead of seeing
+    // only the current messages with no terminal signal (frozen UI).
+    const onConnect = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      type: string;
+      id?: string;
+      error?: boolean;
+      done?: boolean;
+    }>;
+    const terminal = onConnect.find((m) => m.error === true && m.done === true);
+    expect(terminal).toBeTruthy();
+    expect(terminal?.id).toBe("r-fail");
+
+    // A subsequent completed turn resolves it — no stale error replayed.
+    await agent.fireResponseHookForTest({
+      requestId: "r-ok",
+      status: "completed"
+    });
+    const afterOk = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      error?: boolean;
+    }>;
+    expect(afterOk.some((m) => m.error === true)).toBe(false);
+  });
+
   it("resets the attempt budget when recovery makes forward progress", async () => {
     const agent = await freshRecoveryAgent("recovery-progress-reset");
     await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -643,6 +643,12 @@ function ensureValidContinueCheckpoint(
   return [...messages, { role: "user", content: CONTINUE_CHECKPOINT_PROMPT }];
 }
 
+// Durable record of the last turn that ended in a terminal error / abandoned
+// recovery. Replayed to clients on connect so a turn that failed while they
+// were disconnected (e.g. during a deploy/WS reconnect storm) is not silently
+// frozen — the terminal `MSG_CHAT_RESPONSE` broadcast is otherwise transient.
+const CHAT_LAST_TERMINAL_KEY = "cf:chat:last-terminal";
+
 /**
  * Callback interface for streaming chat events from a Think sub-agent.
  *
@@ -5353,12 +5359,9 @@ export class Think<
         // until the stream finishes.
         this._notifyStreamResuming(connection);
       } else {
-        connection.send(
-          JSON.stringify({
-            type: MSG_CHAT_MESSAGES,
-            messages: this.messages
-          })
-        );
+        for (const message of await this._buildIdleConnectMessages()) {
+          connection.send(JSON.stringify(message));
+        }
       }
       return _onConnect(connection, ctx);
     };
@@ -6682,6 +6685,11 @@ export class Think<
       incident.requestId,
       config.terminalMessage
     );
+    await this._recordTerminalChatStatus(
+      "interrupted",
+      incident.requestId,
+      config.terminalMessage
+    );
     this._broadcastChat({
       type: MSG_CHAT_RESPONSE,
       id: incident.requestId,
@@ -7490,6 +7498,13 @@ export class Think<
   // ── Response hook ──────────────────────────────────────────────
 
   private async _fireResponseHook(result: ChatResponseResult): Promise<void> {
+    // Record the terminal status durably so a client connecting after the turn
+    // ended still learns its outcome (see `_buildIdleConnectMessages`).
+    await this._recordTerminalChatStatus(
+      result.status,
+      result.requestId,
+      result.error ?? "The assistant was interrupted."
+    );
     if (this._insideResponseHook) return;
     this._insideResponseHook = true;
     try {
@@ -7499,6 +7514,61 @@ export class Think<
     } finally {
       this._insideResponseHook = false;
     }
+  }
+
+  /**
+   * Persist (on `error`) or clear (on `completed`/`aborted`) a durable record of
+   * the last terminal turn so it can be replayed to clients on connect. A
+   * `completed`/`aborted` turn is conveyed by the persisted messages, so the
+   * record is cleared; an `error`/`interrupted` turn has no durable trace
+   * otherwise, so it is kept until a later turn resolves.
+   */
+  private async _recordTerminalChatStatus(
+    status: ChatResponseResult["status"] | "interrupted",
+    requestId: string,
+    body: string
+  ): Promise<void> {
+    if (status === "error" || status === "interrupted") {
+      await this.ctx.storage.put(CHAT_LAST_TERMINAL_KEY, { requestId, body });
+    } else {
+      await this.ctx.storage.delete(CHAT_LAST_TERMINAL_KEY);
+    }
+  }
+
+  private async _pendingTerminalChatResponse(): Promise<{
+    requestId: string;
+    body: string;
+  } | null> {
+    return (
+      (await this.ctx.storage.get<{ requestId: string; body: string }>(
+        CHAT_LAST_TERMINAL_KEY
+      )) ?? null
+    );
+  }
+
+  /**
+   * Messages sent to a client on connect when no stream is active: the current
+   * transcript, plus a replay of the last terminal error (if any) so a turn
+   * that failed while the client was disconnected is surfaced rather than
+   * silently frozen.
+   */
+  private async _buildIdleConnectMessages(): Promise<
+    Array<Record<string, unknown>>
+  > {
+    const messages: Array<Record<string, unknown>> = [
+      { type: MSG_CHAT_MESSAGES, messages: this.messages }
+    ];
+    const pending = await this._pendingTerminalChatResponse();
+    if (pending) {
+      messages.push({
+        type: MSG_CHAT_RESPONSE,
+        id: pending.requestId,
+        body: pending.body,
+        done: true,
+        error: true
+      });
+    }
+    return messages;
   }
 
   // ── Resume helpers ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

An interrupted/failed chat turn could leave the client "frozen" — no completed
response and no error — after a WebSocket reconnect. The terminal
`MSG_CHAT_RESPONSE { error: true }` broadcast (on a turn error or exhausted
recovery) is **transient**: a client disconnected at that moment (e.g. during a
deploy / reconnect storm) misses it, and on reconnect `onConnect` replayed only
the current messages with no terminal signal.

So the bug was not a *missing* broadcast — it was a **hydration gap**: terminal
status was never replayed to a reconnecting client.

## Fix

Think now persists a durable record of the last terminal turn and replays it on
connect:

- `_recordTerminalChatStatus(status, requestId, body)` — on `error` (from
  `_fireResponseHook`) or exhausted recovery (`_exhaustChatRecovery`), persist
  `{ requestId, body }` under `cf:chat:last-terminal`; on `completed`/`aborted`,
  clear it (the persisted messages convey the outcome).
- `_buildIdleConnectMessages()` — on connect with no active stream, send the
  current messages **plus** a replay of the last terminal error (if any) as a
  terminal `MSG_CHAT_RESPONSE { done: true, error: true }`.

Benign recovery skips (e.g. `conversation_changed`, where a newer turn owns the
UI) are intentionally **not** recorded, so they don't false-banner. The terminal
message type is unchanged, so existing clients handle it as before.

This is the **A + C** half of the silent-interrupted issue (surface terminal
failures; keep benign skips silent). The **B** half — a live "recovering…"
progress indicator — is a separate client-facing feature tracked in its own
issue (it needs a new chat-protocol signal + `useAgentChat`/SPA rendering).

## Test

`think-session.test.ts` → "replays a terminal error to a reconnecting client
(hydration)": a failed turn is surfaced in the connect payload (`error: true`,
matching requestId); a later completed turn clears it.

`examples/deploy-churn` gains a `fail`-triggered failing model so the
frozen-on-reconnect behavior can be confirmed manually in a browser
(`npm start`, send a message containing "fail", reload).

## Test plan

- [x] `npm run check` (sherif + exports + oxfmt + oxlint + typecheck — 91 projects)
- [x] `npm run test -w @cloudflare/think` — 432 pass (incl. new test)
- [x] `npm run test:e2e -w @cloudflare/think` — 9 pass (exercises connect/recovery)
- [ ] CI green

## Related

Part of the deploy-churn recovery hardening: #1615, #1617, and #1618
(continuation assistant-prefill). Companion follow-up: the "recovering…"
progress indicator (B), filed separately.

Made with [Cursor](https://cursor.com)