### PR TITLE
Persist settled tool results durably so recovery never re-runs completed tool calls

### DIFF
--- a/.changeset/persist-settled-tool-results.md
+++ b/.changeset/persist-settled-tool-results.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/think": patch
+---
+
+Settled tool results are now flushed to durable storage immediately during a
+chat turn, so recovery never re-runs an already-completed (often non-idempotent)
+tool call. Stream chunks are batched in memory and flushed to SQLite every ~10
+chunks; the WebSocket chat path did not force a flush on settled tool results,
+so an isolate eviction (deploy) before the next batch flush lost them. Recovery
+then rebuilt the partial assistant message without those tool calls and the
+model re-ran them (e.g. duplicate INSERTs). The sub-agent RPC streaming path
+already flushed recoverable content; this brings the WebSocket path to parity
+via a shared `_storeChunkDurably` helper that flushes immediately on
+`tool-output-available` / `tool-output-error`. Net effect: recovery loses at
+most the single in-flight step, even when multiple evictions hit one turn.

--- a/.changeset/persist-settled-tool-results.md
+++ b/.changeset/persist-settled-tool-results.md
@@ -13,3 +13,11 @@ already flushed recoverable content; this brings the WebSocket path to parity
 via a shared `_storeChunkDurably` helper that flushes immediately on
 `tool-output-available` / `tool-output-error`. Net effect: recovery loses at
 most the single in-flight step, even when multiple evictions hit one turn.
+
+Also closes two remaining "frozen turn" hydration gaps from the terminal-status
+work: a turn that fails before the stream starts (e.g. a message reconciliation
+error in `_handleChatRequest`) now records its terminal status, and a recovery
+skip caused by `onChatRecovery` returning `{ continue: false }` now surfaces a
+terminal error too. Both were previously broadcast (or silent) but not persisted,
+so a client disconnected at that moment stayed frozen on reconnect. Benign skips
+such as `conversation_changed` (a newer turn already owns the UI) remain silent.

--- a/packages/agents/src/e2e-tests/fiber-eviction.test.ts
+++ b/packages/agents/src/e2e-tests/fiber-eviction.test.ts
@@ -14,9 +14,16 @@
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { setDefaultAutoSelectFamily } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import fs from "node:fs";
+
+// Disable happy-eyeballs dual-stack racing. When a probe `fetch`/WebSocket
+// connects to a server that is mid-SIGKILL/restart, the abandoned racing socket
+// can throw a connect-time `setTypeOfService` EINVAL that surfaces as an
+// unhandled error and fails an otherwise-green chaos run.
+setDefaultAutoSelectFamily(false);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 18799;

--- a/packages/agents/src/e2e-tests/vitest.config.ts
+++ b/packages/agents/src/e2e-tests/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
     name: "e2e",
     include: [path.join(testsDir, "**/*.test.ts")],
     testTimeout: 120_000,
-    hookTimeout: 60_000
+    hookTimeout: 60_000,
+    // Spawns `wrangler dev`; give the pool room to terminate the worker after
+    // workerd + sockets drain so a slow teardown doesn't fail a green run.
+    teardownTimeout: 60_000,
+    fileParallelism: false
   }
 });

--- a/packages/ai-chat/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/ai-chat/src/e2e-tests/chat-recovery.test.ts
@@ -9,13 +9,24 @@
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { setDefaultAutoSelectFamily } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import fs from "node:fs";
 
+// Disable happy-eyeballs dual-stack racing. When a probe `fetch`/WebSocket
+// connects to a server that is mid-SIGKILL/restart, the abandoned racing socket
+// can throw a connect-time `setTypeOfService` EINVAL that surfaces as an
+// unhandled error and fails an otherwise-green chaos run.
+setDefaultAutoSelectFamily(false);
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 18798;
-const AGENT_URL = `http://localhost:${PORT}`;
+// Use a literal IPv4 address rather than `localhost`: resolving `localhost`
+// triggers happy-eyeballs dual-stack racing, which intermittently throws a
+// connect-time `setTypeOfService` EINVAL on the abandoned socket while probing
+// a server that is mid-SIGKILL/restart.
+const AGENT_URL = `http://127.0.0.1:${PORT}`;
 const AGENT_NAME = "chat-recovery-e2e";
 const PERSIST_DIR = path.join(__dirname, ".wrangler-chat-e2e-state");
 
@@ -89,10 +100,13 @@ function startWrangler(): ChildProcess {
   return child;
 }
 
-async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
+async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const res = await fetch(`${AGENT_URL}/`);
+      // Drain the body so the connection is released rather than left open,
+      // which would leak sockets across the kill/restart churn.
+      await res.body?.cancel();
       if (res.status > 0) return;
     } catch {
       // Not ready
@@ -105,7 +119,8 @@ async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
 async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
-      await fetch(`${AGENT_URL}/`);
+      const res = await fetch(`${AGENT_URL}/`);
+      await res.body?.cancel();
     } catch {
       return;
     }

--- a/packages/ai-chat/src/e2e-tests/vitest.config.ts
+++ b/packages/ai-chat/src/e2e-tests/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
     name: "ai-chat-e2e",
     include: [path.join(testsDir, "**/*.test.ts")],
     testTimeout: 120_000,
-    hookTimeout: 60_000
+    hookTimeout: 60_000,
+    // Spawns `wrangler dev`; give the pool room to terminate the worker after
+    // workerd + sockets drain so a slow teardown doesn't fail a green run.
+    teardownTimeout: 60_000,
+    fileParallelism: false
   }
 });

--- a/packages/think/src/e2e-tests/assistant-e2e.test.ts
+++ b/packages/think/src/e2e-tests/assistant-e2e.test.ts
@@ -7,9 +7,16 @@
  */
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { setDefaultAutoSelectFamily } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import fs from "node:fs";
+
+// Disable happy-eyeballs dual-stack racing. When a probe `fetch`/WebSocket
+// connects to a server that is mid-SIGKILL/restart, the abandoned racing socket
+// can throw a connect-time `setTypeOfService` EINVAL that surfaces as an
+// unhandled error and fails an otherwise-green chaos run.
+setDefaultAutoSelectFamily(false);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 18798;

--- a/packages/think/src/e2e-tests/assistant-e2e.test.ts
+++ b/packages/think/src/e2e-tests/assistant-e2e.test.ts
@@ -106,7 +106,7 @@ function startWrangler(): ChildProcess {
   return child;
 }
 
-async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
+async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const res = await fetch(`${BASE_URL}/`);
@@ -126,9 +126,15 @@ function killProcess(child: ChildProcess): Promise<void> {
       resolve();
       return;
     }
-    child.on("exit", () => resolve());
+    // Clear the fallback timer once the child exits — an uncleared timer keeps
+    // the vitest worker's event loop alive and can push teardown past the pool's
+    // termination window ("Timeout terminating forks worker").
+    const fallback = setTimeout(resolve, 3000);
+    child.on("exit", () => {
+      clearTimeout(fallback);
+      resolve();
+    });
     killProcessTree(child.pid);
-    setTimeout(resolve, 3000);
   });
 }
 

--- a/packages/think/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/think/src/e2e-tests/chat-recovery.test.ts
@@ -9,9 +9,16 @@
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { setDefaultAutoSelectFamily } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import fs from "node:fs";
+
+// Disable happy-eyeballs dual-stack racing. When a probe `fetch`/WebSocket
+// connects to a server that is mid-SIGKILL/restart, the abandoned racing socket
+// can throw a connect-time `setTypeOfService` EINVAL that surfaces as an
+// unhandled error and fails an otherwise-green chaos run.
+setDefaultAutoSelectFamily(false);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 18797;

--- a/packages/think/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/think/src/e2e-tests/chat-recovery.test.ts
@@ -124,7 +124,7 @@ function startWrangler(): ChildProcess {
   return child;
 }
 
-async function waitForReady(maxAttempts = 30, delayMs = 1000): Promise<void> {
+async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const res = await fetch(`${AGENT_URL}/`);

--- a/packages/think/src/e2e-tests/vitest.config.ts
+++ b/packages/think/src/e2e-tests/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     // Run in Node.js — we spawn wrangler as a child process
     testTimeout: 120_000,
     hookTimeout: 60_000,
+    // Each file spawns `wrangler dev`; tearing down workerd + draining keep-alive
+    // sockets can take a while under load. Give the pool room to terminate the
+    // worker cleanly so a slow teardown doesn't fail an otherwise-green run.
+    teardownTimeout: 60_000,
     fileParallelism: false,
     include: ["src/e2e-tests/**/*.test.ts"]
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3321,6 +3321,49 @@ export class ThinkRecoveryTestAgent extends Think {
     ];
   }
 
+  /**
+   * Stream a couple of text chunks (throttled → buffered) then a settled tool
+   * result, and report how many chunks are durably persisted (raw SQLite, no
+   * flush) before vs. after the tool result. Proves a settled tool result is
+   * flushed immediately rather than left in the in-memory buffer.
+   */
+  async probeToolResultDurabilityForTest(): Promise<{
+    bufferedTextCount: number;
+    afterToolOutputCount: number;
+  }> {
+    const self = this as unknown as {
+      _resumableStream: { start(id: string): string };
+      _storeChunkDurably(
+        streamId: string,
+        chunk: unknown,
+        chunkBody: string,
+        state: { chunksSinceFlush: number; hasFlushedContent: boolean }
+      ): void;
+    };
+    const streamId = self._resumableStream.start("req-tool-durability");
+    const state = { chunksSinceFlush: 0, hasFlushedContent: false };
+    const store = (chunk: Record<string, unknown>): void =>
+      self._storeChunkDurably(streamId, chunk, JSON.stringify(chunk), state);
+    const rawCount = (): number => {
+      const rows = this.sql<{ count: number }>`
+        SELECT COUNT(*) as count FROM cf_ai_chat_stream_chunks
+        WHERE stream_id = ${streamId}
+      `;
+      return rows[0]?.count ?? 0;
+    };
+
+    store({ type: "text-delta", id: "t", delta: "hello " });
+    store({ type: "text-delta", id: "t", delta: "there" });
+    const bufferedTextCount = rawCount();
+    store({
+      type: "tool-output-available",
+      toolCallId: "tc1",
+      output: { ok: true }
+    });
+    const afterToolOutputCount = rawCount();
+    return { bufferedTextCount, afterToolOutputCount };
+  }
+
   /** Seed a session that ends in a PARTIAL assistant message (the state a
    * deploy-interrupted turn leaves behind, which `continueLastTurn` replays). */
   async seedPartialAssistantTurnForTest(): Promise<void> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3186,6 +3186,7 @@ export class ThinkRecoveryTestAgent extends Think {
   private _stashResult: { success: boolean; error?: string } | null = null;
   private _rejectPrefill = false;
   private _lastPromptRole: string | undefined;
+  private _throwBeforeTurnMessage: string | null = null;
 
   override getModel(): LanguageModel {
     if (this._rejectPrefill) {
@@ -3199,6 +3200,12 @@ export class ThinkRecoveryTestAgent extends Think {
   }
 
   override beforeTurn(ctx: TurnContext): void {
+    // Simulate a pre-stream failure (e.g. message reconciliation) that throws
+    // before any stream is produced, so it surfaces in `_handleChatRequest`'s
+    // outer catch rather than the stream-level `_fireResponseHook` path.
+    if (this._throwBeforeTurnMessage) {
+      throw new Error(this._throwBeforeTurnMessage);
+    }
     this._turnCallCount++;
     this._turnBodies.push(ctx.body);
     this._turnClientToolNames.push(Object.keys(ctx.tools));
@@ -3423,6 +3430,42 @@ export class ThinkRecoveryTestAgent extends Think {
       status: result.status,
       ...(result.error !== undefined ? { error: result.error } : {})
     });
+  }
+
+  /**
+   * Drive a real chat request through `_handleChatRequest` that fails before
+   * the stream starts (a `beforeTurn` throw stands in for a message
+   * reconciliation/persist failure). Recovery is disabled so the error reaches
+   * the outer catch instead of being intercepted by the recovery fiber.
+   */
+  async simulatePreStreamChatFailureForTest(input: {
+    requestId: string;
+    userText: string;
+    error: string;
+  }): Promise<void> {
+    this.chatRecovery = false;
+    this._throwBeforeTurnMessage = input.error;
+    const connection = { id: "c-prestream", send() {} };
+    const event = {
+      type: "chat-request" as const,
+      id: input.requestId,
+      init: {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              id: `u-${input.requestId}`,
+              role: "user",
+              parts: [{ type: "text", text: input.userText }]
+            }
+          ]
+        })
+      }
+    };
+    const self = this as unknown as {
+      _handleChatRequest(c: unknown, e: unknown): Promise<void>;
+    };
+    await self._handleChatRequest(connection, event);
   }
 
   /** What `onConnect` replays to a reconnecting client (no active stream). */

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2102,6 +2102,20 @@ describe("Think — onChatRecovery", () => {
     expect(afterOk.some((m) => m.error === true)).toBe(false);
   });
 
+  it("flushes a settled tool result to durable storage immediately", async () => {
+    const agent = await freshRecoveryAgent("tool-result-durability");
+
+    const { bufferedTextCount, afterToolOutputCount } =
+      await agent.probeToolResultDurabilityForTest();
+
+    // Streamed text after the first flush stays buffered in memory (throttled).
+    expect(bufferedTextCount).toBe(1);
+    // A settled tool result forces an immediate flush, so it (and the buffered
+    // text) are durable before the stream completes — surviving an eviction
+    // that would otherwise lose the result and re-run the (non-idempotent) tool.
+    expect(afterToolOutputCount).toBeGreaterThan(bufferedTextCount);
+  });
+
   it("resets the attempt budget when recovery makes forward progress", async () => {
     const agent = await freshRecoveryAgent("recovery-progress-reset");
     await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2116,6 +2116,30 @@ describe("Think — onChatRecovery", () => {
     expect(afterToolOutputCount).toBeGreaterThan(bufferedTextCount);
   });
 
+  it("replays a pre-stream error to a reconnecting client (hydration)", async () => {
+    const agent = await freshRecoveryAgent("pre-stream-hydration");
+
+    // A turn that fails before streaming starts (e.g. message reconciliation).
+    // The error broadcast is transient — a client disconnected at that moment
+    // misses it, so it must be persisted for replay on reconnect.
+    await agent.simulatePreStreamChatFailureForTest({
+      requestId: "r-prestream",
+      userText: "hello",
+      error: "pre-stream boom"
+    });
+
+    const onConnect = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      id?: string;
+      body?: string;
+      error?: boolean;
+      done?: boolean;
+    }>;
+    const terminal = onConnect.find((m) => m.error === true && m.done === true);
+    expect(terminal).toBeTruthy();
+    expect(terminal?.id).toBe("r-prestream");
+    expect(terminal?.body).toContain("pre-stream boom");
+  });
+
   it("resets the attempt budget when recovery makes forward progress", async () => {
     const agent = await freshRecoveryAgent("recovery-progress-reset");
     await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });
@@ -2533,6 +2557,39 @@ describe("Think — onChatRecovery", () => {
     await agent.triggerFiberRecovery();
 
     expect(await agent.getTurnCallCount()).toBe(0);
+  });
+
+  it("{ continue: false } surfaces a terminal error on reconnect", async () => {
+    const agent = await freshRecoveryAgent("no-continue-terminal");
+
+    await agent.setRecoveryOverride({ continue: false });
+
+    await agent.insertInterruptedStream("stream-nct", "req-nct", [
+      {
+        body: JSON.stringify({ type: "start", messageId: "a-nct" }),
+        index: 0
+      },
+      { body: JSON.stringify({ type: "text-start" }), index: 1 },
+      {
+        body: JSON.stringify({ type: "text-delta", delta: "Partial" }),
+        index: 2
+      }
+    ]);
+    await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-nct");
+
+    await agent.triggerFiberRecovery();
+
+    // Disabling recovery abandons the turn with no superseding turn, so a
+    // reconnecting client must see a terminal error rather than a frozen,
+    // half-streamed turn (unlike a benign `conversation_changed` skip).
+    const onConnect = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      body?: string;
+      error?: boolean;
+      done?: boolean;
+    }>;
+    const terminal = onConnect.find((m) => m.error === true && m.done === true);
+    expect(terminal).toBeTruthy();
+    expect(terminal?.body).toContain("chat recovery was disabled");
   });
 
   it("does not continue a recovered chat fiber whose stream already completed", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -5926,8 +5926,7 @@ export class Think<
 
     try {
       this._insideInferenceLoop = true;
-      let chunksSinceFlush = 0;
-      let hasFlushedContent = false;
+      const flushState = { chunksSinceFlush: 0, hasFlushedContent: false };
       try {
         for await (const chunk of result.toUIMessageStream()) {
           if (abortSignal?.aborted) {
@@ -5955,19 +5954,7 @@ export class Think<
           }
 
           const chunkBody = JSON.stringify(chunk);
-          this._resumableStream.storeChunk(streamId, chunkBody);
-          chunksSinceFlush++;
-          if (
-            this._shouldFlushRpcStreamChunk(
-              streamChunk,
-              chunksSinceFlush,
-              hasFlushedContent
-            )
-          ) {
-            this._resumableStream.flushBuffer();
-            chunksSinceFlush = 0;
-            hasFlushedContent = true;
-          }
+          this._storeChunkDurably(streamId, streamChunk, chunkBody, flushState);
           this._broadcastChat({
             type: MSG_CHAT_RESPONSE,
             id: requestId,
@@ -6081,21 +6068,62 @@ export class Think<
     }
   }
 
-  private _shouldFlushRpcStreamChunk(
+  /**
+   * Whether storing this chunk should immediately flush the resumable-stream
+   * buffer to SQLite.
+   *
+   * A settled tool result (`tool-output-available` / `tool-output-error`)
+   * captures a completed, often non-idempotent side effect, so it is flushed
+   * **immediately** — an isolate eviction (deploy) before the next batch flush
+   * would otherwise lose it, and recovery would re-anchor without it and re-run
+   * the already-completed tool call. Frequent recoverable content (text /
+   * reasoning / tool-input streaming) is throttled to avoid write amplification.
+   */
+  private _shouldFlushRecoverableChunk(
     chunk: StreamChunkData,
     chunksSinceFlush: number,
     hasFlushedContent: boolean
   ): boolean {
-    const isRecoverableContent =
+    if (
+      chunk.type === "tool-output-available" ||
+      chunk.type === "tool-output-error"
+    ) {
+      return true;
+    }
+    const isThrottledRecoverable =
       chunk.type === "text-delta" ||
       chunk.type === "reasoning-delta" ||
-      chunk.type === "tool-input-available" ||
-      chunk.type === "tool-output-available" ||
-      chunk.type === "tool-output-error";
-
+      chunk.type === "tool-input-available";
     return (
-      isRecoverableContent && (!hasFlushedContent || chunksSinceFlush >= 10)
+      isThrottledRecoverable && (!hasFlushedContent || chunksSinceFlush >= 10)
     );
+  }
+
+  /**
+   * Store a stream chunk, flushing settled tool results durably and promptly.
+   * Shared by the WebSocket and sub-agent RPC streaming paths so both get
+   * tool-call-level recovery durability (recovery loses at most the in-flight
+   * step, never an already-completed tool call).
+   */
+  private _storeChunkDurably(
+    streamId: string,
+    chunk: StreamChunkData,
+    chunkBody: string,
+    state: { chunksSinceFlush: number; hasFlushedContent: boolean }
+  ): void {
+    this._resumableStream.storeChunk(streamId, chunkBody);
+    state.chunksSinceFlush++;
+    if (
+      this._shouldFlushRecoverableChunk(
+        chunk,
+        state.chunksSinceFlush,
+        state.hasFlushedContent
+      )
+    ) {
+      this._resumableStream.flushBuffer();
+      state.chunksSinceFlush = 0;
+      state.hasFlushedContent = true;
+    }
   }
 
   private async _streamResult(
@@ -6129,6 +6157,7 @@ export class Think<
     let streamAborted = false;
     let streamError: string | undefined;
     let output: unknown;
+    const flushState = { chunksSinceFlush: 0, hasFlushedContent: false };
 
     try {
       this._insideInferenceLoop = true;
@@ -6139,9 +6168,8 @@ export class Think<
             break;
           }
 
-          const { action } = accumulator.applyChunk(
-            chunk as unknown as StreamChunkData
-          );
+          const streamChunk = chunk as unknown as StreamChunkData;
+          const { action } = accumulator.applyChunk(streamChunk);
 
           if (action?.type === "error") {
             streamError = action.error;
@@ -6160,7 +6188,7 @@ export class Think<
           }
 
           const chunkBody = JSON.stringify(chunk);
-          this._resumableStream.storeChunk(streamId, chunkBody);
+          this._storeChunkDurably(streamId, streamChunk, chunkBody, flushState);
           this._broadcastChat({
             type: MSG_CHAT_RESPONSE,
             id: requestId,

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -5797,6 +5797,11 @@ export class Think<
         messagesPersisted,
         error: errorMessage
       });
+      // Persist the terminal error before broadcasting it: the broadcast is
+      // transient, so a client disconnected at this moment (a pre-stream
+      // failure like message reconciliation) would otherwise never learn the
+      // turn failed and stay frozen on reconnect (see `_buildIdleConnectMessages`).
+      await this._recordTerminalChatStatus("error", requestId, errorMessage);
       this._broadcastChat({
         type: MSG_CHAT_RESPONSE,
         id: requestId,
@@ -6934,10 +6939,27 @@ export class Think<
           "skipped",
           "continue_disabled"
         );
+        const disabledMessage =
+          "Submission was interrupted and chat recovery was disabled.";
         await this._markRecoveredSubmissionInterrupted(
           requestId,
-          "Submission was interrupted and chat recovery was disabled."
+          disabledMessage
         );
+        // Unlike `conversation_changed` (a newer turn owns the UI, so silence
+        // is correct), disabling recovery abandons the turn with no superseding
+        // turn. Surface it like exhaustion so a reconnecting client isn't frozen.
+        await this._recordTerminalChatStatus(
+          "interrupted",
+          requestId,
+          disabledMessage
+        );
+        this._broadcastChat({
+          type: MSG_CHAT_RESPONSE,
+          id: requestId,
+          body: disabledMessage,
+          done: true,
+          error: true
+        });
       } else {
         await this._updateChatRecoveryIncident(
           incident.incidentId,


### PR DESCRIPTION
## Summary

Under deploy churn, recovery could re-run **already-completed tool calls** (the customer observed byte-identical duplicate, non-idempotent INSERTs — a whole message's tool calls rolling back, not just the interrupted step).

Root cause: resumable-stream chunks are buffered in memory and batch-flushed to SQLite every ~10 chunks (`CHUNK_BUFFER_SIZE`). The main **WebSocket** `_streamResult` (used by chat turns and `continueLastTurn` recoveries) did **not** force a flush on settled tool results, so an isolate eviction before the next batch flush lost them. On recovery, `_persistOrphanedStream` rebuilds the partial assistant message from SQLite — without those settled tool calls — so the continuation re-anchors without them and the model re-runs the completed tool call.

The **sub-agent RPC** streaming path (`_streamResultToRpcCallback`) already flushed recoverable content on settle (the tool-call-level durability referenced by #1615/#1617). This PR brings the WebSocket path to parity.

## Fix

A shared `_storeChunkDurably` helper (used by both the WebSocket and RPC stream loops) stores each chunk and flushes the buffer **immediately** on a settled tool result (`tool-output-available` / `tool-output-error`). Frequent recoverable content (text / reasoning / tool-input streaming) stays throttled (first chunk + every ~10) to avoid write amplification. `_shouldFlushRpcStreamChunk` is generalized to `_shouldFlushRecoverableChunk`.

Net effect: a settled tool result is durable the moment it settles, so `_persistOrphanedStream` always reconstructs every completed tool call, and **recovery loses at most the single in-flight step** — even when multiple evictions hit one turn.

## Also: two terminal-status hydration gaps (#1619 follow-up)

Review of #1619 surfaced two remaining "frozen turn" cases where a terminal outcome was broadcast (or silent) but never **persisted**, so a client disconnected at that moment stayed frozen on reconnect. Both are folded in here:

- **Pre-stream errors in `_handleChatRequest`.** The outer catch broadcasts `MSG_CHAT_RESPONSE { error, done }` for failures before the stream starts (e.g. message reconciliation/persist), but never called `_recordTerminalChatStatus`. #1619 only hooked the stream-level `_fireResponseHook` and recovery exhaustion. It now records terminal `"error"` before broadcasting, so `_buildIdleConnectMessages` replays it on connect.
- **`continue_disabled` recovery skip.** When `onChatRecovery` returns `{ continue: false }`, the turn was only marked interrupted via `_markRecoveredSubmissionInterrupted` (which updates the programmatic submission row — it does **not** touch the WS transcript), so a WS chat client got no durable terminal signal at all. Unlike a benign `conversation_changed` skip (a newer turn already owns the UI), disabling recovery abandons the turn with no superseding turn, so it now records terminal status and broadcasts an error like exhaustion does. `conversation_changed` / `not_recoverable` skips remain silent.

## Test

`think-session.test.ts`:
- "flushes a settled tool result to durable storage immediately": stream two text deltas (throttled → one stays buffered), then a settled tool result; assert the tool result forces a flush so it is durable in SQLite **before** the stream completes. Verified to fail without the tool-output special-case (`expected 1 to be greater than 1`).
- "replays a pre-stream error to a reconnecting client (hydration)": a `beforeTurn` throw (standing in for a reconciliation failure) drives `_handleChatRequest`'s outer catch; assert the idle-connect replay surfaces the terminal error.
- "{ continue: false } surfaces a terminal error on reconnect": an interrupted turn whose `onChatRecovery` returns `{ continue: false }`; assert the idle-connect replay surfaces the terminal error.

## Test plan

- [x] `npm run test -w @cloudflare/think` — `think-session.test.ts` 130 pass (incl. 3 new regression tests)
- [x] Confirmed the tool-result test fails without the fix and passes with it
- [x] lint + typecheck (`tsc --noEmit -p packages/think/tsconfig.json`)
- [ ] `npm run test:e2e -w @cloudflare/think` — confirmed green by the author locally
- [ ] CI green

## Related

Completes the deploy-churn recovery hardening series: #1615, #1617, #1618, #1619.

Made with [Cursor](https://cursor.com)