### PR TITLE
Fix approved Think tool continuation results reaching clients

### DIFF
--- a/.changeset/fix-think-approval-continuations.md
+++ b/.changeset/fix-think-approval-continuations.md
@@ -1,5 +1,6 @@
 ---
 "@cloudflare/think": patch
+"agents": patch
 ---
 
 Fix server-side `needsApproval` tool continuations remaining stuck after the
@@ -8,3 +9,13 @@ model transcript, updates its live transcript before an immediate continuation,
 and persists and broadcasts terminal tool output emitted for a prior assistant
 message. Continuation response frames are also labelled consistently so
 `useAgentChat` can apply streamed continuation updates to the active UI state.
+A pending `approval-responded` tool is no longer mis-reported by the
+incomplete-tool-call backstop, so approval continuations stop logging a false
+"repair gap" warning and emitting a spurious `chat:transcript:repaired` event.
+
+The cross-message tool result now flows through `StreamAccumulator`'s
+`cross-message-tool-update` action and a shared, replay-safe
+`crossMessageToolResultUpdate` builder (exported from `agents/chat`): it matches
+terminal states for first-write-wins idempotency against provider replays (e.g.
+the OpenAI Responses API, #1404), preserves a streamed `preliminary` flag, and
+lets `Think` skip redundant writes/broadcasts when a result is already settled.

--- a/.changeset/fix-think-approval-continuations.md
+++ b/.changeset/fix-think-approval-continuations.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/think": patch
+---
+
+Fix server-side `needsApproval` tool continuations remaining stuck after the
+user approves them. Think now keeps approved/denied/errored tool parts in the
+model transcript, updates its live transcript before an immediate continuation,
+and persists and broadcasts terminal tool output emitted for a prior assistant
+message. Continuation response frames are also labelled consistently so
+`useAgentChat` can apply streamed continuation updates to the active UI state.

--- a/packages/agents/src/chat/__tests__/tool-state.test.ts
+++ b/packages/agents/src/chat/__tests__/tool-state.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   applyToolUpdate,
   toolResultUpdate,
+  crossMessageToolResultUpdate,
   toolApprovalUpdate
 } from "../tool-state";
 
@@ -49,6 +50,122 @@ describe("toolResultUpdate", () => {
       state: "input-available"
     });
     expect(applied.errorText).toBe("Tool execution denied by user");
+  });
+});
+
+describe("crossMessageToolResultUpdate", () => {
+  it("matches the broad set of pre-terminal and terminal states", () => {
+    const update = crossMessageToolResultUpdate("tc1", "output-available", 1);
+    expect(update.matchStates).toEqual([
+      "input-streaming",
+      "input-available",
+      "approval-requested",
+      "approval-responded",
+      "output-available",
+      "output-error",
+      "output-denied"
+    ]);
+  });
+
+  it("resolves an approved tool part to output-available", () => {
+    const update = crossMessageToolResultUpdate("tc1", "output-available", {
+      enabled: true
+    });
+    const applied = update.apply(makePart("tc1", "approval-responded"));
+    expect(applied.state).toBe("output-available");
+    expect(applied.output).toEqual({ enabled: true });
+    // A final result is marked non-preliminary so settled detection works.
+    expect(applied.preliminary).toBe(false);
+  });
+
+  it("preserves a streamed preliminary flag when present", () => {
+    const update = crossMessageToolResultUpdate(
+      "tc1",
+      "output-available",
+      "partial",
+      undefined,
+      true
+    );
+    const applied = update.apply(makePart("tc1", "approval-responded"));
+    expect(applied.state).toBe("output-available");
+    expect(applied.output).toBe("partial");
+    expect(applied.preliminary).toBe(true);
+  });
+
+  it("resolves to output-error with the provided errorText", () => {
+    const update = crossMessageToolResultUpdate(
+      "tc1",
+      "output-error",
+      undefined,
+      "Trigger update failed"
+    );
+    const applied = update.apply(makePart("tc1", "approval-responded"));
+    expect(applied.state).toBe("output-error");
+    expect(applied.errorText).toBe("Trigger update failed");
+  });
+
+  it("uses a default errorText when none is provided", () => {
+    const update = crossMessageToolResultUpdate("tc1", "output-error");
+    const applied = update.apply(makePart("tc1", "approval-responded"));
+    expect(applied.errorText).toBe("Tool execution failed");
+  });
+
+  it("is first-write-wins: returns the same reference for a settled part", () => {
+    const update = crossMessageToolResultUpdate(
+      "tc1",
+      "output-available",
+      "replayed-output"
+    );
+
+    for (const state of ["output-available", "output-error", "output-denied"]) {
+      const part = makePart("tc1", state, { output: "original" });
+      const applied = update.apply(part);
+      // Same reference signals an idempotent no-op so callers skip the
+      // durable write + broadcast — and the original output is never lost.
+      expect(applied).toBe(part);
+      expect(applied.output).toBe("original");
+    }
+  });
+
+  it("does not overwrite an errored tool on replay", () => {
+    const update = crossMessageToolResultUpdate(
+      "tc1",
+      "output-available",
+      "late-success"
+    );
+    const part = makePart("tc1", "output-error", { errorText: "boom" });
+    const applied = update.apply(part);
+    expect(applied).toBe(part);
+    expect(applied.state).toBe("output-error");
+    expect(applied.errorText).toBe("boom");
+  });
+
+  it("matches a terminal part via applyToolUpdate but yields an unchanged reference", () => {
+    // toolResultUpdate would return null here (terminal not in its match
+    // states); the cross-message builder matches so a replay still resolves
+    // to the part, but apply leaves it untouched.
+    const parts = [makePart("tc1", "output-available", { output: "done" })];
+    const result = applyToolUpdate(
+      parts,
+      crossMessageToolResultUpdate("tc1", "output-available", "done-again")
+    );
+    expect(result).not.toBeNull();
+    expect(result!.parts[result!.index]).toBe(parts[result!.index]);
+  });
+
+  it("transitions a fresh approval-responded part via applyToolUpdate", () => {
+    const parts = [
+      makePart("tc1", "approval-responded", { approval: { approved: true } })
+    ];
+    const result = applyToolUpdate(
+      parts,
+      crossMessageToolResultUpdate("tc1", "output-available", { ok: 1 })
+    );
+    expect(result).not.toBeNull();
+    expect(result!.parts[0]).not.toBe(parts[0]);
+    expect(result!.parts[0]).toEqual(
+      expect.objectContaining({ state: "output-available", output: { ok: 1 } })
+    );
   });
 });
 

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -65,6 +65,7 @@ export { AbortRegistry } from "./abort-registry";
 export {
   applyToolUpdate,
   toolResultUpdate,
+  crossMessageToolResultUpdate,
   toolApprovalUpdate,
   type ToolPartUpdate
 } from "./tool-state";

--- a/packages/agents/src/chat/tool-state.ts
+++ b/packages/agents/src/chat/tool-state.ts
@@ -74,6 +74,75 @@ export function toolResultUpdate(
 }
 
 /**
+ * Build an update descriptor for a terminal tool result that belongs to a
+ * tool part in a *different* (earlier) assistant message than the one
+ * currently being streamed.
+ *
+ * This is the "cross-message" case: an approved server tool executes during a
+ * continuation stream, but its tool part lives in the assistant message that
+ * originally requested it. `StreamAccumulator` surfaces this as a
+ * `cross-message-tool-update` action because the accumulator only owns the
+ * current turn's new content and cannot mutate a part from a prior message.
+ *
+ * Compared to {@link toolResultUpdate} this builder is deliberately more
+ * defensive, mirroring the equivalent fallback in `@cloudflare/ai-chat`:
+ *
+ * - It matches the broad set of pre-terminal **and** terminal states, so a
+ *   provider that replays the entire prior tool round-trip during a
+ *   continuation (notably the OpenAI Responses API — issue #1404) still
+ *   resolves to the same part instead of silently missing it.
+ * - It is **first-write-wins**: a chunk arriving for a tool that already holds
+ *   a terminal result is treated as a replay and the existing output is never
+ *   overwritten. In that case `apply` returns the *same part reference*, which
+ *   callers use as an idempotent-no-op signal to skip the durable write and a
+ *   redundant `MESSAGE_UPDATED` broadcast.
+ * - It preserves a streamed `preliminary` flag when one is present, otherwise
+ *   marks the result final (`preliminary: false`).
+ */
+export function crossMessageToolResultUpdate(
+  toolCallId: string,
+  updateType: "output-available" | "output-error",
+  output?: unknown,
+  errorText?: string,
+  preliminary?: boolean
+): ToolPartUpdate {
+  return {
+    toolCallId,
+    matchStates: [
+      "input-streaming",
+      "input-available",
+      "approval-requested",
+      "approval-responded",
+      "output-available",
+      "output-error",
+      "output-denied"
+    ],
+    apply: (part) => {
+      if (
+        part.state === "output-available" ||
+        part.state === "output-error" ||
+        part.state === "output-denied"
+      ) {
+        return part;
+      }
+      if (updateType === "output-error") {
+        return {
+          ...part,
+          state: "output-error",
+          errorText: errorText ?? "Tool execution failed"
+        };
+      }
+      return {
+        ...part,
+        state: "output-available",
+        output,
+        preliminary: preliminary ?? false
+      };
+    }
+  };
+}
+
+/**
  * Build an update descriptor for applying a tool approval.
  *
  * Matches parts in `input-available` or `approval-requested` state.

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -5,7 +5,9 @@
  * and text on subsequent invocations (after tool results are applied).
  */
 
-import type { LanguageModel, UIMessage } from "ai";
+import type { LanguageModel, ToolSet, UIMessage } from "ai";
+import { tool } from "ai";
+import { z } from "zod";
 import { Think } from "../../think";
 import type { ChatResponseResult, MessageConcurrency } from "../../think";
 import type { ClientToolSchema } from "agents/chat";
@@ -69,6 +71,91 @@ function createClientToolMockModel(): LanguageModel {
             });
           }
 
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
+function createServerApprovalToolMockModel(): LanguageModel {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-server-approval-tool-model",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented");
+    },
+    doStream(options: Record<string, unknown>) {
+      const messages = (options as { prompt?: unknown[] }).prompt ?? [];
+      const hasToolResult = messages.some(
+        (m: unknown) =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).role === "tool"
+      );
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          if (!hasToolResult) {
+            controller.enqueue({
+              type: "tool-input-start",
+              id: "tc-server-approval-1",
+              toolName: "updateTrigger"
+            });
+            controller.enqueue({
+              type: "tool-input-delta",
+              id: "tc-server-approval-1",
+              delta: JSON.stringify({ enabled: true })
+            });
+            controller.enqueue({
+              type: "tool-input-end",
+              id: "tc-server-approval-1"
+            });
+            controller.enqueue({
+              type: "tool-call",
+              toolCallId: "tc-server-approval-1",
+              toolName: "updateTrigger",
+              input: JSON.stringify({ enabled: true })
+            });
+            controller.enqueue({
+              type: "finish",
+              finishReason: { unified: "tool-calls", raw: undefined },
+              usage: {
+                inputTokens: {
+                  total: 10,
+                  noCache: 10,
+                  cacheRead: 0,
+                  cacheWrite: 0
+                },
+                outputTokens: { total: 5, text: 5, reasoning: 0 }
+              }
+            });
+          } else {
+            controller.enqueue({ type: "text-start", id: "t-approved" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t-approved",
+              delta: "Trigger updated"
+            });
+            controller.enqueue({ type: "text-end", id: "t-approved" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: { unified: "stop", raw: undefined },
+              usage: {
+                inputTokens: {
+                  total: 20,
+                  noCache: 20,
+                  cacheRead: 0,
+                  cacheWrite: 0
+                },
+                outputTokens: { total: 10, text: 10, reasoning: 0 }
+              }
+            });
+          }
           controller.close();
         }
       });
@@ -154,6 +241,9 @@ function createTextOnlyMockModel(): LanguageModel {
 export class ThinkClientToolsAgent extends Think {
   private _useTextOnly = false;
   private _useSlowStream = false;
+  private _useServerApprovalTool = false;
+  private _serverApprovalToolExecutions = 0;
+  private _serverApprovalToolFails = false;
   private _slowDelayMs = 40;
   private _slowChunkCount = 4;
   private _responseLog: ChatResponseResult[] = [];
@@ -170,7 +260,26 @@ export class ThinkClientToolsAgent extends Think {
     if (this._useSlowStream)
       return createSlowMockModel(this._slowDelayMs, this._slowChunkCount);
     if (this._useTextOnly) return createTextOnlyMockModel();
+    if (this._useServerApprovalTool) return createServerApprovalToolMockModel();
     return createClientToolMockModel();
+  }
+
+  override getTools(): ToolSet {
+    if (!this._useServerApprovalTool) return {};
+    return {
+      updateTrigger: tool({
+        description: "Enable or disable a trigger",
+        inputSchema: z.object({ enabled: z.boolean() }),
+        needsApproval: true,
+        execute: async ({ enabled }: { enabled: boolean }) => {
+          this._serverApprovalToolExecutions++;
+          if (this._serverApprovalToolFails) {
+            throw new Error("Trigger update failed");
+          }
+          return { enabled };
+        }
+      })
+    };
   }
 
   getSystemPrompt(): string {
@@ -179,6 +288,18 @@ export class ThinkClientToolsAgent extends Think {
 
   async setTextOnlyMode(value: boolean): Promise<void> {
     this._useTextOnly = value;
+  }
+
+  async setServerApprovalToolMode(value: boolean): Promise<void> {
+    this._useServerApprovalTool = value;
+  }
+
+  async getServerApprovalToolExecutions(): Promise<number> {
+    return this._serverApprovalToolExecutions;
+  }
+
+  async setServerApprovalToolFailure(value: boolean): Promise<void> {
+    this._serverApprovalToolFails = value;
   }
 
   async setSlowStreamMode(

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -731,6 +731,157 @@ describe("Think — auto-continuation", () => {
     await closeWS(ws);
   });
 
+  it("streams and persists output from an approved server tool continuation (#1627)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    await agent.setServerApprovalToolMode(true);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    const initialDone = waitForDone(ws, 15000);
+    sendChatRequest(ws, [makeUserMessage("update my trigger")]);
+    const initialFrames = await initialDone;
+    const initialChunks = initialFrames
+      .filter(
+        (frame) =>
+          frame.type === MSG_CHAT_RESPONSE &&
+          typeof frame.body === "string" &&
+          frame.body.length > 0
+      )
+      .map(
+        (frame) => JSON.parse(frame.body as string) as Record<string, unknown>
+      );
+    expect(
+      initialChunks.some(
+        (chunk) =>
+          chunk.type === "tool-approval-request" &&
+          chunk.toolCallId === "tc-server-approval-1"
+      )
+    ).toBe(true);
+
+    const continuationDone = waitForDone(ws, 15000);
+    ws.send(
+      JSON.stringify({
+        type: MSG_TOOL_APPROVAL,
+        toolCallId: "tc-server-approval-1",
+        approved: true,
+        autoContinue: true
+      })
+    );
+    const continuationFrames = await continuationDone;
+    const outputUpdateFrame = continuationFrames.find((frame) => {
+      if (frame.type !== MSG_MESSAGE_UPDATED) return false;
+      const message = frame.message as UIMessage;
+      return message.parts.some(
+        (part) =>
+          "toolCallId" in part &&
+          part.toolCallId === "tc-server-approval-1" &&
+          "state" in part &&
+          part.state === "output-available"
+      );
+    });
+    const continuationComplete = continuationFrames.find(
+      (frame) => frame.type === MSG_CHAT_RESPONSE && frame.done === true
+    );
+
+    expect(await agent.getServerApprovalToolExecutions()).toBe(1);
+    expect(outputUpdateFrame).toBeDefined();
+    expect(continuationComplete?.continuation).toBe(true);
+
+    const messages = (await agent.getMessages()) as UIMessage[];
+    const toolPart = messages
+      .flatMap((message) => message.parts)
+      .find(
+        (part) =>
+          "toolCallId" in part && part.toolCallId === "tc-server-approval-1"
+      ) as Record<string, unknown> | undefined;
+    expect(toolPart).toMatchObject({
+      state: "output-available",
+      output: { enabled: true }
+    });
+
+    await closeWS(ws);
+  });
+
+  it("does not execute a rejected server approval tool and retains denial", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    await agent.setServerApprovalToolMode(true);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    const initialDone = waitForDone(ws, 15000);
+    sendChatRequest(ws, [makeUserMessage("do not update my trigger")]);
+    await initialDone;
+
+    const continuationDone = waitForDone(ws, 15000);
+    ws.send(
+      JSON.stringify({
+        type: MSG_TOOL_APPROVAL,
+        toolCallId: "tc-server-approval-1",
+        approved: false,
+        autoContinue: true
+      })
+    );
+    const continuationFrames = await continuationDone;
+
+    expect(await agent.getServerApprovalToolExecutions()).toBe(0);
+    const messages = (await agent.getMessages()) as UIMessage[];
+    const toolPart = messages
+      .flatMap((message) => message.parts)
+      .find(
+        (part) =>
+          "toolCallId" in part && part.toolCallId === "tc-server-approval-1"
+      ) as Record<string, unknown> | undefined;
+    expect(toolPart?.state).toBe("output-denied");
+    expect(
+      continuationFrames.find(
+        (frame) => frame.type === MSG_CHAT_RESPONSE && frame.done === true
+      )?.continuation
+    ).toBe(true);
+
+    await closeWS(ws);
+  });
+
+  it("persists an approved server tool execution error as terminal output", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    await agent.setServerApprovalToolMode(true);
+    await agent.setServerApprovalToolFailure(true);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    const initialDone = waitForDone(ws, 15000);
+    sendChatRequest(ws, [makeUserMessage("update a broken trigger")]);
+    await initialDone;
+
+    const continuationDone = waitForDone(ws, 15000);
+    ws.send(
+      JSON.stringify({
+        type: MSG_TOOL_APPROVAL,
+        toolCallId: "tc-server-approval-1",
+        approved: true,
+        autoContinue: true
+      })
+    );
+    await continuationDone;
+
+    expect(await agent.getServerApprovalToolExecutions()).toBe(1);
+    const messages = (await agent.getMessages()) as UIMessage[];
+    const toolPart = messages
+      .flatMap((message) => message.parts)
+      .find(
+        (part) =>
+          "toolCallId" in part && part.toolCallId === "tc-server-approval-1"
+      ) as Record<string, unknown> | undefined;
+    expect(toolPart).toMatchObject({
+      state: "output-error",
+      errorText: "Trigger update failed"
+    });
+
+    await closeWS(ws);
+  });
+
   it("rejection with autoContinue still triggers continuation", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1,6 +1,7 @@
 import { env, exports } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "agents";
+import { subscribe } from "agents/observability";
 import type { UIMessage } from "ai";
 import type { ChatResponseResult } from "../think";
 
@@ -801,6 +802,53 @@ describe("Think — auto-continuation", () => {
     });
 
     await closeWS(ws);
+  });
+
+  it("treats a pending approved tool as complete — no spurious transcript-repair backstop (#1627)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    await agent.setServerApprovalToolMode(true);
+
+    // While its continuation runs, the approved tool sits at
+    // `approval-responded` with no result yet. It must NOT be flagged by the
+    // incomplete-tool-call backstop: `convertToModelMessages` keeps and
+    // executes the call, so flagging it would log a misleading "repair gap"
+    // warning and emit a spurious `chat:transcript:repaired` event.
+    const repairedToolCallIds: Array<string[] | undefined> = [];
+    const unsubscribe = subscribe("transcript", (event) => {
+      if (event.type === "chat:transcript:repaired" && event.name === room) {
+        repairedToolCallIds.push(event.payload.toolCallIds);
+      }
+    });
+
+    try {
+      const { ws } = await connectWS(room);
+      await collectMessages(ws, 3);
+
+      const initialDone = waitForDone(ws, 15000);
+      sendChatRequest(ws, [makeUserMessage("update my trigger")]);
+      await initialDone;
+
+      const continuationDone = waitForDone(ws, 15000);
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_APPROVAL,
+          toolCallId: "tc-server-approval-1",
+          approved: true,
+          autoContinue: true
+        })
+      );
+      await continuationDone;
+
+      expect(await agent.getServerApprovalToolExecutions()).toBe(1);
+      expect(
+        repairedToolCallIds.some((ids) => ids?.includes("tc-server-approval-1"))
+      ).toBe(false);
+
+      await closeWS(ws);
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("does not execute a rejected server approval tool and retains denial", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -6868,7 +6868,8 @@ export class Think<
               type: MSG_CHAT_RESPONSE,
               id: requestId,
               body: "",
-              done: true
+              done: true,
+              ...(continuation && { continuation: true })
             });
             doneSent = true;
           }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1672,6 +1672,16 @@ export class Think<
         }
 
         if (!this._toolPartHasSettledResult(record)) {
+          const state = typeof record.state === "string" ? record.state : "";
+          // An approved server tool waits at `approval-responded` until its
+          // scheduled continuation runs `execute()`. It is not abandoned, so
+          // preserve it verbatim — flipping it to an error (or removing it)
+          // would strand the approval and prevent the real result from ever
+          // being produced by the continuation.
+          if (state === "approval-responded") {
+            parts.push(part);
+            continue;
+          }
           // Preserve the interrupted/abandoned tool call instead of deleting
           // it. Deleting makes the call "disappear" from the (broadcast)
           // transcript and lets the model silently re-run it. `input` is
@@ -6744,6 +6754,34 @@ export class Think<
           const streamChunk = chunk as unknown as StreamChunkData;
           const { action } = accumulator.applyChunk(streamChunk);
 
+          // Approved server tools execute during a continuation stream, but
+          // their original tool part lives in an earlier assistant message.
+          // The accumulator only builds this turn's new content, so persist
+          // that cross-message result directly as soon as it arrives.
+          if (
+            (streamChunk.type === "tool-output-available" ||
+              streamChunk.type === "tool-output-error") &&
+            typeof streamChunk.toolCallId === "string" &&
+            !accumulator.parts.some(
+              (part) =>
+                "toolCallId" in part &&
+                part.toolCallId === streamChunk.toolCallId
+            )
+          ) {
+            await this._applyToolResult(
+              streamChunk.toolCallId,
+              streamChunk.type === "tool-output-available"
+                ? streamChunk.output
+                : undefined,
+              streamChunk.type === "tool-output-error"
+                ? "output-error"
+                : undefined,
+              streamChunk.type === "tool-output-error"
+                ? streamChunk.errorText
+                : undefined
+            );
+          }
+
           if (action?.type === "error") {
             streamError = action.error;
             if (options?.captureProgrammaticStreamError) {
@@ -6755,7 +6793,8 @@ export class Think<
               id: requestId,
               body: action.error,
               done: false,
-              error: true
+              error: true,
+              ...(continuation && { continuation: true })
             });
             break;
           }
@@ -6771,7 +6810,8 @@ export class Think<
             type: MSG_CHAT_RESPONSE,
             id: requestId,
             body: chunkBody,
-            done: false
+            done: false,
+            ...(continuation && { continuation: true })
           });
         }
       } finally {
@@ -6788,7 +6828,8 @@ export class Think<
         type: MSG_CHAT_RESPONSE,
         id: requestId,
         body: "",
-        done: true
+        done: true,
+        ...(continuation && { continuation: true })
       });
       doneSent = true;
     } catch (error) {
@@ -6862,7 +6903,8 @@ export class Think<
           id: requestId,
           body: streamError,
           done: true,
-          error: true
+          error: true,
+          ...(continuation && { continuation: true })
         });
         doneSent = true;
       }
@@ -6874,7 +6916,8 @@ export class Think<
           type: MSG_CHAT_RESPONSE,
           id: requestId,
           body: "",
-          done: true
+          done: true,
+          ...(continuation && { continuation: true })
         });
       }
     }
@@ -7034,6 +7077,9 @@ export class Think<
           parts: result.parts as UIMessage["parts"]
         };
         const safe = await this._updateMessageInHistory(updatedMsg);
+        // Session change callbacks may run after an immediately scheduled
+        // continuation begins. Keep its input cache coherent synchronously.
+        this._patchCachedMessage(safe);
         // Patch the live cache in place instead of doing a full
         // `_syncMessages()` round-trip.
         // A full re-read during a streaming turn drops in-flight messages

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -142,6 +142,7 @@ import {
   AbortRegistry,
   applyToolUpdate,
   toolResultUpdate,
+  crossMessageToolResultUpdate,
   toolApprovalUpdate,
   parseProtocolMessage,
   applyChunkToParts,
@@ -1594,6 +1595,13 @@ export class Think<
    * Tool-call ids that still have no recorded result. After repair this should
    * be empty; a non-empty result means the backstop (`ignoreIncompleteToolCalls`)
    * will drop those calls — i.e. repair missed a shape and should be extended.
+   *
+   * `approval-responded` is deliberately excluded: an approved server tool has
+   * no result *yet*, but it is not incomplete or abandoned — it is waiting for
+   * its continuation to run `execute()`. `convertToModelMessages` keeps that
+   * call (and the SDK executes it), so flagging it here would log a misleading
+   * "repair gap" warning and emit a spurious `chat:transcript:repaired` event
+   * on every approval continuation.
    */
   private _incompleteToolCallIds(messages: UIMessage[]): string[] {
     const ids: string[] = [];
@@ -1607,6 +1615,7 @@ export class Think<
           (record.type.startsWith("tool-") || record.type === "dynamic-tool") &&
           toolCallId;
         if (!isToolPart) continue;
+        if (record.state === "approval-responded") continue;
         if (!this._toolPartHasSettledResult(record)) ids.push(toolCallId);
       }
     }
@@ -6756,29 +6765,22 @@ export class Think<
 
           // Approved server tools execute during a continuation stream, but
           // their original tool part lives in an earlier assistant message.
-          // The accumulator only builds this turn's new content, so persist
-          // that cross-message result directly as soon as it arrives.
-          if (
-            (streamChunk.type === "tool-output-available" ||
-              streamChunk.type === "tool-output-error") &&
-            typeof streamChunk.toolCallId === "string" &&
-            !accumulator.parts.some(
-              (part) =>
-                "toolCallId" in part &&
-                part.toolCallId === streamChunk.toolCallId
-            )
-          ) {
-            await this._applyToolResult(
-              streamChunk.toolCallId,
-              streamChunk.type === "tool-output-available"
-                ? streamChunk.output
-                : undefined,
-              streamChunk.type === "tool-output-error"
-                ? "output-error"
-                : undefined,
-              streamChunk.type === "tool-output-error"
-                ? streamChunk.errorText
-                : undefined
+          // The accumulator can only own this turn's new content, so it
+          // surfaces a terminal result for a prior message as a
+          // `cross-message-tool-update`. Persist + broadcast it directly so
+          // the approved result reaches clients and durable storage. The
+          // update builder is first-write-wins (replay-safe) and preserves a
+          // streamed `preliminary` flag; `_applyToolUpdateToMessages` skips
+          // the write/broadcast when the matched part is already settled.
+          if (action?.type === "cross-message-tool-update") {
+            await this._applyToolUpdateToMessages(
+              crossMessageToolResultUpdate(
+                action.toolCallId,
+                action.updateType,
+                action.output,
+                action.errorText,
+                action.preliminary
+              )
             );
           }
 
@@ -7067,11 +7069,17 @@ export class Think<
     const history = await this._readMessagesFromStorage();
     for (let i = 0; i < history.length; i++) {
       const msg = history[i];
-      const result = applyToolUpdate(
-        msg.parts as Array<Record<string, unknown>>,
-        update
-      );
+      const msgParts = msg.parts as Array<Record<string, unknown>>;
+      const result = applyToolUpdate(msgParts, update);
       if (result) {
+        // First-write-wins / idempotent re-apply: when `apply` leaves the
+        // matched part untouched (same reference) — e.g. a provider replay of
+        // an already-settled cross-message tool result (#1404) — there is
+        // nothing to persist. Skip the durable write and the redundant
+        // `MESSAGE_UPDATED` broadcast so clients don't churn on a no-op.
+        if (result.parts[result.index] === msgParts[result.index]) {
+          return;
+        }
         const updatedMsg = {
           ...msg,
           parts: result.parts as UIMessage["parts"]


### PR DESCRIPTION
## Summary

Fixes the `@cloudflare/think` server-side `needsApproval` continuation path so an approved tool result is delivered to the client and persisted instead of leaving the UI indefinitely at `approval-responded` / “Executing…”.

Fixes #1627.

## What was happening

For an approved server-executed tool, Think handles the approval in one message update and then runs the actual tool in an automatically scheduled continuation. There were several gaps in that handoff:

1. The durable approval update did not synchronously update Think's live message cache before the continuation read it.
2. Transcript repair treated `approval-responded`, `output-denied`, and `output-error` parts without an `output` field as abandoned tool calls and removed them from model context.
3. A server tool's eventual `tool-output-available` / `tool-output-error` chunk is emitted during the continuation, but the corresponding tool part belongs to the preceding assistant message. The continuation accumulator cannot persist that cross-message state transition by itself.
4. Think's WebSocket continuation response frames were missing the `continuation: true` marker used by `useAgentChat` when applying server-pushed continuation events to existing client state.

Together these could leave the server having performed the approved side effect while the browser remained stuck at `approval-responded`.

## Changes

### `packages/think/src/think.ts`

- Keep valid non-output-bearing tool lifecycle states (`approval-responded`, `output-denied`, `output-error`) in transcript repair.
- Synchronously patch the in-memory transcript after an approval/tool update is persisted, before an immediate continuation consumes it.
- When terminal tool output arrives during a continuation for a tool part stored in a prior assistant message, apply it to that stored message and broadcast `cf_agent_message_updated`.
- Include `continuation: true` on continuation stream chunks, errors, and completion frames.

### Tests

Added an actual server `needsApproval` tool to the Think WebSocket test agent and regression tests covering:

- **Approval success:** the tool executes exactly once, broadcasts an `output-available` update, persists output, and marks completion as a continuation.
- **Rejection:** the tool is not executed and `output-denied` is retained through continuation processing.
- **Execution error after approval:** the tool is invoked once and its terminal `output-error` / error text is persisted.

### Release note

- Added a patch changeset for `@cloudflare/think`.

## Reviewer notes

The key code path to review is the transition across messages:

```text
approval-requested
  -> CF_AGENT_TOOL_APPROVAL
  -> approval-responded persisted + live cache patched
  -> continuation runs approved execute()
  -> tool-output-available/error targets original assistant message
  -> MESSAGE_UPDATED reaches frontend + terminal state persists
```

The cross-message update mirrors the situation already handled in `@cloudflare/ai-chat`: the continuation's newly accumulated assistant content is not the message that owns the original tool part.