### PR TITLE
fix(think,ai-chat): make chat-recovery progress signal compaction-immune (#1628)

### DIFF
--- a/.changeset/chat-recovery-progress-monotonic.md
+++ b/.changeset/chat-recovery-progress-monotonic.md
@@ -1,0 +1,16 @@
+---
+"@cloudflare/think": patch
+"@cloudflare/ai-chat": patch
+---
+
+Fix chat recovery prematurely exhausting its retry budget under compaction
+(#1628). The deploy-churn forward-progress signal — which resets the recovery
+budget when an interrupted turn is actually advancing — was recomputed from the
+live transcript by counting assistant messages. Compaction collapses older
+assistant messages into a summary, lowering that count, so a turn that had
+genuinely advanced could read as "no progress" between recovery attempts and
+exhaust at `maxAttempts`, sealing a healthy turn. Progress is now tracked by a
+durable, monotonic counter incremented when `_persistOrphanedStream` materializes
+a non-empty partial (the exact event the message count was proxying for), so
+compaction can never lower it. A turn that genuinely fails to advance still
+exhausts at the cap, and the 15-minute wall-clock ceiling is unchanged.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -114,16 +114,23 @@ type ChatRecoveryIncident = {
   lastAttemptAt: number;
   reason?: string;
   /**
-   * High-water mark of a monotonic recovery-progress signal (count of persisted
-   * assistant messages) observed for this incident. Used to distinguish a turn
-   * that is making forward progress but keeps getting interrupted by isolate
-   * resets (deploys) — which should NOT exhaust the budget — from one that
-   * genuinely fails to advance.
+   * High-water mark of the durable, monotonic recovery-progress counter (see
+   * `_chatRecoveryProgressMarker`) observed for this incident. Used to
+   * distinguish a turn that is making forward progress but keeps getting
+   * interrupted by isolate resets (deploys) — which should NOT exhaust the
+   * budget — from one that genuinely fails to advance. Sourced from a persisted
+   * counter rather than the live transcript so compaction cannot lower it
+   * (#1628).
    */
   progress?: number;
 };
 
 const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
+// Durable, monotonic forward-progress counter for recovery budget resets.
+// Incremented once per non-empty partial materialized by
+// `_persistOrphanedStream`; never recomputed from the (compactable) transcript.
+// See `_chatRecoveryProgressMarker`.
+const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 6;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Delay before retrying a recovery that timed out waiting for stable state.
@@ -994,7 +1001,7 @@ export class AIChatAgent<
             // assistant message from stored chunks and persist it so it
             // survives further page refreshes.
             if (orphanedStreamId) {
-              this._persistOrphanedStream(orphanedStreamId);
+              await this._persistOrphanedStream(orphanedStreamId);
             }
           } else if (this._resumableStream.hasActiveStream()) {
             // Ignore ACKs for a different active stream request id.
@@ -1311,7 +1318,7 @@ export class AIChatAgent<
    * message parts, then persists the result so it survives further refreshes.
    * @internal
    */
-  protected _persistOrphanedStream(streamId: string) {
+  protected async _persistOrphanedStream(streamId: string): Promise<void> {
     const chunks = this._resumableStream.getStreamChunks(streamId);
     if (!chunks.length) return;
 
@@ -1379,6 +1386,11 @@ export class AIChatAgent<
           ? this.messages.map((m, i) => (i === existingIdx ? message : m))
           : [...this.messages, message];
       this.persistMessages(updatedMessages);
+      // Real forward progress: a non-empty partial was materialized. Advance
+      // the durable, compaction-immune progress counter so a deploy-churned
+      // turn that keeps producing content resets its recovery budget instead
+      // of exhausting it (#1628).
+      await this._bumpChatRecoveryProgress();
     }
   }
 
@@ -3004,16 +3016,29 @@ export class AIChatAgent<
   }
 
   /**
-   * Monotonic-ish recovery-progress signal: the number of persisted assistant
-   * messages. An interrupted partial is persisted as an assistant message (and
-   * not pruned), so this grows whenever recovery makes forward progress and
-   * never shrinks mid-incident.
+   * Monotonic forward-progress signal for recovery budget resets.
+   *
+   * This used to count assistant messages in `this.messages`, but that is
+   * recomputed from the live, mutable transcript. Compaction collapses older
+   * assistant messages into a summary, lowering the count — so a turn that had
+   * genuinely advanced could read as "no progress" between attempts and exhaust
+   * its budget prematurely (#1628). Instead we read a durably-persisted counter
+   * that only ever increments — bumped once per non-empty partial materialized
+   * by `_persistOrphanedStream`, which is the exact "forward progress" event the
+   * old message-count tracked — so compaction can never lower it.
    */
-  private _chatRecoveryProgressMarker(): number {
-    return this.messages.reduce(
-      (count, message) => (message.role === "assistant" ? count + 1 : count),
-      0
+  private async _chatRecoveryProgressMarker(): Promise<number> {
+    return (
+      (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0
     );
+  }
+
+  /** Advance the durable recovery-progress counter. Called when a partial
+   *  assistant message is materialized (real forward progress). */
+  private async _bumpChatRecoveryProgress(): Promise<void> {
+    const current =
+      (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0;
+    await this.ctx.storage.put(CHAT_RECOVERY_PROGRESS_KEY, current + 1);
   }
 
   /** Sweep recovery incidents that have been inactive past the TTL. */
@@ -3060,7 +3085,7 @@ export class AIChatAgent<
     // attempt saw) as environmental and reset the budget, while a turn that
     // never advances still exhausts at `maxAttempts`.
     const prevProgress = existing?.progress ?? 0;
-    const currentProgress = this._chatRecoveryProgressMarker();
+    const currentProgress = await this._chatRecoveryProgressMarker();
     const madeProgress = existing != null && currentProgress > prevProgress;
     const windowExceeded =
       existing != null &&
@@ -3276,7 +3301,7 @@ export class AIChatAgent<
         this._resumableStream.activeStreamId === streamId;
 
       if (options.persist !== false && streamStillActive) {
-        this._persistOrphanedStream(streamId);
+        await this._persistOrphanedStream(streamId);
       }
 
       if (streamStillActive) {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -1385,7 +1385,7 @@ export class AIChatAgent<
         existingIdx >= 0
           ? this.messages.map((m, i) => (i === existingIdx ? message : m))
           : [...this.messages, message];
-      this.persistMessages(updatedMessages);
+      await this.persistMessages(updatedMessages);
       // Real forward progress: a non-empty partial was materialized. Advance
       // the durable, compaction-immune progress counter so a deploy-churned
       // turn that keeps producing content resets its recovery budget instead

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -49,6 +49,8 @@ interface ChatRecoveryTestStub {
   }): Promise<void>;
   getChatRecoveryIncidentsForTest(): Promise<unknown[]>;
   addAssistantMessageForTest(id: string): Promise<void>;
+  bumpRecoveryProgressForTest(): Promise<void>;
+  dropAssistantMessagesForTest(): Promise<void>;
   setRecoveryShouldThrowForTest(shouldThrow: boolean): Promise<void>;
   enableThrowingOnExhaustedForTest(
     maxAttempts: number,
@@ -263,9 +265,9 @@ describe("onChatRecovery", () => {
     expect((await agentStub.beginIncidentForTest(input)).attempt).toBe(1);
     expect((await agentStub.beginIncidentForTest(input)).attempt).toBe(2);
 
-    // Forward progress (an assistant message persisted, as `_persistOrphanedStream`
-    // does after a partial) resets the budget — this is the deploy-churn fix.
-    await agentStub.addAssistantMessageForTest("asst-1");
+    // Forward progress (the durable counter advances, as `_persistOrphanedStream`
+    // does after materializing a partial) resets the budget — the deploy-churn fix.
+    await agentStub.bumpRecoveryProgressForTest();
     const afterProgress = await agentStub.beginIncidentForTest(input);
     expect(afterProgress.attempt).toBe(1);
     expect(afterProgress.exhausted).toBe(false);
@@ -275,6 +277,33 @@ describe("onChatRecovery", () => {
     const exhausted = await agentStub.beginIncidentForTest(input);
     expect(exhausted.attempt).toBe(3);
     expect(exhausted.exhausted).toBe(true);
+  });
+
+  it("detects forward progress even after compaction collapses the transcript (#1628)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const input = {
+      requestId: "req-compact",
+      recoveryRootRequestId: "req-compact",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+
+    // First detection opens the incident.
+    expect((await agentStub.beginIncidentForTest(input)).attempt).toBe(1);
+
+    // The turn advances (a partial is materialized) AND compaction then
+    // collapses every assistant message out of the live transcript. The old
+    // message-count marker would now read FEWER messages than the previous
+    // attempt and miss the progress; the durable counter is immune.
+    await agentStub.bumpRecoveryProgressForTest();
+    await agentStub.dropAssistantMessagesForTest();
+
+    const afterProgress = await agentStub.beginIncidentForTest(input);
+    expect(afterProgress.attempt).toBe(1);
+    expect(afterProgress.exhausted).toBe(false);
   });
 
   it("exhausts via the wall-clock window even while making progress", async () => {
@@ -295,7 +324,7 @@ describe("onChatRecovery", () => {
     });
 
     // Even with fresh progress, the wall-clock ceiling terminalizes it.
-    await agentStub.addAssistantMessageForTest("asst-old");
+    await agentStub.bumpRecoveryProgressForTest();
     const next = await agentStub.beginIncidentForTest({
       requestId: "req-old-2",
       recoveryRootRequestId: "req-old",

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1718,6 +1718,24 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     await this.persistMessages(this.messages);
   }
 
+  /** Simulate recovery forward progress: advance the durable progress counter
+   *  exactly as `_persistOrphanedStream` does when it materializes a non-empty
+   *  partial. The recovery budget keys off this counter (not the live message
+   *  count), so this is how a test marks "the turn advanced". */
+  async bumpRecoveryProgressForTest(): Promise<void> {
+    const self = this as unknown as {
+      _bumpChatRecoveryProgress(): Promise<void>;
+    };
+    await self._bumpChatRecoveryProgress();
+  }
+
+  /** Simulate compaction collapsing the transcript by dropping all assistant
+   *  messages from the live cache. Used to prove the recovery progress signal
+   *  is compaction-immune (#1628). */
+  async dropAssistantMessagesForTest(): Promise<void> {
+    this.messages = this.messages.filter((m) => m.role !== "assistant");
+  }
+
   getPersistedMessages(): ChatMessage[] {
     return (
       this.sql`select * from cf_ai_chat_agent_messages order by created_at` ||

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3406,6 +3406,27 @@ export class ThinkRecoveryTestAgent extends Think {
     ];
   }
 
+  /** Simulate recovery forward progress: advance the durable progress counter
+   *  exactly as `_persistOrphanedStream` does when it materializes a non-empty
+   *  partial. The recovery budget keys off this counter (not the live message
+   *  count), so this is how a test marks "the turn advanced". */
+  async bumpRecoveryProgressForTest(): Promise<void> {
+    const self = this as unknown as {
+      _bumpChatRecoveryProgress(): Promise<void>;
+    };
+    await self._bumpChatRecoveryProgress();
+  }
+
+  /** Simulate compaction collapsing the transcript by dropping all assistant
+   *  messages from the live cache. Used to prove the recovery progress signal
+   *  is compaction-immune (#1628). */
+  async dropAssistantMessagesForTest(): Promise<void> {
+    const self = this as unknown as { _cachedMessages: UIMessage[] };
+    self._cachedMessages = self._cachedMessages.filter(
+      (m) => m.role !== "assistant"
+    );
+  }
+
   /**
    * Stream a couple of text chunks (throttled → buffered) then a settled tool
    * result, and report how many chunks are durably persisted (raw SQLite, no

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2215,9 +2215,9 @@ describe("Think — onChatRecovery", () => {
     expect((await agent.beginIncidentForTest(input)).attempt).toBe(1);
     expect((await agent.beginIncidentForTest(input)).attempt).toBe(2);
 
-    // Forward progress (an assistant message persisted, as `_persistOrphanedStream`
-    // does after a partial) resets the budget — this is the deploy-churn fix.
-    await agent.addAssistantMessageForTest("asst-1");
+    // Forward progress (the durable counter advances, as `_persistOrphanedStream`
+    // does after materializing a partial) resets the budget — the deploy-churn fix.
+    await agent.bumpRecoveryProgressForTest();
     const afterProgress = await agent.beginIncidentForTest(input);
     expect(afterProgress.attempt).toBe(1);
     expect(afterProgress.exhausted).toBe(false);
@@ -2227,6 +2227,32 @@ describe("Think — onChatRecovery", () => {
     const exhausted = await agent.beginIncidentForTest(input);
     expect(exhausted.attempt).toBe(3);
     expect(exhausted.exhausted).toBe(true);
+  });
+
+  it("detects forward progress even after compaction collapses the transcript (#1628)", async () => {
+    const agent = await freshRecoveryAgent("recovery-progress-compaction");
+    await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const input = {
+      requestId: "req-compact",
+      recoveryRootRequestId: "req-compact",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+
+    // First detection opens the incident.
+    expect((await agent.beginIncidentForTest(input)).attempt).toBe(1);
+
+    // The turn advances (a partial is materialized) AND compaction then
+    // collapses every assistant message out of the live transcript. The old
+    // message-count marker would now read FEWER messages than the previous
+    // attempt and miss the progress; the durable counter is immune.
+    await agent.bumpRecoveryProgressForTest();
+    await agent.dropAssistantMessagesForTest();
+
+    const afterProgress = await agent.beginIncidentForTest(input);
+    expect(afterProgress.attempt).toBe(1);
+    expect(afterProgress.exhausted).toBe(false);
   });
 
   it("exhausts via the wall-clock window even while making progress", async () => {
@@ -2246,7 +2272,7 @@ describe("Think — onChatRecovery", () => {
     });
 
     // Even with fresh progress, the wall-clock ceiling terminalizes it.
-    await agent.addAssistantMessageForTest("asst-old");
+    await agent.bumpRecoveryProgressForTest();
     const next = await agent.beginIncidentForTest({
       requestId: "req-old-2",
       recoveryRootRequestId: "req-old",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -604,16 +604,23 @@ type ChatRecoveryIncident = {
   lastAttemptAt: number;
   reason?: string;
   /**
-   * High-water mark of a monotonic recovery-progress signal (count of persisted
-   * assistant messages) observed for this incident. Used to distinguish a turn
-   * that is making forward progress but keeps getting interrupted by isolate
-   * resets (deploys) — which should NOT exhaust the budget — from one that
-   * genuinely fails to advance.
+   * High-water mark of the durable, monotonic recovery-progress counter (see
+   * `_chatRecoveryProgressMarker`) observed for this incident. Used to
+   * distinguish a turn that is making forward progress but keeps getting
+   * interrupted by isolate resets (deploys) — which should NOT exhaust the
+   * budget — from one that genuinely fails to advance. Sourced from a persisted
+   * counter rather than the live transcript so compaction cannot lower it
+   * (#1628).
    */
   progress?: number;
 };
 
 const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
+// Durable, monotonic forward-progress counter for recovery budget resets.
+// Incremented once per non-empty partial materialized by
+// `_persistOrphanedStream`; never recomputed from the (compactable) transcript.
+// See `_chatRecoveryProgressMarker`.
+const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 6;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Delay before retrying a continuation that timed out waiting for stable state.
@@ -6773,16 +6780,29 @@ export class Think<
   }
 
   /**
-   * Monotonic-ish recovery-progress signal: the number of persisted assistant
-   * messages. `_persistOrphanedStream` turns each interrupted partial into a
-   * persisted assistant message (and does not prune it), so this grows whenever
-   * recovery makes forward progress and never shrinks mid-incident.
+   * Monotonic forward-progress signal for recovery budget resets.
+   *
+   * This used to count assistant messages in `this.messages`, but that is
+   * recomputed from the live, mutable transcript. Compaction collapses older
+   * assistant messages into a summary, lowering the count — so a turn that had
+   * genuinely advanced could read as "no progress" between attempts and exhaust
+   * its budget prematurely (#1628). Instead we read a durably-persisted counter
+   * that only ever increments — bumped once per non-empty partial materialized
+   * by `_persistOrphanedStream`, which is the exact "forward progress" event the
+   * old message-count tracked — so compaction can never lower it.
    */
-  private _chatRecoveryProgressMarker(): number {
-    return this.messages.reduce(
-      (count, message) => (message.role === "assistant" ? count + 1 : count),
-      0
+  private async _chatRecoveryProgressMarker(): Promise<number> {
+    return (
+      (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0
     );
+  }
+
+  /** Advance the durable recovery-progress counter. Called when a partial
+   *  assistant message is materialized (real forward progress). */
+  private async _bumpChatRecoveryProgress(): Promise<void> {
+    const current =
+      (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0;
+    await this.ctx.storage.put(CHAT_RECOVERY_PROGRESS_KEY, current + 1);
   }
 
   /** Sweep recovery incidents that have been inactive past the TTL. */
@@ -6829,7 +6849,7 @@ export class Think<
     // attempt saw) as environmental and reset the budget, while a turn that
     // never advances still exhausts at `maxAttempts`.
     const prevProgress = existing?.progress ?? 0;
-    const currentProgress = this._chatRecoveryProgressMarker();
+    const currentProgress = await this._chatRecoveryProgressMarker();
     const madeProgress = existing != null && currentProgress > prevProgress;
     const windowExceeded =
       existing != null &&
@@ -7980,6 +8000,11 @@ export class Think<
 
     if (accumulator.parts.length > 0) {
       await this._persistAssistantMessage(accumulator.toMessage());
+      // Real forward progress: a non-empty partial was materialized. Advance
+      // the durable, compaction-immune progress counter so a deploy-churned
+      // turn that keeps producing content resets its recovery budget instead
+      // of exhausting it (#1628).
+      await this._bumpChatRecoveryProgress();
       this._broadcastMessages();
     }
   }


### PR DESCRIPTION
## Stack

This is **PR 1 of 4** addressing #1631 (recovery/repair ergonomics) and #1628. The series is stacked; review/merge bottom-up:

1. **➡️ #1628 — progress signal compaction-immune (this PR)** · patch
2. preserve settled work when a turn is given up · patch
3. `repairInterruptedToolPart` hook · minor
4. incident identity + `onExhausted` payload · minor

Each PR is independently reviewable; this one has no dependency on the others (it's the base of the stack). Targets `main`.

---

## Problem (#1628)

Bounded chat recovery (#1623) resets the per-incident retry budget when an interrupted turn is making **forward progress**, so that a turn repeatedly interrupted by deploy churn isn't falsely treated as a poison turn and sealed at `maxAttempts`. That progress signal was **recomputed from the live transcript** by counting assistant messages:

```ts
// packages/think/src/think.ts (and the verbatim mirror in packages/ai-chat/src/index.ts)
private _chatRecoveryProgressMarker(): number {
  return this.messages.reduce(
    (count, message) => (message.role === "assistant" ? count + 1 : count),
    0
  );
}
// ...in _beginChatRecoveryIncident:
const prevProgress = existing?.progress ?? 0;
const currentProgress = this._chatRecoveryProgressMarker();
const madeProgress = existing != null && currentProgress > prevProgress;
```

`this.messages` is the live, mutable transcript. **Compaction collapses older assistant messages into a summary, lowering the count.** So a turn that genuinely advanced between two recovery attempts can read as `currentProgress < prevProgress` → `madeProgress = false` → the budget is **not** reset → the turn exhausts at `maxAttempts` and is sealed, even though it was healthy. The stored `progress: Math.max(prevProgress, currentProgress)` only protects the persisted high-water; the *comparison* still uses the live (compacted) recompute, so it doesn't help.

This is the data-loss path a tool-heavy agent under continuous deploys actually hits.

## Fix

Track progress with a **durable, monotonic counter** that compaction can never lower, instead of recomputing from the transcript:

- New storage key `cf:chat-recovery:progress`.
- Bumped exactly once when `_persistOrphanedStream` materializes a **non-empty** partial assistant message — which is precisely the "forward progress" event the old assistant-message count was a proxy for.
- `_chatRecoveryProgressMarker()` now reads that counter; `_beginChatRecoveryIncident` awaits it.

Because it only ever increments, compaction is irrelevant. Semantics are otherwise preserved:

- **Healthy turn under churn:** each interruption persists a non-empty partial → counter grows → `madeProgress` true → budget resets. ✅
- **Poison turn (no chunks):** `_persistOrphanedStream` early-returns on empty chunks → counter flat → budget counts toward the cap → exhausts. ✅
- **Genuinely-stuck-but-producing turn:** still ultimately bounded by the unchanged 15-minute `CHAT_RECOVERY_MAX_WINDOW_MS` wall-clock ceiling.

### Timing (why the counter is read at incident-begin and bumped at persist)

Per interruption: `_beginChatRecoveryIncident` reads the counter and compares against the stored high-water → then (if not exhausted) `_persistOrphanedStream` bumps it. So attempt _N_'s bump is observed at attempt _N+1_'s comparison, exactly mirroring how the old assistant-message count grew after each persist.

## Back-compat / migration

A session interrupted mid-incident *before* this counter existed has no `cf:chat-recovery:progress` key → it reads `0`. For a **new** incident that's fine (no comparison on first detection). For an in-flight incident at upgrade time the comparison is conservative (treats it as no-progress for that one alarm), which is bounded and harmless. No persisted-data migration required.

## Bonus

`@cloudflare/ai-chat`'s `_persistOrphanedStream` **merges** a continuation partial into the existing assistant message in place, so its old marker barely grew across continuations (only the first persist added a message) — it was *already* under-counting progress. The monotonic counter fixes that too and brings ai-chat in line with think.

## Files

- `packages/think/src/think.ts` — counter constant, `_chatRecoveryProgressMarker` (now async, reads storage), new `_bumpChatRecoveryProgress`, bump in `_persistOrphanedStream`, `await` in `_beginChatRecoveryIncident`, updated `ChatRecoveryIncident.progress` doc.
- `packages/ai-chat/src/index.ts` — same changes; `_persistOrphanedStream` made `async` (callers updated to `await`).
- Tests + harness helpers (`bumpRecoveryProgressForTest`, `dropAssistantMessagesForTest`).
- `.changeset/chat-recovery-progress-monotonic.md` (patch · think + ai-chat).

## Tests

New regression test in **both** packages — *"detects forward progress even after compaction collapses the transcript (#1628)"*: open an incident, make progress (bump the counter), then drop every assistant message from the live cache (simulating compaction), and assert the next alarm still resets the budget. The old message-count marker fails this; the durable counter passes. Existing progress-reset and wall-clock-ceiling tests were re-pointed at the counter and still pass.

## Verification

- `tsc --noEmit` clean for `@cloudflare/think` and `@cloudflare/ai-chat`.
- `oxlint` clean; `oxfmt` applied.
- Full suites green: think **460 passed** (15 files), ai-chat **481 passed** (42 files).

## Test plan

- [ ] CI green (`npm run build && npm run check && nx affected -t test`)
- [ ] Confirm the compaction regression test fails on `main` and passes here
- [ ] Sanity-check the back-compat note for in-flight incidents at deploy time

Made with [Cursor](https://cursor.com)