### PR TITLE
fix(think,ai-chat): preserve settled work when a recovery turn is given up (#1631)

### DIFF
--- a/.changeset/chat-recovery-preserve-settled-work.md
+++ b/.changeset/chat-recovery-preserve-settled-work.md
@@ -1,0 +1,26 @@
+---
+"@cloudflare/think": patch
+"@cloudflare/ai-chat": patch
+---
+
+Stop chat recovery from discarding settled work when a turn is given up on
+(#1631).
+
+Two paths could throw away a partial assistant message containing completed,
+often non-idempotent tool results:
+
+- When the framework's own recovery budget was exhausted, `_exhaustChatRecovery`
+  sealed the turn (terminal status + banner) **before** the orphaned stream was
+  ever persisted — so every settled tool result the turn had produced was lost
+  and the model re-ran them on the next message. Exhaustion now persists the
+  settled partial first, using the same gating as the normal recovery path so it
+  can't duplicate an already-saved partial.
+- A subclass `onChatRecovery` returning `{ persist: false }` to stop a turn used
+  to silently drop the settled partial. Settled work is now **never** dropped:
+  `persist: false` only suppresses persistence of a partial that has nothing
+  settled to lose; a partial carrying settled tool results is persisted
+  regardless. An app can no longer accidentally discard completed work — and it
+  never needs `{ persist: true }` just to stay safe. (A safe default beats a
+  warning about an unsafe one.)
+
+Applied identically to `@cloudflare/think` and `@cloudflare/ai-chat`.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -3227,6 +3227,26 @@ export class AIChatAgent<
     await this._bumpChatRecoveryProgress();
   }
 
+  /** Whether a reconstructed partial carries any settled (provider-accepted)
+   *  tool result — the completed, often non-idempotent work that a
+   *  `{ persist: false }` recovery return would silently discard.
+   *  `convertToModelMessages` treats `output-available` / `output-error` /
+   *  `output-denied` (or a part carrying `output`/`result`) as settled. */
+  private _partialHasSettledToolResults(parts: MessagePart[]): boolean {
+    return parts.some((part) => {
+      const record = part as Record<string, unknown>;
+      const type = typeof record.type === "string" ? record.type : "";
+      if (!(type.startsWith("tool-") || type === "dynamic-tool")) return false;
+      if ("output" in record || "result" in record) return true;
+      const state = typeof record.state === "string" ? record.state : "";
+      return (
+        state === "output-available" ||
+        state === "output-error" ||
+        state === "output-denied"
+      );
+    });
+  }
+
   /** Sweep recovery incidents that have been inactive past the TTL. */
   private async _sweepStaleChatRecoveryIncidents(now: number): Promise<void> {
     const entries = await this.ctx.storage.list<ChatRecoveryIncident>({
@@ -3458,6 +3478,15 @@ export class AIChatAgent<
       ? this._getPartialStreamText(streamId)
       : { text: "", parts: [] as MessagePart[] };
 
+    // Only persist while the stream is still active. The ACK handler (client
+    // reconnect → replayChunks) may have already persisted + completed the
+    // orphaned stream before fiber recovery runs; persisting again on the same
+    // chunks would double the assistant message's parts.
+    const streamStillActive =
+      streamId &&
+      this._resumableStream.hasActiveStream() &&
+      this._resumableStream.activeStreamId === streamId;
+
     const shouldRetryPreStream = this._shouldRetryRecoveredPreStreamTurn(
       recoverySnapshot,
       streamId ?? "",
@@ -3477,6 +3506,13 @@ export class AIChatAgent<
       });
 
     if (exhausted) {
+      // Preserve the settled partial before sealing the turn. Exhaustion is
+      // decided BEFORE `onChatRecovery` is consulted, so without this the
+      // settled (often non-idempotent) tool results the turn already produced
+      // are discarded and the model re-runs them on the next message (#1631).
+      if (streamStillActive) {
+        await this._persistOrphanedStream(streamId);
+      }
       await this._exhaustChatRecovery(incident, config);
       return true;
     }
@@ -3504,17 +3540,17 @@ export class AIChatAgent<
           createdAt: ctx.createdAt
         })) ?? {};
 
-      // Only persist and complete if the stream is still active. The ACK
-      // handler (client reconnect → replayChunks) may have already persisted
-      // the orphaned stream and completed it before fiber recovery runs.
-      // Without this guard, _persistOrphanedStream runs twice on the same
-      // chunks, doubling the assistant message's parts.
-      const streamStillActive =
-        streamId &&
-        this._resumableStream.hasActiveStream() &&
-        this._resumableStream.activeStreamId === streamId;
-
-      if (options.persist !== false && streamStillActive) {
+      // Settled work — completed, often non-idempotent tool results — is NEVER
+      // dropped by recovery. `persist: false` only suppresses persistence of a
+      // partial that has nothing settled to lose; a partial carrying settled
+      // tool results is persisted regardless, so an app can never accidentally
+      // discard completed work (and never needs `{ persist: true }` just to be
+      // safe). A safe default beats a warning about an unsafe one (#1631).
+      if (
+        streamStillActive &&
+        (options.persist !== false ||
+          this._partialHasSettledToolResults(partial.parts))
+      ) {
         await this._persistOrphanedStream(streamId);
       }
 

--- a/packages/ai-chat/src/tests/chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/chat-recovery.test.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:workers";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getAgentByName } from "agents";
 import type { UIMessage as ChatMessage } from "ai";
 import { connectChatWS, isUseChatResponseMessage } from "./test-utils";
@@ -37,6 +37,21 @@ interface ChatTestStub {
   ): Promise<void>;
   insertInterruptedFiber(name: string, snapshot?: unknown): Promise<void>;
   triggerFiberRecovery(): Promise<void>;
+  setChatRecoveryConfigForTest(config: {
+    maxAttempts?: number;
+    terminalMessage?: string;
+  }): Promise<void>;
+  seedIncidentForTest(incident: {
+    incidentId: string;
+    requestId: string;
+    recoveryKind: "retry" | "continue";
+    attempt: number;
+    maxAttempts: number;
+    status: string;
+    firstSeenAt: number;
+    lastAttemptAt: number;
+  }): Promise<void>;
+  getChatRecoveryIncidentsForTest(): Promise<Array<{ status: string }>>;
 }
 
 interface SlowStreamStub {
@@ -546,6 +561,182 @@ describe("chatRecovery", () => {
       expect(lastCtx.recoveryData).toEqual(stashedData);
       expect(lastCtx.partialText).toBe("Partial with stash");
       expect(lastCtx.streamId).toBe("stream-stash");
+    });
+  });
+
+  describe("recovery preserves settled work (#1631)", () => {
+    it("persists the settled partial when the recovery budget is exhausted", async () => {
+      const room = crypto.randomUUID();
+      const stub = (await getAgentByName(
+        env.ChatRecoveryTestAgent,
+        room
+      )) as unknown as ChatTestStub;
+      // maxAttempts: 1 so a seeded attempt at the cap exhausts on the next wake.
+      await stub.setChatRecoveryConfigForTest({ maxAttempts: 1 });
+
+      // text PLUS a settled (completed, non-idempotent) tool call — the work
+      // the budget-exhaustion path used to discard and force the model to re-run.
+      await stub.insertInterruptedStream("stream-exh", "req-exh", [
+        {
+          body: JSON.stringify({ type: "start", messageId: "a-exh" }),
+          index: 0
+        },
+        {
+          body: JSON.stringify({
+            type: "tool-input-available",
+            toolCallId: "tc-exh",
+            toolName: "writeFile",
+            input: { path: "out.txt" }
+          }),
+          index: 1
+        },
+        {
+          body: JSON.stringify({
+            type: "tool-output-available",
+            toolCallId: "tc-exh",
+            output: { bytesWritten: 12 }
+          }),
+          index: 2
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 3 },
+        {
+          body: JSON.stringify({ type: "text-delta", delta: "did real work" }),
+          index: 4
+        }
+      ]);
+      await stub.insertInterruptedFiber("__cf_internal_chat_turn:req-exh");
+      // Seed an incident already at the cap so this recovery exhausts.
+      // `lastAttemptAt` is aged past the alarm-debounce window (#1637/#1638) so
+      // this wake counts as a genuine new attempt (1 → 2 > maxAttempts) rather
+      // than being collapsed as a debounced reconnect (which would hold the
+      // attempt at 1 and never exhaust).
+      await stub.seedIncidentForTest({
+        incidentId: "req-exh:",
+        requestId: "req-exh",
+        recoveryKind: "continue",
+        attempt: 1,
+        maxAttempts: 1,
+        status: "scheduled",
+        firstSeenAt: Date.now() - 60_000,
+        lastAttemptAt: Date.now() - 60_000
+      });
+
+      await stub.triggerFiberRecovery();
+
+      // Exhaustion seals the turn but must NOT discard the settled partial.
+      const messages = await stub.getPersistedMessages();
+      const assistantMsgs = messages.filter((m) => m.role === "assistant");
+      expect(assistantMsgs).toHaveLength(1);
+      expect(extractAssistantText(messages)).toContain("did real work");
+      // The settled tool result is preserved (not just the text).
+      const settledTool = assistantMsgs[0]?.parts?.find((p) => {
+        const part = p as { type?: unknown; output?: unknown; state?: unknown };
+        return (
+          typeof part.type === "string" &&
+          part.type.startsWith("tool-") &&
+          (part.output !== undefined || part.state === "output-available")
+        );
+      });
+      expect(settledTool).toBeDefined();
+
+      const incidents = await stub.getChatRecoveryIncidentsForTest();
+      expect(incidents[0]?.status).toBe("exhausted");
+    });
+
+    it("never drops settled tool results on { persist: false } — preserves them anyway", async () => {
+      const room = crypto.randomUUID();
+      const stub = (await getAgentByName(
+        env.ChatRecoveryTestAgent,
+        room
+      )) as unknown as ChatTestStub;
+      await stub.setRecoveryOverride({ persist: false, continue: false });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await stub.insertInterruptedStream("stream-settled", "req-settled", [
+          {
+            body: JSON.stringify({ type: "start", messageId: "a-settled" }),
+            index: 0
+          },
+          {
+            body: JSON.stringify({
+              type: "tool-input-available",
+              toolCallId: "tc1",
+              toolName: "calc",
+              input: { x: 1 }
+            }),
+            index: 1
+          },
+          {
+            body: JSON.stringify({
+              type: "tool-output-available",
+              toolCallId: "tc1",
+              output: { result: 42 }
+            }),
+            index: 2
+          }
+        ]);
+        await stub.insertInterruptedFiber(
+          "__cf_internal_chat_turn:req-settled"
+        );
+
+        await stub.triggerFiberRecovery();
+
+        // R1: settled work is preserved regardless of `persist: false` — the
+        // assistant partial with the completed tool call IS persisted, with no
+        // warning (a safe default beats a warning about an unsafe one).
+        const messages = await stub.getPersistedMessages();
+        const assistantMsgs = messages.filter((m) => m.role === "assistant");
+        expect(assistantMsgs).toHaveLength(1);
+        const hasSettledTool = assistantMsgs[0]?.parts?.some((p) => {
+          const type = (p as { type?: unknown }).type;
+          return typeof type === "string" && type.startsWith("tool-");
+        });
+        expect(hasSettledTool).toBe(true);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("honors { persist: false } for a text-only partial with no settled work", async () => {
+      const room = crypto.randomUUID();
+      const stub = (await getAgentByName(
+        env.ChatRecoveryTestAgent,
+        room
+      )) as unknown as ChatTestStub;
+      await stub.setRecoveryOverride({ persist: false, continue: false });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await stub.insertInterruptedStream("stream-textonly", "req-textonly", [
+          {
+            body: JSON.stringify({ type: "start", messageId: "a-textonly" }),
+            index: 0
+          },
+          { body: JSON.stringify({ type: "text-start" }), index: 1 },
+          {
+            body: JSON.stringify({
+              type: "text-delta",
+              delta: "just prose, no tools"
+            }),
+            index: 2
+          }
+        ]);
+        await stub.insertInterruptedFiber(
+          "__cf_internal_chat_turn:req-textonly"
+        );
+
+        await stub.triggerFiberRecovery();
+
+        // No settled tool results to preserve, so `persist: false` is honored —
+        // nothing is persisted, and there is no warning.
+        const messages = await stub.getPersistedMessages();
+        expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/think/src/e2e-tests/persist-false-preserves.test.ts
+++ b/packages/think/src/e2e-tests/persist-false-preserves.test.ts
@@ -1,0 +1,317 @@
+/**
+ * E2E: `onChatRecovery` returning `{ persist: false, continue: false }` must
+ * NOT drop settled tool results under a REAL process kill (#1631 / R1).
+ *
+ * A turn runs a `recordStep` tool loop (each execution settles a non-idempotent
+ * ledger row). We let a few steps settle, SIGKILL + restart wrangler mid-turn,
+ * and the agent's `onChatRecovery` returns `{ persist: false, continue: false }`
+ * — the explicit "stop this turn" override. The R1 default guarantees the
+ * settled tool results produced before the kill are still materialized into the
+ * durable transcript (never dropped), while `continue: false` stops the turn.
+ *
+ * Without R1 (the old "persist:false discards the partial" behavior), the
+ * transcript would have ZERO settled tool parts after recovery — so this test
+ * fails on the pre-R1 code and passes after it.
+ */
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { setDefaultAutoSelectFamily } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+setDefaultAutoSelectFamily(false);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 18797;
+const AGENT_URL = `http://127.0.0.1:${PORT}`;
+const AGENT_SLUG = "think-persist-false-e2-e-agent";
+const AGENT_NAME = "persist-false-e2e";
+const PERSIST_DIR = path.join(__dirname, ".wrangler-persist-false-state");
+const TOTAL_STEPS = 30;
+
+type PersistFalseStatus = {
+  totalExecutions: number;
+  uniqueIndices: number;
+  maxIndex: number;
+  recoveryCount: number;
+  assistantMessages: number;
+  settledToolPartsInTranscript: number;
+  hasFiberRows: boolean;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function killProcessOnPort(port: number): void {
+  try {
+    const output = execSync(
+      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
+    )
+      .toString()
+      .trim();
+    if (output) {
+      for (const pid of output.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {
+          // already dead
+        }
+      }
+    }
+  } catch {
+    // lsof unavailable
+  }
+}
+
+function killProcessTree(pid: number): void {
+  let children: number[] = [];
+  try {
+    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    // pgrep unavailable
+  }
+  for (const child of children) killProcessTree(child);
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // already dead
+  }
+}
+
+function startWrangler(): ChildProcess {
+  const configPath = path.join(__dirname, "wrangler.jsonc");
+  const child = spawn(
+    "npx",
+    [
+      "wrangler",
+      "dev",
+      "--config",
+      configPath,
+      "--port",
+      String(PORT),
+      "--persist-to",
+      PERSIST_DIR,
+      "--inspector-port",
+      "0"
+    ],
+    {
+      cwd: __dirname,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, NODE_ENV: "test" }
+    }
+  );
+  child.stdout?.on("data", (d: Buffer) => {
+    const line = d.toString().trim();
+    if (line) console.log(`[wrangler] ${line}`);
+  });
+  child.stderr?.on("data", (d: Buffer) => {
+    const line = d.toString().trim();
+    if (line) console.log(`[wrangler:err] ${line}`);
+  });
+  return child;
+}
+
+async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`${AGENT_URL}/`);
+      await res.body?.cancel();
+      if (res.status > 0) return;
+    } catch {
+      // not ready
+    }
+    await sleep(delayMs);
+  }
+  throw new Error("Wrangler did not start in time");
+}
+
+async function waitForPortFree(maxAttempts = 60, delayMs = 500): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`${AGENT_URL}/`);
+      await res.body?.cancel();
+    } catch {
+      return;
+    }
+    await sleep(delayMs);
+  }
+  throw new Error(`Port ${PORT} did not free in time`);
+}
+
+function killProcess(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (!child.pid) {
+      resolve();
+      return;
+    }
+    const fallback = setTimeout(resolve, 3000);
+    child.on("exit", () => {
+      clearTimeout(fallback);
+      resolve();
+    });
+    killProcessTree(child.pid);
+  });
+}
+
+async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {
+  await killProcess(child);
+  await waitForPortFree();
+  const next = startWrangler();
+  await waitForReady();
+  return next;
+}
+
+function sendChatMessage(text: string): Promise<void> {
+  const url = `${AGENT_URL}/agents/${AGENT_SLUG}/${AGENT_NAME}`;
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timeout = setTimeout(() => {
+      ws.close();
+      resolve();
+    }, 4000);
+    ws.onopen = () => {
+      ws.send(
+        JSON.stringify({
+          type: "cf_agent_use_chat_request",
+          id: crypto.randomUUID(),
+          init: {
+            method: "POST",
+            body: JSON.stringify({
+              messages: [
+                {
+                  id: `user-${Date.now()}`,
+                  role: "user",
+                  parts: [{ type: "text", text }]
+                }
+              ]
+            })
+          }
+        })
+      );
+      setTimeout(() => {
+        clearTimeout(timeout);
+        ws.close();
+        resolve();
+      }, 1500);
+    };
+    ws.onerror = (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    };
+  });
+}
+
+async function callAgent(
+  method: string,
+  args: unknown[] = []
+): Promise<unknown> {
+  const url = `${AGENT_URL}/agents/${AGENT_SLUG}/${AGENT_NAME}`;
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const id = crypto.randomUUID();
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`RPC ${method} timed out`));
+    }, 10000);
+    ws.onopen = () =>
+      ws.send(JSON.stringify({ type: "rpc", id, method, args }));
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "rpc" && msg.id === id) {
+          clearTimeout(timeout);
+          ws.close();
+          if (msg.success) resolve(msg.result);
+          else reject(new Error(msg.error || "RPC failed"));
+        }
+      } catch {
+        // ignore non-rpc frames
+      }
+    };
+    ws.onerror = () => {
+      clearTimeout(timeout);
+      reject(new Error(`RPC ${method} socket error`));
+    };
+  });
+}
+
+async function readStatus(): Promise<PersistFalseStatus | null> {
+  try {
+    return (await callAgent("getPersistFalseStatus")) as PersistFalseStatus;
+  } catch {
+    return null;
+  }
+}
+
+describe("persist:false preserves settled work under a real kill", () => {
+  let wrangler: ChildProcess | null = null;
+
+  beforeEach(() => {
+    killProcessOnPort(PORT);
+    try {
+      fs.rmSync(PERSIST_DIR, { recursive: true, force: true });
+    } catch {
+      // OK
+    }
+  });
+
+  afterEach(async () => {
+    if (wrangler) {
+      await killProcess(wrangler);
+      wrangler = null;
+    }
+    killProcessOnPort(PORT);
+    try {
+      fs.rmSync(PERSIST_DIR, { recursive: true, force: true });
+    } catch {
+      // OK
+    }
+  });
+
+  it("keeps settled tool results in the transcript when recovery returns { persist: false } (#1631 R1)", async () => {
+    wrangler = startWrangler();
+    await waitForReady();
+
+    await sendChatMessage("record steps in order");
+
+    // Let a few steps settle (each ~600ms), then SIGKILL mid-turn so recovery
+    // fires on restart and returns { persist: false, continue: false }.
+    await sleep(3000);
+    wrangler = await restartWrangler(wrangler);
+
+    // Settle: wait for recovery to fire and the turn to stop (continue:false).
+    let status: PersistFalseStatus | null = null;
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      await sleep(2500);
+      status = await readStatus();
+      if (status) {
+        console.log(
+          `[persist-false] poll: maxIndex=${status.maxIndex} unique=${status.uniqueIndices} settledInTranscript=${status.settledToolPartsInTranscript} recoveries=${status.recoveryCount} fibers=${status.hasFiberRows}`
+        );
+        if (status.recoveryCount >= 1 && !status.hasFiberRows) break;
+      }
+    }
+
+    expect(status).not.toBeNull();
+    const final = status as PersistFalseStatus;
+    console.log(`[persist-false] FINAL: ${JSON.stringify(final)}`);
+
+    // Recovery fired and returned persist:false/continue:false.
+    expect(final.recoveryCount).toBeGreaterThanOrEqual(1);
+    // R1: the settled tool results produced before the kill are preserved in
+    // the durable transcript (the headline guarantee). Pre-R1 this would be 0.
+    expect(final.settledToolPartsInTranscript).toBeGreaterThanOrEqual(1);
+    // At least one ledger step actually settled before the kill.
+    expect(final.maxIndex).toBeGreaterThanOrEqual(1);
+    // continue:false stopped the turn — it did NOT run to completion.
+    expect(final.maxIndex).toBeLessThan(TOTAL_STEPS);
+  }, 120_000);
+});

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -25,6 +25,7 @@ type Env = {
   ThinkRecoveryHelperParent: DurableObjectNamespace<ThinkRecoveryHelperParent>;
   ThinkRecoveryHelperAgent: DurableObjectNamespace<ThinkRecoveryHelperAgent>;
   ThinkToolRollbackE2EAgent: DurableObjectNamespace<ThinkToolRollbackE2EAgent>;
+  ThinkPersistFalseE2EAgent: DurableObjectNamespace<ThinkPersistFalseE2EAgent>;
   ThinkTaskParentE2EAgent: DurableObjectNamespace<ThinkTaskParentE2EAgent>;
   ThinkAgentToolNaturalParentE2EAgent: DurableObjectNamespace<ThinkAgentToolNaturalParentE2EAgent>;
   AI: Ai;
@@ -207,6 +208,107 @@ export class ThinkToolRollbackE2EAgent extends Think<Env> {
   @callable()
   override async getMessages(): Promise<UIMessage[]> {
     return this.messages;
+  }
+}
+
+/**
+ * #1631 (R1) e2e: a `recordStep` tool loop whose `onChatRecovery` returns
+ * `{ persist: false, continue: false }` — the explicit "stop this turn"
+ * override. Under a real SIGKILL, recovery fires and returns persist:false;
+ * R1 guarantees the SETTLED tool results produced before the kill are still
+ * preserved in the durable transcript (never dropped), while continue:false
+ * stops the turn (no re-run). This proves the persist:false no-loss default
+ * survives a REAL process kill, not just a unit-seeded incident.
+ */
+export class ThinkPersistFalseE2EAgent extends Think<Env> {
+  static options = { keepAliveIntervalMs: 2_000 };
+  override chatRecovery = true;
+  override maxSteps = 500;
+  private _ledgerReady = false;
+
+  override getModel(): LanguageModel {
+    return createToolLoopMockModel(TOOL_ROLLBACK_TOTAL_STEPS);
+  }
+
+  override getSystemPrompt(): string {
+    return "Record each step in order using the recordStep tool.";
+  }
+
+  override getTools(): ToolSet {
+    return {
+      recordStep: tool({
+        description: "Record a step by its index.",
+        inputSchema: z.object({ index: z.number() }),
+        execute: async ({ index }) => {
+          this._ensureLedger();
+          this
+            .sql`INSERT INTO tool_ledger (idx, at) VALUES (${index}, ${Date.now()})`;
+          await new Promise((r) => setTimeout(r, TOOL_ROLLBACK_EXEC_DELAY_MS));
+          return { recorded: index };
+        }
+      })
+    };
+  }
+
+  override async onChatRecovery(): Promise<ChatRecoveryOptions> {
+    const n = (await this.ctx.storage.get<number>("tool:recovery-count")) ?? 0;
+    await this.ctx.storage.put("tool:recovery-count", n + 1);
+    // Explicit "stop this turn" — but R1 must STILL preserve the settled work.
+    return { persist: false, continue: false };
+  }
+
+  private _ensureLedger(): void {
+    if (this._ledgerReady) return;
+    this
+      .sql`CREATE TABLE IF NOT EXISTS tool_ledger (seq INTEGER PRIMARY KEY AUTOINCREMENT, idx INTEGER, at INTEGER)`;
+    this._ledgerReady = true;
+  }
+
+  @callable()
+  async getPersistFalseStatus(): Promise<{
+    totalExecutions: number;
+    uniqueIndices: number;
+    maxIndex: number;
+    recoveryCount: number;
+    assistantMessages: number;
+    settledToolPartsInTranscript: number;
+    hasFiberRows: boolean;
+  }> {
+    this._ensureLedger();
+    const rows = this.sql<{ idx: number; count: number }>`
+      SELECT idx, COUNT(*) as count FROM tool_ledger GROUP BY idx ORDER BY idx
+    `;
+    const fiberRows = this.sql<{ c: number }>`
+      SELECT COUNT(*) as c FROM cf_agents_runs
+    `;
+    const assistant = this.messages.filter((m) => m.role === "assistant");
+    const settledToolPartsInTranscript = assistant.reduce((n, m) => {
+      return (
+        n +
+        m.parts.filter((p) => {
+          const part = p as {
+            type?: unknown;
+            output?: unknown;
+            state?: unknown;
+          };
+          return (
+            typeof part.type === "string" &&
+            part.type.startsWith("tool-") &&
+            (part.output !== undefined || part.state === "output-available")
+          );
+        }).length
+      );
+    }, 0);
+    return {
+      totalExecutions: rows.reduce((n, r) => n + r.count, 0),
+      uniqueIndices: rows.length,
+      maxIndex: rows.reduce((m, r) => Math.max(m, r.idx), 0),
+      recoveryCount:
+        (await this.ctx.storage.get<number>("tool:recovery-count")) ?? 0,
+      assistantMessages: assistant.length,
+      settledToolPartsInTranscript,
+      hasFiberRows: (fiberRows[0]?.c ?? 0) > 0
+    };
   }
 }
 

--- a/packages/think/src/e2e-tests/wrangler.jsonc
+++ b/packages/think/src/e2e-tests/wrangler.jsonc
@@ -32,6 +32,10 @@
         "class_name": "ThinkToolRollbackE2EAgent"
       },
       {
+        "name": "ThinkPersistFalseE2EAgent",
+        "class_name": "ThinkPersistFalseE2EAgent"
+      },
+      {
         "name": "ThinkTaskParentE2EAgent",
         "class_name": "ThinkTaskParentE2EAgent"
       },
@@ -61,6 +65,10 @@
     {
       "tag": "v4",
       "new_sqlite_classes": ["ThinkAgentToolNaturalParentE2EAgent"]
+    },
+    {
+      "tag": "v5",
+      "new_sqlite_classes": ["ThinkPersistFalseE2EAgent"]
     }
   ],
   "r2_buckets": [

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3311,6 +3311,196 @@ describe("Think — onChatRecovery", () => {
     expect(messages).toHaveLength(0);
     expect(await agent.getTurnCallCount()).toBe(0);
   });
+
+  it("persists the settled partial when the recovery budget is exhausted (#1631)", async () => {
+    const agent = await freshRecoveryAgent("exhaust-preserves-partial");
+    // maxAttempts: 1 so a seeded attempt at the cap exhausts on the next wake.
+    await agent.setChatRecoveryConfigForTest({ maxAttempts: 1 });
+
+    // Terminal stream carrying a settled partial: text PLUS a completed
+    // (settled, non-idempotent) tool call — the exact work the budget-exhaustion
+    // path used to discard, forcing the model to re-run it on the next message.
+    await agent.insertInterruptedStream(
+      "stream-exh",
+      "req-exh",
+      [
+        {
+          body: JSON.stringify({ type: "start", messageId: "a-exh" }),
+          index: 0
+        },
+        {
+          body: JSON.stringify({
+            type: "tool-input-available",
+            toolCallId: "tc-exh",
+            toolName: "writeFile",
+            input: { path: "out.txt" }
+          }),
+          index: 1
+        },
+        {
+          body: JSON.stringify({
+            type: "tool-output-available",
+            toolCallId: "tc-exh",
+            output: { bytesWritten: 12 }
+          }),
+          index: 2
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 3 },
+        {
+          body: JSON.stringify({ type: "text-delta", delta: "did real work" }),
+          index: 4
+        }
+      ],
+      "completed"
+    );
+    await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-exh");
+
+    // Seed an incident already at the cap so this recovery exhausts. The
+    // incident id is `<recoveryRootRequestId>:<latestUserMessageId>` — here the
+    // root is the requestId and there is no latest user message.
+    // `lastAttemptAt` is aged past the alarm-debounce window (#1637/#1638) so
+    // this wake counts as a genuine new attempt (1 → 2 > maxAttempts) rather
+    // than being collapsed as a debounced reconnect (which would hold the
+    // attempt at 1 and never exhaust).
+    await agent.seedIncidentForTest({
+      incidentId: "req-exh:",
+      requestId: "req-exh",
+      recoveryKind: "continue",
+      attempt: 1,
+      maxAttempts: 1,
+      status: "scheduled",
+      firstSeenAt: Date.now() - 60_000,
+      lastAttemptAt: Date.now() - 60_000
+    });
+
+    await agent.triggerFiberRecovery();
+
+    // Exhaustion seals the turn but must NOT discard the settled partial — the
+    // bug was that `_exhaustChatRecovery` returned before persisting it.
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("assistant");
+    const text = messages[0].parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    expect(text).toContain("did real work");
+    // The settled tool result is preserved (not just the text) — it's the
+    // non-idempotent work the model would otherwise re-run.
+    const settledTool = messages[0].parts.find((p) => {
+      const part = p as { type?: unknown; output?: unknown; state?: unknown };
+      return (
+        typeof part.type === "string" &&
+        part.type.startsWith("tool-") &&
+        (part.output !== undefined || part.state === "output-available")
+      );
+    });
+    expect(settledTool).toBeDefined();
+
+    // And the incident is recorded as exhausted.
+    const incidents = (await agent.getChatRecoveryIncidentsForTest()) as Array<{
+      status: string;
+    }>;
+    expect(incidents[0]?.status).toBe("exhausted");
+  });
+
+  it("never drops settled tool results on { persist: false } — preserves them anyway (#1631)", async () => {
+    const agent = await freshRecoveryAgent("persist-false-preserves-settled");
+    await agent.setRecoveryOverride({ persist: false, continue: false });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // Terminal stream (so the persist gate is reached) carrying a SETTLED
+      // tool result — the non-idempotent work `persist: false` must NOT drop.
+      await agent.insertInterruptedStream(
+        "stream-settled",
+        "req-settled",
+        [
+          {
+            body: JSON.stringify({ type: "start", messageId: "a-settled" }),
+            index: 0
+          },
+          {
+            body: JSON.stringify({
+              type: "tool-input-available",
+              toolCallId: "tc1",
+              toolName: "calc",
+              input: { x: 1 }
+            }),
+            index: 1
+          },
+          {
+            body: JSON.stringify({
+              type: "tool-output-available",
+              toolCallId: "tc1",
+              output: { result: 42 }
+            }),
+            index: 2
+          }
+        ],
+        "completed"
+      );
+      await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-settled");
+
+      await agent.triggerFiberRecovery();
+
+      // R1: settled work is preserved regardless of `persist: false` — the
+      // assistant partial carrying the completed tool call IS persisted, and
+      // there is no warning (a safe default beats a warning about an unsafe one).
+      const messages = (await agent.getStoredMessages()) as UIMessage[];
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe("assistant");
+      const hasSettledTool = messages[0].parts.some((p) => {
+        const type = (p as { type?: unknown }).type;
+        return typeof type === "string" && type.startsWith("tool-");
+      });
+      expect(hasSettledTool).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("honors { persist: false } for a text-only partial with no settled work (#1631)", async () => {
+    const agent = await freshRecoveryAgent("persist-false-text-only");
+    await agent.setRecoveryOverride({ persist: false, continue: false });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await agent.insertInterruptedStream(
+        "stream-textonly",
+        "req-textonly",
+        [
+          {
+            body: JSON.stringify({ type: "start", messageId: "a-textonly" }),
+            index: 0
+          },
+          { body: JSON.stringify({ type: "text-start" }), index: 1 },
+          {
+            body: JSON.stringify({
+              type: "text-delta",
+              delta: "just prose, no tools"
+            }),
+            index: 2
+          }
+        ],
+        "completed"
+      );
+      await agent.insertInterruptedFiber(
+        "__cf_internal_chat_turn:req-textonly"
+      );
+
+      await agent.triggerFiberRecovery();
+
+      // No settled tool results to preserve, so `persist: false` is honored —
+      // nothing is persisted, and there is no warning.
+      const messages = (await agent.getStoredMessages()) as UIMessage[];
+      expect(messages).toHaveLength(0);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 // ── waitUntilStable / hasPendingInteraction ───────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7321,6 +7321,21 @@ export class Think<
       });
 
     if (exhausted) {
+      // Preserve the settled partial before sealing the turn. Exhaustion is
+      // decided BEFORE `onChatRecovery` is consulted, so without this the
+      // settled (often non-idempotent) tool results the turn already produced
+      // are discarded and the model re-runs them on the next message (#1631).
+      // Same gating as the normal path below so an already-persisted partial is
+      // never duplicated.
+      if (
+        await this._shouldPersistOrphanedPartial(streamId, {
+          streamStillActive: Boolean(streamStillActive),
+          streamIsTerminal,
+          snapshot: recoverySnapshot
+        })
+      ) {
+        await this._persistOrphanedStream(streamId);
+      }
       await this._exhaustChatRecovery(incident, config);
       return true;
     }
@@ -7348,14 +7363,22 @@ export class Think<
           createdAt: ctx.createdAt
         })) ?? {};
 
-      const streamAlreadyPersisted =
-        streamIsTerminal &&
-        (await this._hasPersistedRecoveredAssistant(recoverySnapshot));
+      const shouldPersist = await this._shouldPersistOrphanedPartial(streamId, {
+        streamStillActive: Boolean(streamStillActive),
+        streamIsTerminal,
+        snapshot: recoverySnapshot
+      });
 
+      // Settled work — completed, often non-idempotent tool results — is NEVER
+      // dropped by recovery. `persist: false` only suppresses persistence of a
+      // partial that has nothing settled to lose; a partial carrying settled
+      // tool results is persisted regardless, so an app can never accidentally
+      // discard completed work (and never needs `{ persist: true }` just to be
+      // safe). A safe default beats a warning about an unsafe one (#1631).
       if (
-        options.persist !== false &&
-        streamId &&
-        (streamStillActive || (streamIsTerminal && !streamAlreadyPersisted))
+        shouldPersist &&
+        (options.persist !== false ||
+          this._partialHasSettledToolResults(partial.parts))
       ) {
         await this._persistOrphanedStream(streamId);
       }
@@ -7534,6 +7557,44 @@ export class Think<
       lastLeaf?.role === "assistant" &&
       lastLeaf.id !== snapshot?.latestMessageId
     );
+  }
+
+  /**
+   * Whether the orphaned stream's partial should be materialized into an
+   * assistant message: there is a stream, and it is either still active or
+   * terminal-but-not-yet-persisted. Shared by the normal recovery path AND the
+   * exhaustion path so neither discards settled work nor duplicates a partial
+   * an earlier attempt already saved.
+   */
+  private async _shouldPersistOrphanedPartial(
+    streamId: string,
+    opts: {
+      streamStillActive: boolean;
+      streamIsTerminal: boolean;
+      snapshot: ChatFiberSnapshot<"think-chat-turn"> | null;
+    }
+  ): Promise<boolean> {
+    if (!streamId) return false;
+    const alreadyPersisted =
+      opts.streamIsTerminal &&
+      (await this._hasPersistedRecoveredAssistant(opts.snapshot));
+    return (
+      opts.streamStillActive || (opts.streamIsTerminal && !alreadyPersisted)
+    );
+  }
+
+  /** Whether a reconstructed partial carries any settled (provider-accepted)
+   *  tool result — the completed, often non-idempotent work that a
+   *  `{ persist: false }` recovery return would silently discard. */
+  private _partialHasSettledToolResults(parts: MessagePart[]): boolean {
+    return parts.some((part) => {
+      const record = part as Record<string, unknown>;
+      const type = typeof record.type === "string" ? record.type : "";
+      return (
+        (type.startsWith("tool-") || type === "dynamic-tool") &&
+        this._toolPartHasSettledResult(record)
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

When a chat-recovery turn is given up, the framework could throw away a partial assistant message holding **completed, often non-idempotent tool results** — the most valuable, least-reproducible state in a turn. This PR makes sure that never happens.

> **Updated:** rebased onto `main` (it now includes #1633, #1638/N1, #1640, and #1641/N9) and the `persist: false` footgun is now fixed with the **stronger default (R1)** instead of a warning — see below.

## Two paths fixed

### 1. Framework budget exhaustion dropped the settled partial
The budget check returns **before** `onChatRecovery` is consulted, and `_exhaustChatRecovery` sealed the turn (terminal status + banner) **without** persisting the orphaned stream. So when the framework's own budget tripped, every settled tool result was discarded and the model re-ran them on the next message.

**Fix:** the exhaustion branch now persists the settled partial **first**, reusing the normal path's gating (`_shouldPersistOrphanedPartial`) so it can never duplicate a partial an earlier attempt already saved. Because this sits in the same `if (exhausted)` branch that N1/#1638 rewrote, it now covers **every** exhaustion path (no-progress window + 15-min ceiling + attempt cap), not just the raw attempt cap.

### 2. `onChatRecovery` returning `{ persist: false }` dropped settled work (R1 — stronger default)
`{ persist: false }` reads like "don't bother continuing," but it actually **deleted** the settled partial — losing completed tool calls with no signal.

**Fix (R1): settled work is now NEVER dropped.** `{ persist: false }` only suppresses persistence of a partial that has **nothing settled to lose**; a partial carrying settled tool results is persisted regardless. An app can no longer accidentally discard completed work — and never needs `{ persist: true }` just to stay safe. (A safe default beats a warning about an unsafe one — chosen over the earlier "warn once" approach so there is no footgun and no app decision.)

New helpers: `_shouldPersistOrphanedPartial`, `_partialHasSettledToolResults` (recognizes `output-available` / `output-error` / `output-denied` and `output`/`result` shapes). Applied identically to `@cloudflare/think` and `@cloudflare/ai-chat`.

## g3 impact
Lets g3 delete its `{ persist: true }` recovery override (the default already persists by default, and now never loses settled work even on an explicit `persist: false`).

## Tests
- **Exhaustion preserves the settled partial** — seed an incident at the cap + a terminal stream with a partial, trigger recovery, assert the partial is persisted and the incident is `exhausted`. (Adapted to N1/#1638's alarm-debounce: the seeded incident's `lastAttemptAt` is aged past the debounce window so the wake counts as a genuine attempt and actually exhausts.)
- **`{ persist: false }` never drops settled tool results** — settled partial IS persisted, with no warning.
- **`{ persist: false }` honored for a text-only partial** — nothing settled to lose → nothing persisted, no warning.
- Full suites green: think **463**, ai-chat **485**; `npm run check` clean (91 projects).

## Notes for reviewers
- Rebased onto current `main` (the original branch carried the now-merged #1633 commit; dropped it). The diff is just this PR's change.
- The earlier revision of this PR shipped a one-time `console.warn` on `persist: false` data loss; this revision replaces it with the stronger no-loss default (R1) per the defaults-over-APIs review.

## Test plan
- [x] CI green
- [x] think + ai-chat suites green (463 / 485)
- [x] `npm run check` clean