### PR TITLE
feat(think): add repairInterruptedToolPart hook for client-resolved tools (#1631)

### DIFF
--- a/.changeset/think-repair-interrupted-tool-part-hook.md
+++ b/.changeset/think-repair-interrupted-tool-part-hook.md
@@ -1,0 +1,20 @@
+---
+"@cloudflare/think": minor
+---
+
+Add a `repairInterruptedToolPart` hook so subclasses can control how an
+interrupted tool call is repaired during transcript repair (#1631).
+
+Transcript repair flips a tool call with no settled result to an errored
+tool-result (preserving the record and keeping the provider from 400ing). That
+is the right default for server tools, but wrong for client-resolved tools like
+`ask_user` — a question with no server `execute`, answered by the user's next
+message — where the interrupted call _is_ a question and should be preserved as
+text so the model sees normal Q→A conversation and compaction keeps the prompt
+verbatim. Because repair runs (and persists) before `beforeTurn`, a subclass had
+no way to shape this for the current turn.
+
+`repairInterruptedToolPart(part)` defaults to the existing errored-result
+behavior and runs during repair, so an override (e.g. converting an interrupted
+`ask_user` into a text part carrying the prompt) takes effect on the same turn,
+not just the next one.

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -651,7 +651,9 @@ Common return values:
 
 - `{}` — persist partial + auto-continue (default, works with providers that support assistant prefill)
 - `{ continue: false }` — persist partial but do not auto-continue (handle continuation yourself)
-- `{ persist: false, continue: false }` — handle everything yourself (e.g., retrieve a completed response from the provider)
+- `{ persist: false, continue: false }` — do not persist the unsettled remainder and handle everything yourself (e.g., retrieve a completed response from the provider)
+
+Settled work is never dropped: `persist: false` only suppresses persistence of a partial that has nothing settled to lose. A partial that already carries settled tool results (completed, often non-idempotent work) is persisted regardless, so an app cannot accidentally discard completed tool calls — and never needs `{ persist: true }` just to stay safe.
 
 When recovery happens before any stream chunks were written, there is no partial assistant message to continue. If the latest persisted message is still the unanswered user message from the interrupted turn, the framework retries that turn automatically unless `continue` is `false`.
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -416,6 +416,33 @@ export class MyAgent extends Think<Env> {
 
 The same recovery events are available through `agents/observability` on the `chat` channel. Transcript repairs are emitted on the `transcript` channel.
 
+#### Repairing interrupted tool calls
+
+When a turn is interrupted mid-flight, the transcript can contain a tool call with no settled result. Before the next provider call, Think repairs each such call so the model does not silently re-run it and the provider does not reject the transcript with `AI_MissingToolResultsError`. The default flips the interrupted call to an errored tool result, so the record survives and conversion still has a tool result for it.
+
+Override `repairInterruptedToolPart` to customize the repaired shape. The common case is a client-resolved tool — for example an `ask_user` question that has no server `execute` and is normally answered by the user's next message. Converting it to a plain text part lets the model treat it as ordinary conversation rather than a tool error, and keeps the question verbatim through compaction:
+
+```typescript
+import type { UIMessage } from "ai";
+
+export class MyAgent extends Think<Env> {
+  protected override repairInterruptedToolPart(
+    part: UIMessage["parts"][number]
+  ): UIMessage["parts"][number] {
+    const record = part as Record<string, unknown>;
+    if (record.type === "tool-ask_user") {
+      const input = record.input as { prompt?: string } | undefined;
+      if (input?.prompt) {
+        return { type: "text", text: input.prompt };
+      }
+    }
+    return super.repairInterruptedToolPart(part);
+  }
+}
+```
+
+This runs during transcript repair — before the repaired transcript is persisted and sent to the model — so the conversion shapes the current turn, not just the next one. The `input` is already normalized to a valid object. A returned tool part must carry a settled result (`output-available`, `output-error`, or `output-denied`); returning a non-tool part such as text is also fine.
+
 ## Dynamic Configuration
 
 `configure()` and `getConfig()` persist a JSON-serializable config blob in SQLite. It survives hibernation and restarts. Pass the config shape as a method-level generic for typed call sites:

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -355,6 +355,27 @@ export class MyAgent extends Think<Env> {
 }
 ```
 
+When a turn is interrupted mid-flight, an unsettled tool call left in the
+transcript is repaired before the next provider call so the model does not
+re-run it (and the provider does not 400 with `AI_MissingToolResultsError`). The
+default flips it to an errored tool result; override `repairInterruptedToolPart`
+to customize the repaired shape — for example, convert an interrupted
+client-resolved `ask_user` (a question with no server `execute`) into a plain
+text part carrying the prompt so the model treats it as ordinary conversation:
+
+```ts
+protected override repairInterruptedToolPart(
+  part: UIMessage["parts"][number]
+): UIMessage["parts"][number] {
+  const record = part as Record<string, unknown>;
+  if (record.type === "tool-ask_user") {
+    const input = record.input as { prompt?: string } | undefined;
+    if (input?.prompt) return { type: "text", text: input.prompt };
+  }
+  return super.repairInterruptedToolPart(part);
+}
+```
+
 ### Scheduled tasks
 
 Use `getScheduledTasks()` for code-declared recurring prompts or deterministic

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -197,6 +197,33 @@ export class ThinkClientToolsAgent extends Think {
     )._lastClientTools;
   }
 
+  // Demonstrates the `repairInterruptedToolPart` override: a client-resolved
+  // `ask_user` (a question with no server execute) is preserved as a text part
+  // carrying the prompt rather than flipped to a generic errored tool result.
+  protected override repairInterruptedToolPart(
+    part: UIMessage["parts"][number]
+  ): UIMessage["parts"][number] {
+    const record = part as Record<string, unknown>;
+    if (record.type === "tool-ask_user") {
+      const input = record.input as { prompt?: unknown } | undefined;
+      const prompt = typeof input?.prompt === "string" ? input.prompt : "";
+      if (prompt) {
+        return { type: "text", text: prompt } as UIMessage["parts"][number];
+      }
+    }
+    return super.repairInterruptedToolPart(part);
+  }
+
+  async repairToolTranscriptPartsForTest(
+    messages: UIMessage[]
+  ): Promise<UIMessage[]> {
+    return (
+      this as unknown as {
+        _repairToolTranscriptParts(m: UIMessage[]): { messages: UIMessage[] };
+      }
+    )._repairToolTranscriptParts(messages).messages;
+  }
+
   async persistToolCallMessage(messages: UIMessage[]): Promise<void> {
     for (const msg of messages) {
       await this.session.appendMessage(msg);

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1931,3 +1931,78 @@ describe("Think — messageConcurrency", () => {
     await closeWS(ws);
   });
 });
+
+describe("repairInterruptedToolPart override (#1631)", () => {
+  it("converts an interrupted ask_user into a text part carrying the prompt", async () => {
+    const agent = await freshAgent();
+    const messages = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-ask_user",
+            toolCallId: "tc1",
+            state: "input-available",
+            input: { prompt: "Ship it tonight?" }
+          }
+        ]
+      }
+    ] as unknown as UIMessage[];
+
+    const repaired = await agent.repairToolTranscriptPartsForTest(messages);
+    const part = (repaired[1] as UIMessage).parts[0] as Record<string, unknown>;
+    // The client-resolved question is preserved as prose, not flipped to a
+    // generic errored tool result.
+    expect(part.type).toBe("text");
+    expect(part.text).toBe("Ship it tonight?");
+  });
+
+  it("falls back to the default errored-result repair for non-ask_user tools", async () => {
+    const agent = await freshAgent();
+    const messages = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-client_action",
+            toolCallId: "tc1",
+            state: "input-available",
+            input: {}
+          }
+        ]
+      }
+    ] as unknown as UIMessage[];
+
+    const repaired = await agent.repairToolTranscriptPartsForTest(messages);
+    const part = (repaired[0] as UIMessage).parts[0] as Record<string, unknown>;
+    expect(part.type).toBe("tool-client_action");
+    expect(part.state).toBe("output-error");
+  });
+
+  it("leaves a settled ask_user untouched (only interrupted calls are repaired)", async () => {
+    const agent = await freshAgent();
+    const messages = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-ask_user",
+            toolCallId: "tc1",
+            state: "output-available",
+            input: { prompt: "Q?" },
+            output: { answer: "yes" }
+          }
+        ]
+      }
+    ] as unknown as UIMessage[];
+
+    const repaired = await agent.repairToolTranscriptPartsForTest(messages);
+    const part = (repaired[0] as UIMessage).parts[0] as Record<string, unknown>;
+    expect(part.type).toBe("tool-ask_user");
+    expect(part.state).toBe("output-available");
+  });
+});

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1588,6 +1588,37 @@ export class Think<
     return ids;
   }
 
+  /**
+   * Repair a single interrupted tool call — a tool part with no settled result,
+   * left behind when a stream was cut off mid-flight. Returns the replacement
+   * part that takes its place in the transcript. `input` has already been
+   * normalized to a valid object.
+   *
+   * The default flips it to an errored tool result so the record survives (no
+   * "disappearing" tool call) and `convertToModelMessages` still gets a
+   * tool-result for it (avoiding `AI_MissingToolResultsError`).
+   *
+   * Override to customize the repaired shape for client-resolved tools — e.g.
+   * convert an interrupted `ask_user` (a question with no server `execute`,
+   * normally answered by the user's next message) into a plain text part
+   * carrying the question prose, so the model sees it as ordinary conversation
+   * rather than a tool error and compaction keeps the question verbatim. This
+   * runs DURING transcript repair — before the repaired transcript is persisted
+   * and sent to the model — so the conversion shapes the current turn, not just
+   * the next one. A returned tool part MUST carry a settled result
+   * (`output-available` / `output-error` / `output-denied` or an
+   * `output`/`result` field); returning a non-tool part (e.g. text) is fine.
+   */
+  protected repairInterruptedToolPart(
+    part: UIMessage["parts"][number]
+  ): UIMessage["parts"][number] {
+    return {
+      ...part,
+      state: "output-error",
+      errorText: "The tool call was interrupted before a result was recorded."
+    } as UIMessage["parts"][number];
+  }
+
   private _repairToolTranscriptParts(messages: UIMessage[]): {
     messages: UIMessage[];
     removedToolCalls: number;
@@ -1616,19 +1647,21 @@ export class Think<
         }
 
         if (!this._toolPartHasSettledResult(record)) {
-          // Preserve the interrupted/abandoned tool call as an errored result
-          // instead of deleting it. Deleting makes the call "disappear" from the
-          // (broadcast) transcript and lets the model silently re-run it; an
-          // errored result keeps the user-visible record AND gives conversion a
-          // tool-result so the provider doesn't 400 (AI_MissingToolResultsError).
+          // Preserve the interrupted/abandoned tool call instead of deleting
+          // it. Deleting makes the call "disappear" from the (broadcast)
+          // transcript and lets the model silently re-run it. `input` is
+          // normalized to a valid object first, then `repairInterruptedToolPart`
+          // decides the replacement shape (default: an errored result, so
+          // conversion still gets a tool-result and the provider doesn't 400
+          // with AI_MissingToolResultsError). Subclasses can override it to
+          // preserve client-resolved tools (e.g. `ask_user`) as text.
           const normalized = this._normalizeToolInput(record);
-          parts.push({
-            ...part,
-            input: normalized.input,
-            state: "output-error",
-            errorText:
-              "The tool call was interrupted before a result was recorded."
-          } as UIMessage["parts"][number]);
+          parts.push(
+            this.repairInterruptedToolPart({
+              ...part,
+              input: normalized.input
+            } as UIMessage["parts"][number])
+          );
           if (normalized.changed) normalizedInputs++;
           removedToolCalls++;
           messageChanged = true;


### PR DESCRIPTION
## Stack

This is **PR 3 of 4** for #1631. Stacked; **base is `fix/chat-recovery-preserve-settled-work`** (PR #1634). Retargets to `main` as the stack merges. Diff shown is only this PR's commit.

1. #1633 — progress signal compaction-immune (#1628) · patch
2. #1634 — preserve settled work when a turn is given up · patch
3. **➡️ `repairInterruptedToolPart` hook (this PR)** · minor
4. incident identity + `onExhausted` payload · minor

This is a **public-API addition** (a new `protected` override point) — the one most worth a careful API-shape review. `@cloudflare/think` only (ai-chat has no transcript-repair pass).

---

## Problem (#1631, item 2)

Transcript repair (`_repairToolTranscriptParts`) flips a tool call with no settled result to an errored tool-result — preserving the record and keeping the provider from 400ing (`AI_MissingToolResultsError`). That's the right default for **server** tools.

It's wrong for **client-resolved** tools like `ask_user` — a question with no server `execute`, answered by the user's *next message*. There, the interrupted call **is** a question, and the right repair is to preserve it as a **text part carrying the prompt**, so the model sees a normal Q→A exchange and compaction keeps the question verbatim. Flipping it to `output-error` turns *\"the assistant asked X\"* into *\"a tool errored\"* and loses the prose.

Crucially, repair runs **and persists** before `beforeTurn`:

```ts
// _runInference
const history = await this._repairTranscriptForProvider(this.messages); // repairs + persists + broadcasts
const messages = await convertToModelMessages(truncated, { ... });       // builds model ctx
...
const subclassConfig = (await this.beforeTurn(ctx)) ?? {};               // too late: ctx.messages already built/persisted
```

So a subclass had **no way** to shape this for the current turn — any `beforeTurn` fix-up lands a turn late and races the framework's persisted `output-error`.

## Fix

Extract the per-orphan flip into a `protected` overridable hook that repair consults during the repair pass (before persist), defaulting to the existing behavior:

```ts
/** Repair a single interrupted tool call (no settled result). `input` is already
 *  normalized. Default flips it to an errored tool-result. Override to preserve
 *  client-resolved tools (e.g. ask_user -> a text part carrying the prompt) so the
 *  conversion shapes THIS turn, before repair persists + sends to the model. */
protected repairInterruptedToolPart(
  part: UIMessage["parts"][number]
): UIMessage["parts"][number] {
  return { ...part, state: "output-error", errorText: "The tool call was interrupted before a result was recorded." };
}
```

`_repairToolTranscriptParts` now calls `this.repairInterruptedToolPart({ ...part, input: normalizedInput })`. Default behavior is byte-for-byte unchanged. A subclass returning a text part for `ask_user` takes effect **on the same turn**, because it runs inside the repair pass.

Contract (documented on the method): a returned **tool** part must carry a settled result (so the `ignoreIncompleteToolCalls` backstop / `_incompleteToolCallIds` don't drop it); returning a **non-tool** part (e.g. text) is fine.

## Files

- `packages/think/src/think.ts` — new `protected repairInterruptedToolPart`; `_repairToolTranscriptParts` refactored to call it (default unchanged).
- `packages/think/src/tests/agents/client-tools.ts` — `ThinkClientToolsAgent` overrides the hook (ask_user → text) to demonstrate the intended usage + a `repairToolTranscriptPartsForTest` harness.
- `packages/think/src/tests/client-tools.test.ts` — tests.
- `.changeset/think-repair-interrupted-tool-part-hook.md` (minor · think).

## Tests

- *converts an interrupted `ask_user` into a text part carrying the prompt* (the override).
- *falls back to the default errored-result repair for non-`ask_user` tools* (default preserved).
- *leaves a settled `ask_user` untouched* (only interrupted calls are repaired).

The pre-existing repair tests (`message-reconciliation.test.ts`: orphan → `output-error`) still pass — the refactor is behavior-preserving for the default, and the demo override only matches `tool-ask_user` (other agents' orphans are unaffected).

## Verification

- `tsc --noEmit` clean (think); `oxlint` clean; `oxfmt` applied.
- `client-tools` + `message-reconciliation` suites: **58 passed**. Full think suite: **460 passed**.

## API review notes

- Name/shape up for discussion: `repairInterruptedToolPart(part) -> part`. Alternatives considered: a `beforeTranscriptRepair(messages)` pre-hook (rejected — needs extra persist-gating to avoid the repair's early-return swallowing hook-only changes; per-part is cleaner and persists naturally).
- This only resolves item 2 for `think`. ai-chat doesn't run this repair pass, so no change there.

## Test plan

- [ ] CI green
- [ ] API-shape sign-off on `repairInterruptedToolPart`
- [ ] Confirm default-path repair unchanged (existing repair tests green)

Made with [Cursor](https://cursor.com)