### PR TITLE
feat(think,ai-chat,agents): expose incident identity + enrich onExhausted payload (#1631)

### DIFF
--- a/.changeset/chat-recovery-exhausted-context.md
+++ b/.changeset/chat-recovery-exhausted-context.md
@@ -1,0 +1,23 @@
+---
+"agents": minor
+"@cloudflare/think": minor
+"@cloudflare/ai-chat": minor
+---
+
+Expose recovery incident identity and enrich the `onExhausted` payload so
+products can build a terminal-state policy without re-deriving anything (#1631).
+
+- `ChatRecoveryContext` (the `onChatRecovery` argument) now includes
+  `recoveryRootRequestId` — the stable request ID for the whole continuation
+  chain. Unlike `requestId`, it doesn't change across chained continuations, so
+  it's the right key for per-incident budget tracking / fresh-incident detection
+  without re-deriving identity from message IDs.
+- `ChatRecoveryExhaustedContext` (the `onExhausted` argument) now carries
+  `recoveryRootRequestId`, `terminalMessage` (the exact text shown to the user),
+  `partialText` / `partialParts` (what the turn produced before it was given up
+  on), and `streamId` / `createdAt` — enough to render or persist a user-facing
+  terminal banner AND emit correlated terminal telemetry (e.g. time-since-turn-start,
+  stream correlation) directly, without re-deriving anything.
+
+All fields are additive. Applied across `agents` (shared types),
+`@cloudflare/think`, and `@cloudflare/ai-chat`.

--- a/packages/agents/src/chat/lifecycle.ts
+++ b/packages/agents/src/chat/lifecycle.ts
@@ -88,6 +88,14 @@ export type SaveMessagesResult = {
 export type ChatRecoveryContext = {
   /** Stable identifier for this recovery incident. */
   incidentId: string;
+  /**
+   * Stable request ID for the whole continuation chain (the recovery "root").
+   * Unlike `requestId` — which changes on every chained continuation — this is
+   * constant for the lifetime of the incident, so it's the right key for
+   * per-incident budget tracking or fresh-incident detection without
+   * re-deriving identity from message IDs.
+   */
+  recoveryRootRequestId: string;
   /** Attempt number for this recovery incident, starting at 1. */
   attempt: number;
   /** Maximum attempts before the framework terminalizes recovery. */
@@ -130,12 +138,29 @@ export type ChatRecoveryOptions = {
 
 /**
  * Context passed when framework-owned chat recovery exhausts its retry budget.
+ *
+ * Carries enough to render/persist a user-facing terminal banner without
+ * re-deriving anything: the `terminalMessage` that was shown, the
+ * `recoveryRootRequestId` (stable incident identity), and the partial the turn
+ * produced before it was given up on.
  */
 export type ChatRecoveryExhaustedContext = Pick<
   ChatRecoveryContext,
-  "incidentId" | "requestId" | "attempt" | "maxAttempts" | "recoveryKind"
+  | "incidentId"
+  | "requestId"
+  | "recoveryRootRequestId"
+  | "attempt"
+  | "maxAttempts"
+  | "recoveryKind"
+  | "streamId"
+  | "createdAt"
+  | "partialText"
+  | "partialParts"
 > & {
+  /** Why recovery stopped: `max_attempts_exceeded` or `max_recovery_window_exceeded`. */
   reason: string;
+  /** The terminal message shown to the user (from the `chatRecovery` config). */
+  terminalMessage: string;
 };
 
 /**

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -99,6 +99,8 @@ type ChatRecoveryKind = "retry" | "continue";
 type ChatRecoveryIncident = {
   incidentId: string;
   requestId: string;
+  /** Stable request ID for the whole continuation chain (the recovery root). */
+  recoveryRootRequestId?: string;
   recoveryKind: ChatRecoveryKind;
   attempt: number;
   maxAttempts: number;
@@ -3328,6 +3330,7 @@ export class AIChatAgent<
     const incident: ChatRecoveryIncident = {
       incidentId,
       requestId: input.requestId,
+      recoveryRootRequestId: input.recoveryRootRequestId ?? input.requestId,
       recoveryKind: input.recoveryKind,
       attempt,
       maxAttempts: config.maxAttempts,
@@ -3413,15 +3416,25 @@ export class AIChatAgent<
 
   private async _exhaustChatRecovery(
     incident: ChatRecoveryIncident,
-    config: ResolvedChatRecoveryConfig
+    config: ResolvedChatRecoveryConfig,
+    partial: { text: string; parts: MessagePart[] },
+    streamId: string,
+    createdAt: number
   ): Promise<void> {
     const ctx: ChatRecoveryExhaustedContext = {
       incidentId: incident.incidentId,
       requestId: incident.requestId,
+      recoveryRootRequestId:
+        incident.recoveryRootRequestId ?? incident.requestId,
       attempt: incident.attempt,
       maxAttempts: incident.maxAttempts,
       recoveryKind: incident.recoveryKind,
-      reason: incident.reason ?? "max_attempts_exceeded"
+      streamId,
+      createdAt,
+      partialText: partial.text,
+      partialParts: partial.parts,
+      reason: incident.reason ?? "max_attempts_exceeded",
+      terminalMessage: config.terminalMessage
     };
     this._emit("chat:recovery:exhausted", ctx);
     // A throwing onExhausted hook must not prevent the terminal UX from being
@@ -3513,7 +3526,13 @@ export class AIChatAgent<
       if (streamStillActive) {
         await this._persistOrphanedStream(streamId);
       }
-      await this._exhaustChatRecovery(incident, config);
+      await this._exhaustChatRecovery(
+        incident,
+        config,
+        partial,
+        streamId,
+        ctx.createdAt
+      );
       return true;
     }
 
@@ -3525,6 +3544,7 @@ export class AIChatAgent<
       const options =
         (await this.onChatRecovery({
           incidentId: incident.incidentId,
+          recoveryRootRequestId,
           attempt: incident.attempt,
           maxAttempts: incident.maxAttempts,
           recoveryKind,

--- a/packages/ai-chat/src/tests/chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/chat-recovery.test.ts
@@ -10,7 +10,23 @@ interface ChatTestStub {
   getActiveFibers(): Promise<Array<{ id: string; name: string }>>;
   getOnChatMessageCallCount(): Promise<number>;
   getRecoveryContexts(): Promise<
-    Array<{ recoveryData: unknown; partialText: string; streamId: string }>
+    Array<{
+      recoveryData: unknown;
+      partialText: string;
+      streamId: string;
+      recoveryRootRequestId: string;
+    }>
+  >;
+  enableExhaustedCaptureForTest(maxAttempts: number): Promise<void>;
+  getExhaustedContextsForTest(): Promise<
+    Array<{
+      recoveryRootRequestId: string;
+      terminalMessage: string;
+      partialText: string;
+      reason: string;
+      streamId: string;
+      createdAt: number;
+    }>
   >;
   waitForIdleForTest(): Promise<void>;
   persistMessages(messages: unknown[]): Promise<void>;
@@ -737,6 +753,85 @@ describe("chatRecovery", () => {
       } finally {
         warnSpy.mockRestore();
       }
+    });
+
+    it("exposes recoveryRootRequestId on the onChatRecovery context", async () => {
+      const room = crypto.randomUUID();
+      const stub = (await getAgentByName(
+        env.ChatRecoveryTestAgent,
+        room
+      )) as unknown as ChatTestStub;
+
+      await stub.insertInterruptedStream("stream-root", "req-root", [
+        {
+          body: JSON.stringify({ type: "start", messageId: "a-root" }),
+          index: 0
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 1 },
+        {
+          body: JSON.stringify({ type: "text-delta", delta: "partial" }),
+          index: 2
+        }
+      ]);
+      await stub.insertInterruptedFiber("__cf_internal_chat_turn:req-root");
+
+      await stub.triggerFiberRecovery();
+
+      const contexts = await stub.getRecoveryContexts();
+      expect(contexts.length).toBeGreaterThanOrEqual(1);
+      expect(contexts[0]?.recoveryRootRequestId).toBe("req-root");
+    });
+
+    it("onExhausted context carries terminalMessage, recoveryRootRequestId, and the partial", async () => {
+      const room = crypto.randomUUID();
+      const stub = (await getAgentByName(
+        env.ChatRecoveryTestAgent,
+        room
+      )) as unknown as ChatTestStub;
+      await stub.enableExhaustedCaptureForTest(1);
+
+      await stub.insertInterruptedStream("stream-exctx", "req-exctx", [
+        {
+          body: JSON.stringify({ type: "start", messageId: "a-exctx" }),
+          index: 0
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 1 },
+        {
+          body: JSON.stringify({
+            type: "text-delta",
+            delta: "work before giving up"
+          }),
+          index: 2
+        }
+      ]);
+      await stub.insertInterruptedFiber("__cf_internal_chat_turn:req-exctx");
+      // `lastAttemptAt` aged past the alarm-debounce window (#1637/#1638) so this
+      // wake counts as a genuine new attempt (1 → 2 > maxAttempts) and exhausts,
+      // rather than being collapsed as a debounced reconnect.
+      await stub.seedIncidentForTest({
+        incidentId: "req-exctx:",
+        requestId: "req-exctx",
+        recoveryKind: "continue",
+        attempt: 1,
+        maxAttempts: 1,
+        status: "scheduled",
+        firstSeenAt: Date.now() - 60_000,
+        lastAttemptAt: Date.now() - 60_000
+      });
+
+      await stub.triggerFiberRecovery();
+
+      const exhausted = await stub.getExhaustedContextsForTest();
+      expect(exhausted).toHaveLength(1);
+      const ctx = exhausted[0];
+      expect(ctx.recoveryRootRequestId).toBe("req-exctx");
+      expect(ctx.terminalMessage.length).toBeGreaterThan(0);
+      expect(ctx.partialText).toContain("work before giving up");
+      expect(ctx.reason).toBe("max_attempts_exceeded");
+      // streamId + createdAt let a consumer emit correlated terminal telemetry
+      // (e.g. msSinceTurnStart) without re-deriving identity (D4).
+      expect(ctx.streamId).toBe("stream-exctx");
+      expect(typeof ctx.createdAt).toBe("number");
     });
   });
 

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -23,6 +23,7 @@ import type {
   ClientToolSchema,
   ChatRecoveryConfig,
   ChatRecoveryContext,
+  ChatRecoveryExhaustedContext,
   ChatRecoveryOptions
 } from "../";
 import { ResumableStream } from "agents/chat";
@@ -1457,6 +1458,7 @@ export class AgentWithoutSuperCall extends AIChatAgent<Env> {
 export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
   override chatRecovery: ChatRecoveryConfig = true;
   recoveryContexts: ChatRecoveryContext[] = [];
+  exhaustedContexts: ChatRecoveryExhaustedContext[] = [];
   recoveryOverride: ChatRecoveryOptions | null = null;
   onChatMessageCallCount = 0;
   onChatMessageBodies: Array<Record<string, unknown> | undefined> = [];
@@ -1588,6 +1590,21 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 
   getOnExhaustedCallsForTest(): number {
     return this.onExhaustedCalls;
+  }
+
+  /** Capture the `onExhausted` context for assertions (instead of throwing). */
+  enableExhaustedCaptureForTest(maxAttempts: number): void {
+    this.exhaustedContexts = [];
+    this.chatRecovery = {
+      maxAttempts,
+      onExhausted: (exhaustedCtx) => {
+        this.exhaustedContexts.push(exhaustedCtx);
+      }
+    };
+  }
+
+  getExhaustedContextsForTest(): ChatRecoveryExhaustedContext[] {
+    return this.exhaustedContexts;
   }
 
   setChatRecoveryConfigForTest(config: ChatRecoveryConfig): void {
@@ -1995,6 +2012,7 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     const options =
       (await this.onChatRecovery({
         incidentId: `test:${requestId}`,
+        recoveryRootRequestId: requestId,
         attempt: 1,
         maxAttempts: 6,
         recoveryKind: "continue",

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -18,6 +18,7 @@ import type {
   SaveMessagesResult,
   ChatRecoveryConfig,
   ChatRecoveryContext,
+  ChatRecoveryExhaustedContext,
   ChatRecoveryOptions,
   ThinkSubmissionInspection,
   ThinkSubmissionStatus,
@@ -3404,6 +3405,7 @@ export class ThinkRecoveryTestAgent extends Think {
 
   private _recoveryContexts: Array<{
     incidentId: string;
+    recoveryRootRequestId: string;
     attempt: number;
     maxAttempts: number;
     recoveryKind: "retry" | "continue";
@@ -3416,6 +3418,7 @@ export class ThinkRecoveryTestAgent extends Think {
   }> = [];
   private _recoveryOverride: ChatRecoveryOptions = {};
   private _recoveryShouldThrow = false;
+  private _exhaustedContexts: ChatRecoveryExhaustedContext[] = [];
   private _onExhaustedCalls = 0;
   private _turnCallCount = 0;
   private _turnBodies: Array<Record<string, unknown> | undefined> = [];
@@ -3466,6 +3469,7 @@ export class ThinkRecoveryTestAgent extends Think {
   ): Promise<ChatRecoveryOptions> {
     this._recoveryContexts.push({
       incidentId: ctx.incidentId,
+      recoveryRootRequestId: ctx.recoveryRootRequestId,
       attempt: ctx.attempt,
       maxAttempts: ctx.maxAttempts,
       recoveryKind: ctx.recoveryKind,
@@ -3509,6 +3513,7 @@ export class ThinkRecoveryTestAgent extends Think {
   async getRecoveryContexts(): Promise<
     Array<{
       incidentId: string;
+      recoveryRootRequestId: string;
       attempt: number;
       maxAttempts: number;
       recoveryKind: "retry" | "continue";
@@ -3521,6 +3526,41 @@ export class ThinkRecoveryTestAgent extends Think {
     }>
   > {
     return this._recoveryContexts;
+  }
+
+  /** Capture the `onExhausted` context for assertions (instead of throwing). */
+  async enableExhaustedCaptureForTest(maxAttempts: number): Promise<void> {
+    this._exhaustedContexts = [];
+    this.chatRecovery = {
+      maxAttempts,
+      onExhausted: (exhaustedCtx) => {
+        this._exhaustedContexts.push(exhaustedCtx);
+      }
+    };
+  }
+
+  // Explicit serializable return shape (rather than `ChatRecoveryExhaustedContext[]`):
+  // the context's `partialParts: MessagePart[]` is a deeply-generic AI SDK union
+  // that the RPC stub-type machinery cannot instantiate (TS2589), which also
+  // poisons sibling stub methods. `unknown[]` keeps the RPC type shallow; the
+  // test only reads the scalar fields below.
+  async getExhaustedContextsForTest(): Promise<
+    Array<{
+      incidentId: string;
+      requestId: string;
+      recoveryRootRequestId: string;
+      attempt: number;
+      maxAttempts: number;
+      recoveryKind: "retry" | "continue";
+      streamId: string;
+      createdAt: number;
+      partialText: string;
+      partialParts: unknown[];
+      reason: string;
+      terminalMessage: string;
+    }>
+  > {
+    return this._exhaustedContexts;
   }
 
   async getTurnBodies(): Promise<Array<Record<string, unknown> | undefined>> {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3501,6 +3501,98 @@ describe("Think — onChatRecovery", () => {
       warnSpy.mockRestore();
     }
   });
+
+  it("exposes recoveryRootRequestId on the onChatRecovery context (#1631)", async () => {
+    const agent = await freshRecoveryAgent("recovery-root-id");
+
+    await agent.insertInterruptedStream("stream-root", "req-root", [
+      {
+        body: JSON.stringify({ type: "start", messageId: "a-root" }),
+        index: 0
+      },
+      { body: JSON.stringify({ type: "text-start" }), index: 1 },
+      {
+        body: JSON.stringify({ type: "text-delta", delta: "partial" }),
+        index: 2
+      }
+    ]);
+    await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-root");
+
+    await agent.triggerFiberRecovery();
+
+    // Cast the RPC return to the shape under test — the stub type machinery
+    // collapses these complex recovery-context returns to `never` at the call
+    // site (same quirk handled elsewhere in these tests).
+    const contexts = (await agent.getRecoveryContexts()) as Array<{
+      recoveryRootRequestId: string;
+    }>;
+    expect(contexts.length).toBeGreaterThanOrEqual(1);
+    // The stable incident root (constant across chained continuations) is now a
+    // first-class field — no re-deriving identity from message IDs.
+    expect(contexts[0]?.recoveryRootRequestId).toBe("req-root");
+  });
+
+  it("onExhausted context carries terminalMessage, recoveryRootRequestId, and the partial (#1631)", async () => {
+    const agent = await freshRecoveryAgent("exhausted-ctx");
+    await agent.enableExhaustedCaptureForTest(1);
+
+    await agent.insertInterruptedStream(
+      "stream-exctx",
+      "req-exctx",
+      [
+        {
+          body: JSON.stringify({ type: "start", messageId: "a-exctx" }),
+          index: 0
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 1 },
+        {
+          body: JSON.stringify({
+            type: "text-delta",
+            delta: "work before giving up"
+          }),
+          index: 2
+        }
+      ],
+      "completed"
+    );
+    await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-exctx");
+    // `lastAttemptAt` aged past the alarm-debounce window (#1637/#1638) so this
+    // wake counts as a genuine new attempt (1 → 2 > maxAttempts) and exhausts,
+    // rather than being collapsed as a debounced reconnect.
+    await agent.seedIncidentForTest({
+      incidentId: "req-exctx:",
+      requestId: "req-exctx",
+      recoveryKind: "continue",
+      attempt: 1,
+      maxAttempts: 1,
+      status: "scheduled",
+      firstSeenAt: Date.now() - 60_000,
+      lastAttemptAt: Date.now() - 60_000
+    });
+
+    await agent.triggerFiberRecovery();
+
+    const exhausted = (await agent.getExhaustedContextsForTest()) as Array<{
+      recoveryRootRequestId: string;
+      terminalMessage: string;
+      partialText: string;
+      reason: string;
+      streamId: string;
+      createdAt: number;
+    }>;
+    expect(exhausted).toHaveLength(1);
+    const ctx = exhausted[0];
+    // Enough to render/persist a terminal banner AND emit correlated telemetry
+    // without re-deriving anything (the streamId + createdAt let a consumer
+    // compute msSinceTurnStart and correlate the failure — D4).
+    expect(ctx.recoveryRootRequestId).toBe("req-exctx");
+    expect(ctx.terminalMessage.length).toBeGreaterThan(0);
+    expect(ctx.partialText).toContain("work before giving up");
+    expect(ctx.reason).toBe("max_attempts_exceeded");
+    expect(ctx.streamId).toBe("stream-exctx");
+    expect(typeof ctx.createdAt).toBe("number");
+    expect(ctx.createdAt).toBeGreaterThan(0);
+  });
 });
 
 // ── waitUntilStable / hasPendingInteraction ───────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7241,15 +7241,25 @@ export class Think<
 
   private async _exhaustChatRecovery(
     incident: ChatRecoveryIncident,
-    config: ResolvedChatRecoveryConfig
+    config: ResolvedChatRecoveryConfig,
+    partial: { text: string; parts: MessagePart[] },
+    streamId: string,
+    createdAt: number
   ): Promise<void> {
     const ctx: ChatRecoveryExhaustedContext = {
       incidentId: incident.incidentId,
       requestId: incident.requestId,
+      recoveryRootRequestId:
+        incident.recoveryRootRequestId ?? incident.requestId,
       attempt: incident.attempt,
       maxAttempts: incident.maxAttempts,
       recoveryKind: incident.recoveryKind,
-      reason: incident.reason ?? "max_attempts_exceeded"
+      streamId,
+      createdAt,
+      partialText: partial.text,
+      partialParts: partial.parts,
+      reason: incident.reason ?? "max_attempts_exceeded",
+      terminalMessage: config.terminalMessage
     };
     this._emit("chat:recovery:exhausted", ctx);
     // A throwing onExhausted hook must not prevent the terminal UX from being
@@ -7369,7 +7379,13 @@ export class Think<
       ) {
         await this._persistOrphanedStream(streamId);
       }
-      await this._exhaustChatRecovery(incident, config);
+      await this._exhaustChatRecovery(
+        incident,
+        config,
+        partial,
+        streamId ?? "",
+        ctx.createdAt
+      );
       return true;
     }
 
@@ -7381,6 +7397,7 @@ export class Think<
       const options =
         (await this.onChatRecovery({
           incidentId: incident.incidentId,
+          recoveryRootRequestId,
           attempt: incident.attempt,
           maxAttempts: incident.maxAttempts,
           recoveryKind,


### PR DESCRIPTION
## Stack

This is **PR 4 of 4** (top) for #1631. Stacked; **base is `feat/think-repair-interrupted-tool-part-hook`** (PR #1635). Retargets to `main` as the stack merges. Diff shown is only this PR's commit.

1. #1633 — progress signal compaction-immune (#1628) · patch
2. #1634 — preserve settled work when a turn is given up · patch
3. #1635 — `repairInterruptedToolPart` hook · minor
4. **➡️ incident identity + `onExhausted` payload (this PR)** · minor

**Public-API addition** to shared types — additive only. Touches `agents` (shared `lifecycle.ts` types), `@cloudflare/think`, and `@cloudflare/ai-chat`.

---

## Problem (#1631, item 3)

A production agent needs a *persisted, user-visible terminal signal* when recovery gives up, and a stable way to key per-incident budget state — but the framework made products re-derive both:

- **`onExhausted` payload is too thin.** `ChatRecoveryExhaustedContext` carried only `incidentId / requestId / attempt / maxAttempts / recoveryKind / reason`. To render or persist a *\"this turn failed, send a new message\"* banner (especially when the client was disconnected at the moment recovery exhausted — exactly when this happens under deploy churn), products re-implemented it in a full `onChatRecovery` override.
- **No stable incident identity exposed.** `onChatRecovery` got `incidentId` (`<root>:<latestUserMessageId>`) but not the `recoveryRootRequestId` on its own. Since `requestId` changes on every chained continuation, products keyed budget/fresh-incident logic off message IDs — error-prone, and the source of premature exhaustion when a custom budget lacked the framework's progress-aware reset.

## Fix (additive)

In the shared `packages/agents/src/chat/lifecycle.ts`:

- **`ChatRecoveryContext`** gains `recoveryRootRequestId: string` — the stable request ID for the whole continuation chain (constant across chained continuations). The right key for per-incident budget tracking / fresh-incident detection without touching message IDs.
- **`ChatRecoveryExhaustedContext`** gains `recoveryRootRequestId`, `terminalMessage` (the exact user-facing text from the `chatRecovery` config), and `partialText` / `partialParts` (what the turn produced before being given up on) — enough to render/persist a contextual terminal banner with zero re-derivation.

Wired through both packages: `onChatRecovery` ctx now includes `recoveryRootRequestId`; `_exhaustChatRecovery` takes the reconstructed `partial` and builds the enriched ctx (ai-chat's local `ChatRecoveryIncident` gained `recoveryRootRequestId`, mirroring think).

## Safety of the required field

`recoveryRootRequestId` is **required** on `ChatRecoveryContext`, but that type is only ever *constructed* by the framework (`think.ts`, `ai-chat/index.ts`, and the test workers — all updated here). Consumers only *override* `onChatRecovery(ctx)` and **read** the context, so adding a field is backward-compatible for them. Verified there are no other `ChatRecoveryContext` constructors in the repo.

> Heads-up for reviewers: this edits `packages/agents/src/chat/lifecycle.ts`, whose types ship via the built `dist` consumed by `think`/`ai-chat`. Local typecheck required rebuilding `agents` first (`nx run agents:build`); CI builds in dependency order so it's a non-issue there.

## Files

- `packages/agents/src/chat/lifecycle.ts` — `recoveryRootRequestId` on `ChatRecoveryContext`; enriched `ChatRecoveryExhaustedContext`.
- `packages/think/src/think.ts` — pass `recoveryRootRequestId` into the `onChatRecovery` ctx; `_exhaustChatRecovery(incident, config, partial)` builds the enriched ctx.
- `packages/ai-chat/src/index.ts` — same; local `ChatRecoveryIncident` gains `recoveryRootRequestId` (set in `_beginChatRecoveryIncident`).
- Test agents capture the exhausted ctx (`enableExhaustedCaptureForTest` / `getExhaustedContextsForTest`) and the recovery ctx's `recoveryRootRequestId`.
- `.changeset/chat-recovery-exhausted-context.md` (minor · agents + think + ai-chat).

## Tests (both packages)

- *exposes `recoveryRootRequestId` on the `onChatRecovery` context.*
- *`onExhausted` context carries `terminalMessage`, `recoveryRootRequestId`, and the partial* — drive an incident to exhaustion and assert the captured exhausted ctx.

## Verification

- `tsc --noEmit` clean (think + ai-chat, after rebuilding `agents`); `oxlint` clean; `oxfmt` applied.
- Full suites green: think **460**, ai-chat **481**.

## Test plan

- [ ] CI green
- [ ] API-shape sign-off on the new `ChatRecoveryContext` / `ChatRecoveryExhaustedContext` fields
- [ ] Confirm no external constructors of `ChatRecoveryContext` break (none in-repo)

Made with [Cursor](https://cursor.com)