### PR TITLE
fix(think,ai-chat): wall-clock-keyed-to-progress recovery budget + alarm debounce (#1637)

### DIFF
--- a/.changeset/recovery-wall-clock-budget.md
+++ b/.changeset/recovery-wall-clock-budget.md
@@ -1,0 +1,34 @@
+---
+"@cloudflare/think": minor
+"@cloudflare/ai-chat": minor
+---
+
+Make chat recovery's budget wall-clock-keyed-to-progress instead of raw attempt
+count, so a healthy turn under deploy churn isn't sealed prematurely (#1637).
+
+Under continuous deploys the attempt count is the wrong primary bound: one
+rollout drops/reconnects the socket several times (~11–22s), each firing a
+recovery alarm, so the count inflated far faster than the real interruption rate
+and exhausted turns that were still advancing (0/23 model calls errored in the
+reported incident — it was pure eviction churn).
+
+Now:
+
+- **Primary bound: a 5-minute no-progress wall clock** keyed to `lastProgressAt`,
+  which resets on every progress-bearing attempt. A turn that keeps producing
+  content survives churn indefinitely; one that genuinely goes quiet is sealed
+  within 5 minutes.
+- **Alarm debounce (~30s):** recovery alarms bunched within the window (a single
+  rollout's reconnect storm) collapse into one attempt.
+- **Attempt cap is now a high secondary backstop** (default raised 6 → 10),
+  resets on progress; it only catches a pathological tight alarm-loop.
+- The existing 15-minute absolute incident-age ceiling is kept as the final
+  non-resetting hard stop.
+- **Progress signal moved to production time** (when new content is durably
+  flushed/streamed) instead of persist time — so it advances only on genuinely
+  new content and is immune to client reconnects and recovery re-persists, which
+  the no-progress window depends on. (Builds on the compaction-immune counter
+  from #1628.)
+
+Applies to both `@cloudflare/think` and `@cloudflare/ai-chat`, including the
+`TaskSubAgent`/sub-agent recovery path.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -112,6 +112,14 @@ type ChatRecoveryIncident = {
     | "failed";
   firstSeenAt: number;
   lastAttemptAt: number;
+  /**
+   * Epoch ms of the last attempt that observed forward progress. The recovery
+   * budget is keyed to this (`now - lastProgressAt > NO_PROGRESS_WINDOW`), so a
+   * turn that keeps producing content survives churn indefinitely while a
+   * genuinely stuck turn is sealed within the window (#1637). Optional for
+   * backward-compat — falls back to `firstSeenAt`.
+   */
+  lastProgressAt?: number;
   reason?: string;
   /**
    * High-water mark of the durable, monotonic recovery-progress counter (see
@@ -131,7 +139,11 @@ const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
 // `_persistOrphanedStream`; never recomputed from the (compactable) transcript.
 // See `_chatRecoveryProgressMarker`.
 const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
-const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 6;
+// Secondary backstop only. The primary recovery bound is the no-progress
+// wall clock below; with alarm debounce this cap rarely binds (it catches a
+// pathological tight alarm-loop). Kept high so the no-progress window seals
+// first under normal deploy cadence (#1637).
+const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Delay before retrying a recovery that timed out waiting for stable state.
 // Gives an actively-churning isolate (e.g. a deploy in flight) time to settle.
@@ -141,10 +153,18 @@ const DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE =
 // Incidents that have not seen a new attempt within this window are assumed
 // abandoned and swept so durable storage does not grow without bound.
 const CHAT_RECOVERY_INCIDENT_TTL_MS = 60 * 60 * 1000;
-// Hard wall-clock ceiling for a single recovery incident. The attempt budget
-// can be reset by forward progress (see `_beginChatRecoveryIncident`), so this
-// is the ultimate stop that prevents an environment churning indefinitely from
-// retrying forever.
+// PRIMARY recovery bound (#1637): seal an incident that has made no forward
+// progress for this long. Keyed to `lastProgressAt`, which resets on every
+// progress-bearing attempt — so a turn that keeps producing content survives
+// deploy churn indefinitely, while a genuinely stuck turn dies within 5 min.
+const CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS = 5 * 60 * 1000;
+// Alarm debounce: recovery alarms bunched within this window collapse into a
+// single attempt. A deploy rollout drops/reconnects the socket several times
+// over ~11–22s; without this, one logical deploy would burn several attempts.
+const CHAT_RECOVERY_ALARM_DEBOUNCE_MS = 30 * 1000;
+// ABSOLUTE ceiling for a single recovery incident, keyed to `firstSeenAt` and
+// NEVER reset by progress — the final hard stop so even a degenerate
+// slowly-progressing loop cannot run forever.
 const CHAT_RECOVERY_MAX_WINDOW_MS = 15 * 60 * 1000;
 
 type StreamResultStatus = {
@@ -3064,6 +3084,8 @@ export class AIChatAgent<
     latestUserMessageId?: string | null;
     targetAssistantId?: string | null;
     recoveryKind: ChatRecoveryKind;
+    /** Test-only clock injection for deterministic debounce/window timing. */
+    nowMs?: number;
   }): Promise<{
     incident: ChatRecoveryIncident;
     config: ResolvedChatRecoveryConfig;
@@ -3072,28 +3094,51 @@ export class AIChatAgent<
     const config = this._resolveChatRecoveryConfig();
     const incidentId = this._chatRecoveryIncidentId(input);
     const key = this._chatRecoveryIncidentKey(incidentId);
-    const now = Date.now();
+    const now = input.nowMs ?? Date.now();
     await this._sweepStaleChatRecoveryIncidents(now);
     const existing = await this.ctx.storage.get<ChatRecoveryIncident>(key);
 
     // Forward-progress detection. A mid-turn deploy resets the Durable Object
     // ("code was updated"); the interrupted continuation is re-detected on the
-    // next wake. Without this, every such interruption consumes one attempt, so
-    // a deploy roughly every few minutes burns the whole budget and permanently
-    // abandons a turn that is actually advancing. We treat an interruption that
-    // followed real progress (more persisted assistant content than the last
-    // attempt saw) as environmental and reset the budget, while a turn that
-    // never advances still exhausts at `maxAttempts`.
+    // next wake. A turn that followed real progress (more durably-produced
+    // content than the last attempt saw) is environmental churn, not a poison
+    // turn.
     const prevProgress = existing?.progress ?? 0;
     const currentProgress = await this._chatRecoveryProgressMarker();
     const madeProgress = existing != null && currentProgress > prevProgress;
-    const windowExceeded =
+
+    // Wall-clock-keyed-to-progress budget (#1637). The raw attempt count is the
+    // wrong primary bound under deploy churn: one rollout drops/reconnects the
+    // socket several times (~11–22s), each firing an alarm, so a count inflates
+    // far faster than the real interruption rate and seals a healthy turn.
+    //  • PRIMARY — no-progress window: `lastProgressAt` resets on every
+    //    progress-bearing attempt, so a turn that keeps producing content
+    //    survives churn indefinitely; a stuck turn is sealed after 5 min.
+    //  • DEBOUNCE — alarms bunched within `ALARM_DEBOUNCE_MS` collapse into one
+    //    attempt, so a single rollout's reconnect storm isn't N attempts.
+    //  • SECONDARY — the attempt cap is a high backstop (resets on progress).
+    //  • ABSOLUTE — the 15-min incident-age ceiling never resets (final stop).
+    const lastProgressAt = madeProgress
+      ? now
+      : (existing?.lastProgressAt ?? existing?.firstSeenAt ?? now);
+    const noProgressExceeded =
+      existing != null &&
+      now - lastProgressAt > CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS;
+    const incidentAgeExceeded =
       existing != null &&
       now - existing.firstSeenAt > CHAT_RECOVERY_MAX_WINDOW_MS;
+    const debounced =
+      existing != null &&
+      !madeProgress &&
+      now - existing.lastAttemptAt < CHAT_RECOVERY_ALARM_DEBOUNCE_MS;
 
-    const attempt =
-      madeProgress && !windowExceeded ? 1 : (existing?.attempt ?? 0) + 1;
-    const exhausted = windowExceeded || attempt > config.maxAttempts;
+    const attempt = madeProgress
+      ? 1
+      : debounced
+        ? (existing?.attempt ?? 1)
+        : (existing?.attempt ?? 0) + 1;
+    const exhausted =
+      noProgressExceeded || incidentAgeExceeded || attempt > config.maxAttempts;
     const incident: ChatRecoveryIncident = {
       incidentId,
       requestId: input.requestId,
@@ -3103,12 +3148,15 @@ export class AIChatAgent<
       status: exhausted ? "exhausted" : "attempting",
       firstSeenAt: existing?.firstSeenAt ?? now,
       lastAttemptAt: now,
+      lastProgressAt,
       progress: Math.max(prevProgress, currentProgress),
       ...(exhausted
         ? {
-            reason: windowExceeded
+            reason: incidentAgeExceeded
               ? "max_recovery_window_exceeded"
-              : "max_attempts_exceeded"
+              : noProgressExceeded
+                ? "no_progress_timeout"
+                : "max_attempts_exceeded"
           }
         : {})
     };

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -135,9 +135,10 @@ type ChatRecoveryIncident = {
 
 const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
 // Durable, monotonic forward-progress counter for recovery budget resets.
-// Incremented once per non-empty partial materialized by
-// `_persistOrphanedStream`; never recomputed from the (compactable) transcript.
-// See `_chatRecoveryProgressMarker`.
+// Bumped at production time when new content is streamed (`_storeStreamChunk`),
+// so it reflects genuinely new content and is immune to reconnects/re-persists;
+// never recomputed from the (compactable) transcript. See
+// `_chatRecoveryProgressMarker`.
 const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 // Secondary backstop only. The primary recovery bound is the no-progress
 // wall clock below; with alarm debounce this cap rarely binds (it catches a
@@ -1303,9 +1304,39 @@ export class AIChatAgent<
     }
   }
 
-  /** @internal Delegate to _resumableStream */
-  protected _storeStreamChunk(streamId: string, body: string) {
+  /** @internal Delegate to _resumableStream. Also advances the recovery
+   *  progress counter at production time (see `_maybeBumpRecoveryProgress`). */
+  protected async _storeStreamChunk(streamId: string, body: string) {
     this._resumableStream.storeChunk(streamId, body);
+    let type: string | undefined;
+    try {
+      type = (JSON.parse(body) as { type?: string }).type;
+    } catch {
+      // non-JSON chunk body — nothing to credit
+    }
+    await this._maybeBumpRecoveryProgress(type);
+  }
+
+  /** Advance the recovery-progress counter when a chunk represents genuinely
+   *  new produced content — a started text/reasoning segment or a settled tool
+   *  input/output. Bumped at production time (the streaming path), so it
+   *  reflects real forward progress and is immune to client reconnects /
+   *  recovery re-persists (which replay or re-materialize stored chunks rather
+   *  than flow through here). This is what the recovery no-progress window keys
+   *  off (#1637), and stays compaction-proof (#1628). */
+  private async _maybeBumpRecoveryProgress(
+    type: string | undefined
+  ): Promise<void> {
+    if (
+      type === "text-start" ||
+      type === "reasoning-start" ||
+      type === "tool-input-available" ||
+      type === "tool-output-available" ||
+      type === "tool-output-error" ||
+      type === "tool-output-denied"
+    ) {
+      await this._bumpChatRecoveryProgress();
+    }
   }
 
   /** @internal Delegate to _resumableStream */
@@ -1406,11 +1437,9 @@ export class AIChatAgent<
           ? this.messages.map((m, i) => (i === existingIdx ? message : m))
           : [...this.messages, message];
       await this.persistMessages(updatedMessages);
-      // Real forward progress: a non-empty partial was materialized. Advance
-      // the durable, compaction-immune progress counter so a deploy-churned
-      // turn that keeps producing content resets its recovery budget instead
-      // of exhausting it (#1628).
-      await this._bumpChatRecoveryProgress();
+      // NOTE: progress is bumped at production/flush time in `_storeStreamChunk`
+      // (#1637), NOT here — persisting on recovery or a client reconnect must
+      // not be miscounted as new forward progress.
     }
   }
 
@@ -1484,7 +1513,7 @@ export class AIChatAgent<
    * @param event - The text event payload (text-start, text-delta with delta, or text-end)
    * @param continuation - Whether this is a continuation of a previous stream
    */
-  private _broadcastTextEvent(
+  private async _broadcastTextEvent(
     streamId: string,
     event:
       | { type: "text-start"; id: string }
@@ -1493,7 +1522,7 @@ export class AIChatAgent<
     continuation: boolean
   ) {
     const body = JSON.stringify(event);
-    this._storeStreamChunk(streamId, body);
+    await this._storeStreamChunk(streamId, body);
     this._broadcastChatMessage({
       body,
       done: false,
@@ -3043,9 +3072,11 @@ export class AIChatAgent<
    * assistant messages into a summary, lowering the count — so a turn that had
    * genuinely advanced could read as "no progress" between attempts and exhaust
    * its budget prematurely (#1628). Instead we read a durably-persisted counter
-   * that only ever increments — bumped once per non-empty partial materialized
-   * by `_persistOrphanedStream`, which is the exact "forward progress" event the
-   * old message-count tracked — so compaction can never lower it.
+   * that only ever increments — bumped at production time when new content is
+   * streamed (see `_storeStreamChunk` / `_maybeBumpRecoveryProgress`), which is
+   * genuine forward progress and is immune to client reconnects / recovery
+   * re-persists — so compaction can never lower it and a reconnect can't fake
+   * it (#1637).
    */
   private async _chatRecoveryProgressMarker(): Promise<number> {
     return (
@@ -3053,8 +3084,9 @@ export class AIChatAgent<
     );
   }
 
-  /** Advance the durable recovery-progress counter. Called when a partial
-   *  assistant message is materialized (real forward progress). */
+  /** Advance the durable recovery-progress counter. Called from
+   *  `_maybeBumpRecoveryProgress` when new content is streamed (real,
+   *  reconnect-immune forward progress). */
   private async _bumpChatRecoveryProgress(): Promise<void> {
     const current =
       (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0;
@@ -4768,7 +4800,7 @@ export class AIChatAgent<
 
             // Store chunk for replay and broadcast to clients
             const chunkBody = JSON.stringify(eventToSend);
-            this._storeStreamChunk(streamId, chunkBody);
+            await this._storeStreamChunk(streamId, chunkBody);
             this._broadcastChatMessage({
               body: chunkBody,
               done: false,
@@ -4833,7 +4865,7 @@ export class AIChatAgent<
       // Skip broadcasting text-start — the client already has this part
     } else {
       // if not AI SDK SSE format, we need to inject text-start and text-end events ourselves
-      this._broadcastTextEvent(
+      await this._broadcastTextEvent(
         streamId,
         { type: "text-start", id },
         continuation
@@ -4871,7 +4903,7 @@ export class AIChatAgent<
         if (abortSignal?.aborted) break;
         textPart.state = "done";
 
-        this._broadcastTextEvent(
+        await this._broadcastTextEvent(
           streamId,
           { type: "text-end", id },
           continuation
@@ -4896,7 +4928,7 @@ export class AIChatAgent<
       // Accumulate into the single text part to preserve exact formatting
       if (chunk.length > 0) {
         textPart.text += chunk;
-        this._broadcastTextEvent(
+        await this._broadcastTextEvent(
           streamId,
           { type: "text-delta", id, delta: chunk },
           continuation
@@ -4907,7 +4939,7 @@ export class AIChatAgent<
     // If we exited due to abort, send a done signal so clients know the stream ended
     if (!streamCompleted.value) {
       textPart.state = "done";
-      this._broadcastTextEvent(
+      await this._broadcastTextEvent(
         streamId,
         { type: "text-end", id },
         continuation

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -62,7 +62,14 @@ interface ChatRecoveryTestStub {
     recoveryRootRequestId?: string | null;
     latestUserMessageId?: string | null;
     recoveryKind: "retry" | "continue";
-  }): Promise<{ incidentId: string; attempt: number; exhausted: boolean }>;
+    nowMs?: number;
+  }): Promise<{
+    incidentId: string;
+    attempt: number;
+    exhausted: boolean;
+    reason?: string;
+  }>;
+  ageIncidentForTest(incidentId: string, ms: number): Promise<void>;
   updateIncidentForTest(
     incidentId: string,
     status: string,
@@ -230,6 +237,9 @@ describe("onChatRecovery", () => {
       recoveryKind: "continue"
     });
 
+    // Age past the alarm-debounce window so the second recovery counts as a
+    // genuinely separate attempt (not a collapsed reconnect-storm alarm) (#1637).
+    await agentStub.ageIncidentForTest("req-cap:", 40_000);
     await agentStub.insertInterruptedFiber("__cf_internal_chat_turn:req-cap");
     await agentStub.triggerFiberRecovery();
 
@@ -254,27 +264,34 @@ describe("onChatRecovery", () => {
     const agentStub = await getTestAgent(room);
     await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 2 });
 
-    const input = {
+    const baseInput = {
       requestId: "req-prog",
       recoveryRootRequestId: "req-prog",
       latestUserMessageId: "u1",
       recoveryKind: "continue" as const
     };
+    // Space attempts >30s apart so alarm-debounce (#1637) doesn't collapse them.
+    let t = 1_000_000;
+    const at = () => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...baseInput, nowMs };
+    };
 
-    // Two consecutive detections with no progress climb toward the cap.
-    expect((await agentStub.beginIncidentForTest(input)).attempt).toBe(1);
-    expect((await agentStub.beginIncidentForTest(input)).attempt).toBe(2);
+    // Two debounce-spaced detections with no progress climb toward the cap.
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(1);
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(2);
 
     // Forward progress (the durable counter advances, as `_persistOrphanedStream`
     // does after materializing a partial) resets the budget — the deploy-churn fix.
     await agentStub.bumpRecoveryProgressForTest();
-    const afterProgress = await agentStub.beginIncidentForTest(input);
+    const afterProgress = await agentStub.beginIncidentForTest(at());
     expect(afterProgress.attempt).toBe(1);
     expect(afterProgress.exhausted).toBe(false);
 
     // Without further progress it climbs again and still exhausts at the cap.
-    expect((await agentStub.beginIncidentForTest(input)).attempt).toBe(2);
-    const exhausted = await agentStub.beginIncidentForTest(input);
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(2);
+    const exhausted = await agentStub.beginIncidentForTest(at());
     expect(exhausted.attempt).toBe(3);
     expect(exhausted.exhausted).toBe(true);
   });
@@ -284,7 +301,7 @@ describe("onChatRecovery", () => {
     const agentStub = await getTestAgent(room);
     await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 2 });
 
-    const input = {
+    const base = {
       requestId: "req-compact",
       recoveryRootRequestId: "req-compact",
       latestUserMessageId: "u1",
@@ -292,7 +309,10 @@ describe("onChatRecovery", () => {
     };
 
     // First detection opens the incident.
-    expect((await agentStub.beginIncidentForTest(input)).attempt).toBe(1);
+    expect(
+      (await agentStub.beginIncidentForTest({ ...base, nowMs: 1_000_000 }))
+        .attempt
+    ).toBe(1);
 
     // The turn advances (a partial is materialized) AND compaction then
     // collapses every assistant message out of the live transcript. The old
@@ -301,7 +321,10 @@ describe("onChatRecovery", () => {
     await agentStub.bumpRecoveryProgressForTest();
     await agentStub.dropAssistantMessagesForTest();
 
-    const afterProgress = await agentStub.beginIncidentForTest(input);
+    const afterProgress = await agentStub.beginIncidentForTest({
+      ...base,
+      nowMs: 1_040_000
+    });
     expect(afterProgress.attempt).toBe(1);
     expect(afterProgress.exhausted).toBe(false);
   });
@@ -342,6 +365,66 @@ describe("onChatRecovery", () => {
       status: "exhausted",
       reason: "max_recovery_window_exceeded"
     });
+  });
+
+  it("seals an incident after the no-progress window even below the attempt cap (#1637)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 100 });
+
+    const base = {
+      requestId: "req-np",
+      recoveryRootRequestId: "req-np",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    const t0 = 2_000_000;
+    expect(
+      (await agentStub.beginIncidentForTest({ ...base, nowMs: t0 })).exhausted
+    ).toBe(false);
+
+    // A later alarm past the 5-min no-progress window, no progress in between,
+    // seals it even though the attempt count is far below the cap.
+    const past = await agentStub.beginIncidentForTest({
+      ...base,
+      nowMs: t0 + 6 * 60 * 1000
+    });
+    expect(past.exhausted).toBe(true);
+    expect(past.reason).toBe("no_progress_timeout");
+  });
+
+  it("collapses a rollout's reconnect storm into one attempt via debounce (#1637)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const base = {
+      requestId: "req-db",
+      recoveryRootRequestId: "req-db",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    const t0 = 3_000_000;
+
+    expect(
+      (await agentStub.beginIncidentForTest({ ...base, nowMs: t0 })).attempt
+    ).toBe(1);
+    // A burst within the debounce window must not advance the attempt count.
+    expect(
+      (await agentStub.beginIncidentForTest({ ...base, nowMs: t0 + 5_000 }))
+        .attempt
+    ).toBe(1);
+    expect(
+      (await agentStub.beginIncidentForTest({ ...base, nowMs: t0 + 20_000 }))
+        .attempt
+    ).toBe(1);
+    // Beyond the debounce window it's a genuinely separate attempt.
+    const later = await agentStub.beginIncidentForTest({
+      ...base,
+      nowMs: t0 + 60_000
+    });
+    expect(later.attempt).toBe(2);
+    expect(later.exhausted).toBe(false);
   });
 
   it("recovers when the continuation alarm fires on a superseded isolate", async () => {
@@ -392,13 +475,16 @@ describe("onChatRecovery", () => {
       requestId: "req-flip",
       recoveryRootRequestId: "req-flip",
       latestUserMessageId: "user-flip",
-      recoveryKind: "retry"
+      recoveryKind: "retry",
+      nowMs: 1_000_000
     });
     const second = await agentStub.beginIncidentForTest({
       requestId: "req-flip-2",
       recoveryRootRequestId: "req-flip",
       latestUserMessageId: "user-flip",
-      recoveryKind: "continue"
+      recoveryKind: "continue",
+      // >30s after the first so alarm-debounce doesn't collapse the attempt.
+      nowMs: 1_040_000
     });
 
     expect(first.incidentId).toBe("req-flip:user-flip");
@@ -508,6 +594,8 @@ describe("onChatRecovery", () => {
         "__cf_internal_chat_turn:req-ex-throw"
       );
       await agentStub.triggerFiberRecovery();
+      // Past the alarm-debounce window → a genuinely separate attempt (#1637).
+      await agentStub.ageIncidentForTest("req-ex-throw:", 40_000);
       await agentStub.insertInterruptedFiber(
         "__cf_internal_chat_turn:req-ex-throw"
       );

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -70,6 +70,11 @@ interface ChatRecoveryTestStub {
     reason?: string;
   }>;
   ageIncidentForTest(incidentId: string, ms: number): Promise<void>;
+  probeProgressReconnectImmunityForTest(): Promise<{
+    start: number;
+    afterFlush: number;
+    afterPersist: number;
+  }>;
   updateIncidentForTest(
     incidentId: string,
     status: string,
@@ -425,6 +430,21 @@ describe("onChatRecovery", () => {
     });
     expect(later.attempt).toBe(2);
     expect(later.exhausted).toBe(false);
+  });
+
+  it("advances progress on streamed content but not on an orphan re-persist (reconnect-immune, #1637)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+
+    const { start, afterFlush, afterPersist } =
+      await agentStub.probeProgressReconnectImmunityForTest();
+
+    // Streaming new content advanced progress.
+    expect(afterFlush).toBeGreaterThan(start);
+    // Re-persisting that same content (a recovery/reconnect would) must NOT be
+    // miscounted as new progress — otherwise a reconnecting client could reset
+    // the no-progress window of a stuck turn forever.
+    expect(afterPersist).toBe(afterFlush);
   });
 
   it("recovers when the continuation alarm fires on a superseded isolate", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -541,16 +541,16 @@ export class TestChatAgent extends AIChatAgent<Env> {
     return this._startStream(requestId);
   }
 
-  testStoreStreamChunk(streamId: string, body: string): void {
-    this._storeStreamChunk(streamId, body);
+  async testStoreStreamChunk(streamId: string, body: string): Promise<void> {
+    await this._storeStreamChunk(streamId, body);
   }
 
-  testBroadcastLiveChunk(
+  async testBroadcastLiveChunk(
     requestId: string,
     streamId: string,
     body: string
-  ): void {
-    this._storeStreamChunk(streamId, body);
+  ): Promise<void> {
+    await this._storeStreamChunk(streamId, body);
     const message: OutgoingMessage = {
       body,
       done: false,
@@ -1592,6 +1592,56 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 
   setChatRecoveryConfigForTest(config: ChatRecoveryConfig): void {
     this.chatRecovery = config;
+  }
+
+  /** Stream content (which advances progress at production time) then re-persist
+   *  the same orphan, reading the recovery-progress counter at each step.
+   *  Proves progress advances on new content but NOT on a reconnect/recovery
+   *  re-persist (#1637 reconnect-immunity). */
+  async probeProgressReconnectImmunityForTest(): Promise<{
+    start: number;
+    afterFlush: number;
+    afterPersist: number;
+  }> {
+    const self = this as unknown as {
+      _resumableStream: { start(id: string): string };
+      _storeStreamChunk(streamId: string, body: string): Promise<void>;
+      _persistOrphanedStream(streamId: string): Promise<void>;
+    };
+    const read = async (): Promise<number> =>
+      (await this.ctx.storage.get<number>("cf:chat-recovery:progress")) ?? 0;
+
+    const start = await read();
+    const streamId = self._resumableStream.start("req-progress-immunity");
+    await self._storeStreamChunk(
+      streamId,
+      JSON.stringify({ type: "text-start", id: "t" })
+    );
+    await self._storeStreamChunk(
+      streamId,
+      JSON.stringify({
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "x",
+        input: {}
+      })
+    );
+    await self._storeStreamChunk(
+      streamId,
+      JSON.stringify({
+        type: "tool-output-available",
+        toolCallId: "tc1",
+        output: { ok: true }
+      })
+    );
+    const afterFlush = await read();
+
+    // A recovery/reconnect persist of the same already-streamed content must
+    // NOT be miscounted as new forward progress.
+    await self._persistOrphanedStream(streamId);
+    const afterPersist = await read();
+
+    return { start, afterFlush, afterPersist };
   }
 
   async beginIncidentForTest(input: {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1599,10 +1599,16 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     recoveryRootRequestId?: string | null;
     latestUserMessageId?: string | null;
     recoveryKind: "retry" | "continue";
-  }): Promise<{ incidentId: string; attempt: number; exhausted: boolean }> {
+    nowMs?: number;
+  }): Promise<{
+    incidentId: string;
+    attempt: number;
+    exhausted: boolean;
+    reason?: string;
+  }> {
     const self = this as unknown as {
       _beginChatRecoveryIncident(i: typeof input): Promise<{
-        incident: { incidentId: string; attempt: number };
+        incident: { incidentId: string; attempt: number; reason?: string };
         exhausted: boolean;
       }>;
     };
@@ -1611,8 +1617,19 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     return {
       incidentId: incident.incidentId,
       attempt: incident.attempt,
-      exhausted
+      exhausted,
+      reason: incident.reason
     };
+  }
+
+  /** Push an incident's `lastAttemptAt` back so a subsequent real-time recovery
+   *  isn't collapsed by alarm-debounce (#1637). */
+  async ageIncidentForTest(incidentId: string, ms: number): Promise<void> {
+    const key = `cf:chat-recovery:incident:${encodeURIComponent(incidentId)}`;
+    const inc = await this.ctx.storage.get<{ lastAttemptAt: number }>(key);
+    if (!inc) return;
+    inc.lastAttemptAt -= ms;
+    await this.ctx.storage.put(key, inc);
   }
 
   async updateIncidentForTest(

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3605,10 +3605,16 @@ export class ThinkRecoveryTestAgent extends Think {
     recoveryRootRequestId?: string | null;
     latestUserMessageId?: string | null;
     recoveryKind: "retry" | "continue";
-  }): Promise<{ incidentId: string; attempt: number; exhausted: boolean }> {
+    nowMs?: number;
+  }): Promise<{
+    incidentId: string;
+    attempt: number;
+    exhausted: boolean;
+    reason?: string;
+  }> {
     const self = this as unknown as {
       _beginChatRecoveryIncident(i: typeof input): Promise<{
-        incident: { incidentId: string; attempt: number };
+        incident: { incidentId: string; attempt: number; reason?: string };
         exhausted: boolean;
       }>;
     };
@@ -3617,8 +3623,20 @@ export class ThinkRecoveryTestAgent extends Think {
     return {
       incidentId: incident.incidentId,
       attempt: incident.attempt,
-      exhausted
+      exhausted,
+      reason: incident.reason
     };
+  }
+
+  /** Push an incident's `lastAttemptAt` back so a subsequent real-time recovery
+   *  isn't collapsed by alarm-debounce (#1637) — lets flow tests simulate
+   *  genuinely-separate interruptions without real delays. */
+  async ageIncidentForTest(incidentId: string, ms: number): Promise<void> {
+    const key = `cf:chat-recovery:incident:${encodeURIComponent(incidentId)}`;
+    const inc = await this.ctx.storage.get<{ lastAttemptAt: number }>(key);
+    if (!inc) return;
+    inc.lastAttemptAt -= ms;
+    await this.ctx.storage.put(key, inc);
   }
 
   async updateIncidentForTest(

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3444,11 +3444,11 @@ export class ThinkRecoveryTestAgent extends Think {
         chunk: unknown,
         chunkBody: string,
         state: { chunksSinceFlush: number; hasFlushedContent: boolean }
-      ): void;
+      ): Promise<void>;
     };
     const streamId = self._resumableStream.start("req-tool-durability");
     const state = { chunksSinceFlush: 0, hasFlushedContent: false };
-    const store = (chunk: Record<string, unknown>): void =>
+    const store = (chunk: Record<string, unknown>): Promise<void> =>
       self._storeChunkDurably(streamId, chunk, JSON.stringify(chunk), state);
     const rawCount = (): number => {
       const rows = this.sql<{ count: number }>`
@@ -3458,10 +3458,10 @@ export class ThinkRecoveryTestAgent extends Think {
       return rows[0]?.count ?? 0;
     };
 
-    store({ type: "text-delta", id: "t", delta: "hello " });
-    store({ type: "text-delta", id: "t", delta: "there" });
+    await store({ type: "text-delta", id: "t", delta: "hello " });
+    await store({ type: "text-delta", id: "t", delta: "there" });
     const bufferedTextCount = rawCount();
-    store({
+    await store({
       type: "tool-output-available",
       toolCallId: "tc1",
       output: { ok: true }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3470,6 +3470,56 @@ export class ThinkRecoveryTestAgent extends Think {
     return { bufferedTextCount, afterToolOutputCount };
   }
 
+  /** Stream content (which durably flushes) then re-persist the same orphan,
+   *  reading the recovery-progress counter at each step. Proves the production-
+   *  time signal advances on new content but NOT on a reconnect/recovery
+   *  re-persist (#1637 reconnect-immunity). */
+  async probeProgressReconnectImmunityForTest(): Promise<{
+    start: number;
+    afterFlush: number;
+    afterPersist: number;
+  }> {
+    const self = this as unknown as {
+      _resumableStream: { start(id: string): string };
+      _storeChunkDurably(
+        streamId: string,
+        chunk: unknown,
+        chunkBody: string,
+        state: { chunksSinceFlush: number; hasFlushedContent: boolean }
+      ): Promise<void>;
+      _persistOrphanedStream(streamId: string): Promise<void>;
+    };
+    const read = async (): Promise<number> =>
+      (await this.ctx.storage.get<number>("cf:chat-recovery:progress")) ?? 0;
+
+    const start = await read();
+    const streamId = self._resumableStream.start("req-progress-immunity");
+    const state = { chunksSinceFlush: 0, hasFlushedContent: false };
+    const store = (chunk: Record<string, unknown>): Promise<void> =>
+      self._storeChunkDurably(streamId, chunk, JSON.stringify(chunk), state);
+
+    await store({ type: "text-delta", id: "t", delta: "hello" });
+    await store({
+      type: "tool-input-available",
+      toolCallId: "tc1",
+      toolName: "x",
+      input: {}
+    });
+    await store({
+      type: "tool-output-available",
+      toolCallId: "tc1",
+      output: { ok: true }
+    });
+    const afterFlush = await read();
+
+    // A recovery/reconnect persist of the same already-streamed content must
+    // NOT be miscounted as new forward progress.
+    await self._persistOrphanedStream(streamId);
+    const afterPersist = await read();
+
+    return { start, afterFlush, afterPersist };
+  }
+
   /** Seed a session that ends in a PARTIAL assistant message (the state a
    * deploy-interrupted turn leaves behind, which `continueLastTurn` replays). */
   async seedPartialAssistantTurnForTest(): Promise<void> {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2375,6 +2375,20 @@ describe("Think — onChatRecovery", () => {
     expect(later.exhausted).toBe(false);
   });
 
+  it("advances progress on durable flush but not on an orphan re-persist (reconnect-immune, #1637)", async () => {
+    const agent = await freshRecoveryAgent("recovery-progress-immunity");
+
+    const { start, afterFlush, afterPersist } =
+      await agent.probeProgressReconnectImmunityForTest();
+
+    // Streaming new content durably flushed → progress advanced.
+    expect(afterFlush).toBeGreaterThan(start);
+    // Re-persisting that same content (a recovery/reconnect would) must NOT be
+    // miscounted as new progress — otherwise a reconnecting client could reset
+    // the no-progress window of a stuck turn forever.
+    expect(afterPersist).toBe(afterFlush);
+  });
+
   it("shares one attempt budget when an incident flips between retry and continue", async () => {
     const agent = await freshRecoveryAgent("recovery-kind-flip");
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2071,7 +2071,7 @@ describe("Think — onChatRecovery", () => {
     expect(ctx).toMatchObject({
       incidentId: "req-1:",
       attempt: 1,
-      maxAttempts: 6,
+      maxAttempts: 10,
       recoveryKind: "continue"
     });
     expect(ctx.partialText).toBe("Partial text");
@@ -2092,6 +2092,10 @@ describe("Think — onChatRecovery", () => {
 
     await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-exhaust");
     await agent.triggerFiberRecovery();
+    // Age the incident past the alarm-debounce window so the second recovery
+    // counts as a genuinely separate attempt (not a collapsed reconnect-storm
+    // alarm) — otherwise debounce keeps it at attempt 1 (#1637).
+    await agent.ageIncidentForTest("req-exhaust:", 40_000);
     await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-exhaust");
     await agent.triggerFiberRecovery();
 
@@ -2204,27 +2208,35 @@ describe("Think — onChatRecovery", () => {
     const agent = await freshRecoveryAgent("recovery-progress-reset");
     await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });
 
-    const input = {
+    const base = {
       requestId: "req-prog",
       recoveryRootRequestId: "req-prog",
       latestUserMessageId: "u1",
       recoveryKind: "continue" as const
     };
+    // Space attempts >30s apart so alarm-debounce (#1637) doesn't collapse
+    // them; controlled clock keeps it deterministic.
+    let t = 1_000_000;
+    const at = () => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...base, nowMs };
+    };
 
-    // Two consecutive detections with no progress climb toward the cap.
-    expect((await agent.beginIncidentForTest(input)).attempt).toBe(1);
-    expect((await agent.beginIncidentForTest(input)).attempt).toBe(2);
+    // Two debounce-spaced detections with no progress climb toward the cap.
+    expect((await agent.beginIncidentForTest(at())).attempt).toBe(1);
+    expect((await agent.beginIncidentForTest(at())).attempt).toBe(2);
 
     // Forward progress (the durable counter advances, as `_persistOrphanedStream`
     // does after materializing a partial) resets the budget — the deploy-churn fix.
     await agent.bumpRecoveryProgressForTest();
-    const afterProgress = await agent.beginIncidentForTest(input);
+    const afterProgress = await agent.beginIncidentForTest(at());
     expect(afterProgress.attempt).toBe(1);
     expect(afterProgress.exhausted).toBe(false);
 
     // Without further progress it climbs again and still exhausts at the cap.
-    expect((await agent.beginIncidentForTest(input)).attempt).toBe(2);
-    const exhausted = await agent.beginIncidentForTest(input);
+    expect((await agent.beginIncidentForTest(at())).attempt).toBe(2);
+    const exhausted = await agent.beginIncidentForTest(at());
     expect(exhausted.attempt).toBe(3);
     expect(exhausted.exhausted).toBe(true);
   });
@@ -2233,7 +2245,7 @@ describe("Think — onChatRecovery", () => {
     const agent = await freshRecoveryAgent("recovery-progress-compaction");
     await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });
 
-    const input = {
+    const base = {
       requestId: "req-compact",
       recoveryRootRequestId: "req-compact",
       latestUserMessageId: "u1",
@@ -2241,7 +2253,9 @@ describe("Think — onChatRecovery", () => {
     };
 
     // First detection opens the incident.
-    expect((await agent.beginIncidentForTest(input)).attempt).toBe(1);
+    expect(
+      (await agent.beginIncidentForTest({ ...base, nowMs: 1_000_000 })).attempt
+    ).toBe(1);
 
     // The turn advances (a partial is materialized) AND compaction then
     // collapses every assistant message out of the live transcript. The old
@@ -2250,7 +2264,10 @@ describe("Think — onChatRecovery", () => {
     await agent.bumpRecoveryProgressForTest();
     await agent.dropAssistantMessagesForTest();
 
-    const afterProgress = await agent.beginIncidentForTest(input);
+    const afterProgress = await agent.beginIncidentForTest({
+      ...base,
+      nowMs: 1_040_000
+    });
     expect(afterProgress.attempt).toBe(1);
     expect(afterProgress.exhausted).toBe(false);
   });
@@ -2291,6 +2308,73 @@ describe("Think — onChatRecovery", () => {
     });
   });
 
+  it("seals an incident after the no-progress window even below the attempt cap (#1637)", async () => {
+    const agent = await freshRecoveryAgent("recovery-no-progress");
+    // High cap so the no-progress wall clock — not the attempt count — is what binds.
+    await agent.setChatRecoveryConfigForTest({ maxAttempts: 100 });
+
+    const base = {
+      requestId: "req-np",
+      recoveryRootRequestId: "req-np",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    const t0 = 2_000_000;
+    // First detection opens the incident; not yet exhausted.
+    expect(
+      (await agent.beginIncidentForTest({ ...base, nowMs: t0 })).exhausted
+    ).toBe(false);
+
+    // A later alarm past the 5-min no-progress window, with no progress in
+    // between, seals it — even though the attempt count is far below the cap.
+    const past = await agent.beginIncidentForTest({
+      ...base,
+      nowMs: t0 + 6 * 60 * 1000
+    });
+    expect(past.exhausted).toBe(true);
+    expect(past.reason).toBe("no_progress_timeout");
+  });
+
+  it("collapses a rollout's reconnect storm into one attempt via debounce (#1637)", async () => {
+    const agent = await freshRecoveryAgent("recovery-debounce");
+    await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const base = {
+      requestId: "req-db",
+      recoveryRootRequestId: "req-db",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    const t0 = 3_000_000;
+
+    // First alarm opens the incident (attempt 1).
+    expect(
+      (await agent.beginIncidentForTest({ ...base, nowMs: t0 })).attempt
+    ).toBe(1);
+
+    // A burst of alarms within the debounce window (one rollout's reconnects)
+    // must NOT advance the attempt count.
+    expect(
+      (await agent.beginIncidentForTest({ ...base, nowMs: t0 + 5_000 })).attempt
+    ).toBe(1);
+    expect(
+      (await agent.beginIncidentForTest({ ...base, nowMs: t0 + 12_000 }))
+        .attempt
+    ).toBe(1);
+    expect(
+      (await agent.beginIncidentForTest({ ...base, nowMs: t0 + 20_000 }))
+        .attempt
+    ).toBe(1);
+
+    // An alarm beyond the debounce window is a genuinely separate attempt.
+    const later = await agent.beginIncidentForTest({
+      ...base,
+      nowMs: t0 + 60_000
+    });
+    expect(later.attempt).toBe(2);
+    expect(later.exhausted).toBe(false);
+  });
+
   it("shares one attempt budget when an incident flips between retry and continue", async () => {
     const agent = await freshRecoveryAgent("recovery-kind-flip");
 
@@ -2298,13 +2382,16 @@ describe("Think — onChatRecovery", () => {
       requestId: "req-flip",
       recoveryRootRequestId: "req-flip",
       latestUserMessageId: "user-flip",
-      recoveryKind: "retry"
+      recoveryKind: "retry",
+      nowMs: 1_000_000
     });
     const second = await agent.beginIncidentForTest({
       requestId: "req-flip-2",
       recoveryRootRequestId: "req-flip",
       latestUserMessageId: "user-flip",
-      recoveryKind: "continue"
+      recoveryKind: "continue",
+      // >30s after the first so alarm-debounce doesn't collapse the attempt.
+      nowMs: 1_040_000
     });
 
     // Same identity despite the kind change, so the attempt budget accrues.
@@ -2411,6 +2498,8 @@ describe("Think — onChatRecovery", () => {
         "__cf_internal_chat_turn:req-ex-throw"
       );
       await agent.triggerFiberRecovery();
+      // Past the alarm-debounce window → a genuinely separate attempt (#1637).
+      await agent.ageIncidentForTest("req-ex-throw:", 40_000);
       await agent.insertInterruptedFiber(
         "__cf_internal_chat_turn:req-ex-throw"
       );

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -625,9 +625,10 @@ type ChatRecoveryIncident = {
 
 const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
 // Durable, monotonic forward-progress counter for recovery budget resets.
-// Incremented once per non-empty partial materialized by
-// `_persistOrphanedStream`; never recomputed from the (compactable) transcript.
-// See `_chatRecoveryProgressMarker`.
+// Bumped on each durable content flush (`_storeChunkDurably`) — production time,
+// so it reflects genuinely new content and is immune to reconnects/re-persists;
+// never recomputed from the (compactable) transcript. See
+// `_chatRecoveryProgressMarker`.
 const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 // Secondary backstop only. The primary recovery bound is the no-progress
 // wall clock below; with alarm debounce this cap rarely binds (it catches a
@@ -6124,7 +6125,12 @@ export class Think<
           }
 
           const chunkBody = JSON.stringify(chunk);
-          this._storeChunkDurably(streamId, streamChunk, chunkBody, flushState);
+          await this._storeChunkDurably(
+            streamId,
+            streamChunk,
+            chunkBody,
+            flushState
+          );
           this._broadcastChat({
             type: MSG_CHAT_RESPONSE,
             id: requestId,
@@ -6278,12 +6284,12 @@ export class Think<
    * tool-call-level recovery durability (recovery loses at most the in-flight
    * step, never an already-completed tool call).
    */
-  private _storeChunkDurably(
+  private async _storeChunkDurably(
     streamId: string,
     chunk: StreamChunkData,
     chunkBody: string,
     state: { chunksSinceFlush: number; hasFlushedContent: boolean }
-  ): void {
+  ): Promise<void> {
     this._resumableStream.storeChunk(streamId, chunkBody);
     state.chunksSinceFlush++;
     if (
@@ -6296,6 +6302,13 @@ export class Think<
       this._resumableStream.flushBuffer();
       state.chunksSinceFlush = 0;
       state.hasFlushedContent = true;
+      // Forward progress: new durable content was just flushed. Advance the
+      // monotonic, compaction-immune progress counter HERE (production time)
+      // rather than in `_persistOrphanedStream` — so it bumps only on genuinely
+      // new content and is immune to client reconnects / recovery re-persists
+      // (which don't flow through this path). This is what the recovery
+      // no-progress window keys off (#1637), and stays compaction-proof (#1628).
+      await this._bumpChatRecoveryProgress();
     }
   }
 
@@ -6447,7 +6460,12 @@ export class Think<
           }
 
           const chunkBody = JSON.stringify(chunk);
-          this._storeChunkDurably(streamId, streamChunk, chunkBody, flushState);
+          await this._storeChunkDurably(
+            streamId,
+            streamChunk,
+            chunkBody,
+            flushState
+          );
           this._broadcastChat({
             type: MSG_CHAT_RESPONSE,
             id: requestId,
@@ -6807,9 +6825,10 @@ export class Think<
    * assistant messages into a summary, lowering the count — so a turn that had
    * genuinely advanced could read as "no progress" between attempts and exhaust
    * its budget prematurely (#1628). Instead we read a durably-persisted counter
-   * that only ever increments — bumped once per non-empty partial materialized
-   * by `_persistOrphanedStream`, which is the exact "forward progress" event the
-   * old message-count tracked — so compaction can never lower it.
+   * that only ever increments — bumped at production time when new content is
+   * durably flushed (see `_storeChunkDurably`), which is genuine forward
+   * progress and is immune to client reconnects / recovery re-persists — so
+   * compaction can never lower it and a reconnect can't fake it (#1637).
    */
   private async _chatRecoveryProgressMarker(): Promise<number> {
     return (
@@ -6817,8 +6836,9 @@ export class Think<
     );
   }
 
-  /** Advance the durable recovery-progress counter. Called when a partial
-   *  assistant message is materialized (real forward progress). */
+  /** Advance the durable recovery-progress counter. Called from
+   *  `_storeChunkDurably` when new content is durably flushed (real, reconnect-
+   *  immune forward progress). */
   private async _bumpChatRecoveryProgress(): Promise<void> {
     const current =
       (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0;
@@ -8048,11 +8068,9 @@ export class Think<
 
     if (accumulator.parts.length > 0) {
       await this._persistAssistantMessage(accumulator.toMessage());
-      // Real forward progress: a non-empty partial was materialized. Advance
-      // the durable, compaction-immune progress counter so a deploy-churned
-      // turn that keeps producing content resets its recovery budget instead
-      // of exhausting it (#1628).
-      await this._bumpChatRecoveryProgress();
+      // NOTE: progress is bumped at production/flush time in `_storeChunkDurably`
+      // (#1637), NOT here — persisting on recovery or a client reconnect must
+      // not be miscounted as new forward progress.
       this._broadcastMessages();
     }
   }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -602,6 +602,14 @@ type ChatRecoveryIncident = {
     | "failed";
   firstSeenAt: number;
   lastAttemptAt: number;
+  /**
+   * Epoch ms of the last attempt that observed forward progress. The recovery
+   * budget is keyed to this (`now - lastProgressAt > NO_PROGRESS_WINDOW`), so a
+   * turn that keeps producing content survives churn indefinitely while a
+   * genuinely stuck turn is sealed within the window (#1637). Optional for
+   * backward-compat — falls back to `firstSeenAt`.
+   */
+  lastProgressAt?: number;
   reason?: string;
   /**
    * High-water mark of the durable, monotonic recovery-progress counter (see
@@ -621,7 +629,11 @@ const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
 // `_persistOrphanedStream`; never recomputed from the (compactable) transcript.
 // See `_chatRecoveryProgressMarker`.
 const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
-const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 6;
+// Secondary backstop only. The primary recovery bound is the no-progress
+// wall clock below; with alarm debounce this cap rarely binds (it catches a
+// pathological tight alarm-loop). Kept high so the no-progress window seals
+// first under normal deploy cadence (#1637).
+const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Delay before retrying a continuation that timed out waiting for stable state.
 // Gives an actively-churning isolate (e.g. a deploy in flight) time to settle.
@@ -631,10 +643,18 @@ const DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE =
 // Incidents that have not seen a new attempt within this window are assumed
 // abandoned and swept so durable storage does not grow without bound.
 const CHAT_RECOVERY_INCIDENT_TTL_MS = 60 * 60 * 1000;
-// Hard wall-clock ceiling for a single recovery incident. The attempt budget
-// can be reset by forward progress (see `_beginChatRecoveryIncident`), so this
-// is the ultimate stop that prevents an environment churning indefinitely from
-// retrying forever.
+// PRIMARY recovery bound (#1637): seal an incident that has made no forward
+// progress for this long. Keyed to `lastProgressAt`, which resets on every
+// progress-bearing attempt — so a turn that keeps producing content survives
+// deploy churn indefinitely, while a genuinely stuck turn dies within 5 min.
+const CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS = 5 * 60 * 1000;
+// Alarm debounce: recovery alarms bunched within this window collapse into a
+// single attempt. A deploy rollout drops/reconnects the socket several times
+// over ~11–22s; without this, one logical deploy would burn several attempts.
+const CHAT_RECOVERY_ALARM_DEBOUNCE_MS = 30 * 1000;
+// ABSOLUTE ceiling for a single recovery incident, keyed to `firstSeenAt` and
+// NEVER reset by progress — the final hard stop so even a degenerate
+// slowly-progressing loop cannot run forever.
 const CHAT_RECOVERY_MAX_WINDOW_MS = 15 * 60 * 1000;
 
 // Ephemeral user message appended when a model request would otherwise end in
@@ -6828,6 +6848,8 @@ export class Think<
     latestUserMessageId?: string | null;
     targetAssistantId?: string | null;
     recoveryKind: ChatRecoveryKind;
+    /** Test-only clock injection for deterministic debounce/window timing. */
+    nowMs?: number;
   }): Promise<{
     incident: ChatRecoveryIncident;
     config: ResolvedChatRecoveryConfig;
@@ -6836,28 +6858,51 @@ export class Think<
     const config = this._resolveChatRecoveryConfig();
     const incidentId = this._chatRecoveryIncidentId(input);
     const key = this._chatRecoveryIncidentKey(incidentId);
-    const now = Date.now();
+    const now = input.nowMs ?? Date.now();
     await this._sweepStaleChatRecoveryIncidents(now);
     const existing = await this.ctx.storage.get<ChatRecoveryIncident>(key);
 
     // Forward-progress detection. A mid-turn deploy resets the Durable Object
     // ("code was updated"); the interrupted continuation is re-detected on the
-    // next wake. Without this, every such interruption consumes one attempt, so
-    // a deploy roughly every few minutes burns the whole budget and permanently
-    // abandons a turn that is actually advancing. We treat an interruption that
-    // followed real progress (more persisted assistant content than the last
-    // attempt saw) as environmental and reset the budget, while a turn that
-    // never advances still exhausts at `maxAttempts`.
+    // next wake. A turn that followed real progress (more durably-produced
+    // content than the last attempt saw) is environmental churn, not a poison
+    // turn.
     const prevProgress = existing?.progress ?? 0;
     const currentProgress = await this._chatRecoveryProgressMarker();
     const madeProgress = existing != null && currentProgress > prevProgress;
-    const windowExceeded =
+
+    // Wall-clock-keyed-to-progress budget (#1637). The raw attempt count is the
+    // wrong primary bound under deploy churn: one rollout drops/reconnects the
+    // socket several times (~11–22s), each firing an alarm, so a count inflates
+    // far faster than the real interruption rate and seals a healthy turn.
+    //  • PRIMARY — no-progress window: `lastProgressAt` resets on every
+    //    progress-bearing attempt, so a turn that keeps producing content
+    //    survives churn indefinitely; a stuck turn is sealed after 5 min.
+    //  • DEBOUNCE — alarms bunched within `ALARM_DEBOUNCE_MS` collapse into one
+    //    attempt, so a single rollout's reconnect storm isn't N attempts.
+    //  • SECONDARY — the attempt cap is a high backstop (resets on progress).
+    //  • ABSOLUTE — the 15-min incident-age ceiling never resets (final stop).
+    const lastProgressAt = madeProgress
+      ? now
+      : (existing?.lastProgressAt ?? existing?.firstSeenAt ?? now);
+    const noProgressExceeded =
+      existing != null &&
+      now - lastProgressAt > CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS;
+    const incidentAgeExceeded =
       existing != null &&
       now - existing.firstSeenAt > CHAT_RECOVERY_MAX_WINDOW_MS;
+    const debounced =
+      existing != null &&
+      !madeProgress &&
+      now - existing.lastAttemptAt < CHAT_RECOVERY_ALARM_DEBOUNCE_MS;
 
-    const attempt =
-      madeProgress && !windowExceeded ? 1 : (existing?.attempt ?? 0) + 1;
-    const exhausted = windowExceeded || attempt > config.maxAttempts;
+    const attempt = madeProgress
+      ? 1
+      : debounced
+        ? (existing?.attempt ?? 1)
+        : (existing?.attempt ?? 0) + 1;
+    const exhausted =
+      noProgressExceeded || incidentAgeExceeded || attempt > config.maxAttempts;
     const incident: ChatRecoveryIncident = {
       incidentId,
       requestId: input.requestId,
@@ -6868,12 +6913,15 @@ export class Think<
       status: exhausted ? "exhausted" : "attempting",
       firstSeenAt: existing?.firstSeenAt ?? now,
       lastAttemptAt: now,
+      lastProgressAt,
       progress: Math.max(prevProgress, currentProgress),
       ...(exhausted
         ? {
-            reason: windowExceeded
+            reason: incidentAgeExceeded
               ? "max_recovery_window_exceeded"
-              : "max_attempts_exceeded"
+              : noProgressExceeded
+                ? "no_progress_timeout"
+                : "max_attempts_exceeded"
           }
         : {})
     };


### PR DESCRIPTION
Closes #1637.

## Stack / base

Built on the compaction-immune progress counter from **#1633** (#1628), so this PR's **base is `fix/chat-recovery-progress-monotonic`**, not `main` — GitHub will retarget to `main` once #1633 merges. It's the structural follow-up in the #1631 recovery hardening series.

## Problem

After #1623's bounded recovery, the budget is capped primarily by **attempt count** (`attempt > maxAttempts`) plus a 15-min incident-age ceiling. Under continuous deploys the attempt count is the wrong primary bound, and a healthy in-flight turn gets sealed while still advancing.

Producer-side evidence (customer session): one prompt → **23 successful LLM calls / 16.8k output tokens / ~6 min**, **0/23 errored**, 0 MB (not OOM) — yet recovery exhausted and sealed. Why:

- **One deploy ≠ one alarm.** A rollout takes ~11–22s and the socket drops/reconnects several times — ~15 disconnects from ~10 deploys; **4 disconnects in 37s** when deploys bunched. Each fires a recovery alarm, so the counter inflates far faster than the real interruption rate.
- **Retries aren't independent.** Each eviction forces a cold re-run with growing context (no prompt cache) → each attempt is slower and less likely to finish a unit of work before the next deploy. So "raise the cap" buys little.

## Change

Budget is now **wall-clock-keyed to forward progress**, attempt cap demoted to a secondary backstop:

1. **Primary — 5-min no-progress window.** `lastProgressAt` resets on every progress-bearing attempt; exhaust only when `now - lastProgressAt > 5min`. A turn that keeps producing content survives churn indefinitely; a stuck turn seals within 5 min.
2. **Alarm debounce (30s).** Alarms bunched within the window (a rollout's reconnect storm) collapse into **one** attempt.
3. **Attempt cap → high secondary backstop** (default 6 → 10; resets on progress) — only catches a pathological tight alarm-loop.
4. **15-min absolute incident-age ceiling** kept (non-resetting final stop).
5. Applies to the **`TaskSubAgent`/sub-agent** recovery path (extends Think).
6. No new public config — internal constants + the existing `maxAttempts`.

### Progress signal moved to production time (required, not cosmetic)
The no-progress window only works if "progress" means **new content was produced**. The previous bump fired at persist time — which also fires on a **client reconnect** (`_handleStreamResumeAck` → `_persistOrphanedStream`) and on re-persisting unchanged content. Either would reset `lastProgressAt` without real progress, so a reconnecting-but-stuck turn would dodge the timeout forever. The bump now happens at production time:
- **think:** on each durable flush in `_storeChunkDurably` (`_storeChunkDurably` is now async).
- **ai-chat** (no `_storeChunkDurably`): on production milestones (`text-start` / `reasoning-start` / `tool-input-available` / `tool-output-*`) in the single chunk chokepoint `_storeStreamChunk`.

Both are growth-based and immune to reconnects/recovery re-persists. Builds on #1633's durable, compaction-immune counter.

## Tests

- New per-package tests: **no-progress window seals below the cap**, **debounce collapses a reconnect storm into one attempt**, and **reconnect-immunity** (streaming advances progress; an orphan re-persist does not).
- Existing budget/flow tests updated for the new semantics (rapid successive triggers now correctly debounce; a `nowMs` test-clock injection + an `ageIncidentForTest` harness make timing deterministic). The default `maxAttempts` assertion updated 6 → 10.

## Verification

- `tsc` clean (think + ai-chat); `oxlint` clean; `oxfmt` applied.
- Full suites green: think **145**, ai-chat **479**.

## Test plan

- [ ] CI green
- [ ] Validate against `examples/deploy-churn` + the customer's chaos harness (the acceptance test: a healthy multi-tool turn survives 90s-ish churn; a genuinely stuck turn seals at ~5 min)
- [ ] Sanity-check defaults don't regress a simple (no-tool) chat agent
- [ ] Review the debounce window (30s) / no-progress window (5 min) / cap (10) values

Made with [Cursor](https://cursor.com)