### PR TITLE
fix(mcp): safely route colliding streamable HTTP responses

### DIFF
--- a/.changeset/fix-streamable-http-colliding-request-routing.md
+++ b/.changeset/fix-streamable-http-colliding-request-routing.md
@@ -1,0 +1,11 @@
+---
+"agents": patch
+---
+
+Prevent MCP Streamable HTTP result responses from crossing between concurrent
+POST streams when a reused session receives duplicate in-flight JSON-RPC
+request ids. Responses now prefer the live connection that originated their
+request and reject ambiguous routing when no origin can safely disambiguate.
+
+Completion tracking for batched POST streams is now scoped per stream so an id
+collision on another POST cannot prevent the original stream from closing.

--- a/.changeset/fix-streamable-http-colliding-request-routing.md
+++ b/.changeset/fix-streamable-http-colliding-request-routing.md
@@ -5,7 +5,8 @@
 Prevent MCP Streamable HTTP result responses from crossing between concurrent
 POST streams when a reused session receives duplicate in-flight JSON-RPC
 request ids. Responses now prefer the live connection that originated their
-request and reject ambiguous routing when no origin can safely disambiguate.
+request and return JSON-RPC internal errors instead of guessing when no origin
+can safely disambiguate colliding streams.
 
 Completion tracking for batched POST streams is now scoped per stream so an id
 collision on another POST cannot prevent the original stream from closing.

--- a/packages/agents/src/mcp/transport.ts
+++ b/packages/agents/src/mcp/transport.ts
@@ -376,6 +376,47 @@ export class StreamableHTTPServerTransport implements Transport {
     this.onclose?.();
   }
 
+  private async sendOnStream(
+    agent: McpAgent,
+    connection: Connection<TransportConnState>,
+    message: JSONRPCMessage,
+    requestId: RequestId
+  ): Promise<void> {
+    const streamId = connection.state?.streamId ?? connection.id;
+
+    let eventId: string | undefined;
+
+    if (this._eventStore) {
+      eventId = await this._eventStore.storeEvent(streamId, message);
+    }
+
+    let shouldClose = false;
+
+    if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
+      let responseIds = this._streamResponseIds.get(streamId);
+      if (!responseIds) {
+        responseIds = new Set<RequestId>();
+        this._streamResponseIds.set(streamId, responseIds);
+      }
+      responseIds.add(requestId);
+      const relatedIds = connection.state?.requestIds ?? [];
+      // Check if we have responses for all requests using this connection.
+      shouldClose = relatedIds.every((id) => responseIds.has(id));
+
+      if (shouldClose) {
+        this._streamResponseIds.delete(streamId);
+
+        // POST stream is fully responded — drop the persisted requestIds
+        // mapping and the stored events. No client should resume past
+        // this point.
+        await agent.deleteStreamRequestIds(streamId);
+        const clearable = this._eventStore as ClearableEventStore | undefined;
+        await clearable?.clearStream?.(streamId);
+      }
+    }
+    this.writeSSEEvent(connection, message, eventId, shouldClose);
+  }
+
   async send(
     message: JSONRPCMessage,
     options?: { relatedRequestId?: RequestId }
@@ -446,47 +487,26 @@ export class StreamableHTTPServerTransport implements Transport {
       (matchingConnections.length === 1 ? matchingConnections[0] : undefined);
     if (!connection) {
       if (matchingConnections.length > 1) {
-        throw new Error(
-          `Multiple connections established for request ID without an originating connection: ${String(requestId)}`
+        // No candidate can safely receive the original result. Terminate each
+        // affected request with a protocol error rather than returning a 500
+        // or exposing another request's plausible-looking response.
+        const routingError: JSONRPCMessage = {
+          jsonrpc: "2.0",
+          id: requestId,
+          error: { code: -32603, message: "Internal error" }
+        };
+        await Promise.all(
+          matchingConnections.map((candidate) =>
+            this.sendOnStream(agent, candidate, routingError, requestId)
+          )
         );
+        return;
       }
       throw new Error(
         `No connection established for request ID: ${String(requestId)}`
       );
     }
 
-    const streamId = connection.state?.streamId ?? connection.id;
-
-    let eventId: string | undefined;
-
-    if (this._eventStore) {
-      eventId = await this._eventStore.storeEvent(streamId, message);
-    }
-
-    let shouldClose = false;
-
-    if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
-      let responseIds = this._streamResponseIds.get(streamId);
-      if (!responseIds) {
-        responseIds = new Set<RequestId>();
-        this._streamResponseIds.set(streamId, responseIds);
-      }
-      responseIds.add(requestId);
-      const relatedIds = connection.state?.requestIds ?? [];
-      // Check if we have responses for all requests using this connection.
-      shouldClose = relatedIds.every((id) => responseIds.has(id));
-
-      if (shouldClose) {
-        this._streamResponseIds.delete(streamId);
-
-        // POST stream is fully responded — drop the persisted requestIds
-        // mapping and the stored events. No client should resume past
-        // this point.
-        await agent.deleteStreamRequestIds(streamId);
-        const clearable = this._eventStore as ClearableEventStore | undefined;
-        await clearable?.clearStream?.(streamId);
-      }
-    }
-    this.writeSSEEvent(connection, message, eventId, shouldClose);
+    await this.sendOnStream(agent, connection, message, requestId);
   }
 }

--- a/packages/agents/src/mcp/transport.ts
+++ b/packages/agents/src/mcp/transport.ts
@@ -113,10 +113,12 @@ export class StreamableHTTPServerTransport implements Transport {
   private _started = false;
   private _eventStore?: EventStore;
 
-  // This is to keep track whether all messages from a single POST request have been answered.
-  // I's fine that we don't persist this since it's only for backwards compatibility as clients
-  // should no longer batch requests, per the spec.
-  private _requestResponseMap: Map<RequestId, JSONRPCMessage> = new Map();
+  // This tracks which messages on each POST stream have been answered.
+  // It is fine that we do not persist this since it only supports backwards
+  // compatibility for clients batching requests, which the spec discourages.
+  // Keying by stream avoids colliding ids on independent POST streams sharing
+  // completion state with one another.
+  private _streamResponseIds: Map<string, Set<RequestId>> = new Map();
 
   sessionId: string;
   onclose?: () => void;
@@ -378,7 +380,8 @@ export class StreamableHTTPServerTransport implements Transport {
     message: JSONRPCMessage,
     options?: { relatedRequestId?: RequestId }
   ): Promise<void> {
-    const { agent } = getCurrentAgent<McpAgent>();
+    const { agent, connection: originatingConnection } =
+      getCurrentAgent<McpAgent>();
     if (!agent) throw new Error("Agent was not found in send");
 
     let requestId = options?.relatedRequestId;
@@ -424,14 +427,29 @@ export class StreamableHTTPServerTransport implements Transport {
       return;
     }
 
-    // Get the response for this request. We look up by `requestIds` on
-    // connection state, which is set both for fresh POST connections and
-    // for resumed GET connections that inherited the POST's requestIds
-    // via Last-Event-ID.
-    const connection = Array.from(
+    // Get the stream for this request. Normally request ids uniquely identify
+    // a POST connection. If a client violates that constraint, prefer the
+    // connection whose handler is currently producing this message rather
+    // than leaking a plausible response to the first matching POST stream.
+    // Only prefer an originating connection while it is still live: after a
+    // POST stream disconnects, a resumed GET connection inherits requestIds
+    // and must be allowed to receive the eventual response.
+    const matchingConnections = Array.from(
       agent.getConnections<TransportConnState>()
-    ).find((conn) => conn.state?.requestIds?.includes(requestId as RequestId));
+    ).filter((conn) =>
+      conn.state?.requestIds?.includes(requestId as RequestId)
+    );
+    const connection =
+      matchingConnections.find(
+        (conn) => conn.id === originatingConnection?.id
+      ) ??
+      (matchingConnections.length === 1 ? matchingConnections[0] : undefined);
     if (!connection) {
+      if (matchingConnections.length > 1) {
+        throw new Error(
+          `Multiple connections established for request ID without an originating connection: ${String(requestId)}`
+        );
+      }
       throw new Error(
         `No connection established for request ID: ${String(requestId)}`
       );
@@ -448,16 +466,18 @@ export class StreamableHTTPServerTransport implements Transport {
     let shouldClose = false;
 
     if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
-      this._requestResponseMap.set(requestId, message);
+      let responseIds = this._streamResponseIds.get(streamId);
+      if (!responseIds) {
+        responseIds = new Set<RequestId>();
+        this._streamResponseIds.set(streamId, responseIds);
+      }
+      responseIds.add(requestId);
       const relatedIds = connection.state?.requestIds ?? [];
-      // Check if we have responses for all requests using this connection
-      shouldClose = relatedIds.every((id) => this._requestResponseMap.has(id));
+      // Check if we have responses for all requests using this connection.
+      shouldClose = relatedIds.every((id) => responseIds.has(id));
 
       if (shouldClose) {
-        // Clean up
-        for (const id of relatedIds) {
-          this._requestResponseMap.delete(id);
-        }
+        this._streamResponseIds.delete(streamId);
 
         // POST stream is fully responded — drop the persisted requestIds
         // mapping and the stored events. No client should resume past

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -38,6 +38,7 @@ type Props = {
 
 export class TestMcpAgent extends McpAgent<Cloudflare.Env, unknown, Props> {
   private tempToolHandle?: { remove: () => void };
+  private collisionBarrierResolvers: Array<() => void> = [];
 
   server = new McpServer(
     { name: "test-server", version: "1.0.0" },
@@ -60,6 +61,27 @@ export class TestMcpAgent extends McpAgent<Cloudflare.Env, unknown, Props> {
       },
       async ({ name }) => {
         return { content: [{ text: `Hello, ${name}!`, type: "text" }] };
+      }
+    );
+
+    this.server.registerTool(
+      "collisionBarrierEcho",
+      {
+        description: "Echo after two concurrent calls reach a barrier",
+        inputSchema: { label: z.string() }
+      },
+      async ({ label }) => {
+        await new Promise<void>((resolve) => {
+          this.collisionBarrierResolvers.push(resolve);
+          if (this.collisionBarrierResolvers.length === 2) {
+            for (const release of this.collisionBarrierResolvers) {
+              release();
+            }
+            this.collisionBarrierResolvers = [];
+          }
+        });
+
+        return { content: [{ text: `collision:${label}`, type: "text" }] };
       }
     );
 

--- a/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
+++ b/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
@@ -469,24 +469,38 @@ describe("Streamable HTTP Transport", () => {
       result: { content: "right response" }
     };
 
-    it("rejects duplicate live streams when no originating stream is available", async () => {
+    it("returns internal errors to duplicate live streams when no origin is available", async () => {
       const first = createConnection("first");
       const second = createConnection("second");
       const { agent, transport } = createTransport([first, second]);
 
-      await expect(
-        agentContext.run(
-          {
-            agent,
-            connection: undefined,
-            email: undefined,
-            request: undefined
-          },
-          () => transport.send(result)
-        )
-      ).rejects.toThrow(/Multiple connections established/);
-      expect(first.send).not.toHaveBeenCalled();
-      expect(second.send).not.toHaveBeenCalled();
+      await agentContext.run(
+        {
+          agent,
+          connection: undefined,
+          email: undefined,
+          request: undefined
+        },
+        () => transport.send(result)
+      );
+
+      for (const connection of [first, second]) {
+        expect(connection.send).toHaveBeenCalledOnce();
+        const event = JSON.parse(String(connection.send.mock.calls[0][0])) as {
+          event: string;
+          close?: boolean;
+        };
+        const error = parseSSEData(event.event) as {
+          error: { code: number; message: string };
+          id: string;
+        };
+        expect(error).toMatchObject({
+          error: { code: -32603, message: "Internal error" },
+          id: "same-id"
+        });
+        expect(event.event).not.toContain("right response");
+        expect(event.close).toBe(true);
+      }
     });
 
     it("routes to a live resumed stream instead of a stale originating stream", async () => {

--- a/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
+++ b/packages/agents/src/tests/mcp/transports/streamable-http.test.ts
@@ -7,7 +7,10 @@ import type {
   JSONRPCNotification,
   JSONRPCResultResponse
 } from "@modelcontextprotocol/sdk/types.js";
-import { describe, expect, it } from "vitest";
+import type { Connection } from "partyserver";
+import { describe, expect, it, vi } from "vitest";
+import { __DO_NOT_USE_WILL_BREAK__agentContext as agentContext } from "../../../internal_context";
+import { StreamableHTTPServerTransport } from "../../../mcp/transport";
 import worker from "../../worker";
 import {
   TEST_MESSAGES,
@@ -390,6 +393,147 @@ describe("Streamable HTTP Transport", () => {
 
       await reader1?.cancel();
       await reader2?.cancel();
+    });
+
+    it("keeps colliding request ids on their originating POST streams", async () => {
+      const ctx = createExecutionContext();
+      const sessionId = await initializeStreamableHTTPServer(ctx);
+      const collidingRequest = (label: string): JSONRPCMessage => ({
+        id: "same-id",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          arguments: { label },
+          name: "collisionBarrierEcho"
+        }
+      });
+
+      const [responseA, responseB] = await Promise.all([
+        sendPostRequest(ctx, baseUrl, collidingRequest("A"), sessionId),
+        sendPostRequest(ctx, baseUrl, collidingRequest("B"), sessionId)
+      ]);
+      const readerA = responseA.body?.getReader();
+      const readerB = responseB.body?.getReader();
+      expect(readerA).toBeTruthy();
+      expect(readerB).toBeTruthy();
+      if (!readerA || !readerB) throw new Error("No POST stream reader");
+
+      const [frameA, frameB] = await Promise.all([
+        readSSEEventWithTimeout(readerA, 1000),
+        readSSEEventWithTimeout(readerB, 1000)
+      ]);
+
+      expect(frameA).not.toBeNull();
+      expect(frameB).not.toBeNull();
+      expect(frameA).toContain("collision:A");
+      expect(frameB).toContain("collision:B");
+
+      await readerA.cancel();
+      await readerB.cancel();
+    });
+  });
+
+  describe("Ambiguous request id routing", () => {
+    const createConnection = (
+      id: string,
+      requestIds: string[] = ["same-id"]
+    ) => ({
+      id,
+      state: { streamId: id, requestIds },
+      send: vi.fn()
+    });
+
+    const createTransport = (
+      liveConnections: ReturnType<typeof createConnection>[]
+    ) => {
+      const agent = {
+        deleteStreamRequestIds: vi.fn(async () => undefined),
+        getConnections: () => liveConnections,
+        getSessionId: () => "session-id"
+      };
+      const transport = agentContext.run(
+        {
+          agent,
+          connection: undefined,
+          email: undefined,
+          request: undefined
+        },
+        () => new StreamableHTTPServerTransport({})
+      );
+      return { agent, transport };
+    };
+
+    const result = {
+      id: "same-id",
+      jsonrpc: "2.0" as const,
+      result: { content: "right response" }
+    };
+
+    it("rejects duplicate live streams when no originating stream is available", async () => {
+      const first = createConnection("first");
+      const second = createConnection("second");
+      const { agent, transport } = createTransport([first, second]);
+
+      await expect(
+        agentContext.run(
+          {
+            agent,
+            connection: undefined,
+            email: undefined,
+            request: undefined
+          },
+          () => transport.send(result)
+        )
+      ).rejects.toThrow(/Multiple connections established/);
+      expect(first.send).not.toHaveBeenCalled();
+      expect(second.send).not.toHaveBeenCalled();
+    });
+
+    it("routes to a live resumed stream instead of a stale originating stream", async () => {
+      const staleOrigin = createConnection("closed-post");
+      const resumed = createConnection("resumed-get");
+      const { agent, transport } = createTransport([resumed]);
+
+      await agentContext.run(
+        {
+          agent,
+          connection: staleOrigin as unknown as Connection,
+          email: undefined,
+          request: undefined
+        },
+        () => transport.send(result)
+      );
+
+      expect(staleOrigin.send).not.toHaveBeenCalled();
+      expect(resumed.send).toHaveBeenCalledOnce();
+    });
+
+    it("tracks colliding batch response completion independently per stream", async () => {
+      const batch = createConnection("batch", ["same-id", "batch-only"]);
+      const colliding = createConnection("colliding");
+      const { agent, transport } = createTransport([batch, colliding]);
+      const sendFrom = (
+        connection: ReturnType<typeof createConnection>,
+        id: string
+      ) =>
+        agentContext.run(
+          {
+            agent,
+            connection: connection as unknown as Connection,
+            email: undefined,
+            request: undefined
+          },
+          () => transport.send({ ...result, id })
+        );
+
+      await sendFrom(batch, "same-id");
+      await sendFrom(colliding, "same-id");
+      await sendFrom(batch, "batch-only");
+
+      const finalBatchEvent = JSON.parse(
+        String(batch.send.mock.calls.at(-1)?.[0])
+      ) as { close?: boolean };
+      expect(finalBatchEvent.close).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #1632 by preventing `StreamableHTTPServerTransport.send()` from routing a JSON-RPC result/error response to an unrelated POST stream when concurrent requests on one MCP session reuse the same request id.

Although duplicate in-flight ids violate the client-side correlation contract, the current fallback is unsafe: it silently delivers a valid-looking response to whichever matching connection is returned first. This change hardens that failure mode rather than allowing responses to cross request streams.

## Approach

- Prefer the live connection from the current agent async context when multiple live streams claim the same request id.
- Preserve resumed POST-stream delivery: the originating connection is preferred only while it is still live, so a GET connection that inherited `requestIds` after `Last-Event-ID` resumption can continue receiving the response.
- When multiple live matching streams exist and no originating live connection can disambiguate them, return JSON-RPC `-32603 Internal error` responses to the affected streams instead of guessing or producing a transport-level failure.
- Track batched POST response completion by stream rather than globally by request id, so a collision on another POST cannot interfere with stream closure bookkeeping.

## Reviewer pointers

- `packages/agents/src/mcp/transport.ts`: the routing selection immediately after standalone SSE handling is the key behavioral change. The live-origin check is intentional because `handleGetRequest()` can replace a disconnected POST stream with a resumed GET stream carrying the same `requestIds`.
- `packages/agents/src/mcp/transport.ts`: `sendOnStream()` ensures the ambiguity-generated protocol error follows the same event-store and stream-completion path as ordinary responses.
- `packages/agents/src/mcp/transport.ts`: `_streamResponseIds` is separate hardening for batched requests; the previous request-id-only map shared completion state across colliding streams.
- `packages/agents/src/tests/mcp/transports/streamable-http.test.ts`: includes the same-id concurrent POST scenario from the issue plus the stale-origin/resumed-stream and no-origin protocol-error edge cases.
- `packages/agents/src/tests/agents/mcp.ts`: `collisionBarrierEcho` forces both colliding requests to remain in flight before either response is emitted, making the collision deterministic.
