### PR TITLE
fix(agents,think,ai-chat): count a sub-agent's progress as the orchestrating parent's recovery progress (N9)

### DIFF
--- a/.changeset/parent-progress-on-child-stream.md
+++ b/.changeset/parent-progress-on-child-stream.md
@@ -1,0 +1,28 @@
+---
+"@cloudflare/think": patch
+"@cloudflare/ai-chat": patch
+"agents": patch
+---
+
+Count a sub-agent's progress as the orchestrating parent's recovery progress
+
+A parent turn whose work is "run a sub-agent and await its result" produced no
+recoverable content of its own, so under deploy churn the **parent's** own
+chat-recovery no-progress window could exhaust while the child was still
+healthily streaming — abandoning the turn as `interrupted` and collecting an
+interrupted result even though the child went on to complete. (Reproduced by
+the `examples/deploy-churn --mode subagent` harness: the parent exhausted at
+`attempt 6/6` with `progress: 1` while the child self-healed all 30 steps.)
+
+Forwarding a child's stream to the parent's connections is now treated as
+genuine forward progress for the parent's recovery budget: `Think` and
+`AIChatAgent` advance their durable recovery-progress marker (throttled) each
+time `_forwardAgentToolStream` forwards child output, so a parent that keeps
+re-attaching to and streaming a live child survives churn indefinitely. The
+credit is only granted when the child actually produces output — a silent or
+hung child still lets the parent exhaust on its own no-progress timer, so a
+stuck sub-agent can never pin a parent's recovery open forever.
+
+This completes the sub-agent recovery story started by the stable-runId +
+bounded re-attach fix (#1630): the child self-heals and the parent both
+re-attaches to it _and_ keeps its own recovery alive while doing so.

--- a/examples/deploy-churn/src/server.ts
+++ b/examples/deploy-churn/src/server.ts
@@ -958,8 +958,11 @@ export class DeployChurnAgent extends Think<Env> {
       );
     }
     // Wipe submissions, the tool ledger, and tool config so a fresh run starts
-    // from zero. (Each orchestrator run also uses a fresh session/DO instance,
-    // so the durable transcript starts empty too.)
+    // from zero. Also clear the durable chat transcript: a REUSED session would
+    // otherwise keep the prior turn's tool result, so the sub-agent mock model
+    // (which only emits `runTask` when no tool result is present) would short-
+    // circuit to "DONE" and never dispatch the child.
+    await this.clearMessages();
     await this.deleteSubmissions();
     this._ensureLedgerTable();
     this.sql`DELETE FROM harness_ledger`;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -7741,6 +7741,12 @@ export class Agent<
       abortListener = () => resolveAbort?.();
       signal.addEventListener("abort", abortListener, { once: true });
     }
+    // N9: track whether any chunk was forwarded since the last progress hook so
+    // a parent that is merely orchestrating a child still records forward
+    // progress for its OWN recovery budget — but ONLY when the child actually
+    // produces output (a silent/hung child forwards nothing → no credit → the
+    // parent still exhausts on its own no-progress timer).
+    let forwardedSinceProgress = false;
     try {
       const forwardChunk = (chunk: AgentToolStoredChunk) => {
         this._broadcastAgentToolEvent(parentToolCallId, next++, {
@@ -7748,6 +7754,7 @@ export class Agent<
           runId,
           body: chunk.body
         });
+        forwardedSinceProgress = true;
       };
       const forwardLine = (line: string) => {
         try {
@@ -7801,6 +7808,20 @@ export class Agent<
         } else {
           forwardChunk(value);
         }
+        if (forwardedSinceProgress) {
+          forwardedSinceProgress = false;
+          // Credit the parent's recovery progress for forwarding child output
+          // (no-op in the base Agent; chat-recovery subclasses override). Kept
+          // off the hot per-chunk path — runs once per read iteration and is
+          // throttled inside the override. Best-effort: progress crediting is
+          // advisory, so a bump failure must never break the child stream the
+          // user is watching.
+          try {
+            await this._onAgentToolStreamProgress();
+          } catch {
+            // Ignore and keep forwarding; the next iteration tries again.
+          }
+        }
       }
     } finally {
       if (abortListener && signal) {
@@ -7824,6 +7845,28 @@ export class Agent<
     }
     return next;
   }
+
+  /**
+   * Hook invoked by `_forwardAgentToolStream` after a child produces output that
+   * was forwarded to the parent's connections. Forwarding a sub-agent's stream
+   * is genuine forward progress for the *parent* turn (the parent is
+   * orchestrating the child), so chat-recovery subclasses (Think / AIChatAgent)
+   * override this to advance their recovery progress marker.
+   *
+   * Without it, a parent whose turn merely `await`s a sub-agent banks zero
+   * progress of its own, so under deploy churn the parent's no-progress recovery
+   * window exhausts and abandons the turn as `interrupted` — even though the
+   * child is healthily streaming and ultimately completes (observed in the
+   * `deploy-churn --mode subagent` harness: `attempt 6/6, stable_timeout,
+   * progress: 1`).
+   *
+   * Called ONLY after at least one chunk was actually forwarded — never merely
+   * because a child is attached — so a silent / hung child still lets the parent
+   * exhaust on its own timer. The base Agent has no recovery budget, so this is
+   * a no-op; subclasses should throttle the (durable) bump since this can be
+   * called repeatedly while a child streams.
+   */
+  protected async _onAgentToolStreamProgress(): Promise<void> {}
 
   private _broadcastAgentToolTerminal<Output>(
     parentToolCallId: string | undefined,

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -167,6 +167,14 @@ const CHAT_RECOVERY_ALARM_DEBOUNCE_MS = 30 * 1000;
 // NEVER reset by progress — the final hard stop so even a degenerate
 // slowly-progressing loop cannot run forever.
 const CHAT_RECOVERY_MAX_WINDOW_MS = 15 * 60 * 1000;
+// N9: while a parent re-attaches to and forwards a sub-agent's stream, credit
+// the parent's recovery progress at most this often. The marker only needs to
+// advance ≥once between recovery attempts (the no-progress window is minutes),
+// so this caps storage writes during high-rate child streaming. The throttle
+// state is in-memory (reset per isolate), so the first forwarded chunk after
+// ANY restart always bumps — guaranteeing every recovery attempt that observes
+// child output registers forward progress.
+const AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS = 5_000;
 
 type StreamResultStatus = {
   status: Exclude<SaveMessagesResult["status"], "skipped">;
@@ -3192,6 +3200,31 @@ export class AIChatAgent<
     const current =
       (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0;
     await this.ctx.storage.put(CHAT_RECOVERY_PROGRESS_KEY, current + 1);
+  }
+
+  /** In-memory wall-clock of the last N9 child-stream progress bump (reset per
+   *  isolate so the first forwarded chunk after a restart always credits). */
+  private _lastAgentToolStreamProgressAt = 0;
+
+  /**
+   * N9: forwarding a sub-agent's chunks IS forward progress for this parent
+   * turn, so credit the parent's recovery progress marker — otherwise a parent
+   * whose turn merely `await`s a child banks no progress of its own and its
+   * no-progress window exhausts while the child is healthily streaming. Only
+   * invoked after a child actually produced output (see
+   * `_forwardAgentToolStream`), so a silent child still lets the parent exhaust.
+   * Throttled (and reset per isolate) so we never write storage per token.
+   */
+  protected override async _onAgentToolStreamProgress(): Promise<void> {
+    const now = Date.now();
+    if (
+      now - this._lastAgentToolStreamProgressAt <
+      AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS
+    ) {
+      return;
+    }
+    this._lastAgentToolStreamProgressAt = now;
+    await this._bumpChatRecoveryProgress();
   }
 
   /** Sweep recovery incidents that have been inactive past the TTL. */

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -50,6 +50,9 @@ interface ChatRecoveryTestStub {
   getChatRecoveryIncidentsForTest(): Promise<unknown[]>;
   addAssistantMessageForTest(id: string): Promise<void>;
   bumpRecoveryProgressForTest(): Promise<void>;
+  forwardChildStreamProgressForTest(
+    chunks: number
+  ): Promise<{ start: number; after: number }>;
   dropAssistantMessagesForTest(): Promise<void>;
   setRecoveryShouldThrowForTest(shouldThrow: boolean): Promise<void>;
   enableThrowingOnExhaustedForTest(
@@ -296,6 +299,70 @@ describe("onChatRecovery", () => {
 
     // Without further progress it climbs again and still exhausts at the cap.
     expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(2);
+    const exhausted = await agentStub.beginIncidentForTest(at());
+    expect(exhausted.attempt).toBe(3);
+    expect(exhausted.exhausted).toBe(true);
+  });
+
+  it("credits forwarding a sub-agent's stream as parent forward progress (N9)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const baseInput = {
+      requestId: "req-n9",
+      recoveryRootRequestId: "req-n9",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    let t = 1_000_000;
+    const at = () => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...baseInput, nowMs };
+    };
+
+    // A parent whose turn merely awaits a sub-agent climbs toward the cap.
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(1);
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(2);
+
+    // Re-attaching and forwarding the child's stream IS the parent's forward
+    // progress (N9) — the durable marker advances through the real
+    // `_forwardAgentToolStream` path, so the budget resets just like in-band
+    // content does. Without this the deploy-churn parent exhausts while the
+    // child streams healthily.
+    const forwarded = await agentStub.forwardChildStreamProgressForTest(3);
+    expect(forwarded.after).toBe(forwarded.start + 1);
+    const afterChildStream = await agentStub.beginIncidentForTest(at());
+    expect(afterChildStream.attempt).toBe(1);
+    expect(afterChildStream.exhausted).toBe(false);
+  });
+
+  it("does NOT credit a silent/hung sub-agent, so the parent still exhausts (N9)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const baseInput = {
+      requestId: "req-n9-silent",
+      recoveryRootRequestId: "req-n9-silent",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    let t = 2_000_000;
+    const at = () => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...baseInput, nowMs };
+    };
+
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(1);
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(2);
+
+    // A re-attach where the child produces NO output forwards nothing, so the
+    // parent banks no progress and the cap still binds.
+    const forwarded = await agentStub.forwardChildStreamProgressForTest(0);
+    expect(forwarded.after).toBe(forwarded.start);
     const exhausted = await agentStub.beginIncidentForTest(at());
     expect(exhausted.attempt).toBe(3);
     expect(exhausted.exhausted).toBe(true);

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1796,6 +1796,43 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     await self._bumpChatRecoveryProgress();
   }
 
+  /** Simulate a parent re-attach that forwards `chunks` of a child's stream by
+   *  driving the real `_forwardAgentToolStream` over a synthetic child stream.
+   *  The in-memory throttle is reset first so this models a fresh post-restart
+   *  isolate. Returns the durable recovery-progress counter before/after so a
+   *  test can assert forwarding child output credits the PARENT's progress
+   *  marker (N9) — and that a SILENT child (chunks = 0) does NOT. */
+  async forwardChildStreamProgressForTest(chunks: number): Promise<{
+    start: number;
+    after: number;
+  }> {
+    const self = this as unknown as {
+      _forwardAgentToolStream(
+        stream: ReadableStream<{ body: string }>,
+        parentToolCallId: string | undefined,
+        runId: string,
+        sequence: number
+      ): Promise<number>;
+      _lastAgentToolStreamProgressAt: number;
+    };
+    self._lastAgentToolStreamProgressAt = 0;
+    const read = async (): Promise<number> =>
+      (await this.ctx.storage.get<number>("cf:chat-recovery:progress")) ?? 0;
+    const start = await read();
+    const bodies = Array.from({ length: chunks }, (_, i) => ({
+      body: `chunk-${i}`
+    }));
+    const stream = new ReadableStream<{ body: string }>({
+      start(controller) {
+        for (const b of bodies) controller.enqueue(b);
+        controller.close();
+      }
+    });
+    await self._forwardAgentToolStream(stream, undefined, "n9-probe-run", 1);
+    const after = await read();
+    return { start, after };
+  }
+
   /** Simulate compaction collapsing the transcript by dropping all assistant
    *  messages from the live cache. Used to prove the recovery progress signal
    *  is compaction-immune (#1628). */

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3680,6 +3680,44 @@ export class ThinkRecoveryTestAgent extends Think {
     return { start, afterFlush, afterPersist };
   }
 
+  /** Simulate a parent re-attach that forwards `chunks` of a child's stream by
+   *  driving the real `_forwardAgentToolStream` over a synthetic child stream
+   *  (each chunk closed normally). The in-memory throttle is reset first so this
+   *  models a fresh post-restart isolate (where the first forwarded chunk always
+   *  credits). Returns the durable recovery-progress counter before/after so a
+   *  test can assert that forwarding child output credits the PARENT's progress
+   *  marker (N9) — and that a SILENT child (chunks = 0) does NOT. */
+  async forwardChildStreamProgressForTest(chunks: number): Promise<{
+    start: number;
+    after: number;
+  }> {
+    const self = this as unknown as {
+      _forwardAgentToolStream(
+        stream: ReadableStream<{ body: string }>,
+        parentToolCallId: string | undefined,
+        runId: string,
+        sequence: number
+      ): Promise<number>;
+      _lastAgentToolStreamProgressAt: number;
+    };
+    self._lastAgentToolStreamProgressAt = 0;
+    const read = async (): Promise<number> =>
+      (await this.ctx.storage.get<number>("cf:chat-recovery:progress")) ?? 0;
+    const start = await read();
+    const bodies = Array.from({ length: chunks }, (_, i) => ({
+      body: `chunk-${i}`
+    }));
+    const stream = new ReadableStream<{ body: string }>({
+      start(controller) {
+        for (const b of bodies) controller.enqueue(b);
+        controller.close();
+      }
+    });
+    await self._forwardAgentToolStream(stream, undefined, "n9-probe-run", 1);
+    const after = await read();
+    return { start, after };
+  }
+
   /** Seed a session that ends in a PARTIAL assistant message (the state a
    * deploy-interrupted turn leaves behind, which `continueLastTurn` replays). */
   async seedPartialAssistantTurnForTest(): Promise<void> {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2241,6 +2241,69 @@ describe("Think — onChatRecovery", () => {
     expect(exhausted.exhausted).toBe(true);
   });
 
+  it("credits forwarding a sub-agent's stream as parent forward progress (N9)", async () => {
+    const agent = await freshRecoveryAgent("recovery-n9-child-progress");
+    await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const base = {
+      requestId: "req-n9",
+      recoveryRootRequestId: "req-n9",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    let t = 1_000_000;
+    const at = () => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...base, nowMs };
+    };
+
+    // A parent whose turn merely awaits a sub-agent climbs toward the cap.
+    expect((await agent.beginIncidentForTest(at())).attempt).toBe(1);
+    expect((await agent.beginIncidentForTest(at())).attempt).toBe(2);
+
+    // Re-attaching and forwarding the child's stream IS the parent's forward
+    // progress (N9) — the durable marker advances through the real
+    // `_forwardAgentToolStream` path, so the budget resets just like in-band
+    // content does. Without this, the deploy-churn parent exhausts at `attempt
+    // 6/6, progress: 1` while the child streams healthily.
+    const forwarded = await agent.forwardChildStreamProgressForTest(3);
+    expect(forwarded.after).toBe(forwarded.start + 1);
+    const afterChildStream = await agent.beginIncidentForTest(at());
+    expect(afterChildStream.attempt).toBe(1);
+    expect(afterChildStream.exhausted).toBe(false);
+  });
+
+  it("does NOT credit a silent/hung sub-agent, so the parent still exhausts (N9)", async () => {
+    const agent = await freshRecoveryAgent("recovery-n9-silent-child");
+    await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });
+
+    const base = {
+      requestId: "req-n9-silent",
+      recoveryRootRequestId: "req-n9-silent",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    let t = 2_000_000;
+    const at = () => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...base, nowMs };
+    };
+
+    expect((await agent.beginIncidentForTest(at())).attempt).toBe(1);
+    expect((await agent.beginIncidentForTest(at())).attempt).toBe(2);
+
+    // A re-attach where the child produces NO output forwards nothing, so the
+    // parent banks no progress and the cap still binds — a genuinely hung child
+    // must not pin the parent's recovery open forever.
+    const forwarded = await agent.forwardChildStreamProgressForTest(0);
+    expect(forwarded.after).toBe(forwarded.start);
+    const exhausted = await agent.beginIncidentForTest(at());
+    expect(exhausted.attempt).toBe(3);
+    expect(exhausted.exhausted).toBe(true);
+  });
+
   it("detects forward progress even after compaction collapses the transcript (#1628)", async () => {
     const agent = await freshRecoveryAgent("recovery-progress-compaction");
     await agent.setChatRecoveryConfigForTest({ maxAttempts: 2 });

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -657,6 +657,14 @@ const CHAT_RECOVERY_ALARM_DEBOUNCE_MS = 30 * 1000;
 // NEVER reset by progress — the final hard stop so even a degenerate
 // slowly-progressing loop cannot run forever.
 const CHAT_RECOVERY_MAX_WINDOW_MS = 15 * 60 * 1000;
+// N9: while a parent re-attaches to and forwards a sub-agent's stream, credit
+// the parent's recovery progress at most this often. The marker only needs to
+// advance ≥once between recovery attempts (the no-progress window is minutes),
+// so this caps storage writes during high-rate child streaming. The throttle
+// state is in-memory (reset per isolate), so the first forwarded chunk after
+// ANY restart always bumps — guaranteeing every recovery attempt that observes
+// child output registers forward progress.
+const AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS = 5_000;
 
 // Ephemeral user message appended when a model request would otherwise end in
 // an assistant message (see `ensureValidContinueCheckpoint`).
@@ -7006,6 +7014,31 @@ export class Think<
     const current =
       (await this.ctx.storage.get<number>(CHAT_RECOVERY_PROGRESS_KEY)) ?? 0;
     await this.ctx.storage.put(CHAT_RECOVERY_PROGRESS_KEY, current + 1);
+  }
+
+  /** In-memory wall-clock of the last N9 child-stream progress bump (reset per
+   *  isolate so the first forwarded chunk after a restart always credits). */
+  private _lastAgentToolStreamProgressAt = 0;
+
+  /**
+   * N9: forwarding a sub-agent's chunks IS forward progress for this parent
+   * turn, so credit the parent's recovery progress marker — otherwise a parent
+   * whose turn merely `await`s a child banks no progress of its own and its
+   * no-progress window exhausts while the child is healthily streaming. Only
+   * invoked after a child actually produced output (see
+   * `_forwardAgentToolStream`), so a silent child still lets the parent exhaust.
+   * Throttled (and reset per isolate) so we never write storage per token.
+   */
+  protected override async _onAgentToolStreamProgress(): Promise<void> {
+    const now = Date.now();
+    if (
+      now - this._lastAgentToolStreamProgressAt <
+      AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS
+    ) {
+      return;
+    }
+    this._lastAgentToolStreamProgressAt = now;
+    await this._bumpChatRecoveryProgress();
   }
 
   /** Sweep recovery incidents that have been inactive past the TTL. */


### PR DESCRIPTION
## Summary

A parent turn whose work is *"run a sub-agent and `await` its result"* produces **no recoverable content of its own**. Under deploy churn, the **parent's own** chat-recovery no-progress window could therefore exhaust while the child was still healthily streaming — the parent abandoned its turn as `interrupted` and collected an interrupted result *even though the child went on to complete*.

This is the other half of the sub-agent recovery story: #1630/#1640 made the child **self-heal** and made the parent **re-attach** to it, but the parent's *own* recovery budget still expired while it waited. It's what still forced a customer-side `MAX_TASK_TURN_RETRIES` cap.

Reproduced by the `examples/deploy-churn --mode subagent` harness with real `wrangler deploy`s mid-loop: the parent exhausted at **`attempt 6/6`, `progress: 1`** while the child self-healed all 30 steps with no amplification.

## Root cause

`_forwardAgentToolStream` (base `Agent`) only **relayed** child chunks to the parent's connections via `_broadcastAgentToolEvent`. It never touched the parent's durable recovery-progress marker (`_bumpChatRecoveryProgress`), which lives in the chat layer (`Think` / `AIChatAgent`), not in base `Agent`. So an awaiting parent banked **zero** forward progress, and the no-progress window (`lastProgressAt`, #1638) tripped.

## Fix

- Add a base-`Agent` seam **`_onAgentToolStreamProgress()`** (no-op by default), invoked by `_forwardAgentToolStream` **once per read iteration that actually forwarded ≥1 child chunk**.
- `Think` and `AIChatAgent` **override** it to bump their recovery-progress marker, throttled in-memory (`AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS = 5s`, reset per isolate — so the **first forwarded chunk after any restart always credits**, guaranteeing each recovery attempt that observes child output registers progress).
- Covers **both** the live `runAgentTool` path and the recovery `_reconcileAgentToolRuns` / re-attach path (all route through `_forwardAgentToolStream`).
- The bump is **best-effort** — wrapped so a transient failure can never break the child stream the user is watching.

### Design guard (the important invariant)

Credit is granted **only on a genuinely-forwarded chunk** — never merely because a child is attached. A **silent / hung child forwards nothing → no credit → the parent still exhausts on its own no-progress timer**, so a stuck sub-agent can never pin a parent's recovery open forever. (Covered by a dedicated unit test.)

## No new public API / config

Zero new app-facing surface — a parent using `agentTool()` / `runAgentTool()` now survives churn while its child streams, automatically. The seam is an internal (`_`-prefixed) protected hook for the framework's own chat-recovery agents.

## Validation (all three layers green)

- **Unit (think + ai-chat, deterministic):** forwarding a child stream via the real `_forwardAgentToolStream` advances the durable marker and **resets the parent's attempt budget** exactly like in-band content (mirrors the existing #1637/#1638 budget-reset test); a **silent** child (0 chunks) does **not** credit, so the cap still binds. New harness seam `forwardChildStreamProgressForTest` in both packages. Full suites green (think 460, ai-chat 482).
- **SIGKILL e2e:** the `task-amplification` natural-`agentTool()` scenario stays **BOUNDED** (child 30/30, 1 bounded re-run) and the parent collects `completed` — **no regression** to #1640's re-attach.
- **Real-deploy (`deploy-churn --mode subagent`, 3 mid-loop `wrangler deploy`s):** verdict flipped **`NOT COLLECTED` → `RE-ATTACHED`** — `parentChildStatus: completed`, child 30/30, and the parent's recovery incident shows **`progress: 8`, `attempt: 5/6` (did not exhaust)** vs the prior `progress: 1, attempt 6/6 → interrupted`.
- Also fixed a harness gap: `deploy-churn`'s `reset()` now clears the parent's chat transcript, so a **reused** session no longer silently short-circuits the sub-agent mock model to "DONE".
- `npm run check` clean (sherif, exports, oxfmt, oxlint, typecheck — 91 projects).

## Follow-up (deliberately out of scope — tracked as N10)

N9 keeps the parent alive *while the child streams new output*; it is not an infinite hold (by design — a silent child must let the parent exhaust). Under **extreme** churn where the child itself is repeatedly reset and produces no *new* forwarded chunks between two parent attempts, the parent can still climb to the cap (the real-deploy run collected at `attempt 5/6` — one beat from exhausting). The hardening backstop — **re-attach a still-recoverable `interrupted` row on a later restart** in `_reconcileAgentToolRuns` (using #1640's soft-`interrupted` + N6's transcript-reconcile to repair it to `completed`) — is left as a separate follow-up because it touches the same fragile reconcile code and needs its own real-deploy gate.

## Semver

Marked all three packages `patch` — this is a behavior bug fix with no new public API (the seam is an internal protected hook). Happy to bump `agents` to `minor` if reviewers prefer to treat the new protected hook as additive.

## Test plan

- [x] think + ai-chat unit suites green
- [x] SIGKILL `task-amplification` e2e BOUNDED + parent collects `completed`
- [x] `deploy-churn --mode subagent` real-deploy verdict = RE-ATTACHED
- [x] `npm run check` clean

Made with [Cursor](https://cursor.com)