### PR TITLE
fix(think,ai-chat): terminalize via onExhausted when recovery gives up waiting for stable state

### DIFF
--- a/.changeset/recovery-stable-timeout-exhaustion.md
+++ b/.changeset/recovery-stable-timeout-exhaustion.md
@@ -1,0 +1,26 @@
+---
+"@cloudflare/think": patch
+"@cloudflare/ai-chat": patch
+---
+
+Terminalize a chat-recovery turn through `onExhausted` when it gives up waiting for stable state
+
+Under extreme churn (a long turn interrupted many times in quick succession), a
+recovery callback (`_chatRecoveryRetry` / `_chatRecoveryContinue`) could keep
+timing out waiting for the isolate to reach stable state until its retry budget
+drained. The give-up path only marked the incident `failed` and completed the
+recovered submission as `error` — it **bypassed `_exhaustChatRecovery`**, so
+`onExhausted` never fired, the `chat:recovery:exhausted` event was not emitted,
+the configured `terminalMessage` banner was never delivered, and the terminal
+chat status was not recorded. Apps relying on `onExhausted` for the terminal
+banner saw an eternal spinner with no terminal signal.
+
+The stable-state-timeout give-up now routes through the **same**
+`_exhaustChatRecovery` path as deploy-recovery and stall exhaustion: it fires
+`onExhausted` (with `reason: "stable_timeout"`), emits `chat:recovery:exhausted`,
+marks the durable submission interrupted, records the terminal chat status, and
+delivers the `terminalMessage`. As an extra backstop against silent drops, the
+give-up also terminalizes when the incident record is missing (no `incidentId`,
+or it was swept/deleted before a stale alarm fired) by synthesizing a terminal
+incident from the recovery-root request id — so a turn can never be dropped with
+no terminal UX.

--- a/packages/agents/src/chat/lifecycle.ts
+++ b/packages/agents/src/chat/lifecycle.ts
@@ -157,7 +157,16 @@ export type ChatRecoveryExhaustedContext = Pick<
   | "partialText"
   | "partialParts"
 > & {
-  /** Why recovery stopped: `max_attempts_exceeded` or `max_recovery_window_exceeded`. */
+  /**
+   * Why recovery stopped. One of:
+   * - `max_attempts_exceeded` — the per-incident attempt budget was spent.
+   * - `no_progress_timeout` — no forward progress within the no-progress window.
+   * - `max_recovery_window_exceeded` — the absolute incident-age ceiling was hit.
+   * - `stable_timeout` — a recovery attempt kept timing out waiting for the
+   *   isolate to reach stable state until the budget drained (extreme churn).
+   *
+   * Treat this as an open string: new reasons may be added.
+   */
   reason: string;
   /** The terminal message shown to the user (from the `chatRecovery` config). */
   terminalMessage: string;

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -3828,6 +3828,22 @@ export class AIChatAgent<
    * `onExhausted` for the terminal banner regressed to an eternal spinner when
    * recovery gave up under extreme churn. Shared by `_chatRecoveryRetry` and
    * `_chatRecoveryContinue`; mirrors the same helper in `@cloudflare/think`.
+   *
+   * Exactly-once terminalization here rests SOLELY on the
+   * `stored?.status === "exhausted"` re-entry guard below — unlike
+   * `@cloudflare/think`, `@cloudflare/ai-chat` has no durable-submission layer
+   * to short-circuit a duplicate alarm earlier. The sealed incident is
+   * re-persisted even when the record was found missing, so a swept record is
+   * re-armed for the guard on the next alarm.
+   *
+   * Two residual at-least-once edges, both deliberately accepted as "deliver a
+   * second banner" ≫ "silently drop the turn":
+   *  • No `incidentId` at all in the payload (only reachable via a direct/test
+   *    invocation — every production scheduler carries one): the synthesized
+   *    incident can't be persisted (no key), so the guard can't arm.
+   *  • The record is swept AGAIN between two alarms (the guard re-persists on
+   *    the first, so this needs a second independent sweep) — vanishingly
+   *    unlikely.
    */
   private async _exhaustRecoveryAfterStableTimeout(
     callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
@@ -3841,9 +3857,9 @@ export class AIChatAgent<
       ? await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)
       : null;
 
-    // Re-entry guard: a duplicate stale alarm (or a retried callback) must not
-    // fire `onExhausted` / broadcast the terminal banner twice. Once an
-    // incident is sealed `exhausted`, terminalization already happened.
+    // Re-entry guard (see method doc): a sealed incident means terminalization
+    // already happened, so a duplicate stale alarm must not re-fire
+    // `onExhausted` / re-broadcast the banner. This is ai-chat's ONLY guard.
     if (stored?.status === "exhausted") return;
 
     const rootRequestId =

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -3700,10 +3700,13 @@ export class AIChatAgent<
         ) {
           return;
         }
-        await this._updateChatRecoveryIncident(
-          data?.incidentId,
-          "failed",
-          "stable_timeout"
+        // Budget spent: terminalize through the SAME exhaustion path as deploy
+        // recovery (fires `onExhausted`, delivers the `terminalMessage` banner)
+        // instead of silently dropping the turn — otherwise an app relying on
+        // `onExhausted` sees an eternal spinner.
+        await this._exhaustRecoveryAfterStableTimeout(
+          "_chatRecoveryContinue",
+          data
         );
         return;
       }
@@ -3795,6 +3798,105 @@ export class AIChatAgent<
     return true;
   }
 
+  /**
+   * Resolve the stream id for a recovery turn so the give-up terminalization
+   * can surface whatever partial the turn produced. Prefers the durable stream
+   * row keyed by the recovery-root request id; falls back to the live active
+   * stream. Returns `""` when neither is available.
+   */
+  private _resolveRecoveryStreamId(requestId: string): string {
+    if (requestId) {
+      const fromMetadata = this._resumableStream
+        .getAllStreamMetadata()
+        .find((metadata) => metadata.request_id === requestId)?.id;
+      if (fromMetadata) return fromMetadata;
+    }
+    return this._resumableStream.hasActiveStream()
+      ? (this._resumableStream.activeStreamId ?? "")
+      : "";
+  }
+
+  /**
+   * Terminalize a recovery turn that has run out of stable-state-timeout retry
+   * budget — or whose incident record has vanished — by routing through the
+   * SAME `_exhaustChatRecovery` path as deploy-recovery exhaustion. It fires
+   * `onExhausted`, emits `chat:recovery:exhausted`, and delivers the configured
+   * `terminalMessage`.
+   *
+   * This replaces the older give-up that only set the incident to `failed`,
+   * which bypassed `_exhaustChatRecovery` entirely — so an app relying on
+   * `onExhausted` for the terminal banner regressed to an eternal spinner when
+   * recovery gave up under extreme churn. Shared by `_chatRecoveryRetry` and
+   * `_chatRecoveryContinue`; mirrors the same helper in `@cloudflare/think`.
+   */
+  private async _exhaustRecoveryAfterStableTimeout(
+    callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
+    data: ChatRecoveryContinueData | ChatRecoveryRetryData | undefined
+  ): Promise<void> {
+    const config = this._resolveChatRecoveryConfig();
+    const incidentKey = data?.incidentId
+      ? this._chatRecoveryIncidentKey(data.incidentId)
+      : null;
+    const stored = incidentKey
+      ? await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)
+      : null;
+
+    // Re-entry guard: a duplicate stale alarm (or a retried callback) must not
+    // fire `onExhausted` / broadcast the terminal banner twice. Once an
+    // incident is sealed `exhausted`, terminalization already happened.
+    if (stored?.status === "exhausted") return;
+
+    const rootRequestId =
+      data?.originalRequestId ??
+      this._activeChatRecoveryRootRequestId ??
+      stored?.recoveryRootRequestId ??
+      stored?.requestId ??
+      "";
+
+    // `stable_timeout` distinguishes a give-up driven by repeated stable-state
+    // timeouts from the generic max-attempts / no-progress exhaustion reasons.
+    const incident: ChatRecoveryIncident = stored
+      ? { ...stored, status: "exhausted", reason: "stable_timeout" }
+      : {
+          // Silent-drop guard: the incident record is gone (no `incidentId`, or
+          // it was swept/deleted before this stale alarm fired). Synthesize a
+          // minimal incident so the turn STILL terminalizes through
+          // `onExhausted` instead of being dropped with no terminal UX.
+          incidentId: data?.incidentId ?? crypto.randomUUID(),
+          requestId: rootRequestId,
+          recoveryRootRequestId: rootRequestId,
+          recoveryKind:
+            callback === "_chatRecoveryRetry" ? "retry" : "continue",
+          attempt: config.maxAttempts,
+          maxAttempts: config.maxAttempts,
+          status: "exhausted",
+          firstSeenAt: Date.now(),
+          lastAttemptAt: Date.now(),
+          reason: "stable_timeout"
+        };
+
+    // Persist the sealed incident (retained for inspection / TTL sweep) so the
+    // re-entry guard above sees `exhausted` if a duplicate stale alarm fires.
+    if (incidentKey) {
+      await this.ctx.storage.put(incidentKey, incident);
+    }
+
+    const streamId = this._resolveRecoveryStreamId(
+      incident.recoveryRootRequestId ?? incident.requestId
+    );
+    const partial = streamId
+      ? this._getPartialStreamText(streamId)
+      : { text: "", parts: [] as MessagePart[] };
+
+    await this._exhaustChatRecovery(
+      incident,
+      config,
+      partial,
+      streamId,
+      incident.firstSeenAt
+    );
+  }
+
   private _shouldRetryRecoveredPreStreamTurn(
     snapshot: ChatFiberSnapshot<"ai-chat-turn"> | null,
     streamId: string,
@@ -3843,10 +3945,13 @@ export class AIChatAgent<
         ) {
           return;
         }
-        await this._updateChatRecoveryIncident(
-          data?.incidentId,
-          "failed",
-          "stable_timeout"
+        // Budget spent: terminalize through the SAME exhaustion path as deploy
+        // recovery (fires `onExhausted`, delivers the `terminalMessage` banner)
+        // instead of silently dropping the turn — otherwise an app relying on
+        // `onExhausted` sees an eternal spinner.
+        await this._exhaustRecoveryAfterStableTimeout(
+          "_chatRecoveryRetry",
+          data
         );
         return;
       }

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -97,6 +97,9 @@ interface ChatRecoveryTestStub {
   runChatRecoveryContinueDirectForTest(
     data: Record<string, unknown>
   ): Promise<void>;
+  runChatRecoveryRetryDirectForTest(
+    data: Record<string, unknown>
+  ): Promise<void>;
   preScheduleRecoveryContinueForTest(
     data: Record<string, unknown>
   ): Promise<void>;
@@ -105,6 +108,18 @@ interface ChatRecoveryTestStub {
     status: string;
     reason?: string;
   } | null>;
+  enableExhaustedCaptureForTest(
+    maxAttempts: number,
+    terminalMessage?: string
+  ): Promise<void>;
+  getExhaustedContextsForTest(): Promise<
+    Array<{
+      recoveryRootRequestId: string;
+      recoveryKind: "retry" | "continue";
+      reason: string;
+      terminalMessage: string;
+    }>
+  >;
 }
 
 async function getTestAgent(room: string): Promise<ChatRecoveryTestStub> {
@@ -1089,10 +1104,11 @@ describe("onChatRecovery", () => {
     expect(incident?.status).toBe("scheduled");
   });
 
-  it("fails terminally once the stable-state retry budget is exhausted", async () => {
+  it("exhausts via onExhausted once the stable-state continue budget is spent", async () => {
     const agentStub = await getTestAgent(
       `stable-exhaust-${crypto.randomUUID()}`
     );
+    await agentStub.enableExhaustedCaptureForTest(6, "the assistant gave up");
     await agentStub.setForceStableTimeoutForTest(true);
     await agentStub.seedIncidentForTest({
       incidentId: "inc-exhaust",
@@ -1111,11 +1127,114 @@ describe("onChatRecovery", () => {
       targetAssistantId: "a-x"
     });
 
+    // No re-arm: the budget is spent.
     expect(
       await agentStub.getScheduleCountForCallback("_chatRecoveryContinue")
     ).toBe(0);
+    // The incident is sealed `exhausted` (not the old silent `failed`).
     const incident = await agentStub.getIncidentForTest("inc-exhaust");
-    expect(incident?.status).toBe("failed");
+    expect(incident?.status).toBe("exhausted");
     expect(incident?.reason).toBe("stable_timeout");
+    // onExhausted fires exactly once with the terminalMessage — the regression
+    // this guards (apps relying on it for the terminal banner).
+    const exhausted = await agentStub.getExhaustedContextsForTest();
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].reason).toBe("stable_timeout");
+    expect(exhausted[0].recoveryKind).toBe("continue");
+    expect(exhausted[0].terminalMessage).toBe("the assistant gave up");
+  });
+
+  it("exhausts via onExhausted once the stable-state retry budget is spent", async () => {
+    const agentStub = await getTestAgent(
+      `stable-exhaust-retry-${crypto.randomUUID()}`
+    );
+    await agentStub.enableExhaustedCaptureForTest(6, "retry gave up");
+    await agentStub.setForceStableTimeoutForTest(true);
+    await agentStub.seedIncidentForTest({
+      incidentId: "inc-exhaust-retry",
+      requestId: "root-exhaust-retry",
+      recoveryKind: "retry",
+      attempt: 6,
+      maxAttempts: 6,
+      status: "scheduled",
+      firstSeenAt: Date.now(),
+      lastAttemptAt: Date.now()
+    });
+
+    await agentStub.runChatRecoveryRetryDirectForTest({
+      incidentId: "inc-exhaust-retry",
+      originalRequestId: "root-exhaust-retry",
+      targetUserId: "u-x"
+    });
+
+    expect(
+      await agentStub.getScheduleCountForCallback("_chatRecoveryRetry")
+    ).toBe(0);
+    const incident = await agentStub.getIncidentForTest("inc-exhaust-retry");
+    expect(incident?.status).toBe("exhausted");
+    expect(incident?.reason).toBe("stable_timeout");
+    const exhausted = await agentStub.getExhaustedContextsForTest();
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].reason).toBe("stable_timeout");
+    expect(exhausted[0].recoveryKind).toBe("retry");
+    expect(exhausted[0].terminalMessage).toBe("retry gave up");
+  });
+
+  it("terminalizes a stable-state give-up even when the incident record is missing (silent-drop guard)", async () => {
+    const agentStub = await getTestAgent(
+      `stable-silent-drop-${crypto.randomUUID()}`
+    );
+    await agentStub.enableExhaustedCaptureForTest(6, "lost incident gave up");
+    await agentStub.setForceStableTimeoutForTest(true);
+    // No incident is seeded: simulate a stale alarm firing after the incident
+    // record was swept/deleted. The give-up must STILL terminalize through
+    // onExhausted rather than drop the turn into an eternal spinner.
+
+    await agentStub.runChatRecoveryContinueDirectForTest({
+      incidentId: "inc-gone",
+      originalRequestId: "root-missing",
+      targetAssistantId: "a-x"
+    });
+
+    const exhausted = await agentStub.getExhaustedContextsForTest();
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].reason).toBe("stable_timeout");
+    expect(exhausted[0].recoveryRootRequestId).toBe("root-missing");
+    expect(exhausted[0].terminalMessage).toBe("lost incident gave up");
+  });
+
+  it("does not re-fire onExhausted when a duplicate stale alarm runs after exhaustion", async () => {
+    const agentStub = await getTestAgent(
+      `stable-exhaust-dup-${crypto.randomUUID()}`
+    );
+    await agentStub.enableExhaustedCaptureForTest(6, "gave up once");
+    await agentStub.setForceStableTimeoutForTest(true);
+    await agentStub.seedIncidentForTest({
+      incidentId: "inc-dup",
+      requestId: "root-dup",
+      recoveryKind: "continue",
+      attempt: 6,
+      maxAttempts: 6,
+      status: "scheduled",
+      firstSeenAt: Date.now(),
+      lastAttemptAt: Date.now()
+    });
+
+    const data = {
+      incidentId: "inc-dup",
+      originalRequestId: "root-dup",
+      targetAssistantId: "a-x"
+    };
+    // First give-up terminalizes; the incident is sealed `exhausted`.
+    await agentStub.runChatRecoveryContinueDirectForTest(data);
+    // A duplicate stale alarm fires the SAME callback again (ai-chat has no
+    // durable-submission short-circuit, so the incident-status guard is the
+    // only thing preventing a second terminal banner / onExhausted).
+    await agentStub.runChatRecoveryContinueDirectForTest(data);
+
+    const exhausted = await agentStub.getExhaustedContextsForTest();
+    expect(exhausted).toHaveLength(1);
+    const incident = await agentStub.getIncidentForTest("inc-dup");
+    expect(incident?.status).toBe("exhausted");
   });
 });

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1593,10 +1593,14 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
   }
 
   /** Capture the `onExhausted` context for assertions (instead of throwing). */
-  enableExhaustedCaptureForTest(maxAttempts: number): void {
+  enableExhaustedCaptureForTest(
+    maxAttempts: number,
+    terminalMessage?: string
+  ): void {
     this.exhaustedContexts = [];
     this.chatRecovery = {
       maxAttempts,
+      ...(terminalMessage ? { terminalMessage } : {}),
       onExhausted: (exhaustedCtx) => {
         this.exhaustedContexts.push(exhaustedCtx);
       }
@@ -1756,6 +1760,14 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
   ): Promise<void> {
     await super._chatRecoveryContinue(
       data as Parameters<AIChatAgent<Env>["_chatRecoveryContinue"]>[0]
+    );
+  }
+
+  async runChatRecoveryRetryDirectForTest(
+    data: Record<string, unknown>
+  ): Promise<void> {
+    await super._chatRecoveryRetry(
+      data as Parameters<AIChatAgent<Env>["_chatRecoveryRetry"]>[0]
     );
   }
 

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3675,10 +3675,14 @@ export class ThinkRecoveryTestAgent extends Think {
   }
 
   /** Capture the `onExhausted` context for assertions (instead of throwing). */
-  async enableExhaustedCaptureForTest(maxAttempts: number): Promise<void> {
+  async enableExhaustedCaptureForTest(
+    maxAttempts: number,
+    terminalMessage?: string
+  ): Promise<void> {
     this._exhaustedContexts = [];
     this.chatRecovery = {
       maxAttempts,
+      ...(terminalMessage ? { terminalMessage } : {}),
       onExhausted: (exhaustedCtx) => {
         this._exhaustedContexts.push(exhaustedCtx);
       }

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3119,10 +3119,11 @@ describe("Think — onChatRecovery", () => {
     expect(incident?.status).toBe("scheduled");
   });
 
-  it("fails terminally once the stable-state retry budget is exhausted", async () => {
+  it("exhausts via onExhausted once the stable-state continue budget is spent", async () => {
     const agent = await freshRecoveryAgent(
       `stable-exhaust-${crypto.randomUUID()}`
     );
+    await agent.enableExhaustedCaptureForTest(6, "the assistant gave up");
     await agent.setForceStableTimeoutForTest(true);
     await agent.seedRunningSubmissionForTest("root-D");
     await agent.seedIncidentForTest({
@@ -3143,12 +3144,185 @@ describe("Think — onChatRecovery", () => {
       originalRequestId: "root-D"
     });
 
+    // No re-arm: the budget is spent.
     expect(
       await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
     ).toBe(0);
+    // The submission is sealed (interrupted → error), not left running.
     expect(await agent.getSubmissionStatusForTest("root-D")).toBe("error");
+    // The incident is sealed `exhausted` (not the old silent `failed`), with a
+    // reason that pins the give-up to repeated stable-state timeouts.
     const incident = await agent.getIncidentAttemptForTest("inc-D");
-    expect(incident?.status).toBe("failed");
+    expect(incident?.status).toBe("exhausted");
+    expect(incident?.reason).toBe("stable_timeout");
+    // onExhausted fires exactly once — the regression this guards.
+    const exhausted = (await agent.getExhaustedContextsForTest()) as Array<{
+      reason: string;
+      recoveryKind: string;
+      terminalMessage: string;
+      recoveryRootRequestId: string;
+    }>;
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].reason).toBe("stable_timeout");
+    expect(exhausted[0].recoveryKind).toBe("continue");
+    expect(exhausted[0].terminalMessage).toBe("the assistant gave up");
+    // The terminal banner is persisted so a reconnecting client isn't frozen.
+    const onConnect = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      body?: string;
+      error?: boolean;
+      done?: boolean;
+    }>;
+    const terminal = onConnect.find((m) => m.error === true && m.done === true);
+    expect(terminal?.body).toBe("the assistant gave up");
+  });
+
+  it("exhausts via onExhausted once the stable-state retry budget is spent", async () => {
+    const agent = await freshRecoveryAgent(
+      `stable-exhaust-retry-${crypto.randomUUID()}`
+    );
+    await agent.enableExhaustedCaptureForTest(6, "retry gave up");
+    await agent.setForceStableTimeoutForTest(true);
+    await agent.seedRunningSubmissionForTest("root-RE");
+    await agent.seedIncidentForTest({
+      incidentId: "inc-RE",
+      requestId: "root-RE",
+      recoveryKind: "retry",
+      attempt: 6,
+      maxAttempts: 6,
+      status: "scheduled",
+      firstSeenAt: Date.now(),
+      lastAttemptAt: Date.now()
+    });
+
+    await agent.runChatRecoveryRetryForTestWith({
+      recoveredRequestId: "root-RE",
+      targetUserId: "u-x",
+      incidentId: "inc-RE",
+      originalRequestId: "root-RE"
+    });
+
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
+    ).toBe(0);
+    expect(await agent.getSubmissionStatusForTest("root-RE")).toBe("error");
+    const incident = await agent.getIncidentAttemptForTest("inc-RE");
+    expect(incident?.status).toBe("exhausted");
+    expect(incident?.reason).toBe("stable_timeout");
+    const exhausted = (await agent.getExhaustedContextsForTest()) as Array<{
+      reason: string;
+      recoveryKind: string;
+      terminalMessage: string;
+      recoveryRootRequestId: string;
+    }>;
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].reason).toBe("stable_timeout");
+    expect(exhausted[0].recoveryKind).toBe("retry");
+    const onConnect = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      body?: string;
+      error?: boolean;
+      done?: boolean;
+    }>;
+    const terminal = onConnect.find((m) => m.error === true && m.done === true);
+    expect(terminal?.body).toBe("retry gave up");
+  });
+
+  it("terminalizes a stable-state give-up even when the incident record is missing (silent-drop guard)", async () => {
+    const agent = await freshRecoveryAgent(
+      `stable-silent-drop-${crypto.randomUUID()}`
+    );
+    await agent.enableExhaustedCaptureForTest(6, "lost incident gave up");
+    await agent.setForceStableTimeoutForTest(true);
+    await agent.seedRunningSubmissionForTest("root-MISS");
+    // No incident is seeded: simulate a stale alarm firing after the incident
+    // record was swept/deleted. The reschedule helper finds nothing and the
+    // give-up must STILL terminalize — not drop the turn into an eternal
+    // spinner (the worst-case variant of the bug).
+
+    await agent.runChatRecoveryContinueForTestWith({
+      recoveredRequestId: "root-MISS",
+      targetAssistantId: "a-x",
+      incidentId: "inc-gone",
+      originalRequestId: "root-MISS"
+    });
+
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
+    ).toBe(0);
+    expect(await agent.getSubmissionStatusForTest("root-MISS")).toBe("error");
+    const exhausted = (await agent.getExhaustedContextsForTest()) as Array<{
+      reason: string;
+      recoveryKind: string;
+      terminalMessage: string;
+      recoveryRootRequestId: string;
+    }>;
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].reason).toBe("stable_timeout");
+    expect(exhausted[0].recoveryRootRequestId).toBe("root-MISS");
+    const onConnect = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      body?: string;
+      error?: boolean;
+      done?: boolean;
+    }>;
+    const terminal = onConnect.find((m) => m.error === true && m.done === true);
+    expect(terminal?.body).toBe("lost incident gave up");
+  });
+
+  it("terminalizes a stable-state give-up with no incidentId at all", async () => {
+    const agent = await freshRecoveryAgent(
+      `stable-no-incident-${crypto.randomUUID()}`
+    );
+    await agent.enableExhaustedCaptureForTest(6, "no incident gave up");
+    await agent.setForceStableTimeoutForTest(true);
+    await agent.seedRunningSubmissionForTest("root-NOID");
+
+    // Neither an incident record NOR an incidentId in the payload — the give-up
+    // synthesizes a terminal incident from the root request id so onExhausted
+    // still fires.
+    await agent.runChatRecoveryContinueForTestWith({
+      recoveredRequestId: "root-NOID",
+      targetAssistantId: "a-x",
+      originalRequestId: "root-NOID"
+    });
+
+    expect(await agent.getSubmissionStatusForTest("root-NOID")).toBe("error");
+    const exhausted = (await agent.getExhaustedContextsForTest()) as Array<{
+      reason: string;
+    }>;
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].reason).toBe("stable_timeout");
+  });
+
+  it("does not re-fire onExhausted when a duplicate stable-state give-up runs (no submission)", async () => {
+    const agent = await freshRecoveryAgent(
+      `stable-exhaust-dup-${crypto.randomUUID()}`
+    );
+    await agent.enableExhaustedCaptureForTest(6, "gave up once");
+    await agent.setForceStableTimeoutForTest(true);
+    // No running submission seeded: the give-up reaches the exhaustion path
+    // directly (the submission-not-running short-circuit only fires when a
+    // `recoveredRequestId` is present), so the incident-status guard is what
+    // prevents a second onExhausted on a duplicate alarm.
+    await agent.seedIncidentForTest({
+      incidentId: "inc-dup",
+      requestId: "root-dup",
+      recoveryKind: "continue",
+      attempt: 6,
+      maxAttempts: 6,
+      status: "scheduled",
+      firstSeenAt: Date.now(),
+      lastAttemptAt: Date.now()
+    });
+
+    const data = { incidentId: "inc-dup", originalRequestId: "root-dup" };
+    await agent.runChatRecoveryContinueForTestWith(data);
+    await agent.runChatRecoveryContinueForTestWith(data);
+
+    const exhausted = (await agent.getExhaustedContextsForTest()) as Array<{
+      reason: string;
+    }>;
+    expect(exhausted).toHaveLength(1);
+    const incident = await agent.getIncidentAttemptForTest("inc-dup");
+    expect(incident?.status).toBe("exhausted");
   });
 
   it("re-reconstructing the same interrupted stream is idempotent (no duplicate, no loss)", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7998,6 +7998,113 @@ export class Think<
     return true;
   }
 
+  /**
+   * Resolve the stream id for a recovery turn so the give-up terminalization
+   * can surface whatever partial the turn produced. Prefers the durable stream
+   * row keyed by the recovery-root request id; falls back to the live active
+   * stream. Returns `""` when neither is available (the terminal banner still
+   * fires — `_exhaustChatRecovery` does not require a stream).
+   */
+  private _resolveRecoveryStreamId(requestId: string): string {
+    if (requestId) {
+      const fromMetadata = this._resumableStream
+        .getAllStreamMetadata()
+        .find((metadata) => metadata.request_id === requestId)?.id;
+      if (fromMetadata) return fromMetadata;
+    }
+    return this._resumableStream.hasActiveStream()
+      ? (this._resumableStream.activeStreamId ?? "")
+      : "";
+  }
+
+  /**
+   * Terminalize a recovery turn that has run out of stable-state-timeout retry
+   * budget — or whose incident record has vanished — by routing through the
+   * SAME `_exhaustChatRecovery` path as deploy-recovery and stall exhaustion
+   * (#1626/#1631). It fires `onExhausted`, emits `chat:recovery:exhausted`,
+   * marks the durable submission interrupted, records the terminal chat status,
+   * and delivers the configured `terminalMessage`.
+   *
+   * This replaces the older give-up that only set the incident to `failed` and
+   * completed the recovered submission as `error`, which bypassed
+   * `_exhaustChatRecovery` entirely — so an app relying on `onExhausted` for the
+   * terminal banner regressed to an eternal spinner when recovery gave up under
+   * extreme churn (the stable-state wait timing out every attempt until the
+   * budget drained). Shared by `_chatRecoveryRetry` and `_chatRecoveryContinue`.
+   */
+  private async _exhaustRecoveryAfterStableTimeout(
+    callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
+    data: ChatRecoveryContinueData | ChatRecoveryRetryData | undefined
+  ): Promise<void> {
+    const config = this._resolveChatRecoveryConfig();
+    const incidentKey = data?.incidentId
+      ? this._chatRecoveryIncidentKey(data.incidentId)
+      : null;
+    const stored = incidentKey
+      ? await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)
+      : null;
+
+    // Re-entry guard: a duplicate stale alarm (or a retried callback) must not
+    // fire `onExhausted` / broadcast the terminal banner twice. Once an
+    // incident is sealed `exhausted`, terminalization already happened. (The
+    // durable-submission paths also short-circuit earlier via the
+    // submission-not-running check, but this covers callers with no submission
+    // — e.g. `@cloudflare/ai-chat`.)
+    if (stored?.status === "exhausted") return;
+
+    const rootRequestId =
+      data?.originalRequestId ??
+      data?.recoveredRequestId ??
+      this._activeChatRecoveryRootRequestId ??
+      stored?.recoveryRootRequestId ??
+      stored?.requestId ??
+      "";
+
+    // `stable_timeout` distinguishes a give-up driven by repeated stable-state
+    // timeouts from the generic max-attempts / no-progress exhaustion reasons.
+    const incident: ChatRecoveryIncident = stored
+      ? { ...stored, status: "exhausted", reason: "stable_timeout" }
+      : {
+          // Silent-drop guard: the incident record is gone (no `incidentId`, or
+          // it was swept/deleted before this stale alarm fired). Synthesize a
+          // minimal incident so the turn STILL terminalizes through
+          // `onExhausted` instead of being dropped with no terminal UX — the
+          // exact "eternal spinner" failure mode this fix closes.
+          incidentId: data?.incidentId ?? crypto.randomUUID(),
+          requestId: rootRequestId,
+          recoveryRootRequestId: rootRequestId,
+          recoveryKind:
+            callback === "_chatRecoveryRetry" ? "retry" : "continue",
+          attempt: config.maxAttempts,
+          maxAttempts: config.maxAttempts,
+          status: "exhausted",
+          firstSeenAt: Date.now(),
+          lastAttemptAt: Date.now(),
+          reason: "stable_timeout"
+        };
+
+    // Persist the sealed incident (retained for inspection / TTL sweep) so the
+    // re-entry guard above sees `exhausted` if a duplicate stale alarm fires.
+    if (incidentKey) {
+      await this.ctx.storage.put(incidentKey, incident);
+    }
+
+    const streamId = this._resolveRecoveryStreamId(
+      incident.recoveryRootRequestId ?? incident.requestId
+    );
+    const partial = streamId
+      ? this._getPartialStreamText(streamId)
+      : { text: "", parts: [] as MessagePart[] };
+
+    await this._exhaustChatRecovery(
+      incident,
+      config,
+      partial,
+      streamId,
+      incident.firstSeenAt
+    );
+  }
+
   async _chatRecoveryRetry(data?: ChatRecoveryRetryData): Promise<void> {
     const recoveredSubmission = data?.recoveredRequestId
       ? this._readRunningSubmissionByRequestId(data.recoveredRequestId)
@@ -8039,19 +8146,15 @@ export class Think<
         ) {
           return;
         }
-        await this._updateChatRecoveryIncident(
-          data?.incidentId,
-          "failed",
-          "stable_timeout"
+        // Budget spent: terminalize through the SAME exhaustion path as deploy
+        // recovery (fires `onExhausted`, delivers the `terminalMessage` banner,
+        // marks the submission interrupted) instead of silently dropping the
+        // turn — otherwise an app relying on `onExhausted` sees an eternal
+        // spinner.
+        await this._exhaustRecoveryAfterStableTimeout(
+          "_chatRecoveryRetry",
+          data
         );
-        if (data?.recoveredRequestId) {
-          await this._completeRecoveredSubmission(
-            data.recoveredRequestId,
-            "error",
-            null,
-            "Recovered chat retry timed out waiting for stable state."
-          );
-        }
         return;
       }
 
@@ -8284,19 +8387,15 @@ export class Think<
         ) {
           return;
         }
-        await this._updateChatRecoveryIncident(
-          data?.incidentId,
-          "failed",
-          "stable_timeout"
+        // Budget spent: terminalize through the SAME exhaustion path as deploy
+        // recovery (fires `onExhausted`, delivers the `terminalMessage` banner,
+        // marks the submission interrupted) instead of silently dropping the
+        // turn — otherwise an app relying on `onExhausted` sees an eternal
+        // spinner.
+        await this._exhaustRecoveryAfterStableTimeout(
+          "_chatRecoveryContinue",
+          data
         );
-        if (data?.recoveredRequestId) {
-          await this._completeRecoveredSubmission(
-            data.recoveredRequestId,
-            "error",
-            null,
-            "Recovered chat continuation timed out waiting for stable state."
-          );
-        }
         return;
       }
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -8031,6 +8031,25 @@ export class Think<
    * terminal banner regressed to an eternal spinner when recovery gave up under
    * extreme churn (the stable-state wait timing out every attempt until the
    * budget drained). Shared by `_chatRecoveryRetry` and `_chatRecoveryContinue`.
+   *
+   * Exactly-once terminalization is defended by two independent guards:
+   *  1. The `stored?.status === "exhausted"` re-entry guard below — once an
+   *     incident is sealed, a duplicate stale alarm (or retried callback)
+   *     returns before re-firing. The sealed incident is re-persisted even when
+   *     the record was found missing, so a swept record is re-armed for the
+   *     guard on the next alarm.
+   *  2. The durable-submission paths additionally short-circuit earlier at the
+   *     `submission_not_running` check (the submission is already `error` after
+   *     the first give-up). This is the ONLY guard `@cloudflare/ai-chat` lacks
+   *     (no submission layer), so guard #1 carries it there.
+   *
+   * Two residual at-least-once edges, both deliberately accepted as "deliver a
+   * second banner" ≫ "silently drop the turn":
+   *  • No `incidentId` at all in the payload (only reachable via a direct/test
+   *    invocation — every production scheduler carries one): the synthesized
+   *    incident can't be persisted (no key), so guard #1 can't arm.
+   *  • The record is swept AGAIN between two alarms (guard #1 re-persists on the
+   *    first, so this needs a second independent sweep) — vanishingly unlikely.
    */
   private async _exhaustRecoveryAfterStableTimeout(
     callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
@@ -8044,12 +8063,9 @@ export class Think<
       ? await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)
       : null;
 
-    // Re-entry guard: a duplicate stale alarm (or a retried callback) must not
-    // fire `onExhausted` / broadcast the terminal banner twice. Once an
-    // incident is sealed `exhausted`, terminalization already happened. (The
-    // durable-submission paths also short-circuit earlier via the
-    // submission-not-running check, but this covers callers with no submission
-    // — e.g. `@cloudflare/ai-chat`.)
+    // Re-entry guard #1 (see method doc): a sealed incident means
+    // terminalization already happened, so a duplicate stale alarm must not
+    // re-fire `onExhausted` / re-broadcast the banner.
     if (stored?.status === "exhausted") return;
 
     const rootRequestId =


### PR DESCRIPTION
## Summary

Under extreme deploy churn (a long multi-tool turn interrupted many times in quick succession), a chat-recovery callback (`_chatRecoveryRetry` / `_chatRecoveryContinue`) could keep timing out waiting for the isolate to reach **stable state** until its retry budget drained. The give-up path only marked the incident `failed` and completed the recovered submission as `error` — it **bypassed `_exhaustChatRecovery` entirely**. So:

- `onExhausted` never fired,
- `chat:recovery:exhausted` was never emitted,
- the configured `terminalMessage` banner was never delivered,
- the terminal chat status was never recorded.

An app that trusts the framework's progress-keyed budget and relies on `onExhausted` for the terminal banner regressed to an **eternal spinner** with no terminal signal. In the worst case (incident record missing/swept before a stale alarm fired) the turn was dropped with **no terminalization at all**.

This is the give-up path in the recovery callbacks — distinct from, and **not** covered by, #1626, which fixed the sibling stall-watchdog exhaustion path to route through `_exhaustChatRecovery`. This PR brings the stable-state-timeout give-up in line with every other "recovery gave up" path.

Reported against the `@1636` preview pin (the give-up was unchanged at that commit and at the #1626 head).

## What changed

- **New shared helper `_exhaustRecoveryAfterStableTimeout(callback, data)`** in both `@cloudflare/think` and `@cloudflare/ai-chat`. The budget-spent stable-state give-up now routes through the **same** `_exhaustChatRecovery` path as deploy-recovery and stall exhaustion: fires `onExhausted` (with `reason: \"stable_timeout\"`), emits `chat:recovery:exhausted`, marks the durable submission interrupted (think), records the terminal chat status (think), and delivers the configured `terminalMessage`.
- **Silent-drop backstop:** when the incident record is missing (no `incidentId`, or it was swept/deleted before a stale alarm fired), the give-up **synthesizes** a terminal incident from the recovery-root request id so the turn STILL terminalizes through `onExhausted` instead of being dropped with no terminal UX.
- **Re-entry guard:** once an incident is sealed `exhausted`, a duplicate stale alarm (or retried callback) returns early so `onExhausted` / the terminal banner cannot fire twice. The durable-submission paths already short-circuit via the submission-not-running check; this guard additionally covers callers with no submission layer (notably `@cloudflare/ai-chat`).
- **`_resolveRecoveryStreamId` helper** surfaces the turn's partial into the `onExhausted` context best-effort (read-only; no orphan re-persist — matching the prior give-up behavior, since `waitUntilStable` failed before any turn ran so there is no new settled work).
- Both give-up branches in both callbacks, in both packages, now call the helper instead of `_updateChatRecoveryIncident(\"failed\")` + `_completeRecoveredSubmission(\"error\")`.
- **Docs:** `ChatRecoveryExhaustedContext.reason` JSDoc now enumerates all four emittable reasons (`max_attempts_exceeded`, `no_progress_timeout`, `max_recovery_window_exceeded`, `stable_timeout`) and notes it is an open string.

## Behavior notes (observable changes)

- The stable-timeout give-up now emits **`chat:recovery:exhausted`** instead of `chat:recovery:failed`. This is the correct semantics (it *is* exhaustion) and aligns with deploy/stall exhaustion — exactly what an `onExhausted`-based app expects.
- The recovered submission's error message is now the user-facing `terminalMessage` (via `_markRecoveredSubmissionInterrupted`) rather than an internal diagnostic string; status is still `error`.
- The incident is retained as `exhausted` (was `failed`); same TTL-sweep retention, no storage leak.

## Deliberate scope choice

The give-up terminalizes unconditionally (it is reached only after `waitUntilStable` fails, before the leaf/`targetUserId` checks). The existing `_exhaustChatRecovery` callers (fiber-recovery + stall exhaustion) also terminalize unconditionally, so adding a superseded-turn guard *only here* would make exhaustion semantics inconsistent across paths. The progress-keyed budget makes a superseded-during-give-up scenario contrived; left as a possible future unification across all exhaustion paths.

## Tests

- **think** (`think-session.test.ts`): rewrote the old "fails terminally" test to assert `exhausted` + `onExhausted` + persisted terminal banner; added retry-path coverage, a missing-incident silent-drop guard, a no-`incidentId` case, and a no-submission duplicate-alarm re-entry guard. **159 pass.**
- **ai-chat** (`durable-chat-recovery.test.ts`): mirrored continue + retry exhaustion, the silent-drop guard, and the duplicate-alarm re-entry guard. **33 pass** (489 across the full workers suite).
- Extended harnesses: `enableExhaustedCaptureForTest` gains an optional terminal-message arg; added `runChatRecoveryRetryDirectForTest` (ai-chat).
- No e2e added: forcing repeated real stable-state timeouts to drain the budget over real alarms is slow/flaky, and the exhausted branch already flows through the same `_exhaustChatRecovery` the existing stall-recovery e2e and deploy-churn harness exercise end-to-end. Covered deterministically at the seam.

## Changeset

`@cloudflare/think` + `@cloudflare/ai-chat` patch.

## Follow-up

- ai-chat has weaker terminal hydration than think (its `_exhaustChatRecovery` only broadcasts transiently; no durable last-terminal record replayed on reconnect). Pre-existing and affects **all** ai-chat exhaustion paths — tracked in #1645, out of scope here.

## Test plan

- [x] `npm run check` (all 91 projects typecheck; format + lint clean)
- [x] `packages/think` `think-session.test.ts` — 159 pass
- [x] `packages/ai-chat` full workers suite — 489 pass
- [ ] CI green

Made with [Cursor](https://cursor.com)