### PR TITLE
fix(think): add StreamCallback.onInterrupted for recovering chat() turns (#1644)

### DIFF
--- a/.changeset/stream-callback-on-interrupted.md
+++ b/.changeset/stream-callback-on-interrupted.md
@@ -1,0 +1,29 @@
+---
+"@cloudflare/think": minor
+---
+
+Add `StreamCallback.onInterrupted()` so a `chat()`-driven turn interrupted by recovery isn't silently abandoned
+
+When a turn driven through `chat(userMessage, callback)` is interrupted and routed
+into bounded recovery (a stream-stall watchdog abort), the scheduled continuation
+runs in a **later isolate invocation without the original callback** — so neither
+`onDone()` nor `onError()` ever fires for that callback. Because the isolate is
+still alive, the RPC promise resolves **cleanly**, and a consumer that keys off the
+clean resolve mis-reads it as success: it finalizes whatever partial it had
+streamed. For the built-in messenger delivery this meant posting a **truncated**
+answer as final, while the real recovered answer was produced later and broadcast
+only to WebSocket connections.
+
+`StreamCallback` now has an optional `onInterrupted?()` signal, emitted from the
+stall→recovery branches of the RPC stream path instead of returning silently. It
+means "not done, not a terminal error — a continuation owns the final outcome";
+consumers should keep the channel open / show a recovering state / re-attach
+rather than finalizing the partial. It is **optional**, so existing
+`StreamCallback` implementers are unaffected.
+
+Messenger delivery is wired to it: an interrupted reply now surfaces an
+"interrupted, please retry" message instead of finalizing the truncated partial.
+
+Note: a deploy/eviction interruption kills the isolate (and the callback) before
+this can fire — the caller observes a transport break instead. `onInterrupted`
+covers the in-isolate stall→recovery path.

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -726,6 +726,11 @@ interface StreamCallback {
   onEvent(json: string): void | Promise<void>;
   onDone(): void | Promise<void>;
   onError(error: string): void | Promise<void>;
+  // Optional. The attempt was interrupted (a stream-stall watchdog abort routed
+  // into bounded recovery) and a scheduled continuation — in a later isolate,
+  // without this callback — owns the final outcome. NOT done, NOT a terminal
+  // error. Defaults to a no-op, so existing implementers are unaffected.
+  onInterrupted?(): void | Promise<void>;
 }
 
 const agent = await this.subAgent(MyAgent, "thread-1");
@@ -735,6 +740,17 @@ await agent.chat("Summarize the project", relay);
 `onStart` exposes the request id for RPC-safe cancellation. Call
 `agent.cancelChat(requestId, reason)` if the parent needs to stop the child turn
 after it has started.
+
+`onInterrupted` matters for a `chat()`-driven turn that is interrupted and
+recovers: the RPC promise resolves **cleanly** (the isolate is still alive), so a
+consumer that keys off the clean resolve would mis-read it as success and
+finalize whatever partial it had streamed. Treat `onInterrupted` as "not done,
+not failed — a continuation owns the answer": keep the channel open, show a
+recovering state, or re-attach, rather than finalizing the partial. (The built-in
+messenger delivery already does this — it surfaces an "interrupted, please retry"
+reply instead of posting the truncated partial.) Note: a deploy/eviction
+interruption kills the isolate before this can fire — the caller sees a transport
+break instead; `onInterrupted` covers the in-isolate stall→recovery path.
 
 Tools belong to the child agent; define them with `getTools()` or use
 `agentTool()` / `runAgentTool()` for parent-child orchestration.

--- a/packages/think/src/messengers/delivery.ts
+++ b/packages/think/src/messengers/delivery.ts
@@ -28,6 +28,7 @@ export class TextStreamCallback extends RpcTarget implements StreamCallback {
   private readonly visibleSoftLimit?: number;
   private chatRequestId?: string;
   private closed = false;
+  private interrupted = false;
   private error?: Error;
   private text = "";
   private visibleClosed = false;
@@ -62,6 +63,20 @@ export class TextStreamCallback extends RpcTarget implements StreamCallback {
 
   onError(error: string): void {
     this.fail(new Error(error));
+  }
+
+  onInterrupted(): void {
+    // The attempt was interrupted and a continuation (not this callback) owns
+    // the real answer — delivered only to WebSocket connections, never to this
+    // surface. Mark interrupted and stop the visible stream WITHOUT failing it,
+    // so delivery surfaces the interrupted apology instead of treating the
+    // partial as the final reply (#1644).
+    this.interrupted = true;
+    this.close();
+  }
+
+  wasInterrupted(): boolean {
+    return this.interrupted;
   }
 
   close(): void {
@@ -364,6 +379,27 @@ export async function deliverMessengerReply(
       );
     } else {
       await options.target.chat(userMessage, callback);
+    }
+    if (callback.wasInterrupted()) {
+      // The model turn was interrupted and routed into bounded recovery; the
+      // recovered answer is produced later by a scheduled continuation and
+      // broadcast only to WebSocket connections, NOT to this one-shot messenger
+      // delivery. Do NOT mark the turn complete or finalize the truncated
+      // partial as the reply — surface the interrupted apology so the user
+      // knows to retry (#1644). `completedModelTurn` stays false.
+      callback.close();
+      await post.catch(() => undefined);
+      await options.surface
+        .post(interruptedResponseText)
+        .catch(() => undefined);
+      await checkpoint(
+        messengerReplySnapshot(
+          "completed",
+          snapshotEvent,
+          options.snapshotThread
+        )
+      );
+      return;
     }
     completedModelTurn = true;
     callback.close();

--- a/packages/think/src/tests/agents/assistant-agent-loop.ts
+++ b/packages/think/src/tests/agents/assistant-agent-loop.ts
@@ -21,12 +21,14 @@ type TestChatResult = {
   events: string[];
   done: boolean;
   error?: string;
+  interruptedCalls: number;
 };
 
 class TestCollectingCallback implements StreamCallback {
   events: string[] = [];
   doneCalled = false;
   errorMessage?: string;
+  interruptedCalls = 0;
   onStart(): void {}
   onEvent(json: string): void {
     this.events.push(json);
@@ -36,6 +38,9 @@ class TestCollectingCallback implements StreamCallback {
   }
   onError(error: string): void {
     this.errorMessage = error;
+  }
+  onInterrupted(): void {
+    this.interruptedCalls++;
   }
 }
 
@@ -276,7 +281,12 @@ export class LoopToolTestAgent extends Think {
   async testChat(message: string): Promise<TestChatResult> {
     const cb = new TestCollectingCallback();
     await this.chat(message, cb);
-    return { events: cb.events, done: cb.doneCalled, error: cb.errorMessage };
+    return {
+      events: cb.events,
+      done: cb.doneCalled,
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
+    };
   }
 
   async getBeforeToolCallLog(): Promise<

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -48,6 +48,7 @@ export type TestChatResult = {
   events: string[];
   done: boolean;
   error?: string;
+  interruptedCalls: number;
 };
 
 /** Shallow JSON object for DO RPC returns (`Record<string, unknown>` fails RPC typing). */
@@ -455,6 +456,7 @@ class TestCollectingCallback implements StreamCallback {
   doneCalled = false;
   errorMessage?: string;
   requestId?: string;
+  interruptedCalls = 0;
 
   onStart(event: { requestId: string }): void {
     this.requestId = event.requestId;
@@ -470,6 +472,10 @@ class TestCollectingCallback implements StreamCallback {
 
   onError(error: string): void {
     this.errorMessage = error;
+  }
+
+  onInterrupted(): void {
+    this.interruptedCalls++;
   }
 }
 
@@ -826,7 +832,8 @@ export class ThinkTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -870,7 +877,8 @@ export class ThinkTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -890,7 +898,8 @@ export class ThinkTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -965,6 +974,7 @@ export class ThinkTestAgent extends Think {
     timeoutMs: number
   ): Promise<{
     firstError: string | undefined;
+    firstInterruptedCalls: number;
     scheduledContinues: number;
     assistantMessages: number;
     finalAssistantText: string;
@@ -1007,6 +1017,7 @@ export class ThinkTestAgent extends Think {
         : "";
       return {
         firstError: first.error,
+        firstInterruptedCalls: first.interruptedCalls,
         scheduledContinues,
         assistantMessages: assistant.length,
         finalAssistantText
@@ -1233,7 +1244,7 @@ export class ThinkTestAgent extends Think {
 
     await this.chat(message, cb, { signal: controller.signal });
 
-    return { events, done: doneCalled, doneCalled };
+    return { events, done: doneCalled, doneCalled, interruptedCalls: 0 };
   }
 
   async testChatWithCancelChat(
@@ -1264,7 +1275,13 @@ export class ThinkTestAgent extends Think {
 
     await this.chat(message, cb);
 
-    return { events, done: doneCalled, doneCalled, requestId };
+    return {
+      events,
+      done: doneCalled,
+      doneCalled,
+      requestId,
+      interruptedCalls: 0
+    };
   }
 
   async setResponse(response: string): Promise<void> {
@@ -2049,7 +2066,8 @@ export class ThinkSessionTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -2137,7 +2155,8 @@ export class ThinkAsyncConfigSessionAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -2262,7 +2281,8 @@ export class ThinkConfigInSessionAgent extends Think<Cloudflare.Env> {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -2496,7 +2516,8 @@ export class ThinkToolsTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -3202,7 +3223,8 @@ export class ThinkProgrammaticTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 }
@@ -3526,7 +3548,8 @@ export class ThinkAsyncHookTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -3638,7 +3661,8 @@ export class ThinkRecoveryTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 
@@ -4554,7 +4578,8 @@ export class ThinkNonRecoveryTestAgent extends Think {
     return {
       events: cb.events,
       done: cb.doneCalled,
-      error: cb.errorMessage
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
     };
   }
 

--- a/packages/think/src/tests/messengers.test.ts
+++ b/packages/think/src/tests/messengers.test.ts
@@ -13,7 +13,9 @@ import {
   defaultConversationName,
   deliverMessengerReply,
   defineMessengers,
+  EMPTY_MESSENGER_RESPONSE,
   ERROR_MESSENGER_RESPONSE,
+  INTERRUPTED_MESSENGER_RESPONSE,
   idempotencyKeyForEvent,
   MESSENGER_REPLY_FIBER_NAME,
   messengerReplyFailureMode,
@@ -508,6 +510,57 @@ describe("think messengers core", () => {
 
     expect(posts).toEqual(["hello"]);
     expect(stages).toEqual(["streaming", "completed"]);
+  });
+
+  it("surfaces the interrupted apology, not a truncated final reply, when the model turn is interrupted by recovery (#1644)", async () => {
+    const posts: string[] = [];
+    const stages: string[] = [];
+
+    await deliverMessengerReply({
+      event: baseEvent,
+      fiber: {
+        stash(snapshot: unknown) {
+          stages.push(
+            parseMessengerReplySnapshot(snapshot)?.stage ?? "unknown"
+          );
+        }
+      } as unknown as FiberContext,
+      surface: {
+        async post(message) {
+          if (isAsyncIterable(message)) {
+            posts.push(...(await collectText(message)));
+            return;
+          }
+          posts.push(typeof message === "string" ? message : message.markdown);
+        }
+      },
+      target: {
+        cancelChat() {
+          return Promise.resolve(false);
+        },
+        chat(_message, callback) {
+          callback.onStart({ requestId: "req-interrupted" });
+          callback.onEvent(
+            JSON.stringify({ type: "text-delta", delta: "partial answer" })
+          );
+          // The attempt is interrupted and routed into bounded recovery; the
+          // real answer is produced later by the continuation (WS only). A
+          // clean resolve must NOT be treated as completion.
+          callback.onInterrupted?.();
+          return Promise.resolve();
+        }
+      }
+    });
+
+    // The user is told the reply was interrupted (so they can retry) rather
+    // than receiving the truncated partial as the final answer...
+    expect(posts).toContain(INTERRUPTED_MESSENGER_RESPONSE);
+    // ...and the "empty response" fallback must NOT fire (the turn wasn't a
+    // completed-with-no-text turn — it was interrupted).
+    expect(posts).not.toContain(EMPTY_MESSENGER_RESPONSE);
+    // The one-shot delivery is checkpointed completed (recovery owns the WS
+    // answer; this surface won't receive it).
+    expect(stages).toContain("completed");
   });
 
   it("delivers successful replies with active messenger context and overflow chunks", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -528,10 +528,31 @@ describe("Think — error handling", () => {
 
     // The stall did NOT terminalize — no terminal error surfaced...
     expect(result.firstError).toBeUndefined();
+    // ...the interrupted attempt signaled `onInterrupted` exactly once (NOT
+    // onDone/onError) so a `chat()` consumer doesn't read the clean resolve as
+    // a successful completion and finalize the truncated partial (#1644)...
+    expect(result.firstInterruptedCalls).toBe(1);
     // ...a continuation was scheduled...
     expect(result.scheduledContinues).toBeGreaterThanOrEqual(1);
     // ...and it streamed the turn to completion (recovered, not failed).
     expect(result.finalAssistantText.length).toBeGreaterThan(0);
+  });
+
+  it("does not call onInterrupted on a normally-completing or terminally-erroring turn (#1644)", async () => {
+    const ok = await freshAgent(`no-interrupt-ok-${crypto.randomUUID()}`);
+    const okResult = await ok.testChat("hello");
+    expect(okResult.done).toBe(true);
+    expect(okResult.interruptedCalls).toBe(0);
+
+    // A terminal in-band stream error fires onError, never onInterrupted.
+    const errAgent = await freshAgent(
+      `no-interrupt-err-${crypto.randomUUID()}`
+    );
+    const errResult = await errAgent.testChatWithError(
+      "boom under no-interrupt"
+    );
+    expect(errResult.error).toContain("boom under no-interrupt");
+    expect(errResult.interruptedCalls).toBe(0);
   });
 
   it("honors a per-turn TurnConfig.chatStreamStallTimeoutMs override even when the instance watchdog is off (#1626)", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -727,6 +727,25 @@ export interface StreamCallback {
   onEvent(json: string): void | Promise<void>;
   onDone(): void | Promise<void>;
   onError(error: string): void | Promise<void>;
+  /**
+   * The current attempt was interrupted (a stream-stall watchdog abort routed
+   * into bounded recovery, #1626) and a scheduled continuation — running in a
+   * LATER isolate invocation, without this callback — owns the final outcome.
+   * This is NOT `onDone` (the turn did not complete) and NOT `onError` (it is
+   * not a terminal failure): the callback contract `onStart → onEvent* →
+   * (onDone | onError)` would otherwise be silently abandoned, and a consumer
+   * that treats the clean resolve as success finalizes a truncated partial.
+   *
+   * Consumers should AVOID finalizing on this signal — keep the channel open,
+   * show a "recovering…" state, or re-attach — rather than treating the clean
+   * resolve as completion. Optional → defaults to a no-op, so this is fully
+   * backward-compatible.
+   *
+   * Note: a deploy/eviction interruption kills the isolate (and this callback)
+   * before this can fire — the caller observes a transport break instead. This
+   * fires only for an in-isolate interruption (the stall→recovery path).
+   */
+  onInterrupted?(): void | Promise<void>;
 }
 
 /**
@@ -6488,8 +6507,11 @@ export class Think<
             });
             doneSent = true;
           }
-          // No `callback.onError`/response hook: the scheduled continuation owns
-          // the real terminal outcome (mirrors a deploy-interrupted attempt).
+          // The scheduled continuation (a later isolate invocation, without this
+          // callback) owns the real terminal outcome. Signal the interruption so
+          // the caller doesn't read this clean resolve as success and finalize a
+          // truncated partial (#1644); NOT onDone/onError — see `onInterrupted`.
+          await callback.onInterrupted?.();
           return;
         }
         if (outcome === "exhausted") {
@@ -6503,6 +6525,11 @@ export class Think<
             streamFinalized = true;
           }
           doneSent = true;
+          // Exhaustion is terminal for the turn, but it was delivered out-of-band
+          // by `_exhaustChatRecovery` (banner/`onExhausted`), NOT through this
+          // callback's `onError`. Signal the interruption so a `chat()` consumer
+          // doesn't mis-read the clean resolve as a successful completion (#1644).
+          await callback.onInterrupted?.();
           return;
         }
         // outcome === "disabled" (chat recovery off): fall through to the

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -729,17 +729,26 @@ export interface StreamCallback {
   onError(error: string): void | Promise<void>;
   /**
    * The current attempt was interrupted (a stream-stall watchdog abort routed
-   * into bounded recovery, #1626) and a scheduled continuation — running in a
-   * LATER isolate invocation, without this callback — owns the final outcome.
-   * This is NOT `onDone` (the turn did not complete) and NOT `onError` (it is
-   * not a terminal failure): the callback contract `onStart → onEvent* →
-   * (onDone | onError)` would otherwise be silently abandoned, and a consumer
-   * that treats the clean resolve as success finalizes a truncated partial.
+   * into bounded recovery, #1626) and its final outcome will NOT arrive through
+   * this callback. One of two things is true:
+   *  - a scheduled continuation — running in a LATER isolate invocation, without
+   *    this callback — will produce the answer (delivered to other channels,
+   *    e.g. WebSocket connections), OR
+   *  - the recovery budget was exhausted, so the turn was already terminalized
+   *    out-of-band (the configured `terminalMessage` + `onExhausted`) and is
+   *    terminally over — there is NO continuation to come.
    *
-   * Consumers should AVOID finalizing on this signal — keep the channel open,
-   * show a "recovering…" state, or re-attach — rather than treating the clean
-   * resolve as completion. Optional → defaults to a no-op, so this is fully
-   * backward-compatible.
+   * This is NOT `onDone` (this attempt did not complete) and NOT `onError` (the
+   * raw stall is not surfaced as a terminal error here); without it the contract
+   * `onStart → onEvent* → (onDone | onError)` is silently abandoned and a
+   * consumer that treats the clean resolve as success finalizes a truncated
+   * partial.
+   *
+   * Consumers should AVOID finalizing the partial on this signal — surface a
+   * "recovering…" / "interrupted, please retry" state, or re-attach via a
+   * durable channel — but must ALSO NOT block indefinitely waiting for a
+   * continuation: per the exhausted case above, one may never come. Optional →
+   * defaults to a no-op, so this is fully backward-compatible.
    *
    * Note: a deploy/eviction interruption kills the isolate (and this callback)
    * before this can fire — the caller observes a transport break instead. This


### PR DESCRIPTION
Closes #1644.

## Summary

When a turn driven through `chat(userMessage, callback)` is interrupted and routed into bounded recovery (a stream-stall watchdog abort — #1626/#1643), the scheduled continuation runs in a **later isolate invocation that doesn't hold the original `callback`** — so neither `onDone()` nor `onError()` ever fires for it. Because the isolate is still alive, the RPC promise resolves **cleanly**, silently violating the `onStart → onEvent* → (onDone | onError)` contract.

**The deploy/stall asymmetry (the subtle part):** a deploy/eviction kills the isolate, so the caller observes a transport break and re-attaches; a stall→recovery interruption returns cleanly, so the caller **cannot distinguish "finished" from "interrupted, continuing elsewhere."** A consumer that keys off the clean resolve mis-reads it as success and finalizes whatever partial it streamed.

**Real-world impact (messenger truncation):** `deliverMessengerReply` calls `callback.close()` right after `chat()` resolves and posts the streamed text as the final reply. So a recovering stall made it post a **truncated** answer, while the real recovered answer was produced later by the continuation and broadcast **only to WebSocket connections** — never to the messenger surface. The messenger user got a truncated/empty reply.

This was flagged in #1643 review (option C, recommended). The fix there intentionally kept the silent clean-return because none of the existing terminal signals is correct for a recovering turn; this PR adds the dedicated signal and wires the consumer that truncates.

## What changed

- **API:** optional `onInterrupted?()` on `StreamCallback` (think.ts). Means *not done, not a terminal error — a continuation owns the final outcome*; consumers should keep the channel open / show a recovering state / re-attach instead of finalizing. **Optional → default no-op, fully backward-compatible.**
- **Emit:** `_streamResultToRpcCallback` calls `await callback.onInterrupted?.()` in **both** stall branches (`scheduled` and `exhausted`) instead of returning silently. `_streamResult` is the WebSocket-broadcast path (no `StreamCallback`) so it's unaffected; a deploy/eviction can't fire this (the isolate is already gone).
- **Messenger wiring:** `TextStreamCallback` gains `onInterrupted()` / `wasInterrupted()`; `deliverMessengerReply` no longer marks the turn complete or posts the truncated partial on interruption — it surfaces the `INTERRUPTED_MESSENGER_RESPONSE` (\"interrupted, please retry\") reply and checkpoints the one-shot delivery completed.
- **Docs:** README `StreamCallback` sub-agent-streaming section documents `onInterrupted` + the clean-resolve gotcha.

## Why a new signal (not onDone/onError)

For an interrupted-but-recovering turn: `onDone()` falsely signals success (messenger finalizes a partial as final); `onError()` falsely signals terminal failure (error banner / sub-agent driver aborts); the current clean return is least-wrong but **silent** and truncates messenger answers. Only a dedicated signal is correct.

## Tests

- `think-session.test.ts`: a stall-recovering `chat()` turn calls `onInterrupted` **exactly once** (NOT onDone/onError); a normally-completing turn calls onDone and an in-band stream error calls onError — neither fires `onInterrupted`.
- `messengers.test.ts`: an interrupted messenger turn surfaces the interrupted apology (not the truncated partial, not the empty-response fallback) and checkpoints completed.
- Harness: `TestCollectingCallback` captures `interruptedCalls`; `TestChatResult` carries it; `testChatWithStallThenRecover` surfaces `firstInterruptedCalls`.

## Scope / compatibility

- Does **not** change `runAgentTool()` / `agentTool()` (durable ledger + re-attach path, #1630/#1640) — unaffected.
- A `StreamCallback` implementer that doesn't define `onInterrupted` behaves exactly as before.

## Changeset

`@cloudflare/think` minor (new optional API + messenger behavior fix).

## Test plan

- [x] `npm run check` — all 91 projects typecheck; format + lint clean
- [x] `packages/think` full unit suite — 481 pass (think-session 160, messengers 27)
- [ ] CI green

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->