### PR TITLE
feat(think,ai-chat): live "recovering…" status to chat clients (#1620) + flaky-test retries

### DIFF
--- a/.changeset/recovering-status-and-telemetry.md
+++ b/.changeset/recovering-status-and-telemetry.md
@@ -1,0 +1,26 @@
+---
+"@cloudflare/think": minor
+"@cloudflare/ai-chat": minor
+"agents": minor
+---
+
+Surface a live "recovering…" status to chat clients during durable recovery (#1620)
+
+When a durable chat turn is interrupted (a deploy/eviction, or a stream-stall
+watchdog abort) and resumes, clients had no "in progress" signal — the turn
+looked frozen until it completed or a terminal error was replayed. A new
+`cf_agent_chat_recovering` protocol frame is now broadcast on recovery schedule
+and cleared on every terminal outcome (completed/skipped/failed/exhausted), so
+the indicator can't spin forever. In `@cloudflare/think` it's also persisted and
+replayed on connect, so a client that joins mid-recovery learns the turn is
+working. `useAgentChat` exposes a new `isRecovering` flag (distinct from
+`isStreaming` — a recovering turn isn't producing tokens yet); most UIs render
+`isStreaming || isRecovering` as "busy". Backward-compatible: clients that don't
+understand the frame ignore it.
+
+> Note: `@cloudflare/ai-chat` broadcasts the live signal but does not yet replay
+> it on connect (it has no idle-connect hydration path; tracked in #1645).
+> `@cloudflare/think` has both.
+
+For recovery telemetry, subscribe to the `chat:recovery:*` observability events
+and route them to your analytics sink.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   e2e-ai-chat:
     name: "E2E: ai-chat (Playwright)"
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +49,7 @@ jobs:
 
   e2e-think:
     name: "E2E: think (chat recovery)"
-    timeout-minutes: 10
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -682,6 +682,12 @@ const unsubscribe = subscribe("chat", (event) => {
 });
 ```
 
+#### Recovering status on the client
+
+While a turn is being recovered, the agent broadcasts a `cf_agent_chat_recovering` status frame so clients can show a "recovering…" indicator instead of looking frozen. It is set when a recovery continuation is scheduled and cleared on every terminal outcome (so the indicator never spins forever). `@cloudflare/think` also replays it on connect, so a client that joins mid-recovery still learns the turn is working. Consume it via `useAgentChat`'s `isRecovering` flag (see [Client API](#useagentchat)). The signal is purely advisory and backward-compatible — clients that do not understand it ignore it.
+
+> `@cloudflare/ai-chat` broadcasts the live signal but does not yet replay it on connect (a client connecting mid-recovery will not be re-told until it reconnects to an active stream).
+
 Transcript repairs — healing orphaned tool calls (preserving them as errored results rather than deleting them, so the record survives and the model does not silently re-run the tool) and normalizing malformed/stringified or missing tool inputs before a provider call — are emitted on the `transcript` channel.
 
 #### Guarding against stale recoveries
@@ -805,7 +811,8 @@ function Chat() {
     setMessages,
     status,
     isServerStreaming,
-    isStreaming
+    isStreaming,
+    isRecovering
   } = useAgentChat({ agent });
 
   // ...
@@ -828,17 +835,18 @@ function Chat() {
 
 ### Return Values
 
-| Property                  | Type                               | Description                                                                |
-| ------------------------- | ---------------------------------- | -------------------------------------------------------------------------- |
-| `messages`                | `ChatMessage[]`                    | Current conversation messages                                              |
-| `sendMessage`             | `(message) => void`                | Send a message                                                             |
-| `clearHistory`            | `() => void`                       | Clear conversation (client and server)                                     |
-| `addToolOutput`           | `({ toolCallId, output }) => void` | Provide output for a client-side tool                                      |
-| `addToolApprovalResponse` | `({ id, approved }) => void`       | Approve or reject a tool requiring approval                                |
-| `setMessages`             | `(messages \| updater) => void`    | Set messages directly (syncs to server)                                    |
-| `status`                  | `string`                           | `"idle"`, `"submitted"`, `"streaming"`, or `"error"`                       |
-| `isServerStreaming`       | `boolean`                          | `true` when a server-initiated stream is active (e.g. from `saveMessages`) |
-| `isStreaming`             | `boolean`                          | `true` when any stream is active (client or server-initiated)              |
+| Property                  | Type                               | Description                                                                                                                                                                                                                                   |
+| ------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `messages`                | `ChatMessage[]`                    | Current conversation messages                                                                                                                                                                                                                 |
+| `sendMessage`             | `(message) => void`                | Send a message                                                                                                                                                                                                                                |
+| `clearHistory`            | `() => void`                       | Clear conversation (client and server)                                                                                                                                                                                                        |
+| `addToolOutput`           | `({ toolCallId, output }) => void` | Provide output for a client-side tool                                                                                                                                                                                                         |
+| `addToolApprovalResponse` | `({ id, approved }) => void`       | Approve or reject a tool requiring approval                                                                                                                                                                                                   |
+| `setMessages`             | `(messages \| updater) => void`    | Set messages directly (syncs to server)                                                                                                                                                                                                       |
+| `status`                  | `string`                           | `"idle"`, `"submitted"`, `"streaming"`, or `"error"`                                                                                                                                                                                          |
+| `isServerStreaming`       | `boolean`                          | `true` when a server-initiated stream is active (e.g. from `saveMessages`)                                                                                                                                                                    |
+| `isStreaming`             | `boolean`                          | `true` when any stream is active (client or server-initiated)                                                                                                                                                                                 |
+| `isRecovering`            | `boolean`                          | `true` while a durable turn is being recovered (interrupted and resuming). Distinct from `isStreaming` — a recovering turn is not producing tokens yet. Render a "recovering…" hint; most UIs treat `isStreaming \|\| isRecovering` as "busy" |
 
 ## Tools
 

--- a/examples/agents-as-tools/src/tests/vitest.config.ts
+++ b/examples/agents-as-tools/src/tests/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   ],
   test: {
     name: "agents-as-tools-example",
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     setupFiles: [path.join(testsDir, "setup.ts")],
     testTimeout: 15_000,

--- a/examples/assistant/src/tests/vitest.config.ts
+++ b/examples/assistant/src/tests/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   ],
   test: {
     name: "assistant-example",
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     setupFiles: [path.join(testsDir, "setup.ts")],
     testTimeout: 15_000,

--- a/examples/chat-sdk-messenger/src/tests/vitest.config.ts
+++ b/examples/chat-sdk-messenger/src/tests/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   ],
   test: {
     name: "chat-sdk-messenger-example",
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     testTimeout: 15_000
   }

--- a/examples/deploy-churn/src/client.tsx
+++ b/examples/deploy-churn/src/client.tsx
@@ -150,7 +150,8 @@ function App() {
     )
   });
 
-  const { messages, sendMessage, isStreaming, stop } = useAgentChat({ agent });
+  const { messages, sendMessage, isStreaming, isRecovering, stop } =
+    useAgentChat({ agent });
 
   // Poll the agent's recovery view so we can watch incidents/turns evolve while
   // deploys churn underneath. Cheap RPC; harness-only.
@@ -396,6 +397,18 @@ function App() {
       </div>
 
       <div className="border-t border-kumo-line bg-kumo-base">
+        {/* #1620: a live "recovering…" hint from `useAgentChat.isRecovering`, so
+            a turn being recovered across a deploy reads as working, not frozen. */}
+        {isRecovering && (
+          <div className="max-w-5xl mx-auto px-5 pt-3">
+            <span className="inline-flex items-center gap-2 rounded-full border border-kumo-line bg-kumo-base px-3 py-1">
+              <span className="size-2 rounded-full bg-kumo-accent animate-pulse" />
+              <Text size="xs" variant="secondary">
+                Recovering the interrupted turn…
+              </Text>
+            </span>
+          </div>
+        )}
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/experimental/forever-chat/vitest.config.ts
+++ b/experimental/forever-chat/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    retry: 3,
     include: ["src/**/*.test.ts"]
   }
 });

--- a/packages/agents/src/browser-tests/vitest.config.ts
+++ b/packages/agents/src/browser-tests/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "browser",
+    retry: 3,
     include: [path.join(import.meta.dirname, "**/*.test.ts")],
     testTimeout: 120_000,
     hookTimeout: 60_000

--- a/packages/agents/src/chat/__tests__/vitest.config.ts
+++ b/packages/agents/src/chat/__tests__/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "chat",
+    retry: 3,
     environment: "node",
     include: [path.join(import.meta.dirname, "**/*.test.ts")]
   }

--- a/packages/agents/src/chat/protocol.ts
+++ b/packages/agents/src/chat/protocol.ts
@@ -17,5 +17,12 @@ export const CHAT_MESSAGE_TYPES = {
   STREAM_RESUME_NONE: "cf_agent_stream_resume_none",
   TOOL_RESULT: "cf_agent_tool_result",
   TOOL_APPROVAL: "cf_agent_tool_approval",
-  MESSAGE_UPDATED: "cf_agent_message_updated"
+  MESSAGE_UPDATED: "cf_agent_message_updated",
+  // Server→client: a durable chat turn is being recovered (interrupted by a
+  // deploy/eviction or a stream-stall watchdog abort and now resuming). Sent
+  // when a recovery continuation is scheduled and cleared on every terminal
+  // outcome; `@cloudflare/think` also replays it on connect so a client that
+  // joins mid-recovery learns it. Purely a progress hint — backward-compatible
+  // (clients that don't understand it ignore it). See issue #1620.
+  CHAT_RECOVERING: "cf_agent_chat_recovering"
 } as const;

--- a/packages/agents/src/cli-tests/vitest.config.ts
+++ b/packages/agents/src/cli-tests/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "cli",
+    retry: 3,
     environment: "node",
     clearMocks: true
   }

--- a/packages/agents/src/e2e-tests/vitest.config.ts
+++ b/packages/agents/src/e2e-tests/vitest.config.ts
@@ -6,6 +6,8 @@ const testsDir = import.meta.dirname;
 export default defineConfig({
   test: {
     name: "e2e",
+    // Retry flaky e2e runs (real `wrangler dev` + network) before failing.
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     testTimeout: 120_000,
     hookTimeout: 60_000,

--- a/packages/agents/src/react-tests/vitest.config.ts
+++ b/packages/agents/src/react-tests/vitest.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
   },
   test: {
     name: "react",
+    // Retry flaky browser/Playwright runs before failing.
+    retry: 3,
     browser: {
       enabled: true,
       instances: [

--- a/packages/agents/src/tests/vitest.config.ts
+++ b/packages/agents/src/tests/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   ],
   test: {
     name: "workers",
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     setupFiles: [path.join(testsDir, "setup.ts")],
     testTimeout: 10000,

--- a/packages/agents/src/webmcp-tests/vitest.config.ts
+++ b/packages/agents/src/webmcp-tests/vitest.config.ts
@@ -4,6 +4,7 @@ import { playwright } from "@vitest/browser-playwright";
 export default defineConfig({
   test: {
     name: "webmcp",
+    retry: 3,
     browser: {
       enabled: true,
       instances: [{ browser: "chromium", headless: true }],

--- a/packages/agents/src/x402-tests/vitest.config.ts
+++ b/packages/agents/src/x402-tests/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "x402",
+    retry: 3,
     environment: "node",
     clearMocks: true
   }

--- a/packages/ai-chat/src/e2e-tests/vitest.config.ts
+++ b/packages/ai-chat/src/e2e-tests/vitest.config.ts
@@ -6,6 +6,8 @@ const testsDir = import.meta.dirname;
 export default defineConfig({
   test: {
     name: "ai-chat-e2e",
+    // Retry flaky e2e runs (real `wrangler dev` + network) before failing.
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     testTimeout: 120_000,
     hookTimeout: 60_000,

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -153,6 +153,14 @@ const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 const CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS = 3;
 const DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE =
   "The assistant was interrupted and could not recover. Please try again.";
+// Durable record of an in-progress recovery so a "recovering…" status (#1620)
+// can be broadcast live and survives the set/clear happening in different
+// isolates (a continuation runs in a later alarm invocation). NOTE: unlike
+// `@cloudflare/think`, AIChatAgent has no connect-time replay yet (it lacks the
+// idle-connect hydration path) — a client that connects mid-recovery won't be
+// re-told until #1645 adds hydration. The live broadcast + reliable clear work
+// regardless.
+const CHAT_RECOVERING_KEY = "cf:chat:recovering";
 // Incidents that have not seen a new attempt within this window are assumed
 // abandoned and swept so durable storage does not grow without bound.
 const CHAT_RECOVERY_INCIDENT_TTL_MS = 60 * 60 * 1000;
@@ -3412,6 +3420,21 @@ export class AIChatAgent<
         ...(reason ? { reason } : {})
       });
     }
+
+    // Live "recovering…" status (#1620): a scheduled continuation/retry means
+    // recovery is in progress; a terminal incident state resolves it.
+    if (status === "scheduled") {
+      await this._setChatRecovering(
+        true,
+        incident.recoveryRootRequestId ?? incident.requestId
+      );
+    } else if (
+      status === "completed" ||
+      status === "skipped" ||
+      status === "failed"
+    ) {
+      await this._setChatRecovering(false);
+    }
   }
 
   private async _exhaustChatRecovery(
@@ -3451,8 +3474,49 @@ export class AIChatAgent<
       id: incident.requestId,
       type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
     });
+    // Exhaustion resolves recovery — clear the "recovering…" status (#1620).
+    await this._setChatRecovering(false);
     // The exhausted record is retained for inspection and reclaimed later by
     // the TTL sweep; only successful (completed) incidents are deleted eagerly.
+  }
+
+  /**
+   * Set or clear the live "recovering…" status (#1620). Persists a durable
+   * record (so set/clear stay consistent across the isolates a recovery spans)
+   * and broadcasts a `CF_AGENT_CHAT_RECOVERING` frame on a genuine transition.
+   * NOTE: AIChatAgent does not yet replay this on connect (no idle-connect
+   * hydration; tracked in #1645) — this is the live signal only.
+   */
+  private async _setChatRecovering(
+    active: boolean,
+    requestId?: string
+  ): Promise<void> {
+    const existing = await this.ctx.storage.get<{
+      requestId?: string;
+      at?: number;
+    }>(CHAT_RECOVERING_KEY);
+    // A record older than the max recovery window is stale: the owning incident
+    // was abandoned without a terminal (e.g. the DO went idle before recovery
+    // could exhaust). Treat it as not-recovering so it can't suppress a
+    // genuinely-new recovering signal.
+    const activeExisting =
+      existing && Date.now() - (existing.at ?? 0) < CHAT_RECOVERY_MAX_WINDOW_MS;
+    if (active) {
+      if (activeExisting) return; // already recovering — idempotent, no re-broadcast
+      await this.ctx.storage.put(CHAT_RECOVERING_KEY, {
+        ...(requestId ? { requestId } : {}),
+        at: Date.now()
+      });
+    } else {
+      if (!existing) return; // not recovering — nothing to clear
+      await this.ctx.storage.delete(CHAT_RECOVERING_KEY);
+      requestId = requestId ?? existing.requestId;
+    }
+    this._broadcastChatMessage({
+      type: MessageType.CF_AGENT_CHAT_RECOVERING,
+      recovering: active,
+      ...(requestId ? { id: requestId } : {})
+    });
   }
 
   protected override async _handleInternalFiberRecovery(

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -2176,6 +2176,64 @@ describe("useAgentChat tool continuation status (issue #1157)", () => {
       .toHaveTextContent("ready");
   });
 
+  it("surfaces isRecovering from CF_AGENT_CHAT_RECOVERING, cleared on resolve (#1620)", async () => {
+    const { agent, target } = createAgentWithTarget({
+      name: "recovering-status",
+      url: "ws://localhost:3000/agents/chat/recovering-status?_pk=abc"
+    });
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: () => Promise.resolve([]),
+        resume: false
+      });
+      return <div data-testid="recovering">{String(chat.isRecovering)}</div>;
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(50);
+      return screen;
+    });
+
+    await expect
+      .element(screen.getByTestId("recovering"))
+      .toHaveTextContent("false");
+
+    // Server reports the turn is being recovered → the hook surfaces it.
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_chat_recovering",
+        recovering: true,
+        id: "root-1"
+      });
+      await sleep(10);
+    });
+    await expect
+      .element(screen.getByTestId("recovering"))
+      .toHaveTextContent("true");
+
+    // Recovery resolves → cleared (so a "recovering…" indicator can't stick).
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_chat_recovering",
+        recovering: false,
+        id: "root-1"
+      });
+      await sleep(10);
+    });
+    await expect
+      .element(screen.getByTestId("recovering"))
+      .toHaveTextContent("false");
+  });
+
   it("defers tool continuation resume until the active request settles", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")

--- a/packages/ai-chat/src/react-tests/vitest.config.ts
+++ b/packages/ai-chat/src/react-tests/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
   },
   test: {
     name: "react",
+    // Retry flaky browser/Playwright runs before failing.
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.{ts,tsx}")],
     browser: {
       enabled: true,

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -620,6 +620,16 @@ export function useAgentChat<
    */
   isStreaming: boolean;
   /**
+   * `true` while a durable chat turn is being recovered (interrupted by a
+   * deploy/eviction or a stream-stall watchdog abort and now resuming, #1620).
+   * Distinct from `isStreaming` — a recovering turn isn't producing tokens yet,
+   * so a client can show a "recovering…" hint instead of looking frozen. Most
+   * UIs treat `isStreaming || isRecovering` as "busy". Driven by the server's
+   * `CF_AGENT_CHAT_RECOVERING` frames (also replayed on connect for
+   * `@cloudflare/think`); cleared automatically on the next stream or terminal.
+   */
+  isRecovering: boolean;
+  /**
    * `true` when the current `status`/`isServerStreaming` activity is
    * driven by a server-pushed tool continuation (i.e. the server is
    * auto-continuing the conversation after `addToolOutput` or
@@ -1679,6 +1689,11 @@ export function useAgentChat<
   const streamStateRef = useRef<BroadcastStreamState>({ status: "idle" });
 
   const [isServerStreaming, setIsServerStreaming] = useState(false);
+  // #1620: a durable chat turn is being recovered (interrupted by a
+  // deploy/eviction or a stream-stall watchdog abort and now resuming). Driven
+  // by the server's `CF_AGENT_CHAT_RECOVERING` frames; surfaced as a "working,
+  // not frozen" hint distinct from active streaming.
+  const [isRecovering, setIsRecovering] = useState(false);
 
   useEffect(() => {
     const localResponseIds = localResponseMessageIdsRef.current;
@@ -1704,8 +1719,17 @@ export function useAgentChat<
             type: "clear"
           }).state;
           setIsServerStreaming(false);
+          setIsRecovering(false);
           // Shared local-state reset — see `resetLocalChatState`.
           resetLocalChatState();
+          break;
+
+        case MessageType.CF_AGENT_CHAT_RECOVERING:
+          // Durable recovery progress hint (#1620): show "recovering…" while a
+          // turn is being resumed. Cleared by the server's `recovering: false`
+          // frame on any terminal outcome (and locally on stream-resume /
+          // terminal response / clear below, for a snappy handoff).
+          setIsRecovering(Boolean(data.recovering));
           break;
 
         case MessageType.CF_AGENT_CHAT_MESSAGES:
@@ -1815,6 +1839,9 @@ export function useAgentChat<
           }).state;
           customTransport.observeServerTurn(data.id);
           setIsServerStreaming(true);
+          // The recovered turn is now streaming live to us — it's no longer
+          // "recovering", it's producing the answer (#1620).
+          setIsRecovering(false);
           agentRef.current.send(
             JSON.stringify({
               type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
@@ -1922,6 +1949,8 @@ export function useAgentChat<
           }
           if (data.done) {
             customTransport.handleServerTurnCompleted(data.id);
+            // A terminal turn outcome resolves any in-progress recovery (#1620).
+            setIsRecovering(false);
           }
           const completedObservedToolContinuation =
             data.done &&
@@ -1968,6 +1997,7 @@ export function useAgentChat<
       agent.removeEventListener("message", onAgentMessage);
       streamStateRef.current = { status: "idle" };
       setIsServerStreaming(false);
+      setIsRecovering(false);
       protectedStreamingAssistantRef.current = null;
       localResponseIds.clear();
     };
@@ -2228,6 +2258,14 @@ export function useAgentChat<
     messages: messagesWithToolResults,
     isServerStreaming: effectiveIsServerStreaming,
     isStreaming,
+    /**
+     * True while a durable chat turn is being recovered (interrupted by a
+     * deploy/eviction or a stream-stall watchdog abort and now resuming, #1620).
+     * Distinct from `isStreaming` — a recovering turn isn't producing tokens
+     * yet. Render a "recovering…" hint; most UIs treat `isStreaming ||
+     * isRecovering` as "busy". Cleared automatically on the next stream/terminal.
+     */
+    isRecovering,
     isToolContinuation,
     sendMessage: sendMessageWithStreamingProtection,
     stop: stopWithToolContinuationAbort,

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -108,6 +108,7 @@ interface ChatRecoveryTestStub {
     status: string;
     reason?: string;
   } | null>;
+  getChatRecoveringForTest(): Promise<{ requestId?: string } | null>;
   enableExhaustedCaptureForTest(
     maxAttempts: number,
     terminalMessage?: string
@@ -1236,5 +1237,26 @@ describe("onChatRecovery", () => {
     expect(exhausted).toHaveLength(1);
     const incident = await agentStub.getIncidentForTest("inc-dup");
     expect(incident?.status).toBe("exhausted");
+  });
+
+  it("tracks a durable 'recovering…' record, cleared on terminal (#1620)", async () => {
+    const agentStub = await getTestAgent(`recovering-${crypto.randomUUID()}`);
+    const begun = await agentStub.beginIncidentForTest({
+      requestId: "root-rec",
+      recoveryRootRequestId: "root-rec",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue"
+    });
+
+    // Scheduling marks the turn "recovering" (durable so set/clear stay
+    // consistent across the isolates a recovery spans).
+    await agentStub.updateIncidentForTest(begun.incidentId, "scheduled");
+    expect((await agentStub.getChatRecoveringForTest())?.requestId).toBe(
+      "root-rec"
+    );
+
+    // A terminal outcome clears it so the indicator can't spin forever.
+    await agentStub.updateIncidentForTest(begun.incidentId, "failed", "boom");
+    expect(await agentStub.getChatRecoveringForTest()).toBeNull();
   });
 });

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1780,6 +1780,14 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     });
   }
 
+  async getChatRecoveringForTest(): Promise<{ requestId?: string } | null> {
+    return (
+      (await this.ctx.storage.get<{ requestId?: string }>(
+        "cf:chat:recovering"
+      )) ?? null
+    );
+  }
+
   async getIncidentForTest(incidentId: string): Promise<{
     attempt: number;
     status: string;

--- a/packages/ai-chat/src/types.ts
+++ b/packages/ai-chat/src/types.ts
@@ -24,7 +24,17 @@ export enum MessageType {
   /** Server notifies client that a message was updated (e.g., tool result applied) */
   CF_AGENT_MESSAGE_UPDATED = "cf_agent_message_updated",
   /** Client sends tool approval response to server (for tools with needsApproval) */
-  CF_AGENT_TOOL_APPROVAL = "cf_agent_tool_approval"
+  CF_AGENT_TOOL_APPROVAL = "cf_agent_tool_approval",
+
+  /**
+   * Server→client progress hint: a durable chat turn is being recovered
+   * (interrupted by a deploy/eviction or a stream-stall watchdog abort and now
+   * resuming). Sent when a recovery continuation is scheduled and cleared on
+   * every terminal outcome. (`@cloudflare/think` also replays it on connect;
+   * `@cloudflare/ai-chat` broadcasts the live signal only — see #1645.)
+   * Backward-compatible — clients that don't understand it ignore it. See #1620.
+   */
+  CF_AGENT_CHAT_RECOVERING = "cf_agent_chat_recovering"
 }
 
 /**
@@ -74,6 +84,18 @@ export type OutgoingMessage<ChatMessage extends UIMessage = UIMessage> =
   | {
       /** Server responds to resume request when no active stream exists */
       type: MessageType.CF_AGENT_STREAM_RESUME_NONE;
+    }
+  | {
+      /**
+       * Progress hint: a durable chat turn is being recovered (`recovering:
+       * true`) or recovery has resolved (`recovering: false`). Purely advisory;
+       * a client renders a "recovering…" indicator while true.
+       */
+      type: MessageType.CF_AGENT_CHAT_RECOVERING;
+      /** Whether recovery is in progress (true) or has resolved (false). */
+      recovering: boolean;
+      /** The recovery-root request id of the turn being recovered, if known. */
+      id?: string;
     };
 
 /**

--- a/packages/codemode/vitest.browser.config.ts
+++ b/packages/codemode/vitest.browser.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "browser",
+    retry: 3,
     include: ["src/tests/**/*.browser.test.ts"],
     browser: {
       enabled: true,

--- a/packages/codemode/vitest.config.ts
+++ b/packages/codemode/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   ],
   test: {
     name: "workers",
+    retry: 3,
     include: ["src/tests/**/*.test.ts"],
     exclude: ["src/tests/**/*.browser.test.ts"]
   }

--- a/packages/shell/vitest.config.ts
+++ b/packages/shell/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   ],
   test: {
     name: "workers",
+    retry: 3,
     include: ["src/tests/**/*.test.ts"]
   }
 });

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -376,6 +376,14 @@ protected override repairInterruptedToolPart(
 }
 ```
 
+While a turn is being recovered, Think broadcasts a `cf_agent_chat_recovering`
+status (and replays it on connect) so clients can show a "recovering…" indicator
+instead of looking frozen — surface it on the client with `useAgentChat`'s
+`isRecovering` flag. It is set when a recovery continuation is scheduled and
+cleared on every terminal outcome, so the indicator never spins forever. To
+record recovery counts or reasons in your own analytics, subscribe to the
+`chat:recovery:*` observability events and route them to your sink.
+
 ### Scheduled tasks
 
 Use `getScheduledTasks()` for code-declared recurring prompts or deterministic

--- a/packages/think/src/e2e-tests/vitest.config.ts
+++ b/packages/think/src/e2e-tests/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "think-e2e",
+    // Retry flaky e2e runs (real `wrangler dev` + network) before failing.
+    retry: 3,
     // Run in Node.js — we spawn wrangler as a child process
     testTimeout: 120_000,
     hookTimeout: 60_000,

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2215,6 +2215,42 @@ describe("Think — onChatRecovery", () => {
     expect(afterOk.some((m) => m.error === true)).toBe(false);
   });
 
+  it("broadcasts + hydrates a 'recovering…' status, cleared on terminal (#1620)", async () => {
+    const agent = await freshRecoveryAgent(`recovering-${crypto.randomUUID()}`);
+    await agent.seedIncidentForTest({
+      incidentId: "inc-rec",
+      requestId: "root-rec",
+      recoveryKind: "continue",
+      attempt: 1,
+      maxAttempts: 6,
+      status: "attempting",
+      firstSeenAt: Date.now(),
+      lastAttemptAt: Date.now()
+    });
+
+    // Scheduling a recovery continuation marks the turn "recovering".
+    await agent.updateIncidentForTest("inc-rec", "scheduled");
+    const onConnect = (await agent.getIdleConnectMessagesForTest()) as Array<{
+      type: string;
+      recovering?: boolean;
+      id?: string;
+    }>;
+    const recovering = onConnect.find(
+      (m) => m.type === "cf_agent_chat_recovering"
+    );
+    // A client connecting mid-recovery learns the turn is working, not frozen.
+    expect(recovering?.recovering).toBe(true);
+    expect(recovering?.id).toBe("root-rec");
+
+    // A terminal outcome clears it so the indicator can't spin forever.
+    await agent.updateIncidentForTest("inc-rec", "failed", "boom");
+    const afterTerminal =
+      (await agent.getIdleConnectMessagesForTest()) as Array<{ type: string }>;
+    expect(
+      afterTerminal.some((m) => m.type === "cf_agent_chat_recovering")
+    ).toBe(false);
+  });
+
   it("flushes a settled tool result to durable storage immediately", async () => {
     const agent = await freshRecoveryAgent("tool-result-durability");
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -183,6 +183,7 @@ const MSG_CHAT_CLEAR = CHAT_MESSAGE_TYPES.CHAT_CLEAR;
 const MSG_STREAM_RESUMING = CHAT_MESSAGE_TYPES.STREAM_RESUMING;
 const MSG_STREAM_RESUME_NONE = CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE;
 const MSG_MESSAGE_UPDATED = CHAT_MESSAGE_TYPES.MESSAGE_UPDATED;
+const MSG_CHAT_RECOVERING = CHAT_MESSAGE_TYPES.CHAT_RECOVERING;
 
 function sendIfOpen(connection: Connection, message: string): boolean {
   try {
@@ -711,6 +712,13 @@ function ensureValidContinueCheckpoint(
 // were disconnected (e.g. during a deploy/WS reconnect storm) is not silently
 // frozen — the terminal `MSG_CHAT_RESPONSE` broadcast is otherwise transient.
 const CHAT_LAST_TERMINAL_KEY = "cf:chat:last-terminal";
+
+// Durable record of an in-progress durable recovery, so a "recovering…" status
+// can be broadcast live AND replayed to a client that connects mid-recovery
+// (#1620). Set when a recovery continuation/retry is scheduled; cleared on every
+// terminal outcome (completed/skipped/failed/exhausted) so the indicator can't
+// spin forever.
+const CHAT_RECOVERING_KEY = "cf:chat:recovering";
 
 /**
  * Callback interface for streaming chat events from a Think sub-agent.
@@ -7483,6 +7491,25 @@ export class Think<
         ...(reason ? { reason } : {})
       });
     }
+
+    // Live "recovering…" status (#1620): a scheduled continuation/retry means
+    // recovery is in progress; a terminal incident state resolves it. Keyed by
+    // the recovery-root request id so it lines up with the turn the client is
+    // watching. (Exhaustion + normal completion also clear via
+    // `_recordTerminalChatStatus`; this covers the benign-skip / failed paths
+    // that never reach a turn-level terminal.)
+    if (status === "scheduled") {
+      await this._setChatRecovering(
+        true,
+        incident.recoveryRootRequestId ?? incident.requestId
+      );
+    } else if (
+      status === "completed" ||
+      status === "skipped" ||
+      status === "failed"
+    ) {
+      await this._setChatRecovering(false);
+    }
   }
 
   private async _exhaustChatRecovery(
@@ -8760,6 +8787,10 @@ export class Think<
     } else {
       await this.ctx.storage.delete(CHAT_LAST_TERMINAL_KEY);
     }
+    // Any terminal turn outcome resolves an in-progress recovery (#1620): a
+    // recovered turn that completes, errors, or is exhausted must clear the
+    // "recovering…" indicator so it never spins forever.
+    await this._setChatRecovering(false);
   }
 
   private async _pendingTerminalChatResponse(): Promise<{
@@ -8771,6 +8802,47 @@ export class Think<
         CHAT_LAST_TERMINAL_KEY
       )) ?? null
     );
+  }
+
+  /**
+   * Set or clear the live "recovering…" status for a durable chat turn (#1620).
+   * Persists a durable record (replayed on connect via `_buildIdleConnectMessages`)
+   * and broadcasts a `MSG_CHAT_RECOVERING` frame — but only on a genuine
+   * transition, so a deploy/reconnect storm (which re-detects recovery many
+   * times) doesn't spam the wire. Cleared on every terminal outcome so the
+   * indicator can't spin forever.
+   */
+  private async _setChatRecovering(
+    active: boolean,
+    requestId?: string
+  ): Promise<void> {
+    const existing = await this.ctx.storage.get<{
+      requestId?: string;
+      at?: number;
+    }>(CHAT_RECOVERING_KEY);
+    // A record older than the max recovery window is stale: the owning incident
+    // was abandoned without ever reaching a terminal (e.g. the DO went idle
+    // before recovery could exhaust), so its terminal-clear never ran. Treat it
+    // as not-recovering so a stuck record can neither pin the indicator "on"
+    // forever nor suppress a genuinely-new recovering signal.
+    const activeExisting =
+      existing && Date.now() - (existing.at ?? 0) < CHAT_RECOVERY_MAX_WINDOW_MS;
+    if (active) {
+      if (activeExisting) return; // already recovering — idempotent, no re-broadcast
+      await this.ctx.storage.put(CHAT_RECOVERING_KEY, {
+        ...(requestId ? { requestId } : {}),
+        at: Date.now()
+      });
+    } else {
+      if (!existing) return; // not recovering — nothing to clear
+      await this.ctx.storage.delete(CHAT_RECOVERING_KEY);
+      requestId = requestId ?? existing.requestId;
+    }
+    this._broadcastChat({
+      type: MSG_CHAT_RECOVERING,
+      recovering: active,
+      ...(requestId ? { id: requestId } : {})
+    });
   }
 
   /**
@@ -8793,6 +8865,26 @@ export class Think<
         body: pending.body,
         done: true,
         error: true
+      });
+    }
+    // Replay an in-progress "recovering…" status so a client that connects
+    // mid-recovery reads the turn as working rather than frozen (#1620). It's
+    // mutually exclusive with `pending` (a terminal outcome clears recovering).
+    // Skip a stale record (older than the max recovery window) so a turn whose
+    // recovery was abandoned without a terminal can't show "recovering…"
+    // forever on reconnect.
+    const recovering = await this.ctx.storage.get<{
+      requestId?: string;
+      at?: number;
+    }>(CHAT_RECOVERING_KEY);
+    if (
+      recovering &&
+      Date.now() - (recovering.at ?? 0) < CHAT_RECOVERY_MAX_WINDOW_MS
+    ) {
+      messages.push({
+        type: MSG_CHAT_RECOVERING,
+        recovering: true,
+        ...(recovering.requestId ? { id: recovering.requestId } : {})
       });
     }
     return messages;

--- a/packages/voice/src/react-tests/vitest.config.ts
+++ b/packages/voice/src/react-tests/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   },
   test: {
     name: "voice-react",
+    retry: 3,
     browser: {
       enabled: true,
       instances: [

--- a/packages/voice/src/tests/vitest.config.ts
+++ b/packages/voice/src/tests/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   ],
   test: {
     name: "voice-workers",
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     exclude: [
       // SFU integration tests need real API credentials via process.env.

--- a/packages/worker-bundler/src/tests/vitest.config.ts
+++ b/packages/worker-bundler/src/tests/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   ],
   test: {
     name: "workers",
+    retry: 3,
     include: [path.join(testsDir, "**/*.test.ts")],
     // Copies esbuild.wasm into src/ before tests, removes after
     globalSetup: [path.join(testsDir, "global-setup.ts")]

--- a/voice-providers/telnyx/vitest.config.ts
+++ b/voice-providers/telnyx/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    retry: 3,
     environment: "node",
     include: ["tests/**/*.test.ts"]
   }


### PR DESCRIPTION
Closes #1620.

Two things, bundled: the **#1620 recovering-status feature** (the substantive change) and a small **test-infra pass** (retries + nightly timeout) to address the flakiness we've been seeing.

---

## 1. Live "recovering…" status (#1620)

When a durable chat turn is interrupted (a deploy/eviction, or a stream-stall watchdog abort) and resumes, clients had **no "in progress" signal** — the turn looked frozen until it completed or a terminal error was replayed. #1619 fixed the *terminal* half (failed/exhausted turns surface + replay on connect). This is the remaining **progress** half: a live "recovering…" status.

### Server
- **Protocol:** new `cf_agent_chat_recovering` frame — `CHAT_MESSAGE_TYPES` in `agents/chat`, `MessageType` + an `OutgoingMessage` variant in `@cloudflare/ai-chat`; payload `{ recovering: boolean, id? }`.
- **`_setChatRecovering(active, requestId?)`** (think + ai-chat): broadcasts the frame **and** persists a durable record, but **only on a genuine transition** (so a deploy/reconnect storm doesn't spam the wire). Set when a recovery continuation is scheduled; **cleared on every terminal outcome** (completed/skipped/failed via the incident update; exhausted + normal completion via `_recordTerminalChatStatus`/`_exhaustChatRecovery`) so the indicator can never spin forever.
- **Connect hydration (think):** replayed in `_buildIdleConnectMessages`, so a client that joins mid-recovery reads the turn as working, not frozen. *(`@cloudflare/ai-chat` broadcasts the live signal but has no idle-connect hydration yet — deferred to #1645.)*
- **Staleness guard:** the durable record carries an `at` timestamp; a record older than the max recovery window (15m) is treated as not-recovering in both the setter and hydration — so an **abandoned** recovery (DO went idle before it could exhaust) can't pin the indicator on forever or suppress a fresh signal. This aligns with the max-window: a legitimate recovery always terminalizes (and clears) by then.

### Client
- `useAgentChat` returns a new **`isRecovering`** flag — distinct from `isStreaming` (a recovering turn isn't producing tokens yet); most UIs render `isStreaming || isRecovering` as "busy". Set from the frame; cleared on a terminal response / stream-resume / chat-clear / unmount.

### Telemetry note (scope decision)
An earlier draft also added a durable `getChatRecoveryEvents` query API + per-DO table (the "N2" item). **Dropped on review:** it added a public RPC + a table to *every* agent for something the existing `chat:recovery:*` observability events + the app's analytics bridge already cover (and which the recovery design treats as the intended integration point). For recovery telemetry, subscribe to `chat:recovery:*` and route to your sink.

### Backward-compatible
Clients that don't understand the frame ignore it; existing `useAgentChat` consumers are unaffected.

### Tests / docs / example
- **think:** recovering broadcast + connect-hydration + clear-on-terminal.
- **ai-chat:** durable recovering record set/clear.
- **react (Playwright):** `isRecovering` set from the frame, cleared on resolve.
- **docs:** `docs/chat-agents.md` (recovering-status subsection + `isRecovering` in the `useAgentChat` table) and `packages/think/README.md`.
- **example:** `examples/deploy-churn` renders a live "Recovering…" pill.

Changeset: `agents` / `@cloudflare/think` / `@cloudflare/ai-chat` minor.

---

## 2. Flaky-test retries + nightly timeout (second commit)

We've been seeing intermittent flakiness (real `wrangler dev` + network in e2e, browser/Playwright timing, Workers-runtime startup).

- **`retry: 3`** added to every leaf vitest config that lacked it (matching the convention already used by `think`/`ai-chat` workers suites): agents (workers/react/e2e/browser/webmcp/chat/x402/cli), ai-chat (react/e2e), think (e2e), codemode (+browser), shell, worker-bundler, voice (workers/react), voice-providers/telnyx, experimental/forever-chat, and the example suites. Aggregator root configs only declare `projects:` and delegate, so retry lives in the leaves. Playwright configs already set `retries`. Retries only re-run *failing* tests → zero overhead on a healthy run.
- **Nightly e2e timeout:** both `.github/workflows/nightly.yml` jobs (`e2e-ai-chat`, `e2e-think`) raised from 15m/10m → **`timeout-minutes: 30`**, so a slow-but-recovering real-deploy/Playwright run + retries isn't killed mid-flight.

No source changes in this commit — CI/test hygiene only.

---

## Test plan

- [x] `npm run check` — all 91 projects typecheck; format + lint clean
- [x] `packages/think` unit suite (recovering-status set/clear/hydration tests)
- [x] `packages/ai-chat` workers suite + react Playwright (`isRecovering`)
- [ ] CI green (incl. the nightly e2e on next run)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->