### PR TITLE
fix(think,ai-chat): wait for all parallel client-tool results before auto-continuing (#1649)

### DIFF
--- a/.changeset/fix-parallel-client-tool-continuation.md
+++ b/.changeset/fix-parallel-client-tool-continuation.md
@@ -1,0 +1,19 @@
+---
+"@cloudflare/think": patch
+"@cloudflare/ai-chat": patch
+---
+
+Fix auto-continuation firing before all parallel client-tool results arrive
+(#1649). When the model emitted multiple tool calls in one step and the client
+resolved them independently via `addToolOutput`, a fast result's `autoContinue`
+could trigger the next inference while a slower sibling was still
+`input-available`. That fed the provider an incomplete tool-result set
+(`MissingToolResultsError`) or — via the transcript-repair backstop — silently
+flipped the in-flight sibling to errored and ran a spurious extra continuation.
+
+Auto-continuation now waits until the transcript is stable (no
+`input-available`/`approval-requested` parts) before continuing, so a fanned-out
+tool batch coalesces into a single continuation regardless of result arrival
+order. The wait is bounded, so a genuinely orphaned tool call (e.g. the client
+disconnected mid-batch) still falls through to the existing backstop instead of
+pinning the continuation open.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -148,6 +148,15 @@ const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 // first under normal deploy cadence (#1637).
 const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
+// Auto-continuation barrier (#1649): when the model emits parallel tool calls,
+// the client answers each one independently and sends a tool result with
+// `autoContinue` per result. A fast tool's result must NOT trigger inference
+// while a slower sibling is still `input-available` — that feeds the provider
+// an incomplete tool-result set. So we wait until the transcript is stable (no
+// `input-available`/`approval-requested` parts) before continuing, bounded by
+// this timeout so a genuinely orphaned tool call (e.g. the client disconnected
+// mid-batch) still falls through instead of pinning the continuation open.
+const AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS = 60_000;
 // Delay before retrying a recovery that timed out waiting for stable state.
 // Gives an actively-churning isolate (e.g. a deploy in flight) time to settle.
 const CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS = 3;
@@ -2090,7 +2099,7 @@ export class AIChatAgent<
     while (true) {
       const prerequisite = this._continuation.pending?.prerequisite;
       if (!prerequisite) {
-        return true;
+        break;
       }
 
       const applied = await prerequisite;
@@ -2103,9 +2112,88 @@ export class AIChatAgent<
       );
 
       if (this._continuation.pending?.prerequisite === prerequisite) {
-        return true;
+        break;
       }
     }
+
+    // #1649 barrier: the prior step may have emitted parallel tool calls. The
+    // client answers each one independently, so the result that triggered this
+    // continuation can arrive while slower siblings are still `input-available`
+    // (or `approval-requested`). Continuing now would send the provider an
+    // incomplete tool-result set. Hold until the batch settles, bounded so a
+    // genuinely orphaned tool call (client disconnected mid-batch) still falls
+    // through rather than pinning the continuation open forever.
+    await this._awaitPendingInteractionBarrier();
+    return true;
+  }
+
+  /**
+   * Block until the latest assistant step's parallel tool batch is fully
+   * answered, or `AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS` elapses. Awaits the
+   * in-flight tool-result apply when one exists (so a sibling that lands
+   * mid-wait is observed promptly) and polls otherwise. Runs inside the
+   * continuation turn, so — unlike `waitUntilStable` — it must not wait on the
+   * turn queue (that would deadlock).
+   */
+  private async _awaitPendingInteractionBarrier(): Promise<void> {
+    const deadline = Date.now() + AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      // The pending continuation was cleared (chat clear / turn reset) — nothing
+      // to wait for; bail so the turn isn't held by a stale wait.
+      if (!this._continuation.pending) return;
+      const pending = this._pendingInteractionPromise;
+      if (pending) {
+        try {
+          await pending;
+        } catch {
+          // Ignore — re-evaluate the batch below.
+        }
+        continue;
+      }
+      if (!this._hasIncompleteToolBatch()) return;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    // Timed out with the batch still incomplete: a sibling tool result never
+    // arrived (e.g. the client disconnected mid-batch). Proceed anyway rather
+    // than pinning the continuation turn open forever.
+    console.warn(
+      `[AIChatAgent] Auto-continuation proceeding after waiting ${AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS}ms for unanswered parallel tool result(s) (#1649).`
+    );
+  }
+
+  /**
+   * `true` when the latest assistant message is mid-batch: it carries at least
+   * one settled tool result AND at least one tool call/approval still awaiting a
+   * client result. That is the #1649 signature — the model fanned out parallel
+   * tool calls and only some have been answered. Scoped to the leaf (the step
+   * the continuation answers) so an unrelated dangling tool in an earlier
+   * message doesn't block a legitimate follow-up continuation.
+   */
+  private _hasIncompleteToolBatch(): boolean {
+    const leaf = [...this.messages]
+      .reverse()
+      .find((message) => message.role === "assistant");
+    if (!leaf) return false;
+    let hasPending = false;
+    let hasSettled = false;
+    for (const part of leaf.parts) {
+      const record = part as Record<string, unknown>;
+      const state = record.state;
+      if (state === "input-available" || state === "approval-requested") {
+        hasPending = true;
+      } else if (
+        typeof record.type === "string" &&
+        record.type.startsWith("tool-") &&
+        (state === "output-available" ||
+          state === "output-error" ||
+          state === "output-denied" ||
+          state === "approval-responded")
+      ) {
+        hasSettled = true;
+      }
+      if (hasPending && hasSettled) return true;
+    }
+    return false;
   }
 
   private _queueAutoContinuation(requestId: string) {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -2134,6 +2134,12 @@ export class AIChatAgent<
    * mid-wait is observed promptly) and polls otherwise. Runs inside the
    * continuation turn, so — unlike `waitUntilStable` — it must not wait on the
    * turn queue (that would deadlock).
+   *
+   * No concurrent-entry guard is needed (unlike Think's `_continuationBarrier
+   * Active`): this runs inside the exclusive continuation turn, and a sibling
+   * result arriving while it waits hits the merge branch of
+   * `_enqueueAutoContinuation` (it updates `pending.prerequisite`) rather than
+   * enqueuing a second turn — so the turn queue serializes barrier waits.
    */
   private async _awaitPendingInteractionBarrier(): Promise<void> {
     const deadline = Date.now() + AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS;
@@ -2143,6 +2149,10 @@ export class AIChatAgent<
       if (!this._continuation.pending) return;
       const pending = this._pendingInteractionPromise;
       if (pending) {
+        // `_pendingInteractionPromise` is a single slot — awaiting it is only a
+        // "wake up as soon as an apply lands" optimization, NOT the correctness
+        // gate (that is `_hasIncompleteToolBatch()`, re-checked each loop). If
+        // sibling results overwrite the slot, each apply still patches the cache.
         try {
           await pending;
         } catch {
@@ -2170,9 +2180,16 @@ export class AIChatAgent<
    * message doesn't block a legitimate follow-up continuation.
    */
   private _hasIncompleteToolBatch(): boolean {
-    const leaf = [...this.messages]
-      .reverse()
-      .find((message) => message.role === "assistant");
+    // Zero-allocation backward scan for the latest assistant message — this
+    // runs on every barrier poll tick, and `this.messages` can be large.
+    const messages = this.messages;
+    let leaf: (typeof messages)[number] | undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") {
+        leaf = messages[i];
+        break;
+      }
+    }
     if (!leaf) return false;
     let hasPending = false;
     let hasSettled = false;

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -2200,7 +2200,7 @@ export class AIChatAgent<
         hasPending = true;
       } else if (
         typeof record.type === "string" &&
-        record.type.startsWith("tool-") &&
+        (record.type.startsWith("tool-") || record.type === "dynamic-tool") &&
         (state === "output-available" ||
           state === "output-error" ||
           state === "output-denied" ||

--- a/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
+++ b/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
@@ -286,6 +286,94 @@ describe("Client-side tool duplicate message prevention", () => {
     ws.close(1000);
   });
 
+  it("waits for ALL parallel client-tool results before continuing (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const res = await exports.default.fetch(
+      `http://example.com/agents/test-chat-agent/${room}`,
+      { headers: { Upgrade: "websocket" } }
+    );
+    expect(res.status).toBe(101);
+    const ws = res.webSocket as WebSocket;
+    ws.accept();
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    // Assistant turn that emitted TWO parallel client tool calls.
+    await agentStub.persistMessages([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Use two tools" }]
+      },
+      {
+        id: "assistant-parallel",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-testTool",
+            toolCallId: "call_fast",
+            state: "input-available",
+            input: { which: "fast" }
+          },
+          {
+            type: "tool-testTool",
+            toolCallId: "call_slow",
+            state: "input-available",
+            input: { which: "slow" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    // Fast result arrives first, with autoContinue. The slow sibling is still
+    // in flight, so NO continuation may run yet.
+    ws.send(
+      JSON.stringify({
+        type: "cf_agent_tool_result",
+        toolCallId: "call_fast",
+        toolName: "testTool",
+        output: { which: "fast" },
+        autoContinue: true
+      })
+    );
+
+    // Well past the coalesce window (and the no-active-stream settle delay).
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // The batch is incomplete — the continuation (onChatMessage) must not have
+    // run.
+    expect(await agentStub.getChatMessageCallCountForTest()).toBe(0);
+
+    // Slow result completes the batch and triggers exactly one continuation.
+    ws.send(
+      JSON.stringify({
+        type: "cf_agent_tool_result",
+        toolCallId: "call_slow",
+        toolName: "testTool",
+        output: { which: "slow" },
+        autoContinue: true
+      })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    await agentStub.waitForIdleForTest();
+
+    expect(await agentStub.getChatMessageCallCountForTest()).toBe(1);
+
+    const messages = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const assistant = messages.find((m) => m.id === "assistant-parallel")!;
+    const partFor = (toolCallId: string) =>
+      assistant.parts.find(
+        (p) => "toolCallId" in p && p.toolCallId === toolCallId
+      ) as { state: string; output?: unknown };
+    expect(partFor("call_fast").state).toBe("output-available");
+    expect(partFor("call_fast").output).toEqual({ which: "fast" });
+    expect(partFor("call_slow").state).toBe("output-available");
+    expect(partFor("call_slow").output).toEqual({ which: "slow" });
+
+    ws.close(1000);
+  });
+
   it("preserves earlier assistant parts across chained continuation approvals (#1160)", async () => {
     const room = crypto.randomUUID();
     const res = await exports.default.fetch(

--- a/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
+++ b/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
@@ -374,6 +374,80 @@ describe("Client-side tool duplicate message prevention", () => {
     ws.close(1000);
   });
 
+  it("holds the barrier when a settled dynamic-tool sits beside a pending tool (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const res = await exports.default.fetch(
+      `http://example.com/agents/test-chat-agent/${room}`,
+      { headers: { Upgrade: "websocket" } }
+    );
+    expect(res.status).toBe(101);
+    const ws = res.webSocket as WebSocket;
+    ws.accept();
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    // Parallel batch mixing a `dynamic-tool` part with a regular tool part.
+    await agentStub.persistMessages([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Use a dynamic tool and a regular tool" }]
+      },
+      {
+        id: "assistant-dynamic",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "dynAction",
+            toolCallId: "call_dyn",
+            state: "input-available",
+            input: { which: "dyn" }
+          },
+          {
+            type: "tool-testTool",
+            toolCallId: "call_reg",
+            state: "input-available",
+            input: { which: "reg" }
+          }
+        ] as ChatMessage["parts"]
+      }
+    ]);
+
+    // Resolve the dynamic tool first (autoContinue). The regular tool is still
+    // pending → the continuation must NOT run yet.
+    ws.send(
+      JSON.stringify({
+        type: "cf_agent_tool_result",
+        toolCallId: "call_dyn",
+        toolName: "dynAction",
+        output: { which: "dyn" },
+        autoContinue: true
+      })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    expect(await agentStub.getChatMessageCallCountForTest()).toBe(0);
+
+    // Resolve the regular tool: batch complete → exactly one continuation.
+    ws.send(
+      JSON.stringify({
+        type: "cf_agent_tool_result",
+        toolCallId: "call_reg",
+        toolName: "testTool",
+        output: { which: "reg" },
+        autoContinue: true
+      })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    await agentStub.waitForIdleForTest();
+
+    expect(await agentStub.getChatMessageCallCountForTest()).toBe(1);
+
+    ws.close(1000);
+  });
+
   it("preserves earlier assistant parts across chained continuation approvals (#1160)", async () => {
     const room = crypto.randomUUID();
     const res = await exports.default.fetch(

--- a/packages/ai-chat/src/tests/client-tools-continuation.test.ts
+++ b/packages/ai-chat/src/tests/client-tools-continuation.test.ts
@@ -925,6 +925,8 @@ describe("Client tools continuation", () => {
         }
       ]);
 
+      // Parallel tool calls in one step: both results must arrive before the
+      // continuation runs (#1649). The first alone must NOT start a turn.
       ws.send(
         JSON.stringify({
           type: MessageType.CF_AGENT_TOOL_RESULT,
@@ -934,7 +936,18 @@ describe("Client tools continuation", () => {
           autoContinue: true
         })
       );
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_TOOL_RESULT,
+          toolCallId: "call_second_stream_error",
+          toolName: "secondTool",
+          output: { ok: true },
+          autoContinue: true
+        })
+      );
 
+      // The single continuation becomes active (its error stream is delayed
+      // 250ms) once the batch is complete.
       let activeContinuation:
         | Awaited<ReturnType<typeof agentStub.getContinuationStateForTest>>
         | undefined;
@@ -948,16 +961,6 @@ describe("Client tools continuation", () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
       }
       expect(activeContinuation).toBeDefined();
-
-      ws.send(
-        JSON.stringify({
-          type: MessageType.CF_AGENT_TOOL_RESULT,
-          toolCallId: "call_second_stream_error",
-          toolName: "secondTool",
-          output: { ok: true },
-          autoContinue: true
-        })
-      );
 
       await agentStub.waitForIdleForTest();
       await new Promise((resolve) => setTimeout(resolve, 300));

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -962,6 +962,107 @@ describe("Think — auto-continuation", () => {
 
     await closeWS(ws);
   });
+
+  it("waits for ALL parallel client-tool results before continuing (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    // Seed an assistant turn that emitted TWO parallel client tool calls — the
+    // shape `addToolOutput` produces when the model fans out in a single step.
+    await agent.persistToolCallMessage([
+      makeUserMessage("use two tools"),
+      {
+        id: "assistant-parallel",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-fast",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "fast" }
+          },
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-slow",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "slow" }
+          }
+        ]
+      } as unknown as UIMessage
+    ]);
+    await agent.clearResponseLog();
+
+    // A premature continuation (firing on the fast result while `tc-slow` is
+    // still in flight) would flip `tc-slow` to errored via transcript repair
+    // and emit a repaired event for it.
+    const repairedToolCallIds: Array<string[] | undefined> = [];
+    const unsubscribe = subscribe("transcript", (event) => {
+      if (event.type === "chat:transcript:repaired" && event.name === room) {
+        repairedToolCallIds.push(event.payload.toolCallIds);
+      }
+    });
+
+    try {
+      // Fast tool resolves immediately, with autoContinue.
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_RESULT,
+          toolCallId: "tc-fast",
+          toolName: "client_action",
+          output: "fast output",
+          autoContinue: true
+        })
+      );
+
+      // Wait well past the 50ms coalesce window WITHOUT sending the slow
+      // result. The old behavior fired a continuation here (it saw only the
+      // fast result and treated `tc-slow` as an orphan).
+      await delay(400);
+
+      let log = (await agent.getResponseLog()) as ChatResponseResult[];
+      expect(log.filter((entry) => entry.continuation).length).toBe(0);
+
+      // Slow tool resolves later, with autoContinue: this completes the batch
+      // and must trigger exactly ONE continuation.
+      const continuationDone = waitForDone(ws, 15000);
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_RESULT,
+          toolCallId: "tc-slow",
+          toolName: "client_action",
+          output: "slow output",
+          autoContinue: true
+        })
+      );
+      await continuationDone;
+      await delay(200);
+
+      log = (await agent.getResponseLog()) as ChatResponseResult[];
+      expect(log.filter((entry) => entry.continuation).length).toBe(1);
+
+      // `tc-slow` was never flipped to errored by a premature repair.
+      expect(repairedToolCallIds.flat()).not.toContain("tc-slow");
+
+      const messages = (await agent.getMessages()) as UIMessage[];
+      const assistant = messages.find((m) => m.id === "assistant-parallel")!;
+      const partFor = (toolCallId: string) =>
+        assistant.parts.find(
+          (p) => (p as Record<string, unknown>).toolCallId === toolCallId
+        ) as Record<string, unknown>;
+      expect(partFor("tc-fast").state).toBe("output-available");
+      expect(partFor("tc-fast").output).toBe("fast output");
+      expect(partFor("tc-slow").state).toBe("output-available");
+      expect(partFor("tc-slow").output).toBe("slow output");
+    } finally {
+      unsubscribe();
+    }
+
+    await closeWS(ws);
+  });
 });
 
 // ── Client tool schemas ──────────────────────────────────────────
@@ -1463,7 +1564,7 @@ describe("resume coordination during pending continuation", () => {
 // ── Deferred continuation ────────────────────────────────────────
 
 describe("deferred continuation", () => {
-  it("deferred tool result runs after active continuation completes", async () => {
+  it("coalesces parallel tool results into a single continuation regardless of arrival order (#1649)", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);
     const { ws } = await connectWS(room);
@@ -1509,7 +1610,11 @@ describe("deferred continuation", () => {
         ]
       } as unknown as UIMessage
     ]);
+    await agent.clearResponseLog();
 
+    // First result arrives and auto-continues — but the second tool call is
+    // still in flight, so no continuation may run yet (it would error the
+    // sibling via transcript repair).
     ws.send(
       JSON.stringify({
         type: MSG_TOOL_RESULT,
@@ -1520,10 +1625,13 @@ describe("deferred continuation", () => {
       })
     );
 
-    const firstDone = waitForDone(ws, 10000);
-    await firstDone;
-    await delay(100);
+    // Hold past the coalesce window with the batch still incomplete.
+    await delay(300);
+    let log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log.filter((entry) => entry.continuation).length).toBe(0);
 
+    // Second result completes the batch: exactly one continuation runs.
+    const continuationDone = waitForDone(ws, 10000);
     ws.send(
       JSON.stringify({
         type: MSG_TOOL_RESULT,
@@ -1533,9 +1641,11 @@ describe("deferred continuation", () => {
         autoContinue: true
       })
     );
+    await continuationDone;
+    await delay(200);
 
-    const secondDone = waitForDone(ws, 10000);
-    await secondDone;
+    log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log.filter((entry) => entry.continuation).length).toBe(1);
 
     const stored = await agent.getMessages();
     const assistantMessages = (stored as UIMessage[]).filter(

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1063,6 +1063,76 @@ describe("Think — auto-continuation", () => {
 
     await closeWS(ws);
   });
+
+  it("holds the barrier when a settled dynamic-tool sits beside a pending tool (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    // Parallel batch mixing a `dynamic-tool` part with a regular tool part —
+    // both `input-available`. `dynamic-tool` must be recognized as a tool so a
+    // settled one still counts toward the mid-batch barrier.
+    await agent.persistToolCallMessage([
+      makeUserMessage("use a dynamic tool and a regular tool"),
+      {
+        id: "assistant-dynamic",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "dyn_action",
+            toolCallId: "tc-dyn",
+            state: "input-available",
+            input: { action: "dyn" }
+          },
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-reg",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "reg" }
+          }
+        ]
+      } as unknown as UIMessage
+    ]);
+    await agent.clearResponseLog();
+
+    // Resolve the dynamic tool first (autoContinue). The regular tool is still
+    // pending, so the continuation must NOT run yet.
+    ws.send(
+      JSON.stringify({
+        type: MSG_TOOL_RESULT,
+        toolCallId: "tc-dyn",
+        toolName: "dyn_action",
+        output: "dyn output",
+        autoContinue: true
+      })
+    );
+
+    await delay(400);
+    let log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log.filter((entry) => entry.continuation).length).toBe(0);
+
+    // Resolve the regular tool: now the batch is complete → one continuation.
+    const continuationDone = waitForDone(ws, 15000);
+    ws.send(
+      JSON.stringify({
+        type: MSG_TOOL_RESULT,
+        toolCallId: "tc-reg",
+        toolName: "client_action",
+        output: "reg output",
+        autoContinue: true
+      })
+    );
+    await continuationDone;
+    await delay(200);
+
+    log = (await agent.getResponseLog()) as ChatResponseResult[];
+    expect(log.filter((entry) => entry.continuation).length).toBe(1);
+
+    await closeWS(ws);
+  });
 });
 
 // ── Client tool schemas ──────────────────────────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -653,6 +653,18 @@ const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 // first under normal deploy cadence (#1637).
 const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
+// Auto-continuation barrier (#1649): when the model emits parallel tool calls,
+// the client answers each one independently and sends a `tool-result` with
+// `autoContinue` per result. A fast tool's result must NOT trigger inference
+// while a slower sibling is still `input-available` — doing so feeds the
+// provider an incomplete tool-result set (MissingToolResultsError) or, with the
+// transcript-repair backstop, silently flips the in-flight sibling to errored
+// and runs a spurious extra continuation. So we hold the continuation until the
+// step's batch settles (no `input-available`/`approval-requested` siblings),
+// bounded by this timeout so a genuinely orphaned tool call (e.g. the client
+// disconnected mid-batch) still falls through to the repair backstop instead of
+// pinning the continuation open forever.
+const AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS = 60_000;
 // Delay before retrying a continuation that timed out waiting for stable state.
 // Gives an actively-churning isolate (e.g. a deploy in flight) time to settle.
 const CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS = 3;
@@ -1893,6 +1905,10 @@ export class Think<
   private _lastBody: Record<string, unknown> | undefined;
   private _continuation = new ContinuationState<Connection>();
   private _continuationTimer: ReturnType<typeof setTimeout> | null = null;
+  // True while a continuation is parked on the parallel-tool-batch barrier
+  // (#1649) waiting for in-flight tool results/approvals to settle. Prevents a
+  // second barrier wait (and a double-fire) when more results arrive mid-wait.
+  private _continuationBarrierActive = false;
   private _insideResponseHook = false;
   private _insideInferenceLoop = false;
   private _pendingInteractionPromise: Promise<boolean> | null = null;
@@ -6297,6 +6313,7 @@ export class Think<
     }
     this._submitConcurrency.reset();
     this._pendingInteractionPromise = null;
+    this._continuationBarrierActive = false;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();
   }
@@ -8678,13 +8695,131 @@ export class Think<
       this._continuationTimer = null;
       const pending = this._continuation.pending;
       if (!pending) return;
-      this._fireAutoContinuation(pending.connection);
+      this._fireAutoContinuationWhenStable(pending.connection);
     }, 50);
+  }
+
+  /**
+   * Fire an auto-continuation, but only once the model's parallel tool-call
+   * batch is fully answered (#1649). When the model emits several tool calls in
+   * one step the client answers each independently, so the first `autoContinue`
+   * arrives while slower siblings are still `input-available`. Continuing then
+   * would feed the provider an incomplete tool-result set
+   * (`MissingToolResultsError`) or, via the transcript-repair backstop, silently
+   * error the in-flight sibling and run a spurious extra continuation. We hold
+   * the continuation on a barrier until the batch settles. The wait is bounded
+   * (`AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS`) so a genuinely orphaned tool
+   * call — e.g. the client disconnected mid-batch — still falls through to the
+   * repair backstop rather than pinning the continuation open forever.
+   */
+  private _fireAutoContinuationWhenStable(connection: Connection): void {
+    if (!this._continuation.pending) return;
+    // The continuation is already running (a sibling result re-armed the timer
+    // after it started). New results coalesce/defer into it — don't double-fire.
+    if (this._continuation.pending.pastCoalesce) return;
+    // A barrier wait is already in progress; it will fire once stable. Each
+    // newly-arrived result re-arms the 50ms timer, but only one wait must run.
+    if (this._continuationBarrierActive) return;
+    // Fast path: no apply in flight and the leaf step is not mid-batch.
+    if (!this._pendingInteractionPromise && !this._hasIncompleteToolBatch()) {
+      this._fireAutoContinuation(connection);
+      return;
+    }
+    this._continuationBarrierActive = true;
+    // keepAlive so the isolate stays up while the (typically sub-second)
+    // remainder of the tool batch lands — the pending-continuation state is
+    // in-memory, so hibernating mid-wait would drop it.
+    this.keepAliveWhile(() => this._awaitToolBatch())
+      .catch(() => {})
+      .finally(() => {
+        this._continuationBarrierActive = false;
+        // Fire whether the batch settled or the wait timed out: on timeout the
+        // transcript-repair backstop handles the genuine orphan exactly as it
+        // did before this barrier existed.
+        const pending = this._continuation.pending;
+        if (pending) this._fireAutoContinuation(pending.connection);
+      });
+  }
+
+  /**
+   * Block until the latest assistant step's parallel tool batch is fully
+   * answered, or `AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS` elapses. Awaits the
+   * in-flight tool-result apply when one exists (so a sibling that lands
+   * mid-wait is observed promptly) and polls otherwise.
+   */
+  private async _awaitToolBatch(): Promise<void> {
+    const deadline = Date.now() + AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      // The pending continuation was cleared (chat clear / turn reset) — nothing
+      // to wait for; bail so the isolate isn't held by a stale wait.
+      if (!this._continuation.pending) return;
+      const pending = this._pendingInteractionPromise;
+      if (pending) {
+        try {
+          await pending;
+        } catch {
+          // Ignore — re-evaluate the batch below.
+        }
+        continue;
+      }
+      if (!this._hasIncompleteToolBatch()) return;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    // Timed out with the batch still incomplete: a sibling tool result never
+    // arrived (e.g. the client disconnected mid-batch). Proceed anyway — the
+    // transcript-repair backstop errors the unanswered call rather than
+    // pinning the continuation open forever.
+    console.warn(
+      `[Think] Auto-continuation proceeding after waiting ${AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS}ms for unanswered parallel tool result(s) (#1649).`
+    );
+  }
+
+  /**
+   * `true` when the latest assistant message is mid-batch: it carries at least
+   * one settled tool result AND at least one tool call/approval still awaiting a
+   * client result. That is the #1649 signature — the model fanned out parallel
+   * tool calls and only some have been answered. Scoped to the leaf (the step
+   * the continuation answers) so an unrelated dangling tool in an earlier
+   * message doesn't block a legitimate follow-up continuation.
+   */
+  private _hasIncompleteToolBatch(): boolean {
+    const leaf = [...this.messages]
+      .reverse()
+      .find((message) => message.role === "assistant");
+    if (!leaf) return false;
+    let hasPending = false;
+    let hasSettled = false;
+    for (const part of leaf.parts) {
+      const record = part as Record<string, unknown>;
+      const state = record.state;
+      if (state === "input-available" || state === "approval-requested") {
+        hasPending = true;
+      } else if (
+        typeof record.type === "string" &&
+        record.type.startsWith("tool-") &&
+        (state === "output-available" ||
+          state === "output-error" ||
+          state === "output-denied" ||
+          state === "approval-responded")
+      ) {
+        hasSettled = true;
+      }
+      if (hasPending && hasSettled) return true;
+    }
+    return false;
   }
 
   private _fireAutoContinuation(connection: Connection): void {
     const pending = this._continuation.pending;
     if (!pending) return;
+
+    // Cancel any still-armed coalesce timer so a sibling result that re-armed
+    // it during a barrier wait can't fire a duplicate continuation after this
+    // one starts (#1649).
+    if (this._continuationTimer) {
+      clearTimeout(this._continuationTimer);
+      this._continuationTimer = null;
+    }
 
     const { requestId, clientTools } = pending;
     const abortSignal = this._aborts.getSignal(requestId);
@@ -8746,7 +8881,7 @@ export class Think<
     );
     if (!pending) return;
 
-    this._fireAutoContinuation(pending.connection);
+    this._fireAutoContinuationWhenStable(pending.connection);
   }
 
   // ── Response hook ──────────────────────────────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -8809,7 +8809,7 @@ export class Think<
         hasPending = true;
       } else if (
         typeof record.type === "string" &&
-        record.type.startsWith("tool-") &&
+        (record.type.startsWith("tool-") || record.type === "dynamic-tool") &&
         (state === "output-available" ||
           state === "output-error" ||
           state === "output-denied" ||

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -8755,6 +8755,12 @@ export class Think<
       if (!this._continuation.pending) return;
       const pending = this._pendingInteractionPromise;
       if (pending) {
+        // `_pendingInteractionPromise` is a single slot — awaiting it is only a
+        // "wake up as soon as an apply lands" optimization, NOT the correctness
+        // gate. If sibling results arrive together one overwrites the other, but
+        // each apply still patches the message cache; the real gate is
+        // `_hasIncompleteToolBatch()` re-checked on the next loop. A rejected
+        // apply is likewise irrelevant — we just re-check.
         try {
           await pending;
         } catch {
@@ -8783,9 +8789,16 @@ export class Think<
    * message doesn't block a legitimate follow-up continuation.
    */
   private _hasIncompleteToolBatch(): boolean {
-    const leaf = [...this.messages]
-      .reverse()
-      .find((message) => message.role === "assistant");
+    // Zero-allocation backward scan for the latest assistant message — this
+    // runs on every barrier poll tick, and `this.messages` can be large.
+    const messages = this.messages;
+    let leaf: (typeof messages)[number] | undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") {
+        leaf = messages[i];
+        break;
+      }
+    }
     if (!leaf) return false;
     let hasPending = false;
     let hasSettled = false;


### PR DESCRIPTION
Fixes #1649.

## Problem

When the model emits **multiple tool calls in a single step** and the client resolves them independently (each `addToolOutput` sends `cf_agent_tool_result` with `autoContinue: true`), a **fast** tool's result could trigger the next inference while a **slower** sibling was still `input-available`.

The server's auto-continuation fired on a short coalesce timer (think `50ms`, ai-chat `10ms`), not on "is the model's tool-call batch actually complete." So the first result's `autoContinue` would continue the turn with an incomplete tool-result set:

- On a build without transcript repair → `AI_MissingToolResultsError` (the crash the reporter saw).
- On current `main` (Think repairs + `convertToModelMessages(..., { ignoreIncompleteToolCalls: true })`) → arguably worse: the still-in-flight sibling is silently flipped to errored and a **spurious extra continuation** runs, then the real result lands and churns the transcript.

Repro shape (from the issue):

```ts
onToolCall: async ({ toolCall, addToolOutput }) => {
  if (toolCall.toolName === "fastTool") {
    addToolOutput({ toolCallId: toolCall.toolCallId, output: { ok: true } }); // sync
  }
  if (toolCall.toolName === "slowTool") {
    const result = await agent.call("someCallable", [toolCall.input]); // >50ms
    addToolOutput({ toolCallId: toolCall.toolCallId, output: result });
  }
}
```

## Fix

Add a **server-side barrier**: auto-continuation now holds until the model's parallel tool batch is fully answered, then runs a single continuation — regardless of result arrival order. This uses the transcript state the framework already tracks, so it covers tool results *and* approvals and needs no counting.

### Scoped to the leaf (the key design choice)

The barrier fires only when the **latest assistant message** is *mid-batch* — it carries **both** a settled tool result **and** a still-pending (`input-available`/`approval-requested`) sibling (`_hasIncompleteToolBatch()`). That is precisely the #1649 signature (the model fanned out parallel calls and only some are answered).

It is intentionally **not** "any pending interaction anywhere in the transcript." A broad barrier over-blocked a legitimate, pre-existing path — a follow-up continuation when a result lands in a *separate* assistant message before a stream starts (`chat-turn-serialization` test). Leaf-scoping fixes #1649 without disturbing that.

### Mechanics

- **think** (`packages/think/src/think.ts`): `_scheduleAutoContinuation`'s timer now calls `_fireAutoContinuationWhenStable`, which gates `_fireAutoContinuation` behind `_awaitToolBatch`. The wait runs **before** the turn is enqueued, so it never occupies the turn queue, and is wrapped in `keepAliveWhile` so the (typically sub-second) remainder of the batch can land. It awaits the in-flight tool-result apply (`_pendingInteractionPromise`) so a sibling that lands mid-wait is observed promptly.
- **ai-chat** (`packages/ai-chat/src/index.ts`): `_awaitPendingInteractionBarrier` runs **inside** the queued continuation (after `_awaitPendingAutoContinuationPrerequisite`), because that path runs in-queue and so can't reuse the queue-idle `waitUntilStable` (it would deadlock). Same `_hasIncompleteToolBatch` predicate.
- **Bounded** by `AUTO_CONTINUATION_PENDING_TOOL_TIMEOUT_MS` (60s): on timeout the continuation proceeds — Think's repair backstop errors the unanswered call, ai-chat surfaces the provider error — so a genuinely orphaned tool (client disconnected mid-batch) never pins the continuation open. A `console.warn` makes that fall-through visible.

### Hardening found during review

- **Double-fire race:** during a barrier wait, each sibling result re-arms the `50ms` coalesce timer; when the barrier fired the continuation, that leftover timer could enqueue a **second** continuation in the window before `pastCoalesce` was set. `_fireAutoContinuation` now cancels any still-armed timer when it fires, and `_fireAutoContinuationWhenStable` bails if the continuation is already `pastCoalesce`. (ai-chat is structurally immune — a sibling during a pending continuation hits the merge branch, not a re-queue.)
- **Stale barrier on clear:** `resetTurnState` now clears the barrier flag, and both wait loops bail when `_continuation.pending` is gone, so a chat clear / turn reset can't strand the wait holding the isolate.

## Why server-side (not the client-side option from the issue)

The issue floated "client only sends `autoContinue` on the last result." That's fragile (tools resolve independently in `onToolCall`; the client isn't the transcript's source of truth) and wouldn't protect custom / non-`useAgentChat` clients. The server already owns the transcript and the completeness invariant, so the barrier belongs there.

## Tests

- **New** parallel fast/slow coverage in both packages: assert exactly **one** continuation fires after **both** results land, and the slow tool is never flipped to errored by a premature repair.
- **Updated** the think `deferred continuation` test and the ai-chat continuation-stream-error test — both previously encoded the old partial-continuation behavior (continue after the first of two parallel tools).
- Full suites green: **think 483**, **ai-chat 492**. Typecheck, oxlint, oxfmt clean.

## Follow-up

#1650 tracks making the Think barrier **event-driven** (return-and-wait-for-the-next-result-event instead of a bounded timer) to avoid the 60s fire-through for human-in-the-loop tools (e.g. `ask_user`/`display_ui` emitted in parallel) and the orphan keepAlive hold. Kept symmetric (bounded-wait) with ai-chat here on purpose, since #1642 (N3) wants to unify the duplicated think↔ai-chat layer.

## Test plan

- [ ] CI green (`npm run build` + `npm run check` + affected tests)
- [ ] Manual: parallel client tools where one resolves synchronously and one via a >50ms backend RPC → single clean continuation, no `MissingToolResultsError`, no spurious repair
- [ ] Sanity: a single client tool still auto-continues immediately (no added latency)
- [ ] Sanity: server-approval continuation (#1627) and chained approvals (#1160) still work

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->