### PR TITLE
fix(mcp): guard callTool/readResource/getPrompt against missing connections

### DIFF
--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -1696,6 +1696,23 @@ export class MCPClientManager {
   }
 
   /**
+   * Resolve a live connection by server id. The in-memory `mcpConnections`
+   * map can diverge from storage-backed `listServers()` — stale id after a
+   * reconnect, restore still in flight post-hibernation, or a removed
+   * connection. Throw a named error instead of the opaque "Cannot read
+   * properties of undefined (reading 'client')" so callers can react.
+   */
+  #requireConnection(serverId: string): MCPClientConnection {
+    const connection = this.mcpConnections[serverId];
+    if (connection === undefined) {
+      throw new Error(
+        `No active MCP connection for serverId "${serverId}". The server may not be connected yet, may have been removed, or the id may be stale after a reconnect.`
+      );
+    }
+    return connection;
+  }
+
+  /**
    * Namespaced version of callTool
    */
   async callTool(
@@ -1707,7 +1724,7 @@ export class MCPClientManager {
   ) {
     const { serverId, ...mcpParams } = params;
     const unqualifiedName = mcpParams.name.replace(`${serverId}.`, "");
-    return this.mcpConnections[serverId].client.callTool(
+    return this.#requireConnection(serverId).client.callTool(
       {
         ...mcpParams,
         name: unqualifiedName
@@ -1724,7 +1741,7 @@ export class MCPClientManager {
     params: ReadResourceRequest["params"] & { serverId: string },
     options: RequestOptions
   ) {
-    return this.mcpConnections[params.serverId].client.readResource(
+    return this.#requireConnection(params.serverId).client.readResource(
       params,
       options
     );
@@ -1737,7 +1754,7 @@ export class MCPClientManager {
     params: GetPromptRequest["params"] & { serverId: string },
     options: RequestOptions
   ) {
-    return this.mcpConnections[params.serverId].client.getPrompt(
+    return this.#requireConnection(params.serverId).client.getPrompt(
       params,
       options
     );

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -4037,3 +4037,78 @@ describe("MCPClientManager OAuth Integration", () => {
     });
   });
 });
+
+describe("MCPClientManager missing-connection guards", () => {
+  let manager: TestMCPClientManager;
+
+  beforeEach(() => {
+    const mockDOStorage = {
+      sql: { exec: () => [][Symbol.iterator]() },
+      get: async () => undefined,
+      put: async () => {},
+      kv: {
+        get: () => undefined,
+        put: () => {},
+        list: vi.fn(),
+        delete: vi.fn()
+      }
+    } as unknown as DurableObjectStorage;
+
+    manager = new TestMCPClientManager("test-client", "1.0.0", {
+      storage: mockDOStorage
+    });
+  });
+
+  function makeReadyConnection(): MCPClientConnection {
+    const connection = new MCPClientConnection(
+      new URL("http://example.com"),
+      { name: "test-client", version: "1.0.0" },
+      { transport: { type: "auto" }, client: {} }
+    );
+    connection.connectionState = "ready";
+    connection.client.callTool = vi.fn().mockResolvedValue({ content: [] });
+    connection.client.readResource = vi
+      .fn()
+      .mockResolvedValue({ contents: [] });
+    connection.client.getPrompt = vi.fn().mockResolvedValue({ messages: [] });
+    return connection;
+  }
+
+  it("callTool throws a named error when the connection is missing", async () => {
+    await expect(
+      manager.callTool({ serverId: "ghost", name: "do_thing", arguments: {} })
+    ).rejects.toThrow(/No active MCP connection for serverId "ghost"/);
+  });
+
+  it("readResource throws a named error when the connection is missing", () => {
+    expect(() =>
+      manager.readResource(
+        { serverId: "ghost", uri: "file://x" },
+        {} as never
+      )
+    ).toThrow(/No active MCP connection for serverId "ghost"/);
+  });
+
+  it("getPrompt throws a named error when the connection is missing", () => {
+    expect(() =>
+      manager.getPrompt({ serverId: "ghost", name: "p" }, {} as never)
+    ).toThrow(/No active MCP connection for serverId "ghost"/);
+  });
+
+  it("callTool reaches the underlying client when the connection exists", async () => {
+    const connection = makeReadyConnection();
+    manager.mcpConnections["live"] = connection;
+
+    await manager.callTool({
+      serverId: "live",
+      name: "do_thing",
+      arguments: { a: 1 }
+    });
+
+    expect(connection.client.callTool).toHaveBeenCalledWith(
+      { name: "do_thing", arguments: { a: 1 } },
+      undefined,
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`MCPClientManager.callTool`, `readResource`, and `getPrompt` dereference
`this.mcpConnections[serverId].client` directly. When no in-memory connection
exists for the id, this surfaces as the opaque:

```
Cannot read properties of undefined (reading 'client')
```

The in-memory `mcpConnections` map and the storage-backed `listServers()` can
legitimately diverge:

- a caller holds a `serverId` from an earlier snapshot whose connection has
  since been removed;
- the agent woke from hibernation and connection restore is still in flight;
- the id is stale after a reconnect (e.g. a remove+add that minted a new id).

In all three cases callers get a `TypeError` with no way to react.

## Fix

Route all three call sites through a private `#requireConnection(serverId)`
helper that throws a named, actionable error when the connection is missing,
so callers can retry, re-sync, or fail gracefully instead of crashing.

## Tests

Adds coverage for the missing-connection path of all three methods plus the
happy path for `callTool` (`client-manager.test.ts`). Full workers project
suite passes locally (145 tests).

## Context

Surfaced in a downstream consumer (per-user `MCPClientManager` in a Durable
Object, tools proxied across a second DO) where a snapshotted `serverId` could
outlive its connection within a single turn. That consumer also adds its own
wait+recheck guard, but the SDK dereferencing `undefined` is the root defect.