### PR TITLE
fix(ai-chat): avoid stale MCP tool calls pinning isStreaming

### DIFF
--- a/.changeset/fix-aborted-server-tool-streaming.md
+++ b/.changeset/fix-aborted-server-tool-streaming.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Fix `isStreaming` staying true after aborting during server-side tool calls.

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -4789,6 +4789,91 @@ describe("useAgentChat isServerStreaming / isStreaming (issue #1226)", () => {
   });
 });
 
+// Issue #1614: Previously, we derived "isStreaming" from the presence of
+// an input-available message part, and a definition of `onToolCall`. This caused
+// a problem because a server-side MCP tool call could remain in input-available
+// after an abort/reconnect, and if onToolCall was defined, the app would appear
+// to stay busy even though no client work was pending.
+describe("useAgentChat isStreaming with stale server-side (MCP) tool calls (issue #1614)", () => {
+  it("does not stay busy for a stale server-side tool call that onToolCall does not handle", async () => {
+    const agent = createAgent({
+      name: "mcp-tool-abort",
+      url: "ws://localhost:3000/agents/chat/mcp-tool-abort?_pk=abc",
+      send: () => {}
+    });
+
+    // A tool call the model made that is fulfilled SERVER-SIDE (e.g. via MCP).
+    // It sits in input-available while the server runs it.
+    const initialMessages: UIMessage[] = [
+      {
+        id: "msg-mcp-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-searchDatabase",
+            toolCallId: "mcp-call-1",
+            state: "input-available",
+            input: { query: "SELECT 1" }
+          }
+        ]
+      }
+    ];
+
+    // The app defines onToolCall for its OWN client tools (here, getLocation).
+    // It deliberately does not handle searchDatabase — that's the server's job.
+    const onToolCall = vi.fn(
+      async ({
+        toolCall,
+        addToolOutput
+      }: {
+        toolCall: { toolName: string; toolCallId: string };
+        addToolOutput: (r: { toolCallId: string; output: unknown }) => void;
+      }) => {
+        if (toolCall.toolName === "getLocation") {
+          addToolOutput({
+            toolCallId: toolCall.toolCallId,
+            output: { lat: 51.5, lng: -0.1 }
+          });
+        }
+        // searchDatabase (MCP) is intentionally not handled here.
+      }
+    );
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: () => Promise.resolve(initialMessages),
+        onToolCall
+      });
+      return (
+        <div>
+          <div data-testid="isStreaming">{String(chat.isStreaming)}</div>
+          <div data-testid="status">{chat.status}</div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(50);
+      return screen;
+    });
+
+    // A persisted server-side tool part by itself does not prove anything is
+    // still running after abort/reload. Without an active server stream or a
+    // pending client tool callback, the hook must not stay busy forever.
+    await expect
+      .element(screen.getByTestId("isStreaming"))
+      .toHaveTextContent("false");
+  });
+});
+
 describe("useAgentChat tool approval continuations (issue #1108)", () => {
   function createAgentWithTarget({ name, url }: { name: string; url: string }) {
     const target = new EventTarget();

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -1430,6 +1430,18 @@ export function useAgentChat<
 
   const pendingConfirmationsRef = useRef(pendingConfirmations);
   pendingConfirmationsRef.current = pendingConfirmations;
+  const [pendingOnToolCallIds, setPendingOnToolCallIds] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  const finishOnToolCall = useCallback((toolCallId: string) => {
+    setPendingOnToolCallIds((prev) => {
+      if (!prev.has(toolCallId)) return prev;
+      const next = new Set(prev);
+      next.delete(toolCallId);
+      return next;
+    });
+  }, []);
 
   // ── DEPRECATED: automatic tool resolution effect ────────────────────
   // This entire useEffect is deprecated. Use onToolCall instead.
@@ -1651,6 +1663,14 @@ export function useAgentChat<
         // Mark as processed to prevent re-triggering
         processedToolCalls.current.add(toolCallId);
 
+        // track pending `onToolCall` calls to derive streaming state
+        setPendingOnToolCallIds((prev) => {
+          if (prev.has(toolCallId)) return prev;
+          const next = new Set(prev);
+          next.add(toolCallId);
+          return next;
+        });
+
         // Create addToolOutput function for this specific tool call
         const addToolOutput = (opts: AddToolOutputOptions) => {
           sendToolOutputToServer(
@@ -1674,17 +1694,16 @@ export function useAgentChat<
 
         // Call the onToolCall callback
         // The callback is responsible for calling addToolOutput when ready
-        currentOnToolCall({
-          toolCall: {
-            toolCallId,
-            toolName,
-            input: part.input
-          },
+        const result = currentOnToolCall({
+          toolCall: { toolCallId, toolName, input: part.input },
           addToolOutput
+        });
+        void Promise.resolve(result).finally(() => {
+          finishOnToolCall(toolCallId);
         });
       }
     }
-  }, [chatMessages, sendToolOutputToServer, addToolResult]);
+  }, [chatMessages, sendToolOutputToServer, addToolResult, finishOnToolCall]);
 
   const streamStateRef = useRef<BroadcastStreamState>({ status: "idle" });
 
@@ -2218,10 +2237,10 @@ export function useAgentChat<
   // execute, which drops `status` back to "ready" while the client's
   // async `onToolCall` handler is still running. Without this signal,
   // consumers see a blank "nothing happening" window for the full
-  // duration of `tool.execute()` — often a `fetch` taking seconds.
+  // duration of the client-side work — often a `fetch` taking seconds.
   //
-  // We scope this to tool calls that have an actual handler:
-  //   - `onToolCall` is provided (new, supported path), OR
+  // We scope this to tool calls that have actual client-side work in flight:
+  //   - an `onToolCall` callback promise is still pending, OR
   //   - a matching entry in the deprecated `tools` option has `execute`.
   // Tools waiting on explicit user confirmation are excluded — nothing
   // is happening until the user acts, so the "busy" indicator would be
@@ -2234,8 +2253,7 @@ export function useAgentChat<
   const lastAssistantMessage =
     messagesWithToolResults[messagesWithToolResults.length - 1];
   const hasPendingClientToolCalls = (() => {
-    const hasOnToolCall = !!onToolCall;
-    if (!hasOnToolCall && !tools) return false;
+    if (pendingOnToolCallIds.size === 0 && !tools) return false;
     if (!lastAssistantMessage || lastAssistantMessage.role !== "assistant") {
       return false;
     }
@@ -2244,7 +2262,8 @@ export function useAgentChat<
       if (part.state !== "input-available") continue;
       const toolName = getToolName(part);
       if (toolsRequiringConfirmation.includes(toolName)) continue;
-      if (hasOnToolCall || tools?.[toolName]?.execute) return true;
+      if (pendingOnToolCallIds.has(part.toolCallId)) return true;
+      if (tools?.[toolName]?.execute) return true;
     }
     return false;
   })();

--- a/packages/ai-chat/src/react.tsx
+++ b/packages/ai-chat/src/react.tsx
@@ -1378,6 +1378,7 @@ export function useAgentChat<
     markInitialMessagesSeeded();
     setMessages([]);
     setClientToolResults(new Map());
+    setPendingOnToolCallIds(new Set());
     resetToolContinuation();
     processedToolCalls.current.clear();
     localResponseMessageIdsRef.current.clear();
@@ -1694,10 +1695,16 @@ export function useAgentChat<
 
         // Call the onToolCall callback
         // The callback is responsible for calling addToolOutput when ready
-        const result = currentOnToolCall({
-          toolCall: { toolCallId, toolName, input: part.input },
-          addToolOutput
-        });
+        let result: ReturnType<OnToolCallCallback>;
+        try {
+          result = currentOnToolCall({
+            toolCall: { toolCallId, toolName, input: part.input },
+            addToolOutput
+          });
+        } catch (error) {
+          finishOnToolCall(toolCallId);
+          throw error;
+        }
         void Promise.resolve(result).finally(() => {
           finishOnToolCall(toolCallId);
         });


### PR DESCRIPTION
This PR fixes #1614, where `useAgentChat().isStreaming` could remain true after aborting while a server-side MCP tool call was in flight.

Investigation summary:

- Reproduced the issue interactively using the `examples/ai-chat` app connected to an MCP server with a delayed tool.
- Confirmed that aborting returned the AI SDK chat `status` to `ready`, but the UI still derived `isStreaming: true` from a persisted `input-available` tool part.
- Added temporary diagnostics and found that the app defines `onToolCall` for browser/client tools, while the delayed MCP tool is server-owned.
- Discovered the old derivation treated any latest-assistant `input-available` tool part as pending client work whenever `onToolCall` existed, even when that tool was an MCP/server-side tool the client did not handle.
- Binary-searched several candidate fixes interactively and narrowed the necessary change to tracking the lifetime of actual `onToolCall` callbacks rather than using the presence of `onToolCall` as a proxy.

Problem:

- Server-side MCP tools can leave a tool part in `input-available` if the user aborts before the tool output arrives.
- Apps may still define `onToolCall` for unrelated browser tools.
- The previous hook logic combined those facts and kept `isStreaming` true indefinitely, including after reconnect/hydration.

Solution:

- Track tool call IDs only while an `onToolCall` callback is actually in flight.
- Derive pending client-tool streaming state from those in-flight callback IDs instead of from `!!onToolCall`.
- Preserve the existing behavior where asynchronous client-side tool callbacks keep `isStreaming` true while they are actively running.
- Add a regression test for a stale server-side/MCP-style tool part that `onToolCall` does not handle.
- Add a patch changeset for `@cloudflare/ai-chat`.
