### PR TITLE
chore: document example package rebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ cd examples/playground   # or any example
 npm run dev              # starts Vite dev server + Workers runtime via @cloudflare/vite-plugin
 ```
 
+Example apps will normally hot reload when the dev server is running. When the dev server is running, make sure to rebuild changed packages (`npm run build`) to see changes reflected in the running app.
+
 ## Code standards
 
 ### TypeScript


### PR DESCRIPTION
This PR documents a workflow detail for validating examples locally: when an example app is running and package source changes, rebuild the changed package so the example consumes the updated package output.

This came up while interactively validating an `@cloudflare/ai-chat` fix in an example app. The example dev server hot reloaded the app shell, but SDK package source changes were not reflected until the package was rebuilt.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->