### PR TITLE
fix(think): serialize parallel client-tool result/approval applies (#1649 follow-up)

### DIFF
--- a/.changeset/apply-midstream-client-tool-results.md
+++ b/.changeset/apply-midstream-client-tool-results.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/think": patch
+---
+
+fix(think): apply client-tool results that arrive mid-stream so they aren't dropped (#1649 follow-up)
+
+The serialization fix in #1657 stopped parallel results from clobbering each other, but a deeper window remained: during a streaming turn the assistant message lives only in the in-flight `StreamAccumulator` until `_persistAssistantMessage` writes it at the turn boundary. The `tool-input-available` chunk is broadcast to the client mid-stream, so a fast client can resolve the tool and send `cf_agent_tool_result` before the message is ever persisted. `_applyToolUpdateToMessages` only scanned durable storage, so the apply silently no-op'd, the end-of-stream persist then wrote `input-available`, and the auto-continuation's transcript repair errored the call with "The tool call was interrupted before a result was recorded."
+
+`_applyToolUpdateToMessages` now applies the update to the in-flight accumulator (in place, so it rides into the eventual persist) in addition to durable storage, mirroring `@cloudflare/ai-chat`'s `_streamingMessage` handling. The accumulator is exposed via `_streamingAssistant` for the duration of each streaming turn and cleared on every exit path and on `resetTurnState`. Applying to both locations is monotonic, so a stall-recovery partial persist can't downgrade an already-applied result back to `input-available`.

--- a/.changeset/serialize-parallel-tool-result-applies.md
+++ b/.changeset/serialize-parallel-tool-result-applies.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+fix(think): serialize parallel client-tool result/approval applies so siblings aren't clobbered (#1649 follow-up)
+
+The auto-continuation barrier added in #1651 stopped premature continuation, but a deeper race remained in Think. Each `tool-result`/`tool-approval` WebSocket message fired an independent read-modify-write of the whole assistant message, and `_applyToolUpdateToMessages` awaits a storage read before its write. When the model fanned out parallel tool calls, the concurrent applies all read the same `input-available` snapshot, each patched only its own part, and the last write clobbered its siblings back to `input-available`. The continuation barrier then timed out and the transcript-repair backstop errored the lost calls with "The tool call was interrupted before a result was recorded."
+
+Applies are now chained off a serialization tail so each read-modify-write commits atomically in arrival order. `_pendingInteractionPromise` still tracks the newest link, so the barrier's single-slot wake-up transitively waits for every predecessor.
+
+The same serialization is applied to `@cloudflare/ai-chat` defensively: its apply is currently synchronous (no await between the message read and the SQLite write), so it does not exhibit this clobber today, but the queue keeps the invariant safe if that ever changes.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -409,6 +409,15 @@ export class AIChatAgent<
   private _pendingInteractionPromise: Promise<boolean> | null = null;
 
   /**
+   * Serialization tail for client-tool result/approval applies (#1649). Each
+   * apply is a read-modify-write of the full message; running siblings from a
+   * parallel tool batch concurrently lets last-write-wins clobber the others
+   * back to `input-available`. Chaining every apply off this tail makes them
+   * commit atomically in arrival order.
+   */
+  private _interactionApplyTail: Promise<void> = Promise.resolve();
+
+  /**
    * Tracks the ID of a streaming message that was persisted early due to
    * a tool entering approval-requested state. When set, stream completion
    * updates the existing persisted message instead of appending a new one.
@@ -1096,21 +1105,15 @@ export class AIChatAgent<
 
           this._emit("tool:result", { toolCallId, toolName });
 
-          const applyPromise = this._applyToolResult(
-            toolCallId,
-            toolName,
-            output,
-            overrideState,
-            errorText
+          const applyPromise = this._enqueueInteractionApply(() =>
+            this._applyToolResult(
+              toolCallId,
+              toolName,
+              output,
+              overrideState,
+              errorText
+            )
           );
-          this._pendingInteractionPromise = applyPromise;
-          applyPromise
-            .finally(() => {
-              if (this._pendingInteractionPromise === applyPromise) {
-                this._pendingInteractionPromise = null;
-              }
-            })
-            .catch(() => {});
 
           if (autoContinue) {
             this._enqueueAutoContinuation(
@@ -1128,15 +1131,9 @@ export class AIChatAgent<
         if (data.type === MessageType.CF_AGENT_TOOL_APPROVAL) {
           const { toolCallId, approved, autoContinue } = data;
           this._emit("tool:approval", { toolCallId, approved });
-          const approvalPromise = this._applyToolApproval(toolCallId, approved);
-          this._pendingInteractionPromise = approvalPromise;
-          approvalPromise
-            .finally(() => {
-              if (this._pendingInteractionPromise === approvalPromise) {
-                this._pendingInteractionPromise = null;
-              }
-            })
-            .catch(() => {});
+          const approvalPromise = this._enqueueInteractionApply(() =>
+            this._applyToolApproval(toolCallId, approved)
+          );
 
           if (autoContinue) {
             this._enqueueAutoContinuation(
@@ -1928,6 +1925,9 @@ export class AIChatAgent<
     this._abortRegistry.destroyAll();
     this._submitConcurrency.reset();
     this._pendingInteractionPromise = null;
+    // Drop the apply chain so new interactions don't serialize behind a stale
+    // (possibly hung) apply from the turn we just reset (#1649).
+    this._interactionApplyTail = Promise.resolve();
     this._continuation.sendResumeNone();
     this._continuation.clearAll();
     this._pendingChatResponseResults.length = 0;
@@ -4842,6 +4842,44 @@ export class AIChatAgent<
       );
     }
     return false;
+  }
+
+  /**
+   * Serialize a client-tool result/approval apply behind any in-flight apply
+   * (#1649, defensive). Each apply is a read-modify-write of the message and
+   * parallel tool results arrive as independent WebSocket messages. Today
+   * `_findAndUpdateToolPart` performs that read-modify-write synchronously (no
+   * await between reading `this.messages` and the SQLite write), so concurrent
+   * applies can't actually interleave — unlike Think, ai-chat does not exhibit
+   * the #1649 clobber. This queue is a guard so the invariant survives if the
+   * apply ever gains an await between read and write (e.g. async storage): each
+   * apply commits atomically in arrival order.
+   *
+   * `_pendingInteractionPromise` is set to the newest link so the barrier's
+   * single-slot wake-up observes the latest apply; because the chain is serial,
+   * awaiting it transitively waits for every predecessor.
+   *
+   * @internal
+   */
+  protected _enqueueInteractionApply(
+    apply: () => Promise<boolean>
+  ): Promise<boolean> {
+    // `.then(apply, apply)` runs regardless of a predecessor's outcome so one
+    // rejected apply can't poison the rest of the batch.
+    const resultPromise = this._interactionApplyTail.then(apply, apply);
+    this._interactionApplyTail = resultPromise.then(
+      () => undefined,
+      () => undefined
+    );
+    this._pendingInteractionPromise = resultPromise;
+    resultPromise
+      .finally(() => {
+        if (this._pendingInteractionPromise === resultPromise) {
+          this._pendingInteractionPromise = null;
+        }
+      })
+      .catch(() => {});
+    return resultPromise;
   }
 
   /**

--- a/packages/ai-chat/src/tests/client-tools-continuation.test.ts
+++ b/packages/ai-chat/src/tests/client-tools-continuation.test.ts
@@ -1398,4 +1398,16 @@ describe("Client tools continuation", () => {
       wsB.close(1000);
     }
   });
+
+  it("serializes overlapping tool-result applies so neither clobbers the other (#1649, defensive)", async () => {
+    // ai-chat's apply is synchronous today so it doesn't exhibit the #1649
+    // clobber, but the interaction-apply queue guards the invariant. Two
+    // overlapping read-modify-writes: without serialization the second reads
+    // the stale value before the first commits and the result is 1; serialized,
+    // the second waits and it is 2.
+    const room = crypto.randomUUID();
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    const result = await agentStub.testInteractionApplySerialization();
+    expect(result).toBe(2);
+  });
 });

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -536,6 +536,27 @@ export class TestChatAgent extends AIChatAgent<Env> {
     return messageWithToolOutput;
   }
 
+  /**
+   * Drives two overlapping read-modify-write applies through the
+   * interaction-apply queue (#1649). Each apply reads a shared counter, yields
+   * across an async gap, then writes `read + 1`. Without serialization both
+   * read 0 before either writes, so the result is 1 (one update clobbered).
+   * With serialization the second apply waits for the first, yielding 2.
+   */
+  async testInteractionApplySerialization(): Promise<number> {
+    let shared = 0;
+    const rmw = (gapMs: number) => async () => {
+      const read = shared;
+      await new Promise((resolve) => setTimeout(resolve, gapMs));
+      shared = read + 1;
+      return true;
+    };
+    const first = this._enqueueInteractionApply(rmw(30));
+    const second = this._enqueueInteractionApply(rmw(0));
+    await Promise.all([first, second]);
+    return shared;
+  }
+
   // Resumable streaming test helpers
 
   testStartStream(requestId: string): string {

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -351,6 +351,29 @@ export class ThinkClientToolsAgent extends Think {
     }
   }
 
+  /**
+   * Drives two overlapping read-modify-write applies through the
+   * interaction-apply queue (#1649). Each apply reads a shared counter, yields
+   * across an async gap, then writes `read + 1`. Without serialization both
+   * read 0 before either writes, so the result is 1 (one update clobbered).
+   * With serialization the second apply waits for the first, yielding 2.
+   * Returns the final counter value.
+   */
+  async testInteractionApplySerialization(): Promise<number> {
+    let shared = 0;
+    const rmw = (gapMs: number) => async () => {
+      const read = shared;
+      await new Promise((resolve) => setTimeout(resolve, gapMs));
+      shared = read + 1;
+    };
+    // First apply takes the longer gap so a second, un-serialized apply would
+    // read + write the stale value before the first commits.
+    const first = this._enqueueInteractionApply(rmw(30));
+    const second = this._enqueueInteractionApply(rmw(0));
+    await Promise.all([first, second]);
+    return shared;
+  }
+
   async getBranches(messageId: string): Promise<UIMessage[]> {
     return (await this.session.getBranches(messageId)) as UIMessage[];
   }

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -10,7 +10,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { Think } from "../../think";
 import type { ChatResponseResult, MessageConcurrency } from "../../think";
-import type { ClientToolSchema } from "agents/chat";
+import { StreamAccumulator, type ClientToolSchema } from "agents/chat";
 
 function createClientToolMockModel(): LanguageModel {
   let callCount = 0;
@@ -51,6 +51,105 @@ function createClientToolMockModel(): LanguageModel {
               type: "tool-input-end",
               id: "tc-client-1"
             });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 10, outputTokens: 5 }
+            });
+          } else {
+            controller.enqueue({ type: "text-start", id: "t-cont" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t-cont",
+              delta: "Continuation after tool"
+            });
+            controller.enqueue({ type: "text-end", id: "t-cont" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 20, outputTokens: 10 }
+            });
+          }
+
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
+// Emits a client tool call (`tc-client-1`), then keeps the stream OPEN for a
+// while (a series of timed gaps) before finishing. That open window is the
+// #1649 race: the `tool-input-available` chunk has already been broadcast to
+// the client — which can resolve the tool and send `cf_agent_tool_result` —
+// but the assistant message hasn't been persisted yet. On the continuation
+// invocation it emits plain text.
+function createSlowClientToolMockModel(
+  delayMs: number,
+  trailingGaps: number
+): LanguageModel {
+  let callCount = 0;
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-slow-client-tool",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented");
+    },
+    doStream(options: Record<string, unknown>) {
+      callCount++;
+      const messages = (options as { prompt?: unknown[] }).prompt ?? [];
+      const hasToolResult = messages.some(
+        (m: unknown) =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).role === "tool"
+      );
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+
+          if (!hasToolResult && callCount === 1) {
+            controller.enqueue({
+              type: "tool-input-start",
+              id: "tc-client-1",
+              toolName: "client_action"
+            });
+            controller.enqueue({
+              type: "tool-input-delta",
+              id: "tc-client-1",
+              delta: JSON.stringify({ action: "do_thing" })
+            });
+            controller.enqueue({
+              type: "tool-input-end",
+              id: "tc-client-1"
+            });
+            // Finalize the tool call NOW so the SDK emits `tool-input-available`
+            // mid-stream (a tool part left at `input-streaming` is only promoted
+            // at `finish`, which is too late to model the race).
+            controller.enqueue({
+              type: "tool-call",
+              toolCallId: "tc-client-1",
+              toolName: "client_action",
+              input: JSON.stringify({ action: "do_thing" })
+            });
+            // Hold the stream open with trailing text so a client tool result
+            // can arrive before the end-of-stream persist (the #1649 window).
+            // Streaming real chunks (not silent gaps) keeps the stall watchdog
+            // happy and guarantees the tool call is already in the accumulator.
+            controller.enqueue({ type: "text-start", id: "t-trail" });
+            for (let i = 0; i < trailingGaps; i++) {
+              await new Promise((r) => setTimeout(r, delayMs));
+              controller.enqueue({
+                type: "text-delta",
+                id: "t-trail",
+                delta: "."
+              });
+            }
+            controller.enqueue({ type: "text-end", id: "t-trail" });
             controller.enqueue({
               type: "finish",
               finishReason: "tool-calls",
@@ -241,6 +340,9 @@ function createTextOnlyMockModel(): LanguageModel {
 export class ThinkClientToolsAgent extends Think {
   private _useTextOnly = false;
   private _useSlowStream = false;
+  private _useSlowClientToolStream = false;
+  private _slowClientToolDelayMs = 30;
+  private _slowClientToolGaps = 12;
   private _useServerApprovalTool = false;
   private _serverApprovalToolExecutions = 0;
   private _serverApprovalToolFails = false;
@@ -259,6 +361,11 @@ export class ThinkClientToolsAgent extends Think {
   getModel(): LanguageModel {
     if (this._useSlowStream)
       return createSlowMockModel(this._slowDelayMs, this._slowChunkCount);
+    if (this._useSlowClientToolStream)
+      return createSlowClientToolMockModel(
+        this._slowClientToolDelayMs,
+        this._slowClientToolGaps
+      );
     if (this._useTextOnly) return createTextOnlyMockModel();
     if (this._useServerApprovalTool) return createServerApprovalToolMockModel();
     return createClientToolMockModel();
@@ -310,6 +417,128 @@ export class ThinkClientToolsAgent extends Think {
     this._useSlowStream = enabled;
     if (delayMs !== undefined) this._slowDelayMs = delayMs;
     if (chunkCount !== undefined) this._slowChunkCount = chunkCount;
+  }
+
+  async setSlowClientToolStreamMode(
+    enabled: boolean,
+    delayMs?: number,
+    trailingGaps?: number
+  ): Promise<void> {
+    this._useSlowClientToolStream = enabled;
+    if (delayMs !== undefined) this._slowClientToolDelayMs = delayMs;
+    if (trailingGaps !== undefined) this._slowClientToolGaps = trailingGaps;
+  }
+
+  /**
+   * The state of a tool part in the in-flight streaming accumulator, or
+   * undefined if no stream is active or the call isn't present yet. Lets a
+   * test deterministically wait until the streaming turn has exposed a tool
+   * call (so it can send the result mid-stream) instead of racing on timing.
+   */
+  async streamingToolCallState(
+    toolCallId: string
+  ): Promise<string | undefined> {
+    const acc = (
+      this as unknown as {
+        _streamingAssistant: {
+          parts: Array<Record<string, unknown>>;
+        } | null;
+      }
+    )._streamingAssistant;
+    if (!acc) return undefined;
+    const part = acc.parts.find((p) => p.toolCallId === toolCallId);
+    return part?.state as string | undefined;
+  }
+
+  /**
+   * Deterministic reproduction of the #1649 "result arrives before persist"
+   * race without depending on stream timing: a client tool call lives ONLY in
+   * the in-flight accumulator (not yet persisted), a tool result is applied,
+   * then the stream's end-of-stream persist runs. Returns the persisted state
+   * so the test can assert the result survived (`output-available`) rather than
+   * being dropped and later repaired (`input-available` → errored).
+   */
+  async simulateMidStreamClientToolResult(opts: {
+    toolCallId: string;
+    output: string;
+  }): Promise<{ state: string; output: string }> {
+    const internal = this as unknown as {
+      _streamingAssistant: StreamAccumulator | null;
+      _applyToolResult(toolCallId: string, output: unknown): Promise<void>;
+      _persistAssistantMessage(msg: UIMessage): Promise<void>;
+    };
+
+    const accumulator = new StreamAccumulator({
+      messageId: crypto.randomUUID(),
+      existingParts: [
+        {
+          type: "tool-client_action",
+          toolCallId: opts.toolCallId,
+          toolName: "client_action",
+          state: "input-available",
+          input: { action: "do_thing" }
+        } as unknown as UIMessage["parts"][number]
+      ]
+    });
+
+    // The assistant message exists ONLY in the accumulator — a storage read
+    // would not find it (mirrors a turn mid-stream, before persist).
+    internal._streamingAssistant = accumulator;
+    // A client tool result arrives over the WebSocket while the stream is open.
+    await internal._applyToolResult(opts.toolCallId, opts.output);
+    // The stream ends and persists the accumulated message.
+    await internal._persistAssistantMessage(accumulator.toMessage());
+    internal._streamingAssistant = null;
+
+    const messages = (await this.getMessages()) as UIMessage[];
+    const part = messages
+      .flatMap((m) => m.parts as Array<Record<string, unknown>>)
+      .find((p) => p.toolCallId === opts.toolCallId);
+    return {
+      state: (part?.state as string) ?? "missing",
+      output: (part?.output as string) ?? ""
+    };
+  }
+
+  /**
+   * Same mid-stream race as {@link simulateMidStreamClientToolResult}, but for
+   * an approval response: an `approval-requested` part lives only in the
+   * in-flight accumulator when the approval arrives. Confirms the fix covers
+   * the approval path (shared `_applyToolUpdateToMessages`), not just results.
+   */
+  async simulateMidStreamClientToolApproval(opts: {
+    toolCallId: string;
+    approved: boolean;
+  }): Promise<{ state: string }> {
+    const internal = this as unknown as {
+      _streamingAssistant: StreamAccumulator | null;
+      _applyToolApproval(toolCallId: string, approved: boolean): Promise<void>;
+      _persistAssistantMessage(msg: UIMessage): Promise<void>;
+    };
+
+    const accumulator = new StreamAccumulator({
+      messageId: crypto.randomUUID(),
+      existingParts: [
+        {
+          type: "tool-client_action",
+          toolCallId: opts.toolCallId,
+          toolName: "client_action",
+          state: "approval-requested",
+          input: { action: "do_thing" }
+        } as unknown as UIMessage["parts"][number]
+      ]
+    });
+
+    internal._streamingAssistant = accumulator;
+    await internal._applyToolApproval(opts.toolCallId, opts.approved);
+    await internal._persistAssistantMessage(accumulator.toMessage());
+    internal._streamingAssistant = null;
+
+    const messages = (await this.getMessages()) as UIMessage[];
+    const part = messages
+      .flatMap((m) => m.parts as Array<Record<string, unknown>>)
+      .find((p) => p.toolCallId === opts.toolCallId);
+    return { state: (part?.state as string) ?? "missing" };
   }
 
   async getCapturedClientTools(): Promise<ClientToolSchema[] | undefined> {

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1064,6 +1064,106 @@ describe("Think — auto-continuation", () => {
     await closeWS(ws);
   });
 
+  it("serializes overlapping tool-result applies so neither clobbers the other (#1649)", async () => {
+    const agent = await freshAgent();
+    // Two overlapping read-modify-writes through the interaction-apply queue.
+    // Without serialization the second reads the stale value before the first
+    // commits and the result is 1; serialized, the second waits and it is 2.
+    const result = await agent.testInteractionApplySerialization();
+    expect(result).toBe(2);
+  });
+
+  it("does not clobber siblings when parallel results arrive concurrently (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    // Three parallel client tool calls in a single assistant step.
+    await agent.persistToolCallMessage([
+      makeUserMessage("use three tools"),
+      {
+        id: "assistant-concurrent",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-a",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "a" }
+          },
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-b",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "b" }
+          },
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-c",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "c" }
+          }
+        ]
+      } as unknown as UIMessage
+    ]);
+    await agent.clearResponseLog();
+
+    const repairedToolCallIds: Array<string[] | undefined> = [];
+    const unsubscribe = subscribe("transcript", (event) => {
+      if (event.type === "chat:transcript:repaired" && event.name === room) {
+        repairedToolCallIds.push(event.payload.toolCallIds);
+      }
+    });
+
+    try {
+      // Fire all three results back-to-back WITHOUT awaiting between sends. Each
+      // apply is a read-modify-write of the whole assistant message; without
+      // serialization they read the same all-`input-available` snapshot and the
+      // last write clobbers its siblings back to `input-available`.
+      const continuationDone = waitForDone(ws, 15000);
+      for (const id of ["tc-a", "tc-b", "tc-c"]) {
+        ws.send(
+          JSON.stringify({
+            type: MSG_TOOL_RESULT,
+            toolCallId: id,
+            toolName: "client_action",
+            output: `${id} output`,
+            autoContinue: true
+          })
+        );
+      }
+      await continuationDone;
+      await delay(200);
+
+      // All three results survived — none was clobbered back to input-available.
+      const messages = (await agent.getMessages()) as UIMessage[];
+      const assistant = messages.find((m) => m.id === "assistant-concurrent")!;
+      const partFor = (toolCallId: string) =>
+        assistant.parts.find(
+          (p) => (p as Record<string, unknown>).toolCallId === toolCallId
+        ) as Record<string, unknown>;
+      for (const id of ["tc-a", "tc-b", "tc-c"]) {
+        expect(partFor(id).state).toBe("output-available");
+        expect(partFor(id).output).toBe(`${id} output`);
+      }
+
+      // No sibling was flipped to errored by a premature repair.
+      expect(repairedToolCallIds.flat()).toEqual([]);
+
+      // Exactly one continuation ran for the completed batch.
+      const log = (await agent.getResponseLog()) as ChatResponseResult[];
+      expect(log.filter((entry) => entry.continuation).length).toBe(1);
+    } finally {
+      unsubscribe();
+    }
+
+    await closeWS(ws);
+  });
+
   it("holds the barrier when a settled dynamic-tool sits beside a pending tool (#1649)", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1073,6 +1073,103 @@ describe("Think — auto-continuation", () => {
     expect(result).toBe(2);
   });
 
+  it("applies a client tool result delivered before the assistant message is persisted (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    // Deterministic reproduction of the streaming race: the tool call exists
+    // ONLY in the in-flight accumulator (not yet persisted) when the result
+    // arrives. A storage-only apply misses it, and the end-of-stream persist
+    // then writes `input-available`, which transcript repair later errors with
+    // "The tool call was interrupted before a result was recorded." Applying to
+    // the accumulator lets the result ride into the persist.
+    const result = await agent.simulateMidStreamClientToolResult({
+      toolCallId: "tc-midstream-1",
+      output: "mid-stream result"
+    });
+    expect(result.state).toBe("output-available");
+    expect(result.output).toBe("mid-stream result");
+  });
+
+  it("applies a client tool approval delivered before the assistant message is persisted (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    // Approvals flow through the same `_applyToolUpdateToMessages` path, so the
+    // mid-stream fix must cover them too: an `approval-requested` part that
+    // exists only in the in-flight accumulator must reach `approval-responded`
+    // rather than being dropped and repaired as interrupted.
+    const result = await agent.simulateMidStreamClientToolApproval({
+      toolCallId: "tc-midstream-approval-1",
+      approved: true
+    });
+    expect(result.state).toBe("approval-responded");
+  });
+
+  it("applies a client tool result that arrives mid-stream over the WebSocket (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    // Hold the stream open after the client tool call so the result can arrive
+    // before the end-of-stream persist (the real #1649 window).
+    await agent.setSlowClientToolStreamMode(true, 25, 16);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    const repairedToolCallIds: Array<string[] | undefined> = [];
+    const unsubscribe = subscribe("transcript", (event) => {
+      if (event.type === "chat:transcript:repaired" && event.name === room) {
+        repairedToolCallIds.push(event.payload.toolCallIds);
+      }
+    });
+
+    try {
+      sendChatRequest(ws, [makeUserMessage("do the thing")], {
+        clientTools: [{ name: "client_action", description: "A client tool" }]
+      });
+
+      // Wait until the streaming turn has exposed the client tool call, then
+      // resolve it WHILE the stream is still open — deterministic, no timing
+      // guess. On `main` this result lands before the message is persisted and
+      // is dropped.
+      await waitUntil(async () => {
+        const state = await agent.streamingToolCallState("tc-client-1");
+        if (state === undefined) return false;
+        if (state !== "input-available") {
+          throw new Error(`unexpected streaming tool state: ${state}`);
+        }
+        return true;
+      }, 8000);
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_RESULT,
+          toolCallId: "tc-client-1",
+          toolName: "client_action",
+          output: "mid-stream output",
+          autoContinue: true
+        })
+      );
+
+      // The continuation only runs once the result has been recorded, so
+      // waiting for it confirms the result survived.
+      await waitUntil(async () => {
+        const log = (await agent.getResponseLog()) as ChatResponseResult[];
+        return log.some((entry) => entry.continuation);
+      }, 8000);
+      await delay(100);
+
+      const messages = (await agent.getMessages()) as UIMessage[];
+      const toolPart = messages
+        .flatMap((m) => m.parts as Array<Record<string, unknown>>)
+        .find((p) => p.toolCallId === "tc-client-1");
+      expect(toolPart?.state).toBe("output-available");
+      expect(toolPart?.output).toBe("mid-stream output");
+      // The result was applied in time, so repair never errored the call.
+      expect(repairedToolCallIds.flat()).not.toContain("tc-client-1");
+    } finally {
+      unsubscribe();
+    }
+
+    await closeWS(ws);
+  }, 25000);
+
   it("does not clobber siblings when parallel results arrive concurrently (#1649)", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1918,6 +1918,17 @@ export class Think<
   // back to `input-available`. Chaining every apply off this tail makes them
   // commit atomically in arrival order.
   private _interactionApplyTail: Promise<void> = Promise.resolve();
+  // The in-flight assistant message for the active streaming turn. Until
+  // `_persistAssistantMessage` writes it at a turn boundary, the message lives
+  // ONLY in this accumulator — not in storage and not in `this.messages`. A
+  // client tool result can arrive over the WebSocket before that write (the
+  // tool-call chunk was already broadcast), so a storage-only lookup in
+  // `_applyToolUpdateToMessages` would miss the message and the part would
+  // later be repaired as "interrupted" (#1649). Exposing the accumulator here
+  // lets the apply write the result in place so it rides into the eventual
+  // persist. Null when no stream is active. Mirrors `@cloudflare/ai-chat`'s
+  // `_streamingMessage` handling.
+  private _streamingAssistant: StreamAccumulator | null = null;
   private _submitConcurrency = new SubmitConcurrencyController({
     defaultDebounceMs: Think.MESSAGE_DEBOUNCE_MS
   });
@@ -6304,6 +6315,9 @@ export class Think<
     // Drop the apply chain so new interactions don't serialize behind a stale
     // (possibly hung) apply from the turn we just reset (#1649).
     this._interactionApplyTail = Promise.resolve();
+    // The streaming turn (if any) is being torn down; stop exposing its
+    // accumulator so a late tool result doesn't apply to an abandoned message.
+    this._streamingAssistant = null;
     this._continuationBarrierActive = false;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();
@@ -6384,6 +6398,10 @@ export class Think<
     const accumulator = new StreamAccumulator({
       messageId: crypto.randomUUID()
     });
+    // Expose the in-flight message so a client tool result arriving before the
+    // end-of-stream persist lands on the accumulator instead of being dropped
+    // (#1649). Cleared in the `finally` below.
+    this._streamingAssistant = accumulator;
 
     let streamFinalized = false;
     let assistantMsg: UIMessage | null = null;
@@ -6608,6 +6626,11 @@ export class Think<
       }
 
       await callback.onError(errorMessage);
+    } finally {
+      // The message is now durably persisted (success, error, or recovery
+      // path), so subsequent tool results resolve against storage; stop
+      // exposing the sealed accumulator (#1649).
+      this._streamingAssistant = null;
     }
 
     if (pendingRpcError) {
@@ -6778,6 +6801,10 @@ export class Think<
     const accumulator = new StreamAccumulator({
       messageId: crypto.randomUUID()
     });
+    // Expose the in-flight message so a client tool result arriving before the
+    // end-of-stream persist lands on the accumulator instead of being dropped
+    // (#1649). Cleared before every return path below.
+    this._streamingAssistant = accumulator;
 
     let doneSent = false;
     let streamAborted = false;
@@ -6929,6 +6956,7 @@ export class Think<
           // the scheduled continuation owns the real terminal outcome. No
           // response hook fires here (the continuation fires it), mirroring how
           // a deploy-interrupted attempt is superseded by its continuation.
+          this._streamingAssistant = null;
           return { status: "aborted" };
         }
         if (outcome === "exhausted") {
@@ -6940,6 +6968,7 @@ export class Think<
           this._resumableStream.markError(streamId);
           this._pendingResumeConnections.clear();
           doneSent = true;
+          this._streamingAssistant = null;
           return { status: "aborted" };
         }
         // outcome === "disabled" (chat recovery off): fall through to the
@@ -7018,6 +7047,10 @@ export class Think<
         console.error("Failed to persist assistant message:", e);
       }
     }
+
+    // The message is now persisted (or the turn was cleared), so subsequent
+    // tool results resolve against storage; stop exposing the accumulator.
+    this._streamingAssistant = null;
 
     return streamError
       ? { status: "error", error: streamError }
@@ -7162,6 +7195,39 @@ export class Think<
     matchStates: string[];
     apply: (part: Record<string, unknown>) => Record<string, unknown>;
   }): Promise<void> {
+    // The message to update can live in two places. During a streaming turn
+    // the assistant message exists ONLY in the in-flight accumulator until
+    // `_persistAssistantMessage` writes it at a turn boundary; a parallel-
+    // batch sibling can also have been persisted already by stall recovery.
+    // Apply to BOTH so the result is correct regardless of where the message
+    // currently is and survives the eventual `accumulator.toMessage()` persist
+    // (which would otherwise downgrade an applied result back to
+    // `input-available` — #1649). Mirrors `@cloudflare/ai-chat`'s streaming-
+    // message handling, generalized to also cover the post-persist case.
+    let broadcastMessage: UIMessage | undefined;
+
+    // (1) In-flight accumulator. A client tool result that arrives over the
+    // WebSocket before the end-of-stream persist would be missed by a
+    // storage-only lookup and later repaired as "interrupted". Writing it in
+    // place lets it ride into the persist.
+    const streaming = this._streamingAssistant;
+    if (streaming) {
+      const accParts = streaming.parts as unknown as Array<
+        Record<string, unknown>
+      >;
+      const result = applyToolUpdate(accParts, update);
+      if (result && result.parts[result.index] !== accParts[result.index]) {
+        // `accParts` is a typed alias of the accumulator's live array, so this
+        // in-place write is reflected by `streaming.toMessage()` and the
+        // eventual end-of-stream persist.
+        accParts[result.index] = result.parts[result.index];
+        broadcastMessage = streaming.toMessage();
+      }
+    }
+
+    // (2) Durable storage. Handles messages already persisted — including
+    // partials written mid-stream by stall recovery and cross-message tool
+    // results that target an earlier message than this turn's.
     const history = await this._readMessagesFromStorage();
     for (let i = 0; i < history.length; i++) {
       const msg = history[i];
@@ -7174,7 +7240,7 @@ export class Think<
         // nothing to persist. Skip the durable write and the redundant
         // `MESSAGE_UPDATED` broadcast so clients don't churn on a no-op.
         if (result.parts[result.index] === msgParts[result.index]) {
-          return;
+          break;
         }
         const updatedMsg = {
           ...msg,
@@ -7192,9 +7258,16 @@ export class Think<
         // and 6e76bd49 "update cached messages in-place"). The cache is
         // the source of truth during a turn; we only reconcile it here to
         // reflect the tool update that was just written to storage.
-        this._broadcast({ type: MSG_MESSAGE_UPDATED, message: safe });
-        return;
+        broadcastMessage = safe;
+        break;
       }
+    }
+
+    if (broadcastMessage) {
+      this._broadcast({
+        type: MSG_MESSAGE_UPDATED,
+        message: broadcastMessage
+      });
     }
   }
 
@@ -8747,6 +8820,13 @@ export class Think<
    * repair backstop rather than pinning the continuation open forever.
    */
   private _fireAutoContinuationWhenStable(connection: Connection): void {
+    // NOTE: when a result arrives mid-stream, the in-flight assistant message
+    // lives only in `_streamingAssistant` and is NOT yet in `this.messages`, so
+    // `_hasIncompleteToolBatch()` here inspects a stale (prior) leaf. That does
+    // not break correctness: the continuation is enqueued behind the active
+    // streaming turn on the turn queue, and that turn persists the (now
+    // settled) result before the continuation's transcript repair runs. The
+    // ordering guarantee is the turn queue, not this barrier's cache view.
     if (!this._continuation.pending) return;
     // The continuation is already running (a sibling result re-armed the timer
     // after it started). New results coalesce/defer into it — don't double-fire.

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1912,6 +1912,12 @@ export class Think<
   private _insideResponseHook = false;
   private _insideInferenceLoop = false;
   private _pendingInteractionPromise: Promise<boolean> | null = null;
+  // Serialization tail for client-tool result/approval applies (#1649). Each
+  // apply is a read-modify-write of the full message; running siblings from a
+  // parallel tool batch concurrently lets last-write-wins clobber the others
+  // back to `input-available`. Chaining every apply off this tail makes them
+  // commit atomically in arrival order.
+  private _interactionApplyTail: Promise<void> = Promise.resolve();
   private _submitConcurrency = new SubmitConcurrencyController({
     defaultDebounceMs: Think.MESSAGE_DEBOUNCE_MS
   });
@@ -5913,23 +5919,14 @@ export class Think<
           this._lastClientTools = event.clientTools as ClientToolSchema[];
           this._persistClientTools();
         }
-        const resultPromise = Promise.resolve().then(async () => {
-          await this._applyToolResult(
+        this._enqueueInteractionApply(() =>
+          this._applyToolResult(
             event.toolCallId,
             event.output,
             event.state as "output-error" | undefined,
             event.errorText
-          );
-          return true;
-        });
-        this._pendingInteractionPromise = resultPromise;
-        resultPromise
-          .finally(() => {
-            if (this._pendingInteractionPromise === resultPromise) {
-              this._pendingInteractionPromise = null;
-            }
-          })
-          .catch(() => {});
+          )
+        );
         if (event.autoContinue) {
           this._scheduleAutoContinuation(connection);
         }
@@ -5937,18 +5934,9 @@ export class Think<
       }
 
       case "tool-approval": {
-        const approvalPromise = Promise.resolve().then(async () => {
-          await this._applyToolApproval(event.toolCallId, event.approved);
-          return true;
-        });
-        this._pendingInteractionPromise = approvalPromise;
-        approvalPromise
-          .finally(() => {
-            if (this._pendingInteractionPromise === approvalPromise) {
-              this._pendingInteractionPromise = null;
-            }
-          })
-          .catch(() => {});
+        this._enqueueInteractionApply(() =>
+          this._applyToolApproval(event.toolCallId, event.approved)
+        );
         if (event.autoContinue) {
           this._scheduleAutoContinuation(connection);
         }
@@ -6313,6 +6301,9 @@ export class Think<
     }
     this._submitConcurrency.reset();
     this._pendingInteractionPromise = null;
+    // Drop the apply chain so new interactions don't serialize behind a stale
+    // (possibly hung) apply from the turn we just reset (#1649).
+    this._interactionApplyTail = Promise.resolve();
     this._continuationBarrierActive = false;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();
@@ -7099,6 +7090,49 @@ export class Think<
   }
 
   // ── Tool state updates (shared primitives from agents/chat) ─────
+
+  /**
+   * Serialize a client-tool result/approval apply behind any in-flight apply
+   * (#1649). Parallel tool results arrive as independent WebSocket messages,
+   * and each apply is a read-modify-write of the full message in durable
+   * storage. Running them concurrently means every apply reads the same
+   * snapshot (all siblings still `input-available`), patches only its own part,
+   * and writes the whole message back — so the last write clobbers the others
+   * back to `input-available`, and the auto-continuation barrier later times
+   * out and the transcript-repair backstop errors the lost siblings.
+   *
+   * Chaining each apply off `_interactionApplyTail` makes the read-modify-write
+   * atomic per result and in arrival order. `_pendingInteractionPromise` is set
+   * to the newest link so the barrier's single-slot wake-up still observes the
+   * latest apply; because the chain is serial, awaiting it transitively waits
+   * for every predecessor.
+   *
+   * @internal
+   */
+  protected _enqueueInteractionApply(
+    apply: () => Promise<void>
+  ): Promise<boolean> {
+    const run = async (): Promise<boolean> => {
+      await apply();
+      return true;
+    };
+    // `.then(run, run)` runs regardless of a predecessor's outcome so one
+    // rejected apply can't poison the rest of the batch.
+    const resultPromise = this._interactionApplyTail.then(run, run);
+    this._interactionApplyTail = resultPromise.then(
+      () => undefined,
+      () => undefined
+    );
+    this._pendingInteractionPromise = resultPromise;
+    resultPromise
+      .finally(() => {
+        if (this._pendingInteractionPromise === resultPromise) {
+          this._pendingInteractionPromise = null;
+        }
+      })
+      .catch(() => {});
+    return resultPromise;
+  }
 
   private async _applyToolResult(
     toolCallId: string,


### PR DESCRIPTION
## Summary

Follow-up to #1651. The auto-continuation **barrier** added there stopped *premature* continuation, but a deeper **data race** remained in Think that still produced the reported failure: parallel client tool calls intermittently error one sibling with _"The tool call was interrupted before a result was recorded."_

This PR serializes the per-result read-modify-write so siblings can no longer clobber each other.

## Root cause

Each `cf_agent_tool_result` / `cf_agent_tool_approval` WebSocket message triggers a read-modify-write of the **whole** assistant message via `_applyToolUpdateToMessages`, which `await`s a storage read before writing:

```ts
const history = await this._readMessagesFromStorage(); // <-- await: microtask boundary
// ...patch this result's part...
await this._updateMessageInHistory(updatedMessage);    // write full message back
```

When the model fans out parallel tool calls in one assistant step, the per-result applies run concurrently:

1. Apply **A** and apply **B** both `await` the storage read and resolve with the **same snapshot** — every sibling still `input-available`.
2. **A** patches only its own part and writes the full message back.
3. **B**, still holding the stale snapshot, patches only *its* part and writes the full message back — **clobbering A back to `input-available`**.

The clobber lands in both durable storage and the `this.messages` cache, so `_hasIncompleteToolBatch()` keeps seeing an unanswered sibling. The continuation barrier then times out and the transcript-repair backstop errors the lost call.

## Fix

Introduce a per-instance serialization tail (`_interactionApplyTail`) and route every result/approval apply through `_enqueueInteractionApply`, which chains each apply off the previous one — making each read-modify-write atomic and ordered.

- `.then(run, run)` is used so a rejected apply can't poison the rest of the batch.
- `_pendingInteractionPromise` still tracks the newest link; because the chain is serial, the barrier's single-slot wake-up transitively waits for every predecessor.
- `resetTurnState` drops the tail so a new turn never queues behind a stale (possibly hung) apply from a reset turn.

## ai-chat (defensive only)

The same serialization is added to `@cloudflare/ai-chat` for symmetry, but **ai-chat does not exhibit this bug today**: `_findAndUpdateToolPart` performs the read-modify-write **synchronously** (no await between reading `this.messages` and the synchronous SQLite write), so concurrent applies cannot interleave. The queue is a forward-guard that keeps the invariant safe if that apply ever gains an await (e.g. async storage). The changeset and the test label this explicitly as defensive.

## Tests

- **Deterministic serialization test** in both packages (`testInteractionApplySerialization`): drives two overlapping read-modify-writes through the queue. Without serialization the result is `1` (clobbered); serialized it is `2`. Verified the Think test **fails without the fix** (`expected 1 to be 2`).
- **Integration test** in Think: three concurrently-sent parallel results all settle to `output-available`, none is repaired, and exactly one continuation runs.
- `_enqueueInteractionApply` is `protected` + `@internal` so the test agents can drive it deterministically. (The vitest-workers harness can't reproduce the real storage interleave because DO SQLite is synchronous — hence the unit-level serialization test rather than relying on WebSocket timing.)

## Verification

- `npm run format`, `oxlint` — 0 warnings / 0 errors
- `npm run typecheck` — 91/91 projects
- `@cloudflare/think` — 486 passed
- `@cloudflare/ai-chat` — 566 passed

## Changeset

`patch` for `@cloudflare/think` (real fix) and `@cloudflare/ai-chat` (defensive).

## Notes / out of scope

This addresses the *only-the-slow-sibling-errored* signature. The separately-reported client crash (`Cannot read properties of undefined (reading 'state')`) stems from the upstream `vercel/ai#15668` `activeResponse` issue and is tracked independently.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->