### PR TITLE
fix(agents,think): recover server-tool turns, terminalize thrown recovery, re-run alarms killed by a script-upgrade supersede

### DIFF
--- a/.changeset/defer-superseded-isolate-alarm.md
+++ b/.changeset/defer-superseded-isolate-alarm.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+---
+
+Recover one-shot scheduled work (alarms) killed by a `"This script has been upgraded…"` deploy/code-update, not just `"Durable Object reset because its code was updated."`.
+
+`_executeScheduleCallback` only re-runs a one-shot schedule row after a superseded-isolate error if the error matched `/reset because its code was updated/i`. The platform also surfaces the same failure class as `"This script has been upgraded. Please send a new request to connect to the new version."` (a stub/connection to a superseded script), which fell through to the swallow-and-delete branch — the one-shot row was deleted and the work abandoned. For a queued submission this orphaned the pending row with no driver (no alarm, no retry) until something unrelated woke the Durable Object, leaving the user on an indefinite spinner.
+
+The superseded-isolate matcher now recognizes both messages, so either causes the row to be preserved and re-run on the fresh isolate under the at-least-once alarm guarantee. `"Network connection lost."` is intentionally not included (it is a connection error that may succeed on in-process retry, not an isolate replacement).

--- a/.changeset/server-tool-recovery-deadlock.md
+++ b/.changeset/server-tool-recovery-deadlock.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/think": patch
+---
+
+Fix two chat-recovery failures that could leave a turn wedged at a half-finished assistant message after a deploy/eviction, with no terminal banner.
+
+1. **Server-tool recovery deadlock.** When a server-side tool's `execute()` was interrupted by an eviction, the recovered turn's orphaned tool part was left at `input-available` — but no client `tool-result` will ever arrive for a server tool, so `waitUntilStable` could never converge. The recovery continuation burned its whole attempt budget on a wait that could not succeed. `waitUntilStable` now treats an `input-available` part as pending only when it is genuinely client-resolvable (a registered client tool whose result the SPA can replay, or an `approval-requested` part). A dead server-tool orphan no longer blocks stability, so recovery converges and the existing transcript-repair pass flips the orphan to an errored result and the model continues the turn.
+
+2. **Silent seal on a thrown recovery callback.** A non-reset error thrown by `_chatRecoveryContinue` / `_chatRecoveryRetry` was re-thrown and then swallowed by the scheduler, which deleted the one-shot recovery alarm row — terminating the turn with no `onExhausted` event and no terminal banner. The recovery callbacks now terminalize a non-reset throw through the same exhaustion path (firing `onExhausted` with reason `recovery_error` and delivering the `terminalMessage`), while still re-throwing a genuine Durable Object code-update reset so the platform re-runs recovery on the fresh isolate. The terminal banner is also now broadcast before the bookkeeping storage writes in the exhaustion path, and those writes are best-effort, so a storage failure during give-up can no longer suppress the user-visible terminalization.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1232,6 +1232,12 @@ function resolveRetryConfig(
  *     the new version."  (a stub/connection to a superseded script; the message
  *     literally instructs the caller to retry on the new version)
  *
+ * The match stays close to the verbatim platform strings (rather than a loose
+ * "upgraded"/"reset" substring) so an ordinary application error that happens
+ * to mention those words is NOT misclassified as a supersede — a false positive
+ * would defer + re-run a genuinely-failing callback on the platform's alarm
+ * retries instead of abandoning it.
+ *
  * NOTE: "Network connection lost." is deliberately NOT included — it is a
  * connection error, not an isolate replacement, and may succeed on in-process
  * retry (it is gated by the CF `retryable` property via `isErrorRetryable`),
@@ -1244,7 +1250,7 @@ function isDurableObjectCodeUpdateReset(error: unknown): boolean {
       : typeof error === "string"
         ? error
         : "";
-  return /reset because its code was updated|script has been upgraded/i.test(
+  return /reset because its code was updated|this script has been upgraded/i.test(
     message
   );
 }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1218,13 +1218,24 @@ function resolveRetryConfig(
 }
 
 /**
- * Whether an error is a Durable Object reset caused by a code update (deploy).
+ * Whether an error is a transient "superseded isolate" failure — the invocation
+ * is running on an isolate the platform has replaced with a new version (a
+ * deploy / code update). For the rest of that invocation every operation throws
+ * the same error (code never reloads mid-invocation), so in-process retries are
+ * futile; but the next fresh invocation runs the new code and succeeds.
  *
- * This is a transient, environmental failure: the invocation started on a
- * superseded isolate, so every `ctx.storage` op throws this for the entire
- * life of the invocation (code never reloads mid-invocation) — but the next
- * fresh invocation runs the new code and succeeds. workerd surfaces it as a
- * plain `Error` with this message, so a message match is the only signal.
+ * workerd surfaces this as a plain `Error` with one of a few messages, all the
+ * same failure class — a message match is the only signal:
+ *   - "Durable Object reset because its code was updated."  (DO storage op on a
+ *     superseded isolate / deploy bounce)
+ *   - "This script has been upgraded. Please send a new request to connect to
+ *     the new version."  (a stub/connection to a superseded script; the message
+ *     literally instructs the caller to retry on the new version)
+ *
+ * NOTE: "Network connection lost." is deliberately NOT included — it is a
+ * connection error, not an isolate replacement, and may succeed on in-process
+ * retry (it is gated by the CF `retryable` property via `isErrorRetryable`),
+ * so it stays on the normal retry path rather than the immediate-defer path.
  */
 function isDurableObjectCodeUpdateReset(error: unknown): boolean {
   const message =
@@ -1233,7 +1244,9 @@ function isDurableObjectCodeUpdateReset(error: unknown): boolean {
       : typeof error === "string"
         ? error
         : "";
-  return /reset because its code was updated/i.test(message);
+  return /reset because its code was updated|script has been upgraded/i.test(
+    message
+  );
 }
 
 export function getCurrentAgent<
@@ -5647,14 +5660,16 @@ export class Agent<
         }
 
         // A one-shot row is deleted by `alarm()` once this returns normally.
-        // If it fails with a Durable Object code-update reset (a deploy
-        // superseded the isolate), burning in-process retries is futile (code
-        // never reloads mid-invocation) and swallowing the error would let
-        // `alarm()` delete the row — permanently abandoning the work (e.g. an
-        // interrupted chat-recovery continuation). For that transient we skip
-        // the doomed retries and re-throw so `alarm()` rejects, the one-shot
-        // row survives, and the platform re-runs it on a fresh isolate (= new
-        // code) under the at-least-once alarm guarantee.
+        // If it fails with a superseded-isolate error (a deploy / code update
+        // replaced the isolate — "reset because its code was updated" or "this
+        // script has been upgraded"), burning in-process retries is futile
+        // (code never reloads mid-invocation) and swallowing the error would
+        // let `alarm()` delete the row — permanently abandoning the work (e.g.
+        // an interrupted chat-recovery continuation, or a queued submission's
+        // drain alarm, leaving the submission orphaned with no driver). For
+        // that transient we skip the doomed retries and re-throw so `alarm()`
+        // rejects, the one-shot row survives, and the platform re-runs it on a
+        // fresh isolate (= new code) under the at-least-once alarm guarantee.
         const isOneShotSchedule =
           row.type === "delayed" || row.type === "scheduled";
         const shouldDeferReset = (error: unknown): boolean =>

--- a/packages/agents/src/tests/agents/schedule.ts
+++ b/packages/agents/src/tests/agents/schedule.ts
@@ -389,6 +389,54 @@ export class TestScheduleAgent extends Agent {
     return result[0].count;
   }
 
+  // --- Superseded-isolate (deploy/code-update) defer test helpers ---
+
+  private _platformErrorForTest = "";
+
+  // One-shot callback that throws a configurable error. Used to assert that
+  // `_executeScheduleCallback` DEFERS (re-throws → preserves the row so the
+  // platform re-runs it) for the superseded-isolate error family, vs SWALLOWS
+  // + deletes the row for other errors.
+  async platformErrorCallbackForTest(): Promise<void> {
+    throw new Error(this._platformErrorForTest);
+  }
+
+  // Schedule a one-shot throwing callback (due now), drive `alarm()` once
+  // in-instance, and report whether the alarm rejected (deferred) and whether
+  // the one-shot row survived. Deterministic — no reliance on the external
+  // alarm scheduler's timing.
+  @callable()
+  async runOneShotThrowingForTest(
+    message: string
+  ): Promise<{ threw: boolean; remaining: number }> {
+    this._platformErrorForTest = message;
+    // Retry disabled so a non-deferred error fails fast and deterministically
+    // instead of burning the default in-process retries with backoff.
+    const schedule = await this.schedule(
+      60,
+      "platformErrorCallbackForTest",
+      undefined,
+      { retry: { maxAttempts: 1 } }
+    );
+    // Backdate so the row is due when alarm() scans `time <= now`.
+    this.sql`
+      UPDATE cf_agents_schedules
+      SET time = ${Math.floor(Date.now() / 1000) - 1}
+      WHERE id = ${schedule.id}
+    `;
+    let threw = false;
+    try {
+      await this.alarm();
+    } catch {
+      // A deferred (re-thrown) error rejects alarm(); a swallowed one does not.
+      threw = true;
+    }
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_agents_schedules WHERE id = ${schedule.id}
+    `;
+    return { threw, remaining: rows[0].count };
+  }
+
   @callable()
   async insertStaleDelayedRows(count: number, cb: string): Promise<void> {
     const past = Math.floor(Date.now() / 1000) - 60;

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -1062,5 +1062,19 @@ describe("schedule operations", () => {
       expect(threw).toBe(false);
       expect(remaining).toBe(0);
     });
+
+    it("does NOT treat an ordinary error that merely mentions an upgraded script as a supersede", async () => {
+      // Guards the tightened matcher: only the verbatim platform phrase ("this
+      // script has been upgraded") defers; a lookalike app error is swallowed.
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "no-defer-lookalike"
+      );
+      const { threw, remaining } = await agentStub.runOneShotThrowingForTest(
+        "Your subscription script has been upgraded to the new plan."
+      );
+      expect(threw).toBe(false);
+      expect(remaining).toBe(0);
+    });
   });
 });

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -1009,4 +1009,58 @@ describe("schedule operations", () => {
       await agentStub.cancelScheduleById(ids[0]);
     });
   });
+
+  describe("one-shot defer on a superseded-isolate error", () => {
+    // A one-shot alarm whose callback throws because the isolate was replaced
+    // by a deploy must be PRESERVED (re-thrown so alarm() rejects), so the
+    // platform re-runs it on the new code — not swallowed + deleted, which
+    // would orphan the work (e.g. a queued submission's drain alarm).
+    it('preserves the row + rejects alarm for "reset because its code was updated" (deploy bounce)', async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "defer-code-update-reset"
+      );
+      const { threw, remaining } = await agentStub.runOneShotThrowingForTest(
+        "Durable Object reset because its code was updated."
+      );
+      expect(threw).toBe(true);
+      expect(remaining).toBe(1);
+    });
+
+    it('preserves the row + rejects alarm for "This script has been upgraded" (superseded script)', async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "defer-script-upgraded"
+      );
+      const { threw, remaining } = await agentStub.runOneShotThrowingForTest(
+        "This script has been upgraded. Please send a new request to connect to the new version."
+      );
+      expect(threw).toBe(true);
+      expect(remaining).toBe(1);
+    });
+
+    it("swallows + deletes the row for an ordinary (non-supersede) error", async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "swallow-ordinary-error"
+      );
+      const { threw, remaining } = await agentStub.runOneShotThrowingForTest(
+        "some ordinary application error"
+      );
+      expect(threw).toBe(false);
+      expect(remaining).toBe(0);
+    });
+
+    it('does NOT defer "Network connection lost." (not an isolate replacement)', async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "no-defer-connection-lost"
+      );
+      const { threw, remaining } = await agentStub.runOneShotThrowingForTest(
+        "Network connection lost."
+      );
+      expect(threw).toBe(false);
+      expect(remaining).toBe(0);
+    });
+  });
 });

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -4248,6 +4248,110 @@ export class ThinkRecoveryTestAgent extends Think {
     };
   }
 
+  /**
+   * Drive `_handleRecoveryCallbackError` (the catch path of
+   * `_chatRecoveryContinue` / `_chatRecoveryRetry`) and report the outcome.
+   *
+   * - A non-reset throw must terminalize (fire `onExhausted` + broadcast the
+   *   terminal banner, seal the incident `exhausted`) and NOT re-throw — so
+   *   `Agent._executeScheduleCallback` doesn't swallow it and delete the
+   *   one-shot row with no terminal UX.
+   * - A deploy code-update reset must re-throw (so the platform re-runs
+   *   recovery on the fresh isolate) and NOT terminalize.
+   */
+  async testRecoveryCallbackError(input: {
+    reset: boolean;
+    maxAttempts?: number;
+    terminalMessage?: string;
+  }): Promise<{
+    threw: boolean;
+    exhaustedContexts: number;
+    exhaustedReason: string | undefined;
+    terminalBroadcast: string | undefined;
+    incidentStatus: string | undefined;
+  }> {
+    const maxAttempts = input.maxAttempts ?? 5;
+    const terminalMessage =
+      input.terminalMessage ?? "Conversation interrupted.";
+    const captured: ChatRecoveryExhaustedContext[] = [];
+    this.chatRecovery = {
+      maxAttempts,
+      terminalMessage,
+      onExhausted: (ctx) => {
+        captured.push(ctx);
+      }
+    };
+
+    const requestId = `recovery-error-${crypto.randomUUID()}`;
+    const begun = await this.beginIncidentForTest({
+      requestId,
+      recoveryRootRequestId: requestId,
+      latestUserMessageId: null,
+      recoveryKind: "continue"
+    });
+
+    let terminalBroadcast: string | undefined;
+    const realBroadcast = (
+      this as unknown as {
+        _broadcastChat(m: {
+          body?: string;
+          error?: boolean;
+          done?: boolean;
+        }): void;
+      }
+    )._broadcastChat.bind(this);
+    (
+      this as unknown as {
+        _broadcastChat: (m: {
+          body?: string;
+          error?: boolean;
+          done?: boolean;
+        }) => void;
+      }
+    )._broadcastChat = (m) => {
+      if (m.error && m.done) terminalBroadcast = m.body;
+      realBroadcast(m);
+    };
+
+    const error = input.reset
+      ? new Error("Durable Object reset because its code was updated.")
+      : new Error("transient storage failure mid-recovery");
+
+    let threw = false;
+    try {
+      await (
+        this as unknown as {
+          _handleRecoveryCallbackError(
+            callback: string,
+            data: unknown,
+            error: unknown
+          ): Promise<void>;
+        }
+      )._handleRecoveryCallbackError(
+        "_chatRecoveryContinue",
+        { incidentId: begun.incidentId, originalRequestId: requestId },
+        error
+      );
+    } catch {
+      threw = true;
+    } finally {
+      (
+        this as unknown as { _broadcastChat: (m: unknown) => void }
+      )._broadcastChat = realBroadcast as (m: unknown) => void;
+    }
+
+    const incidents = await this.ctx.storage.list<{ status: string }>({
+      prefix: "cf:chat-recovery:incident:"
+    });
+    return {
+      threw,
+      exhaustedContexts: captured.length,
+      exhaustedReason: captured[0]?.reason,
+      terminalBroadcast,
+      incidentStatus: [...incidents.values()][0]?.status
+    };
+  }
+
   async setStashData(data: unknown): Promise<void> {
     this._stashData = data;
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -4260,7 +4260,7 @@ export class ThinkRecoveryTestAgent extends Think {
    *   recovery on the fresh isolate) and NOT terminalize.
    */
   async testRecoveryCallbackError(input: {
-    reset: boolean;
+    errorMessage: string;
     maxAttempts?: number;
     terminalMessage?: string;
   }): Promise<{
@@ -4313,9 +4313,7 @@ export class ThinkRecoveryTestAgent extends Think {
       realBroadcast(m);
     };
 
-    const error = input.reset
-      ? new Error("Durable Object reset because its code was updated.")
-      : new Error("transient storage failure mid-recovery");
+    const error = new Error(input.errorMessage);
 
     let threw = false;
     try {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3870,6 +3870,44 @@ describe("Think — onChatRecovery", () => {
     // "Chat stream stalled..." error.
     expect(result.terminalBroadcast).toBe(terminalMessage);
   });
+
+  it("terminalizes a non-reset throw in a recovery callback instead of letting it be swallowed + silently sealed", async () => {
+    const agent = await freshRecoveryAgent("recovery-throw-terminalize");
+    const terminalMessage = "The assistant was interrupted. Please try again.";
+
+    const result = await agent.testRecoveryCallbackError({
+      reset: false,
+      maxAttempts: 5,
+      terminalMessage
+    });
+
+    // The catch must NOT re-throw — re-throwing a non-reset error lets
+    // Agent._executeScheduleCallback swallow it and delete the one-shot row
+    // with no terminal UX (the silent-seal bug).
+    expect(result.threw).toBe(false);
+    // Instead it routes through the give-up path: onExhausted fires once with
+    // the recovery_error reason, the banner is delivered, the incident sealed.
+    expect(result.exhaustedContexts).toBe(1);
+    expect(result.exhaustedReason).toBe("recovery_error");
+    expect(result.terminalBroadcast).toBe(terminalMessage);
+    expect(result.incidentStatus).toBe("exhausted");
+  });
+
+  it("re-throws a deploy code-update reset (preserve the row to re-run on the fresh isolate) and does NOT terminalize", async () => {
+    const agent = await freshRecoveryAgent("recovery-throw-reset");
+
+    const result = await agent.testRecoveryCallbackError({
+      reset: true,
+      maxAttempts: 5
+    });
+
+    // A code-update reset is re-thrown so the platform re-runs recovery on the
+    // new code — it must NOT terminalize (the turn can still recover).
+    expect(result.threw).toBe(true);
+    expect(result.exhaustedContexts).toBe(0);
+    expect(result.terminalBroadcast).toBeUndefined();
+    expect(result.incidentStatus).toBe("failed");
+  });
 });
 
 // ── waitUntilStable / hasPendingInteraction ───────────────────────
@@ -3891,8 +3929,15 @@ describe("Think — waitUntilStable", () => {
     expect(stable).toBe(true);
   });
 
-  it("detects pending tool interaction", async () => {
+  it("detects a pending CLIENT-tool interaction (the SPA can still replay the tool-result)", async () => {
     const agent = await freshRecoveryAgent("stable-pending");
+
+    // `client_action` is a client tool (no server execute); its
+    // `input-available` orphan is resolved by the SPA replaying a tool-result
+    // over the WebSocket, so recovery must keep waiting for it.
+    await agent.setRequestContextForTest(undefined, [
+      { name: "client_action" }
+    ]);
 
     await agent.persistTestMessage({
       id: "user-1",
@@ -3916,6 +3961,46 @@ describe("Think — waitUntilStable", () => {
 
     const hasPending = await agent.hasPendingInteractionForTest();
     expect(hasPending).toBe(true);
+  });
+
+  it("does NOT block stability on a dead SERVER-tool input-available orphan", async () => {
+    const agent = await freshRecoveryAgent("stable-server-orphan");
+
+    // `preview_tool` is a SERVER tool (has execute) — it is NOT in the client
+    // tool set. After an eviction mid-execute(), its in-flight promise is gone
+    // and nothing will ever post a result, so it must NOT keep waitUntilStable
+    // open (otherwise the recovery continuation can never converge — the
+    // server-tool recovery deadlock). The orphan is instead flipped to an
+    // errored result by the transcript-repair pass once the wait converges.
+    await agent.setRequestContextForTest(undefined, [
+      { name: "client_action" }
+    ]);
+
+    await agent.persistTestMessage({
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "Render a preview" }]
+    } as UIMessage);
+
+    await agent.persistTestMessage({
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-preview_tool",
+          toolCallId: "tc-server-1",
+          toolName: "preview_tool",
+          state: "input-available",
+          input: { url: "https://example.com" }
+        }
+      ]
+    } as unknown as UIMessage);
+
+    const hasPending = await agent.hasPendingInteractionForTest();
+    expect(hasPending).toBe(false);
+
+    const stable = await agent.waitUntilStableForTest(1000);
+    expect(stable).toBe(true);
   });
 
   it("detects pending approval", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3876,7 +3876,7 @@ describe("Think — onChatRecovery", () => {
     const terminalMessage = "The assistant was interrupted. Please try again.";
 
     const result = await agent.testRecoveryCallbackError({
-      reset: false,
+      errorMessage: "transient storage failure mid-recovery",
       maxAttempts: 5,
       terminalMessage
     });
@@ -3897,12 +3897,30 @@ describe("Think — onChatRecovery", () => {
     const agent = await freshRecoveryAgent("recovery-throw-reset");
 
     const result = await agent.testRecoveryCallbackError({
-      reset: true,
+      errorMessage: "Durable Object reset because its code was updated.",
       maxAttempts: 5
     });
 
     // A code-update reset is re-thrown so the platform re-runs recovery on the
     // new code — it must NOT terminalize (the turn can still recover).
+    expect(result.threw).toBe(true);
+    expect(result.exhaustedContexts).toBe(0);
+    expect(result.terminalBroadcast).toBeUndefined();
+    expect(result.incidentStatus).toBe("failed");
+  });
+
+  it('re-throws a "This script has been upgraded" supersede (defer + re-run) and does NOT terminalize', async () => {
+    const agent = await freshRecoveryAgent("recovery-throw-script-upgraded");
+
+    // Same superseded-isolate class as a code-update reset — in-process retry
+    // is futile, but the platform re-runs recovery on the new version. It must
+    // re-throw (defer), NOT terminalize via onExhausted.
+    const result = await agent.testRecoveryCallbackError({
+      errorMessage:
+        "This script has been upgraded. Please send a new request to connect to the new version.",
+      maxAttempts: 5
+    });
+
     expect(result.threw).toBe(true);
     expect(result.exhaustedContexts).toBe(0);
     expect(result.terminalBroadcast).toBeUndefined();

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -8420,13 +8420,19 @@ export class Think<
   }
 
   /**
-   * Whether an error is a Durable Object reset caused by a code update
-   * (deploy). Mirrors the private check in the base `Agent`
-   * (`isDurableObjectCodeUpdateReset`): the invocation started on a superseded
-   * isolate, so every op throws for its whole life, but a fresh invocation on
-   * the new code succeeds. `Agent._executeScheduleCallback` re-throws this for
-   * a one-shot row (preserving it for the platform to re-run on the new code),
-   * so a recovery callback must NOT terminalize on it — recovery will re-run.
+   * Whether an error is a transient "superseded isolate" failure — a deploy /
+   * code update replaced the isolate mid-invocation. Mirrors the base `Agent`
+   * check (`isDurableObjectCodeUpdateReset`) and MUST stay in lockstep with it:
+   * the base `_executeScheduleCallback` re-throws this class for a one-shot row
+   * (preserving it so the platform re-runs on the new code), so a recovery
+   * callback must also re-throw — NOT terminalize — since recovery will re-run
+   * and succeed on the fresh isolate. The matched family (kept identical to the
+   * base):
+   *   - "Durable Object reset because its code was updated." (deploy bounce)
+   *   - "This script has been upgraded. Please send a new request to connect to
+   *     the new version." (a stub/connection to a superseded script)
+   * "Network connection lost." is intentionally excluded (a connection error,
+   * not an isolate replacement — see the base helper's note).
    */
   private _isDeployCodeUpdateReset(error: unknown): boolean {
     const message =
@@ -8435,7 +8441,9 @@ export class Think<
         : typeof error === "string"
           ? error
           : "";
-    return /reset because its code was updated/i.test(message);
+    return /reset because its code was updated|script has been upgraded/i.test(
+      message
+    );
   }
 
   /**

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7274,10 +7274,11 @@ export class Think<
   // ── Stability + pending interactions ─────────────────────────────
 
   protected hasPendingInteraction(): boolean {
+    const clientResolvable = this._clientResolvableToolNames();
     return this.messages.some(
       (message) =>
         message.role === "assistant" &&
-        this._messageHasPendingInteraction(message)
+        this._messageHasPendingInteraction(message, clientResolvable)
     );
   }
 
@@ -7346,13 +7347,74 @@ export class Think<
     return result;
   }
 
-  private _messageHasPendingInteraction(message: UIMessage): boolean {
-    return message.parts.some(
-      (part) =>
-        "state" in part &&
-        ((part as Record<string, unknown>).state === "input-available" ||
-          (part as Record<string, unknown>).state === "approval-requested")
+  private _messageHasPendingInteraction(
+    message: UIMessage,
+    clientResolvable: Set<string>
+  ): boolean {
+    return message.parts.some((part) =>
+      this._partAwaitsClientInteraction(part, clientResolvable)
     );
+  }
+
+  /**
+   * Names of the tools whose interrupted `input-available` part can still be
+   * resolved by the CLIENT after a restart — i.e. the client tools (no server
+   * `execute`) from the last request, which the SPA answers by replaying a
+   * `tool-result` over the WebSocket. A server tool is intentionally absent:
+   * its `execute()` promise died with the evicted isolate, so nothing will
+   * ever post its result.
+   */
+  private _clientResolvableToolNames(): Set<string> {
+    const names = new Set<string>();
+    for (const tool of this._lastClientTools ?? []) {
+      if (tool?.name) names.add(tool.name);
+    }
+    return names;
+  }
+
+  /** Extract a tool part's name from its `tool-<name>` / `dynamic-tool` shape. */
+  private _toolPartName(record: Record<string, unknown>): string | undefined {
+    const type = typeof record.type === "string" ? record.type : "";
+    if (type === "dynamic-tool") {
+      return typeof record.toolName === "string" ? record.toolName : undefined;
+    }
+    if (type.startsWith("tool-")) {
+      return type.slice("tool-".length);
+    }
+    return undefined;
+  }
+
+  /**
+   * Whether a part is still awaiting a CLIENT interaction that can genuinely
+   * arrive after a restart, so `waitUntilStable` must keep waiting for it:
+   *  - `approval-requested`: a reconnecting client can replay the approval.
+   *  - `input-available` for a CLIENT tool: the SPA can replay the
+   *    `tool-result` (this is why client-tool recovery works — see the
+   *    `tool-result` handler, which sets `_pendingInteractionPromise`).
+   *
+   * A SERVER tool's `input-available` is deliberately NOT pending. After an
+   * eviction its `execute()` promise is gone and no interaction will ever
+   * resolve it, so treating it as pending wedges `waitUntilStable` forever:
+   * the recovery continuation times out every attempt, burns the attempt
+   * budget on a wait that can never converge, and — if any transient
+   * storage/schedule error throws on the way — the one-shot recovery alarm row
+   * is swallowed and deleted with no terminal `onExhausted` (the half-finished
+   * message wedges silently). Excluding it lets `waitUntilStable` converge so
+   * `continueLastTurn` runs, where the existing transcript-repair pass
+   * (`_repairTranscriptForProvider`) flips the orphan to an errored result and
+   * the model proceeds.
+   */
+  private _partAwaitsClientInteraction(
+    part: UIMessage["parts"][number],
+    clientResolvable: Set<string>
+  ): boolean {
+    if (!("state" in part)) return false;
+    const record = part as Record<string, unknown>;
+    const state = record.state;
+    if (state === "approval-requested") return true;
+    if (state !== "input-available") return false;
+    const toolName = this._toolPartName(record);
+    return toolName != null && clientResolvable.has(toolName);
   }
 
   // ── Chat recovery via fibers ───────────────────────────────────
@@ -7666,6 +7728,20 @@ export class Think<
     } catch (error) {
       console.error("[Think] chatRecovery onExhausted hook threw", error);
     }
+    // Deliver the user-visible terminal banner BEFORE the bookkeeping storage
+    // writes below. A `ctx.storage` write can reject mid-deploy (the exact
+    // window recovery exhausts in), and if it threw before this broadcast the
+    // user would be left staring at a half-finished message with no terminal
+    // resolution. The broadcast itself touches no storage, so ordering it first
+    // makes the banner resilient to a failing `_markRecoveredSubmissionInterrupted`
+    // / `_recordTerminalChatStatus`.
+    this._broadcastChat({
+      type: MSG_CHAT_RESPONSE,
+      id: incident.requestId,
+      body: config.terminalMessage,
+      done: true,
+      error: true
+    });
     // The submission is keyed by the recovery ROOT request id; `incident.requestId`
     // is the latest per-continuation id and won't match a chained submission.
     await this._markRecoveredSubmissionInterrupted(
@@ -7677,13 +7753,6 @@ export class Think<
       incident.requestId,
       config.terminalMessage
     );
-    this._broadcastChat({
-      type: MSG_CHAT_RESPONSE,
-      id: incident.requestId,
-      body: config.terminalMessage,
-      done: true,
-      error: true
-    });
     // The exhausted record is retained for inspection and reclaimed later by
     // the TTL sweep; only successful (completed) incidents are deleted eagerly.
   }
@@ -8205,19 +8274,26 @@ export class Think<
   }
 
   /**
-   * Terminalize a recovery turn that has run out of stable-state-timeout retry
-   * budget — or whose incident record has vanished — by routing through the
-   * SAME `_exhaustChatRecovery` path as deploy-recovery and stall exhaustion
+   * Terminalize a recovery turn that is giving up — whether because the
+   * stable-state-timeout retry budget drained, or because the recovery
+   * continuation threw a non-recoverable error — by routing through the SAME
+   * `_exhaustChatRecovery` path as deploy-recovery and stall exhaustion
    * (#1626/#1631). It fires `onExhausted`, emits `chat:recovery:exhausted`,
    * marks the durable submission interrupted, records the terminal chat status,
-   * and delivers the configured `terminalMessage`.
+   * and delivers the configured `terminalMessage`. `reason` carries the cause
+   * (`stable_timeout` for a budget give-up, `recovery_error` for a thrown
+   * error) through to `onExhausted` / `chat:recovery:exhausted`.
    *
    * This replaces the older give-up that only set the incident to `failed` and
    * completed the recovered submission as `error`, which bypassed
    * `_exhaustChatRecovery` entirely — so an app relying on `onExhausted` for the
    * terminal banner regressed to an eternal spinner when recovery gave up under
-   * extreme churn (the stable-state wait timing out every attempt until the
-   * budget drained). Shared by `_chatRecoveryRetry` and `_chatRecoveryContinue`.
+   * extreme churn. The error path matters just as much: a non-reset throw in a
+   * recovery callback is SWALLOWED by `Agent._executeScheduleCallback` (only a
+   * code-update reset is re-thrown to preserve the one-shot row), so without
+   * routing it here the alarm row is deleted with no terminal UX at all — the
+   * half-finished message wedges silently. Shared by `_chatRecoveryRetry` and
+   * `_chatRecoveryContinue`.
    *
    * Exactly-once terminalization is defended by two independent guards:
    *  1. The `stored?.status === "exhausted"` re-entry guard below — once an
@@ -8238,17 +8314,34 @@ export class Think<
    *  • The record is swept AGAIN between two alarms (guard #1 re-persists on the
    *    first, so this needs a second independent sweep) — vanishingly unlikely.
    */
-  private async _exhaustRecoveryAfterStableTimeout(
+  private async _exhaustRecoveryGiveUp(
     callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
-    data: ChatRecoveryContinueData | ChatRecoveryRetryData | undefined
+    data: ChatRecoveryContinueData | ChatRecoveryRetryData | undefined,
+    reason: string
   ): Promise<void> {
     const config = this._resolveChatRecoveryConfig();
     const incidentKey = data?.incidentId
       ? this._chatRecoveryIncidentKey(data.incidentId)
       : null;
-    const stored = incidentKey
-      ? await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)
-      : null;
+    // The incident read/write below are best-effort: they back the re-entry
+    // guard, not the terminal UX. Under deploy storage stress they can reject,
+    // but terminalization MUST still fire — a failed bookkeeping op here is
+    // exactly what used to drop the turn silently. So tolerate a failed read
+    // (synthesize the incident) and a failed write (accept a possible second
+    // banner) rather than letting either abort `_exhaustChatRecovery`.
+    let stored: ChatRecoveryIncident | null = null;
+    if (incidentKey) {
+      try {
+        stored =
+          (await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)) ??
+          null;
+      } catch (readError) {
+        console.error(
+          "[Think] failed to read recovery incident during give-up; synthesizing",
+          readError
+        );
+      }
+    }
 
     // Re-entry guard #1 (see method doc): a sealed incident means
     // terminalization already happened, so a duplicate stale alarm must not
@@ -8263,10 +8356,8 @@ export class Think<
       stored?.requestId ??
       "";
 
-    // `stable_timeout` distinguishes a give-up driven by repeated stable-state
-    // timeouts from the generic max-attempts / no-progress exhaustion reasons.
     const incident: ChatRecoveryIncident = stored
-      ? { ...stored, status: "exhausted", reason: "stable_timeout" }
+      ? { ...stored, status: "exhausted", reason }
       : {
           // Silent-drop guard: the incident record is gone (no `incidentId`, or
           // it was swept/deleted before this stale alarm fired). Synthesize a
@@ -8283,13 +8374,21 @@ export class Think<
           status: "exhausted",
           firstSeenAt: Date.now(),
           lastAttemptAt: Date.now(),
-          reason: "stable_timeout"
+          reason
         };
 
     // Persist the sealed incident (retained for inspection / TTL sweep) so the
     // re-entry guard above sees `exhausted` if a duplicate stale alarm fires.
+    // Best-effort: a failed persist must not block terminalization below.
     if (incidentKey) {
-      await this.ctx.storage.put(incidentKey, incident);
+      try {
+        await this.ctx.storage.put(incidentKey, incident);
+      } catch (writeError) {
+        console.error(
+          "[Think] failed to persist sealed recovery incident during give-up",
+          writeError
+        );
+      }
     }
 
     const streamId = this._resolveRecoveryStreamId(
@@ -8306,6 +8405,89 @@ export class Think<
       streamId,
       incident.firstSeenAt
     );
+  }
+
+  /**
+   * Give-up after the stable-state-timeout retry budget drained. Thin wrapper
+   * over `_exhaustRecoveryGiveUp` so the give-up cause is recorded as
+   * `stable_timeout`.
+   */
+  private _exhaustRecoveryAfterStableTimeout(
+    callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
+    data: ChatRecoveryContinueData | ChatRecoveryRetryData | undefined
+  ): Promise<void> {
+    return this._exhaustRecoveryGiveUp(callback, data, "stable_timeout");
+  }
+
+  /**
+   * Whether an error is a Durable Object reset caused by a code update
+   * (deploy). Mirrors the private check in the base `Agent`
+   * (`isDurableObjectCodeUpdateReset`): the invocation started on a superseded
+   * isolate, so every op throws for its whole life, but a fresh invocation on
+   * the new code succeeds. `Agent._executeScheduleCallback` re-throws this for
+   * a one-shot row (preserving it for the platform to re-run on the new code),
+   * so a recovery callback must NOT terminalize on it — recovery will re-run.
+   */
+  private _isDeployCodeUpdateReset(error: unknown): boolean {
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : "";
+    return /reset because its code was updated/i.test(message);
+  }
+
+  /**
+   * Handle an error thrown by `_chatRecoveryContinue` / `_chatRecoveryRetry`
+   * after the incident was opened.
+   *
+   * - A deploy code-update reset is re-thrown (after marking the incident
+   *   `failed` for observability) so `Agent._executeScheduleCallback` preserves
+   *   the one-shot alarm row and the platform re-runs recovery on the fresh
+   *   isolate — the turn can still recover, so it must NOT terminalize.
+   * - Any OTHER error is terminalized through the give-up path
+   *   (`onExhausted` + the `terminalMessage` banner) and NOT re-thrown. This is
+   *   the fix for the silent-seal failure mode: `_executeScheduleCallback`
+   *   swallows a non-reset throw and then `alarm()` deletes the one-shot row, so
+   *   without terminalizing here the half-finished turn is dropped with no
+   *   terminal event and no banner (the user stares at a frozen message until
+   *   they send something new).
+   */
+  private async _handleRecoveryCallbackError(
+    callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
+    data: ChatRecoveryContinueData | ChatRecoveryRetryData | undefined,
+    error: unknown
+  ): Promise<void> {
+    if (this._isDeployCodeUpdateReset(error)) {
+      const message = error instanceof Error ? error.message : String(error);
+      await this._updateChatRecoveryIncident(
+        data?.incidentId,
+        "failed",
+        message
+      );
+      if (data?.recoveredRequestId) {
+        await this._completeRecoveredSubmission(
+          data.recoveredRequestId,
+          "error",
+          null,
+          message
+        );
+      }
+      throw error;
+    }
+    // Preserve the underlying error for operators — the give-up path records
+    // only the `recovery_error` category on the incident / `onExhausted` ctx,
+    // so without this log the actual cause (e.g. a transient storage reject)
+    // would be lost. Mirrors `Agent._executeScheduleCallback`'s own logging.
+    console.error(
+      `[Think] ${callback} threw during recovery; terminalizing instead of leaving the turn wedged`,
+      error
+    );
+    // `_exhaustRecoveryGiveUp` marks the submission interrupted + records the
+    // terminal chat status itself (via `_exhaustChatRecovery`), so it fully
+    // replaces the old mark-failed + complete-as-error bookkeeping here.
+    await this._exhaustRecoveryGiveUp(callback, data, "recovery_error");
   }
 
   async _chatRecoveryRetry(data?: ChatRecoveryRetryData): Promise<void> {
@@ -8428,20 +8610,11 @@ export class Think<
         );
       }
     } catch (error) {
-      await this._updateChatRecoveryIncident(
-        data?.incidentId,
-        "failed",
-        error instanceof Error ? error.message : String(error)
+      await this._handleRecoveryCallbackError(
+        "_chatRecoveryRetry",
+        data,
+        error
       );
-      if (data?.recoveredRequestId) {
-        await this._completeRecoveredSubmission(
-          data.recoveredRequestId,
-          "error",
-          null,
-          error instanceof Error ? error.message : String(error)
-        );
-      }
-      throw error;
     } finally {
       this._activeChatRecoveryRootRequestId = previousRootRequestId;
       if (recoveredSubmission) {
@@ -8656,20 +8829,11 @@ export class Think<
         );
       }
     } catch (error) {
-      await this._updateChatRecoveryIncident(
-        data?.incidentId,
-        "failed",
-        error instanceof Error ? error.message : String(error)
+      await this._handleRecoveryCallbackError(
+        "_chatRecoveryContinue",
+        data,
+        error
       );
-      if (data?.recoveredRequestId) {
-        await this._completeRecoveredSubmission(
-          data.recoveredRequestId,
-          "error",
-          null,
-          error instanceof Error ? error.message : String(error)
-        );
-      }
-      throw error;
     } finally {
       this._activeChatRecoveryRootRequestId = previousRootRequestId;
       if (recoveredSubmission) {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -8432,7 +8432,9 @@ export class Think<
    *   - "This script has been upgraded. Please send a new request to connect to
    *     the new version." (a stub/connection to a superseded script)
    * "Network connection lost." is intentionally excluded (a connection error,
-   * not an isolate replacement — see the base helper's note).
+   * not an isolate replacement — see the base helper's note). The match stays
+   * close to the verbatim platform strings so an ordinary error mentioning
+   * those words isn't misclassified as a supersede.
    */
   private _isDeployCodeUpdateReset(error: unknown): boolean {
     const message =
@@ -8441,7 +8443,7 @@ export class Think<
         : typeof error === "string"
           ? error
           : "";
-    return /reset because its code was updated|script has been upgraded/i.test(
+    return /reset because its code was updated|this script has been upgraded/i.test(
       message
     );
   }


### PR DESCRIPTION
## Summary

Three chat-recovery / durable-execution failures that could leave a turn **wedged at a half-finished assistant message after a deploy/eviction, with no terminal banner** — the turn never recovers and never terminalizes until something unrelated wakes the Durable Object. All three were reproduced from production incidents on a server-tool-heavy app (a preview tool whose `execute()` bridges to the SPA over HTTP and parks awaiting external I/O).

1. **Server-tool recovery deadlock** — recovery can never converge for a server tool interrupted mid-`execute()`. *(think)*
2. **Silent seal on a thrown recovery callback** — a non-reset throw in the recovery continuation is swallowed and the alarm row deleted, so no `onExhausted` / banner ever fires. *(think)*
3. **One-shot alarm killed by a `"script upgraded"` supersede is not re-run** — only `"reset because its code was updated"` was recognized as a deferrable platform kill, so the sibling supersede message orphaned the work with no driver. *(agents core + think)*

This is a follow-up in the same `#1649` / `#1651` / `#1657` recovery-hardening line; it targets the **server-tool + deploy-recovery** half of the "interrupted tool" symptom (whereas #1657 fixed the **client-tool + normal/auto-continuation** half). See "Relationship to #1657" below.

---

## Bug 1 — server-tool recovery deadlock

### Repro
1. App registers a **server-side** tool whose `execute()` awaits external I/O (e.g. a long-poll bridge: the SPA fetches the tool input and posts the result back over HTTP; the in-flight promise lives only in DO memory).
2. Model calls the tool; the `tool-input-available` chunk is flushed durably.
3. Worker is redeployed while `execute()` is parked. The DO is evicted; the in-memory promise is gone.
4. On restart, `_handleInternalFiberRecovery` persists the orphaned partial (the resumable stream is restored from SQLite, so `streamStillActive` is true → `_persistOrphanedStream` runs), landing a new assistant message with the tool part at `state: "input-available"`.
5. Recovery schedules `_chatRecoveryContinue`, which calls `waitUntilStable` **before** `continueLastTurn`. `hasPendingInteraction()` returns `true` because of the `input-available` part — but **nothing will ever resolve it**: there is no client `tool-result` for a server tool, no in-memory `_pendingInteractionPromise` (it died with the isolate), and `_repairToolTranscriptParts` (which would flip it to an errored result) only runs **inside** `_runInferenceLoop`, i.e. downstream of the very gate that won't converge.
6. `waitUntilStable` times out every attempt; the continuation reschedules until the budget drains (pure waste — the wait can never converge).

`hasPendingInteraction` can't tell "a client is about to post a result over WS" from "a server tool's `execute()` promise died with the DO". For a server tool the second case is permanent.

### Fix
Narrow the recovery stability predicate. An `input-available` part is now only "pending" when it is genuinely **client-resolvable**:
- `approval-requested` — a reconnecting client can replay the approval; **or**
- `input-available` for a **client** tool (its name is in the last request's client-tool set) — the SPA can replay the `tool-result`.

A **server** tool's `input-available` is no longer treated as pending. `waitUntilStable` converges, `continueLastTurn` runs, and the existing transcript-repair pass flips the orphan to `output-error` so the model continues with an errored tool result.

**Why client-tool recovery is preserved:** client tools are persisted to config at *request acceptance* (`_persistClientTools`, before any tool streams) and restored in `onStart` (`_restoreClientTools`), which `alarm()` awaits before dispatching the recovery callback. So `_lastClientTools` is always populated during the wait and a client-tool orphan is correctly kept "pending". `waitUntilStable` / `hasPendingInteraction` are **recovery-only** (their sole callers are `_chatRecoveryContinue` / `_chatRecoveryRetry`), so the change is tightly scoped and can't affect a normal turn.

---

## Bug 2 — silent seal on a thrown recovery callback

### Root cause
`onExhausted` only fired on the clean budget-exhaustion branch. Any error thrown by `_chatRecoveryContinue` / `_chatRecoveryRetry` after the incident was opened was marked `failed` and **re-thrown**. `Agent._executeScheduleCallback` re-throws only a Durable Object **code-update reset** (to preserve the one-shot row for re-run on the fresh isolate); it **swallows any other error** and returns normally, after which `alarm()` deletes the one-shot row. Net: the turn is sealed with **no `onExhausted` event and no terminal banner** — the half-finished message wedges silently until the user sends something new. (This matched the production trace: "recovery alarm threw, no terminal event, message frozen ~6 min until the user typed again".)

### Fix
Route a non-reset throw through the **same exhaustion path** as a budget give-up (`_exhaustRecoveryGiveUp`, reason `recovery_error`) so `onExhausted` fires and the configured `terminalMessage` banner is delivered, then return **without** re-throwing. A genuine code-update / supersede reset is still re-thrown so the platform re-runs recovery on the fresh isolate (see Bug 3). The underlying error is logged for operators (the give-up records only the `recovery_error` category).

### Hardening (closes the original telemetry observation)
- `_exhaustChatRecovery` now broadcasts the terminal banner **before** its bookkeeping storage writes (`_markRecoveredSubmissionInterrupted` / `_recordTerminalChatStatus`), so a failing write can't suppress the user-visible terminalization.
- `_exhaustRecoveryGiveUp`'s incident read/write are **best-effort** (try/catch): a storage failure during give-up degrades to "maybe a second banner" rather than "silently drop the turn".

---

## Bug 3 — one-shot alarm killed by a `"script upgraded"` supersede is not re-run

### Root cause
The deploy-survival mechanism hinges on one matcher. `Agent._executeScheduleCallback` only **defers** (re-throws → preserves the one-shot row → the platform re-runs it on the fresh isolate under the at-least-once alarm guarantee) when the error matches `isDurableObjectCodeUpdateReset`, whose regex was `/reset because its code was updated/i`. The platform surfaces the **same** superseded-isolate failure class as a *second* message — `"This script has been upgraded. Please send a new request to connect to the new version."` (a stub/connection to a superseded script) — which fell through to the **swallow-and-delete** branch.

For a `submitMessages` turn, the driver is a one-shot drain alarm (`_scheduleSubmissionDrain` → `this.schedule(0, "_drainThinkSubmissions", …)`). When it dies with `"script upgraded"`, the row is deleted and the submission is left with **no driver**: no alarm, and inbound reconnects are canceled during the bounce, so `onStart` (which would run `_recoverSubmissionsOnStart` → `_startSubmissionDrain` to re-drive it) never fires. The turn sits orphaned for minutes until something unrelated wakes the DO — an indefinite user-facing spinner with no terminal event. A normal deploy bounce surfaces as `"reset because its code was updated"` and **recovers**, which is exactly why the two looked inconsistent in the field.

### Fix
Broaden the superseded-isolate matcher to recognize **both** messages, so either causes the one-shot row to be preserved and re-run on the fresh isolate. Applied in lockstep to:
- **`isDurableObjectCodeUpdateReset`** in the base `Agent` scheduler (`packages/agents/src/index.ts`) — the primary path (the submission drain / recovery one-shot alarm). This also benefits `@cloudflare/ai-chat`, which shares the scheduler.
- **`_isDeployCodeUpdateReset`** in `Think` — so a supersede thrown *inside* a `_chatRecoveryContinue` / `_chatRecoveryRetry` callback re-throws (defers + re-runs) instead of terminalizing via `onExhausted` (correcting Bug 2's classification for this class).

`"Network connection lost."` is **deliberately not** treated as a supersede: it is a connection error that may succeed on in-process retry (gated by the CF `retryable` property via `isErrorRetryable`), not an isolate replacement, so it stays on the normal retry path.

---

## Relationship to #1657 (complementary, not overlapping)

Both fix the **same customer-facing symptom** — the default repair message `"The tool call was interrupted before a result was recorded."` — and both live in `packages/think/src/think.ts` around the `_pendingInteractionPromise` continuation barrier, but they address **different root causes** in **non-overlapping code**:

- **#1657** (merged): **client tools** in the **normal / auto-continuation** path — (a) parallel applies clobbering each other (`_enqueueInteractionApply` serialization) and (b) a mid-stream client result dropped before persist (`_streamingAssistant`). It makes the client result **land** so the repair backstop doesn't spuriously error it.
- **This PR**: **server tools** after **deploy/eviction** in the **chat-recovery** path — the orphan deadlocks `waitUntilStable`, a thrown recovery callback seals silently, and a `"script upgraded"` kill orphans the drain alarm.

They reinforce each other: #1657 reduces spurious client-tool `input-available` orphans; this PR ensures a genuinely-dead server orphan no longer wedges recovery. Rebased cleanly on top of #1657.

---

## Tests

- **think — predicate** (`waitUntilStable` suite): a client-tool `input-available` orphan stays pending (SPA can replay); an `approval-requested` orphan stays pending; a **server-tool** `input-available` orphan does **not** block stability and `waitUntilStable` returns `true`.
- **think — throw handling**: a non-reset throw in a recovery callback terminalizes (fires `onExhausted` with reason `recovery_error`, delivers the banner, seals the incident `exhausted`) and does **not** re-throw; a code-update reset **and** a `"script has been upgraded"` supersede each re-throw (defer + re-run) and do **not** terminalize.
- **agents — scheduler** (`schedule.test.ts`): a one-shot callback throwing `"reset because its code was updated"` or `"This script has been upgraded…"` **preserves** the row and rejects `alarm()` (deferred); an ordinary error and `"Network connection lost."` **swallow + delete** the row.

## Verification

- `tsc --noEmit` for `agents` and `think` — clean
- `oxlint` (`agents` + `think` src) — 0 warnings / 0 errors; `oxfmt` — clean
- **`agents` — 1295 passed** (full workers suite); **`@cloudflare/think` — 493 passed**

## Changeset

`patch` for `agents` (Bug 3 scheduler fix) and `@cloudflare/think` (Bugs 1 & 2).

## Behavior note

A thrown recovery callback now emits `chat:recovery:exhausted` (reason `recovery_error`) instead of `chat:recovery:failed`, and the recovered submission's `error_message` is the configured `terminalMessage` (the raw error is logged). For observability bridges keyed on `chat:recovery:*` this is more accurate (the turn is terminalized, not left ambiguously failed).

## Follow-ups (out of scope)

- Mirror Bugs 1 & 2 into `@cloudflare/ai-chat` (duplicated recovery layer); note ai-chat has **no** transcript-repair pass, so Bug 1 there needs the predicate change *plus* a repair step. (Bug 3's base-scheduler fix already covers ai-chat.)
- Optional: surface the underlying error on `ChatRecoveryExhaustedContext` (additive API) if observability bridges want the cause string, not just the `recovery_error` category.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
