### PR TITLE
fix(agents,think,ai-chat): enforce object-shaped tool_use.input to stop silent session wedge

### DIFF
--- a/.changeset/ai-chat-heal-tool-input-on-load.md
+++ b/.changeset/ai-chat-heal-tool-input-on-load.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/ai-chat": patch
+---
+
+Heal a malformed `tool_use.input` when loading persisted messages.
+
+`AIChatAgent` delegates `convertToModelMessages` to your `onChatMessage`, so it has no framework-side pre-send pass to repair a transcript. A session that persisted a non-object tool `input` — `null`, `undefined`, `""`, an array, or a raw string — before the write-side guard shipped would therefore keep 400ing with `tool_use.input: Input should be an object` on every turn, wedged across reconnects/redeploys/evictions.
+
+`autoTransformMessage` (run on every load) now normalizes malformed tool inputs to `{}` (parsing stringified-JSON objects, and leaving healthy object inputs untouched), so existing wedged sessions self-heal on their next load without per-DO storage surgery. Healthy messages are returned by reference, so the persistence cache stays a no-op for them.

--- a/.changeset/normalize-tool-use-input.md
+++ b/.changeset/normalize-tool-use-input.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+---
+
+Enforce the `tool_use.input` invariant at the chat write boundary.
+
+A streamed tool call that finishes with no `input_json_delta` events (the model called the tool with no args), or whose input surfaces as a stringified JSON blob, could persist a non-object `input` — `null`, `undefined`, `""`, an array, or a raw string. The Anthropic Messages API requires `tool_use.input` to be a JSON object and rejects every subsequent turn with `tool_use.input: Input should be an object` (verified against the live API: `{}` → 200, but `""`, `[]`, and `[{...}]` all → 400). Because the bad shape lives in durable storage, the session is wedged across reconnects, redeploys, and DO evictions.
+
+`applyChunkToParts` (the shared accumulator used by `@cloudflare/ai-chat` and `@cloudflare/think`) now normalizes the finalized tool `input` on `tool-input-available` / `tool-input-error`: a plain object passes through untouched, a stringified-JSON object is parsed, and everything else (`null`/`undefined`/`""`/arrays/primitives/unparseable strings) collapses to `{}`. A new `normalizeToolInput` helper is exported from `agents/chat` so read-side transcript repair can enforce the same invariant.

--- a/.changeset/repair-malformed-tool-input.md
+++ b/.changeset/repair-malformed-tool-input.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/think": patch
+---
+
+Unwedge sessions corrupted by a malformed `tool_use.input`, and make the failure observable.
+
+1. **Read-side repair gap.** Transcript repair already normalized a `null`/`undefined`/stringified-JSON tool input, but left an empty string `""`, an array, and other non-object primitives untouched — so a session that persisted one of those shapes before the write-side guard shipped kept 400ing forever with `tool_use.input: Input should be an object` (Anthropic rejects array inputs the same way it rejects `""`/`null`). `_normalizeToolInput` now delegates to the shared `normalizeToolInput`, collapsing any non-object input to `{}` so the pre-send repair pass rescues the session on its next turn.
+
+2. **Observability.** An AI-SDK provider error surfaces as a stream error part, not a thrown exception, so it took the in-band `error` branch that emitted `message:error` but never `chat:request:failed`. That branch now also emits `chat:request:failed` (`stage: "stream"`), so observers and turn-count telemetry see the post-`beforeTurn`, in-stream failure class without needing to know whether the error threw or arrived as a chunk.

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -1,6 +1,7 @@
 export {
   applyChunkToParts,
   isReplayChunk,
+  normalizeToolInput,
   type MessageParts,
   type MessagePart,
   type StreamChunkData

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -56,6 +56,46 @@ export type StreamChunkData = {
   [key: string]: unknown;
 };
 
+/** Whether a value is a plain (non-array, non-null) object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Coerce a tool part's `input` into a provider-acceptable object.
+ *
+ * The Anthropic Messages API requires `tool_use.input` to be a JSON **object** —
+ * `null`, `undefined`, `""`, a raw string, **or an array** are all rejected with
+ * `tool_use.input: Input should be an object` (verified empirically against the
+ * live API: `{}` → 200, but `""`, `[]`, and `[{...}]` all → 400). A streamed
+ * tool call that finishes with no `input_json_delta` events (the model called
+ * the tool with no args), or whose input surfaces as a stringified JSON blob,
+ * can persist one of these shapes — and because it lives in durable storage, the
+ * session is then wedged across reconnects, redeploys, and DO evictions.
+ * Enforcing the invariant at the write boundary (and as a read-side repair
+ * backstop) keeps the transcript valid.
+ *
+ * - A plain (non-array) object is returned untouched (`changed: false`).
+ * - A string that parses to a plain object is parsed.
+ * - Everything else (`null`, `undefined`, `""`, arrays, primitives, non-object
+ *   or unparseable JSON) collapses to `{}`.
+ */
+export function normalizeToolInput(raw: unknown): {
+  input: unknown;
+  changed: boolean;
+} {
+  if (isPlainObject(raw)) return { input: raw, changed: false };
+  if (typeof raw === "string" && raw.trim().startsWith("{")) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (isPlainObject(parsed)) return { input: parsed, changed: true };
+    } catch {
+      // Unparseable / partial JSON — fall through to the empty-object default.
+    }
+  }
+  return { input: {}, changed: true };
+}
+
 /**
  * Applies a stream chunk to a mutable parts array, building up the message
  * incrementally. Returns true if the chunk was handled, false if it was
@@ -242,7 +282,7 @@ export function applyChunkToParts(
         // resolved input/output. See the comment on tool-input-start.
         if (p.state === "input-streaming") {
           p.state = "input-available";
-          p.input = chunk.input;
+          p.input = normalizeToolInput(chunk.input).input;
           if (chunk.providerExecuted != null) {
             p.providerExecuted = chunk.providerExecuted;
           }
@@ -260,7 +300,7 @@ export function applyChunkToParts(
         toolCallId: chunk.toolCallId,
         toolName: chunk.toolName,
         state: "input-available",
-        input: chunk.input,
+        input: normalizeToolInput(chunk.input).input,
         ...(chunk.providerExecuted != null
           ? { providerExecuted: chunk.providerExecuted }
           : {}),
@@ -289,7 +329,7 @@ export function applyChunkToParts(
         }
         p.state = "output-error";
         p.errorText = chunk.errorText;
-        p.input = chunk.input;
+        p.input = normalizeToolInput(chunk.input).input;
         if (chunk.providerExecuted != null) {
           p.providerExecuted = chunk.providerExecuted;
         }
@@ -302,7 +342,7 @@ export function applyChunkToParts(
           toolCallId: chunk.toolCallId,
           toolName: chunk.toolName,
           state: "output-error",
-          input: chunk.input,
+          input: normalizeToolInput(chunk.input).input,
           errorText: chunk.errorText,
           ...(chunk.providerExecuted != null
             ? { providerExecuted: chunk.providerExecuted }

--- a/packages/ai-chat/src/ai-chat-v5-migration.ts
+++ b/packages/ai-chat/src/ai-chat-v5-migration.ts
@@ -1,9 +1,45 @@
 import type { UIMessage } from "ai";
+import { normalizeToolInput } from "agents/chat";
 
 /**
  * AI SDK v5 Migration following https://jhak.im/blog/ai-sdk-migration-handling-previously-saved-messages
  * Using exact types from the official AI SDK documentation
  */
+
+/**
+ * Heal tool parts whose persisted `input` is not a provider-acceptable object.
+ *
+ * The write boundary (`applyChunkToParts`) now coerces malformed input to `{}`,
+ * but sessions corrupted before that guard shipped still carry a `null`,
+ * `undefined`, `""`, array, or stringified-JSON `input` in storage. Because
+ * the Anthropic Messages API rejects a `tool_use` block whose `input` is not an
+ * object, such a session 400s on every later turn and stays wedged across
+ * reconnects/redeploys/evictions. Repairing on load (where there's no
+ * framework-side `convertToModelMessages` to hook) unwedges them without
+ * per-DO storage surgery. Only malformed inputs are touched; a healthy message
+ * is returned by reference so the persistence cache stays a no-op.
+ */
+function normalizeToolPartInputs(message: UIMessage): UIMessage {
+  const parts = message.parts;
+  const isMalformedToolPart = (part: unknown): boolean => {
+    const record = part as Record<string, unknown>;
+    const type = typeof record.type === "string" ? record.type : "";
+    if (!(type.startsWith("tool-") || type === "dynamic-tool")) return false;
+    return "input" in record && normalizeToolInput(record.input).changed;
+  };
+
+  if (!parts.some(isMalformedToolPart)) return message;
+
+  const nextParts = parts.map((part) => {
+    if (!isMalformedToolPart(part)) return part;
+    const record = part as Record<string, unknown>;
+    return {
+      ...record,
+      input: normalizeToolInput(record.input).input
+    } as UIMessage["parts"][number];
+  });
+  return { ...message, parts: nextParts };
+}
 
 /**
  * One-shot deprecation warnings (warns once per key per session).
@@ -184,7 +220,7 @@ export function autoTransformMessage(
 ): UIMessage {
   // Already in v5 format
   if (isUIMessage(message)) {
-    return message;
+    return normalizeToolPartInputs(message);
   }
 
   const parts: TransformMessagePart[] = [];
@@ -268,14 +304,14 @@ export function autoTransformMessage(
     });
   }
 
-  return {
+  return normalizeToolPartInputs({
     id: message.id || `msg-${index}`,
     role:
       message.role === "data"
         ? "system"
         : (message.role as "user" | "assistant" | "system") || "user",
     parts: parts as UIMessage["parts"]
-  };
+  });
 }
 
 /**

--- a/packages/ai-chat/src/ai-chat-v5-migration.ts
+++ b/packages/ai-chat/src/ai-chat-v5-migration.ts
@@ -18,6 +18,11 @@ import { normalizeToolInput } from "agents/chat";
  * framework-side `convertToModelMessages` to hook) unwedges them without
  * per-DO storage surgery. Only malformed inputs are touched; a healthy message
  * is returned by reference so the persistence cache stays a no-op.
+ *
+ * An absent `input` key is treated as `undefined` (→ `{}`): a JSON round-trip of
+ * `input: undefined` drops the key entirely (e.g. a tool call interrupted at the
+ * `tool-input-start` stage), so the missing-key case must coerce too. Mirrors
+ * the read-side repair in `@cloudflare/think`.
  */
 function normalizeToolPartInputs(message: UIMessage): UIMessage {
   const parts = message.parts;
@@ -25,7 +30,7 @@ function normalizeToolPartInputs(message: UIMessage): UIMessage {
     const record = part as Record<string, unknown>;
     const type = typeof record.type === "string" ? record.type : "";
     if (!(type.startsWith("tool-") || type === "dynamic-tool")) return false;
-    return "input" in record && normalizeToolInput(record.input).changed;
+    return normalizeToolInput(record.input).changed;
   };
 
   if (!parts.some(isMalformedToolPart)) return message;

--- a/packages/ai-chat/src/tests/message-builder.test.ts
+++ b/packages/ai-chat/src/tests/message-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   applyChunkToParts,
   isReplayChunk,
+  normalizeToolInput,
   type MessageParts,
   type StreamChunkData
 } from "agents/chat";
@@ -266,6 +267,109 @@ describe("applyChunkToParts", () => {
         output: "result"
       });
       expect(parts.length).toBe(0); // Nothing added
+    });
+  });
+
+  describe("tool-input normalization (provider 400 guard)", () => {
+    // A streamed tool call that finishes with no `input_json_delta` events
+    // (model called the tool with no args) can otherwise persist a non-object
+    // `input`, which 400s every later turn with
+    // `tool_use.input: Input should be an object` and wedges the session.
+    const malformed: Array<[string, unknown]> = [
+      ["null", null],
+      ["undefined", undefined],
+      ["empty string", ""],
+      ["array", [{ id: 1 }, { id: 2 }]],
+      ["empty array", []],
+      ["number", 42],
+      ["boolean", true],
+      ["non-object JSON string", "hello"]
+    ];
+
+    for (const [label, value] of malformed) {
+      it(`coerces ${label} input to {} on tool-input-available (new part)`, () => {
+        const parts = makeParts();
+        applyChunkToParts(parts, {
+          type: "tool-input-available",
+          toolCallId: "call_1",
+          toolName: "doThing",
+          input: value
+        });
+        expect((parts[0] as Record<string, unknown>).input).toEqual({});
+      });
+
+      it(`coerces ${label} input to {} on tool-input-available (finalize streaming part)`, () => {
+        const parts = makeParts();
+        applyChunkToParts(parts, {
+          type: "tool-input-start",
+          toolCallId: "call_1",
+          toolName: "doThing"
+        });
+        applyChunkToParts(parts, {
+          type: "tool-input-available",
+          toolCallId: "call_1",
+          toolName: "doThing",
+          input: value
+        });
+        expect((parts[0] as Record<string, unknown>).input).toEqual({});
+      });
+
+      it(`coerces ${label} input to {} on tool-input-error (new part)`, () => {
+        const parts = makeParts();
+        applyChunkToParts(parts, {
+          type: "tool-input-error",
+          toolCallId: "call_1",
+          toolName: "doThing",
+          input: value,
+          errorText: "boom"
+        });
+        const part = parts[0] as Record<string, unknown>;
+        expect(part.input).toEqual({});
+        expect(part.state).toBe("output-error");
+      });
+
+      it(`coerces ${label} input to {} on tool-input-error (finalize streaming part)`, () => {
+        const parts = makeParts();
+        applyChunkToParts(parts, {
+          type: "tool-input-start",
+          toolCallId: "call_1",
+          toolName: "doThing"
+        });
+        applyChunkToParts(parts, {
+          type: "tool-input-error",
+          toolCallId: "call_1",
+          toolName: "doThing",
+          input: value,
+          errorText: "boom"
+        });
+        const part = parts[0] as Record<string, unknown>;
+        expect(part.input).toEqual({});
+        expect(part.state).toBe("output-error");
+      });
+    }
+
+    it("leaves a valid object input untouched", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "doThing",
+        input: { a: 1 }
+      });
+      expect((parts[0] as Record<string, unknown>).input).toEqual({ a: 1 });
+    });
+
+    it("parses a stringified-JSON object input", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "doThing",
+        input: '{"prompt":"a cat"}'
+      });
+      expect((parts[0] as Record<string, unknown>).input).toEqual({
+        prompt: "a cat"
+      });
     });
   });
 
@@ -1383,5 +1487,37 @@ describe("applyChunkToParts", () => {
         })
       ).toBe(false);
     });
+  });
+});
+
+describe("normalizeToolInput", () => {
+  it("returns a plain object untouched and unchanged", () => {
+    const input = { city: "London" };
+    const result = normalizeToolInput(input);
+    expect(result.input).toBe(input);
+    expect(result.changed).toBe(false);
+  });
+
+  it("parses a stringified-JSON object", () => {
+    const result = normalizeToolInput('{"prompt":"a cat"}');
+    expect(result.input).toEqual({ prompt: "a cat" });
+    expect(result.changed).toBe(true);
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+    ["array", [{ id: 1 }]],
+    ["empty array", []],
+    ["stringified array", "[1,2]"],
+    ["number", 42],
+    ["boolean", true],
+    ["non-JSON string", "hello"],
+    ["unparseable JSON", '{"a":']
+  ])("coerces %s to {} (changed)", (_label, value) => {
+    const result = normalizeToolInput(value);
+    expect(result.input).toEqual({});
+    expect(result.changed).toBe(true);
   });
 });

--- a/packages/ai-chat/src/tests/migration.test.ts
+++ b/packages/ai-chat/src/tests/migration.test.ts
@@ -49,6 +49,70 @@ describe("AI SDK v5 Migration", () => {
       expect(autoTransformMessage(msg)).toBe(msg);
     });
 
+    it("heals a malformed tool_use.input on an already-v5 message", () => {
+      const cases: Array<[string, unknown]> = [
+        ["empty string", ""],
+        ["null", null],
+        ["array", [{ id: 1 }]],
+        ["number", 7]
+      ];
+      for (const [label, badInput] of cases) {
+        const result = autoTransformMessage({
+          id: `tool-bad-${label}`,
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-doThing",
+              toolCallId: "call_1",
+              state: "output-available",
+              input: badInput,
+              output: { ok: true }
+            }
+          ]
+        } as unknown as UIMessage);
+        const part = result.parts[0] as Record<string, unknown>;
+        expect(part.input).toEqual({});
+        // Other fields are preserved.
+        expect(part.state).toBe("output-available");
+        expect(part.output).toEqual({ ok: true });
+      }
+    });
+
+    it("parses a stringified-JSON tool input on an already-v5 message", () => {
+      const result = autoTransformMessage({
+        id: "tool-str",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-doThing",
+            toolCallId: "call_1",
+            state: "input-available",
+            input: '{"prompt":"a cat"}'
+          }
+        ]
+      } as unknown as UIMessage);
+      expect((result.parts[0] as Record<string, unknown>).input).toEqual({
+        prompt: "a cat"
+      });
+    });
+
+    it("leaves a healthy v5 tool message untouched (same reference)", () => {
+      const msg = {
+        id: "tool-ok",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-doThing",
+            toolCallId: "call_1",
+            state: "output-available",
+            input: { a: 1 },
+            output: "done"
+          }
+        ]
+      } as unknown as UIMessage;
+      expect(autoTransformMessage(msg)).toBe(msg);
+    });
+
     it("transforms legacy string content to text part", () => {
       const result = autoTransformMessage({
         id: "legacy-1",

--- a/packages/ai-chat/src/tests/migration.test.ts
+++ b/packages/ai-chat/src/tests/migration.test.ts
@@ -78,6 +78,28 @@ describe("AI SDK v5 Migration", () => {
       }
     });
 
+    it("heals a tool part with an absent input key (undefined dropped on serialize)", () => {
+      // A JSON round-trip of `input: undefined` drops the key entirely (e.g. a
+      // tool call interrupted at tool-input-start). The repair must still coerce.
+      const result = autoTransformMessage({
+        id: "tool-no-input",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-doThing",
+            toolCallId: "call_1",
+            state: "output-available",
+            output: { ok: true }
+            // note: no `input` key at all
+          }
+        ]
+      } as unknown as UIMessage);
+      const part = result.parts[0] as Record<string, unknown>;
+      expect(part.input).toEqual({});
+      expect(part.state).toBe("output-available");
+      expect(part.output).toEqual({ ok: true });
+    });
+
     it("parses a stringified-JSON tool input on an already-v5 message", () => {
       const result = autoTransformMessage({
         id: "tool-str",

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -2582,3 +2582,60 @@ describe("repairInterruptedToolPart override (#1631)", () => {
     expect(part.state).toBe("output-available");
   });
 });
+
+describe("malformed tool_use.input repair (provider 400 wedge)", () => {
+  // A settled tool call whose `input` is a non-object 400s every later turn
+  // with `tool_use.input: Input should be an object`. Read-side repair must
+  // unwedge sessions corrupted before the write-side guard shipped.
+  it.each([
+    ["empty string", ""],
+    ["null", null],
+    ["array", [{ id: 1 }]],
+    ["number", 7]
+  ])("normalizes settled tool input %s to {}", async (_label, value) => {
+    const agent = await freshAgent();
+    const messages = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-doThing",
+            toolCallId: "tc1",
+            state: "output-available",
+            input: value,
+            output: { ok: true }
+          }
+        ]
+      }
+    ] as unknown as UIMessage[];
+
+    const repaired = await agent.repairToolTranscriptPartsForTest(messages);
+    const part = (repaired[0] as UIMessage).parts[0] as Record<string, unknown>;
+    expect(part.input).toEqual({});
+    expect(part.state).toBe("output-available");
+  });
+
+  it("parses a stringified-JSON object input", async () => {
+    const agent = await freshAgent();
+    const messages = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-doThing",
+            toolCallId: "tc1",
+            state: "output-available",
+            input: '{"prompt":"a cat"}',
+            output: { ok: true }
+          }
+        ]
+      }
+    ] as unknown as UIMessage[];
+
+    const repaired = await agent.repairToolTranscriptPartsForTest(messages);
+    const part = (repaired[0] as UIMessage).parts[0] as Record<string, unknown>;
+    expect(part.input).toEqual({ prompt: "a cat" });
+  });
+});

--- a/packages/think/src/tests/message-reconciliation.test.ts
+++ b/packages/think/src/tests/message-reconciliation.test.ts
@@ -346,7 +346,11 @@ describe("Think — message reconciliation on incoming submits", () => {
     ws.close(1000);
   });
 
-  it("parses a stringified ARRAY tool input back into structured form", async () => {
+  it("coerces an array tool input to {} (Anthropic rejects non-object input)", async () => {
+    // Verified against the live Anthropic Messages API: a `tool_use` block whose
+    // `input` is an array (or a string that parses to one) 400s with
+    // `tool_use.input: Input should be an object`, exactly like ""/null. So an
+    // array input must be coerced to {} on the read path, not preserved.
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);
     const ws = await connectWS(room);
@@ -381,7 +385,7 @@ describe("Think — message reconciliation on incoming submits", () => {
     const toolPart = repaired!.parts.find(
       (part) => (part as Record<string, unknown>).toolCallId === TOOL_CALL_ID
     ) as Record<string, unknown> | undefined;
-    expect(toolPart?.input).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(toolPart?.input).toEqual({});
 
     ws.close(1000);
   });

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -458,6 +458,68 @@ describe("Think — error handling", () => {
     );
   });
 
+  it("bridges an in-band stream error to chat:request:failed", async () => {
+    // An AI-SDK error arrives as a stream error part, not a thrown exception,
+    // so it takes the `action.type === "error"` branch. That branch must still
+    // emit chat:request:failed so observability/turn-count telemetry sees it.
+    const agent = await freshAgent(`inband-failed-${crypto.randomUUID()}`);
+    const events: Array<{ type: string; payload: { stage?: string } }> = [];
+    const unsubscribe = subscribe("chat", (event) => {
+      if (event.type === "chat:request:failed") {
+        events.push(event);
+      }
+    });
+
+    try {
+      await agent.runInBandStreamErrorForTest("In-band failed event");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "chat:request:failed",
+        payload: expect.objectContaining({
+          stage: "stream",
+          messagesPersisted: true,
+          error: "In-band failed event"
+        })
+      })
+    );
+  });
+
+  it("bridges an in-band stream error to chat:request:failed on the RPC path", async () => {
+    // The programmatic chat() RPC path streams through
+    // `_streamResultToRpcCallback`, a separate error-chunk branch from the WS
+    // path above — it must emit chat:request:failed too.
+    const agent = await freshAgent(`rpc-inband-failed-${crypto.randomUUID()}`);
+    const events: Array<{ type: string; payload: { stage?: string } }> = [];
+    const unsubscribe = subscribe("chat", (event) => {
+      if (event.type === "chat:request:failed") {
+        events.push(event);
+      }
+    });
+
+    try {
+      await agent.setInBandErrorResponse("RPC failed event");
+      const result = await agent.testChat("trigger rpc in-band error");
+      expect(result.error).toContain("RPC failed event");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "chat:request:failed",
+        payload: expect.objectContaining({
+          stage: "stream",
+          messagesPersisted: true,
+          error: "RPC failed event"
+        })
+      })
+    );
+  });
+
   it("aborts a stalled stream via the inactivity watchdog instead of hanging forever", async () => {
     const agent = await freshAgent(`stall-${crypto.randomUUID()}`);
     const stalled: Array<{ requestId?: string; timeoutMs?: number }> = [];

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -146,6 +146,7 @@ import {
   toolApprovalUpdate,
   parseProtocolMessage,
   applyChunkToParts,
+  normalizeToolInput,
   reconcileMessages,
   resolveToolMergeId,
   createChatFiberSnapshot,
@@ -1587,33 +1588,20 @@ export class Think<
   /**
    * Normalize a tool part's `input` into something the provider will accept.
    *
-   * Two malformed shapes 400 modern providers (and persist forever once
-   * written): a stringified-JSON `input` (e.g. `'{"prompt":"a cat"}'` instead
-   * of the object) and a missing/`null` `input` on a settled or interrupted
-   * tool call (Anthropic rejects a `tool_use` block whose `input` is absent).
-   * We parse the former and default the latter to an empty object so the
-   * tool-call/tool-result pair stays valid. Any other value is left untouched.
+   * Malformed shapes 400 modern providers and persist forever once written:
+   * a stringified-JSON `input` (e.g. `'{"prompt":"a cat"}'` instead of the
+   * object), and any non-object `input` — `null`, `undefined`, `""`, an array,
+   * or a primitive — on a settled or interrupted tool call (Anthropic rejects
+   * a `tool_use` block whose `input` is not an object). We parse the former and
+   * default the latter to an empty object so the tool-call/tool-result pair
+   * stays valid. Delegates to the shared `normalizeToolInput` so the read-side
+   * repair and the write-side accumulator guard enforce the same invariant.
    */
   private _normalizeToolInput(record: Record<string, unknown>): {
     input: unknown;
     changed: boolean;
   } {
-    const raw = "input" in record ? record.input : undefined;
-    if (typeof raw === "string") {
-      const trimmed = raw.trim();
-      // Stringified JSON object or array — parse back into structured input.
-      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-        try {
-          return { input: JSON.parse(raw) as unknown, changed: true };
-        } catch {
-          return { input: raw, changed: false };
-        }
-      }
-    }
-    if (raw === undefined || raw === null) {
-      return { input: {}, changed: true };
-    }
-    return { input: raw, changed: false };
+    return normalizeToolInput("input" in record ? record.input : undefined);
   }
 
   /**
@@ -6445,6 +6433,18 @@ export class Think<
           if (action?.type === "error") {
             streamError = action.error;
             this._emit("message:error", { error: streamError });
+            // An AI-SDK error surfaces as a stream error part (not a thrown
+            // exception), so it lands here rather than in the `catch` below.
+            // Bridge it to `chat:request:failed` too — observers shouldn't have
+            // to know whether the failure threw or arrived as a chunk (the
+            // post-`beforeTurn`, in-stream provider 400 class), and turn-count
+            // telemetry needs the failed signal to balance `turn.started`.
+            this._emit("chat:request:failed", {
+              requestId,
+              stage: "stream",
+              messagesPersisted: true,
+              error: streamError
+            });
             this._broadcastChat({
               type: MSG_CHAT_RESPONSE,
               id: requestId,
@@ -6869,6 +6869,18 @@ export class Think<
               this._programmaticStreamErrors.set(requestId, streamError);
             }
             this._emit("message:error", { error: streamError });
+            // An AI-SDK error surfaces as a stream error part (not a thrown
+            // exception), so it lands here rather than in the `catch` below.
+            // Bridge it to `chat:request:failed` too — observers shouldn't have
+            // to know whether the failure threw or arrived as a chunk (the
+            // post-`beforeTurn`, in-stream provider 400 class), and turn-count
+            // telemetry needs the failed signal to balance `turn.started`.
+            this._emit("chat:request:failed", {
+              requestId,
+              stage: "stream",
+              messagesPersisted: true,
+              error: streamError
+            });
             this._broadcastChat({
               type: MSG_CHAT_RESPONSE,
               id: requestId,


### PR DESCRIPTION
## Summary

A persisted chat transcript can end up with a tool part whose `input` is **not a JSON object** — `null`, `undefined`, `""`, an array, or a raw/stringified-JSON string. The Anthropic Messages API then rejects the `tool_use` block with `AI_APICallError: ... tool_use.input: Input should be an object`. Because the bad shape lives in durable storage, the session is **wedged forever**: every later turn replays the same history and re-throws, surviving reconnects, redeploys, and DO evictions. The user sees their message render optimistically and then nothing.

The framework itself produces the shape — a streamed tool call that finishes with **no `input_json_delta` events** (the model called the tool with no args) persists `input` as `null`/`""`/the raw string instead of `{}` — and nothing on the read path rescued it. (Originated from an `@cloudflare/think` production report; the same shared write path affects `@cloudflare/ai-chat`.)

## Empirical provider contract

I verified the invariant against three **live** providers (Anthropic Messages API, OpenAI Chat Completions, Workers AI Kimi K2.6 via an `AI` binding):

| `tool_use.input` | Anthropic | OpenAI | Workers AI (Kimi K2.6) |
|---|---|---|---|
| `{}` (object) | ✅ 200 | ✅ 200 | ✅ 200 |
| `[{...}]` / `[]` (array) | ❌ 400 | ✅ 200 | ✅ 200 |
| `""` (empty string) | ❌ 400 | ✅ 200 | ❌ 400 (zero-length doc) |
| `null` | ❌ 400 | ✅ 200 | ✅ 200 |
| `"hello"` (non-JSON) | ❌ 400 | ✅ 200 | ❌ 400 (unexpected char) |

Three distinct contracts: Anthropic requires an **object**; OpenAI treats `arguments` as an opaque string (fully lenient); Workers AI parses the `arguments` string as JSON and rejects anything unparseable. `{}` is the **only** shape accepted everywhere, and `""` (the reported value) breaks both Anthropic **and** Workers AI. Coercing to `{}` is therefore both necessary and provider-safe.

## Changes

1. **Write boundary (`agents/chat`)** — new exported `normalizeToolInput` helper, applied in `applyChunkToParts` at the terminal `tool-input-available` / `tool-input-error` writes (new-part **and** finalize-streaming branches). A plain object passes through untouched, a stringified-JSON object is parsed, and everything else (`null`/`undefined`/`""`/arrays/primitives/unparseable JSON) collapses to `{}`. Guards persistence for both `@cloudflare/ai-chat` and `@cloudflare/think`.
2. **Read-side repair (`think`)** — `_normalizeToolInput` delegates to the shared helper, closing a gap where `""`, arrays, and other non-object primitives were left untouched. Sessions corrupted before the write guard shipped self-heal on their next turn.
3. **Read-side rescue (`ai-chat`)** — `AIChatAgent` delegates `convertToModelMessages` to user code and has no pre-send repair pass, so `autoTransformMessage` (run on every load) now normalizes malformed tool inputs, unwedging existing sessions without per-DO storage surgery. Healthy messages are returned by reference (persistence cache stays a no-op).
4. **Observability (`think`)** — an AI-SDK provider error surfaces as a stream **error part**, not a thrown exception, so it took the in-band branch that emitted `message:error` but never `chat:request:failed`. Both stream paths (`_streamResult`, `_streamResultToRpcCallback`) now also emit `chat:request:failed` (stage `"stream"`), so observers and turn-count telemetry (`turn.started` vs `turn.finished`) see the post-`beforeTurn`, in-stream failure class.

### Behavior change to note
A pre-existing `think` test asserted that a stringified **array** input was parsed back into an array. Live testing showed Anthropic rejects array inputs the same way it rejects `""`/`null`, so that test now asserts coercion to `{}`.

### Not changed
`useAgentChat` already surfaces the error: the WS transport calls `controller.error(...)` on an error frame, which the AI SDK `Chat` exposes as `status: "error"` / `error`. Verified, no change needed.

## Test plan

- [x] `agents` chat primitives — `vitest --project chat` (229 pass)
- [x] `ai-chat` unit — `message-builder.test.ts` + `migration.test.ts` (normalize helper, write guard both branches, array/empty-array/`""`/null/primitive coercion, stringified-object parse, heal-on-load, healthy-by-reference)
- [x] `ai-chat` workers suite (531 pass)
- [x] `think` — `client-tools.test.ts` (settled-input repair), `message-reconciliation.test.ts` (array → `{}`), `think-session.test.ts` (`chat:request:failed` bridge on both WS and RPC paths)
- [x] `npm run check` — lint/format/exports/typecheck across 91 projects
- [x] Empirical verification against Anthropic, OpenAI, and Workers AI/Kimi K2.6 (see table)

Changesets: `agents` (patch), `@cloudflare/think` (patch), `@cloudflare/ai-chat` (patch).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->