### PR TITLE
fix(think): hold continuation barrier for a slow tool sibling pending only in the streaming accumulator (#1649 follow-up)

### DIFF
--- a/.changeset/streaming-accumulator-tool-batch-barrier.md
+++ b/.changeset/streaming-accumulator-tool-batch-barrier.md
@@ -1,0 +1,27 @@
+---
+"@cloudflare/think": patch
+"@cloudflare/ai-chat": patch
+---
+
+fix(think): hold the auto-continuation barrier for a slow tool sibling pending only in the streaming accumulator (#1649 follow-up)
+
+When the model fans out parallel client tool calls in one streaming step and a
+fast sibling resolves mid-stream, its `autoContinue` schedules the continuation
+and arms the 50ms barrier timer. That timer can fire while the assistant
+message still lives only in the streaming accumulator (`_streamingAssistant`)
+and has not yet been persisted. `_hasIncompleteToolBatch()` only scanned
+`this.messages`, so it saw a stale (prior) leaf, reported "not mid-batch", and
+the fast path fired the continuation — bypassing the barrier. When the stream
+then persisted with the slow sibling still `input-available`, the continuation's
+transcript repair errored it with "The tool call was interrupted before a result
+was recorded", and the slow RPC result (2–5s later) arrived too late.
+
+`_hasIncompleteToolBatch()` now inspects the streaming accumulator first (the
+true in-flight leaf), falling back to the latest persisted assistant message,
+so a slow sibling keeps the barrier closed until its result lands or the
+existing 60s timeout elapses.
+
+The same guard is applied to `@cloudflare/ai-chat`'s `_hasIncompleteToolBatch`
+for symmetry. ai-chat's barrier runs in the post-stream continuation turn (where
+`_streamingMessage` is already null), so it does not exhibit the bypass today —
+this keeps the two implementations aligned and safe against future flow changes.

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -2189,7 +2189,8 @@ export class AIChatAgent<
     const streamingParts = this._streamingMessage?.parts;
     if (streamingParts) {
       return AIChatAgent._partsAreMidBatch(
-        streamingParts as ReadonlyArray<Record<string, unknown>>
+        streamingParts as ReadonlyArray<Record<string, unknown>>,
+        { streaming: true }
       );
     }
     // Zero-allocation backward scan for the latest assistant message — this
@@ -2211,17 +2212,26 @@ export class AIChatAgent<
    * signature. Shared by the streaming-message and persisted-leaf scans.
    */
   private static _partsAreMidBatch(
-    parts: ReadonlyArray<Record<string, unknown>>
+    parts: ReadonlyArray<Record<string, unknown>>,
+    options?: { streaming?: boolean }
   ): boolean {
     let hasPending = false;
     let hasSettled = false;
     for (const record of parts) {
       const state = record.state;
-      if (state === "input-available" || state === "approval-requested") {
+      const isToolPart =
+        typeof record.type === "string" &&
+        (record.type.startsWith("tool-") || record.type === "dynamic-tool");
+      if (
+        state === "input-available" ||
+        state === "approval-requested" ||
+        (options?.streaming === true &&
+          isToolPart &&
+          (state === "input-streaming" || !("state" in record)))
+      ) {
         hasPending = true;
       } else if (
-        typeof record.type === "string" &&
-        (record.type.startsWith("tool-") || record.type === "dynamic-tool") &&
+        isToolPart &&
         (state === "output-available" ||
           state === "output-error" ||
           state === "output-denied" ||

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -2180,21 +2180,42 @@ export class AIChatAgent<
    * message doesn't block a legitimate follow-up continuation.
    */
   private _hasIncompleteToolBatch(): boolean {
+    // During an active stream the leaf assistant message lives only in
+    // `_streamingMessage` and is not yet in `this.messages`. Inspect it first
+    // (mirroring `hasPendingInteraction`) so a slow sibling still
+    // `input-available` keeps the barrier closed. ai-chat's barrier normally
+    // runs in the post-stream continuation turn (where `_streamingMessage` is
+    // already null), so this is defensive symmetry with Think (#1649).
+    const streamingParts = this._streamingMessage?.parts;
+    if (streamingParts) {
+      return AIChatAgent._partsAreMidBatch(
+        streamingParts as ReadonlyArray<Record<string, unknown>>
+      );
+    }
     // Zero-allocation backward scan for the latest assistant message — this
     // runs on every barrier poll tick, and `this.messages` can be large.
     const messages = this.messages;
-    let leaf: (typeof messages)[number] | undefined;
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === "assistant") {
-        leaf = messages[i];
-        break;
+        return AIChatAgent._partsAreMidBatch(
+          messages[i].parts as ReadonlyArray<Record<string, unknown>>
+        );
       }
     }
-    if (!leaf) return false;
+    return false;
+  }
+
+  /**
+   * `true` when `parts` carry at least one settled tool result AND at least one
+   * tool call/approval still awaiting a client result — the #1649 mid-batch
+   * signature. Shared by the streaming-message and persisted-leaf scans.
+   */
+  private static _partsAreMidBatch(
+    parts: ReadonlyArray<Record<string, unknown>>
+  ): boolean {
     let hasPending = false;
     let hasSettled = false;
-    for (const part of leaf.parts) {
-      const record = part as Record<string, unknown>;
+    for (const record of parts) {
       const state = record.state;
       if (state === "input-available" || state === "approval-requested") {
         hasPending = true;

--- a/packages/think/src/e2e-tests/parallel-client-tool.test.ts
+++ b/packages/think/src/e2e-tests/parallel-client-tool.test.ts
@@ -1,0 +1,362 @@
+/**
+ * E2E test for the #1649 slow-sibling barrier bypass.
+ *
+ * Spins up a real `wrangler dev` worker, connects over a real WebSocket, and
+ * drives ThinkParallelClientToolE2EAgent (deterministic mock model emitting two
+ * parallel client tool calls). The fast sibling is answered mid-stream; the
+ * slow sibling only after the stream has ended. The continuation barrier must
+ * hold for the slow sibling so it ends `output-available` instead of being
+ * errored by the transcript-repair backstop.
+ *
+ * Unlike the in-process (vitest-pool-workers) test, this exercises a real
+ * process boundary, the real scheduler, and a real socket — the conditions
+ * under which the customer originally hit the bug.
+ */
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { setDefaultAutoSelectFamily } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+setDefaultAutoSelectFamily(false);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 18799;
+const BASE_URL = `http://localhost:${PORT}`;
+const AGENT_SLUG = "think-parallel-client-tool-e2-e-agent";
+const PERSIST_DIR = path.join(
+  __dirname,
+  ".wrangler-parallel-client-tool-state"
+);
+
+const MSG_CHAT_REQUEST = "cf_agent_use_chat_request";
+const MSG_TOOL_RESULT = "cf_agent_tool_result";
+
+// ── Process/harness helpers (mirror assistant-e2e.test.ts) ──────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function killProcessOnPort(port: number): void {
+  try {
+    const output = execSync(`lsof -ti tcp:${port} 2>/dev/null || true`)
+      .toString()
+      .trim();
+    if (output) {
+      for (const pid of output.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function killProcessTree(pid: number): void {
+  let children: number[] = [];
+  try {
+    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    // pgrep may be unavailable
+  }
+  for (const childPid of children) killProcessTree(childPid);
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // already dead
+  }
+}
+
+function startWrangler(): ChildProcess {
+  const configPath = path.join(__dirname, "wrangler.jsonc");
+  const child = spawn(
+    "npx",
+    [
+      "wrangler",
+      "dev",
+      "--config",
+      configPath,
+      "--port",
+      String(PORT),
+      "--persist-to",
+      PERSIST_DIR,
+      "--inspector-port",
+      "0"
+    ],
+    {
+      cwd: __dirname,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, NODE_ENV: "test" }
+    }
+  );
+  child.stdout?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[wrangler] ${line}`);
+  });
+  child.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[wrangler:err] ${line}`);
+  });
+  return child;
+}
+
+async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`${BASE_URL}/`);
+      await res.body?.cancel();
+      if (res.status > 0) return;
+    } catch {
+      // not ready yet
+    }
+    await sleep(delayMs);
+  }
+  throw new Error(`Wrangler did not start within ${maxAttempts * delayMs}ms`);
+}
+
+function killProcess(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (!child.pid) {
+      resolve();
+      return;
+    }
+    const fallback = setTimeout(resolve, 3000);
+    child.on("exit", () => {
+      clearTimeout(fallback);
+      resolve();
+    });
+    killProcessTree(child.pid);
+  });
+}
+
+// ── Agent helpers ───────────────────────────────────────────────────────
+
+function openWS(room: string): Promise<WebSocket> {
+  const url = `${BASE_URL}/agents/${AGENT_SLUG}/${room}`;
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("WebSocket connection timed out"));
+    }, 10000);
+    ws.onopen = () => {
+      clearTimeout(timeout);
+      resolve(ws);
+    };
+    ws.onerror = (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    };
+  });
+}
+
+/** Call a @callable method over a short-lived WebSocket RPC. */
+function callAgent(
+  room: string,
+  method: string,
+  args: unknown[] = []
+): Promise<unknown> {
+  const url = `${BASE_URL}/agents/${AGENT_SLUG}/${room}`;
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const id = crypto.randomUUID();
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`RPC call ${method} timed out`));
+    }, 15000);
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "rpc", id, method, args }));
+    };
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "rpc" && msg.id === id) {
+          clearTimeout(timeout);
+          ws.close();
+          if (msg.success) resolve(msg.result);
+          else reject(new Error(msg.error || "RPC failed"));
+        }
+      } catch {
+        // ignore non-RPC frames
+      }
+    };
+    ws.onerror = (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    };
+  });
+}
+
+function drainInitialMessages(
+  ws: WebSocket,
+  count = 3,
+  timeout = 5000
+): Promise<void> {
+  return new Promise((resolve) => {
+    let received = 0;
+    const timer = setTimeout(() => resolve(), timeout);
+    const handler = () => {
+      received++;
+      if (received >= count) {
+        clearTimeout(timer);
+        ws.removeEventListener("message", handler);
+        resolve();
+      }
+    };
+    ws.addEventListener("message", handler);
+  });
+}
+
+function sendChatRequest(
+  ws: WebSocket,
+  text: string,
+  clientTools: Array<{ name: string; description: string }>
+): string {
+  const id = crypto.randomUUID();
+  ws.send(
+    JSON.stringify({
+      type: MSG_CHAT_REQUEST,
+      id,
+      init: {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              id: crypto.randomUUID(),
+              role: "user",
+              parts: [{ type: "text", text }]
+            }
+          ],
+          clientTools
+        })
+      }
+    })
+  );
+  return id;
+}
+
+function sendToolResult(
+  ws: WebSocket,
+  toolCallId: string,
+  output: string
+): void {
+  ws.send(
+    JSON.stringify({
+      type: MSG_TOOL_RESULT,
+      toolCallId,
+      toolName: "client_action",
+      output,
+      autoContinue: true
+    })
+  );
+}
+
+async function waitUntil(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+  intervalMs = 50
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await sleep(intervalMs);
+  }
+  throw new Error("waitUntil timed out");
+}
+
+// ── Test ──────────────────────────────────────────────────────────────
+
+describe("think e2e — parallel client tool slow sibling (#1649)", () => {
+  let wrangler: ChildProcess | null = null;
+
+  beforeAll(async () => {
+    killProcessOnPort(PORT);
+    wrangler = startWrangler();
+    await waitForReady();
+    console.log("[test] Wrangler is ready");
+  });
+
+  afterAll(async () => {
+    if (wrangler) {
+      await killProcess(wrangler);
+      wrangler = null;
+    }
+    killProcessOnPort(PORT);
+    try {
+      fs.rmSync(PERSIST_DIR, { recursive: true, force: true });
+    } catch {
+      // OK
+    }
+  });
+
+  it("does not error a slow client tool when a fast sibling auto-continues mid-stream", async () => {
+    const room = `e2e-parallel-${Date.now()}`;
+    const ws = await openWS(room);
+    await drainInitialMessages(ws);
+
+    sendChatRequest(ws, "delete the 4th slide and rewrite the 1st", [
+      { name: "client_action", description: "A client tool" }
+    ]);
+
+    // Wait until both parallel calls are exposed in the streaming accumulator.
+    await waitUntil(async () => {
+      const fast = await callAgent(room, "streamingToolState", ["tc-fast"]);
+      const slow = await callAgent(room, "streamingToolState", ["tc-slow"]);
+      return fast === "input-available" && slow === "input-available";
+    }, 15000);
+
+    // Answer the FAST tool mid-stream with autoContinue (schedules the
+    // continuation; its 50ms barrier timer fires while the message is still
+    // only in the accumulator — the slow-sibling bypass window).
+    sendToolResult(ws, "tc-fast", "fast output");
+
+    // Let the stream finish and persist (tc-slow still pending) WITHOUT
+    // answering the slow tool — `_streamingAssistant` cleared.
+    await waitUntil(async () => {
+      const slow = await callAgent(room, "streamingToolState", ["tc-slow"]);
+      return slow === undefined;
+    }, 15000);
+
+    // On `main` the bypassed continuation runs here and errors tc-slow; the
+    // barrier must instead still be holding.
+    await sleep(500);
+
+    // The slow RPC finally resolves, well after the stream ended.
+    sendToolResult(ws, "tc-slow", "slow output");
+
+    // The continuation runs only once the slow result is recorded.
+    await waitUntil(async () => {
+      const count = (await callAgent(room, "continuationCount", [])) as number;
+      return count >= 1;
+    }, 15000);
+    await sleep(200);
+
+    const states = (await callAgent(room, "toolStates", [])) as Record<
+      string,
+      { state?: string; output?: string }
+    >;
+    expect(states["tc-fast"]?.state).toBe("output-available");
+    expect(states["tc-slow"]?.state).toBe("output-available");
+    expect(states["tc-slow"]?.output).toBe("slow output");
+
+    const continuationCount = (await callAgent(
+      room,
+      "continuationCount",
+      []
+    )) as number;
+    expect(continuationCount).toBe(1);
+
+    ws.close();
+  }, 90000);
+});

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -14,6 +14,7 @@ import { Think, Workspace } from "../think";
 import type {
   ChatRecoveryContext,
   ChatRecoveryOptions,
+  ChatResponseResult,
   StreamCallback,
   TurnConfig,
   TurnContext
@@ -29,6 +30,7 @@ type Env = {
   ThinkStallRecoveryE2EAgent: DurableObjectNamespace<ThinkStallRecoveryE2EAgent>;
   ThinkTaskParentE2EAgent: DurableObjectNamespace<ThinkTaskParentE2EAgent>;
   ThinkAgentToolNaturalParentE2EAgent: DurableObjectNamespace<ThinkAgentToolNaturalParentE2EAgent>;
+  ThinkParallelClientToolE2EAgent: DurableObjectNamespace<ThinkParallelClientToolE2EAgent>;
   AI: Ai;
   R2: R2Bucket;
 };
@@ -1005,6 +1007,161 @@ export class ThinkRecoveryHelperParent extends Agent<Env> {
   }> {
     const helper = await this.subAgent(ThinkRecoveryHelperAgent, helperName);
     return helper.getRecoveryStatus();
+  }
+}
+
+/**
+ * #1649 slow-sibling barrier bypass: emits TWO parallel client tool calls
+ * (`tc-fast` + `tc-slow`) in one step, then holds the stream open with trailing
+ * text. The client answers `tc-fast` mid-stream (fast) and `tc-slow` only after
+ * the stream ends (slow RPC). The continuation barrier must hold for `tc-slow`
+ * rather than firing on the fast result and erroring the slow sibling.
+ */
+function createParallelClientToolE2EMockModel(
+  delayMs: number,
+  trailingGaps: number
+): LanguageModel {
+  let callCount = 0;
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-parallel-client-tool-e2e",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented in mock");
+    },
+    doStream(options: Record<string, unknown>) {
+      callCount++;
+      const messages = (options as { prompt?: unknown[] }).prompt ?? [];
+      const hasToolResult = messages.some(
+        (m: unknown) =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).role === "tool"
+      );
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+
+          if (!hasToolResult && callCount === 1) {
+            for (const toolCallId of ["tc-fast", "tc-slow"]) {
+              controller.enqueue({
+                type: "tool-input-start",
+                id: toolCallId,
+                toolName: "client_action"
+              });
+              controller.enqueue({
+                type: "tool-input-delta",
+                id: toolCallId,
+                delta: JSON.stringify({ action: toolCallId })
+              });
+              controller.enqueue({ type: "tool-input-end", id: toolCallId });
+              controller.enqueue({
+                type: "tool-call",
+                toolCallId,
+                toolName: "client_action",
+                input: JSON.stringify({ action: toolCallId })
+              });
+            }
+            controller.enqueue({ type: "text-start", id: "t-trail" });
+            for (let i = 0; i < trailingGaps; i++) {
+              await new Promise((r) => setTimeout(r, delayMs));
+              controller.enqueue({
+                type: "text-delta",
+                id: "t-trail",
+                delta: "."
+              });
+            }
+            controller.enqueue({ type: "text-end", id: "t-trail" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: v3FinishReason("tool-calls"),
+              usage: v3Usage(10, 5)
+            });
+          } else {
+            controller.enqueue({ type: "text-start", id: "t-cont" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t-cont",
+              delta: "Continuation after parallel tools"
+            });
+            controller.enqueue({ type: "text-end", id: "t-cont" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: v3FinishReason("stop"),
+              usage: v3Usage(20, 10)
+            });
+          }
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
+export class ThinkParallelClientToolE2EAgent extends Think<Env> {
+  static options = { keepAliveIntervalMs: 2_000 };
+
+  override getModel(): LanguageModel {
+    // ~1s open window: long enough for the fast result + 50ms barrier timer to
+    // land while the message is still only in the streaming accumulator.
+    return createParallelClientToolE2EMockModel(25, 40);
+  }
+
+  override getSystemPrompt(): string {
+    return "Parallel client-tool e2e agent.";
+  }
+
+  override onChatResponse(result: ChatResponseResult): void {
+    if (!result.continuation) return;
+    this.ctx.storage
+      .get<number>("e2e:continuation-count")
+      .then((n = 0) => this.ctx.storage.put("e2e:continuation-count", n + 1))
+      .catch(console.error);
+  }
+
+  /** State of a tool part in the in-flight streaming accumulator (or undefined
+   * once the stream has ended / the call isn't present yet). */
+  @callable()
+  async streamingToolState(toolCallId: string): Promise<string | undefined> {
+    const acc = (
+      this as unknown as {
+        _streamingAssistant: {
+          parts: Array<Record<string, unknown>>;
+        } | null;
+      }
+    )._streamingAssistant;
+    if (!acc) return undefined;
+    return acc.parts.find((p) => p.toolCallId === toolCallId)?.state as
+      | string
+      | undefined;
+  }
+
+  /** Persisted tool-part states keyed by toolCallId, for post-turn assertions. */
+  @callable()
+  async toolStates(): Promise<
+    Record<string, { state?: string; output?: string }>
+  > {
+    const messages = await this.getMessages();
+    const out: Record<string, { state?: string; output?: string }> = {};
+    for (const message of messages) {
+      for (const part of message.parts as Array<Record<string, unknown>>) {
+        if (typeof part.toolCallId === "string") {
+          out[part.toolCallId] = {
+            state: part.state as string | undefined,
+            output: part.output as string | undefined
+          };
+        }
+      }
+    }
+    return out;
+  }
+
+  @callable()
+  async continuationCount(): Promise<number> {
+    return (await this.ctx.storage.get<number>("e2e:continuation-count")) ?? 0;
   }
 }
 

--- a/packages/think/src/e2e-tests/wrangler.jsonc
+++ b/packages/think/src/e2e-tests/wrangler.jsonc
@@ -46,6 +46,10 @@
       {
         "name": "ThinkAgentToolNaturalParentE2EAgent",
         "class_name": "ThinkAgentToolNaturalParentE2EAgent"
+      },
+      {
+        "name": "ThinkParallelClientToolE2EAgent",
+        "class_name": "ThinkParallelClientToolE2EAgent"
       }
     ]
   },
@@ -77,6 +81,10 @@
     {
       "tag": "v6",
       "new_sqlite_classes": ["ThinkStallRecoveryE2EAgent"]
+    },
+    {
+      "tag": "v7",
+      "new_sqlite_classes": ["ThinkParallelClientToolE2EAgent"]
     }
   ],
   "r2_buckets": [

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -178,6 +178,99 @@ function createSlowClientToolMockModel(
   } as LanguageModel;
 }
 
+// Emits TWO parallel client tool calls (`tc-fast` + `tc-slow`) in one step,
+// then holds the stream open with trailing text. Models the slow-sibling case
+// of #1649: the client answers `tc-fast` quickly (mid-stream) while `tc-slow`
+// (an RPC-backed tool) is still `input-available`. On the continuation
+// invocation it emits plain text.
+function createParallelClientToolMockModel(
+  delayMs: number,
+  trailingGaps: number
+): LanguageModel {
+  let callCount = 0;
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-parallel-client-tool",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented");
+    },
+    doStream(options: Record<string, unknown>) {
+      callCount++;
+      const messages = (options as { prompt?: unknown[] }).prompt ?? [];
+      const hasToolResult = messages.some(
+        (m: unknown) =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).role === "tool"
+      );
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+
+          if (!hasToolResult && callCount === 1) {
+            for (const toolCallId of ["tc-fast", "tc-slow"]) {
+              controller.enqueue({
+                type: "tool-input-start",
+                id: toolCallId,
+                toolName: "client_action"
+              });
+              controller.enqueue({
+                type: "tool-input-delta",
+                id: toolCallId,
+                delta: JSON.stringify({ action: toolCallId })
+              });
+              controller.enqueue({ type: "tool-input-end", id: toolCallId });
+              controller.enqueue({
+                type: "tool-call",
+                toolCallId,
+                toolName: "client_action",
+                input: JSON.stringify({ action: toolCallId })
+              });
+            }
+            // Hold the stream open so the fast result lands (and the 50ms
+            // auto-continuation timer fires) while the message is still only in
+            // the accumulator — the slow-sibling barrier-bypass window (#1649).
+            controller.enqueue({ type: "text-start", id: "t-trail" });
+            for (let i = 0; i < trailingGaps; i++) {
+              await new Promise((r) => setTimeout(r, delayMs));
+              controller.enqueue({
+                type: "text-delta",
+                id: "t-trail",
+                delta: "."
+              });
+            }
+            controller.enqueue({ type: "text-end", id: "t-trail" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 10, outputTokens: 5 }
+            });
+          } else {
+            controller.enqueue({ type: "text-start", id: "t-cont" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t-cont",
+              delta: "Continuation after parallel tools"
+            });
+            controller.enqueue({ type: "text-end", id: "t-cont" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 20, outputTokens: 10 }
+            });
+          }
+
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
 function createServerApprovalToolMockModel(): LanguageModel {
   return {
     specificationVersion: "v3",
@@ -343,6 +436,9 @@ export class ThinkClientToolsAgent extends Think {
   private _useSlowClientToolStream = false;
   private _slowClientToolDelayMs = 30;
   private _slowClientToolGaps = 12;
+  private _useParallelClientToolStream = false;
+  private _parallelClientToolDelayMs = 25;
+  private _parallelClientToolGaps = 20;
   private _useServerApprovalTool = false;
   private _serverApprovalToolExecutions = 0;
   private _serverApprovalToolFails = false;
@@ -365,6 +461,11 @@ export class ThinkClientToolsAgent extends Think {
       return createSlowClientToolMockModel(
         this._slowClientToolDelayMs,
         this._slowClientToolGaps
+      );
+    if (this._useParallelClientToolStream)
+      return createParallelClientToolMockModel(
+        this._parallelClientToolDelayMs,
+        this._parallelClientToolGaps
       );
     if (this._useTextOnly) return createTextOnlyMockModel();
     if (this._useServerApprovalTool) return createServerApprovalToolMockModel();
@@ -427,6 +528,16 @@ export class ThinkClientToolsAgent extends Think {
     this._useSlowClientToolStream = enabled;
     if (delayMs !== undefined) this._slowClientToolDelayMs = delayMs;
     if (trailingGaps !== undefined) this._slowClientToolGaps = trailingGaps;
+  }
+
+  async setParallelClientToolStreamMode(
+    enabled: boolean,
+    delayMs?: number,
+    trailingGaps?: number
+  ): Promise<void> {
+    this._useParallelClientToolStream = enabled;
+    if (delayMs !== undefined) this._parallelClientToolDelayMs = delayMs;
+    if (trailingGaps !== undefined) this._parallelClientToolGaps = trailingGaps;
   }
 
   /**
@@ -539,6 +650,54 @@ export class ThinkClientToolsAgent extends Think {
       .flatMap((m) => m.parts as Array<Record<string, unknown>>)
       .find((p) => p.toolCallId === opts.toolCallId);
     return { state: (part?.state as string) ?? "missing" };
+  }
+
+  /**
+   * Deterministic regression guard for the slow-sibling barrier bypass (#1649):
+   * when a parallel tool batch lives ONLY in the in-flight accumulator (a
+   * settled `tc-fast` beside a still-pending `tc-slow`), `_hasIncompleteToolBatch`
+   * must report mid-batch so the auto-continuation barrier holds. Before the fix
+   * it inspected only `this.messages` — which is empty mid-stream — and returned
+   * false, letting the continuation fire and error the slow sibling.
+   *
+   * Returns the check result while the accumulator is exposed and again after it
+   * is cleared (no streaming, empty history → must be false, proving the true
+   * result came from the accumulator, not a stale cache).
+   */
+  async detectsMidBatchInStreamingAccumulator(): Promise<{
+    whileStreaming: boolean;
+    afterStreamCleared: boolean;
+  }> {
+    const internal = this as unknown as {
+      _streamingAssistant: StreamAccumulator | null;
+      _hasIncompleteToolBatch(): boolean;
+    };
+    const accumulator = new StreamAccumulator({
+      messageId: crypto.randomUUID(),
+      existingParts: [
+        {
+          type: "tool-client_action",
+          toolCallId: "tc-fast",
+          toolName: "client_action",
+          state: "output-available",
+          input: { action: "fast" },
+          output: "fast output"
+        },
+        {
+          type: "tool-client_action",
+          toolCallId: "tc-slow",
+          toolName: "client_action",
+          state: "input-available",
+          input: { action: "slow" }
+        }
+      ] as unknown as UIMessage["parts"]
+    });
+
+    internal._streamingAssistant = accumulator;
+    const whileStreaming = internal._hasIncompleteToolBatch();
+    internal._streamingAssistant = null;
+    const afterStreamCleared = internal._hasIncompleteToolBatch();
+    return { whileStreaming, afterStreamCleared };
   }
 
   async getCapturedClientTools(): Promise<ClientToolSchema[] | undefined> {

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -664,7 +664,9 @@ export class ThinkClientToolsAgent extends Think {
    * is cleared (no streaming, empty history → must be false, proving the true
    * result came from the accumulator, not a stale cache).
    */
-  async detectsMidBatchInStreamingAccumulator(): Promise<{
+  async detectsMidBatchInStreamingAccumulator(
+    pendingState: "input-available" | "approval-requested" = "input-available"
+  ): Promise<{
     whileStreaming: boolean;
     afterStreamCleared: boolean;
   }> {
@@ -687,7 +689,7 @@ export class ThinkClientToolsAgent extends Think {
           type: "tool-client_action",
           toolCallId: "tc-slow",
           toolName: "client_action",
-          state: "input-available",
+          state: pendingState,
           input: { action: "slow" }
         }
       ] as unknown as UIMessage["parts"]

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -674,6 +674,23 @@ export class ThinkClientToolsAgent extends Think {
     whileStreaming: boolean;
     afterStreamCleared: boolean;
   }> {
+    return this.detectsMidBatchInStreamingAccumulatorWithPendingSiblings(
+      pendingState,
+      1
+    );
+  }
+
+  async detectsMidBatchInStreamingAccumulatorWithPendingSiblings(
+    pendingState:
+      | "input-available"
+      | "approval-requested"
+      | "input-streaming"
+      | "stateless",
+    pendingCount: number
+  ): Promise<{
+    whileStreaming: boolean;
+    afterStreamCleared: boolean;
+  }> {
     const internal = this as unknown as {
       _streamingAssistant: StreamAccumulator | null;
       _hasIncompleteToolBatch(): boolean;
@@ -689,13 +706,13 @@ export class ThinkClientToolsAgent extends Think {
           input: { action: "fast" },
           output: "fast output"
         },
-        {
+        ...Array.from({ length: pendingCount }, (_, i) => ({
           type: "tool-client_action",
-          toolCallId: "tc-slow",
+          toolCallId: `tc-slow-${i}`,
           toolName: "client_action",
           ...(pendingState === "stateless" ? {} : { state: pendingState }),
-          input: { action: "slow" }
-        }
+          input: { action: "slow", index: i }
+        }))
       ] as unknown as UIMessage["parts"]
     });
 

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -665,7 +665,11 @@ export class ThinkClientToolsAgent extends Think {
    * result came from the accumulator, not a stale cache).
    */
   async detectsMidBatchInStreamingAccumulator(
-    pendingState: "input-available" | "approval-requested" = "input-available"
+    pendingState:
+      | "input-available"
+      | "approval-requested"
+      | "input-streaming"
+      | "stateless" = "input-available"
   ): Promise<{
     whileStreaming: boolean;
     afterStreamCleared: boolean;
@@ -689,7 +693,7 @@ export class ThinkClientToolsAgent extends Think {
           type: "tool-client_action",
           toolCallId: "tc-slow",
           toolName: "client_action",
-          state: pendingState,
+          ...(pendingState === "stateless" ? {} : { state: pendingState }),
           input: { action: "slow" }
         }
       ] as unknown as UIMessage["parts"]

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1183,6 +1183,17 @@ describe("Think — auto-continuation", () => {
     expect(afterStreamCleared).toBe(false);
   });
 
+  it("keeps the barrier closed for an approval-requested sibling pending only in the streaming accumulator (#1649)", async () => {
+    // Same bypass, approval path: the slow sibling is awaiting an approval
+    // response (not a tool result). `_partsAreMidBatch` treats
+    // `approval-requested` as pending, so the barrier must hold for it too.
+    const agent = await freshAgent();
+    const { whileStreaming, afterStreamCleared } =
+      await agent.detectsMidBatchInStreamingAccumulator("approval-requested");
+    expect(whileStreaming).toBe(true);
+    expect(afterStreamCleared).toBe(false);
+  });
+
   it("does not error a slow client tool when a fast sibling auto-continues mid-stream (#1649)", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1210,6 +1210,19 @@ describe("Think — auto-continuation", () => {
     expect(inputStreaming.afterStreamCleared).toBe(false);
   });
 
+  it("keeps the barrier closed for multiple unmaterialized slow siblings (#1649)", async () => {
+    // Mirrors the customer report: one fast tool settles while several slow RPC
+    // client tools are still represented by raw live accumulator parts.
+    const agent = await freshAgent();
+    const result =
+      await agent.detectsMidBatchInStreamingAccumulatorWithPendingSiblings(
+        "stateless",
+        3
+      );
+    expect(result.whileStreaming).toBe(true);
+    expect(result.afterStreamCleared).toBe(false);
+  });
+
   it("does not error a slow client tool when a fast sibling auto-continues mid-stream (#1649)", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1194,6 +1194,22 @@ describe("Think — auto-continuation", () => {
     expect(afterStreamCleared).toBe(false);
   });
 
+  it("keeps the barrier closed for unmaterialized streaming tool parts (#1649)", async () => {
+    // Real UI streams can expose live accumulator tool parts before their final
+    // `input-available` state is visible on the raw part. The streaming scan
+    // must still treat them as pending siblings.
+    const agent = await freshAgent();
+    const stateless =
+      await agent.detectsMidBatchInStreamingAccumulator("stateless");
+    expect(stateless.whileStreaming).toBe(true);
+    expect(stateless.afterStreamCleared).toBe(false);
+
+    const inputStreaming =
+      await agent.detectsMidBatchInStreamingAccumulator("input-streaming");
+    expect(inputStreaming.whileStreaming).toBe(true);
+    expect(inputStreaming.afterStreamCleared).toBe(false);
+  });
+
   it("does not error a slow client tool when a fast sibling auto-continues mid-stream (#1649)", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1170,6 +1170,109 @@ describe("Think — auto-continuation", () => {
     await closeWS(ws);
   }, 25000);
 
+  it("keeps the continuation barrier closed for a slow sibling pending only in the streaming accumulator (#1649)", async () => {
+    // Deterministic guard for the slow-sibling barrier bypass: mid-stream the
+    // assistant message lives only in `_streamingAssistant`, so the batch check
+    // must inspect the accumulator. On `main` it only scanned `this.messages`
+    // (empty mid-stream) and returned false, bypassing the barrier and letting
+    // the continuation error the slow sibling.
+    const agent = await freshAgent();
+    const { whileStreaming, afterStreamCleared } =
+      await agent.detectsMidBatchInStreamingAccumulator();
+    expect(whileStreaming).toBe(true);
+    expect(afterStreamCleared).toBe(false);
+  });
+
+  it("does not error a slow client tool when a fast sibling auto-continues mid-stream (#1649)", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    // Two parallel client tool calls in one streaming step; the stream stays
+    // open long enough for the fast result + 50ms barrier timer to land while
+    // the message is still only in the accumulator.
+    await agent.setParallelClientToolStreamMode(true, 25, 24);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    const repairedToolCallIds: Array<string[] | undefined> = [];
+    const unsubscribe = subscribe("transcript", (event) => {
+      if (event.type === "chat:transcript:repaired" && event.name === room) {
+        repairedToolCallIds.push(event.payload.toolCallIds);
+      }
+    });
+
+    try {
+      sendChatRequest(
+        ws,
+        [makeUserMessage("delete the 4th slide and rewrite the 1st")],
+        {
+          clientTools: [{ name: "client_action", description: "A client tool" }]
+        }
+      );
+
+      // Wait until both parallel calls are exposed in the accumulator.
+      await waitUntil(async () => {
+        const fast = await agent.streamingToolCallState("tc-fast");
+        const slow = await agent.streamingToolCallState("tc-slow");
+        return fast === "input-available" && slow === "input-available";
+      }, 8000);
+
+      // Answer the FAST tool mid-stream with autoContinue. This schedules the
+      // continuation; its 50ms barrier timer fires while the message is still
+      // only in the accumulator — the slow-sibling bypass window.
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_RESULT,
+          toolCallId: "tc-fast",
+          toolName: "client_action",
+          output: "fast output",
+          autoContinue: true
+        })
+      );
+
+      // Let the stream finish and persist (tc-slow still `input-available`)
+      // WITHOUT answering the slow tool yet — `_streamingAssistant` cleared.
+      await waitUntil(async () => {
+        const slow = await agent.streamingToolCallState("tc-slow");
+        return slow === undefined;
+      }, 8000);
+      // On `main` the bypassed continuation runs here and errors tc-slow; the
+      // barrier must instead still be holding.
+      await delay(300);
+
+      // The slow RPC finally resolves, well after the stream ended.
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_RESULT,
+          toolCallId: "tc-slow",
+          toolName: "client_action",
+          output: "slow output",
+          autoContinue: true
+        })
+      );
+
+      await waitUntil(async () => {
+        const log = (await agent.getResponseLog()) as ChatResponseResult[];
+        return log.some((entry) => entry.continuation);
+      }, 8000);
+      await delay(100);
+
+      const messages = (await agent.getMessages()) as UIMessage[];
+      const partFor = (toolCallId: string) =>
+        messages
+          .flatMap((m) => m.parts as Array<Record<string, unknown>>)
+          .find((p) => p.toolCallId === toolCallId);
+      expect(partFor("tc-fast")?.state).toBe("output-available");
+      expect(partFor("tc-slow")?.state).toBe("output-available");
+      expect(partFor("tc-slow")?.output).toBe("slow output");
+      // tc-slow was never errored by a premature repair.
+      expect(repairedToolCallIds.flat()).not.toContain("tc-slow");
+    } finally {
+      unsubscribe();
+    }
+
+    await closeWS(ws);
+  }, 25000);
+
   it("does not clobber siblings when parallel results arrive concurrently (#1649)", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -9121,7 +9121,8 @@ export class Think<
     const streaming = this._streamingAssistant;
     if (streaming) {
       return Think._partsAreMidBatch(
-        streaming.parts as ReadonlyArray<Record<string, unknown>>
+        streaming.parts as ReadonlyArray<Record<string, unknown>>,
+        { streaming: true }
       );
     }
     // Zero-allocation backward scan for the latest assistant message — this
@@ -9143,17 +9144,26 @@ export class Think<
    * signature. Shared by the streaming-accumulator and persisted-leaf scans.
    */
   private static _partsAreMidBatch(
-    parts: ReadonlyArray<Record<string, unknown>>
+    parts: ReadonlyArray<Record<string, unknown>>,
+    options?: { streaming?: boolean }
   ): boolean {
     let hasPending = false;
     let hasSettled = false;
     for (const record of parts) {
       const state = record.state;
-      if (state === "input-available" || state === "approval-requested") {
+      const isToolPart =
+        typeof record.type === "string" &&
+        (record.type.startsWith("tool-") || record.type === "dynamic-tool");
+      if (
+        state === "input-available" ||
+        state === "approval-requested" ||
+        (options?.streaming === true &&
+          isToolPart &&
+          (state === "input-streaming" || !("state" in record)))
+      ) {
         hasPending = true;
       } else if (
-        typeof record.type === "string" &&
-        (record.type.startsWith("tool-") || record.type === "dynamic-tool") &&
+        isToolPart &&
         (state === "output-available" ||
           state === "output-error" ||
           state === "output-denied" ||

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -9032,13 +9032,11 @@ export class Think<
    * repair backstop rather than pinning the continuation open forever.
    */
   private _fireAutoContinuationWhenStable(connection: Connection): void {
-    // NOTE: when a result arrives mid-stream, the in-flight assistant message
-    // lives only in `_streamingAssistant` and is NOT yet in `this.messages`, so
-    // `_hasIncompleteToolBatch()` here inspects a stale (prior) leaf. That does
-    // not break correctness: the continuation is enqueued behind the active
-    // streaming turn on the turn queue, and that turn persists the (now
-    // settled) result before the continuation's transcript repair runs. The
-    // ordering guarantee is the turn queue, not this barrier's cache view.
+    // When a result arrives mid-stream the in-flight assistant message lives
+    // only in `_streamingAssistant`; `_hasIncompleteToolBatch()` inspects that
+    // accumulator directly (not just `this.messages`) so a slow sibling still
+    // awaiting its result keeps the barrier closed rather than slipping through
+    // the fast path below (#1649).
     if (!this._continuation.pending) return;
     // The continuation is already running (a sibling result re-armed the timer
     // after it started). New results coalesce/defer into it — don't double-fire.
@@ -9115,21 +9113,41 @@ export class Think<
    * message doesn't block a legitimate follow-up continuation.
    */
   private _hasIncompleteToolBatch(): boolean {
+    // During an active stream the leaf assistant message lives only in the
+    // accumulator and is NOT yet in `this.messages`. Inspect it directly so a
+    // slow sibling (e.g. an RPC-backed client tool still `input-available`)
+    // keeps the barrier closed instead of letting the bypass fire the
+    // continuation before its result lands (#1649).
+    const streaming = this._streamingAssistant;
+    if (streaming) {
+      return Think._partsAreMidBatch(
+        streaming.parts as ReadonlyArray<Record<string, unknown>>
+      );
+    }
     // Zero-allocation backward scan for the latest assistant message — this
     // runs on every barrier poll tick, and `this.messages` can be large.
     const messages = this.messages;
-    let leaf: (typeof messages)[number] | undefined;
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === "assistant") {
-        leaf = messages[i];
-        break;
+        return Think._partsAreMidBatch(
+          messages[i].parts as ReadonlyArray<Record<string, unknown>>
+        );
       }
     }
-    if (!leaf) return false;
+    return false;
+  }
+
+  /**
+   * `true` when `parts` carry at least one settled tool result AND at least one
+   * tool call/approval still awaiting a client result — the #1649 mid-batch
+   * signature. Shared by the streaming-accumulator and persisted-leaf scans.
+   */
+  private static _partsAreMidBatch(
+    parts: ReadonlyArray<Record<string, unknown>>
+  ): boolean {
     let hasPending = false;
     let hasSettled = false;
-    for (const part of leaf.parts) {
-      const record = part as Record<string, unknown>;
+    for (const record of parts) {
       const state = record.state;
       if (state === "input-available" || state === "approval-requested") {
         hasPending = true;


### PR DESCRIPTION
## Summary

Follow-up to #1657. A customer reported that #1657 fixed the **fast** parallel tool case but they still hit `"The tool call was interrupted before a result was recorded."` on a **slow** client-resolved sibling (an RPC taking 2–5s) running beside a fast one (e.g. _"delete the 4th slide and rewrite the 1st"_ → `deleteSlides` fast + `modifySlide` slow).

Their root-cause analysis was correct: `_hasIncompleteToolBatch` didn't account for the in-flight streaming accumulator.

## Root cause

When the model fans out parallel client tool calls in one streaming step:

1. The fast sibling resolves mid-stream and is applied to `_streamingAssistant`.
2. Its `autoContinue` schedules the continuation and arms the 50ms barrier timer.
3. The timer fires while the assistant message lives **only** in `_streamingAssistant` — not yet persisted.
4. `_hasIncompleteToolBatch()` scanned only `this.messages`, so it inspected a stale prior leaf, reported "not mid-batch", and the fast path fired the continuation — **bypassing the barrier**.
5. The stream ends and persists with the slow sibling still `input-available`; the continuation's transcript repair errors it.
6. The slow RPC result arrives 2–5s later — too late.

A `NOTE` comment had claimed this was safe because "the turn queue persists the (now settled) result before the continuation's repair runs". That holds for a fast sibling that settles before end-of-stream, but **not** for a slow RPC sibling that settles after.

## Fix

`_hasIncompleteToolBatch()` now inspects the in-flight `_streamingAssistant` accumulator first (the true current leaf), falling back to the latest persisted assistant message. A slow sibling still `input-available` in the accumulator now keeps the barrier closed until its result lands or the existing 60s timeout elapses. The part-scan is extracted into a shared `_partsAreMidBatch` helper, and the misleading `NOTE` is corrected.

## ai-chat (defensive)

The same guard is applied to `@cloudflare/ai-chat`'s `_hasIncompleteToolBatch`. ai-chat's barrier runs in the **post-stream** continuation turn (where `_streamingMessage` is already null), so it does **not** exhibit the bypass today — this keeps the two implementations aligned and mirrors the existing `hasPendingInteraction()`, which already checks `_streamingMessage`.

## Tests

- **Deterministic guard** (`detectsMidBatchInStreamingAccumulator`): a settled `tc-fast` beside a pending `tc-slow` exposed only in the accumulator must report mid-batch; a cleared accumulator + empty history must not (no false positive).
- **Integration test**: two parallel client tools streamed, fast answered mid-stream with `autoContinue`, slow answered *after* the stream ends. Asserts the slow tool ends `output-available` (not errored) with exactly one continuation.
- Both verified to **fail without the fix** — the integration test reproduces the exact customer signature (`expected 'output-error' to be 'output-available'`).

## Verification

- `npm run format`, `oxlint` — 0 warnings / 0 errors
- `npm run typecheck` — 91/91 projects
- `@cloudflare/think` — 495 passed
- `@cloudflare/ai-chat` — 566 passed

## Changeset

`patch` for `@cloudflare/think` (real fix) and `@cloudflare/ai-chat` (defensive symmetry).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->