### PR TITLE
fix(agents,think): stabilize chat SDK messenger tests

### DIFF
--- a/.changeset/calm-think-startup-drains.md
+++ b/.changeset/calm-think-startup-drains.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Avoid starting empty submission and workflow notification drains during agent startup, preventing short-lived facet initializations from leaving background keep-alive work behind.

--- a/.changeset/quiet-chat-sdk-cleanup.md
+++ b/.changeset/quiet-chat-sdk-cleanup.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Await Chat SDK state-agent cleanup scheduling during startup so tests and short-lived worker isolates do not leave dangling cleanup work.

--- a/examples/chat-sdk-messenger/src/tests/conversation-facet.test.ts
+++ b/examples/chat-sdk-messenger/src/tests/conversation-facet.test.ts
@@ -1,0 +1,27 @@
+import { env } from "cloudflare:workers";
+import { getAgentByName } from "agents";
+import { describe, expect, it } from "vitest";
+import type { TestHostAgent } from "./worker";
+
+type TestEnv = typeof env & {
+  TestHostAgent: DurableObjectNamespace<TestHostAgent>;
+};
+
+function uniqueName(): string {
+  return `chat-sdk-messenger-facet-${crypto.randomUUID()}`;
+}
+
+async function getHost(): Promise<TestHostAgent> {
+  return (await getAgentByName(
+    (env as TestEnv).TestHostAgent,
+    uniqueName()
+  )) as unknown as TestHostAgent;
+}
+
+describe("ConversationAgent facet", () => {
+  it("can be created in the Vitest worker pool", async () => {
+    const host = await getHost();
+
+    await expect(host.testConversationFacet()).resolves.toBe("ok");
+  });
+});

--- a/examples/chat-sdk-messenger/src/tests/state-adapter.test.ts
+++ b/examples/chat-sdk-messenger/src/tests/state-adapter.test.ts
@@ -93,10 +93,4 @@ describe("ChatSdkStateAdapter", () => {
       fallbackThread: "telegram:123"
     });
   });
-
-  it("creates ConversationAgent facets in the Vitest worker pool", async () => {
-    const host = await getHost();
-
-    await expect(host.testConversationFacet()).resolves.toBe("ok");
-  });
 });

--- a/examples/chat-sdk-messenger/src/tests/worker.ts
+++ b/examples/chat-sdk-messenger/src/tests/worker.ts
@@ -1,6 +1,8 @@
 import { Agent, routeAgentRequest } from "agents";
+import type { RetryOptions, Schedule } from "agents";
 import {
   ChatSdkStateAdapter,
+  ChatSdkStateAgent,
   defaultKeyShard,
   defaultThreadShard
 } from "agents/chat-sdk";
@@ -9,6 +11,49 @@ import appWorker, { ChatIngressAgent, ConversationAgent } from "../index";
 import { shardTelegramStateKey } from "@cloudflare/think/messengers/telegram";
 
 export { ChatSdkStateAgent } from "agents/chat-sdk";
+
+export class TestChatSdkStateAgent extends ChatSdkStateAgent {
+  override async schedule<T = string>(
+    when: Date | string | number,
+    callback: keyof this,
+    payload?: T,
+    _options?: { retry?: RetryOptions; idempotent?: boolean }
+  ): Promise<Schedule<T>> {
+    if (callback !== "cleanupExpired") {
+      return super.schedule(when, callback, payload, _options);
+    }
+
+    const base = {
+      id: crypto.randomUUID(),
+      callback: String(callback),
+      payload: payload as T
+    };
+
+    if (when instanceof Date) {
+      return {
+        ...base,
+        type: "scheduled",
+        time: Math.floor(when.getTime() / 1000)
+      };
+    }
+
+    if (typeof when === "string") {
+      return {
+        ...base,
+        type: "cron",
+        time: Math.floor(Date.now() / 1000),
+        cron: when
+      };
+    }
+
+    return {
+      ...base,
+      type: "delayed",
+      time: Math.floor(Date.now() / 1000) + when,
+      delayInSeconds: when
+    };
+  }
+}
 
 interface TestLockResult {
   first: boolean;
@@ -157,17 +202,10 @@ export class TestHostAgent extends Agent {
     };
   }
 
-  async testConversationFacet(): Promise<string> {
-    await this.subAgent(
-      ConversationAgent,
-      `conversation:${crypto.randomUUID()}`
-    );
-    return "ok";
-  }
-
   private async createState(): Promise<ChatSdkStateAdapter> {
     const state = new ChatSdkStateAdapter({
-      parent: this
+      parent: this,
+      agent: TestChatSdkStateAgent
     });
     await state.connect();
     return state;

--- a/examples/chat-sdk-messenger/src/tests/worker.ts
+++ b/examples/chat-sdk-messenger/src/tests/worker.ts
@@ -202,6 +202,14 @@ export class TestHostAgent extends Agent {
     };
   }
 
+  async testConversationFacet(): Promise<string> {
+    await this.subAgent(
+      ConversationAgent,
+      `conversation:${crypto.randomUUID()}`
+    );
+    return "ok";
+  }
+
   private async createState(): Promise<ChatSdkStateAdapter> {
     const state = new ChatSdkStateAdapter({
       parent: this,

--- a/examples/chat-sdk-messenger/src/tests/wrangler.jsonc
+++ b/examples/chat-sdk-messenger/src/tests/wrangler.jsonc
@@ -31,6 +31,10 @@
       {
         "class_name": "ChatSdkStateAgent",
         "name": "ChatSdkStateAgent"
+      },
+      {
+        "class_name": "TestChatSdkStateAgent",
+        "name": "TestChatSdkStateAgent"
       }
     ]
   },

--- a/packages/agents/src/chat-sdk/agent.ts
+++ b/packages/agents/src/chat-sdk/agent.ts
@@ -15,9 +15,9 @@ const NEXT_CLEANUP_AT_KEY = "next_cleanup_at";
 const CLEANUP_SCHEDULE_ID_KEY = "cleanup_schedule_id";
 
 export class ChatSdkStateAgent extends Agent {
-  onStart(): void {
+  async onStart(): Promise<void> {
     this.migrate();
-    void this.scheduleNextCleanup();
+    await this.scheduleNextCleanup();
   }
 
   subscribe(threadId: string): void {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1563,8 +1563,12 @@ export class Think<
       // after subclass initialization has completed.
       await this._recoverSubmissionsOnStart();
       this._recoverWorkflowNotifications();
-      this._startSubmissionDrain();
-      this._startWorkflowNotificationDrain();
+      if (this._hasPendingSubmissions()) {
+        this._startSubmissionDrain();
+      }
+      if (this._hasPendingWorkflowNotifications()) {
+        this._startWorkflowNotificationDrain();
+      }
     };
   }
 
@@ -4792,6 +4796,17 @@ export class Think<
     );
   }
 
+  private _hasPendingWorkflowNotifications(): boolean {
+    this._ensureWorkflowNotificationTable();
+    const pending = this.sql<{ notification_id: string }>`
+      SELECT notification_id
+      FROM cf_think_workflow_notifications
+      WHERE delivered_at IS NULL
+      LIMIT 1
+    `;
+    return pending.length > 0;
+  }
+
   private async _drainWorkflowNotifications(): Promise<void> {
     if (this._drainingWorkflowNotifications) return;
     this._ensureWorkflowNotificationTable();
@@ -5108,6 +5123,17 @@ export class Think<
     void this.keepAliveWhile(() => this._drainSubmissions()).catch((error) => {
       console.error("[Think] Failed to drain submissions", error);
     });
+  }
+
+  private _hasPendingSubmissions(): boolean {
+    this._ensureSubmissionTable();
+    const pending = this.sql<{ submission_id: string }>`
+      SELECT submission_id
+      FROM cf_think_submissions
+      WHERE status = 'pending'
+      LIMIT 1
+    `;
+    return pending.length > 0;
   }
 
   async _drainThinkSubmissions(): Promise<void> {


### PR DESCRIPTION
## Summary
- Await `ChatSdkStateAgent` startup cleanup scheduling and isolate the chat-sdk-messenger state adapter tests from auto-fired cleanup alarms.
- Avoid starting empty `Think` submission/workflow drains during startup, so plain facet initialization does not leave background keep-alive RPC work pending at Vitest teardown.
- Restore the `ConversationAgent` facet smoke coverage in its own test file after fixing the `Think` startup path.

## Root Cause
The failing CI run showed all chat-sdk-messenger assertions passing, followed by a Vitest unhandled teardown error:

`EnvironmentTeardownError: [vitest-worker]: Closing rpc while "resolve" was pending`

There were two overlapping sources of background work:

1. `ChatSdkStateAgent.onStart()` kicked off cleanup rescheduling with `void this.scheduleNextCleanup()`, so startup could return while cleanup scheduling was still in flight.
2. `Think.onStart()` unconditionally started submission and workflow notification drains, even when no durable rows were pending. Creating the real `ConversationAgent` facet in tests was enough to start those empty fire-and-forget `keepAliveWhile(...)` drains.

Retries did not help because the failure happened after assertions passed, during worker teardown, not inside an individual test body.

## Changes
- Changed `ChatSdkStateAgent.onStart()` to await `scheduleNextCleanup()`.
- Added a test-only `TestChatSdkStateAgent` for the example state-adapter tests that intercepts only `cleanupExpired` schedules. Other scheduled callbacks still use the real scheduler.
- Moved facet creation coverage out of the state-adapter suite into `conversation-facet.test.ts`.
- Updated `Think` startup to start submission/workflow drains only when durable storage has pending work.
- Added patch changesets for `agents` and `@cloudflare/think`.

## Test Plan
- `npm run build`
- `cd examples/chat-sdk-messenger && npx vitest --run --config src/tests/vitest.config.ts src/tests/state-adapter.test.ts src/tests/conversation-facet.test.ts`
- `cd examples/chat-sdk-messenger && npm run test`
- `npm run check`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->