### PR TITLE
fix(mcp): bind OAuth PKCE verifiers to callback state

### DIFF
--- a/.changeset/stateful-pkce-verifiers.md
+++ b/.changeset/stateful-pkce-verifiers.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Fix MCP OAuth PKCE verifier lookup for overlapping authorization attempts.
+
+`DurableObjectOAuthClientProvider` now binds pending PKCE verifiers to the OAuth callback state instead of storing a single verifier per client/server. Callback handling runs token exchange and verifier cleanup in the returned state's context, so older auth windows and retry churn no longer exchange an authorization code with another attempt's verifier.

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -252,19 +252,26 @@ export class MCPClientConnection {
   /**
    * Complete OAuth authorization
    */
-  async completeAuthorization(code: string): Promise<void> {
-    if (this.connectionState !== MCPConnectionState.AUTHENTICATING) {
+  async completeAuthorization(
+    code: string,
+    options: { alreadyAccepted?: boolean } = {}
+  ): Promise<void> {
+    const expectedState = options.alreadyAccepted
+      ? MCPConnectionState.CONNECTING
+      : MCPConnectionState.AUTHENTICATING;
+    if (this.connectionState !== expectedState) {
       throw new Error(
-        "Connection must be in authenticating state to complete authorization"
+        `Connection must be in ${expectedState} state to complete authorization`
       );
+    }
+
+    if (!options.alreadyAccepted) {
+      this.connectionState = MCPConnectionState.CONNECTING;
     }
 
     try {
       // Finish OAuth by probing transports per configuration
       await this.finishAuthProbe(code);
-
-      // Mark as connecting
-      this.connectionState = MCPConnectionState.CONNECTING;
     } catch (error) {
       this.connectionState = MCPConnectionState.FAILED;
       throw error;

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -641,6 +641,13 @@ export class MCPClientManager {
     state: string
   ): Promise<void> {
     try {
+      const stateValidation = await authProvider.checkState(state);
+      if (!stateValidation.valid) {
+        console.warn(
+          `[MCPClientManager] Ignoring stale OAuth callback with invalid state for server "${serverId}": ${stateValidation.error ?? "Invalid state"}`
+        );
+        return;
+      }
       await authProvider.consumeState(state);
     } catch (cleanupError) {
       console.warn(

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -606,6 +606,89 @@ export class MCPClientManager {
     return { serverId, authSuccess: false, authError: error };
   }
 
+  private isAuthAcceptedConnection(conn: MCPClientConnection): boolean {
+    return (
+      conn.connectionState === MCPConnectionState.READY ||
+      conn.connectionState === MCPConnectionState.CONNECTED ||
+      conn.connectionState === MCPConnectionState.CONNECTING ||
+      conn.connectionState === MCPConnectionState.DISCOVERING
+    );
+  }
+
+  private oauthCallbackSuccess(
+    serverId: string,
+    conn: MCPClientConnection
+  ): MCPOAuthCallbackResult {
+    this.clearServerAuthUrl(serverId);
+    conn.connectionError = null;
+    return { serverId, authSuccess: true };
+  }
+
+  private async runWithCodeVerifierState<T>(
+    authProvider: AgentMcpOAuthProvider,
+    state: string,
+    callback: () => Promise<T>
+  ): Promise<T> {
+    if (authProvider.runWithCodeVerifierState) {
+      return authProvider.runWithCodeVerifierState(state, callback);
+    }
+    return callback();
+  }
+
+  private async consumeStaleOAuthState(
+    serverId: string,
+    authProvider: AgentMcpOAuthProvider,
+    state: string
+  ): Promise<void> {
+    try {
+      await authProvider.consumeState(state);
+    } catch (cleanupError) {
+      console.warn(
+        `[MCPClientManager] Failed to clean up stale OAuth callback state for server "${serverId}":`,
+        cleanupError
+      );
+    }
+  }
+
+  private async completeAuthorizationAndCleanupVerifier(
+    serverId: string,
+    conn: MCPClientConnection,
+    authProvider: AgentMcpOAuthProvider,
+    state: string,
+    code: string
+  ): Promise<void> {
+    await this.runWithCodeVerifierState(authProvider, state, async () => {
+      let completeError: unknown;
+      let cleanupError: unknown;
+
+      try {
+        await conn.completeAuthorization(code, { alreadyAccepted: true });
+      } catch (error) {
+        completeError = error;
+      }
+
+      try {
+        await authProvider.deleteCodeVerifier();
+      } catch (deleteError) {
+        cleanupError = deleteError;
+      }
+
+      if (completeError) {
+        if (cleanupError) {
+          console.warn(
+            `[MCPClientManager] Failed to clean up OAuth code verifier for server "${serverId}":`,
+            cleanupError
+          );
+        }
+        throw completeError;
+      }
+
+      if (cleanupError) {
+        throw cleanupError;
+      }
+    });
+  }
+
   /**
    * Create an auth provider for a server
    * @internal
@@ -939,9 +1022,29 @@ export class MCPClientManager {
     // Handle OAuth completion if we have a reconnect code
     if (options.reconnect?.oauthCode) {
       try {
-        await this.mcpConnections[id].completeAuthorization(
-          options.reconnect.oauthCode
-        );
+        const authProvider =
+          this.mcpConnections[id].options.transport.authProvider;
+        let completeError: unknown;
+        try {
+          await this.mcpConnections[id].completeAuthorization(
+            options.reconnect.oauthCode
+          );
+        } catch (error) {
+          completeError = error;
+        }
+
+        try {
+          await authProvider?.deleteCodeVerifier();
+        } catch (cleanupError) {
+          console.warn(
+            `[MCPClientManager] Failed to clean up OAuth code verifier for server "${id}":`,
+            cleanupError
+          );
+        }
+
+        if (completeError) {
+          throw completeError;
+        }
 
         // Reinitialize connection
         await this.mcpConnections[id].init();
@@ -1208,7 +1311,7 @@ export class MCPClientManager {
     req: Request
   ):
     | { valid: true; serverId: string; code: string; state: string }
-    | { valid: false; serverId?: string; error: string } {
+    | { valid: false; serverId?: string; state?: string; error: string } {
     const url = new URL(req.url);
     const code = url.searchParams.get("code");
     const state = url.searchParams.get("state");
@@ -1235,6 +1338,7 @@ export class MCPClientManager {
     if (error) {
       return {
         serverId: serverId,
+        state: state,
         valid: false,
         error: errorDescription || error
       };
@@ -1243,6 +1347,7 @@ export class MCPClientManager {
     if (!code) {
       return {
         serverId: serverId,
+        state: state,
         valid: false,
         error: "Unauthorized: no code provided"
       };
@@ -1278,7 +1383,22 @@ export class MCPClientManager {
     const validation = this.validateCallbackRequest(req);
 
     if (!validation.valid) {
-      if (validation.serverId && this.mcpConnections[validation.serverId]) {
+      const conn = validation.serverId
+        ? this.mcpConnections[validation.serverId]
+        : undefined;
+      if (validation.serverId && conn) {
+        if (this.isAuthAcceptedConnection(conn)) {
+          const authProvider = conn.options.transport.authProvider;
+          if (validation.state && authProvider) {
+            authProvider.serverId = validation.serverId;
+            await this.consumeStaleOAuthState(
+              validation.serverId,
+              authProvider,
+              validation.state
+            );
+          }
+          return this.oauthCallbackSuccess(validation.serverId, conn);
+        }
         return this.failConnection(validation.serverId, validation.error);
       }
 
@@ -1306,16 +1426,18 @@ export class MCPClientManager {
       // This prevents DoS attacks where attacker consumes valid state before legitimate callback
       const stateValidation = await authProvider.checkState(state);
       if (!stateValidation.valid) {
+        if (this.isAuthAcceptedConnection(conn)) {
+          await this.consumeStaleOAuthState(serverId, authProvider, state);
+          return this.oauthCallbackSuccess(serverId, conn);
+        }
         throw new Error(stateValidation.error || "Invalid state");
       }
 
-      // Already authenticated - just return success
-      if (
-        conn.connectionState === MCPConnectionState.READY ||
-        conn.connectionState === MCPConnectionState.CONNECTED
-      ) {
-        this.clearServerAuthUrl(serverId);
-        return { serverId, authSuccess: true };
+      // A stale popup can complete after another callback already exchanged tokens.
+      // Treat it as success, but consume its state so it cannot be replayed.
+      if (this.isAuthAcceptedConnection(conn)) {
+        await this.consumeStaleOAuthState(serverId, authProvider, state);
+        return this.oauthCallbackSuccess(serverId, conn);
       }
 
       if (conn.connectionState !== MCPConnectionState.AUTHENTICATING) {
@@ -1324,15 +1446,20 @@ export class MCPClientManager {
         );
       }
 
+      conn.connectionState = MCPConnectionState.CONNECTING;
       await authProvider.consumeState(state);
-      await conn.completeAuthorization(code);
+      await this.completeAuthorizationAndCleanupVerifier(
+        serverId,
+        conn,
+        authProvider,
+        state,
+        code
+      );
       this.updateStoredSessionId(serverId, conn.sessionId);
-      await authProvider.deleteCodeVerifier();
-      this.clearServerAuthUrl(serverId);
-      conn.connectionError = null;
+      const result = this.oauthCallbackSuccess(serverId, conn);
       this._onServerStateChanged.fire();
 
-      return { serverId, authSuccess: true };
+      return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return this.failConnection(serverId, message);

--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -306,7 +306,11 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
       deleteKeys.push(this.tokenKey(this.clientId));
     }
     if (scope === "all" || scope === "verifier") {
-      deleteKeys.push(...(await this.codeVerifierKeys(this.clientId)));
+      deleteKeys.push(
+        ...(await this.codeVerifierKeys(this.clientId, {
+          includeChallengeKeys: true
+        }))
+      );
     }
 
     if (deleteKeys.length > 0) {
@@ -334,11 +338,30 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
     return `${this.challengeCodeVerifierPrefix(clientId)}${codeChallenge}`;
   }
 
-  async codeVerifierKeys(clientId: string): Promise<string[]> {
-    const keys = await this.storage.list({
-      prefix: this.codeVerifierKey(clientId)
+  async codeVerifierKeys(
+    clientId: string,
+    options: { includeChallengeKeys?: boolean } = {}
+  ): Promise<string[]> {
+    const legacyKey = this.codeVerifierKey(clientId);
+    const keys: string[] = [];
+
+    if (await this.storage.get(legacyKey)) {
+      keys.push(legacyKey);
+    }
+
+    const stateKeys = await this.storage.list({
+      prefix: this.stateCodeVerifierPrefix(clientId)
     });
-    return [...keys.keys()];
+    keys.push(...stateKeys.keys());
+
+    if (options.includeChallengeKeys) {
+      const challengeKeys = await this.storage.list({
+        prefix: this.challengeCodeVerifierPrefix(clientId)
+      });
+      keys.push(...challengeKeys.keys());
+    }
+
+    return keys;
   }
 
   async saveCodeVerifier(verifier: string): Promise<void> {

--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -5,13 +5,24 @@ import type {
   OAuthClientMetadata,
   OAuthTokens
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { nanoid } from "nanoid";
 
 const STATE_EXPIRATION_MS = 10 * 60 * 1000; // 10 minutes
 
+const codeVerifierStateStorage = new AsyncLocalStorage<{
+  state: string;
+  servedKey?: string;
+}>();
+
 interface StoredState {
   nonce: string;
   serverId: string;
+  createdAt: number;
+}
+
+interface StoredCodeVerifier {
+  verifier: string;
   createdAt: number;
 }
 
@@ -25,7 +36,50 @@ export interface AgentMcpOAuthProvider extends OAuthClientProvider {
     state: string
   ): Promise<{ valid: boolean; serverId?: string; error?: string }>;
   consumeState(state: string): Promise<void>;
+  runWithCodeVerifierState?<T>(
+    state: string,
+    callback: () => Promise<T>
+  ): Promise<T>;
   deleteCodeVerifier(): Promise<void>;
+}
+
+function parseOAuthState(
+  state: string
+): { nonce: string; serverId: string } | undefined {
+  const parts = state.split(".");
+  if (parts.length !== 2) {
+    return undefined;
+  }
+
+  const [nonce, serverId] = parts;
+  if (!nonce || !serverId) {
+    return undefined;
+  }
+
+  return { nonce, serverId };
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function createCodeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier)
+  );
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+function isExpired(createdAt: number): boolean {
+  return Date.now() - createdAt > STATE_EXPIRATION_MS;
 }
 
 /**
@@ -161,12 +215,12 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
   async checkState(
     state: string
   ): Promise<{ valid: boolean; serverId?: string; error?: string }> {
-    const parts = state.split(".");
-    if (parts.length !== 2) {
+    const parsed = parseOAuthState(state);
+    if (!parsed) {
       return { valid: false, error: "Invalid state format" };
     }
 
-    const [nonce, serverId] = parts;
+    const { nonce, serverId } = parsed;
     const key = this.stateKey(nonce);
     const storedState = await this.storage.get<StoredState>(key);
 
@@ -179,9 +233,12 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
       return { valid: false, error: "State serverId mismatch" };
     }
 
-    const age = Date.now() - storedState.createdAt;
-    if (age > STATE_EXPIRATION_MS) {
-      await this.storage.delete(key);
+    if (isExpired(storedState.createdAt)) {
+      const deleteKeys = [key];
+      if (this._clientId_) {
+        deleteKeys.push(this.stateCodeVerifierKey(this.clientId, nonce));
+      }
+      await this.storage.delete(deleteKeys);
       return { valid: false, error: "State expired" };
     }
 
@@ -189,19 +246,50 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
   }
 
   async consumeState(state: string): Promise<void> {
-    const parts = state.split(".");
-    if (parts.length !== 2) {
+    const parsed = parseOAuthState(state);
+    if (!parsed) {
       // This should never happen since checkState validates format first.
       // Log for debugging but don't throw - state consumption is best-effort.
       console.warn(`[OAuth] consumeState called with invalid state format`);
       return;
     }
-    const [nonce] = parts;
-    await this.storage.delete(this.stateKey(nonce));
+    await this.storage.delete(this.stateKey(parsed.nonce));
   }
 
   async redirectToAuthorization(authUrl: URL): Promise<void> {
     this._authUrl_ = authUrl.toString();
+
+    const state = authUrl.searchParams.get("state");
+    const codeChallenge = authUrl.searchParams.get("code_challenge");
+    if (!state || !codeChallenge) {
+      return;
+    }
+
+    const parsed = parseOAuthState(state);
+    if (!parsed || parsed.serverId !== this.serverId) {
+      return;
+    }
+
+    const challengeKey = this.challengeCodeVerifierKey(
+      this.clientId,
+      codeChallenge
+    );
+    const pendingVerifier =
+      await this.storage.get<StoredCodeVerifier>(challengeKey);
+    if (!pendingVerifier) {
+      return;
+    }
+
+    if (isExpired(pendingVerifier.createdAt)) {
+      await this.storage.delete(challengeKey);
+      return;
+    }
+
+    await this.storage.put(
+      this.stateCodeVerifierKey(this.clientId, parsed.nonce),
+      pendingVerifier
+    );
+    await this.storage.delete(challengeKey);
   }
 
   async invalidateCredentials(
@@ -218,7 +306,7 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
       deleteKeys.push(this.tokenKey(this.clientId));
     }
     if (scope === "all" || scope === "verifier") {
-      deleteKeys.push(this.codeVerifierKey(this.clientId));
+      deleteKeys.push(...(await this.codeVerifierKeys(this.clientId)));
     }
 
     if (deleteKeys.length > 0) {
@@ -230,29 +318,142 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
     return `${this.keyPrefix(clientId)}/code_verifier`;
   }
 
+  stateCodeVerifierPrefix(clientId: string) {
+    return `${this.keyPrefix(clientId)}/code_verifier/`;
+  }
+
+  stateCodeVerifierKey(clientId: string, nonce: string) {
+    return `${this.stateCodeVerifierPrefix(clientId)}${nonce}`;
+  }
+
+  challengeCodeVerifierPrefix(clientId: string) {
+    return `${this.keyPrefix(clientId)}/code_verifier_challenge/`;
+  }
+
+  challengeCodeVerifierKey(clientId: string, codeChallenge: string) {
+    return `${this.challengeCodeVerifierPrefix(clientId)}${codeChallenge}`;
+  }
+
+  async codeVerifierKeys(clientId: string): Promise<string[]> {
+    const keys = await this.storage.list({
+      prefix: this.codeVerifierKey(clientId)
+    });
+    return [...keys.keys()];
+  }
+
   async saveCodeVerifier(verifier: string): Promise<void> {
-    const key = this.codeVerifierKey(this.clientId);
+    const codeChallenge = await createCodeChallenge(verifier);
+    const storedVerifier: StoredCodeVerifier = {
+      verifier,
+      createdAt: Date.now()
+    };
 
-    // Don't overwrite existing verifier to preserve first PKCE verifier
-    const existing = await this.storage.get<string>(key);
-    if (existing) {
-      return;
-    }
-
-    await this.storage.put(key, verifier);
+    await this.storage.put(
+      this.challengeCodeVerifierKey(this.clientId, codeChallenge),
+      storedVerifier
+    );
   }
 
   async codeVerifier(): Promise<string> {
-    const codeVerifier = await this.storage.get<string>(
+    const context = codeVerifierStateStorage.getStore();
+    if (context) {
+      const stateVerifier = await this.codeVerifierForState(context.state);
+      if (stateVerifier) {
+        context.servedKey = stateVerifier.key;
+        return stateVerifier.verifier;
+      }
+    }
+
+    const legacyVerifier = await this.storage.get<string>(
       this.codeVerifierKey(this.clientId)
     );
-    if (!codeVerifier) {
-      throw new Error("No code verifier found");
+    if (legacyVerifier) {
+      if (context) {
+        context.servedKey = this.codeVerifierKey(this.clientId);
+      }
+      return legacyVerifier;
     }
-    return codeVerifier;
+
+    if (context) {
+      throw new Error("No code verifier found for OAuth state");
+    }
+
+    const pendingVerifiers = await this.storage.list<StoredCodeVerifier>({
+      prefix: this.stateCodeVerifierPrefix(this.clientId)
+    });
+    const unexpiredPendingVerifiers = [...pendingVerifiers.entries()].filter(
+      ([, storedVerifier]) => !isExpired(storedVerifier.createdAt)
+    );
+    const expiredKeys = [...pendingVerifiers.entries()]
+      .filter(([, storedVerifier]) => isExpired(storedVerifier.createdAt))
+      .map(([key]) => key);
+    if (expiredKeys.length > 0) {
+      await this.storage.delete(expiredKeys);
+    }
+
+    if (unexpiredPendingVerifiers.length === 1) {
+      const [[, storedVerifier]] = unexpiredPendingVerifiers;
+      return storedVerifier.verifier;
+    }
+
+    if (unexpiredPendingVerifiers.length > 1) {
+      throw new Error(
+        "Multiple OAuth code verifiers are pending; complete authorization with the callback state"
+      );
+    }
+
+    throw new Error("No code verifier found");
+  }
+
+  private async codeVerifierForState(
+    state: string
+  ): Promise<{ key: string; verifier: string } | undefined> {
+    const parsed = parseOAuthState(state);
+    if (!parsed) {
+      throw new Error("Invalid state format");
+    }
+
+    const key = this.stateCodeVerifierKey(this.clientId, parsed.nonce);
+    const storedVerifier = await this.storage.get<StoredCodeVerifier>(key);
+    if (!storedVerifier) {
+      return undefined;
+    }
+
+    if (isExpired(storedVerifier.createdAt)) {
+      await this.storage.delete(key);
+      throw new Error("Code verifier expired");
+    }
+
+    return { key, verifier: storedVerifier.verifier };
+  }
+
+  async runWithCodeVerifierState<T>(
+    state: string,
+    callback: () => Promise<T>
+  ): Promise<T> {
+    return codeVerifierStateStorage.run({ state }, callback);
   }
 
   async deleteCodeVerifier(): Promise<void> {
-    await this.storage.delete(this.codeVerifierKey(this.clientId));
+    const context = codeVerifierStateStorage.getStore();
+    if (context?.servedKey) {
+      await this.storage.delete(context.servedKey);
+      return;
+    }
+
+    if (context) {
+      const parsed = parseOAuthState(context.state);
+      if (parsed) {
+        await this.storage.delete(
+          this.stateCodeVerifierKey(this.clientId, parsed.nonce)
+        );
+        return;
+      }
+    }
+
+    const keys = await this.codeVerifierKeys(this.clientId);
+    if (keys.length > 0) {
+      await this.storage.delete(keys);
+    }
   }
 }

--- a/packages/agents/src/mcp/do-oauth-client-provider.ts
+++ b/packages/agents/src/mcp/do-oauth-client-provider.ts
@@ -259,6 +259,12 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
   async redirectToAuthorization(authUrl: URL): Promise<void> {
     this._authUrl_ = authUrl.toString();
 
+    const clientId = this._clientId_;
+    const serverId = this._serverId_;
+    if (!clientId || !serverId) {
+      return;
+    }
+
     const state = authUrl.searchParams.get("state");
     const codeChallenge = authUrl.searchParams.get("code_challenge");
     if (!state || !codeChallenge) {
@@ -266,14 +272,11 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
     }
 
     const parsed = parseOAuthState(state);
-    if (!parsed || parsed.serverId !== this.serverId) {
+    if (!parsed || parsed.serverId !== serverId) {
       return;
     }
 
-    const challengeKey = this.challengeCodeVerifierKey(
-      this.clientId,
-      codeChallenge
-    );
+    const challengeKey = this.challengeCodeVerifierKey(clientId, codeChallenge);
     const pendingVerifier =
       await this.storage.get<StoredCodeVerifier>(challengeKey);
     if (!pendingVerifier) {
@@ -286,7 +289,7 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
     }
 
     await this.storage.put(
-      this.stateCodeVerifierKey(this.clientId, parsed.nonce),
+      this.stateCodeVerifierKey(clientId, parsed.nonce),
       pendingVerifier
     );
     await this.storage.delete(challengeKey);
@@ -365,6 +368,8 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
   }
 
   async saveCodeVerifier(verifier: string): Promise<void> {
+    await this.deleteExpiredChallengeCodeVerifiers(this.clientId);
+
     const codeChallenge = await createCodeChallenge(verifier);
     const storedVerifier: StoredCodeVerifier = {
       verifier,
@@ -375,6 +380,20 @@ export class DurableObjectOAuthClientProvider implements AgentMcpOAuthProvider {
       this.challengeCodeVerifierKey(this.clientId, codeChallenge),
       storedVerifier
     );
+  }
+
+  private async deleteExpiredChallengeCodeVerifiers(
+    clientId: string
+  ): Promise<void> {
+    const challengeVerifiers = await this.storage.list<StoredCodeVerifier>({
+      prefix: this.challengeCodeVerifierPrefix(clientId)
+    });
+    const expiredKeys = [...challengeVerifiers.entries()]
+      .filter(([, storedVerifier]) => isExpired(storedVerifier.createdAt))
+      .map(([key]) => key);
+    if (expiredKeys.length > 0) {
+      await this.storage.delete(expiredKeys);
+    }
   }
 
   async codeVerifier(): Promise<string> {

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -484,6 +484,24 @@ export class TestOAuthAgent extends Agent {
     };
   }
 
+  async testRedirectWithoutIdsDoesNotThrow(): Promise<{ authUrl: string }> {
+    const provider = new DurableObjectOAuthClientProvider(
+      this.ctx.storage,
+      `pkce-branch-${crypto.randomUUID()}`,
+      "https://client.example.com/callback"
+    );
+    const authUrl = new URL("https://auth.example.com/authorize");
+    authUrl.searchParams.set("state", `nonce-${crypto.randomUUID()}.server`);
+    authUrl.searchParams.set(
+      "code_challenge",
+      `challenge-${crypto.randomUUID()}`
+    );
+
+    await provider.redirectToAuthorization(authUrl);
+
+    return { authUrl: provider.authUrl ?? "" };
+  }
+
   // codeVerifier() with no ALS context and multiple pending verifiers must fail
   // loudly rather than guess (this replaces the old silent wrong-verifier bug).
   async testCodeVerifierMultiplePendingThrows(): Promise<{
@@ -660,6 +678,38 @@ export class TestOAuthAgent extends Agent {
       })
     ).length;
     return { defaultBefore, withChallengeBefore, after };
+  }
+
+  async testSaveCodeVerifierDeletesExpiredChallengeOrphans(): Promise<{
+    expiredBefore: boolean;
+    expiredAfter: boolean;
+    freshAfter: boolean;
+  }> {
+    const provider = this.newPkceProvider();
+    const expiredKey = provider.challengeCodeVerifierKey(
+      provider.clientId,
+      `expired-challenge-${crypto.randomUUID()}`
+    );
+    await provider.storage.put(expiredKey, {
+      verifier: "expired-verifier",
+      createdAt: Date.now() - 11 * 60 * 1000
+    });
+
+    const freshVerifier = `fresh-verifier-${crypto.randomUUID()}`;
+    const freshChallenge = await createCodeChallenge(freshVerifier);
+    const freshKey = provider.challengeCodeVerifierKey(
+      provider.clientId,
+      freshChallenge
+    );
+
+    const expiredBefore = await this.storageHas(provider, expiredKey);
+    await provider.saveCodeVerifier(freshVerifier);
+
+    return {
+      expiredBefore,
+      expiredAfter: await this.storageHas(provider, expiredKey),
+      freshAfter: await this.storageHas(provider, freshKey)
+    };
   }
 }
 

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -258,6 +258,7 @@ export class TestOAuthAgent extends Agent {
     state1Verifier: string;
     state2Verifier: string;
     staleStateIgnoredVerifier: string;
+    challengeVerifierAfterFallbackCleanup: string;
   }> {
     const provider = new DurableObjectOAuthClientProvider(
       this.ctx.storage,
@@ -313,7 +314,24 @@ export class TestOAuthAgent extends Agent {
         provider.codeVerifier()
       );
 
-    return { state1Verifier, state2Verifier, staleStateIgnoredVerifier };
+    const verifier4 = `verifier-four-${crypto.randomUUID()}`;
+    const state4 = await provider.state();
+    await provider.saveCodeVerifier(verifier4);
+    await provider.deleteCodeVerifier();
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(state4, verifier4)
+    );
+    const challengeVerifierAfterFallbackCleanup =
+      await statefulProvider.runWithCodeVerifierState(state4, () =>
+        provider.codeVerifier()
+      );
+
+    return {
+      state1Verifier,
+      state2Verifier,
+      staleStateIgnoredVerifier,
+      challengeVerifierAfterFallbackCleanup
+    };
   }
 }
 

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -4,6 +4,39 @@ import type { AgentMcpOAuthProvider } from "../../mcp/do-oauth-client-provider";
 import type { MCPClientConnection } from "../../mcp/client-connection";
 import type { MCPClientOAuthResult } from "../../mcp/client.ts";
 
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function createCodeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier)
+  );
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+async function createAuthorizationUrl(
+  state: string,
+  verifier: string
+): Promise<URL> {
+  const authUrl = new URL("https://auth.example.com/authorize");
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set(
+    "code_challenge",
+    await createCodeChallenge(verifier)
+  );
+  authUrl.searchParams.set("code_challenge_method", "S256");
+  return authUrl;
+}
+
 // Test Agent for OAuth client side flows
 export class TestOAuthAgent extends Agent {
   async onRequest(_request: Request): Promise<Response> {
@@ -219,6 +252,68 @@ export class TestOAuthAgent extends Agent {
         provider instanceof DurableObjectOAuthClientProvider,
       callbackUrl: String(provider.redirectUrl ?? "")
     };
+  }
+
+  async testPkceVerifierStateCorrelation(): Promise<{
+    state1Verifier: string;
+    state2Verifier: string;
+    staleStateIgnoredVerifier: string;
+  }> {
+    const provider = new DurableObjectOAuthClientProvider(
+      this.ctx.storage,
+      `pkce-correlation-${crypto.randomUUID()}`,
+      "https://client.example.com/callback"
+    );
+    provider.serverId = `server-${crypto.randomUUID()}`;
+    provider.clientId = `client-${crypto.randomUUID()}`;
+
+    const verifier1 = `verifier-one-${crypto.randomUUID()}`;
+    const verifier2 = `verifier-two-${crypto.randomUUID()}`;
+
+    const state1 = await provider.state();
+    await provider.saveCodeVerifier(verifier1);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(state1, verifier1)
+    );
+
+    const state2 = await provider.state();
+    await provider.saveCodeVerifier(verifier2);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(state2, verifier2)
+    );
+
+    const statefulProvider = provider as DurableObjectOAuthClientProvider & {
+      runWithCodeVerifierState?: <T>(
+        state: string,
+        callback: () => Promise<T>
+      ) => Promise<T>;
+    };
+    if (!statefulProvider.runWithCodeVerifierState) {
+      throw new Error("PKCE verifier state context is not available");
+    }
+
+    const state1Verifier = await statefulProvider.runWithCodeVerifierState(
+      state1,
+      () => provider.codeVerifier()
+    );
+    const state2Verifier = await statefulProvider.runWithCodeVerifierState(
+      state2,
+      () => provider.codeVerifier()
+    );
+
+    await provider.consumeState(state1);
+    const verifier3 = `verifier-three-${crypto.randomUUID()}`;
+    const state3 = await provider.state();
+    await provider.saveCodeVerifier(verifier3);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(state3, verifier3)
+    );
+    const staleStateIgnoredVerifier =
+      await statefulProvider.runWithCodeVerifierState(state3, () =>
+        provider.codeVerifier()
+      );
+
+    return { state1Verifier, state2Verifier, staleStateIgnoredVerifier };
   }
 }
 

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -386,11 +386,58 @@ export class TestOAuthAgent extends Agent {
     };
   }
 
+  // Positive control for the binding guard: a matching serverId MUST promote the
+  // verifier from the challenge key to the state-nonce key (and delete the
+  // challenge key). Pairs with the negative guard tests so those cannot pass
+  // simply because promotion is broken everywhere.
+  async testRedirectPromotesMatchingServerId(): Promise<{
+    challengeBefore: boolean;
+    stateBefore: boolean;
+    challengeAfter: boolean;
+    stateAfter: boolean;
+    storedVerifierMatches: boolean;
+  }> {
+    const provider = this.newPkceProvider();
+    const verifier = `verifier-${crypto.randomUUID()}`;
+    const challenge = await createCodeChallenge(verifier);
+    const state = await provider.state();
+    const [nonce] = state.split(".");
+    if (!nonce) {
+      throw new Error("Test setup failed to derive nonce from state");
+    }
+    await provider.saveCodeVerifier(verifier);
+
+    const challengeKey = provider.challengeCodeVerifierKey(
+      provider.clientId,
+      challenge
+    );
+    const stateKey = provider.stateCodeVerifierKey(provider.clientId, nonce);
+    const challengeBefore = await this.storageHas(provider, challengeKey);
+    const stateBefore = await this.storageHas(provider, stateKey);
+
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(state, verifier)
+    );
+
+    const stored = await provider.storage.get<{ verifier: string }>(stateKey);
+    return {
+      challengeBefore,
+      stateBefore,
+      challengeAfter: await this.storageHas(provider, challengeKey),
+      stateAfter: await this.storageHas(provider, stateKey),
+      storedVerifierMatches: stored?.verifier === verifier
+    };
+  }
+
   // redirectToAuthorization is a no-op when the authorization URL lacks state or
-  // code_challenge; the verifier stays under the challenge key (fail-soft orphan).
+  // code_challenge; the verifier stays orphaned under the challenge key and no
+  // state-nonce key is created (distinguishes a correct early-return from a
+  // silently broken promotion).
   async testRedirectWithoutStateOrChallengeKeepsOrphan(): Promise<{
-    afterNoState: boolean;
-    afterNoChallenge: boolean;
+    challengeAfterNoState: boolean;
+    stateAfterNoState: boolean;
+    challengeAfterNoChallenge: boolean;
+    stateAfterNoChallenge: boolean;
   }> {
     const provider = this.newPkceProvider();
     const verifier = `verifier-${crypto.randomUUID()}`;
@@ -401,20 +448,40 @@ export class TestOAuthAgent extends Agent {
       challenge
     );
 
+    const noStateNonce = `nonce-${crypto.randomUUID()}`;
     const noState = new URL("https://auth.example.com/authorize");
     noState.searchParams.set("code_challenge", challenge);
+    // Even though this URL has no state param, assert nothing was promoted under
+    // a nonce we control for comparison.
     await provider.redirectToAuthorization(noState);
-    const afterNoState = await this.storageHas(provider, challengeKey);
+    const challengeAfterNoState = await this.storageHas(provider, challengeKey);
+    const stateAfterNoState = await this.storageHas(
+      provider,
+      provider.stateCodeVerifierKey(provider.clientId, noStateNonce)
+    );
 
+    const noChallengeNonce = `nonce-${crypto.randomUUID()}`;
     const noChallenge = new URL("https://auth.example.com/authorize");
     noChallenge.searchParams.set(
       "state",
-      `nonce-${crypto.randomUUID()}.${provider.serverId}`
+      `${noChallengeNonce}.${provider.serverId}`
     );
     await provider.redirectToAuthorization(noChallenge);
-    const afterNoChallenge = await this.storageHas(provider, challengeKey);
+    const challengeAfterNoChallenge = await this.storageHas(
+      provider,
+      challengeKey
+    );
+    const stateAfterNoChallenge = await this.storageHas(
+      provider,
+      provider.stateCodeVerifierKey(provider.clientId, noChallengeNonce)
+    );
 
-    return { afterNoState, afterNoChallenge };
+    return {
+      challengeAfterNoState,
+      stateAfterNoState,
+      challengeAfterNoChallenge,
+      stateAfterNoChallenge
+    };
   }
 
   // codeVerifier() with no ALS context and multiple pending verifiers must fail
@@ -552,8 +619,12 @@ export class TestOAuthAgent extends Agent {
 
   // invalidateCredentials("verifier") sweeps every pending verifier (both bound
   // state verifiers and orphaned challenge verifiers), not just one slot.
+  // Also pins that codeVerifierKeys excludes orphaned challenge keys by default
+  // (so a no-context deleteCodeVerifier cannot nuke another flow's pending
+  // challenge verifier) but includes them under includeChallengeKeys.
   async testInvalidateVerifierDeletesAllPending(): Promise<{
-    before: number;
+    defaultBefore: number;
+    withChallengeBefore: number;
     after: number;
   }> {
     const provider = this.newPkceProvider();
@@ -572,10 +643,23 @@ export class TestOAuthAgent extends Agent {
     // An orphaned challenge verifier (saved but never redirected).
     await provider.saveCodeVerifier(`verifier-three-${crypto.randomUUID()}`);
 
-    const before = (await provider.codeVerifierKeys(provider.clientId)).length;
+    // Default excludes the orphaned challenge key: only the 2 promoted state
+    // verifiers are counted.
+    const defaultBefore = (await provider.codeVerifierKeys(provider.clientId))
+      .length;
+    // With challenge keys included, the orphan is counted too -> 3.
+    const withChallengeBefore = (
+      await provider.codeVerifierKeys(provider.clientId, {
+        includeChallengeKeys: true
+      })
+    ).length;
     await provider.invalidateCredentials("verifier");
-    const after = (await provider.codeVerifierKeys(provider.clientId)).length;
-    return { before, after };
+    const after = (
+      await provider.codeVerifierKeys(provider.clientId, {
+        includeChallengeKeys: true
+      })
+    ).length;
+    return { defaultBefore, withChallengeBefore, after };
   }
 }
 

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -333,6 +333,250 @@ export class TestOAuthAgent extends Agent {
       challengeVerifierAfterFallbackCleanup
     };
   }
+
+  // --- Provider-level PKCE branch coverage helpers ---
+
+  private newPkceProvider(): DurableObjectOAuthClientProvider {
+    const provider = new DurableObjectOAuthClientProvider(
+      this.ctx.storage,
+      `pkce-branch-${crypto.randomUUID()}`,
+      "https://client.example.com/callback"
+    );
+    provider.serverId = `server-${crypto.randomUUID()}`;
+    provider.clientId = `client-${crypto.randomUUID()}`;
+    return provider;
+  }
+
+  private async storageHas(
+    provider: DurableObjectOAuthClientProvider,
+    key: string
+  ): Promise<boolean> {
+    return (await provider.storage.get(key)) !== undefined;
+  }
+
+  // redirectToAuthorization must NOT bind the verifier when the state's serverId
+  // belongs to a different server (cross-server binding guard).
+  async testRedirectIgnoresServerIdMismatch(): Promise<{
+    challengeBefore: boolean;
+    challengeStillPresent: boolean;
+    stateVerifierCreated: boolean;
+  }> {
+    const provider = this.newPkceProvider();
+    const verifier = `verifier-${crypto.randomUUID()}`;
+    const challenge = await createCodeChallenge(verifier);
+    await provider.saveCodeVerifier(verifier);
+    const challengeKey = provider.challengeCodeVerifierKey(
+      provider.clientId,
+      challenge
+    );
+    const challengeBefore = await this.storageHas(provider, challengeKey);
+
+    const nonce = `nonce-${crypto.randomUUID()}`;
+    const foreignState = `${nonce}.other-server-${crypto.randomUUID()}`;
+    const authUrl = new URL("https://auth.example.com/authorize");
+    authUrl.searchParams.set("state", foreignState);
+    authUrl.searchParams.set("code_challenge", challenge);
+    await provider.redirectToAuthorization(authUrl);
+
+    const stateKey = provider.stateCodeVerifierKey(provider.clientId, nonce);
+    return {
+      challengeBefore,
+      challengeStillPresent: await this.storageHas(provider, challengeKey),
+      stateVerifierCreated: await this.storageHas(provider, stateKey)
+    };
+  }
+
+  // redirectToAuthorization is a no-op when the authorization URL lacks state or
+  // code_challenge; the verifier stays under the challenge key (fail-soft orphan).
+  async testRedirectWithoutStateOrChallengeKeepsOrphan(): Promise<{
+    afterNoState: boolean;
+    afterNoChallenge: boolean;
+  }> {
+    const provider = this.newPkceProvider();
+    const verifier = `verifier-${crypto.randomUUID()}`;
+    const challenge = await createCodeChallenge(verifier);
+    await provider.saveCodeVerifier(verifier);
+    const challengeKey = provider.challengeCodeVerifierKey(
+      provider.clientId,
+      challenge
+    );
+
+    const noState = new URL("https://auth.example.com/authorize");
+    noState.searchParams.set("code_challenge", challenge);
+    await provider.redirectToAuthorization(noState);
+    const afterNoState = await this.storageHas(provider, challengeKey);
+
+    const noChallenge = new URL("https://auth.example.com/authorize");
+    noChallenge.searchParams.set(
+      "state",
+      `nonce-${crypto.randomUUID()}.${provider.serverId}`
+    );
+    await provider.redirectToAuthorization(noChallenge);
+    const afterNoChallenge = await this.storageHas(provider, challengeKey);
+
+    return { afterNoState, afterNoChallenge };
+  }
+
+  // codeVerifier() with no ALS context and multiple pending verifiers must fail
+  // loudly rather than guess (this replaces the old silent wrong-verifier bug).
+  async testCodeVerifierMultiplePendingThrows(): Promise<{
+    threw: boolean;
+    message: string;
+  }> {
+    const provider = this.newPkceProvider();
+    const v1 = `verifier-one-${crypto.randomUUID()}`;
+    const v2 = `verifier-two-${crypto.randomUUID()}`;
+    const s1 = await provider.state();
+    await provider.saveCodeVerifier(v1);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(s1, v1)
+    );
+    const s2 = await provider.state();
+    await provider.saveCodeVerifier(v2);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(s2, v2)
+    );
+
+    try {
+      await provider.codeVerifier();
+      return { threw: false, message: "" };
+    } catch (err) {
+      return {
+        threw: true,
+        message: err instanceof Error ? err.message : String(err)
+      };
+    }
+  }
+
+  // codeVerifier() with no ALS context and exactly one pending verifier resolves
+  // it (the deprecated reconnect path's happy case).
+  async testCodeVerifierSinglePendingFallback(): Promise<{
+    resolved: string;
+    expected: string;
+  }> {
+    const provider = this.newPkceProvider();
+    const v1 = `verifier-only-${crypto.randomUUID()}`;
+    const s1 = await provider.state();
+    await provider.saveCodeVerifier(v1);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(s1, v1)
+    );
+    const resolved = await provider.codeVerifier();
+    return { resolved, expected: v1 };
+  }
+
+  // codeVerifier() inside a state context with no stored verifier throws a
+  // state-specific error rather than falling back.
+  async testCodeVerifierStateContextNoVerifierThrows(): Promise<{
+    threw: boolean;
+    message: string;
+  }> {
+    const provider = this.newPkceProvider();
+    const state = await provider.state();
+    try {
+      await provider.runWithCodeVerifierState(state, () =>
+        provider.codeVerifier()
+      );
+      return { threw: false, message: "" };
+    } catch (err) {
+      return {
+        threw: true,
+        message: err instanceof Error ? err.message : String(err)
+      };
+    }
+  }
+
+  // checkState() on an expired state also deletes the bound state verifier
+  // (the closest thing to a client-side verifier TTL).
+  async testCheckStateExpiredDeletesVerifier(): Promise<{
+    valid: boolean;
+    error: string;
+    stateKeyExists: boolean;
+    verifierKeyExists: boolean;
+  }> {
+    const provider = this.newPkceProvider();
+    const nonce = `nonce-${crypto.randomUUID()}`;
+    const old = Date.now() - 11 * 60 * 1000;
+    await provider.storage.put(provider.stateKey(nonce), {
+      nonce,
+      serverId: provider.serverId,
+      createdAt: old
+    });
+    const verifierKey = provider.stateCodeVerifierKey(provider.clientId, nonce);
+    await provider.storage.put(verifierKey, {
+      verifier: "stale-verifier",
+      createdAt: old
+    });
+
+    const result = await provider.checkState(`${nonce}.${provider.serverId}`);
+    return {
+      valid: result.valid,
+      error: result.error ?? "",
+      stateKeyExists: await this.storageHas(provider, provider.stateKey(nonce)),
+      verifierKeyExists: await this.storageHas(provider, verifierKey)
+    };
+  }
+
+  // codeVerifier() resolving an expired state verifier deletes it and throws.
+  async testCodeVerifierStateExpiredThrows(): Promise<{
+    threw: boolean;
+    message: string;
+    verifierKeyExists: boolean;
+  }> {
+    const provider = this.newPkceProvider();
+    const nonce = `nonce-${crypto.randomUUID()}`;
+    const old = Date.now() - 11 * 60 * 1000;
+    const verifierKey = provider.stateCodeVerifierKey(provider.clientId, nonce);
+    await provider.storage.put(verifierKey, {
+      verifier: "stale-verifier",
+      createdAt: old
+    });
+
+    let threw = false;
+    let message = "";
+    try {
+      await provider.runWithCodeVerifierState(
+        `${nonce}.${provider.serverId}`,
+        () => provider.codeVerifier()
+      );
+    } catch (err) {
+      threw = true;
+      message = err instanceof Error ? err.message : String(err);
+    }
+    return {
+      threw,
+      message,
+      verifierKeyExists: await this.storageHas(provider, verifierKey)
+    };
+  }
+
+  // invalidateCredentials("verifier") sweeps every pending verifier (both bound
+  // state verifiers and orphaned challenge verifiers), not just one slot.
+  async testInvalidateVerifierDeletesAllPending(): Promise<{
+    before: number;
+    after: number;
+  }> {
+    const provider = this.newPkceProvider();
+    const v1 = `verifier-one-${crypto.randomUUID()}`;
+    const v2 = `verifier-two-${crypto.randomUUID()}`;
+    const s1 = await provider.state();
+    await provider.saveCodeVerifier(v1);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(s1, v1)
+    );
+    const s2 = await provider.state();
+    await provider.saveCodeVerifier(v2);
+    await provider.redirectToAuthorization(
+      await createAuthorizationUrl(s2, v2)
+    );
+    // An orphaned challenge verifier (saved but never redirected).
+    await provider.saveCodeVerifier(`verifier-three-${crypto.randomUUID()}`);
+
+    const before = (await provider.codeVerifierKeys(provider.clientId)).length;
+    await provider.invalidateCredentials("verifier");
+    const after = (await provider.codeVerifierKeys(provider.clientId)).length;
+    return { before, after };
+  }
 }
 
 // Test Agent that overrides createMcpOAuthProvider with a custom implementation

--- a/packages/agents/src/tests/mcp/client-connection.test.ts
+++ b/packages/agents/src/tests/mcp/client-connection.test.ts
@@ -6,6 +6,16 @@ import { z } from "zod";
 import { MCPClientConnection } from "../../mcp/client-connection";
 import type { MCPObservabilityEvent } from "../../observability/mcp";
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 /**
  * Mock MCP server for testing different scenarios
  */
@@ -804,15 +814,11 @@ describe("MCP Client Connection Integration", () => {
       expect(connection.connectionState).toBe("ready");
     });
 
-    it("should preserve PKCE verifier during multiple saveCodeVerifier calls", async () => {
-      // Mock storage to simulate DurableObject storage behavior
-      const storageData = new Map<string, unknown>();
-
-      // This test verifies the PKCE preservation logic in DurableObjectOAuthClientProvider
+    it("should mark connection as connecting while OAuth token exchange is pending", async () => {
       const mockAuthProvider = {
         authUrl: undefined,
-        clientId: "test-client-id",
-        serverId: "test-server-id",
+        clientId: undefined,
+        serverId: undefined,
         redirectUrl: "http://localhost:3000/callback",
         clientMetadata: {
           client_name: "test-client",
@@ -824,47 +830,37 @@ describe("MCP Client Connection Integration", () => {
         clientInformation: vi.fn(),
         saveClientInformation: vi.fn(),
         redirectToAuthorization: vi.fn(),
-        // Mock actual preservation behavior: simulate storage-based preservation
-        saveCodeVerifier: vi
-          .fn()
-          .mockImplementation(async (verifier: string) => {
-            // Simulate the actual preservation logic from DurableObjectOAuthClientProvider
-            const existingVerifier = storageData.get("verifier-key");
-            if (existingVerifier) {
-              // Preserve existing verifier (don't overwrite) - this is the expected behavior
-              return;
-            }
-            // Save first verifier
-            storageData.set("verifier-key", verifier);
-          }),
-        codeVerifier: vi.fn().mockImplementation(async () => {
-          const stored = storageData.get("verifier-key");
-          if (!stored) throw new Error("No code verifier found");
-          return stored as string;
-        }),
+        saveCodeVerifier: vi.fn(),
+        codeVerifier: vi.fn(),
         checkState: vi.fn().mockResolvedValue({ valid: true }),
         consumeState: vi.fn().mockResolvedValue(undefined),
         deleteCodeVerifier: vi.fn().mockResolvedValue(undefined)
       };
-
-      // Test the PKCE preservation logic - this tests EXPECTED behavior
-      await mockAuthProvider.saveCodeVerifier("original-verifier");
-      await mockAuthProvider.saveCodeVerifier("should-be-ignored");
-
-      // EXPECTED: Original verifier should be preserved, second one ignored
-      const retrievedVerifier = await mockAuthProvider.codeVerifier();
-      expect(retrievedVerifier).toBe("original-verifier");
-
-      // Verify both calls were made but only first one was stored
-      expect(mockAuthProvider.saveCodeVerifier).toHaveBeenCalledTimes(2);
-      expect(mockAuthProvider.saveCodeVerifier).toHaveBeenNthCalledWith(
-        1,
-        "original-verifier"
+      const connection = new MCPClientConnection(
+        new URL(serverUrl),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: {
+            type: "streamable-http",
+            authProvider: mockAuthProvider
+          },
+          client: {}
+        }
       );
-      expect(mockAuthProvider.saveCodeVerifier).toHaveBeenNthCalledWith(
-        2,
-        "should-be-ignored"
-      );
+      const finishAuthComplete = createDeferred<void>();
+      const mockTransport = {
+        finishAuth: vi.fn().mockReturnValue(finishAuthComplete.promise)
+      };
+      connection.getTransport = vi.fn().mockReturnValue(mockTransport);
+      connection.connectionState = "authenticating";
+
+      const authorizationPromise =
+        connection.completeAuthorization("auth-code");
+
+      expect(connection.connectionState).toBe("connecting");
+      finishAuthComplete.resolve(undefined);
+      await authorizationPromise;
+      expect(connection.connectionState).toBe("connecting");
     });
   });
 

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -29,6 +29,16 @@ function createMockStateStorage() {
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function createMockAuthProvider(
   stateStorage: ReturnType<typeof createMockStateStorage>
 ) {
@@ -236,6 +246,63 @@ describe("MCPClientManager OAuth Integration", () => {
       expect(manager.mcpConnections[serverId]).toBe(connection);
       expect(connection.connectionState).toBe("authenticating");
     });
+
+    it("should clean up verifier after deprecated OAuth reconnect completion", async () => {
+      const serverId = "test-server-id";
+      const authProvider = {
+        authUrl: undefined,
+        clientId: "test-client-id",
+        serverId,
+        redirectUrl: "http://localhost:3000/callback",
+        clientMetadata: {
+          client_name: "test-client",
+          client_uri: "http://localhost:3000",
+          redirect_uris: ["http://localhost:3000/callback"]
+        },
+        tokens: vi.fn(),
+        saveTokens: vi.fn(),
+        clientInformation: vi.fn(),
+        saveClientInformation: vi.fn(),
+        redirectToAuthorization: vi.fn(),
+        saveCodeVerifier: vi.fn(),
+        codeVerifier: vi.fn(),
+        checkState: vi.fn().mockResolvedValue({ valid: true }),
+        consumeState: vi.fn().mockResolvedValue(undefined),
+        deleteCodeVerifier: vi.fn().mockResolvedValue(undefined)
+      };
+      const connection = new MCPClientConnection(
+        new URL("http://example.com"),
+        { name: "test-client", version: "1.0.0" },
+        { transport: { type: "auto", authProvider }, client: {} }
+      );
+      connection.connectionState = "authenticating";
+      connection.init = vi.fn().mockResolvedValue(undefined);
+      connection.completeAuthorization = vi
+        .fn()
+        .mockImplementation(async () => {
+          connection.connectionState = "connected";
+        });
+      manager.mcpConnections[serverId] = connection;
+      vi.spyOn(manager, "discoverIfConnected").mockResolvedValue({
+        state: "ready",
+        success: true
+      });
+
+      const result = await manager.connect("http://example.com", {
+        reconnect: {
+          id: serverId,
+          oauthClientId: "test-client-id",
+          oauthCode: "test-auth-code"
+        },
+        transport: { type: "auto", authProvider }
+      });
+
+      expect(result.id).toBe(serverId);
+      expect(connection.completeAuthorization).toHaveBeenCalledWith(
+        "test-auth-code"
+      );
+      expect(authProvider.deleteCodeVerifier).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("Callback URL Management", () => {
@@ -349,7 +416,9 @@ describe("MCPClientManager OAuth Integration", () => {
 
       expect(result.serverId).toBe(serverId);
       expect(result.authSuccess).toBe(true);
-      expect(completeAuthSpy).toHaveBeenCalledWith(authCode);
+      expect(completeAuthSpy).toHaveBeenCalledWith(authCode, {
+        alreadyAccepted: true
+      });
       // Verify auth provider has correct serverId and preserved clientId
       expect(connection.options.transport.authProvider?.serverId).toBe(
         serverId
@@ -1110,6 +1179,377 @@ describe("MCPClientManager OAuth Integration", () => {
         new Request(`${callbackUrl}?code=code2&state=${state2}`)
       );
       expect(result2.authSuccess).toBe(true);
+    });
+
+    it("should ignore stale valid callback after auth is already progressing", async () => {
+      const serverId = "test-server";
+      const callbackUrl = "http://localhost:3000/callback";
+      const stateStorage = createMockStateStorage();
+
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: "test-client-id",
+        auth_url: null,
+        server_options: null
+      });
+
+      const mockAuthProvider = createMockAuthProvider(stateStorage);
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.connectionState = "authenticating";
+      connection.completeAuthorization = vi
+        .fn()
+        .mockImplementation(async () => {
+          connection.connectionState = "connecting";
+        });
+      manager.mcpConnections[serverId] = connection;
+
+      const state1 = stateStorage.createState(serverId);
+      const state2 = stateStorage.createState(serverId);
+      const [state2Nonce] = state2.split(".");
+      if (!state2Nonce) {
+        throw new Error("Test setup failed to create an OAuth state nonce");
+      }
+
+      const result1 = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code1&state=${state1}`)
+      );
+      expect(result1.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+
+      const result2 = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code2&state=${state2}`)
+      );
+      expect(result2.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+      expect(connection.connectionError).toBe(null);
+      expect(connection.completeAuthorization).toHaveBeenCalledTimes(1);
+      expect(stateStorage.storage.has(state2Nonce)).toBe(false);
+    });
+
+    it("should ignore callback that becomes stale while state validation is pending", async () => {
+      const serverId = "test-server";
+      const callbackUrl = "http://localhost:3000/callback";
+      const stateStorage = createMockStateStorage();
+
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: "test-client-id",
+        auth_url: null,
+        server_options: null
+      });
+
+      const state1 = stateStorage.createState(serverId);
+      const state2 = stateStorage.createState(serverId);
+      const [state2Nonce] = state2.split(".");
+      if (!state2Nonce) {
+        throw new Error("Test setup failed to create an OAuth state nonce");
+      }
+
+      const state2CheckStarted = createDeferred<void>();
+      const releaseState2Check = createDeferred<void>();
+      const baseAuthProvider = createMockAuthProvider(stateStorage);
+      const mockAuthProvider = {
+        ...baseAuthProvider,
+        async checkState(
+          state: string
+        ): Promise<{ valid: boolean; serverId?: string; error?: string }> {
+          if (state === state2) {
+            state2CheckStarted.resolve(undefined);
+            await releaseState2Check.promise;
+          }
+          return baseAuthProvider.checkState(state);
+        }
+      };
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.connectionState = "authenticating";
+      connection.completeAuthorization = vi
+        .fn()
+        .mockImplementation(async () => {
+          connection.connectionState = "connecting";
+        });
+      manager.mcpConnections[serverId] = connection;
+
+      const result2Promise = manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code2&state=${state2}`)
+      );
+      await state2CheckStarted.promise;
+
+      const result1 = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code1&state=${state1}`)
+      );
+      expect(result1.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+
+      releaseState2Check.resolve(undefined);
+      const result2 = await result2Promise;
+
+      expect(result2.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+      expect(connection.connectionError).toBe(null);
+      expect(connection.completeAuthorization).toHaveBeenCalledTimes(1);
+      expect(stateStorage.storage.has(state2Nonce)).toBe(false);
+    });
+
+    it("should ignore stale OAuth error callback after auth is already progressing", async () => {
+      const serverId = "test-server";
+      const callbackUrl = "http://localhost:3000/callback";
+      const stateStorage = createMockStateStorage();
+
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: "test-client-id",
+        auth_url: null,
+        server_options: null
+      });
+
+      const mockAuthProvider = createMockAuthProvider(stateStorage);
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.connectionState = "authenticating";
+      connection.completeAuthorization = vi
+        .fn()
+        .mockImplementation(async () => {
+          connection.connectionState = "connecting";
+        });
+      manager.mcpConnections[serverId] = connection;
+
+      const state1 = stateStorage.createState(serverId);
+      const state2 = stateStorage.createState(serverId);
+      const [state2Nonce] = state2.split(".");
+      if (!state2Nonce) {
+        throw new Error("Test setup failed to create an OAuth state nonce");
+      }
+
+      const result1 = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code1&state=${state1}`)
+      );
+      expect(result1.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+
+      const result2 = await manager.handleCallbackRequest(
+        new Request(
+          `${callbackUrl}?error=access_denied&state=${state2}&error_description=denied`
+        )
+      );
+
+      expect(result2.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+      expect(connection.connectionError).toBe(null);
+      expect(connection.completeAuthorization).toHaveBeenCalledTimes(1);
+      expect(stateStorage.storage.has(state2Nonce)).toBe(false);
+    });
+
+    it("should ignore stale OAuth error callback after auth is accepted but before state cleanup finishes", async () => {
+      const serverId = "test-server";
+      const callbackUrl = "http://localhost:3000/callback";
+      const stateStorage = createMockStateStorage();
+
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: "test-client-id",
+        auth_url: null,
+        server_options: null
+      });
+
+      const state1 = stateStorage.createState(serverId);
+      const state2 = stateStorage.createState(serverId);
+      const [state1Nonce] = state1.split(".");
+      const [state2Nonce] = state2.split(".");
+      if (!state1Nonce || !state2Nonce) {
+        throw new Error("Test setup failed to create OAuth state nonces");
+      }
+
+      const consumeStateStarted = createDeferred<void>();
+      const releaseConsumeState = createDeferred<void>();
+      const baseAuthProvider = createMockAuthProvider(stateStorage);
+      const mockAuthProvider = {
+        ...baseAuthProvider,
+        async consumeState(state: string): Promise<void> {
+          if (state === state1) {
+            consumeStateStarted.resolve(undefined);
+            await releaseConsumeState.promise;
+          }
+          await baseAuthProvider.consumeState(state);
+        }
+      };
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.connectionState = "authenticating";
+      connection.completeAuthorization = vi
+        .fn()
+        .mockImplementation(async () => {
+          connection.connectionState = "connecting";
+        });
+      manager.mcpConnections[serverId] = connection;
+
+      const result1Promise = manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code1&state=${state1}`)
+      );
+      await consumeStateStarted.promise;
+      expect(connection.connectionState).toBe("connecting");
+
+      const result2 = await manager.handleCallbackRequest(
+        new Request(
+          `${callbackUrl}?error=access_denied&state=${state2}&error_description=denied`
+        )
+      );
+      expect(result2.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+      expect(connection.connectionError).toBe(null);
+      expect(stateStorage.storage.has(state2Nonce)).toBe(false);
+
+      releaseConsumeState.resolve(undefined);
+      const result1 = await result1Promise;
+      expect(result1.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+      expect(connection.connectionError).toBe(null);
+      expect(connection.completeAuthorization).toHaveBeenCalledTimes(1);
+      expect(stateStorage.storage.has(state1Nonce)).toBe(false);
+    });
+
+    it("should not delete active verifier for duplicate callback with same state", async () => {
+      const serverId = "test-server";
+      const callbackUrl = "http://localhost:3000/callback";
+      const stateStorage = createMockStateStorage();
+
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: "test-client-id",
+        auth_url: null,
+        server_options: null
+      });
+
+      const state = stateStorage.createState(serverId);
+      const completeAuthorizationStarted = createDeferred<void>();
+      const releaseCompleteAuthorization = createDeferred<void>();
+      const mockAuthProvider = {
+        ...createMockAuthProvider(stateStorage),
+        deleteCodeVerifier: vi.fn().mockResolvedValue(undefined)
+      };
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.connectionState = "authenticating";
+      connection.completeAuthorization = vi
+        .fn()
+        .mockImplementation(async () => {
+          completeAuthorizationStarted.resolve(undefined);
+          await releaseCompleteAuthorization.promise;
+        });
+      manager.mcpConnections[serverId] = connection;
+
+      const result1Promise = manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code1&state=${state}`)
+      );
+      await completeAuthorizationStarted.promise;
+      expect(connection.connectionState).toBe("connecting");
+
+      const result2 = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code1&state=${state}`)
+      );
+      expect(result2.authSuccess).toBe(true);
+      expect(mockAuthProvider.deleteCodeVerifier).not.toHaveBeenCalled();
+
+      releaseCompleteAuthorization.resolve(undefined);
+      const result1 = await result1Promise;
+      expect(result1.authSuccess).toBe(true);
+      expect(mockAuthProvider.deleteCodeVerifier).toHaveBeenCalledTimes(1);
+      expect(connection.completeAuthorization).toHaveBeenCalledTimes(1);
+    });
+
+    it("should run token exchange with callback state for PKCE lookup", async () => {
+      const serverId = "test-server";
+      const callbackUrl = "http://localhost:3000/callback";
+      const stateStorage = createMockStateStorage();
+
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: "test-client-id",
+        auth_url: null,
+        server_options: null
+      });
+
+      const state = stateStorage.createState(serverId);
+      const runWithCodeVerifierStateSpy = vi.fn();
+      const mockAuthProvider = {
+        ...createMockAuthProvider(stateStorage),
+        async runWithCodeVerifierState<T>(
+          stateArg: string,
+          callback: () => Promise<T>
+        ): Promise<T> {
+          runWithCodeVerifierStateSpy(stateArg);
+          expect(stateArg).toBe(state);
+          return callback();
+        }
+      };
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.connectionState = "authenticating";
+      connection.completeAuthorization = vi.fn().mockResolvedValue(undefined);
+      manager.mcpConnections[serverId] = connection;
+
+      const result = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=code1&state=${state}`)
+      );
+
+      expect(result.authSuccess).toBe(true);
+      expect(runWithCodeVerifierStateSpy).toHaveBeenCalledTimes(1);
+      expect(runWithCodeVerifierStateSpy.mock.calls[0]?.[0]).toBe(state);
     });
   });
 

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -1368,6 +1368,49 @@ describe("MCPClientManager OAuth Integration", () => {
       expect(stateStorage.storage.has(state2Nonce)).toBe(false);
     });
 
+    it("should not consume an invalid stale OAuth error callback state", async () => {
+      const serverId = "test-server";
+      const callbackUrl = "http://localhost:3000/callback";
+      const stateStorage = createMockStateStorage();
+
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: "test-client-id",
+        auth_url: null,
+        server_options: null
+      });
+
+      const baseAuthProvider = createMockAuthProvider(stateStorage);
+      const mockAuthProvider = {
+        ...baseAuthProvider,
+        consumeState: vi.fn(baseAuthProvider.consumeState)
+      };
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.connectionState = "connecting";
+      manager.mcpConnections[serverId] = connection;
+
+      const result = await manager.handleCallbackRequest(
+        new Request(
+          `${callbackUrl}?error=access_denied&state=forged-nonce.${serverId}`
+        )
+      );
+
+      expect(result.authSuccess).toBe(true);
+      expect(connection.connectionState).toBe("connecting");
+      expect(connection.connectionError).toBe(null);
+      expect(mockAuthProvider.consumeState).not.toHaveBeenCalled();
+    });
+
     it("should ignore stale OAuth error callback after auth is accepted but before state cleanup finishes", async () => {
       const serverId = "test-server";
       const callbackUrl = "http://localhost:3000/callback";

--- a/packages/agents/src/tests/mcp/create-oauth-provider.test.ts
+++ b/packages/agents/src/tests/mcp/create-oauth-provider.test.ts
@@ -38,4 +38,18 @@ describe("createMcpOAuthProvider", () => {
     expect(result.overrideWasCalled).toBe(true);
     expect(result.restoredProviderClientId).toBe("custom-client-id");
   });
+
+  it("should resolve PKCE verifiers by OAuth callback state", async () => {
+    const agentId = env.TestOAuthAgent.newUniqueId();
+    const agentStub = env.TestOAuthAgent.get(agentId);
+
+    const result = await agentStub.testPkceVerifierStateCorrelation();
+
+    expect(result.state1Verifier).toMatch(/^verifier-one-/);
+    expect(result.state2Verifier).toMatch(/^verifier-two-/);
+    expect(result.staleStateIgnoredVerifier).toMatch(/^verifier-three-/);
+    expect(result.state1Verifier).not.toBe(result.state2Verifier);
+    expect(result.staleStateIgnoredVerifier).not.toBe(result.state1Verifier);
+    expect(result.staleStateIgnoredVerifier).not.toBe(result.state2Verifier);
+  });
 });

--- a/packages/agents/src/tests/mcp/create-oauth-provider.test.ts
+++ b/packages/agents/src/tests/mcp/create-oauth-provider.test.ts
@@ -48,8 +48,20 @@ describe("createMcpOAuthProvider", () => {
     expect(result.state1Verifier).toMatch(/^verifier-one-/);
     expect(result.state2Verifier).toMatch(/^verifier-two-/);
     expect(result.staleStateIgnoredVerifier).toMatch(/^verifier-three-/);
+    expect(result.challengeVerifierAfterFallbackCleanup).toMatch(
+      /^verifier-four-/
+    );
     expect(result.state1Verifier).not.toBe(result.state2Verifier);
     expect(result.staleStateIgnoredVerifier).not.toBe(result.state1Verifier);
     expect(result.staleStateIgnoredVerifier).not.toBe(result.state2Verifier);
+    expect(result.challengeVerifierAfterFallbackCleanup).not.toBe(
+      result.state1Verifier
+    );
+    expect(result.challengeVerifierAfterFallbackCleanup).not.toBe(
+      result.state2Verifier
+    );
+    expect(result.challengeVerifierAfterFallbackCleanup).not.toBe(
+      result.staleStateIgnoredVerifier
+    );
   });
 });

--- a/packages/agents/src/tests/mcp/do-oauth-client-provider.test.ts
+++ b/packages/agents/src/tests/mcp/do-oauth-client-provider.test.ts
@@ -12,6 +12,18 @@ describe("DurableObjectOAuthClientProvider PKCE binding", () => {
   }
 
   describe("redirectToAuthorization binding guard", () => {
+    it("promotes the verifier from the challenge key to the state-nonce key on a matching serverId", async () => {
+      const result = await agent().testRedirectPromotesMatchingServerId();
+
+      // Before redirect: verifier sits under the challenge key only.
+      expect(result.challengeBefore).toBe(true);
+      expect(result.stateBefore).toBe(false);
+      // After redirect: promoted to the state-nonce key, challenge key deleted.
+      expect(result.challengeAfter).toBe(false);
+      expect(result.stateAfter).toBe(true);
+      expect(result.storedVerifierMatches).toBe(true);
+    });
+
     it("does not bind a verifier when the state's serverId belongs to another server", async () => {
       const result = await agent().testRedirectIgnoresServerIdMismatch();
 
@@ -22,12 +34,16 @@ describe("DurableObjectOAuthClientProvider PKCE binding", () => {
       expect(result.stateVerifierCreated).toBe(false);
     });
 
-    it("leaves the verifier under the challenge key when state or code_challenge is missing", async () => {
+    it("leaves the verifier orphaned and creates no state key when state or code_challenge is missing", async () => {
       const result =
         await agent().testRedirectWithoutStateOrChallengeKeepsOrphan();
 
-      expect(result.afterNoState).toBe(true);
-      expect(result.afterNoChallenge).toBe(true);
+      // Missing state: challenge key untouched, no state-nonce key created.
+      expect(result.challengeAfterNoState).toBe(true);
+      expect(result.stateAfterNoState).toBe(false);
+      // Missing code_challenge: same — early-return, no promotion.
+      expect(result.challengeAfterNoChallenge).toBe(true);
+      expect(result.stateAfterNoChallenge).toBe(false);
     });
   });
 
@@ -79,7 +95,12 @@ describe("DurableObjectOAuthClientProvider PKCE binding", () => {
     it("sweeps every pending verifier (bound and orphaned), not a single slot", async () => {
       const result = await agent().testInvalidateVerifierDeletesAllPending();
 
-      expect(result.before).toBe(3);
+      // codeVerifierKeys excludes orphaned challenge keys by default (so a
+      // no-context deleteCodeVerifier cannot delete another flow's pending
+      // challenge verifier), but counts them under includeChallengeKeys.
+      expect(result.defaultBefore).toBe(2);
+      expect(result.withChallengeBefore).toBe(3);
+      // invalidateCredentials("verifier") sweeps all three, including the orphan.
       expect(result.after).toBe(0);
     });
   });

--- a/packages/agents/src/tests/mcp/do-oauth-client-provider.test.ts
+++ b/packages/agents/src/tests/mcp/do-oauth-client-provider.test.ts
@@ -45,6 +45,12 @@ describe("DurableObjectOAuthClientProvider PKCE binding", () => {
       expect(result.challengeAfterNoChallenge).toBe(true);
       expect(result.stateAfterNoChallenge).toBe(false);
     });
+
+    it("does not throw when ids are unset", async () => {
+      const result = await agent().testRedirectWithoutIdsDoesNotThrow();
+
+      expect(result.authUrl).toContain("https://auth.example.com/authorize");
+    });
   });
 
   describe("codeVerifier resolution without ALS context", () => {
@@ -73,6 +79,15 @@ describe("DurableObjectOAuthClientProvider PKCE binding", () => {
   });
 
   describe("expiry cleanup", () => {
+    it("deletes expired orphaned challenge verifiers before saving a new verifier", async () => {
+      const result =
+        await agent().testSaveCodeVerifierDeletesExpiredChallengeOrphans();
+
+      expect(result.expiredBefore).toBe(true);
+      expect(result.expiredAfter).toBe(false);
+      expect(result.freshAfter).toBe(true);
+    });
+
     it("deletes the bound state verifier when checkState finds the state expired", async () => {
       const result = await agent().testCheckStateExpiredDeletesVerifier();
 

--- a/packages/agents/src/tests/mcp/do-oauth-client-provider.test.ts
+++ b/packages/agents/src/tests/mcp/do-oauth-client-provider.test.ts
@@ -1,0 +1,86 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+
+// Provider-level branch coverage for DurableObjectOAuthClientProvider's
+// PKCE-verifier-by-callback-state logic. These run inside TestOAuthAgent so the
+// provider uses real DurableObjectStorage (the behavior cannot be faithfully
+// reproduced with an in-memory mock).
+describe("DurableObjectOAuthClientProvider PKCE binding", () => {
+  function agent() {
+    const id = env.TestOAuthAgent.newUniqueId();
+    return env.TestOAuthAgent.get(id);
+  }
+
+  describe("redirectToAuthorization binding guard", () => {
+    it("does not bind a verifier when the state's serverId belongs to another server", async () => {
+      const result = await agent().testRedirectIgnoresServerIdMismatch();
+
+      expect(result.challengeBefore).toBe(true);
+      // Cross-server state must be ignored: verifier stays orphaned under the
+      // challenge key and is never promoted to a state-nonce key.
+      expect(result.challengeStillPresent).toBe(true);
+      expect(result.stateVerifierCreated).toBe(false);
+    });
+
+    it("leaves the verifier under the challenge key when state or code_challenge is missing", async () => {
+      const result =
+        await agent().testRedirectWithoutStateOrChallengeKeepsOrphan();
+
+      expect(result.afterNoState).toBe(true);
+      expect(result.afterNoChallenge).toBe(true);
+    });
+  });
+
+  describe("codeVerifier resolution without ALS context", () => {
+    it("throws loudly when multiple verifiers are pending (no silent wrong-verifier)", async () => {
+      const result = await agent().testCodeVerifierMultiplePendingThrows();
+
+      expect(result.threw).toBe(true);
+      expect(result.message).toContain("Multiple OAuth code verifiers");
+    });
+
+    it("resolves the sole pending verifier (deprecated reconnect happy path)", async () => {
+      const result = await agent().testCodeVerifierSinglePendingFallback();
+
+      expect(result.resolved).toBe(result.expected);
+    });
+
+    it("throws a state-specific error inside a state context with no stored verifier", async () => {
+      const result =
+        await agent().testCodeVerifierStateContextNoVerifierThrows();
+
+      expect(result.threw).toBe(true);
+      expect(result.message).toContain(
+        "No code verifier found for OAuth state"
+      );
+    });
+  });
+
+  describe("expiry cleanup", () => {
+    it("deletes the bound state verifier when checkState finds the state expired", async () => {
+      const result = await agent().testCheckStateExpiredDeletesVerifier();
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("State expired");
+      expect(result.stateKeyExists).toBe(false);
+      expect(result.verifierKeyExists).toBe(false);
+    });
+
+    it("deletes and throws when resolving an expired state verifier", async () => {
+      const result = await agent().testCodeVerifierStateExpiredThrows();
+
+      expect(result.threw).toBe(true);
+      expect(result.message).toContain("Code verifier expired");
+      expect(result.verifierKeyExists).toBe(false);
+    });
+  });
+
+  describe("invalidateCredentials", () => {
+    it("sweeps every pending verifier (bound and orphaned), not a single slot", async () => {
+      const result = await agent().testInvalidateVerifierDeletesAllPending();
+
+      expect(result.before).toBe(3);
+      expect(result.after).toBe(0);
+    });
+  });
+});

--- a/packages/agents/src/tests/mcp/oauth2-mcp-client.test.ts
+++ b/packages/agents/src/tests/mcp/oauth2-mcp-client.test.ts
@@ -630,7 +630,7 @@ describe("OAuth2 MCP Client - Multiple Servers", () => {
 });
 
 describe("OAuth2 MCP Client - State Security", () => {
-  it("should reject reused state (single-use enforcement)", async () => {
+  it("should treat reused state as stale success after auth is already complete", async () => {
     const agentId = env.TestOAuthAgent.newUniqueId();
     const agentStub = env.TestOAuthAgent.get(agentId);
     const serverId = nanoid(8);
@@ -665,9 +665,9 @@ describe("OAuth2 MCP Client - State Security", () => {
     const response2 = await agentStub.fetch(
       new Request(`${callbackUrl}?code=test-code&state=${state}`)
     );
-    expect(response2.status).toBeGreaterThanOrEqual(400);
-    const body = (await response2.json()) as { error: string };
-    expect(body.error).toContain("State not found or already used");
+    expect(response2.status).toBe(200);
+    const body = (await response2.json()) as { success: boolean };
+    expect(body.success).toBe(true);
   });
 
   it("should reject state with mismatched serverId", async () => {
@@ -747,6 +747,7 @@ describe("OAuth2 MCP Client - Custom Handler", () => {
       callbackUrl,
       "client-id"
     );
+    await agentStub.setupMockOAuthState(serverId, "test-code", "test-state");
 
     const state = await createStateWithSetup(agentStub, serverId);
     const response = await agentStub.fetch(
@@ -789,6 +790,7 @@ describe("OAuth2 MCP Client - Custom Handler", () => {
       callbackUrl,
       "client-id"
     );
+    await agentStub.setupMockOAuthState(serverId, "test-code", "test-state");
 
     const state = await createStateWithSetup(agentStub, serverId);
     // Send OAuth error


### PR DESCRIPTION
## Problem

`DurableObjectOAuthClientProvider` stores OAuth state per nonce, but stored the PKCE `code_verifier` in a single client/server slot.

When multiple OAuth attempts overlap for the same MCP server/client, a callback can arrive for one state while the provider reads the verifier from another attempt. The token exchange then fails with the upstream OAuth error:

```
Invalid PKCE code_verifier
```

This can happen when a user retries auth, opens multiple auth popups, completes an older popup, or hits reauth churn.

## Fix

Store PKCE verifier data by OAuth callback state instead of by client/server.

The MCP SDK calls `saveCodeVerifier(verifier)` without passing `state`, then later calls `redirectToAuthorization(authUrl)` with an authorization URL that contains both `state` and `code_challenge`. The provider now uses that `code_challenge` as the bridge to bind the saved verifier to the generated OAuth state without changing the MCP SDK provider interface.

Callback handling now runs token exchange in the returned state verifier context, so `codeVerifier()` resolves the verifier for that exact callback.

Stale/duplicate callbacks are treated idempotently once auth is already accepted or progressing. Their state is consumed to prevent replay, but verifier cleanup is left to the active completion path, direct reconnect cleanup, invalidation, or expiry so stale callbacks cannot delete the verifier currently in use.

## Tests

Adds coverage for:

- resolving PKCE verifiers by OAuth callback state;
- overlapping OAuth states for the same server/client;
- stale valid callbacks after auth is already progressing;
- callbacks that become stale while state validation is pending;
- stale OAuth error callbacks after auth is accepted/progressing;
- duplicate callbacks with the same active state;
- deprecated direct reconnect verifier cleanup;
- connection state while OAuth token exchange is pending.

Verification:

- `npm --workspace packages/agents run test:workers -- --run src/tests/mcp/create-oauth-provider.test.ts src/tests/mcp/client-manager.test.ts src/tests/mcp/client-connection.test.ts`
- `npm run check`

## Context

This fixes the MCP OAuth failure mode where downstream clients surface `Invalid PKCE code_verifier` after overlapping or stale auth windows. The manager-driven callback path is now concurrency-safe for overlapping attempts.

The deprecated direct `connect(..., { reconnect: { oauthCode } })` path remains best-effort because it does not carry OAuth state, but it now performs verifier cleanup after completion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->