### PR TITLE
Fix RPC resource leaks in workflows

### DIFF
--- a/.changeset/dispose-workflow-rpc-results.md
+++ b/.changeset/dispose-workflow-rpc-results.md
@@ -1,0 +1,8 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+---
+
+Fix RPC resource leaks in workflows.
+
+Workflows that use `waitForApproval()` or `ThinkWorkflow.prompt()` now release their RPC stubs promptly, preventing resource leaks and the associated "RPC stub was not disposed" warnings in your logs.

--- a/packages/agents/src/tests/workflow-prototype.test.ts
+++ b/packages/agents/src/tests/workflow-prototype.test.ts
@@ -7,8 +7,45 @@
  * through the integration tests.
  */
 import { describe, expect, it } from "vitest";
-import { AgentWorkflow } from "../workflows";
+import { AgentWorkflow, WorkflowRejectedError } from "../workflows";
 import type { AgentWorkflowEvent, AgentWorkflowStep } from "../workflows";
+
+type DisposableAgentStub = {
+  fetch(): Promise<Response>;
+  [Symbol.dispose](): void;
+};
+
+type DisposableWorkflow = {
+  _agent?: DisposableAgentStub;
+  __agentInitCalled: boolean;
+  _disposeAgent(): void;
+  readonly agent: DisposableAgentStub;
+};
+
+type ApprovalWorkflow = {
+  waitForApproval<T>(
+    step: AgentWorkflowStep,
+    options?: { stepName?: string; timeout?: string; eventType?: string }
+  ): Promise<T>;
+};
+
+function createDisposableWorkflow(onDispose: () => void): DisposableWorkflow {
+  const stub: DisposableAgentStub = {
+    fetch: async () => new Response("ok"),
+    [Symbol.dispose]: onDispose
+  };
+
+  return Object.assign(Object.create(AgentWorkflow.prototype), {
+    _agent: stub,
+    __agentInitCalled: true
+  }) as DisposableWorkflow;
+}
+
+function createApprovalWorkflow(): ApprovalWorkflow {
+  return Object.assign(Object.create(AgentWorkflow.prototype), {
+    _workflowId: "workflow-id"
+  }) as ApprovalWorkflow;
+}
 
 describe("AgentWorkflow prototype wrapping", () => {
   describe("static prototype analysis", () => {
@@ -142,6 +179,91 @@ describe("AgentWorkflow prototype wrapping", () => {
 
       expect(extended).toBe(step);
       expect(extended.customPrompt).toBe(true);
+    });
+  });
+
+  describe("agent stub lifecycle", () => {
+    it("has cleanup that disposes and clears the initialized agent stub", () => {
+      let disposeCount = 0;
+      const workflow = createDisposableWorkflow(() => {
+        disposeCount++;
+      });
+
+      expect(typeof workflow._disposeAgent).toBe("function");
+
+      workflow._disposeAgent();
+
+      expect(disposeCount).toBe(1);
+      expect(() => workflow.agent).toThrow("Agent not initialized");
+    });
+
+    it("makes cleanup idempotent when called after the stub was cleared", () => {
+      let disposeCount = 0;
+      const workflow = createDisposableWorkflow(() => {
+        disposeCount++;
+      });
+
+      expect(typeof workflow._disposeAgent).toBe("function");
+
+      workflow._disposeAgent();
+      workflow._disposeAgent();
+
+      expect(disposeCount).toBe(1);
+      expect(() => workflow.agent).toThrow("Agent not initialized");
+    });
+  });
+
+  describe("approval event lifecycle", () => {
+    it("disposes the waitForApproval event after reading approval metadata", async () => {
+      let disposeCount = 0;
+      const waitEvent = {
+        payload: {
+          approved: true,
+          metadata: { answer: "approved" }
+        },
+        [Symbol.dispose]: () => {
+          disposeCount++;
+        }
+      };
+      const step = {
+        waitForEvent: async () => waitEvent,
+        reportError: async () => {
+          throw new Error("reportError should not be called");
+        }
+      } as unknown as AgentWorkflowStep;
+
+      const workflow = createApprovalWorkflow();
+      await expect(workflow.waitForApproval(step)).resolves.toEqual({
+        answer: "approved"
+      });
+      expect(disposeCount).toBe(1);
+    });
+
+    it("disposes the waitForApproval event after reporting rejection", async () => {
+      let disposeCount = 0;
+      const reportErrors: string[] = [];
+      const waitEvent = {
+        payload: {
+          approved: false,
+          reason: "not safe"
+        },
+        [Symbol.dispose]: () => {
+          disposeCount++;
+        }
+      };
+      const step = {
+        waitForEvent: async () => waitEvent,
+        reportError: async (error: string | Error) => {
+          reportErrors.push(error instanceof Error ? error.message : error);
+        }
+      } as unknown as AgentWorkflowStep;
+
+      const workflow = createApprovalWorkflow();
+      await expect(workflow.waitForApproval(step)).rejects.toBeInstanceOf(
+        WorkflowRejectedError
+      );
+      expect(reportErrors).toEqual(["not safe"]);
+      expect(disposeCount).toBe(1);
     });
   });
 

--- a/packages/agents/src/workflows.ts
+++ b/packages/agents/src/workflows.ts
@@ -34,7 +34,11 @@
  */
 
 import { WorkflowEntrypoint } from "cloudflare:workers";
-import type { WorkflowEvent, WorkflowStep } from "cloudflare:workers";
+import type {
+  WorkflowEvent,
+  WorkflowStep,
+  WorkflowStepEvent
+} from "cloudflare:workers";
 import { getAgentByName, type Agent } from "./index";
 import type {
   AgentWorkflowParams,
@@ -69,7 +73,7 @@ export class AgentWorkflow<
    * The Agent stub - initialized before run() is called.
    * Use this.agent to access the Agent's RPC methods.
    */
-  private _agent!: DurableObjectStub<AgentType>;
+  private _agent?: DurableObjectStub<AgentType>;
 
   /**
    * Workflow instance ID
@@ -132,37 +136,35 @@ export class AgentWorkflow<
           );
           this.__agentInitCalled = true;
 
-          // Pass cleaned event and wrapped step to user's implementation
-          const cleanedEvent = {
-            ...event,
-            payload: userParams as Params
-          } as WorkflowEvent<Params>;
-
-          const wrappedStep = this.extendStep(
-            this._wrapStep(step),
-            cleanedEvent
-          );
-
           try {
-            return await originalRun.call(this, cleanedEvent, wrappedStep);
-          } catch (err) {
-            await this._autoReportError(err);
-            throw err;
+            // Pass cleaned event and wrapped step to user's implementation
+            const cleanedEvent = {
+              ...event,
+              payload: userParams as Params
+            } as WorkflowEvent<Params>;
+
+            const wrappedStep = this.extendStep(
+              this._wrapStep(step),
+              cleanedEvent
+            );
+
+            return await this._runWithErrorReporting(
+              originalRun,
+              cleanedEvent,
+              wrappedStep
+            );
+          } finally {
+            this._disposeAgent();
           }
         }
 
         // If already initialized (e.g., called via super.run()),
-        // just call the original with the event as-is
-        try {
-          return await originalRun.call(
-            this,
-            event as WorkflowEvent<Params>,
-            step as AgentWorkflowStep
-          );
-        } catch (err) {
-          await this._autoReportError(err);
-          throw err;
-        }
+        // just call the original with the event as-is.
+        return await this._runWithErrorReporting(
+          originalRun,
+          event as WorkflowEvent<Params>,
+          step as AgentWorkflowStep
+        );
       };
 
       wrappedPrototypes.add(proto);
@@ -188,6 +190,7 @@ export class AgentWorkflow<
 
     this._workflowId = instanceId;
     this._workflowName = workflowName;
+    this._errorReported = false;
 
     // Get the Agent namespace from env
     const namespace = (this.env as Record<string, unknown>)[
@@ -205,6 +208,35 @@ export class AgentWorkflow<
       namespace,
       agentName
     );
+  }
+
+  /**
+   * Call user workflow code and report unhandled errors to the Agent.
+   */
+  private async _runWithErrorReporting(
+    originalRun: (
+      event: WorkflowEvent<Params>,
+      step: AgentWorkflowStep
+    ) => Promise<unknown>,
+    event: WorkflowEvent<Params>,
+    step: AgentWorkflowStep
+  ): Promise<unknown> {
+    try {
+      return await originalRun.call(this, event, step);
+    } catch (err) {
+      await this._autoReportError(err);
+      throw err;
+    }
+  }
+
+  /**
+   * Dispose the Agent stub owned by this workflow run.
+   */
+  private _disposeAgent(): void {
+    const agent = this._agent;
+    this._agent = undefined;
+    this.__agentInitCalled = false;
+    disposeIfPresent(agent);
   }
 
   /**
@@ -425,27 +457,49 @@ export class AgentWorkflow<
 
     // Wait for the approval event
     // Note: Call reportProgress() before this method if you want to update progress
-    const event = await step.waitForEvent(stepName, {
+    const event = (await step.waitForEvent(stepName, {
       type: eventType,
       timeout
-    });
-
-    // Cast the payload to our expected type
-    const payload = event.payload as {
+    })) as WorkflowStepEvent<{
       approved: boolean;
       reason?: string;
       metadata?: T;
-    };
+    }>;
 
-    // Check if rejected
-    if (!payload.approved) {
-      const reason = payload.reason;
-      await step.reportError(reason ?? "Workflow rejected");
-      throw new WorkflowRejectedError(reason, this._workflowId);
+    try {
+      const payload = event.payload;
+
+      // Check if rejected
+      if (!payload.approved) {
+        const reason = payload.reason;
+        await step.reportError(reason ?? "Workflow rejected");
+        throw new WorkflowRejectedError(reason, this._workflowId);
+      }
+
+      // Return the approval metadata as the result
+      return payload.metadata as T;
+    } finally {
+      disposeIfPresent(event);
     }
+  }
+}
 
-    // Return the approval metadata as the result
-    return payload.metadata as T;
+type DisposableResource = {
+  [Symbol.dispose](): void;
+};
+
+function isDisposableResource(value: unknown): value is DisposableResource {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    Symbol.dispose in value &&
+    typeof value[Symbol.dispose] === "function"
+  );
+}
+
+function disposeIfPresent(value: unknown): void {
+  if (isDisposableResource(value)) {
+    value[Symbol.dispose]();
   }
 }
 

--- a/packages/think/src/tests/workflows.test.ts
+++ b/packages/think/src/tests/workflows.test.ts
@@ -1,0 +1,229 @@
+import type { WorkflowEvent } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { z, type ZodObject } from "zod";
+import type { AgentWorkflowStep } from "agents/workflows";
+import type { SubmitMessagesResult } from "../think";
+import { ThinkPromptTimeoutError, ThinkWorkflow } from "../workflows";
+
+type PromptStepRunner = {
+  _promptStep<Schema extends ZodObject>(
+    stepName: string,
+    options: {
+      prompt: string;
+      output: Schema;
+      timeout?: string;
+      key?: string;
+      cancelOnTimeout?: boolean;
+    },
+    step: AgentWorkflowStep,
+    event: WorkflowEvent<unknown>
+  ): Promise<z.infer<Schema>>;
+};
+
+type DisposableSubmissionResult = SubmitMessagesResult & {
+  extraRpcField: string;
+  [Symbol.dispose](): void;
+};
+
+type FakeThinkAgent = {
+  submitMessages(): Promise<DisposableSubmissionResult>;
+  cancelSubmission(submissionId: string, reason: string): Promise<void>;
+};
+
+function createWorkflow(agent: FakeThinkAgent): PromptStepRunner {
+  return Object.assign(Object.create(ThinkWorkflow.prototype), {
+    _agent: agent,
+    _workflowId: "workflow-id",
+    _workflowName: "TEST_WORKFLOW"
+  }) as PromptStepRunner;
+}
+
+function createEvent(): WorkflowEvent<unknown> {
+  return {
+    instanceId: "workflow-id",
+    payload: {}
+  } as WorkflowEvent<unknown>;
+}
+
+function createSubmissionResult(
+  submissionId: string,
+  onDispose: () => void
+): DisposableSubmissionResult {
+  return {
+    submissionId,
+    accepted: true,
+    status: "pending",
+    createdAt: Date.now(),
+    extraRpcField: "must-not-leave-step-do",
+    [Symbol.dispose]: onDispose
+  };
+}
+
+describe("ThinkWorkflow", () => {
+  describe("prompt step RPC disposal", () => {
+    it("disposes submitMessages and waitForEvent results after copying serializable data", async () => {
+      let submissionDisposeCount = 0;
+      let waitEventDisposeCount = 0;
+      let submitStepResult: unknown;
+
+      const submissionResult = createSubmissionResult("submission-1", () => {
+        submissionDisposeCount++;
+      });
+
+      const agent: FakeThinkAgent = {
+        async submitMessages() {
+          return submissionResult;
+        },
+        async cancelSubmission() {
+          throw new Error("cancelSubmission should not be called");
+        }
+      };
+
+      const waitEvent = {
+        payload: {
+          submissionId: "submission-1",
+          status: "completed",
+          output: { answer: "done" }
+        },
+        [Symbol.dispose]: () => {
+          waitEventDisposeCount++;
+        }
+      };
+
+      const step = {
+        do: async (_name: string, callback: () => Promise<unknown>) => {
+          submitStepResult = await callback();
+          return submitStepResult;
+        },
+        waitForEvent: async () => waitEvent
+      } as unknown as AgentWorkflowStep;
+
+      const workflow = createWorkflow(agent);
+      const output = await workflow._promptStep(
+        "structure",
+        {
+          prompt: "Return structured output",
+          output: z.object({ answer: z.string() })
+        },
+        step,
+        createEvent()
+      );
+
+      expect(output).toEqual({ answer: "done" });
+      expect(submitStepResult).toEqual({ submissionId: "submission-1" });
+      expect(submissionDisposeCount).toBe(1);
+      expect(waitEventDisposeCount).toBe(1);
+    });
+
+    it("keeps the waitForEvent result alive while validating nested output", async () => {
+      let waitEventDisposed = false;
+
+      const submissionResult = createSubmissionResult(
+        "submission-proxy",
+        () => {}
+      );
+      const agent: FakeThinkAgent = {
+        async submitMessages() {
+          return submissionResult;
+        },
+        async cancelSubmission() {
+          throw new Error("cancelSubmission should not be called");
+        }
+      };
+
+      const output = {
+        get answer() {
+          if (waitEventDisposed) {
+            throw new Error("output read after wait event disposal");
+          }
+          return "still readable";
+        }
+      };
+
+      const waitEvent = {
+        payload: {
+          submissionId: "submission-proxy",
+          status: "completed",
+          output
+        },
+        [Symbol.dispose]: () => {
+          waitEventDisposed = true;
+        }
+      };
+
+      const step = {
+        do: async (_name: string, callback: () => Promise<unknown>) => {
+          return callback();
+        },
+        waitForEvent: async () => waitEvent
+      } as unknown as AgentWorkflowStep;
+
+      const workflow = createWorkflow(agent);
+      await expect(
+        workflow._promptStep(
+          "structure",
+          {
+            prompt: "Return structured output",
+            output: z.object({ answer: z.string() })
+          },
+          step,
+          createEvent()
+        )
+      ).resolves.toEqual({ answer: "still readable" });
+      expect(waitEventDisposed).toBe(true);
+    });
+
+    it("disposes the submitMessages result before cancelling a timed-out prompt", async () => {
+      let submissionDisposeCount = 0;
+      const cancelCalls: Array<{ submissionId: string; reason: string }> = [];
+
+      const submissionResult = createSubmissionResult(
+        "submission-timeout",
+        () => {
+          submissionDisposeCount++;
+        }
+      );
+
+      const agent: FakeThinkAgent = {
+        async submitMessages() {
+          return submissionResult;
+        },
+        async cancelSubmission(submissionId: string, reason: string) {
+          cancelCalls.push({ submissionId, reason });
+        }
+      };
+
+      const step = {
+        do: async (_name: string, callback: () => Promise<unknown>) => {
+          return callback();
+        },
+        waitForEvent: async () => {
+          throw new Error("timed out");
+        }
+      } as unknown as AgentWorkflowStep;
+
+      const workflow = createWorkflow(agent);
+
+      await expect(
+        workflow._promptStep(
+          "structure",
+          {
+            prompt: "Return structured output",
+            output: z.object({ answer: z.string() }),
+            timeout: "1 minute"
+          },
+          step,
+          createEvent()
+        )
+      ).rejects.toBeInstanceOf(ThinkPromptTimeoutError);
+
+      expect(submissionDisposeCount).toBe(1);
+      expect(cancelCalls).toEqual([
+        {
+          submissionId: "submission-timeout",
+          reason: "Workflow prompt wait timed out"
+        }
+      ]);
+    });
+  });
+});

--- a/packages/think/src/workflows.ts
+++ b/packages/think/src/workflows.ts
@@ -1,4 +1,8 @@
-import type { WorkflowEvent, WorkflowSleepDuration } from "cloudflare:workers";
+import type {
+  WorkflowEvent,
+  WorkflowSleepDuration,
+  WorkflowStepEvent
+} from "cloudflare:workers";
 import {
   AgentWorkflow,
   type AgentWorkflowStep,
@@ -126,7 +130,7 @@ export class ThinkWorkflow<
     );
 
     const submission = (await step.do(`${stepName}:submit`, async () => {
-      return this.agent.submitMessages(
+      const submissionResult = (await this.agent.submitMessages(
         [
           {
             id: crypto.randomUUID(),
@@ -151,42 +155,70 @@ export class ThinkWorkflow<
             }
           }
         }
-      );
-    })) as SubmitMessagesResult;
+      )) as SubmitMessagesResult;
 
-    let eventPayload: ThinkPromptEventPayload;
+      try {
+        return { submissionId: submissionResult.submissionId };
+      } finally {
+        disposeIfPresent(submissionResult);
+      }
+    })) as Pick<SubmitMessagesResult, "submissionId">;
+
+    const event = await this._waitForPromptEvent(
+      step,
+      `${stepName}:wait`,
+      eventType,
+      options.timeout,
+      options.cancelOnTimeout,
+      submission.submissionId
+    );
+
     try {
-      const event = await step.waitForEvent(`${stepName}:wait`, {
+      const payload = event.payload;
+
+      if (payload.status !== "completed") {
+        throw this._terminalPromptError(payload);
+      }
+
+      const parsed = options.output.safeParse(payload.output);
+      if (!parsed.success) {
+        throw new ThinkPromptValidationError(
+          payload.submissionId,
+          parsed.error
+        );
+      }
+      return parsed.data;
+    } finally {
+      disposeIfPresent(event);
+    }
+  }
+
+  private async _waitForPromptEvent(
+    step: AgentWorkflowStep,
+    stepName: string,
+    eventType: string,
+    timeout: WorkflowSleepDuration | undefined,
+    cancelOnTimeout: boolean | undefined,
+    submissionId: string
+  ): Promise<WorkflowStepEvent<ThinkPromptEventPayload>> {
+    try {
+      return (await step.waitForEvent(stepName, {
         type: eventType,
-        timeout: options.timeout
-      });
-      eventPayload = event.payload as ThinkPromptEventPayload;
+        timeout
+      })) as WorkflowStepEvent<ThinkPromptEventPayload>;
     } catch (error) {
-      if (options.cancelOnTimeout !== false) {
+      if (cancelOnTimeout !== false) {
         try {
           await this.agent.cancelSubmission(
-            submission.submissionId,
+            submissionId,
             "Workflow prompt wait timed out"
           );
         } catch {
           // Cancellation is best-effort cleanup; preserve the timeout error.
         }
       }
-      throw new ThinkPromptTimeoutError(submission.submissionId, error);
+      throw new ThinkPromptTimeoutError(submissionId, error);
     }
-
-    if (eventPayload.status !== "completed") {
-      throw this._terminalPromptError(eventPayload);
-    }
-
-    const parsed = options.output.safeParse(eventPayload.output);
-    if (!parsed.success) {
-      throw new ThinkPromptValidationError(
-        eventPayload.submissionId,
-        parsed.error
-      );
-    }
-    return parsed.data;
   }
 
   private _terminalPromptError(
@@ -227,6 +259,25 @@ export class ThinkWorkflow<
     const bytes = new TextEncoder().encode(value);
     const digest = await crypto.subtle.digest("SHA-256", bytes);
     return base64Url(digest).slice(0, 22);
+  }
+}
+
+type DisposableResource = {
+  [Symbol.dispose](): void;
+};
+
+function isDisposableResource(value: unknown): value is DisposableResource {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    Symbol.dispose in value &&
+    typeof value[Symbol.dispose] === "function"
+  );
+}
+
+function disposeIfPresent(value: unknown): void {
+  if (isDisposableResource(value)) {
+    value[Symbol.dispose]();
   }
 }
 


### PR DESCRIPTION
AgentWorkflow and ThinkWorkflow were not disposing the Durable Object references returned by waitForEvent(), submitMessages(), and getAgentByName(). These references hold an open connection to the remote object and must be explicitly disposed; without it, the runtime logs "RPC stub was not disposed" warnings and the connections leak for the duration of the workflow run. Because workflows can be long-lived and may retry, the leaks compound over time.

Regression tests are included for the approval flow, the Think prompt flow, and the agent stub cleanup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->