### PR TITLE
fix(think): don't re-arm auto-continuation barrier on RPC stall recovery

### DIFF
--- a/.changeset/rpc-stall-recovery-no-rearm.md
+++ b/.changeset/rpc-stall-recovery-no-rearm.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/think": patch
+---
+
+fix(think): don't re-arm the auto-continuation barrier when an RPC stall routes into bounded recovery (#1667 follow-up)
+
+The RPC streaming path (`_streamResultToRpcCallback`) re-armed the auto-continuation coalesce timer in its `finally` even on the stream-stall recovery early-returns (`scheduled`/`exhausted`), unlike the WebSocket `_streamResult` recovery paths which deliberately do a plain `_streamingAssistant = null` without re-arming. When a parallel tool batch had a pending continuation at the moment the stall watchdog fired, that re-arm could fire a second continuation alongside the alarm-scheduled recovery continuation — a spurious double model invocation on the turn queue. The RPC recovery early-returns now mirror the WebSocket path (plain clear, no re-arm); the scheduled recovery continuation re-runs the turn and its own stream finalize re-triggers the held barrier exactly once.

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -1090,6 +1090,88 @@ export class ThinkTestAgent extends Think {
   }
 
   /**
+   * Regression for the RPC stall-recovery re-arm asymmetry: with a pending
+   * auto-continuation already armed (as if a prior parallel tool-batch sibling
+   * had opted in with `autoContinue: true` but the batch isn't whole yet), a
+   * stream stall that routes into bounded recovery must NOT re-arm the 50ms
+   * coalesce timer in the RPC `_streamResultToRpcCallback` `finally`. The
+   * scheduled recovery continuation re-runs the turn and its own stream finalize
+   * re-triggers the held barrier; re-arming here too would fire a SECOND
+   * continuation alongside the recovery one (a spurious double model
+   * invocation). This mirrors the deliberate plain-clear in the WebSocket
+   * `_streamResult` recovery paths.
+   *
+   * Returns whether the coalesce timer was left armed after the stalled turn
+   * resolved (must be `false` with the fix) and whether `_streamingAssistant`
+   * was cleared (must be `true`). Read synchronously on resolve — before the
+   * (erroneously) armed macrotask timer could fire.
+   */
+  async testStallRecoveryDoesNotRearmPendingContinuation(
+    afterChunks: number,
+    timeoutMs: number
+  ): Promise<{
+    firstError: string | undefined;
+    scheduledContinues: number;
+    coalesceTimerArmedAfterStall: boolean;
+    streamingAssistantCleared: boolean;
+  }> {
+    const internal = this as unknown as {
+      _continuation: {
+        pending: Record<string, unknown> | null;
+        awaitingConnections: Map<string, unknown>;
+      };
+      _continuationTimer: ReturnType<typeof setTimeout> | null;
+      _streamingAssistant: unknown;
+    };
+    // Seed a pending auto-continuation with `pastCoalesce: false` so the buggy
+    // re-arm path (`_rearmPendingAutoContinuationForBatch`) would reset the
+    // coalesce timer in the recovery `finally`.
+    internal._continuation.pending = {
+      connection: undefined,
+      connectionId: "test-conn",
+      requestId: crypto.randomUUID(),
+      clientTools: undefined,
+      body: undefined,
+      errorPrefix: "[Think] Auto-continuation failed:",
+      prerequisite: null,
+      pastCoalesce: false
+    };
+    this._stallAfterChunks = afterChunks;
+    this._stallAttemptsRemaining = 1;
+    this.chatStreamStallTimeoutMs = timeoutMs;
+    try {
+      const first = await this.testChat("seeded pending, then stall");
+      // Read synchronously: no `await` has yielded since the recovery `finally`
+      // ran, so an erroneously armed 50ms timer cannot have fired yet.
+      const coalesceTimerArmedAfterStall = internal._continuationTimer !== null;
+      const streamingAssistantCleared = internal._streamingAssistant === null;
+      const scheduledContinues =
+        this.sql<{ count: number }>`
+          SELECT COUNT(*) as count FROM cf_agents_schedules
+          WHERE callback = '_chatRecoveryContinue'
+        `[0]?.count ?? 0;
+      return {
+        firstError: first.error,
+        scheduledContinues,
+        coalesceTimerArmedAfterStall,
+        streamingAssistantCleared
+      };
+    } finally {
+      // Tear down the seeded pending + any armed timer so nothing leaks into a
+      // later turn (and the seeded undefined connection never gets used).
+      if (internal._continuationTimer) {
+        clearTimeout(internal._continuationTimer);
+        internal._continuationTimer = null;
+      }
+      internal._continuation.pending = null;
+      internal._continuation.awaitingConnections.clear();
+      this._stallAfterChunks = null;
+      this._stallAttemptsRemaining = null;
+      this.chatStreamStallTimeoutMs = 0;
+    }
+  }
+
+  /**
    * Stream each chunk after `delayMs` with the watchdog armed at `timeoutMs`
    * (> delay). Proves the watchdog resets per chunk and does NOT false-fire on
    * a slow-but-steady stream.

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -1668,6 +1668,116 @@ describe("Think — auto-continuation", () => {
     await closeWS(ws);
   });
 
+  it("documents the known gap: eviction + an errored autoContinue:false completing result drops the held continuation (#1650)", async () => {
+    // Non-evicted, this combination DOES continue once: the errored
+    // (autoContinue:false) result re-arms the EXISTING pending the fast sibling
+    // created (see the mixed-batch test above). But the only signal that
+    // continuation was requested — the fast sibling's autoContinue:true — lives
+    // in the in-memory pending, not the persisted transcript. So if the isolate
+    // is evicted between siblings, the errored completing result finds no
+    // pending and `_rearmPendingAutoContinuationForBatch` no-ops (it never
+    // CREATES a pending): the continuation is silently dropped.
+    //
+    // This is NOT a regression (the old in-memory timer was equally fragile to
+    // eviction) and a later user message / chat recovery repairs the transcript.
+    // This test pins the current behavior and the limitation; fixing it would
+    // require persisting the continuation-requested intent across eviction.
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    await agent.persistToolCallMessage([
+      makeUserMessage("use two tools"),
+      {
+        id: "assistant-evict-err",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-fast",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "fast" }
+          },
+          {
+            type: "tool-client_action",
+            toolCallId: "tc-slow",
+            toolName: "client_action",
+            state: "input-available",
+            input: { action: "slow" }
+          }
+        ]
+      } as unknown as UIMessage
+    ]);
+    await agent.clearResponseLog();
+
+    const repairedToolCallIds: Array<string[] | undefined> = [];
+    const unsubscribe = subscribe("transcript", (event) => {
+      if (event.type === "chat:transcript:repaired" && event.name === room) {
+        repairedToolCallIds.push(event.payload.toolCallIds);
+      }
+    });
+
+    try {
+      // Fast result opts into continuation and parks the barrier (slow sibling
+      // still pending).
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_RESULT,
+          toolCallId: "tc-fast",
+          toolName: "client_action",
+          output: "fast output",
+          autoContinue: true
+        })
+      );
+      await delay(300);
+      expect(
+        ((await agent.getResponseLog()) as ChatResponseResult[]).filter(
+          (entry) => entry.continuation
+        ).length
+      ).toBe(0);
+
+      // Eviction drops the in-memory pending (the autoContinue:true intent is
+      // lost); the fast result stays persisted in the transcript.
+      await agent.evictInMemoryContinuationState();
+
+      // The completing sibling errors with autoContinue:false. With no pending
+      // to re-arm, NO continuation fires — the held continuation is dropped.
+      ws.send(
+        JSON.stringify({
+          type: MSG_TOOL_RESULT,
+          toolCallId: "tc-slow",
+          toolName: "client_action",
+          state: "output-error",
+          errorText: "tool failed",
+          autoContinue: false
+        })
+      );
+      await delay(400);
+
+      const log = (await agent.getResponseLog()) as ChatResponseResult[];
+      expect(log.filter((entry) => entry.continuation).length).toBe(0);
+      // The drop is silent — no premature transcript repair either.
+      expect(repairedToolCallIds.flat()).toEqual([]);
+
+      // Both results are still applied to the transcript; only the continuation
+      // is lost (repaired later by a user message / chat recovery).
+      const messages = (await agent.getMessages()) as UIMessage[];
+      const assistant = messages.find((m) => m.id === "assistant-evict-err")!;
+      const partFor = (toolCallId: string) =>
+        assistant.parts.find(
+          (p) => (p as Record<string, unknown>).toolCallId === toolCallId
+        ) as Record<string, unknown>;
+      expect(partFor("tc-fast").state).toBe("output-available");
+      expect(partFor("tc-slow").state).toBe("output-error");
+    } finally {
+      unsubscribe();
+    }
+
+    await closeWS(ws);
+  });
+
   it("waits for a sibling tool emitted LATER in the same stream before continuing (#1649 headline / #1650)", async () => {
     // The exact race from #1649: the model emits parallel tool calls
     // sequentially within one step. A fast client tool resolves mid-stream —

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -617,6 +617,27 @@ describe("Think — error handling", () => {
     expect(errResult.interruptedCalls).toBe(0);
   });
 
+  it("does not re-arm a held auto-continuation when an RPC stall routes into bounded recovery", async () => {
+    const agent = await freshAgent(`stall-rearm-${crypto.randomUUID()}`);
+    // A pending auto-continuation is already armed when the stream stalls and
+    // routes into bounded recovery. The recovery continuation re-runs the turn
+    // and re-triggers the held barrier itself, so the RPC finally must do a
+    // plain clear (NOT re-arm the 50ms coalesce timer) — otherwise it would
+    // fire a second continuation alongside the scheduled recovery one. This
+    // mirrors the WebSocket `_streamResult` recovery paths.
+    const result = await agent.testStallRecoveryDoesNotRearmPendingContinuation(
+      3,
+      50
+    );
+
+    expect(result.firstError).toBeUndefined();
+    expect(result.scheduledContinues).toBeGreaterThanOrEqual(1);
+    // The fix: streaming accumulator cleared, but the coalesce timer was NOT
+    // re-armed by the recovery early-return.
+    expect(result.streamingAssistantCleared).toBe(true);
+    expect(result.coalesceTimerArmedAfterStall).toBe(false);
+  });
+
   it("honors a per-turn TurnConfig.chatStreamStallTimeoutMs override even when the instance watchdog is off (#1626)", async () => {
     const agent = await freshAgent(`stall-perturn-${crypto.randomUUID()}`);
     // Instance watchdog is OFF; only the per-turn override (from beforeTurn)

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -6437,6 +6437,13 @@ export class Think<
     let doneSent = false;
     let streamError: string | undefined;
     let pendingRpcError: string | undefined;
+    // When a stall-recovery early-return schedules a continuation, the
+    // continuation re-runs the turn and its own stream finalize re-triggers the
+    // held barrier. Re-arming here too would let the 50ms coalesce timer fire a
+    // SECOND continuation alongside the scheduled recovery one — a spurious
+    // double model invocation. Mirror the WebSocket `_streamResult` recovery
+    // paths and clear `_streamingAssistant` WITHOUT re-arming in that case.
+    let skipFinalizeRearm = false;
 
     const stallTimeoutMs =
       this._activeStallTimeoutMs ?? this.chatStreamStallTimeoutMs;
@@ -6594,6 +6601,7 @@ export class Think<
           // callback) owns the real terminal outcome. Signal the interruption so
           // the caller doesn't read this clean resolve as success and finalize a
           // truncated partial (#1644); NOT onDone/onError — see `onInterrupted`.
+          skipFinalizeRearm = true;
           await callback.onInterrupted?.();
           return;
         }
@@ -6612,6 +6620,7 @@ export class Think<
           // by `_exhaustChatRecovery` (banner/`onExhausted`), NOT through this
           // callback's `onError`. Signal the interruption so a `chat()` consumer
           // doesn't mis-read the clean resolve as a successful completion (#1644).
+          skipFinalizeRearm = true;
           await callback.onInterrupted?.();
           return;
         }
@@ -6670,8 +6679,15 @@ export class Think<
       // The message is now durably persisted (success, error, or recovery
       // path), so subsequent tool results resolve against storage; stop
       // exposing the sealed accumulator (#1649) and re-check any continuation
-      // the stream-active barrier held (#1650).
-      this._onStreamingTurnFinalized();
+      // the stream-active barrier held (#1650). A stall-recovery early-return
+      // does a plain clear instead (no re-arm): its scheduled continuation
+      // re-runs the turn and that finalize re-triggers the held barrier, so
+      // re-arming here would double-fire alongside the recovery continuation.
+      if (skipFinalizeRearm) {
+        this._streamingAssistant = null;
+      } else {
+        this._onStreamingTurnFinalized();
+      }
     }
 
     if (pendingRpcError) {


### PR DESCRIPTION
Follow-up to #1667 (event-driven auto-continuation barrier). Addresses two review findings.

## Finding #1 — fix (real bug)

The RPC streaming path `_streamResultToRpcCallback` re-armed the auto-continuation coalesce timer in its `finally` **even on the stream-stall recovery early-returns** (`scheduled` / `exhausted`). A `return` inside the `catch` still runs the `finally`, so `_onStreamingTurnFinalized()` — which calls `_rearmPendingAutoContinuationForBatch()` — always fired.

This diverges from the WebSocket `_streamResult` recovery paths, which deliberately do a plain `this._streamingAssistant = null` **without** re-arming (see the comment at the WS `scheduled` branch: *"recovery re-runs the turn and its own stream finalize re-triggers the held barrier"*).

**Impact:** when a parallel tool batch had a pending continuation at the moment the stall watchdog fired, the RPC re-arm scheduled a 50ms coalesce timer that could fire `_fireAutoContinuation` **alongside** the alarm-scheduled `_chatRecoveryContinue` continuation → a spurious double model invocation on the turn queue. `idempotent: true` only dedupes the scheduled task, not the auto-continuation.

**Fix:** a `skipFinalizeRearm` flag, set in the `scheduled`/`exhausted` branches, makes the `finally` do a plain `_streamingAssistant = null` clear instead of `_onStreamingTurnFinalized()` — mirroring the WS path. The held barrier is then re-triggered exactly once, by the recovery continuation's own stream finalize.

## Finding #2 — document (not a regression, not safely fixable here)

The eviction self-healing path relies on the completing result carrying `autoContinue: true` — that re-creates `_continuation.pending` from the persisted transcript via `_scheduleAutoContinuation`. If the completing result is an errored `autoContinue: false` sibling **after** eviction, `_rearmPendingAutoContinuationForBatch` finds no pending (evicted) and no-ops, so the continuation is silently dropped.

The only signal that continuation was requested (the fast sibling's `autoContinue: true`) lives in the in-memory pending, not the persisted transcript — so it can't self-heal after eviction. This is **not a regression** (the old in-memory 60s timer was equally eviction-fragile) and a later user message / chat recovery repairs the transcript. A proper fix would require persisting the continuation-requested intent across eviction. Pinned the current behavior with an explicit test rather than changing it.

## Tests

- **`think-session.test.ts`** — *"does not re-arm a held auto-continuation when an RPC stall routes into bounded recovery"*: seeds a pending continuation, stalls into recovery, and asserts the coalesce timer is **not** re-armed (while `_streamingAssistant` is still cleared). Adds the `testStallRecoveryDoesNotRearmPendingContinuation` harness method.
- **`client-tools.test.ts`** — *"documents the known gap: eviction + an errored autoContinue:false completing result drops the held continuation"*: asserts 0 continuations fire and both tool results are still applied to the transcript.

## Verification

- `npm run check` passes (sherif, export checks, oxfmt, oxlint, typecheck across 91 projects).
- New + existing stall / self-heal tests green.
- Changeset added: patch to `@cloudflare/think`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->