### PR TITLE
fix(chat-recovery): survive unbounded deploy churn; add work budget + shouldKeepRecovering runaway guard

### DIFF
--- a/.changeset/chat-recovery-work-budget.md
+++ b/.changeset/chat-recovery-work-budget.md
@@ -1,0 +1,19 @@
+---
+"@cloudflare/ai-chat": minor
+"@cloudflare/think": minor
+"agents": minor
+---
+
+fix(chat-recovery): a turn making forward progress now survives unbounded deploy churn; add a work budget + `shouldContinue` runaway guard
+
+Durable chat recovery used to bound a single incident with a non-resetting 15-minute wall-clock ceiling (`CHAT_RECOVERY_MAX_WINDOW_MS`). That ceiling was overloaded — it served as both a recovery-duration bound and a runaway-loop guard — and it terminated _healthy, actively-progressing_ turns that simply took longer than 15 minutes of wall-clock to finish while being repeatedly interrupted by a dense deploy window, sealing them with `reason="max_recovery_window_exceeded"` and discarding completed work.
+
+The two jobs are now decoupled (see `design/rfc-chat-recovery-work-budget.md`):
+
+- **Duration is no longer a bound for a progressing turn.** The non-resetting wall-clock ceiling is removed. A turn that keeps producing content survives unbounded deploy churn. Stuck turns are still sealed by the no-progress window (5 min, resets on progress); tight no-progress alarm loops by the attempt cap.
+- **New runaway-loop guard, keyed to work, not time.** The existing durable, monotonic, reconnect-immune progress counter is reused as a work meter. `chatRecovery.maxRecoveryWork` caps the produced content/tool units since an incident opened; exceeding it seals with `reason="work_budget_exceeded"`. **Defaults to `Infinity`** — the SDK ships the mechanism but imposes no implicit cap, so it never terminates a progressing turn on its own.
+- **New caller predicate.** `chatRecovery.shouldContinue(ctx)` is consulted per recovery attempt (only when no hard bound has already sealed the incident); returning `false` seals with `reason="recovery_aborted"`. This is where integrators express token/cost/step budgets the SDK should not hardcode. A throwing predicate is logged and treated as "continue".
+
+New public types from `agents/chat`: `ChatRecoveryProgressContext`. New `ChatRecoveryConfig` fields: `maxRecoveryWork`, `shouldContinue`. `ChatRecoveryExhaustedContext.reason` gains `work_budget_exceeded` and `recovery_aborted`; `max_recovery_window_exceeded` is retained as an open-string value but is no longer emitted.
+
+Both `@cloudflare/ai-chat` and `@cloudflare/think` (which carries its own copy of the recovery engine) are updated identically. Defaults are unchanged except that a progressing turn is no longer terminated by wall-clock age.

--- a/.changeset/chat-recovery-work-budget.md
+++ b/.changeset/chat-recovery-work-budget.md
@@ -4,7 +4,7 @@
 "agents": minor
 ---
 
-fix(chat-recovery): a turn making forward progress now survives unbounded deploy churn; add a work budget + `shouldContinue` runaway guard
+fix(chat-recovery): a turn making forward progress now survives unbounded deploy churn; add a work budget + `shouldKeepRecovering` runaway guard
 
 Durable chat recovery used to bound a single incident with a non-resetting 15-minute wall-clock ceiling (`CHAT_RECOVERY_MAX_WINDOW_MS`). That ceiling was overloaded — it served as both a recovery-duration bound and a runaway-loop guard — and it terminated _healthy, actively-progressing_ turns that simply took longer than 15 minutes of wall-clock to finish while being repeatedly interrupted by a dense deploy window, sealing them with `reason="max_recovery_window_exceeded"` and discarding completed work.
 
@@ -12,8 +12,9 @@ The two jobs are now decoupled (see `design/rfc-chat-recovery-work-budget.md`):
 
 - **Duration is no longer a bound for a progressing turn.** The non-resetting wall-clock ceiling is removed. A turn that keeps producing content survives unbounded deploy churn. Stuck turns are still sealed by the no-progress window (5 min, resets on progress); tight no-progress alarm loops by the attempt cap.
 - **New runaway-loop guard, keyed to work, not time.** The existing durable, monotonic, reconnect-immune progress counter is reused as a work meter. `chatRecovery.maxRecoveryWork` caps the produced content/tool units since an incident opened; exceeding it seals with `reason="work_budget_exceeded"`. **Defaults to `Infinity`** — the SDK ships the mechanism but imposes no implicit cap, so it never terminates a progressing turn on its own.
-- **New caller predicate.** `chatRecovery.shouldContinue(ctx)` is consulted per recovery attempt (only when no hard bound has already sealed the incident); returning `false` seals with `reason="recovery_aborted"`. This is where integrators express token/cost/step budgets the SDK should not hardcode. A throwing predicate is logged and treated as "continue".
+- **New caller predicate.** `chatRecovery.shouldKeepRecovering(ctx)` is consulted per recovery attempt from the second onward (only when no hard bound has already sealed the incident); returning `false` seals with `reason="recovery_aborted"`. This is where integrators express token/cost/step budgets the SDK should not hardcode. A throwing predicate is logged and treated as "keep recovering".
+- **The no-progress timeout is now configurable.** `chatRecovery.noProgressTimeoutMs` (default 5 min, resets on progress) is the primary stuck-turn bound, now overridable per agent instead of a hardcoded constant.
 
-New public types from `agents/chat`: `ChatRecoveryProgressContext`. New `ChatRecoveryConfig` fields: `maxRecoveryWork`, `shouldContinue`. `ChatRecoveryExhaustedContext.reason` gains `work_budget_exceeded` and `recovery_aborted`; `max_recovery_window_exceeded` is retained as an open-string value but is no longer emitted.
+New public types from `agents/chat`: `ChatRecoveryProgressContext`. New `ChatRecoveryConfig` fields: `maxRecoveryWork`, `shouldKeepRecovering`, `noProgressTimeoutMs`. `ChatRecoveryExhaustedContext.reason` gains `work_budget_exceeded` and `recovery_aborted`; `max_recovery_window_exceeded` is retained as an open-string value but is no longer emitted.
 
 Both `@cloudflare/ai-chat` and `@cloudflare/think` (which carries its own copy of the recovery engine) are updated identically. Defaults are unchanged except that a progressing turn is no longer terminated by wall-clock age.

--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -69,28 +69,29 @@ Keep it concise. A few paragraphs is fine. These are records, not essays.
 
 ## Current contents
 
-| File                                    | Type       | Scope                                                                                 |
-| --------------------------------------- | ---------- | ------------------------------------------------------------------------------------- |
-| `chat-shared-layer.md`                  | design doc | Chat shared layer — streaming, sanitization, and protocol primitives in agents/chat   |
-| `think.md`                              | design doc | Think — chat agent base class, streaming, client tools, resumable streams, extensions |
-| `think-sessions.md`                     | design doc | Think + Session integration design (implemented in Phase 1)                           |
-| `think-vs-aichat.md`                    | design doc | Think vs AIChatAgent — comparison, use cases, architectural differences               |
-| `think-roadmap.md`                      | design doc | Think implementation plan — all 5 phases complete, full AIChatAgent parity            |
-| `chat-api.md`                           | analysis   | AIChatAgent + useAgentChat API analysis — pain points, improvements, Think influence  |
-| `chat-improvements.md`                  | design doc | Non-breaking improvements — shared extraction complete, client DX items remain        |
-| `readonly-connections.md`               | design doc | Readonly connections — enforcement, storage wrapping, caveats                         |
-| `retries.md`                            | design doc | Retry system — primitives, integration points, backoff strategy, tradeoffs            |
-| `visuals.md`                            | design doc | UI component library (Kumo), dark mode, custom patterns, routing integration          |
-| `workspace.md`                          | design doc | Workspace — hybrid SQLite+R2 filesystem, bash, symlinks, observability                |
-| `agent-tools.md`                        | design doc | Agent tools — chat sub-agent orchestration, parent registry, event replay             |
-| `sub-agent-routing.md`                  | design doc | Sub-agent routing as shipped — facets, nested URLs, registry, parent lookup, caveats  |
-| `rfc-sub-agents.md`                     | RFC        | Sub-agents — child DOs via facets, typed stubs, built into Agent (accepted)           |
-| `rfc-sub-agent-routing.md`              | RFC        | Sub-agent external addressability — nested URLs, `onBeforeSubAgent`, per-call bridge  |
-| `rfc-helper-sub-agent-orchestration.md` | RFC        | Agent tool orchestration — `runAgentTool`, `agentTool`, event forwarding              |
-| `rfc-think-multi-session.md`            | RFC        | Multi-session Think / Chats pattern — parent directory + per-chat child DOs           |
-| `rfc-ai-chat-maintenance.md`            | RFC        | AIChatAgent first-class stance, shared chat toolkit, multi-session example direction  |
-| `loopback.md`                           | design doc | Loopback pattern — cross-boundary RPC for sub-agents and dynamic isolates             |
-| `worker-bundler.md`                     | design doc | Worker bundler — host-side assets, no code generation, mounting is caller's concern   |
+| File                                    | Type       | Scope                                                                                              |
+| --------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| `chat-shared-layer.md`                  | design doc | Chat shared layer — streaming, sanitization, and protocol primitives in agents/chat                |
+| `think.md`                              | design doc | Think — chat agent base class, streaming, client tools, resumable streams, extensions              |
+| `think-sessions.md`                     | design doc | Think + Session integration design (implemented in Phase 1)                                        |
+| `think-vs-aichat.md`                    | design doc | Think vs AIChatAgent — comparison, use cases, architectural differences                            |
+| `think-roadmap.md`                      | design doc | Think implementation plan — all 5 phases complete, full AIChatAgent parity                         |
+| `chat-api.md`                           | analysis   | AIChatAgent + useAgentChat API analysis — pain points, improvements, Think influence               |
+| `chat-improvements.md`                  | design doc | Non-breaking improvements — shared extraction complete, client DX items remain                     |
+| `readonly-connections.md`               | design doc | Readonly connections — enforcement, storage wrapping, caveats                                      |
+| `retries.md`                            | design doc | Retry system — primitives, integration points, backoff strategy, tradeoffs                         |
+| `visuals.md`                            | design doc | UI component library (Kumo), dark mode, custom patterns, routing integration                       |
+| `workspace.md`                          | design doc | Workspace — hybrid SQLite+R2 filesystem, bash, symlinks, observability                             |
+| `agent-tools.md`                        | design doc | Agent tools — chat sub-agent orchestration, parent registry, event replay                          |
+| `sub-agent-routing.md`                  | design doc | Sub-agent routing as shipped — facets, nested URLs, registry, parent lookup, caveats               |
+| `rfc-sub-agents.md`                     | RFC        | Sub-agents — child DOs via facets, typed stubs, built into Agent (accepted)                        |
+| `rfc-sub-agent-routing.md`              | RFC        | Sub-agent external addressability — nested URLs, `onBeforeSubAgent`, per-call bridge               |
+| `rfc-helper-sub-agent-orchestration.md` | RFC        | Agent tool orchestration — `runAgentTool`, `agentTool`, event forwarding                           |
+| `rfc-think-multi-session.md`            | RFC        | Multi-session Think / Chats pattern — parent directory + per-chat child DOs                        |
+| `rfc-chat-recovery-work-budget.md`      | RFC        | Decouple chat-recovery duration from the runaway guard — work budget + `shouldContinue` (accepted) |
+| `rfc-ai-chat-maintenance.md`            | RFC        | AIChatAgent first-class stance, shared chat toolkit, multi-session example direction               |
+| `loopback.md`                           | design doc | Loopback pattern — cross-boundary RPC for sub-agents and dynamic isolates                          |
+| `worker-bundler.md`                     | design doc | Worker bundler — host-side assets, no code generation, mounting is caller's concern                |
 
 ## Relationship to `/docs`
 

--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -69,29 +69,29 @@ Keep it concise. A few paragraphs is fine. These are records, not essays.
 
 ## Current contents
 
-| File                                    | Type       | Scope                                                                                              |
-| --------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
-| `chat-shared-layer.md`                  | design doc | Chat shared layer — streaming, sanitization, and protocol primitives in agents/chat                |
-| `think.md`                              | design doc | Think — chat agent base class, streaming, client tools, resumable streams, extensions              |
-| `think-sessions.md`                     | design doc | Think + Session integration design (implemented in Phase 1)                                        |
-| `think-vs-aichat.md`                    | design doc | Think vs AIChatAgent — comparison, use cases, architectural differences                            |
-| `think-roadmap.md`                      | design doc | Think implementation plan — all 5 phases complete, full AIChatAgent parity                         |
-| `chat-api.md`                           | analysis   | AIChatAgent + useAgentChat API analysis — pain points, improvements, Think influence               |
-| `chat-improvements.md`                  | design doc | Non-breaking improvements — shared extraction complete, client DX items remain                     |
-| `readonly-connections.md`               | design doc | Readonly connections — enforcement, storage wrapping, caveats                                      |
-| `retries.md`                            | design doc | Retry system — primitives, integration points, backoff strategy, tradeoffs                         |
-| `visuals.md`                            | design doc | UI component library (Kumo), dark mode, custom patterns, routing integration                       |
-| `workspace.md`                          | design doc | Workspace — hybrid SQLite+R2 filesystem, bash, symlinks, observability                             |
-| `agent-tools.md`                        | design doc | Agent tools — chat sub-agent orchestration, parent registry, event replay                          |
-| `sub-agent-routing.md`                  | design doc | Sub-agent routing as shipped — facets, nested URLs, registry, parent lookup, caveats               |
-| `rfc-sub-agents.md`                     | RFC        | Sub-agents — child DOs via facets, typed stubs, built into Agent (accepted)                        |
-| `rfc-sub-agent-routing.md`              | RFC        | Sub-agent external addressability — nested URLs, `onBeforeSubAgent`, per-call bridge               |
-| `rfc-helper-sub-agent-orchestration.md` | RFC        | Agent tool orchestration — `runAgentTool`, `agentTool`, event forwarding                           |
-| `rfc-think-multi-session.md`            | RFC        | Multi-session Think / Chats pattern — parent directory + per-chat child DOs                        |
-| `rfc-chat-recovery-work-budget.md`      | RFC        | Decouple chat-recovery duration from the runaway guard — work budget + `shouldContinue` (accepted) |
-| `rfc-ai-chat-maintenance.md`            | RFC        | AIChatAgent first-class stance, shared chat toolkit, multi-session example direction               |
-| `loopback.md`                           | design doc | Loopback pattern — cross-boundary RPC for sub-agents and dynamic isolates                          |
-| `worker-bundler.md`                     | design doc | Worker bundler — host-side assets, no code generation, mounting is caller's concern                |
+| File                                    | Type       | Scope                                                                                                    |
+| --------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `chat-shared-layer.md`                  | design doc | Chat shared layer — streaming, sanitization, and protocol primitives in agents/chat                      |
+| `think.md`                              | design doc | Think — chat agent base class, streaming, client tools, resumable streams, extensions                    |
+| `think-sessions.md`                     | design doc | Think + Session integration design (implemented in Phase 1)                                              |
+| `think-vs-aichat.md`                    | design doc | Think vs AIChatAgent — comparison, use cases, architectural differences                                  |
+| `think-roadmap.md`                      | design doc | Think implementation plan — all 5 phases complete, full AIChatAgent parity                               |
+| `chat-api.md`                           | analysis   | AIChatAgent + useAgentChat API analysis — pain points, improvements, Think influence                     |
+| `chat-improvements.md`                  | design doc | Non-breaking improvements — shared extraction complete, client DX items remain                           |
+| `readonly-connections.md`               | design doc | Readonly connections — enforcement, storage wrapping, caveats                                            |
+| `retries.md`                            | design doc | Retry system — primitives, integration points, backoff strategy, tradeoffs                               |
+| `visuals.md`                            | design doc | UI component library (Kumo), dark mode, custom patterns, routing integration                             |
+| `workspace.md`                          | design doc | Workspace — hybrid SQLite+R2 filesystem, bash, symlinks, observability                                   |
+| `agent-tools.md`                        | design doc | Agent tools — chat sub-agent orchestration, parent registry, event replay                                |
+| `sub-agent-routing.md`                  | design doc | Sub-agent routing as shipped — facets, nested URLs, registry, parent lookup, caveats                     |
+| `rfc-sub-agents.md`                     | RFC        | Sub-agents — child DOs via facets, typed stubs, built into Agent (accepted)                              |
+| `rfc-sub-agent-routing.md`              | RFC        | Sub-agent external addressability — nested URLs, `onBeforeSubAgent`, per-call bridge                     |
+| `rfc-helper-sub-agent-orchestration.md` | RFC        | Agent tool orchestration — `runAgentTool`, `agentTool`, event forwarding                                 |
+| `rfc-think-multi-session.md`            | RFC        | Multi-session Think / Chats pattern — parent directory + per-chat child DOs                              |
+| `rfc-chat-recovery-work-budget.md`      | RFC        | Decouple chat-recovery duration from the runaway guard — work budget + `shouldKeepRecovering` (accepted) |
+| `rfc-ai-chat-maintenance.md`            | RFC        | AIChatAgent first-class stance, shared chat toolkit, multi-session example direction                     |
+| `loopback.md`                           | design doc | Loopback pattern — cross-boundary RPC for sub-agents and dynamic isolates                                |
+| `worker-bundler.md`                     | design doc | Worker bundler — host-side assets, no code generation, mounting is caller's concern                      |
 
 ## Relationship to `/docs`
 

--- a/design/rfc-chat-recovery-work-budget.md
+++ b/design/rfc-chat-recovery-work-budget.md
@@ -1,0 +1,110 @@
+Status: accepted
+
+# RFC: Decouple chat-recovery duration from the runaway-loop guard
+
+## The problem
+
+Durable chat recovery (`AIChatAgent` in `@cloudflare/ai-chat`, mirrored in
+`@cloudflare/think`) bounds an in-progress recovery incident with three limits,
+computed in `_beginChatRecoveryIncident`:
+
+- **No-progress window** (`CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS`, 5 min) — keyed
+  to `lastProgressAt`, **resets on forward progress**. Catches a stuck turn.
+- **Attempt cap** (`maxAttempts`, default 10) — **resets on forward progress**.
+  Catches a tight no-progress alarm loop.
+- **Absolute incident-age ceiling** (`CHAT_RECOVERY_MAX_WINDOW_MS`, 15 min) —
+  keyed to `firstSeenAt`, **never resets**.
+
+A long agentic turn that makes genuine forward progress on every recovery but
+takes more than 15 minutes of wall-clock to finish (because it is repeatedly
+interrupted by a dense deploy window) is sealed with
+`reason="max_recovery_window_exceeded"`, discarding completed work and forcing a
+re-prompt. A customer hit this in production: ~99 model generations, ~3 deploys
+in ~95 minutes, sealed at exactly 901,929 ms (≈ the 15-min ceiling) while still
+healthy (`attempt=1`, meaning the no-progress window and attempt cap had just
+reset on progress — only the non-resetting ceiling could fire).
+
+The ceiling is overloaded: it does duty as both a _recovery-duration bound_ and
+a _runaway-loop guard_. Those jobs want different instruments. The no-progress
+window already catches stuck turns; the only thing the absolute ceiling uniquely
+catches is a loop that **keeps emitting content but never converges** — and that
+is a **bounded-work** condition, not a duration. A healthy long turn and a
+runaway loop are distinguished by _work done_, not by _elapsed time_.
+
+## The proposal
+
+Decouple the two jobs.
+
+1. **Remove the non-resetting wall-clock ceiling.** Recovery duration is no
+   longer bounded for a progressing turn. A turn making genuine forward progress
+   survives unbounded deploy churn. Stuck turns are still sealed by the
+   no-progress window; tight no-progress alarm loops by the attempt cap.
+
+2. **Add a work budget** as the runaway-loop guard. Reuse the existing durable,
+   monotonic, reconnect-immune progress counter (`CHAT_RECOVERY_PROGRESS_KEY`,
+   bumped once per produced content/tool unit — not per token) as a **work
+   meter**. Record the counter value at incident open (`workBaseline`) and seal
+   when `work = progress - workBaseline` exceeds `maxRecoveryWork`
+   (`reason="work_budget_exceeded"`).
+
+3. **Add a caller predicate hook** `shouldContinue(ctx)`, invoked per recovery
+   attempt (only when no hard bound has already sealed the incident). Returning
+   `false` seals with `reason="recovery_aborted"`. This is where integrators
+   express token / cost / semantic-step budgets the SDK should not hardcode. A
+   throwing predicate is logged and treated as "continue" so a buggy hook cannot
+   wedge a turn.
+
+All three new knobs live on `ChatRecoveryConfig`:
+
+```ts
+maxRecoveryWork?: number; // default Infinity
+shouldContinue?(ctx: ChatRecoveryProgressContext): boolean | Promise<boolean>;
+```
+
+### Default behavior
+
+`maxRecoveryWork` defaults to **`Infinity`** — the SDK ships the _mechanism_ but
+imposes **no** implicit work cap. By default the only remaining bounds are the
+no-progress window and the attempt cap (both reset on progress). This is a
+deliberate decision (see "Decision"): a progressing turn is never terminated by
+the framework on its own; integrators that need a runaway backstop set
+`maxRecoveryWork` or `shouldContinue`. Note `maxSteps` is **not** a substitute —
+it bounds a single continuation and resets on each recovery, so it does not
+bound cumulative recovery work (the gap the work budget exists to fill).
+
+`max_recovery_window_exceeded` is no longer emitted. It is retained in the
+documented `reason` union (an open string) for back-compat with persisted
+incidents.
+
+## The alternatives
+
+- **B — expose `maxRecoveryWindowMs` + `recoveryWindowResetsOnProgress`.** A
+  minimal unblock that keeps the wall-clock instrument but makes it tunable /
+  progress-resetting. Rejected as the end state: a progress-resetting wall-clock
+  cap is just a slower no-progress window, and a non-resetting one keeps the
+  false-positive footgun. Useful only as an interim; we went straight to A.
+
+- **C — sliding window.** Each progress event pushes the ceiling out, capped at
+  a larger hard maximum. Rejected: same false-positive class as today, only
+  later; still bounds a progressing turn by duration.
+
+- **Finite default `maxRecoveryWork`.** Preserves an implicit backstop for
+  existing users. Rejected: requires inventing a magic work number, which is the
+  same class of fragile proxy that caused the original bug. We prefer an
+  explicit `Infinity` default and let integrators opt into a cap they understand.
+
+- **Per-token work meter.** Rejected: the existing counter is per-content-unit
+  (text/reasoning-start, settled tool input/output), durable and reconnect-
+  immune. It is already the right granularity for "work done" and free to reuse.
+
+## The decision
+
+Accepted. Ship A in both `@cloudflare/ai-chat` and `@cloudflare/think` (the two
+copies of the recovery engine), with `maxRecoveryWork` defaulting to `Infinity`.
+
+Invariant:
+
+> A turn making genuine forward progress survives unbounded deploy churn — no
+> matter how long it runs or how many recoveries occur — and is terminated only
+> by (a) a no-progress timeout (stuck), (b) the attempt cap (no-progress alarm
+> loop), (c) a work-budget violation (runaway), or (d) a caller predicate.

--- a/design/rfc-chat-recovery-work-budget.md
+++ b/design/rfc-chat-recovery-work-budget.md
@@ -47,19 +47,36 @@ Decouple the two jobs.
    when `work = progress - workBaseline` exceeds `maxRecoveryWork`
    (`reason="work_budget_exceeded"`).
 
-3. **Add a caller predicate hook** `shouldContinue(ctx)`, invoked per recovery
-   attempt (only when no hard bound has already sealed the incident). Returning
-   `false` seals with `reason="recovery_aborted"`. This is where integrators
-   express token / cost / semantic-step budgets the SDK should not hardcode. A
-   throwing predicate is logged and treated as "continue" so a buggy hook cannot
-   wedge a turn.
+3. **Add a caller predicate hook** `shouldKeepRecovering(ctx)`, invoked per
+   recovery attempt from the second onward (only when no hard bound has already
+   sealed the incident). Returning `false` seals with
+   `reason="recovery_aborted"`. This is where integrators express token / cost /
+   semantic-step budgets the SDK should not hardcode. A throwing predicate is
+   logged and treated as "keep recovering" so a buggy hook cannot wedge a turn.
 
-All three new knobs live on `ChatRecoveryConfig`:
+4. **Expose the no-progress timeout** as `noProgressTimeoutMs` (default 5 min,
+   resets on progress). With the wall-clock ceiling gone it is the primary
+   stuck-turn bound, and it was the only recovery limit still hardcoded;
+   exposing it keeps the config surface consistent (`maxAttempts`,
+   `stableTimeoutMs`, `maxRecoveryWork` are all configurable). Safe to expose
+   because it resets on progress, so it only bites genuinely idle turns.
+
+The new knobs live on `ChatRecoveryConfig`:
 
 ```ts
 maxRecoveryWork?: number; // default Infinity
-shouldContinue?(ctx: ChatRecoveryProgressContext): boolean | Promise<boolean>;
+noProgressTimeoutMs?: number; // default 300_000 (5 min)
+shouldKeepRecovering?(ctx: ChatRecoveryProgressContext): boolean | Promise<boolean>;
 ```
+
+### Naming
+
+The predicate is `shouldKeepRecovering`, not `shouldContinue`: `continue` is
+already overloaded in this API (`ChatRecoveryOptions.continue` and
+`continueLastTurn()`), so `shouldContinue` read as "should I call
+`continueLastTurn`?" rather than "should the recovery loop keep going?". The
+work cap stays `maxRecoveryWork`/`ctx.work` — "work" honestly conveys "units of
+progress" and the config/context pair is self-documenting.
 
 ### Default behavior
 
@@ -68,7 +85,7 @@ imposes **no** implicit work cap. By default the only remaining bounds are the
 no-progress window and the attempt cap (both reset on progress). This is a
 deliberate decision (see "Decision"): a progressing turn is never terminated by
 the framework on its own; integrators that need a runaway backstop set
-`maxRecoveryWork` or `shouldContinue`. Note `maxSteps` is **not** a substitute —
+`maxRecoveryWork` or `shouldKeepRecovering`. Note `maxSteps` is **not** a substitute —
 it bounds a single continuation and resets on each recovery, so it does not
 bound cumulative recovery work (the gap the work budget exists to fill).
 

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -664,14 +664,18 @@ override chatRecovery = {
   maxAttempts: 10,
   stableTimeoutMs: 10_000,
   terminalMessage: "The assistant was interrupted and could not recover.",
+  // Primary stuck-turn bound. Resets on every progress-bearing attempt, so a
+  // turn that keeps producing content survives unbounded interruption.
+  noProgressTimeoutMs: 5 * 60 * 1000,
   // Runaway-loop guard. Defaults to Infinity (no cap). Set a finite value to
   // seal a turn that keeps emitting content but never converges.
   maxRecoveryWork: 200,
   // Caller policy consulted from the second recovery attempt onward. Return
   // false to stop recovery. This is where you enforce a token/cost budget.
-  // Note: this is called as `config.shouldContinue(ctx)`, so it is not bound to
-  // the agent instance — track spend in your own store keyed by the incident.
-  async shouldContinue(ctx) {
+  // Note: this is called as `config.shouldKeepRecovering(ctx)`, so it is not
+  // bound to the agent instance — track spend in your own store keyed by the
+  // incident.
+  async shouldKeepRecovering(ctx) {
     return (await getSpendForTurn(ctx.recoveryRootRequestId)) < MAX_SPEND;
   },
   async onExhausted(ctx) {
@@ -682,24 +686,38 @@ override chatRecovery = {
 
 **`chatRecovery` configuration:**
 
-| Field             | Default         | Description                                                                                                                                                                                                                                                                                                |
-| ----------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `maxAttempts`     | `10`            | Attempt cap before terminal exhaustion. Resets on forward progress, so it catches a tight no-progress alarm loop, not a healthy long turn.                                                                                                                                                                 |
-| `stableTimeoutMs` | `10_000`        | How long a recovery attempt waits for the isolate to reach stable state before rescheduling.                                                                                                                                                                                                               |
-| `terminalMessage` | generic message | The message shown to the user when recovery is given up on.                                                                                                                                                                                                                                                |
-| `maxRecoveryWork` | `Infinity`      | Runaway-loop guard. Maximum produced content/tool units since the incident began before a still-progressing turn is sealed. Defaults to no cap.                                                                                                                                                            |
-| `shouldContinue`  | —               | Caller policy consulted from the second recovery attempt onward (never on the first detection, never once a hard bound has sealed the incident). Return `false` to stop recovery. The hook point for a token/cost budget — `ctx.work` is a coarse segment count, not tokens, so track real spend yourself. |
-| `onExhausted`     | —               | Called once when recovery is given up on, before the terminal message is delivered. Inspect `ctx.reason` for why.                                                                                                                                                                                          |
+| Field                  | Default           | Description                                                                                                                                                                                                                                                                                                |
+| ---------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxAttempts`          | `10`              | Attempt cap before terminal exhaustion. Resets on forward progress, so it catches a tight no-progress alarm loop, not a healthy long turn.                                                                                                                                                                 |
+| `stableTimeoutMs`      | `10_000`          | How long a recovery attempt waits for the isolate to reach stable state before rescheduling.                                                                                                                                                                                                               |
+| `terminalMessage`      | generic message   | The message shown to the user when recovery is given up on.                                                                                                                                                                                                                                                |
+| `noProgressTimeoutMs`  | `300_000` (5 min) | Primary stuck-turn bound: how long an incident may go without forward progress before it is sealed (`no_progress_timeout`). **Resets on every progress-bearing attempt**, so a turn that keeps producing content survives unbounded interruption.                                                          |
+| `maxRecoveryWork`      | `Infinity`        | Runaway-loop guard. Maximum produced content/tool units since the incident began before a still-progressing turn is sealed. Defaults to no cap.                                                                                                                                                            |
+| `shouldKeepRecovering` | —                 | Caller policy consulted from the second recovery attempt onward (never on the first detection, never once a hard bound has sealed the incident). Return `false` to stop recovery. The hook point for a token/cost budget — `ctx.work` is a coarse segment count, not tokens, so track real spend yourself. |
+| `onExhausted`          | —                 | Called once when recovery is given up on, before the terminal message is delivered. Inspect `ctx.reason` for why.                                                                                                                                                                                          |
+
+**`ChatRecoveryProgressContext`** (the `ctx` passed to `shouldKeepRecovering`):
+
+| Field                   | Type                    | Description                                                                                       |
+| ----------------------- | ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `incidentId`            | `string`                | Stable ID for this recovery incident.                                                             |
+| `requestId`             | `string`                | Request ID for the current continuation (changes per chained continuation).                       |
+| `recoveryRootRequestId` | `string`                | Stable ID for the whole continuation chain — the right key for per-incident budget tracking.      |
+| `attempt`               | `number`                | Attempt number for this incident (2 or greater when this hook runs).                              |
+| `maxAttempts`           | `number`                | Configured attempt cap.                                                                           |
+| `recoveryKind`          | `"retry" \| "continue"` | Whether recovery retries an unanswered user turn or continues a partial assistant turn.           |
+| `work`                  | `number`                | Coarse, monotonic count of content/tool segments produced since the incident opened (not tokens). |
+| `ageMs`                 | `number`                | Wall-clock ms since the incident's first interruption.                                            |
 
 A progressing turn is never terminated by the framework on its own — it survives unbounded interruption (for example a dense deploy window) as long as it keeps making forward progress. Recovery is sealed only by one of these `ctx.reason` values:
 
 - `no_progress_timeout` — no forward progress within the no-progress window (a stuck turn).
 - `max_attempts_exceeded` — the attempt cap was spent on a tight no-progress alarm loop.
 - `work_budget_exceeded` — the turn kept producing content but exceeded `maxRecoveryWork` (a runaway loop).
-- `recovery_aborted` — your `shouldContinue` hook returned `false`.
+- `recovery_aborted` — your `shouldKeepRecovering` hook returned `false`.
 - `stable_timeout` — recovery attempts kept timing out waiting for stable state until the budget drained (extreme churn).
 
-> Setting a finite `maxRecoveryWork` reintroduces a false-positive risk for a legitimately long turn — pick a cap well above what a healthy turn produces, or prefer `shouldContinue` with real token/cost accounting for a precise budget.
+> Setting a finite `maxRecoveryWork` reintroduces a false-positive risk for a legitimately long turn — pick a cap well above what a healthy turn produces, or prefer `shouldKeepRecovering` with real token/cost accounting for a precise budget.
 
 Monitor recovery through observability:
 

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -657,18 +657,49 @@ Settled work is never dropped: `persist: false` only suppresses persistence of a
 
 When recovery happens before any stream chunks were written, there is no partial assistant message to continue. If the latest persisted message is still the unanswered user message from the interrupted turn, the framework retries that turn automatically unless `continue` is `false`.
 
-`chatRecovery` can also be configured with an attempt cap and terminal behavior:
+`chatRecovery` can also be configured with budgets and terminal behavior:
 
 ```typescript
 override chatRecovery = {
-  maxAttempts: 6,
+  maxAttempts: 10,
   stableTimeoutMs: 10_000,
   terminalMessage: "The assistant was interrupted and could not recover.",
+  // Runaway-loop guard. Defaults to Infinity (no cap). Set a finite value to
+  // seal a turn that keeps emitting content but never converges.
+  maxRecoveryWork: 200,
+  // Caller policy consulted from the second recovery attempt onward. Return
+  // false to stop recovery. This is where you enforce a token/cost budget.
+  // Note: this is called as `config.shouldContinue(ctx)`, so it is not bound to
+  // the agent instance — track spend in your own store keyed by the incident.
+  async shouldContinue(ctx) {
+    return (await getSpendForTurn(ctx.recoveryRootRequestId)) < MAX_SPEND;
+  },
   async onExhausted(ctx) {
-    console.warn("Chat recovery exhausted", ctx.incidentId);
+    console.warn("Chat recovery exhausted", ctx.incidentId, ctx.reason);
   }
 };
 ```
+
+**`chatRecovery` configuration:**
+
+| Field             | Default         | Description                                                                                                                                                                                                                                                                                                |
+| ----------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxAttempts`     | `10`            | Attempt cap before terminal exhaustion. Resets on forward progress, so it catches a tight no-progress alarm loop, not a healthy long turn.                                                                                                                                                                 |
+| `stableTimeoutMs` | `10_000`        | How long a recovery attempt waits for the isolate to reach stable state before rescheduling.                                                                                                                                                                                                               |
+| `terminalMessage` | generic message | The message shown to the user when recovery is given up on.                                                                                                                                                                                                                                                |
+| `maxRecoveryWork` | `Infinity`      | Runaway-loop guard. Maximum produced content/tool units since the incident began before a still-progressing turn is sealed. Defaults to no cap.                                                                                                                                                            |
+| `shouldContinue`  | —               | Caller policy consulted from the second recovery attempt onward (never on the first detection, never once a hard bound has sealed the incident). Return `false` to stop recovery. The hook point for a token/cost budget — `ctx.work` is a coarse segment count, not tokens, so track real spend yourself. |
+| `onExhausted`     | —               | Called once when recovery is given up on, before the terminal message is delivered. Inspect `ctx.reason` for why.                                                                                                                                                                                          |
+
+A progressing turn is never terminated by the framework on its own — it survives unbounded interruption (for example a dense deploy window) as long as it keeps making forward progress. Recovery is sealed only by one of these `ctx.reason` values:
+
+- `no_progress_timeout` — no forward progress within the no-progress window (a stuck turn).
+- `max_attempts_exceeded` — the attempt cap was spent on a tight no-progress alarm loop.
+- `work_budget_exceeded` — the turn kept producing content but exceeded `maxRecoveryWork` (a runaway loop).
+- `recovery_aborted` — your `shouldContinue` hook returned `false`.
+- `stable_timeout` — recovery attempts kept timing out waiting for stable state until the budget drained (extreme churn).
+
+> Setting a finite `maxRecoveryWork` reintroduces a false-positive risk for a legitimately long turn — pick a cap well above what a healthy turn produces, or prefer `shouldContinue` with real token/cost accounting for a precise budget.
 
 Monitor recovery through observability:
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -403,7 +403,7 @@ import type {
 
 export class MyAgent extends Think<Env> {
   override chatRecovery = {
-    maxAttempts: 6,
+    maxAttempts: 10,
     terminalMessage: "The assistant was interrupted. Please try again."
   };
 

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -378,17 +378,21 @@ onChatRecovery(ctx: ChatRecoveryContext): ChatRecoveryOptions | void
 
 ### ChatRecoveryContext
 
-| Field             | Type                       | Description                                          |
-| ----------------- | -------------------------- | ---------------------------------------------------- |
-| `streamId`        | `string`                   | The stream ID of the interrupted turn                |
-| `requestId`       | `string`                   | The request ID of the interrupted turn               |
-| `partialText`     | `string`                   | Text generated before the interruption               |
-| `partialParts`    | `MessagePart[]`            | Parts accumulated before the interruption            |
-| `recoveryData`    | `unknown \| null`          | Data from `this.stash()` during the turn             |
-| `messages`        | `UIMessage[]`              | Current conversation history                         |
-| `lastBody`        | `Record<string, unknown>?` | Body from the interrupted turn                       |
-| `lastClientTools` | `ClientToolSchema[]?`      | Client tools from the interrupted turn               |
-| `createdAt`       | `number`                   | Epoch milliseconds when the underlying fiber started |
+| Field             | Type                       | Description                                                                            |
+| ----------------- | -------------------------- | -------------------------------------------------------------------------------------- |
+| `incidentId`      | `string`                   | Stable ID for this recovery incident                                                   |
+| `attempt`         | `number`                   | Current attempt number for this incident, starting at 1                                |
+| `maxAttempts`     | `number`                   | Configured attempt cap before terminal exhaustion                                      |
+| `recoveryKind`    | `"retry" \| "continue"`    | Whether recovery retries an unanswered user turn or continues a partial assistant turn |
+| `streamId`        | `string`                   | The stream ID of the interrupted turn                                                  |
+| `requestId`       | `string`                   | The request ID of the interrupted turn                                                 |
+| `partialText`     | `string`                   | Text generated before the interruption                                                 |
+| `partialParts`    | `MessagePart[]`            | Parts accumulated before the interruption                                              |
+| `recoveryData`    | `unknown \| null`          | Data from `this.stash()` during the turn                                               |
+| `messages`        | `UIMessage[]`              | Current conversation history                                                           |
+| `lastBody`        | `Record<string, unknown>?` | Body from the interrupted turn                                                         |
+| `lastClientTools` | `ClientToolSchema[]?`      | Client tools from the interrupted turn                                                 |
+| `createdAt`       | `number`                   | Epoch milliseconds when the underlying fiber started                                   |
 
 ### ChatRecoveryOptions
 
@@ -442,6 +446,43 @@ onChatRecovery(ctx: ChatRecoveryContext): ChatRecoveryOptions {
   return {};
 }
 ```
+
+### Recovery budgets and limits
+
+Instead of `chatRecovery = true`, assign an object to tune how long recovery is allowed to run and when it is given up on. A turn that keeps making forward progress is never terminated by the framework on its own — duration is not a bound. Recovery is only sealed by one of the limits below.
+
+```typescript
+export class MyAgent extends Think<Env> {
+  chatRecovery = {
+    maxAttempts: 10,
+    noProgressTimeoutMs: 5 * 60 * 1000,
+    maxRecoveryWork: Infinity,
+    terminalMessage: "The assistant was interrupted and could not recover.",
+    // Consulted from the second recovery attempt onward. Return false to stop.
+    // Called as `config.shouldKeepRecovering(ctx)`, so it is NOT bound to the
+    // agent instance — track real token/cost spend in your own store keyed by
+    // `ctx.recoveryRootRequestId`.
+    async shouldKeepRecovering(ctx) {
+      return (await getSpendForTurn(ctx.recoveryRootRequestId)) < MAX_SPEND;
+    },
+    async onExhausted(ctx) {
+      console.warn("Recovery exhausted", ctx.incidentId, ctx.reason);
+    }
+  };
+}
+```
+
+| Field                  | Default           | Description                                                                                                                                                                         |
+| ---------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxAttempts`          | `10`              | Attempt cap. Resets on forward progress, so it catches a tight no-progress alarm loop, not a healthy long turn.                                                                     |
+| `stableTimeoutMs`      | `10_000`          | How long an attempt waits for the isolate to reach stable state before rescheduling.                                                                                                |
+| `noProgressTimeoutMs`  | `300_000` (5 min) | Primary stuck-turn bound: max time without forward progress before sealing. **Resets on every progress-bearing attempt.**                                                           |
+| `maxRecoveryWork`      | `Infinity`        | Runaway-loop guard: max produced content/tool units since the incident opened before a still-progressing turn is sealed. No cap by default.                                         |
+| `shouldKeepRecovering` | —                 | Caller policy consulted from the second attempt onward. Return `false` to stop recovery. The hook point for a token/cost budget (`ctx.work` is a coarse segment count, not tokens). |
+| `terminalMessage`      | generic message   | Message shown to the user when recovery is given up on.                                                                                                                             |
+| `onExhausted`          | —                 | Called once when recovery is given up on. Inspect `ctx.reason`.                                                                                                                     |
+
+`ctx.reason` on the exhausted hook is one of: `no_progress_timeout` (stuck), `max_attempts_exceeded` (no-progress alarm loop), `work_budget_exceeded` (runaway), `recovery_aborted` (your `shouldKeepRecovering` returned `false`), or `stable_timeout` (extreme churn). See [`chat-agents.md`](../chat-agents.md#stream-recovery) for the full shared reference — Think and `@cloudflare/ai-chat` use the same recovery configuration.
 
 ---
 

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -91,6 +91,7 @@ export type {
   ChatRecoveryConfig,
   ChatRecoveryContext,
   ChatRecoveryExhaustedContext,
+  ChatRecoveryProgressContext,
   ChatRecoveryOptions,
   ResolvedChatRecoveryConfig,
   MessageConcurrency,

--- a/packages/agents/src/chat/lifecycle.ts
+++ b/packages/agents/src/chat/lifecycle.ts
@@ -163,7 +163,7 @@ export type ChatRecoveryExhaustedContext = Pick<
    * - `no_progress_timeout` — no forward progress within the no-progress window.
    * - `work_budget_exceeded` — the turn kept producing content but exceeded the
    *   configured `maxRecoveryWork` runaway-loop budget.
-   * - `recovery_aborted` — the caller's `shouldContinue` hook returned `false`.
+   * - `recovery_aborted` — the caller's `shouldKeepRecovering` hook returned `false`.
    * - `stable_timeout` — a recovery attempt kept timing out waiting for the
    *   isolate to reach stable state until the budget drained (extreme churn).
    * - `max_recovery_window_exceeded` — DEPRECATED. The old absolute incident-age
@@ -178,9 +178,11 @@ export type ChatRecoveryExhaustedContext = Pick<
 };
 
 /**
- * Context passed to the `shouldContinue` recovery predicate on each attempt.
- * Lets an integrator impose a runaway-loop guard expressed as bounded work
- * (steps / tool-calls / tokens / cost) rather than wall-clock duration.
+ * Context passed to the `shouldKeepRecovering` recovery predicate on each
+ * attempt. Lets an integrator impose a runaway-loop guard expressed as their
+ * own budget (steps / tool-calls / tokens / cost) rather than wall-clock
+ * duration. `ctx.work` is the SDK's coarse progress signal; map it (or your own
+ * accounting) onto whatever budget you enforce.
  */
 export type ChatRecoveryProgressContext = {
   incidentId: string;
@@ -202,8 +204,8 @@ export type ChatRecoveryProgressContext = {
 
 /**
  * Configuration for durable chat recovery. `true` uses these defaults:
- * `maxAttempts: 10`, `stableTimeoutMs: 10_000`, `maxRecoveryWork: Infinity`,
- * and a generic terminal message.
+ * `maxAttempts: 10`, `stableTimeoutMs: 10_000`, `noProgressTimeoutMs: 300_000`
+ * (5 min), `maxRecoveryWork: Infinity`, and a generic terminal message.
  */
 export type ChatRecoveryConfig =
   | boolean
@@ -212,29 +214,38 @@ export type ChatRecoveryConfig =
       stableTimeoutMs?: number;
       terminalMessage?: string;
       /**
+       * How long an incident may go WITHOUT forward progress before it is
+       * sealed with `reason="no_progress_timeout"`. This is the primary
+       * stuck-turn bound. It **resets on every progress-bearing attempt**, so a
+       * turn that keeps producing content survives unbounded interruption while
+       * a genuinely idle turn is sealed within the window. Defaults to 5 min.
+       */
+      noProgressTimeoutMs?: number;
+      /**
        * Runaway-loop guard. Maximum recovery WORK — produced content/tool units
        * since the incident began — before a still-progressing turn is sealed
        * with `reason="work_budget_exceeded"`. Defaults to `Infinity` (no cap):
        * the SDK never terminates a progressing turn on its own. Set a finite
-       * value (or use `shouldContinue`) to bound a loop that keeps emitting
-       * content but never converges.
+       * value (or use `shouldKeepRecovering`) to bound a loop that keeps
+       * emitting content but never converges.
        */
       maxRecoveryWork?: number;
       /**
        * Caller policy consulted on each recovery attempt from the second
        * onward — it is NOT called on the first detection (the attempt that
        * opens the incident), and not at all once a hard bound (no-progress
-       * window, attempt cap, or `maxRecoveryWork`) has already sealed the
+       * timeout, attempt cap, or `maxRecoveryWork`) has already sealed the
        * incident. Return `false` to stop recovery with
-       * `reason="recovery_aborted"`. A throwing hook is logged and treated as
-       * "continue" so a buggy predicate cannot wedge a turn.
+       * `reason="recovery_aborted"`; return `true` (or omit the hook) to keep
+       * recovering. A throwing hook is logged and treated as "keep recovering"
+       * so a buggy predicate cannot wedge a turn.
        *
        * This is the hook point for a token/cost/step budget, but note
        * `ctx.work` is a coarse count of produced content/tool segments, not
        * tokens — track real token/cost yourself (keyed by
        * `ctx.recoveryRootRequestId`) and consult it here.
        */
-      shouldContinue?(
+      shouldKeepRecovering?(
         ctx: ChatRecoveryProgressContext
       ): boolean | Promise<boolean>;
       onExhausted?(ctx: ChatRecoveryExhaustedContext): void | Promise<void>;
@@ -245,8 +256,9 @@ export type ResolvedChatRecoveryConfig = {
   maxAttempts: number;
   stableTimeoutMs: number;
   terminalMessage: string;
+  noProgressTimeoutMs: number;
   maxRecoveryWork: number;
-  shouldContinue?: (
+  shouldKeepRecovering?: (
     ctx: ChatRecoveryProgressContext
   ) => boolean | Promise<boolean>;
   onExhausted?: (ctx: ChatRecoveryExhaustedContext) => void | Promise<void>;

--- a/packages/agents/src/chat/lifecycle.ts
+++ b/packages/agents/src/chat/lifecycle.ts
@@ -161,9 +161,14 @@ export type ChatRecoveryExhaustedContext = Pick<
    * Why recovery stopped. One of:
    * - `max_attempts_exceeded` — the per-incident attempt budget was spent.
    * - `no_progress_timeout` — no forward progress within the no-progress window.
-   * - `max_recovery_window_exceeded` — the absolute incident-age ceiling was hit.
+   * - `work_budget_exceeded` — the turn kept producing content but exceeded the
+   *   configured `maxRecoveryWork` runaway-loop budget.
+   * - `recovery_aborted` — the caller's `shouldContinue` hook returned `false`.
    * - `stable_timeout` — a recovery attempt kept timing out waiting for the
    *   isolate to reach stable state until the budget drained (extreme churn).
+   * - `max_recovery_window_exceeded` — DEPRECATED. The old absolute incident-age
+   *   ceiling. No longer emitted (a progressing turn is no longer bounded by
+   *   wall-clock); retained only for back-compat with persisted incidents.
    *
    * Treat this as an open string: new reasons may be added.
    */
@@ -173,8 +178,32 @@ export type ChatRecoveryExhaustedContext = Pick<
 };
 
 /**
+ * Context passed to the `shouldContinue` recovery predicate on each attempt.
+ * Lets an integrator impose a runaway-loop guard expressed as bounded work
+ * (steps / tool-calls / tokens / cost) rather than wall-clock duration.
+ */
+export type ChatRecoveryProgressContext = {
+  incidentId: string;
+  requestId: string;
+  recoveryRootRequestId: string;
+  attempt: number;
+  maxAttempts: number;
+  recoveryKind: "retry" | "continue";
+  /**
+   * Recovery work units produced since this incident began — a durable,
+   * monotonic, reconnect-immune count of produced content/tool segments (not
+   * tokens). The signal that distinguishes a healthy long turn from a runaway
+   * loop.
+   */
+  work: number;
+  /** Wall-clock ms since the incident's first interruption. */
+  ageMs: number;
+};
+
+/**
  * Configuration for durable chat recovery. `true` uses these defaults:
- * `maxAttempts: 6`, `stableTimeoutMs: 10_000`, and a generic terminal message.
+ * `maxAttempts: 10`, `stableTimeoutMs: 10_000`, `maxRecoveryWork: Infinity`,
+ * and a generic terminal message.
  */
 export type ChatRecoveryConfig =
   | boolean
@@ -182,6 +211,32 @@ export type ChatRecoveryConfig =
       maxAttempts?: number;
       stableTimeoutMs?: number;
       terminalMessage?: string;
+      /**
+       * Runaway-loop guard. Maximum recovery WORK — produced content/tool units
+       * since the incident began — before a still-progressing turn is sealed
+       * with `reason="work_budget_exceeded"`. Defaults to `Infinity` (no cap):
+       * the SDK never terminates a progressing turn on its own. Set a finite
+       * value (or use `shouldContinue`) to bound a loop that keeps emitting
+       * content but never converges.
+       */
+      maxRecoveryWork?: number;
+      /**
+       * Caller policy consulted on each recovery attempt from the second
+       * onward — it is NOT called on the first detection (the attempt that
+       * opens the incident), and not at all once a hard bound (no-progress
+       * window, attempt cap, or `maxRecoveryWork`) has already sealed the
+       * incident. Return `false` to stop recovery with
+       * `reason="recovery_aborted"`. A throwing hook is logged and treated as
+       * "continue" so a buggy predicate cannot wedge a turn.
+       *
+       * This is the hook point for a token/cost/step budget, but note
+       * `ctx.work` is a coarse count of produced content/tool segments, not
+       * tokens — track real token/cost yourself (keyed by
+       * `ctx.recoveryRootRequestId`) and consult it here.
+       */
+      shouldContinue?(
+        ctx: ChatRecoveryProgressContext
+      ): boolean | Promise<boolean>;
       onExhausted?(ctx: ChatRecoveryExhaustedContext): void | Promise<void>;
     };
 
@@ -190,6 +245,10 @@ export type ResolvedChatRecoveryConfig = {
   maxAttempts: number;
   stableTimeoutMs: number;
   terminalMessage: string;
+  maxRecoveryWork: number;
+  shouldContinue?: (
+    ctx: ChatRecoveryProgressContext
+  ) => boolean | Promise<boolean>;
   onExhausted?: (ctx: ChatRecoveryExhaustedContext) => void | Promise<void>;
 };
 

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -133,6 +133,15 @@ type ChatRecoveryIncident = {
    * (#1628).
    */
   progress?: number;
+  /**
+   * Value of the durable progress counter when this incident first opened. The
+   * runaway-loop work budget is `progress - workBaseline` (work produced since
+   * the incident began); compared against `maxRecoveryWork`. Optional for
+   * backward-compat with incidents persisted before this field existed — a
+   * missing baseline is treated as the current marker (zero work so far), so an
+   * in-flight incident from an older build is never falsely sealed.
+   */
+  workBaseline?: number;
 };
 
 const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
@@ -147,6 +156,11 @@ const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 // pathological tight alarm-loop). Kept high so the no-progress window seals
 // first under normal deploy cadence (#1637).
 const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
+// Runaway-loop guard default. `Infinity` = no SDK-imposed work cap: a turn that
+// keeps making forward progress is never terminated by the framework on its own
+// (rfc-chat-recovery-work-budget). Integrators bound a content-emitting runaway
+// by setting `maxRecoveryWork` or a `shouldContinue` predicate.
+const DEFAULT_CHAT_RECOVERY_MAX_WORK = Number.POSITIVE_INFINITY;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Auto-continuation barrier (#1649): when the model emits parallel tool calls,
 // the client answers each one independently and sends a tool result with
@@ -182,10 +196,13 @@ const CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS = 5 * 60 * 1000;
 // single attempt. A deploy rollout drops/reconnects the socket several times
 // over ~11–22s; without this, one logical deploy would burn several attempts.
 const CHAT_RECOVERY_ALARM_DEBOUNCE_MS = 30 * 1000;
-// ABSOLUTE ceiling for a single recovery incident, keyed to `firstSeenAt` and
-// NEVER reset by progress — the final hard stop so even a degenerate
-// slowly-progressing loop cannot run forever.
-const CHAT_RECOVERY_MAX_WINDOW_MS = 15 * 60 * 1000;
+// Staleness bound for the live "recovering…" flag (#1620). A flag older than
+// this is treated as abandoned (the owning incident died without a terminal,
+// e.g. the DO went idle) so it can neither pin the indicator on forever nor
+// suppress a genuinely-new recovering signal. This is NOT a recovery budget —
+// a progressing turn is bounded by work, not wall-clock
+// (rfc-chat-recovery-work-budget).
+const CHAT_RECOVERING_FLAG_TTL_MS = 15 * 60 * 1000;
 // N9: while a parent re-attaches to and forwards a sub-agent's stream, credit
 // the parent's recovery progress at most this often. The marker only needs to
 // advance ≥once between recovery attempts (the no-progress window is minutes),
@@ -3263,6 +3280,14 @@ export class AIChatAgent<
       ),
       terminalMessage:
         custom?.terminalMessage ?? DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE,
+      maxRecoveryWork:
+        typeof custom?.maxRecoveryWork === "number" &&
+        custom.maxRecoveryWork >= 0
+          ? custom.maxRecoveryWork
+          : DEFAULT_CHAT_RECOVERY_MAX_WORK,
+      ...(custom?.shouldContinue
+        ? { shouldContinue: custom.shouldContinue }
+        : {}),
       ...(custom?.onExhausted ? { onExhausted: custom.onExhausted } : {})
     };
   }
@@ -3408,26 +3433,37 @@ export class AIChatAgent<
     const currentProgress = await this._chatRecoveryProgressMarker();
     const madeProgress = existing != null && currentProgress > prevProgress;
 
-    // Wall-clock-keyed-to-progress budget (#1637). The raw attempt count is the
-    // wrong primary bound under deploy churn: one rollout drops/reconnects the
-    // socket several times (~11–22s), each firing an alarm, so a count inflates
-    // far faster than the real interruption rate and seals a healthy turn.
-    //  • PRIMARY — no-progress window: `lastProgressAt` resets on every
+    // Recovery budget (#1637, rfc-chat-recovery-work-budget). A turn making
+    // genuine forward progress survives unbounded deploy churn — duration is
+    // never a bound. The instruments are decoupled by what they catch:
+    //  • STUCK — no-progress window: `lastProgressAt` resets on every
     //    progress-bearing attempt, so a turn that keeps producing content
     //    survives churn indefinitely; a stuck turn is sealed after 5 min.
     //  • DEBOUNCE — alarms bunched within `ALARM_DEBOUNCE_MS` collapse into one
     //    attempt, so a single rollout's reconnect storm isn't N attempts.
-    //  • SECONDARY — the attempt cap is a high backstop (resets on progress).
-    //  • ABSOLUTE — the 15-min incident-age ceiling never resets (final stop).
+    //  • ALARM-LOOP — the attempt cap (resets on progress) catches a tight
+    //    no-progress alarm loop.
+    //  • RUNAWAY — the work budget seals a loop that keeps emitting content but
+    //    never converges. Keyed to WORK done (produced content/tool units since
+    //    the incident opened), not wall-clock, because a healthy long turn and a
+    //    runaway differ by bounded work, not duration. Defaults to no cap.
+    //  • CALLER — `shouldContinue` lets the integrator express a token/cost/step
+    //    budget the SDK should not hardcode.
     const lastProgressAt = madeProgress
       ? now
       : (existing?.lastProgressAt ?? existing?.firstSeenAt ?? now);
     const noProgressExceeded =
       existing != null &&
       now - lastProgressAt > CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS;
-    const incidentAgeExceeded =
+    // Reuse the durable progress counter as a work meter. Baseline is captured
+    // when the incident opens; `work` is what the turn produced since.
+    const workBaseline = existing?.workBaseline ?? currentProgress;
+    const progress = Math.max(prevProgress, currentProgress);
+    const work = progress - workBaseline;
+    const workBudgetExceeded =
       existing != null &&
-      now - existing.firstSeenAt > CHAT_RECOVERY_MAX_WINDOW_MS;
+      Number.isFinite(config.maxRecoveryWork) &&
+      work > config.maxRecoveryWork;
     const debounced =
       existing != null &&
       !madeProgress &&
@@ -3438,8 +3474,43 @@ export class AIChatAgent<
       : debounced
         ? (existing?.attempt ?? 1)
         : (existing?.attempt ?? 0) + 1;
+
+    // Consult the caller predicate only when no hard bound has already sealed
+    // the incident — a buggy/expensive hook must not run after we've decided,
+    // and a throwing hook must not wedge the turn (log and treat as "continue").
+    let abortedByCaller = false;
+    if (
+      existing != null &&
+      config.shouldContinue &&
+      !noProgressExceeded &&
+      !workBudgetExceeded &&
+      attempt <= config.maxAttempts
+    ) {
+      try {
+        const decision = await config.shouldContinue({
+          incidentId,
+          requestId: input.requestId,
+          recoveryRootRequestId: input.recoveryRootRequestId ?? input.requestId,
+          attempt,
+          maxAttempts: config.maxAttempts,
+          recoveryKind: input.recoveryKind,
+          work,
+          ageMs: now - (existing.firstSeenAt ?? now)
+        });
+        abortedByCaller = decision === false;
+      } catch (error) {
+        console.error(
+          "[AIChatAgent] chatRecovery shouldContinue hook threw",
+          error
+        );
+      }
+    }
+
     const exhausted =
-      noProgressExceeded || incidentAgeExceeded || attempt > config.maxAttempts;
+      noProgressExceeded ||
+      workBudgetExceeded ||
+      abortedByCaller ||
+      attempt > config.maxAttempts;
     const incident: ChatRecoveryIncident = {
       incidentId,
       requestId: input.requestId,
@@ -3451,14 +3522,17 @@ export class AIChatAgent<
       firstSeenAt: existing?.firstSeenAt ?? now,
       lastAttemptAt: now,
       lastProgressAt,
-      progress: Math.max(prevProgress, currentProgress),
+      progress,
+      workBaseline,
       ...(exhausted
         ? {
-            reason: incidentAgeExceeded
-              ? "max_recovery_window_exceeded"
+            reason: workBudgetExceeded
+              ? "work_budget_exceeded"
               : noProgressExceeded
                 ? "no_progress_timeout"
-                : "max_attempts_exceeded"
+                : abortedByCaller
+                  ? "recovery_aborted"
+                  : "max_attempts_exceeded"
           }
         : {})
     };
@@ -3600,12 +3674,12 @@ export class AIChatAgent<
       requestId?: string;
       at?: number;
     }>(CHAT_RECOVERING_KEY);
-    // A record older than the max recovery window is stale: the owning incident
-    // was abandoned without a terminal (e.g. the DO went idle before recovery
-    // could exhaust). Treat it as not-recovering so it can't suppress a
-    // genuinely-new recovering signal.
+    // A flag older than the TTL is stale: the owning incident was abandoned
+    // without a terminal (e.g. the DO went idle before recovery could resolve).
+    // Treat it as not-recovering so it can't suppress a genuinely-new recovering
+    // signal.
     const activeExisting =
-      existing && Date.now() - (existing.at ?? 0) < CHAT_RECOVERY_MAX_WINDOW_MS;
+      existing && Date.now() - (existing.at ?? 0) < CHAT_RECOVERING_FLAG_TTL_MS;
     if (active) {
       if (activeExisting) return; // already recovering — idempotent, no re-broadcast
       await this.ctx.storage.put(CHAT_RECOVERING_KEY, {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -71,6 +71,7 @@ export type {
   ChatRecoveryConfig,
   ChatRecoveryContext,
   ChatRecoveryExhaustedContext,
+  ChatRecoveryProgressContext,
   ChatRecoveryOptions,
   MessageConcurrency,
   ResolvedChatRecoveryConfig,

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -160,7 +160,7 @@ const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
 // Runaway-loop guard default. `Infinity` = no SDK-imposed work cap: a turn that
 // keeps making forward progress is never terminated by the framework on its own
 // (rfc-chat-recovery-work-budget). Integrators bound a content-emitting runaway
-// by setting `maxRecoveryWork` or a `shouldContinue` predicate.
+// by setting `maxRecoveryWork` or a `shouldKeepRecovering` predicate.
 const DEFAULT_CHAT_RECOVERY_MAX_WORK = Number.POSITIVE_INFINITY;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Auto-continuation barrier (#1649): when the model emits parallel tool calls,
@@ -192,7 +192,8 @@ const CHAT_RECOVERY_INCIDENT_TTL_MS = 60 * 60 * 1000;
 // progress for this long. Keyed to `lastProgressAt`, which resets on every
 // progress-bearing attempt — so a turn that keeps producing content survives
 // deploy churn indefinitely, while a genuinely stuck turn dies within 5 min.
-const CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS = 5 * 60 * 1000;
+// Overridable per-agent via `chatRecovery.noProgressTimeoutMs`.
+const DEFAULT_CHAT_RECOVERY_NO_PROGRESS_TIMEOUT_MS = 5 * 60 * 1000;
 // Alarm debounce: recovery alarms bunched within this window collapse into a
 // single attempt. A deploy rollout drops/reconnects the socket several times
 // over ~11–22s; without this, one logical deploy would burn several attempts.
@@ -3281,13 +3282,20 @@ export class AIChatAgent<
       ),
       terminalMessage:
         custom?.terminalMessage ?? DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE,
+      noProgressTimeoutMs: Math.max(
+        0,
+        Math.floor(
+          custom?.noProgressTimeoutMs ??
+            DEFAULT_CHAT_RECOVERY_NO_PROGRESS_TIMEOUT_MS
+        )
+      ),
       maxRecoveryWork:
         typeof custom?.maxRecoveryWork === "number" &&
         custom.maxRecoveryWork >= 0
           ? custom.maxRecoveryWork
           : DEFAULT_CHAT_RECOVERY_MAX_WORK,
-      ...(custom?.shouldContinue
-        ? { shouldContinue: custom.shouldContinue }
+      ...(custom?.shouldKeepRecovering
+        ? { shouldKeepRecovering: custom.shouldKeepRecovering }
         : {}),
       ...(custom?.onExhausted ? { onExhausted: custom.onExhausted } : {})
     };
@@ -3448,14 +3456,13 @@ export class AIChatAgent<
     //    never converges. Keyed to WORK done (produced content/tool units since
     //    the incident opened), not wall-clock, because a healthy long turn and a
     //    runaway differ by bounded work, not duration. Defaults to no cap.
-    //  • CALLER — `shouldContinue` lets the integrator express a token/cost/step
-    //    budget the SDK should not hardcode.
+    //  • CALLER — `shouldKeepRecovering` lets the integrator express a
+    //    token/cost/step budget the SDK should not hardcode.
     const lastProgressAt = madeProgress
       ? now
       : (existing?.lastProgressAt ?? existing?.firstSeenAt ?? now);
     const noProgressExceeded =
-      existing != null &&
-      now - lastProgressAt > CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS;
+      existing != null && now - lastProgressAt > config.noProgressTimeoutMs;
     // Reuse the durable progress counter as a work meter. Baseline is captured
     // when the incident opens; `work` is what the turn produced since.
     const workBaseline = existing?.workBaseline ?? currentProgress;
@@ -3482,13 +3489,13 @@ export class AIChatAgent<
     let abortedByCaller = false;
     if (
       existing != null &&
-      config.shouldContinue &&
+      config.shouldKeepRecovering &&
       !noProgressExceeded &&
       !workBudgetExceeded &&
       attempt <= config.maxAttempts
     ) {
       try {
-        const decision = await config.shouldContinue({
+        const decision = await config.shouldKeepRecovering({
           incidentId,
           requestId: input.requestId,
           recoveryRootRequestId: input.recoveryRootRequestId ?? input.requestId,
@@ -3501,7 +3508,7 @@ export class AIChatAgent<
         abortedByCaller = decision === false;
       } catch (error) {
         console.error(
-          "[AIChatAgent] chatRecovery shouldContinue hook threw",
+          "[AIChatAgent] chatRecovery shouldKeepRecovering hook threw",
           error
         );
       }

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -47,8 +47,9 @@ interface ChatRecoveryTestStub {
     maxAttempts?: number;
     terminalMessage?: string;
     maxRecoveryWork?: number;
+    noProgressTimeoutMs?: number;
   }): Promise<void>;
-  setRecoveryShouldContinueForTest(shouldContinue: boolean): Promise<void>;
+  setShouldKeepRecoveringForTest(keepRecovering: boolean): Promise<void>;
   getChatRecoveryIncidentsForTest(): Promise<unknown[]>;
   addAssistantMessageForTest(id: string): Promise<void>;
   bumpRecoveryProgressForTest(): Promise<void>;
@@ -495,10 +496,10 @@ describe("onChatRecovery", () => {
     expect(next.reason).toBe("work_budget_exceeded");
   });
 
-  it("seals when the shouldContinue predicate returns false (recovery_aborted)", async () => {
+  it("seals when the shouldKeepRecovering predicate returns false (recovery_aborted)", async () => {
     const room = crypto.randomUUID();
     const agentStub = await getTestAgent(room);
-    await agentStub.setRecoveryShouldContinueForTest(false);
+    await agentStub.setShouldKeepRecoveringForTest(false);
 
     const base = {
       requestId: "req-abort",
@@ -543,6 +544,36 @@ describe("onChatRecovery", () => {
     const past = await agentStub.beginIncidentForTest({
       ...base,
       nowMs: t0 + 6 * 60 * 1000
+    });
+    expect(past.exhausted).toBe(true);
+    expect(past.reason).toBe("no_progress_timeout");
+  });
+
+  it("honors a custom noProgressTimeoutMs override", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    // A tight 1-min no-progress window instead of the 5-min default.
+    await agentStub.setChatRecoveryConfigForTest({
+      maxAttempts: 100,
+      noProgressTimeoutMs: 60_000
+    });
+
+    const base = {
+      requestId: "req-np-cfg",
+      recoveryRootRequestId: "req-np-cfg",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    const t0 = 8_000_000;
+    expect(
+      (await agentStub.beginIncidentForTest({ ...base, nowMs: t0 })).exhausted
+    ).toBe(false);
+
+    // 90s later with no progress — past the custom 1-min window (the 5-min
+    // default would NOT have sealed here), so it seals on no-progress.
+    const past = await agentStub.beginIncidentForTest({
+      ...base,
+      nowMs: t0 + 90_000
     });
     expect(past.exhausted).toBe(true);
     expect(past.reason).toBe("no_progress_timeout");

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -46,7 +46,9 @@ interface ChatRecoveryTestStub {
   setChatRecoveryConfigForTest(config: {
     maxAttempts?: number;
     terminalMessage?: string;
+    maxRecoveryWork?: number;
   }): Promise<void>;
+  setRecoveryShouldContinueForTest(shouldContinue: boolean): Promise<void>;
   getChatRecoveryIncidentsForTest(): Promise<unknown[]>;
   addAssistantMessageForTest(id: string): Promise<void>;
   bumpRecoveryProgressForTest(): Promise<void>;
@@ -92,6 +94,9 @@ interface ChatRecoveryTestStub {
     status: string;
     firstSeenAt: number;
     lastAttemptAt: number;
+    lastProgressAt?: number;
+    progress?: number;
+    workBaseline?: number;
   }): Promise<void>;
   setForceStableTimeoutForTest(value: boolean): Promise<void>;
   runChatRecoveryContinueDirectForTest(
@@ -417,12 +422,13 @@ describe("onChatRecovery", () => {
     expect(afterProgress.exhausted).toBe(false);
   });
 
-  it("exhausts via the wall-clock window even while making progress", async () => {
+  it("a progressing turn survives past the old wall-clock ceiling (rfc-chat-recovery-work-budget)", async () => {
     const room = crypto.randomUUID();
     const agentStub = await getTestAgent(room);
+    // Default config: maxRecoveryWork is Infinity, so duration is never a bound.
     await agentStub.setChatRecoveryConfigForTest({ maxAttempts: 6 });
 
-    // An incident that opened more than the 15-minute window ago.
+    // An incident that opened well past the old 15-minute ceiling.
     await agentStub.seedIncidentForTest({
       incidentId: "req-old:u1",
       requestId: "req-old",
@@ -430,11 +436,12 @@ describe("onChatRecovery", () => {
       attempt: 1,
       maxAttempts: 6,
       status: "scheduled",
-      firstSeenAt: Date.now() - 16 * 60 * 1000,
+      firstSeenAt: Date.now() - 30 * 60 * 1000,
       lastAttemptAt: Date.now() - 1000
     });
 
-    // Even with fresh progress, the wall-clock ceiling terminalizes it.
+    // Fresh forward progress: the turn is healthy. It must NOT be sealed —
+    // wall-clock age no longer terminalizes a progressing turn.
     await agentStub.bumpRecoveryProgressForTest();
     const next = await agentStub.beginIncidentForTest({
       requestId: "req-old-2",
@@ -442,17 +449,77 @@ describe("onChatRecovery", () => {
       latestUserMessageId: "u1",
       recoveryKind: "continue"
     });
-    expect(next.exhausted).toBe(true);
+    expect(next.exhausted).toBe(false);
+    expect(next.attempt).toBe(1);
 
     const incidents =
       (await agentStub.getChatRecoveryIncidentsForTest()) as Array<{
         status: string;
         reason?: string;
       }>;
-    expect(incidents[0]).toMatchObject({
-      status: "exhausted",
-      reason: "max_recovery_window_exceeded"
+    expect(incidents[0]).toMatchObject({ status: "attempting" });
+    expect(incidents[0]?.reason).toBeUndefined();
+  });
+
+  it("seals a content-emitting runaway via the work budget", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setChatRecoveryConfigForTest({
+      maxAttempts: 100,
+      maxRecoveryWork: 2
     });
+
+    const base = {
+      requestId: "req-runaway",
+      recoveryRootRequestId: "req-runaway",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    let t = 5_000_000;
+    const at = (): typeof base & { nowMs: number } => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...base, nowMs };
+    };
+
+    // Open the incident — the work baseline is captured at the current marker.
+    expect((await agentStub.beginIncidentForTest(at())).attempt).toBe(1);
+
+    // Three units of new content → work since the incident opened = 3 > budget
+    // (2), even though every unit is genuine forward progress.
+    await agentStub.bumpRecoveryProgressForTest();
+    await agentStub.bumpRecoveryProgressForTest();
+    await agentStub.bumpRecoveryProgressForTest();
+    const next = await agentStub.beginIncidentForTest(at());
+    expect(next.exhausted).toBe(true);
+    expect(next.reason).toBe("work_budget_exceeded");
+  });
+
+  it("seals when the shouldContinue predicate returns false (recovery_aborted)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    await agentStub.setRecoveryShouldContinueForTest(false);
+
+    const base = {
+      requestId: "req-abort",
+      recoveryRootRequestId: "req-abort",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    let t = 6_000_000;
+    const at = (): typeof base & { nowMs: number } => {
+      const nowMs = t;
+      t += 40_000;
+      return { ...base, nowMs };
+    };
+
+    // First detection opens the incident (predicate isn't consulted on open).
+    expect((await agentStub.beginIncidentForTest(at())).exhausted).toBe(false);
+
+    // Next attempt — below every hard bound, so only the caller predicate fires.
+    const next = await agentStub.beginIncidentForTest(at());
+    expect(next.exhausted).toBe(true);
+    expect(next.reason).toBe("recovery_aborted");
   });
 
   it("seals an incident after the no-progress window even below the attempt cap (#1637)", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1594,11 +1594,11 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     this.recoveryShouldThrow = shouldThrow;
   }
 
-  /** Configure recovery with a built-in `shouldContinue` predicate. Functions
-   *  can't cross the RPC boundary, so this sets the predicate in-DO rather than
-   *  accepting one through `setChatRecoveryConfigForTest`. */
-  setRecoveryShouldContinueForTest(shouldContinue: boolean): void {
-    this.chatRecovery = { shouldContinue: () => shouldContinue };
+  /** Configure recovery with a built-in `shouldKeepRecovering` predicate.
+   *  Functions can't cross the RPC boundary, so this sets the predicate in-DO
+   *  rather than accepting one through `setChatRecoveryConfigForTest`. */
+  setShouldKeepRecoveringForTest(keepRecovering: boolean): void {
+    this.chatRecovery = { shouldKeepRecovering: () => keepRecovering };
   }
 
   enableThrowingOnExhaustedForTest(

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1594,6 +1594,13 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     this.recoveryShouldThrow = shouldThrow;
   }
 
+  /** Configure recovery with a built-in `shouldContinue` predicate. Functions
+   *  can't cross the RPC boundary, so this sets the predicate in-DO rather than
+   *  accepting one through `setChatRecoveryConfigForTest`. */
+  setRecoveryShouldContinueForTest(shouldContinue: boolean): void {
+    this.chatRecovery = { shouldContinue: () => shouldContinue };
+  }
+
   enableThrowingOnExhaustedForTest(
     maxAttempts: number,
     terminalMessage: string
@@ -1749,6 +1756,9 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     status: string;
     firstSeenAt: number;
     lastAttemptAt: number;
+    lastProgressAt?: number;
+    progress?: number;
+    workBaseline?: number;
   }): Promise<void> {
     await this.ctx.storage.put(
       `cf:chat-recovery:incident:${encodeURIComponent(incident.incidentId)}`,

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3837,13 +3837,11 @@ export class ThinkRecoveryTestAgent extends Think {
     this.chatRecovery = config;
   }
 
-  /** Configure recovery with a built-in `shouldContinue` predicate. Functions
-   *  can't cross the RPC boundary, so this sets the predicate in-DO rather than
-   *  accepting one through `setChatRecoveryConfigForTest`. */
-  async setRecoveryShouldContinueForTest(
-    shouldContinue: boolean
-  ): Promise<void> {
-    this.chatRecovery = { shouldContinue: () => shouldContinue };
+  /** Configure recovery with a built-in `shouldKeepRecovering` predicate.
+   *  Functions can't cross the RPC boundary, so this sets the predicate in-DO
+   *  rather than accepting one through `setChatRecoveryConfigForTest`. */
+  async setShouldKeepRecoveringForTest(keepRecovering: boolean): Promise<void> {
+    this.chatRecovery = { shouldKeepRecovering: () => keepRecovering };
   }
 
   async getChatRecoveryIncidentsForTest(): Promise<unknown[]> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3837,6 +3837,15 @@ export class ThinkRecoveryTestAgent extends Think {
     this.chatRecovery = config;
   }
 
+  /** Configure recovery with a built-in `shouldContinue` predicate. Functions
+   *  can't cross the RPC boundary, so this sets the predicate in-DO rather than
+   *  accepting one through `setChatRecoveryConfigForTest`. */
+  async setRecoveryShouldContinueForTest(
+    shouldContinue: boolean
+  ): Promise<void> {
+    this.chatRecovery = { shouldContinue: () => shouldContinue };
+  }
+
   async getChatRecoveryIncidentsForTest(): Promise<unknown[]> {
     const entries = await this.ctx.storage.list({
       prefix: "cf:chat-recovery:incident:"
@@ -4208,6 +4217,9 @@ export class ThinkRecoveryTestAgent extends Think {
     status: string;
     firstSeenAt: number;
     lastAttemptAt: number;
+    lastProgressAt?: number;
+    progress?: number;
+    workBaseline?: number;
   }): Promise<void> {
     await this.ctx.storage.put(
       `cf:chat-recovery:incident:${encodeURIComponent(incident.incidentId)}`,

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2503,11 +2503,12 @@ describe("Think — onChatRecovery", () => {
     expect(afterProgress.exhausted).toBe(false);
   });
 
-  it("exhausts via the wall-clock window even while making progress", async () => {
-    const agent = await freshRecoveryAgent("recovery-window");
+  it("a progressing turn survives past the old wall-clock ceiling (rfc-chat-recovery-work-budget)", async () => {
+    const agent = await freshRecoveryAgent("recovery-window-survives");
+    // Default config: maxRecoveryWork is Infinity, so duration is never a bound.
     await agent.setChatRecoveryConfigForTest({ maxAttempts: 6 });
 
-    // An incident that opened more than the 15-minute window ago.
+    // An incident that opened well past the old 15-minute ceiling.
     await agent.seedIncidentForTest({
       incidentId: "req-old:u1",
       requestId: "req-old",
@@ -2515,15 +2516,61 @@ describe("Think — onChatRecovery", () => {
       attempt: 1,
       maxAttempts: 6,
       status: "scheduled",
-      firstSeenAt: Date.now() - 16 * 60 * 1000,
+      firstSeenAt: Date.now() - 30 * 60 * 1000,
       lastAttemptAt: Date.now() - 1000
     });
 
-    // Even with fresh progress, the wall-clock ceiling terminalizes it.
+    // Fresh forward progress: the turn is healthy. It must NOT be sealed —
+    // wall-clock age no longer terminalizes a progressing turn.
     await agent.bumpRecoveryProgressForTest();
     const next = await agent.beginIncidentForTest({
       requestId: "req-old-2",
       recoveryRootRequestId: "req-old",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue"
+    });
+    expect(next.exhausted).toBe(false);
+    expect(next.attempt).toBe(1);
+
+    const incidents = (await agent.getChatRecoveryIncidentsForTest()) as Array<{
+      status: string;
+      reason?: string;
+    }>;
+    expect(incidents[0]).toMatchObject({ status: "attempting" });
+    expect(incidents[0]?.reason).toBeUndefined();
+  });
+
+  it("seals a content-emitting runaway via the work budget", async () => {
+    const agent = await freshRecoveryAgent("recovery-work-budget");
+    // Tiny work budget so a turn that keeps producing content is sealed by
+    // bounded work, not wall-clock.
+    await agent.setChatRecoveryConfigForTest({
+      maxAttempts: 100,
+      maxRecoveryWork: 2
+    });
+
+    // Incident opened with a work baseline of 0 (no work produced yet).
+    await agent.seedIncidentForTest({
+      incidentId: "req-runaway:u1",
+      requestId: "req-runaway",
+      recoveryKind: "continue",
+      attempt: 1,
+      maxAttempts: 100,
+      status: "scheduled",
+      firstSeenAt: Date.now() - 1000,
+      lastAttemptAt: Date.now() - 60_000,
+      progress: 0,
+      workBaseline: 0
+    });
+
+    // Three units of new content → work = 3 > budget(2), even though every unit
+    // is genuine forward progress.
+    await agent.bumpRecoveryProgressForTest();
+    await agent.bumpRecoveryProgressForTest();
+    await agent.bumpRecoveryProgressForTest();
+    const next = await agent.beginIncidentForTest({
+      requestId: "req-runaway-2",
+      recoveryRootRequestId: "req-runaway",
       latestUserMessageId: "u1",
       recoveryKind: "continue"
     });
@@ -2535,7 +2582,43 @@ describe("Think — onChatRecovery", () => {
     }>;
     expect(incidents[0]).toMatchObject({
       status: "exhausted",
-      reason: "max_recovery_window_exceeded"
+      reason: "work_budget_exceeded"
+    });
+  });
+
+  it("seals when the shouldContinue predicate returns false (recovery_aborted)", async () => {
+    const agent = await freshRecoveryAgent("recovery-should-continue");
+    await agent.setRecoveryShouldContinueForTest(false);
+
+    // An open incident below every hard bound — only the caller predicate fires.
+    await agent.seedIncidentForTest({
+      incidentId: "req-abort:u1",
+      requestId: "req-abort",
+      recoveryKind: "continue",
+      attempt: 1,
+      maxAttempts: 10,
+      status: "scheduled",
+      firstSeenAt: 1_000_000,
+      lastAttemptAt: 1_000_000
+    });
+
+    const next = await agent.beginIncidentForTest({
+      requestId: "req-abort-2",
+      recoveryRootRequestId: "req-abort",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue",
+      // Well within the no-progress window, past the alarm debounce.
+      nowMs: 1_060_000
+    });
+    expect(next.exhausted).toBe(true);
+
+    const incidents = (await agent.getChatRecoveryIncidentsForTest()) as Array<{
+      status: string;
+      reason?: string;
+    }>;
+    expect(incidents[0]).toMatchObject({
+      status: "exhausted",
+      reason: "recovery_aborted"
     });
   });
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2586,9 +2586,9 @@ describe("Think — onChatRecovery", () => {
     });
   });
 
-  it("seals when the shouldContinue predicate returns false (recovery_aborted)", async () => {
-    const agent = await freshRecoveryAgent("recovery-should-continue");
-    await agent.setRecoveryShouldContinueForTest(false);
+  it("seals when the shouldKeepRecovering predicate returns false (recovery_aborted)", async () => {
+    const agent = await freshRecoveryAgent("recovery-should-keep-recovering");
+    await agent.setShouldKeepRecoveringForTest(false);
 
     // An open incident below every hard bound — only the caller predicate fires.
     await agent.seedIncidentForTest({
@@ -2644,6 +2644,35 @@ describe("Think — onChatRecovery", () => {
     const past = await agent.beginIncidentForTest({
       ...base,
       nowMs: t0 + 6 * 60 * 1000
+    });
+    expect(past.exhausted).toBe(true);
+    expect(past.reason).toBe("no_progress_timeout");
+  });
+
+  it("honors a custom noProgressTimeoutMs override", async () => {
+    const agent = await freshRecoveryAgent("recovery-no-progress-cfg");
+    // A tight 1-min no-progress window instead of the 5-min default.
+    await agent.setChatRecoveryConfigForTest({
+      maxAttempts: 100,
+      noProgressTimeoutMs: 60_000
+    });
+
+    const base = {
+      requestId: "req-np-cfg",
+      recoveryRootRequestId: "req-np-cfg",
+      latestUserMessageId: "u1",
+      recoveryKind: "continue" as const
+    };
+    const t0 = 4_500_000;
+    expect(
+      (await agent.beginIncidentForTest({ ...base, nowMs: t0 })).exhausted
+    ).toBe(false);
+
+    // 90s later with no progress — past the custom 1-min window (the 5-min
+    // default would NOT have sealed here), so it seals on no-progress.
+    const past = await agent.beginIncidentForTest({
+      ...base,
+      nowMs: t0 + 90_000
     });
     expect(past.exhausted).toBe(true);
     expect(past.reason).toBe("no_progress_timeout");

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -640,6 +640,15 @@ type ChatRecoveryIncident = {
    * (#1628).
    */
   progress?: number;
+  /**
+   * Value of the durable progress counter when this incident first opened. The
+   * runaway-loop work budget is `progress - workBaseline` (work produced since
+   * the incident began); compared against `maxRecoveryWork`. Optional for
+   * backward-compat with incidents persisted before this field existed — a
+   * missing baseline is treated as the current marker (zero work so far), so an
+   * in-flight incident from an older build is never falsely sealed.
+   */
+  workBaseline?: number;
 };
 
 const CHAT_RECOVERY_INCIDENT_KEY_PREFIX = "cf:chat-recovery:incident:";
@@ -654,6 +663,11 @@ const CHAT_RECOVERY_PROGRESS_KEY = "cf:chat-recovery:progress";
 // pathological tight alarm-loop). Kept high so the no-progress window seals
 // first under normal deploy cadence (#1637).
 const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
+// Runaway-loop guard default. `Infinity` = no SDK-imposed work cap: a turn that
+// keeps making forward progress is never terminated by the framework on its own
+// (rfc-chat-recovery-work-budget). Integrators bound a content-emitting runaway
+// by setting `maxRecoveryWork` or a `shouldContinue` predicate.
+const DEFAULT_CHAT_RECOVERY_MAX_WORK = Number.POSITIVE_INFINITY;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Auto-continuation barrier (#1649 / #1650): when the model emits parallel tool
 // calls, the client answers each one independently and sends a `tool-result`
@@ -692,10 +706,13 @@ const CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS = 5 * 60 * 1000;
 // single attempt. A deploy rollout drops/reconnects the socket several times
 // over ~11–22s; without this, one logical deploy would burn several attempts.
 const CHAT_RECOVERY_ALARM_DEBOUNCE_MS = 30 * 1000;
-// ABSOLUTE ceiling for a single recovery incident, keyed to `firstSeenAt` and
-// NEVER reset by progress — the final hard stop so even a degenerate
-// slowly-progressing loop cannot run forever.
-const CHAT_RECOVERY_MAX_WINDOW_MS = 15 * 60 * 1000;
+// Staleness bound for the live "recovering…" flag (#1620). A flag older than
+// this is treated as abandoned (the owning incident died without a terminal,
+// e.g. the DO went idle) so it can neither pin the indicator on forever nor
+// suppress a genuinely-new recovering signal. This is NOT a recovery budget —
+// a progressing turn is bounded by work, not wall-clock
+// (rfc-chat-recovery-work-budget).
+const CHAT_RECOVERING_FLAG_TTL_MS = 15 * 60 * 1000;
 // N9: while a parent re-attaches to and forwards a sub-agent's stream, credit
 // the parent's recovery progress at most this often. The marker only needs to
 // advance ≥once between recovery attempts (the no-progress window is minutes),
@@ -7506,6 +7523,14 @@ export class Think<
       ),
       terminalMessage:
         custom?.terminalMessage ?? DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE,
+      maxRecoveryWork:
+        typeof custom?.maxRecoveryWork === "number" &&
+        custom.maxRecoveryWork >= 0
+          ? custom.maxRecoveryWork
+          : DEFAULT_CHAT_RECOVERY_MAX_WORK,
+      ...(custom?.shouldContinue
+        ? { shouldContinue: custom.shouldContinue }
+        : {}),
       ...(custom?.onExhausted ? { onExhausted: custom.onExhausted } : {})
     };
   }
@@ -7630,26 +7655,37 @@ export class Think<
     const currentProgress = await this._chatRecoveryProgressMarker();
     const madeProgress = existing != null && currentProgress > prevProgress;
 
-    // Wall-clock-keyed-to-progress budget (#1637). The raw attempt count is the
-    // wrong primary bound under deploy churn: one rollout drops/reconnects the
-    // socket several times (~11–22s), each firing an alarm, so a count inflates
-    // far faster than the real interruption rate and seals a healthy turn.
-    //  • PRIMARY — no-progress window: `lastProgressAt` resets on every
+    // Recovery budget (#1637, rfc-chat-recovery-work-budget). A turn making
+    // genuine forward progress survives unbounded deploy churn — duration is
+    // never a bound. The instruments are decoupled by what they catch:
+    //  • STUCK — no-progress window: `lastProgressAt` resets on every
     //    progress-bearing attempt, so a turn that keeps producing content
     //    survives churn indefinitely; a stuck turn is sealed after 5 min.
     //  • DEBOUNCE — alarms bunched within `ALARM_DEBOUNCE_MS` collapse into one
     //    attempt, so a single rollout's reconnect storm isn't N attempts.
-    //  • SECONDARY — the attempt cap is a high backstop (resets on progress).
-    //  • ABSOLUTE — the 15-min incident-age ceiling never resets (final stop).
+    //  • ALARM-LOOP — the attempt cap (resets on progress) catches a tight
+    //    no-progress alarm loop.
+    //  • RUNAWAY — the work budget seals a loop that keeps emitting content but
+    //    never converges. Keyed to WORK done (produced content/tool units since
+    //    the incident opened), not wall-clock, because a healthy long turn and a
+    //    runaway differ by bounded work, not duration. Defaults to no cap.
+    //  • CALLER — `shouldContinue` lets the integrator express a token/cost/step
+    //    budget the SDK should not hardcode.
     const lastProgressAt = madeProgress
       ? now
       : (existing?.lastProgressAt ?? existing?.firstSeenAt ?? now);
     const noProgressExceeded =
       existing != null &&
       now - lastProgressAt > CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS;
-    const incidentAgeExceeded =
+    // Reuse the durable progress counter as a work meter. Baseline is captured
+    // when the incident opens; `work` is what the turn produced since.
+    const workBaseline = existing?.workBaseline ?? currentProgress;
+    const progress = Math.max(prevProgress, currentProgress);
+    const work = progress - workBaseline;
+    const workBudgetExceeded =
       existing != null &&
-      now - existing.firstSeenAt > CHAT_RECOVERY_MAX_WINDOW_MS;
+      Number.isFinite(config.maxRecoveryWork) &&
+      work > config.maxRecoveryWork;
     const debounced =
       existing != null &&
       !madeProgress &&
@@ -7660,8 +7696,40 @@ export class Think<
       : debounced
         ? (existing?.attempt ?? 1)
         : (existing?.attempt ?? 0) + 1;
+
+    // Consult the caller predicate only when no hard bound has already sealed
+    // the incident — a buggy/expensive hook must not run after we've decided,
+    // and a throwing hook must not wedge the turn (log and treat as "continue").
+    let abortedByCaller = false;
+    if (
+      existing != null &&
+      config.shouldContinue &&
+      !noProgressExceeded &&
+      !workBudgetExceeded &&
+      attempt <= config.maxAttempts
+    ) {
+      try {
+        const decision = await config.shouldContinue({
+          incidentId,
+          requestId: input.requestId,
+          recoveryRootRequestId: input.recoveryRootRequestId ?? input.requestId,
+          attempt,
+          maxAttempts: config.maxAttempts,
+          recoveryKind: input.recoveryKind,
+          work,
+          ageMs: now - (existing.firstSeenAt ?? now)
+        });
+        abortedByCaller = decision === false;
+      } catch (error) {
+        console.error("[Think] chatRecovery shouldContinue hook threw", error);
+      }
+    }
+
     const exhausted =
-      noProgressExceeded || incidentAgeExceeded || attempt > config.maxAttempts;
+      noProgressExceeded ||
+      workBudgetExceeded ||
+      abortedByCaller ||
+      attempt > config.maxAttempts;
     const incident: ChatRecoveryIncident = {
       incidentId,
       requestId: input.requestId,
@@ -7673,14 +7741,17 @@ export class Think<
       firstSeenAt: existing?.firstSeenAt ?? now,
       lastAttemptAt: now,
       lastProgressAt,
-      progress: Math.max(prevProgress, currentProgress),
+      progress,
+      workBaseline,
       ...(exhausted
         ? {
-            reason: incidentAgeExceeded
-              ? "max_recovery_window_exceeded"
+            reason: workBudgetExceeded
+              ? "work_budget_exceeded"
               : noProgressExceeded
                 ? "no_progress_timeout"
-                : "max_attempts_exceeded"
+                : abortedByCaller
+                  ? "recovery_aborted"
+                  : "max_attempts_exceeded"
           }
         : {})
     };
@@ -9382,13 +9453,13 @@ export class Think<
       requestId?: string;
       at?: number;
     }>(CHAT_RECOVERING_KEY);
-    // A record older than the max recovery window is stale: the owning incident
-    // was abandoned without ever reaching a terminal (e.g. the DO went idle
-    // before recovery could exhaust), so its terminal-clear never ran. Treat it
-    // as not-recovering so a stuck record can neither pin the indicator "on"
+    // A flag older than the TTL is stale: the owning incident was abandoned
+    // without ever reaching a terminal (e.g. the DO went idle before recovery
+    // could resolve), so its terminal-clear never ran. Treat it as
+    // not-recovering so a stuck record can neither pin the indicator "on"
     // forever nor suppress a genuinely-new recovering signal.
     const activeExisting =
-      existing && Date.now() - (existing.at ?? 0) < CHAT_RECOVERY_MAX_WINDOW_MS;
+      existing && Date.now() - (existing.at ?? 0) < CHAT_RECOVERING_FLAG_TTL_MS;
     if (active) {
       if (activeExisting) return; // already recovering — idempotent, no re-broadcast
       await this.ctx.storage.put(CHAT_RECOVERING_KEY, {
@@ -9432,16 +9503,16 @@ export class Think<
     // Replay an in-progress "recovering…" status so a client that connects
     // mid-recovery reads the turn as working rather than frozen (#1620). It's
     // mutually exclusive with `pending` (a terminal outcome clears recovering).
-    // Skip a stale record (older than the max recovery window) so a turn whose
-    // recovery was abandoned without a terminal can't show "recovering…"
-    // forever on reconnect.
+    // Skip a stale record (older than the flag TTL) so a turn whose recovery
+    // was abandoned without a terminal can't show "recovering…" forever on
+    // reconnect.
     const recovering = await this.ctx.storage.get<{
       requestId?: string;
       at?: number;
     }>(CHAT_RECOVERING_KEY);
     if (
       recovering &&
-      Date.now() - (recovering.at ?? 0) < CHAT_RECOVERY_MAX_WINDOW_MS
+      Date.now() - (recovering.at ?? 0) < CHAT_RECOVERING_FLAG_TTL_MS
     ) {
       messages.push({
         type: MSG_CHAT_RECOVERING,

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -666,7 +666,7 @@ const DEFAULT_CHAT_RECOVERY_MAX_ATTEMPTS = 10;
 // Runaway-loop guard default. `Infinity` = no SDK-imposed work cap: a turn that
 // keeps making forward progress is never terminated by the framework on its own
 // (rfc-chat-recovery-work-budget). Integrators bound a content-emitting runaway
-// by setting `maxRecoveryWork` or a `shouldContinue` predicate.
+// by setting `maxRecoveryWork` or a `shouldKeepRecovering` predicate.
 const DEFAULT_CHAT_RECOVERY_MAX_WORK = Number.POSITIVE_INFINITY;
 const DEFAULT_CHAT_RECOVERY_STABLE_TIMEOUT_MS = 10_000;
 // Auto-continuation barrier (#1649 / #1650): when the model emits parallel tool
@@ -701,7 +701,8 @@ const CHAT_RECOVERY_INCIDENT_TTL_MS = 60 * 60 * 1000;
 // progress for this long. Keyed to `lastProgressAt`, which resets on every
 // progress-bearing attempt — so a turn that keeps producing content survives
 // deploy churn indefinitely, while a genuinely stuck turn dies within 5 min.
-const CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS = 5 * 60 * 1000;
+// Overridable per-agent via `chatRecovery.noProgressTimeoutMs`.
+const DEFAULT_CHAT_RECOVERY_NO_PROGRESS_TIMEOUT_MS = 5 * 60 * 1000;
 // Alarm debounce: recovery alarms bunched within this window collapse into a
 // single attempt. A deploy rollout drops/reconnects the socket several times
 // over ~11–22s; without this, one logical deploy would burn several attempts.
@@ -7524,13 +7525,20 @@ export class Think<
       ),
       terminalMessage:
         custom?.terminalMessage ?? DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE,
+      noProgressTimeoutMs: Math.max(
+        0,
+        Math.floor(
+          custom?.noProgressTimeoutMs ??
+            DEFAULT_CHAT_RECOVERY_NO_PROGRESS_TIMEOUT_MS
+        )
+      ),
       maxRecoveryWork:
         typeof custom?.maxRecoveryWork === "number" &&
         custom.maxRecoveryWork >= 0
           ? custom.maxRecoveryWork
           : DEFAULT_CHAT_RECOVERY_MAX_WORK,
-      ...(custom?.shouldContinue
-        ? { shouldContinue: custom.shouldContinue }
+      ...(custom?.shouldKeepRecovering
+        ? { shouldKeepRecovering: custom.shouldKeepRecovering }
         : {}),
       ...(custom?.onExhausted ? { onExhausted: custom.onExhausted } : {})
     };
@@ -7670,14 +7678,13 @@ export class Think<
     //    never converges. Keyed to WORK done (produced content/tool units since
     //    the incident opened), not wall-clock, because a healthy long turn and a
     //    runaway differ by bounded work, not duration. Defaults to no cap.
-    //  • CALLER — `shouldContinue` lets the integrator express a token/cost/step
-    //    budget the SDK should not hardcode.
+    //  • CALLER — `shouldKeepRecovering` lets the integrator express a
+    //    token/cost/step budget the SDK should not hardcode.
     const lastProgressAt = madeProgress
       ? now
       : (existing?.lastProgressAt ?? existing?.firstSeenAt ?? now);
     const noProgressExceeded =
-      existing != null &&
-      now - lastProgressAt > CHAT_RECOVERY_NO_PROGRESS_WINDOW_MS;
+      existing != null && now - lastProgressAt > config.noProgressTimeoutMs;
     // Reuse the durable progress counter as a work meter. Baseline is captured
     // when the incident opens; `work` is what the turn produced since.
     const workBaseline = existing?.workBaseline ?? currentProgress;
@@ -7704,13 +7711,13 @@ export class Think<
     let abortedByCaller = false;
     if (
       existing != null &&
-      config.shouldContinue &&
+      config.shouldKeepRecovering &&
       !noProgressExceeded &&
       !workBudgetExceeded &&
       attempt <= config.maxAttempts
     ) {
       try {
-        const decision = await config.shouldContinue({
+        const decision = await config.shouldKeepRecovering({
           incidentId,
           requestId: input.requestId,
           recoveryRootRequestId: input.recoveryRootRequestId ?? input.requestId,
@@ -7722,7 +7729,10 @@ export class Think<
         });
         abortedByCaller = decision === false;
       } catch (error) {
-        console.error("[Think] chatRecovery shouldContinue hook threw", error);
+        console.error(
+          "[Think] chatRecovery shouldKeepRecovering hook threw",
+          error
+        );
       }
     }
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1076,6 +1076,7 @@ export type {
   ChatRecoveryConfig,
   ChatRecoveryContext,
   ChatRecoveryExhaustedContext,
+  ChatRecoveryProgressContext,
   ChatRecoveryOptions,
   MessageConcurrency,
   ResolvedChatRecoveryConfig,


### PR DESCRIPTION
## Problem

Durable chat recovery bounded a single incident with a **non-resetting 15-minute wall-clock ceiling** (`CHAT_RECOVERY_MAX_WINDOW_MS`). That ceiling was overloaded — it did duty as **both** a recovery-duration bound **and** a runaway-loop guard. Those jobs want different instruments.

The no-progress window (5 min, resets on progress) and the attempt cap (resets on progress) already catch a *stuck* turn. The only thing the absolute ceiling uniquely caught was a loop that **keeps emitting content but never converges** — a **bounded-work** condition, not a duration. So the ceiling's real cost was terminating *healthy, actively-progressing* turns that simply took longer than 15 minutes of wall-clock because they were repeatedly interrupted by a dense deploy window — sealing them with `reason="max_recovery_window_exceeded"` and discarding completed work.

A customer hit this in production: ~99 model generations, ~3 deploys in ~95 minutes, sealed at ~901,929 ms (≈ the 15-min ceiling) while still **healthy** (`attempt=1` — the no-progress window and attempt cap had just reset on progress, so only the non-resetting ceiling could fire).

## Change

Decouple the two jobs (full rationale in `design/rfc-chat-recovery-work-budget.md`):

1. **Duration is no longer a bound for a progressing turn.** The non-resetting wall-clock ceiling is removed. A turn that keeps producing content survives unbounded deploy churn. Stuck turns are still sealed by the no-progress timeout; tight no-progress alarm loops by the attempt cap.

2. **New runaway-loop guard, keyed to work not time.** The existing durable, monotonic, reconnect-immune progress counter is reused as a work meter. `chatRecovery.maxRecoveryWork` caps produced content/tool units since an incident opened (`work = progress - workBaseline`); exceeding it seals with `reason="work_budget_exceeded"`. **Defaults to `Infinity`** — the SDK ships the mechanism but imposes no implicit cap, so it never terminates a progressing turn on its own.

3. **New caller predicate `shouldKeepRecovering(ctx)`.** Consulted per recovery attempt from the second onward (only when no hard bound has already sealed the incident); returning `false` seals with `reason="recovery_aborted"`. This is the hook point for token/cost/step budgets the SDK should not hardcode. A throwing predicate is logged and treated as "keep recovering".

4. **The no-progress timeout is now configurable** as `chatRecovery.noProgressTimeoutMs` (default 5 min, resets on progress). With the wall-clock ceiling gone it is the primary stuck-turn bound, and it was the only recovery limit still hardcoded — exposing it keeps the config surface consistent.

### Invariant

> A turn making genuine forward progress survives unbounded deploy churn — no matter how long it runs or how many recoveries occur — and is terminated only by (a) a no-progress timeout (stuck), (b) the attempt cap (no-progress alarm loop), (c) a work-budget violation (runaway), or (d) a caller predicate.

## Naming

The predicate is `shouldKeepRecovering`, **not** `shouldContinue`: `continue` is already overloaded in this API (`ChatRecoveryOptions.continue` and `continueLastTurn()`), so `shouldContinue` read as "should I call `continueLastTurn`?" rather than "should the recovery loop keep going?". The work cap stays `maxRecoveryWork` / `ctx.work` — "work" honestly conveys "units of progress" and the config/context pair is self-documenting.

## API surface (`agents/chat`, re-exported by both packages)

- New type `ChatRecoveryProgressContext` (the `ctx` for `shouldKeepRecovering`).
- New `ChatRecoveryConfig` fields: `noProgressTimeoutMs`, `maxRecoveryWork`, `shouldKeepRecovering`.
- `ChatRecoveryExhaustedContext.reason` documents `work_budget_exceeded` and `recovery_aborted`. `max_recovery_window_exceeded` is retained as a deprecated open-string value for back-compat with persisted incidents (no longer emitted).
- Incident records gain `workBaseline` (optional; a missing baseline fails safe to the current marker = zero work, so an in-flight incident from an older build is never falsely sealed).

Both `@cloudflare/ai-chat` and `@cloudflare/think` carry their own copy of the recovery engine and are updated identically. **Defaults are unchanged except that a progressing turn is no longer terminated by wall-clock age.**

## Upgrade note

With the default `maxRecoveryWork: Infinity`, a *content-emitting* runaway has **no SDK backstop** (the old 15-min ceiling was the only thing that caught it). Exposure is narrow — recovery only re-fires on interruptions, and a single continuation is still bounded by `maxSteps` — but integrators that want a runaway guard should set `maxRecoveryWork` or `shouldKeepRecovering`. Note `maxSteps` is **not** a substitute: it resets per continuation and does not bound cumulative recovery work.

## Tests

- Rewrote the obsolete "exhausts via the wall-clock window" test in **both** packages to assert a progressing 30-min-old turn **survives** (not sealed).
- Added `work_budget_exceeded`, `recovery_aborted`, and `noProgressTimeoutMs` override coverage in both packages.
- `@cloudflare/ai-chat` 37/37, `@cloudflare/think` 171/171.
- `npm run check` green across all 90 projects (sherif, export checks, oxfmt, oxlint, typecheck).

## Docs

- `docs/chat-agents.md`: documented `noProgressTimeoutMs` / `maxRecoveryWork` / `shouldKeepRecovering`, a full config table, a `ChatRecoveryProgressContext` field table, and the `ctx.reason` values (plus the finite-cap false-positive caveat, and a note that recovery hooks are not bound to the agent instance).
- `docs/think/sub-agents.md`: brought the Think recovery reference to parity — completed the `ChatRecoveryContext` table and added a "Recovery budgets and limits" section.
- `docs/think/index.md`: fixed a stale `maxAttempts: 6` example.
- Registered the RFC in `design/AGENTS.md`.

## Changeset

`minor` for `agents`, `@cloudflare/ai-chat`, and `@cloudflare/think`.
