### PR TITLE
perf(chat): batch and pack SQLite writes for chat persistence

### DIFF
--- a/.changeset/batch-stream-chunk-writes.md
+++ b/.changeset/batch-stream-chunk-writes.md
@@ -1,0 +1,12 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Batch and pack chat-persistence SQLite writes to reduce rows written and round-trips.
+
+- `agents`: `ResumableStream` now **packs** each buffered group of stream chunks into a single SQLite row (a JSON array of chunk bodies) instead of writing one row per chunk. Single-chunk and large-chunk segments are stored unwrapped, and a per-segment byte cap keeps rows within the 2 MB SQLite row limit. This cuts chunk rows written / stored / scanned-on-replay by up to ~10×. Reads (replay, orphan reconstruction, `getStreamChunks`) transparently unpack both packed segments and legacy per-chunk rows, so existing stored data keeps working. Adds shared `buildInClauseStrings` and `MAX_BOUND_PARAMS` helpers exported from `agents/chat`.
+- `@cloudflare/ai-chat`: message cleanup (stale-row pruning and `maxPersistedMessages` enforcement) previously issued one `DELETE` per row in a loop; it now deletes rows in batched `DELETE ... WHERE id IN (...)` queries (capped at 100 bound parameters per query).
+- `@cloudflare/think`: `deleteSubmissions()` cleanup previously issued one `DELETE` per terminal submission (up to 500 per call); it now deletes rows in batched `DELETE ... WHERE submission_id IN (...)` queries.
+- `@cloudflare/ai-chat` & `@cloudflare/think`: chat-recovery incident TTL sweep previously deleted each stale incident with a separate awaited `storage.delete(key)` (which also defeats Durable Object write-coalescing); it now deletes incidents in batched `storage.delete(keys)` calls (up to 128 keys per call).

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -38,6 +38,8 @@ export {
 
 export { ResumableStream, type SqlTaggedTemplate } from "./resumable-stream";
 
+export { MAX_BOUND_PARAMS, buildInClauseStrings } from "./sql-batch";
+
 export {
   createToolsFromClientSchemas,
   type ClientToolSchema

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -14,16 +14,44 @@ import { nanoid } from "nanoid";
 import type { Connection } from "agents";
 import { CHAT_MESSAGE_TYPES } from "./protocol";
 
-/** Number of chunks to buffer before flushing to SQLite */
+/** Number of chunks to pack into a single SQLite row before flushing */
 const CHUNK_BUFFER_SIZE = 10;
 /** Maximum buffer size to prevent memory issues on rapid reconnections */
 const CHUNK_BUFFER_MAX_SIZE = 100;
+/**
+ * Max accumulated raw chunk bytes packed into one row before forcing a flush.
+ * The SQLite row limit is 2 MB; packing serializes bodies into a JSON array,
+ * which re-escapes their contents (quotes/backslashes), so we keep the raw
+ * total well under the limit to leave generous headroom for escaping overhead.
+ * A chunk larger than this is flushed as its own (unwrapped) row.
+ */
+const SEGMENT_MAX_BYTES = 512_000;
 /** Default cleanup interval for old streams (ms) - every 10 minutes */
 const CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
 /** Default age threshold for cleaning up completed streams (ms) - 24 hours */
 const CLEANUP_AGE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 /** Shared encoder for UTF-8 byte length measurement */
 const textEncoder = new TextEncoder();
+
+/**
+ * A stored row body is either a single chunk body (a JSON object string —
+ * legacy per-chunk rows and single-chunk segments) or a packed segment (a JSON
+ * array of chunk body strings). Unpack to the individual chunk bodies in order.
+ *
+ * Stored chunk bodies are always serialized JSON *objects*, never arrays, so
+ * `Array.isArray` reliably distinguishes a packed segment from a single body.
+ */
+function unpackSegmentBody(rowBody: string): string[] {
+  try {
+    const parsed = JSON.parse(rowBody);
+    if (Array.isArray(parsed)) {
+      return parsed as string[];
+    }
+  } catch {
+    // Not valid JSON — treat as a single opaque body.
+  }
+  return [rowBody];
+}
 
 function sendIfOpen(connection: Connection, message: string): boolean {
   try {
@@ -79,7 +107,8 @@ export type SqlTaggedTemplate = {
 export class ResumableStream {
   private _activeStreamId: string | null = null;
   private _activeRequestId: string | null = null;
-  private _streamChunkIndex = 0;
+  /** Monotonic row-ordering index; one increment per flushed segment row. */
+  private _segmentIndex = 0;
 
   /**
    * Whether the active stream was started in this instance (true) or
@@ -89,12 +118,8 @@ export class ResumableStream {
    */
   private _isLive = false;
 
-  private _chunkBuffer: Array<{
-    id: string;
-    streamId: string;
-    body: string;
-    index: number;
-  }> = [];
+  private _chunkBuffer: Array<{ streamId: string; body: string }> = [];
+  private _chunkBufferBytes = 0;
   private _isFlushingChunks = false;
   private _lastCleanupTime = 0;
 
@@ -160,7 +185,7 @@ export class ResumableStream {
     const streamId = nanoid();
     this._activeStreamId = streamId;
     this._activeRequestId = requestId;
-    this._streamChunkIndex = 0;
+    this._segmentIndex = 0;
     this._isLive = true;
 
     this.sql`
@@ -185,7 +210,7 @@ export class ResumableStream {
     `;
     this._activeStreamId = null;
     this._activeRequestId = null;
-    this._streamChunkIndex = 0;
+    this._segmentIndex = 0;
     this._isLive = false;
 
     // Periodically clean up old streams
@@ -206,7 +231,7 @@ export class ResumableStream {
     `;
     this._activeStreamId = null;
     this._activeRequestId = null;
-    this._streamChunkIndex = 0;
+    this._segmentIndex = 0;
     this._isLive = false;
   }
 
@@ -240,23 +265,35 @@ export class ResumableStream {
       this.flushBuffer();
     }
 
-    this._chunkBuffer.push({
-      id: nanoid(),
-      streamId,
-      body,
-      index: this._streamChunkIndex
-    });
-    this._streamChunkIndex++;
+    // Byte guard: keep a packed segment safely under the SQLite row limit. If
+    // the buffer already holds chunks and adding this body would push the
+    // segment past the threshold, flush first so this chunk starts a fresh
+    // segment. A single large chunk therefore ends up alone and is written
+    // unwrapped by flushBuffer (no array-escaping inflation).
+    if (
+      this._chunkBuffer.length > 0 &&
+      this._chunkBufferBytes + bodyBytes > SEGMENT_MAX_BYTES
+    ) {
+      this.flushBuffer();
+    }
 
-    // Flush when buffer reaches threshold
+    this._chunkBuffer.push({ streamId, body });
+    this._chunkBufferBytes += bodyBytes;
+
+    // Flush when buffer reaches the per-segment chunk threshold
     if (this._chunkBuffer.length >= CHUNK_BUFFER_SIZE) {
       this.flushBuffer();
     }
   }
 
   /**
-   * Flush buffered chunks to SQLite in a single batch.
+   * Flush the buffered chunks to SQLite as a single packed row.
    * Uses a lock to prevent concurrent flush operations.
+   *
+   * The whole buffer becomes one row: a single-chunk segment is stored
+   * unwrapped (legacy object format) so a large chunk avoids array-escaping
+   * inflation, while a multi-chunk segment stores a JSON array of bodies. This
+   * collapses N chunk rows into one, cutting rows written / stored / scanned.
    */
   flushBuffer() {
     if (this._isFlushingChunks || this._chunkBuffer.length === 0) {
@@ -267,14 +304,21 @@ export class ResumableStream {
     try {
       const chunks = this._chunkBuffer;
       this._chunkBuffer = [];
+      this._chunkBufferBytes = 0;
 
-      const now = Date.now();
-      for (const chunk of chunks) {
-        this.sql`
-          insert into cf_ai_chat_stream_chunks (id, stream_id, body, chunk_index, created_at)
-          values (${chunk.id}, ${chunk.streamId}, ${chunk.body}, ${chunk.index}, ${now})
-        `;
-      }
+      // All chunks in a buffer belong to the same stream: start() flushes
+      // before switching streams, so the buffer is never cross-stream.
+      const streamId = chunks[0].streamId;
+      const segmentBody =
+        chunks.length === 1
+          ? chunks[0].body
+          : JSON.stringify(chunks.map((chunk) => chunk.body));
+
+      this.sql`
+        insert into cf_ai_chat_stream_chunks (id, stream_id, body, chunk_index, created_at)
+        values (${nanoid()}, ${streamId}, ${segmentBody}, ${this._segmentIndex}, ${Date.now()})
+      `;
+      this._segmentIndex++;
     } finally {
       this._isFlushingChunks = false;
     }
@@ -316,21 +360,23 @@ export class ResumableStream {
     `;
 
     for (const chunk of chunks || []) {
-      if (
-        !sendIfOpen(
-          connection,
-          JSON.stringify({
-            body: chunk.body,
-            done: false,
-            id: requestId,
-            type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
-            replay: true
-          })
-        )
-      ) {
-        // Connection closed mid-replay — leave the stream active so the
-        // next reconnect can retry from the start.
-        return null;
+      for (const body of unpackSegmentBody(chunk.body)) {
+        if (
+          !sendIfOpen(
+            connection,
+            JSON.stringify({
+              body,
+              done: false,
+              id: requestId,
+              type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
+              replay: true
+            })
+          )
+        ) {
+          // Connection closed mid-replay — leave the stream active so the
+          // next reconnect can retry from the start.
+          return null;
+        }
       }
     }
 
@@ -413,19 +459,21 @@ export class ResumableStream {
     `;
 
     for (const chunk of chunks || []) {
-      if (
-        !sendIfOpen(
-          connection,
-          JSON.stringify({
-            body: chunk.body,
-            done: false,
-            id: requestId,
-            type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
-            replay: true
-          })
-        )
-      ) {
-        return false;
+      for (const body of unpackSegmentBody(chunk.body)) {
+        if (
+          !sendIfOpen(
+            connection,
+            JSON.stringify({
+              body,
+              done: false,
+              id: requestId,
+              type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
+              replay: true
+            })
+          )
+        ) {
+          return false;
+        }
       }
     }
 
@@ -461,13 +509,13 @@ export class ResumableStream {
       this._activeStreamId = stream.id;
       this._activeRequestId = stream.request_id;
 
-      // Get the last chunk index
+      // Resume the segment row-ordering index past the highest stored value.
       const lastChunk = this.sql<{ max_index: number }>`
         select max(chunk_index) as max_index 
         from cf_ai_chat_stream_chunks 
         where stream_id = ${this._activeStreamId}
       `;
-      this._streamChunkIndex =
+      this._segmentIndex =
         lastChunk && lastChunk[0]?.max_index != null
           ? lastChunk[0].max_index + 1
           : 0;
@@ -479,11 +527,12 @@ export class ResumableStream {
    */
   clearAll() {
     this._chunkBuffer = [];
+    this._chunkBufferBytes = 0;
     this.sql`delete from cf_ai_chat_stream_chunks`;
     this.sql`delete from cf_ai_chat_stream_metadata`;
     this._activeStreamId = null;
     this._activeRequestId = null;
-    this._streamChunkIndex = 0;
+    this._segmentIndex = 0;
   }
 
   /**
@@ -538,17 +587,30 @@ export class ResumableStream {
 
   // ── Test helpers (matching old AIChatAgent test API) ────────────────
 
-  /** @internal For testing only */
+  /**
+   * Return the stored chunks for a stream as individual chunk bodies in order,
+   * unpacking packed segment rows. The returned `chunk_index` is a running
+   * per-chunk sequence (0, 1, 2, …) — stable across calls because rows are
+   * append-only — so callers can use it as a monotonic chunk sequence.
+   */
   getStreamChunks(
     streamId: string
   ): Array<{ body: string; chunk_index: number }> {
-    return (
-      this.sql<{ body: string; chunk_index: number }>`
-        select body, chunk_index from cf_ai_chat_stream_chunks 
+    const rows =
+      this.sql<{ body: string }>`
+        select body from cf_ai_chat_stream_chunks 
         where stream_id = ${streamId} 
         order by chunk_index asc
-      ` || []
-    );
+      ` || [];
+    const out: Array<{ body: string; chunk_index: number }> = [];
+    let index = 0;
+    for (const row of rows) {
+      for (const body of unpackSegmentBody(row.body)) {
+        out.push({ body, chunk_index: index });
+        index++;
+      }
+    }
+    return out;
   }
 
   /** @internal For testing only */

--- a/packages/agents/src/chat/sql-batch.ts
+++ b/packages/agents/src/chat/sql-batch.ts
@@ -1,0 +1,46 @@
+/**
+ * Helpers for building batched SQLite statements that run through the Agent's
+ * `sql` tagged template (which interleaves a `?` placeholder between every
+ * string fragment). Used to collapse per-row INSERT/DELETE loops into a small
+ * number of multi-row statements.
+ *
+ * SQLite (Durable Object / D1) caps bound parameters at 100 per query, so
+ * callers must chunk their inputs to stay within {@link MAX_BOUND_PARAMS}.
+ * See https://developers.cloudflare.com/d1/platform/limits/
+ */
+
+/** Maximum bound parameters allowed in a single SQLite (DO / D1) query. */
+export const MAX_BOUND_PARAMS = 100;
+
+/**
+ * Attach a self-referential `raw` property so a plain string[] satisfies the
+ * TemplateStringsArray shape. `sql` only reads indexed string fragments, so
+ * `raw` is never consumed — this just keeps the type system happy.
+ */
+function asTemplateStringsArray(parts: string[]): TemplateStringsArray {
+  (parts as unknown as { raw: readonly string[] }).raw = parts;
+  return parts as unknown as TemplateStringsArray;
+}
+
+/**
+ * Build a TemplateStringsArray for a single-column `IN (...)` clause. Produces
+ * fragments for:
+ *   `${prefix}(?, ?, ...)`
+ *
+ * @throws if `count` is less than 1.
+ */
+export function buildInClauseStrings(
+  prefix: string,
+  count: number
+): TemplateStringsArray {
+  if (count < 1) {
+    throw new Error(`buildInClauseStrings requires count >= 1 (got ${count})`);
+  }
+  const parts = new Array<string>(count + 1);
+  parts[0] = `${prefix}(`;
+  for (let i = 1; i < count; i++) {
+    parts[i] = ", ";
+  }
+  parts[count] = ")";
+  return asTemplateStringsArray(parts);
+}

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -45,6 +45,7 @@ import {
   type ChatFiberSnapshot
 } from "agents/chat";
 import { ResumableStream } from "agents/chat";
+import { MAX_BOUND_PARAMS, buildInClauseStrings } from "agents/chat";
 import {
   ContinuationState,
   AbortRegistry,
@@ -188,6 +189,9 @@ const CHAT_RECOVERING_KEY = "cf:chat:recovering";
 // Incidents that have not seen a new attempt within this window are assumed
 // abandoned and swept so durable storage does not grow without bound.
 const CHAT_RECOVERY_INCIDENT_TTL_MS = 60 * 60 * 1000;
+// Max keys per Durable Object KV `delete([...])` call.
+// See https://developers.cloudflare.com/durable-objects/api/sqlite-storage-api/
+const KV_DELETE_MAX_KEYS = 128;
 // PRIMARY recovery bound (#1637): seal an incident that has made no forward
 // progress for this long. Keyed to `lastProgressAt`, which resets on every
 // progress-bearing attempt — so a turn that keeps producing content survives
@@ -313,10 +317,6 @@ type AIChatStreamMetadataRow = {
   id: string;
   status: string;
   request_id: string;
-};
-type AIChatStreamChunkRow = {
-  body: string;
-  chunk_index: number;
 };
 
 /**
@@ -3104,16 +3104,15 @@ export class AIChatAgent<
     const streamId = this._getAgentToolStreamId(requestId);
     if (!streamId) return [];
 
-    const rows = this.sql<AIChatStreamChunkRow>`
-      select body, chunk_index
-      from cf_ai_chat_stream_chunks
-      where stream_id = ${streamId} and chunk_index > ${afterSequence}
-      order by chunk_index asc
-    `;
-    return rows.map((row) => ({
-      sequence: row.chunk_index,
-      body: row.body
-    }));
+    // Read through ResumableStream so packed segment rows are unpacked into
+    // individual chunk bodies with a running per-chunk index. That per-chunk
+    // sequence matches the in-memory live counter (`_agentToolLiveSequences`),
+    // so a tailing parent can switch from stored replay to live forwarding
+    // without gaps or duplicates.
+    return this._resumableStream
+      .getStreamChunks(streamId)
+      .filter((chunk) => chunk.chunk_index > afterSequence)
+      .map((chunk) => ({ sequence: chunk.chunk_index, body: chunk.body }));
   }
 
   private _getAgentToolMessagesAfterStart(runId: string): UIMessage[] {
@@ -3549,8 +3548,10 @@ export class AIChatAgent<
         staleKeys.push(key);
       }
     }
-    for (const key of staleKeys) {
-      await this.ctx.storage.delete(key);
+    // Batch deletes — the DO storage KV delete accepts up to 128 keys per call,
+    // collapsing N awaited round-trips into ceil(N / 128).
+    for (let i = 0; i < staleKeys.length; i += KV_DELETE_MAX_KEYS) {
+      await this.ctx.storage.delete(staleKeys.slice(i, i + KV_DELETE_MAX_KEYS));
     }
   }
 
@@ -4575,14 +4576,10 @@ export class AIChatAgent<
           this.sql<{ id: string }>`
             select id from cf_ai_chat_agent_messages
           ` || [];
-        for (const row of allDbRows) {
-          if (!keepIds.has(row.id)) {
-            this.sql`
-              delete from cf_ai_chat_agent_messages where id = ${row.id}
-            `;
-            this._persistedMessageCache.delete(row.id);
-          }
-        }
+        const staleIds = allDbRows
+          .map((row) => row.id)
+          .filter((id) => !keepIds.has(id));
+        this._deleteMessagesByIds(staleIds);
       }
     }
 
@@ -4790,6 +4787,26 @@ export class AIChatAgent<
   }
 
   /**
+   * Delete the given message rows from SQLite in batched `IN (...)` queries
+   * and evict them from the persistence cache. Batches stay within the SQLite
+   * 100 bound-parameter limit. No-op for an empty list.
+   * @internal
+   */
+  private _deleteMessagesByIds(ids: string[]) {
+    for (let i = 0; i < ids.length; i += MAX_BOUND_PARAMS) {
+      const batch = ids.slice(i, i + MAX_BOUND_PARAMS);
+      const strings = buildInClauseStrings(
+        "delete from cf_ai_chat_agent_messages where id in ",
+        batch.length
+      );
+      this.sql(strings, ...batch);
+      for (const id of batch) {
+        this._persistedMessageCache.delete(id);
+      }
+    }
+  }
+
+  /**
    * Deletes oldest messages from SQLite when the count exceeds maxPersistedMessages.
    * Called after each persist to keep storage bounded.
    */
@@ -4814,10 +4831,7 @@ export class AIChatAgent<
     `;
 
     if (toDelete && toDelete.length > 0) {
-      for (const row of toDelete) {
-        this.sql`delete from cf_ai_chat_agent_messages where id = ${row.id}`;
-        this._persistedMessageCache.delete(row.id);
-      }
+      this._deleteMessagesByIds(toDelete.map((row) => row.id));
     }
   }
 

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -232,8 +232,22 @@ describe("AIChatAgent as an agent-tool child", () => {
       chunks.some((chunk) => chunk.body.includes("write the report"))
     ).toBe(true);
 
+    // Each forwarded chunk must be an individual, unpacked chunk event — never
+    // a packed segment array — and sequences must be contiguous per chunk so a
+    // tailing parent can switch from stored replay to the live counter without
+    // gaps. Guards the chunk-packing storage format (segment rows are unpacked
+    // back into per-chunk bodies before forwarding).
+    chunks.forEach((chunk, i) => {
+      expect(chunk.sequence).toBe(i);
+      const parsed = JSON.parse(chunk.body) as unknown;
+      expect(Array.isArray(parsed)).toBe(false);
+      expect(parsed).toMatchObject({ type: expect.any(String) });
+    });
+
     const laterChunks = await parent.getChildChunks(runId, 0);
     expect(laterChunks.every((chunk) => chunk.sequence > 0)).toBe(true);
+    // afterSequence is a per-chunk cursor: everything past sequence 0.
+    expect(laterChunks).toEqual(chunks.slice(1));
   });
 
   it("finalizes lifecycle hooks and terminal events during parent recovery reconciliation", async () => {

--- a/packages/ai-chat/src/tests/max-persisted-messages.test.ts
+++ b/packages/ai-chat/src/tests/max-persisted-messages.test.ts
@@ -161,6 +161,41 @@ describe("maxPersistedMessages", () => {
     ws.close(1000);
   });
 
+  it("deletes more than 100 excess messages via batched IN deletes", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+    // Limit of 5 with 250 persisted messages forces a single enforcement pass
+    // to delete 245 rows — exceeding the SQLite 100 bound-parameter limit and
+    // exercising the batched `DELETE ... WHERE id IN (...)` sub-batching.
+    await agentStub.setMaxPersistedMessages(5);
+
+    const messages: ChatMessage[] = Array.from({ length: 250 }, (_, i) => ({
+      id: `msg-bulk-${i}`,
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: `Message ${i}` }]
+    }));
+
+    await agentStub.persistMessages(messages);
+
+    const count = await agentStub.getMessageCount();
+    expect(count).toBe(5);
+
+    const persisted = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    expect(persisted.map((m) => m.id)).toEqual([
+      "msg-bulk-245",
+      "msg-bulk-246",
+      "msg-bulk-247",
+      "msg-bulk-248",
+      "msg-bulk-249"
+    ]);
+
+    ws.close(1000);
+  });
+
   it("can be disabled by setting to null", async () => {
     const room = crypto.randomUUID();
     const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -535,6 +535,170 @@ describe("Resumable Streaming", () => {
 
       ws.close(1000);
     });
+
+    it("persists many chunks in order, packed into far fewer rows", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      const streamId = await agentStub.testStartStream("req-batch");
+
+      // 45 small chunks: auto-flushed every CHUNK_BUFFER_SIZE (10) → 4 packed
+      // rows of 10, plus a manual flush of the remaining 5 → 5 rows total,
+      // while all 45 chunks are still individually recoverable.
+      const total = 45;
+      for (let i = 0; i < total; i++) {
+        await agentStub.testStoreStreamChunk(
+          streamId,
+          `{"type":"text","text":"c${i}"}`
+        );
+      }
+
+      // Flush any remainder still in the buffer.
+      await agentStub.testFlushChunkBuffer();
+
+      const chunks = await agentStub.getStreamChunks(streamId);
+      expect(chunks.length).toBe(total);
+      for (let i = 0; i < total; i++) {
+        expect(chunks[i].chunk_index).toBe(i);
+        expect(chunks[i].body).toBe(`{"type":"text","text":"c${i}"}`);
+      }
+
+      // The 45 chunks are packed into 5 rows (4×10 + 1×5), not 45.
+      const rowCount = await agentStub.getStreamChunkRowCount(streamId);
+      expect(rowCount).toBe(5);
+
+      ws.close(1000);
+    });
+
+    it("packs a single flush of multiple chunks into one row", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      const streamId = await agentStub.testStartStream("req-pack-one");
+
+      // 3 small chunks, then a manual flush → exactly one packed row.
+      for (let i = 0; i < 3; i++) {
+        await agentStub.testStoreStreamChunk(
+          streamId,
+          `{"type":"text","text":"p${i}"}`
+        );
+      }
+      await agentStub.testFlushChunkBuffer();
+
+      expect(await agentStub.getStreamChunkRowCount(streamId)).toBe(1);
+
+      const chunks = await agentStub.getStreamChunks(streamId);
+      expect(chunks.map((c) => c.body)).toEqual([
+        '{"type":"text","text":"p0"}',
+        '{"type":"text","text":"p1"}',
+        '{"type":"text","text":"p2"}'
+      ]);
+
+      ws.close(1000);
+    });
+
+    it("stores a single buffered chunk as one unwrapped row", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      const streamId = await agentStub.testStartStream("req-single");
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text","text":"solo"}'
+      );
+      await agentStub.testFlushChunkBuffer();
+
+      expect(await agentStub.getStreamChunkRowCount(streamId)).toBe(1);
+      const chunks = await agentStub.getStreamChunks(streamId);
+      expect(chunks.length).toBe(1);
+      expect(chunks[0].body).toBe('{"type":"text","text":"solo"}');
+
+      ws.close(1000);
+    });
+
+    it("splits a large chunk into its own row to respect the byte cap", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      const streamId = await agentStub.testStartStream("req-bytecap");
+
+      // A small chunk, then a chunk larger than SEGMENT_MAX_BYTES (512 KB),
+      // then another small chunk. The large chunk forces a flush boundary on
+      // each side, so it lands in its own (unwrapped) row.
+      const big = "x".repeat(600_000);
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text","text":"before"}'
+      );
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        `{"type":"text","text":"${big}"}`
+      );
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text","text":"after"}'
+      );
+      await agentStub.testFlushChunkBuffer();
+
+      // 3 rows: [before], [big], [after] — the byte cap prevents packing the
+      // large chunk with its neighbors.
+      expect(await agentStub.getStreamChunkRowCount(streamId)).toBe(3);
+
+      const chunks = await agentStub.getStreamChunks(streamId);
+      expect(chunks.length).toBe(3);
+      expect(chunks[0].body).toBe('{"type":"text","text":"before"}');
+      expect(chunks[1].body).toBe(`{"type":"text","text":"${big}"}`);
+      expect(chunks[2].body).toBe('{"type":"text","text":"after"}');
+
+      ws.close(1000);
+    });
+
+    it("reads back legacy per-chunk rows (backward compatibility)", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      // Seed the table with legacy one-row-per-chunk records (unwrapped object
+      // bodies), as written by older builds, then verify they unpack 1:1.
+      const streamId = "legacy-stream";
+      await agentStub.insertLegacyChunkRows(streamId, "req-legacy", [
+        '{"type":"text","text":"L0"}',
+        '{"type":"text","text":"L1"}',
+        '{"type":"text","text":"L2"}'
+      ]);
+
+      // 3 legacy rows on disk…
+      expect(await agentStub.getStreamChunkRowCount(streamId)).toBe(3);
+
+      // …read back as 3 individual chunks in order.
+      const chunks = await agentStub.getStreamChunks(streamId);
+      expect(chunks.map((c) => c.body)).toEqual([
+        '{"type":"text","text":"L0"}',
+        '{"type":"text","text":"L1"}',
+        '{"type":"text","text":"L2"}'
+      ]);
+
+      ws.close(1000);
+    });
   });
 
   describe("Completed stream handling", () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -612,13 +612,40 @@ export class TestChatAgent extends AIChatAgent<Env> {
   getStreamChunks(
     streamId: string
   ): Array<{ body: string; chunk_index: number }> {
-    return (
-      this.sql<{ body: string; chunk_index: number }>`
-        select body, chunk_index from cf_ai_chat_stream_chunks 
-        where stream_id = ${streamId} 
-        order by chunk_index asc
-      ` || []
-    );
+    // Delegate to ResumableStream so tests see the same unpacked, per-chunk
+    // view that production consumers get (packed segment rows are expanded).
+    return this._resumableStream.getStreamChunks(streamId);
+  }
+
+  /** Raw count of stored rows for a stream (packed segments count as 1 each). */
+  getStreamChunkRowCount(streamId: string): number {
+    const result = this.sql<{ cnt: number }>`
+      select count(*) as cnt from cf_ai_chat_stream_chunks
+      where stream_id = ${streamId}
+    `;
+    return result?.[0]?.cnt ?? 0;
+  }
+
+  /**
+   * Seed legacy one-row-per-chunk records (the pre-packing storage format) so
+   * tests can verify backward-compatible unpacking of older data.
+   */
+  insertLegacyChunkRows(
+    streamId: string,
+    requestId: string,
+    bodies: string[]
+  ): void {
+    const now = Date.now();
+    this.sql`
+      insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at)
+      values (${streamId}, ${requestId}, 'completed', ${now})
+    `;
+    bodies.forEach((body, index) => {
+      this.sql`
+        insert into cf_ai_chat_stream_chunks (id, stream_id, body, chunk_index, created_at)
+        values (${`${streamId}-${index}`}, ${streamId}, ${body}, ${index}, ${now})
+      `;
+    });
   }
 
   getStreamMetadata(

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -4845,12 +4845,15 @@ export class ThinkRecoveryTestAgent extends Think {
     const stream = streams[0];
     if (!stream) return null;
 
-    const chunks = this.sql<{ body: string }>`
-      SELECT body
-      FROM cf_ai_chat_stream_chunks
-      WHERE stream_id = ${stream.id}
-      ORDER BY chunk_index ASC
-    `;
+    // Use ResumableStream.getStreamChunks so packed segment rows are unpacked
+    // into individual chunk bodies (matching production replay/reconstruction).
+    const chunks = (
+      this as unknown as {
+        _resumableStream: {
+          getStreamChunks(id: string): Array<{ body: string }>;
+        };
+      }
+    )._resumableStream.getStreamChunks(stream.id);
 
     const text = chunks
       .map((chunk) => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -151,7 +151,9 @@ import {
   resolveToolMergeId,
   createChatFiberSnapshot,
   unwrapChatFiberSnapshot,
-  wrapChatFiberSnapshot
+  wrapChatFiberSnapshot,
+  MAX_BOUND_PARAMS,
+  buildInClauseStrings
 } from "agents/chat";
 import type {
   StreamChunkData,
@@ -697,6 +699,9 @@ const DEFAULT_CHAT_RECOVERY_TERMINAL_MESSAGE =
 // Incidents that have not seen a new attempt within this window are assumed
 // abandoned and swept so durable storage does not grow without bound.
 const CHAT_RECOVERY_INCIDENT_TTL_MS = 60 * 60 * 1000;
+// Max keys per Durable Object KV `delete([...])` call.
+// See https://developers.cloudflare.com/durable-objects/api/sqlite-storage-api/
+const KV_DELETE_MAX_KEYS = 128;
 // PRIMARY recovery bound (#1637): seal an incident that has made no forward
 // progress for this long. Keyed to `lastProgressAt`, which resets on every
 // progress-bearing attempt — so a turn that keeps producing content survives
@@ -5528,15 +5533,21 @@ export class Think<
       )
       .slice(0, limit);
 
+    const idsToDelete = rows
+      .filter((row) => this._isTerminalSubmissionStatus(row.status))
+      .map((row) => row.submission_id);
+
+    // Batch deletes into `IN (...)` queries within the SQLite 100
+    // bound-parameter limit to minimize round-trips during cleanup.
     let deleted = 0;
-    for (const row of rows) {
-      if (!this._isTerminalSubmissionStatus(row.status)) continue;
-      this.sql`
-        DELETE FROM cf_think_submissions
-        WHERE submission_id = ${row.submission_id}
-          AND status IN ('completed', 'aborted', 'skipped', 'error')
-      `;
-      deleted++;
+    for (let i = 0; i < idsToDelete.length; i += MAX_BOUND_PARAMS) {
+      const batch = idsToDelete.slice(i, i + MAX_BOUND_PARAMS);
+      const strings = buildInClauseStrings(
+        "DELETE FROM cf_think_submissions WHERE status IN ('completed', 'aborted', 'skipped', 'error') AND submission_id IN ",
+        batch.length
+      );
+      this.sql(strings, ...batch);
+      deleted += batch.length;
     }
     return deleted;
   }
@@ -8396,8 +8407,10 @@ export class Think<
         staleKeys.push(key);
       }
     }
-    for (const key of staleKeys) {
-      await this.ctx.storage.delete(key);
+    // Batch deletes — the DO storage KV delete accepts up to 128 keys per call,
+    // collapsing N awaited round-trips into ceil(N / 128).
+    for (let i = 0; i < staleKeys.length; i += KV_DELETE_MAX_KEYS) {
+      await this.ctx.storage.delete(staleKeys.slice(i, i + KV_DELETE_MAX_KEYS));
     }
   }
 


### PR DESCRIPTION
## Summary

Reduces SQLite **statements written**, **rows written**, and **rows scanned on replay** across the chat-persistence paths in `agents`, `@cloudflare/ai-chat`, and `@cloudflare/think`.

The headline change is **chunk packing** in `ResumableStream`: instead of writing one SQLite row per streamed chunk, each buffer flush now writes a **single packed row**. Combined with batched deletes elsewhere, a normal turn drops from hundreds of single-row writes to a handful.

There are **no user-facing behaviour changes** beyond an internal, forward-compatible storage-format change for stream chunks (details below).

## Motivation

Stream chunks were persisted one-`INSERT`-per-chunk, one-**row**-per-chunk. For a medium assistant reply (~250 chunks) that is ~250 statements and ~250 rows per turn, repeated for every turn. Rows-written and rows-scanned are the meaningful SQLite cost/perf metrics, so collapsing them is a direct win for cost, latency, and replay/reconstruction time.

## What changed

### 1. Pack stream chunks into one row per flush (`agents` — `ResumableStream`)

- `flushBuffer()` now writes **one row per flush**:
  - **Multi-chunk segment** → body is a JSON array of the chunk bodies.
  - **Single-chunk segment** → body stored **unwrapped** (legacy object shape), so a large lone chunk avoids JSON array-escaping inflation.
- `storeChunk()` gains a per-segment **byte cap** (`SEGMENT_MAX_BYTES = 512 KB`): if appending a chunk would push the buffered segment over the cap, it flushes first. So a large chunk lands alone (unwrapped), and packed multi-chunk segments stay well under the 2 MB SQLite row limit even after re-escaping. The existing **>1.8 MB per-chunk skip** is unchanged.
- All reads transparently **unpack** both packed segments and legacy per-chunk rows via `unpackSegmentBody()`:
  - `replayChunks`, `replayCompletedChunksByRequestId`
  - `getStreamChunks` (now returns a running **per-chunk** index — stable across calls because rows are append-only)
- `chunk_index` is now a per-**segment** ordering index; `restore()` resumes it past `max(chunk_index)`.
- Removed the now-unused multi-row `INSERT` helper (`buildMultiRowInsertStrings`) — packing supersedes it. Kept `MAX_BOUND_PARAMS` and `buildInClauseStrings` (used by the batched deletes), exported from `agents/chat`.

### 2. Fix agent-as-tool forwarding for the packed format (`@cloudflare/ai-chat`)

`_getAgentToolStoredChunks()` previously read the chunk table raw and filtered on `chunk_index`. Under packing, `body` became a packed array and `chunk_index` became a segment index — breaking tailing. It now delegates to the unpacking `getStreamChunks()`, preserving the **exact per-chunk sequence** semantics that align with the in-memory live counter (`_agentToolLiveSequences`), so a tailing parent transitions from stored replay to live forwarding without gaps or duplicates.

### 3. Batched deletes

- **`@cloudflare/ai-chat`**: stale-row pruning and `maxPersistedMessages` enforcement now delete via batched `DELETE ... WHERE id IN (...)` (capped at 100 bound params/query) instead of one `DELETE` per row.
- **`@cloudflare/think`**: `deleteSubmissions()` cleanup now uses batched `DELETE ... WHERE submission_id IN (...)`.
- **`@cloudflare/ai-chat` & `@cloudflare/think`**: the chat-recovery incident TTL sweep now deletes via batched `storage.delete(keys)` (≤128 keys/call), which also re-enables Durable Object write-coalescing (previously defeated by per-key awaited deletes).

## Estimated savings (per turn)

Flush cadence is every 10 chunks (or the byte cap), so rows ≈ ⌈chunks / 10⌉.

| Reply size | chunks | INSERT statements (before → after) | rows written (before → after) |
|---|---|---|---|
| Short (~60) | ~70 | 70 → 7 | 70 → 7 |
| Medium (~250) | ~260 | 260 → 26 | 260 → 26 |
| Long (~800) | ~810 | 810 → 81 | 810 → 81 |

≈ **90% fewer chunk INSERT statements and ~90% fewer chunk rows written** per turn (≈ `0.9 × chunks` saved on each). Replay/orphan-reconstruction scans the same ~10× fewer rows. A clean turn does no chunk reads; read savings apply per reconnect/resume and during agent-as-tool tailing.

## Compatibility

- **Forward-compatible:** new code reads existing legacy per-chunk rows (`unpackSegmentBody` handles both shapes). Verified by tests that seed legacy rows.
- **Rollback caveat:** old code cannot interpret packed rows, so a rollback would mis-replay only the streams **in-flight at rollback time**. Stream chunks are ephemeral (24h TTL) and chat recovery papers over it. Accepted by design (discussed and deemed acceptable for ephemeral data).
- **Durability:** unchanged flush cadence; a flush is now a single-row `INSERT` (marginally more atomic than the previous multi-row write).

## Tests

- **`resumable-streaming`**: packing into fewer rows (45 chunks → 5 rows), single-flush packing, single unwrapped row, byte-cap splitting a large chunk into its own row, and backward-compat reads of legacy per-chunk rows. Added `getStreamChunkRowCount` + `insertLegacyChunkRows` test helpers.
- **`agent-tools`**: assert forwarded chunks are individual (non-array) events with contiguous per-chunk sequences and a correct `afterSequence` cursor (`laterChunks === chunks.slice(1)`).
- **think-session / worker fixtures**: updated to read via the unpacking `getStreamChunks`.
- Chat-recovery suites exercised against the packed format (orphan reconstruction, settled-tool-result durability boundary, persist/no-persist, retry-vs-continue, fiber recovery).

## Verification

- `pnpm run check` — sherif, export checks, oxfmt, oxlint, and typecheck (92 projects): green.
- Tests — `@cloudflare/ai-chat` **633**, `@cloudflare/think` **549**, `agents` chat **231**; recovery-focused: ai-chat **59**, agents **5**.

## Changeset

`.changeset/batch-stream-chunk-writes.md` — patch bumps for `agents`, `@cloudflare/ai-chat`, `@cloudflare/think`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Cost impact (Durable Objects pricing)

This change targets **rows written** (chunk packing ~90% fewer, plus batched deletes) and **rows read** (~90% fewer rows scanned on replay/reconstruction). It does not materially change duration or request billing.

Why it matters: LLM streaming emits hundreds of tiny chunks per turn, each previously its own row write at **$1.00 / M rows**, whereas duration is **$12.50 / M GB-s** but only a fraction of a GB-s per turn — so for chat agents, **row writes dominate the bill** (~10× duration).

**Worked "medium" turn** (~250-chunk reply, ~15 s active streaming, hibernates between turns):

| Dimension | Before | After | Cost before | Cost after |
|---|---|---|---|---|
| Duration (0.125 GB × 15 s = 1.875 GB-s) | 1.875 GB-s | ~1.875 GB-s | ~23.4 µ$ | ~23.4 µ$ |
| Rows written (chunks ~250 + msgs/meta ~30) | ~280 | ~40 | ~280 µ$ | ~40 µ$ |
| **Total** | | | **~304 µ$** | **~64 µ$** |

≈ **79% lower per-turn cost** for a streaming-dominant turn (the dominant write term drops ~85%; unchanged duration is the floor).

**Overall savings are workload-dependent:**

- **Chat/streaming-dominant** (hibernates between turns — i.e. `AIChatAgent`/`think` chat): **~60–80%** off DO compute + storage-write cost.
- **Mixed/typical** agent: **~30–50%**.
- **Compute/tool-heavy** (long wall-clock dominates duration): **~10–25%** (duration is unchanged by this PR).

**Scale "cliff":** the included allowance is **50 M rows written/month**. At ~1 M turns/month, chunk writes drop from ~280 M rows (≈ $230/mo billable) to ~40 M rows — **below the free tier**, i.e. potentially ~$0.

**Caveats:** hibernation behaviour is unchanged (idle-between-turns is already free); the duration win from ~260→~26 `INSERT`s/turn is negligible (<1%); rows-read savings are real but financially tiny at $0.001/M (the win there is latency, not cost). All figures are order-of-magnitude estimates anchored to published Workers Paid rates; SQLite storage billing has been in effect since Jan 7, 2026.
