### PR TITLE
fix(think): make step.prompt structured output work across all providers (#1685)

### DIFF
--- a/.changeset/think-step-prompt-final-answer-tool.md
+++ b/.changeset/think-step-prompt-final-answer-tool.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/think": patch
+---
+
+Fix `ThinkWorkflow` `step.prompt({ output })` failing on Workers AI with `AiError 5023: JSON Schema mode is not supported with stream mode`.
+
+Structured workflow prompts previously requested output via the AI SDK `Output.object` path, which streams a JSON Schema `response_format` — rejected by some providers (notably Workers AI). `step.prompt()` now runs a full agentic turn that returns its structured result by calling an internal `think_final_answer` tool whose arguments match the schema. This uses ordinary tool calling, so it works across every provider Think supports (verified on Workers AI, OpenAI, and Anthropic), keeps Think's streaming engine (persistence, recovery, resumable streams), and lets the agent use its own tools across multiple steps before producing the final structured answer.
+
+The `think_final_answer` tool name is reserved; its call and result are stripped from the persisted conversation so the transcript and later turns do not see Think's internal plumbing.

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -115,6 +115,16 @@ a terminal error state and `step.prompt()` throws.
   `think_final_answer_*` variant) is reserved; its call and result are stripped
   from the persisted conversation, so the transcript and later turns do not see
   Think's internal plumbing.
+- **The model must support streaming tool calls.** Think streams every turn, so
+  `step.prompt()` works only with models that reliably emit a forced tool call
+  while streaming. Strong tool-callers (for example OpenAI `gpt-4o-mini`,
+  Anthropic `claude-haiku-4-5`, and Workers AI `@cf/moonshotai/kimi-k2.6`) are
+  verified to work. Some models honor a forced `toolChoice` only on
+  non-streaming requests and will reply in plain text and stop while streaming —
+  for example Workers AI `@cf/meta/llama-3.3-70b-instruct-fp8-fast`. With those
+  models the turn ends without a `think_final_answer` call and `step.prompt()`
+  fails (`Model ended the turn without calling the think_final_answer tool`); use
+  a model with working streaming tool calls instead.
 
 ## How It Runs
 

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -84,15 +84,37 @@ await this.sendWorkflowEvent("TRIAGE_WORKFLOW", workflowId, {
 ```
 
 `step.prompt()` accepts a prompt string and a Zod object schema. The schema is
-converted to JSON Schema before the Workflow calls the Agent, then Think
-reconstructs the AI SDK structured output configuration for the turn. When the
+converted to JSON Schema before the Workflow calls the Agent. Think then runs a
+full agentic turn: the Agent may use its tools across multiple steps and returns
+the structured result by calling an internal `final_answer` tool whose arguments
+match the schema. This uses ordinary tool calling rather than a streaming
+`response_format`, so it works across every provider Think supports — including
+Workers AI, which rejects JSON Schema responses on streaming requests. When the
 Workflow resumes, the payload is validated again with the original Zod schema
 before the typed value is returned.
 
 Unsupported Zod features that cannot be represented as JSON Schema fail while
 creating the prompt step. Think does not silently repair invalid model output.
-If the model or provider cannot produce valid output, the submission reaches a
-terminal error state and `step.prompt()` throws.
+If the model does not produce a valid `final_answer` call, the submission reaches
+a terminal error state and `step.prompt()` throws.
+
+### Behavior notes
+
+- **The Agent may use its tools first.** A `step.prompt()` turn is a full agentic
+  turn: the Agent can call its own tools across multiple steps and then call the
+  final-answer tool. Allow at least `maxSteps: 2` if you expect the Agent to use
+  a tool before answering — with `maxSteps: 1` it is forced to answer on the
+  first step and cannot call any other tool.
+- **Tool use is forced during a structured turn.** To guarantee the Agent
+  terminates with a structured answer (rather than replying in plain text), Think
+  sets `toolChoice` for the turn. Do not override `toolChoice` from `beforeTurn`
+  on a `step.prompt()` turn — doing so can prevent the Agent from calling the
+  final-answer tool, which makes the prompt fail.
+- **`think_final_answer` is reserved.** Think injects an internal
+  `think_final_answer` tool to carry the structured result. This name (and any
+  `think_final_answer_*` variant) is reserved; its call and result are stripped
+  from the persisted conversation, so the transcript and later turns do not see
+  Think's internal plumbing.
 
 ## How It Runs
 

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -27,6 +27,8 @@
     "just-bash": "^3.0.1"
   },
   "devDependencies": {
+    "@ai-sdk/anthropic": "^3.0.81",
+    "@ai-sdk/openai": "^3.0.67",
     "@chat-adapter/telegram": "^4.30.0",
     "ai": "^6.0.196",
     "zod": "^4.4.3"

--- a/packages/think/src/e2e-tests/step-prompt-structured.test.ts
+++ b/packages/think/src/e2e-tests/step-prompt-structured.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Cross-provider E2E for issue #1685.
+ *
+ * `ThinkWorkflow.step.prompt({ output })` must return a schema-shaped object on
+ * every provider Think supports. Before the fix, Think streamed the structured
+ * turn through the AI SDK `output`/`response_format` path, which Workers AI
+ * rejects with `AiError 5023: JSON Schema mode is not supported with stream
+ * mode`. The fix runs the structured turn as a full agentic turn that
+ * terminates by calling a synthetic `final_answer` tool — plain tool-calling
+ * that streams on every provider.
+ *
+ * Workers AI always runs (real `AI` binding). The OpenAI / Anthropic legs run
+ * only when the matching API key is exported in the environment; otherwise they
+ * skip so CI without keys still exercises the provider that originally broke.
+ *
+ * Provide keys via the shell, e.g.:
+ *   OPENAI_API_KEY=sk-... ANTHROPIC_API_KEY=sk-ant-... pnpm run test:e2e
+ */
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { setDefaultAutoSelectFamily } from "node:net";
+import "./harden-net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+setDefaultAutoSelectFamily(false);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 18799;
+const BASE_URL = `http://localhost:${PORT}`;
+const AGENT_SLUG = "test-structured-agent";
+const PERSIST_DIR = path.join(__dirname, ".wrangler-structured-state");
+
+type StructuredResult = {
+  status: string;
+  output?: Record<string, unknown> | null;
+  error?: string;
+};
+
+const GREETING_PROMPT =
+  "Return a short, friendly greeting in the `greeting` field.";
+// Forces real (workspace) tool use before answering, exercising the multi-step
+// toolChoice:"required" path that terminates with the synthetic final-answer
+// tool.
+const TOOL_PROMPT =
+  "Use the write tool to create the file /secret.txt with the exact contents " +
+  '"banana". Then use the read tool to read /secret.txt and return its exact ' +
+  "contents in the `word` field.";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function killProcessOnPort(port: number): void {
+  try {
+    const output = execSync(`lsof -ti tcp:${port} 2>/dev/null || true`)
+      .toString()
+      .trim();
+    if (output) {
+      for (const pid of output.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {
+          // already exited
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function killProcessTree(pid: number): void {
+  let children: number[] = [];
+  try {
+    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    // pgrep may be unavailable
+  }
+  for (const childPid of children) killProcessTree(childPid);
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // already dead
+  }
+}
+
+function startWrangler(): ChildProcess {
+  const configPath = path.join(__dirname, "wrangler.jsonc");
+  const args = [
+    "wrangler",
+    "dev",
+    "--config",
+    configPath,
+    "--port",
+    String(PORT),
+    "--persist-to",
+    PERSIST_DIR,
+    "--inspector-port",
+    "0"
+  ];
+  // Forward provider keys only when present so the worker can construct the
+  // OpenAI / Anthropic models. Workers AI needs no key.
+  if (process.env.OPENAI_API_KEY) {
+    args.push("--var", `OPENAI_API_KEY:${process.env.OPENAI_API_KEY}`);
+  }
+  if (process.env.ANTHROPIC_API_KEY) {
+    args.push("--var", `ANTHROPIC_API_KEY:${process.env.ANTHROPIC_API_KEY}`);
+  }
+
+  const child = spawn("npx", args, {
+    cwd: __dirname,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, NODE_ENV: "test" }
+  });
+
+  child.stdout?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[wrangler] ${line}`);
+  });
+  child.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[wrangler:err] ${line}`);
+  });
+
+  return child;
+}
+
+async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`${BASE_URL}/`);
+      await res.body?.cancel();
+      if (res.status > 0) return;
+    } catch {
+      // not ready yet
+    }
+    await sleep(delayMs);
+  }
+  throw new Error(`Wrangler did not start within ${maxAttempts * delayMs}ms`);
+}
+
+function killProcess(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (!child.pid) {
+      resolve();
+      return;
+    }
+    const fallback = setTimeout(resolve, 3000);
+    child.on("exit", () => {
+      clearTimeout(fallback);
+      resolve();
+    });
+    killProcessTree(child.pid);
+  });
+}
+
+/** Call a @callable method on the agent via WebSocket RPC. */
+async function callAgent(
+  room: string,
+  method: string,
+  args: unknown[] = [],
+  timeoutMs = 110_000
+): Promise<unknown> {
+  const url = `${BASE_URL}/agents/${AGENT_SLUG}/${room}`;
+
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const id = crypto.randomUUID();
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`RPC call ${method} timed out`));
+    }, timeoutMs);
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "rpc", id, method, args }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "rpc" && msg.id === id) {
+          clearTimeout(timeout);
+          ws.close();
+          if (msg.success) resolve(msg.result);
+          else reject(new Error(msg.error || "RPC failed"));
+        }
+      } catch {
+        // ignore non-RPC messages
+      }
+    };
+
+    ws.onerror = (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    };
+  });
+}
+
+async function runStructuredPrompt(
+  provider: "workers-ai" | "openai" | "anthropic",
+  mode: "greeting" | "tool" = "greeting"
+): Promise<StructuredResult> {
+  const room = `e2e-structured-${provider}-${mode}-${Date.now()}`;
+  await callAgent(room, "setTestProvider", [provider]);
+  const prompt = mode === "tool" ? TOOL_PROMPT : GREETING_PROMPT;
+  return (await callAgent(room, "runStructuredPrompt", [
+    prompt,
+    mode
+  ])) as StructuredResult;
+}
+
+describe("think e2e — step.prompt structured output (#1685)", () => {
+  let wrangler: ChildProcess | null = null;
+
+  beforeAll(async () => {
+    killProcessOnPort(PORT);
+    wrangler = startWrangler();
+    await waitForReady();
+    console.log("[test] Wrangler is ready");
+  });
+
+  afterAll(async () => {
+    if (wrangler) {
+      await killProcess(wrangler);
+      wrangler = null;
+    }
+    killProcessOnPort(PORT);
+    try {
+      fs.rmSync(PERSIST_DIR, { recursive: true, force: true });
+    } catch {
+      // OK
+    }
+  });
+
+  it("workers-ai: step.prompt returns a schema-shaped object", async () => {
+    const result = await runStructuredPrompt("workers-ai");
+    expect(result.error).toBeFalsy();
+    expect(result.status).toBe("complete");
+    expect(result.output).toBeTruthy();
+    const greeting = result.output?.greeting;
+    expect(typeof greeting).toBe("string");
+    expect((greeting as string).length).toBeGreaterThan(0);
+  });
+
+  it.skipIf(!process.env.OPENAI_API_KEY)(
+    "openai: step.prompt returns a schema-shaped object",
+    async () => {
+      const result = await runStructuredPrompt("openai");
+      expect(result.error).toBeFalsy();
+      expect(result.status).toBe("complete");
+      expect(typeof result.output?.greeting).toBe("string");
+    }
+  );
+
+  it.skipIf(!process.env.ANTHROPIC_API_KEY)(
+    "anthropic: step.prompt returns a schema-shaped object",
+    async () => {
+      const result = await runStructuredPrompt("anthropic");
+      expect(result.error).toBeFalsy();
+      expect(result.status).toBe("complete");
+      expect(typeof result.output?.greeting).toBe("string");
+    }
+  );
+
+  // Multi-step agentic path: the model must call real (workspace) tools before
+  // producing the structured answer via the final-answer tool.
+  it("workers-ai: step.prompt runs a tool-using turn then returns structured output", async () => {
+    const result = await runStructuredPrompt("workers-ai", "tool");
+    expect(result.error).toBeFalsy();
+    expect(result.status).toBe("complete");
+    const word = result.output?.word;
+    expect(typeof word).toBe("string");
+    expect((word as string).toLowerCase()).toContain("banana");
+  });
+
+  it.skipIf(!process.env.OPENAI_API_KEY)(
+    "openai: step.prompt runs a tool-using turn then returns structured output",
+    async () => {
+      const result = await runStructuredPrompt("openai", "tool");
+      expect(result.error).toBeFalsy();
+      expect(result.status).toBe("complete");
+      const word = result.output?.word;
+      expect((word as string).toLowerCase()).toContain("banana");
+    }
+  );
+
+  it.skipIf(!process.env.ANTHROPIC_API_KEY)(
+    "anthropic: step.prompt runs a tool-using turn then returns structured output",
+    async () => {
+      const result = await runStructuredPrompt("anthropic", "tool");
+      expect(result.error).toBeFalsy();
+      expect(result.status).toBe("complete");
+      const word = result.output?.word;
+      expect((word as string).toLowerCase()).toContain("banana");
+    }
+  );
+});

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -4,13 +4,17 @@
  * ThinkRecoveryE2EAgent: mock slow stream with chatRecovery for kill/restart testing.
  */
 import { createWorkersAI } from "workers-ai-provider";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { Agent, callable, routeAgentRequest } from "agents";
 import { agentTool } from "agents/agent-tools";
 import { RpcTarget } from "cloudflare:workers";
+import type { WorkflowEvent } from "cloudflare:workers";
 import { tool } from "ai";
 import type { LanguageModel, ToolSet, UIMessage } from "ai";
 import { z } from "zod";
 import { Think, Workspace } from "../think";
+import { ThinkWorkflow, type ThinkWorkflowStep } from "../workflows";
 import type {
   ChatRecoveryContext,
   ChatRecoveryOptions,
@@ -31,9 +35,19 @@ type Env = {
   ThinkAgentToolNaturalParentE2EAgent: DurableObjectNamespace<ThinkAgentToolNaturalParentE2EAgent>;
   ThinkSlowChildE2EAgent: DurableObjectNamespace<ThinkSlowChildE2EAgent>;
   ThinkSlowChildParentE2EAgent: DurableObjectNamespace<ThinkSlowChildParentE2EAgent>;
+  TestStructuredAgent: DurableObjectNamespace<TestStructuredAgent>;
+  STEP_PROMPT_WORKFLOW: Workflow;
   AI: Ai;
   R2: R2Bucket;
+  // Optional — only set when the corresponding key is exported in the test env.
+  // The OpenAI/Anthropic legs of the structured-output e2e skip when absent.
+  OPENAI_API_KEY?: string;
+  ANTHROPIC_API_KEY?: string;
 };
+
+/** Providers exercised by the cross-provider structured-output e2e (#1685). */
+type StructuredProvider = "workers-ai" | "openai" | "anthropic";
+const STRUCTURED_PROVIDER_KEY = "test:structured-provider";
 
 // AI SDK v3 LanguageModel spec helpers (mirror tests/agents/assistant-agent-loop.ts).
 const v3FinishReason = (unified: "stop" | "tool-calls") => ({
@@ -1202,6 +1216,118 @@ export class ThinkRecoveryHelperParent extends Agent<Env> {
   }> {
     const helper = await this.subAgent(ThinkRecoveryHelperAgent, helperName);
     return helper.getRecoveryStatus();
+  }
+}
+
+/**
+ * Cross-provider regression fixture for issue #1685: `step.prompt({ output })`
+ * must return a schema-shaped object on Workers AI, OpenAI, and Anthropic.
+ *
+ * The provider is selected per-instance (persisted so it survives the workflow
+ * event re-entry / hibernation) and read synchronously in `getModel()`.
+ */
+export class TestStructuredAgent extends Think<Env> {
+  static options = { keepAliveIntervalMs: 2_000 };
+  override maxSteps = 6;
+  private _provider: StructuredProvider = "workers-ai";
+
+  override async onStart(): Promise<void> {
+    const stored = (await this.ctx.storage.get(STRUCTURED_PROVIDER_KEY)) as
+      | StructuredProvider
+      | undefined;
+    if (stored) this._provider = stored;
+  }
+
+  override getModel(): LanguageModel {
+    switch (this._provider) {
+      case "openai":
+        return createOpenAI({ apiKey: this.env.OPENAI_API_KEY })("gpt-4o-mini");
+      case "anthropic":
+        return createAnthropic({ apiKey: this.env.ANTHROPIC_API_KEY })(
+          "claude-haiku-4-5"
+        );
+      default:
+        return createWorkersAI({ binding: this.env.AI })(
+          "@cf/moonshotai/kimi-k2.6",
+          { sessionAffinity: this.sessionAffinity }
+        );
+    }
+  }
+
+  override getSystemPrompt(): string {
+    return "You are a helpful assistant.";
+  }
+
+  @callable()
+  async setTestProvider(provider: StructuredProvider): Promise<void> {
+    this._provider = provider;
+    await this.ctx.storage.put(STRUCTURED_PROVIDER_KEY, provider);
+  }
+
+  /**
+   * Run the structured-prompt workflow and poll to a terminal state, returning
+   * the workflow's output (the validated object) or the failure details.
+   */
+  @callable()
+  async runStructuredPrompt(
+    prompt: string,
+    mode?: "greeting" | "tool"
+  ): Promise<{
+    status: string;
+    output?: unknown;
+    error?: string;
+  }> {
+    const id = await this.runWorkflow("STEP_PROMPT_WORKFLOW", { prompt, mode });
+    for (let i = 0; i < 90; i++) {
+      const status = await this.getWorkflowStatus("STEP_PROMPT_WORKFLOW", id);
+      if (status.status === "complete") {
+        return { status: "complete", output: status.output };
+      }
+      if (status.status === "errored" || status.status === "terminated") {
+        return {
+          status: status.status,
+          error: JSON.stringify(status.error ?? status.output ?? status)
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+    return { status: "timeout" };
+  }
+}
+
+const GREETING_SCHEMA = z.object({
+  greeting: z.string()
+});
+const WORD_SCHEMA = z.object({
+  word: z.string()
+});
+
+/**
+ * `ThinkWorkflow` that issues a single structured `step.prompt`. In `greeting`
+ * mode it is the exact shape from issue #1685 (no real tool use needed). In
+ * `tool` mode the prompt forces the agent to use its workspace tools before
+ * answering, exercising the full agentic `toolChoice: "required"` path that
+ * terminates with the synthetic final-answer tool.
+ */
+export class StepPromptWorkflow extends ThinkWorkflow<TestStructuredAgent> {
+  async run(
+    event: WorkflowEvent<unknown>,
+    step: ThinkWorkflowStep
+  ): Promise<unknown> {
+    const { prompt, mode } = event.payload as {
+      prompt: string;
+      mode?: "greeting" | "tool";
+    };
+    if (mode === "tool") {
+      return step.prompt("structured-word", {
+        prompt,
+        output: WORD_SCHEMA
+      });
+    }
+    return step.prompt("structured-greeting", {
+      prompt,
+      output: GREETING_SCHEMA
+    });
   }
 }
 

--- a/packages/think/src/e2e-tests/wrangler.jsonc
+++ b/packages/think/src/e2e-tests/wrangler.jsonc
@@ -56,9 +56,20 @@
       {
         "name": "ThinkSlowChildParentE2EAgent",
         "class_name": "ThinkSlowChildParentE2EAgent"
+      },
+      {
+        "name": "TestStructuredAgent",
+        "class_name": "TestStructuredAgent"
       }
     ]
   },
+  "workflows": [
+    {
+      "name": "STEP_PROMPT_WORKFLOW",
+      "binding": "STEP_PROMPT_WORKFLOW",
+      "class_name": "StepPromptWorkflow"
+    }
+  ],
   "migrations": [
     {
       "tag": "v1",
@@ -94,6 +105,10 @@
         "ThinkSlowChildParentE2EAgent",
         "ThinkSlowChildE2EAgent"
       ]
+    },
+    {
+      "tag": "v8",
+      "new_sqlite_classes": ["TestStructuredAgent"]
     }
   ],
   "r2_buckets": [

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -2819,6 +2819,59 @@ function createToolCallingMockModel(): LanguageModel {
   } as LanguageModel;
 }
 
+// Emits a single tool call for whichever tool the turn forces via `toolChoice`
+// (or the first `think_final_answer*` tool advertised), with the configured
+// arguments. Mirrors how a real model terminates a structured workflow turn by
+// calling the synthetic final-answer tool — exercises the #1685 capture path
+// without a network round-trip.
+function createFinalAnswerMockModel(args: unknown): LanguageModel {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-final-answer",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented in mock");
+    },
+    doStream(options: Record<string, unknown>) {
+      const opts = options as {
+        toolChoice?: { type?: string; toolName?: string };
+        tools?: Array<{ name?: string }>;
+      };
+      const toolName =
+        opts.toolChoice?.type === "tool" && opts.toolChoice.toolName
+          ? opts.toolChoice.toolName
+          : ((opts.tools ?? [])
+              .map((t) => t.name)
+              .find((n) => n?.startsWith("think_final_answer")) ??
+            "think_final_answer");
+      const input = JSON.stringify(args);
+      const id = "final-answer-call";
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({ type: "tool-input-start", id, toolName });
+          controller.enqueue({ type: "tool-input-delta", id, delta: input });
+          controller.enqueue({ type: "tool-input-end", id });
+          controller.enqueue({
+            type: "tool-call",
+            toolCallId: id,
+            toolName,
+            input
+          });
+          controller.enqueue({
+            type: "finish",
+            finishReason: v3FinishReason("tool-calls"),
+            usage: v3Usage(10, 5)
+          });
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
 export class ThinkToolsTestAgent extends Think {
   override maxSteps = 3;
 
@@ -3031,6 +3084,7 @@ export class ThinkProgrammaticTestAgent extends Think {
   private _throwBeforeTurnError: string | null = null;
   private _submissionStatusDelayMs = 0;
   private _programmaticResponse = "Programmatic response";
+  private _finalAnswerResponse: unknown = undefined;
   private _inBandErrorResponse: {
     errorText: string;
     textChunks: string[];
@@ -3042,6 +3096,9 @@ export class ThinkProgrammaticTestAgent extends Think {
         this._inBandErrorResponse.errorText,
         this._inBandErrorResponse.textChunks
       );
+    }
+    if (this._finalAnswerResponse !== undefined) {
+      return createFinalAnswerMockModel(this._finalAnswerResponse);
     }
     if (this._delayedChunks) {
       return createDelayedMultiChunkMockModel(
@@ -3165,6 +3222,23 @@ export class ThinkProgrammaticTestAgent extends Think {
 
   async setProgrammaticResponseForTest(response: string): Promise<void> {
     this._programmaticResponse = response;
+  }
+
+  // Make the next turn(s) terminate by calling the structured-output
+  // `think_final_answer` tool with `args` as its arguments (issue #1685).
+  async setFinalAnswerResponseForTest(args: unknown): Promise<void> {
+    this._finalAnswerResponse = args;
+  }
+
+  // Drive the assistant-message persistence chokepoint directly. Used to
+  // simulate the recovery re-persist path (which runs outside an active turn)
+  // and assert the internal `think_final_answer` tool is stripped statelessly.
+  async persistAssistantMessageForTest(msg: UIMessage): Promise<void> {
+    await (
+      this as unknown as {
+        _persistAssistantMessage: (m: UIMessage) => Promise<void>;
+      }
+    )._persistAssistantMessage(msg);
   }
 
   async setLastBodyForTest(body: Record<string, unknown>): Promise<void> {

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -1,6 +1,7 @@
 import { env } from "cloudflare:workers";
 import { getServerByName } from "partyserver";
 import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
 import type { ThinkProgrammaticTestAgent } from "./agents/think-session";
 import type {
   SubmitMessagesResult,
@@ -25,6 +26,8 @@ type ThinkSubmissionTestStub = {
   runNonSubmissionStreamFailureForTest(requestId: string): Promise<void>;
   setSubmissionStatusDelayForTest(delayMs: number): Promise<void>;
   setProgrammaticResponseForTest(response: string): Promise<void>;
+  setFinalAnswerResponseForTest(args: unknown): Promise<void>;
+  persistAssistantMessageForTest(msg: UIMessage): Promise<void>;
   setLastBodyForTest(body: Record<string, unknown>): Promise<void>;
   setSubmissionRecoveryStaleMsForTest(ms: number): Promise<void>;
   setWorkflowEventFailuresForTest(count: number): Promise<void>;
@@ -510,12 +513,12 @@ describe("Think durable submissions", () => {
 
   it("captures workflow structured output in terminal notifications", async () => {
     const agent = await freshAgent();
-    await agent.setProgrammaticResponseForTest(
-      JSON.stringify({
-        title: "Workflow output",
-        labels: ["ops", "review"]
-      })
-    );
+    // The structured workflow turn now terminates by calling the synthetic
+    // `think_final_answer` tool; the mock model emits that call (issue #1685).
+    await agent.setFinalAnswerResponseForTest({
+      title: "Workflow output",
+      labels: ["ops", "review"]
+    });
 
     const accepted = await agent.testSubmitMessages("produce workflow output", {
       submissionId: "sub-workflow-output",
@@ -571,6 +574,100 @@ describe("Think durable submissions", () => {
         }
       }
     });
+  });
+
+  it("does not persist the internal final-answer tool into the conversation", async () => {
+    const agent = await freshAgent();
+    await agent.setFinalAnswerResponseForTest({ title: "Hidden", labels: [] });
+
+    const accepted = await agent.testSubmitMessages("structured, no noise", {
+      submissionId: "sub-workflow-no-noise",
+      metadata: {
+        [workflowPromptMetadataKey]: {
+          workflow: {
+            name: "TEST_WORKFLOW",
+            id: "workflow-no-noise",
+            stepName: "draft",
+            eventType: "think-prompt-no-noise"
+          },
+          output: {
+            schema: {
+              type: "object",
+              properties: {
+                title: { type: "string" },
+                labels: { type: "array", items: { type: "string" } }
+              },
+              required: ["title", "labels"],
+              additionalProperties: false
+            }
+          },
+          fingerprint: "fingerprint"
+        }
+      }
+    });
+
+    await waitForSubmission(
+      agent,
+      accepted.submissionId,
+      (submission) => submission.status === "completed"
+    );
+    // The output is still delivered via the workflow event...
+    const event = await waitForWorkflowEvent(
+      agent,
+      (entry) => entry.event.type === "think-prompt-no-noise"
+    );
+    expect((event.event.payload as { output?: unknown }).output).toEqual({
+      title: "Hidden",
+      labels: []
+    });
+
+    // ...but the synthetic `think_final_answer` tool call must not leak into the
+    // stored conversation. The turn called only the internal tool, so no
+    // assistant message should be persisted at all — just the user message.
+    const stored = await agent.getStoredMessages();
+    const toolParts = stored.flatMap((m) =>
+      (m.parts ?? []).filter((p) => {
+        const part = p as { type?: string; toolName?: string };
+        return (
+          part.type === "tool-think_final_answer" ||
+          (part.type === "dynamic-tool" &&
+            part.toolName === "think_final_answer")
+        );
+      })
+    );
+    expect(toolParts).toHaveLength(0);
+    expect(stored.every((m) => m.role !== "assistant")).toBe(true);
+  });
+
+  it("strips the internal final-answer tool from a recovered assistant message", async () => {
+    // The recovery re-persist path runs outside an active turn, so stripping
+    // must be stateless (matched by the reserved tool name). Real content must
+    // survive; the internal tool call/result must not.
+    const agent = await freshAgent();
+    await agent.persistAssistantMessageForTest({
+      id: "asst-recovered",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { type: "text", text: "Here is the answer." },
+        {
+          type: "tool-think_final_answer",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { word: "banana" },
+          output: "Final answer recorded."
+        }
+      ]
+    } as unknown as UIMessage);
+
+    const stored = await agent.getStoredMessages();
+    const recovered = stored.find((m) => m.id === "asst-recovered");
+    expect(recovered).toBeTruthy();
+    const partTypes = (recovered?.parts ?? []).map(
+      (p) => (p as { type?: string }).type
+    );
+    expect(partTypes).toContain("text");
+    expect(partTypes).not.toContain("tool-think_final_answer");
   });
 
   it("drains workflow notifications and clears delivered payloads", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -95,10 +95,11 @@ import type {
 } from "ai";
 import {
   convertToModelMessages,
+  hasToolCall,
   jsonSchema,
-  Output,
   stepCountIs,
-  streamText
+  streamText,
+  tool
 } from "ai";
 import * as skills from "agents/skills";
 import { SkillRegistry } from "agents/skills";
@@ -1017,6 +1018,50 @@ type ThinkWorkflowPromptContext = {
 };
 
 const THINK_WORKFLOW_PROMPT_METADATA_KEY = "__thinkWorkflowPrompt";
+
+/**
+ * Reserved name for the synthetic tool a workflow `step.prompt` turn uses to
+ * deliver its structured final answer. The agent runs a full multi-step,
+ * tool-using turn and ends it by calling this tool with arguments matching the
+ * requested schema — exactly the way a sub-agent returns a result.
+ *
+ * Why a tool instead of the AI SDK `output`/`response_format` path: streaming a
+ * JSON Schema `response_format` is rejected by some providers (Workers AI
+ * returns `AiError 5023: JSON Schema mode is not supported with stream mode`),
+ * whereas plain tool-calling streams on every provider. Capturing the tool
+ * call's INPUT as the result keeps Think's single streaming engine intact
+ * (persistence, recovery, resumable streams) and works uniformly across
+ * Workers AI, OpenAI, and Anthropic.
+ *
+ * The name is namespaced to avoid clashing with user tools; if a user tool
+ * already uses it, the turn picks a suffixed variant (see `_handleTurn`).
+ */
+const THINK_FINAL_ANSWER_TOOL_NAME = "think_final_answer";
+
+/**
+ * Whether `name` is (or is a collision-suffixed variant of) the reserved
+ * structured-output final-answer tool. Used to strip the internal tool's parts
+ * from persisted assistant messages regardless of which per-turn name was used.
+ */
+function isThinkFinalAnswerToolName(name: string): boolean {
+  return (
+    name === THINK_FINAL_ANSWER_TOOL_NAME ||
+    name.startsWith(`${THINK_FINAL_ANSWER_TOOL_NAME}_`)
+  );
+}
+
+/**
+ * Build the system-prompt instruction that tells the model to terminate a
+ * structured workflow turn by calling the given final-answer tool.
+ */
+function thinkFinalAnswerInstruction(toolName: string): string {
+  return (
+    "When you have everything you need to answer, you MUST call the " +
+    `\`${toolName}\` tool exactly once with arguments that match the required ` +
+    "schema. Do not write the final answer as plain text — the " +
+    `\`${toolName}\` tool call IS the answer and ends the task.`
+  );
+}
 
 export type ThinkSubmissionInspection = {
   submissionId: string;
@@ -3289,11 +3334,14 @@ export class Think<
     const subclassConfig = (await this.beforeTurn(ctx)) ?? {};
     const config = await this._pipelineExtensionBeforeTurn(ctx, subclassConfig);
     const workflowPrompt = input.workflowPrompt;
-    const workflowOutput = workflowPrompt?.output
-      ? Output.object({
-          schema: jsonSchema(workflowPrompt.output.schema as never)
-        })
+    // Workflow `step.prompt` turns produce their structured result by calling
+    // the synthetic `final_answer` tool (see THINK_FINAL_ANSWER_TOOL_NAME) —
+    // NOT via the AI SDK `output`/`response_format` path, which some providers
+    // reject when streaming. We pre-build the JSON Schema once here.
+    const structuredOutputSchema = workflowPrompt?.output
+      ? jsonSchema(workflowPrompt.output.schema as never)
       : undefined;
+    const wantsStructuredOutput = structuredOutputSchema !== undefined;
 
     const finalModel = config.model ?? model;
     const finalSystem =
@@ -3314,6 +3362,25 @@ export class Think<
     // `substitute` returns `output` directly, `allow` runs the original
     // (optionally with modified `input`).
     const finalTools: ToolSet = this._wrapToolsWithDecision(mergedTools);
+    // For a structured workflow turn, expose a final-answer tool alongside the
+    // agent's real tools. The agent loops with its tools and terminates by
+    // calling this one; its arguments are captured as the structured result.
+    // Guard against a clash with a user tool of the same name by suffixing.
+    let finalAnswerToolName = THINK_FINAL_ANSWER_TOOL_NAME;
+    if (structuredOutputSchema) {
+      let suffix = 1;
+      while (finalAnswerToolName in finalTools) {
+        finalAnswerToolName = `${THINK_FINAL_ANSWER_TOOL_NAME}_${suffix++}`;
+      }
+      finalTools[finalAnswerToolName] = tool({
+        description:
+          "Provide your final answer. The arguments MUST match the required " +
+          "schema. Calling this tool ends the task — call it exactly once when " +
+          "you have everything you need.",
+        inputSchema: structuredOutputSchema,
+        execute: async () => "Final answer recorded."
+      });
+    }
 
     // Baseline for the proactive context guard: everything the AI SDK appends
     // to the model-message list after the assembled turn messages belongs to
@@ -3331,9 +3398,38 @@ export class Think<
     // the watchdog. `??` so a `0` override is honored, not treated as "unset".
     this._activeStallTimeoutMs =
       config.chatStreamStallTimeoutMs ?? this.chatStreamStallTimeoutMs;
-    const finalOutput = workflowOutput ?? config.output;
+    // `output` (AI SDK structured-output / `response_format`) is reserved for
+    // the opt-in chat `TurnConfig.output` API. Workflow prompts use the
+    // `final_answer` tool instead (see `wantsStructuredOutput`).
+    const finalOutput = config.output;
+    // On a structured workflow turn, append the instruction telling the model to
+    // finish by calling `final_answer`. `filter(Boolean)` drops an absent system
+    // prompt so we never stringify `undefined` into the prompt.
+    const turnSystem = wantsStructuredOutput
+      ? [finalSystem, thinkFinalAnswerInstruction(finalAnswerToolName)]
+          .filter(Boolean)
+          .join("\n\n")
+      : finalSystem;
+    // Structured turns must not end with a plain-text answer that skips
+    // `final_answer` (some models, e.g. Workers AI llama, otherwise just reply
+    // in text and stop). Force tool use: when the agent has real tools, require
+    // *a* tool each step so it can do work and then call `final_answer`; with no
+    // real tools, pin the choice directly to `final_answer`. A caller-provided
+    // `toolChoice` still wins.
+    const structuredHasRealTools =
+      wantsStructuredOutput &&
+      Object.keys(finalTools).some((name) => name !== finalAnswerToolName);
+    const finalToolChoice = wantsStructuredOutput
+      ? (config.toolChoice ??
+        (structuredHasRealTools
+          ? "required"
+          : { type: "tool" as const, toolName: finalAnswerToolName }))
+      : config.toolChoice;
     const finalStopWhen = [
       stepCountIs(finalMaxSteps),
+      // Stop as soon as the model calls `final_answer` so the structured turn
+      // terminates at the answer instead of continuing to stream more steps.
+      ...(wantsStructuredOutput ? [hasToolCall(finalAnswerToolName)] : []),
       ...(Array.isArray(config.stopWhen)
         ? config.stopWhen
         : config.stopWhen
@@ -3343,11 +3439,17 @@ export class Think<
 
     const result = streamText({
       model: finalModel,
-      system: finalSystem,
+      system: turnSystem,
       messages: finalMessages,
       tools: finalTools,
-      activeTools: config.activeTools,
-      toolChoice: config.toolChoice,
+      // Keep the synthetic final-answer tool callable even when a caller
+      // restricts `activeTools` — otherwise a structured turn could never call
+      // it and would fail to produce output.
+      activeTools:
+        wantsStructuredOutput && config.activeTools
+          ? [...config.activeTools, finalAnswerToolName]
+          : config.activeTools,
+      toolChoice: finalToolChoice,
       maxOutputTokens: config.maxOutputTokens,
       temperature: config.temperature,
       topP: config.topP,
@@ -3393,10 +3495,29 @@ export class Think<
         // Only apply the guard's recompacted messages when the subclass didn't
         // set its own `messages` override for this step.
         const baseMessages = (base as { messages?: unknown }).messages;
-        if (guarded && baseMessages === undefined) {
-          return { ...base, messages: guarded };
+        const withMessages =
+          guarded && baseMessages === undefined
+            ? { ...base, messages: guarded }
+            : base;
+        // Safety net for structured workflow turns: on the final permitted step,
+        // force the model to call `final_answer` so the turn always terminates
+        // with a schema-shaped result instead of running out of steps. Respect a
+        // `toolChoice` the subclass already set for this step.
+        if (
+          wantsStructuredOutput &&
+          event.stepNumber >= finalMaxSteps - 1 &&
+          (withMessages as { toolChoice?: unknown }).toolChoice === undefined
+        ) {
+          return {
+            ...withMessages,
+            toolChoice: {
+              type: "tool" as const,
+              toolName: finalAnswerToolName
+            },
+            activeTools: [finalAnswerToolName]
+          };
         }
-        return base;
+        return withMessages;
       }) satisfies PrepareStepFunction<ToolSet>,
       onChunk: async (event) => {
         // Pass the AI SDK's chunk event through unchanged — gives users
@@ -3420,6 +3541,10 @@ export class Think<
       // accurate `durationMs` and the discriminated `success`/`error`
       // outcome — including failures that propagate out of `execute`.
       experimental_onToolCallFinish: (async (event) => {
+        // The synthetic final-answer tool is internal plumbing for structured
+        // workflow turns — do not surface it to user `afterToolCall` hooks or
+        // extensions.
+        if (event.toolCall.toolName === finalAnswerToolName) return;
         const base = {
           ...event.toolCall,
           stepNumber: event.stepNumber,
@@ -3436,8 +3561,26 @@ export class Think<
       }) satisfies StreamTextOnToolCallFinishCallback<ToolSet>
     });
 
-    const outputPromise =
-      finalOutput && result.output ? Promise.resolve(result.output) : undefined;
+    const outputPromise = wantsStructuredOutput
+      ? // Structured workflow result = the `final_answer` tool call's INPUT
+        // (its arguments), captured after the stream finishes. Take the last
+        // call in case the model emitted more than one. `result.toolCalls` is a
+        // `PromiseLike`, so wrap it to get a real `Promise` (for `.catch` below).
+        Promise.resolve(result.toolCalls).then((calls) => {
+          const finalCalls = calls.filter(
+            (call) => call.toolName === finalAnswerToolName
+          );
+          const last = finalCalls[finalCalls.length - 1];
+          if (!last) {
+            throw new Error(
+              `Model ended the turn without calling the ${finalAnswerToolName} tool`
+            );
+          }
+          return last.input;
+        })
+      : finalOutput && result.output
+        ? Promise.resolve(result.output)
+        : undefined;
     if (outputPromise) {
       // Attach a rejection observer immediately. `_streamResult()` will still
       // await this promise when captureOutput is enabled, but aborted streams can
@@ -7932,7 +8075,51 @@ export class Think<
     msg: UIMessage,
     parentId?: string
   ): Promise<void> {
+    const stripped = this._stripInternalFinalAnswerParts(msg);
+    if (stripped !== msg) {
+      // If removing the internal final-answer tool leaves nothing user-facing
+      // (only structural `step-start` markers, or nothing), skip persistence so
+      // a structured workflow turn does not leave an empty assistant message in
+      // the conversation.
+      const hasMeaningfulParts = stripped.parts.some(
+        (part) => (part as { type?: string }).type !== "step-start"
+      );
+      if (!hasMeaningfulParts) return;
+      await this._upsertMessageInHistory(stripped, parentId);
+      return;
+    }
     await this._upsertMessageInHistory(msg, parentId);
+  }
+
+  /**
+   * Remove parts belonging to Think's internal structured-output final-answer
+   * tool (`think_final_answer`, or a collision-suffixed variant) from a UI
+   * message so the internal call/result never enters the persisted conversation
+   * (and is never re-fed to the model on later turns). Stateless and matched by
+   * the reserved name so it also covers recovery re-persist paths. Handles both
+   * the static (`tool-<name>`) and dynamic (`dynamic-tool`) part shapes the AI
+   * SDK can emit.
+   */
+  private _stripInternalFinalAnswerParts(msg: UIMessage): UIMessage {
+    const parts = msg.parts.filter((part) => {
+      const candidate = part as { type?: string; toolName?: string };
+      if (
+        typeof candidate.type === "string" &&
+        candidate.type.startsWith("tool-") &&
+        isThinkFinalAnswerToolName(candidate.type.slice("tool-".length))
+      ) {
+        return false;
+      }
+      if (
+        candidate.type === "dynamic-tool" &&
+        typeof candidate.toolName === "string" &&
+        isThinkFinalAnswerToolName(candidate.toolName)
+      ) {
+        return false;
+      }
+      return true;
+    });
+    return parts.length === msg.parts.length ? msg : { ...msg, parts };
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3380,6 +3380,12 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
     devDependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.81
+        version: 3.0.81(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^3.0.67
+        version: 3.0.67(zod@4.4.3)
       '@chat-adapter/telegram':
         specifier: ^4.30.0
         version: 4.30.0(ai@6.0.196(zod@4.4.3))(zod@4.4.3)


### PR DESCRIPTION
## Summary

Fixes #1685. `ThinkWorkflow.step.prompt({ output })` failed on Workers AI with:

```
AiError 5023: JSON Schema mode is not supported with stream mode
```

Structured workflow prompts requested output via the AI SDK `Output.object` path, which streams a JSON Schema `response_format`. Workers AI (Think's default provider) rejects JSON Schema on streaming requests, so `step.prompt()` was effectively broken there.

## What changed

Workflow-prompt turns no longer use `Output.object`. Instead Think injects a synthetic **`think_final_answer`** tool whose input schema is the prompt's Zod schema, instructs the model to terminate the turn by calling it, and reads the validated structured result from that tool call's input.

Because this is ordinary tool calling, it works uniformly across **Workers AI, OpenAI, and Anthropic**, and keeps Think's streaming engine intact (persistence, recovery, resumable streams). A structured `step.prompt()` is now a full agentic turn — the agent can use its own tools across multiple steps before producing the final answer.

## Key details / edge cases handled

- **Forced tool choice.** `toolChoice` is forced for structured turns (`"required"` when real tools are present, otherwise pinned to the final-answer tool). A `hasToolCall` stop condition alone is insufficient — some models (kimi, llama) answer in plain text and stop at step 0 without ever calling the tool.
- **Reserved name + collision guard.** `think_final_answer` is reserved and namespaced; if a user tool already uses the name, the turn picks a collision-suffixed variant.
- **Clean transcript.** The internal tool's call/result are stripped from the persisted conversation (stateless, matched by the reserved name) so the transcript and later turns never see Think's internal plumbing. Stateless matching also covers the recovery re-persist path.
- **No hook leakage.** The synthetic tool is excluded from user-facing `afterToolCall` / extension hooks, and is always kept in `activeTools` on structured turns even when a caller overrides `activeTools` via `beforeTurn`.

## Tests

- **New cross-provider e2e harness** (`packages/think/src/e2e-tests/step-prompt-structured.test.ts`) exercising:
  - a no-tool structured prompt, and
  - a multi-step tool-using prompt (write → read → final answer, i.e. the `toolChoice: "required"` path)

  on Workers AI, OpenAI, and Anthropic.
- **Unit tests**: structured output via a final-answer mock, "does not persist the internal final-answer tool", and a recovered-assistant-message strip test.

## Docs

- `docs/think/workflows.md` gains a **Behavior notes** section:
  - the agent may use its tools first (allow `maxSteps >= 2`),
  - tool use is forced during a structured turn — do not override `toolChoice` from `beforeTurn` on a `step.prompt()` turn,
  - `think_final_answer` is reserved and stripped from the transcript.

> [!NOTE]
> `docs/think/workflows.md` still needs a manual port to `cloudflare/cloudflare-docs` (`src/content/docs/agents/...`).

## Verification

- think unit suite: **551 passed** (16 files)
- `step-prompt-structured` e2e: **6 passed** (Workers AI `kimi-k2.6`, OpenAI `gpt-4o-mini`, Anthropic `claude-haiku-4-5`; greeting + multi-step tool legs)
- `pnpm run check`: green across **92 projects**

Changeset included (`@cloudflare/think` patch).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->