### PR TITLE
chore(think-starters): scope starter package names and ignore in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": ["@cloudflare/agents-*"],
+  "ignore": ["@cloudflare/agents-*", "@cloudflare/think-*-starter"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/think-starters/basic/package.json
+++ b/think-starters/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "think-basic-starter",
+  "name": "@cloudflare/think-basic-starter",
   "description": "Minimal Think chat agent on Cloudflare Workers",
   "private": true,
   "type": "module",

--- a/think-starters/coding-agent/package.json
+++ b/think-starters/coding-agent/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "think-coding-agent-starter",
+  "name": "@cloudflare/think-coding-agent-starter",
   "description": "Think coding agent with workspace file tools and a coding skill",
   "private": true,
   "type": "module",

--- a/think-starters/customer-support/package.json
+++ b/think-starters/customer-support/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "think-customer-support-starter",
+  "name": "@cloudflare/think-customer-support-starter",
   "description": "Think customer support agent with custom tools and an escalation skill",
   "private": true,
   "type": "module",

--- a/think-starters/personal-assistant/package.json
+++ b/think-starters/personal-assistant/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "think-personal-assistant-starter",
+  "name": "@cloudflare/think-personal-assistant-starter",
   "description": "Think personal assistant with persistent memory and scheduled tasks",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Scopes the starter workspace package names and tells changesets to ignore them.

- Rename the four starter `package.json` names to the `@cloudflare/think-*-starter` scope:
  - `think-basic-starter` → `@cloudflare/think-basic-starter`
  - `think-personal-assistant-starter` → `@cloudflare/think-personal-assistant-starter`
  - `think-coding-agent-starter` → `@cloudflare/think-coding-agent-starter`
  - `think-customer-support-starter` → `@cloudflare/think-customer-support-starter`
- Add `@cloudflare/think-*-starter` to the changeset `ignore` list so these unpublished (`private: true`) workspaces never receive version bumps or changelog entries.

The ignore glob is intentionally scoped to the `-starter` suffix so it can't match the published `@cloudflare/think` package or any future `@cloudflare/think-*` package.

## Notes

- Worker `name` fields in each `wrangler.jsonc` are left unchanged (they're deploy names and are rewritten to the user's project name on scaffold).
- `pnpm run check` green (sherif + 102 projects typecheck); no lockfile churn since nothing depends on the starters by name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->