### PR TITLE
fix(think): stop alarms firing every 30s when no workflow notifications pending (#1703)

### DIFF
--- a/.changeset/think-alarm-no-pending-workflow-notifications.md
+++ b/.changeset/think-alarm-no-pending-workflow-notifications.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/think": patch
+---
+
+Fix Think agents firing an alarm every 30s forever when they don't use workflow notifications (#1703).
+
+`alarm()` called `_startWorkflowNotificationDrain()` unconditionally, which wrapped its work in `keepAliveWhile(...)`. Acquiring the keepAlive lease armed the 30s keepAlive heartbeat alarm even though there was nothing to drain, and releasing the lease did not pull the alarm back — so the DO re-scheduled itself every 30s and never hibernated.
+
+`_startWorkflowNotificationDrain()` now returns early when there are no pending notifications, matching its other call sites. Affected DOs self-heal on their next alarm fire after upgrading: `super.alarm()` reschedules to the next legitimate task (or clears the alarm entirely) and the drain no longer re-arms the heartbeat.

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -4083,6 +4083,25 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
     const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
     return child.listSchedulesForTest();
   }
+
+  // ── #1703: alarm() must not arm a keepAlive heartbeat when there are
+  // no pending workflow notifications, otherwise the DO fires every 30s
+  // forever and never hibernates.
+  async getKeepAliveRefsForTest(): Promise<number> {
+    return (this as unknown as { _keepAliveRefs: number })._keepAliveRefs;
+  }
+
+  async runAlarmForTest(): Promise<{
+    keepAliveRefs: number;
+    scheduledAlarm: number | null;
+  }> {
+    await this.alarm();
+    return {
+      keepAliveRefs: (this as unknown as { _keepAliveRefs: number })
+        ._keepAliveRefs,
+      scheduledAlarm: await this.ctx.storage.getAlarm()
+    };
+  }
 }
 
 // ── ThinkAsyncHookTestAgent ──────────────────────────────────

--- a/packages/think/src/tests/scheduled-tasks.test.ts
+++ b/packages/think/src/tests/scheduled-tasks.test.ts
@@ -94,6 +94,11 @@ type ThinkScheduledTasksTestStub = {
   listChildSchedulesForTest(
     name: string
   ): Promise<Array<{ id: string; payload: unknown }>>;
+  getKeepAliveRefsForTest(): Promise<number>;
+  runAlarmForTest(): Promise<{
+    keepAliveRefs: number;
+    scheduledAlarm: number | null;
+  }>;
 };
 
 async function freshAgent(
@@ -519,5 +524,21 @@ describe("Think scheduled tasks", () => {
     expect(
       await parent.listChildDeclaredScheduledTaskRowsForTest("beta")
     ).toHaveLength(1);
+  });
+
+  it("does not arm a keepAlive heartbeat on alarm() when no workflow notifications are pending (#1703)", async () => {
+    const agent = await freshAgent();
+
+    // An agent that never uses workflow notifications must not turn alarm()
+    // into a self-perpetuating 30s heartbeat. With no pending notifications
+    // and no other scheduled work, the drain must be a no-op: keepAlive refs
+    // stay at 0 and no near-future alarm is left behind.
+    const before = await agent.getKeepAliveRefsForTest();
+    expect(before).toBe(0);
+
+    const { keepAliveRefs, scheduledAlarm } = await agent.runAlarmForTest();
+
+    expect(keepAliveRefs).toBe(0);
+    expect(scheduledAlarm).toBeNull();
   });
 });

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -5537,6 +5537,7 @@ export class Think<
   }
 
   private _startWorkflowNotificationDrain(): void {
+    if (!this._hasPendingWorkflowNotifications()) return;
     void this.keepAliveWhile(() => this._drainWorkflowNotifications()).catch(
       (error) => {
         console.error("[Think] Failed to drain workflow notifications", error);


### PR DESCRIPTION
## Summary

Fixes #1703 — Think agents that don't use workflow notifications fire an alarm every 30s forever.

`Think.alarm()` called `_startWorkflowNotificationDrain()` unconditionally on every fire. The drain wraps its work in `keepAliveWhile(...)`, which acquires a keepAlive lease (`_keepAliveRefs` `0 → 1`) and arms the 30s keepAlive heartbeat alarm via `_scheduleNextAlarm()`. With nothing to drain, releasing the lease does **not** pull the alarm back, so the DO re-schedules itself every 30s and never hibernates. The reporter saw a sustained ~10k alarm fires/hour across their fleet, with `outcome: ok`, `cpuTimeMs ~0`, no user logs, and all driver tables empty.

## The fix

A one-line guard in `_startWorkflowNotificationDrain()`:

```ts
private _startWorkflowNotificationDrain(): void {
  if (!this._hasPendingWorkflowNotifications()) return;
  void this.keepAliveWhile(() => this._drainWorkflowNotifications()).catch(...);
}
```

This matches the pattern already used at the other call sites (the boot fiber and `_recoverWorkflowNotifications`). Placing the guard inside the function covers all four callers.

## Why this is safe

- **Nothing is lost in the empty case.** `_hasPendingWorkflowNotifications()` checks `delivered_at IS NULL` — exactly the rows the drain processes. When empty, the old drain did an empty SELECT and a no-op `_scheduleWorkflowNotificationAlarm()`; the only observable effect was the keepAlive bump (the bug).
- **Retry/backoff preserved.** Failed deliveries keep `delivered_at` NULL → stay pending → the drain's `finally` re-arms the exponential-backoff alarm → next fire the guard passes and retries.
- **New notifications always drain.** `_enqueueWorkflowNotification` inserts *then* calls the drain, so the guard always passes there.
- **Eviction/recovery covered.** The boot fiber and `_recoverWorkflowNotifications` re-check pending rows and drain after a wake.

## Self-healing on existing deploys

No migration needed. Affected DOs heal on their **next** alarm fire after the upgrade is live: `super.alarm()` recomputes the alarm from persistent state (next schedule row, or clears it) with `_keepAliveRefs === 0`, and the guarded drain no longer re-arms the +30s heartbeat. Since affected DOs already have an alarm pending within 30s, this happens automatically and quickly.

## Tests

Added a regression test in `scheduled-tasks.test.ts` asserting that `alarm()` with no pending notifications leaves `_keepAliveRefs` at 0 and no near-future alarm. Verified it **fails without** the guard (`_keepAliveRefs` is 1, alarm bumped to +30s) and **passes with** it. Broader run of `scheduled-tasks` + `submissions` + `workflows` (59 tests) passes, confirming the drain-when-pending path is unaffected.

```
✓ does not arm a keepAlive heartbeat on alarm() when no workflow notifications are pending (#1703)
```

## Follow-up

A deeper, framework-level root cause — `keepAlive()`'s dispose decrements `_keepAliveRefs` but never calls `_scheduleNextAlarm()`, so any brief lease can leave a stale 30s heartbeat — is tracked in #1704, along with two related alarm-ownership cleanups (`super.alarm()` clobbering the notification backoff alarm, and the fire-and-forget drain).

## Changeset

`@cloudflare/think` patch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->