### PR TITLE
fix(agents): reschedule alarm when keepAlive lease is released (#1704)

### DIFF
--- a/.changeset/keepalive-dispose-reschedule-alarm.md
+++ b/.changeset/keepalive-dispose-reschedule-alarm.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix `keepAlive()` leaving a stale 30s heartbeat alarm after the lease is released. Previously the dispose returned by `keepAlive()` (and used by `keepAliveWhile()`) only decremented the in-memory ref count and never rescheduled the alarm, so a short-lived lease could permanently bump the next alarm to `now + keepAliveIntervalMs` with nothing to pull it back. The dispose now recomputes the alarm from persistent state when the last lease is released (mirroring the facet release path), clearing the heartbeat when no other work needs it. Fixes #1704 (root cause behind #1703).

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4426,6 +4426,21 @@ export class Agent<
       if (disposed) return;
       disposed = true;
       this._keepAliveRefs = Math.max(0, this._keepAliveRefs - 1);
+      // When the last lease is released, recompute the alarm from persistent
+      // state so a short-lived keepAlive does not leave a stale
+      // `now + keepAliveIntervalMs` heartbeat armed. The dispose contract is
+      // synchronous, so fire-and-forget the async reschedule via waitUntil
+      // (mirrors `_cf_releaseFacetKeepAlive`).
+      if (this._keepAliveRefs === 0) {
+        this.ctx.waitUntil(
+          this._scheduleNextAlarm().catch((e) => {
+            console.error(
+              "[Agent] Failed to reschedule alarm after keepAlive dispose:",
+              e
+            );
+          })
+        );
+      }
     };
   }
 

--- a/packages/agents/src/tests/agents/keep-alive.ts
+++ b/packages/agents/src/tests/agents/keep-alive.ts
@@ -44,4 +44,14 @@ export class TestKeepAliveAgent extends Agent {
     `;
     return result[0].count;
   }
+
+  async getCurrentAlarm(): Promise<number | null> {
+    return this.ctx.storage.getAlarm();
+  }
+
+  async scheduleFarFutureTask(delaySeconds: number): Promise<void> {
+    await this.schedule(delaySeconds, "noop");
+  }
+
+  noop(): void {}
 }

--- a/packages/agents/src/tests/keep-alive.test.ts
+++ b/packages/agents/src/tests/keep-alive.test.ts
@@ -116,6 +116,114 @@ describe("keepAlive", () => {
     await agent.stopKeepAlive();
     expect(await getKeepAliveRefs(agent)).toBe(0);
   });
+
+  // Regression coverage for #1704: a short-lived keepAlive must not leave a
+  // stale `now + keepAliveIntervalMs` heartbeat armed once the lease is gone.
+  describe("alarm rescheduling on dispose (#1704)", () => {
+    it("arms a heartbeat alarm while a lease is held", async () => {
+      const agent = await getAgentByName(env.TestKeepAliveAgent, "arm-alarm");
+
+      expect(await agent.getCurrentAlarm()).toBeNull();
+
+      const before = Date.now();
+      await agent.startKeepAlive();
+
+      const alarm = await agent.getCurrentAlarm();
+      expect(alarm).not.toBeNull();
+      // Capped at now + keepAliveIntervalMs (default 30s) with slack.
+      expect(alarm as number).toBeGreaterThan(before);
+      expect(alarm as number).toBeLessThanOrEqual(before + 30_000 + 5_000);
+    });
+
+    it("clears the stale heartbeat when the last lease is disposed", async () => {
+      const agent = await getAgentByName(env.TestKeepAliveAgent, "clear-alarm");
+
+      await agent.startKeepAlive();
+      expect(await agent.getCurrentAlarm()).not.toBeNull();
+
+      await agent.stopKeepAlive();
+
+      // With no pending schedules, the heartbeat must be pulled back.
+      expect(await agent.getCurrentAlarm()).toBeNull();
+    });
+
+    it("keeps the alarm armed until the final concurrent lease is released", async () => {
+      const agent = await getAgentByName(
+        env.TestKeepAliveAgent,
+        "concurrent-alarm"
+      );
+
+      await agent.startKeepAlive();
+      await agent.startKeepAlive();
+      expect(await agent.getCurrentAlarm()).not.toBeNull();
+
+      // Releasing one of two leases must NOT clear the heartbeat.
+      await agent.stopKeepAlive();
+      expect(await agent.getCurrentAlarm()).not.toBeNull();
+
+      // Releasing the last lease clears it.
+      await agent.stopKeepAlive();
+      expect(await agent.getCurrentAlarm()).toBeNull();
+    });
+
+    it("clears the heartbeat after keepAliveWhile completes", async () => {
+      const agent = await getAgentByName(
+        env.TestKeepAliveAgent,
+        "while-clears-alarm"
+      );
+
+      expect(await agent.getCurrentAlarm()).toBeNull();
+
+      const result = await agent.runWithKeepAliveWhile();
+      expect(result).toBe("completed");
+
+      expect(await getKeepAliveRefs(agent)).toBe(0);
+      expect(await agent.getCurrentAlarm()).toBeNull();
+    });
+
+    it("re-acquiring after dispose keeps the heartbeat armed (no clobber)", async () => {
+      const agent = await getAgentByName(
+        env.TestKeepAliveAgent,
+        "reacquire-alarm"
+      );
+
+      // Acquire then release: the dispose fire-and-forgets a reschedule that
+      // would clear the alarm. Immediately re-acquiring must win, because the
+      // reschedule reads the live ref count rather than a stale snapshot.
+      await agent.startKeepAlive();
+      await agent.stopKeepAlive();
+      await agent.startKeepAlive();
+
+      expect(await getKeepAliveRefs(agent)).toBe(1);
+      expect(await agent.getCurrentAlarm()).not.toBeNull();
+    });
+
+    it("falls back to the next legitimate schedule instead of the heartbeat", async () => {
+      const agent = await getAgentByName(
+        env.TestKeepAliveAgent,
+        "fallback-alarm"
+      );
+
+      // A real task far beyond the keepAlive interval.
+      await agent.scheduleFarFutureTask(600);
+      const before = Date.now();
+
+      await agent.startKeepAlive();
+      // While the lease is held, the heartbeat caps the alarm to ~30s.
+      const cappedAlarm = await agent.getCurrentAlarm();
+      expect(cappedAlarm as number).toBeLessThanOrEqual(
+        before + 30_000 + 5_000
+      );
+
+      await agent.stopKeepAlive();
+
+      // After dispose, the alarm is recomputed to the real task, not cleared
+      // and not left at the heartbeat interval.
+      const alarm = await agent.getCurrentAlarm();
+      expect(alarm).not.toBeNull();
+      expect(alarm as number).toBeGreaterThan(before + 60_000);
+    });
+  });
 });
 
 async function getKeepAliveRefs(


### PR DESCRIPTION
## Summary

`keepAlive()` arms a `now + keepAliveIntervalMs` heartbeat alarm when `_keepAliveRefs` goes `0 -> 1`, but the dispose it returned **only decremented the ref count** — it never called `_scheduleNextAlarm()`. So a short-lived lease could permanently leave a stale 30s heartbeat armed, and any work that re-leases on each alarm wake turned that into a perpetual 30s heartbeat.

This is the framework-level root cause behind **#1703** (Think agents firing every 30s forever), which was previously patched narrowly in `@cloudflare/think` by guarding `_startWorkflowNotificationDrain()`.

Fixes #1704.

## The bug

```ts
// keepAlive() acquire — arms the heartbeat
this._keepAliveRefs++;
if (this._keepAliveRefs === 1) {
  await this._scheduleNextAlarm();
}

// dispose — decrements but never reschedules ❌
return () => {
  if (disposed) return;
  disposed = true;
  this._keepAliveRefs = Math.max(0, this._keepAliveRefs - 1);
};
```

The facet release path (`_cf_releaseFacetKeepAlive()`) already reschedules after decrementing — the local path was the odd one out.

## The fix

When the **last** lease is released (`_keepAliveRefs === 0`), recompute the alarm from persistent state so the heartbeat is cleared — or pulled back to the next legitimate schedule — when no other work needs it.

```ts
return () => {
  if (disposed) return;
  disposed = true;
  this._keepAliveRefs = Math.max(0, this._keepAliveRefs - 1);
  if (this._keepAliveRefs === 0) {
    this.ctx.waitUntil(
      this._scheduleNextAlarm().catch((e) => {
        console.error("[Agent] Failed to reschedule alarm after keepAlive dispose:", e);
      })
    );
  }
};
```

Design notes:

- **Synchronous dispose contract preserved.** `_scheduleNextAlarm()` is async (`setAlarm`/`deleteAlarm`); the dispose stays `() => void` by fire-and-forgetting via `ctx.waitUntil`, mirroring the facet path. No breaking change to `keepAliveWhile()` or any caller.
- **Only reschedules on `=== 0`**, symmetric with the `=== 1` acquire gate — avoids redundant alarm writes under concurrent leases.
- **Race-safe re-acquire.** `_scheduleNextAlarm()` reads `_keepAliveRefs` live, so a new `keepAlive()` that races the queued reschedule still wins (the reschedule sees `refs === 1` and keeps the alarm armed rather than clearing it).
- **Recompute, not blind delete.** With a pending schedule, the alarm falls back to that task instead of being cleared or stuck at the heartbeat interval.

## Relationship to #1703

The `@cloudflare/think` guard in `_startWorkflowNotificationDrain()` (skip the lease when there's nothing to drain) is now belt-and-suspenders rather than the sole defense — kept, because it still avoids spurious lease churn on every alarm wake.

## Tests

New `alarm rescheduling on dispose (#1704)` block in `packages/agents/src/tests/keep-alive.test.ts`, asserting the **physical** alarm (`ctx.storage.getAlarm()`):

- armed while a lease is held
- cleared when the final lease is disposed
- held across concurrent leases until the last release
- cleared after `keepAliveWhile()` completes
- preserved on immediate re-acquire (no clobber from the queued reschedule)
- falls back to a real pending schedule instead of the heartbeat

Test agent gains `getCurrentAlarm()`, `scheduleFarFutureTask()`, and a `noop` callback.

## Verification

- `keep-alive.test.ts`: 14/14 pass (8 existing + 6 new)
- `sub-agent` + `schedule` + `keep-alive` suites: 189 pass, no regressions
- `pnpm run check`: green (sherif, export checks, oxfmt, oxlint, typecheck across 102 projects)

## Changeset

`agents` — patch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->