### PR TITLE
feat(voice): add output device selection

### DIFF
--- a/.changeset/voice-output-device.md
+++ b/.changeset/voice-output-device.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/voice": minor
+---
+
+Add `outputDeviceId` and `setOutputDevice()` for routing assistant playback to a selected audio output device when the browser supports sink selection.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -317,6 +317,8 @@ Wraps `VoiceClient` for `withVoice` agents. Manages connection, mic capture, pla
 ```tsx
 import { useVoiceAgent } from "@cloudflare/voice/react";
 
+const selectedSpeakerId = "default";
+
 const {
   status, // "idle" | "listening" | "thinking" | "speaking"
   transcript, // TranscriptMessage[] — conversation history
@@ -326,6 +328,7 @@ const {
   isMuted, // boolean
   connected, // boolean — WebSocket connected
   error, // string | null
+  outputDeviceError, // string | null — non-fatal speaker routing issue
   startCall, // () => Promise<void>
   endCall, // () => void
   toggleMute, // () => void
@@ -336,11 +339,27 @@ const {
   agent: "MyAgent", // Required: Durable Object class name
   name: "default", // Instance name (default: "default")
   host: window.location.host, // Host to connect to
+  outputDeviceId: selectedSpeakerId, // Optional audiooutput device ID
   enabled: true // Set false to delay connecting until prerequisites are ready
 });
 ```
 
 Use `enabled: false` when the app must wait for async connection prerequisites, such as a user-scoped capability token. While disabled, the hook does not create or connect a `VoiceClient`, returns the idle/disconnected state, and action callbacks such as `startCall()`, `sendText()`, and `sendJSON()` are safe no-ops. When `enabled` changes to `true`, the hook connects with the current options. The first enable is treated as an initial connection, so `onReconnect` only fires for later connection identity changes while the hook remains enabled.
+
+#### Output Device Selection
+
+Pass `outputDeviceId` to route assistant playback to a selected speaker when the browser supports `HTMLMediaElement.setSinkId()`:
+
+```tsx
+const [outputDeviceId, setOutputDeviceId] = useState("default");
+
+const voice = useVoiceAgent({
+  agent: "MyAgent",
+  outputDeviceId
+});
+```
+
+Use a `MediaDeviceInfo.deviceId` from `navigator.mediaDevices.enumerateDevices()` where `kind === "audiooutput"`. `"default"` and `undefined` use the system default output. Browsers without sink selection support continue playing through the default output and set `outputDeviceError` when a non-default output is requested. Device labels may be blank until the user grants microphone permission, so refresh device lists after `startCall()` if you show a speaker picker.
 
 #### Tuning Options
 
@@ -412,6 +431,9 @@ client.addEventListener("error", (err) => {
 client.connect();
 await client.startCall();
 
+// Switch assistant playback without reconnecting the call.
+await client.setOutputDevice(selectedSpeakerId);
+
 // Later:
 client.endCall();
 client.disconnect();
@@ -429,6 +451,7 @@ client.disconnect();
 | `connectionchange`  | `boolean`              | WebSocket connected/disconnected      |
 | `mutechange`        | `boolean`              | Mute state changed                    |
 | `error`             | `string \| null`       | Error occurred                        |
+| `outputdeviceerror` | `string \| null`       | Non-fatal speaker routing issue       |
 | `custommessage`     | `unknown`              | Non-voice message from server         |
 
 ### Advanced Options
@@ -438,6 +461,7 @@ client.disconnect();
 | `transport`       | `VoiceTransport`   | Custom transport (default: WebSocket via PartySocket) |
 | `audioInput`      | `VoiceAudioInput`  | Custom mic capture (default: built-in AudioWorklet)   |
 | `preferredFormat` | `VoiceAudioFormat` | Hint for server audio format (advisory only)          |
+| `outputDeviceId`  | `string`           | Preferred `audiooutput` device for assistant playback |
 
 ## Providers
 

--- a/examples/voice-agent/README.md
+++ b/examples/voice-agent/README.md
@@ -40,13 +40,14 @@ Browser                          Durable Object (VoiceAgent)
 3. Flux detects speech start and turn completion server-side
 4. Agent runs the voice pipeline: STT → LLM (with tools) → streaming TTS
 5. TTS audio streams back per-sentence as MP3 while the LLM is still generating
-6. Browser decodes and plays audio; user can interrupt at any time
+6. Browser decodes and plays audio through the selected speaker when supported; user can interrupt at any time
 
 ## Features
 
 - **Streaming TTS** — LLM output is split into sentences and synthesized concurrently, so the user hears the first sentence while the rest is still being generated.
 - **Interruption handling** — speak over the agent to cut it off mid-sentence. Flux speech-start events abort the server pipeline and stop queued browser playback; client audio-level detection remains as a fallback.
 - **Server-side turn detection** — Flux handles speech boundaries, so the example does not need client-side end-of-speech signaling to run the voice pipeline.
+- **Speaker selection** — choose an audio output device for assistant playback. Unsupported browsers keep using the system default output.
 - **Conversation persistence** — all messages are stored in SQLite and survive restarts. The agent remembers previous conversations.
 - **Agent tools** — the LLM can call `get_current_time`, `set_reminder`, and `get_weather` during conversation.
 - **Proactive scheduling** — reminders set via voice fire on schedule and are spoken to connected clients (or saved to history if disconnected).

--- a/examples/voice-agent/src/client.tsx
+++ b/examples/voice-agent/src/client.tsx
@@ -393,6 +393,7 @@ function App() {
     isMuted,
     connected,
     error,
+    outputDeviceError,
     startCall,
     endCall,
     toggleMute,
@@ -473,6 +474,11 @@ function App() {
   useEffect(() => {
     transcriptEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [transcript, interimTranscript]);
+
+  const handleStartCall = useCallback(async () => {
+    await startCall();
+    await refreshAudioOutputs().catch(() => {});
+  }, [refreshAudioOutputs, startCall]);
 
   // Detect speaker conflict from error messages
   useEffect(() => {
@@ -839,23 +845,31 @@ function App() {
 
         {/* Controls */}
         <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-          <select
-            value={outputDeviceId}
-            onChange={(event) => setOutputDeviceId(event.target.value)}
-            className="min-w-0 rounded-lg border border-kumo-line bg-kumo-base px-3 py-2 text-sm text-kumo-default"
-          >
-            <option value="default">System default</option>
-            {audioOutputDevices
-              .filter((device) => device.deviceId !== "default")
-              .map((device, index) => (
-                <option key={device.deviceId} value={device.deviceId}>
-                  {getAudioOutputLabel(device, index)}
-                </option>
-              ))}
-          </select>
+          <div className="flex flex-col items-center gap-1">
+            <select
+              aria-label="Audio output"
+              value={outputDeviceId}
+              onChange={(event) => setOutputDeviceId(event.target.value)}
+              className="min-w-0 rounded-lg border border-kumo-line bg-kumo-base px-3 py-2 text-sm text-kumo-default"
+            >
+              <option value="default">System default</option>
+              {audioOutputDevices
+                .filter((device) => device.deviceId !== "default")
+                .map((device, index) => (
+                  <option key={device.deviceId} value={device.deviceId}>
+                    {getAudioOutputLabel(device, index)}
+                  </option>
+                ))}
+            </select>
+            {outputDeviceError && (
+              <span className="max-w-48 text-center text-xs text-kumo-warning">
+                {outputDeviceError}
+              </span>
+            )}
+          </div>
           {!isInCall ? (
             <Button
-              onClick={startCall}
+              onClick={handleStartCall}
               className="px-8 justify-center"
               variant="primary"
               disabled={!connected || speakerConflict}

--- a/examples/voice-agent/src/client.tsx
+++ b/examples/voice-agent/src/client.tsx
@@ -382,6 +382,7 @@ function App() {
   );
   const [sttModel, setSttModel] = useState<"flux" | "nova-3">("flux");
   const [llmModel, setLlmModel] = useState<LlmModel>("glm");
+  const [outputDeviceId, setOutputDeviceId] = useState("default");
 
   const {
     status,
@@ -400,6 +401,7 @@ function App() {
     agent: "my-voice-agent",
     name: sessionId,
     query: { model: sttModel, llm: llmModel },
+    outputDeviceId,
     onReconnect: () => {
       setToast("Reconnected to agent.");
     }
@@ -413,7 +415,6 @@ function App() {
   const [audioOutputDevices, setAudioOutputDevices] = useState<
     MediaDeviceInfo[]
   >([]);
-  const [outputDeviceId, setOutputDeviceId] = useState("default");
 
   // Listen for custom protocol messages (speaker_conflict, kicked, speaker_available)
   // by observing the VoiceClient's raw message events. Since useVoiceAgent abstracts
@@ -693,35 +694,6 @@ function App() {
           </Button>
         </div>
 
-        {/* Audio output picker */}
-        <Surface className="mb-4 rounded-xl p-3 ring ring-kumo-line">
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-xs text-kumo-secondary">Speaker</span>
-              <span className="text-[10px] text-kumo-secondary">
-                Selected output is not wired to SDK playback yet
-              </span>
-            </div>
-            <select
-              value={outputDeviceId}
-              onChange={(event) => setOutputDeviceId(event.target.value)}
-              className="min-w-0 flex-1 rounded-lg border border-kumo-line bg-kumo-base px-3 py-2 text-sm text-kumo-default"
-            >
-              <option value="default">System default</option>
-              {audioOutputDevices
-                .filter((device) => device.deviceId !== "default")
-                .map((device, index) => (
-                  <option key={device.deviceId} value={device.deviceId}>
-                    {getAudioOutputLabel(device, index)}
-                  </option>
-                ))}
-            </select>
-            <span className="text-[11px] text-kumo-secondary">
-              Call audio still uses the SDK default output.
-            </span>
-          </div>
-        </Surface>
-
         {/* Toast notification */}
         {toast && (
           <div className="mb-4 px-4 py-2.5 rounded-lg bg-blue-500/10 border border-blue-500/20 text-sm text-blue-600 dark:text-blue-400">
@@ -866,7 +838,21 @@ function App() {
         </Surface>
 
         {/* Controls */}
-        <div className="flex items-center justify-center gap-4">
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <select
+            value={outputDeviceId}
+            onChange={(event) => setOutputDeviceId(event.target.value)}
+            className="min-w-0 rounded-lg border border-kumo-line bg-kumo-base px-3 py-2 text-sm text-kumo-default"
+          >
+            <option value="default">System default</option>
+            {audioOutputDevices
+              .filter((device) => device.deviceId !== "default")
+              .map((device, index) => (
+                <option key={device.deviceId} value={device.deviceId}>
+                  {getAudioOutputLabel(device, index)}
+                </option>
+              ))}
+          </select>
           {!isInCall ? (
             <Button
               onClick={startCall}

--- a/examples/voice-agent/src/client.tsx
+++ b/examples/voice-agent/src/client.tsx
@@ -110,6 +110,12 @@ function ModeToggle() {
 
 type LlmModel = "kimi" | "glm" | "gpt-oss-20b";
 
+function getAudioOutputLabel(device: MediaDeviceInfo, index: number) {
+  if (device.deviceId === "default") return "System default";
+  if (device.deviceId === "communications") return "Communications default";
+  return device.label || `Speaker ${index + 1}`;
+}
+
 function WebRTCApp({
   llmModel,
   onLlmModelChange
@@ -404,6 +410,10 @@ function App() {
   const [speakerConflict, setSpeakerConflict] = useState(false);
   const [kicked, setKicked] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const [audioOutputDevices, setAudioOutputDevices] = useState<
+    MediaDeviceInfo[]
+  >([]);
+  const [outputDeviceId, setOutputDeviceId] = useState("default");
 
   // Listen for custom protocol messages (speaker_conflict, kicked, speaker_available)
   // by observing the VoiceClient's raw message events. Since useVoiceAgent abstracts
@@ -431,6 +441,32 @@ function App() {
       return () => clearTimeout(timer);
     }
   }, [toast]);
+
+  const refreshAudioOutputs = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) return;
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    setAudioOutputDevices(
+      devices.filter((device) => device.kind === "audiooutput")
+    );
+  }, []);
+
+  useEffect(() => {
+    refreshAudioOutputs().catch(() => {
+      setToast("Could not list speakers for this browser.");
+    });
+
+    navigator.mediaDevices?.addEventListener(
+      "devicechange",
+      refreshAudioOutputs
+    );
+    return () => {
+      navigator.mediaDevices?.removeEventListener(
+        "devicechange",
+        refreshAudioOutputs
+      );
+    };
+  }, [refreshAudioOutputs]);
 
   // Auto-scroll transcript
   useEffect(() => {
@@ -656,6 +692,35 @@ function App() {
             Kimi
           </Button>
         </div>
+
+        {/* Audio output picker */}
+        <Surface className="mb-4 rounded-xl p-3 ring ring-kumo-line">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs text-kumo-secondary">Speaker</span>
+              <span className="text-[10px] text-kumo-secondary">
+                Selected output is not wired to SDK playback yet
+              </span>
+            </div>
+            <select
+              value={outputDeviceId}
+              onChange={(event) => setOutputDeviceId(event.target.value)}
+              className="min-w-0 flex-1 rounded-lg border border-kumo-line bg-kumo-base px-3 py-2 text-sm text-kumo-default"
+            >
+              <option value="default">System default</option>
+              {audioOutputDevices
+                .filter((device) => device.deviceId !== "default")
+                .map((device, index) => (
+                  <option key={device.deviceId} value={device.deviceId}>
+                    {getAudioOutputLabel(device, index)}
+                  </option>
+                ))}
+            </select>
+            <span className="text-[11px] text-kumo-secondary">
+              Call audio still uses the SDK default output.
+            </span>
+          </div>
+        </Surface>
 
         {/* Toast notification */}
         {toast && (

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -119,6 +119,7 @@ export class DictationAgent extends InputAgent<Env> {
 import { useVoiceAgent } from "@cloudflare/voice/react";
 
 function App() {
+  const selectedSpeakerId = "default";
   const {
     status, // "idle" | "listening" | "thinking" | "speaking"
     transcript, // TranscriptMessage[]
@@ -128,6 +129,7 @@ function App() {
     isMuted, // boolean
     connected, // boolean
     error, // string | null
+    outputDeviceError, // string | null
     startCall, // () => Promise<void>
     endCall, // () => void
     toggleMute, // () => void
@@ -135,6 +137,8 @@ function App() {
     sendJSON // (data: Record<string, unknown>) => void
   } = useVoiceAgent({
     agent: "my-agent",
+    // Route assistant playback to a selected audiooutput device when supported.
+    outputDeviceId: selectedSpeakerId,
     // Set false to delay connecting until async prerequisites are ready.
     enabled: true
   });
@@ -144,6 +148,8 @@ function App() {
 ```
 
 When `enabled` is `false`, the hook does not create or connect a `VoiceClient`, returns the idle/disconnected state, and action callbacks such as `startCall()`, `sendText()`, and `sendJSON()` are safe no-ops. The first change from disabled to enabled connects with the current options without firing `onReconnect`; later connection identity changes while enabled do fire `onReconnect`.
+
+`outputDeviceId` accepts a `MediaDeviceInfo.deviceId` from an `audiooutput` device. Browsers without `HTMLMediaElement.setSinkId()` support continue playing through the default output and set `outputDeviceError` for non-default devices. Use `"default"` or `undefined` to return to the system default output. Device labels may be blank until the user grants microphone permission.
 
 For voice input only:
 
@@ -160,10 +166,14 @@ const { transcript, interimTranscript, isListening, start, stop, clear } =
 import { VoiceClient } from "@cloudflare/voice/client";
 
 const client = new VoiceClient({ agent: "my-agent" });
+const selectedSpeakerId = "default";
 
 client.addEventListener("statuschange", () => console.log(client.status));
 client.connect();
 await client.startCall();
+
+// Switch assistant playback without reconnecting the call.
+await client.setOutputDevice(selectedSpeakerId);
 ```
 
 ## Workers AI providers (built-in)

--- a/packages/voice/src/react-tests/useVoiceAgent.test.tsx
+++ b/packages/voice/src/react-tests/useVoiceAgent.test.tsx
@@ -120,10 +120,28 @@ function createMockAudioContext() {
 }
 
 let mockAudioCtx: ReturnType<typeof createMockAudioContext>;
+let mockAudioElement: {
+  autoplay: boolean;
+  srcObject: MediaStream | null;
+  play: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  setSinkId: ReturnType<typeof vi.fn>;
+  rejectSinkId: boolean;
+};
 const mockTrackStop = vi.fn();
 
 function setupAudioMocks() {
   mockAudioCtx = createMockAudioContext();
+  mockAudioElement = {
+    autoplay: false,
+    srcObject: null,
+    play: vi.fn(async () => {}),
+    pause: vi.fn(),
+    setSinkId: vi.fn(async function (this: { rejectSinkId: boolean }) {
+      if (this.rejectSinkId) throw new Error("setSinkId rejected");
+    }),
+    rejectSinkId: false
+  };
   workletPortOnMessage = null;
 
   vi.stubGlobal(
@@ -143,13 +161,7 @@ function setupAudioMocks() {
   vi.stubGlobal(
     "Audio",
     vi.fn(function () {
-      return {
-        autoplay: false,
-        srcObject: null,
-        play: vi.fn(async () => {}),
-        pause: vi.fn(),
-        setSinkId: vi.fn(async () => {})
-      };
+      return mockAudioElement;
     })
   );
 
@@ -193,6 +205,7 @@ function TestVoiceComponent({
     result.status,
     result.connected,
     result.error,
+    result.outputDeviceError,
     result.isMuted,
     result.transcript,
     result.metrics,
@@ -206,6 +219,9 @@ function TestVoiceComponent({
       <span data-testid="status">{result.status}</span>
       <span data-testid="connected">{String(result.connected)}</span>
       <span data-testid="error">{result.error ?? ""}</span>
+      <span data-testid="output-device-error">
+        {result.outputDeviceError ?? ""}
+      </span>
       <span data-testid="muted">{String(result.isMuted)}</span>
       <span data-testid="transcript-count">{result.transcript.length}</span>
     </div>
@@ -478,6 +494,34 @@ describe("useVoiceAgent", () => {
       expect(vi.mocked(PartySocket)).toHaveBeenCalledTimes(1);
       expect(setOutputDevice).toHaveBeenCalledWith("speaker-1");
       expect(setOutputDevice).toHaveBeenCalledWith("speaker-2");
+    });
+
+    it("should expose output device failures separately from global errors", async () => {
+      mockAudioElement.rejectSinkId = true;
+      const { container, getResult } = await renderHook({
+        outputDeviceId: "missing-speaker"
+      });
+
+      await act(async () => {
+        fireJSON({ type: "error", message: "Voice pipeline failed" });
+        fireJSON({ type: "audio_config", format: "mp3" });
+        fireMessage(new ArrayBuffer(4));
+        await sleep(10);
+      });
+
+      await vi.waitFor(() => {
+        expect(getResult().error).toBe("Voice pipeline failed");
+        expect(getResult().outputDeviceError).toBe(
+          "Could not switch audio output device."
+        );
+        expect(
+          container.querySelector('[data-testid="error"]')?.textContent
+        ).toBe("Voice pipeline failed");
+        expect(
+          container.querySelector('[data-testid="output-device-error"]')
+            ?.textContent
+        ).toBe("Could not switch audio output device.");
+      });
     });
 
     it("should disconnect and reset state when enabled flips true to false", async () => {

--- a/packages/voice/src/react-tests/useVoiceAgent.test.tsx
+++ b/packages/voice/src/react-tests/useVoiceAgent.test.tsx
@@ -66,6 +66,7 @@ import {
   type UseVoiceAgentReturn,
   type UseVoiceAgentOptions
 } from "../voice-react";
+import { VoiceClient } from "../voice-client";
 
 // --- Audio API mocks ---
 
@@ -100,6 +101,7 @@ function createMockAudioContext() {
     resume: vi.fn(async () => {}),
     close: vi.fn(async () => {}),
     destination: {},
+    createMediaStreamDestination: vi.fn(() => ({ stream: {} })),
     audioWorklet: {
       addModule: vi.fn(async () => {})
     },
@@ -135,6 +137,19 @@ function setupAudioMocks() {
     "AudioWorkletNode",
     vi.fn(function () {
       return mockAudioCtx._mockWorkletNode;
+    })
+  );
+
+  vi.stubGlobal(
+    "Audio",
+    vi.fn(function () {
+      return {
+        autoplay: false,
+        srcObject: null,
+        play: vi.fn(async () => {}),
+        pause: vi.fn(),
+        setSinkId: vi.fn(async () => {})
+      };
     })
   );
 
@@ -434,6 +449,35 @@ describe("useVoiceAgent", () => {
       expect(vi.mocked(PartySocket)).toHaveBeenCalledTimes(2);
       expect(socketOptions?.room).toBe("second");
       expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("should update output device without reconnecting", async () => {
+      const setOutputDevice = vi.spyOn(
+        VoiceClient.prototype,
+        "setOutputDevice"
+      );
+      const screen = await render(
+        <TestVoiceComponent
+          options={{ agent: "voice-agent", outputDeviceId: "speaker-1" }}
+          onResult={vi.fn()}
+        />
+      );
+      await sleep(10);
+
+      await act(async () => {
+        screen.rerender(
+          <TestVoiceComponent
+            options={{ agent: "voice-agent", outputDeviceId: "speaker-2" }}
+            onResult={vi.fn()}
+          />
+        );
+        await sleep(10);
+      });
+
+      expect(socketClose).not.toHaveBeenCalled();
+      expect(vi.mocked(PartySocket)).toHaveBeenCalledTimes(1);
+      expect(setOutputDevice).toHaveBeenCalledWith("speaker-1");
+      expect(setOutputDevice).toHaveBeenCalledWith("speaker-2");
     });
 
     it("should disconnect and reset state when enabled flips true to false", async () => {

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -273,6 +273,29 @@ describe("VoiceClient playback interrupt", () => {
     expect(errors).toContain("Could not switch audio output device.");
   });
 
+  it("clears output device errors after a later successful switch", async () => {
+    const transport = new MockTransport();
+    const errors: Array<string | null> = [];
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      outputDeviceId: "missing-speaker"
+    });
+    audioElement.rejectSinkId = true;
+    client.addEventListener("error", (error) => errors.push(error));
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await waitForConnectedSource();
+
+    audioElement.rejectSinkId = false;
+    await client.setOutputDevice("speaker-1");
+
+    expect(errors).toContain("Could not switch audio output device.");
+    expect(errors.at(-1)).toBeNull();
+  });
+
   it("falls back to the default AudioContext destination when HTML audio playback is unavailable", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const transport = new MockTransport();

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -92,6 +92,8 @@ class FakeAudioElement {
   paused = false;
   playCount = 0;
   rejectPlay = false;
+  rejectSinkId = false;
+  sinkIds: string[] = [];
 
   async play(): Promise<void> {
     this.playCount++;
@@ -100,6 +102,11 @@ class FakeAudioElement {
 
   pause(): void {
     this.paused = true;
+  }
+
+  async setSinkId(sinkId: string): Promise<void> {
+    this.sinkIds.push(sinkId);
+    if (this.rejectSinkId) throw new Error("setSinkId rejected");
   }
 }
 
@@ -182,6 +189,7 @@ describe("VoiceClient playback interrupt", () => {
       audioContext.mediaStreamDestination.stream
     );
     expect(audioElement.playCount).toBe(1);
+    expect(audioElement.sinkIds).toEqual(["default"]);
 
     transport.receive(JSON.stringify({ type: "playback_interrupt" }));
     expect(() =>
@@ -204,6 +212,65 @@ describe("VoiceClient playback interrupt", () => {
 
     expect(audioElement.paused).toBe(true);
     expect(audioElement.srcObject).toBeNull();
+  });
+
+  it("applies the configured output device to assistant playback", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      outputDeviceId: "speaker-1"
+    });
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+
+    await waitForConnectedSource();
+
+    expect(audioElement.sinkIds).toEqual(["speaker-1"]);
+  });
+
+  it("updates the output device without reconnecting playback", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      outputDeviceId: "speaker-1"
+    });
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await waitForConnectedSource();
+
+    await client.setOutputDevice("speaker-2");
+    await client.setOutputDevice();
+
+    expect(audioElement.sinkIds).toEqual(["speaker-1", "speaker-2", "default"]);
+  });
+
+  it("reports output device failures without stopping playback", async () => {
+    const transport = new MockTransport();
+    const errors: Array<string | null> = [];
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      outputDeviceId: "missing-speaker"
+    });
+    audioElement.rejectSinkId = true;
+    client.addEventListener("error", (error) => errors.push(error));
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+
+    const source = await waitForConnectedSource();
+
+    expect(source.connectedTo).toBe(audioContext.mediaStreamDestination);
+    expect(audioElement.playCount).toBe(1);
+    expect(audioElement.sinkIds).toEqual(["missing-speaker"]);
+    expect(errors).toContain("Could not switch audio output device.");
   });
 
   it("falls back to the default AudioContext destination when HTML audio playback is unavailable", async () => {

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -63,6 +63,7 @@ class FakeAudioContext {
   pendingDecode: (() => void) | null = null;
   destination = {};
   mediaStreamDestination = { stream: {} };
+  mediaStreamDestinationCount = 0;
 
   async resume(): Promise<void> {}
 
@@ -81,6 +82,7 @@ class FakeAudioContext {
   }
 
   createMediaStreamDestination(): MediaStreamAudioDestinationNode {
+    this.mediaStreamDestinationCount++;
     return this
       .mediaStreamDestination as unknown as MediaStreamAudioDestinationNode;
   }
@@ -92,11 +94,25 @@ class FakeAudioElement {
   paused = false;
   playCount = 0;
   rejectPlay = false;
+  deferPlay = false;
+  pendingPlayResolve: (() => void) | null = null;
   rejectSinkId = false;
   sinkIds: string[] = [];
+  currentSinkId: string | null = null;
+  deferredSinkIds = new Set<string>();
+  pendingSinkIdResolves = new Map<string, () => void>();
 
   async play(): Promise<void> {
     this.playCount++;
+    if (this.deferPlay) {
+      await new Promise<void>((resolve) => {
+        this.pendingPlayResolve = () => {
+          this.deferPlay = false;
+          this.pendingPlayResolve = null;
+          resolve();
+        };
+      });
+    }
     if (this.rejectPlay) throw new Error("play rejected");
   }
 
@@ -106,7 +122,25 @@ class FakeAudioElement {
 
   async setSinkId(sinkId: string): Promise<void> {
     this.sinkIds.push(sinkId);
+    if (this.deferredSinkIds.has(sinkId)) {
+      await new Promise<void>((resolve) => {
+        this.pendingSinkIdResolves.set(sinkId, () => {
+          this.deferredSinkIds.delete(sinkId);
+          this.pendingSinkIdResolves.delete(sinkId);
+          resolve();
+        });
+      });
+    }
     if (this.rejectSinkId) throw new Error("setSinkId rejected");
+    this.currentSinkId = sinkId;
+  }
+
+  resolveSinkId(sinkId: string): void {
+    this.pendingSinkIdResolves.get(sinkId)?.();
+  }
+
+  resolvePlay(): void {
+    this.pendingPlayResolve?.();
   }
 }
 
@@ -136,6 +170,14 @@ async function waitForConnectedSource(): Promise<FakeAudioBufferSourceNode> {
     await Promise.resolve();
   }
   throw new Error("expected audio source to be connected");
+}
+
+async function waitForPlayCount(count: number): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    if (audioElement.playCount >= count) return;
+    await Promise.resolve();
+  }
+  throw new Error(`expected audio play count to reach ${count}`);
 }
 
 describe("VoiceClient playback interrupt", () => {
@@ -252,14 +294,16 @@ describe("VoiceClient playback interrupt", () => {
 
   it("reports output device failures without stopping playback", async () => {
     const transport = new MockTransport();
-    const errors: Array<string | null> = [];
+    const outputDeviceErrors: Array<string | null> = [];
     const client = new VoiceClient({
       agent: "test-agent",
       transport,
       outputDeviceId: "missing-speaker"
     });
     audioElement.rejectSinkId = true;
-    client.addEventListener("error", (error) => errors.push(error));
+    client.addEventListener("outputdeviceerror", (error) =>
+      outputDeviceErrors.push(error)
+    );
 
     client.connect();
     transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
@@ -270,19 +314,27 @@ describe("VoiceClient playback interrupt", () => {
     expect(source.connectedTo).toBe(audioContext.mediaStreamDestination);
     expect(audioElement.playCount).toBe(1);
     expect(audioElement.sinkIds).toEqual(["missing-speaker"]);
-    expect(errors).toContain("Could not switch audio output device.");
+    expect(outputDeviceErrors).toContain(
+      "Could not switch audio output device."
+    );
+    expect(client.error).toBeNull();
+    expect(client.outputDeviceError).toBe(
+      "Could not switch audio output device."
+    );
   });
 
   it("clears output device errors after a later successful switch", async () => {
     const transport = new MockTransport();
-    const errors: Array<string | null> = [];
+    const outputDeviceErrors: Array<string | null> = [];
     const client = new VoiceClient({
       agent: "test-agent",
       transport,
       outputDeviceId: "missing-speaker"
     });
     audioElement.rejectSinkId = true;
-    client.addEventListener("error", (error) => errors.push(error));
+    client.addEventListener("outputdeviceerror", (error) =>
+      outputDeviceErrors.push(error)
+    );
 
     client.connect();
     transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
@@ -292,8 +344,109 @@ describe("VoiceClient playback interrupt", () => {
     audioElement.rejectSinkId = false;
     await client.setOutputDevice("speaker-1");
 
-    expect(errors).toContain("Could not switch audio output device.");
-    expect(errors.at(-1)).toBeNull();
+    expect(outputDeviceErrors).toContain(
+      "Could not switch audio output device."
+    );
+    expect(outputDeviceErrors.at(-1)).toBeNull();
+    expect(client.outputDeviceError).toBeNull();
+  });
+
+  it("clears unsupported output device errors when switching back to default", async () => {
+    const transport = new MockTransport();
+    const outputDeviceErrors: Array<string | null> = [];
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      outputDeviceId: "speaker-1"
+    });
+    (
+      audioElement as { setSinkId?: (sinkId: string) => Promise<void> }
+    ).setSinkId = undefined;
+    client.addEventListener("outputdeviceerror", (error) =>
+      outputDeviceErrors.push(error)
+    );
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await waitForConnectedSource();
+
+    await client.setOutputDevice();
+
+    expect(outputDeviceErrors).toContain(
+      "Audio output device selection is not supported in this browser."
+    );
+    expect(outputDeviceErrors.at(-1)).toBeNull();
+    expect(client.outputDeviceError).toBeNull();
+  });
+
+  it("does not overwrite global errors when output device switching fails", async () => {
+    const transport = new MockTransport();
+    const globalErrors: Array<string | null> = [];
+    const outputDeviceErrors: Array<string | null> = [];
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      outputDeviceId: "missing-speaker"
+    });
+    audioElement.rejectSinkId = true;
+    client.addEventListener("error", (error) => globalErrors.push(error));
+    client.addEventListener("outputdeviceerror", (error) =>
+      outputDeviceErrors.push(error)
+    );
+
+    client.connect();
+    transport.receive(
+      JSON.stringify({ type: "error", message: "Voice pipeline failed" })
+    );
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+
+    await waitForConnectedSource();
+
+    expect(globalErrors).toContain("Voice pipeline failed");
+    expect(globalErrors).not.toContain("Could not switch audio output device.");
+    expect(client.error).toBe("Voice pipeline failed");
+    expect(outputDeviceErrors).toContain(
+      "Could not switch audio output device."
+    );
+  });
+
+  it("keeps the latest output device when sink switches resolve out of order", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      outputDeviceId: "default"
+    });
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await waitForConnectedSource();
+
+    audioElement.deferredSinkIds.add("speaker-1");
+    audioElement.deferredSinkIds.add("speaker-2");
+
+    const firstSwitch = client.setOutputDevice("speaker-1");
+    await Promise.resolve();
+    const secondSwitch = client.setOutputDevice("speaker-2");
+    await Promise.resolve();
+
+    audioElement.resolveSinkId("speaker-2");
+    await secondSwitch;
+    expect(audioElement.currentSinkId).toBe("speaker-2");
+
+    audioElement.resolveSinkId("speaker-1");
+    await firstSwitch;
+
+    expect(audioElement.currentSinkId).toBe("speaker-2");
+    expect(audioElement.sinkIds).toEqual([
+      "default",
+      "speaker-1",
+      "speaker-2",
+      "speaker-2"
+    ]);
   });
 
   it("falls back to the default AudioContext destination when HTML audio playback is unavailable", async () => {
@@ -317,6 +470,60 @@ describe("VoiceClient playback interrupt", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it("shares playback output setup when audio arrives while call start is prewarming playback", async () => {
+    const transport = new MockTransport();
+    const audioInput = new FakeAudioInput();
+    const client = new VoiceClient({
+      agent: "test-agent",
+      transport,
+      audioInput
+    });
+    audioElement.deferPlay = true;
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+
+    const startCall = client.startCall();
+    await Promise.resolve();
+    transport.receive(new ArrayBuffer(4));
+    await waitForPlayCount(1);
+
+    expect(audioContext.mediaStreamDestinationCount).toBe(1);
+    expect(audioElement.playCount).toBe(1);
+
+    audioElement.resolvePlay();
+    await startCall;
+    const source = await waitForConnectedSource();
+
+    expect(source.connectedTo).toBe(audioContext.mediaStreamDestination);
+    expect(audioContext.mediaStreamDestinationCount).toBe(1);
+  });
+
+  it("does not orphan playback output if call ends while HTML audio is starting", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+    audioElement.deferPlay = true;
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+    await waitForPlayCount(1);
+
+    expect(audioElement.playCount).toBe(1);
+
+    client.endCall();
+    expect(audioElement.paused).toBe(true);
+    expect(audioElement.srcObject).toBeNull();
+
+    audioElement.resolvePlay();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(audioContext.source).toBeNull();
+    expect(audioElement.paused).toBe(true);
+    expect(audioElement.srcObject).toBeNull();
   });
 
   it("does not start playback if interrupted while audio is decoding", async () => {

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceClient } from "../voice-client";
 import type { VoiceAudioInput, VoiceTransport } from "../types";
 
@@ -39,8 +39,11 @@ class FakeAudioBufferSourceNode {
   onended: (() => void) | null = null;
   stopped = false;
   started = false;
+  connectedTo: unknown = null;
 
-  connect(): void {}
+  connect(destination: unknown): void {
+    this.connectedTo = destination;
+  }
 
   start(): void {
     this.started = true;
@@ -59,6 +62,7 @@ class FakeAudioContext {
   deferDecode = false;
   pendingDecode: (() => void) | null = null;
   destination = {};
+  mediaStreamDestination = { stream: {} };
 
   async resume(): Promise<void> {}
 
@@ -74,6 +78,28 @@ class FakeAudioContext {
   createBufferSource(): AudioBufferSourceNode {
     this.source = new FakeAudioBufferSourceNode();
     return this.source as unknown as AudioBufferSourceNode;
+  }
+
+  createMediaStreamDestination(): MediaStreamAudioDestinationNode {
+    return this
+      .mediaStreamDestination as unknown as MediaStreamAudioDestinationNode;
+  }
+}
+
+class FakeAudioElement {
+  autoplay = false;
+  srcObject: MediaStream | null = null;
+  paused = false;
+  playCount = 0;
+  rejectPlay = false;
+
+  async play(): Promise<void> {
+    this.playCount++;
+    if (this.rejectPlay) throw new Error("play rejected");
+  }
+
+  pause(): void {
+    this.paused = true;
   }
 }
 
@@ -93,25 +119,37 @@ class FakeAudioInput implements VoiceAudioInput {
 }
 
 let originalAudioContext: typeof AudioContext | undefined;
+let originalAudio: typeof Audio | undefined;
 let audioContext: FakeAudioContext;
+let audioElement: FakeAudioElement;
 
-async function waitForSource(): Promise<FakeAudioBufferSourceNode> {
+async function waitForConnectedSource(): Promise<FakeAudioBufferSourceNode> {
   for (let i = 0; i < 10; i++) {
-    if (audioContext.source) return audioContext.source;
+    if (audioContext.source?.connectedTo) return audioContext.source;
     await Promise.resolve();
   }
-  throw new Error("expected audio source to be created");
+  throw new Error("expected audio source to be connected");
 }
 
 describe("VoiceClient playback interrupt", () => {
   beforeEach(() => {
     originalAudioContext = globalThis.AudioContext;
+    originalAudio = globalThis.Audio;
     audioContext = new FakeAudioContext();
+    audioElement = new FakeAudioElement();
     Object.defineProperty(globalThis, "AudioContext", {
       configurable: true,
       value: class {
         constructor() {
           return audioContext;
+        }
+      }
+    });
+    Object.defineProperty(globalThis, "Audio", {
+      configurable: true,
+      value: class {
+        constructor() {
+          return audioElement;
         }
       }
     });
@@ -121,6 +159,10 @@ describe("VoiceClient playback interrupt", () => {
     Object.defineProperty(globalThis, "AudioContext", {
       configurable: true,
       value: originalAudioContext
+    });
+    Object.defineProperty(globalThis, "Audio", {
+      configurable: true,
+      value: originalAudio
     });
   });
 
@@ -133,8 +175,13 @@ describe("VoiceClient playback interrupt", () => {
     transport.receive(new ArrayBuffer(4));
     transport.receive(new ArrayBuffer(4));
 
-    const source = await waitForSource();
+    const source = await waitForConnectedSource();
     expect(source.stopped).toBe(false);
+    expect(source.connectedTo).toBe(audioContext.mediaStreamDestination);
+    expect(audioElement.srcObject).toBe(
+      audioContext.mediaStreamDestination.stream
+    );
+    expect(audioElement.playCount).toBe(1);
 
     transport.receive(JSON.stringify({ type: "playback_interrupt" }));
     expect(() =>
@@ -142,6 +189,44 @@ describe("VoiceClient playback interrupt", () => {
     ).not.toThrow();
 
     expect(source.stopped).toBe(true);
+  });
+
+  it("releases the HTML audio playback output when the call ends", async () => {
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+
+    client.connect();
+    transport.receive(JSON.stringify({ type: "audio_config", format: "mp3" }));
+    transport.receive(new ArrayBuffer(4));
+
+    await waitForConnectedSource();
+    client.endCall();
+
+    expect(audioElement.paused).toBe(true);
+    expect(audioElement.srcObject).toBeNull();
+  });
+
+  it("falls back to the default AudioContext destination when HTML audio playback is unavailable", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+    audioElement.rejectPlay = true;
+
+    try {
+      client.connect();
+      transport.receive(
+        JSON.stringify({ type: "audio_config", format: "mp3" })
+      );
+      transport.receive(new ArrayBuffer(4));
+
+      const source = await waitForConnectedSource();
+
+      expect(source.connectedTo).toBe(audioContext.destination);
+      expect(audioElement.playCount).toBe(1);
+      expect(audioElement.srcObject).toBeNull();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("does not start playback if interrupted while audio is decoding", async () => {

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -81,7 +81,19 @@ export interface VoiceClientOptions {
   interruptChunks?: number;
   /** Maximum transcript messages to keep in memory. @default 200 */
   maxTranscriptMessages?: number;
+
+  /**
+   * Preferred audio output device for assistant playback.
+   * Pass a MediaDeviceInfo.deviceId from an audiooutput device.
+   * Unsupported browsers continue playing through the default output.
+   * @default "default"
+   */
+  outputDeviceId?: string;
 }
+
+type AudioElementWithSinkId = HTMLAudioElement & {
+  setSinkId?: (sinkId: string) => Promise<void>;
+};
 
 /** Maps each event name to the data type passed to its listeners. */
 export interface VoiceClientEventMap {
@@ -279,6 +291,7 @@ export class VoiceClient {
   #playbackElement: HTMLAudioElement | null = null;
   #playbackDestination: MediaStreamAudioDestinationNode | null = null;
   #useDefaultPlaybackDestination = false;
+  #outputDeviceId: string;
   #playbackGeneration = 0;
   #interruptChunkCount = 0;
 
@@ -292,6 +305,7 @@ export class VoiceClient {
     this.#interruptThreshold = options.interruptThreshold ?? 0.05;
     this.#interruptChunks = options.interruptChunks ?? 2;
     this.#maxTranscriptMessages = options.maxTranscriptMessages ?? 200;
+    this.#outputDeviceId = options.outputDeviceId ?? "default";
   }
 
   // --- Public getters ---
@@ -552,6 +566,17 @@ export class VoiceClient {
   }
 
   /**
+   * Set the preferred audio output device for assistant playback.
+   * Unsupported browsers continue playing through the default output.
+   */
+  async setOutputDevice(outputDeviceId?: string): Promise<void> {
+    this.#outputDeviceId = outputDeviceId ?? "default";
+    if (this.#playbackElement) {
+      await this.#applyOutputDevice(this.#playbackElement);
+    }
+  }
+
+  /**
    * The last custom (non-voice-protocol) message received from the server.
    * Listen for the `"custommessage"` event to be notified when this changes.
    */
@@ -718,6 +743,7 @@ export class VoiceClient {
       audio.srcObject = destination.stream;
       this.#playbackElement = audio;
       this.#playbackDestination = destination;
+      await this.#applyOutputDevice(audio);
       await audio.play();
       return destination;
     } catch (err) {
@@ -728,6 +754,25 @@ export class VoiceClient {
       this.#closePlaybackOutput();
       this.#useDefaultPlaybackDestination = true;
       return ctx.destination;
+    }
+  }
+
+  async #applyOutputDevice(audio: HTMLAudioElement): Promise<void> {
+    const sinkId = this.#outputDeviceId;
+    const setSinkId = (audio as AudioElementWithSinkId).setSinkId;
+    if (!setSinkId) {
+      if (sinkId === "default") return;
+      this.#error =
+        "Audio output device selection is not supported in this browser.";
+      this.#emit("error", this.#error);
+      return;
+    }
+
+    try {
+      await setSinkId.call(audio, sinkId);
+    } catch {
+      this.#error = "Could not switch audio output device.";
+      this.#emit("error", this.#error);
     }
   }
 

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -95,6 +95,10 @@ type AudioElementWithSinkId = HTMLAudioElement & {
   setSinkId?: (sinkId: string) => Promise<void>;
 };
 
+const UNSUPPORTED_OUTPUT_DEVICE_ERROR =
+  "Audio output device selection is not supported in this browser.";
+const OUTPUT_DEVICE_SWITCH_ERROR = "Could not switch audio output device.";
+
 /** Maps each event name to the data type passed to its listeners. */
 export interface VoiceClientEventMap {
   statuschange: VoiceStatus;
@@ -762,16 +766,22 @@ export class VoiceClient {
     const setSinkId = (audio as AudioElementWithSinkId).setSinkId;
     if (!setSinkId) {
       if (sinkId === "default") return;
-      this.#error =
-        "Audio output device selection is not supported in this browser.";
+      this.#error = UNSUPPORTED_OUTPUT_DEVICE_ERROR;
       this.#emit("error", this.#error);
       return;
     }
 
     try {
       await setSinkId.call(audio, sinkId);
+      if (
+        this.#error === UNSUPPORTED_OUTPUT_DEVICE_ERROR ||
+        this.#error === OUTPUT_DEVICE_SWITCH_ERROR
+      ) {
+        this.#error = null;
+        this.#emit("error", null);
+      }
     } catch {
-      this.#error = "Could not switch audio output device.";
+      this.#error = OUTPUT_DEVICE_SWITCH_ERROR;
       this.#emit("error", this.#error);
     }
   }

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -276,6 +276,9 @@ export class VoiceClient {
   #playbackQueue: ArrayBuffer[] = [];
   #isPlaying = false;
   #activeSource: AudioBufferSourceNode | null = null;
+  #playbackElement: HTMLAudioElement | null = null;
+  #playbackDestination: MediaStreamAudioDestinationNode | null = null;
+  #useDefaultPlaybackDestination = false;
   #playbackGeneration = 0;
   #interruptChunkCount = 0;
 
@@ -465,6 +468,8 @@ export class VoiceClient {
       startMsg.preferred_format = this.#options.preferredFormat;
     }
     this.#transport.sendJSON(startMsg);
+    const ctx = await this.#getAudioContext();
+    await this.#getPlaybackDestination(ctx);
     if (this.#options.audioInput) {
       this.#options.audioInput.onAudioLevel = (rms) =>
         this.#processAudioLevel(rms);
@@ -695,10 +700,45 @@ export class VoiceClient {
   /** Close the AudioContext and release resources. */
   #closeAudioContext(): void {
     if (this.#audioContext) {
+      this.#closePlaybackOutput();
       this.#audioContext.close().catch(() => {});
       this.#audioContext = null;
       this.#workletRegistered = false;
     }
+  }
+
+  async #getPlaybackDestination(ctx: AudioContext): Promise<AudioNode> {
+    if (this.#playbackDestination) return this.#playbackDestination;
+    if (this.#useDefaultPlaybackDestination) return ctx.destination;
+
+    try {
+      const destination = ctx.createMediaStreamDestination();
+      const audio = new Audio();
+      audio.autoplay = true;
+      audio.srcObject = destination.stream;
+      this.#playbackElement = audio;
+      this.#playbackDestination = destination;
+      await audio.play();
+      return destination;
+    } catch (err) {
+      console.warn(
+        "[VoiceClient] HTMLAudioElement playback output unavailable; using default AudioContext destination.",
+        err
+      );
+      this.#closePlaybackOutput();
+      this.#useDefaultPlaybackDestination = true;
+      return ctx.destination;
+    }
+  }
+
+  #closePlaybackOutput(): void {
+    if (this.#playbackElement) {
+      this.#playbackElement.pause();
+      this.#playbackElement.srcObject = null;
+      this.#playbackElement = null;
+    }
+    this.#playbackDestination = null;
+    this.#useDefaultPlaybackDestination = false;
   }
 
   // --- Audio playback ---
@@ -724,7 +764,8 @@ export class VoiceClient {
 
       const source = ctx.createBufferSource();
       source.buffer = audioBuffer;
-      source.connect(ctx.destination);
+      const destination = await this.#getPlaybackDestination(ctx);
+      source.connect(destination);
       if (generation !== this.#playbackGeneration) return;
       this.#activeSource = source;
 

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -108,6 +108,7 @@ export interface VoiceClientEventMap {
   audiolevelchange: number;
   connectionchange: boolean;
   error: string | null;
+  outputdeviceerror: string | null;
   mutechange: boolean;
   custommessage: unknown;
 }
@@ -265,6 +266,7 @@ export class VoiceClient {
   #isMuted = false;
   #connected = false;
   #error: string | null = null;
+  #outputDeviceError: string | null = null;
   #lastCustomMessage: unknown = null;
   #audioFormat: VoiceAudioFormat | null = null;
   #interimTranscript: string | null = null;
@@ -294,8 +296,11 @@ export class VoiceClient {
   #activeSource: AudioBufferSourceNode | null = null;
   #playbackElement: HTMLAudioElement | null = null;
   #playbackDestination: MediaStreamAudioDestinationNode | null = null;
+  #playbackDestinationPromise: Promise<AudioNode> | null = null;
   #useDefaultPlaybackDestination = false;
   #outputDeviceId: string;
+  #outputDeviceSwitchGeneration = 0;
+  #playbackOutputGeneration = 0;
   #playbackGeneration = 0;
   #interruptChunkCount = 0;
 
@@ -340,6 +345,10 @@ export class VoiceClient {
 
   get error(): string | null {
     return this.#error;
+  }
+
+  get outputDeviceError(): string | null {
+    return this.#outputDeviceError;
   }
 
   /**
@@ -396,6 +405,12 @@ export class VoiceClient {
     if (this.#transcript.length > this.#maxTranscriptMessages) {
       this.#transcript = this.#transcript.slice(-this.#maxTranscriptMessages);
     }
+  }
+
+  #setOutputDeviceError(error: string | null): void {
+    if (this.#outputDeviceError === error) return;
+    this.#outputDeviceError = error;
+    this.#emit("outputdeviceerror", error);
   }
 
   // --- Connection ---
@@ -575,8 +590,9 @@ export class VoiceClient {
    */
   async setOutputDevice(outputDeviceId?: string): Promise<void> {
     this.#outputDeviceId = outputDeviceId ?? "default";
+    const generation = ++this.#outputDeviceSwitchGeneration;
     if (this.#playbackElement) {
-      await this.#applyOutputDevice(this.#playbackElement);
+      await this.#applyOutputDevice(this.#playbackElement, generation);
     }
   }
 
@@ -737,9 +753,28 @@ export class VoiceClient {
   }
 
   async #getPlaybackDestination(ctx: AudioContext): Promise<AudioNode> {
+    if (this.#playbackDestinationPromise) {
+      return this.#playbackDestinationPromise;
+    }
     if (this.#playbackDestination) return this.#playbackDestination;
     if (this.#useDefaultPlaybackDestination) return ctx.destination;
 
+    const outputGeneration = this.#playbackOutputGeneration;
+    const promise = this.#initializePlaybackDestination(ctx, outputGeneration);
+    this.#playbackDestinationPromise = promise;
+    try {
+      return await promise;
+    } finally {
+      if (this.#playbackDestinationPromise === promise) {
+        this.#playbackDestinationPromise = null;
+      }
+    }
+  }
+
+  async #initializePlaybackDestination(
+    ctx: AudioContext,
+    outputGeneration: number
+  ): Promise<AudioNode> {
     try {
       const destination = ctx.createMediaStreamDestination();
       const audio = new Audio();
@@ -747,8 +782,16 @@ export class VoiceClient {
       audio.srcObject = destination.stream;
       this.#playbackElement = audio;
       this.#playbackDestination = destination;
-      await this.#applyOutputDevice(audio);
+      await this.#applyOutputDevice(audio, this.#outputDeviceSwitchGeneration);
+      if (!this.#isCurrentPlaybackOutput(audio, outputGeneration)) {
+        this.#releasePlaybackElement(audio);
+        return ctx.destination;
+      }
       await audio.play();
+      if (!this.#isCurrentPlaybackOutput(audio, outputGeneration)) {
+        this.#releasePlaybackElement(audio);
+        return ctx.destination;
+      }
       return destination;
     } catch (err) {
       console.warn(
@@ -761,39 +804,82 @@ export class VoiceClient {
     }
   }
 
-  async #applyOutputDevice(audio: HTMLAudioElement): Promise<void> {
+  #isCurrentPlaybackOutput(
+    audio: HTMLAudioElement,
+    outputGeneration: number
+  ): boolean {
+    return (
+      this.#playbackElement === audio &&
+      this.#playbackOutputGeneration === outputGeneration
+    );
+  }
+
+  async #applyOutputDevice(
+    audio: HTMLAudioElement,
+    generation: number
+  ): Promise<void> {
     const sinkId = this.#outputDeviceId;
     const setSinkId = (audio as AudioElementWithSinkId).setSinkId;
     if (!setSinkId) {
-      if (sinkId === "default") return;
-      this.#error = UNSUPPORTED_OUTPUT_DEVICE_ERROR;
-      this.#emit("error", this.#error);
+      if (sinkId === "default") {
+        this.#setOutputDeviceError(null);
+        return;
+      }
+      this.#setOutputDeviceError(UNSUPPORTED_OUTPUT_DEVICE_ERROR);
       return;
     }
 
     try {
       await setSinkId.call(audio, sinkId);
       if (
-        this.#error === UNSUPPORTED_OUTPUT_DEVICE_ERROR ||
-        this.#error === OUTPUT_DEVICE_SWITCH_ERROR
+        generation !== this.#outputDeviceSwitchGeneration ||
+        sinkId !== this.#outputDeviceId
       ) {
-        this.#error = null;
-        this.#emit("error", null);
+        if (this.#playbackElement === audio) {
+          await this.#applyOutputDevice(
+            audio,
+            this.#outputDeviceSwitchGeneration
+          );
+        }
+        return;
+      }
+      if (
+        this.#outputDeviceError === UNSUPPORTED_OUTPUT_DEVICE_ERROR ||
+        this.#outputDeviceError === OUTPUT_DEVICE_SWITCH_ERROR
+      ) {
+        this.#setOutputDeviceError(null);
       }
     } catch {
-      this.#error = OUTPUT_DEVICE_SWITCH_ERROR;
-      this.#emit("error", this.#error);
+      if (
+        generation !== this.#outputDeviceSwitchGeneration ||
+        sinkId !== this.#outputDeviceId
+      ) {
+        if (this.#playbackElement === audio) {
+          await this.#applyOutputDevice(
+            audio,
+            this.#outputDeviceSwitchGeneration
+          );
+        }
+        return;
+      }
+      this.#setOutputDeviceError(OUTPUT_DEVICE_SWITCH_ERROR);
     }
   }
 
   #closePlaybackOutput(): void {
+    this.#playbackOutputGeneration++;
     if (this.#playbackElement) {
-      this.#playbackElement.pause();
-      this.#playbackElement.srcObject = null;
+      this.#releasePlaybackElement(this.#playbackElement);
       this.#playbackElement = null;
     }
     this.#playbackDestination = null;
+    this.#playbackDestinationPromise = null;
     this.#useDefaultPlaybackDestination = false;
+  }
+
+  #releasePlaybackElement(audio: HTMLAudioElement): void {
+    audio.pause();
+    audio.srcObject = null;
   }
 
   // --- Audio playback ---
@@ -817,9 +903,11 @@ export class VoiceClient {
       }
       if (generation !== this.#playbackGeneration) return;
 
+      const destination = await this.#getPlaybackDestination(ctx);
+      if (generation !== this.#playbackGeneration) return;
+
       const source = ctx.createBufferSource();
       source.buffer = audioBuffer;
-      const destination = await this.#getPlaybackDestination(ctx);
       source.connect(destination);
       if (generation !== this.#playbackGeneration) return;
       this.#activeSource = source;

--- a/packages/voice/src/voice-react.tsx
+++ b/packages/voice/src/voice-react.tsx
@@ -50,6 +50,7 @@ export interface UseVoiceAgentReturn {
   isMuted: boolean;
   connected: boolean;
   error: string | null;
+  outputDeviceError: string | null;
   startCall: () => Promise<void>;
   endCall: () => void;
   toggleMute: () => void;
@@ -284,6 +285,9 @@ export function useVoiceAgent(
   const [isMuted, setIsMuted] = useState(false);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [outputDeviceError, setOutputDeviceError] = useState<string | null>(
+    null
+  );
   const [interimTranscript, setInterimTranscript] = useState<string | null>(
     null
   );
@@ -299,6 +303,7 @@ export function useVoiceAgent(
     setIsMuted(false);
     setConnected(false);
     setError(null);
+    setOutputDeviceError(null);
     setInterimTranscript(null);
     setLastCustomMessage(null);
 
@@ -334,6 +339,7 @@ export function useVoiceAgent(
     const onMute = (muted: boolean) => setIsMuted(muted);
     const onConnection = (c: boolean) => setConnected(c);
     const onError = (e: string | null) => setError(e);
+    const onOutputDeviceError = (e: string | null) => setOutputDeviceError(e);
     const onInterim = (text: string | null) => setInterimTranscript(text);
 
     client.addEventListener("statuschange", onStatus);
@@ -344,6 +350,7 @@ export function useVoiceAgent(
     client.addEventListener("mutechange", onMute);
     client.addEventListener("connectionchange", onConnection);
     client.addEventListener("error", onError);
+    client.addEventListener("outputdeviceerror", onOutputDeviceError);
 
     return () => {
       client.removeEventListener("statuschange", onStatus);
@@ -354,6 +361,7 @@ export function useVoiceAgent(
       client.removeEventListener("mutechange", onMute);
       client.removeEventListener("connectionchange", onConnection);
       client.removeEventListener("error", onError);
+      client.removeEventListener("outputdeviceerror", onOutputDeviceError);
       if (clientRef.current === client) {
         clientRef.current = null;
       }
@@ -401,6 +409,7 @@ export function useVoiceAgent(
     isMuted,
     connected,
     error,
+    outputDeviceError,
     startCall,
     endCall,
     toggleMute,

--- a/packages/voice/src/voice-react.tsx
+++ b/packages/voice/src/voice-react.tsx
@@ -249,6 +249,7 @@ export function useVoiceAgent(
   );
 
   const enabled = options.enabled ?? true;
+  const outputDeviceId = options.outputDeviceId;
 
   const connectionKey = useMemo(
     () =>
@@ -386,6 +387,10 @@ export function useVoiceAgent(
     client.addEventListener("custommessage", onCustom);
     return () => client.removeEventListener("custommessage", onCustom);
   }, [effectKey]);
+
+  useEffect(() => {
+    void clientRef.current?.setOutputDevice(outputDeviceId);
+  }, [effectKey, outputDeviceId]);
 
   return {
     status,


### PR DESCRIPTION
This PR adds output device selection for `@cloudflare/voice` playback and wires the voice-agent example to use it. Fixes https://github.com/cloudflare/agents/issues/1550.

## Why

Users need call audio to follow the speaker selected in their app UI instead of always playing through the system default output. The SDK previously played decoded audio directly to `AudioContext.destination`, which left consumers no path to apply `HTMLMediaElement.setSinkId()`.

The implementation routes SDK playback through a hidden `HTMLAudioElement`, then applies sink selection to that element. This avoids relying on `AudioContext.setSinkId()`, which has weaker cross-browser support, while keeping playback alive on the default or previous output when sink selection is unsupported or rejected.

## Public API Surface

- Adds `outputDeviceId?: string` to `VoiceClientOptions`, inherited by `useVoiceAgent()` options:
  ```ts
  const client = new VoiceClient({
    agent: "my-voice-agent",
    outputDeviceId: selectedSpeaker.deviceId
  });

  const voice = useVoiceAgent({
    agent: "my-voice-agent",
    outputDeviceId
  });
  ```
- Adds `VoiceClient.setOutputDevice(outputDeviceId?: string): Promise<void>` to update the active client without reconnecting the call.
- Adds `VoiceClient.outputDeviceError` and an `outputdeviceerror` event for non-fatal speaker-routing failures.
- Adds `outputDeviceError` to `useVoiceAgent()` so React apps can render speaker-routing warnings separately from call/connection errors.
- Treats `undefined` and `"default"` as default output.

## Architectural Changes

Playback now flows through `AudioBufferSourceNode -> MediaStreamAudioDestinationNode -> hidden HTMLAudioElement` instead of connecting assistant audio directly to `AudioContext.destination`. The hidden media element becomes the output-routing boundary for browser sink selection. If that setup fails, playback falls back to `AudioContext.destination`.

`useVoiceAgent()` applies `outputDeviceId` changes to the existing `VoiceClient`, so changing speakers does not reconnect the WebSocket or restart the call.

Output-device failures are intentionally separated from the global `error` channel because playback can continue even when routing to a selected speaker fails. Apps can show `outputDeviceError` near a speaker picker while keeping global `error` reserved for call, mic, connection, and server failures.

## Reliability and Browser Behavior

- Serializes playback-output initialization so `startCall()` pre-warm and early audio chunks share one hidden media element setup.
- Guards teardown during async media-element startup so ended calls do not orphan audio routing.
- Handles rapid `setOutputDevice()` calls by preserving the latest requested device even when `setSinkId()` promises resolve out of order.
- Continues playback on the default or previous output when `setSinkId()` is unsupported or rejected.
- Documents browser support caveats and the fact that output device labels may be blank until microphone permission is granted.

## Code Changes

- Refactored `VoiceClient` playback output management and cleanup.
- Added sink selection, runtime output switching, and dedicated output-device warning state in `VoiceClient`.
- Updated `useVoiceAgent()` to apply output device changes without reconnecting and expose `outputDeviceError`.
- Added an output picker to the voice-agent example call controls with inline routing warnings.
- Updated package README, docs, and example README for output-device selection.
- Added unit and React hook tests for sink routing, fallback behavior, no-reconnect updates, warning separation, race handling, and cleanup.
- Added a changeset for `@cloudflare/voice`.

## Validation

- `pnpm --filter @cloudflare/voice test`
- `pnpm --filter @cloudflare/voice test:react`
- `pnpm run build`
- `pnpm run check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->