### PR TITLE
fix(agents): reclaim resumable-stream buffers from an alarm (#1706)

### DIFF
--- a/.changeset/stream-buffer-alarm-cleanup.md
+++ b/.changeset/stream-buffer-alarm-cleanup.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+"agents": patch
+---
+
+Reclaim resumable-stream buffers from an alarm so idle chats don't leak storage (#1706)
+
+Resumable-stream chunk buffers (`cf_ai_chat_stream_*`) were only swept lazily when a _subsequent_ stream completed. A chat that received a single turn and then went idle never triggered that sweep, so its buffers lingered in the Durable Object's SQLite for the lifetime of the DO.
+
+`AIChatAgent` and `Think` now arm a scheduled cleanup alarm whenever a stream starts and whenever it finishes (completes or errors). Arming on start guarantees that a stream whose DO is evicted mid-flight and never reaches a finish still gets a future sweep instead of leaking. This is the safety net for the non-durable path (e.g. `chatRecovery: false`, the `AIChatAgent` default): those turns don't run inside `runFiber`, so there's no leftover `keepAlive` alarm and no fiber-recovery scan, and if the client never reconnects nothing else wakes the DO. (Durable `runFiber` turns already self-heal — the `keepAlive` alarm survives eviction, wakes the DO, and recovery finalizes the stream, which arms cleanup — so arming on start is belt-and-suspenders there.) The alarm sweeps aged buffers via the retention windows below and re-arms only while reclaimable rows remain, so a fully-swept DO stops waking itself. Arming is idempotent so high-turn-count chats never accumulate cleanup schedules; the in-callback re-arm uses a fresh (non-idempotent) row so it survives the one-shot deletion of the firing schedule. No per-turn Durable Object and no change to the session DO lifecycle are required.
+
+Retention is now split into two short, purpose-specific windows instead of a single 24h threshold: completed/errored buffers are kept for a brief **10-minute** reconnect-and-replay grace (the assistant message is persisted separately, so the buffer is only needed to replay a just-finished stream or deliver a terminal error frame to a reconnecting client), while abandoned in-flight (`streaming`) rows are kept for **1 hour** so an interrupted turn has ample time to be resumed or recovered before its buffer is presumed dead. The abandoned-row sweep keys off **last chunk activity** rather than stream start time, so a long-running stream that is still emitting chunks is never reclaimed mid-flight.
+
+`ResumableStream` gains `cleanup(now?)` (force a sweep, bypassing the lazy interval gate) and `hasReclaimableStreams()` to support alarm-driven cleanup.

--- a/docs/resumable-streaming.md
+++ b/docs/resumable-streaming.md
@@ -70,7 +70,7 @@ function Chat() {
 - Chunks are batched (every 10 chunks) and flushed to SQLite for performance
 - When a client sends `CF_AGENT_STREAM_RESUME_REQUEST`, the server checks for active streams and responds with `CF_AGENT_STREAM_RESUMING`
 - Stale streams (older than 5 minutes) are cleaned up on restore
-- Completed streams older than 24 hours are periodically garbage collected
+- Stream buffers are garbage collected from a scheduled alarm: completed or errored streams are retained for 10 minutes (a brief reconnect-and-replay grace; the assistant message itself is persisted separately), and abandoned in-flight streams are retained for 1 hour after their last chunk before being reclaimed
 
 ### Client-side (`useAgentChat`)
 

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -28,8 +28,28 @@ const CHUNK_BUFFER_MAX_SIZE = 100;
 const SEGMENT_MAX_BYTES = 512_000;
 /** Default cleanup interval for old streams (ms) - every 10 minutes */
 const CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
-/** Default age threshold for cleaning up completed streams (ms) - 24 hours */
-const CLEANUP_AGE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+/**
+ * Retention for completed/errored stream buffers, measured from completion.
+ *
+ * The assistant message is persisted separately (`cf_ai_chat_agent_messages`),
+ * so once a stream completes its buffer is no longer the source of truth — it
+ * is only a brief reconnect-and-replay grace window: long enough to cover a
+ * client that dropped at the completion boundary and reconnects to replay the
+ * just-finished stream, and to deliver a pending terminal error frame on a
+ * resumed stream (#1645). It is deliberately short (not the chat's lifetime)
+ * so idle/one-off chat DOs don't accumulate stale buffers (#1706).
+ */
+const COMPLETED_RETENTION_MS = 10 * 60 * 1000;
+/**
+ * Retention for abandoned `streaming` rows, measured from LAST chunk activity.
+ *
+ * Generous relative to {@link COMPLETED_RETENTION_MS}: an interrupted turn must
+ * have ample time to be resumed by a reconnecting client or healed by fiber
+ * recovery before its buffer is reaped. Only a stream that has produced no
+ * chunk for this long is treated as truly dead. Keyed off last activity (not
+ * start time) so a long but still-active stream is never swept mid-flight.
+ */
+const ABANDONED_STREAM_RETENTION_MS = 60 * 60 * 1000;
 /** Shared encoder for UTF-8 byte length measurement */
 const textEncoder = new TextEncoder();
 
@@ -595,6 +615,29 @@ export class ResumableStream {
     this._activeRequestId = null;
   }
 
+  /**
+   * Force a sweep of aged stream buffers now, bypassing the lazy interval
+   * gate used by {@link _maybeCleanupOldStreams}. Intended to be driven by an
+   * alarm so idle/hibernated chat DOs still reclaim buffers even when no
+   * further stream ever completes to trigger the lazy path.
+   */
+  cleanup(now: number = Date.now()): void {
+    this._lastCleanupTime = now;
+    this._sweepOldStreams(now);
+  }
+
+  /**
+   * True if any stream rows remain at all. Used by alarm-driven cleanup to
+   * decide whether to re-arm: once no rows remain there is nothing left to
+   * sweep, so the DO can stop waking itself.
+   */
+  hasReclaimableStreams(): boolean {
+    const rows = this.sql<{ n: number }>`
+      select count(*) as n from cf_ai_chat_stream_metadata
+    `;
+    return (rows?.[0]?.n ?? 0) > 0;
+  }
+
   // ── Internal ───────────────────────────────────────────────────────
 
   private _maybeCleanupOldStreams() {
@@ -603,34 +646,64 @@ export class ResumableStream {
       return;
     }
     this._lastCleanupTime = now;
+    this._sweepOldStreams(now);
+  }
 
-    const cutoff = now - CLEANUP_AGE_THRESHOLD_MS;
+  /** Delete completed/errored buffers past the completion grace window, plus
+   *  abandoned "streaming" rows past the stale-in-flight window. The two use
+   *  different retentions: a completed buffer is redundant with the persisted
+   *  message and needs only a brief replay grace, whereas an in-flight buffer
+   *  must outlive resume/recovery before it is presumed dead. */
+  private _sweepOldStreams(now: number) {
+    const completedCutoff = now - COMPLETED_RETENTION_MS;
     this.sql`
       delete from cf_ai_chat_stream_chunks 
       where stream_id in (
         select id from cf_ai_chat_stream_metadata 
-        where status in ('completed', 'error') and completed_at < ${cutoff}
+        where status in ('completed', 'error') and completed_at < ${completedCutoff}
       )
     `;
     this.sql`
       delete from cf_ai_chat_stream_metadata 
-      where status in ('completed', 'error') and completed_at < ${cutoff}
+      where status in ('completed', 'error') and completed_at < ${completedCutoff}
     `;
 
     // Clean up abandoned "streaming" rows. These are orphaned streams that
     // were never completed or recovered (e.g. non-durable agents that never
     // reconnected). By this point, fiber recovery has already had its chance
     // to claim them — safe to delete.
+    //
+    // "Abandoned" is keyed off LAST ACTIVITY (the most recent chunk write),
+    // not the stream's start time: a long-running stream that is still
+    // actively emitting chunks must never be swept mid-flight just because it
+    // started long ago. A row with no chunks falls back to its start time.
+    // Note `created_at <= max(chunk.created_at)` always (the row is inserted
+    // before any chunk), so this set is stable across the two deletes even
+    // though the first removes the chunks the second's subquery reads.
+    const abandonedCutoff = now - ABANDONED_STREAM_RETENTION_MS;
     this.sql`
       delete from cf_ai_chat_stream_chunks
       where stream_id in (
-        select id from cf_ai_chat_stream_metadata
-        where status = 'streaming' and created_at < ${cutoff}
+        select m.id from cf_ai_chat_stream_metadata m
+        where m.status = 'streaming'
+          and coalesce(
+            (select max(c.created_at) from cf_ai_chat_stream_chunks c
+             where c.stream_id = m.id),
+            m.created_at
+          ) < ${abandonedCutoff}
       )
     `;
     this.sql`
       delete from cf_ai_chat_stream_metadata
-      where status = 'streaming' and created_at < ${cutoff}
+      where id in (
+        select m.id from cf_ai_chat_stream_metadata m
+        where m.status = 'streaming'
+          and coalesce(
+            (select max(c.created_at) from cf_ai_chat_stream_chunks c
+             where c.stream_id = m.id),
+            m.created_at
+          ) < ${abandonedCutoff}
+      )
     `;
   }
 
@@ -697,6 +770,20 @@ export class ResumableStream {
     this.sql`
       insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at)
       values (${streamId}, ${requestId}, 'streaming', ${createdAt})
+    `;
+  }
+
+  /**
+   * Append a chunk to a stream dated `ageMs` in the past. Used to exercise the
+   * last-activity sweep threshold: a long-running streaming row with a *recent*
+   * chunk must survive even when its start time is older than the cutoff.
+   * @internal For testing only
+   */
+  insertChunkAt(streamId: string, body: string, ageMs: number): void {
+    const createdAt = Date.now() - ageMs;
+    this.sql`
+      insert into cf_ai_chat_stream_chunks (id, stream_id, body, chunk_index, created_at)
+      values (${nanoid()}, ${streamId}, ${body}, 0, ${createdAt})
     `;
   }
 }

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -226,6 +226,16 @@ const CHAT_RECOVERING_FLAG_TTL_MS = 15 * 60 * 1000;
 // child output registers forward progress.
 const AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS = 5_000;
 
+// How far ahead to schedule the resumable-stream buffer cleanup alarm. Set to
+// ResumableStream's short completion-grace window (COMPLETED_RETENTION_MS, 10m)
+// so a finished buffer is reclaimed promptly. The re-arm-while-reclaimable loop
+// (see _cleanupStreamBuffers) revisits any longer-lived rows — e.g. an
+// abandoned in-flight buffer on its 1h window — by waking again each interval
+// until they age out, then stops. Driving cleanup from an alarm (rather than
+// only piggybacking on the next stream completion) ensures idle/one-off chat
+// DOs still reclaim their buffers without waking forever (#1706).
+const STREAM_CLEANUP_DELAY_SECONDS = 10 * 60;
+
 type StreamResultStatus = {
   status: Exclude<SaveMessagesResult["status"], "skipped">;
   error?: string;
@@ -1367,6 +1377,17 @@ export class AIChatAgent<
       this._flushAwaitingStreamStartConnections();
       this._activateDeferredAutoContinuation();
     }
+    // Arm on START as well as finish so a stream whose DO is evicted mid-flight
+    // and never reaches a finish still gets a future sweep instead of leaking.
+    // This matters for `chatRecovery: false` (the default): those turns don't
+    // run inside `runFiber`, so there is no durable keepAlive alarm and no
+    // fiber-recovery scan — if the client never reconnects, nothing else ever
+    // wakes the DO to finalize the orphan. (With `chatRecovery: true` the
+    // leftover keepAlive alarm wakes the DO within ~keepAliveIntervalMs and
+    // recovery finalizes the stream, which arms cleanup anyway — so this is
+    // belt-and-suspenders there.) The last-activity sweep threshold keeps an
+    // actively streaming run from being reclaimed before it goes quiet (#1706).
+    void this._ensureStreamCleanupScheduled();
     return streamId;
   }
 
@@ -1378,6 +1399,48 @@ export class AIChatAgent<
     if (completedRequestId === this._continuation.activeRequestId) {
       this._continuation.activeRequestId = null;
       this._continuation.activeConnectionId = null;
+    }
+    void this._ensureStreamCleanupScheduled();
+  }
+
+  /**
+   * Ensure a single cleanup alarm is pending for this DO's resumable-stream
+   * buffers. Armed whenever a stream finishes (completes or errors) so that
+   * idle/one-off chat DOs still reclaim their buffers — the lazy sweep in
+   * {@link ResumableStream} only fires when a *subsequent* stream completes,
+   * which never happens for a chat that receives a single turn (#1706).
+   *
+   * `idempotent` dedupes on (callback, payload, owner) so repeated finishes
+   * collapse onto one pending alarm rather than stacking.
+   * @internal
+   */
+  protected async _ensureStreamCleanupScheduled({
+    idempotent = true
+  }: { idempotent?: boolean } = {}): Promise<void> {
+    await this.schedule(
+      STREAM_CLEANUP_DELAY_SECONDS,
+      "_cleanupStreamBuffers",
+      undefined,
+      { idempotent }
+    );
+  }
+
+  /**
+   * Alarm callback: sweep aged stream buffers, then re-arm only while rows
+   * remain so a fully-swept DO stops waking itself. Public so it is reachable
+   * as a schedule callback.
+   * @internal
+   */
+  async _cleanupStreamBuffers(): Promise<void> {
+    this._resumableStream.cleanup();
+    if (this._resumableStream.hasReclaimableStreams()) {
+      // Must NOT be idempotent: this runs INSIDE the currently-executing
+      // one-shot schedule row, which `alarm()` deletes only after we return. An
+      // idempotent reschedule would dedup onto that row and then be deleted with
+      // it — the re-arm would silently never fire, leaving buffers that survived
+      // this sweep (e.g. a younger turn) uncollected. A fresh delayed row
+      // survives the deletion.
+      await this._ensureStreamCleanupScheduled({ idempotent: false });
     }
   }
 
@@ -1435,6 +1498,7 @@ export class AIChatAgent<
       this._continuation.activeRequestId = null;
       this._continuation.activeConnectionId = null;
     }
+    void this._ensureStreamCleanupScheduled();
   }
 
   /**
@@ -4191,6 +4255,7 @@ export class AIChatAgent<
 
       if (streamStillActive) {
         this._resumableStream.complete(streamId);
+        void this._ensureStreamCleanupScheduled();
       }
 
       // A NEW turn (not a continuation) that produced no persisted assistant

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -1771,7 +1771,7 @@ describe("Resumable Streaming", () => {
 
       const agentStub = await getAgentByName(env.TestChatAgent, room);
 
-      // Insert an old errored stream (25 hours old, past the 24h cleanup threshold)
+      // Insert an old errored stream (25 hours old, well past the completion grace)
       await agentStub.testInsertOldErroredStream(
         "old-errored",
         "req-errored",
@@ -1795,7 +1795,7 @@ describe("Resumable Streaming", () => {
       ws.close(1000);
     });
 
-    it("abandoned streaming rows are cleaned up after 24 hours", async () => {
+    it("abandoned streaming rows are cleaned up after the stale-in-flight window", async () => {
       const room = crypto.randomUUID();
       const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
       await new Promise((r) => setTimeout(r, 50));
@@ -1820,6 +1820,315 @@ describe("Resumable Streaming", () => {
         "abandoned-streaming"
       );
       expect(afterMetadata).toBeNull();
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+  });
+
+  describe("alarm-driven stream cleanup (#1706)", () => {
+    it("arms a single cleanup alarm when a stream finishes, deduping repeats", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      // No cleanup alarm before any stream finishes.
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
+
+      // Finishing a stream arms exactly one cleanup alarm.
+      await agentStub.testTriggerStreamCleanup();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      // Subsequent finishes collapse onto the same pending alarm (idempotent),
+      // so DOs with many turns never accumulate cleanup schedules.
+      await agentStub.testTriggerStreamCleanup();
+      await agentStub.testTriggerStreamCleanup();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("reclaims aged buffers when the alarm fires without a new stream completing", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      // The exact #1706 scenario: a one-off chat whose buffers age out, with no
+      // further stream ever completing to drive the lazy in-line sweep.
+      await agentStub.testInsertOldErroredStream(
+        "old-errored",
+        "req-errored",
+        25 * 60 * 60 * 1000
+      );
+      await agentStub.testInsertStaleStream(
+        "abandoned-streaming",
+        "req-abandoned",
+        25 * 60 * 60 * 1000
+      );
+
+      // The alarm callback alone (no completeStream) reclaims both.
+      await agentStub.testRunStreamCleanup();
+
+      expect(await agentStub.getStreamMetadata("old-errored")).toBeNull();
+      expect(
+        await agentStub.getStreamMetadata("abandoned-streaming")
+      ).toBeNull();
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("re-arms only while reclaimable buffers remain", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      // Fully-swept DO: running cleanup with nothing left does NOT re-arm, so an
+      // idle/dead chat stops waking itself.
+      await agentStub.testRunStreamCleanup();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
+
+      // A still-recent stream survives the sweep (not yet aged), so the DO must
+      // keep an alarm pending to revisit it later.
+      await agentStub.testInsertStaleStream(
+        "recent-streaming",
+        "req-recent",
+        60 * 1000
+      );
+      await agentStub.testRunStreamCleanup();
+      expect(
+        await agentStub.getStreamMetadata("recent-streaming")
+      ).not.toBeNull();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("survives the real alarm fire and re-arms when a younger buffer remains", async () => {
+      // Guards the idempotent-reschedule footgun: when the cleanup alarm fires,
+      // `alarm()` deletes the fired one-shot row after the callback returns. An
+      // idempotent re-arm would dedup onto that doomed row and vanish with it,
+      // leaking any buffer that survived the sweep. The re-arm must be fresh.
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      await agentStub.testInsertStaleStream("young", "req-young", 60 * 1000);
+      await agentStub.testArmStreamCleanup();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      // Fire the alarm for real — the fired row is deleted after the callback.
+      await agentStub.testFireDueCleanupAlarm();
+
+      // The young buffer survived the sweep, so a FRESH cleanup alarm must
+      // remain pending (this is exactly 0 if the re-arm were idempotent).
+      expect(await agentStub.getStreamMetadata("young")).not.toBeNull();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("stops re-arming after the real alarm sweeps the last buffer", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      await agentStub.testInsertOldErroredStream(
+        "old",
+        "req-old",
+        25 * 60 * 60 * 1000
+      );
+      await agentStub.testArmStreamCleanup();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      await agentStub.testFireDueCleanupAlarm();
+
+      // Nothing reclaimable remains, so no re-arm: the DO stops waking itself.
+      expect(await agentStub.getStreamMetadata("old")).toBeNull();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("does not sweep a long-running stream that is still emitting chunks", async () => {
+      // The abandoned-streaming sweep keys off LAST chunk activity, not start
+      // time: a stream that began > 24h ago but is still writing chunks must
+      // survive, while one that has been silent past the window is reclaimed.
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      // Started 25h ago but emitted a chunk a minute ago — still active.
+      await agentStub.testInsertStaleStream(
+        "long-active",
+        "req-active",
+        25 * 60 * 60 * 1000
+      );
+      await agentStub.testInsertStreamChunkAt("long-active", 60 * 1000);
+
+      // Started 25h ago and went silent (last chunk 25h ago) — abandoned.
+      await agentStub.testInsertStaleStream(
+        "long-silent",
+        "req-silent",
+        25 * 60 * 60 * 1000
+      );
+      await agentStub.testInsertStreamChunkAt(
+        "long-silent",
+        25 * 60 * 60 * 1000
+      );
+
+      await agentStub.testRunStreamCleanup();
+
+      expect(await agentStub.getStreamMetadata("long-active")).not.toBeNull();
+      expect(await agentStub.getStreamMetadata("long-silent")).toBeNull();
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("arms cleanup when a stream starts (covers never-finished orphans)", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      // No alarm yet on a fresh DO.
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
+
+      // Starting a stream (without ever finishing it) must arm cleanup so an
+      // evicted, never-resumed mid-stream orphan still gets a future sweep.
+      await agentStub.testStartStream("req-orphan");
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("arms the cleanup alarm at the completion-grace delay (10 minutes)", async () => {
+      // Locks the arming interval: a regression that lengthens it back toward
+      // the old 24h window (re-introducing the #1706 leak) fails here.
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      await agentStub.testArmStreamCleanup();
+      expect(await agentStub.testStreamCleanupScheduleDelaySeconds()).toBe(
+        10 * 60
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("sweeps a finished buffer past the 10-minute grace, keeps a recent one", async () => {
+      // Completion retention is short: the assistant message is persisted
+      // separately, so a finished buffer is only a brief replay grace.
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      await agentStub.testInsertOldErroredStream(
+        "done-stale",
+        "req-done-stale",
+        11 * 60 * 1000
+      );
+      await agentStub.testInsertOldErroredStream(
+        "done-recent",
+        "req-done-recent",
+        5 * 60 * 1000
+      );
+
+      await agentStub.testRunStreamCleanup();
+
+      expect(await agentStub.getStreamMetadata("done-stale")).toBeNull();
+      expect(await agentStub.getStreamMetadata("done-recent")).not.toBeNull();
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("keeps an abandoned in-flight buffer until the 1-hour stale window", async () => {
+      // In-flight retention is generous so an interrupted turn has ample time
+      // to be resumed or recovered before its buffer is presumed dead.
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      await agentStub.testInsertStaleStream(
+        "inflight-recent",
+        "req-inflight-recent",
+        30 * 60 * 1000
+      );
+      await agentStub.testInsertStaleStream(
+        "inflight-stale",
+        "req-inflight-stale",
+        70 * 60 * 1000
+      );
+
+      await agentStub.testRunStreamCleanup();
+
+      expect(
+        await agentStub.getStreamMetadata("inflight-recent")
+      ).not.toBeNull();
+      expect(await agentStub.getStreamMetadata("inflight-stale")).toBeNull();
+
+      await new Promise((r) => setTimeout(r, 50));
+      ws.close(1000);
+    });
+
+    it("keeps an in-flight buffer's chunks reconstructable past the completion grace", async () => {
+      // Recovery reconstructs a partial assistant message from the stream
+      // buffer (getStreamChunks / _persistOrphanedStream), and only ever does
+      // so for an ACTIVE `streaming` row — which uses the generous 1h
+      // last-activity window, NOT the 10min completion grace. A buffer whose
+      // last chunk is older than the completion grace but within the in-flight
+      // window must survive a sweep with its chunks intact, otherwise a turn
+      // interrupted >10min could not be recovered.
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
+
+      await agentStub.testInsertStaleStream(
+        "recovering",
+        "req-recovering",
+        30 * 60 * 1000
+      );
+      // Last chunk 20 minutes ago: past the 10min grace, within the 1h window.
+      await agentStub.testInsertStreamChunkAt("recovering", 20 * 60 * 1000);
+
+      await agentStub.testRunStreamCleanup();
+
+      expect((await agentStub.getStreamMetadata("recovering"))?.status).toBe(
+        "streaming"
+      );
+      expect(
+        (await agentStub.getStreamChunks("recovering")).length
+      ).toBeGreaterThan(0);
 
       await new Promise((r) => setTimeout(r, 50));
       ws.close(1000);

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -689,6 +689,11 @@ export class TestChatAgent extends AIChatAgent<Env> {
     `;
   }
 
+  /** Append a chunk to a stream dated `ageMs` in the past (last-activity sweep). */
+  testInsertStreamChunkAt(streamId: string, ageMs: number): void {
+    this._resumableStream.insertChunkAt(streamId, '{"type":"text"}', ageMs);
+  }
+
   testInsertOldErroredStream(
     streamId: string,
     requestId: string,
@@ -711,6 +716,51 @@ export class TestChatAgent extends AIChatAgent<Env> {
     // We do this by starting and immediately completing a dummy stream
     const dummyId = this._startStream("cleanup-trigger");
     this._completeStream(dummyId);
+  }
+
+  /** Invoke the alarm-driven cleanup callback directly (no new stream needed). */
+  async testRunStreamCleanup(): Promise<void> {
+    await this._cleanupStreamBuffers();
+  }
+
+  /** Number of pending alarm-driven stream-cleanup schedules for this DO. */
+  testCountStreamCleanupSchedules(): number {
+    return this.getSchedules().filter(
+      (s) => s.callback === "_cleanupStreamBuffers"
+    ).length;
+  }
+
+  /**
+   * The delay (seconds) of the pending cleanup schedule, or null if none.
+   * Locks the arming interval (STREAM_CLEANUP_DELAY_SECONDS) so a regression
+   * that lengthens it back toward the old 24h leak window is caught.
+   */
+  testStreamCleanupScheduleDelaySeconds(): number | null {
+    const schedule = this.getSchedules().find(
+      (s) => s.callback === "_cleanupStreamBuffers"
+    );
+    if (!schedule || schedule.type !== "delayed") return null;
+    return schedule.delayInSeconds;
+  }
+
+  /** Arm the cleanup alarm without finishing a stream (leaves no new buffer). */
+  async testArmStreamCleanup(): Promise<void> {
+    await this._ensureStreamCleanupScheduled();
+  }
+
+  /**
+   * Backdate any pending cleanup schedule so it is due, then run the REAL
+   * `alarm()` handler. This exercises the production path where `alarm()`
+   * deletes the fired one-shot row after the callback returns — so a re-arm
+   * must create a fresh row to survive (the idempotent-reschedule footgun).
+   */
+  async testFireDueCleanupAlarm(): Promise<void> {
+    this.sql`
+      update cf_agents_schedules
+      set time = ${Math.floor(Date.now() / 1000) - 1}
+      where callback = '_cleanupStreamBuffers'
+    `;
+    await this.alarm();
   }
 
   /**

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -5139,6 +5139,103 @@ export class ThinkRecoveryTestAgent extends Think {
     return rows[0]?.count ?? 0;
   }
 
+  /** Insert a stream-metadata row aged `ageMs` in the past (for cleanup tests). */
+  async insertAgedStreamForTest(
+    streamId: string,
+    requestId: string,
+    status: "streaming" | "completed" | "error",
+    ageMs: number
+  ): Promise<void> {
+    const createdAt = Date.now() - ageMs;
+    const completedAt = status === "streaming" ? null : createdAt + 1000;
+    this.sql`
+      INSERT INTO cf_ai_chat_stream_metadata (id, request_id, status, created_at, completed_at)
+      VALUES (${streamId}, ${requestId}, ${status}, ${createdAt}, ${completedAt})
+    `;
+  }
+
+  /** Status of a single stream-metadata row, or null if absent. */
+  async getStreamStatusForTest(streamId: string): Promise<string | null> {
+    const rows = this.sql<{ status: string }>`
+      SELECT status FROM cf_ai_chat_stream_metadata WHERE id = ${streamId}
+    `;
+    return rows[0]?.status ?? null;
+  }
+
+  /** Append a chunk to a stream dated `ageMs` in the past (last-activity sweep). */
+  async insertStreamChunkForTest(
+    streamId: string,
+    ageMs: number
+  ): Promise<void> {
+    (
+      this as unknown as {
+        _resumableStream: {
+          insertChunkAt(id: string, body: string, ageMs: number): void;
+        };
+      }
+    )._resumableStream.insertChunkAt(streamId, '{"type":"text"}', ageMs);
+  }
+
+  /** Start a stream via the cleanup-arming wrapper (without ever finishing it). */
+  async startStreamForTest(requestId: string): Promise<string> {
+    return (
+      this as unknown as {
+        _startResumableStream(requestId: string): string;
+      }
+    )._startResumableStream(requestId);
+  }
+
+  /** Invoke the alarm-driven cleanup callback directly. */
+  async runStreamCleanupForTest(): Promise<void> {
+    await (
+      this as unknown as { _cleanupStreamBuffers(): Promise<void> }
+    )._cleanupStreamBuffers();
+  }
+
+  /** Finish a stream via the cleanup-arming wrapper (mirrors a real turn end). */
+  async completeStreamForTest(streamId: string): Promise<void> {
+    (
+      this as unknown as { _completeResumableStream(id: string): void }
+    )._completeResumableStream(streamId);
+  }
+
+  /** Arm the cleanup alarm without finishing a stream (leaves no new buffer). */
+  async armStreamCleanupForTest(): Promise<void> {
+    await (
+      this as unknown as { _ensureStreamCleanupScheduled(): Promise<void> }
+    )._ensureStreamCleanupScheduled();
+  }
+
+  /**
+   * The delay (seconds) of the pending cleanup schedule, or null if none.
+   * Locks the arming interval (STREAM_CLEANUP_DELAY_SECONDS) so a regression
+   * that lengthens it back toward the old 24h leak window is caught.
+   */
+  async streamCleanupScheduleDelaySecondsForTest(): Promise<number | null> {
+    const rows = this.sql<{ delayInSeconds: number | null }>`
+      SELECT delayInSeconds
+      FROM cf_agents_schedules
+      WHERE callback = '_cleanupStreamBuffers'
+      LIMIT 1
+    `;
+    return rows[0]?.delayInSeconds ?? null;
+  }
+
+  /**
+   * Backdate any pending cleanup schedule so it is due, then run the REAL
+   * `alarm()` handler. This exercises the production path where `alarm()`
+   * deletes the fired one-shot row after the callback returns — so a re-arm
+   * must create a fresh row to survive (the idempotent-reschedule footgun).
+   */
+  async fireDueCleanupAlarmForTest(): Promise<void> {
+    this.sql`
+      UPDATE cf_agents_schedules
+      SET time = ${Math.floor(Date.now() / 1000) - 1}
+      WHERE callback = '_cleanupStreamBuffers'
+    `;
+    await this.alarm();
+  }
+
   async insertInterruptedFiber(
     name: string,
     snapshot?: unknown

--- a/packages/think/src/tests/stream-cleanup.test.ts
+++ b/packages/think/src/tests/stream-cleanup.test.ts
@@ -1,0 +1,276 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "agents";
+import type { ThinkRecoveryTestAgent } from "./agents/think-session";
+
+// Covers alarm-driven resumable-stream buffer cleanup (#1706): Think arms a
+// scheduled cleanup alarm whenever a stream finishes so idle/one-off chat DOs
+// still reclaim their buffers, instead of only sweeping lazily when a
+// *subsequent* stream completes. Uses ThinkRecoveryTestAgent, which carries the
+// stream/schedule test helpers.
+
+const CLEANUP_CALLBACK = "_cleanupStreamBuffers";
+
+async function freshAgent(name?: string) {
+  return getAgentByName(
+    env.ThinkRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkRecoveryTestAgent>,
+    name ?? crypto.randomUUID()
+  );
+}
+
+describe("Think — alarm-driven stream cleanup (#1706)", () => {
+  it("arms a single cleanup alarm when a stream finishes, deduping repeats", async () => {
+    const agent = await freshAgent();
+
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(0);
+
+    await agent.insertAgedStreamForTest("s1", "req-1", "streaming", 1000);
+    await agent.completeStreamForTest("s1");
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(1);
+
+    // Subsequent finishes collapse onto the same pending alarm (idempotent).
+    await agent.insertAgedStreamForTest("s2", "req-2", "streaming", 1000);
+    await agent.completeStreamForTest("s2");
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(1);
+  });
+
+  it("reclaims aged buffers when the alarm fires without a new stream completing", async () => {
+    const agent = await freshAgent();
+
+    // The #1706 scenario: a one-off chat whose buffers age out with no further
+    // stream ever completing to drive the lazy in-line sweep.
+    await agent.insertAgedStreamForTest(
+      "old-errored",
+      "req-errored",
+      "error",
+      25 * 60 * 60 * 1000
+    );
+    await agent.insertAgedStreamForTest(
+      "abandoned",
+      "req-abandoned",
+      "streaming",
+      25 * 60 * 60 * 1000
+    );
+
+    await agent.runStreamCleanupForTest();
+
+    expect(await agent.getStreamStatusForTest("old-errored")).toBeNull();
+    expect(await agent.getStreamStatusForTest("abandoned")).toBeNull();
+  });
+
+  it("re-arms only while reclaimable buffers remain", async () => {
+    const agent = await freshAgent();
+
+    // Fully-swept DO: running cleanup with nothing left does NOT re-arm.
+    await agent.runStreamCleanupForTest();
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(0);
+
+    // A still-recent stream survives the sweep, so an alarm stays pending.
+    await agent.insertAgedStreamForTest(
+      "recent",
+      "req-recent",
+      "streaming",
+      60 * 1000
+    );
+    await agent.runStreamCleanupForTest();
+    expect(await agent.getStreamStatusForTest("recent")).toBe("streaming");
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(1);
+  });
+
+  it("survives the real alarm fire and re-arms when a younger buffer remains", async () => {
+    // Guards the idempotent-reschedule footgun: when the cleanup alarm fires,
+    // `alarm()` deletes the fired one-shot row after the callback returns. An
+    // idempotent re-arm would dedup onto that doomed row and vanish with it,
+    // leaking any buffer that survived this sweep. The re-arm must be a fresh
+    // row.
+    const agent = await freshAgent();
+
+    // A recent buffer that survives the 24h sweep, plus a finish to arm the
+    // alarm.
+    await agent.insertAgedStreamForTest(
+      "young",
+      "req-young",
+      "streaming",
+      60 * 1000
+    );
+    await agent.completeStreamForTest("young");
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(1);
+
+    // Fire the alarm for real — the fired row is deleted after the callback.
+    await agent.fireDueCleanupAlarmForTest();
+
+    // The young buffer survived the sweep, so a FRESH cleanup alarm must remain
+    // pending (this is exactly 0 if the re-arm were idempotent).
+    expect(await agent.getStreamStatusForTest("young")).toBe("completed");
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(1);
+  });
+
+  it("stops re-arming after the real alarm sweeps the last buffer", async () => {
+    const agent = await freshAgent();
+
+    // An aged buffer that the sweep will reclaim. Arm directly so we don't
+    // leave a fresh surviving buffer (completing a stream would reset its age).
+    await agent.insertAgedStreamForTest(
+      "old",
+      "req-old",
+      "completed",
+      25 * 60 * 60 * 1000
+    );
+    await agent.armStreamCleanupForTest();
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(1);
+
+    await agent.fireDueCleanupAlarmForTest();
+
+    // Nothing reclaimable remains, so no re-arm: the DO stops waking itself.
+    expect(await agent.getStreamStatusForTest("old")).toBeNull();
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(0);
+  });
+
+  it("does not sweep a long-running stream that is still emitting chunks", async () => {
+    // The abandoned-streaming sweep keys off LAST chunk activity, not start
+    // time: a stream that began > 24h ago but is still writing chunks must
+    // survive, while one silent past the window is reclaimed.
+    const agent = await freshAgent();
+
+    await agent.insertAgedStreamForTest(
+      "long-active",
+      "req-active",
+      "streaming",
+      25 * 60 * 60 * 1000
+    );
+    await agent.insertStreamChunkForTest("long-active", 60 * 1000);
+
+    await agent.insertAgedStreamForTest(
+      "long-silent",
+      "req-silent",
+      "streaming",
+      25 * 60 * 60 * 1000
+    );
+    await agent.insertStreamChunkForTest("long-silent", 25 * 60 * 60 * 1000);
+
+    await agent.runStreamCleanupForTest();
+
+    expect(await agent.getStreamStatusForTest("long-active")).toBe("streaming");
+    expect(await agent.getStreamStatusForTest("long-silent")).toBeNull();
+  });
+
+  it("arms cleanup when a stream starts (covers never-finished orphans)", async () => {
+    const agent = await freshAgent();
+
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(0);
+
+    // Starting a stream (without ever finishing it) must arm cleanup so an
+    // evicted, never-resumed mid-stream orphan still gets a future sweep.
+    await agent.startStreamForTest("req-orphan");
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(1);
+  });
+
+  it("arms the cleanup alarm at the completion-grace delay (10 minutes)", async () => {
+    // Locks the arming interval: a regression that lengthens it back toward
+    // the old 24h window (re-introducing the #1706 leak) fails here.
+    const agent = await freshAgent();
+
+    await agent.armStreamCleanupForTest();
+    expect(await agent.streamCleanupScheduleDelaySecondsForTest()).toBe(
+      10 * 60
+    );
+  });
+
+  it("sweeps a finished buffer past the 10-minute grace, keeps a recent one", async () => {
+    // Completion retention is short: the assistant message is persisted
+    // separately, so a finished buffer is only a brief replay grace.
+    const agent = await freshAgent();
+
+    await agent.insertAgedStreamForTest(
+      "done-stale",
+      "req-done-stale",
+      "completed",
+      11 * 60 * 1000
+    );
+    await agent.insertAgedStreamForTest(
+      "done-recent",
+      "req-done-recent",
+      "completed",
+      5 * 60 * 1000
+    );
+
+    await agent.runStreamCleanupForTest();
+
+    expect(await agent.getStreamStatusForTest("done-stale")).toBeNull();
+    expect(await agent.getStreamStatusForTest("done-recent")).toBe("completed");
+  });
+
+  it("keeps an abandoned in-flight buffer until the 1-hour stale window", async () => {
+    // In-flight retention is generous so an interrupted turn has ample time to
+    // be resumed or recovered before its buffer is presumed dead.
+    const agent = await freshAgent();
+
+    await agent.insertAgedStreamForTest(
+      "inflight-recent",
+      "req-inflight-recent",
+      "streaming",
+      30 * 60 * 1000
+    );
+    await agent.insertAgedStreamForTest(
+      "inflight-stale",
+      "req-inflight-stale",
+      "streaming",
+      70 * 60 * 1000
+    );
+
+    await agent.runStreamCleanupForTest();
+
+    expect(await agent.getStreamStatusForTest("inflight-recent")).toBe(
+      "streaming"
+    );
+    expect(await agent.getStreamStatusForTest("inflight-stale")).toBeNull();
+  });
+
+  it("keeps an in-flight buffer's chunks reconstructable past the completion grace", async () => {
+    // Recovery reconstructs a partial assistant message from the stream buffer
+    // (getStreamChunks), and only ever does so for an ACTIVE `streaming` row —
+    // which uses the generous 1h last-activity window, NOT the 10min completion
+    // grace. A buffer whose last chunk is older than the completion grace but
+    // within the in-flight window must survive a sweep with its chunks intact,
+    // otherwise a turn interrupted >10min could not be recovered.
+    const agent = await freshAgent();
+
+    await agent.insertAgedStreamForTest(
+      "recovering",
+      "req-recovering",
+      "streaming",
+      30 * 60 * 1000
+    );
+    // Last chunk 20 minutes ago: past the 10min grace, within the 1h window.
+    await agent.insertStreamChunkForTest("recovering", 20 * 60 * 1000);
+
+    await agent.runStreamCleanupForTest();
+
+    expect(await agent.getStreamStatusForTest("recovering")).toBe("streaming");
+    const snapshot = await agent.getLatestStreamSnapshot();
+    expect(snapshot?.requestId).toBe("req-recovering");
+    expect(snapshot?.chunkCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -729,6 +729,16 @@ const CHAT_RECOVERING_FLAG_TTL_MS = 15 * 60 * 1000;
 // child output registers forward progress.
 const AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS = 5_000;
 
+// How far ahead to schedule the resumable-stream buffer cleanup alarm. Set to
+// ResumableStream's short completion-grace window (COMPLETED_RETENTION_MS, 10m)
+// so a finished buffer is reclaimed promptly. The re-arm-while-reclaimable loop
+// (see _cleanupStreamBuffers) revisits any longer-lived rows — e.g. an
+// abandoned in-flight buffer on its 1h window — by waking again each interval
+// until they age out, then stops. Driving cleanup from an alarm (rather than
+// only piggybacking on the next stream completion) ensures idle/one-off chat
+// DOs still reclaim their buffers without waking forever (#1706).
+const STREAM_CLEANUP_DELAY_SECONDS = 10 * 60;
+
 // Ephemeral user message appended when a model request would otherwise end in
 // an assistant message (see `ensureValidContinueCheckpoint`).
 const CONTINUE_CHECKPOINT_PROMPT =
@@ -7423,15 +7433,15 @@ export class Think<
       // The live-streamed chunks already reached clients; the driver's
       // post-retry `_broadcastMessages()` reconciles them to the real answer.
       if (overflowRetry) {
-        this._resumableStream.complete(streamId);
+        this._completeResumableStream(streamId);
         streamFinalized = true;
         return { status: "overflow_retry", error: streamError };
       }
 
       if (streamError) {
-        this._resumableStream.markError(streamId);
+        this._errorResumableStream(streamId);
       } else {
-        this._resumableStream.complete(streamId);
+        this._completeResumableStream(streamId);
       }
       streamFinalized = true;
       this._broadcastChat({
@@ -7492,7 +7502,7 @@ export class Think<
         });
         if (outcome === "scheduled") {
           if (!streamFinalized) {
-            this._resumableStream.complete(streamId);
+            this._completeResumableStream(streamId);
             streamFinalized = true;
           }
           if (!doneSent) {
@@ -7519,7 +7529,7 @@ export class Think<
           // Finalize the stream and return WITHOUT the generic terminal path,
           // which would otherwise re-broadcast the raw stall error.
           if (!streamFinalized) {
-            this._resumableStream.markError(streamId);
+            this._errorResumableStream(streamId);
             streamFinalized = true;
           }
           doneSent = true;
@@ -7535,7 +7545,7 @@ export class Think<
         // generic terminal path below (unchanged watchdog behavior).
       }
       if (!streamFinalized) {
-        this._resumableStream.markError(streamId);
+        this._errorResumableStream(streamId);
         streamFinalized = true;
       }
       if (!doneSent) {
@@ -7768,7 +7778,7 @@ export class Think<
     }
   ): Promise<StreamResultStatus> {
     const clearGen = this._turnQueue.generation;
-    const streamId = this._resumableStream.start(requestId);
+    const streamId = this._startResumableStream(requestId);
     const continuation = options?.continuation ?? false;
     const parentId = options?.parentId;
 
@@ -7921,7 +7931,7 @@ export class Think<
       // The live-streamed chunks already reached clients; the retry's
       // `_broadcastMessages()` reconciles them to the real answer.
       if (overflowRetry && options?.overflowRecovery) {
-        this._resumableStream.complete(streamId);
+        this._completeResumableStream(streamId);
         this._pendingResumeConnections.clear();
         doneSent = true;
         options.overflowRecovery.onRetry(streamError);
@@ -7930,9 +7940,9 @@ export class Think<
       }
 
       if (streamError) {
-        this._resumableStream.markError(streamId);
+        this._errorResumableStream(streamId);
       } else {
-        this._resumableStream.complete(streamId);
+        this._completeResumableStream(streamId);
       }
       this._pendingResumeConnections.clear();
       this._broadcastChat({
@@ -7970,7 +7980,7 @@ export class Think<
           // Recovering: close the stream cleanly (no terminal error frame); the
           // scheduled continuation drives the turn to completion. Report
           // `aborted` so the caller does not terminalize the turn.
-          this._resumableStream.complete(streamId);
+          this._completeResumableStream(streamId);
           this._pendingResumeConnections.clear();
           if (!doneSent) {
             this._broadcastChat({
@@ -7997,7 +8007,7 @@ export class Think<
           // submission interrupted), identical to deploy-recovery exhaustion.
           // Finalize the stream and report `aborted` (not `error`) so the caller
           // does not re-run the generic terminal path on top of it.
-          this._resumableStream.markError(streamId);
+          this._errorResumableStream(streamId);
           this._pendingResumeConnections.clear();
           doneSent = true;
           this._streamingAssistant = null;
@@ -8011,7 +8021,7 @@ export class Think<
       if (options?.captureProgrammaticStreamError) {
         this._programmaticStreamErrors.set(requestId, streamError);
       }
-      this._resumableStream.markError(streamId);
+      this._errorResumableStream(streamId);
       this._pendingResumeConnections.clear();
       if (!doneSent) {
         this._broadcastChat({
@@ -8026,7 +8036,7 @@ export class Think<
       }
     } finally {
       if (!doneSent) {
-        this._resumableStream.markError(streamId);
+        this._errorResumableStream(streamId);
         this._pendingResumeConnections.clear();
         this._broadcastChat({
           type: MSG_CHAT_RESPONSE,
@@ -9185,7 +9195,7 @@ export class Think<
       }
 
       if (streamStillActive) {
-        this._resumableStream.complete(streamId);
+        this._completeResumableStream(streamId);
       }
 
       const shouldRetry =
@@ -10737,6 +10747,86 @@ export class Think<
     );
     if (sent) {
       this._pendingResumeConnections.add(connection.id);
+    }
+  }
+
+  /**
+   * Start a resumable stream and arm buffer cleanup. Wrapper around
+   * `ResumableStream.start`: arming on START as well as finish guarantees a
+   * stream whose DO is evicted mid-flight and never reaches a finish still gets
+   * a future sweep instead of leaking its buffer.
+   *
+   * When a turn runs inside `runFiber` (durable recovery), the DO already
+   * self-heals: `runFiber` holds `keepAlive`, which leaves a durable alarm in
+   * storage that survives eviction, fires within ~keepAliveIntervalMs, and runs
+   * the fiber-recovery scan — finalizing the stream (which arms cleanup) without
+   * any client reconnect. Arming here is the safety net for any non-fiber stream
+   * path, where no such alarm exists. The last-activity sweep threshold prevents
+   * an actively streaming run from being reclaimed before it goes quiet (#1706).
+   */
+  protected _startResumableStream(
+    requestId: string,
+    options?: { messageId?: string }
+  ): string {
+    const streamId = this._resumableStream.start(requestId, options);
+    void this._ensureStreamCleanupScheduled();
+    return streamId;
+  }
+
+  /**
+   * Mark a resumable stream completed and arm buffer cleanup. Wrapper around
+   * `ResumableStream.complete` so every stream-finish path also schedules the
+   * cleanup alarm (#1706).
+   */
+  protected _completeResumableStream(streamId: string): void {
+    this._resumableStream.complete(streamId);
+    void this._ensureStreamCleanupScheduled();
+  }
+
+  /**
+   * Mark a resumable stream errored and arm buffer cleanup. Wrapper around
+   * `ResumableStream.markError` — see {@link _completeResumableStream}.
+   */
+  protected _errorResumableStream(streamId: string): void {
+    this._resumableStream.markError(streamId);
+    void this._ensureStreamCleanupScheduled();
+  }
+
+  /**
+   * Ensure a single cleanup alarm is pending for this DO's resumable-stream
+   * buffers. Armed whenever a stream finishes so that idle/one-off chat DOs
+   * still reclaim their buffers — the lazy sweep in {@link ResumableStream}
+   * only fires when a *subsequent* stream completes, which never happens for a
+   * chat that receives a single turn (#1706).
+   *
+   * `idempotent` dedupes on (callback, payload, owner) so repeated finishes
+   * collapse onto one pending alarm rather than stacking.
+   */
+  protected async _ensureStreamCleanupScheduled({
+    idempotent = true
+  }: { idempotent?: boolean } = {}): Promise<void> {
+    await this.schedule(
+      STREAM_CLEANUP_DELAY_SECONDS,
+      "_cleanupStreamBuffers",
+      undefined,
+      { idempotent }
+    );
+  }
+
+  /**
+   * Alarm callback: sweep aged stream buffers, then re-arm only while rows
+   * remain so a fully-swept DO stops waking itself.
+   */
+  async _cleanupStreamBuffers(): Promise<void> {
+    this._resumableStream.cleanup();
+    if (this._resumableStream.hasReclaimableStreams()) {
+      // Must NOT be idempotent: this runs INSIDE the currently-executing
+      // one-shot schedule row, which `alarm()` deletes only after we return. An
+      // idempotent reschedule would dedup onto that row and then be deleted with
+      // it — the re-arm would silently never fire, leaving buffers that survived
+      // this sweep (e.g. a younger turn) uncollected. A fresh delayed row
+      // survives the deletion (mirrors the chat-recovery reschedule).
+      await this._ensureStreamCleanupScheduled({ idempotent: false });
     }
   }
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7307,7 +7307,7 @@ export class Think<
     status: "completed" | "error" | "aborted" | "overflow_retry";
     error?: string;
   }> {
-    const streamId = this._resumableStream.start(requestId);
+    const streamId = this._startResumableStream(requestId);
     const accumulator = new StreamAccumulator({
       messageId: crypto.randomUUID()
     });


### PR DESCRIPTION
## Summary

Resumable-stream chunk buffers (`cf_ai_chat_stream_*`) were only swept lazily when a *subsequent* stream completed. A chat that received a single turn and then went idle never triggered that sweep, so its buffers lingered in the Durable Object's SQLite for the lifetime of the DO — an unbounded storage leak for one-off / low-traffic chats.

This PR drives buffer cleanup from a **scheduled alarm** and replaces the single 24h retention threshold with **two short, purpose-specific windows**.

Fixes #1706.

## Alarm-driven cleanup

`AIChatAgent` and `Think` now arm a scheduled cleanup alarm whenever a stream **starts** and whenever it **finishes** (completes or errors):

- **Arming on start** is the safety net for the non-durable path (`chatRecovery: false`, the `AIChatAgent` default). Those turns don't run inside `runFiber`, so there's no leftover `keepAlive` alarm and no fiber-recovery scan; if the client never reconnects, nothing else wakes the DO. Arming on start guarantees a stream whose DO is evicted mid-flight still gets a future sweep instead of leaking.
- **Arming on finish** covers the common completed/errored case.
- Durable `runFiber` turns already self-heal (keepAlive survives eviction → recovery finalizes → arms cleanup), so arming on start is belt-and-suspenders there.

The alarm sweeps aged buffers and **re-arms only while reclaimable rows remain**, so a fully-swept DO stops waking itself. Arming is idempotent so high-turn-count chats never accumulate cleanup schedules.

> [!NOTE]
> The re-arm inside the fired callback is deliberately **non-idempotent**: `alarm()` deletes the fired one-shot row *after* the callback returns, so an idempotent reschedule would dedup onto that doomed row and vanish with it — leaking any buffer that survived the sweep. There's a dedicated regression test for this footgun.

## Two retention windows

Replaces the single 24h threshold (which would have kept the leak alive for a day) with windows matched to what each buffer is actually for:

| Window | Value | Measured from | Rationale |
| --- | --- | --- | --- |
| `COMPLETED_RETENTION_MS` | **10 min** | completion | The assistant message is persisted separately (`cf_ai_chat_agent_messages`), so a finished buffer is only a brief reconnect-and-replay grace: enough to cover a client that dropped at the completion boundary, and to deliver a pending terminal error frame (#1645) on a resumed stream. |
| `ABANDONED_STREAM_RETENTION_MS` | **1 h** | last chunk activity | Generous so an interrupted turn has time to be resumed/recovered before its buffer is presumed dead. Keyed off **last activity**, not start time, so a long-running stream still emitting chunks is never swept mid-flight. |

**Why two windows matter for recovery:** server-side reconstruction (fiber recovery and resume-ACK, via `_persistOrphanedStream`) only ever reads **active `streaming` rows**, which live in the 1h window — never the 10min completed grace. So recovering a turn interrupted more than 10 minutes ago still works. A regression test pins this.

**No new public configuration.** Correctness never depends on the window (the durable message is the source of truth), so these are sane internal defaults rather than another knob to misconfigure.

## Behavior change to be aware of

The chunk-replay window for **completed** streams shrinks from 24h to ~10 min. A client reconnecting after that still gets the full conversation via persisted history (state sync) — it just won't get token-by-token *replay* of an old finished stream, which degrades gracefully to a clean `done` frame. No data is lost (the message is always persisted independently).

## API

`ResumableStream` gains:
- `cleanup(now?)` — force a sweep, bypassing the lazy interval gate (alarm entrypoint).
- `hasReclaimableStreams()` — whether any rows remain, to decide re-arming.

## Tests

New `stream-cleanup` coverage in **both** `ai-chat` and `think`:

- arms a single alarm on finish, deduping repeats
- reclaims aged buffers when the alarm fires (no `completeStream`)
- re-arms only while reclaimable buffers remain; stops once swept
- survives the real alarm fire and re-arms when a younger buffer remains (the non-idempotent-reschedule footgun)
- arms cleanup when a stream starts
- window boundaries — completed grace (10m) vs abandoned stale (1h)
- locks the arming delay at 10 min (guards against re-lengthening toward the old leak window)
- keeps an in-flight buffer's chunks reconstructable past the completion grace (proves recovery reads the 1h `streaming` window)

Verification:
- `pnpm run check` — passes (sherif + export checks + oxfmt + oxlint + typecheck, 102 projects)
- ai-chat full suite **657 passed**; think full suite **601 passed**
- Manual smoke in `examples/playground`: normal streaming, resume-after-reconnect, and late reconnect all behave correctly

## Docs

Updated `docs/resumable-streaming.md` to describe the two windows.

> [!IMPORTANT]
> Per `docs/AGENTS.md`, this doc change must be **manually ported** to `cloudflare/cloudflare-docs` (`src/content/docs/agents/`) — there is no automated sync.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->