### PR TITLE
feat(think): support client tools on the chat() RPC path (#1709)

### DIFF
--- a/.changeset/think-chat-client-tools.md
+++ b/.changeset/think-chat-client-tools.md
@@ -1,6 +1,6 @@
 ---
-"@cloudflare/think": minor
-"agents": minor
+"@cloudflare/think": patch
+"agents": patch
 ---
 
 Support client tools on the Think sub-agent `chat()` RPC path (#1709)

--- a/.changeset/think-chat-client-tools.md
+++ b/.changeset/think-chat-client-tools.md
@@ -1,0 +1,23 @@
+---
+"@cloudflare/think": minor
+"agents": minor
+---
+
+Support client tools on the Think sub-agent `chat()` RPC path (#1709)
+
+`ChatOptions` now accepts `clientTools` (the same `ClientToolSchema[]` carried over the WebSocket chat protocol) and an `onClientToolCall` executor. This lets a parent agent that drives a Think sub-agent over `chat()` expose client-defined tools to the sub-agent and complete the tool round trip within the same turn:
+
+```ts
+await child.chat(message, callback, {
+  signal,
+  clientTools: [{ name: "get_user_timezone", parameters: { type: "object" } }],
+  onClientToolCall: async ({ toolName, input }) =>
+    runClientTool(toolName, input)
+});
+```
+
+Without `onClientToolCall`, the schemas are still registered and the model's call is surfaced through the stream callback (execute-less), matching the WebSocket behavior. With it, the call is resolved inline so the turn can continue to completion — the RPC stream callback has no inbound result channel of its own.
+
+Unlike the WebSocket path, the schemas and executor are kept per-turn and are NOT persisted: the executor is a live RPC reference that cannot survive an eviction, and there is no SPA to replay a `tool-result`. This keeps chat recovery correct — an eviction-interrupted client-tool call is repaired like a server tool (the model proceeds) rather than being mistaken for a pending human interaction and parking forever.
+
+`agents/chat`'s `createToolsFromClientSchemas` gains an optional `{ execute }` delegate (and exports a new `ClientToolExecutor` type) to build the executable variant. Both additions are backward-compatible.

--- a/docs/think/client-tools.md
+++ b/docs/think/client-tools.md
@@ -48,6 +48,41 @@ function Chat() {
 
 The `parameters` field is a JSON Schema object describing the tool's input. The `execute` function runs in the browser.
 
+## Client Tools over the Sub-Agent RPC `chat()` Path
+
+When a parent agent delegates to a Think sub-agent over RPC with `chat()` (rather than the browser WebSocket), there is no WebSocket to carry `clientTools` or to send tool results back. Pass them through `ChatOptions` instead:
+
+```typescript
+await child.chat(message, callback, {
+  signal,
+  clientTools: [
+    {
+      name: "get_user_timezone",
+      description: "Get the caller's timezone",
+      parameters: { type: "object" }
+    }
+  ],
+  onClientToolCall: async ({ toolName, input }) => {
+    // Run the client tool wherever the parent can — return its output.
+    return runClientTool(toolName, input);
+  }
+});
+```
+
+- `clientTools` registers the tool schemas for the turn, exactly like the WebSocket `clientTools` field.
+- `onClientToolCall` executes a client-tool call and returns its output. The model can call a client tool, receive the result, and continue — all within the single `chat()` call.
+
+If you omit `onClientToolCall`, the tools are registered but have no result: the model's call is surfaced through the stream callback and the turn ends with a dangling tool call (the RPC stream callback has no inbound result channel of its own). Supply `onClientToolCall` whenever you want the round trip to complete.
+
+### Behavior notes
+
+- **Recovery:** neither the schemas nor the `onClientToolCall` executor are persisted — they are per-turn only. The executor is a live RPC reference that dies with the isolate, and (unlike the WebSocket path) there is no SPA to replay a `tool-result` after an eviction. So if an eviction interrupts the turn while a client-tool call is mid-flight, chat recovery treats the orphaned call like a server tool: `continueLastTurn`'s transcript repair errors it and the model proceeds. (Persisting the schemas would instead make recovery mistake the orphan for a pending human interaction and park forever.) To re-run cleanly, the parent re-invokes `chat()` with the `clientTools` and `onClientToolCall` again.
+- **Errors:** if `onClientToolCall` throws, the failure is surfaced to the model as a tool error (`output-error`) and the turn continues — it does not crash the turn.
+- **Serialization:** the value returned from `onClientToolCall` becomes the tool output, so it must be JSON-serializable (it travels back over RPC and into the model context).
+- **No approval gate:** RPC client tools execute immediately through `onClientToolCall`. The WebSocket approval flow (`needsApproval`) does not apply on this path — gate execution inside your executor if you need it.
+- **Name precedence:** client tools are merged after server tools, so a client tool that shares a name with a server tool (for example a workspace tool) overrides it for that turn — the same as the WebSocket path.
+- **Abort:** aborting the turn via `signal` stops the loop, but an in-flight `onClientToolCall` is not itself cancelled; the turn ends after the current call resolves.
+
 ## Tool Approval
 
 Tools can require user approval before execution. This works for both server-side and client-side tools.

--- a/packages/agents/src/chat/__tests__/client-tools.test.ts
+++ b/packages/agents/src/chat/__tests__/client-tools.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { createToolsFromClientSchemas } from "../client-tools";
+
+describe("createToolsFromClientSchemas", () => {
+  it("returns an empty set for no schemas", () => {
+    expect(createToolsFromClientSchemas()).toEqual({});
+    expect(createToolsFromClientSchemas([])).toEqual({});
+  });
+
+  it("builds execute-less tools by default", () => {
+    const tools = createToolsFromClientSchemas([
+      { name: "get_time", description: "Get the time" }
+    ]);
+    expect(Object.keys(tools)).toEqual(["get_time"]);
+    expect(tools.get_time.description).toBe("Get the time");
+    // No execute — the model's call is meant to be sent back to the client.
+    expect(tools.get_time.execute).toBeUndefined();
+  });
+
+  it("wires an execute that delegates to the supplied executor", async () => {
+    const calls: Array<{
+      toolName: string;
+      input: unknown;
+      toolCallId: string;
+    }> = [];
+    const tools = createToolsFromClientSchemas(
+      [
+        {
+          name: "get_time",
+          description: "Get the time",
+          parameters: {
+            type: "object",
+            properties: { tz: { type: "string" } }
+          }
+        }
+      ],
+      {
+        execute: (call) => {
+          calls.push(call);
+          return { now: "12:00" };
+        }
+      }
+    );
+
+    expect(typeof tools.get_time.execute).toBe("function");
+    const output = await tools.get_time.execute!({ tz: "UTC" }, {
+      toolCallId: "tc-1"
+    } as never);
+    expect(output).toEqual({ now: "12:00" });
+    expect(calls).toEqual([
+      { toolName: "get_time", input: { tz: "UTC" }, toolCallId: "tc-1" }
+    ]);
+  });
+
+  it("falls back to an empty toolCallId when execute options are absent", async () => {
+    let seen: string | undefined;
+    const tools = createToolsFromClientSchemas([{ name: "ping" }], {
+      execute: (call) => {
+        seen = call.toolCallId;
+        return "pong";
+      }
+    });
+    const output = await tools.ping.execute!({}, undefined as never);
+    expect(output).toBe("pong");
+    expect(seen).toBe("");
+  });
+});

--- a/packages/agents/src/chat/client-tools.ts
+++ b/packages/agents/src/chat/client-tools.ts
@@ -2,8 +2,13 @@
  * Client tool schema handling for the cf_agent_chat protocol.
  *
  * Converts client-provided tool schemas (JSON wire format) into AI SDK
- * tool definitions. These tools have no `execute` function — when the
- * model calls them, the tool call is sent back to the client.
+ * tool definitions. By default these tools have no `execute` function —
+ * when the model calls them, the tool call is sent back to the client.
+ *
+ * When an `execute` delegate is supplied (e.g. a parent agent that drives a
+ * Think sub-agent over RPC and can run the client tools itself), the tools are
+ * built WITH an `execute` so the model's call is resolved inline within the
+ * same turn instead of being surfaced as a dangling tool call.
  *
  * Used by both @cloudflare/ai-chat and @cloudflare/think.
  */
@@ -26,16 +31,39 @@ export type ClientToolSchema = {
 };
 
 /**
+ * Executes a client-defined tool and returns its output.
+ *
+ * Used for the RPC path (e.g. a parent agent delegating to a Think sub-agent)
+ * where the caller can run the client tools itself, rather than the
+ * browser/WebSocket path where results are sent back asynchronously.
+ */
+export type ClientToolExecutor = (call: {
+  /** The name of the client tool the model called. */
+  toolName: string;
+  /** The model-generated input for the tool call. */
+  input: unknown;
+  /** The AI SDK tool-call id for the invocation. */
+  toolCallId: string;
+}) => unknown | Promise<unknown>;
+
+/**
  * Converts client tool schemas to AI SDK tool format.
  *
- * These tools have no `execute` function — when the AI model calls them,
- * the tool call is sent back to the client for execution.
+ * By default these tools have no `execute` function — when the AI model calls
+ * them, the tool call is sent back to the client for execution.
+ *
+ * When `options.execute` is provided, each tool is built WITH an `execute` that
+ * delegates to it. This is used by the RPC path (e.g. a parent agent driving a
+ * Think sub-agent) so the model's client-tool call is resolved inline within
+ * the same turn.
  *
  * @param clientTools - Array of tool schemas from the client
+ * @param options - Optional `execute` delegate to run the tools inline
  * @returns Record of AI SDK tools that can be spread into your tools object
  */
 export function createToolsFromClientSchemas(
-  clientTools?: ClientToolSchema[]
+  clientTools?: ClientToolSchema[],
+  options?: { execute?: ClientToolExecutor }
 ): ToolSet {
   if (!clientTools || clientTools.length === 0) {
     return {};
@@ -51,12 +79,39 @@ export function createToolsFromClientSchemas(
     seenNames.add(t.name);
   }
 
+  const execute = options?.execute;
+  // The AI SDK's `tool()` overloads infer the input type as `never` when an
+  // `execute` is combined with a runtime `jsonSchema(...)`. Cast to a
+  // permissive signature (same approach as `agentTool()`), since the wire
+  // schema is untyped JSON.
+  const createTool = tool as unknown as (config: {
+    description: string;
+    inputSchema: ReturnType<typeof jsonSchema>;
+    execute?: (
+      input: unknown,
+      executeOptions?: { toolCallId?: string }
+    ) => unknown | Promise<unknown>;
+  }) => Tool;
+
   return Object.fromEntries(
     clientTools.map((t) => [
       t.name,
-      tool({
+      createTool({
         description: t.description ?? "",
-        inputSchema: jsonSchema(t.parameters ?? { type: "object" })
+        inputSchema: jsonSchema(t.parameters ?? { type: "object" }),
+        ...(execute
+          ? {
+              execute: (
+                input: unknown,
+                executeOptions?: { toolCallId?: string }
+              ) =>
+                execute({
+                  toolName: t.name,
+                  input,
+                  toolCallId: executeOptions?.toolCallId ?? ""
+                })
+            }
+          : {})
       })
     ])
   );

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -42,7 +42,8 @@ export { MAX_BOUND_PARAMS, buildInClauseStrings } from "./sql-batch";
 
 export {
   createToolsFromClientSchemas,
-  type ClientToolSchema
+  type ClientToolSchema,
+  type ClientToolExecutor
 } from "./client-tools";
 
 export { CHAT_MESSAGE_TYPES } from "./protocol";

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -9,7 +9,11 @@ import type { LanguageModel, ToolSet, UIMessage } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
 import { Think } from "../../think";
-import type { ChatResponseResult, MessageConcurrency } from "../../think";
+import type {
+  ChatResponseResult,
+  MessageConcurrency,
+  StreamCallback
+} from "../../think";
 import { StreamAccumulator, type ClientToolSchema } from "agents/chat";
 
 function createClientToolMockModel(): LanguageModel {
@@ -426,6 +430,206 @@ function createSlowMockModel(
   } as LanguageModel;
 }
 
+// Like createClientToolMockModel, but emits a complete `tool-call` chunk so the
+// AI SDK will execute the tool server-side when it has an `execute` (the RPC
+// `chat()` client-tool executor path, #1709). On the continuation step (after a
+// tool result is in the prompt) it emits plain text.
+function createExecutableClientToolMockModel(): LanguageModel {
+  let callCount = 0;
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-executable-client-tool",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented");
+    },
+    doStream(options: Record<string, unknown>) {
+      callCount++;
+      const messages = (options as { prompt?: unknown[] }).prompt ?? [];
+      const hasToolResult = messages.some(
+        (m: unknown) =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).role === "tool"
+      );
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+
+          if (!hasToolResult && callCount === 1) {
+            const input = JSON.stringify({ action: "do_thing" });
+            controller.enqueue({
+              type: "tool-input-start",
+              id: "tc-client-1",
+              toolName: "client_action"
+            });
+            controller.enqueue({
+              type: "tool-input-delta",
+              id: "tc-client-1",
+              delta: input
+            });
+            controller.enqueue({ type: "tool-input-end", id: "tc-client-1" });
+            controller.enqueue({
+              type: "tool-call",
+              toolCallId: "tc-client-1",
+              toolName: "client_action",
+              input
+            });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 10, outputTokens: 5 }
+            });
+          } else {
+            controller.enqueue({ type: "text-start", id: "t-cont" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t-cont",
+              delta: "Continuation after tool"
+            });
+            controller.enqueue({ type: "text-end", id: "t-cont" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 20, outputTokens: 10 }
+            });
+          }
+
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
+// Emits a complete client-tool call (input-start/delta/end + tool-call) onto a
+// stream controller. Shared by the parallel/multi-step executable mocks below.
+function enqueueClientToolCall(
+  controller: ReadableStreamDefaultController,
+  toolCallId: string,
+  toolName: string,
+  input: Record<string, unknown>
+): void {
+  const json = JSON.stringify(input);
+  controller.enqueue({ type: "tool-input-start", id: toolCallId, toolName });
+  controller.enqueue({ type: "tool-input-delta", id: toolCallId, delta: json });
+  controller.enqueue({ type: "tool-input-end", id: toolCallId });
+  controller.enqueue({ type: "tool-call", toolCallId, toolName, input: json });
+}
+
+// Emits TWO client-tool calls in a single step, then text on the continuation.
+// Exercises parallel server-side execution of caller-supplied client tools.
+function createParallelExecutableClientToolMockModel(): LanguageModel {
+  let callCount = 0;
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-parallel-executable-client-tool",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented");
+    },
+    doStream() {
+      callCount++;
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          if (callCount === 1) {
+            enqueueClientToolCall(controller, "tc-par-1", "client_action", {
+              action: "first"
+            });
+            enqueueClientToolCall(controller, "tc-par-2", "client_action_2", {
+              action: "second"
+            });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 10, outputTokens: 5 }
+            });
+          } else {
+            controller.enqueue({ type: "text-start", id: "t-par" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t-par",
+              delta: "Continuation after parallel tools"
+            });
+            controller.enqueue({ type: "text-end", id: "t-par" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 20, outputTokens: 10 }
+            });
+          }
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
+// Emits a client-tool call on step 1, a DIFFERENT client-tool call on step 2
+// (after the first result lands), then text on step 3. Exercises the executor
+// being invoked across multiple sequential steps within one chat() turn.
+function createMultiStepExecutableClientToolMockModel(): LanguageModel {
+  let callCount = 0;
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "mock-multistep-executable-client-tool",
+    supportedUrls: {},
+    doGenerate() {
+      throw new Error("doGenerate not implemented");
+    },
+    doStream() {
+      callCount++;
+      const step = callCount;
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          if (step === 1) {
+            enqueueClientToolCall(controller, "tc-ms-1", "client_action", {
+              action: "one"
+            });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 10, outputTokens: 5 }
+            });
+          } else if (step === 2) {
+            enqueueClientToolCall(controller, "tc-ms-2", "client_action_2", {
+              action: "two"
+            });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 10, outputTokens: 5 }
+            });
+          } else {
+            controller.enqueue({ type: "text-start", id: "t-ms" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t-ms",
+              delta: "Done after two steps"
+            });
+            controller.enqueue({ type: "text-end", id: "t-ms" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 20, outputTokens: 10 }
+            });
+          }
+          controller.close();
+        }
+      });
+      return Promise.resolve({ stream });
+    }
+  } as LanguageModel;
+}
+
 function createTextOnlyMockModel(): LanguageModel {
   return {
     specificationVersion: "v3",
@@ -472,9 +676,21 @@ export class ThinkClientToolsAgent extends Think {
   private _useServerApprovalTool = false;
   private _serverApprovalToolExecutions = 0;
   private _serverApprovalToolFails = false;
+  private _useExecutableClientTool = false;
+  private _useParallelExecutableClientTool = false;
+  private _useMultiStepExecutableClientTool = false;
   private _slowDelayMs = 40;
   private _slowChunkCount = 4;
   private _responseLog: ChatResponseResult[] = [];
+  private _lastTurnToolNames: string[] = [];
+
+  override beforeTurn(ctx: { tools: ToolSet }): void {
+    this._lastTurnToolNames = Object.keys(ctx.tools);
+  }
+
+  async getLastTurnToolNames(): Promise<string[]> {
+    return this._lastTurnToolNames;
+  }
 
   override onChatResponse(result: ChatResponseResult): void {
     this._responseLog.push(result);
@@ -484,7 +700,19 @@ export class ThinkClientToolsAgent extends Think {
     return this._responseLog;
   }
 
+  // Drive a directly-invoked `chat()` (e.g. a caller passing `onClientToolCall`
+  // over RPC) through the executable client-tool mock.
+  async enableExecutableClientToolForTest(): Promise<void> {
+    this._useExecutableClientTool = true;
+  }
+
   getModel(): LanguageModel {
+    if (this._useParallelExecutableClientTool)
+      return createParallelExecutableClientToolMockModel();
+    if (this._useMultiStepExecutableClientTool)
+      return createMultiStepExecutableClientToolMockModel();
+    if (this._useExecutableClientTool)
+      return createExecutableClientToolMockModel();
     if (this._useSlowStream)
       return createSlowMockModel(this._slowDelayMs, this._slowChunkCount);
     if (this._useSlowClientToolStream)
@@ -693,6 +921,50 @@ export class ThinkClientToolsAgent extends Think {
     )._lastClientTools;
   }
 
+  /**
+   * Recovery-classification probe (#1709). Seeds a persisted assistant message
+   * holding a `client_action` tool part stuck at `input-available` — the orphan
+   * an eviction leaves when the model emitted the call but `execute` never
+   * finished. Returns whether recovery would treat it as a pending CLIENT
+   * interaction (park forever, waiting for an SPA replay) vs a recoverable
+   * orphan (repaired by `continueLastTurn`). When `polluteRegistry` is set it
+   * first writes the tool name into `_lastClientTools`, simulating the (wrong)
+   * behavior of persisting RPC client tools — proving the registry is the lever.
+   */
+  async probeClientToolOrphanPending(opts: {
+    polluteRegistry: boolean;
+  }): Promise<boolean> {
+    const internal = this as unknown as {
+      _lastClientTools: ClientToolSchema[] | undefined;
+      _persistAssistantMessage: (msg: UIMessage) => Promise<void>;
+      hasPendingInteraction: () => boolean;
+    };
+
+    if (opts.polluteRegistry) {
+      internal._lastClientTools = [
+        { name: "client_action", description: "A client tool" }
+      ];
+    } else {
+      internal._lastClientTools = undefined;
+    }
+
+    await internal._persistAssistantMessage({
+      id: crypto.randomUUID(),
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-client_action",
+          toolCallId: "tc-orphan-1",
+          toolName: "client_action",
+          state: "input-available",
+          input: { action: "do_thing" }
+        } as unknown as UIMessage["parts"][number]
+      ]
+    });
+
+    return internal.hasPendingInteraction();
+  }
+
   // Demonstrates the `repairInterruptedToolPart` override: a client-resolved
   // `ask_user` (a question with no server execute) is preserved as a text part
   // carrying the prompt rather than flipped to a generic errored tool result.
@@ -828,5 +1100,115 @@ export class ThinkClientToolsAgent extends Think {
     internal._continuationBarrierActive = false;
     internal._pendingInteractionPromise = null;
     internal._interactionApplyTail = Promise.resolve();
+  }
+
+  /**
+   * Drive the sub-agent RPC `chat()` entry point with client tools (#1709).
+   *
+   * Collects the streamed events through a local StreamCallback and, when
+   * `withExecutor` is set, records each client-tool invocation the model makes
+   * and resolves it inline. Mirrors a parent agent delegating to this sub-agent
+   * over RPC. Returns enough state to assert the round trip completed.
+   */
+  async runChatWithClientTools(
+    message: string,
+    opts?: {
+      withExecutor?: boolean;
+      executorThrows?: boolean;
+      mode?: "single" | "parallel" | "multistep";
+    }
+  ): Promise<{
+    executorCalls: Array<{ toolName: string; inputJson: string }>;
+    done: boolean;
+    error?: string;
+    assistantText: string;
+    toolPartStates: string[];
+    toolCalls: Array<{ toolName: string; state: string }>;
+  }> {
+    const mode = opts?.mode ?? "single";
+    if (mode === "parallel") {
+      this._useParallelExecutableClientTool = true;
+    } else if (mode === "multistep") {
+      this._useMultiStepExecutableClientTool = true;
+    } else {
+      this._useExecutableClientTool = true;
+    }
+
+    const executorCalls: Array<{ toolName: string; inputJson: string }> = [];
+    let done = false;
+    let error: string | undefined;
+    const callback: StreamCallback = {
+      onStart() {},
+      onEvent() {},
+      onDone() {
+        done = true;
+      },
+      onError(e: string) {
+        error = e;
+      }
+    };
+
+    // The parallel/multi-step mocks reference a second client tool; register
+    // both so the model's calls resolve regardless of mode.
+    const clientTools: ClientToolSchema[] = [
+      {
+        name: "client_action",
+        description: "A client tool",
+        parameters: {
+          type: "object",
+          properties: { action: { type: "string" } }
+        }
+      },
+      {
+        name: "client_action_2",
+        description: "A second client tool",
+        parameters: {
+          type: "object",
+          properties: { action: { type: "string" } }
+        }
+      }
+    ];
+
+    await this.chat(message, callback, {
+      clientTools,
+      onClientToolCall: opts?.withExecutor
+        ? ({ toolName, input }: { toolName: string; input: unknown }) => {
+            executorCalls.push({ toolName, inputJson: JSON.stringify(input) });
+            if (opts?.executorThrows) {
+              throw new Error("client tool executor failed");
+            }
+            return { ok: true, echoed: input };
+          }
+        : undefined
+    });
+
+    const messages = (await this.getMessages()) as UIMessage[];
+    const assistantParts = messages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => m.parts as Array<Record<string, unknown>>);
+    const assistantText = assistantParts
+      .filter((p) => p.type === "text")
+      .map((p) => p.text as string)
+      .join("");
+    const toolParts = assistantParts.filter(
+      (p) => typeof p.toolCallId === "string"
+    );
+    const toolPartStates = toolParts.map((p) => p.state as string);
+    const toolCalls = toolParts.map((p) => ({
+      toolName:
+        typeof p.type === "string" && p.type.startsWith("tool-")
+          ? p.type.slice("tool-".length)
+          : ((p.toolName as string) ?? ""),
+      state: p.state as string
+    }));
+
+    return {
+      executorCalls,
+      done,
+      error,
+      assistantText,
+      toolPartStates,
+      toolCalls
+    };
   }
 }

--- a/packages/think/src/tests/chat-options.test-d.ts
+++ b/packages/think/src/tests/chat-options.test-d.ts
@@ -1,0 +1,115 @@
+/**
+ * Type-level tests for the client-tool surface of Think's `chat()` RPC entry
+ * point (cloudflare/agents#1709).
+ *
+ * These lock the public shape of {@link ChatOptions.clientTools} and
+ * {@link ChatOptions.onClientToolCall}, plus the {@link ClientToolExecutor}
+ * contract re-used from `agents/chat`. A regression in either — a dropped
+ * field, a narrowed type, or a changed executor signature — would silently
+ * break parent agents delegating to a Think sub-agent over RPC.
+ *
+ * Checked by the typecheck script, not vitest (filename ends in `.test-d.ts`,
+ * which the workers vitest `**\/*.test.ts` glob does not match).
+ */
+
+import type { ClientToolExecutor, ClientToolSchema } from "agents/chat";
+import type { ChatOptions } from "../think";
+
+// ── ChatOptions.clientTools ────────────────────────────────────────
+
+// Accepts an array of client tool schemas.
+const withClientTools: ChatOptions = {
+  clientTools: [
+    {
+      name: "getLocation",
+      description: "Get the user's current location",
+      parameters: { type: "object", properties: {} }
+    }
+  ]
+};
+void withClientTools;
+
+// `clientTools` is optional — an empty options object compiles.
+const emptyOptions: ChatOptions = {};
+void emptyOptions;
+
+// `parameters`/`description` are optional on a schema entry.
+const minimalSchema: ChatOptions = {
+  clientTools: [{ name: "ping" }]
+};
+void minimalSchema;
+
+const wrongClientTools: ChatOptions = {
+  // @ts-expect-error — clientTools must be an array of schemas, not a string.
+  clientTools: "getLocation"
+};
+void wrongClientTools;
+
+const schemaMissingName: ChatOptions = {
+  clientTools: [
+    // @ts-expect-error — `name` is required on a client tool schema.
+    { description: "no name" }
+  ]
+};
+void schemaMissingName;
+
+// ── ChatOptions.onClientToolCall ───────────────────────────────────
+
+// Accepts a synchronous executor returning a value.
+const syncExecutor: ChatOptions = {
+  onClientToolCall: ({ toolName, input, toolCallId }) => {
+    void toolName;
+    void input;
+    void toolCallId;
+    return { ok: true };
+  }
+};
+void syncExecutor;
+
+// Accepts an async executor returning a promise.
+const asyncExecutor: ChatOptions = {
+  onClientToolCall: async () => ({ ok: true })
+};
+void asyncExecutor;
+
+// A bare `ClientToolExecutor` is assignable to the option.
+const executor: ClientToolExecutor = (call) => call.input;
+const fromTyped: ChatOptions = { onClientToolCall: executor };
+void fromTyped;
+
+const wrongExecutor: ChatOptions = {
+  // @ts-expect-error — onClientToolCall must be a function, not a string.
+  onClientToolCall: "run"
+};
+void wrongExecutor;
+
+const extraOption: ChatOptions = {
+  // @ts-expect-error — unknown options are rejected (guards against typos
+  // such as `onClientToolCalls` / `clientTool`).
+  onClientToolCalls: executor
+};
+void extraOption;
+
+// ── ClientToolExecutor call shape ──────────────────────────────────
+
+// The executor is invoked with `{ toolName, input, toolCallId }`; `input` is
+// `unknown` (the wire schema is untyped JSON) and the ids are strings.
+const probeExecutor: ClientToolExecutor = (call) => {
+  const name: string = call.toolName;
+  const id: string = call.toolCallId;
+  const input: unknown = call.input;
+  void name;
+  void id;
+  void input;
+
+  // @ts-expect-error — `input` is `unknown`; it must be narrowed before use.
+  const length: number = call.input.length;
+  void length;
+
+  return undefined;
+};
+void probeExecutor;
+
+// A schema entry is structurally a `ClientToolSchema`.
+const schema: ClientToolSchema = { name: "noop" };
+void schema;

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -3554,3 +3554,212 @@ describe("malformed tool_use.input repair (provider 400 wedge)", () => {
     expect(part.input).toEqual({ prompt: "a cat" });
   });
 });
+
+// ── Client tools over the sub-agent RPC chat() path (#1709) ──────
+
+describe("Think — client tools via chat() RPC", () => {
+  it("completes the client-tool round trip inline when an executor is supplied", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.runChatWithClientTools("use client tool", {
+      withExecutor: true
+    });
+
+    expect(await agent.getLastTurnToolNames()).toContain("client_action");
+
+    // The model called the client tool; the executor resolved it and the turn
+    // continued to a text answer — all within a single chat() call.
+    expect(result.error).toBeUndefined();
+    expect(result.done).toBe(true);
+    expect(result.executorCalls).toEqual([
+      {
+        toolName: "client_action",
+        inputJson: JSON.stringify({ action: "do_thing" })
+      }
+    ]);
+    expect(result.assistantText).toContain("Continuation after tool");
+    // The tool call was resolved (not left dangling at input-available).
+    expect(result.toolPartStates).toContain("output-available");
+    expect(result.toolPartStates).not.toContain("input-available");
+  });
+
+  it("registers client tools for the turn WITHOUT polluting the persisted registry (recovery safety)", async () => {
+    const agent = await freshAgent();
+
+    await agent.runChatWithClientTools("use client tool", {
+      withExecutor: true
+    });
+
+    // The tool was registered for the inference turn...
+    expect(await agent.getLastTurnToolNames()).toContain("client_action");
+    // ...but the RPC executor path must NOT persist it into `_lastClientTools`.
+    // Otherwise an `input-available` orphan left by an eviction would be
+    // misclassified by `_clientResolvableToolNames()` as a pending human
+    // interaction (no SPA can replay it — the executor died with the isolate),
+    // wedging recovery into parking forever instead of repairing the orphan.
+    expect(await agent.getCapturedClientTools()).toBeUndefined();
+  });
+
+  it("does not classify an interrupted RPC client-tool call as a pending human interaction (recovers, not parks)", async () => {
+    const agent = await freshAgent();
+
+    // RPC path: the executor is gone after an eviction and nothing will replay
+    // the call — so the orphan must NOT be treated as awaiting a human, letting
+    // recovery repair it instead of parking forever.
+    const pendingWhenNotPersisted = await agent.probeClientToolOrphanPending({
+      polluteRegistry: false
+    });
+    expect(pendingWhenNotPersisted).toBe(false);
+  });
+
+  it("would wedge recovery if the RPC client tool were persisted (guards the fix)", async () => {
+    const agent = await freshAgent();
+
+    // Demonstrates the lever: had the RPC path persisted the schema into
+    // `_lastClientTools` (like the WebSocket path), the very same orphan would
+    // be misclassified as a pending human interaction — which is exactly why
+    // `chat()` keeps RPC client tools per-turn only.
+    const pendingWhenPersisted = await agent.probeClientToolOrphanPending({
+      polluteRegistry: true
+    });
+    expect(pendingWhenPersisted).toBe(true);
+  });
+
+  it("handles an executor that throws without crashing the turn", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.runChatWithClientTools("use client tool", {
+      withExecutor: true,
+      executorThrows: true
+    });
+
+    // The executor was invoked and threw; the failure is surfaced to the model
+    // as a tool error (not an unhandled crash) and the call resolves.
+    expect(result.executorCalls).toHaveLength(1);
+    expect(result.done).toBe(true);
+    expect(result.toolPartStates).toContain("output-error");
+    expect(result.toolPartStates).not.toContain("output-available");
+  });
+
+  it("surfaces a dangling tool call when no executor is supplied (documents the gap the executor closes)", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.runChatWithClientTools("use client tool");
+
+    // Without an executor the client tool has no result: the model's call is
+    // surfaced to the caller and the turn ends with a dangling tool call rather
+    // than continuing to a text answer.
+    expect(result.error).toBeUndefined();
+    expect(result.done).toBe(true);
+    expect(result.executorCalls).toEqual([]);
+    expect(result.assistantText).not.toContain("Continuation after tool");
+    expect(result.toolPartStates).toContain("input-available");
+    expect(result.toolPartStates).not.toContain("output-available");
+  });
+
+  it("resolves multiple client tools called in parallel within one turn", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.runChatWithClientTools("use client tools", {
+      withExecutor: true,
+      mode: "parallel"
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.done).toBe(true);
+    // Both parallel calls were dispatched to the executor and resolved.
+    expect(result.executorCalls.map((c) => c.toolName).sort()).toEqual([
+      "client_action",
+      "client_action_2"
+    ]);
+    expect(
+      result.toolCalls
+        .filter((c) => c.state === "output-available")
+        .map((c) => c.toolName)
+        .sort()
+    ).toEqual(["client_action", "client_action_2"]);
+    expect(result.assistantText).toContain("Continuation after parallel tools");
+  });
+
+  it("invokes the executor across multiple sequential steps in one turn", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.runChatWithClientTools("use client tools", {
+      withExecutor: true,
+      mode: "multistep"
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.done).toBe(true);
+    // Step 1 called client_action, step 2 (after its result) called
+    // client_action_2 — the executor fired once per step, in order.
+    expect(result.executorCalls.map((c) => c.toolName)).toEqual([
+      "client_action",
+      "client_action_2"
+    ]);
+    expect(
+      result.toolCalls
+        .filter((c) => c.state === "output-available")
+        .map((c) => c.toolName)
+        .sort()
+    ).toEqual(["client_action", "client_action_2"]);
+    expect(result.assistantText).toContain("Done after two steps");
+  });
+
+  it("invokes onClientToolCall across the RPC boundary (caller-supplied executor)", async () => {
+    const agent = await freshAgent();
+    await agent.enableExecutableClientToolForTest();
+
+    // The callback and executor are defined HERE (the caller's isolate) and
+    // passed into the child's chat() over RPC — the child calls them back
+    // across the isolate boundary, exactly as a parent agent driving a Think
+    // sub-agent would. Functions cross RPC as stubs, so this exercises the real
+    // serialization path, not an in-process shortcut.
+    let executorRan = false;
+    let executorInputJson = "";
+    const callback = {
+      onStart() {},
+      onEvent() {},
+      onDone() {},
+      onError() {}
+    };
+
+    await agent.chat("use client tool", callback as never, {
+      clientTools: [
+        {
+          name: "client_action",
+          description: "A client tool",
+          parameters: {
+            type: "object",
+            properties: { action: { type: "string" } }
+          }
+        }
+      ],
+      onClientToolCall: ({ input }: { toolName: string; input: unknown }) => {
+        executorRan = true;
+        executorInputJson = JSON.stringify(input);
+        return { ok: true, echoed: input };
+      }
+    });
+
+    // The executor (in this isolate) was invoked by the child across RPC...
+    expect(executorRan).toBe(true);
+    expect(executorInputJson).toBe(JSON.stringify({ action: "do_thing" }));
+
+    // ...and its returned output flowed back into the child's turn, which
+    // resolved the call and continued to a text answer.
+    const messages = (await agent.getMessages()) as UIMessage[];
+    const parts = messages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => m.parts as Array<Record<string, unknown>>);
+    const text = parts
+      .filter((p) => p.type === "text")
+      .map((p) => p.text as string)
+      .join("");
+    const toolStates = parts
+      .filter((p) => p.toolCallId === "tc-client-1")
+      .map((p) => p.state as string);
+    expect(text).toContain("Continuation after tool");
+    expect(toolStates).toContain("output-available");
+  });
+});

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -159,6 +159,7 @@ import {
 import type {
   StreamChunkData,
   ClientToolSchema,
+  ClientToolExecutor,
   MessagePart,
   SubmitConcurrencyDecision,
   ChatFiberSnapshot
@@ -837,6 +838,28 @@ export interface StreamableResult {
  */
 export interface ChatOptions {
   signal?: AbortSignal;
+  /**
+   * Client-defined tool schemas to expose to the model for this turn, mirroring
+   * the `clientTools` carried over the WebSocket chat protocol. Use this when a
+   * parent agent delegates to a Think sub-agent over RPC but the sub-agent still
+   * needs access to tools the client (or parent) defines at runtime.
+   *
+   * On their own these are execute-less — the model's call surfaces as a tool
+   * call through the stream callback. Provide {@link ChatOptions.onClientToolCall}
+   * to also resolve those calls inline so the turn can continue to completion.
+   */
+  clientTools?: ClientToolSchema[];
+  /**
+   * Executes a client tool call and returns its output, completing the
+   * round trip for {@link ChatOptions.clientTools} within the same turn.
+   *
+   * Without this, a client-tool call has no result and the turn ends with a
+   * dangling tool call (the RPC stream callback has no inbound result channel).
+   * With it, the model can call a client tool, receive the result, and keep
+   * going — the same multi-step behavior the WebSocket path gets from
+   * `cf_agent_tool_result` messages.
+   */
+  onClientToolCall?: ClientToolExecutor;
 }
 
 type AgentToolChildRunStatus =
@@ -1167,6 +1190,13 @@ export interface TurnInput {
   signal?: AbortSignal;
   /** Client-provided tool schemas for dynamic tool registration. */
   clientTools?: ClientToolSchema[];
+  /**
+   * Executor that resolves client-tool calls inline (RPC `chat()` path). When
+   * present, `clientTools` are built WITH an `execute` that delegates to it, so
+   * the turn completes the tool round trip itself instead of surfacing a
+   * dangling tool call. Not persisted — recovery cannot replay a live executor.
+   */
+  clientToolExecutor?: ClientToolExecutor;
   /** Custom body fields from the client request. */
   body?: Record<string, unknown>;
   /** Internal workflow prompt configuration, never sourced from client body. */
@@ -3311,7 +3341,12 @@ export class Think<
     await this._refreshSkillsIfChanged();
     const contextTools = await this.session.tools();
     const skillTools = this._skillRegistry?.tools() ?? {};
-    const clientToolSet = createToolsFromClientSchemas(input.clientTools);
+    const clientToolSet = createToolsFromClientSchemas(
+      input.clientTools,
+      input.clientToolExecutor
+        ? { execute: input.clientToolExecutor }
+        : undefined
+    );
     const tools: ToolSet = {
       ...workspaceTools,
       ...baseTools,
@@ -4093,6 +4128,23 @@ export class Think<
       );
     }
 
+    // Client tools supplied by the caller (e.g. a parent agent delegating to
+    // this sub-agent). Both the schemas and the `onClientToolCall` executor are
+    // forwarded per-turn only — deliberately NOT persisted into
+    // `_lastClientTools`. The executor is a live RPC ref that dies with the
+    // isolate, so unlike the WebSocket path there is no SPA that could ever
+    // replay a `tool-result` after an eviction. Persisting the names would put
+    // them in `_clientResolvableToolNames()`, causing recovery to misclassify a
+    // dangling `input-available` orphan as a pending human interaction and park
+    // forever. Keeping them per-turn lets such an orphan recover like a server
+    // tool: `continueLastTurn`'s transcript repair errors it and the model
+    // proceeds. `_runInferenceLoop` sources client tools from `input.clientTools`
+    // (not `_lastClientTools`), so the live turn is unaffected.
+    const clientTools = options?.clientTools?.length
+      ? options.clientTools
+      : undefined;
+    const clientToolExecutor = options?.onClientToolCall;
+
     try {
       await callback.onStart({ requestId });
       await this.keepAliveWhile(async () => {
@@ -4130,6 +4182,8 @@ export class Think<
                   () =>
                     this._runInferenceLoop({
                       signal: abortSignal,
+                      clientTools,
+                      clientToolExecutor,
                       continuation: false
                     })
                 );


### PR DESCRIPTION
## Summary

Closes #1709.

Think's `chat()` sub-agent RPC entry point now supports **client-defined tools**, matching the capability `@cloudflare/ai-chat` already exposes over the WebSocket chat protocol. A parent agent that drives a Think sub-agent over `chat()` can now expose client tools to the sub-agent **and complete the tool round trip within the same turn**.

```ts
await child.chat(message, callback, {
  signal,
  clientTools: [{ name: "get_user_timezone", parameters: { type: "object" } }],
  onClientToolCall: async ({ toolName, input }) => runClientTool(toolName, input)
});
```

Previously `chat()` had no way to pass client tool schemas, so a parent delegating over RPC couldn't give the sub-agent access to tools the client/parent defines at runtime — the gap reported in #1709.

## What changed

**`agents/chat`**
- `createToolsFromClientSchemas()` gains an optional `{ execute }` delegate and exports a new `ClientToolExecutor` type.
- Without a delegate the tools are execute-less (**unchanged** behavior). With one, each tool is built *with* an `execute` that delegates to the caller-supplied executor. Fully backward compatible.

**`@cloudflare/think`**
- `ChatOptions` now accepts `clientTools` (`ClientToolSchema[]`) and `onClientToolCall` (`ClientToolExecutor`).
- `chat()` forwards both into `_runInferenceLoop` via `TurnInput.clientTools` / `clientToolExecutor`, which builds the client tool set from the **live turn input** and merges it with server tools.
- Without `onClientToolCall`, schemas are still registered and the model's call surfaces through the stream callback (execute-less), matching the WebSocket behavior. With it, the call is resolved inline so the turn continues to completion — the RPC stream callback has no inbound result channel of its own.

## Recovery correctness (important)

Unlike the WebSocket path, the schemas and executor are kept **per-turn** and are deliberately **NOT persisted** into `_lastClientTools`:

- The executor is a **live RPC reference** that cannot survive an isolate eviction, and there is no SPA to replay a `cf_agent_tool_result`.
- Persisting the names would put them in `_clientResolvableToolNames()`, causing recovery to **misclassify a dangling `input-available` orphan as a pending human interaction and park forever**.

Keeping them per-turn lets such an orphan recover like a server tool: transcript repair errors the dangling call and the model proceeds. `_runInferenceLoop` sources client tools from `input` (not `_lastClientTools`), so the live turn is unaffected.

## Tests

- **`agents/chat` unit** (`src/chat/__tests__/client-tools.test.ts`): execute-less default + executor delegation.
- **Think behavioral** (`src/tests/client-tools.test.ts`): inline executor round trip, executor throws, dangling call (no executor), **parallel** client-tool calls in one turn, **multi-step** client-tool calls, and a **real cross-DO test** where the executor is defined in the *caller* isolate and invoked by the child over the actual RPC boundary.
- **Recovery-classification probe**: proves RPC client-tool orphans are not parked.
- **Type-level** (`src/tests/chat-options.test-d.ts`): locks the `ChatOptions` client-tool surface and the `ClientToolExecutor` contract (`@ts-expect-error` guards against dropped fields / narrowed types / typos).

## Docs + changeset

- `docs/think/client-tools.md`: new section on client tools over the `chat()` RPC path — recovery, error handling, serialization, approval gating, name precedence, abort behavior.
- `.changeset/think-chat-client-tools.md`: **patch** bump for `@cloudflare/think` and `agents`.

## Verification

- `pnpm run typecheck` — green across **102 projects** (includes the new type-level test).
- `@cloudflare/think` `client-tools.test.ts` — **85 passed** (9 in the `via chat() RPC` group).
- `agents` chat-project `client-tools.test.ts` — **4 passed**.

## Backward compatibility

Both additions are additive and optional. Existing `chat()` callers, WebSocket client-tool flows, and `createToolsFromClientSchemas` call sites are unaffected.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
