### PR TITLE
fix(worker-bundler): eliminate polynomial ReDoS in import/export regexes

### DIFF
--- a/.changeset/redos-import-regex.md
+++ b/.changeset/redos-import-regex.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/worker-bundler": patch
+---
+
+fix: eliminate polynomial-time ReDoS in import/export matching. The `importExportRegex` in `rewriteImports` and the regex fallback in `parseImports` matched the import clause with `[\w*{}\s,]+` followed by `\s+`, letting both quantifiers consume the same whitespace and backtrack catastrophically on near-match inputs (`import` + 10k spaces took ~175s). Clauses are now matched as non-whitespace tokens separated by whitespace, which is linear and behaviorally equivalent.

--- a/packages/worker-bundler/src/resolver.ts
+++ b/packages/worker-bundler/src/resolver.ts
@@ -339,8 +339,10 @@ function parseImportsRegex(code: string): string[] {
   // import { foo } from 'bar'
   // import * as foo from 'bar'
   // import 'bar'
+  // Token-separated clause form — see rewriteImports in transformer.ts; the
+  // `[\w*{}\s,]+\s+` shape backtracks polynomially on near-matches (#1537).
   const importRegex =
-    /import\s+(?:(?:[\w*{}\s,]+)\s+from\s+)?['"]([^'"]+)['"]/g;
+    /import\s+(?:[\w*{},]+(?:\s+[\w*{},]+)*\s+from\s+)?['"]([^'"]+)['"]/g;
   for (const match of code.matchAll(importRegex)) {
     const specifier = match[1];
     if (specifier) {
@@ -363,7 +365,7 @@ function parseImportsRegex(code: string): string[] {
   // export { foo } from 'bar'
   // export * from 'bar'
   const exportFromRegex =
-    /export\s+(?:[\w*{}\s,]+\s+)?from\s+['"]([^'"]+)['"]/g;
+    /export\s+(?:[\w*{},]+(?:\s+[\w*{},]+)*\s+)?from\s+['"]([^'"]+)['"]/g;
   for (const match of code.matchAll(exportFromRegex)) {
     const specifier = match[1];
     if (specifier) {

--- a/packages/worker-bundler/src/tests/redos.test.ts
+++ b/packages/worker-bundler/src/tests/redos.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryFileSystem } from "../file-system";
+import { parseImports } from "../resolver";
+import { transformAndResolve } from "../transformer";
+
+// Regression tests for #1537: the import/export rewrite and the regex
+// fallback parser used `[\w*{}\s,]+` followed by `\s+`, where both
+// quantifiers can consume the same whitespace. On near-match inputs like
+// `import <many spaces> X` the engine backtracked polynomially —
+// ~175s for 10k spaces. The clause is now matched as non-whitespace tokens
+// separated by whitespace, which is linear. The timing bounds below are
+// deliberately generous (the fixed code runs in milliseconds); the old code
+// exceeds them by orders of magnitude.
+
+const WHITESPACE_BOMB = `import ${" ".repeat(50_000)}X`;
+
+describe("import rewriting is ReDoS-safe (#1537)", () => {
+  it("transformAndResolve completes quickly on a whitespace-bomb module", async () => {
+    const files = new InMemoryFileSystem({ "index.js": WHITESPACE_BOMB });
+    const start = performance.now();
+    const result = await transformAndResolve(files, "index.js", []);
+    const elapsed = performance.now() - start;
+    expect(result.mainModule).toBe("index.js");
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("parseImports regex fallback completes quickly on a whitespace bomb", () => {
+    // JSX forces es-module-lexer to throw, exercising parseImportsRegex.
+    const code = `const jsx = <div />;\n${WHITESPACE_BOMB}\nexport ${" ".repeat(50_000)}from!`;
+    const start = performance.now();
+    parseImports(code);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("still rewrites every import/export form", async () => {
+    const files = new InMemoryFileSystem({
+      "index.js": [
+        `import def from './dep.js';`,
+        `import { a, b } from './dep.js';`,
+        `import * as ns from './dep.js';`,
+        `import def2, { c } from './dep.js';`,
+        `import './dep.js';`,
+        `import {`,
+        `  multi,`,
+        `  line`,
+        `} from './dep.js';`,
+        `export { a } from './dep.js';`,
+        `export * from './dep.js';`,
+        `export const local = 1;`
+      ].join("\n"),
+      "dep.js":
+        "export const a = 1, b = 2, c = 3, multi = 4, line = 5;\nexport default 6;"
+    });
+    const result = await transformAndResolve(files, "index.js", []);
+    const code = result.modules["index.js"] as string;
+    // Every one of the 8 import/export statements still references the dep
+    // module after rewriting — none are dropped or mangled.
+    const matches = code.match(/dep\.js/g) ?? [];
+    expect(matches.length).toBe(8);
+    expect(result.modules["dep.js"]).toBeDefined();
+  });
+
+  it("regex fallback still extracts every import/export form", () => {
+    const code = [
+      `const jsx = <div />;`, // force es-module-lexer failure
+      `import a from 'mod-a';`,
+      `import { b } from "mod-b";`,
+      `import * as c from 'mod-c';`,
+      `import 'mod-side';`,
+      `import d, { e } from 'mod-d';`,
+      `export { f } from 'mod-e';`,
+      `export * from 'mod-f';`,
+      `import('mod-dyn');`
+    ].join("\n");
+    expect(new Set(parseImports(code))).toEqual(
+      new Set([
+        "mod-a",
+        "mod-b",
+        "mod-c",
+        "mod-side",
+        "mod-d",
+        "mod-e",
+        "mod-f",
+        "mod-dyn"
+      ])
+    );
+  });
+});

--- a/packages/worker-bundler/src/transformer.ts
+++ b/packages/worker-bundler/src/transformer.ts
@@ -281,8 +281,12 @@ function rewriteImports(
 ): string {
   // Match import/export statements with string specifiers
   // Handles: import x from 'y', import { x } from 'y', import 'y', export { x } from 'y', export * from 'y'
+  // The clause is matched as non-whitespace tokens separated by whitespace
+  // (`[\w*{},]+(?:\s+[\w*{},]+)*`) so no two adjacent quantifiers can consume
+  // the same whitespace — the previous `[\w*{}\s,]+\s+` form backtracked
+  // polynomially on near-match inputs like `import <many spaces> X` (#1537).
   const importExportRegex =
-    /(import\s+(?:[\w*{}\s,]+\s+from\s+)?|export\s+(?:[\w*{}\s,]+\s+)?from\s+)(['"])([^'"]+)\2/g;
+    /(import\s+(?:[\w*{},]+(?:\s+[\w*{},]+)*\s+from\s+)?|export\s+(?:[\w*{},]+(?:\s+[\w*{},]+)*\s+)?from\s+)(['"])([^'"]+)\2/g;
 
   // Get importer's output path to use as the base for resolving
   const importerOutputPath = pathMap.get(importer) ?? importer;


### PR DESCRIPTION
> [!NOTE]
> This is a Fable experiment (model-authored PR). Please close if it adds no value.

Fixes #1537

## Problem

`rewriteImports` (`packages/worker-bundler/src/transformer.ts`) matched import/export clauses with:

```
(?:[\w*{}\s,]+\s+from\s+)?
```

`[\w*{}\s,]+` includes `\s`, so it overlaps with the adjacent `\s+` — on near-match input the engine backtracks through every split of the whitespace between the two quantifiers. The issue's PoC reproduces on main:

| input | old regex | new regex |
|---|---|---|
| `import` + 1k spaces + `X` | 180 ms | 0.1 ms |
| `import` + 5k spaces + `X` | 22.7 s | 0.0 ms |
| `import` + 10k spaces + `X` | **175.6 s** | 0.0 ms |

The same shape exists in two more places the issue didn't mention: `parseImportsRegex` in `resolver.ts` (`importRegex` and `exportFromRegex`) — the fallback parser that runs whenever es-module-lexer throws (e.g. on JSX/TSX), so it's reachable with untrusted module source too. Fixed all three.

## Fix

Match the clause as non-whitespace tokens separated by whitespace:

```
[\w*{},]+(?:\s+[\w*{},]+)*
```

No two adjacent quantifiers can consume the same characters, so matching is linear. I considered the bounded-quantifier mitigation (`{1,200}`) but rejected it: it caps rather than removes the overlap (still ~2.7s at n=5000) and silently stops matching legitimately long clauses (a 200+ char multi-line named-import list).

Verified equivalent on a 15-case corpus (default/named/namespace/side-effect/mixed/multi-line imports, `export {…} from` / `export * from`, near-miss non-imports, dynamic import) and stress-tested the new pattern against other adversarial shapes (repeated `from` tokens, stacked near-matches, token tails) — all sub-20ms.

## Tests

`packages/worker-bundler/src/tests/redos.test.ts` (new):

- `transformAndResolve` on a 50k-space whitespace-bomb module completes in ms (bounded at 5s; old code takes tens of minutes at this size, so the bound is generous but unambiguous)
- `parseImports` regex fallback (forced via JSX) on the same bomb completes in ms
- All 8 import/export statement forms still rewrite correctly through `transformAndResolve`
- The regex fallback still extracts every specifier form (static, named, namespace, side-effect, mixed, `export … from`, dynamic)

Full package suite: 185 passed (6 files) via `pnpm test`. Typecheck/oxfmt/oxlint clean.

## Notes for maintainers

- Behavior is unchanged for valid code; the only observable difference is performance on pathological input.
- The reporter filed this through HackerOne first (triaged informative), so discussing the fix publicly here is fine.
- The third occurrence (`dynamicImportRegex`) has no overlapping quantifiers and is untouched.
- Changeset included (`@cloudflare/worker-bundler` patch).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->