### PR TITLE
fix(agents): warn when addMcpServer falls back to the default callback URL

### DIFF
--- a/.changeset/default-callback-warn.md
+++ b/.changeset/default-callback-warn.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+fix: `addMcpServer` now warns when it falls back to the default OAuth callback URL because no `callbackPath` was provided. The default path embeds the agent instance name and only works when the Worker routes the agents prefix through `routeAgentRequest`; previously the fallback was silent whenever `sendIdentityOnConnect` was `true`, letting OAuth flows hang in `AUTHENTICATING` with no signal.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -10779,9 +10779,21 @@ export class Agent<
     let callbackUrl: string | undefined;
     if (resolvedCallbackHost) {
       const normalizedHost = resolvedCallbackHost.replace(/\/$/, "");
-      callbackUrl = resolvedCallbackPath
-        ? `${normalizedHost}/${resolvedCallbackPath.replace(/^\//, "")}`
-        : `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
+      if (resolvedCallbackPath) {
+        callbackUrl = `${normalizedHost}/${resolvedCallbackPath.replace(/^\//, "")}`;
+      } else {
+        // The sendIdentityOnConnect:false guard above throws for this case;
+        // every other path that lands here gets a warning instead — the
+        // default URL leaks the instance name and only works when the Worker
+        // routes the agents prefix through routeAgentRequest (#1378).
+        callbackUrl = `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
+        console.warn(
+          `addMcpServer("${serverName}"): no callbackPath was provided, falling back to the default OAuth callback URL ${callbackUrl}. ` +
+            `This exposes the agent instance name in the URL and only works if your Worker routes /${resolvedAgentsPrefix}/* ` +
+            `through routeAgentRequest. If that route is handled elsewhere (e.g. static assets), the OAuth flow will hang in ` +
+            `AUTHENTICATING — pass an explicit callbackPath and route it to this agent via getAgentByName.`
+        );
+      }
     }
 
     const id = requestedId ?? nanoid(8);

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -10782,10 +10782,13 @@ export class Agent<
       if (resolvedCallbackPath) {
         callbackUrl = `${normalizedHost}/${resolvedCallbackPath.replace(/^\//, "")}`;
       } else {
-        // The sendIdentityOnConnect:false guard above throws for this case;
-        // every other path that lands here gets a warning instead — the
-        // default URL leaks the instance name and only works when the Worker
-        // routes the agents prefix through routeAgentRequest (#1378).
+        // The guard above throws only for sendIdentityOnConnect:false with an
+        // explicitly provided callbackHost. Every path that still lands here —
+        // sendIdentityOnConnect:true, or an auto-derived host regardless of
+        // that option — gets a warning instead: the default URL leaks the
+        // instance name and only works when the Worker routes the agents
+        // prefix through routeAgentRequest (#1378). Escalating the derived-
+        // host case to a throw would break currently-working setups.
         callbackUrl = `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
         console.warn(
           `addMcpServer("${serverName}"): no callbackPath was provided, falling back to the default OAuth callback URL ${callbackUrl}. ` +

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -1054,6 +1054,45 @@ export class TestHttpMcpDedupAgent extends Agent {
       };
     }
   }
+
+  // #1378: capture console.warn during addMcpServer to assert the default
+  // callback URL warning fires (and stays silent with an explicit path).
+  private async _captureWarnings(
+    fn: () => Promise<unknown>
+  ): Promise<string[]> {
+    const captured: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      captured.push(args.map(String).join(" "));
+    };
+    try {
+      await fn();
+    } catch {
+      // connection failures from the mocked transport are expected
+    } finally {
+      console.warn = originalWarn;
+    }
+    return captured;
+  }
+
+  async testDefaultCallbackUrlWarns() {
+    const warnings = await this._captureWarnings(() =>
+      this.addMcpServer("warn-server", "https://mcp.example.com/warn", {
+        callbackHost: "https://example.com"
+      })
+    );
+    return { warnings };
+  }
+
+  async testExplicitCallbackPathDoesNotWarn() {
+    const warnings = await this._captureWarnings(() =>
+      this.addMcpServer("no-warn-server", "https://mcp.example.com/no-warn", {
+        callbackHost: "https://example.com",
+        callbackPath: "/auth/mcp-callback"
+      })
+    );
+    return { warnings };
+  }
 }
 
 /**

--- a/packages/agents/src/tests/mcp/add-mcp-server.test.ts
+++ b/packages/agents/src/tests/mcp/add-mcp-server.test.ts
@@ -72,6 +72,43 @@ describe("addMcpServer callbackPath enforcement", () => {
   });
 });
 
+describe("addMcpServer default callback URL warning (#1378)", () => {
+  it("warns when the default callback URL is used without callbackPath", async () => {
+    const agentStub = await getAgentByName(
+      env.TestHttpMcpDedupAgent,
+      "test-default-callback-warn"
+    );
+    const { warnings } = (await agentStub.testDefaultCallbackUrlWarns()) as {
+      warnings: string[];
+    };
+    const warning = warnings.find((w) =>
+      w.includes("falling back to the default OAuth callback URL")
+    );
+    expect(warning).toBeDefined();
+    expect(warning).toContain('addMcpServer("warn-server")');
+    // Default URL embeds the agents prefix and the instance name
+    expect(warning).toContain("https://example.com/agents/");
+    expect(warning).toContain("/test-default-callback-warn/callback");
+    expect(warning).toContain("callbackPath");
+  });
+
+  it("does not warn when an explicit callbackPath is provided", async () => {
+    const agentStub = await getAgentByName(
+      env.TestHttpMcpDedupAgent,
+      "test-explicit-callback-no-warn"
+    );
+    const { warnings } =
+      (await agentStub.testExplicitCallbackPathDoesNotWarn()) as {
+        warnings: string[];
+      };
+    expect(
+      warnings.filter((w) =>
+        w.includes("falling back to the default OAuth callback URL")
+      )
+    ).toEqual([]);
+  });
+});
+
 describe("addMcpServer API overloads", () => {
   describe("new options-based API", () => {
     it("should resolve options object with all fields", async () => {


### PR DESCRIPTION
> [!NOTE]
> This is a Fable experiment (model-authored PR). Please close if it adds no value.

Fixes #1378

## Problem

`addMcpServer` has a guard that throws when `sendIdentityOnConnect: false` + explicit `callbackHost` + no `callbackPath`. But the guard is bypassed on two paths:

- `sendIdentityOnConnect: true` (the case in the issue — an option about WS identity broadcasting silently disabling callback-path safety), and
- a `callbackHost` auto-derived from the current request/connection (derivation happens *after* the guard).

On both paths the default callback URL (`…/{agentsPrefix}/{kebab(class)}/{this.name}/callback`) is silently generated and persisted. If the Worker doesn't route `/agents/*` through `routeAgentRequest` (e.g. narrowed `run_worker_first` + SPA assets, as in `examples/assistant`), the OAuth redirect never reaches the DO and the MCP server hangs in `AUTHENTICATING` with zero server-side signal.

## Fix

Per the issue's least-disruptive option (and Matt's call): `console.warn` whenever the default callback URL is constructed because no `callbackPath` was provided. The warning names the server, prints the exact fallback URL, explains the routing requirement and the failure mode, and says what to do (`callbackPath` + `getAgentByName`).

The existing `sendIdentityOnConnect: false` **throw is unchanged** — this only adds a signal to the paths that previously proceeded silently. No behavioral change to URL construction.

## Tests

Two new tests in `packages/agents/src/tests/mcp/add-mcp-server.test.ts`, via warn-capturing probe methods on the existing `TestHttpMcpDedupAgent` (default `sendIdentityOnConnect: true`, mocked `connectToServer`):

- default URL without `callbackPath` → warning fires, includes server name, the full default URL (instance name visible), and the `callbackPath` remediation
- explicit `callbackPath` → no warning

Full MCP suite: 492 passed (26 files). Typecheck/oxfmt/oxlint clean.

## Notes for maintainers

- Deliberately a warn, not a throw — throwing on the derived-host default would break currently-working setups that do route `/agents/*` correctly (the default URL is fine there). Escalating to a throw in the next major could be paired with #844.
- The warning fires once per `addMcpServer` call (server registration time), not per request, so it can't spam logs.
- Changeset included (`agents` patch).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->