### PR TITLE
feat(mcp): MCP conformance test suites + two OAuth client fixes

### DIFF
--- a/.changeset/mcp-conformance-oauth-fixes.md
+++ b/.changeset/mcp-conformance-oauth-fixes.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+---
+
+Fix two MCP client OAuth bugs found by the new conformance suite, and add MCP conformance testing.
+
+- `MCPClientConnection` now finishes OAuth on the transport that received the 401. A fresh transport loses the resource metadata URL from the `WWW-Authenticate` header, so token exchange fell back to the default `/token` path and failed against authorization servers at non-default locations.
+- `MCPClientConnection.init()` detaches the previous transport before reconnecting. Re-authorizing after a mid-session 401 (scope step-up, token revocation) previously failed permanently with "Already connected to a transport".
+- Added the official `@modelcontextprotocol/conformance` suite (as used by the MCP TypeScript SDK) running against the MCP client (`Agent` + `MCPClientManager`), `McpAgent`, and `createMcpHandler` + `WorkerTransport` — all hosted in workerd via `wrangler dev`. See `packages/agents/conformance/README.md`.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,37 @@
+name: MCP Conformance
+
+on:
+  pull_request:
+    paths:
+      - "packages/agents/**"
+      - ".github/workflows/conformance.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/agents/**"
+      - ".github/workflows/conformance.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  client-conformance:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install
+      - run: pnpm --filter agents run test:conformance:client
+
+  server-conformance:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        variant: [mcp-agent, handler]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install
+      - run: pnpm --filter agents run test:conformance:server:${{ matrix.variant }}

--- a/packages/agents/conformance/README.md
+++ b/packages/agents/conformance/README.md
@@ -1,0 +1,60 @@
+# MCP conformance tests
+
+Runs the official [MCP conformance suite](https://github.com/modelcontextprotocol/conformance)
+(`@modelcontextprotocol/conformance`) against the MCP implementations in this
+package, the same way the
+[MCP TypeScript SDK does](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/test/conformance).
+
+Everything under test runs inside workerd (via `wrangler dev`), so the
+implementations are exercised as they actually run in production — Durable
+Object storage, real routes, real transports — not a Node approximation.
+
+## What is tested
+
+| Suite    | Implementation under test                                                               | Entry point                      |
+| -------- | --------------------------------------------------------------------------------------- | -------------------------------- |
+| `client` | `Agent` + `MCPClientManager` (+ `DurableObjectOAuthClientProvider` for OAuth scenarios) | `ConformanceHost` in `worker.ts` |
+| `server` | `McpAgent`                                                                              | `/mcp-agent` in `worker.ts`      |
+| `server` | `createMcpHandler` + `WorkerTransport` inside an `Agent`                                | `/mcp-handler` in `worker.ts`    |
+
+Both server variants register the same feature set (`everything-server.ts`,
+ported from the TypeScript SDK's conformance "everything server").
+
+## How it works
+
+```
+conformance CLI ──spawns per scenario──▶ driver.mjs (Node, plays "browser")
+                                            │ POST /agents/conformance-host/<uuid>/run
+                                            ▼
+wrangler dev ──▶ ConformanceHost (Agent DO) ──addMcpServer()──▶ conformance test server
+                       ▲ real OAuth callback route ◀── driver follows authUrl redirect
+```
+
+- **Client suite**: the conformance CLI starts a reference MCP server per
+  scenario and spawns `driver.mjs` to connect to it. The driver forwards the
+  scenario to a fresh `ConformanceHost` agent instance, which connects out via
+  `addMcpServer()`. For OAuth scenarios the worker returns the authorization
+  URL and the driver simulates the user's browser: it follows the redirect
+  chain into the worker's real `/callback` route, then resumes the scenario.
+- **Server suites**: the conformance CLI acts as a reference MCP client and
+  talks directly to the two server endpoints on the worker.
+
+## Running locally
+
+```sh
+cd packages/agents
+pnpm run test:conformance                    # all three suites
+pnpm run test:conformance:client             # client only
+pnpm run test:conformance:server:mcp-agent   # McpAgent server only
+pnpm run test:conformance:server:handler     # createMcpHandler server only
+
+# Single scenario:
+bash conformance/run.sh client --scenario initialize
+bash conformance/run.sh server-mcp-agent --scenario tools-call-simple-text
+```
+
+## Baselines (expected failures)
+
+Known gaps are recorded in `baseline-*.yml` so CI stays green while still
+catching regressions and new failures. Each entry documents why the scenario
+fails — remove entries as the gaps get fixed.

--- a/packages/agents/conformance/baseline-client.yml
+++ b/packages/agents/conformance/baseline-client.yml
@@ -1,0 +1,20 @@
+# Expected failures for the MCP client conformance suite.
+# Each entry documents a known gap — remove entries as gaps are fixed.
+client:
+  # Elicitation is delegated to the platform (McpAgent.elicitInput / custom
+  # handleElicitationRequest overrides); MCPClientConnection hardcodes the
+  # `elicitation` capability without `form.applyDefaults`, so SEP-1034
+  # client-side defaults are not applied.
+  - elicitation-sep1034-client-defaults
+  # SHOULD-level warning only (all checks pass): the client registers via
+  # dynamic client registration instead of using a URL-based client ID
+  # (client_id_metadata_document, CIMD).
+  - auth/basic-cimd
+  # The client_credentials grant (SEP-835 extension) is not supported by
+  # DurableObjectOAuthClientProvider, which implements the
+  # authorization_code + refresh_token flows.
+  - auth/client-credentials-jwt
+  - auth/client-credentials-basic
+  # Requires RFC 8693 token exchange (extension; also baselined by the MCP
+  # TypeScript SDK).
+  - auth/cross-app-access-complete-flow

--- a/packages/agents/conformance/baseline-server-handler.yml
+++ b/packages/agents/conformance/baseline-server-handler.yml
@@ -9,3 +9,10 @@ server:
   # Localhost Host/Origin validation guards local stdio/loopback servers
   # against DNS rebinding; Workers deployments sit behind real hostnames.
   - dns-rebinding-protection
+  # SHOULD-level warnings only for pre-2025-11-25 clients: the harness
+  # probes with protocol version 2025-03-26, and the pinned MCP SDK
+  # deliberately suppresses SEP-1699 priming events for old clients (they
+  # cannot handle empty SSE data). WorkerTransport does emit priming events
+  # for 2025-11-25 clients. Context in
+  # https://github.com/cloudflare/agents/issues/1723
+  - server-sse-polling

--- a/packages/agents/conformance/baseline-server-handler.yml
+++ b/packages/agents/conformance/baseline-server-handler.yml
@@ -1,0 +1,11 @@
+# Expected failures for the createMcpHandler + WorkerTransport server
+# conformance suite.
+# Each entry documents a known gap — remove entries as gaps are fixed.
+server:
+  # The pinned MCP SDK's zod → JSON Schema conversion does not preserve
+  # JSON Schema 2020-12 keywords ($schema, $defs, additionalProperties)
+  # verbatim in tools/list (SEP-1613).
+  - json-schema-2020-12
+  # Localhost Host/Origin validation guards local stdio/loopback servers
+  # against DNS rebinding; Workers deployments sit behind real hostnames.
+  - dns-rebinding-protection

--- a/packages/agents/conformance/baseline-server-mcp-agent.yml
+++ b/packages/agents/conformance/baseline-server-mcp-agent.yml
@@ -1,0 +1,10 @@
+# Expected failures for the McpAgent server conformance suite.
+# Each entry documents a known gap — remove entries as gaps are fixed.
+server:
+  # The pinned MCP SDK's zod → JSON Schema conversion does not preserve
+  # JSON Schema 2020-12 keywords ($schema, $defs, additionalProperties)
+  # verbatim in tools/list (SEP-1613).
+  - json-schema-2020-12
+  # Localhost Host/Origin validation guards local stdio/loopback servers
+  # against DNS rebinding; Workers deployments sit behind real hostnames.
+  - dns-rebinding-protection

--- a/packages/agents/conformance/baseline-server-mcp-agent.yml
+++ b/packages/agents/conformance/baseline-server-mcp-agent.yml
@@ -8,3 +8,7 @@ server:
   # Localhost Host/Origin validation guards local stdio/loopback servers
   # against DNS rebinding; Workers deployments sit behind real hostnames.
   - dns-rebinding-protection
+  # SHOULD-level warnings: McpAgent's internal transport does not implement
+  # SEP-1699 priming events or the retry field. Tracked in
+  # https://github.com/cloudflare/agents/issues/1723
+  - server-sse-polling

--- a/packages/agents/conformance/driver.mjs
+++ b/packages/agents/conformance/driver.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * Conformance client driver.
+ *
+ * Spawned by `@modelcontextprotocol/conformance` once per scenario:
+ *
+ *   MCP_CONFORMANCE_SCENARIO=<scenario> node driver.mjs <server-url>
+ *
+ * The MCP client under test runs inside workerd (see worker.ts), started
+ * separately via `wrangler dev` (see run.sh). This driver forwards the
+ * scenario to a fresh agent instance and, for OAuth scenarios, plays the
+ * role of the user's browser: it follows the authorization URL and the
+ * resulting redirect into the worker's real OAuth callback route.
+ */
+
+const scenario = process.env.MCP_CONFORMANCE_SCENARIO;
+const serverUrl = process.argv[2];
+const workerOrigin =
+  process.env.CONFORMANCE_WORKER_ORIGIN ?? "http://127.0.0.1:8788";
+
+if (!scenario || !serverUrl) {
+  console.error(
+    "Usage: MCP_CONFORMANCE_SCENARIO=<scenario> node driver.mjs <server-url>"
+  );
+  process.exit(1);
+}
+
+// One agent instance (Durable Object) per scenario run so parallel scenarios
+// never share state.
+const base = `${workerOrigin}/agents/conformance-host/${crypto.randomUUID()}`;
+
+// Per-scenario context (e.g. pre-registered OAuth credentials), forwarded to
+// the worker as-is.
+const context = process.env.MCP_CONFORMANCE_CONTEXT;
+
+async function run() {
+  const response = await fetch(`${base}/run`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ scenario, serverUrl, context })
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Conformance host returned ${response.status}: ${await response.text()}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Simulate the user authorizing in a browser: the conformance harness's
+ * authorization endpoint auto-approves and 302s to the redirect_uri, which
+ * points at the worker's OAuth callback route.
+ */
+async function authorize(authUrl) {
+  const authResponse = await fetch(authUrl, { redirect: "manual" });
+  const location = authResponse.headers.get("location");
+  if (!location) {
+    throw new Error(
+      `Authorization endpoint did not redirect (status ${authResponse.status}): ${await authResponse.text()}`
+    );
+  }
+  const callbackResponse = await fetch(location, { redirect: "manual" });
+  if (callbackResponse.status >= 400) {
+    throw new Error(
+      `OAuth callback ${location} failed with ${callbackResponse.status}: ${await callbackResponse.text()}`
+    );
+  }
+}
+
+// Allow a few auth round-trips: initial authorization plus scope step-ups.
+// The cap also keeps misbehaving-server scenarios (e.g. scope-retry-limit)
+// from looping forever.
+const MAX_AUTH_ROUND_TRIPS = 3;
+
+try {
+  let result = await run();
+  for (let i = 0; i < MAX_AUTH_ROUND_TRIPS && result.status === "auth"; i++) {
+    await authorize(result.authUrl);
+    result = await run();
+  }
+
+  if (result.status === "done") {
+    process.exit(0);
+  }
+  console.error(
+    result.status === "auth"
+      ? `Gave up after ${MAX_AUTH_ROUND_TRIPS} OAuth round-trips`
+      : `Scenario failed: ${result.error}`
+  );
+  process.exit(1);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/packages/agents/conformance/everything-server.ts
+++ b/packages/agents/conformance/everything-server.ts
@@ -1,0 +1,774 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type {
+  CallToolResult,
+  GetPromptResult,
+  ReadResourceResult,
+  RequestId
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  CompleteRequestSchema,
+  CreateMessageResultSchema,
+  ElicitResultSchema,
+  SetLevelRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema
+} from "@modelcontextprotocol/sdk/types.js";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker-provider.js";
+import * as z from "zod";
+
+/**
+ * "Everything server" for MCP server conformance testing — implements the
+ * full feature surface the @modelcontextprotocol/conformance server suite
+ * exercises. Ported from the MCP TypeScript SDK's conformance server
+ * (test/conformance/src/everythingServer.ts) to run on Workers.
+ *
+ * Used by both server variants under test (see worker.ts):
+ *  - McpAgent
+ *  - createMcpHandler + WorkerTransport inside an Agent
+ */
+
+// 1x1 red PNG pixel
+const TEST_IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+// Minimal WAV file
+const TEST_AUDIO_BASE64 =
+  "UklGRiYAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAACABAAZGF0YQIAAAA=";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export type EverythingServerOptions = {
+  /**
+   * Closes the SSE stream for an in-flight request, when the hosting
+   * transport supports it (WorkerTransport does, McpAgent's internal
+   * transport does not). Used by test_reconnection (SEP-1699).
+   */
+  closeSSEStream?: (requestId: RequestId) => void;
+};
+
+export function createEverythingServer(
+  options: EverythingServerOptions = {}
+): McpServer {
+  const mcpServer = new McpServer(
+    {
+      name: "agents-conformance-test-server",
+      version: "1.0.0"
+    },
+    {
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { subscribe: true, listChanged: true },
+        prompts: { listChanged: true },
+        logging: {},
+        completions: {}
+      },
+      jsonSchemaValidator: new CfWorkerJsonSchemaValidator()
+    }
+  );
+
+  const resourceSubscriptions = new Set<string>();
+
+  function sendLog(level: "info", message: string) {
+    mcpServer.server
+      .notification({
+        method: "notifications/message",
+        params: {
+          level,
+          logger: "agents-conformance-test-server",
+          data: message
+        }
+      })
+      .catch(() => {
+        // Ignore error if no client is connected
+      });
+  }
+
+  // ===== TOOLS =====
+
+  mcpServer.registerTool(
+    "test_simple_text",
+    { description: "Tests simple text content response" },
+    async (): Promise<CallToolResult> => {
+      return {
+        content: [
+          { type: "text", text: "This is a simple text response for testing." }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_image_content",
+    { description: "Tests image content response" },
+    async (): Promise<CallToolResult> => {
+      return {
+        content: [
+          { type: "image", data: TEST_IMAGE_BASE64, mimeType: "image/png" }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_audio_content",
+    { description: "Tests audio content response" },
+    async (): Promise<CallToolResult> => {
+      return {
+        content: [
+          { type: "audio", data: TEST_AUDIO_BASE64, mimeType: "audio/wav" }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_embedded_resource",
+    { description: "Tests embedded resource content response" },
+    async (): Promise<CallToolResult> => {
+      return {
+        content: [
+          {
+            type: "resource",
+            resource: {
+              uri: "test://embedded-resource",
+              mimeType: "text/plain",
+              text: "This is an embedded resource content."
+            }
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_multiple_content_types",
+    {
+      description:
+        "Tests response with multiple content types (text, image, resource)"
+    },
+    async (): Promise<CallToolResult> => {
+      return {
+        content: [
+          { type: "text", text: "Multiple content types test:" },
+          { type: "image", data: TEST_IMAGE_BASE64, mimeType: "image/png" },
+          {
+            type: "resource",
+            resource: {
+              uri: "test://mixed-content-resource",
+              mimeType: "application/json",
+              text: JSON.stringify({ test: "data", value: 123 })
+            }
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_tool_with_logging",
+    {
+      description: "Tests tool that emits log messages during execution",
+      inputSchema: {}
+    },
+    async (_args, extra): Promise<CallToolResult> => {
+      for (const message of [
+        "Tool execution started",
+        "Tool processing data",
+        "Tool execution completed"
+      ]) {
+        await extra.sendNotification({
+          method: "notifications/message",
+          params: { level: "info", data: message }
+        });
+        await sleep(50);
+      }
+      return {
+        content: [
+          { type: "text", text: "Tool with logging executed successfully" }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_tool_with_progress",
+    {
+      description: "Tests tool that reports progress notifications",
+      inputSchema: {}
+    },
+    async (_args, extra): Promise<CallToolResult> => {
+      const progressToken = extra._meta?.progressToken ?? 0;
+      for (const progress of [0, 50, 100]) {
+        await extra.sendNotification({
+          method: "notifications/progress",
+          params: {
+            progressToken,
+            progress,
+            total: 100,
+            message: `Completed step ${progress} of ${100}`
+          }
+        });
+        await sleep(50);
+      }
+      return {
+        content: [{ type: "text", text: String(progressToken) }]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_error_handling",
+    { description: "Tests error response handling" },
+    async (): Promise<CallToolResult> => {
+      throw new Error("This tool intentionally returns an error for testing");
+    }
+  );
+
+  // SEP-1699: closes the SSE stream mid-call so the client has to reconnect
+  // to receive the result.
+  mcpServer.registerTool(
+    "test_reconnection",
+    {
+      description:
+        "Tests SSE stream disconnection and client reconnection (SEP-1699). Server closes the stream mid-call and sends the result after the client reconnects.",
+      inputSchema: {}
+    },
+    async (_args, extra): Promise<CallToolResult> => {
+      if (options.closeSSEStream && extra.requestId !== undefined) {
+        options.closeSSEStream(extra.requestId);
+      }
+      await sleep(100);
+      return {
+        content: [
+          {
+            type: "text",
+            text: "Reconnection test completed successfully. If you received this, the client properly reconnected after stream closure."
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_sampling",
+    {
+      description: "Tests server-initiated sampling (LLM completion request)",
+      inputSchema: { prompt: z.string() }
+    },
+    async (args, extra): Promise<CallToolResult> => {
+      try {
+        const result = (await extra.sendRequest(
+          {
+            method: "sampling/createMessage",
+            params: {
+              messages: [
+                {
+                  role: "user",
+                  content: { type: "text", text: args.prompt }
+                }
+              ],
+              maxTokens: 100
+            }
+          },
+          CreateMessageResultSchema
+        )) as {
+          content?: { text?: string };
+          message?: { content?: { text?: string } };
+        };
+
+        const modelResponse =
+          result.content?.text ||
+          result.message?.content?.text ||
+          "No response";
+
+        return {
+          content: [{ type: "text", text: `LLM response: ${modelResponse}` }]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Sampling not supported or error: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
+
+  mcpServer.registerTool(
+    "test_elicitation",
+    {
+      description: "Tests server-initiated elicitation (user input request)",
+      inputSchema: {
+        message: z.string().describe("The message to show the user")
+      }
+    },
+    async (args, extra): Promise<CallToolResult> => {
+      try {
+        const result = await extra.sendRequest(
+          {
+            method: "elicitation/create",
+            params: {
+              message: args.message,
+              requestedSchema: {
+                type: "object",
+                properties: {
+                  response: {
+                    type: "string",
+                    description: "User's response"
+                  }
+                },
+                required: ["response"]
+              }
+            }
+          },
+          ElicitResultSchema
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `User response: action=${result.action}, content=${JSON.stringify(result.content || {})}`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Elicitation not supported or error: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
+
+  // SEP-1034: elicitation with default values for all primitive types
+  mcpServer.registerTool(
+    "test_elicitation_sep1034_defaults",
+    {
+      description: "Tests elicitation with default values per SEP-1034",
+      inputSchema: {}
+    },
+    async (_args, extra): Promise<CallToolResult> => {
+      try {
+        const result = await extra.sendRequest(
+          {
+            method: "elicitation/create",
+            params: {
+              message: "Please review and update the form fields with defaults",
+              requestedSchema: {
+                type: "object",
+                properties: {
+                  name: {
+                    type: "string",
+                    description: "User name",
+                    default: "John Doe"
+                  },
+                  age: {
+                    type: "integer",
+                    description: "User age",
+                    default: 30
+                  },
+                  score: {
+                    type: "number",
+                    description: "User score",
+                    default: 95.5
+                  },
+                  status: {
+                    type: "string",
+                    description: "User status",
+                    enum: ["active", "inactive", "pending"],
+                    default: "active"
+                  },
+                  verified: {
+                    type: "boolean",
+                    description: "Verification status",
+                    default: true
+                  }
+                },
+                required: []
+              }
+            }
+          },
+          ElicitResultSchema
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Elicitation completed: action=${result.action}, content=${JSON.stringify(result.content || {})}`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Elicitation not supported or error: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
+
+  // SEP-1330: elicitation with enum schema improvements
+  mcpServer.registerTool(
+    "test_elicitation_sep1330_enums",
+    {
+      description:
+        "Tests elicitation with enum schema improvements per SEP-1330",
+      inputSchema: {}
+    },
+    async (_args, extra): Promise<CallToolResult> => {
+      try {
+        const result = await extra.sendRequest(
+          {
+            method: "elicitation/create",
+            params: {
+              message: "Please select options from the enum fields",
+              requestedSchema: {
+                type: "object",
+                properties: {
+                  untitledSingle: {
+                    type: "string",
+                    description: "Select one option",
+                    enum: ["option1", "option2", "option3"]
+                  },
+                  titledSingle: {
+                    type: "string",
+                    description: "Select one option with titles",
+                    oneOf: [
+                      { const: "value1", title: "First Option" },
+                      { const: "value2", title: "Second Option" },
+                      { const: "value3", title: "Third Option" }
+                    ]
+                  },
+                  legacyEnum: {
+                    type: "string",
+                    description: "Select one option (legacy)",
+                    enum: ["opt1", "opt2", "opt3"],
+                    enumNames: ["Option One", "Option Two", "Option Three"]
+                  },
+                  untitledMulti: {
+                    type: "array",
+                    description: "Select multiple options",
+                    minItems: 1,
+                    maxItems: 3,
+                    items: {
+                      type: "string",
+                      enum: ["option1", "option2", "option3"]
+                    }
+                  },
+                  titledMulti: {
+                    type: "array",
+                    description: "Select multiple options with titles",
+                    minItems: 1,
+                    maxItems: 3,
+                    items: {
+                      anyOf: [
+                        { const: "value1", title: "First Choice" },
+                        { const: "value2", title: "Second Choice" },
+                        { const: "value3", title: "Third Choice" }
+                      ]
+                    }
+                  }
+                },
+                required: []
+              }
+            }
+          },
+          ElicitResultSchema
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Elicitation completed: action=${result.action}, content=${JSON.stringify(result.content || {})}`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Elicitation not supported or error: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
+
+  // SEP-1613: JSON Schema 2020-12 conformance test tool
+  mcpServer.registerTool(
+    "json_schema_2020_12_tool",
+    {
+      description:
+        "Tool with JSON Schema 2020-12 features for conformance testing (SEP-1613)",
+      inputSchema: {
+        name: z.string().optional(),
+        address: z
+          .object({
+            street: z.string().optional(),
+            city: z.string().optional()
+          })
+          .optional()
+      }
+    },
+    async (args): Promise<CallToolResult> => {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `JSON Schema 2020-12 tool called with: ${JSON.stringify(args)}`
+          }
+        ]
+      };
+    }
+  );
+
+  // ===== RESOURCES =====
+
+  mcpServer.registerResource(
+    "static-text",
+    "test://static-text",
+    {
+      title: "Static Text Resource",
+      description: "A static text resource for testing",
+      mimeType: "text/plain"
+    },
+    async (): Promise<ReadResourceResult> => {
+      return {
+        contents: [
+          {
+            uri: "test://static-text",
+            mimeType: "text/plain",
+            text: "This is the content of the static text resource."
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerResource(
+    "static-binary",
+    "test://static-binary",
+    {
+      title: "Static Binary Resource",
+      description: "A static binary resource (image) for testing",
+      mimeType: "image/png"
+    },
+    async (): Promise<ReadResourceResult> => {
+      return {
+        contents: [
+          {
+            uri: "test://static-binary",
+            mimeType: "image/png",
+            blob: TEST_IMAGE_BASE64
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerResource(
+    "template",
+    new ResourceTemplate("test://template/{id}/data", { list: undefined }),
+    {
+      title: "Resource Template",
+      description: "A resource template with parameter substitution",
+      mimeType: "application/json"
+    },
+    async (uri, variables): Promise<ReadResourceResult> => {
+      const id = variables.id;
+      return {
+        contents: [
+          {
+            uri: uri.toString(),
+            mimeType: "application/json",
+            text: JSON.stringify({
+              id,
+              templateTest: true,
+              data: `Data for ID: ${id}`
+            })
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerResource(
+    "watched-resource",
+    "test://watched-resource",
+    {
+      title: "Watched Resource",
+      description: "A watched resource for subscription testing",
+      mimeType: "text/plain"
+    },
+    async (): Promise<ReadResourceResult> => {
+      return {
+        contents: [
+          {
+            uri: "test://watched-resource",
+            mimeType: "text/plain",
+            text: "Watched resource content"
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.server.setRequestHandler(
+    SubscribeRequestSchema,
+    async (request) => {
+      const uri = request.params.uri;
+      resourceSubscriptions.add(uri);
+      sendLog("info", `Subscribed to resource: ${uri}`);
+      return {};
+    }
+  );
+
+  mcpServer.server.setRequestHandler(
+    UnsubscribeRequestSchema,
+    async (request) => {
+      const uri = request.params.uri;
+      resourceSubscriptions.delete(uri);
+      sendLog("info", `Unsubscribed from resource: ${uri}`);
+      return {};
+    }
+  );
+
+  // ===== PROMPTS =====
+
+  mcpServer.registerPrompt(
+    "test_simple_prompt",
+    { description: "A simple prompt without arguments" },
+    async (): Promise<GetPromptResult> => {
+      return {
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: "This is a simple prompt for testing."
+            }
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerPrompt(
+    "test_prompt_with_arguments",
+    {
+      description: "A prompt with required arguments",
+      argsSchema: {
+        arg1: z.string().describe("First test argument"),
+        arg2: z.string().describe("Second test argument")
+      }
+    },
+    async (args): Promise<GetPromptResult> => {
+      return {
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `Prompt with arguments: arg1='${args.arg1}', arg2='${args.arg2}'`
+            }
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerPrompt(
+    "test_prompt_with_embedded_resource",
+    {
+      description: "A prompt that includes an embedded resource",
+      argsSchema: {
+        resourceUri: z.string().describe("URI of the resource to embed")
+      }
+    },
+    async (args): Promise<GetPromptResult> => {
+      return {
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "resource",
+              resource: {
+                uri: args.resourceUri,
+                mimeType: "text/plain",
+                text: "Embedded resource content for testing."
+              }
+            }
+          },
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: "Please process the embedded resource above."
+            }
+          }
+        ]
+      };
+    }
+  );
+
+  mcpServer.registerPrompt(
+    "test_prompt_with_image",
+    { description: "A prompt that includes image content" },
+    async (): Promise<GetPromptResult> => {
+      return {
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "image",
+              data: TEST_IMAGE_BASE64,
+              mimeType: "image/png"
+            }
+          },
+          {
+            role: "user",
+            content: { type: "text", text: "Please analyze the image above." }
+          }
+        ]
+      };
+    }
+  );
+
+  // ===== LOGGING =====
+
+  mcpServer.server.setRequestHandler(SetLevelRequestSchema, async (request) => {
+    sendLog("info", `Log level set to: ${request.params.level}`);
+    return {};
+  });
+
+  // ===== COMPLETION =====
+
+  mcpServer.server.setRequestHandler(CompleteRequestSchema, async () => {
+    return {
+      completion: {
+        values: [],
+        total: 0,
+        hasMore: false
+      }
+    };
+  });
+
+  return mcpServer;
+}

--- a/packages/agents/conformance/run.sh
+++ b/packages/agents/conformance/run.sh
@@ -76,9 +76,13 @@ run_server_scenarios() {
 
 case "$MODE" in
   client)
+    # --timeout: scenarios that exercise SSE reconnection legitimately take
+    # >30s (default) on slow CI runners once the SDK's retry interval and
+    # connection backoff stack up.
     CONFORMANCE_WORKER_ORIGIN="http://127.0.0.1:$PORT" pnpm exec conformance client \
       --command "node conformance/driver.mjs" \
       --expected-failures conformance/baseline-client.yml \
+      --timeout 90000 \
       "$@"
     ;;
   server-mcp-agent)

--- a/packages/agents/conformance/run.sh
+++ b/packages/agents/conformance/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Runs the MCP conformance suite against the implementations in this package.
+#
+# 1. Starts the conformance worker (workerd via wrangler dev) hosting:
+#      - the MCP client under test (Agent + MCPClientManager)
+#      - two MCP servers under test (McpAgent at /mcp-agent,
+#        createMcpHandler + WorkerTransport at /mcp-handler)
+# 2. Runs the @modelcontextprotocol/conformance CLI in the requested mode.
+#
+# Usage:
+#   conformance/run.sh client          [extra conformance CLI args]
+#   conformance/run.sh server-mcp-agent [extra conformance CLI args]
+#   conformance/run.sh server-handler   [extra conformance CLI args]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE="${1:?Usage: run.sh <client|server-mcp-agent|server-handler> [conformance CLI args]}"
+shift
+
+PORT="${CONFORMANCE_WORKER_PORT:-8788}"
+
+pnpm exec wrangler dev --config conformance/wrangler.jsonc --port "$PORT" --ip 127.0.0.1 &
+WRANGLER_PID=$!
+trap 'kill "$WRANGLER_PID" 2>/dev/null || true' EXIT
+
+echo "Waiting for conformance worker on port $PORT..."
+for _ in $(seq 1 60); do
+  if curl -s -o /dev/null "http://127.0.0.1:$PORT/"; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -s -o /dev/null "http://127.0.0.1:$PORT/"; then
+  echo "Conformance worker failed to start" >&2
+  exit 1
+fi
+
+case "$MODE" in
+  client)
+    CONFORMANCE_WORKER_ORIGIN="http://127.0.0.1:$PORT" pnpm exec conformance client \
+      --command "node conformance/driver.mjs" \
+      --expected-failures conformance/baseline-client.yml \
+      "$@"
+    ;;
+  server-mcp-agent)
+    pnpm exec conformance server \
+      --url "http://127.0.0.1:$PORT/mcp-agent" \
+      --expected-failures conformance/baseline-server-mcp-agent.yml \
+      "$@"
+    ;;
+  server-handler)
+    pnpm exec conformance server \
+      --url "http://127.0.0.1:$PORT/mcp-handler" \
+      --expected-failures conformance/baseline-server-handler.yml \
+      "$@"
+    ;;
+  *)
+    echo "Unknown mode: $MODE (expected client, server-mcp-agent, or server-handler)" >&2
+    exit 1
+    ;;
+esac

--- a/packages/agents/conformance/run.sh
+++ b/packages/agents/conformance/run.sh
@@ -37,6 +37,43 @@ if ! curl -s -o /dev/null "http://127.0.0.1:$PORT/"; then
   exit 1
 fi
 
+# Run every server scenario as its own conformance invocation. `--suite`
+# runs scenarios in parallel against the worker, which makes the timing-
+# sensitive SSE scenarios (server-sse-polling) record different results on
+# fast vs slow machines; sequential single-scenario runs are deterministic.
+run_server_scenarios() {
+  local url="$1" baseline="$2"
+  shift 2
+
+  if [ "$#" -gt 0 ]; then
+    pnpm exec conformance server --url "$url" --expected-failures "$baseline" "$@"
+    return
+  fi
+
+  local scenarios failed=0
+  scenarios=$(pnpm exec conformance list 2>/dev/null |
+    awk '/^Server scenarios/{f=1;next} /^Client scenarios/{f=0} f && /^  - /{print $2}')
+  if [ -z "$scenarios" ]; then
+    echo "Failed to list server scenarios" >&2
+    return 1
+  fi
+
+  local out
+  out=$(mktemp)
+  for scenario in $scenarios; do
+    if pnpm exec conformance server --url "$url" --scenario "$scenario" \
+      --expected-failures "$baseline" > "$out" 2>&1; then
+      echo "✓ $scenario"
+    else
+      echo "✗ $scenario"
+      tail -30 "$out"
+      failed=1
+    fi
+  done
+  rm -f "$out"
+  return "$failed"
+}
+
 case "$MODE" in
   client)
     CONFORMANCE_WORKER_ORIGIN="http://127.0.0.1:$PORT" pnpm exec conformance client \
@@ -45,16 +82,12 @@ case "$MODE" in
       "$@"
     ;;
   server-mcp-agent)
-    pnpm exec conformance server \
-      --url "http://127.0.0.1:$PORT/mcp-agent" \
-      --expected-failures conformance/baseline-server-mcp-agent.yml \
-      "$@"
+    run_server_scenarios "http://127.0.0.1:$PORT/mcp-agent" \
+      conformance/baseline-server-mcp-agent.yml "$@"
     ;;
   server-handler)
-    pnpm exec conformance server \
-      --url "http://127.0.0.1:$PORT/mcp-handler" \
-      --expected-failures conformance/baseline-server-handler.yml \
-      "$@"
+    run_server_scenarios "http://127.0.0.1:$PORT/mcp-handler" \
+      conformance/baseline-server-handler.yml "$@"
     ;;
   *)
     echo "Unknown mode: $MODE (expected client, server-mcp-agent, or server-handler)" >&2

--- a/packages/agents/conformance/worker.ts
+++ b/packages/agents/conformance/worker.ts
@@ -210,7 +210,9 @@ export class ConformanceHost extends Agent<Env> {
    * connection is re-established in the background (establishConnection), so
    * the next /run call has to poll for the terminal state.
    */
-  private async waitForReady(serverId: string, timeoutMs = 25_000) {
+  // Generous timeout: on cold CI runners, connection retries (exponential
+  // backoff) plus the SDK's SSE retry interval can stack well past 25s.
+  private async waitForReady(serverId: string, timeoutMs = 50_000) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       const conn = this.mcp.mcpConnections[serverId];

--- a/packages/agents/conformance/worker.ts
+++ b/packages/agents/conformance/worker.ts
@@ -1,0 +1,348 @@
+import {
+  Agent,
+  type AgentNamespace,
+  getAgentByName,
+  routeAgentRequest
+} from "../src/index.ts";
+import { MCPConnectionState } from "../src/mcp/client-connection.ts";
+import { isUnauthorized, toErrorMessage } from "../src/mcp/errors.ts";
+import {
+  createMcpHandler,
+  DurableObjectEventStore,
+  McpAgent,
+  type TransportState,
+  WorkerTransport
+} from "../src/mcp/index.ts";
+import { createEverythingServer } from "./everything-server.ts";
+
+/**
+ * Conformance worker — hosts everything the MCP conformance suite needs from
+ * this repo inside workerd, so the implementations are tested as they actually
+ * run in production (Durable Object storage, real routes, real transports).
+ *
+ * Client under test (`conformance client`):
+ *  - ConformanceHost: Agent + MCPClientManager. The conformance CLI spawns
+ *    driver.mjs once per scenario; the driver POSTs `{ scenario, serverUrl }`
+ *    to a fresh agent instance, which connects out to the conformance
+ *    harness's test server. When the connection needs OAuth, the worker
+ *    responds with the authorization URL; the driver plays the role of the
+ *    user's browser (follows the redirect into this worker's real callback
+ *    route) and then calls /run again to continue the scenario.
+ *
+ * Servers under test (`conformance server --url ...`):
+ *  - /mcp-agent: McpAgent
+ *  - /mcp-handler: createMcpHandler + WorkerTransport inside an Agent
+ *  Both register the same "everything server" feature set (everything-server.ts).
+ */
+
+type Env = {
+  ConformanceHost: DurableObjectNamespace;
+  EverythingMcpAgent: DurableObjectNamespace;
+  EverythingHandlerAgent: AgentNamespace<EverythingHandlerAgent>;
+};
+
+const SERVER_NAME = "conformance";
+
+type RunRequest = { scenario: string; serverUrl: string; context?: string };
+
+type RunResult =
+  | { status: "done" }
+  | { status: "auth"; authUrl: string }
+  | { status: "error"; error: string };
+
+export class ConformanceHost extends Agent<Env> {
+  private _serverId: string | undefined;
+
+  onStart() {
+    // Respond to OAuth callbacks with an explicit status the driver can
+    // assert on, instead of the default redirect-to-origin.
+    this.mcp.configureOAuthCallback({
+      customHandler: (result) =>
+        Response.json(result, { status: result.authSuccess ? 200 : 400 })
+    });
+  }
+
+  async onRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname.endsWith("/run")) {
+      const { scenario, serverUrl, context } =
+        (await request.json()) as RunRequest;
+      try {
+        return Response.json(
+          await this.runScenario(scenario, serverUrl, context)
+        );
+      } catch (error) {
+        return Response.json({
+          status: "error",
+          error: toErrorMessage(error)
+        } satisfies RunResult);
+      }
+    }
+    if (request.method === "GET" && url.pathname.endsWith("/debug")) {
+      return Response.json({ servers: this.mcp.listServers() });
+    }
+    return new Response("Not found", { status: 404 });
+  }
+
+  private async runScenario(
+    scenario: string,
+    serverUrl: string,
+    context?: string
+  ): Promise<RunResult> {
+    try {
+      if (!this._serverId) {
+        const result = await this.addMcpServer(SERVER_NAME, serverUrl, {
+          transport: { type: "streamable-http" }
+        });
+        this._serverId = result.id;
+        if (result.state === MCPConnectionState.AUTHENTICATING) {
+          return { status: "auth", authUrl: result.authUrl };
+        }
+      }
+
+      await this.waitForReady(this._serverId);
+      await this.runScenarioSteps(scenario, this._serverId);
+      return { status: "done" };
+    } catch (error) {
+      // Authorization servers without dynamic client registration require
+      // pre-registered credentials, which the conformance harness provides
+      // via context. Seed them into the OAuth provider and retry once.
+      const seeded = await this.seedPreRegisteredClient(error, context);
+      if (seeded) {
+        return this.runScenario(scenario, serverUrl, undefined);
+      }
+
+      // A 401 can surface from any phase: connect, discovery (servers that
+      // allow unauthenticated initialize but protect tools/list), or a tool
+      // call (scope step-up). In all cases the SDK has already run the OAuth
+      // authorization request and handed the authorization URL to our
+      // provider — surface it so the driver can authorize in its fake
+      // browser and call /run again.
+      const reauth = this.requestReauth(error);
+      if (reauth) {
+        return reauth;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Seed pre-registered OAuth client credentials (auth/pre-registration
+   * scenario). The provider is created during addMcpServer, so the first
+   * connect attempt fails with "does not support dynamic client
+   * registration"; seed the credentials it should have used and signal the
+   * caller to retry.
+   */
+  private async seedPreRegisteredClient(
+    error: unknown,
+    context: string | undefined
+  ): Promise<boolean> {
+    if (
+      !context ||
+      !toErrorMessage(error).includes(
+        "does not support dynamic client registration"
+      )
+    ) {
+      return false;
+    }
+
+    const parsed = JSON.parse(context) as {
+      name?: string;
+      client_id?: string;
+      client_secret?: string;
+    };
+    if (!parsed.client_id) {
+      return false;
+    }
+
+    const serverId =
+      this._serverId ??
+      this.mcp.listServers().find((s) => s.name === SERVER_NAME)?.id;
+    const conn = serverId ? this.mcp.mcpConnections[serverId] : undefined;
+    const provider = conn?.options.transport.authProvider;
+    if (!serverId || !conn || !provider) {
+      return false;
+    }
+    this._serverId = serverId;
+
+    provider.serverId = serverId;
+    await provider.saveClientInformation?.({
+      client_id: parsed.client_id,
+      client_secret: parsed.client_secret,
+      redirect_uris: [String(provider.redirectUrl)]
+    });
+
+    // Retry from a clean connect with the seeded credentials.
+    conn.connectionState = MCPConnectionState.CONNECTING;
+    await this.mcp.establishConnection(serverId).catch(() => {
+      // 401 → AUTHENTICATING is surfaced by the retry in runScenario.
+    });
+    return true;
+  }
+
+  private requestReauth(error: unknown): RunResult | undefined {
+    if (!isUnauthorized(error)) {
+      return undefined;
+    }
+
+    // addMcpServer throws before returning an id when discovery fails, so
+    // fall back to looking the server up by name.
+    const serverId =
+      this._serverId ??
+      this.mcp.listServers().find((s) => s.name === SERVER_NAME)?.id;
+    if (!serverId) {
+      return undefined;
+    }
+    this._serverId = serverId;
+
+    const conn = this.mcp.mcpConnections[serverId];
+    const authUrl = conn?.options.transport.authProvider?.authUrl;
+    if (!conn || !authUrl) {
+      return undefined;
+    }
+
+    conn.connectionState = MCPConnectionState.AUTHENTICATING;
+    return { status: "auth", authUrl };
+  }
+
+  /**
+   * Wait for the connection to reach READY. After an OAuth callback the
+   * connection is re-established in the background (establishConnection), so
+   * the next /run call has to poll for the terminal state.
+   */
+  private async waitForReady(serverId: string, timeoutMs = 25_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const conn = this.mcp.mcpConnections[serverId];
+      if (conn) {
+        if (conn.connectionState === MCPConnectionState.READY) {
+          return conn;
+        }
+        if (conn.connectionState === MCPConnectionState.AUTHENTICATING) {
+          // Routed through requestReauth() by the caller's catch block.
+          throw new Error("Unauthorized: connection requires authorization");
+        }
+        if (conn.connectionState === MCPConnectionState.FAILED) {
+          throw new Error(
+            `Connection failed: ${conn.connectionError ?? "unknown error"}`
+          );
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error(`Timed out waiting for connection to become ready`);
+  }
+
+  private async runScenarioSteps(
+    scenario: string,
+    serverId: string
+  ): Promise<void> {
+    switch (scenario) {
+      case "initialize":
+        // Connecting runs the full initialize handshake plus discovery
+        // (tools/resources/prompts listing) — nothing further to do.
+        return;
+      case "tools_call":
+        await this.callTool(serverId, "add_numbers", { a: 5, b: 3 });
+        return;
+      case "sse-retry":
+        await this.callTool(serverId, "test_reconnection", {});
+        return;
+      case "elicitation-sep1034-client-defaults":
+        await this.callTool(serverId, "test_client_elicitation_defaults", {});
+        return;
+      default:
+        if (scenario.startsWith("auth/")) {
+          await this.callTool(serverId, "test-tool", {});
+          return;
+        }
+        throw new Error(`Unsupported scenario: ${scenario}`);
+    }
+  }
+
+  private async callTool(
+    serverId: string,
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<void> {
+    const result = await this.mcp.callTool({
+      serverId,
+      name,
+      arguments: args
+    });
+    if (result.isError) {
+      throw new Error(
+        `Tool "${name}" returned an error: ${JSON.stringify(result.content)}`
+      );
+    }
+  }
+}
+
+/**
+ * Server conformance variant 1: McpAgent.
+ */
+export class EverythingMcpAgent extends McpAgent<Env> {
+  server = createEverythingServer();
+
+  async init() {}
+}
+
+const everythingMcpAgentHandler = EverythingMcpAgent.serve("/mcp-agent", {
+  binding: "EverythingMcpAgent"
+});
+
+const TRANSPORT_STATE_KEY = "mcp_transport_state";
+
+/**
+ * Server conformance variant 2: createMcpHandler + WorkerTransport inside an
+ * Agent (modeled on the mcp-elicitation example).
+ */
+export class EverythingHandlerAgent extends Agent<Env> {
+  server = createEverythingServer({
+    closeSSEStream: (requestId) => this.transport.closeSSEStream(requestId)
+  });
+
+  transport = new WorkerTransport({
+    sessionIdGenerator: () => this.name,
+    storage: {
+      get: () => {
+        return this.ctx.storage.kv.get<TransportState>(TRANSPORT_STATE_KEY);
+      },
+      set: (state: TransportState) => {
+        this.ctx.storage.kv.put<TransportState>(TRANSPORT_STATE_KEY, state);
+      }
+    },
+    // Persist SSE events so clients can reconnect with `Last-Event-ID` and
+    // replay missed messages (SEP-1699 resumability).
+    eventStore: new DurableObjectEventStore(this.ctx.storage)
+  });
+
+  async onMcpRequest(request: Request) {
+    return createMcpHandler(this.server, {
+      route: "/mcp-handler",
+      transport: this.transport
+    })(request, this.env, {} as ExecutionContext);
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/mcp-agent") {
+      return everythingMcpAgentHandler.fetch(request, env, ctx);
+    }
+
+    if (url.pathname === "/mcp-handler") {
+      const sessionId =
+        request.headers.get("mcp-session-id") ?? crypto.randomUUID();
+      const agent = await getAgentByName(env.EverythingHandlerAgent, sessionId);
+      return agent.onMcpRequest(request);
+    }
+
+    return (
+      (await routeAgentRequest(request, env)) ||
+      new Response("Not found", { status: 404 })
+    );
+  }
+};

--- a/packages/agents/conformance/wrangler.jsonc
+++ b/packages/agents/conformance/wrangler.jsonc
@@ -1,0 +1,32 @@
+{
+  "name": "agents-mcp-conformance-host",
+  "main": "worker.ts",
+  "compatibility_date": "2026-01-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "ConformanceHost",
+        "name": "ConformanceHost"
+      },
+      {
+        "class_name": "EverythingMcpAgent",
+        "name": "EverythingMcpAgent"
+      },
+      {
+        "class_name": "EverythingHandlerAgent",
+        "name": "EverythingHandlerAgent"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "ConformanceHost",
+        "EverythingMcpAgent",
+        "EverythingHandlerAgent"
+      ]
+    }
+  ]
+}

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@ai-sdk/react": "^3.0.204",
+    "@modelcontextprotocol/conformance": "0.1.16",
     "@tanstack/ai": "^0.28.0",
     "@types/react": "^19.2.17",
     "@types/yargs": "^17.0.35",
@@ -259,6 +260,10 @@
     "test:chat": "vitest --project chat",
     "test:webmcp": "vitest --project webmcp",
     "test:x402": "vitest --project x402",
-    "test:e2e": "vitest --run -c src/e2e-tests/vitest.config.ts"
+    "test:e2e": "vitest --run -c src/e2e-tests/vitest.config.ts",
+    "test:conformance": "pnpm run test:conformance:client && pnpm run test:conformance:server:mcp-agent && pnpm run test:conformance:server:handler",
+    "test:conformance:client": "bash conformance/run.sh client --suite all",
+    "test:conformance:server:mcp-agent": "bash conformance/run.sh server-mcp-agent --suite all",
+    "test:conformance:server:handler": "bash conformance/run.sh server-handler --suite all"
   }
 }

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -263,7 +263,7 @@
     "test:e2e": "vitest --run -c src/e2e-tests/vitest.config.ts",
     "test:conformance": "pnpm run test:conformance:client && pnpm run test:conformance:server:mcp-agent && pnpm run test:conformance:server:handler",
     "test:conformance:client": "bash conformance/run.sh client --suite all",
-    "test:conformance:server:mcp-agent": "bash conformance/run.sh server-mcp-agent --suite all",
-    "test:conformance:server:handler": "bash conformance/run.sh server-handler --suite all"
+    "test:conformance:server:mcp-agent": "bash conformance/run.sh server-mcp-agent",
+    "test:conformance:server:handler": "bash conformance/run.sh server-handler"
   }
 }

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -113,6 +113,18 @@ export class MCPClientConnection {
     | StreamableHTTPClientTransport
     | SSEClientTransport
     | RPCClientTransport;
+
+  /**
+   * Transport that received the 401 during the initial connect attempt.
+   * Kept so finishAuth() runs on the transport that captured the resource
+   * metadata URL from the WWW-Authenticate header — a fresh transport would
+   * rediscover from defaults and exchange the code at the wrong token
+   * endpoint when the authorization server is not at the default location.
+   */
+  private _pendingAuthTransport?:
+    | StreamableHTTPClientTransport
+    | SSEClientTransport
+    | RPCClientTransport;
   prompts: Prompt[] = [];
   resources: Resource[] = [];
   resourceTemplates: ResourceTemplate[] = [];
@@ -157,6 +169,19 @@ export class MCPClientConnection {
     const transportType = this.options.transport.type;
     if (!transportType) {
       throw new Error("Transport type must be specified");
+    }
+
+    // init() can be re-entered after a mid-session 401 → OAuth → reconnect
+    // cycle (e.g. scope step-up, token revocation). The SDK client refuses
+    // to connect while a previous transport is still attached, so detach it
+    // first.
+    if (this.client.transport) {
+      this._transport = undefined;
+      try {
+        await this.client.close();
+      } catch {
+        // Closing a transport that just failed auth is best-effort.
+      }
     }
 
     const res = await this.tryConnect(transportType);
@@ -230,6 +255,21 @@ export class MCPClientConnection {
 
     if (configuredType === "rpc") {
       throw new Error("RPC transport does not support authentication");
+    }
+
+    // Prefer the transport that triggered authentication (initial-connect
+    // 401, or the active transport for a mid-session 401 such as a scope
+    // step-up): it holds the resource metadata URL from the WWW-Authenticate
+    // header that finishAuth() needs to locate the authorization server.
+    const authTransport = this._pendingAuthTransport ?? this._transport;
+    this._pendingAuthTransport = undefined;
+    if (
+      authTransport &&
+      "finishAuth" in authTransport &&
+      typeof authTransport.finishAuth === "function"
+    ) {
+      await authTransport.finishAuth(code);
+      return;
     }
 
     if (configuredType === "sse" || configuredType === "streamable-http") {
@@ -768,6 +808,7 @@ export class MCPClientConnection {
       try {
         await this.client.connect(transport);
         this._transport = transport;
+        this._pendingAuthTransport = undefined;
 
         return {
           state: MCPConnectionState.CONNECTED,
@@ -777,6 +818,7 @@ export class MCPClientConnection {
         const error = e instanceof Error ? e : new Error(String(e));
 
         if (isUnauthorized(error)) {
+          this._pendingAuthTransport = transport;
           return {
             state: MCPConnectionState.AUTHENTICATING
           };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3656,6 +3656,9 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.204
         version: 3.0.204(react@19.2.7)(zod@4.4.3)
+      '@modelcontextprotocol/conformance':
+        specifier: 0.1.16
+        version: 0.1.16(@cfworker/json-schema@4.1.1)
       '@tanstack/ai':
         specifier: ^0.28.0
         version: 0.28.0(@opentelemetry/api@1.9.1)
@@ -5889,6 +5892,10 @@ packages:
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
 
+  '@modelcontextprotocol/conformance@0.1.16':
+    resolution: {integrity: sha512-GI7qiN0r39/MH2srVUR3AXaEN0YLCro20lIBbnvc1frBhszenxvUifBuTzxeVQVagILfBzCIcnungUOma8OrgA==}
+    hasBin: true
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -5996,6 +6003,58 @@ packages:
     resolution: {integrity: sha512-ngcMyHdBJ9FSz2nHdbZ7gtJlFq0O2b05sPAsVMkZ18CKzdaA1qrBDJfsMO49hPCny505eiT766+CkKdaCDl5kA==}
     cpu: [x64]
     os: [win32]
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.10':
+    resolution: {integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@oozcitak/dom@2.0.2':
     resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
@@ -7684,6 +7743,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -7890,6 +7952,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -9155,6 +9221,9 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -11027,6 +11096,9 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -12881,6 +12953,21 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
+  '@modelcontextprotocol/conformance@0.1.16(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@octokit/rest': 22.0.1
+      commander: 14.0.3
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      jose: 6.2.3
+      undici: 7.24.8
+      yaml: 2.9.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.25)
@@ -12986,6 +13073,69 @@ snapshots:
 
   '@nx/nx-win32-x64-msvc@22.7.5':
     optional: true
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.10
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.10
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.10':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
 
   '@oozcitak/dom@2.0.2':
     dependencies:
@@ -14597,6 +14747,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.35: {}
 
+  before-after-hook@4.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -14800,6 +14952,8 @@ snapshots:
   command-exists@1.2.9: {}
 
   commander@11.1.0: {}
+
+  commander@14.0.3: {}
 
   commander@4.1.1: {}
 
@@ -16176,6 +16330,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
+
+  json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
 
@@ -18519,6 +18675,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
> 🤖 Coauthored with Fable 5 — as a test to get some stuff done.

Closes #1721

## What

Adds the official [MCP conformance suite](https://github.com/modelcontextprotocol/conformance) (`@modelcontextprotocol/conformance`, the same harness the [MCP TypeScript SDK runs in CI](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/test/conformance)) to this repo:

| Suite | Implementation under test | Entry point |
| --- | --- | --- |
| `client` | `Agent` + `MCPClientManager` (+ `DurableObjectOAuthClientProvider` for OAuth) | `ConformanceHost` in `conformance/worker.ts` |
| `server` | `McpAgent` | `/mcp-agent` |
| `server` | `createMcpHandler` + `WorkerTransport` inside an `Agent` | `/mcp-handler` |

Everything under test runs **inside workerd** (`wrangler dev`), not a Node approximation — Durable Object storage, the real OAuth callback route, real transports. For the client suite, the conformance CLI spawns a thin Node driver per scenario; the driver forwards the scenario to a fresh agent instance and plays the user's browser for OAuth (follows the authorization redirect into the worker's real `/callback` route). Both test servers register the same "everything server" feature set ported from the TypeScript SDK's conformance server.

## Bugs found and fixed

The client suite immediately caught two real OAuth bugs in `MCPClientConnection`, fixed in this PR:

1. **Token exchange hit the wrong endpoint** (`auth/metadata-var3`): `finishAuth` ran on a freshly created transport, losing the resource metadata URL captured from the `WWW-Authenticate` header on the 401. Discovery fell back to default endpoints, so the code was exchanged at `/token` even when the authorization server advertised a different location. Fixed by finishing auth on the transport that received the 401.
2. **Permanent failure after mid-session re-auth** (`auth/scope-step-up`): after a mid-session 401 (scope step-up, token revocation) and successful re-authorization, `init()` failed forever with `Already connected to a transport` because the previous transport was never detached. Fixed by detaching it before reconnecting.

Both ship with a changeset (patch).

## Results

- **Client**: 334 checks passing across 26 scenarios, including the full OAuth matrix (metadata variants, scope selection/step-up/retry-limit, token endpoint auth methods, pre-registration, 2025-03-26 backcompat, offline-access drafts). Baselined: SEP-1034 elicitation defaults (elicitation is platform-delegated), CIMD (SHOULD-level warning), client-credentials/cross-app extensions (grant not supported by `DurableObjectOAuthClientProvider`; cross-app is baselined by the TypeScript SDK too).
- **Servers**: 40 checks passing per variant (tools/resources/prompts/logging/completions, sampling, elicitation incl. SEP-1034/SEP-1330, SSE polling + multi-stream). Baselined: `json-schema-2020-12` (pinned SDK's zod→JSON Schema conversion doesn't preserve `$schema`/`$defs`/`additionalProperties` verbatim) and `dns-rebinding-protection` (localhost Host/Origin validation is a local-server concern).

Baselines are documented per-gap in `conformance/baseline-*.yml` — CI stays green while regressions and new failures are still caught.

## CI

New `conformance.yml` workflow: one client job + a server matrix (mcp-agent, handler), triggered on changes to `packages/agents/**`.

## Running locally

```sh
cd packages/agents
pnpm run test:conformance                  # all three suites
bash conformance/run.sh client --scenario auth/scope-step-up   # single scenario
```

Also verified: `pnpm vitest --run src/tests/mcp/...` (188 tests) and typecheck pass with the library changes.