### PR TITLE
RFC: Rename "Think" to "Assistant" and export from `agents`.

### DIFF
--- a/.changeset/assistant-alias.md
+++ b/.changeset/assistant-alias.md
@@ -1,0 +1,7 @@
+---
+"agents": minor
+---
+
+Add `agents/assistant`, an additive entrypoint that exports `Assistant` as an
+alias for `@cloudflare/think`'s `Think` base class while preserving the existing
+`Think` export.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The agent is a Durable Object, so it needs a binding and a SQLite migration in `
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [`agents`](packages/agents)                             | Core SDK — `Agent` class, routing, state, scheduling, MCP, email, workflows, x402, browser agents |
 | [`@cloudflare/ai-chat`](packages/ai-chat)               | Higher-level AI chat — persistent messages, resumable streaming, tool execution                   |
-| [`@cloudflare/think`](packages/think)                   | Opinionated chat agent base — agentic loop, stream resumption, client tools, workspace tools      |
+| [`@cloudflare/think`](packages/think)                   | Opinionated chat agent base, also available as `Assistant` from `agents/assistant`                |
 | [`@cloudflare/codemode`](packages/codemode)             | LLMs write executable code that calls your tools, instead of one tool call at a time              |
 | [`@cloudflare/shell`](packages/shell)                   | Sandboxed JS execution + virtual filesystem (`Workspace`) for agents                              |
 | [`@cloudflare/voice`](packages/voice)                   | Voice pipeline — STT, TTS, VAD, streaming, SFU utilities                                          |

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -11,6 +11,7 @@ Each export maps to a public entry point that users `import` from. These are the
 | `agents`                     | `src/index.ts`               | Agent base class, routing, connections, RPC, state, scheduling, SQL          |
 | `agents/client`              | `src/client.ts`              | Browser/Node WebSocket client (`AgentClient`) via partysocket                |
 | `agents/react`               | `src/react.tsx`              | `useAgent` React hook, state sync, RPC from components                       |
+| `agents/assistant`           | `src/assistant.ts`           | `Assistant` alias for the opinionated `@cloudflare/think` chat/session agent |
 | `agents/chat`                | `src/chat/index.ts`          | Shared chat primitives used by `@cloudflare/ai-chat` and `@cloudflare/think` |
 | `agents/mcp`                 | `src/mcp/index.ts`           | `McpAgent` base class for building MCP servers                               |
 | `agents/mcp/client`          | `src/mcp/client.ts`          | MCP client manager (connect to remote MCP servers from an Agent)             |

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -234,23 +234,23 @@ segments, subject to the platform's current facet nesting limits.
 
 ### Agent Tools
 
-Run chat-capable sub-agents as tools from a parent chat agent. Think agents and
-`AIChatAgent` subclasses are supported. The child keeps its own messages, tools,
-SQLite storage, and resumable stream, while the parent broadcasts
+Run chat-capable sub-agents as tools from a parent chat agent. Assistant/Think
+agents and `AIChatAgent` subclasses are supported. The child keeps its own
+messages, tools, SQLite storage, and resumable stream, while the parent broadcasts
 `agent-tool-event` frames so the UI can render the child timeline inline.
 
 ```typescript
-import { Think } from "@cloudflare/think";
+import { Assistant } from "agents/assistant";
 import { agentTool } from "agents/agent-tools";
 import { z } from "zod";
 
-export class Researcher extends Think<Env> {
+export class Researcher extends Assistant<Env> {
   getSystemPrompt() {
     return "Research the requested topic and end with a concise summary.";
   }
 }
 
-export class Assistant extends Think<Env> {
+export class Support extends Assistant<Env> {
   getTools() {
     return {
       research: agentTool(Researcher, {
@@ -389,6 +389,25 @@ See [Workflows](../../docs/workflows.md) and [Human in the Loop](../../docs/huma
 ## AI Chat Integration
 
 For AI-powered chat experiences with persistent conversations, streaming responses, and tool support, see [`@cloudflare/ai-chat`](../ai-chat/README.md).
+
+For the opinionated assistant framework with the full agentic loop, Session
+storage, workspace tools, sub-agent RPC, and durable chat recovery, import
+`Assistant` from `agents/assistant`. This is an additive alias for
+`@cloudflare/think`'s `Think` base class, so existing `@cloudflare/think`
+imports continue to work.
+
+```typescript
+import { Assistant } from "agents/assistant";
+import { createWorkersAI } from "workers-ai-provider";
+
+export class Support extends Assistant<Env> {
+  getModel() {
+    return createWorkersAI({ binding: this.env.AI })(
+      "@cf/moonshotai/kimi-k2.6"
+    );
+  }
+}
+```
 
 ```typescript
 import { AIChatAgent } from "@cloudflare/ai-chat";

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -56,6 +56,7 @@
   },
   "peerDependencies": {
     "@cloudflare/ai-chat": ">=0.8.0 <1.0.0",
+    "@cloudflare/think": ">=0.8.6 <1.0.0",
     "@tanstack/ai": ">=0.10.2 <1.0.0",
     "@x402/core": "^2.0.0",
     "@x402/evm": "^2.0.0",
@@ -67,6 +68,9 @@
   },
   "peerDependenciesMeta": {
     "@cloudflare/ai-chat": {
+      "optional": true
+    },
+    "@cloudflare/think": {
       "optional": true
     },
     "@tanstack/ai": {
@@ -106,6 +110,11 @@
       "types": "./dist/agent-tools.d.ts",
       "import": "./dist/agent-tools.js",
       "require": "./dist/agent-tools.js"
+    },
+    "./assistant": {
+      "types": "./dist/assistant.d.ts",
+      "import": "./dist/assistant.js",
+      "require": "./dist/assistant.js"
     },
     "./codemode/ai": {
       "types": "./dist/codemode/ai.d.ts",
@@ -245,7 +254,8 @@
   ],
   "nx": {
     "implicitDependencies": [
-      "!@cloudflare/ai-chat"
+      "!@cloudflare/ai-chat",
+      "!@cloudflare/think"
     ]
   },
   "scripts": {

--- a/packages/agents/src/assistant.ts
+++ b/packages/agents/src/assistant.ts
@@ -1,0 +1,2 @@
+export * from "@cloudflare/think";
+export { Think as Assistant } from "@cloudflare/think";

--- a/packages/agents/src/tests-d/assistant-alias.test-d.ts
+++ b/packages/agents/src/tests-d/assistant-alias.test-d.ts
@@ -1,0 +1,12 @@
+import { Assistant, Think } from "../assistant";
+
+const assistantConstructor: typeof Think = Assistant;
+const thinkConstructor: typeof Assistant = Think;
+
+class TestAssistant extends Assistant<Cloudflare.Env> {}
+class TestThink extends Think<Cloudflare.Env> {}
+
+void assistantConstructor;
+void thinkConstructor;
+void TestAssistant;
+void TestThink;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3302,6 +3302,9 @@ importers:
       '@cloudflare/codemode':
         specifier: '*'
         version: link:../codemode
+      '@cloudflare/think':
+        specifier: '>=0.8.6 <1.0.0'
+        version: link:../think
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)


### PR DESCRIPTION
This is an RFC to consider positioning and naming for the `agents` package and "Think" class. This PR is a non-breaking change to re-export "Think" as "Assistant" directly from `agents`.

In recent days I've tried to talk about or write about Think, and it generally fits poorly into sentences and breaks my brain. I was wondering, what is "Think" really, and could it be part of the `agents` package itself? This led me to add it to the `agents` package as an Assistant, which is a layer on top of Agent which is already there. It provides a more natural migration from an agent to an assistant, even though I realize that the mapping of what Think is does not 100% map to Assistant.

No hard feelings if you don't like it, or if it was already considered and decided against, but thought I'll open an RFC to discuss.