### PR TITLE
fix(agents,ai-chat,think): replay errored-stream content and scope agent-tool error capture per run (#1575)

### DIFF
--- a/.changeset/inband-error-replay-and-run-scoping.md
+++ b/.changeset/inband-error-replay-and-run-scoping.md
@@ -1,0 +1,11 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Fix the two remaining #1575 gaps in how in-band stream errors (`{type: "error", errorText}` chunks inside an otherwise-healthy provider stream) are observed after the fact.
+
+**Errored-stream replay (partial content was lost on reconnect).** A client reconnecting after an in-band error received the terminal error frame (#1645) but not the content the model streamed before the error — the replay path only served `status = 'completed'` streams, so an errored stream's buffered chunks were unreachable, and the server pushes no messages on connect. `ResumableStream` gains `replayErroredChunksByRequestId`, and the resume-ACK terminal replay (`_replayTerminalOnAck` in both AIChatAgent and Think) now replays the errored stream's stored chunks before the `done: true, error: true` frame, so a reconnecting client observes the same sequence a live client did. No wire-format or schema changes: replayed chunks reuse the existing `replay: true` frame shape and the error text still comes from the durable terminal record.
+
+**Agent-tool error attribution (cross-run contamination).** When an in-band error frame was broadcast on a child agent and the active run was unknown, the error was stamped onto every tailed run — so an unrelated turn's failure (or one of several overlapping runs) could mark healthy runs as `error`, and capture depended on a tailer being attached at the right moment. Frames are now attributed by the request id they carry: each agent-tool run is bound to its turn's request id when the turn starts (persisted on the run row at start rather than at terminal, so attribution survives a DO restart mid-run), and only the owning run's error/progress state is updated. Frame inspection also no longer requires an attached tailer, so error capture is independent of tailer timing.

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -538,10 +538,11 @@ export class ResumableStream {
    * messages on connect, and {@link replayCompletedChunksByRequestId} only
    * serves `completed` streams (#1575).
    *
-   * Returns true if an errored stream existed for the request (whether or not
-   * it had chunks); the caller should then send its terminal frame. A send
-   * failure mid-replay returns false so the caller can skip the terminal
-   * frame — the connection is gone and the next reconnect retries.
+   * Returns true when the caller should proceed to send its terminal frame:
+   * either no errored stream existed (nothing to replay) or its chunks were
+   * replayed successfully. Returns false only when a send failed mid-replay,
+   * signalling the caller to skip the terminal frame — the connection is gone
+   * and the next reconnect retries the whole sequence.
    */
   replayErroredChunksByRequestId(
     connection: Connection,

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -509,21 +509,79 @@ export class ResumableStream {
     connection: Connection,
     requestId: string
   ): boolean {
+    const stream = this._latestStreamForRequest(requestId, "completed");
+    if (!stream) return false;
+
+    if (!this._replayStoredChunks(connection, stream.id, requestId)) {
+      return false;
+    }
+
+    return sendIfOpen(
+      connection,
+      JSON.stringify({
+        body: "",
+        done: true,
+        id: requestId,
+        type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
+        replay: true
+      })
+    );
+  }
+
+  /**
+   * Replay the stored chunks of an errored stream for a request, WITHOUT a
+   * terminal frame — the caller follows up with the `done: true, error: true`
+   * frame carrying the durable terminal record's error text, mirroring what a
+   * live client observed (content chunks, then the error). Without this, a
+   * client that missed broadcast frames while disconnected has no other
+   * channel to the pre-error partial content: the server does not push
+   * messages on connect, and {@link replayCompletedChunksByRequestId} only
+   * serves `completed` streams (#1575).
+   *
+   * Returns true if an errored stream existed for the request (whether or not
+   * it had chunks); the caller should then send its terminal frame. A send
+   * failure mid-replay returns false so the caller can skip the terminal
+   * frame — the connection is gone and the next reconnect retries.
+   */
+  replayErroredChunksByRequestId(
+    connection: Connection,
+    requestId: string
+  ): boolean {
+    const stream = this._latestStreamForRequest(requestId, "error");
+    if (!stream) return true;
+
+    return this._replayStoredChunks(connection, stream.id, requestId);
+  }
+
+  /** Latest stream row for a request with the given terminal status. */
+  private _latestStreamForRequest(
+    requestId: string,
+    status: "completed" | "error"
+  ): StreamMetadata | undefined {
     this.flushBuffer();
 
     const streams = this.sql<StreamMetadata>`
       select * from cf_ai_chat_stream_metadata
       where request_id = ${requestId}
-      and status = 'completed'
+      and status = ${status}
       order by created_at desc
       limit 1
     `;
-    const stream = streams[0];
-    if (!stream) return false;
+    return streams[0];
+  }
 
+  /**
+   * Send a finished stream's stored chunks to a connection as replay frames.
+   * Returns false if the connection closed mid-replay.
+   */
+  private _replayStoredChunks(
+    connection: Connection,
+    streamId: string,
+    requestId: string
+  ): boolean {
     const chunks = this.sql<StreamChunk>`
       select * from cf_ai_chat_stream_chunks
-      where stream_id = ${stream.id}
+      where stream_id = ${streamId}
       order by chunk_index asc
     `;
 
@@ -546,16 +604,7 @@ export class ResumableStream {
       }
     }
 
-    return sendIfOpen(
-      connection,
-      JSON.stringify({
-        body: "",
-        done: true,
-        id: requestId,
-        type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
-        replay: true
-      })
-    );
+    return true;
   }
 
   // ── Restore / cleanup ──────────────────────────────────────────────

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -511,7 +511,15 @@ export class AIChatAgent<
   private _agentToolLastErrors = new Map<string, string>();
   private _agentToolPreTurnAssistantIds = new Map<string, Set<string>>();
   private _agentToolLiveSequences = new Map<string, number>();
-  private _agentToolActiveRunId: string | null = null;
+  /**
+   * Request id → run id for in-flight agent-tool turns (null = resolved as
+   * not an agent-tool turn, cached so unrelated turns don't re-query SQLite
+   * per frame). Drives frame attribution in {@link broadcast}: a frame
+   * belongs to a run iff it carries that run's turn request id, so an error
+   * in a user-driven turn or a concurrent run can never leak into another
+   * run's state (#1575).
+   */
+  private _agentToolRunsByRequestId = new Map<string, string | null>();
 
   /**
    * Client tool schemas from the most recent chat request.
@@ -654,42 +662,47 @@ export class AIChatAgent<
     msg: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
   ): void {
-    if (this._agentToolForwarders.size > 0 && typeof msg === "string") {
+    // Inspect frames while any agent-tool run is in flight (live sequences
+    // exist for the run's whole lifecycle), not only while a tailer is
+    // attached — error capture must not depend on tailer timing (#1575).
+    if (
+      (this._agentToolForwarders.size > 0 ||
+        this._agentToolLiveSequences.size > 0) &&
+      typeof msg === "string"
+    ) {
       try {
         const parsed = JSON.parse(msg) as {
           type?: unknown;
           body?: unknown;
           error?: unknown;
+          id?: unknown;
         };
-        if (parsed.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE) {
-          if (parsed.error === true && typeof parsed.body === "string") {
-            const runIds =
-              this._agentToolActiveRunId !== null
-                ? [this._agentToolActiveRunId]
-                : [...this._agentToolForwarders.keys()];
-            for (const runId of runIds) {
+        if (
+          parsed.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+          typeof parsed.id === "string"
+        ) {
+          // A frame belongs to a run iff it carries that run's turn request
+          // id. Frames from unrelated turns (a user-driven turn on this
+          // agent, or another run's turn) resolve to a different — or no —
+          // run and are left alone, so concurrent runs cannot
+          // cross-contaminate each other's progress or error state (#1575).
+          const runId = this._agentToolRunForRequest(parsed.id);
+          if (runId !== null) {
+            if (parsed.error === true && typeof parsed.body === "string") {
               this._agentToolLastErrors.set(runId, parsed.body);
-            }
-          } else if (
-            typeof parsed.body === "string" &&
-            parsed.body.length > 0
-          ) {
-            const entries =
-              this._agentToolActiveRunId !== null
-                ? [
-                    [
-                      this._agentToolActiveRunId,
-                      this._agentToolForwarders.get(
-                        this._agentToolActiveRunId
-                      ) ?? new Set<(chunk: AgentToolStoredChunk) => void>()
-                    ] as const
-                  ]
-                : [...this._agentToolForwarders.entries()];
-            for (const [runId, forwarders] of entries) {
+            } else if (
+              typeof parsed.body === "string" &&
+              parsed.body.length > 0
+            ) {
+              // Advance the live sequence even with no tailer attached so a
+              // tailer registering mid-run resumes at the right offset.
               const sequence = this._agentToolLiveSequences.get(runId) ?? 0;
               this._agentToolLiveSequences.set(runId, sequence + 1);
               const chunk = { sequence, body: parsed.body };
-              for (const forward of forwarders) forward(chunk);
+              const forwarders = this._agentToolForwarders.get(runId);
+              if (forwarders) {
+                for (const forward of forwarders) forward(chunk);
+              }
             }
           }
         }
@@ -698,6 +711,25 @@ export class AIChatAgent<
       }
     }
     super.broadcast(msg, without);
+  }
+
+  /**
+   * Resolve the agent-tool run whose turn owns a request id, or null when the
+   * request is not an agent-tool turn. Falls back to the persisted run row
+   * (written when the turn starts, see `_registerAgentToolTurn`) so
+   * attribution survives a DO restart mid-run; either outcome is cached.
+   */
+  private _agentToolRunForRequest(requestId: string): string | null {
+    const cached = this._agentToolRunsByRequestId.get(requestId);
+    if (cached !== undefined) return cached;
+    const rows = this.sql<{ run_id: string }>`
+      select run_id from cf_ai_chat_agent_tool_runs
+      where request_id = ${requestId} and status = 'running'
+      limit 1
+    `;
+    const runId = rows?.[0]?.run_id ?? null;
+    this._agentToolRunsByRequestId.set(requestId, runId);
+    return runId;
   }
 
   constructor(ctx: AgentContext, env: Env) {
@@ -2802,6 +2834,25 @@ export class AIChatAgent<
     }
   }
 
+  /**
+   * Bind the child turn that is about to stream to its agent-tool run, at
+   * the moment the turn's request id is first knowable (inside the turn,
+   * before any frame is broadcast). The in-memory mapping drives frame
+   * attribution in {@link broadcast}; the run row's `request_id` is
+   * persisted here rather than at terminal so attribution also survives a
+   * DO restart mid-run (#1575).
+   */
+  private _registerAgentToolTurn(runId: string): void {
+    const requestId = this._turnQueue.activeRequestId;
+    if (requestId === null) return;
+    this._agentToolRunsByRequestId.set(requestId, runId);
+    this.sql`
+      update cf_ai_chat_agent_tool_runs
+      set request_id = ${requestId}
+      where run_id = ${runId}
+    `;
+  }
+
   async startAgentToolRun(
     input: unknown,
     options: { runId: string; signal?: AbortSignal }
@@ -2846,7 +2897,7 @@ export class AIChatAgent<
         this._setRequestContext(undefined, { agentToolInput: input });
         const result = await this.saveMessages(
           async (messages) => {
-            this._agentToolActiveRunId = options.runId;
+            this._registerAgentToolTurn(options.runId);
             return [
               ...messages,
               this.formatAgentToolInput(input, { runId: options.runId })
@@ -2936,8 +2987,10 @@ export class AIChatAgent<
         options.signal?.removeEventListener("abort", abortFromParent);
         this._agentToolAbortControllers.delete(options.runId);
         this._agentToolLiveSequences.delete(options.runId);
-        if (this._agentToolActiveRunId === options.runId) {
-          this._agentToolActiveRunId = null;
+        for (const [reqId, runId] of this._agentToolRunsByRequestId) {
+          if (runId === options.runId) {
+            this._agentToolRunsByRequestId.delete(reqId);
+          }
         }
         this._agentToolLastErrors.delete(options.runId);
         this._agentToolPreTurnAssistantIds.delete(options.runId);
@@ -4061,6 +4114,19 @@ export class AIChatAgent<
   ): Promise<boolean> {
     const pending = await this._pendingChatTerminal();
     if (!pending || pending.requestId !== requestId) return false;
+    // Replay any partial content the errored stream produced before the
+    // error, so the reconnecting client observes the same sequence a live
+    // client did — content chunks, then the terminal error (#1575). If the
+    // connection drops mid-replay, skip the terminal frame; the record is
+    // retained, so the next reconnect retries the whole sequence.
+    if (
+      !this._resumableStream.replayErroredChunksByRequestId(
+        connection,
+        pending.requestId
+      )
+    ) {
+      return true;
+    }
     sendIfOpen(
       connection,
       JSON.stringify({

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -2844,7 +2844,16 @@ export class AIChatAgent<
    */
   private _registerAgentToolTurn(runId: string): void {
     const requestId = this._turnQueue.activeRequestId;
-    if (requestId === null) return;
+    if (requestId === null) {
+      // Invariant: this runs inside the turn's enqueued fn, so the turn
+      // queue's active request id is set. If it ever isn't, the run can't be
+      // bound to its frames and its error/progress capture silently degrades
+      // (#1575) — surface it rather than fail quietly.
+      console.warn(
+        `[AIChatAgent] agent-tool run ${runId} has no active request id at turn start; frame attribution will be skipped`
+      );
+      return;
+    }
     this._agentToolRunsByRequestId.set(requestId, runId);
     this.sql`
       update cf_ai_chat_agent_tool_runs
@@ -2987,9 +2996,17 @@ export class AIChatAgent<
         options.signal?.removeEventListener("abort", abortFromParent);
         this._agentToolAbortControllers.delete(options.runId);
         this._agentToolLiveSequences.delete(options.runId);
-        for (const [reqId, runId] of this._agentToolRunsByRequestId) {
-          if (runId === options.runId) {
-            this._agentToolRunsByRequestId.delete(reqId);
+        // Drop this run's request-id mappings. When no runs remain in flight
+        // clear the whole map, so negatively-cached (null) entries for
+        // unrelated turns can't accumulate for the DO's lifetime — the map is
+        // only consulted while a run is active (#1575).
+        if (this._agentToolAbortControllers.size === 0) {
+          this._agentToolRunsByRequestId.clear();
+        } else {
+          for (const [reqId, runId] of this._agentToolRunsByRequestId) {
+            if (runId === options.runId) {
+              this._agentToolRunsByRequestId.delete(reqId);
+            }
           }
         }
         this._agentToolLastErrors.delete(options.runId);

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -192,6 +192,11 @@ type ParentStub = DurableObjectStub & {
     },
     runId?: string
   ): Promise<AgentToolRunInspection>;
+  childAgentToolRunsMapSizeForTest(runId: string): Promise<number>;
+  childResolveAfterRestartForTest(
+    runId: string,
+    requestId: string
+  ): Promise<{ running: string | null; unknown: string | null }>;
   childReconcileStaleRunViaRecoveryForTest(
     path: "continue" | "retry",
     withAssistantTurn: boolean
@@ -654,6 +659,40 @@ describe("AIChatAgent as an agent-tool child", () => {
     );
 
     expect(result).toMatchObject({ runId, status: "completed" });
+  });
+
+  it("does not leak request-id cache entries for unrelated turns (#1575)", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    // The injected unrelated-turn error frame negatively-caches a (null)
+    // entry in the child's request-id map while the run is in flight.
+    const result = await parent.runChildWithInjectedUnrelatedError(
+      { prompt: "stay healthy", chunkDelayMs: 60 },
+      100,
+      runId
+    );
+    expect(result).toMatchObject({ runId, status: "completed" });
+
+    // Once the run ends and no runs remain in flight, the map must be fully
+    // cleared — null entries must not accumulate for the DO's lifetime.
+    expect(await parent.childAgentToolRunsMapSizeForTest(runId)).toBe(0);
+  });
+
+  it("attributes frames via the persisted request id after a DO restart (#1575)", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+    const requestId = crypto.randomUUID();
+
+    // The run row persisted request_id at turn start; after a restart the
+    // in-memory map is empty, so attribution must fall back to SQL.
+    const resolved = await parent.childResolveAfterRestartForTest(
+      runId,
+      requestId
+    );
+
+    expect(resolved.running).toBe(runId);
+    expect(resolved.unknown).toBeNull();
   });
 
   it("marks an in-band stream error as error with no tailer attached (#1575)", async () => {

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -171,6 +171,27 @@ type ParentStub = DurableObjectStub & {
   }>;
   testPreAbortedForwardStreamReleasesReaderLock(): Promise<boolean>;
   forwardMalformedAgentToolStreamForTest(): Promise<AgentToolEventMessage[]>;
+  runChildWithInjectedUnrelatedError(
+    input: {
+      prompt: string;
+      delayMs?: number;
+      chunkDelayMs?: number;
+      structured?: boolean;
+      streamError?: string;
+    },
+    injectAfterMs: number,
+    runId?: string
+  ): Promise<RunAgentToolResult>;
+  startChildWithoutTailForTest(
+    input: {
+      prompt: string;
+      delayMs?: number;
+      chunkDelayMs?: number;
+      structured?: boolean;
+      streamError?: string;
+    },
+    runId?: string
+  ): Promise<AgentToolRunInspection>;
   childReconcileStaleRunViaRecoveryForTest(
     path: "continue" | "retry",
     withAssistantTurn: boolean
@@ -616,6 +637,66 @@ describe("AIChatAgent as an agent-tool child", () => {
 
     const events = await parent.getEventsForTest();
     expect(events.map((event) => event.event.kind)).toContain("error");
+  });
+
+  it("does not contaminate a run's terminal status with an unrelated turn's error frame (#1575)", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    // While the child run streams, an error frame from an UNRELATED turn (a
+    // request id that belongs to no run) is broadcast on the child. Before
+    // #1575 the error was stamped onto every active forwarder's run and this
+    // healthy run finalized as `error`.
+    const result = await parent.runChildWithInjectedUnrelatedError(
+      { prompt: "stay healthy", chunkDelayMs: 60 },
+      100,
+      runId
+    );
+
+    expect(result).toMatchObject({ runId, status: "completed" });
+  });
+
+  it("marks an in-band stream error as error with no tailer attached (#1575)", async () => {
+    const parent = await getParent();
+    const runId = crypto.randomUUID();
+
+    // The run is started directly and never tailed — terminal status must
+    // come from the child turn's own result, not forwarding side effects.
+    const inspection = await parent.startChildWithoutTailForTest(
+      { prompt: "fail untailed", streamError: "untailed failure" },
+      runId
+    );
+
+    expect(inspection).toMatchObject({
+      runId,
+      status: "error",
+      error: "untailed failure"
+    });
+  });
+
+  it("keeps concurrent child runs' error state isolated (#1575)", async () => {
+    const parent = await getParent();
+    const runA = crypto.randomUUID();
+    const runB = crypto.randomUUID();
+
+    const [a, b] = await Promise.all([
+      parent.runChild(
+        {
+          prompt: "failing run",
+          streamError: "run A failed",
+          chunkDelayMs: 40
+        },
+        runA
+      ),
+      parent.runChild({ prompt: "healthy run", chunkDelayMs: 40 }, runB)
+    ]);
+
+    expect(a).toMatchObject({
+      runId: runA,
+      status: "error",
+      error: "run A failed"
+    });
+    expect(b).toMatchObject({ runId: runB, status: "completed" });
   });
 
   it("propagates parent abort signals into AIChatAgent agent-tool runs", async () => {

--- a/packages/ai-chat/src/tests/errored-stream-replay.test.ts
+++ b/packages/ai-chat/src/tests/errored-stream-replay.test.ts
@@ -1,0 +1,235 @@
+import { env } from "cloudflare:workers";
+import type { UIMessage as ChatMessage } from "ai";
+import { getAgentByName } from "agents";
+import { describe, expect, it } from "vitest";
+import type { ChatResponseResult } from "../";
+import { MessageType } from "../types";
+import { connectChatWS } from "./test-utils";
+
+/**
+ * #1575 acceptance tests: a client reconnecting after an in-band stream error
+ * must observe the same terminal outcome a live client did — the partial
+ * content the model produced before the error, followed by a terminal
+ * `done: true, error: true` frame. Chunk replay is the only channel for that
+ * partial content: the server does not push messages on connect, so a client
+ * that missed the live broadcasts has nothing else to recover from.
+ */
+
+const userMessage: ChatMessage = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }]
+};
+
+function sendChatRequest(
+  ws: WebSocket,
+  requestId: string,
+  extraBody: Record<string, unknown>
+) {
+  ws.send(
+    JSON.stringify({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+      id: requestId,
+      init: {
+        method: "POST",
+        body: JSON.stringify({ messages: [userMessage], ...extraBody })
+      }
+    })
+  );
+}
+
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 5000,
+  intervalMs = 25
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await condition())) {
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+type Frame = Record<string, unknown>;
+
+function collectFrames(ws: WebSocket): Frame[] {
+  const frames: Frame[] = [];
+  ws.addEventListener("message", (e: MessageEvent) => {
+    try {
+      frames.push(JSON.parse(e.data as string) as Frame);
+    } catch {
+      // ignore non-JSON frames
+    }
+  });
+  return frames;
+}
+
+/** Extract text-delta deltas from chat-response frames, in arrival order. */
+function textDeltas(frames: Frame[], opts: { replayOnly: boolean }): string[] {
+  return frames
+    .filter(
+      (f) =>
+        f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+        f.error !== true &&
+        typeof f.body === "string" &&
+        f.body.length > 0 &&
+        (!opts.replayOnly || f.replay === true)
+    )
+    .map((f) => {
+      try {
+        return JSON.parse(f.body as string) as {
+          type?: string;
+          delta?: string;
+        };
+      } catch {
+        return {};
+      }
+    })
+    .filter((c) => c.type === "text-delta")
+    .map((c) => c.delta as string);
+}
+
+/**
+ * Run the real WebSocketChatTransport reconnect handshake: send
+ * RESUME_REQUEST, ACK the STREAM_RESUMING offer, and collect everything the
+ * server sends until a terminal `done: true` frame (or RESUME_NONE) arrives.
+ */
+async function reconnectAndCollect(path: string): Promise<Frame[]> {
+  const { ws } = await connectChatWS(path);
+  const frames = collectFrames(ws);
+  ws.addEventListener("message", (e: MessageEvent) => {
+    try {
+      const frame = JSON.parse(e.data as string) as Frame;
+      if (frame.type === MessageType.CF_AGENT_STREAM_RESUMING) {
+        ws.send(
+          JSON.stringify({
+            type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
+            id: frame.id
+          })
+        );
+      }
+    } catch {
+      // ignore
+    }
+  });
+  ws.send(JSON.stringify({ type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST }));
+  await waitFor(() =>
+    frames.some(
+      (f) =>
+        (f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+          f.done === true) ||
+        f.type === MessageType.CF_AGENT_STREAM_RESUME_NONE
+    )
+  );
+  ws.close(1000);
+  return frames;
+}
+
+describe("Errored stream replay (#1575)", () => {
+  it("replays pre-error partial content and the terminal error to a reconnecting client", async () => {
+    const room = crypto.randomUUID();
+    const path = `/agents/slow-stream-agent/${room}`;
+
+    // Live client drives a turn that streams 3 text chunks, then dies with an
+    // in-band error.
+    const { ws: liveWs } = await connectChatWS(path);
+    const liveFrames = collectFrames(liveWs);
+    sendChatRequest(liveWs, "req-err-partial", {
+      format: "sse",
+      streamError: "in-band boom",
+      errorAfterChunks: 3,
+      chunkDelayMs: 10
+    });
+    await waitFor(() =>
+      liveFrames.some(
+        (f) =>
+          f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && f.done === true
+      )
+    );
+
+    // What the live observer saw: the partial content, then the error.
+    expect(textDeltas(liveFrames, { replayOnly: false })).toEqual([
+      "partial-0 ",
+      "partial-1 ",
+      "partial-2 "
+    ]);
+    const liveError = liveFrames.find((f) => f.error === true);
+    expect(liveError?.body).toBe("in-band boom");
+    liveWs.close(1000);
+
+    // Wait for the turn to fully drain (the durable terminal record is
+    // written just before onChatResponse fires).
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+    await waitFor(
+      async () =>
+        ((await agentStub.getChatResponseResults()) as ChatResponseResult[])
+          .length === 1
+    );
+
+    // A fresh client — it observed none of the live frames — reconnects.
+    const frames = await reconnectAndCollect(path);
+
+    // It must observe the SAME outcome: the partial content (as replay
+    // frames), then a terminal done+error frame with the same error text.
+    expect(textDeltas(frames, { replayOnly: true })).toEqual([
+      "partial-0 ",
+      "partial-1 ",
+      "partial-2 "
+    ]);
+    const terminal = frames.find(
+      (f) =>
+        f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+        f.error === true &&
+        f.done === true
+    );
+    expect(terminal?.body).toBe("in-band boom");
+
+    // The terminal frame arrives after all replayed content.
+    const chatFrames = frames.filter(
+      (f) => f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE
+    );
+    expect(chatFrames[chatFrames.length - 1]).toBe(terminal);
+  });
+
+  it("delivers only the terminal error when the error preceded any content", async () => {
+    const room = crypto.randomUUID();
+    const path = `/agents/slow-stream-agent/${room}`;
+
+    // The early in-band error case (#1527): error is the very first chunk.
+    const { ws: liveWs } = await connectChatWS(path);
+    const liveFrames = collectFrames(liveWs);
+    sendChatRequest(liveWs, "req-err-early", {
+      format: "sse",
+      streamError: "early in-band boom"
+    });
+    await waitFor(() =>
+      liveFrames.some(
+        (f) =>
+          f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && f.done === true
+      )
+    );
+    liveWs.close(1000);
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+    await waitFor(
+      async () =>
+        ((await agentStub.getChatResponseResults()) as ChatResponseResult[])
+          .length === 1
+    );
+
+    const frames = await reconnectAndCollect(path);
+
+    // No content existed before the error, so nothing is replayed — just the
+    // terminal error frame.
+    expect(textDeltas(frames, { replayOnly: true })).toEqual([]);
+    const terminal = frames.find(
+      (f) =>
+        f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+        f.error === true &&
+        f.done === true
+    );
+    expect(terminal?.body).toBe("early in-band boom");
+  });
+});

--- a/packages/ai-chat/src/tests/errored-stream-replay.test.ts
+++ b/packages/ai-chat/src/tests/errored-stream-replay.test.ts
@@ -232,4 +232,55 @@ describe("Errored stream replay (#1575)", () => {
     );
     expect(terminal?.body).toBe("early in-band boom");
   });
+
+  it("returns the documented contract from replayErroredChunksByRequestId (#1575)", async () => {
+    const room = crypto.randomUUID();
+    const path = `/agents/slow-stream-agent/${room}`;
+
+    // Produce a real errored stream with buffered partial content.
+    const { ws } = await connectChatWS(path);
+    const frames = collectFrames(ws);
+    sendChatRequest(ws, "req-drop", {
+      format: "sse",
+      streamError: "boom",
+      errorAfterChunks: 3,
+      chunkDelayMs: 10
+    });
+    await waitFor(() =>
+      frames.some(
+        (f) =>
+          f.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE && f.done === true
+      )
+    );
+    ws.close(1000);
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+    await waitFor(
+      async () =>
+        ((await agentStub.getChatResponseResults()) as ChatResponseResult[])
+          .length === 1
+    );
+
+    // No errored stream for the request → nothing to replay, but the caller
+    // should still proceed to send its terminal frame (returns true, sent 0).
+    expect(
+      await agentStub.replayErroredChunksByRequestIdForTest("no-such-req", 999)
+    ).toEqual({ returned: true, sent: 0 });
+
+    // All buffered chunks replay successfully → returns true.
+    const full = await agentStub.replayErroredChunksByRequestIdForTest(
+      "req-drop",
+      999
+    );
+    expect(full.returned).toBe(true);
+    expect(full.sent).toBeGreaterThan(1);
+
+    // Connection drops mid-replay → returns false and stops early, so the
+    // caller skips the terminal frame and the next reconnect retries.
+    const dropped = await agentStub.replayErroredChunksByRequestIdForTest(
+      "req-drop",
+      1
+    );
+    expect(dropped).toEqual({ returned: false, sent: 1 });
+  });
 });

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -884,6 +884,8 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
           chunkCount?: number;
           chunkDelayMs?: number;
           streamError?: string;
+          /** Emit this many text-delta chunks before the in-band error (#1575). */
+          errorAfterChunks?: number;
           throwError?: boolean;
         }
       | undefined;
@@ -893,6 +895,7 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
     const chunkCount = body?.chunkCount ?? 20;
     const chunkDelayMs = body?.chunkDelayMs ?? 50;
     const streamError = body?.streamError;
+    const errorAfterChunks = body?.errorAfterChunks ?? 0;
     const throwError = body?.throwError ?? false;
     const abortSignal = useAbortSignal ? options?.abortSignal : undefined;
 
@@ -904,6 +907,27 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
     const stream = new ReadableStream({
       async pull(controller) {
         if (format === "sse" && streamError) {
+          // Optionally stream real content first so the in-band error
+          // arrives mid-message — the #1575 partial-content scenario.
+          if (errorAfterChunks > 0) {
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "text-start", id: "t-err" })}\n\n`
+              )
+            );
+            for (let i = 0; i < errorAfterChunks; i++) {
+              await new Promise((r) => setTimeout(r, chunkDelayMs));
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({
+                    type: "text-delta",
+                    id: "t-err",
+                    delta: `partial-${i} `
+                  })}\n\n`
+                )
+              );
+            }
+          }
           const chunk = JSON.stringify({
             type: "error",
             errorText: streamError
@@ -2688,6 +2712,23 @@ export class AIChatAgentToolChild extends AIChatAgent<Env> {
     return this.messages;
   }
 
+  /**
+   * #1575: broadcast a chat error frame whose request id belongs to no
+   * agent-tool run, simulating an unrelated turn failing on this agent
+   * while a run is being tailed.
+   */
+  broadcastUnrelatedErrorForTest(requestId: string): void {
+    this.broadcast(
+      JSON.stringify({
+        type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+        id: requestId,
+        error: true,
+        done: false,
+        body: "unrelated turn failure"
+      })
+    );
+  }
+
   private _readChildRunStatusForTest(runId: string): string | null {
     const rows = this.sql<{ status: string }>`
       SELECT status FROM cf_ai_chat_agent_tool_runs WHERE run_id = ${runId}
@@ -2901,6 +2942,49 @@ export class AIChatAgentToolParent extends Agent<Env> {
 
   getFinishesForTest(): AgentToolFinishForTest[] {
     return this.finishes;
+  }
+
+  /**
+   * #1575: run a child while injecting a chat error frame from an UNRELATED
+   * turn (a request id that belongs to no agent-tool run) into the child's
+   * broadcast stream mid-run. The run's terminal status must not be
+   * contaminated by it.
+   */
+  async runChildWithInjectedUnrelatedError(
+    input: AgentToolInput,
+    injectAfterMs: number,
+    runId = crypto.randomUUID()
+  ): Promise<RunAgentToolResult> {
+    this.events = [];
+    this.finishes = [];
+    const child = await this.subAgent(AIChatAgentToolChild, runId);
+    const timer = setTimeout(() => {
+      void child.broadcastUnrelatedErrorForTest(`unrelated-turn-${runId}`);
+    }, injectAfterMs);
+    try {
+      return await this.runAgentTool(AIChatAgentToolChild, {
+        runId,
+        parentToolCallId: "test-tool-call",
+        input,
+        inputPreview: input.prompt
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * #1575: start a child run directly — no tailer/forwarder is ever
+   * attached — and wait for its terminal inspection. Terminal status must
+   * come from the child turn's own result, not from tailing side effects.
+   */
+  async startChildWithoutTailForTest(
+    input: AgentToolInput,
+    runId = crypto.randomUUID()
+  ): Promise<AgentToolRunInspection> {
+    const child = await this.subAgent(AIChatAgentToolChild, runId);
+    await child.startAgentToolRun(input, { runId });
+    return this.waitForTerminalInspectionForTest(child, runId);
   }
 
   private insertRecoverableParentRunForTest(

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1205,6 +1205,36 @@ export class SlowStreamAgent extends AIChatAgent<Env> {
     return [...this._chatResponseResults];
   }
 
+  /**
+   * #1575: drive `ResumableStream.replayErroredChunksByRequestId` against a
+   * controllable connection so the return-value contract is testable in
+   * isolation: `failAfter` sends succeed, then the connection simulates a
+   * post-close send (the only error `sendIfOpen` swallows). Returns the
+   * method's boolean and how many frames actually went out.
+   */
+  replayErroredChunksByRequestIdForTest(
+    requestId: string,
+    failAfter: number
+  ): { returned: boolean; sent: number } {
+    let sent = 0;
+    const fakeConnection = {
+      send(_message: string) {
+        if (sent >= failAfter) {
+          throw new TypeError("WebSocket send() after close");
+        }
+        sent++;
+      }
+    };
+    const rs = this["_resumableStream"];
+    const returned = rs.replayErroredChunksByRequestId(
+      fakeConnection as unknown as Parameters<
+        typeof rs.replayErroredChunksByRequestId
+      >[0],
+      requestId
+    );
+    return { returned, sent };
+  }
+
   async persistToolCallMessage(
     messageId: string,
     toolCallId: string,
@@ -2729,6 +2759,41 @@ export class AIChatAgentToolChild extends AIChatAgent<Env> {
     );
   }
 
+  /**
+   * #1575: number of live request-id → run-id cache entries. Used to assert
+   * the negative cache (null entries for unrelated turns) does not leak past
+   * a run's lifetime.
+   */
+  agentToolRunsByRequestIdSizeForTest(): number {
+    // Bracket access: the field is private on the base AIChatAgent, and this
+    // test-only subclass deliberately peeks at it without widening the
+    // published API.
+    return this["_agentToolRunsByRequestId"].size;
+  }
+
+  /**
+   * #1575: simulate a DO restart mid-run — the in-memory request-id map is
+   * empty (wiped by the restart), but the run row persisted its `request_id`
+   * at turn start. `_agentToolRunForRequest` must still attribute a frame to
+   * the run via the SQL fallback, and an unknown request resolves to null.
+   */
+  resolveAgentToolRunAfterRestartForTest(
+    runId: string,
+    requestId: string
+  ): { running: string | null; unknown: string | null } {
+    this.sql`
+      insert into cf_ai_chat_agent_tool_runs
+        (run_id, request_id, status, input_json, started_at)
+      values (${runId}, ${requestId}, 'running', '{}', ${Date.now()})
+    `;
+    // Cold in-memory map, as after a restart.
+    this["_agentToolRunsByRequestId"].clear();
+    return {
+      running: this["_agentToolRunForRequest"](requestId),
+      unknown: this["_agentToolRunForRequest"]("no-such-request")
+    };
+  }
+
   private _readChildRunStatusForTest(runId: string): string | null {
     const rows = this.sql<{ status: string }>`
       SELECT status FROM cf_ai_chat_agent_tool_runs WHERE run_id = ${runId}
@@ -2971,6 +3036,27 @@ export class AIChatAgentToolParent extends Agent<Env> {
     } finally {
       clearTimeout(timer);
     }
+  }
+
+  /**
+   * #1575: read the child's live request-id cache size after a run, to assert
+   * negatively-cached entries for unrelated turns were swept on completion.
+   */
+  async childAgentToolRunsMapSizeForTest(runId: string): Promise<number> {
+    const child = await this.subAgent(AIChatAgentToolChild, runId);
+    return child.agentToolRunsByRequestIdSizeForTest();
+  }
+
+  /**
+   * #1575: resolve a run via the child's request-id SQL fallback after the
+   * in-memory map is cleared (post-restart attribution).
+   */
+  async childResolveAfterRestartForTest(
+    runId: string,
+    requestId: string
+  ): Promise<{ running: string | null; unknown: string | null }> {
+    const child = await this.subAgent(AIChatAgentToolChild, runId);
+    return child.resolveAgentToolRunAfterRestartForTest(runId, requestId);
   }
 
   /**

--- a/packages/think/src/tests/agent-tools.test.ts
+++ b/packages/think/src/tests/agent-tools.test.ts
@@ -37,6 +37,10 @@ type ThinkAgentToolTestStub = {
     path: "continue" | "retry",
     withAssistantTurn: boolean
   ): Promise<{ before: string | null; after: string | null }>;
+  resolveAgentToolRunAfterRestartForTest(
+    runId: string,
+    requestId: string
+  ): Promise<{ running: string | null; unknown: string | null }>;
   getDefaultReattachBudgetsForTest(): Promise<{
     noProgressTimeoutMs: number;
     maxWindowIsFinite: boolean;
@@ -55,6 +59,16 @@ type ThinkAgentToolParentStub = DurableObjectStub & {
     injectAfterMs: number,
     runId?: string
   ): Promise<RunAgentToolResult>;
+  runThinkChildWithInBandError(
+    input: string,
+    errorText: string,
+    runId?: string
+  ): Promise<RunAgentToolResult>;
+  startThinkChildWithoutTailForTest(
+    input: string,
+    errorText: string,
+    runId?: string
+  ): Promise<NonNullable<AgentToolInspection>>;
   reconcileCompletedThinkChildForTest(
     input: string,
     runId?: string
@@ -325,6 +339,54 @@ describe("Think agent tools", () => {
       status: "completed"
     });
     expect(result.error).toBeUndefined();
+  });
+
+  it("marks an in-band stream error as error with no tailer attached (#1575)", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    // The run is started directly and never tailed — terminal status must
+    // come from the child turn's own result, not forwarding side effects.
+    const inspection = await parent.startThinkChildWithoutTailForTest(
+      "fail untailed",
+      "untailed failure",
+      runId
+    );
+
+    expect(inspection.status).toBe("error");
+    expect(inspection.error).toContain("untailed failure");
+  });
+
+  it("keeps concurrent Think child runs' error state isolated (#1575)", async () => {
+    const parent = await freshParent();
+    const runA = crypto.randomUUID();
+    const runB = crypto.randomUUID();
+
+    const [a, b] = await Promise.all([
+      parent.runThinkChildWithInBandError("failing run", "run A failed", runA),
+      parent.runThinkChild("healthy run", runB)
+    ]);
+
+    expect(a).toMatchObject({ runId: runA, status: "error" });
+    expect(a.error).toContain("run A failed");
+    expect(b).toMatchObject({ runId: runB, status: "completed" });
+    expect(b.error).toBeUndefined();
+  });
+
+  it("attributes frames via the persisted request id after a DO restart (#1575)", async () => {
+    const agent = await freshAgent();
+    const runId = crypto.randomUUID();
+    const requestId = crypto.randomUUID();
+
+    // The child-run row persisted request_id at turn start; after a restart
+    // the in-memory map is empty, so attribution must fall back to SQL.
+    const resolved = await agent.resolveAgentToolRunAfterRestartForTest(
+      runId,
+      requestId
+    );
+
+    expect(resolved.running).toBe(runId);
+    expect(resolved.unknown).toBeNull();
   });
 
   it("recovers completed Think child runs into terminal parent rows", async () => {

--- a/packages/think/src/tests/agent-tools.test.ts
+++ b/packages/think/src/tests/agent-tools.test.ts
@@ -50,6 +50,11 @@ type ThinkAgentToolTestStub = {
 
 type ThinkAgentToolParentStub = DurableObjectStub & {
   runThinkChild(input: string, runId?: string): Promise<RunAgentToolResult>;
+  runThinkChildWithInjectedUnrelatedError(
+    input: string,
+    injectAfterMs: number,
+    runId?: string
+  ): Promise<RunAgentToolResult>;
   reconcileCompletedThinkChildForTest(
     input: string,
     runId?: string
@@ -298,6 +303,28 @@ describe("Think agent tools", () => {
       status: "completed",
       summary: "Hello from the assistant!"
     });
+  });
+
+  it("does not contaminate a run's terminal status with an unrelated turn's error frame (#1575)", async () => {
+    const parent = await freshParent();
+    const runId = crypto.randomUUID();
+
+    // While the tailed child run streams, an error frame from an UNRELATED
+    // turn (a request id that belongs to no run) is broadcast on the child.
+    // Before #1575 the error was stamped onto every active forwarder's run
+    // and this healthy run finalized as `error`.
+    const result = await parent.runThinkChildWithInjectedUnrelatedError(
+      "stay healthy probe",
+      20,
+      runId
+    );
+
+    expect(result).toMatchObject({
+      runId,
+      agentType: "ThinkTestAgent",
+      status: "completed"
+    });
+    expect(result.error).toBeUndefined();
   });
 
   it("recovers completed Think child runs into terminal parent rows", async () => {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -508,6 +508,23 @@ export class ThinkTestAgent extends Think {
     return error;
   }
 
+  /**
+   * #1575: broadcast a chat error frame whose request id belongs to no
+   * agent-tool run, simulating an unrelated turn failing on this agent
+   * while a run is being tailed.
+   */
+  broadcastUnrelatedErrorForTest(requestId: string): void {
+    this.broadcast(
+      JSON.stringify({
+        type: "cf_agent_use_chat_response",
+        id: requestId,
+        error: true,
+        done: false,
+        body: "unrelated turn failure"
+      })
+    );
+  }
+
   private _beforeTurnLog: Array<{
     system: string;
     toolNames: string[];
@@ -1843,6 +1860,35 @@ export class ThinkAgentToolParent extends Agent {
       input,
       inputPreview: input
     });
+  }
+
+  /**
+   * #1575: run a Think child while injecting a chat error frame from an
+   * UNRELATED turn (a request id that belongs to no agent-tool run) into the
+   * child's broadcast stream mid-run. The run's terminal status must not be
+   * contaminated by it.
+   */
+  async runThinkChildWithInjectedUnrelatedError(
+    input: string,
+    injectAfterMs: number,
+    runId = crypto.randomUUID()
+  ): Promise<RunAgentToolResult> {
+    this.events = [];
+    this.finishes = [];
+    const child = await this.subAgent(ThinkTestAgent, runId);
+    const timer = setTimeout(() => {
+      void child.broadcastUnrelatedErrorForTest(`unrelated-turn-${runId}`);
+    }, injectAfterMs);
+    try {
+      return await this.runAgentTool(ThinkTestAgent, {
+        runId,
+        parentToolCallId: "think-tool-call",
+        input,
+        inputPreview: input
+      });
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /**

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -525,6 +525,30 @@ export class ThinkTestAgent extends Think {
     );
   }
 
+  /**
+   * #1575: simulate a DO restart mid-run — the in-memory request-id map is
+   * empty (wiped by the restart), but the child-run row persisted its
+   * `request_id` at turn start. `_agentToolRunForRequest` must still attribute
+   * a frame to the run via the SQL fallback, and an unknown request resolves
+   * to null.
+   */
+  resolveAgentToolRunAfterRestartForTest(
+    runId: string,
+    requestId: string
+  ): { running: string | null; unknown: string | null } {
+    this["_ensureAgentToolChildRunTable"]();
+    this.sql`
+      INSERT INTO cf_agent_tool_child_runs (run_id, request_id, status, started_at)
+      VALUES (${runId}, ${requestId}, 'running', ${Date.now()})
+    `;
+    // Cold in-memory map, as after a restart.
+    this["_agentToolRunsByRequestId"].clear();
+    return {
+      running: this["_agentToolRunForRequest"](requestId),
+      unknown: this["_agentToolRunForRequest"]("no-such-request")
+    };
+  }
+
   private _beforeTurnLog: Array<{
     system: string;
     toolNames: string[];
@@ -1449,6 +1473,46 @@ export class ThinkTestAgent extends Think {
     )._streamResult(crypto.randomUUID(), createEmptyStreamResult());
   }
 
+  /**
+   * #1575: drive `_replayTerminalOnAck` end to end — produce a real errored
+   * stream that buffered partial content, then replay the pending terminal
+   * onto a capturing connection. Returns the frames a reconnecting client
+   * would observe, in order, so the test can assert the partial content is
+   * replayed before the terminal error frame.
+   */
+  async replayTerminalOnAckCaptureForTest(errorText: string): Promise<{
+    returned: boolean;
+    frames: Array<Record<string, unknown>>;
+  }> {
+    const requestId = crypto.randomUUID();
+    await (
+      this as unknown as {
+        _streamResult: (
+          requestId: string,
+          result: StreamableResult
+        ) => Promise<void>;
+      }
+    )._streamResult(
+      requestId,
+      createInBandErrorStreamResult(errorText, ["partial response"])
+    );
+    const frames: Array<Record<string, unknown>> = [];
+    const fakeConnection = {
+      send(message: string) {
+        frames.push(JSON.parse(message) as Record<string, unknown>);
+      }
+    };
+    const returned = await (
+      this as unknown as {
+        _replayTerminalOnAck: (
+          connection: { send(message: string): void },
+          requestId: string
+        ) => Promise<boolean>;
+      }
+    )._replayTerminalOnAck(fakeConnection, requestId);
+    return { returned, frames };
+  }
+
   async runEmptyRpcStreamForTest(): Promise<{ doneCalled: boolean }> {
     let doneCalled = false;
     await (
@@ -1889,6 +1953,44 @@ export class ThinkAgentToolParent extends Agent {
     } finally {
       clearTimeout(timer);
     }
+  }
+
+  /**
+   * #1575: run a Think child whose turn dies with an in-band stream error.
+   * Used to assert error classification independent of tailer timing and that
+   * concurrent runs stay isolated.
+   */
+  async runThinkChildWithInBandError(
+    input: string,
+    errorText: string,
+    runId = crypto.randomUUID()
+  ): Promise<RunAgentToolResult> {
+    this.events = [];
+    this.finishes = [];
+    const child = await this.subAgent(ThinkTestAgent, runId);
+    await child.setInBandErrorResponse(errorText);
+    return this.runAgentTool(ThinkTestAgent, {
+      runId,
+      parentToolCallId: "think-tool-call",
+      input,
+      inputPreview: input
+    });
+  }
+
+  /**
+   * #1575: start a Think child run directly — no tailer is ever attached —
+   * with a turn that dies in-band, and wait for its terminal inspection.
+   * Terminal status must come from the child's own result, not from tailing.
+   */
+  async startThinkChildWithoutTailForTest(
+    input: string,
+    errorText: string,
+    runId = crypto.randomUUID()
+  ): Promise<AgentToolRunInspection> {
+    const child = await this.subAgent(ThinkTestAgent, runId);
+    await child.setInBandErrorResponse(errorText);
+    await child.startAgentToolRun(input, { runId });
+    return this.waitForTerminalInspectionForTest(child, runId);
   }
 
   /**

--- a/packages/think/src/tests/errored-stream-replay.test.ts
+++ b/packages/think/src/tests/errored-stream-replay.test.ts
@@ -1,0 +1,62 @@
+import { env } from "cloudflare:workers";
+import { getServerByName } from "partyserver";
+import { describe, expect, it } from "vitest";
+import type { ThinkTestAgent } from "./agents";
+
+/**
+ * #1575 parity for Think: a client reconnecting after an in-band stream error
+ * must observe the same terminal outcome a live client did — the partial
+ * content the model produced before the error, replayed first, then a terminal
+ * `done: true, error: true` frame. This mirrors the ai-chat coverage; Think's
+ * `_replayTerminalOnAck` is the same fix in a separate package, so it needs its
+ * own guard.
+ */
+
+type Frame = Record<string, unknown>;
+
+type ThinkReplayStub = {
+  replayTerminalOnAckCaptureForTest(
+    errorText: string
+  ): Promise<{ returned: boolean; frames: Frame[] }>;
+};
+
+async function freshAgent(name: string): Promise<ThinkReplayStub> {
+  return getServerByName(
+    env.ThinkTestAgent as unknown as DurableObjectNamespace<ThinkTestAgent>,
+    name
+  ) as unknown as Promise<ThinkReplayStub>;
+}
+
+describe("Think errored stream replay (#1575)", () => {
+  it("replays pre-error partial content before the terminal error on resume-ACK", async () => {
+    const agent = await freshAgent(`inband-replay-${crypto.randomUUID()}`);
+
+    const { returned, frames } =
+      await agent.replayTerminalOnAckCaptureForTest("boom");
+
+    // The terminal was pending and handled.
+    expect(returned).toBe(true);
+
+    // The partial content is replayed (replay frames carry the buffered
+    // chunk bodies) before any terminal frame.
+    const replayBodies = frames
+      .filter((f) => f.replay === true && typeof f.body === "string")
+      .map((f) => f.body as string)
+      .join("");
+    expect(replayBodies).toContain("partial response");
+
+    // The last frame is the terminal error with the recorded error text.
+    const terminal = frames[frames.length - 1];
+    expect(terminal?.done).toBe(true);
+    expect(terminal?.error).toBe(true);
+    expect(terminal?.body).toBe("boom");
+
+    // No terminal frame appears before the replayed content.
+    const terminalIndex = frames.findIndex(
+      (f) => f.done === true && f.error === true
+    );
+    const firstReplayIndex = frames.findIndex((f) => f.replay === true);
+    expect(firstReplayIndex).toBeGreaterThanOrEqual(0);
+    expect(firstReplayIndex).toBeLessThan(terminalIndex);
+  });
+});

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -4533,9 +4533,17 @@ export class Think<
         this._agentToolAbortControllers.delete(options.runId);
         this._agentToolForwarders.delete(options.runId);
         this._agentToolLiveSequences.delete(options.runId);
-        for (const [reqId, runId] of this._agentToolRunsByRequestId) {
-          if (runId === options.runId) {
-            this._agentToolRunsByRequestId.delete(reqId);
+        // Drop this run's request-id mappings. When no runs remain in flight
+        // clear the whole map, so negatively-cached (null) entries for
+        // unrelated turns can't accumulate for the DO's lifetime — the map is
+        // only consulted while a run is active (#1575).
+        if (this._agentToolAbortControllers.size === 0) {
+          this._agentToolRunsByRequestId.clear();
+        } else {
+          for (const [reqId, runId] of this._agentToolRunsByRequestId) {
+            if (runId === options.runId) {
+              this._agentToolRunsByRequestId.delete(reqId);
+            }
           }
         }
         this._agentToolLastErrors.delete(options.runId);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2239,6 +2239,15 @@ export class Think<
   private _agentToolLastErrors = new Map<string, string>();
   private _agentToolPreTurnAssistantIds = new Map<string, Set<string>>();
   private _agentToolLiveSequences = new Map<string, number>();
+  /**
+   * Request id → run id for in-flight agent-tool turns (null = resolved as
+   * not an agent-tool turn, cached so unrelated turns don't re-query SQLite
+   * per frame). Drives frame attribution in {@link broadcast}: a frame
+   * belongs to a run iff it carries that run's turn request id, so an error
+   * in an unrelated turn or a concurrent run can never leak into another
+   * run's state (#1575).
+   */
+  private _agentToolRunsByRequestId = new Map<string, string | null>();
   private _submissionTableEnsured = false;
   private _workflowNotificationTableEnsured = false;
   private _declaredScheduledTasksTableEnsured = false;
@@ -2252,27 +2261,47 @@ export class Think<
     msg: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
   ): void {
-    if (this._agentToolForwarders.size > 0 && typeof msg === "string") {
+    // Inspect frames while any agent-tool run is in flight (live sequences
+    // exist for the run's whole lifecycle), not only while a tailer is
+    // attached — error capture must not depend on tailer timing (#1575).
+    if (
+      (this._agentToolForwarders.size > 0 ||
+        this._agentToolLiveSequences.size > 0) &&
+      typeof msg === "string"
+    ) {
       try {
         const parsed = JSON.parse(msg) as {
           type?: unknown;
           body?: unknown;
           error?: unknown;
+          id?: unknown;
         };
-        if (parsed.type === MSG_CHAT_RESPONSE) {
-          if (parsed.error === true && typeof parsed.body === "string") {
-            for (const runId of this._agentToolForwarders.keys()) {
+        if (
+          parsed.type === MSG_CHAT_RESPONSE &&
+          typeof parsed.id === "string"
+        ) {
+          // A frame belongs to a run iff it carries that run's turn request
+          // id. Frames from unrelated turns (a user-driven turn on this
+          // agent, or another run's turn) resolve to a different — or no —
+          // run and are left alone, so concurrent runs cannot
+          // cross-contaminate each other's progress or error state (#1575).
+          const runId = this._agentToolRunForRequest(parsed.id);
+          if (runId !== null) {
+            if (parsed.error === true && typeof parsed.body === "string") {
               this._agentToolLastErrors.set(runId, parsed.body);
-            }
-          } else if (
-            typeof parsed.body === "string" &&
-            parsed.body.length > 0
-          ) {
-            for (const [runId, forwarders] of this._agentToolForwarders) {
+            } else if (
+              typeof parsed.body === "string" &&
+              parsed.body.length > 0
+            ) {
+              // Advance the live sequence even with no tailer attached so a
+              // tailer registering mid-run resumes at the right offset.
               const sequence = this._agentToolLiveSequences.get(runId) ?? 0;
               this._agentToolLiveSequences.set(runId, sequence + 1);
               const chunk = { sequence, body: parsed.body };
-              for (const forward of forwarders) forward(chunk);
+              const forwarders = this._agentToolForwarders.get(runId);
+              if (forwarders) {
+                for (const forward of forwarders) forward(chunk);
+              }
             }
           }
         }
@@ -2281,6 +2310,26 @@ export class Think<
       }
     }
     super.broadcast(msg, without);
+  }
+
+  /**
+   * Resolve the agent-tool run whose turn owns a request id, or null when the
+   * request is not an agent-tool turn. Falls back to the persisted child-run
+   * row (whose `request_id` is written when the run's turn is bound, see
+   * `startAgentToolRun`) so attribution survives a DO restart mid-run; either
+   * outcome is cached.
+   */
+  private _agentToolRunForRequest(requestId: string): string | null {
+    const cached = this._agentToolRunsByRequestId.get(requestId);
+    if (cached !== undefined) return cached;
+    const rows = this.sql<{ run_id: string }>`
+      SELECT run_id FROM cf_agent_tool_child_runs
+      WHERE request_id = ${requestId} AND completed_at IS NULL
+      LIMIT 1
+    `;
+    const runId = rows[0]?.run_id ?? null;
+    this._agentToolRunsByRequestId.set(requestId, runId);
+    return runId;
   }
 
   override async alarm(): Promise<void> {
@@ -4418,7 +4467,20 @@ export class Think<
           SET status = 'running'
           WHERE run_id = ${options.runId} AND status = 'starting'
         `;
-        const result = await this.saveMessages(
+        // Bind the run to its turn's request id BEFORE the turn starts —
+        // in memory for live frame attribution in `broadcast`, and on the
+        // child-run row so attribution survives a DO restart mid-run
+        // (#1575). `saveMessages` would generate the id internally, so call
+        // the inner turn runner with a pre-generated one instead.
+        const requestId = crypto.randomUUID();
+        this._agentToolRunsByRequestId.set(requestId, options.runId);
+        this.sql`
+          UPDATE cf_agent_tool_child_runs
+          SET request_id = ${requestId}
+          WHERE run_id = ${options.runId}
+        `;
+        const result = await this._runProgrammaticMessagesTurn(
+          requestId,
           [this.formatAgentToolInput(input)],
           {
             signal: controller.signal
@@ -4471,6 +4533,11 @@ export class Think<
         this._agentToolAbortControllers.delete(options.runId);
         this._agentToolForwarders.delete(options.runId);
         this._agentToolLiveSequences.delete(options.runId);
+        for (const [reqId, runId] of this._agentToolRunsByRequestId) {
+          if (runId === options.runId) {
+            this._agentToolRunsByRequestId.delete(reqId);
+          }
+        }
         this._agentToolLastErrors.delete(options.runId);
         this._agentToolPreTurnAssistantIds.delete(options.runId);
         for (const close of this._agentToolClosers.get(options.runId) ?? []) {
@@ -10969,6 +11036,19 @@ export class Think<
   ): Promise<boolean> {
     const pending = await this._pendingChatTerminal();
     if (!pending || pending.requestId !== requestId) return false;
+    // Replay any partial content the errored stream produced before the
+    // error, so the reconnecting client observes the same sequence a live
+    // client did — content chunks, then the terminal error (#1575). If the
+    // connection drops mid-replay, skip the terminal frame; the record is
+    // retained, so the next reconnect retries the whole sequence.
+    if (
+      !this._resumableStream.replayErroredChunksByRequestId(
+        connection,
+        pending.requestId
+      )
+    ) {
+      return true;
+    }
     sendIfOpen(
       connection,
       JSON.stringify({


### PR DESCRIPTION
Closes the two gaps in #1575 that remained after @threepointone's recent durability fixes: (1) replaying pre-error content from errored streams, and (2) capture individual child agent errors instead of allowing one child to contaminate the whole run.

## Why

In-band stream errors ({type:"error",errorText} chunks inside a healthy provider stream) bypass exception handling, so their terminal outcome has to be recorded and replayed explicitly. Two observers still saw the wrong thing:

1. Partial content was lost on reconnect. A client reconnecting after an in-band error got the terminal error frame (#1645) but NOT the content the model streamed before dying. The replay-by-request-id path filters `status = 'completed'`, so an errored stream's buffered chunks were unreachable — and the server pushes no messages on connect, so chunk replay is the ONLY channel for content a disconnected client missed. Issue acceptance criterion: "Partial content before the error is still recoverable."

2. Agent-tool error capture cross-contaminated runs. broadcast() on a child agent stamped an in-band error onto EVERY tailed run whenever the active run id was unknown (always, in Think's copy), so an unrelated turn's failure could finalize healthy runs as 'error'. Capture was also gated on a tailer being attached at the right moment. Issue acceptance criteria: no cross-contamination; tailer timing must not affect terminal classification.

## What

* agents (packages/agents/src/chat/resumable-stream.ts)
  - New ResumableStream.replayErroredChunksByRequestId(): replays the stored chunks of the latest errored stream for a request, WITHOUT a terminal frame (the caller appends it). Returns false if the connection died mid-replay so the caller skips the terminal frame and the next reconnect retries the whole sequence.
  - Shared private helpers (_latestStreamForRequest, _replayStoredChunks) extracted from replayCompletedChunksByRequestId; its behavior is unchanged.

* ai-chat + think (_replayTerminalOnAck in both)
  - On resume-ACK of a pending terminal, replay the errored stream's chunks before the done:true,error:true frame. A reconnecting client now observes the same sequence a live client did: content chunks, then the error.

* ai-chat + think (broadcast / startAgentToolRun)
  - Frames are attributed to runs by the request id they carry. Each run is bound to its turn's request id at turn start — in memory for live attribution, and persisted to the run row's request_id column at start (previously only at terminal) so attribution survives a DO restart mid-run via a cached SQL fallback.
  - ai-chat binds inside the saveMessages message-builder callback (which runs inside the turn) using TurnQueue.activeRequestId; think pre-generates the request id and calls _runProgrammaticMessagesTurn directly (saveMessages is a one-line wrapper around it, so this is behavior-identical).
  - Frame inspection now also runs while any run is in flight (_agentToolLiveSequences non-empty), not only while a tailer is attached — error capture no longer depends on tailer timing.
  - Removed ai-chat's _agentToolActiveRunId field; the request-id map replaces its only consumer (broadcast attribution).

## Design tradeoffs

- No wire-format changes: replayed chunks reuse the existing replay:true frame shape; the terminal frame is the existing #1645 frame. No schema migration either: error text still lives in the durable terminal record (storage KV), which only remembers the most recent terminal — by design, since the resume handshake only ever offers the most recent turn. A per-stream error_text column was considered and rejected as covering no reachable handshake path.
- Errored-stream chunks were already retained for the 10-minute completion grace window (the sweep treats completed and error rows identically); after the sweep a reconnecting client still gets the terminal error, just without the partial content — same grace semantics as completed streams.
- Targeted fix, not the issue's broader "single terminal-status model" redesign: #1567/#1645 already built that model piecemeal (status enum + terminal record + result-driven run status), so the redesign would churn recently-shipped code for no behavioral gain.
- Content-frame forwarding got the same per-request scoping as error capture (the old code also forwarded unrelated turns' content to all tailers). Same mechanism, strictly more correct progress streams.
- Unmatched request ids are negative-cached (map value null) so non-run turns cost one SQLite lookup total, not one per frame.

## API surface

- ResumableStream gains the public replayErroredChunksByRequestId() method (exported via agents/chat). Additive; no existing signatures changed. No client-visible protocol changes.
- cf_ai_chat_agent_tool_runs / cf_agent_tool_child_runs rows now have request_id populated from turn start (was: null until terminal). Column and meaning unchanged, only the write moment moved earlier.

## Tests

- packages/ai-chat/src/tests/errored-stream-replay.test.ts (new): live-vs-reconnect parity for partial-content in-band errors, and the early-error (#1527) case. The partial-content test FAILS on main (zero replayed chunks).
- ai-chat + think agent-tools tests: unrelated-turn error frame does not contaminate a tailed run (FAILS on main in both packages); no-tailer in-band error still classifies 'error'; concurrent error/healthy runs stay isolated.
- Full suites pass: agents (1760), ai-chat (664 incl. new), think workers (614 incl. new).

Closes #1575
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->