### PR TITLE
fix(agents,ai-chat,think): defer recovery on platform transients

### DIFF
--- a/.changeset/defer-one-shot-on-platform-transient.md
+++ b/.changeset/defer-one-shot-on-platform-transient.md
@@ -1,0 +1,13 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Defer one-shot scheduled callbacks (and chat-recovery give-ups) on platform transients instead of consuming them mid-deploy (#1730).
+
+A mid-execution Durable Object code-update reset surfaces storage failures in two shapes: the verbatim reset/supersede messages (already deferred) and `SqlError: SQL query failed: Network connection lost.` — a wrapper that drops the CF `retryable` flag and dodges the reset matcher. The second shape burned the in-process retry budget inside the same few-seconds reset window (which outlasts the retry schedule by design) and then consumed the one-shot row on exhaustion, freezing the turn for minutes until incident re-detection — in the reported production capture, storage was healthy again 15 ms after the final attempt.
+
+- **`agents`** — new cause-aware `isPlatformTransientError` classifier (exported, alongside `isDurableObjectCodeUpdateReset`): reset/supersede messages, `retryable`-flagged platform errors (excluding overloaded), and "Network connection lost.", looked up through wrapper `cause` chains. `_executeScheduleCallback` keeps in-process retries for connection-lost transients (a genuine blip heals fast) but on exhaustion of a one-shot row it now re-throws instead of swallowing, so the row survives and the alarm re-runs it in the healthy window that follows. Genuine application errors are still abandoned after `maxAttempts` exactly as before.
+- **`@cloudflare/think`** — `_handleRecoveryCallbackError` now defers (re-throws) on any platform transient instead of terminalizing through a give-up whose own seal needs the storage that is down; the bookkeeping write on the defer path is best-effort. The defer path no longer marks the recovered submission `error` (which made the deferred re-run skip with `submission_not_running` — a self-defeating defer); it stays `running` for the re-run to pick up. The give-up now seals the incident `exhausted` only after the terminal writes succeed, so a transient mid-seal defers the whole give-up for an idempotent re-run instead of half-sealing.
+- **`@cloudflare/ai-chat`** — same give-up seal ordering: the incident is sealed only after `_exhaustChatRecovery` (incl. the durable terminal record) succeeds, so a transient mid-seal preserves the one-shot row and the give-up re-runs in full on a healthy isolate.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -43,8 +43,14 @@ export { camelCaseToKebabCase } from "./utils";
 import {
   type RetryOptions,
   tryN,
+  isDurableObjectCodeUpdateReset,
   isErrorRetryable,
+  isPlatformTransientError,
   validateRetryOptions
+} from "./retries";
+export {
+  isDurableObjectCodeUpdateReset,
+  isPlatformTransientError
 } from "./retries";
 import {
   MCPClientManager,
@@ -1301,43 +1307,11 @@ function resolveRetryConfig(
   };
 }
 
-/**
- * Whether an error is a transient "superseded isolate" failure — the invocation
- * is running on an isolate the platform has replaced with a new version (a
- * deploy / code update). For the rest of that invocation every operation throws
- * the same error (code never reloads mid-invocation), so in-process retries are
- * futile; but the next fresh invocation runs the new code and succeeds.
- *
- * workerd surfaces this as a plain `Error` with one of a few messages, all the
- * same failure class — a message match is the only signal:
- *   - "Durable Object reset because its code was updated."  (DO storage op on a
- *     superseded isolate / deploy bounce)
- *   - "This script has been upgraded. Please send a new request to connect to
- *     the new version."  (a stub/connection to a superseded script; the message
- *     literally instructs the caller to retry on the new version)
- *
- * The match stays close to the verbatim platform strings (rather than a loose
- * "upgraded"/"reset" substring) so an ordinary application error that happens
- * to mention those words is NOT misclassified as a supersede — a false positive
- * would defer + re-run a genuinely-failing callback on the platform's alarm
- * retries instead of abandoning it.
- *
- * NOTE: "Network connection lost." is deliberately NOT included — it is a
- * connection error, not an isolate replacement, and may succeed on in-process
- * retry (it is gated by the CF `retryable` property via `isErrorRetryable`),
- * so it stays on the normal retry path rather than the immediate-defer path.
- */
-function isDurableObjectCodeUpdateReset(error: unknown): boolean {
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === "string"
-        ? error
-        : "";
-  return /reset because its code was updated|this script has been upgraded/i.test(
-    message
-  );
-}
+// `isDurableObjectCodeUpdateReset` / `isPlatformTransientError` (used by the
+// scheduler's defer-vs-abandon decisions below) live in ./retries next to
+// `isErrorRetryable`, and are re-exported from the package root so higher
+// layers (e.g. `@cloudflare/think`) classify with the SAME matcher instead of
+// drifting copies.
 
 export function getCurrentAgent<
   T extends Agent<Cloudflare.Env> = Agent<Cloudflare.Env>
@@ -5852,10 +5826,24 @@ export class Agent<
         // that transient we skip the doomed retries and re-throw so `alarm()`
         // rejects, the one-shot row survives, and the platform re-runs it on a
         // fresh isolate (= new code) under the at-least-once alarm guarantee.
+        //
+        // Other platform transients ("Network connection lost." / errors the
+        // platform flags `retryable`) MAY succeed on an in-process retry (a
+        // momentary blip), so they keep the normal retry budget — but if the
+        // budget drains while the platform is still unhealthy (#1730: a
+        // deploy-reset window outlasts the few-seconds retry schedule by
+        // design), the row is deferred on exhaustion instead of consumed: the
+        // platform failed, not the callback, and the same work succeeds when
+        // the alarm re-fires in the healthy window that follows. A genuinely
+        // failing callback throws application-shaped errors (none of the
+        // platform signals) and is still abandoned after `maxAttempts` exactly
+        // as before.
         const isOneShotSchedule =
           row.type === "delayed" || row.type === "scheduled";
         const shouldDeferReset = (error: unknown): boolean =>
           isOneShotSchedule && isDurableObjectCodeUpdateReset(error);
+        const shouldDeferOnExhaustion = (error: unknown): boolean =>
+          isOneShotSchedule && isPlatformTransientError(error);
 
         try {
           this._emit("schedule:execute", {
@@ -5891,6 +5879,12 @@ export class Agent<
           if (shouldDeferReset(e)) {
             console.warn(
               `Deferring scheduled callback "${row.callback}" to a fresh invocation after a Durable Object code-update reset; the one-shot row is preserved and the alarm will re-run on new code.`
+            );
+            throw e;
+          }
+          if (shouldDeferOnExhaustion(e)) {
+            console.warn(
+              `Deferring scheduled callback "${row.callback}" after exhausting in-process retries on a transient platform error; the one-shot row is preserved and the alarm will re-run once the platform recovers.`
             );
             throw e;
           }

--- a/packages/agents/src/retries.ts
+++ b/packages/agents/src/retries.ts
@@ -157,3 +157,105 @@ export function isErrorRetryable(err: unknown): boolean {
     !msg.includes("Durable Object is overloaded")
   );
 }
+
+/**
+ * The "superseded isolate" platform messages — the invocation is running on an
+ * isolate the platform has replaced with a new version (a deploy / code
+ * update). For the rest of that invocation every operation throws the same
+ * error (code never reloads mid-invocation), so in-process retries are futile;
+ * but the next fresh invocation runs the new code and succeeds.
+ *
+ * workerd surfaces this as a plain `Error` with one of a few messages, all the
+ * same failure class — a message match is the only signal:
+ *   - "Durable Object reset because its code was updated."  (DO storage op on a
+ *     superseded isolate / deploy bounce)
+ *   - "This script has been upgraded. Please send a new request to connect to
+ *     the new version."  (a stub/connection to a superseded script; the message
+ *     literally instructs the caller to retry on the new version)
+ *
+ * The match stays close to the verbatim platform strings (rather than a loose
+ * "upgraded"/"reset" substring) so an ordinary application error that happens
+ * to mention those words is NOT misclassified as a supersede.
+ */
+const SUPERSEDED_ISOLATE_PATTERN =
+  /reset because its code was updated|this script has been upgraded/i;
+
+/**
+ * The "Network connection lost." platform transient — the connection between
+ * the isolate and its storage (or another DO) dropped. Unlike a supersede this
+ * MAY succeed on an in-process retry (a momentary blip), so it must not skip
+ * the in-process retry budget — but during a deploy-reset window it never
+ * succeeds in-process and surfaces interleaved with the supersede messages
+ * (SQL ops throw `SqlError: SQL query failed: Network connection lost.` while
+ * KV ops throw the reset message), so on retry exhaustion it must be treated
+ * as the platform's failure, not the callback's.
+ */
+const CONNECTION_LOST_PATTERN = /network connection lost/i;
+
+function errorMessageOf(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : typeof error === "string"
+      ? error
+      : "";
+}
+
+/**
+ * Iterate an error and its `cause` chain (depth-limited so a cyclic chain
+ * can't spin). Wrappers like `SqlError` carry the original platform error in
+ * `cause` and may not propagate signal properties (e.g. the CF `retryable`
+ * flag), so classification must look through them.
+ */
+function* selfAndCauses(error: unknown): Generator<unknown> {
+  let current = error;
+  for (let depth = 0; depth < 8 && current != null; depth++) {
+    yield current;
+    current =
+      typeof current === "object"
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+}
+
+/**
+ * Whether an error (or anything in its `cause` chain) is a transient
+ * "superseded isolate" failure — see `SUPERSEDED_ISOLATE_PATTERN`. In-process
+ * retries are futile for this class; the work must be deferred to a fresh
+ * invocation, which runs the new code and succeeds.
+ */
+export function isDurableObjectCodeUpdateReset(error: unknown): boolean {
+  for (const e of selfAndCauses(error)) {
+    if (SUPERSEDED_ISOLATE_PATTERN.test(errorMessageOf(e))) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether an error (or anything in its `cause` chain) is a transient failure
+ * of the PLATFORM rather than of the code that threw it:
+ *
+ *   - a superseded-isolate reset ("reset because its code was updated" /
+ *     "this script has been upgraded") — a deploy replaced the isolate;
+ *   - an error the platform itself flags `retryable: true` (excluding
+ *     overloaded errors, where retrying the same object won't help) — see
+ *     `isErrorRetryable`;
+ *   - "Network connection lost." — the storage/stub connection dropped. The
+ *     CF `retryable` flag does not survive error wrappers (e.g. `SqlError`
+ *     copies only the message + `cause`) and is absent in some local-dev
+ *     shapes, so the verbatim message is matched as well.
+ *
+ * Used to decide whether failed work should be RE-RUN LATER (platform
+ * transient — the same work succeeds once the platform recovers, typically
+ * seconds after a deploy) versus ABANDONED as genuinely failing (application
+ * error — re-running yields the same failure). A genuine application error
+ * carries none of these signals, so it is never misclassified by this check.
+ */
+export function isPlatformTransientError(error: unknown): boolean {
+  for (const e of selfAndCauses(error)) {
+    const message = errorMessageOf(e);
+    if (SUPERSEDED_ISOLATE_PATTERN.test(message)) return true;
+    if (CONNECTION_LOST_PATTERN.test(message)) return true;
+    if (isErrorRetryable(e)) return true;
+  }
+  return false;
+}

--- a/packages/agents/src/tests/agents/schedule.ts
+++ b/packages/agents/src/tests/agents/schedule.ts
@@ -437,6 +437,90 @@ export class TestScheduleAgent extends Agent {
     return { threw, remaining: rows[0].count };
   }
 
+  // --- Exhaustion-defer (platform-transient) test helpers (#1730) ---
+
+  private _errorSequenceForTest: Array<{
+    kind: "throw" | "throw-retryable" | "throw-wrapped" | "succeed";
+    message?: string;
+  }> = [];
+  private _errorSequenceCallsForTest = 0;
+
+  // One-shot callback that consumes a scripted step per attempt, so tests can
+  // exercise the in-process retry loop with attempt-by-attempt error shapes
+  // (e.g. "Network connection lost." on attempt 1, success on attempt 2).
+  async sequencedErrorCallbackForTest(): Promise<void> {
+    const step = this._errorSequenceForTest[
+      this._errorSequenceCallsForTest
+    ] ?? {
+      kind: "succeed" as const
+    };
+    this._errorSequenceCallsForTest++;
+    switch (step.kind) {
+      case "succeed":
+        return;
+      case "throw":
+        throw new Error(step.message ?? "scripted error");
+      case "throw-retryable": {
+        const e = new Error(step.message ?? "scripted retryable error");
+        (e as unknown as { retryable: boolean }).retryable = true;
+        throw e;
+      }
+      case "throw-wrapped":
+        // The `SqlError` shape: a wrapper that prefixes the message and keeps
+        // the original platform error only in `cause` (no `retryable` flag on
+        // the wrapper itself).
+        throw new Error(`SQL query failed: ${step.message ?? "inner error"}`, {
+          cause: new Error(step.message ?? "inner error")
+        });
+    }
+  }
+
+  // Schedule a one-shot callback driven by a scripted error sequence (one step
+  // per in-process attempt), drive `alarm()` once in-instance, and report
+  // whether the alarm rejected (deferred), whether the one-shot row survived,
+  // and how many attempts ran. Deterministic — tight retry delays, no reliance
+  // on the external alarm scheduler's timing.
+  @callable()
+  async runOneShotSequenceForTest(
+    steps: Array<{
+      kind: "throw" | "throw-retryable" | "throw-wrapped" | "succeed";
+      message?: string;
+    }>,
+    maxAttempts: number
+  ): Promise<{ threw: boolean; remaining: number; calls: number }> {
+    this._errorSequenceForTest = steps;
+    this._errorSequenceCallsForTest = 0;
+    const schedule = await this.schedule(
+      60,
+      "sequencedErrorCallbackForTest",
+      undefined,
+      { retry: { maxAttempts, baseDelayMs: 1, maxDelayMs: 2 } }
+    );
+    // Backdate so the row is due when alarm() scans `time <= now`.
+    this.sql`
+      UPDATE cf_agents_schedules
+      SET time = ${Math.floor(Date.now() / 1000) - 1}
+      WHERE id = ${schedule.id}
+    `;
+    let threw = false;
+    try {
+      await this.alarm();
+    } catch {
+      // A deferred (re-thrown) error rejects alarm(); a swallowed one does not.
+      threw = true;
+    }
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_agents_schedules WHERE id = ${schedule.id}
+    `;
+    const calls = this._errorSequenceCallsForTest;
+    this._errorSequenceForTest = [];
+    this._errorSequenceCallsForTest = 0;
+    // Clean up a deferred (surviving) row so it doesn't leak into later tests
+    // on the same instance.
+    this.sql`DELETE FROM cf_agents_schedules WHERE id = ${schedule.id}`;
+    return { threw, remaining: rows[0].count, calls };
+  }
+
   @callable()
   async insertStaleDelayedRows(count: number, cb: string): Promise<void> {
     const past = Math.floor(Date.now() / 1000) - 60;

--- a/packages/agents/src/tests/retries.test.ts
+++ b/packages/agents/src/tests/retries.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  isDurableObjectCodeUpdateReset,
   isErrorRetryable,
+  isPlatformTransientError,
   jitterBackoff,
   tryN,
   validateRetryOptions
@@ -368,6 +370,152 @@ describe("retries", () => {
       expect(isErrorRetryable(undefined)).toBe(false);
       expect(isErrorRetryable("string error")).toBe(false);
       expect(isErrorRetryable(42)).toBe(false);
+    });
+  });
+
+  describe("isDurableObjectCodeUpdateReset", () => {
+    it("matches the verbatim supersede messages", () => {
+      expect(
+        isDurableObjectCodeUpdateReset(
+          new Error("Durable Object reset because its code was updated.")
+        )
+      ).toBe(true);
+      expect(
+        isDurableObjectCodeUpdateReset(
+          new Error(
+            "This script has been upgraded. Please send a new request to connect to the new version."
+          )
+        )
+      ).toBe(true);
+    });
+
+    it("looks through wrapper errors via the cause chain (SqlError shape)", () => {
+      // `SqlError` includes the cause message in its own message, but other
+      // wrappers may not — the cause chain is the robust signal.
+      const wrapped = new Error("query aborted", {
+        cause: new Error("Durable Object reset because its code was updated.")
+      });
+      expect(isDurableObjectCodeUpdateReset(wrapped)).toBe(true);
+    });
+
+    it("does not match lookalike application errors", () => {
+      expect(
+        isDurableObjectCodeUpdateReset(
+          new Error("Your subscription script has been upgraded to a new plan.")
+        )
+      ).toBe(false);
+      expect(
+        isDurableObjectCodeUpdateReset(new Error("Network connection lost."))
+      ).toBe(false);
+      expect(isDurableObjectCodeUpdateReset(null)).toBe(false);
+      expect(isDurableObjectCodeUpdateReset(undefined)).toBe(false);
+    });
+
+    it("terminates on a cyclic cause chain", () => {
+      const e = new Error("app error");
+      (e as unknown as { cause: unknown }).cause = e;
+      expect(isDurableObjectCodeUpdateReset(e)).toBe(false);
+    });
+  });
+
+  describe("isPlatformTransientError", () => {
+    function retryableError(msg: string) {
+      const e = new Error(msg);
+      (e as unknown as { retryable: boolean }).retryable = true;
+      return e;
+    }
+
+    it("classifies supersede messages as transient", () => {
+      expect(
+        isPlatformTransientError(
+          new Error("Durable Object reset because its code was updated.")
+        )
+      ).toBe(true);
+      expect(
+        isPlatformTransientError(
+          new Error(
+            "This script has been upgraded. Please send a new request to connect to the new version."
+          )
+        )
+      ).toBe(true);
+    });
+
+    it('classifies "Network connection lost." as transient (bare and SqlError-wrapped)', () => {
+      // The deploy-reset window surfaces SQL failures as
+      // `SqlError: SQL query failed: Network connection lost.` — the wrapper
+      // drops the CF `retryable` flag, so the message itself must classify
+      // (#1730).
+      expect(
+        isPlatformTransientError(new Error("Network connection lost."))
+      ).toBe(true);
+      expect(
+        isPlatformTransientError(
+          new Error("SQL query failed: Network connection lost.")
+        )
+      ).toBe(true);
+    });
+
+    it("classifies a retryable-flagged platform error as transient", () => {
+      expect(isPlatformTransientError(retryableError("internal error"))).toBe(
+        true
+      );
+    });
+
+    it("excludes overloaded errors (retrying the same object won't help)", () => {
+      expect(
+        isPlatformTransientError(
+          retryableError(
+            "Durable Object is overloaded. Too many requests queued."
+          )
+        )
+      ).toBe(false);
+      const e = retryableError("some error");
+      (e as unknown as { overloaded: boolean }).overloaded = true;
+      expect(isPlatformTransientError(e)).toBe(false);
+    });
+
+    it("looks through wrapper errors via the cause chain", () => {
+      // A wrapper whose own message carries no signal but whose cause is a
+      // retryable platform error (the flag does not survive the wrapper).
+      const wrapped = new Error("operation failed", {
+        cause: retryableError("internal error")
+      });
+      expect(isPlatformTransientError(wrapped)).toBe(true);
+
+      const deeplyWrapped = new Error("outer", {
+        cause: new Error("middle", {
+          cause: new Error("Network connection lost.")
+        })
+      });
+      expect(isPlatformTransientError(deeplyWrapped)).toBe(true);
+    });
+
+    it("does NOT classify application errors as transient", () => {
+      expect(isPlatformTransientError(new Error("boom"))).toBe(false);
+      expect(
+        isPlatformTransientError(
+          new Error("Your subscription script has been upgraded to a new plan.")
+        )
+      ).toBe(false);
+      expect(
+        isPlatformTransientError(
+          new Error("app failure", { cause: new Error("inner app failure") })
+        )
+      ).toBe(false);
+      expect(isPlatformTransientError(null)).toBe(false);
+      expect(isPlatformTransientError(undefined)).toBe(false);
+      expect(isPlatformTransientError(42)).toBe(false);
+    });
+
+    it("accepts bare string errors", () => {
+      expect(isPlatformTransientError("Network connection lost.")).toBe(true);
+      expect(isPlatformTransientError("some app error")).toBe(false);
+    });
+
+    it("terminates on a cyclic cause chain", () => {
+      const e = new Error("app error");
+      (e as unknown as { cause: unknown }).cause = e;
+      expect(isPlatformTransientError(e)).toBe(false);
     });
   });
 });

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -1051,18 +1051,6 @@ describe("schedule operations", () => {
       expect(remaining).toBe(0);
     });
 
-    it('does NOT defer "Network connection lost." (not an isolate replacement)', async () => {
-      const agentStub = await getAgentByName(
-        env.TestScheduleAgent,
-        "no-defer-connection-lost"
-      );
-      const { threw, remaining } = await agentStub.runOneShotThrowingForTest(
-        "Network connection lost."
-      );
-      expect(threw).toBe(false);
-      expect(remaining).toBe(0);
-    });
-
     it("does NOT treat an ordinary error that merely mentions an upgraded script as a supersede", async () => {
       // Guards the tightened matcher: only the verbatim platform phrase ("this
       // script has been upgraded") defers; a lookalike app error is swallowed.
@@ -1075,6 +1063,153 @@ describe("schedule operations", () => {
       );
       expect(threw).toBe(false);
       expect(remaining).toBe(0);
+    });
+  });
+
+  describe("one-shot defer on retry exhaustion of a platform transient (#1730)", () => {
+    // A deploy-reset window outlasts the in-process retry schedule by design
+    // (all attempts land inside the same few-seconds storage-unavailable
+    // window). When the budget drains on a PLATFORM transient — "Network
+    // connection lost.", a `retryable`-flagged error, or a wrapped supersede —
+    // the platform failed, not the callback, so the one-shot row must be
+    // PRESERVED (alarm rejected → platform re-runs it in the healthy window
+    // that follows), not consumed.
+    it('defers "Network connection lost." on exhaustion instead of consuming the row', async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "exhaust-defer-connection-lost"
+      );
+      const { threw, remaining, calls } =
+        await agentStub.runOneShotSequenceForTest(
+          [
+            { kind: "throw", message: "Network connection lost." },
+            { kind: "throw", message: "Network connection lost." },
+            { kind: "throw", message: "Network connection lost." }
+          ],
+          3
+        );
+      // All in-process retries ran (a genuine blip would have healed), THEN
+      // the row was deferred.
+      expect(calls).toBe(3);
+      expect(threw).toBe(true);
+      expect(remaining).toBe(1);
+    });
+
+    it("defers the SqlError shape (wrapped, retryable flag lost) on exhaustion", async () => {
+      // The production #1730 shape: `SqlError: SQL query failed: Network
+      // connection lost.` — the wrapper prefixes the message and drops the CF
+      // `retryable` flag, keeping the platform error only in `cause`.
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "exhaust-defer-sqlerror"
+      );
+      const { threw, remaining } = await agentStub.runOneShotSequenceForTest(
+        [
+          { kind: "throw-wrapped", message: "Network connection lost." },
+          { kind: "throw-wrapped", message: "Network connection lost." }
+        ],
+        2
+      );
+      expect(threw).toBe(true);
+      expect(remaining).toBe(1);
+    });
+
+    it("defers a retryable-flagged platform error on exhaustion", async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "exhaust-defer-retryable-flag"
+      );
+      const { threw, remaining } = await agentStub.runOneShotSequenceForTest(
+        [
+          { kind: "throw-retryable", message: "internal error" },
+          { kind: "throw-retryable", message: "internal error" }
+        ],
+        2
+      );
+      expect(threw).toBe(true);
+      expect(remaining).toBe(1);
+    });
+
+    it('still retries "Network connection lost." in-process first (a momentary blip heals without deferral)', async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "ncl-in-process-retry-heals"
+      );
+      const { threw, remaining, calls } =
+        await agentStub.runOneShotSequenceForTest(
+          [
+            { kind: "throw", message: "Network connection lost." },
+            { kind: "succeed" }
+          ],
+          3
+        );
+      // Attempt 2 succeeded — no deferral, row consumed normally.
+      expect(calls).toBe(2);
+      expect(threw).toBe(false);
+      expect(remaining).toBe(0);
+    });
+
+    it("still abandons the row when the FINAL error is an application error", async () => {
+      // Mixed shapes ending in an app error: the callback itself failed on a
+      // healthy platform, so the existing swallow-and-delete semantics hold.
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "exhaust-consume-app-error"
+      );
+      const { threw, remaining, calls } =
+        await agentStub.runOneShotSequenceForTest(
+          [
+            { kind: "throw", message: "Network connection lost." },
+            { kind: "throw", message: "some ordinary application error" }
+          ],
+          2
+        );
+      expect(calls).toBe(2);
+      expect(threw).toBe(false);
+      expect(remaining).toBe(0);
+    });
+
+    it("still abandons the row on exhaustion of a pure application error", async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "exhaust-consume-pure-app-error"
+      );
+      const { threw, remaining, calls } =
+        await agentStub.runOneShotSequenceForTest(
+          [
+            { kind: "throw", message: "boom" },
+            { kind: "throw", message: "boom" },
+            { kind: "throw", message: "boom" }
+          ],
+          3
+        );
+      expect(calls).toBe(3);
+      expect(threw).toBe(false);
+      expect(remaining).toBe(0);
+    });
+
+    it("a supersede error mid-sequence still defers IMMEDIATELY without burning the remaining budget", async () => {
+      const agentStub = await getAgentByName(
+        env.TestScheduleAgent,
+        "supersede-immediate-defer-budget"
+      );
+      const { threw, remaining, calls } =
+        await agentStub.runOneShotSequenceForTest(
+          [
+            { kind: "throw", message: "Network connection lost." },
+            {
+              kind: "throw",
+              message: "Durable Object reset because its code was updated."
+            },
+            { kind: "succeed" }
+          ],
+          5
+        );
+      // Attempt 2's reset stops the in-process loop cold (retrying on a
+      // superseded isolate is futile) — attempt 3 never runs.
+      expect(calls).toBe(2);
+      expect(threw).toBe(true);
+      expect(remaining).toBe(1);
     });
   });
 });

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -4699,9 +4699,10 @@ export class AIChatAgent<
    * Exactly-once terminalization here rests SOLELY on the
    * `stored?.status === "exhausted"` re-entry guard below — unlike
    * `@cloudflare/think`, `@cloudflare/ai-chat` has no durable-submission layer
-   * to short-circuit a duplicate alarm earlier. The sealed incident is
-   * re-persisted even when the record was found missing, so a swept record is
-   * re-armed for the guard on the next alarm.
+   * to short-circuit a duplicate alarm earlier. The incident read/write are
+   * best-effort because they back only that guard, not the terminal UX: a
+   * failed read synthesizes the incident and a failed seal write costs at most
+   * a re-delivered banner on a duplicate alarm.
    *
    * Two residual at-least-once edges, both deliberately accepted as "deliver a
    * second banner" ≫ "silently drop the turn":
@@ -4720,9 +4721,19 @@ export class AIChatAgent<
     const incidentKey = data?.incidentId
       ? this._chatRecoveryIncidentKey(data.incidentId)
       : null;
-    const stored = incidentKey
-      ? await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)
-      : null;
+    let stored: ChatRecoveryIncident | null = null;
+    if (incidentKey) {
+      try {
+        stored =
+          (await this.ctx.storage.get<ChatRecoveryIncident>(incidentKey)) ??
+          null;
+      } catch (readError) {
+        console.error(
+          "[AIChatAgent] failed to read recovery incident during give-up; synthesizing",
+          readError
+        );
+      }
+    }
 
     // Re-entry guard (see method doc): a sealed incident means terminalization
     // already happened, so a duplicate stale alarm must not re-fire
@@ -4786,8 +4797,17 @@ export class AIChatAgent<
 
     // Persist the sealed incident (retained for inspection / TTL sweep) so the
     // re-entry guard above sees `exhausted` if a duplicate stale alarm fires.
+    // Best-effort: terminalization already fully succeeded, so a failed seal
+    // write costs at most a re-delivered banner on a duplicate alarm.
     if (incidentKey) {
-      await this.ctx.storage.put(incidentKey, incident);
+      try {
+        await this.ctx.storage.put(incidentKey, incident);
+      } catch (writeError) {
+        console.error(
+          "[AIChatAgent] failed to persist sealed recovery incident during give-up",
+          writeError
+        );
+      }
     }
   }
 

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -4758,12 +4758,6 @@ export class AIChatAgent<
           reason: "stable_timeout"
         };
 
-    // Persist the sealed incident (retained for inspection / TTL sweep) so the
-    // re-entry guard above sees `exhausted` if a duplicate stale alarm fires.
-    if (incidentKey) {
-      await this.ctx.storage.put(incidentKey, incident);
-    }
-
     const streamId = this._resolveRecoveryStreamId(
       incident.recoveryRootRequestId ?? incident.requestId
     );
@@ -4771,6 +4765,17 @@ export class AIChatAgent<
       ? this._getPartialStreamText(streamId)
       : { text: "", parts: [] as MessagePart[] };
 
+    // Terminalize BEFORE sealing the incident. The terminal write inside
+    // `_exhaustChatRecovery` (`_recordChatTerminal`) hits storage and can
+    // reject with a platform transient in exactly the window a give-up tends
+    // to run in (#1730: deploy reset / storage outage). Letting that throw
+    // propagate is deliberate: `Agent._executeScheduleCallback` defers the
+    // one-shot row on a platform transient, so the WHOLE give-up re-runs on a
+    // healthy isolate instead of half-sealing. Sealing first would arm the
+    // re-entry guard above and turn that re-run into a no-op — dropping the
+    // durable terminal record (#1645). The re-run is idempotent
+    // (`_recordChatTerminal` overwrites the same key); `onExhausted` + the
+    // banner may fire again — the documented at-least-once edge.
     await this._exhaustChatRecovery(
       incident,
       config,
@@ -4778,6 +4783,12 @@ export class AIChatAgent<
       streamId,
       incident.firstSeenAt
     );
+
+    // Persist the sealed incident (retained for inspection / TTL sweep) so the
+    // re-entry guard above sees `exhausted` if a duplicate stale alarm fires.
+    if (incidentKey) {
+      await this.ctx.storage.put(incidentKey, incident);
+    }
   }
 
   private _shouldRetryRecoveredPreStreamTurn(

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -45,7 +45,19 @@ interface ChatRecoveryTestStub {
   getRunFiberCountForTest(): Promise<number>;
   runAlarmForTest(): Promise<void>;
   setSimulateSupersededIsolateForTest(value: boolean): Promise<void>;
+  setSimulateTransientErrorForTest(message: string | null): Promise<void>;
   getSupersededThrowsForTest(): Promise<number>;
+  testStableTimeoutSealTransientDefer(input: {
+    transientMessage: string;
+    terminalMessage: string;
+  }): Promise<{
+    firstThrew: boolean;
+    incidentStatusAfterFirst: string | undefined;
+    secondThrew: boolean;
+    incidentStatusAfterSecond: string | undefined;
+    terminalBroadcast: string | undefined;
+    exhaustedReasons: string[];
+  }>;
   setChatRecoveryConfigForTest(config: {
     maxAttempts?: number;
     terminalMessage?: string;
@@ -769,6 +781,75 @@ describe("onChatRecovery", () => {
 
     // Stop simulating so any platform-retried alarm can complete cleanly.
     await agentStub.setSimulateSupersededIsolateForTest(false);
+  });
+
+  it("recovers when the continuation alarm exhausts its retries on a storage transient (#1730)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+
+    // Simulate the OTHER deploy-reset-window shape: SQL ops fail with
+    // `SqlError: SQL query failed: Network connection lost.` (wrapped, no
+    // `retryable` flag, no reset phrasing). Unlike the supersede this keeps
+    // its in-process retries — but a reset window outlasts the retry schedule
+    // by design, so every attempt fails and (pre-fix) the budget exhaustion
+    // swallowed the error, letting `alarm()` delete the one-shot row
+    // milliseconds before storage recovered.
+    await agentStub.setSimulateTransientErrorForTest(
+      "Network connection lost."
+    );
+
+    await agentStub.insertInterruptedFiber(
+      "__cf_internal_chat_turn:req-transient"
+    );
+    await agentStub.triggerFiberRecovery();
+    expect(await agentStub.getRunFiberCountForTest()).toBe(0);
+
+    await agentStub.runAlarmForTest();
+    // The in-process retries actually ran (this is not the immediate-defer
+    // supersede path) ...
+    expect(await agentStub.getSupersededThrowsForTest()).toBeGreaterThanOrEqual(
+      2
+    );
+
+    // ... and on exhaustion the platform transient must DEFER the row, not
+    // consume it: the turn stays resumable for the healthy window that
+    // follows the deploy.
+    const pendingContinuations = await agentStub.getScheduleCountForCallback(
+      "_chatRecoveryContinue"
+    );
+    const pendingFibers = await agentStub.getRunFiberCountForTest();
+    expect(pendingContinuations + pendingFibers).toBeGreaterThanOrEqual(1);
+
+    await agentStub.setSimulateTransientErrorForTest(null);
+  });
+
+  it("defers a give-up whose terminal write hits a platform transient instead of half-sealing, then seals fully on the re-run (#1730)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    const terminalMessage = "The assistant was interrupted. Please try again.";
+
+    const result = await agentStub.testStableTimeoutSealTransientDefer({
+      transientMessage: "Network connection lost.",
+      terminalMessage
+    });
+
+    // First give-up: the durable terminal write (#1645) rejects mid-deploy →
+    // the transient propagates (so the base scheduler preserves the one-shot
+    // row) and the incident is NOT sealed — sealing first would turn the
+    // deferred re-run into a no-op and drop the terminal record.
+    expect(result.firstThrew).toBe(true);
+    expect(result.incidentStatusAfterFirst).not.toBe("exhausted");
+    // Second give-up (the deferred re-run on a healthy isolate): terminalizes
+    // fully — banner delivered, incident sealed, no re-throw.
+    expect(result.secondThrew).toBe(false);
+    expect(result.incidentStatusAfterSecond).toBe("exhausted");
+    expect(result.terminalBroadcast).toBe(terminalMessage);
+    // `onExhausted` fired on both passes — the documented at-least-once edge
+    // ("deliver a second banner" ≫ "silently drop the turn").
+    expect(result.exhaustedReasons).toEqual([
+      "stable_timeout",
+      "stable_timeout"
+    ]);
   });
 
   it("shares one attempt budget when an incident flips between retry and continue", async () => {

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -58,6 +58,24 @@ interface ChatRecoveryTestStub {
     terminalBroadcast: string | undefined;
     exhaustedReasons: string[];
   }>;
+  testStableTimeoutIncidentReadBestEffort(input: {
+    transientMessage: string;
+    terminalMessage: string;
+  }): Promise<{
+    threw: boolean;
+    terminalBroadcast: string | undefined;
+    exhaustedReasons: string[];
+    incidentStatus: string | undefined;
+  }>;
+  testStableTimeoutSealWriteBestEffort(input: {
+    transientMessage: string;
+    terminalMessage: string;
+  }): Promise<{
+    threw: boolean;
+    terminalBroadcast: string | undefined;
+    exhaustedReasons: string[];
+    incidentStatus: string | undefined;
+  }>;
   setChatRecoveryConfigForTest(config: {
     maxAttempts?: number;
     terminalMessage?: string;
@@ -850,6 +868,45 @@ describe("onChatRecovery", () => {
       "stable_timeout",
       "stable_timeout"
     ]);
+  });
+
+  it("still terminalizes if the ai-chat incident read fails during give-up bookkeeping", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    const terminalMessage = "The assistant was interrupted. Please try again.";
+
+    const result = await agentStub.testStableTimeoutIncidentReadBestEffort({
+      transientMessage: "Network connection lost.",
+      terminalMessage
+    });
+
+    // The incident read only backs the duplicate-alarm guard. If storage
+    // rejects here, ai-chat should synthesize an incident and still deliver the
+    // terminal UX (matching Think's `_exhaustRecoveryGiveUp`).
+    expect(result.threw).toBe(false);
+    expect(result.terminalBroadcast).toBe(terminalMessage);
+    expect(result.exhaustedReasons).toEqual(["stable_timeout"]);
+    expect(result.incidentStatus).toBe("exhausted");
+  });
+
+  it("does not defer/replay ai-chat give-up when the post-terminal incident seal write fails", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+    const terminalMessage = "The assistant was interrupted. Please try again.";
+
+    const result = await agentStub.testStableTimeoutSealWriteBestEffort({
+      transientMessage: "Network connection lost.",
+      terminalMessage
+    });
+
+    // `_exhaustChatRecovery` already persisted the durable terminal record and
+    // delivered the banner. The incident seal is best-effort bookkeeping, so a
+    // transient here must not propagate to `_executeScheduleCallback` and
+    // re-deliver the whole give-up unnecessarily.
+    expect(result.threw).toBe(false);
+    expect(result.terminalBroadcast).toBe(terminalMessage);
+    expect(result.exhaustedReasons).toEqual(["stable_timeout"]);
+    expect(result.incidentStatus).not.toBe("exhausted");
   });
 
   it("shares one attempt budget when an incident flips between retry and continue", async () => {

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -1697,6 +1697,16 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
    */
   _supersededThrows = 0;
 
+  /**
+   * Simulate the recovery continuation alarm firing inside a deploy-reset
+   * window where SQL ops fail with the `SqlError`-wrapped transient
+   * (`SQL query failed: <message>`, original error only in `cause`) rather
+   * than the verbatim reset message (#1730). Unlike the supersede simulation
+   * this shape keeps its in-process retries — the row must still be deferred
+   * (not consumed) once they exhaust.
+   */
+  _simulateTransientErrorMessage: string | null = null;
+
   override async _chatRecoveryContinue(
     ...args: Parameters<AIChatAgent<Env>["_chatRecoveryContinue"]>
   ): Promise<void> {
@@ -1704,11 +1714,22 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
       this._supersededThrows += 1;
       throw new Error("Durable Object reset because its code was updated.");
     }
+    if (this._simulateTransientErrorMessage) {
+      this._supersededThrows += 1;
+      throw new Error(
+        `SQL query failed: ${this._simulateTransientErrorMessage}`,
+        { cause: new Error(this._simulateTransientErrorMessage) }
+      );
+    }
     return super._chatRecoveryContinue(...args);
   }
 
   setSimulateSupersededIsolateForTest(value: boolean): void {
     this._simulateSupersededIsolate = value;
+  }
+
+  setSimulateTransientErrorForTest(message: string | null): void {
+    this._simulateTransientErrorMessage = message;
   }
 
   getSupersededThrowsForTest(): number {
@@ -1915,6 +1936,119 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
       prefix: "cf:chat-recovery:incident:"
     });
     return [...entries.values()];
+  }
+
+  /**
+   * #1730 layer 3: drive the stable-timeout give-up
+   * (`_exhaustRecoveryAfterStableTimeout`) while the durable terminal write
+   * (`_recordChatTerminal`, #1645) rejects with a platform transient — the
+   * exact window a give-up tends to run in. The FIRST give-up must re-throw
+   * (so `Agent._executeScheduleCallback` preserves the one-shot row) and must
+   * NOT seal the incident `exhausted` (a half-seal would make the deferred
+   * re-run a no-op and drop the durable terminal record). The SECOND give-up
+   * (the deferred re-run on a healthy isolate) must terminalize fully.
+   */
+  async testStableTimeoutSealTransientDefer(input: {
+    transientMessage: string;
+    terminalMessage: string;
+  }): Promise<{
+    firstThrew: boolean;
+    incidentStatusAfterFirst: string | undefined;
+    secondThrew: boolean;
+    incidentStatusAfterSecond: string | undefined;
+    terminalBroadcast: string | undefined;
+    exhaustedReasons: string[];
+  }> {
+    const captured: ChatRecoveryExhaustedContext[] = [];
+    this.chatRecovery = {
+      maxAttempts: 5,
+      terminalMessage: input.terminalMessage,
+      onExhausted: (ctx) => {
+        captured.push(ctx);
+      }
+    };
+
+    const requestId = `seal-transient-${crypto.randomUUID()}`;
+    const begun = await this.beginIncidentForTest({
+      requestId,
+      recoveryRootRequestId: requestId,
+      latestUserMessageId: null,
+      recoveryKind: "continue"
+    });
+
+    let terminalBroadcast: string | undefined;
+    const self = this as unknown as {
+      _broadcastChatMessage(
+        msg: { body?: string; error?: boolean; done?: boolean },
+        exclude?: string[]
+      ): void;
+      _recordChatTerminal(requestId: string, body: string): Promise<void>;
+      _exhaustRecoveryAfterStableTimeout(
+        callback: string,
+        data: unknown
+      ): Promise<void>;
+    };
+    const realBroadcast = self._broadcastChatMessage.bind(this);
+    self._broadcastChatMessage = (m, exclude) => {
+      if (m.error && m.done) terminalBroadcast = m.body;
+      realBroadcast(m, exclude);
+    };
+    const realRecordTerminal = self._recordChatTerminal.bind(this);
+    let failTerminalWriteOnce = true;
+    self._recordChatTerminal = async (reqId, body) => {
+      if (failTerminalWriteOnce) {
+        failTerminalWriteOnce = false;
+        throw new Error(`SQL query failed: ${input.transientMessage}`, {
+          cause: new Error(input.transientMessage)
+        });
+      }
+      await realRecordTerminal(reqId, body);
+    };
+
+    const data = {
+      incidentId: begun.incidentId,
+      originalRequestId: requestId
+    };
+    const readIncidentStatus = async (): Promise<string | undefined> => {
+      const incidents = await this.ctx.storage.list<{ status: string }>({
+        prefix: "cf:chat-recovery:incident:"
+      });
+      return [...incidents.values()][0]?.status;
+    };
+
+    let firstThrew = false;
+    try {
+      await self._exhaustRecoveryAfterStableTimeout(
+        "_chatRecoveryContinue",
+        data
+      );
+    } catch {
+      firstThrew = true;
+    }
+    const incidentStatusAfterFirst = await readIncidentStatus();
+
+    let secondThrew = false;
+    try {
+      await self._exhaustRecoveryAfterStableTimeout(
+        "_chatRecoveryContinue",
+        data
+      );
+    } catch {
+      secondThrew = true;
+    } finally {
+      self._broadcastChatMessage = realBroadcast;
+      self._recordChatTerminal = realRecordTerminal;
+    }
+    const incidentStatusAfterSecond = await readIncidentStatus();
+
+    return {
+      firstThrew,
+      incidentStatusAfterFirst,
+      secondThrew,
+      incidentStatusAfterSecond,
+      terminalBroadcast,
+      exhaustedReasons: captured.map((c) => c.reason)
+    };
   }
 
   private _forceStableTimeout = false;

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -2051,6 +2051,188 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
     };
   }
 
+  /**
+   * The incident read is only for the re-entry guard. If it fails during the
+   * give-up window, ai-chat should synthesize an incident and still deliver the
+   * terminal UX instead of aborting terminalization.
+   */
+  async testStableTimeoutIncidentReadBestEffort(input: {
+    transientMessage: string;
+    terminalMessage: string;
+  }): Promise<{
+    threw: boolean;
+    terminalBroadcast: string | undefined;
+    exhaustedReasons: string[];
+    incidentStatus: string | undefined;
+  }> {
+    const captured: ChatRecoveryExhaustedContext[] = [];
+    this.chatRecovery = {
+      maxAttempts: 5,
+      terminalMessage: input.terminalMessage,
+      onExhausted: (ctx) => {
+        captured.push(ctx);
+      }
+    };
+
+    const requestId = `read-transient-${crypto.randomUUID()}`;
+    const begun = await this.beginIncidentForTest({
+      requestId,
+      recoveryRootRequestId: requestId,
+      latestUserMessageId: null,
+      recoveryKind: "continue"
+    });
+    const incidentKey = `cf:chat-recovery:incident:${encodeURIComponent(begun.incidentId)}`;
+
+    let terminalBroadcast: string | undefined;
+    const self = this as unknown as {
+      _broadcastChatMessage(
+        msg: { body?: string; error?: boolean; done?: boolean },
+        exclude?: string[]
+      ): void;
+      _exhaustRecoveryAfterStableTimeout(
+        callback: string,
+        data: unknown
+      ): Promise<void>;
+    };
+    const realBroadcast = self._broadcastChatMessage.bind(this);
+    self._broadcastChatMessage = (m, exclude) => {
+      if (m.error && m.done) terminalBroadcast = m.body;
+      realBroadcast(m, exclude);
+    };
+
+    const storage = this.ctx.storage as unknown as {
+      get<T>(key: string): Promise<T | undefined>;
+    };
+    const realGet = storage.get.bind(this.ctx.storage);
+    let failReadOnce = true;
+    storage.get = async <T>(key: string): Promise<T | undefined> => {
+      if (failReadOnce && key === incidentKey) {
+        failReadOnce = false;
+        throw new Error(`SQL query failed: ${input.transientMessage}`, {
+          cause: new Error(input.transientMessage)
+        });
+      }
+      return realGet<T>(key);
+    };
+
+    let threw = false;
+    try {
+      await self._exhaustRecoveryAfterStableTimeout("_chatRecoveryContinue", {
+        incidentId: begun.incidentId,
+        originalRequestId: requestId
+      });
+    } catch {
+      threw = true;
+    } finally {
+      self._broadcastChatMessage = realBroadcast;
+      storage.get = realGet;
+    }
+
+    const incidents = await this.ctx.storage.list<{ status: string }>({
+      prefix: "cf:chat-recovery:incident:"
+    });
+    return {
+      threw,
+      terminalBroadcast,
+      exhaustedReasons: captured.map((c) => c.reason),
+      incidentStatus: [...incidents.values()][0]?.status
+    };
+  }
+
+  /**
+   * Once terminalization succeeds, sealing the incident is best-effort. A seal
+   * write failure should not propagate back to the scheduler and cause an
+   * unnecessary re-delivery of the whole give-up.
+   */
+  async testStableTimeoutSealWriteBestEffort(input: {
+    transientMessage: string;
+    terminalMessage: string;
+  }): Promise<{
+    threw: boolean;
+    terminalBroadcast: string | undefined;
+    exhaustedReasons: string[];
+    incidentStatus: string | undefined;
+  }> {
+    const captured: ChatRecoveryExhaustedContext[] = [];
+    this.chatRecovery = {
+      maxAttempts: 5,
+      terminalMessage: input.terminalMessage,
+      onExhausted: (ctx) => {
+        captured.push(ctx);
+      }
+    };
+
+    const requestId = `seal-write-transient-${crypto.randomUUID()}`;
+    const begun = await this.beginIncidentForTest({
+      requestId,
+      recoveryRootRequestId: requestId,
+      latestUserMessageId: null,
+      recoveryKind: "continue"
+    });
+    const incidentKey = `cf:chat-recovery:incident:${encodeURIComponent(begun.incidentId)}`;
+
+    let terminalBroadcast: string | undefined;
+    const self = this as unknown as {
+      _broadcastChatMessage(
+        msg: { body?: string; error?: boolean; done?: boolean },
+        exclude?: string[]
+      ): void;
+      _exhaustRecoveryAfterStableTimeout(
+        callback: string,
+        data: unknown
+      ): Promise<void>;
+    };
+    const realBroadcast = self._broadcastChatMessage.bind(this);
+    self._broadcastChatMessage = (m, exclude) => {
+      if (m.error && m.done) terminalBroadcast = m.body;
+      realBroadcast(m, exclude);
+    };
+
+    const storage = this.ctx.storage as unknown as {
+      put(key: string, value: unknown): Promise<void>;
+    };
+    const realPut = storage.put.bind(this.ctx.storage);
+    let failSealWriteOnce = true;
+    storage.put = async (key, value): Promise<void> => {
+      if (
+        failSealWriteOnce &&
+        key === incidentKey &&
+        typeof value === "object" &&
+        value !== null &&
+        (value as { status?: string }).status === "exhausted"
+      ) {
+        failSealWriteOnce = false;
+        throw new Error(`SQL query failed: ${input.transientMessage}`, {
+          cause: new Error(input.transientMessage)
+        });
+      }
+      await realPut(key, value);
+    };
+
+    let threw = false;
+    try {
+      await self._exhaustRecoveryAfterStableTimeout("_chatRecoveryContinue", {
+        incidentId: begun.incidentId,
+        originalRequestId: requestId
+      });
+    } catch {
+      threw = true;
+    } finally {
+      self._broadcastChatMessage = realBroadcast;
+      storage.put = realPut;
+    }
+
+    const incidents = await this.ctx.storage.list<{ status: string }>({
+      prefix: "cf:chat-recovery:incident:"
+    });
+    return {
+      threw,
+      terminalBroadcast,
+      exhaustedReasons: captured.map((c) => c.reason),
+      incidentStatus: [...incidents.values()][0]?.status
+    };
+  }
+
   private _forceStableTimeout = false;
 
   setForceStableTimeoutForTest(value: boolean): void {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -15,6 +15,7 @@ import type {
   StreamableResult,
   ChatOptions,
   ChatResponseResult,
+  SaveMessagesOptions,
   SaveMessagesResult,
   ChatRecoveryConfig,
   ChatRecoveryContext,
@@ -3289,6 +3290,32 @@ export class ThinkProgrammaticTestAgent extends Think {
     errorText: string;
     textChunks: string[];
   } | null = null;
+  private _failNextContinueTransient: string | null = null;
+
+  /**
+   * Arm a ONE-SHOT platform-transient fault on the next `continueLastTurn`
+   * (#1730): the next recovered continuation throws the production `SqlError`
+   * shape (`SQL query failed: <message>` with the bare platform error as
+   * `cause`, no `retryable` flag on the wrapper), then the fault clears so the
+   * deferred re-run succeeds.
+   */
+  async failNextRecoveredContinueForTest(message: string): Promise<void> {
+    this._failNextContinueTransient = message;
+  }
+
+  protected override async continueLastTurn(
+    body?: Record<string, unknown>,
+    options?: SaveMessagesOptions
+  ): Promise<SaveMessagesResult> {
+    if (this._failNextContinueTransient) {
+      const message = this._failNextContinueTransient;
+      this._failNextContinueTransient = null;
+      throw new Error(`SQL query failed: ${message}`, {
+        cause: new Error(message)
+      });
+    }
+    return super.continueLastTurn(body, options);
+  }
 
   override getModel(): LanguageModel {
     if (this._inBandErrorResponse) {
@@ -3583,6 +3610,23 @@ export class ThinkProgrammaticTestAgent extends Think {
 
   async continueRecoveredChatForTest(requestId: string): Promise<void> {
     await this._chatRecoveryContinue({ recoveredRequestId: requestId });
+  }
+
+  /**
+   * Like `continueRecoveredChatForTest` but catches in-DO and returns the
+   * thrown message (or `null` when nothing threw) — a rejection crossing the
+   * RPC boundary is also reported by workerd as an unhandled rejection, which
+   * pollutes test output even when the caller expects it.
+   */
+  async continueRecoveredChatCatchingForTest(
+    requestId: string
+  ): Promise<string | null> {
+    try {
+      await this._chatRecoveryContinue({ recoveredRequestId: requestId });
+      return null;
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
   }
 
   async cancelDuringRecoveredContinuationForTest(
@@ -5024,15 +5068,31 @@ export class ThinkRecoveryTestAgent extends Think {
    * Drive `_handleRecoveryCallbackError` (the catch path of
    * `_chatRecoveryContinue` / `_chatRecoveryRetry`) and report the outcome.
    *
-   * - A non-reset throw must terminalize (fire `onExhausted` + broadcast the
-   *   terminal banner, seal the incident `exhausted`) and NOT re-throw — so
-   *   `Agent._executeScheduleCallback` doesn't swallow it and delete the
-   *   one-shot row with no terminal UX.
-   * - A deploy code-update reset must re-throw (so the platform re-runs
-   *   recovery on the fresh isolate) and NOT terminalize.
+   * - A non-transient (application) throw must terminalize (fire `onExhausted`
+   *   + broadcast the terminal banner, seal the incident `exhausted`) and NOT
+   *   re-throw — so `Agent._executeScheduleCallback` doesn't swallow it and
+   *   delete the one-shot row with no terminal UX.
+   * - A PLATFORM TRANSIENT (deploy code-update reset / script supersede,
+   *   "Network connection lost.", a `retryable`-flagged error — bare or
+   *   wrapped like `SqlError`) must re-throw (so the platform re-runs recovery
+   *   once healthy) and NOT terminalize (#1730). The recovered submission must
+   *   stay `running` so the deferred re-run picks it up instead of skipping
+   *   with `submission_not_running`.
+   *
+   * `errorShape` controls how `errorMessage` is thrown:
+   *   - "plain" (default): `new Error(errorMessage)`
+   *   - "sql-wrapped": the `SqlError` shape — message prefixed with
+   *     "SQL query failed: ", original error only in `cause`, no flag
+   *   - "retryable": `retryable: true` set on the error object
+   *
+   * `seedRunningSubmission` inserts a `running` durable submission keyed by
+   * the incident's requestId and passes it as `recoveredRequestId`, so tests
+   * can assert what the handler does to it on each branch.
    */
   async testRecoveryCallbackError(input: {
     errorMessage: string;
+    errorShape?: "plain" | "sql-wrapped" | "retryable";
+    seedRunningSubmission?: boolean;
     maxAttempts?: number;
     terminalMessage?: string;
   }): Promise<{
@@ -5041,6 +5101,7 @@ export class ThinkRecoveryTestAgent extends Think {
     exhaustedReason: string | undefined;
     terminalBroadcast: string | undefined;
     incidentStatus: string | undefined;
+    submissionStatus: string | null;
   }> {
     const maxAttempts = input.maxAttempts ?? 5;
     const terminalMessage =
@@ -5061,6 +5122,24 @@ export class ThinkRecoveryTestAgent extends Think {
       latestUserMessageId: null,
       recoveryKind: "continue"
     });
+
+    if (input.seedRunningSubmission) {
+      (
+        this as unknown as { _ensureSubmissionTable: () => void }
+      )._ensureSubmissionTable();
+      const now = Date.now();
+      this.sql`
+        INSERT INTO cf_think_submissions (
+          submission_id, idempotency_key, request_id, stream_id, status,
+          messages_json, metadata_json, error_message, created_at,
+          messages_applied_at, started_at, completed_at
+        )
+        VALUES (
+          ${requestId}, NULL, ${requestId}, NULL, 'running',
+          ${JSON.stringify([])}, NULL, NULL, ${now}, ${now}, ${now}, NULL
+        )
+      `;
+    }
 
     let terminalBroadcast: string | undefined;
     const realBroadcast = (
@@ -5085,7 +5164,15 @@ export class ThinkRecoveryTestAgent extends Think {
       realBroadcast(m);
     };
 
-    const error = new Error(input.errorMessage);
+    const error =
+      input.errorShape === "sql-wrapped"
+        ? new Error(`SQL query failed: ${input.errorMessage}`, {
+            cause: new Error(input.errorMessage)
+          })
+        : new Error(input.errorMessage);
+    if (input.errorShape === "retryable") {
+      (error as unknown as { retryable: boolean }).retryable = true;
+    }
 
     let threw = false;
     try {
@@ -5099,7 +5186,13 @@ export class ThinkRecoveryTestAgent extends Think {
         }
       )._handleRecoveryCallbackError(
         "_chatRecoveryContinue",
-        { incidentId: begun.incidentId, originalRequestId: requestId },
+        {
+          incidentId: begun.incidentId,
+          originalRequestId: requestId,
+          ...(input.seedRunningSubmission
+            ? { recoveredRequestId: requestId }
+            : {})
+        },
         error
       );
     } catch {
@@ -5113,12 +5206,141 @@ export class ThinkRecoveryTestAgent extends Think {
     const incidents = await this.ctx.storage.list<{ status: string }>({
       prefix: "cf:chat-recovery:incident:"
     });
+    const submissionRows = input.seedRunningSubmission
+      ? this.sql<{ status: string }>`
+          SELECT status FROM cf_think_submissions
+          WHERE request_id = ${requestId}
+          LIMIT 1
+        `
+      : [];
     return {
       threw,
       exhaustedContexts: captured.length,
       exhaustedReason: captured[0]?.reason,
       terminalBroadcast,
-      incidentStatus: [...incidents.values()][0]?.status
+      incidentStatus: [...incidents.values()][0]?.status,
+      submissionStatus: submissionRows[0]?.status ?? null
+    };
+  }
+
+  /**
+   * #1730 layer 3: drive the give-up path while the durable terminal write
+   * (`_recordTerminalChatStatus`) rejects with a platform transient — the
+   * exact window a give-up tends to run in. The FIRST give-up must re-throw
+   * (so the one-shot row is preserved) and must NOT seal the incident
+   * `exhausted` (a half-seal would make the deferred re-run a no-op and drop
+   * the durable terminal record). The SECOND give-up (the deferred re-run on
+   * a healthy isolate) must terminalize fully: banner + sealed incident.
+   */
+  async testGiveUpSealTransientDefer(input: {
+    transientMessage: string;
+    terminalMessage?: string;
+  }): Promise<{
+    firstThrew: boolean;
+    incidentStatusAfterFirst: string | undefined;
+    secondThrew: boolean;
+    incidentStatusAfterSecond: string | undefined;
+    terminalBroadcast: string | undefined;
+    exhaustedReasons: string[];
+  }> {
+    const terminalMessage =
+      input.terminalMessage ?? "Conversation interrupted.";
+    const captured: ChatRecoveryExhaustedContext[] = [];
+    this.chatRecovery = {
+      maxAttempts: 5,
+      terminalMessage,
+      onExhausted: (ctx) => {
+        captured.push(ctx);
+      }
+    };
+
+    const requestId = `seal-transient-${crypto.randomUUID()}`;
+    const begun = await this.beginIncidentForTest({
+      requestId,
+      recoveryRootRequestId: requestId,
+      latestUserMessageId: null,
+      recoveryKind: "continue"
+    });
+
+    let terminalBroadcast: string | undefined;
+    const self = this as unknown as {
+      _broadcastChat(m: {
+        body?: string;
+        error?: boolean;
+        done?: boolean;
+      }): void;
+      _recordTerminalChatStatus(
+        status: string,
+        requestId: string,
+        body: string
+      ): Promise<void>;
+      _handleRecoveryCallbackError(
+        callback: string,
+        data: unknown,
+        error: unknown
+      ): Promise<void>;
+    };
+    const realBroadcast = self._broadcastChat.bind(this);
+    self._broadcastChat = (m) => {
+      if (m.error && m.done) terminalBroadcast = m.body;
+      realBroadcast(m);
+    };
+    const realRecordTerminal = self._recordTerminalChatStatus.bind(this);
+    let failTerminalWriteOnce = true;
+    self._recordTerminalChatStatus = async (status, reqId, body) => {
+      if (failTerminalWriteOnce) {
+        failTerminalWriteOnce = false;
+        throw new Error(`SQL query failed: ${input.transientMessage}`, {
+          cause: new Error(input.transientMessage)
+        });
+      }
+      await realRecordTerminal(status, reqId, body);
+    };
+
+    const data = { incidentId: begun.incidentId, originalRequestId: requestId };
+    const appError = new Error("model rejected the continuation");
+
+    const readIncidentStatus = async (): Promise<string | undefined> => {
+      const incidents = await this.ctx.storage.list<{ status: string }>({
+        prefix: "cf:chat-recovery:incident:"
+      });
+      return [...incidents.values()][0]?.status;
+    };
+
+    let firstThrew = false;
+    try {
+      await self._handleRecoveryCallbackError(
+        "_chatRecoveryContinue",
+        data,
+        appError
+      );
+    } catch {
+      firstThrew = true;
+    }
+    const incidentStatusAfterFirst = await readIncidentStatus();
+
+    let secondThrew = false;
+    try {
+      await self._handleRecoveryCallbackError(
+        "_chatRecoveryContinue",
+        data,
+        appError
+      );
+    } catch {
+      secondThrew = true;
+    } finally {
+      self._broadcastChat = realBroadcast;
+      self._recordTerminalChatStatus = realRecordTerminal;
+    }
+    const incidentStatusAfterSecond = await readIncidentStatus();
+
+    return {
+      firstThrew,
+      incidentStatusAfterFirst,
+      secondThrew,
+      incidentStatusAfterSecond,
+      terminalBroadcast,
+      exhaustedReasons: captured.map((c) => c.reason)
     };
   }
 

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -74,6 +74,10 @@ type ThinkSubmissionTestStub = {
   resetTurnStateForTest(): Promise<void>;
   recoverChatFiberForTest(requestId: string): Promise<void>;
   continueRecoveredChatForTest(requestId: string): Promise<void>;
+  continueRecoveredChatCatchingForTest(
+    requestId: string
+  ): Promise<string | null>;
+  failNextRecoveredContinueForTest(message: string): Promise<void>;
   cancelDuringRecoveredContinuationForTest(
     requestId: string,
     delayMs: number
@@ -958,6 +962,52 @@ describe("Think durable submissions", () => {
       status: "aborted",
       error: "stop"
     });
+  });
+
+  it("defers a recovered continuation on a platform transient and completes it on the re-run (#1730)", async () => {
+    const agent = await freshAgent();
+    await agent.setDelayedChunkResponse(["seed"], 1);
+    const seed = await agent.testSubmitMessages("seed conversation", {
+      submissionId: "sub-transient-defer-seed"
+    });
+    await waitForSubmission(
+      agent,
+      seed.submissionId,
+      (submission) => submission.status === "completed"
+    );
+
+    await agent.setDelayedChunkResponse(["recovered ", "answer"], 1);
+    await agent.insertSubmissionForTest({
+      submissionId: "sub-transient-defer",
+      requestId: "sub-transient-defer",
+      status: "running",
+      messagesAppliedAt: Date.now()
+    });
+
+    // First continuation lands in a deploy-reset window: storage throws the
+    // `SqlError: SQL query failed: Network connection lost.` shape. The
+    // callback must RE-THROW (so `Agent._executeScheduleCallback` preserves
+    // the one-shot row for the platform to re-run) instead of terminalizing
+    // through a give-up that needs the storage that's down.
+    await agent.failNextRecoveredContinueForTest("Network connection lost.");
+    await expect(
+      agent.continueRecoveredChatCatchingForTest("sub-transient-defer")
+    ).resolves.toMatch(/Network connection lost/);
+
+    // The submission must STILL be running — marking it terminal on the defer
+    // path would make the re-run skip with `submission_not_running` and the
+    // turn would never resume (the self-defeating defer).
+    await expect(
+      agent.inspectSubmissionForTest("sub-transient-defer")
+    ).resolves.toMatchObject({ status: "running" });
+
+    // The deferred re-run (the preserved one-shot row firing on a healthy
+    // isolate): the continuation streams normally and completes the
+    // submission end-to-end.
+    await agent.continueRecoveredChatForTest("sub-transient-defer");
+    await expect(
+      agent.inspectSubmissionForTest("sub-transient-defer")
+    ).resolves.toMatchObject({ status: "completed" });
   });
 
   it("preserves stream error text from recovered continuations", async () => {

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -4354,17 +4354,17 @@ describe("Think — onChatRecovery", () => {
     expect(result.terminalBroadcast).toBe(terminalMessage);
   });
 
-  it("terminalizes a non-reset throw in a recovery callback instead of letting it be swallowed + silently sealed", async () => {
+  it("terminalizes a non-transient (application) throw in a recovery callback instead of letting it be swallowed + silently sealed", async () => {
     const agent = await freshRecoveryAgent("recovery-throw-terminalize");
     const terminalMessage = "The assistant was interrupted. Please try again.";
 
     const result = await agent.testRecoveryCallbackError({
-      errorMessage: "transient storage failure mid-recovery",
+      errorMessage: "model rejected the continuation request",
       maxAttempts: 5,
       terminalMessage
     });
 
-    // The catch must NOT re-throw — re-throwing a non-reset error lets
+    // The catch must NOT re-throw — re-throwing an application error lets
     // Agent._executeScheduleCallback swallow it and delete the one-shot row
     // with no terminal UX (the silent-seal bug).
     expect(result.threw).toBe(false);
@@ -4408,6 +4408,117 @@ describe("Think — onChatRecovery", () => {
     expect(result.exhaustedContexts).toBe(0);
     expect(result.terminalBroadcast).toBeUndefined();
     expect(result.incidentStatus).toBe("failed");
+  });
+
+  it('re-throws "Network connection lost." (storage transient in a deploy-reset window) and does NOT terminalize (#1730)', async () => {
+    const agent = await freshRecoveryAgent("recovery-throw-connection-lost");
+
+    // The production #1730 capture: storage errors during a reset window
+    // surface as connection-lost, not as the verbatim reset message.
+    // Terminalizing here is doomed — the give-up's own seal needs the storage
+    // that's down — so it must defer like a reset.
+    const result = await agent.testRecoveryCallbackError({
+      errorMessage: "Network connection lost.",
+      maxAttempts: 5
+    });
+
+    expect(result.threw).toBe(true);
+    expect(result.exhaustedContexts).toBe(0);
+    expect(result.terminalBroadcast).toBeUndefined();
+    expect(result.incidentStatus).toBe("failed");
+  });
+
+  it("re-throws the SqlError shape (wrapped transient, retryable flag lost) and does NOT terminalize (#1730)", async () => {
+    const agent = await freshRecoveryAgent("recovery-throw-sqlerror");
+
+    // `SqlError: SQL query failed: Network connection lost.` — the wrapper
+    // prefixes the message and keeps the platform error only in `cause`.
+    const result = await agent.testRecoveryCallbackError({
+      errorMessage: "Network connection lost.",
+      errorShape: "sql-wrapped",
+      maxAttempts: 5
+    });
+
+    expect(result.threw).toBe(true);
+    expect(result.exhaustedContexts).toBe(0);
+    expect(result.terminalBroadcast).toBeUndefined();
+    expect(result.incidentStatus).toBe("failed");
+  });
+
+  it("re-throws a retryable-flagged platform error and does NOT terminalize (#1730)", async () => {
+    const agent = await freshRecoveryAgent("recovery-throw-retryable-flag");
+
+    const result = await agent.testRecoveryCallbackError({
+      errorMessage: "internal error",
+      errorShape: "retryable",
+      maxAttempts: 5
+    });
+
+    expect(result.threw).toBe(true);
+    expect(result.exhaustedContexts).toBe(0);
+    expect(result.terminalBroadcast).toBeUndefined();
+    expect(result.incidentStatus).toBe("failed");
+  });
+
+  it("leaves the recovered submission `running` on a deferral so the re-run picks it up (#1730)", async () => {
+    const agent = await freshRecoveryAgent("recovery-defer-keeps-submission");
+
+    // Regression for the self-defeating defer: marking the submission `error`
+    // before re-throwing makes the deferred re-run of `_chatRecoveryContinue`
+    // skip with `submission_not_running` — the preserved row becomes a no-op
+    // and the turn never resumes. A deferral must leave the submission alone.
+    const result = await agent.testRecoveryCallbackError({
+      errorMessage: "Durable Object reset because its code was updated.",
+      seedRunningSubmission: true,
+      maxAttempts: 5
+    });
+
+    expect(result.threw).toBe(true);
+    expect(result.submissionStatus).toBe("running");
+  });
+
+  it("still marks the recovered submission terminal when an application error terminalizes the turn", async () => {
+    const agent = await freshRecoveryAgent("recovery-app-error-submission");
+
+    const result = await agent.testRecoveryCallbackError({
+      errorMessage: "model rejected the continuation request",
+      seedRunningSubmission: true,
+      maxAttempts: 5
+    });
+
+    expect(result.threw).toBe(false);
+    expect(result.incidentStatus).toBe("exhausted");
+    // `_exhaustChatRecovery` → `_markRecoveredSubmissionInterrupted` seals the
+    // submission so it doesn't hang `running` on a turn nobody will finish.
+    expect(result.submissionStatus).toBe("error");
+  });
+
+  it("defers a give-up whose terminal write hits a platform transient instead of half-sealing, then seals fully on the re-run (#1730)", async () => {
+    const agent = await freshRecoveryAgent("recovery-seal-transient-defer");
+    const terminalMessage = "The assistant was interrupted. Please try again.";
+
+    const result = await agent.testGiveUpSealTransientDefer({
+      transientMessage: "Network connection lost.",
+      terminalMessage
+    });
+
+    // First give-up: the terminal write rejects mid-deploy → the transient
+    // propagates (the one-shot row is preserved by the base scheduler) and the
+    // incident is NOT sealed — sealing first would turn the re-run into a
+    // no-op and drop the durable terminal record.
+    expect(result.firstThrew).toBe(true);
+    expect(result.incidentStatusAfterFirst).not.toBe("exhausted");
+    // Second give-up (the deferred re-run on a healthy isolate): terminalizes
+    // fully — banner delivered, incident sealed, no re-throw.
+    expect(result.secondThrew).toBe(false);
+    expect(result.incidentStatusAfterSecond).toBe("exhausted");
+    expect(result.terminalBroadcast).toBe(terminalMessage);
+    // `onExhausted` fired on both passes — the documented at-least-once edge
+    // ("deliver a second banner" ≫ "silently drop the turn").
+    expect(result.exhaustedReasons).toEqual([
+      "recovery_error",
+      "recovery_error"
+    ]);
   });
 });
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -122,6 +122,7 @@ import {
   Agent,
   callable,
   getCurrentAgent,
+  isPlatformTransientError,
   __DO_NOT_USE_WILL_BREAK__agentContext as agentContext
 } from "agents";
 
@@ -9952,31 +9953,35 @@ export class Think<
    * completed the recovered submission as `error`, which bypassed
    * `_exhaustChatRecovery` entirely — so an app relying on `onExhausted` for the
    * terminal banner regressed to an eternal spinner when recovery gave up under
-   * extreme churn. The error path matters just as much: a non-reset throw in a
-   * recovery callback is SWALLOWED by `Agent._executeScheduleCallback` (only a
-   * code-update reset is re-thrown to preserve the one-shot row), so without
-   * routing it here the alarm row is deleted with no terminal UX at all — the
-   * half-finished message wedges silently. Shared by `_chatRecoveryRetry` and
-   * `_chatRecoveryContinue`.
+   * extreme churn. The error path matters just as much: a non-transient throw
+   * in a recovery callback is SWALLOWED by `Agent._executeScheduleCallback`
+   * (only a platform transient is re-thrown to preserve the one-shot row), so
+   * without routing it here the alarm row is deleted with no terminal UX at
+   * all — the half-finished message wedges silently. Shared by
+   * `_chatRecoveryRetry` and `_chatRecoveryContinue`.
    *
    * Exactly-once terminalization is defended by two independent guards:
    *  1. The `stored?.status === "exhausted"` re-entry guard below — once an
    *     incident is sealed, a duplicate stale alarm (or retried callback)
-   *     returns before re-firing. The sealed incident is re-persisted even when
-   *     the record was found missing, so a swept record is re-armed for the
-   *     guard on the next alarm.
+   *     returns before re-firing. The seal is persisted only AFTER the
+   *     terminal writes in `_exhaustChatRecovery` succeed (see the ordering
+   *     note at the call below), so a give-up interrupted by a platform
+   *     transient re-runs in full instead of being half-sealed.
    *  2. The durable-submission paths additionally short-circuit earlier at the
    *     `submission_not_running` check (the submission is already `error` after
    *     the first give-up). This is the ONLY guard `@cloudflare/ai-chat` lacks
    *     (no submission layer), so guard #1 carries it there.
    *
-   * Two residual at-least-once edges, both deliberately accepted as "deliver a
+   * Residual at-least-once edges, all deliberately accepted as "deliver a
    * second banner" ≫ "silently drop the turn":
    *  • No `incidentId` at all in the payload (only reachable via a direct/test
    *    invocation — every production scheduler carries one): the synthesized
    *    incident can't be persisted (no key), so guard #1 can't arm.
    *  • The record is swept AGAIN between two alarms (guard #1 re-persists on the
    *    first, so this needs a second independent sweep) — vanishingly unlikely.
+   *  • A platform transient interrupts `_exhaustChatRecovery` after the banner
+   *    broadcast — the deferred re-run re-fires `onExhausted` + the banner
+   *    (the terminal writes themselves are idempotent).
    */
   private async _exhaustRecoveryGiveUp(
     callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
@@ -10041,9 +10046,40 @@ export class Think<
           reason
         };
 
+    const streamId = this._resolveRecoveryStreamId(
+      incident.recoveryRootRequestId ?? incident.requestId
+    );
+    const partial = streamId
+      ? this._getPartialStreamText(streamId)
+      : { text: "", parts: [] as MessagePart[] };
+
+    // Terminalize BEFORE sealing the incident. The terminal writes inside
+    // `_exhaustChatRecovery` (`_recordTerminalChatStatus`,
+    // `_markRecoveredSubmissionInterrupted`) hit storage and can reject with a
+    // platform transient in exactly the window a give-up tends to run in
+    // (#1730: deploy reset / storage outage). Letting that throw propagate is
+    // deliberate: the recovery callback's caller (`Agent._executeScheduleCallback`)
+    // defers the one-shot row on a platform transient, so the WHOLE give-up
+    // re-runs on a healthy isolate instead of half-sealing. Sealing first
+    // would arm the re-entry guard above and turn that re-run into a no-op —
+    // dropping the durable terminal record and the submission's terminal
+    // state. The re-run is idempotent: `_recordTerminalChatStatus` overwrites
+    // the same key and `_markRecoveredSubmissionInterrupted` is gated on
+    // `status = 'running'`; `onExhausted` + the banner may fire again — the
+    // documented at-least-once edge ("deliver a second banner" ≫ "silently
+    // drop the turn").
+    await this._exhaustChatRecovery(
+      incident,
+      config,
+      partial,
+      streamId,
+      incident.firstSeenAt
+    );
+
     // Persist the sealed incident (retained for inspection / TTL sweep) so the
     // re-entry guard above sees `exhausted` if a duplicate stale alarm fires.
-    // Best-effort: a failed persist must not block terminalization below.
+    // Best-effort: terminalization already fully succeeded, so a failed seal
+    // write costs at most a re-delivered banner on a duplicate alarm.
     if (incidentKey) {
       try {
         await this.ctx.storage.put(incidentKey, incident);
@@ -10054,21 +10090,6 @@ export class Think<
         );
       }
     }
-
-    const streamId = this._resolveRecoveryStreamId(
-      incident.recoveryRootRequestId ?? incident.requestId
-    );
-    const partial = streamId
-      ? this._getPartialStreamText(streamId)
-      : { text: "", parts: [] as MessagePart[] };
-
-    await this._exhaustChatRecovery(
-      incident,
-      config,
-      partial,
-      streamId,
-      incident.firstSeenAt
-    );
   }
 
   /**
@@ -10084,76 +10105,60 @@ export class Think<
   }
 
   /**
-   * Whether an error is a transient "superseded isolate" failure — a deploy /
-   * code update replaced the isolate mid-invocation. Mirrors the base `Agent`
-   * check (`isDurableObjectCodeUpdateReset`) and MUST stay in lockstep with it:
-   * the base `_executeScheduleCallback` re-throws this class for a one-shot row
-   * (preserving it so the platform re-runs on the new code), so a recovery
-   * callback must also re-throw — NOT terminalize — since recovery will re-run
-   * and succeed on the fresh isolate. The matched family (kept identical to the
-   * base):
-   *   - "Durable Object reset because its code was updated." (deploy bounce)
-   *   - "This script has been upgraded. Please send a new request to connect to
-   *     the new version." (a stub/connection to a superseded script)
-   * "Network connection lost." is intentionally excluded (a connection error,
-   * not an isolate replacement — see the base helper's note). The match stays
-   * close to the verbatim platform strings so an ordinary error mentioning
-   * those words isn't misclassified as a supersede.
-   */
-  private _isDeployCodeUpdateReset(error: unknown): boolean {
-    const message =
-      error instanceof Error
-        ? error.message
-        : typeof error === "string"
-          ? error
-          : "";
-    return /reset because its code was updated|this script has been upgraded/i.test(
-      message
-    );
-  }
-
-  /**
    * Handle an error thrown by `_chatRecoveryContinue` / `_chatRecoveryRetry`
    * after the incident was opened.
    *
-   * - A deploy code-update reset is re-thrown (after marking the incident
-   *   `failed` for observability) so `Agent._executeScheduleCallback` preserves
-   *   the one-shot alarm row and the platform re-runs recovery on the fresh
-   *   isolate — the turn can still recover, so it must NOT terminalize.
-   * - Any OTHER error is terminalized through the give-up path
+   * - A platform transient (`isPlatformTransientError` from `agents` — a
+   *   deploy code-update reset / script supersede, a `retryable`-flagged
+   *   platform error, or "Network connection lost.", looking through wrappers
+   *   like `SqlError` via the `cause` chain) is re-thrown (after best-effort
+   *   marking the incident `failed` for observability) so
+   *   `Agent._executeScheduleCallback` preserves the one-shot alarm row and
+   *   the platform re-runs recovery once it is healthy again — the turn can
+   *   still recover, so it must NOT terminalize. Terminalizing here was the
+   *   #1730 freeze: the give-up's own seal needs the very storage that is
+   *   down, so it throws too, burns the in-process retry budget inside the
+   *   same reset window, and the row is consumed milliseconds before storage
+   *   recovers. The submission is deliberately left `running` — the deferred
+   *   re-run reads it via `_readRunningSubmissionByRequestId`, so marking it
+   *   terminal here would turn the preserved row into a guaranteed
+   *   `submission_not_running` no-op skip (a self-defeating defer).
+   * - Any OTHER (application) error is terminalized through the give-up path
    *   (`onExhausted` + the `terminalMessage` banner) and NOT re-thrown. This is
    *   the fix for the silent-seal failure mode: `_executeScheduleCallback`
-   *   swallows a non-reset throw and then `alarm()` deletes the one-shot row, so
-   *   without terminalizing here the half-finished turn is dropped with no
-   *   terminal event and no banner (the user stares at a frozen message until
-   *   they send something new).
+   *   swallows a non-transient throw and then `alarm()` deletes the one-shot
+   *   row, so without terminalizing here the half-finished turn is dropped
+   *   with no terminal event and no banner (the user stares at a frozen
+   *   message until they send something new).
    */
   private async _handleRecoveryCallbackError(
     callback: "_chatRecoveryContinue" | "_chatRecoveryRetry",
     data: ChatRecoveryContinueData | ChatRecoveryRetryData | undefined,
     error: unknown
   ): Promise<void> {
-    if (this._isDeployCodeUpdateReset(error)) {
+    if (isPlatformTransientError(error)) {
       const message = error instanceof Error ? error.message : String(error);
-      await this._updateChatRecoveryIncident(
-        data?.incidentId,
-        "failed",
-        message
-      );
-      if (data?.recoveredRequestId) {
-        await this._completeRecoveredSubmission(
-          data.recoveredRequestId,
-          "error",
-          null,
+      try {
+        await this._updateChatRecoveryIncident(
+          data?.incidentId,
+          "failed",
           message
+        );
+      } catch (bookkeepingError) {
+        // Best-effort observability only — in the exact window this branch
+        // fires (deploy reset / storage outage) the incident write itself can
+        // reject; that must not replace the deferral with its own error.
+        console.error(
+          "[Think] failed to mark recovery incident failed before deferring",
+          bookkeepingError
         );
       }
       throw error;
     }
     // Preserve the underlying error for operators — the give-up path records
     // only the `recovery_error` category on the incident / `onExhausted` ctx,
-    // so without this log the actual cause (e.g. a transient storage reject)
-    // would be lost. Mirrors `Agent._executeScheduleCallback`'s own logging.
+    // so without this log the actual cause would be lost. Mirrors
+    // `Agent._executeScheduleCallback`'s own logging.
     console.error(
       `[Think] ${callback} threw during recovery; terminalizing instead of leaving the turn wedged`,
       error


### PR DESCRIPTION
## Summary
- Adds a shared, cause-aware platform-transient classifier in `agents` for reset/supersede messages, retryable platform errors, and `Network connection lost.` through wrapper `cause` chains.
- Preserves one-shot schedule rows when platform transients exhaust in-process retries, so deploy/reset-window failures are re-run by the alarm instead of consumed.
- Updates `@cloudflare/think` and `@cloudflare/ai-chat` recovery give-up paths so transient mid-seal failures defer the whole terminalization instead of half-sealing and dropping durable terminal state.

## Why
Issue #1730 showed `_chatRecoveryContinue` exhausting its retry budget inside a short Durable Object code-update reset window. The failure often surfaced as `SqlError: SQL query failed: Network connection lost.`, which did not match the existing reset classifier and could lose the platform `retryable` flag through wrapping. The callback was then swallowed and the one-shot row deleted milliseconds before storage recovered.

This PR treats that shape as a platform failure rather than an application failure: retry in-process for momentary blips, but if the one-shot budget is exhausted on a platform-transient error, re-throw so the platform preserves and re-delivers the alarm.

## Details
- `agents`
  - Moves `isDurableObjectCodeUpdateReset` into `retries.ts`, makes it cause-aware, and re-exports it from the package root.
  - Adds and exports `isPlatformTransientError`.
  - Keeps immediate deferral for superseded-isolate/code-update reset errors.
  - Adds defer-on-exhaustion for one-shot schedules when the final error is platform-transient.
- `@cloudflare/think`
  - Uses the shared classifier in `_handleRecoveryCallbackError`.
  - Leaves recovered submissions `running` on deferral so the preserved alarm re-run can actually pick them up.
  - Makes incident bookkeeping before deferral best-effort.
  - Seals recovery incidents only after terminal writes complete, preventing half-sealed give-ups.
- `@cloudflare/ai-chat`
  - Applies the same seal-after-terminal-writes ordering for stable-timeout recovery exhaustion.

## Test plan
- `pnpm exec vitest run -r src/tests --testTimeout 30000 -t "" schedule.test retries.test` in `packages/agents`
- `pnpm exec vitest run -r src/tests think-session.test submissions.test` in `packages/think`
- `pnpm exec vitest run -r src/tests durable-chat-recovery.test` in `packages/ai-chat`
- `pnpm run build`
- `pnpm run check`
- `pnpm exec nx run-many -t test -p agents ai-chat think`
  - Initial combined run hit a known flaky unrelated `@cloudflare/think:test` stream-metadata primary-key collision in a `{ persist: false }` recovery test.
  - Re-ran the failing test in isolation successfully.
  - Re-ran full `@cloudflare/think:test` successfully; Nx reported the task as flaky.

Fixes #1730

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->