### PR TITLE
fix(think): skip cancelled queued submission messages

### DIFF
--- a/.changeset/think-cancel-queued-submission.md
+++ b/.changeset/think-cancel-queued-submission.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Prevent cancelled durable submissions from appending their messages when they were already claimed but still waiting behind an active turn.

--- a/docs/think/programmatic-submissions.md
+++ b/docs/think/programmatic-submissions.md
@@ -119,6 +119,10 @@ submitted messages to the conversation `Session` only when the submission starts
 executing. This preserves FIFO turn semantics: later accepted submissions are
 not visible to the model until their own turn starts.
 
+If you cancel a submission before its messages have been applied, including one
+that has been claimed but is still waiting for its turn, those messages are not
+persisted to the conversation.
+
 If the chat is cleared or turn state is reset before a pending submission runs,
 that submission is marked `skipped`.
 

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3518,6 +3518,107 @@ export class ThinkProgrammaticTestAgent extends Think {
     );
   }
 
+  private async _waitForSubmissionForTest(
+    submissionId: string,
+    predicate: (submission: ThinkSubmissionInspection) => boolean
+  ): Promise<ThinkSubmissionInspection> {
+    for (let attempt = 0; attempt < 80; attempt++) {
+      const submission = await this.inspectSubmission(submissionId);
+      if (submission && predicate(submission)) return submission;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    const submission = await this.inspectSubmission(submissionId);
+    if (!submission) {
+      throw new Error(`Submission ${submissionId} was not found`);
+    }
+    return submission;
+  }
+
+  async cancelQueuedRunningSubmissionBeforeSlotForTest(options?: {
+    submissionId?: string;
+    metadata?: Record<string, unknown>;
+    messageTexts?: string[];
+  }): Promise<{
+    submission: ThinkSubmissionInspection | null;
+    messages: UIMessage[];
+    responses: ChatResponseResult[];
+    submissionLog: ThinkSubmissionInspection[];
+    workflowEvents: Array<{
+      workflowName: string;
+      workflowId: string;
+      event: { type: string; payload?: unknown };
+    }>;
+  }> {
+    const previousDelayedChunks = this._delayedChunks;
+    this._delayedChunks = {
+      chunks: ["active ", "turn ", "still ", "running"],
+      delayMs: 50
+    };
+
+    const activeCallback = new TestCollectingCallback();
+    const activeTurn = this.chat("active turn", activeCallback);
+    try {
+      let activeTurnStarted = false;
+      for (let attempt = 0; attempt < 80; attempt++) {
+        const activeUserMessage = (await this.getMessages()).find(
+          (message) =>
+            message.role === "user" &&
+            message.parts.some(
+              (part) => part.type === "text" && part.text === "active turn"
+            )
+        );
+        if (activeUserMessage) {
+          activeTurnStarted = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      if (!activeTurnStarted) {
+        throw new Error("Active turn did not start before queued submission");
+      }
+
+      const submissionId = options?.submissionId ?? "sub-queued-running-cancel";
+      const messageTexts = options?.messageTexts ?? ["queued then cancelled"];
+      await this.submitMessages(
+        messageTexts.map((text, index) => ({
+          id: `${submissionId}-message-${index}`,
+          role: "user" as const,
+          parts: [{ type: "text" as const, text }]
+        })),
+        {
+          submissionId,
+          metadata: options?.metadata
+        }
+      );
+
+      await this._waitForSubmissionForTest(
+        submissionId,
+        (submission) => submission.status === "running"
+      );
+      await this.cancelSubmission(submissionId, "cancelled before queue slot");
+
+      await activeTurn;
+      await (
+        this as unknown as {
+          _turnQueue: { waitForIdle: () => Promise<void> };
+        }
+      )._turnQueue.waitForIdle();
+      await this.drainWorkflowNotificationsForTest();
+
+      return {
+        submission: await this.inspectSubmission(submissionId),
+        messages: await this.getMessages(),
+        responses: this._responseLog,
+        submissionLog: this._submissionLog,
+        workflowEvents: this._workflowEventLog
+      };
+    } finally {
+      this._delayedChunks = previousDelayedChunks;
+      await activeTurn.catch(() => {});
+    }
+  }
+
   async testSubmitMessagesError(
     text: string,
     options?: {

--- a/packages/think/src/tests/submissions.test.ts
+++ b/packages/think/src/tests/submissions.test.ts
@@ -46,6 +46,21 @@ type ThinkSubmissionTestStub = {
       metadata?: Record<string, unknown>;
     }
   ): Promise<SubmitMessagesResult>;
+  cancelQueuedRunningSubmissionBeforeSlotForTest(options?: {
+    submissionId?: string;
+    metadata?: Record<string, unknown>;
+    messageTexts?: string[];
+  }): Promise<{
+    submission: ThinkSubmissionInspection | null;
+    messages: Array<{ id: string; role: string; parts?: unknown[] }>;
+    responses: Array<{ status: string; requestId: string }>;
+    submissionLog: ThinkSubmissionInspection[];
+    workflowEvents: Array<{
+      workflowName: string;
+      workflowId: string;
+      event: { type: string; payload?: unknown };
+    }>;
+  }>;
   testSubmitMessagesError(
     text: string,
     options?: {
@@ -184,6 +199,24 @@ async function waitForWorkflowEvent(
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error("Workflow event was not delivered");
+}
+
+function textParts(messages: Array<{ parts?: unknown[] }>): string[] {
+  return messages.flatMap((message) =>
+    (message.parts ?? []).flatMap((part) => {
+      if (
+        part !== null &&
+        typeof part === "object" &&
+        "type" in part &&
+        "text" in part &&
+        part.type === "text" &&
+        typeof part.text === "string"
+      ) {
+        return [part.text];
+      }
+      return [];
+    })
+  );
 }
 
 describe("Think durable submissions", () => {
@@ -444,6 +477,96 @@ describe("Think durable submissions", () => {
     await expect(
       agent.inspectSubmissionForTest(accepted.submissionId)
     ).resolves.toMatchObject({ status: "aborted" });
+  });
+
+  it("does not append a running submission cancelled before its queued turn slot", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.cancelQueuedRunningSubmissionBeforeSlotForTest({
+      submissionId: "sub-queued-running-cancel"
+    });
+
+    expect(result.submission).toMatchObject({
+      status: "aborted",
+      error: "cancelled before queue slot"
+    });
+    expect(textParts(result.messages)).toContain("active turn");
+    expect(textParts(result.messages)).not.toContain("queued then cancelled");
+    expect(
+      result.messages.filter((message) => message.role === "user")
+    ).toHaveLength(1);
+    expect(
+      result.responses.map((response) => response.requestId)
+    ).not.toContain("sub-queued-running-cancel");
+    expect(result.submissionLog.map((submission) => submission.status)).toEqual(
+      expect.arrayContaining(["pending", "running", "aborted"])
+    );
+  });
+
+  it("does not partially append multi-message submissions cancelled before their queued turn slot", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.cancelQueuedRunningSubmissionBeforeSlotForTest({
+      submissionId: "sub-queued-running-multi-cancel",
+      messageTexts: [
+        "queued cancelled first",
+        "queued cancelled second",
+        "queued cancelled third"
+      ]
+    });
+
+    const persistedTexts = textParts(result.messages);
+    expect(result.submission).toMatchObject({
+      status: "aborted",
+      error: "cancelled before queue slot"
+    });
+    expect(persistedTexts).toContain("active turn");
+    expect(persistedTexts).not.toContain("queued cancelled first");
+    expect(persistedTexts).not.toContain("queued cancelled second");
+    expect(persistedTexts).not.toContain("queued cancelled third");
+    expect(
+      result.messages.filter((message) => message.role === "user")
+    ).toHaveLength(1);
+  });
+
+  it("emits an aborted workflow notification without appending a queued cancelled prompt", async () => {
+    const agent = await freshAgent();
+
+    const result = await agent.cancelQueuedRunningSubmissionBeforeSlotForTest({
+      submissionId: "sub-queued-workflow-cancel",
+      metadata: {
+        [workflowPromptMetadataKey]: {
+          workflow: {
+            name: "TEST_WORKFLOW",
+            id: "workflow-queued-cancel",
+            stepName: "draft-report",
+            eventType: "think-prompt-queued-cancel"
+          },
+          output: { schema: { type: "object" } },
+          fingerprint: "queued-cancel"
+        }
+      }
+    });
+
+    expect(result.submission).toMatchObject({
+      status: "aborted",
+      error: "cancelled before queue slot"
+    });
+    expect(textParts(result.messages)).not.toContain("queued then cancelled");
+    expect(result.workflowEvents).toContainEqual(
+      expect.objectContaining({
+        workflowName: "TEST_WORKFLOW",
+        workflowId: "workflow-queued-cancel",
+        event: {
+          type: "think-prompt-queued-cancel",
+          payload: {
+            submissionId: "sub-queued-workflow-cancel",
+            status: "aborted",
+            error: "cancelled before queue slot"
+          }
+        }
+      })
+    );
   });
 
   it("aborts a pending submission without running it", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -6118,6 +6118,8 @@ export class Think<
           captureProgrammaticStreamError: true,
           captureOutput: Boolean(workflowPrompt?.output),
           workflowPrompt: workflowPrompt ?? undefined,
+          shouldApplyMessages: () =>
+            this._readSubmission(row.submission_id)?.status === "running",
           onMessagesApplied: () => {
             this.sql`
               UPDATE cf_think_submissions
@@ -6153,17 +6155,13 @@ export class Think<
           WHERE submission_id = ${row.submission_id}
             AND status = 'running'
         `;
-        this._insertWorkflowNotification(
-          {
-            ...this._inspectionFromSubmissionRow(claimed),
-            requestId: result.requestId,
-            status: finalStatus,
-            error:
-              finalStatus === "error" ? (errorMessage ?? undefined) : undefined,
-            completedAt
-          },
-          output
-        );
+        const finalized = this._readSubmission(row.submission_id);
+        if (finalized && this._isTerminalSubmissionStatus(finalized.status)) {
+          this._insertWorkflowNotification(
+            this._inspectionFromSubmissionRow(finalized),
+            output
+          );
+        }
       });
     } catch (error) {
       const errorMessage =
@@ -6178,12 +6176,12 @@ export class Think<
           WHERE submission_id = ${row.submission_id}
             AND status = 'running'
         `;
-        this._insertWorkflowNotification({
-          ...this._inspectionFromSubmissionRow(claimed),
-          status: "error",
-          error: errorMessage,
-          completedAt
-        });
+        const finalized = this._readSubmission(row.submission_id);
+        if (finalized && this._isTerminalSubmissionStatus(finalized.status)) {
+          this._insertWorkflowNotification(
+            this._inspectionFromSubmissionRow(finalized)
+          );
+        }
       });
     } finally {
       this._programmaticStreamErrors.delete(requestId);
@@ -6458,6 +6456,7 @@ export class Think<
       captureOutput?: boolean;
       body?: Record<string, unknown>;
       workflowPrompt?: ThinkWorkflowPromptContext;
+      shouldApplyMessages?: () => boolean | Promise<boolean>;
     }
   ): Promise<ProgrammaticMessagesResult> {
     const clientTools = this._lastClientTools;
@@ -6470,6 +6469,19 @@ export class Think<
 
     await this.keepAliveWhile(async () => {
       await this._turnQueue.enqueue(requestId, async () => {
+        if (this._turnQueue.generation !== epoch) {
+          status = "skipped";
+          return;
+        }
+
+        if (
+          options?.shouldApplyMessages &&
+          !(await options.shouldApplyMessages())
+        ) {
+          status = "aborted";
+          return;
+        }
+
         const resolved =
           typeof messages === "function"
             ? await messages(this.messages)
@@ -6477,6 +6489,14 @@ export class Think<
 
         if (this._turnQueue.generation !== epoch) {
           status = "skipped";
+          return;
+        }
+
+        if (
+          options?.shouldApplyMessages &&
+          !(await options.shouldApplyMessages())
+        ) {
+          status = "aborted";
           return;
         }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/cloudflare/agents/issues/1731.

Durable submissions can be claimed as `running` while their programmatic turn is still queued behind an active turn. Before this change, `cancelSubmission()` could mark that row `aborted`, but the already-enqueued turn closure still appended the submission's messages when its slot arrived. That produced orphan user messages in the transcript that were broadcast to clients but never answered.

This PR closes that race by:

- Adding an internal `shouldApplyMessages` guard to `_runProgrammaticMessagesTurn()` and wiring durable submissions to re-read their row before resolving/appending messages.
- Re-checking after async message resolution, so a submission cancelled while messages are being prepared still aborts before persistence.
- Re-reading the finalized submission row before inserting workflow notifications, so cancellation races do not produce stale `completed` or `error` workflow payloads.
- Documenting that cancelling before messages are applied keeps those messages out of the conversation.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm --filter @cloudflare/think run test`
- [x] Regression test: running submission cancelled before its queued turn slot does not append its prompt.
- [x] Regression test: multi-message submission cancelled before its queued turn slot does not partially append.
- [x] Regression test: workflow-backed queued cancellation emits an `aborted` workflow notification without appending the prompt.

Note: I previously attempted the Think e2e command while investigating this issue, but that run hung in local Vitest startup and was killed. The package-level Think test suite above passed on this branch.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->