### PR TITLE
fix(agents): defer agent teardown to its own alarm invocation so canceled requests can't cut it short

### DIFF
--- a/.changeset/deferred-destroy-alarm-teardown.md
+++ b/.changeset/deferred-destroy-alarm-teardown.md
@@ -1,0 +1,11 @@
+---
+"agents": patch
+---
+
+Make agent teardown reliable when the initiating request is already canceled (#1625).
+
+The MCP Streamable-HTTP session-DELETE handler ran `agent.destroy()` via the request's `ctx.waitUntil`. By the time the DELETE lands the client is usually gone, the runtime gives a canceled request's trailing work little to no grace, and the multi-step teardown (drop tables, delete alarm, delete all storage, dispose connections) was routinely cut short — leaving half-deleted session DOs whose tables the constructor silently recreated on the next wake. (The associated `waitUntil() tasks did not complete` log warning itself originates inside workerd's WebSocket handling and is unaffected by this change.)
+
+Teardown is now deferred to the agent's own alarm invocation. The DELETE handler awaits two fast storage writes — a durable "condemned" marker plus an immediate alarm — and responds 204; the alarm then runs the real `destroy()` with a fresh execution budget. The marker is removed by the final `deleteAll()`, so it survives any interruption: `alarm()` checks it before any other work (including `onStart`) and finishes the teardown instead of resuming normal operation on a condemned agent, and `_scheduleNextAlarm()` keeps the destroy alarm armed rather than deleting it as "no work pending". `destroy()` itself now writes the marker first, so a direct destroy that gets interrupted converges the same way.
+
+New internal API: `Agent._cf_scheduleDestroy()` (used by the MCP handler; unlike `destroy()` it does not abort the isolate, so callers don't need to swallow an abort error). No public API or storage-schema changes; the marker is a single internal KV record (`cf_agents_destroy_pending`).

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -938,7 +938,25 @@ const DEFAULT_AGENT_TOOL_RECOVERY_TOTAL_TIMEOUT_MS = 5_000;
 // with its own execution budget, #1625). The final `deleteAll()` in `destroy()`
 // removes it, so "marker present" always means an unfinished teardown that the
 // next wake must complete instead of resuming normal work.
+//
+// Scope: the marker is only consulted on alarm-driven paths (`alarm()` and
+// `_scheduleNextAlarm()`). It deliberately does NOT gate request entrypoints
+// (`onRequest`/`onMessage`/RPC) — a request that lands between scheduling and
+// the teardown alarm runs normally and `_ensureSchema()` recreates tables. For
+// the MCP session-DELETE use case this is benign: the session id is unique and
+// is never addressed again after DELETE, so no further request reaches a
+// condemned session DO before its teardown alarm fires.
 const DESTROY_PENDING_KEY = "cf_agents_destroy_pending";
+// Delay before the deferred-teardown alarm fires (#1625). `_cf_scheduleDestroy`
+// is awaited by an HTTP handler (the MCP session-DELETE) that then returns its
+// response. The teardown alarm runs `destroy()`, which ends in
+// `ctx.abort("destroyed")` — and an immediate (`Date.now()`) alarm fires and
+// aborts the isolate fast enough to race the still-in-flight RPC response,
+// surfacing to the caller as a 500 instead of the intended 204 (observed
+// against a real deployment; the local test runtime does not exhibit it). A
+// small delay lets the response flush before the abort. Teardown latency of a
+// second is irrelevant for an already-abandoned session.
+const DESTROY_ALARM_DELAY_MS = 1_000;
 // Ceiling for the exponential backoff applied to the runFiber-recovery
 // follow-up alarm. A scan that makes NO forward progress (every pending orphan
 // row's recovery hook threw) but still has work pending backs off so a poison
@@ -9513,15 +9531,29 @@ export class Agent<
    * callers don't need to swallow an abort error.
    */
   async _cf_scheduleDestroy(): Promise<void> {
+    // Hydrate facet state before deciding. `_isFacet` (and the `_parentPath`
+    // /`selfPath` the facet teardown path needs) is only populated by `onStart`
+    // /facet bootstrap, and `destroy()` below branches on the in-memory
+    // `_isFacet`. Without this, an RPC landing before init would see it as
+    // `false`, fall through to `destroy()`'s top-level path, and write the
+    // destroy marker on a facet — which the `alarm()`/`_scheduleNextAlarm()`
+    // guards forbid (only top-level agents write it; facet teardown is
+    // root-coordinated via `ctx.facets.delete`). Mirrors the other internal
+    // RPC entrypoints (`_workflow_*`). We must NOT push this into `destroy()`
+    // itself: the `alarm()` preamble calls `destroy()` precisely to avoid
+    // running `onStart` on a condemned agent.
+    await this.__unsafe_ensureInitialized();
     if (this._isFacet) {
-      // Facet teardown is coordinated by the root (`ctx.facets.delete`
-      // wipes the facet's storage in one step), not by a multi-step local
-      // sequence, so there is nothing to defer.
+      // Facet teardown is coordinated by the root (`ctx.facets.delete` wipes
+      // the facet's storage in one step), so there is nothing to defer.
       await this.destroy();
       return;
     }
     await this.ctx.storage.put(DESTROY_PENDING_KEY, true);
-    await this.ctx.storage.setAlarm(Date.now());
+    // Future, not immediate: see DESTROY_ALARM_DELAY_MS — an immediate alarm
+    // aborts the isolate fast enough to race this RPC's response back to the
+    // DELETE handler, turning the intended 204 into a 500.
+    await this.ctx.storage.setAlarm(Date.now() + DESTROY_ALARM_DELAY_MS);
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -933,6 +933,12 @@ export type AddRpcMcpServerOptions = {
 const DEFAULT_KEEP_ALIVE_INTERVAL_MS = 30_000;
 const DEFAULT_AGENT_TOOL_RECOVERY_TIMEOUT_MS = 2_000;
 const DEFAULT_AGENT_TOOL_RECOVERY_TOTAL_TIMEOUT_MS = 5_000;
+// Durable marker that this agent is condemned: written before teardown begins
+// (and by `_cf_scheduleDestroy`, which defers teardown to an alarm invocation
+// with its own execution budget, #1625). The final `deleteAll()` in `destroy()`
+// removes it, so "marker present" always means an unfinished teardown that the
+// next wake must complete instead of resuming normal work.
+const DESTROY_PENDING_KEY = "cf_agents_destroy_pending";
 // Ceiling for the exponential backoff applied to the runFiber-recovery
 // follow-up alarm. A scan that makes NO forward progress (every pending orphan
 // row's recovery hook threw) but still has work pending backs off so a poison
@@ -5958,6 +5964,14 @@ export class Agent<
   }
 
   private async _scheduleNextAlarm() {
+    // A pending destroy (#1625) owns the alarm: keep it armed immediately so
+    // teardown lands, and never let the "no work pending" branch below
+    // delete it out from under `_cf_scheduleDestroy`.
+    if (await this._hasPendingDestroy()) {
+      await this.ctx.storage.setAlarm(Date.now());
+      return;
+    }
+
     const nowMs = Date.now();
     const nowSeconds = Math.floor(nowMs / 1000);
     const hungCutoffSeconds =
@@ -6087,6 +6101,18 @@ export class Agent<
    * See {@link https://developers.cloudflare.com/agents/api-reference/schedule-tasks/}
    */
   async alarm() {
+    // A pending destroy (#1625) pre-empts everything — including
+    // `super.alarm()`'s onStart, which would re-initialize user state on a
+    // condemned agent. This is both the landing point for the deferred
+    // teardown scheduled by `_cf_scheduleDestroy` (which arms an immediate
+    // alarm precisely so teardown runs here, with this invocation's full
+    // execution budget) and the convergence point for a destroy that a
+    // previous invocation started but couldn't finish.
+    if (await this._hasPendingDestroy()) {
+      await this.destroy();
+      return;
+    }
+
     // Ensure PartyServer initialization (name resolution, onStart) runs
     // before processing any scheduled tasks.
     await super.alarm();
@@ -9438,6 +9464,15 @@ export class Agent<
       return;
     }
 
+    // Persist the teardown decision FIRST, so a destroy that gets cut short
+    // (e.g. the runtime cancelling a request-scoped `waitUntil` it was riding
+    // on, #1625) is finished by the next wake — see the `alarm()` preamble —
+    // instead of leaving a half-deleted agent whose tables get silently
+    // recreated by the constructor. The marker is removed by the
+    // `deleteAll()` below, which is also why it is a KV record rather than a
+    // SQL row: it must outlive `_dropInternalTablesForDestroy`.
+    await this.ctx.storage.put(DESTROY_PENDING_KEY, true);
+
     this._dropInternalTablesForDestroy();
 
     // delete all alarms
@@ -9456,6 +9491,46 @@ export class Agent<
     }, 0);
 
     this._emit("destroy");
+  }
+
+  /**
+   * @internal Defer this agent's destruction to its own alarm invocation
+   * instead of running it inline (#1625).
+   *
+   * `destroy()` is a multi-step I/O sequence (drop tables, delete alarm,
+   * delete all storage, dispose connections). Running it on the `waitUntil`
+   * of a request whose client has already disconnected — the MCP
+   * Streamable-HTTP session-DELETE path — gives it little to no
+   * post-invocation grace, so the runtime routinely cancels it mid-flight.
+   * This method instead performs two fast storage writes (a durable
+   * "condemned" marker and an immediate alarm) that the caller can await
+   * before responding; the alarm then fires as a fresh invocation with its
+   * own full execution budget and runs `destroy()` there. If even that
+   * invocation is interrupted, the marker survives and the next wake
+   * finishes teardown — see the `alarm()` preamble.
+   *
+   * Unlike `destroy()`, this method does not abort the isolate, so RPC
+   * callers don't need to swallow an abort error.
+   */
+  async _cf_scheduleDestroy(): Promise<void> {
+    if (this._isFacet) {
+      // Facet teardown is coordinated by the root (`ctx.facets.delete`
+      // wipes the facet's storage in one step), not by a multi-step local
+      // sequence, so there is nothing to defer.
+      await this.destroy();
+      return;
+    }
+    await this.ctx.storage.put(DESTROY_PENDING_KEY, true);
+    await this.ctx.storage.setAlarm(Date.now());
+  }
+
+  /**
+   * Whether a (deferred or interrupted) destroy is pending. Reads the
+   * durable marker directly — the in-memory `_isFacet` flag may not be
+   * hydrated yet at the call sites, but facets never write the marker.
+   */
+  private async _hasPendingDestroy(): Promise<boolean> {
+    return (await this.ctx.storage.get<boolean>(DESTROY_PENDING_KEY)) === true;
   }
 
   /** @internal Drop every internal Agents SDK table during top-level destroy. */

--- a/packages/agents/src/mcp/utils.ts
+++ b/packages/agents/src/mcp/utils.ts
@@ -501,13 +501,16 @@ export const createStreamingHttpHandler = (
             { status: 404, headers: corsHeaders(request, options.corsOptions) }
           );
         }
-        // .destroy() passes an uncatchable Error, so we make sure we first return
-        // the response to the client.
-        ctx.waitUntil(
-          agent.destroy().catch(() => {
-            /* This will always throw. We silently catch here */
-          })
-        );
+        // Defer the actual teardown to the agent's own alarm invocation
+        // (#1625). Running `destroy()` on this request's `waitUntil` was
+        // unreliable: the client is usually already gone by the time the
+        // DELETE lands, the runtime gives a canceled request's trailing
+        // work little to no grace, and the multi-step teardown got cut
+        // short — leaving half-deleted session DOs. Scheduling is two fast
+        // storage writes, so it is awaited before responding; the alarm
+        // then runs the real teardown with a fresh execution budget and a
+        // durable marker that survives any further interruption.
+        await agent._cf_scheduleDestroy();
         return new Response(null, {
           status: 204,
           headers: corsHeaders(request, options.corsOptions)

--- a/packages/agents/src/tests/deferred-destroy.test.ts
+++ b/packages/agents/src/tests/deferred-destroy.test.ts
@@ -1,0 +1,190 @@
+import { env } from "cloudflare:workers";
+import {
+  createExecutionContext,
+  runDurableObjectAlarm,
+  runInDurableObject
+} from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import { getAgentByName } from "..";
+import { TestMcpJurisdiction } from "./worker";
+import type { Agent } from "..";
+
+/**
+ * #1625: teardown must not ride the initiating request's `waitUntil` (the
+ * runtime gives a canceled request's trailing work little to no grace, so a
+ * multi-step destroy() got cut short, leaving half-deleted session DOs).
+ * `_cf_scheduleDestroy` instead persists a "condemned" marker + an immediate
+ * alarm; the alarm invocation runs the real teardown with its own budget, and
+ * the marker survives any interruption so the next wake converges.
+ */
+
+const DESTROY_PENDING_KEY = "cf_agents_destroy_pending";
+
+/**
+ * Assert (with retries) that teardown fully completed for the named agent:
+ * the condemned marker is gone (it is removed by the final deleteAll, so
+ * "marker gone" === "teardown finished") and no alarm remains armed.
+ *
+ * `destroy()` ends by aborting the isolate, which poisons any stub created
+ * before the abort — so every retry resolves a FRESH stub.
+ */
+async function expectTeardownCompleted(
+  namespace: DurableObjectNamespace<Agent<Cloudflare.Env>>,
+  name: string
+): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const stub = await getAgentByName(namespace, name);
+      await runInDurableObject(stub, async (_instance, ctx) => {
+        expect(await ctx.storage.get(DESTROY_PENDING_KEY)).toBeUndefined();
+        expect(await ctx.storage.getAlarm()).toBeNull();
+      });
+    },
+    { timeout: 10_000 }
+  );
+}
+
+const scheduleAgentNs = () =>
+  env.TestScheduleAgent as unknown as DurableObjectNamespace<
+    Agent<Cloudflare.Env>
+  >;
+
+describe("deferred destroy (#1625)", () => {
+  it("_cf_scheduleDestroy tears the agent down via its own alarm invocation", async () => {
+    const name = crypto.randomUUID();
+    const stub = await getAgentByName(env.TestScheduleAgent, name);
+    // Seed durable state so there is something to tear down.
+    await stub.schedule(86400, "testCallback", undefined);
+    expect(await stub.getSchedules()).toHaveLength(1);
+
+    await stub._cf_scheduleDestroy();
+
+    // The immediate alarm auto-fires and completes the teardown.
+    await expectTeardownCompleted(scheduleAgentNs(), name);
+    const fresh = await getAgentByName(env.TestScheduleAgent, name);
+    expect(await fresh.getSchedules()).toHaveLength(0);
+  });
+
+  it("a pending destroy pre-empts alarm work and converges from a half-torn state", async () => {
+    const name = crypto.randomUUID();
+    const stub = await getAgentByName(env.TestScheduleAgent, name);
+    // Seed a due schedule that an ordinary alarm cycle would execute.
+    await stub.schedule(0, "intervalCallback", undefined);
+
+    // Simulate a destroy that a previous invocation started but couldn't
+    // finish (#1625): some internal tables already dropped, the durable
+    // marker still present. The alarm is set in the future so it cannot
+    // auto-fire before we trigger it deterministically.
+    await runInDurableObject(stub, async (instance, ctx) => {
+      const agent = instance as unknown as {
+        sql: (
+          strings: TemplateStringsArray,
+          ...values: (string | number | boolean | null)[]
+        ) => unknown;
+      };
+      agent.sql`DROP TABLE IF EXISTS cf_agents_schedules`;
+      agent.sql`DROP TABLE IF EXISTS cf_agents_queues`;
+      await ctx.storage.put(DESTROY_PENDING_KEY, true);
+      await ctx.storage.setAlarm(Date.now() + 86_400_000);
+    });
+
+    // The next wake finishes the teardown instead of resuming normal work
+    // (running schedules, re-arming) on the condemned agent. destroy()
+    // aborts the isolate as its final step, so the abort may land before
+    // the test helper's stub call returns — swallow exactly that error.
+    await runDurableObjectAlarm(stub).catch((error) => {
+      if (!String(error).includes("destroyed")) throw error;
+    });
+
+    await expectTeardownCompleted(scheduleAgentNs(), name);
+    const fresh = await getAgentByName(env.TestScheduleAgent, name);
+    expect(await fresh.getSchedules()).toHaveLength(0);
+  });
+
+  it("_scheduleNextAlarm keeps the destroy alarm armed instead of deleting it as no-work", async () => {
+    const stub = await getAgentByName(
+      env.TestScheduleAgent,
+      crypto.randomUUID()
+    );
+    // No schedules, no keepAlive leases — without the pending-destroy guard,
+    // _scheduleNextAlarm's "no work pending" branch would delete the alarm
+    // armed by _cf_scheduleDestroy and the teardown would never land.
+    await runInDurableObject(stub, async (instance, ctx) => {
+      await ctx.storage.put(DESTROY_PENDING_KEY, true);
+      await ctx.storage.setAlarm(Date.now() + 86_400_000);
+      await (
+        instance as unknown as { _scheduleNextAlarm(): Promise<void> }
+      )._scheduleNextAlarm();
+      expect(await ctx.storage.getAlarm()).not.toBeNull();
+      // Leave no pending destroy behind for this DO (the test asserts the
+      // guard only): clear the marker and alarm.
+      await ctx.storage.delete(DESTROY_PENDING_KEY);
+      await ctx.storage.deleteAlarm();
+    });
+  });
+
+  it("a direct destroy leaves no marker behind (clean completion)", async () => {
+    const name = crypto.randomUUID();
+    const stub = await getAgentByName(env.TestScheduleAgent, name);
+    await stub.schedule(86400, "testCallback", undefined);
+
+    // destroy() aborts the isolate after completing, so the RPC may reject.
+    await (stub.destroy() as Promise<void>).catch(() => {});
+
+    await expectTeardownCompleted(scheduleAgentNs(), name);
+  });
+
+  it("MCP streamable-http session DELETE condemns the session DO and teardown completes", async () => {
+    const handler = TestMcpJurisdiction.serve("/mcp", {
+      binding: "TEST_MCP_JURISDICTION",
+      transport: "streamable-http"
+    });
+
+    // Initialize a session.
+    const initResponse = await handler.fetch(
+      new Request("http://example.com/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream"
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "1",
+          method: "initialize",
+          params: {
+            capabilities: {},
+            clientInfo: { name: "test", version: "1.0" },
+            protocolVersion: "2025-03-26"
+          }
+        })
+      }),
+      env,
+      createExecutionContext()
+    );
+    expect(initResponse.status).toBe(200);
+    const sessionId = initResponse.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    // End the session. The handler awaits the (fast) destroy scheduling —
+    // NOT the teardown itself — before responding, so a canceled client
+    // request can no longer cut the teardown short.
+    const deleteResponse = await handler.fetch(
+      new Request("http://example.com/mcp", {
+        method: "DELETE",
+        headers: { "mcp-session-id": sessionId! }
+      }),
+      env,
+      createExecutionContext()
+    );
+    expect(deleteResponse.status).toBe(204);
+
+    // The session DO's own alarm invocation completes the teardown.
+    await expectTeardownCompleted(
+      env.TEST_MCP_JURISDICTION as unknown as DurableObjectNamespace<
+        Agent<Cloudflare.Env>
+      >,
+      `streamable-http:${sessionId}`
+    );
+  });
+});

--- a/packages/agents/src/tests/deferred-destroy.test.ts
+++ b/packages/agents/src/tests/deferred-destroy.test.ts
@@ -123,6 +123,40 @@ describe("deferred destroy (#1625)", () => {
     });
   });
 
+  it("_scheduleNextAlarm keeps the destroy alarm immediate even while a keepAlive lease is held", async () => {
+    const stub = await getAgentByName(
+      env.TestScheduleAgent,
+      crypto.randomUUID()
+    );
+    // With an active keepAlive ref (and no pending destroy), _scheduleNextAlarm
+    // would push the alarm out to now + keepAliveIntervalMs. The pending-destroy
+    // guard must win so teardown still lands immediately instead of waiting a
+    // full heartbeat — otherwise a keepAlive-holding agent delays its own
+    // condemnation by up to keepAliveIntervalMs each reschedule.
+    await runInDurableObject(stub, async (instance, ctx) => {
+      const agent = instance as unknown as {
+        _keepAliveRefs: number;
+        _scheduleNextAlarm(): Promise<void>;
+      };
+      agent._keepAliveRefs = 1;
+      await ctx.storage.put(DESTROY_PENDING_KEY, true);
+      await ctx.storage.setAlarm(Date.now() + 86_400_000);
+
+      const before = Date.now();
+      await agent._scheduleNextAlarm();
+      const alarm = await ctx.storage.getAlarm();
+      expect(alarm).not.toBeNull();
+      // Immediate (within a small window of `before`), NOT pushed out to the
+      // keepAlive horizon (default 30s).
+      expect(alarm! - before).toBeLessThan(5_000);
+
+      // Leave nothing pending behind for this DO.
+      agent._keepAliveRefs = 0;
+      await ctx.storage.delete(DESTROY_PENDING_KEY);
+      await ctx.storage.deleteAlarm();
+    });
+  });
+
   it("a direct destroy leaves no marker behind (clean completion)", async () => {
     const name = crypto.randomUUID();
     const stub = await getAgentByName(env.TestScheduleAgent, name);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3964,6 +3964,34 @@ importers:
         specifier: '*'
         version: link:../../packages/voice
 
+  wip/issue-1625-live:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      agents:
+        specifier: '*'
+        version: link:../../packages/agents
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260612.1
+        version: 4.20260612.1
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      wrangler:
+        specifier: ^4.100.0
+        version: 4.100.0(@cloudflare/workers-types@4.20260612.1)
+
   wip/issue-1677-minimal:
     devDependencies:
       '@cloudflare/workers-types':

--- a/wip/issue-1625-live/.gitignore
+++ b/wip/issue-1625-live/.gitignore
@@ -1,0 +1,5 @@
+.dev.vars
+.wrangler
+env.d.ts
+node_modules
+dist

--- a/wip/issue-1625-live/README.md
+++ b/wip/issue-1625-live/README.md
@@ -1,0 +1,91 @@
+# issue-1625-live — real-deploy MCP teardown repro
+
+Verifies the [#1625](https://github.com/cloudflare/agents/issues/1625) fix
+against a **real Cloudflare deployment**. The bug only manifested in production:
+the MCP Streamable-HTTP session-DELETE handler ran `agent.destroy()` on the
+front Worker's `ctx.waitUntil`, and because the client has usually already
+disconnected by the time a DELETE lands, the runtime gave that trailing task
+little to no grace and cancelled the multi-step teardown mid-flight — leaving a
+half-deleted "zombie" session DO whose tables the constructor silently recreated
+on the next wake.
+
+The local `vitest-pool-workers` runtime **does not cancel `waitUntil`**, which
+is exactly why the unit tests can't reproduce the original defect. This harness
+exercises the real path on deployed infra.
+
+## How it detects a zombie
+
+A clean teardown calls `ctx.storage.deleteAll()`, so re-addressing the session
+afterwards constructs a **fresh** DO whose `state.counter` is back to
+`initialState` (1). A zombie keeps whatever counter was there — the
+constructor's `CREATE TABLE IF NOT EXISTS` does not overwrite a surviving
+`state` row. The harness seeds a sentinel counter (default 7) before DELETE and
+then polls until the session reports `counter === 1`, no condemned marker, no
+alarm, and not `initialized`.
+
+## What it does
+
+1. `POST initialize` → obtain an `mcp-session-id`.
+2. Seed `state.counter` to the sentinel via `/introspect?action=seed`.
+3. Probe to confirm the sentinel stuck and the session is `initialized`.
+4. `DELETE` the session. With `--abort`, the client connection is dropped right
+   after the request is sent — the disconnected-client condition behind #1625.
+5. Poll `/introspect?action=probe` until the session DO is fully wiped, or fail
+   if it stays a zombie past `--timeout`.
+
+## Setup
+
+```bash
+pnpm install      # from repo root (workspace)
+wrangler login    # deploys to your account
+```
+
+## Run
+
+From `wip/issue-1625-live`:
+
+```bash
+# Deploy, run the check, then tear the worker back down:
+pnpm run repro -- --deploy --cleanup
+
+# Deploy once and leave it up (re-run against it, watch logs):
+pnpm run repro -- --deploy
+pnpm run repro -- --url https://issue-1625-live.<you>.workers.dev --abort
+pnpm run tail     # live logs: shows `[1625] DELETE …` and `[1625] alarm: … teardown`
+```
+
+Flags:
+
+- `--deploy` — run `wrangler deploy` first and use the resulting `*.workers.dev` URL.
+- `--url <url>` — run against an already-deployed worker (skip deploy).
+- `--cleanup` — `wrangler delete` the worker after the run (only with `--deploy`).
+- `--abort` — abort the DELETE client-side ~50ms after sending (simulates the
+  disconnected client that starved the old `waitUntil(destroy())`).
+- `--sentinel <n>` — seeded counter value (default 7).
+- `--timeout <ms>` — how long to wait for convergence (default 30000).
+- `--poll <ms>` — probe interval (default 1000).
+
+Exit code: `0` = PASS (teardown converged), `1` = FAIL (zombie/stuck teardown),
+`2` = setup error (no URL, init failed, seed didn't take).
+
+## Interpreting a failure
+
+- **counter still holds the sentinel** → the #1625 zombie: storage survived a
+  cut-short teardown.
+- **marker still present** → teardown started but the alarm is stuck; check
+  `pnpm run tail` for errors thrown inside the destroy alarm.
+
+## A/B against the unfixed package
+
+To watch it fail on the old behavior, point this package's `agents` dependency
+at a pre-fix build (e.g. a `pkg.pr.new` URL for a commit before this PR, or the
+last published version), `pnpm install`, redeploy, and run with `--abort`. The
+sentinel should stick (zombie). Then restore `agents: "*"` and confirm it
+converges.
+
+## Notes
+
+- Verification harness (`wip/`), not part of CI.
+- `--abort` is the most faithful reproduction of the original trigger, but even
+  a plain DELETE exercises the fixed path (teardown now runs in the agent's own
+  alarm with a durable marker rather than on the request's `waitUntil`).

--- a/wip/issue-1625-live/package.json
+++ b/wip/issue-1625-live/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@cloudflare/agents-issue-1625-live",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "repro": "tsx scripts/repro.ts",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "delete": "wrangler delete",
+    "types": "wrangler types env.d.ts --include-runtime false",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "agents": "*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260612.1",
+    "@types/node": "^25.9.3",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
+    "wrangler": "^4.100.0"
+  }
+}

--- a/wip/issue-1625-live/scripts/repro.ts
+++ b/wip/issue-1625-live/scripts/repro.ts
@@ -1,0 +1,293 @@
+/**
+ * Live #1625 teardown repro orchestrator.
+ *
+ * Drives a REAL deployed `McpAgent` through the Streamable-HTTP session
+ * lifecycle and verifies the session DELETE durably tears the session DO down —
+ * the production failure mode the local test runtime cannot reproduce (it never
+ * cancels `waitUntil`).
+ *
+ *   1. POST `initialize` -> obtain an mcp-session-id.
+ *   2. Seed the session DO's `state.counter` to a sentinel (default 7) via the
+ *      worker's `/introspect?action=seed` route.
+ *   3. Probe: confirm the sentinel stuck and the session is `initialized`.
+ *   4. DELETE the session. With `--abort`, the client connection is aborted
+ *      right after the request is sent, mimicking the disconnected client that
+ *      used to cut the old `waitUntil(destroy())` short.
+ *   5. Poll `/introspect?action=probe` until the session DO is fully wiped
+ *      (counter back to initialState 1, no condemned marker, no alarm, not
+ *      initialized) — or fail if it stays a zombie past the timeout.
+ *
+ * Run (from wip/issue-1625-live):
+ *   pnpm run repro -- --deploy                 # deploy, test, leave it up
+ *   pnpm run repro -- --deploy --cleanup       # deploy, test, then delete it
+ *   pnpm run repro -- --url https://issue-1625-live.<you>.workers.dev
+ *   pnpm run repro -- --url <...> --abort      # simulate the disconnected client
+ *
+ * Exit code: 0 = PASS (teardown converged), 1 = FAIL (zombie/stuck), 2 = setup
+ * error (couldn't init the session, no URL, etc.).
+ */
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = path.resolve(__dirname, "..");
+
+type Args = {
+  url: string | null;
+  deploy: boolean;
+  cleanup: boolean;
+  abort: boolean;
+  sentinel: number;
+  timeoutMs: number;
+  pollMs: number;
+};
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const has = (name: string) => argv.includes(`--${name}`);
+  const get = (name: string, fallback: string): string => {
+    const i = argv.indexOf(`--${name}`);
+    return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+  };
+  return {
+    url: argv.includes("--url") ? get("url", "") : null,
+    deploy: has("deploy"),
+    cleanup: has("cleanup"),
+    abort: has("abort"),
+    sentinel: Number(get("sentinel", "7")),
+    timeoutMs: Number(get("timeout", "30000")),
+    pollMs: Number(get("poll", "1000"))
+  };
+}
+
+const args = parseArgs();
+
+function log(msg: string): void {
+  console.log(`[repro] ${msg}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function deployAndResolveUrl(): string {
+  log("deploying with `wrangler deploy`…");
+  const out = execSync("npx wrangler deploy", {
+    cwd: PKG_DIR,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"]
+  });
+  process.stdout.write(out);
+  const match = out.match(/https:\/\/[^\s]*\.workers\.dev/);
+  if (!match) {
+    throw new Error(
+      "could not find a *.workers.dev URL in `wrangler deploy` output"
+    );
+  }
+  return match[0];
+}
+
+function cleanupDeployment(): void {
+  log("deleting worker with `wrangler delete`…");
+  try {
+    // Feed "y" to the confirmation prompt so this works in a non-TTY shell.
+    execSync("npx wrangler delete --name issue-1625-live", {
+      cwd: PKG_DIR,
+      input: "y\n",
+      stdio: ["pipe", "inherit", "inherit"]
+    });
+  } catch (err) {
+    log(`cleanup failed (delete it manually): ${String(err)}`);
+  }
+}
+
+/** Poll the health route until the worker is reachable (covers post-deploy
+ * propagation lag, which otherwise 404s the first request). */
+async function waitForReady(baseUrl: string): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/health`);
+      await res.body?.cancel();
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await sleep(1000);
+  }
+  throw new Error(`worker at ${baseUrl} did not become ready`);
+}
+
+/** POST an MCP `initialize` and return the assigned session id. */
+async function mcpInitialize(baseUrl: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream"
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "1",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "issue-1625-repro", version: "1.0" },
+        protocolVersion: "2025-03-26"
+      }
+    })
+  });
+  const sessionId = res.headers.get("mcp-session-id");
+  // Drain the body so the connection can be reused/closed cleanly.
+  await res.body?.cancel();
+  if (res.status !== 200 || !sessionId) {
+    throw new Error(
+      `initialize failed: status=${res.status} session=${sessionId}`
+    );
+  }
+  return sessionId;
+}
+
+type TeardownProbe = {
+  counter: number;
+  markerPresent: boolean;
+  hasAlarm: boolean;
+  initialized: boolean;
+};
+
+async function seed(
+  baseUrl: string,
+  session: string,
+  counter: number
+): Promise<void> {
+  const res = await fetch(
+    `${baseUrl}/introspect?action=seed&session=${encodeURIComponent(session)}&counter=${counter}`
+  );
+  if (!res.ok) throw new Error(`seed failed: status=${res.status}`);
+  await res.body?.cancel();
+}
+
+async function probe(baseUrl: string, session: string): Promise<TeardownProbe> {
+  const res = await fetch(
+    `${baseUrl}/introspect?action=probe&session=${encodeURIComponent(session)}`
+  );
+  if (!res.ok) throw new Error(`probe failed: status=${res.status}`);
+  return (await res.json()) as TeardownProbe;
+}
+
+/** DELETE the session. With `abort`, drop the client connection right after the
+ * request is dispatched — the disconnected-client condition behind #1625. */
+async function deleteSession(
+  baseUrl: string,
+  session: string,
+  abort: boolean
+): Promise<number | "aborted"> {
+  const controller = new AbortController();
+  const req = fetch(`${baseUrl}/mcp`, {
+    method: "DELETE",
+    headers: { "mcp-session-id": session },
+    signal: controller.signal
+  });
+  if (abort) {
+    // Give the request just enough time to leave the client, then bail — the
+    // server keeps processing but the client is gone, exactly the case that
+    // starved the old `waitUntil(destroy())`.
+    setTimeout(() => controller.abort(), 50);
+  }
+  try {
+    const res = await req;
+    const status = res.status;
+    await res.body?.cancel();
+    return status;
+  } catch (err) {
+    if (controller.signal.aborted) return "aborted";
+    throw err;
+  }
+}
+
+function tornDown(p: TeardownProbe): boolean {
+  return p.counter === 1 && !p.markerPresent && !p.hasAlarm && !p.initialized;
+}
+
+async function main(): Promise<number> {
+  let baseUrl = args.url;
+  if (!baseUrl && args.deploy) baseUrl = deployAndResolveUrl();
+  if (!baseUrl) {
+    log("ERROR: provide --url <deployed-url> or --deploy");
+    return 2;
+  }
+  baseUrl = baseUrl.replace(/\/$/, "");
+  log(`target: ${baseUrl} (abort=${args.abort}, sentinel=${args.sentinel})`);
+
+  try {
+    await waitForReady(baseUrl);
+    const session = await mcpInitialize(baseUrl);
+    log(`initialized session ${session}`);
+
+    await seed(baseUrl, session, args.sentinel);
+    const seeded = await probe(baseUrl, session);
+    log(`after seed: ${JSON.stringify(seeded)}`);
+    if (seeded.counter !== args.sentinel || !seeded.initialized) {
+      log(
+        `ERROR: seed did not take (counter=${seeded.counter}, initialized=${seeded.initialized})`
+      );
+      return 2;
+    }
+
+    const deleteResult = await deleteSession(baseUrl, session, args.abort);
+    log(`DELETE result: ${deleteResult}`);
+
+    const start = Date.now();
+    let last: TeardownProbe | undefined;
+    while (Date.now() - start < args.timeoutMs) {
+      try {
+        last = await probe(baseUrl, session);
+      } catch (err) {
+        // A 500/connection error here is expected transient noise: `destroy()`
+        // ends by aborting the isolate, which poisons any in-flight RPC racing
+        // it. Keep polling — a fresh stub resolves a fresh DO.
+        log(`poll +${Date.now() - start}ms: probe transient (${String(err)})`);
+        await sleep(args.pollMs);
+        continue;
+      }
+      log(
+        `poll +${Date.now() - start}ms: counter=${last.counter} marker=${last.markerPresent} alarm=${last.hasAlarm} initialized=${last.initialized}`
+      );
+      if (tornDown(last)) {
+        console.log("\n================ RESULT ================");
+        console.log(
+          `PASS: session DO fully torn down in ~${Date.now() - start}ms`
+        );
+        console.log(`  abort mode:   ${args.abort}`);
+        console.log(`  final probe:  ${JSON.stringify(last)}`);
+        console.log("========================================\n");
+        return 0;
+      }
+      await sleep(args.pollMs);
+    }
+
+    console.log("\n================ RESULT ================");
+    console.log(`FAIL: teardown did not converge within ${args.timeoutMs}ms`);
+    console.log(`  last probe: ${JSON.stringify(last)}`);
+    if (last && last.counter === args.sentinel) {
+      console.log(
+        "  -> counter still holds the sentinel: this is the #1625 ZOMBIE (storage survived a cut-short teardown)."
+      );
+    } else if (last?.markerPresent) {
+      console.log(
+        "  -> condemned marker still present: teardown started but is stuck (check `wrangler tail` for alarm errors)."
+      );
+    }
+    console.log("========================================\n");
+    return 1;
+  } finally {
+    if (args.cleanup && args.deploy) cleanupDeployment();
+  }
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error("[repro] error:", err);
+    process.exit(2);
+  });

--- a/wip/issue-1625-live/src/server.ts
+++ b/wip/issue-1625-live/src/server.ts
@@ -1,0 +1,159 @@
+/**
+ * Live #1625 teardown repro worker.
+ *
+ * A real `McpAgent` (Streamable-HTTP) deployed to Cloudflare so we can exercise
+ * the *production* failure mode #1625 surfaced: the session-DELETE handler used
+ * to run `agent.destroy()` on the front Worker's `ctx.waitUntil`, and by the
+ * time a DELETE lands the client has usually disconnected — so the runtime gave
+ * that trailing task little to no grace and cancelled the multi-step teardown
+ * mid-flight, leaving a half-deleted "zombie" session DO whose tables the
+ * constructor silently recreated on the next wake. The local
+ * `vitest-pool-workers` runtime does NOT cancel `waitUntil`, which is exactly
+ * why the bug only bit in production and the unit tests cannot reproduce it.
+ *
+ * The fix (this PR) defers teardown to the agent's own alarm invocation behind a
+ * durable "condemned" marker. This worker + the `scripts/repro.ts` orchestrator
+ * verify, against a real deployment, that a DELETE (optionally with a
+ * client-side abort to mimic the disconnected client) reliably converges to a
+ * fully-wiped session DO.
+ *
+ * Zombie detection: we seed the session DO's `state.counter` to a sentinel
+ * value before DELETE. A clean teardown wipes all storage, so re-addressing the
+ * session afterwards constructs a FRESH DO whose counter is back to
+ * `initialState` (1). A zombie keeps the sentinel — the constructor's
+ * `CREATE TABLE IF NOT EXISTS` does not overwrite the surviving `state` row.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpAgent } from "agents/mcp";
+import { getAgentByName } from "agents";
+import { z } from "zod";
+
+type Env = {
+  MCP_TEARDOWN: DurableObjectNamespace<McpTeardownAgent>;
+};
+
+type State = { counter: number };
+
+// Mirrors the SDK-internal marker key so the probe can observe an in-flight
+// (or stuck) teardown directly. Kept in sync with `DESTROY_PENDING_KEY` in
+// packages/agents/src/index.ts.
+const DESTROY_PENDING_KEY = "cf_agents_destroy_pending";
+
+export type TeardownProbe = {
+  counter: number;
+  markerPresent: boolean;
+  hasAlarm: boolean;
+  initialized: boolean;
+};
+
+export class McpTeardownAgent extends McpAgent<
+  Env,
+  State,
+  Record<string, never>
+> {
+  server = new McpServer({
+    name: "TeardownProbe",
+    version: "1.0.0"
+  });
+
+  initialState: State = { counter: 1 };
+
+  async init() {
+    this.server.registerTool(
+      "bump",
+      {
+        description: "Increment the counter",
+        inputSchema: { by: z.number() }
+      },
+      async ({ by }) => {
+        this.setState({ counter: this.state.counter + by });
+        return {
+          content: [{ type: "text", text: String(this.state.counter) }]
+        };
+      }
+    );
+  }
+
+  /**
+   * Test-only: seed a sentinel counter so a later probe can tell a clean wipe
+   * (counter resets to initialState) apart from a zombie (counter survives).
+   * Not part of the SDK surface — lives here purely for the repro harness.
+   */
+  async seedForTest(counter: number): Promise<State> {
+    this.setState({ counter });
+    return this.state;
+  }
+
+  /**
+   * Test-only: report the signals that distinguish "fully torn down" from
+   * "zombie / mid-teardown". `markerPresent` is the durable condemned flag;
+   * `initialized` is the MCP session record the DELETE handler keys on.
+   */
+  async probeForTest(): Promise<TeardownProbe> {
+    const marker = await this.ctx.storage.get<boolean>(DESTROY_PENDING_KEY);
+    const alarm = await this.ctx.storage.getAlarm();
+    const init = await this.getInitializeRequest();
+    return {
+      counter: this.state.counter,
+      markerPresent: marker === true,
+      hasAlarm: alarm !== null,
+      initialized: Boolean(init)
+    };
+  }
+
+  override async alarm() {
+    // Instrumentation: surface the deferred-teardown landing in `wrangler tail`.
+    const marker = await this.ctx.storage.get<boolean>(DESTROY_PENDING_KEY);
+    if (marker === true) {
+      console.log(
+        `[1625] alarm: pending destroy -> running teardown (${this.name})`
+      );
+    }
+    await super.alarm();
+  }
+}
+
+const mcpHandler = McpTeardownAgent.serve("/mcp", { binding: "MCP_TEARDOWN" });
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/introspect") {
+      const session = url.searchParams.get("session");
+      if (!session) {
+        return Response.json(
+          { error: "session query param required" },
+          {
+            status: 400
+          }
+        );
+      }
+      const action = url.searchParams.get("action") ?? "probe";
+      const agent = await getAgentByName(
+        env.MCP_TEARDOWN,
+        `streamable-http:${session}`
+      );
+      if (action === "seed") {
+        const counter = Number(url.searchParams.get("counter") ?? "5");
+        console.log(`[1625] seed session=${session} counter=${counter}`);
+        return Response.json(await agent.seedForTest(counter));
+      }
+      const probe = await agent.probeForTest();
+      console.log(`[1625] probe session=${session} ${JSON.stringify(probe)}`);
+      return Response.json(probe);
+    }
+
+    if (url.pathname === "/" || url.pathname === "/health") {
+      return new Response("issue-1625-live: ok\n", { status: 200 });
+    }
+
+    if (request.method === "DELETE") {
+      console.log(
+        `[1625] DELETE session=${request.headers.get("mcp-session-id")}`
+      );
+    }
+
+    return mcpHandler.fetch(request, env, ctx);
+  }
+};

--- a/wip/issue-1625-live/tsconfig.json
+++ b/wip/issue-1625-live/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "agents/tsconfig",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "node"]
+  },
+  "include": ["src", "scripts"]
+}

--- a/wip/issue-1625-live/wrangler.jsonc
+++ b/wip/issue-1625-live/wrangler.jsonc
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "issue-1625-live",
+  "main": "src/server.ts",
+  "compatibility_date": "2026-01-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "MCP_TEARDOWN",
+        "class_name": "McpTeardownAgent"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["McpTeardownAgent"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR makes MCP session teardown durable by deferring `destroy()` to the agent's own alarm invocation rather than running it on the initiating request's `ctx.waitUntil`. Fixes #1625 (but not the excess warning on disconnection, which, as discussed in the issue comments is caused by a lower-level workerd trigger).

## Why

- `McpAgent`'s Streamable-HTTP session-DELETE handler ran `agent.destroy()` via the front Worker's `ctx.waitUntil`. By the time a DELETE lands, the client is usually already gone, and the runtime gives a canceled request's trailing work little to no post-invocation grace.
- `destroy()` is a multi-step I/O sequence: drop internal tables, `deleteAlarm`, `deleteAll` storage, dispose connections, abort. With a short budget, it was routinely cut short.
- The `_destroyed` flag was only written at the very end of the sequence, so an interrupted teardown was invisible: the DO's constructor (via `CREATE IF NOT EXISTS`) silently recreated the internal tables on next wake and resumed as a live agent. Half-deleted session DOs accumulated indefinitely.
- The `waitUntil() tasks did not complete` warning surfaced in the issue originates inside workerd's WebSocket handling and is emitted on any canceled MCP request, independent of userland `waitUntil` calls. It cannot be silenced from this package. This change fixes the real defect the report surfaced: teardown reliability. The warning itself is unchanged.

## Code Changes

Three cooperating pieces in `packages/agents/src/index.ts`:

- `Agent._cf_scheduleDestroy()` (new, internal): writes a durable "condemned" marker (`cf_agents_destroy_pending`, a KV record that survives `_dropInternalTablesForDestroy`) and arms an immediate alarm. Two fast storage writes. The MCP DELETE handler now awaits them before responding 204 instead of riding `waitUntil`. On a facet it falls through to `destroy()` directly, since facet teardown is a single root-coordinated `ctx.facets.delete`.
- `alarm()` preamble: checks for the pending-destroy marker before any other alarm work, including `super.alarm()`'s `onStart`. This prevents user `onStart` from running on a condemned agent against half-dropped tables (the pre-fix symptom: `no such table: cf_agents_schedules`). If the marker is present, it runs `destroy()` with its own full execution budget and returns.
- Convergence guards: `destroy()` writes the marker first, so a direct destroy that gets interrupted is finished by the next alarm wake. The final `deleteAll()` removes the marker, making "marker absent" the durable definition of "teardown complete". `_scheduleNextAlarm()` treats a pending destroy as scheduled work so it does not delete the destroy alarm as "no work pending".

`packages/agents/src/mcp/utils.ts`: the DELETE handler now calls `_cf_scheduleDestroy()` and awaits it before sending 204, instead of `ctx.waitUntil(agent.destroy())`.

`packages/agents/src/tests/deferred-destroy.test.ts` (new, 5 tests): scheduled teardown completes via alarm; a half-torn agent with marker present and some tables already dropped converges on next alarm instead of resuming schedules; `_scheduleNextAlarm` keeps the destroy alarm armed; direct destroy leaves no marker; end-to-end MCP Streamable-HTTP DELETE responds 204 and the session DO is wiped. The first three tests fail against the previous code, reproducing the zombie-resurrection symptom.

## Design tradeoffs

- Alarm vs marker-only: a marker alone converges only if the DO wakes again for some other reason. An abandoned MCP session (unique session id, never addressed again after DELETE) would keep its half-deleted storage forever. The alarm guarantees the wake. Cost: teardown spans two invocations and touches the alarm-scheduling path.
- The alarm check runs before `super.alarm()`/`onStart` on purpose: running user `onStart` on a condemned agent wastes work and risks failing against half-dropped tables.
- `destroy()` keeps its existing step order (`deleteAlarm` before `deleteAll`). The reverse would risk a storage-leaking zombie: an alarm firing after `deleteAll` would recreate empty tables with no marker left to condemn them. The residual unguarded window between `deleteAlarm` and `deleteAll` (two adjacent awaits inside a fresh alarm invocation) is accepted. Alarm retries cover handler failures before that point, and the original failure mode, a canceled request's budget, no longer applies to any part of the sequence.
- `_hasPendingDestroy()` reads the storage key directly rather than gating on `_isFacet`, because the in-memory facet flag is not yet hydrated at the `alarm()` preamble. Facets never write the marker, so the read is safe pre-initialization.

## Public API Surface

- New internal method: `Agent._cf_scheduleDestroy(): Promise<void>`. The `_cf_` prefix is consistent with the existing internal RPC surface. Unlike `destroy()`, it does not abort the isolate, so callers do not need to swallow an abort error.
- New internal storage record: `cf_agents_destroy_pending` (KV). Treated as reserved namespace, consistent with all other `cf_agents_*` records.
- No public API or type-level changes. `destroy()`'s observable contract is unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->