### PR TITLE
fix(agents): RPC calls no longer hang during connection churn

### DIFF
--- a/.changeset/rpc-calls-no-longer-hang.md
+++ b/.changeset/rpc-calls-no-longer-hang.md
@@ -1,0 +1,15 @@
+---
+"agents": minor
+---
+
+Fix RPC calls hanging forever during connection churn (#1738).
+
+`useAgent`'s RPC layer now survives socket replacement. `usePartySocket` creates a brand-new socket whenever connection options change (async query refresh, `enabled` toggle, path change) — previously, a call issued against a stale `agent` reference was buffered inside the permanently-closed old socket and its promise never settled, and a call transmitted just before replacement lost its response with no rejection either.
+
+- `agent.call()` (and `agent.stub` / `agent.setState`) now route through the live socket, so stale references captured by mount-time effects keep working.
+- RPC requests are only handed to a socket once it's open. Until then they're queued by the hook and flushed on the next open — including on a replacement socket. This is safe: queued requests were never transmitted, so they can't double-execute.
+- Calls whose request was already transmitted are rejected with `Connection closed` when their socket closes or is replaced (the response is connection-bound and can never arrive). Calls in flight on a newer socket are no longer spuriously rejected by a stale close event from an old socket.
+- Queued calls only follow the connection to the _same_ agent instance. If the hook is re-pointed at a different address (the `agent`, `name`, `basePath`, or path props change) before a queued call could be transmitted, the call is rejected instead of executing against an instance it wasn't composed for.
+- `AgentClient` similarly keeps buffered (untransmitted) calls pending across transient disconnects — PartySocket re-sends them on reconnect — and only rejects calls the server actually received.
+- Non-streaming calls now have a default 30s timeout as a backstop so lost responses reject instead of hanging. Configure per client via `defaultCallTimeout` (0 disables) on `useAgent` / `AgentClient`, or per call via the existing `timeout` option (`timeout: 0` opts out). Streaming calls are exempt.
+- RPC responses that arrive with no matching pending call (e.g. after a timeout) now log a `console.warn` instead of being silently discarded.

--- a/packages/agents/src/client.ts
+++ b/packages/agents/src/client.ts
@@ -69,7 +69,22 @@ export type AgentClientOptions<State = unknown> = Omit<
    * { agent: "MyAgent", name: "room", path: "settings" }
    */
   path?: string;
+  /**
+   * Default timeout (in milliseconds) applied to non-streaming `call()`s
+   * that don't pass an explicit `timeout`. Defaults to 30 000 ms.
+   * Set to `0` to disable. Streaming calls never get a default timeout.
+   */
+  defaultCallTimeout?: number;
 };
+
+/**
+ * Default timeout (in milliseconds) applied to non-streaming RPC calls
+ * that don't pass an explicit `timeout`. Acts as a backstop so calls
+ * whose response is lost (e.g. the connection drops mid-flight) reject
+ * instead of hanging forever. Override per client via
+ * `defaultCallTimeout`, or per call via `timeout` (0 disables).
+ */
+export const DEFAULT_CALL_TIMEOUT_MS = 30_000;
 
 /**
  * Options for streaming RPC calls
@@ -267,6 +282,14 @@ export class AgentClient<
       resolve: (value: unknown) => void;
       reject: (error: Error) => void;
       stream?: StreamOptions;
+      /**
+       * Whether the request was actually transmitted to the server.
+       * Requests issued while disconnected sit in PartySocket's internal
+       * buffer (transmitted: false) and are flushed on the next open —
+       * they survive a transient close instead of being rejected, since
+       * the server never saw them and re-delivery can't double-execute.
+       */
+      transmitted: boolean;
     }
   >();
   private _readyPromise!: Promise<void>;
@@ -378,7 +401,13 @@ export class AgentClient<
         if (parsedMessage.type === MessageType.RPC) {
           const response = parsedMessage as RPCResponse;
           const pending = this._pendingCalls.get(response.id);
-          if (!pending) return;
+          if (!pending) {
+            console.warn(
+              `[AgentClient] Discarded an RPC response with no matching pending call (id "${response.id}"). ` +
+                "The call likely timed out or was rejected when its connection closed before the response arrived."
+            );
+            return;
+          }
 
           if (!response.success) {
             pending.reject(new Error(response.error));
@@ -405,14 +434,32 @@ export class AgentClient<
       }
     });
 
+    // PartySocket flushes its internal message buffer right before
+    // dispatching "open" — anything queued has now been transmitted.
+    this.addEventListener("open", () => {
+      for (const pending of this._pendingCalls.values()) {
+        pending.transmitted = true;
+      }
+    });
+
     // Clean up pending calls and reset ready state when connection closes
     this.addEventListener("close", () => {
       // Reset ready state for next connection
       this.identified = false;
       this._resetReady();
 
-      // Reject any remaining pending calls (e.g., from unexpected disconnect)
-      this._rejectPendingCalls("Connection closed");
+      if (this.shouldReconnect) {
+        // Transient disconnect: reject calls whose request was already
+        // transmitted — their response can never arrive. Buffered calls
+        // stay pending; PartySocket re-sends them on reconnect.
+        this._rejectPendingCalls("Connection closed", {
+          onlyTransmitted: true
+        });
+      } else {
+        // Permanent close (close() called or retries exhausted): nothing
+        // will ever flush the buffer, so reject everything.
+        this._rejectPendingCalls("Connection closed");
+      }
     });
 
     this.call = this._callImpl.bind(this) as AgentClientCall<AgentT>;
@@ -422,15 +469,21 @@ export class AgentClient<
   }
 
   /**
-   * Reject all pending RPC calls with the given reason.
+   * Reject pending RPC calls with the given reason.
+   * With `onlyTransmitted`, calls still sitting in the send buffer are
+   * kept pending (they'll be flushed on reconnect).
    */
-  private _rejectPendingCalls(reason: string) {
+  private _rejectPendingCalls(
+    reason: string,
+    { onlyTransmitted = false }: { onlyTransmitted?: boolean } = {}
+  ) {
     const error = new Error(reason);
-    for (const pending of this._pendingCalls.values()) {
+    for (const [id, pending] of this._pendingCalls) {
+      if (onlyTransmitted && !pending.transmitted) continue;
+      this._pendingCalls.delete(id);
       pending.reject(error);
       pending.stream?.onError?.(reason);
     }
-    this._pendingCalls.clear();
   }
 
   setState(state: State) {
@@ -480,15 +533,24 @@ export class AgentClient<
         ? undefined
         : (options as CallOptions | undefined)?.timeout;
 
-      // Set up timeout if specified
-      if (timeout) {
+      // Apply the default timeout as a backstop for non-streaming calls
+      // so a lost response rejects instead of hanging forever. An
+      // explicit `timeout` (including 0 = disabled) always wins.
+      const effectiveTimeout =
+        timeout !== undefined
+          ? timeout
+          : streamOptions
+            ? undefined
+            : (this.options.defaultCallTimeout ?? DEFAULT_CALL_TIMEOUT_MS);
+
+      if (effectiveTimeout) {
         timeoutId = setTimeout(() => {
           const pending = this._pendingCalls.get(id);
           this._pendingCalls.delete(id);
-          const errorMessage = `RPC call to ${method} timed out after ${timeout}ms`;
+          const errorMessage = `RPC call to ${method} timed out after ${effectiveTimeout}ms`;
           pending?.stream?.onError?.(errorMessage);
           reject(new Error(errorMessage));
-        }, timeout);
+        }, effectiveTimeout);
       }
 
       this._pendingCalls.set(id, {
@@ -500,7 +562,11 @@ export class AgentClient<
           if (timeoutId) clearTimeout(timeoutId);
           resolve(value);
         },
-        stream: streamOptions
+        stream: streamOptions,
+        // If the socket is open, send() below transmits synchronously;
+        // otherwise the request is buffered until the next open event
+        // (the "open" listener then marks it transmitted).
+        transmitted: this.readyState === this.OPEN
       });
 
       const request: RPCRequest = {

--- a/packages/agents/src/react-tests/client.test.ts
+++ b/packages/agents/src/react-tests/client.test.ts
@@ -469,6 +469,148 @@ describe("AgentClient", () => {
     });
   });
 
+  describe("RPC robustness", () => {
+    it("rejects transmitted calls on a transient disconnect", async () => {
+      const { host, protocol } = getTestWorkerHost();
+
+      client = new AgentClient({
+        agent: "TestCallableAgent",
+        name: `rpc-transmitted-reject-${Date.now()}`,
+        host,
+        protocol
+      });
+
+      await client.ready;
+
+      // Transmitted while OPEN — its response is lost when the
+      // connection drops, so it must reject, not hang.
+      const inFlight = client.call("asyncMethod", [10000]);
+      client.reconnect();
+
+      await expect(inFlight).rejects.toThrow("Connection closed");
+    });
+
+    it("keeps buffered (untransmitted) calls pending across a transient disconnect and flushes them on reconnect", async () => {
+      const { host, protocol } = getTestWorkerHost();
+
+      client = new AgentClient({
+        agent: "TestCallableAgent",
+        name: `rpc-buffered-survive-${Date.now()}`,
+        host,
+        protocol
+      });
+
+      await client.ready;
+
+      // Drop the connection, then issue a call while disconnected — it
+      // sits in PartySocket's send buffer (never transmitted).
+      client.reconnect();
+      const buffered = client.call("add", [1, 2]);
+
+      // A second disconnect fires another close event. Before the fix,
+      // any close rejected ALL pending calls — including this one, whose
+      // request the server never saw. Now untransmitted calls survive
+      // and are flushed once the socket reconnects.
+      client.reconnect();
+
+      await expect(buffered).resolves.toBe(3);
+    });
+
+    it("applies a default timeout to non-streaming calls", async () => {
+      const { host, protocol } = getTestWorkerHost();
+
+      client = new AgentClient({
+        agent: "TestCallableAgent",
+        name: `rpc-default-timeout-${Date.now()}`,
+        host,
+        protocol,
+        defaultCallTimeout: 300
+      });
+
+      await client.ready;
+
+      // `hang` never responds — the default timeout backstop must fire.
+      await expect(client.call("hang")).rejects.toThrow(
+        /timed out after 300ms/
+      );
+    });
+
+    it("lets an explicit timeout of 0 disable the default timeout", async () => {
+      const { host, protocol } = getTestWorkerHost();
+
+      client = new AgentClient({
+        agent: "TestCallableAgent",
+        name: `rpc-timeout-zero-${Date.now()}`,
+        host,
+        protocol,
+        defaultCallTimeout: 100
+      });
+
+      await client.ready;
+
+      // Takes 400ms server-side — longer than defaultCallTimeout, but
+      // timeout: 0 opts this call out of the backstop entirely.
+      await expect(
+        client.call("asyncMethod", [400], { timeout: 0 })
+      ).resolves.toBe("done");
+    });
+
+    it("does not apply the default timeout to streaming calls", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      const chunks: unknown[] = [];
+
+      client = new AgentClient({
+        agent: "TestCallableAgent",
+        name: `rpc-stream-no-default-${Date.now()}`,
+        host,
+        protocol,
+        defaultCallTimeout: 150
+      });
+
+      await client.ready;
+
+      // 3 chunks × 100ms = ~300ms total, well past defaultCallTimeout.
+      const result = await client.call("streamWithDelay", [["a", "b"], 100], {
+        stream: { onChunk: (chunk) => chunks.push(chunk) }
+      });
+
+      expect(result).toBe("complete");
+      expect(chunks).toEqual(["a", "b"]);
+    });
+
+    it("warns when a response arrives for a call that already timed out", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      const warnSpy = vi.spyOn(console, "warn");
+
+      client = new AgentClient({
+        agent: "TestCallableAgent",
+        name: `rpc-dropped-response-${Date.now()}`,
+        host,
+        protocol
+      });
+
+      await client.ready;
+
+      // Times out client-side after 50ms; the server response arrives
+      // ~300ms later with no matching pending call.
+      await expect(
+        client.call("asyncMethod", [300], { timeout: 50 })
+      ).rejects.toThrow(/timed out/);
+
+      await vi.waitFor(
+        () => {
+          const warned = warnSpy.mock.calls.some((call) =>
+            String(call[0]).includes("Discarded an RPC response")
+          );
+          expect(warned).toBe(true);
+        },
+        { timeout: 5000 }
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("identity change detection", () => {
     it("should detect identity change on reconnect", async () => {
       const { host, protocol } = getTestWorkerHost();

--- a/packages/agents/src/react-tests/rpc-robustness.test.tsx
+++ b/packages/agents/src/react-tests/rpc-robustness.test.tsx
@@ -1,0 +1,487 @@
+/**
+ * Integration tests for useAgent RPC robustness during connection churn.
+ *
+ * `usePartySocket` replaces the underlying socket object whenever
+ * connection options change (query refresh, enabled toggle, path change).
+ * Before these fixes, RPC calls could be silently stranded forever:
+ * - calls issued against a stale `agent` reference were buffered inside
+ *   a permanently-closed socket and never transmitted
+ * - calls transmitted on a socket that was then replaced never got their
+ *   response, and never got rejected either
+ *
+ * Related to: https://github.com/cloudflare/agents/issues/1738
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render as _render, cleanup } from "vitest-browser-react";
+import { useEffect, useRef, useState } from "react";
+import { useAgent, type UseAgentOptions } from "../react";
+import { getTestWorkerHost } from "./test-config";
+
+// Wrap render to disable act() environment after mounting — these integration
+// tests have async WebSocket updates that legitimately happen outside act().
+const render: typeof _render = async (...args) => {
+  const result = await _render(...args);
+  // @ts-expect-error - globalThis is not typed
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  return result;
+};
+
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any -- tests don't need strict agent typing
+type TestAgent = ReturnType<typeof useAgent<any>>;
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * Harness whose useAgent options can be changed from the test, so we can
+ * force `usePartySocket` to replace the socket object (e.g. by changing
+ * `query`) and observe how in-flight / queued RPC calls behave.
+ */
+function ControlledAgentComponent({
+  initialOptions,
+  onAgent,
+  exposeSetOptions
+}: {
+  initialOptions: UseAgentOptions<unknown>;
+  onAgent: (agent: TestAgent) => void;
+  exposeSetOptions: (
+    setOptions: (options: UseAgentOptions<unknown>) => void
+  ) => void;
+}) {
+  const [options, setOptions] = useState(initialOptions);
+  useEffect(() => {
+    exposeSetOptions(setOptions);
+  }, [exposeSetOptions]);
+
+  const agent = useAgent(options);
+  useEffect(() => {
+    onAgent(agent);
+  }, [agent, agent.identified, onAgent]);
+
+  return (
+    <div data-testid="agent-status">
+      {agent.identified ? "connected" : "connecting"}
+    </div>
+  );
+}
+
+/**
+ * Harness that issues an RPC call from a mount-time effect — i.e. before
+ * the WebSocket has opened. This is the exact pattern from issue #1738.
+ */
+function MountCallComponent({
+  options,
+  method,
+  args,
+  onResult,
+  onError
+}: {
+  options: UseAgentOptions<unknown>;
+  method: string;
+  args: unknown[];
+  onResult: (result: unknown) => void;
+  onError: (error: Error) => void;
+}) {
+  const agent = useAgent(options);
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    if (calledRef.current) return;
+    calledRef.current = true;
+    agent.call(method, args).then(onResult, onError);
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- fire exactly once on mount
+  }, [agent]);
+
+  return (
+    <div data-testid="agent-status">
+      {agent.identified ? "connected" : "connecting"}
+    </div>
+  );
+}
+
+describe("useAgent RPC robustness", () => {
+  describe("calls issued before the socket is open", () => {
+    it("resolves a call issued from a mount-time effect", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      const onResult = vi.fn();
+      const onError = vi.fn();
+
+      render(
+        <MountCallComponent
+          options={{
+            agent: "TestCallableAgent",
+            name: `mount-call-${crypto.randomUUID()}`,
+            host,
+            protocol
+          }}
+          method="add"
+          args={[1, 2]}
+          onResult={onResult}
+          onError={onError}
+        />
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(onResult).toHaveBeenCalledWith(3);
+        },
+        { timeout: 10000 }
+      );
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("socket replacement (connection options change)", () => {
+    it("resolves calls made through a stale agent reference after the socket was replaced", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      const seenAgents: TestAgent[] = [];
+      let latestAgent: TestAgent | null = null;
+      let setOptions: ((options: UseAgentOptions<unknown>) => void) | null =
+        null;
+      const name = `stale-ref-${crypto.randomUUID()}`;
+
+      const baseOptions: UseAgentOptions<unknown> = {
+        agent: "TestCallableAgent",
+        name,
+        host,
+        protocol,
+        query: { generation: "1" }
+      };
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={baseOptions}
+          onAgent={(agent) => {
+            latestAgent = agent;
+            if (!seenAgents.includes(agent)) seenAgents.push(agent);
+          }}
+          exposeSetOptions={(fn) => {
+            setOptions = fn;
+          }}
+        />
+      );
+
+      // Wait for the first socket to connect
+      await vi.waitFor(
+        () => {
+          expect(latestAgent?.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+      const staleAgent = latestAgent!;
+
+      // Changing `query` forces usePartySocket to create a brand-new
+      // socket object; the old one is closed permanently.
+      setOptions!({ ...baseOptions, query: { generation: "2" } });
+
+      await vi.waitFor(
+        () => {
+          // A distinct socket object must have taken over and identified
+          expect(seenAgents.length).toBeGreaterThanOrEqual(2);
+          expect(latestAgent).not.toBe(staleAgent);
+          expect(latestAgent!.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      // The old reference's call() must route to the live socket instead
+      // of buffering into the dead one (which hangs forever).
+      const result = await staleAgent.call("add", [3, 4]);
+      expect(result).toBe(7);
+    });
+
+    it("flushes calls queued while disconnected onto a replacement socket", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let latestAgent: TestAgent | null = null;
+      let setOptions: ((options: UseAgentOptions<unknown>) => void) | null =
+        null;
+      const name = `queued-flush-${crypto.randomUUID()}`;
+
+      const baseOptions: UseAgentOptions<unknown> = {
+        agent: "TestCallableAgent",
+        name,
+        host,
+        protocol,
+        enabled: false,
+        query: { generation: "1" }
+      };
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={baseOptions}
+          onAgent={(agent) => {
+            latestAgent = agent;
+          }}
+          exposeSetOptions={(fn) => {
+            setOptions = fn;
+          }}
+        />
+      );
+
+      await vi.waitFor(() => {
+        expect(latestAgent).not.toBeNull();
+      });
+
+      // Issue a call while the socket is disabled (never opened). The
+      // request must be queued by the hook, NOT handed to this socket:
+      // changing options below discards it, losing its internal buffer.
+      const callPromise = latestAgent!.call("add", [2, 3]);
+
+      // Re-enable with different options → a brand-new socket replaces
+      // the disabled one.
+      setOptions!({
+        ...baseOptions,
+        enabled: true,
+        query: { generation: "2" }
+      });
+
+      // The queued call must flush on the replacement socket and resolve.
+      await expect(callPromise).resolves.toBe(5);
+    });
+
+    it("rejects (rather than strands) calls already transmitted on a replaced socket", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let latestAgent: TestAgent | null = null;
+      let setOptions: ((options: UseAgentOptions<unknown>) => void) | null =
+        null;
+      const name = `replaced-inflight-${crypto.randomUUID()}`;
+
+      const baseOptions: UseAgentOptions<unknown> = {
+        agent: "TestCallableAgent",
+        name,
+        host,
+        protocol,
+        query: { generation: "1" }
+      };
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={baseOptions}
+          onAgent={(agent) => {
+            latestAgent = agent;
+          }}
+          exposeSetOptions={(fn) => {
+            setOptions = fn;
+          }}
+        />
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(latestAgent?.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      // Transmit a slow call on the current socket, then replace the
+      // socket before the response can arrive. The response is lost by
+      // design (responses are connection-bound), so the call must reject
+      // promptly instead of hanging.
+      const slowCall = latestAgent!.call("asyncMethod", [10000]);
+      setOptions!({ ...baseOptions, query: { generation: "2" } });
+
+      await expect(slowCall).rejects.toThrow("Connection closed");
+    });
+
+    it("rejects queued calls when the agent address changes (destination guard)", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let latestAgent: TestAgent | null = null;
+      let setOptions: ((options: UseAgentOptions<unknown>) => void) | null =
+        null;
+
+      const baseOptions: UseAgentOptions<unknown> = {
+        agent: "TestCallableAgent",
+        name: `address-guard-a-${crypto.randomUUID()}`,
+        host,
+        protocol,
+        enabled: false
+      };
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={baseOptions}
+          onAgent={(agent) => {
+            latestAgent = agent;
+          }}
+          exposeSetOptions={(fn) => {
+            setOptions = fn;
+          }}
+        />
+      );
+
+      await vi.waitFor(() => {
+        expect(latestAgent).not.toBeNull();
+      });
+
+      // Queued while disconnected, composed for instance "address-guard-a".
+      const callPromise = latestAgent!.call("add", [1, 1]);
+
+      // Re-point the hook at a *different* agent instance. The queued
+      // call must NOT execute there — flushing it would run an RPC
+      // composed for one instance against another.
+      setOptions!({
+        ...baseOptions,
+        enabled: true,
+        name: `address-guard-b-${crypto.randomUUID()}`
+      });
+
+      await expect(callPromise).rejects.toThrow(/agent address changed/);
+    });
+  });
+
+  describe("default call timeout", () => {
+    it("rejects calls that never get a response after defaultCallTimeout", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let latestAgent: TestAgent | null = null;
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={{
+            agent: "TestCallableAgent",
+            name: `default-timeout-${crypto.randomUUID()}`,
+            host,
+            protocol,
+            // Never connects — the call sits queued until the backstop fires
+            enabled: false,
+            defaultCallTimeout: 400
+          }}
+          onAgent={(agent) => {
+            latestAgent = agent;
+          }}
+          exposeSetOptions={() => {}}
+        />
+      );
+
+      await vi.waitFor(() => {
+        expect(latestAgent).not.toBeNull();
+      });
+
+      await expect(latestAgent!.call("add", [1, 2])).rejects.toThrow(
+        /timed out after 400ms/
+      );
+    });
+
+    it("lets an explicit timeout of 0 disable the default timeout", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let latestAgent: TestAgent | null = null;
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={{
+            agent: "TestCallableAgent",
+            name: `timeout-zero-${crypto.randomUUID()}`,
+            host,
+            protocol,
+            defaultCallTimeout: 100
+          }}
+          onAgent={(agent) => {
+            latestAgent = agent;
+          }}
+          exposeSetOptions={() => {}}
+        />
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(latestAgent?.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      // Takes 400ms server-side — longer than defaultCallTimeout, but
+      // timeout: 0 opts this call out of the backstop entirely.
+      await expect(
+        latestAgent!.call("asyncMethod", [400], { timeout: 0 })
+      ).resolves.toBe("done");
+    });
+
+    it("does not apply the default timeout to streaming calls", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let latestAgent: TestAgent | null = null;
+      const chunks: unknown[] = [];
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={{
+            agent: "TestCallableAgent",
+            name: `stream-no-default-${crypto.randomUUID()}`,
+            host,
+            protocol,
+            defaultCallTimeout: 150
+          }}
+          onAgent={(agent) => {
+            latestAgent = agent;
+          }}
+          exposeSetOptions={() => {}}
+        />
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(latestAgent?.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      // 3 chunks × 100ms = ~300ms total, well past defaultCallTimeout.
+      // Streaming calls are exempt from the backstop.
+      const result = await latestAgent!.call(
+        "streamWithDelay",
+        [["a", "b", "c"], 100],
+        { stream: { onChunk: (chunk) => chunks.push(chunk) } }
+      );
+
+      expect(result).toBe("complete");
+      expect(chunks).toEqual(["a", "b", "c"]);
+    });
+  });
+
+  describe("dropped RPC responses", () => {
+    it("warns when a response arrives for a call that already timed out", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      const warnSpy = vi.spyOn(console, "warn");
+      let latestAgent: TestAgent | null = null;
+
+      render(
+        <ControlledAgentComponent
+          initialOptions={{
+            agent: "TestCallableAgent",
+            name: `dropped-response-${crypto.randomUUID()}`,
+            host,
+            protocol
+          }}
+          onAgent={(agent) => {
+            latestAgent = agent;
+          }}
+          exposeSetOptions={() => {}}
+        />
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(latestAgent?.identified).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      // The call times out client-side after 50ms, but the server still
+      // sends its response ~300ms later — with no matching pending call.
+      await expect(
+        latestAgent!.call("asyncMethod", [300], { timeout: 50 })
+      ).rejects.toThrow(/timed out/);
+
+      await vi.waitFor(
+        () => {
+          const warned = warnSpy.mock.calls.some((call) =>
+            String(call[0]).includes("Discarded an RPC response")
+          );
+          expect(warned).toBe(true);
+        },
+        { timeout: 5000 }
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -12,7 +12,7 @@ import type {
   UntypedAgentStub
 } from "./client";
 import type { ClientParameters } from "./serializable";
-import { createStubProxy } from "./client";
+import { createStubProxy, DEFAULT_CALL_TIMEOUT_MS } from "./client";
 import { camelCaseToKebabCase } from "./utils";
 import { MessageType } from "./types";
 import {
@@ -223,6 +223,17 @@ export type UseAgentOptions<State = unknown> = Omit<
    * @experimental The API surface may change before stabilizing.
    */
   sub?: ReadonlyArray<{ agent: string; name: string }>;
+  /**
+   * Default timeout (in milliseconds) applied to non-streaming `call()`s
+   * that don't pass an explicit `timeout`. Acts as a backstop so calls
+   * whose response is lost (e.g. the connection is replaced mid-flight)
+   * reject instead of hanging forever.
+   *
+   * Defaults to 30 000 ms. Set to `0` to disable the default timeout.
+   * Streaming calls never get a default timeout (long-lived streams are
+   * legitimate); pass an explicit `timeout` to bound them.
+   */
+  defaultCallTimeout?: number;
 };
 
 type OptionalArgsAgentMethodCall<AgentT> = <
@@ -314,6 +325,7 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
     cacheTtl,
     sub: subOption,
     path: userPath,
+    defaultCallTimeout,
     ...restOptions
   } = options;
 
@@ -345,7 +357,22 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
     [options.agent, options.name, subChain]
   );
 
-  // Keep track of pending RPC calls
+  // Keep track of pending RPC calls.
+  //
+  // Each entry is tagged with the socket the request was transmitted on
+  // (`sentOn`). Requests are only handed to a socket once it's OPEN —
+  // until then they stay queued here (`sentOn: null`). This matters
+  // because `usePartySocket` *replaces* the socket object whenever
+  // connection options change (async query refresh, path change, etc.):
+  // anything buffered inside a replaced socket is lost forever, and a
+  // call transmitted on a replaced socket can never receive its
+  // response. Tagging lets us:
+  // - flush still-queued requests on whichever socket connects next
+  //   (safe: they were never transmitted, so no double-execution risk)
+  // - reject calls transmitted on a socket that closed or was replaced
+  //   (their response can never arrive)
+  // - avoid rejecting calls in flight on the *new* socket when a stale
+  //   close event from an old socket trickles in
   const pendingCallsRef = useRef(
     new Map<
       string,
@@ -354,9 +381,62 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
         reject: (error: Error) => void;
         stream?: StreamOptions;
         timeoutId?: ReturnType<typeof setTimeout>;
+        /** Serialized RPC request, kept so it can be (re)transmitted */
+        request: string;
+        /** Socket the request was transmitted on; null while queued */
+        sentOn: PartySocket | null;
       }
     >()
   );
+
+  // Always points at the socket from the latest render. `call`,
+  // `setState`, and the queue-flushing logic go through this ref so
+  // that stale `agent` references held by old effect closures still
+  // route their traffic to the live socket instead of a dead one.
+  const socketRef = useRef<PartySocket | null>(null);
+
+  const defaultCallTimeoutRef = useRef(
+    defaultCallTimeout ?? DEFAULT_CALL_TIMEOUT_MS
+  );
+  defaultCallTimeoutRef.current = defaultCallTimeout ?? DEFAULT_CALL_TIMEOUT_MS;
+
+  /** Reject (and remove) every pending call transmitted on `socket`. */
+  const rejectCallsSentOn = (socket: PartySocket, reason: string) => {
+    const error = new Error(reason);
+    for (const [id, pending] of pendingCallsRef.current) {
+      if (pending.sentOn === socket) {
+        if (pending.timeoutId) clearTimeout(pending.timeoutId);
+        pendingCallsRef.current.delete(id);
+        pending.reject(error);
+        pending.stream?.onError?.(reason);
+      }
+    }
+  };
+
+  /** Transmit queued (never-sent) calls if the live socket is open. */
+  const flushQueuedCalls = () => {
+    const socket = socketRef.current;
+    if (!socket || socket.readyState !== socket.OPEN) return;
+    for (const pending of pendingCallsRef.current.values()) {
+      if (pending.sentOn === null) {
+        socket.send(pending.request);
+        pending.sentOn = socket;
+      }
+    }
+  };
+
+  /** Reject (and remove) every still-queued (never transmitted) call. */
+  const rejectQueuedCalls = (reason: string) => {
+    const error = new Error(reason);
+    for (const [id, pending] of pendingCallsRef.current) {
+      if (pending.sentOn === null) {
+        if (pending.timeoutId) clearTimeout(pending.timeoutId);
+        pendingCallsRef.current.delete(id);
+        pending.reject(error);
+        pending.stream?.onError?.(reason);
+      }
+    }
+  };
 
   const cacheKey = useMemo(
     () =>
@@ -539,9 +619,32 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
 
   const socketEnabled = !awaitingQueryRefresh && (restOptions.enabled ?? true);
 
+  // Identifies *which agent instance* this hook is addressing. Queued
+  // (never-transmitted) RPC calls are only safe to flush onto a later
+  // socket if it still points at the same instance — a call composed for
+  // agent "alpha" must not execute on agent "beta" just because the
+  // `name` prop changed while the call was waiting for a connection.
+  // Credentials (query params) are deliberately excluded: a token
+  // refresh doesn't change where calls go.
+  const addressKey = JSON.stringify([
+    options.host ?? null,
+    options.basePath ?? null,
+    agentNamespace,
+    options.name || "default",
+    combinedPath || null
+  ]);
+
   const agent = usePartySocket({
     ...socketOptions,
     enabled: socketEnabled,
+    onOpen: (event: Event) => {
+      // The socket is open: transmit any RPC requests that were issued
+      // while disconnected (or while a previous socket was being
+      // replaced). They were never handed to a socket before, so this
+      // cannot double-execute anything server-side.
+      flushQueuedCalls();
+      options.onOpen?.(event);
+    },
     onMessage: (message) => {
       if (typeof message.data === "string") {
         let parsedMessage: Record<string, unknown>;
@@ -623,7 +726,13 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
         if (parsedMessage.type === MessageType.RPC) {
           const response = parsedMessage as RPCResponse;
           const pending = pendingCallsRef.current.get(response.id);
-          if (!pending) return;
+          if (!pending) {
+            console.warn(
+              `[useAgent] Discarded an RPC response with no matching pending call (id "${response.id}"). ` +
+                "The call likely timed out or was rejected when its connection closed before the response arrived."
+            );
+            return;
+          }
 
           if (!response.success) {
             if (pending.timeoutId) clearTimeout(pending.timeoutId);
@@ -655,30 +764,41 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
       options.onMessage?.(message);
     },
     onClose: (event: CloseEvent) => {
-      // Reset ready state for next connection
-      resetReady();
-      if (mutableAgentRef.current) {
-        mutableAgentRef.current.identified = false;
-      }
-      setIdentity((prev) => ({ ...prev, identified: false }));
+      // Identify which socket actually closed. Close events are
+      // dispatched asynchronously, so a close from an old socket that
+      // was just replaced can arrive while a new socket is already
+      // connecting (or connected). `event.target` is the PartySocket
+      // that dispatched the event; fall back to the live socket if the
+      // environment doesn't populate it.
+      const closedSocket =
+        (event.target as PartySocket | null) ?? socketRef.current;
+      const isCurrentSocket = closedSocket === socketRef.current;
 
-      // Pause reconnection for async queries until fresh query params are ready
-      if (isAsyncQuery) {
-        setAwaitingQueryRefresh(true);
+      // Calls transmitted on the closed socket can never receive their
+      // response — reject them. Calls still queued (never transmitted)
+      // stay pending and are flushed when a socket next opens; calls
+      // in flight on a *different* (newer) socket are untouched.
+      if (closedSocket) {
+        rejectCallsSentOn(closedSocket, "Connection closed");
       }
 
-      // Invalidate cache and trigger re-render to fetch fresh query params
-      deleteCacheEntry(cacheKeyRef.current);
-      setCacheInvalidatedAt(Date.now());
+      if (isCurrentSocket) {
+        // Reset ready state for next connection
+        resetReady();
+        if (mutableAgentRef.current) {
+          mutableAgentRef.current.identified = false;
+        }
+        setIdentity((prev) => ({ ...prev, identified: false }));
 
-      // Reject all pending calls (consistent with AgentClient behavior)
-      const error = new Error("Connection closed");
-      for (const pending of pendingCallsRef.current.values()) {
-        if (pending.timeoutId) clearTimeout(pending.timeoutId);
-        pending.reject(error);
-        pending.stream?.onError?.("Connection closed");
+        // Pause reconnection for async queries until fresh query params are ready
+        if (isAsyncQuery) {
+          setAwaitingQueryRefresh(true);
+        }
+
+        // Invalidate cache and trigger re-render to fetch fresh query params
+        deleteCacheEntry(cacheKeyRef.current);
+        setCacheInvalidatedAt(Date.now());
       }
-      pendingCallsRef.current.clear();
 
       // Call user's onClose if provided
       options.onClose?.(event);
@@ -694,7 +814,52 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
     stub: UntypedAgentStub;
     getHttpUrl: () => string;
   };
-  // Create the call method
+  // Update the live-socket ref before anything below can use it.
+  socketRef.current = agent;
+
+  // When `usePartySocket` replaces the socket object (connection options
+  // changed — async query refresh, path change, enabled toggle, ...) the
+  // old socket's event listeners are detached at the same commit, so its
+  // final close event may never be observed by our onClose handler.
+  // Sweep here instead: anything transmitted on the old socket can never
+  // get a response, and the identity it established no longer applies.
+  // Queued (never-transmitted) calls survive and flush when the new
+  // socket opens.
+  const prevSocketRef = useRef<PartySocket | null>(null);
+  const prevAddressKeyRef = useRef(addressKey);
+  useEffect(() => {
+    const prev = prevSocketRef.current;
+    prevSocketRef.current = agent;
+    const prevAddress = prevAddressKeyRef.current;
+    prevAddressKeyRef.current = addressKey;
+
+    // Destination guard: if the agent address changed (different agent,
+    // name, or path — not just refreshed credentials), calls that are
+    // still queued were composed for the *old* instance. Reject them
+    // before anything can flush them onto the new instance.
+    if (prevAddress !== addressKey) {
+      rejectQueuedCalls(
+        "Call discarded: the agent address changed before the request could be sent"
+      );
+    }
+
+    if (prev && prev !== agent) {
+      rejectCallsSentOn(prev, "Connection closed");
+      resetReady();
+      if (mutableAgentRef.current) {
+        mutableAgentRef.current.identified = false;
+      }
+      setIdentity((current) =>
+        current.identified ? { ...current, identified: false } : current
+      );
+    }
+    // The helpers only touch refs; re-running on socket/address change is all we need.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, addressKey]);
+
+  // Create the call method. Deliberately dependency-free: it routes
+  // through refs, so even a stale `agent` reference captured by an old
+  // effect closure issues calls against the live socket.
   const call = useCallback(
     <T = unknown,>(
       method: string,
@@ -716,38 +881,63 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
           ? undefined
           : (options as CallOptions | undefined)?.timeout;
 
-        if (timeout) {
+        // Apply the default timeout as a backstop for non-streaming
+        // calls so a lost response rejects instead of hanging forever.
+        // An explicit `timeout` (including 0 = disabled) always wins.
+        const effectiveTimeout =
+          timeout !== undefined
+            ? timeout
+            : streamOptions
+              ? undefined
+              : defaultCallTimeoutRef.current;
+
+        if (effectiveTimeout) {
           timeoutId = setTimeout(() => {
             const pending = pendingCallsRef.current.get(id);
             pendingCallsRef.current.delete(id);
-            const errorMessage = `RPC call to ${method} timed out after ${timeout}ms`;
+            const errorMessage = `RPC call to ${method} timed out after ${effectiveTimeout}ms`;
             pending?.stream?.onError?.(errorMessage);
             reject(new Error(errorMessage));
-          }, timeout);
+          }, effectiveTimeout);
         }
 
-        pendingCallsRef.current.set(id, {
-          reject,
-          resolve: resolve as (value: unknown) => void,
-          stream: streamOptions,
-          timeoutId
-        });
-
-        const request: RPCRequest = {
+        const rpcRequest: RPCRequest = {
           args,
           id,
           method,
           type: MessageType.RPC
         };
+        const request = JSON.stringify(rpcRequest);
 
-        agent.send(JSON.stringify(request));
+        pendingCallsRef.current.set(id, {
+          reject,
+          resolve: resolve as (value: unknown) => void,
+          stream: streamOptions,
+          timeoutId,
+          request,
+          sentOn: null
+        });
+
+        // Transmit immediately if the live socket is open; otherwise the
+        // request stays queued and is flushed on the next open event.
+        // We never hand requests to a non-open socket: its internal
+        // buffer is lost forever if the socket gets replaced.
+        const socket = socketRef.current;
+        if (socket && socket.readyState === socket.OPEN) {
+          socket.send(request);
+          const pending = pendingCallsRef.current.get(id);
+          if (pending) pending.sentOn = socket;
+        }
       });
     },
-    [agent]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   agent.setState = (newState: State) => {
-    agent.send(
+    // Route through the live socket so stale `agent` references don't
+    // write into a replaced socket's dead buffer.
+    (socketRef.current ?? agent).send(
       JSON.stringify({ state: newState, type: MessageType.CF_AGENT_STATE })
     );
     setAgentState(newState);

--- a/packages/agents/src/tests/agents/callable.ts
+++ b/packages/agents/src/tests/agents/callable.ts
@@ -27,6 +27,13 @@ export class TestCallableAgent extends Agent<
     throw new Error(message);
   }
 
+  // Method that never responds — for client-side timeout tests
+  @callable()
+  async hang(): Promise<string> {
+    await new Promise(() => {});
+    return "unreachable";
+  }
+
   // Void return type
   @callable()
   voidMethod(): void {


### PR DESCRIPTION
## Summary

Fixes #1738.

`usePartySocket` replaces the underlying socket object whenever connection options change (async query refresh, `enabled` toggle, path change). The RPC layer didn't account for that, producing three ways for a `call()` promise to never settle:

- a call issued against a stale `agent` reference (e.g. captured by a mount-time effect — the exact pattern in the issue) was buffered inside the permanently-closed old socket and never transmitted
- a call transmitted just before replacement lost its response (RPC responses are connection-bound) with no rejection
- the old socket's close event was unobservable after the swap, so "connection closed" cleanup never ran for it

### `useAgent`

- `call()`, `agent.stub`, and `agent.setState` route through a ref to the **live socket**, so stale references keep working after a replacement.
- RPC requests are **only handed to a socket once it's OPEN**. Until then they're queued by the hook and flushed on the next open — including on a replacement socket. Queued requests were never transmitted, so flushing can't double-execute anything server-side.
- Pending calls are **tagged with the socket they were transmitted on**. When a socket closes or is replaced, only calls sent on *that* socket reject with `Connection closed`; queued calls survive, and calls in flight on a newer socket are no longer spuriously rejected by a stale close event from an old one.
- **Destination guard**: queued calls only follow the connection to the *same* agent instance. If the hook is re-pointed at a different address (the `agent`, `name`, `basePath`, or path props change) before a queued call was transmitted, the call rejects instead of executing against an instance it wasn't composed for. Credential-only changes (query refresh) still flush normally.
- **Default 30s timeout** on non-streaming calls as a backstop so a genuinely lost response rejects instead of hanging. Configurable via the new `defaultCallTimeout` option (`0` disables); an explicit per-call `timeout` always wins (`timeout: 0` opts out). Streaming calls are exempt — long-lived streams are legitimate.

### `AgentClient`

- Pending calls track whether their request was actually **transmitted**. On a transient disconnect, transmitted calls reject (their response can never arrive) while buffered calls stay pending — PartySocket re-sends them on reconnect. A permanent close rejects everything.
- Same `defaultCallTimeout` backstop.

Both now `console.warn` when an RPC response arrives with no matching pending call (e.g. after a timeout) instead of silently discarding it.

### Upstream

Companion partysocket PR (cloudflare/partykit#403) fixes the underlying buffered-message loss and unobservable close at the library level — synchronous close events, `send()` returning transmit status, `drainQueuedMessages()`, and destination-guarded buffer transfer in the hooks. This PR is self-contained and doesn't depend on it: the hook-level queue here never relies on PartySocket's internal buffer. The agents react suite was also smoke-tested against the new partysocket build (96/96 passing), so the future dependency bump is safe.

## Test plan

- [x] New `rpc-robustness.test.tsx` suite (9 tests): mount-time call resolves; stale `agent` reference works after socket replacement; queued calls flush onto a replacement socket; in-flight calls on a replaced socket reject promptly; destination guard rejects queued calls when the agent address changes; default timeout fires; `timeout: 0` opts out; streaming calls exempt from the backstop; dropped-response warning
- [x] New `AgentClient` tests in `client.test.ts` (6 tests): transmitted vs. buffered rejection on transient disconnect, buffered calls surviving reconnect, default timeout, `timeout: 0`, streaming exemption, dropped-response warning
- [x] Verified the new tests reproduce the original hang without the fix (calls hang for 500+ seconds)
- [x] Full react test project passes (96 tests, 6 files); `pnpm run check` and `nx affected -t test` (9 projects) green

Changeset included (`agents` minor).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->