### PR TITLE
fix(agents): ignore RPC responses after socket close

### DIFF
--- a/.changeset/silent-rpc-close-race.md
+++ b/.changeset/silent-rpc-close-race.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Ignore RPC responses when the WebSocket has already closed.
+
+Async callable methods can finish after a client disconnects. The server now treats that closed-socket response delivery as a no-op instead of surfacing an uncaught `WebSocket send() after close()` error from the Workers runtime.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -207,6 +207,26 @@ export type RPCResponse = {
     }
 );
 
+function isClosedWebSocketSendError(error: unknown): boolean {
+  return (
+    error instanceof TypeError &&
+    error.message.includes("WebSocket send() after close")
+  );
+}
+
+function sendRpcResponseIfOpen(
+  connection: Connection,
+  response: RPCResponse
+): boolean {
+  try {
+    connection.send(JSON.stringify(response));
+    return true;
+  } catch (error) {
+    if (isClosedWebSocketSendError(error)) return false;
+    throw error;
+  }
+}
+
 /**
  * Type guard for RPC request messages
  */
@@ -2186,7 +2206,7 @@ export class Agent<
                 success: true,
                 type: MessageType.RPC
               };
-              connection.send(JSON.stringify(response));
+              sendRpcResponseIfOpen(connection, response);
             } catch (e) {
               // Send error response
               const response: RPCResponse = {
@@ -2196,7 +2216,7 @@ export class Agent<
                 success: false,
                 type: MessageType.RPC
               };
-              connection.send(JSON.stringify(response));
+              sendRpcResponseIfOpen(connection, response);
               console.error("RPC error:", e);
               this._emit("rpc:error", {
                 method: parsed.method,
@@ -11405,8 +11425,7 @@ export class StreamingResponse {
       success: true,
       type: MessageType.RPC
     };
-    this._connection.send(JSON.stringify(response));
-    return true;
+    return sendRpcResponseIfOpen(this._connection, response);
   }
 
   /**
@@ -11426,8 +11445,7 @@ export class StreamingResponse {
       success: true,
       type: MessageType.RPC
     };
-    this._connection.send(JSON.stringify(response));
-    return true;
+    return sendRpcResponseIfOpen(this._connection, response);
   }
 
   /**
@@ -11446,7 +11464,6 @@ export class StreamingResponse {
       success: false,
       type: MessageType.RPC
     };
-    this._connection.send(JSON.stringify(response));
-    return true;
+    return sendRpcResponseIfOpen(this._connection, response);
   }
 }

--- a/packages/agents/src/tests/agents/callable.ts
+++ b/packages/agents/src/tests/agents/callable.ts
@@ -21,6 +21,13 @@ export class TestCallableAgent extends Agent<
     return "done";
   }
 
+  // Async method used to verify RPC response delivery tolerates disconnects
+  @callable()
+  async delayedThrow(delayMs: number): Promise<never> {
+    await new Promise((r) => setTimeout(r, delayMs));
+    throw new Error("delayed failure");
+  }
+
   // Method that throws an error
   @callable()
   throwError(message: string): never {

--- a/packages/agents/src/tests/callable.test.ts
+++ b/packages/agents/src/tests/callable.test.ts
@@ -1,5 +1,5 @@
 import { env, exports } from "cloudflare:workers";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getAgentByName, type RPCRequest, type RPCResponse } from "../index";
 import { MessageType } from "../types";
 
@@ -185,6 +185,30 @@ describe("@callable decorator", () => {
       expect(response.done).toBe(true);
 
       ws.close();
+    });
+
+    it("should ignore RPC error responses after the client disconnects", async () => {
+      const room = `callable-close-before-error-${crypto.randomUUID()}`;
+      const { ws } = await connectWS(`/agents/test-callable-agent/${room}`);
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        await skipInitialMessages(ws);
+
+        const request: RPCRequest = {
+          type: MessageType.RPC,
+          id: createId(),
+          method: "delayedThrow",
+          args: [25]
+        };
+        ws.send(JSON.stringify(request));
+        ws.close();
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      } finally {
+        consoleError.mockRestore();
+      }
     });
 
     it("should handle void return type", async () => {


### PR DESCRIPTION
## Summary
- Guard RPC response delivery so async callable methods finishing after a WebSocket disconnect do not crash the Worker with `WebSocket send() after close()`.
- Reuse the same best-effort delivery path for `StreamingResponse` so `send()`, `end()`, and `error()` return `false` when the socket is already closed.
- Add a regression test that closes the client before an async callable rejects, matching the CI race seen in Think worker tests.

## Context
The Think worker CI run was failing with an unhandled `Worker exited unexpectedly` error from `@cloudflare/vitest-pool-workers`, with the underlying runtime error pointing at the generic Agent RPC error-response send path. This can happen when the client observes enough state to close the WebSocket while the server is still resolving or rejecting an async RPC.

RPC responses are connection-scoped today, not resumable across reconnects. If the original socket is gone, the safest behavior is to drop the response rather than send it to a later connection that may not have the same pending caller.

## Test plan
- `pnpm --filter agents test:workers -- src/tests/callable.test.ts`
- `pnpm --filter @cloudflare/think test:workers`
- `pnpm run check`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->