### PR TITLE
feat(codemode): add pluggable runtime validators

### DIFF
--- a/.changeset/codemode-validators.md
+++ b/.changeset/codemode-validators.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": minor
+---
+
+Add pluggable runtime validators for reviewing model-generated code before execution and concrete connector calls before they run. Validation failures return bounded, model-actionable diagnostics and fail closed without executing rejected actions.

--- a/docs/codemode/index.md
+++ b/docs/codemode/index.md
@@ -186,6 +186,7 @@ sandbox: github.create_issue(args)
 
 - [Connectors](./connectors.md) — write one class per service; MCP, OpenAPI, toolset, and custom bases
 - [Runtime](./runtime.md) — both API surfaces (handle + sandbox SDK), the durable log, abort-and-replay
+- [Validators](./validators.md) — reject semantically incorrect generated code and connector calls
 - [Approvals](./approvals.md) — annotations, pause/resume flow, wiring an approval UI
 - [Snippets](./snippets.md) — scripts the model saves and reuses
 - [Vite Plugin](./vite-plugin.md) — `*.codemode.ts` discovery and Worker-entry exports

--- a/docs/codemode/runtime.md
+++ b/docs/codemode/runtime.md
@@ -21,6 +21,8 @@ const runtime = createCodemodeRuntime({
 });
 ```
 
+Add `validators` to reject semantically incorrect generated programs before the executor starts or concrete connector calls before they execute. See [Validators](./validators.md).
+
 | Handle method                                        | Purpose                                                                                                                                    |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `runtime.tool(options?)`                             | The single model-facing AI SDK tool, `codemode({ code })`                                                                                  |

--- a/docs/codemode/validators.md
+++ b/docs/codemode/validators.md
@@ -1,0 +1,151 @@
+# Validators
+
+Codemode validators let your application evaluate model-generated code before it runs. Validators are general host-side hooks: they can call a policy engine, run static analysis, ask a model to review the program, or apply application-specific rules.
+
+Add validators to `createCodemodeRuntime`:
+
+```ts
+import {
+  createCodemodeRuntime,
+  type CodemodeValidator
+} from "@cloudflare/codemode";
+
+const policyValidator: CodemodeValidator = {
+  name: "organization-policy",
+
+  async validateCode({ code }) {
+    const decision = await policyEngine.evaluate(code);
+
+    return decision.allowed
+      ? { valid: true }
+      : {
+          valid: false,
+          issues: [
+            {
+              code: decision.code,
+              message: decision.reason ?? "Rejected by organization policy."
+            }
+          ]
+        };
+  }
+};
+
+const runtime = createCodemodeRuntime({
+  ctx: this.ctx,
+  executor,
+  connectors,
+  validators: [policyValidator]
+});
+```
+
+Validation is opt-in. With no validators configured, Codemode behaves as before. A validator that does not implement a particular hook does not participate at that validation point.
+
+Every implemented hook must explicitly return `{ valid: true }` or `{ valid: false, issues? }`. Codemode fails closed if a configured hook returns nothing, returns malformed data, or throws. All participating validators must return valid before execution proceeds.
+
+Codemode runs validators sequentially, collects issues from invalid results, and returns bounded, attributed feedback that the model can use to correct its code.
+
+## Validate the generated program
+
+`validateCode` runs before Codemode creates an execution or starts the executor. Its context contains:
+
+- `code`: source exactly as the model supplied it;
+- `normalizedCode`: source after Codemode strips fences and normalizes it to an async function;
+- `connectors`: the configured connector descriptions, including methods and input schemas.
+
+A validator can use as much or as little of this context as it needs:
+
+```ts
+const programValidator: CodemodeValidator = {
+  name: "program-review",
+
+  async validateCode({ code, normalizedCode, connectors }) {
+    const issues = await reviewGeneratedProgram({
+      request: currentUserRequest,
+      code,
+      normalizedCode,
+      availableMethods: connectors
+    });
+
+    return issues.length > 0 ? { valid: false, issues } : { valid: true };
+  }
+};
+```
+
+An invalid result returns a `status: "error"` tool result with an empty execution ID. The executor does not start and the rejected program does not appear in the runtime's execution history.
+
+If a program reviewer needs the original user request or messages, capture them in the validator closure when creating the runtime. Codemode does not prescribe a model or message representation for validators.
+
+## Validate concrete connector calls
+
+Use the optional `validateToolCall` hook when validation depends on evaluated arguments or current application state. It receives:
+
+- `executionId`;
+- connector and method names;
+- concrete arguments;
+- the method's input schema and annotations, when available.
+
+For example, an application can reject a resource transition that is invalid for the resource's current state:
+
+```ts
+const lifecycleValidator: CodemodeValidator = {
+  name: "resource-lifecycle",
+
+  async validateToolCall({ connector, method, args }) {
+    if (connector !== "resources" || method !== "transition") {
+      return { valid: true };
+    }
+
+    const input = args as { id?: string; state?: string };
+    const resource = await loadResource(input.id);
+
+    if (resource.state === "deleted" && input.state === "active") {
+      return {
+        valid: false,
+        issues: [
+          {
+            code: "invalid-lifecycle-transition",
+            path: "state",
+            message: "A deleted resource cannot transition directly to active.",
+            suggestion: "Restore the resource before activating it."
+          }
+        ]
+      };
+    }
+
+    return { valid: true };
+  }
+};
+```
+
+Call validation runs after the durable runtime decides that the connector will execute, but before `connector.executeTool()`. An invalid result marks the execution as failed, and the connector action does not run. Generated code cannot catch the local error and continue to later connector side effects because the durable execution is already terminal.
+
+Applied calls served from the durable replay log are not revalidated. Ephemeral calls marked `replay: "reexecute"` are validated each time because they execute again. Approval-required calls validate after approval, immediately before the connector action.
+
+Validator implementations are reconstructed with the runtime on each request. Codemode records call-validator names on a paused execution and refuses to resume if one is missing, so an approval handler cannot accidentally bypass the call policy that guarded the original run. Code-only validators do not need to be reconstructed for resume because they already decided whether the stored program could begin.
+
+## Validation issues
+
+Issues are optional. An invalid result without issues uses a generic validation message. Include issues when the model can use the details to correct its program:
+
+```ts
+return {
+  valid: false,
+  issues: [
+    {
+      message: "ownerId and region contain values in the wrong fields.",
+      path: "body.ownerId",
+      code: "swapped-fields",
+      suggestion:
+        "Use the account ID for ownerId and the region code for region."
+    }
+  ]
+};
+```
+
+Validators reject code or calls; they do not transform them. Perform normalization explicitly in a connector if your API requires it. Keeping validation reject-only ensures that generated code, approval data, durable logs, and rollback arguments all describe the same call.
+
+## Failure behavior
+
+Configured validation hooks fail closed. If a hook throws or returns an invalid result, Codemode logs the original value or exception in the host and blocks the operation. The model receives a generic error that names the validator but does not include thrown details, which could contain private application data.
+
+Validators should perform reads rather than side effects. Upstream APIs should still enforce transactional invariants because validation cannot prevent state from changing between a check and the eventual remote operation.

--- a/packages/codemode/src/index.ts
+++ b/packages/codemode/src/index.ts
@@ -18,6 +18,13 @@ export {
   type JsonSchemaToolDescriptors
 } from "./json-schema-types";
 export { normalizeCode } from "./normalize";
+export {
+  type CodemodeValidationIssue,
+  type CodemodeValidationResult,
+  type CodeValidationContext,
+  type ToolCallValidationContext,
+  type CodemodeValidator
+} from "./validation";
 export { resolveProvider } from "./resolve";
 export {
   truncateResponse,

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -44,6 +44,12 @@ import {
 } from "./runtime";
 import type { Snippet, SaveSnippetOptions } from "./snippet";
 import type { CodeOutput } from "./shared";
+import {
+  runCodeValidators,
+  runToolCallValidators,
+  toolCallValidatorNames,
+  type CodemodeValidator
+} from "./validation";
 
 // Connector annotations, flattened to "connector.method" → annotation.
 type AnnotationMap = Record<string, ToolAnnotations>;
@@ -157,6 +163,8 @@ export type CreateProxyToolOptions = {
   maxExecutions?: number;
   /** Optionally reshape the model-facing result (e.g. truncate). */
   transformResult?: TransformResult;
+  /** Host-side validators for generated code and concrete connector calls. */
+  validators?: readonly CodemodeValidator[];
 };
 
 // ---------------------------------------------------------------------------
@@ -336,7 +344,8 @@ function buildConnectorBindings(
   setup: Setup,
   runtime: RuntimeStub,
   executionId: string,
-  cursor: Cursor
+  cursor: Cursor,
+  validators?: readonly CodemodeValidator[]
 ): ConnectorBinding[] {
   return setup.descriptions.map((desc) => ({
     name: desc.name,
@@ -365,6 +374,22 @@ function buildConnectorBindings(
 
         if (decision.kind === "replay") return decision.result;
         if (decision.kind === "pause") return { [CONTROL_KEY]: "pause" };
+
+        const validationError = await runToolCallValidators(validators, {
+          executionId,
+          connector: desc.name,
+          method,
+          args,
+          inputSchema: desc.descriptors[method]?.inputSchema,
+          annotations: annotation
+        });
+        if (validationError) {
+          await runtime.fail(executionId, validationError);
+          return {
+            [CONTROL_KEY]: "error",
+            message: validationError
+          };
+        }
 
         const connector = setup.connectorsByName.get(desc.name);
         if (!connector) throw new Error(`Unknown connector: ${desc.name}`);
@@ -548,10 +573,17 @@ async function runPass(
   setup: Setup,
   runtime: RuntimeStub,
   executor: Executor,
-  transformResult?: TransformResult
+  transformResult?: TransformResult,
+  validators?: readonly CodemodeValidator[]
 ): Promise<ProxyToolOutput> {
   const cursor = createCursor();
-  const bindings = buildConnectorBindings(setup, runtime, executionId, cursor);
+  const bindings = buildConnectorBindings(
+    setup,
+    runtime,
+    executionId,
+    cursor,
+    validators
+  );
   const platformProvider = createPlatformProvider(
     setup,
     bindings,
@@ -717,9 +749,22 @@ export function createProxyTool(
         };
       }
       const setup = await getSetup();
+      const validationError = await runCodeValidators(options.validators, {
+        code,
+        normalizedCode: normalizeCode(code),
+        connectors: setup.descriptions
+      });
+      if (validationError) {
+        return {
+          status: "error",
+          executionId: "",
+          error: validationError
+        };
+      }
       const executionId = await runtime.begin(code, {
         maxExecutions: options.maxExecutions,
-        connectors: connectors.map((c) => c.name())
+        connectors: connectors.map((c) => c.name()),
+        validators: toolCallValidatorNames(options.validators)
       });
       return runPass(
         executionId,
@@ -727,7 +772,8 @@ export function createProxyTool(
         setup,
         runtime,
         options.executor,
-        options.transformResult
+        options.transformResult,
+        options.validators
       );
     }
   });
@@ -796,6 +842,8 @@ export type ResumeCodemodeOptions = {
   maxExecutions?: number;
   /** Optionally reshape the model-facing result (e.g. truncate). */
   transformResult?: TransformResult;
+  /** Host-side validators used by the original runtime configuration. */
+  validators?: readonly CodemodeValidator[];
 };
 
 /** Connectors an execution/snippet recorded but the runtime no longer has. */
@@ -837,6 +885,21 @@ export async function resumeCodemode(
           `configured on this runtime.`
       };
     }
+
+    const missingValidators = missingConnectors(
+      existing.validators,
+      new Set(toolCallValidatorNames(options.validators))
+    );
+    if (missingValidators.length > 0) {
+      return {
+        status: "error",
+        executionId: options.executionId,
+        error:
+          `Execution "${options.executionId}" requires validator(s) ` +
+          `${missingValidators.map((name) => `"${name}"`).join(", ")} that ` +
+          `are not configured on this runtime.`
+      };
+    }
   }
 
   const execution = await runtime.resume(options.executionId);
@@ -859,7 +922,8 @@ export async function resumeCodemode(
     setup,
     runtime,
     options.executor,
-    options.transformResult
+    options.transformResult,
+    options.validators
   );
 }
 

--- a/packages/codemode/src/runtime-handle.ts
+++ b/packages/codemode/src/runtime-handle.ts
@@ -17,6 +17,7 @@ import {
 } from "./proxy-tool";
 import type { ExecutionState, PendingAction } from "./runtime";
 import type { SaveSnippetOptions, Snippet } from "./snippet";
+import { validateValidators, type CodemodeValidator } from "./validation";
 
 export type CreateCodemodeRuntimeOptions = {
   ctx: DurableObjectState;
@@ -44,6 +45,12 @@ export type CreateCodemodeRuntimeOptions = {
    * Applies to both the initial run and a resume after approval.
    */
   transformResult?: TransformResult;
+  /**
+   * Host-side validators for generated code and concrete connector calls.
+   * Validator implementations are transient request objects. Call-validator
+   * names are recorded so a paused execution cannot resume without them.
+   */
+  validators?: readonly CodemodeValidator[];
 };
 
 export type CodemodeRuntimeToolOptions = {
@@ -127,6 +134,7 @@ class DefaultCodemodeRuntimeHandle implements CodemodeRuntimeHandle {
 
   constructor(options: CreateCodemodeRuntimeOptions) {
     validateConnectorNames(options.connectors);
+    validateValidators(options.validators);
     this.#options = options;
   }
 
@@ -141,7 +149,8 @@ class DefaultCodemodeRuntimeHandle implements CodemodeRuntimeHandle {
       description: options?.description,
       connectorHints: options?.connectorHints,
       maxExecutions: this.#options.maxExecutions,
-      transformResult: this.#options.transformResult
+      transformResult: this.#options.transformResult,
+      validators: this.#options.validators
     });
   }
 
@@ -153,7 +162,8 @@ class DefaultCodemodeRuntimeHandle implements CodemodeRuntimeHandle {
       name: this.#options.name,
       executionId: options.executionId,
       maxExecutions: this.#options.maxExecutions,
-      transformResult: this.#options.transformResult
+      transformResult: this.#options.transformResult,
+      validators: this.#options.validators
     });
   }
 

--- a/packages/codemode/src/runtime-tests/runtime.test.ts
+++ b/packages/codemode/src/runtime-tests/runtime.test.ts
@@ -31,6 +31,7 @@ interface Host {
     options?: { maxExecutions?: number; name?: string }
   ): Promise<ProxyToolOutput>;
   approve(executionId: string): Promise<ProxyToolOutput>;
+  approveWithoutValidators(executionId: string): Promise<ProxyToolOutput>;
   approveWithoutItems(executionId: string): Promise<ProxyToolOutput>;
   runSnippetWithoutItems(snippet: string): Promise<ProxyToolOutput>;
   expirePaused(maxAgeMs?: number): Promise<string[]>;
@@ -48,6 +49,14 @@ interface Host {
   ): Promise<Snippet>;
   snippets(): Promise<Snippet[]>;
   sideEffects(): Promise<SideEffects>;
+  validationState(): Promise<{
+    calls: string[];
+    codeContext?: {
+      code: string;
+      normalizedCode: string;
+      connectors: string[];
+    };
+  }>;
   lifecycle(): Promise<{
     opened: string[];
     disposed: Array<{ executionId: string; status: string }>;
@@ -86,6 +95,104 @@ describe("codemode durable runtime (e2e)", () => {
 
     expect(out.status).toBe("completed");
     if (out.status === "completed") expect(out.result).toEqual([]);
+  });
+
+  it("rejects generated code before creating an execution", async () => {
+    const h = host();
+    const out = await h.run(`async () => "INVALID_CODE"`);
+
+    expect(out.status).toBe("error");
+    if (out.status !== "error") return;
+    expect(out.executionId).toBe("");
+    expect(out.error).toContain("Validation failed for generated code");
+    expect(out.error).toContain("[test-policy] (invalid-code)");
+    expect(await h.executions()).toEqual([]);
+
+    const validation = await h.validationState();
+    expect(validation.codeContext?.code).toContain("INVALID_CODE");
+    expect(validation.codeContext?.normalizedCode).toContain("async ()");
+    expect(validation.codeContext?.connectors).toEqual(["items"]);
+  });
+
+  it("rejects a concrete call before its connector executes", async () => {
+    const h = host();
+    const out = await h.run(
+      `async () => await items.add_note({ text: "invalid" })`
+    );
+
+    expect(out.status).toBe("error");
+    if (out.status !== "error") return;
+    expect(out.error).toContain("Validation failed for items.add_note");
+    expect(out.error).toContain("[test-policy] text:");
+    expect((await h.sideEffects()).notes).toEqual([]);
+    expect((await h.executions())[0]?.status).toBe("error");
+  });
+
+  it("fails closed without exposing validator exceptions", async () => {
+    const h = host();
+    const out = await h.run(
+      `async () => await items.add_note({ text: "throw-validator" })`
+    );
+
+    expect(out.status).toBe("error");
+    if (out.status !== "error") return;
+    expect(out.error).toContain(
+      'Validator "test-policy" could not complete; the operation was not executed.'
+    );
+    expect(out.error).not.toContain("secret validator implementation detail");
+    expect((await h.sideEffects()).notes).toEqual([]);
+  });
+
+  it("stops later side effects when sandbox code catches a rejection", async () => {
+    const h = host();
+    const out = await h.run(`async () => {
+      try { await items.add_note({ text: "invalid" }); } catch {}
+      try { await items.add_note({ text: "later" }); } catch {}
+      return "caught";
+    }`);
+
+    expect(out.status).toBe("error");
+    expect((await h.sideEffects()).notes).toEqual([]);
+  });
+
+  it("does not revalidate durable replay but revalidates real execution", async () => {
+    const h = host();
+    const first = await h.run(`async () => {
+      await items.list_items();
+      await items.read_counter();
+      return await items.create_item({ title: "x" });
+    }`);
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    expect((await h.validationState()).calls).toEqual([
+      "items.list_items",
+      "items.read_counter"
+    ]);
+
+    const resumed = await h.approve(first.executionId);
+    expect(resumed.status).toBe("completed");
+    expect((await h.validationState()).calls).toEqual([
+      "items.list_items",
+      "items.read_counter",
+      "items.read_counter",
+      "items.create_item"
+    ]);
+  });
+
+  it("refuses to resume when a required validator is missing", async () => {
+    const h = host();
+    const first = await h.run(
+      `async () => await items.create_item({ title: "x" })`
+    );
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    const resumed = await h.approveWithoutValidators(first.executionId);
+    expect(resumed.status).toBe("error");
+    if (resumed.status !== "error") return;
+    expect(resumed.error).toContain('requires validator(s) "test-policy"');
+    expect((await h.sideEffects()).created).toEqual([]);
   });
 
   it("names the connector globals (and renders hints) in the tool description", async () => {

--- a/packages/codemode/src/runtime-tests/worker.ts
+++ b/packages/codemode/src/runtime-tests/worker.ts
@@ -16,6 +16,7 @@ import {
 } from "../connectors";
 import { DynamicWorkerExecutor } from "../executor";
 import { createCodemodeRuntime } from "../runtime-handle";
+import type { CodemodeValidator } from "../validation";
 import {
   getCodemodeRuntime,
   type ProxyToolInput,
@@ -144,6 +145,12 @@ type RunOptions = { maxExecutions?: number };
 
 export class CodemodeTestHost extends DurableObject<Env> {
   #connector?: ItemsConnector;
+  #validationCalls: string[] = [];
+  #lastCodeContext?: {
+    code: string;
+    normalizedCode: string;
+    connectors: string[];
+  };
   // When set, the runtime wraps every completed result so tests can assert the
   // transformResult hook fires on both the initial run and a resume.
   #shape = false;
@@ -153,15 +160,66 @@ export class CodemodeTestHost extends DurableObject<Env> {
     return this.#connector;
   }
 
-  #runtime(options?: RunOptions & { name?: string; noConnectors?: boolean }) {
+  #runtime(
+    options?: RunOptions & {
+      name?: string;
+      noConnectors?: boolean;
+      noValidators?: boolean;
+    }
+  ) {
     const executor = new DynamicWorkerExecutor({ loader: this.env.LOADER });
+    const validator: CodemodeValidator = {
+      name: "test-policy",
+      validateCode: ({ code, normalizedCode, connectors }) => {
+        this.#lastCodeContext = {
+          code,
+          normalizedCode,
+          connectors: connectors.map((connector) => connector.name)
+        };
+        if (code.includes("INVALID_CODE")) {
+          return {
+            valid: false,
+            issues: [
+              {
+                code: "invalid-code",
+                message: "The generated program violates the test policy.",
+                suggestion: "Remove INVALID_CODE."
+              }
+            ]
+          };
+        }
+        return { valid: true };
+      },
+      validateToolCall: (call) => {
+        this.#validationCalls.push(`${call.connector}.${call.method}`);
+        if (call.connector === "items" && call.method === "add_note") {
+          const text = (call.args as { text?: string } | undefined)?.text;
+          if (text === "throw-validator") {
+            throw new Error("secret validator implementation detail");
+          }
+          if (text === "invalid") {
+            return {
+              valid: false,
+              issues: [
+                {
+                  path: "text",
+                  message: "This note is not allowed."
+                }
+              ]
+            };
+          }
+        }
+        return { valid: true };
+      }
+    };
     return createCodemodeRuntime({
       ctx: this.ctx,
       executor,
       connectors: options?.noConnectors ? [] : [this.#items()],
       name: options?.name,
       maxExecutions: options?.maxExecutions,
-      transformResult: this.#shape ? (r) => ({ shaped: r }) : undefined
+      transformResult: this.#shape ? (r) => ({ shaped: r }) : undefined,
+      validators: options?.noValidators ? [] : [validator]
     });
   }
 
@@ -183,6 +241,10 @@ export class CodemodeTestHost extends DurableObject<Env> {
 
   approve(executionId: string): Promise<ProxyToolOutput> {
     return this.#runtime().approve({ executionId });
+  }
+
+  approveWithoutValidators(executionId: string): Promise<ProxyToolOutput> {
+    return this.#runtime({ noValidators: true }).approve({ executionId });
   }
 
   /**
@@ -254,6 +316,13 @@ export class CodemodeTestHost extends DurableObject<Env> {
   sideEffects() {
     const c = this.#items();
     return { created: c.created, deleted: c.deleted, notes: c.notes };
+  }
+
+  validationState() {
+    return {
+      calls: this.#validationCalls,
+      codeContext: this.#lastCodeContext
+    };
   }
 
   lifecycle() {

--- a/packages/codemode/src/runtime.ts
+++ b/packages/codemode/src/runtime.ts
@@ -104,6 +104,8 @@ export type ExecutionState = {
    * resume can verify the required connectors are still configured.
    */
   connectors?: string[];
+  /** Validator names required to resume this execution safely. */
+  validators?: string[];
   /** Epoch ms the execution was created. */
   createdAt: number;
   /** Epoch ms of the last state change. */
@@ -138,6 +140,8 @@ export type BeginOptions = {
   maxExecutions?: number;
   /** Connector names configured on the runtime starting this execution. */
   connectors?: string[];
+  /** Validator names configured on the runtime starting this execution. */
+  validators?: string[];
 };
 
 /** Default number of terminal executions to retain per runtime. */
@@ -217,6 +221,7 @@ type ExecutionRow = {
   error: string | null;
   logs: string | null;
   connectors: string | null;
+  validators: string | null;
   created_at: number;
   updated_at: number;
 };
@@ -308,6 +313,7 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         error TEXT,
         logs TEXT,
         connectors TEXT,
+        validators TEXT,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       );
@@ -334,6 +340,14 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         connectors TEXT
       );
     `);
+    try {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE cm_executions ADD COLUMN validators TEXT"
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.toLowerCase().includes("duplicate column")) throw error;
+    }
   }
 
   // -----------------------------------------------------------------------
@@ -360,11 +374,12 @@ export class CodemodeRuntime extends DurableObject<unknown> {
     const id = `exec_${now.toString().padStart(16, "0")}_${crypto.randomUUID()}`;
     this.ctx.storage.sql.exec(
       `INSERT INTO cm_executions
-        (id, code, status, connectors, created_at, updated_at)
-        VALUES (?, ?, 'running', ?, ?, ?)`,
+        (id, code, status, connectors, validators, created_at, updated_at)
+        VALUES (?, ?, 'running', ?, ?, ?, ?)`,
       id,
       code,
       options?.connectors ? JSON.stringify(options.connectors) : null,
+      options?.validators ? JSON.stringify(options.validators) : null,
       now,
       now
     );
@@ -1021,6 +1036,9 @@ export class CodemodeRuntime extends DurableObject<unknown> {
       logs: row.logs ? (JSON.parse(row.logs) as string[]) : undefined,
       connectors: row.connectors
         ? (JSON.parse(row.connectors) as string[])
+        : undefined,
+      validators: row.validators
+        ? (JSON.parse(row.validators) as string[])
         : undefined,
       createdAt: row.created_at,
       updatedAt: row.updated_at

--- a/packages/codemode/src/tests/validation.test.ts
+++ b/packages/codemode/src/tests/validation.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  runCodeValidators,
+  runToolCallValidators,
+  toolCallValidatorNames,
+  validateValidators,
+  type CodemodeValidator
+} from "../validation";
+
+const codeContext = {
+  code: "42",
+  normalizedCode: "async () => (42)",
+  connectors: []
+};
+
+describe("codemode validators", () => {
+  it("does nothing when no validator is configured", async () => {
+    await expect(
+      runCodeValidators(undefined, codeContext)
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips validators that do not implement the current hook", async () => {
+    await expect(
+      runCodeValidators([{ name: "call-only" }], codeContext)
+    ).resolves.toBeUndefined();
+  });
+
+  it("records only call-validator names for resume", () => {
+    expect(
+      toolCallValidatorNames([
+        { name: "code-only", validateCode: () => ({ valid: true }) },
+        { name: "call", validateToolCall: () => ({ valid: true }) },
+        {
+          name: "both",
+          validateCode: () => ({ valid: true }),
+          validateToolCall: () => ({ valid: true })
+        }
+      ])
+    ).toEqual(["call", "both"]);
+  });
+
+  it("requires an explicit valid result from configured hooks", async () => {
+    await expect(
+      runCodeValidators(
+        [{ name: "valid", validateCode: () => ({ valid: true }) }],
+        codeContext
+      )
+    ).resolves.toBeUndefined();
+
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const error = await runCodeValidators(
+      [
+        {
+          name: "missing-result",
+          validateCode: () => undefined as never
+        }
+      ],
+      codeContext
+    );
+
+    expect(error).toContain(
+      "did not return an explicit valid or invalid result"
+    );
+
+    const malformed = await runCodeValidators(
+      [
+        {
+          name: "malformed-result",
+          validateCode: () =>
+            ({ valid: false, issues: [{ message: 42 }] }) as never
+        }
+      ],
+      codeContext
+    );
+    expect(malformed).toContain(
+      "did not return an explicit valid or invalid result"
+    );
+    expect(consoleError).toHaveBeenCalledTimes(2);
+    consoleError.mockRestore();
+  });
+
+  it("runs validators sequentially and aggregates attributed issues", async () => {
+    const order: string[] = [];
+    const validators: CodemodeValidator[] = [
+      {
+        name: "lifecycle",
+        validateToolCall: async () => {
+          order.push("lifecycle");
+          return {
+            valid: false,
+            issues: [
+              {
+                code: "invalid-state",
+                path: "state",
+                message: "The state is not applicable.",
+                suggestion: "Load the resource before choosing its next state."
+              }
+            ]
+          };
+        }
+      },
+      {
+        name: "fields",
+        validateToolCall: () => {
+          order.push("fields");
+          return {
+            valid: false,
+            issues: [{ message: "The owner and region appear to be swapped." }]
+          };
+        }
+      }
+    ];
+
+    const error = await runToolCallValidators(validators, {
+      executionId: "exec_1",
+      connector: "resources",
+      method: "patch",
+      args: { state: "active" }
+    });
+
+    expect(order).toEqual(["lifecycle", "fields"]);
+    expect(error).toContain("Validation failed for resources.patch");
+    expect(error).toContain("[lifecycle] (invalid-state) state:");
+    expect(error).toContain("Load the resource");
+    expect(error).toContain("[fields]");
+  });
+
+  it("uses a generic issue for an invalid result without details", async () => {
+    const error = await runCodeValidators(
+      [{ name: "policy", validateCode: () => ({ valid: false }) }],
+      codeContext
+    );
+    expect(error).toContain("Validation failed without further details.");
+  });
+
+  it("rejects empty and duplicate names", () => {
+    expect(() => validateValidators([{ name: " " }])).toThrow(
+      "must not be empty"
+    );
+    expect(() =>
+      validateValidators([{ name: "policy" }, { name: "policy" }])
+    ).toThrow('Duplicate codemode validator name "policy"');
+  });
+
+  it("fails closed without exposing a thrown validator error", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const error = await runCodeValidators(
+      [
+        {
+          name: "private-policy",
+          validateCode: () => {
+            throw new Error("secret internal endpoint");
+          }
+        }
+      ],
+      codeContext
+    );
+
+    expect(error).toContain(
+      'Validator "private-policy" could not complete; the operation was not executed.'
+    );
+    expect(error).not.toContain("secret internal endpoint");
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("bounds the number and length of diagnostics", async () => {
+    const error = await runCodeValidators(
+      [
+        {
+          name: "many",
+          validateCode: () => ({
+            valid: false,
+            issues: Array.from({ length: 30 }, () => ({
+              message: "x".repeat(3_000)
+            }))
+          })
+        }
+      ],
+      codeContext
+    );
+
+    expect(error?.match(/\[many\]/g)).toHaveLength(10);
+    expect(error?.length).toBeLessThanOrEqual(20_000);
+    expect(error).toContain("[truncated]");
+  });
+});

--- a/packages/codemode/src/validation.ts
+++ b/packages/codemode/src/validation.ts
@@ -1,0 +1,220 @@
+import type { JSONSchema7 } from "json-schema";
+import type { ConnectorDescription, ToolAnnotations } from "./connectors";
+
+export type CodemodeValidationIssue = {
+  /** Human- and model-readable explanation of what is wrong. */
+  message: string;
+  /** Optional argument/source path, such as `body.ownerId`. */
+  path?: string;
+  /** Optional stable application-specific identifier. */
+  code?: string;
+  /** Optional concrete advice for correcting the generated program. */
+  suggestion?: string;
+};
+
+/** An explicit result is required from every configured validation hook. */
+export type CodemodeValidationResult =
+  | { valid: true }
+  | { valid: false; issues?: readonly CodemodeValidationIssue[] };
+
+export type CodeValidationContext = {
+  /** Source exactly as supplied by the model. */
+  code: string;
+  /** Source after Codemode fence stripping and function normalization. */
+  normalizedCode: string;
+  /** Methods, schemas, annotations, and instructions available to the code. */
+  connectors: readonly ConnectorDescription[];
+};
+
+export type ToolCallValidationContext = {
+  executionId: string;
+  connector: string;
+  method: string;
+  args: unknown;
+  inputSchema?: JSONSchema7;
+  annotations?: ToolAnnotations;
+};
+
+export interface CodemodeValidator {
+  /** Non-empty name used to attribute results and diagnostics. */
+  name: string;
+  validateCode?(
+    context: CodeValidationContext
+  ): CodemodeValidationResult | Promise<CodemodeValidationResult>;
+  validateToolCall?(
+    context: ToolCallValidationContext
+  ): CodemodeValidationResult | Promise<CodemodeValidationResult>;
+}
+
+type AttributedIssue = CodemodeValidationIssue & { validator: string };
+
+const MAX_ISSUES = 20;
+const MAX_NAME_CHARS = 100;
+const MAX_MESSAGE_CHARS = 2_000;
+const MAX_DETAIL_CHARS = 500;
+const MAX_FORMATTED_CHARS = 20_000;
+
+export function validateValidators(
+  validators: readonly CodemodeValidator[] | undefined
+): void {
+  validatorNames(validators);
+}
+
+export function validatorNames(
+  validators: readonly CodemodeValidator[] | undefined
+): string[] {
+  if (!validators) return [];
+  const names = new Set<string>();
+  for (const validator of validators) {
+    const name = normalizedValidatorName(validator.name);
+    if (!name) throw new Error("Codemode validator names must not be empty.");
+    if (names.has(name)) {
+      throw new Error(`Duplicate codemode validator name "${name}".`);
+    }
+    names.add(name);
+  }
+  return [...names];
+}
+
+/** Call validators that must still be present when a paused run resumes. */
+export function toolCallValidatorNames(
+  validators: readonly CodemodeValidator[] | undefined
+): string[] {
+  return validatorNames(
+    validators?.filter((validator) => validator.validateToolCall !== undefined)
+  );
+}
+
+export async function runCodeValidators(
+  validators: readonly CodemodeValidator[] | undefined,
+  context: CodeValidationContext
+): Promise<string | undefined> {
+  return runValidators(validators, "validateCode", context, "generated code");
+}
+
+export async function runToolCallValidators(
+  validators: readonly CodemodeValidator[] | undefined,
+  context: ToolCallValidationContext
+): Promise<string | undefined> {
+  return runValidators(
+    validators,
+    "validateToolCall",
+    context,
+    `${context.connector}.${context.method}`
+  );
+}
+
+async function runValidators<
+  K extends "validateCode" | "validateToolCall",
+  C extends CodeValidationContext | ToolCallValidationContext
+>(
+  validators: readonly CodemodeValidator[] | undefined,
+  hook: K,
+  context: C,
+  target: string
+): Promise<string | undefined> {
+  if (!validators?.length) return undefined;
+
+  const issues: AttributedIssue[] = [];
+  for (const validator of validators) {
+    const validate = validator[hook] as
+      | ((
+          context: C
+        ) => CodemodeValidationResult | Promise<CodemodeValidationResult>)
+      | undefined;
+    if (!validate) continue;
+
+    const name = normalizedValidatorName(validator.name);
+    try {
+      const result: unknown = await validate(context);
+      if (!isValidationResult(result)) {
+        console.error(
+          `codemode: validator "${name}" returned an invalid result`,
+          result
+        );
+        addIssue(issues, {
+          validator: name,
+          message: `Validator "${name}" did not return an explicit valid or invalid result; the operation was not executed.`
+        });
+      } else if (!result.valid) {
+        const returned = result.issues?.length
+          ? result.issues
+          : [{ message: "Validation failed without further details." }];
+        for (const issue of returned) {
+          if (issues.length >= MAX_ISSUES) break;
+          addIssue(issues, normalizeIssue(name, issue));
+        }
+      }
+    } catch (error) {
+      console.error(`codemode: validator "${name}" threw`, error);
+      addIssue(issues, {
+        validator: name,
+        message: `Validator "${name}" could not complete; the operation was not executed.`
+      });
+    }
+  }
+
+  if (!issues.length) return undefined;
+  return formatIssues(target, issues);
+}
+
+function isValidationResult(value: unknown): value is CodemodeValidationResult {
+  if (!value || typeof value !== "object" || !("valid" in value)) {
+    return false;
+  }
+  const result = value as { valid?: unknown; issues?: unknown };
+  if (result.valid === true) return true;
+  if (result.valid !== false) return false;
+  if (result.issues === undefined) return true;
+  return Array.isArray(result.issues) && result.issues.every(isValidationIssue);
+}
+
+function isValidationIssue(value: unknown): value is CodemodeValidationIssue {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "message" in value &&
+    typeof (value as { message?: unknown }).message === "string"
+  );
+}
+
+function addIssue(issues: AttributedIssue[], issue: AttributedIssue): void {
+  if (issues.length < MAX_ISSUES) issues.push(issue);
+}
+
+function normalizeIssue(
+  validator: string,
+  issue: CodemodeValidationIssue
+): AttributedIssue {
+  return {
+    validator,
+    message: truncate(issue.message, MAX_MESSAGE_CHARS),
+    ...(issue.path ? { path: truncate(issue.path, MAX_DETAIL_CHARS) } : {}),
+    ...(issue.code ? { code: truncate(issue.code, MAX_DETAIL_CHARS) } : {}),
+    ...(issue.suggestion
+      ? { suggestion: truncate(issue.suggestion, MAX_MESSAGE_CHARS) }
+      : {})
+  };
+}
+
+function formatIssues(target: string, issues: AttributedIssue[]): string {
+  const lines = [`Validation failed for ${target}:`];
+  for (const issue of issues) {
+    const code = issue.code ? ` (${issue.code})` : "";
+    const path = issue.path ? ` ${issue.path}:` : ":";
+    const suggestion = issue.suggestion ? ` ${issue.suggestion}` : "";
+    lines.push(
+      `- [${issue.validator}]${code}${path} ${issue.message}${suggestion}`
+    );
+  }
+  return truncate(lines.join("\n"), MAX_FORMATTED_CHARS);
+}
+
+function normalizedValidatorName(name: string): string {
+  return truncate(name.trim(), MAX_NAME_CHARS);
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 14))}… [truncated]`;
+}


### PR DESCRIPTION
## Summary

- add named, pluggable validators to the runtime-first Codemode API
- let applications validate the exact generated code string before an execution is created or the executor starts
- optionally validate concrete connector calls immediately before real execution
- require explicit `{ valid: true }` / `{ valid: false }` results from configured hooks and fail closed on malformed results or validator failures
- return bounded, attributed diagnostics that models can use to correct generated code

## Runtime semantics

- validation is opt-in; runtimes without validators are unchanged
- code validation runs before `runtime.begin()`, so rejected programs create no execution or side effects
- call validation runs only when the durable runtime returns an `execute` decision
- applied durable calls replay without revalidation; ephemeral calls validate again before re-execution
- approval-required calls validate after approval and immediately before execution
- required call-validator names are recorded on executions, preventing approval resume from silently dropping policy
- a rejected call marks the durable execution failed before returning the sandbox error, so generated code cannot catch it and continue to later side effects

## API

```ts
const runtime = createCodemodeRuntime({
  ctx: this.ctx,
  executor,
  connectors,
  validators: [
    {
      name: "organization-policy",
      async validateCode({ code }) {
        const result = await policyEngine.evaluate(code);
        return result.allowed
          ? { valid: true }
          : {
              valid: false,
              issues: [{ code: result.code, message: result.reason }]
            };
      }
    }
  ]
});
```

Validators can implement `validateCode`, `validateToolCall`, or both. A validator that omits a hook does not participate at that validation point.

## Verification

- `pnpm run build`
- `pnpm run check` — all 104 projects typecheck
- `pnpm --filter @cloudflare/codemode test`
  - 305 unit tests
  - 44 durable runtime tests
  - 33 browser tests
