### PR TITLE
Update Kimi model references to kimi-k2.7-code and bump partyserver to 0.5.8

### DIFF
--- a/.changeset/agents-partyserver-0-5-8.md
+++ b/.changeset/agents-partyserver-0-5-8.md
@@ -1,0 +1,11 @@
+---
+"agents": patch
+---
+
+Bump the `partyserver` dependency to `^0.5.8`, which base64-encodes the
+`x-partykit-props` header so props containing non-ASCII characters (e.g.
+accented names) no longer trigger workerd's "header value contains non-ASCII
+characters" warning (which throws a `TypeError` in browser fetch
+implementations). The header is decoded back to the original Unicode payload on
+the server, and raw-JSON values from older callers are still accepted for
+backwards compatibility.

--- a/design/chat-api.md
+++ b/design/chat-api.md
@@ -38,7 +38,7 @@ export class MyAgent extends AIChatAgent<Env> {
   ): Promise<Response | undefined> {
     const result = streamText({
       model: createWorkersAI({ binding: this.env.AI })(
-        "@cf/moonshotai/kimi-k2.6"
+        "@cf/moonshotai/kimi-k2.7-code"
       ),
       system: "You are a helpful assistant.",
       messages: pruneMessages({

--- a/design/think-sessions.md
+++ b/design/think-sessions.md
@@ -436,7 +436,7 @@ For agents that don't need context blocks, `getSystemPrompt()` still works exact
 export class SimpleAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
   getSystemPrompt() {
@@ -804,7 +804,7 @@ This is an advanced feature. Most agents use the default single-session mode and
 export class ChatAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 }
@@ -818,7 +818,7 @@ No `configureSession` needed. No context blocks. `getSystemPrompt()` returns the
 export class ChatAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
   getSystemPrompt() {
@@ -833,7 +833,7 @@ export class ChatAgent extends Think<Env> {
 export class MemoryAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 
@@ -866,7 +866,7 @@ import { createCompactFunction } from "agents/experimental/memory/utils";
 export class LongChatAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 
@@ -895,7 +895,7 @@ import { R2SkillProvider } from "agents/experimental/memory/session";
 export class KnowledgeAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 
@@ -919,7 +919,7 @@ System prompt shows skill metadata (list of available docs). Model uses `load_co
 export class TrackedAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/design/think-vs-aichat.md
+++ b/design/think-vs-aichat.md
@@ -126,7 +126,7 @@ If you don't need context blocks, compaction, search, or multi-session, AIChatAg
 export class MyAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 }

--- a/design/think.md
+++ b/design/think.md
@@ -77,7 +77,7 @@ Think requires almost no boilerplate. The minimal subclass overrides one method:
 export class ChatSession extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 }

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -40,7 +40,7 @@ export class ChatAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages)
     });
 
@@ -166,7 +166,7 @@ async onChatMessage() {
   const workersai = createWorkersAI({ binding: this.env.AI });
 
   const result = streamText({
-    model: workersai("@cf/moonshotai/kimi-k2.6"),
+    model: workersai("@cf/moonshotai/kimi-k2.7-code"),
     system: "You are a helpful assistant.",
     messages: await convertToModelMessages(this.messages)
   });
@@ -221,7 +221,7 @@ async onChatMessage() {
   const workersai = createWorkersAI({ binding: this.env.AI });
 
   const result = streamText({
-    model: workersai("@cf/moonshotai/kimi-k2.6"),
+    model: workersai("@cf/moonshotai/kimi-k2.7-code"),
     messages: pruneMessages({
       messages: await convertToModelMessages(this.messages),
       reasoning: "before-last-message",
@@ -577,7 +577,7 @@ When a user clicks "stop" in the chat UI, the client sends a `CF_AGENT_CHAT_REQU
 ```typescript
 async onChatMessage(_onFinish, options) {
   const result = streamText({
-    model: workersai("@cf/moonshotai/kimi-k2.6"),
+    model: workersai("@cf/moonshotai/kimi-k2.7-code"),
     messages: await convertToModelMessages(this.messages),
     abortSignal: options?.abortSignal // Pass through for cancellation
   });
@@ -927,7 +927,7 @@ async onChatMessage() {
   const workersai = createWorkersAI({ binding: this.env.AI });
 
   const result = streamText({
-    model: workersai("@cf/moonshotai/kimi-k2.6"),
+    model: workersai("@cf/moonshotai/kimi-k2.7-code"),
     messages: await convertToModelMessages(this.messages),
     tools: {
       getWeather: tool({
@@ -994,7 +994,7 @@ import { createToolsFromClientSchemas } from "@cloudflare/ai-chat";
 
 async onChatMessage(_onFinish, options) {
   const result = streamText({
-    model: workersai("@cf/moonshotai/kimi-k2.6"),
+    model: workersai("@cf/moonshotai/kimi-k2.7-code"),
     messages: await convertToModelMessages(this.messages),
     tools: createToolsFromClientSchemas(options?.clientTools)
   });
@@ -1165,7 +1165,7 @@ export class ChatAgent extends AIChatAgent {
     const stream = createUIMessageStream({
       execute: async ({ writer }) => {
         const result = streamText({
-          model: workersai("@cf/moonshotai/kimi-k2.6"),
+          model: workersai("@cf/moonshotai/kimi-k2.7-code"),
           messages: await convertToModelMessages(this.messages)
         });
 
@@ -1357,7 +1357,7 @@ export class ChatAgent extends AIChatAgent {
 
   async onChatMessage() {
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: pruneMessages({
         // LLM context limit
         messages: await convertToModelMessages(this.messages),
@@ -1382,7 +1382,7 @@ import { createWorkersAI } from "workers-ai-provider";
 
 const workersai = createWorkersAI({ binding: this.env.AI });
 const result = streamText({
-  model: workersai("@cf/moonshotai/kimi-k2.6"),
+  model: workersai("@cf/moonshotai/kimi-k2.7-code"),
   messages: await convertToModelMessages(this.messages)
 });
 ```

--- a/docs/client-tools-continuation.md
+++ b/docs/client-tools-continuation.md
@@ -24,7 +24,7 @@ export class MyAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages),
       tools: {
         // Client-side tool: no execute function

--- a/docs/codemode.md
+++ b/docs/codemode.md
@@ -230,7 +230,7 @@ export class BrowserCodemodeAgent extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.5"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages),
       tools: createToolsFromClientSchemas(options?.clientTools),
       stopWhen: stepCountIs(10)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,7 +154,7 @@ For Workers AI integration:
 Access in your agent:
 
 ```typescript
-const response = await this.env.AI.run("@cf/moonshotai/kimi-k2.6", {
+const response = await this.env.AI.run("@cf/moonshotai/kimi-k2.7-code", {
   prompt: "Hello!"
 });
 ```

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -203,7 +203,7 @@ export class MyAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages),
       tools: {
         // Tool with conditional approval
@@ -370,7 +370,7 @@ export class MyAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages),
       tools: {
         // No execute function - client handles via onToolCall

--- a/docs/resumable-streaming.md
+++ b/docs/resumable-streaming.md
@@ -28,7 +28,7 @@ export class ChatAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages)
     });
 

--- a/docs/think/getting-started.md
+++ b/docs/think/getting-started.md
@@ -84,7 +84,7 @@ import { routeAgentRequest } from "agents";
 export class MyAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 
@@ -202,7 +202,7 @@ Override `configureSession` to give the model writable memory that survives rest
 export class MyAgent extends Think<Env> {
   getModel(): LanguageModel {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -24,7 +24,7 @@ import { routeAgentRequest } from "agents";
 export class MyAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 }
@@ -880,7 +880,7 @@ export class MyAgent extends Think<Env> {
   getModel() {
     const tier = this.getConfig<MyConfig>()?.modelTier ?? "fast";
     const models = {
-      fast: "@cf/moonshotai/kimi-k2.6",
+      fast: "@cf/moonshotai/kimi-k2.7-code",
       capable: "@cf/meta/llama-4-scout-17b-16e-instruct"
     };
     return createWorkersAI({ binding: this.env.AI })(models[tier]);

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -118,7 +118,7 @@ a terminal error state and `step.prompt()` throws.
 - **The model must support streaming tool calls.** Think streams every turn, so
   `step.prompt()` works only with models that reliably emit a forced tool call
   while streaming. Strong tool-callers (for example OpenAI `gpt-4o-mini`,
-  Anthropic `claude-haiku-4-5`, and Workers AI `@cf/moonshotai/kimi-k2.6`) are
+  Anthropic `claude-haiku-4-5`, and Workers AI `@cf/moonshotai/kimi-k2.7-code`) are
   verified to work. Some models honor a forced `toolChoice` only on
   non-streaming requests and will reply in plain text and stop while streaming —
   for example Workers AI `@cf/meta/llama-3.3-70b-instruct-fp8-fast`. With those

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -194,7 +194,7 @@ async onTurn(transcript: string, context: VoiceTurnContext) {
   const workersai = createWorkersAI({ binding: this.env.AI });
 
   const result = streamText({
-    model: workersai("@cf/moonshotai/kimi-k2.6"),
+    model: workersai("@cf/moonshotai/kimi-k2.7-code"),
     system: "You are a helpful voice assistant. Keep responses concise.",
     messages: [
       ...context.messages.map(m => ({

--- a/examples/a2a/src/server.ts
+++ b/examples/a2a/src/server.ts
@@ -130,7 +130,7 @@ class AIAgentExecutor implements AgentExecutor {
     // Call Workers AI
     const workersai = createWorkersAI({ binding: this.getEnv().AI });
     const result = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       system:
         "You are a helpful AI assistant. Keep responses concise and clear.",
       messages: [{ role: "user", content: userText }]

--- a/examples/agent-skills/src/server.ts
+++ b/examples/agent-skills/src/server.ts
@@ -12,7 +12,7 @@ type Env = {
 export class SkillsAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       { sessionAffinity: this.sessionAffinity }
     );
   }

--- a/examples/agents-as-tools/e2e/helpers.ts
+++ b/examples/agents-as-tools/e2e/helpers.ts
@@ -99,7 +99,7 @@ export async function waitForChatReady(page: Page): Promise<void> {
  *
  * Timeout is generous (90s) because the wait window has to cover
  * the parent's first-token latency on Workers AI (which can be
- * 5-30s for `kimi-k2.5`) plus the time to actually pick a tool
+ * 5-30s for `kimi-k2.7-code`) plus the time to actually pick a tool
  * and emit the synthesized `started` event the panel renders from.
  */
 export async function waitForHelperOfType(

--- a/examples/agents-as-tools/playwright.config.ts
+++ b/examples/agents-as-tools/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
   testDir: "./e2e",
   testMatch: /.*\.e2e\.ts/,
   // Real-LLM timing — see the comment block above. The example
-  // uses `@cf/moonshotai/kimi-k2.5`, a heavyweight reasoning model.
+  // uses `@cf/moonshotai/kimi-k2.7-code`, a heavyweight reasoning model.
   // A single helper turn pairs a parent-side LLM call (tool
   // selection) with a helper-side LLM call (the helper's own
   // inference loop), so 60-120s per test is realistic. The compare

--- a/examples/agents-as-tools/src/server.ts
+++ b/examples/agents-as-tools/src/server.ts
@@ -33,7 +33,7 @@ class DemoToolAgent extends Think<Env> {
 
   override getModel(): LanguageModel {
     const workersai = createWorkersAI({ binding: this.env.AI });
-    return workersai("@cf/moonshotai/kimi-k2.5", {
+    return workersai("@cf/moonshotai/kimi-k2.7-code", {
       sessionAffinity: this.sessionAffinity
     });
   }
@@ -144,7 +144,7 @@ export class Assistant extends Think<Env> {
 
   override getModel(): LanguageModel {
     const workersai = createWorkersAI({ binding: this.env.AI });
-    return workersai("@cf/moonshotai/kimi-k2.5", {
+    return workersai("@cf/moonshotai/kimi-k2.7-code", {
       sessionAffinity: this.sessionAffinity
     });
   }

--- a/examples/ai-chat/README.md
+++ b/examples/ai-chat/README.md
@@ -30,7 +30,7 @@ npm install
 npm start
 ```
 
-Uses Workers AI (no API key needed) with `@cf/moonshotai/kimi-k2.6`.
+Uses Workers AI (no API key needed) with `@cf/moonshotai/kimi-k2.7-code`.
 
 Recent Wrangler releases run the Browser Rendering binding locally, so no separate Chrome process is required.
 

--- a/examples/ai-chat/src/server.ts
+++ b/examples/ai-chat/src/server.ts
@@ -84,7 +84,7 @@ export class ChatAgent extends AIChatAgent {
 
     const result = streamText({
       abortSignal: options?.abortSignal,
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/assistant/agents/assistant/agent.ts
+++ b/examples/assistant/agents/assistant/agent.ts
@@ -35,7 +35,7 @@ export class AssistantDirectory extends Think<Env, DirectoryState> {
   // accumulator role calls it.
   override getModel(): LanguageModel {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       { sessionAffinity: this.sessionAffinity }
     );
   }

--- a/examples/assistant/agents/assistant/agents/my-assistant/agent.ts
+++ b/examples/assistant/agents/assistant/agents/my-assistant/agent.ts
@@ -84,8 +84,8 @@ export class MyAssistant extends Think<Env> {
   getModel(): LanguageModel {
     const tier = this.getConfig<AgentConfig>()?.modelTier ?? "fast";
     const models: Record<string, string> = {
-      fast: "@cf/moonshotai/kimi-k2.6",
-      capable: "@cf/moonshotai/kimi-k2.6"
+      fast: "@cf/moonshotai/kimi-k2.7-code",
+      capable: "@cf/moonshotai/kimi-k2.7-code"
     };
     return createWorkersAI({ binding: this.env.AI })(
       models[tier] ?? models.fast,

--- a/examples/assistant/src/tests/worker.ts
+++ b/examples/assistant/src/tests/worker.ts
@@ -19,7 +19,7 @@
  *
  * No AI binding is declared. Tests deliberately don't trigger turns —
  * `MyAssistant.getModel()` is never called. That means we don't have
- * to mock Workers AI or worry about `kimi-k2.6` flakiness, and the
+ * to mock Workers AI or worry about `kimi-k2.7-code` flakiness, and the
  * harness focuses on the plumbing the example owns: directory CRUD,
  * `SharedWorkspace` round-trips, change broadcasts, and the MCP
  * empty-state path. See `shared-mcp.test.ts` for why the deep MCP

--- a/examples/auth-agent/src/server.ts
+++ b/examples/auth-agent/src/server.ts
@@ -27,7 +27,7 @@ export class ChatAgent extends AIChatAgent<Env> {
 
     const result = streamText({
       abortSignal: options?.abortSignal,
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: `You are a helpful assistant. The authenticated user's GitHub login is ${this.name}. Address them by their login occasionally.`,

--- a/examples/browser-live-view/src/server.ts
+++ b/examples/browser-live-view/src/server.ts
@@ -26,7 +26,7 @@ const BROWSER_SESSION_KEY = "main";
 export class LiveViewAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/examples/browser-quick-actions/README.md
+++ b/examples/browser-quick-actions/README.md
@@ -45,7 +45,7 @@ const tools = createQuickActionTools({ browser: this.env.BROWSER });
 // browser_markdown, browser_extract, browser_links, browser_scrape
 
 const { text } = await generateText({
-  model: workersai("@cf/moonshotai/kimi-k2.6"),
+  model: workersai("@cf/moonshotai/kimi-k2.7-code"),
   prompt: `Page: ${url}\n\nQuestion: ${question}`,
   tools,
   stopWhen: stepCountIs(6)

--- a/examples/browser-quick-actions/src/server.ts
+++ b/examples/browser-quick-actions/src/server.ts
@@ -74,7 +74,7 @@ export class QuickActionsAgent extends Agent<Env> {
     const tools = createQuickActionTools({ browser: this.env.BROWSER });
 
     const result = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       system:
         "You are a research assistant. Use the browser_* tools to read the " +
         "page the user references, then answer concisely. Prefer " +

--- a/examples/chat-sdk-messenger/src/intelligence/conversation-agent.ts
+++ b/examples/chat-sdk-messenger/src/intelligence/conversation-agent.ts
@@ -5,7 +5,7 @@ import { createWorkersAI } from "workers-ai-provider";
 export class ConversationAgent extends Think {
   override getModel(): LanguageModel {
     const workersai = createWorkersAI({ binding: this.env.AI });
-    return workersai("@cf/moonshotai/kimi-k2.6", {
+    return workersai("@cf/moonshotai/kimi-k2.7-code", {
       sessionAffinity: this.sessionAffinity
     });
   }

--- a/examples/codemode-browser/src/server.ts
+++ b/examples/codemode-browser/src/server.ts
@@ -13,7 +13,7 @@ export class BrowserCodemode extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/codemode-connectors/src/server.ts
+++ b/examples/codemode-connectors/src/server.ts
@@ -144,7 +144,7 @@ export class Chat extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: [

--- a/examples/codemode/README.md
+++ b/examples/codemode/README.md
@@ -32,7 +32,7 @@ npm run build # from repo root
 npm start     # from this directory -- starts Vite dev server
 ```
 
-Uses Workers AI (no API key needed) with `@cf/moonshotai/kimi-k2.5`.
+Uses Workers AI (no API key needed) with `@cf/moonshotai/kimi-k2.7-code`.
 
 ## Try it
 

--- a/examples/codemode/src/server.ts
+++ b/examples/codemode/src/server.ts
@@ -80,7 +80,7 @@ export class Codemode extends AIChatAgent<Env> {
     });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/deploy-churn/INVESTIGATION.md
+++ b/examples/deploy-churn/INVESTIGATION.md
@@ -42,7 +42,7 @@ Run with `npm start`, then curl. `maxRetries: 0` so a 400 surfaces immediately.
 
 Results:
 
-- **Kimi 2.6 (`@cf/moonshotai/kimi-k2.6`, Workers AI): does NOT reproduce.**
+- **Kimi 2.7 Code (`@cf/moonshotai/kimi-k2.7-code`, Workers AI): does NOT reproduce.**
   - trailing-user → `ok` ("Hello, it's a pleasure to connect with you!")
   - trailing-assistant → `ok` ("Hello, it's wonderful to meet you!")
   - Kimi tolerates a trailing assistant message (just responds). No 400.
@@ -175,7 +175,7 @@ cd examples/deploy-churn
 npm start            # vite dev (note: heavy; has crashed the editor — prefer short sessions)
 curl "http://localhost:5173/probe/trailing-user?provider=anthropic&model=claude-sonnet-4-6"
 curl "http://localhost:5173/probe/trailing-assistant?provider=anthropic&model=claude-sonnet-4-6"
-# Kimi (no key): drop the query params (defaults to @cf/moonshotai/kimi-k2.6)
+# Kimi (no key): drop the query params (defaults to @cf/moonshotai/kimi-k2.7-code)
 ```
 
 ## Notes

--- a/examples/deploy-churn/src/server.ts
+++ b/examples/deploy-churn/src/server.ts
@@ -55,7 +55,7 @@ type Env = {
   ANTHROPIC_API_KEY?: string;
 };
 
-const DEFAULT_WORKERS_AI_MODEL = "@cf/moonshotai/kimi-k2.6";
+const DEFAULT_WORKERS_AI_MODEL = "@cf/moonshotai/kimi-k2.7-code";
 const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
 
 /**

--- a/examples/dynamic-tools/README.md
+++ b/examples/dynamic-tools/README.md
@@ -24,7 +24,7 @@ import { createToolsFromClientSchemas } from "@cloudflare/ai-chat";
 
 async onChatMessage(_onFinish, options) {
   const result = streamText({
-    model: workersai("@cf/moonshotai/kimi-k2.6"),
+    model: workersai("@cf/moonshotai/kimi-k2.7-code"),
     tools: createToolsFromClientSchemas(options?.clientTools),
     // ...
   });

--- a/examples/dynamic-tools/src/server.ts
+++ b/examples/dynamic-tools/src/server.ts
@@ -27,7 +27,7 @@ export class DynamicToolsAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/elevenlabs-starter/src/agents/character.ts
+++ b/examples/elevenlabs-starter/src/agents/character.ts
@@ -45,7 +45,7 @@ export class CharacterAgent extends AIChatAgent<Env, CharacterState> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const { text } = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       prompt: `Create a system prompt for an AI character with this personality:
 
 "${personality}"
@@ -150,7 +150,7 @@ Keep it under 200 words. Return ONLY the system prompt text, no wrapper or expla
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       system: this.state.character.systemPrompt,
       messages: pruneMessages({
         messages: await convertToModelMessages(this.messages),

--- a/examples/elevenlabs-starter/src/agents/soundscape.ts
+++ b/examples/elevenlabs-starter/src/agents/soundscape.ts
@@ -36,7 +36,7 @@ export class SoundscapeAgent extends Agent<Env, SoundscapeState> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const { text } = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       prompt: `You are a sound designer. Given this scene description, produce:
 1. A short narration (2-3 sentences) that sets the scene for a listener.
 2. A list of 3-4 distinct ambient sound effects that would bring this scene to life. Each description should be 3-8 words, specific enough for a sound effects generator.

--- a/examples/elevenlabs-starter/src/agents/voice-chat.ts
+++ b/examples/elevenlabs-starter/src/agents/voice-chat.ts
@@ -165,7 +165,7 @@ export class VoiceChatAgent extends AIChatAgent<Env, VoiceChatState> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       system:
         "You are a helpful, friendly assistant. Keep your responses concise — they will be read aloud via text-to-speech, so aim for natural spoken language rather than markdown formatting.",
       messages: pruneMessages({

--- a/examples/mcp-rpc-transport/src/server.ts
+++ b/examples/mcp-rpc-transport/src/server.ts
@@ -59,7 +59,7 @@ export class Chat extends AIChatAgent<Env> {
     const allTools = this.mcp.getAITools();
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: `You are a helpful assistant. The current date and time is ${new Date().toISOString()}.\n`,

--- a/examples/multi-ai-chat/src/server.ts
+++ b/examples/multi-ai-chat/src/server.ts
@@ -322,7 +322,7 @@ export class Chat extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
     const result = streamText({
       abortSignal: options?.abortSignal,
-      model: workersai("@cf/moonshotai/kimi-k2.5", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: systemPrompt,
@@ -439,7 +439,7 @@ export class Researcher extends Agent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const { text } = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.5"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       system:
         "You are a concise research helper. Use only the provided chat context. " +
         "Return a short, practical answer with any uncertainty called out.",

--- a/examples/playground/src/demos/ai/ChatDemo.tsx
+++ b/examples/playground/src/demos/ai/ChatDemo.tsx
@@ -46,7 +46,7 @@ const codeSections: CodeSection[] = [
 class ChatAgent extends AIChatAgent<Env> {
   async onChatMessage(onFinish) {
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: this.messages,
       onFinish,
     });

--- a/examples/playground/src/demos/ai/CodemodeDemo.tsx
+++ b/examples/playground/src/demos/ai/CodemodeDemo.tsx
@@ -42,7 +42,7 @@ import { createCodeTool } from "@cloudflare/codemode/ai";
 class CodemodeAgent extends AIChatAgent<Env> {
   async onChatMessage(onFinish) {
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: this.messages,
       tools: {
         code: createCodeTool(this.env),

--- a/examples/playground/src/demos/ai/ThinkShellDemo.tsx
+++ b/examples/playground/src/demos/ai/ThinkShellDemo.tsx
@@ -87,7 +87,7 @@ import { createWorkersAI } from "workers-ai-provider";
 export class Assistant extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/examples/playground/src/demos/ai/chat-agent.ts
+++ b/examples/playground/src/demos/ai/chat-agent.ts
@@ -16,7 +16,7 @@ export class ChatAgent extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/playground/src/demos/ai/codemode-agent.ts
+++ b/examples/playground/src/demos/ai/codemode-agent.ts
@@ -69,7 +69,7 @@ export class CodemodeAgent extends AIChatAgent<Env> {
     const codemode = createCodeTool({ tools: pmTools, executor });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/playground/src/demos/ai/tools-agent.ts
+++ b/examples/playground/src/demos/ai/tools-agent.ts
@@ -16,7 +16,7 @@ export class ToolsAgent extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/playground/src/demos/voice/voice-agent.ts
+++ b/examples/playground/src/demos/voice/voice-agent.ts
@@ -18,7 +18,7 @@ export class PlaygroundVoiceAgent extends VoiceAgent<Env> {
     const ai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: ai("@cf/moonshotai/kimi-k2.6" as Parameters<typeof ai>[0], {
+      model: ai("@cf/moonshotai/kimi-k2.7-code" as Parameters<typeof ai>[0], {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/examples/resumable-stream-chat/src/server.ts
+++ b/examples/resumable-stream-chat/src/server.ts
@@ -46,7 +46,7 @@ export class ResumableStreamingChat extends AIChatAgent {
         .join("") || "unknown";
 
     const workersai = createWorkersAI({ binding: this.env.AI });
-    const modelId = "@cf/moonshotai/kimi-k2.6";
+    const modelId = "@cf/moonshotai/kimi-k2.7-code";
     const startTime = Date.now();
 
     const stream = createUIMessageStream({

--- a/examples/structured-input/src/server.ts
+++ b/examples/structured-input/src/server.ts
@@ -11,7 +11,7 @@ export class StructuredInputAgent extends AIChatAgent {
 
     const result = streamText({
       abortSignal: options?.abortSignal,
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: `You are a helpful assistant that gathers information from users through structured inputs.

--- a/examples/think-chat-sdk/src/index.ts
+++ b/examples/think-chat-sdk/src/index.ts
@@ -35,7 +35,7 @@ export type TelegramWebhookSetupResult = {
 export class SupportAgent extends Think<Env> {
   override getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/examples/think-submissions/src/server.ts
+++ b/examples/think-submissions/src/server.ts
@@ -15,7 +15,7 @@ type Env = {
 export class TaskAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/examples/think-workflows/src/index.ts
+++ b/examples/think-workflows/src/index.ts
@@ -34,7 +34,7 @@ const reportDraftSchema = z.object({
 export class ReportAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/examples/voice-agent/README.md
+++ b/examples/voice-agent/README.md
@@ -7,7 +7,7 @@ Uses Workers AI for all models — zero external API keys required:
 - **STT**: Deepgram Flux (`@cf/deepgram/flux`) by default, with a Nova 3 (`@cf/deepgram/nova-3`) option in the UI
 - **TTS**: Deepgram Aura (`@cf/deepgram/aura-1`)
 - **Turn detection**: Flux `StartOfTurn` / `EndOfTurn` events
-- **LLM**: Kimi K2.6 (`@cf/moonshotai/kimi-k2.6`), GPT OSS 20B, or GLM 4.7 Flash
+- **LLM**: Kimi K2.7 Code (`@cf/moonshotai/kimi-k2.7-code`), GPT OSS 20B, or GLM 4.7 Flash
 
 ## Run it
 

--- a/examples/voice-agent/src/server.ts
+++ b/examples/voice-agent/src/server.ts
@@ -132,7 +132,7 @@ export class MyVoiceAgent extends VoiceAgent<Env> {
     const llm = url.searchParams.get("llm");
     const llmModel =
       llm === "kimi"
-        ? "@cf/moonshotai/kimi-k2.6"
+        ? "@cf/moonshotai/kimi-k2.7-code"
         : llm === "gpt-oss-20b"
           ? "@cf/openai/gpt-oss-20b"
           : "@cf/zai-org/glm-4.7-flash";

--- a/examples/voice-input/package.json
+++ b/examples/voice-input/package.json
@@ -13,7 +13,7 @@
     "@cloudflare/kumo": "^2.5.2",
     "@cloudflare/voice": "*",
     "@phosphor-icons/react": "^2.1.10",
-    "partyserver": "*",
+    "agents": "*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/examples/worker-bundler-playground/src/server.ts
+++ b/examples/worker-bundler-playground/src/server.ts
@@ -332,7 +332,7 @@ export class WorkerPlayground extends AIChatAgent<Env> {
 
     const result = streamText({
       abortSignal: options?.abortSignal,
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: [

--- a/examples/workspace-chat/src/server.ts
+++ b/examples/workspace-chat/src/server.ts
@@ -46,7 +46,7 @@ export class WorkspaceChatAgent extends AIChatAgent {
 
     const result = streamText({
       abortSignal: options?.abortSignal,
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: [

--- a/experimental/forever-chat/README.md
+++ b/experimental/forever-chat/README.md
@@ -14,7 +14,7 @@ See [forever.md](../forever.md) for the full design doc.
 
 | Provider   | Model             | Recovery strategy                                                                                 |
 | ---------- | ----------------- | ------------------------------------------------------------------------------------------------- |
-| Workers AI | kimi-k2.5         | Persist partial + continue via `continueLastTurn()` (text + reasoning merge into existing blocks) |
+| Workers AI | kimi-k2.7-code    | Persist partial + continue via `continueLastTurn()` (text + reasoning merge into existing blocks) |
 | OpenAI     | gpt-5.4           | Retrieve completed response via Responses API (`store: true`) — zero wasted tokens                |
 | Anthropic  | claude-sonnet-4.6 | Persist partial + continue via synthetic user message (reasoning disabled for recovery)           |
 

--- a/experimental/forever-chat/src/replay-model.test.ts
+++ b/experimental/forever-chat/src/replay-model.test.ts
@@ -243,7 +243,7 @@ describe("Workers AI replay", () => {
           accountId: "replay",
           apiKey: "replay",
           fetch
-        })("@cf/moonshotai/kimi-k2.6")
+        })("@cf/moonshotai/kimi-k2.7-code")
     });
     const parts = await collectStream(model);
     expect(textContent(parts)).toBe("Hello from Workers AI");

--- a/experimental/forever-chat/src/server.ts
+++ b/experimental/forever-chat/src/server.ts
@@ -703,7 +703,7 @@ export class ForeverChatAgent extends AIChatAgent<Env, AgentState> {
           accountId: "buffer-replay",
           apiKey: "buffer-replay",
           fetch: replayFetch
-        })("@cf/moonshotai/kimi-k2.6", {
+        })("@cf/moonshotai/kimi-k2.7-code", {
           sessionAffinity: this.sessionAffinity
         });
     }
@@ -723,7 +723,7 @@ export class ForeverChatAgent extends AIChatAgent<Env, AgentState> {
         })("claude-sonnet-4-6");
       default: {
         const binding = useBuffer ? this._makeBufferedAIBinding() : this.env.AI;
-        return createWorkersAI({ binding })("@cf/moonshotai/kimi-k2.6", {
+        return createWorkersAI({ binding })("@cf/moonshotai/kimi-k2.7-code", {
           sessionAffinity: this.sessionAffinity
         });
       }

--- a/experimental/forever-chat/src/sse-parsers.ts
+++ b/experimental/forever-chat/src/sse-parsers.ts
@@ -26,7 +26,7 @@
  * Anthropic: `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"..."}}`
  *            Tool calls via `content_block_start` (type: "tool_use") + `input_json_delta`.
  *
- * Workers AI: Either OpenAI-compatible (newer models like kimi-k2.5) or
+ * Workers AI: Either OpenAI-compatible (newer models like kimi-k2.7-code) or
  *             native `data: {"response":"text"}` format.
  */
 

--- a/experimental/gadgets-chat/src/server.ts
+++ b/experimental/gadgets-chat/src/server.ts
@@ -121,7 +121,7 @@ export class ChatRoom extends Agent<Env> {
     // Stream the LLM response using the AI SDK's UIMessageStream protocol
     const workersai = createWorkersAI({ binding: this.env.AI });
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:

--- a/experimental/gadgets-gatekeeper/src/server.ts
+++ b/experimental/gadgets-gatekeeper/src/server.ts
@@ -251,7 +251,7 @@ export class GatekeeperAgent extends AIChatAgent<Env, GatekeeperState> {
     const agent = this;
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: `You are a helpful database administrator assistant. You manage a customer database.

--- a/experimental/gadgets-sandbox/src/server.ts
+++ b/experimental/gadgets-sandbox/src/server.ts
@@ -417,7 +417,7 @@ export class SandboxAgent extends AIChatAgent<Env, SandboxState> {
     const agent = this;
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: `You are a helpful assistant that can write and execute JavaScript code to work with a customer database.

--- a/experimental/gadgets-subagents/src/server.ts
+++ b/experimental/gadgets-subagents/src/server.ts
@@ -138,7 +138,7 @@ export class PerspectiveAgent extends Agent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: perspective.system,
@@ -274,7 +274,7 @@ export class CoordinatorAgent extends AIChatAgent<Env, SubagentState> {
     // Synthesize: ask the LLM to combine the three perspectives
     const workersai = createWorkersAI({ binding: this.env.AI });
     const synthesisResult = await generateText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:
@@ -309,7 +309,7 @@ export class CoordinatorAgent extends AIChatAgent<Env, SubagentState> {
     const agent = this;
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: `You are a coordinator that manages three specialist sub-agents to analyze questions from multiple perspectives.

--- a/experimental/inference-buffer/README.md
+++ b/experimental/inference-buffer/README.md
@@ -122,7 +122,7 @@ createModel: (fetch) =>
   createAnthropic({ apiKey: "replay", fetch })("claude-sonnet-4-6");
 createModel: (fetch) =>
   createWorkersAI({ accountId: "replay", apiKey: "replay", fetch })(
-    "@cf/moonshotai/kimi-k2.6"
+    "@cf/moonshotai/kimi-k2.7-code"
   );
 ```
 
@@ -158,7 +158,7 @@ Content-Type: application/json
 ```
 POST /proxy?id=fiber-abc123
 X-Provider-Type: workers-ai
-X-AI-Model: @cf/moonshotai/kimi-k2.5
+X-AI-Model: @cf/moonshotai/kimi-k2.7-code
 Content-Type: application/json
 
 {"messages": [...], "stream": true}

--- a/experimental/session-memory/src/server.ts
+++ b/experimental/session-memory/src/server.ts
@@ -62,7 +62,7 @@ export class ChatAgent extends Agent<Env> {
 
   private getAI() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       { sessionAffinity: this.sessionAffinity }
     );
   }

--- a/experimental/session-multichat/src/server.ts
+++ b/experimental/session-multichat/src/server.ts
@@ -49,7 +49,7 @@ export class MultiSessionAgent extends Agent<Env> {
         summarize: (prompt) =>
           generateText({
             model: createWorkersAI({ binding: this.env.AI })(
-              "@cf/moonshotai/kimi-k2.6"
+              "@cf/moonshotai/kimi-k2.7-code"
             ),
             prompt
           }).then((r) => r.text),
@@ -62,7 +62,7 @@ export class MultiSessionAgent extends Agent<Env> {
 
   private getAI() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       { sessionAffinity: this.sessionAffinity }
     );
   }

--- a/experimental/session-search/src/server.ts
+++ b/experimental/session-search/src/server.ts
@@ -69,7 +69,7 @@ export class SearchAgent extends Agent<Env> {
 
   private getAI() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       { sessionAffinity: this.sessionAffinity }
     );
   }

--- a/experimental/session-skills/README.md
+++ b/experimental/session-skills/README.md
@@ -18,7 +18,7 @@ import { R2SkillProvider } from "agents/experimental/memory/session";
 export class SkillsAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/experimental/session-skills/src/server.ts
+++ b/experimental/session-skills/src/server.ts
@@ -24,7 +24,7 @@ export interface Skill {
 export class SkillsAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       { sessionAffinity: this.sessionAffinity }
     );
   }

--- a/experimental/voice.md
+++ b/experimental/voice.md
@@ -25,7 +25,7 @@ export class MyAgent extends VoiceAgent<Env> {
     const ai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: ai("@cf/moonshotai/kimi-k2.6"),
+      model: ai("@cf/moonshotai/kimi-k2.7-code"),
       system: "You are a helpful voice assistant. Be concise.",
       messages: [
         ...context.messages.map((m) => ({

--- a/guides/human-in-the-loop/src/server.ts
+++ b/guides/human-in-the-loop/src/server.ts
@@ -16,7 +16,7 @@ export class HumanInTheLoop extends AIChatAgent {
 
     const result = streamText({
       messages: await convertToModelMessages(this.messages),
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       tools,

--- a/ideas/messengers.md
+++ b/ideas/messengers.md
@@ -209,7 +209,7 @@ export class SupportBot extends Agent<Env> {
       ...this.sql`SELECT role, content FROM messages ORDER BY timestamp`
     ];
     const result = streamText({
-      model: workersAI("@cf/moonshotai/kimi-k2.6"),
+      model: workersAI("@cf/moonshotai/kimi-k2.7-code"),
       messages: history.map((m) => ({ role: m.role, content: m.content }))
     });
 
@@ -340,7 +340,7 @@ export class OmniBot extends Agent<Env> {
       ...this.sql`SELECT role, content FROM messages ORDER BY timestamp`
     ];
     const response = await generateText({
-      model: workersAI("@cf/moonshotai/kimi-k2.6"),
+      model: workersAI("@cf/moonshotai/kimi-k2.7-code"),
       messages: history.map((m) => ({ role: m.role, content: m.content }))
     });
 

--- a/ideas/voice.md
+++ b/ideas/voice.md
@@ -146,7 +146,7 @@ class RestaurantAgent extends VoiceAgent<Env> {
   async onTurn(transcript: string, context: VoiceTurnContext) {
     const ai = createWorkersAI({ binding: this.env.AI });
     const result = streamText({
-      model: ai("@cf/moonshotai/kimi-k2.6"),
+      model: ai("@cf/moonshotai/kimi-k2.7-code"),
       system: "You are a restaurant booking assistant...",
       messages: [
         ...context.messages.map(m => ({

--- a/openai-sdk/basic/src/server.ts
+++ b/openai-sdk/basic/src/server.ts
@@ -6,7 +6,7 @@ import { Agent as CFAgent, routeAgentRequest } from "agents";
 // import { aisdk } from "@openai/agents-extensions";
 // import { createWorkersAI } from "workers-ai-provider";
 // const model = aisdk(
-//   createWorkersAI({ binding: env.AI })("@cf/moonshotai/kimi-k2.6")
+//   createWorkersAI({ binding: env.AI })("@cf/moonshotai/kimi-k2.7-code")
 // );
 
 export class MyAgent extends CFAgent<Env> {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "nx": "^22.7.5",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",
-    "partyserver": "^0.5.7",
+    "partyserver": "^0.5.8",
     "partysocket": "1.2.0",
     "pkg-pr-new": "^0.0.75",
     "playwright": "^1.60.0",

--- a/packages/agents/evals/scheduling.eval.ts
+++ b/packages/agents/evals/scheduling.eval.ts
@@ -15,7 +15,7 @@ const workersai = createWorkersAI({
   apiKey: process.env.CLOUDFLARE_API_TOKEN!
 });
 
-const model = workersai("@cf/moonshotai/kimi-k2.6");
+const model = workersai("@cf/moonshotai/kimi-k2.7-code");
 // const model = openai("gpt-4o");
 // const model = google("gemini-2.0-pro-exp-02-05");
 // const model = google("gemini-2.0-flash");

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -34,7 +34,7 @@
     "just-bash": "^3.0.1",
     "mimetext": "^3.0.28",
     "nanoid": "^5.1.11",
-    "partyserver": "^0.5.7",
+    "partyserver": "^0.5.8",
     "partysocket": "1.2.0",
     "yaml": "^2.9.0",
     "yargs": "^18.0.0"

--- a/packages/ai-chat/README.md
+++ b/packages/ai-chat/README.md
@@ -22,7 +22,7 @@ export class ChatAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages)
     });
 
@@ -110,7 +110,7 @@ export class ChatAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: await convertToModelMessages(this.messages),
       tools: {
         getWeather: tool({
@@ -409,7 +409,7 @@ export class ChatAgent extends AIChatAgent {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6"),
+      model: workersai("@cf/moonshotai/kimi-k2.7-code"),
       messages: pruneMessages({
         messages: await convertToModelMessages(this.messages),
         reasoning: "before-last-message",

--- a/packages/ai-chat/e2e/llm.spec.ts
+++ b/packages/ai-chat/e2e/llm.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * E2E tests that make real LLM calls via Workers AI (@cf/moonshotai/kimi-k2.5).
+ * E2E tests that make real LLM calls via Workers AI (@cf/moonshotai/kimi-k2.7-code).
  * These verify the full streaming pipeline: streamText → SSE → WebSocket → client.
  *
  * Uses the AI binding configured in wrangler.jsonc -- no API key needed.

--- a/packages/ai-chat/e2e/on-stream-end-llm.spec.ts
+++ b/packages/ai-chat/e2e/on-stream-end-llm.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 /**
  * E2E tests for onChatResponse + server-initiated streaming with a real LLM.
- * Uses Workers AI (@cf/moonshotai/kimi-k2.5) via the StreamEndLlmAgent.
+ * Uses Workers AI (@cf/moonshotai/kimi-k2.7-code) via the StreamEndLlmAgent.
  *
  * These verify:
  * 1. onChatResponse fires with status "completed" after a real LLM stream

--- a/packages/ai-chat/e2e/worker.ts
+++ b/packages/ai-chat/e2e/worker.ts
@@ -71,7 +71,7 @@ export class LlmChatAgent extends AIChatAgent<Env> {
     };
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:
@@ -97,7 +97,7 @@ export class ClientToolAgent extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system:
@@ -250,7 +250,7 @@ export class ResponseLlmAgent extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: "You are a test assistant. Keep responses to 1 sentence max.",
@@ -304,7 +304,7 @@ export class ResponseChainAgent extends AIChatAgent<Env> {
     const workersai = createWorkersAI({ binding: this.env.AI });
 
     const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.6", {
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
         sessionAffinity: this.sessionAffinity
       }),
       system: "You are a test assistant. Keep responses to 1 sentence max.",

--- a/packages/codemode/e2e/codemode.spec.ts
+++ b/packages/codemode/e2e/codemode.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from "@playwright/test";
  *   user prompt → LLM generates code via createCodeTool → DynamicWorkerExecutor
  *   runs the code in an isolated Worker → tool functions called via RPC → result returned.
  *
- * Uses Workers AI (@cf/moonshotai/kimi-k2.5) — no API key needed.
+ * Uses Workers AI (@cf/moonshotai/kimi-k2.7-code) — no API key needed.
  */
 
 async function runChat(

--- a/packages/codemode/e2e/llm-codemode.spec.ts
+++ b/packages/codemode/e2e/llm-codemode.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from "@playwright/test";
  *   user prompt → LLM generates code → createCodeTool → DynamicWorkerExecutor
  *   → sandboxed Worker → tool dispatch via RPC → result → LLM response.
  *
- * Uses Workers AI (@cf/moonshotai/kimi-k2.5) — no API key needed.
+ * Uses Workers AI (@cf/moonshotai/kimi-k2.7-code) — no API key needed.
  */
 
 async function runChat(

--- a/packages/codemode/e2e/worker.ts
+++ b/packages/codemode/e2e/worker.ts
@@ -124,7 +124,7 @@ export class CodemodeAgent extends Agent<Env> {
     const body = (await request.json()) as { messages: UIMessage[] };
 
     const workersai = createWorkersAI({ binding: this.env.AI });
-    const model = workersai("@cf/moonshotai/kimi-k2.6", {
+    const model = workersai("@cf/moonshotai/kimi-k2.7-code", {
       sessionAffinity: this.sessionAffinity
     });
 
@@ -305,7 +305,7 @@ async function handleRunMulti(request: Request, env: Env): Promise<Response> {
   const body = (await request.json()) as { messages: UIMessage[] };
 
   const workersai = createWorkersAI({ binding: env.AI });
-  const model = workersai("@cf/moonshotai/kimi-k2.6");
+  const model = workersai("@cf/moonshotai/kimi-k2.7-code");
 
   const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -15,7 +15,7 @@ import { createWorkersAI } from "workers-ai-provider";
 export class MyAgent extends Think<Env> {
   getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6"
+      "@cf/moonshotai/kimi-k2.7-code"
     );
   }
 

--- a/packages/think/src/cli-tests/cli.test.ts
+++ b/packages/think/src/cli-tests/cli.test.ts
@@ -260,7 +260,7 @@ describe("think CLI", () => {
       "utf8"
     );
     expect(agentSource).toContain("export class Assistant");
-    expect(agentSource).toContain("@cf/moonshotai/kimi-k2.6");
+    expect(agentSource).toContain("@cf/moonshotai/kimi-k2.7-code");
     expect(await readFile(path.join(appRoot, "think.d.ts"), "utf8")).toContain(
       `declare module "virtual:think/entry"`
     );

--- a/packages/think/src/cli/init.ts
+++ b/packages/think/src/cli/init.ts
@@ -406,7 +406,7 @@ function agentSource(): string {
     "export class Assistant extends Think<Env> {",
     "  override getModel() {",
     "    return createWorkersAI({ binding: this.env.AI })(",
-    '      "@cf/moonshotai/kimi-k2.6",',
+    '      "@cf/moonshotai/kimi-k2.7-code",',
     "      { sessionAffinity: this.sessionAffinity }",
     "    );",
     "  }",

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -375,7 +375,7 @@ export class TestAssistant extends Think<Env> {
 
   getModel(): LanguageModel {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       { sessionAffinity: this.sessionAffinity }
     );
   }
@@ -1267,7 +1267,7 @@ export class TestStructuredAgent extends Think<Env> {
         );
       default:
         return createWorkersAI({ binding: this.env.AI })(
-          "@cf/moonshotai/kimi-k2.6",
+          "@cf/moonshotai/kimi-k2.7-code",
           { sessionAffinity: this.sessionAffinity }
         );
     }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -48,7 +48,7 @@
  *
  * export class MyAgent extends Think<Env> {
  *   getModel() {
- *     return createWorkersAI({ binding: this.env.AI })("@cf/moonshotai/kimi-k2.6");
+ *     return createWorkersAI({ binding: this.env.AI })("@cf/moonshotai/kimi-k2.7-code");
  *   }
  *
  *   getSystemPrompt() {

--- a/packages/think/src/tools/browser.ts
+++ b/packages/think/src/tools/browser.ts
@@ -78,7 +78,7 @@ export {
  *
  * export class MyAgent extends Think<Env> {
  *   getModel() {
- *     return createWorkersAI({ binding: this.env.AI })("@cf/moonshotai/kimi-k2.6");
+ *     return createWorkersAI({ binding: this.env.AI })("@cf/moonshotai/kimi-k2.7-code");
  *   }
  *
  *   getTools() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2690,9 +2690,9 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      partyserver:
+      agents:
         specifier: '*'
-        version: 0.5.6(@cloudflare/workers-types@4.20260612.1)
+        version: link:../../packages/agents
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -3129,10 +3129,10 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: '*'
-        version: 3.0.82(zod@4.4.3)
+        version: 3.0.83(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: '*'
-        version: 3.0.69(zod@4.4.3)
+        version: 3.0.70(zod@4.4.3)
       '@ai-sdk/provider':
         specifier: ^3.0.10
         version: 3.0.10
@@ -4297,12 +4297,6 @@ packages:
   '@ag-ui/core@0.0.52':
     resolution: {integrity: sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==}
 
-  '@ai-sdk/anthropic@3.0.82':
-    resolution: {integrity: sha512-WKKou2wbhGGYV8PSALAPyV2YY4nfCqCPkyBzYtJtDA9yCcIFwsbtkTNgg7bqtLCVzeEsY7wwxRoCWy+EMfrw/A==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/anthropic@3.0.83':
     resolution: {integrity: sha512-K4EZaMpZNsflB3dRrOzljEYooW5CI1zFYI/kaNcJ+YJAZe14UOIFL+fC7lg88S21r6RDgFr1Bs9PFFuzZk/4IQ==}
     engines: {node: '>=18'}
@@ -4321,20 +4315,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.69':
-    resolution: {integrity: sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/openai@3.0.70':
     resolution: {integrity: sha512-0sAaS5IrgHvLF1OUHCB1fV+d4HCvfUvhnf5Hpq2yrzFRPLKdLv6TDohWOt/vmf1A6tXO1DuQKKsSuNqG3Rydgw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -9548,11 +9530,6 @@ packages:
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
-  partyserver@0.5.6:
-    resolution: {integrity: sha512-/LKCqlq9nWzNXA8UXZFO/Xz15QDCjJnGAgRQVLnXJO9bA0HKt5J8VM8wLnGc814WatzuQgeG17tqzI//y5WFGA==}
-    peerDependencies:
-      '@cloudflare/workers-types': ^4.20260424.1
-
   partyserver@0.5.8:
     resolution: {integrity: sha512-htgSwiBcBu9zIYLrsxBAOvdkjukHvncbTk0nDrJgfruvZ08rxtEN1Ab4T7j9osykP80Bq3zA2oWFd3ngc4Z9uw==}
     peerDependencies:
@@ -11133,12 +11110,6 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@3.0.82(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
-      zod: 4.4.3
-
   '@ai-sdk/anthropic@3.0.83(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -11158,23 +11129,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.28(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.69(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
-      zod: 4.4.3
-
   '@ai-sdk/openai@3.0.70(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.28(zod@4.4.3)
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.28(zod@4.4.3)':
@@ -11349,7 +11307,7 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.0.2
+      jsesc: 3.1.0
 
   '@babel/generator@8.0.0-rc.6':
     dependencies:
@@ -11929,7 +11887,6 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -11944,7 +11901,6 @@ snapshots:
   '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.4.5':
     dependencies:
@@ -11962,7 +11918,6 @@ snapshots:
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -12493,8 +12448,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
       '@tybys/wasm-util': 0.9.0
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -13065,7 +13020,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -16739,11 +16694,6 @@ snapshots:
   parseurl@1.3.3: {}
 
   partial-json@0.1.7: {}
-
-  partyserver@0.5.6(@cloudflare/workers-types@4.20260612.1):
-    dependencies:
-      '@cloudflare/workers-types': 4.20260612.1
-      nanoid: 5.1.11
 
   partyserver@0.5.8(@cloudflare/workers-types@4.20260612.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^1.69.0
         version: 1.69.0
       partyserver:
-        specifier: ^0.5.7
-        version: 0.5.7(@cloudflare/workers-types@4.20260612.1)
+        specifier: ^0.5.8
+        version: 0.5.8(@cloudflare/workers-types@4.20260612.1)
       partysocket:
         specifier: 1.2.0
         version: 1.2.0(react@19.2.7)
@@ -3564,8 +3564,8 @@ importers:
         specifier: ^5.1.11
         version: 5.1.11
       partyserver:
-        specifier: ^0.5.7
-        version: 0.5.7(@cloudflare/workers-types@4.20260612.1)
+        specifier: ^0.5.8
+        version: 0.5.8(@cloudflare/workers-types@4.20260612.1)
       partysocket:
         specifier: 1.2.0
         version: 1.2.0(react@19.2.7)
@@ -9553,8 +9553,8 @@ packages:
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260424.1
 
-  partyserver@0.5.7:
-    resolution: {integrity: sha512-3xeJh2F7V9qsyVYUJHLDb9P4IJ8PyaWenBOXRWKifAYoS0WdVuTmrK1T2tsRgc5GoeQkeIdRSAZ1cftC47oSyw==}
+  partyserver@0.5.8:
+    resolution: {integrity: sha512-htgSwiBcBu9zIYLrsxBAOvdkjukHvncbTk0nDrJgfruvZ08rxtEN1Ab4T7j9osykP80Bq3zA2oWFd3ngc4Z9uw==}
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260424.1
 
@@ -16745,7 +16745,7 @@ snapshots:
       '@cloudflare/workers-types': 4.20260612.1
       nanoid: 5.1.11
 
-  partyserver@0.5.7(@cloudflare/workers-types@4.20260612.1):
+  partyserver@0.5.8(@cloudflare/workers-types@4.20260612.1):
     dependencies:
       '@cloudflare/workers-types': 4.20260612.1
       nanoid: 5.1.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,4 +71,4 @@ minimumReleaseAgeExclude:
   - miniflare@4.20260611.0
   - partysocket@1.2.0
   - wrangler@4.100.0
-  - partyserver@0.5.7
+  - partyserver@0.5.8

--- a/site/agents/src/components/dev-instructions.tsx
+++ b/site/agents/src/components/dev-instructions.tsx
@@ -53,7 +53,7 @@ export class LunchAgent extends Agent<Env, LunchState> {
 
 	async chooseLunch() {
 		const restaurantWinners = chooseWinners(this.state.todaysVotes);
-		const { response } = await this.env.AI.run("@cf/moonshotai/kimi-k2.6", {
+		const { response } = await this.env.AI.run("@cf/moonshotai/kimi-k2.7-code", {
 			messages: [
 				{role: "system", content: \`
 					You help deliver results to a bunch of co-workers who are choosing lunch together.

--- a/think-starters/basic/agents/assistant/agent.ts
+++ b/think-starters/basic/agents/assistant/agent.ts
@@ -15,7 +15,7 @@ type Env = Cloudflare.Env & {
 export class Assistant extends Think<Env> {
   override getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       {
         sessionAffinity: this.sessionAffinity
       }

--- a/think-starters/coding-agent/agents/coder/agent.ts
+++ b/think-starters/coding-agent/agents/coder/agent.ts
@@ -20,7 +20,7 @@ type Env = Cloudflare.Env & {
 export class Coder extends Think<Env> {
   override getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       {
         sessionAffinity: this.sessionAffinity
       }

--- a/think-starters/customer-support/agents/support/agent.ts
+++ b/think-starters/customer-support/agents/support/agent.ts
@@ -20,7 +20,7 @@ type Env = Cloudflare.Env & {
 export class Support extends Think<Env> {
   override getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       {
         sessionAffinity: this.sessionAffinity
       }

--- a/think-starters/personal-assistant/agents/assistant/agent.ts
+++ b/think-starters/personal-assistant/agents/assistant/agent.ts
@@ -17,7 +17,7 @@ type Env = Cloudflare.Env & {
 export class Assistant extends Think<Env> {
   override getModel() {
     return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.6",
+      "@cf/moonshotai/kimi-k2.7-code",
       {
         sessionAffinity: this.sessionAffinity
       }

--- a/wip/inline-sub-agent-events.md
+++ b/wip/inline-sub-agent-events.md
@@ -1958,7 +1958,7 @@ helperClassByType]`. Adding a class is one site (the registry):
     `webServer`; `workers: 1` keeps tests serialized so they
     don't fight over Workers AI capacity; `retries: 1` rides out
     occasional 504s; `timeout: 180_000` covers the slow
-    `kimi-k2.5` model. Headed and UI modes are wired via
+    `kimi-k2.7-code` model. Headed and UI modes are wired via
     `npm run test:e2e:headed` / `npm run test:e2e:ui`.
   - Added minimal `data-testid` hooks: `helper-panel` (with
     `data-helper-type` / `data-helper-id` / `data-helper-status`)


### PR DESCRIPTION
## Summary

- Replace all Workers AI Kimi model references (`@cf/moonshotai/kimi-k2.5` and `@cf/moonshotai/kimi-k2.6`) with the new [`@cf/moonshotai/kimi-k2.7-code`](https://developers.cloudflare.com/workers-ai/models/kimi-k2.7-code/) across packages, examples, experimental apps, docs, design notes, guides, and think-starters.
- Bump the `partyserver` dependency from `^0.5.7` to `^0.5.8` (root + `packages/agents`), with a patch changeset for the `agents` package.

## Details

**Model rename** (`docs:` commit)
- ~85 files updated: source code, tests, e2e specs, READMEs, and design/docs prose.
- Updated prose labels too (e.g. "Kimi K2.6" → "Kimi K2.7 Code").
- The `"kimi"` value in `examples/voice-agent/src/client.tsx` is intentionally left unchanged — it is a UI selector key, not a model identifier (the model string it maps to was updated).

**partyserver bump** (`chore:` commit)
- `0.5.8` base64-encodes the `x-partykit-props` header so props with non-ASCII characters no longer trigger workerd's non-ASCII header warning (which throws a `TypeError` in browser fetch implementations).

## Test plan

- [ ] `pnpm install --frozen-lockfile`
- [ ] `pnpm run build`
- [ ] `pnpm run check`
- [ ] `pnpm exec nx affected -t test`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->