### PR TITLE
fix(codemode): correct runtime description language

### DIFF
--- a/.changeset/codemode-description-javascript.md
+++ b/.changeset/codemode-description-javascript.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Fix the runtime tool description to say "Execute JavaScript" instead of "Execute TypeScript". The codemode sandbox executes JavaScript only; TypeScript types are generated for LLM context but are not executed.

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -505,7 +505,7 @@ function buildDescription(
   const names = connectors.map((c) => `\`${c.name()}\``).join(", ");
 
   const lines = [
-    "Execute TypeScript in a sandbox with access to connector SDKs.",
+    "Execute JavaScript in a sandbox with access to connector SDKs.",
     "",
     "## Workflow",
     "",


### PR DESCRIPTION
This PR corrects the codemode runtime tool description so it tells models to execute JavaScript, not TypeScript.

## Why

- The codemode sandbox executes JavaScript only.
- The runtime description incorrectly said TypeScript, which could encourage models to use type annotations or other syntax the sandbox cannot run.
- Codemode still exposes TypeScript declarations for connector docs, but those declarations are context for the model, not executable code.

## Code Changes

- Update `packages/codemode/src/proxy-tool.ts` to say "Execute JavaScript" instead of "Execute TypeScript".
- Add a patch changeset for `@cloudflare/codemode`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->