### PR TITLE
fix: reduce Think SQLite read amplification

### DIFF
--- a/.changeset/calm-sqlite-reads.md
+++ b/.changeset/calm-sqlite-reads.md
@@ -1,0 +1,8 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+---
+
+Reduce Think Durable Object SQLite reads during normal wakes and text-only turns.
+
+Think now avoids automatic media-eviction scans until hydration has been windowed or an oversized appended message has been observed. The shared resumable stream buffer also avoids per-wake metadata-column introspection by creating new tables with the current columns and lazily migrating legacy tables only when a stream write needs it.

--- a/.changeset/quick-leaf-cache.md
+++ b/.changeset/quick-leaf-cache.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Cache the active branch tip in `AgentSessionProvider` so finding the latest leaf no longer scans the whole session on every read and append.
+
+`latestLeafRow()` previously ran an anti-join over every message row (O(rows)) to locate the branch tip — on each hydration AND each auto-parent append, so on long transcripts it dominated a wake's read cost. The tip is now maintained in place on append/delete/clear; a cached tip is re-validated on read with an O(1) existence + still-childless check (so it self-heals if another writer deletes the tip or gives it a child), and the full scan only runs when that check fails or the cache is cold. Per-hydration and per-append tip lookups drop from O(rows) to O(1), and the full scan never runs more often than before.

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -90,6 +90,15 @@ function isWebSocketClosedSendError(error: unknown): boolean {
   );
 }
 
+function isMissingMetadataColumnError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    (message.includes("message_id") || message.includes("is_continuation")) &&
+    (message.toLowerCase().includes("no such column") ||
+      message.toLowerCase().includes("has no column named"))
+  );
+}
+
 /**
  * Stored stream chunk for resumable streaming
  */
@@ -182,14 +191,10 @@ export class ResumableStream {
       request_id text not null,
       status text not null,
       created_at integer not null,
-      completed_at integer
+      completed_at integer,
+      message_id text,
+      is_continuation integer
     )`;
-
-    // Backward-compatible migration (#1691): add the column that durably links a
-    // stream to its assistant message. Tables created before this release lack
-    // it, so `alter table add column` is idempotent — the duplicate-column
-    // error (and ONLY that error) is swallowed on an already-migrated table.
-    this._migrateMetadataColumns();
 
     this.sql`create index if not exists idx_stream_chunks_stream_id 
       on cf_ai_chat_stream_chunks(stream_id, chunk_index)`;
@@ -199,10 +204,11 @@ export class ResumableStream {
   }
 
   /**
-   * Add the #1691 recovery column to the metadata table for rows created before
-   * it existed. Inspects the current schema and only runs `alter table` when the
-   * column is absent — idempotent across Durable Object restarts, with no
-   * error-driven control flow.
+   * Add metadata columns for rows created before they existed. Constructors
+   * intentionally do not run this: most wakes never start a stream, so paying a
+   * schema-introspection read every time is wasteful. New tables include these
+   * columns in CREATE TABLE; legacy tables migrate lazily only if a write/read
+   * discovers the columns are missing.
    */
   private _migrateMetadataColumns() {
     const columns =
@@ -269,10 +275,19 @@ export class ResumableStream {
 
     const messageId = options.messageId ?? null;
 
-    this.sql`
-      insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
-      values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
-    `;
+    try {
+      this.sql`
+        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
+        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
+      `;
+    } catch (error) {
+      if (!isMissingMetadataColumnError(error)) throw error;
+      this._migrateMetadataColumns();
+      this.sql`
+        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
+        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
+      `;
+    }
 
     return streamId;
   }
@@ -284,10 +299,16 @@ export class ResumableStream {
    * is a legacy row written before the `message_id` column existed.
    */
   getStreamMessageId(streamId: string): string | null {
-    const rows = this.sql<{ message_id: string | null }>`
-      select message_id from cf_ai_chat_stream_metadata
-      where id = ${streamId}
-    `;
+    let rows: Array<{ message_id: string | null }>;
+    try {
+      rows = this.sql<{ message_id: string | null }>`
+        select message_id from cf_ai_chat_stream_metadata
+        where id = ${streamId}
+      `;
+    } catch (error) {
+      if (!isMissingMetadataColumnError(error)) throw error;
+      return null;
+    }
     if (!rows || rows.length === 0) return null;
     return rows[0].message_id ?? null;
   }

--- a/packages/agents/src/experimental/memory/session/providers/agent.ts
+++ b/packages/agents/src/experimental/memory/session/providers/agent.ts
@@ -45,6 +45,26 @@ export class AgentSessionProvider implements SessionProvider {
   private sessionId: string;
 
   /**
+   * Cached id of the active branch tip (latest leaf). `undefined` means "not
+   * cached" (cold, or last lookup found the session empty).
+   *
+   * Finding the tip from scratch is an anti-join over every row in the
+   * session (`latestLeafRow`), which is O(rows). It runs on every hydration
+   * AND every auto-parent append, so on a long transcript it dominates the
+   * read cost of a wake. The tip is maintained in place on append/delete/
+   * clear, and a cached id is re-validated on read with an O(1) existence +
+   * still-childless check before it's trusted — so the cache self-heals if
+   * something else mutates the cached tip: a deleted tip or a tip that gained
+   * a child fails the check and triggers a single recompute. Direct SQL or a
+   * second provider instance that creates a newer leaf without touching the
+   * cached tip is outside the supported writer model and will be observed on
+   * the next cold lookup. The full scan therefore never runs more often than
+   * the original unconditional version did. Reads are synchronous and the DO
+   * is single-threaded, so no locking is needed.
+   */
+  private activeLeafId: string | undefined = undefined;
+
+  /**
    * @param agent - Agent or any object with a `sql` tagged template method
    * @param sessionId - Optional session ID to isolate multiple sessions in the same DO.
    *                    Messages are filtered by session_id within shared tables.
@@ -253,6 +273,11 @@ export class AgentSessionProvider implements SessionProvider {
       VALUES (${message.id}, ${this.sessionId}, ${parent}, ${message.role}, ${json})
     `;
     this.indexFTS(message);
+
+    // The freshly inserted row is the most recent childless node, so it is
+    // now the latest leaf — true even for an explicit-parent branch append.
+    // Keeping the cache current here is what lets appends skip the anti-join.
+    this.activeLeafId = message.id;
   }
 
   updateMessage(message: SessionMessage): void {
@@ -271,6 +296,15 @@ export class AgentSessionProvider implements SessionProvider {
         .sql`DELETE FROM assistant_messages WHERE id = ${id} AND session_id = ${this.sessionId}`;
       this.deleteFTS(id);
     }
+    // Deleting an interior node never changes the tip; deleting the tip does.
+    // Drop the cache so the next lookup recomputes (deletes are rare relative
+    // to reads/appends, so the occasional rescan is fine).
+    if (
+      typeof this.activeLeafId === "string" &&
+      messageIds.includes(this.activeLeafId)
+    ) {
+      this.activeLeafId = undefined;
+    }
   }
 
   clearMessages(): void {
@@ -286,6 +320,7 @@ export class AgentSessionProvider implements SessionProvider {
     for (const row of ftsRows) {
       this.agent.sql`DELETE FROM assistant_fts WHERE rowid = ${row.rowid}`;
     }
+    this.activeLeafId = undefined;
   }
 
   // ── Compaction ─────────────────────────────────────────────────
@@ -357,6 +392,23 @@ export class AgentSessionProvider implements SessionProvider {
   // ── Internal ───────────────────────────────────────────────────
 
   private latestLeafRow(): { id: string } | null {
+    // Trust a cached tip only after an O(1) check that it still exists and is
+    // still childless. This catches a cached tip that was deleted or given a
+    // child by another writer without re-scanning the whole session.
+    if (this.activeLeafId !== undefined) {
+      const stillTip = this.agent.sql<{ id: string }>`
+        SELECT m.id FROM assistant_messages m
+        WHERE m.id = ${this.activeLeafId} AND m.session_id = ${this.sessionId}
+          AND NOT EXISTS (
+            SELECT 1 FROM assistant_messages c
+            WHERE c.parent_id = ${this.activeLeafId}
+              AND c.session_id = ${this.sessionId}
+          )
+      `;
+      if (stillTip.length > 0) return { id: this.activeLeafId };
+      this.activeLeafId = undefined;
+    }
+
     // id-only on purpose: the ORDER BY sorter would otherwise carry every
     // leaf candidate's full content blob while ranking rows.
     const rows = this.agent.sql<{ id: string }>`
@@ -365,6 +417,7 @@ export class AgentSessionProvider implements SessionProvider {
       WHERE c.id IS NULL AND m.session_id = ${this.sessionId}
       ORDER BY m.created_at DESC, m.rowid DESC LIMIT 1
     `;
+    this.activeLeafId = rows[0]?.id;
     return rows[0] ?? null;
   }
 

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -1,4 +1,5 @@
 import { Agent } from "../../index";
+import { ResumableStream } from "../../chat";
 import {
   Session,
   AgentSessionProvider,
@@ -13,7 +14,34 @@ import {
  * Test Agent — full Session API
  */
 export class TestSessionAgent extends Agent {
-  session = new Session(new AgentSessionProvider(this));
+  /**
+   * Counts how many times the latest-leaf anti-join (`latestLeafRow`) hits
+   * the database. The active-leaf cache should keep this at zero across
+   * repeated reads and auto-parent appends within a wake.
+   */
+  antiJoinCount = 0;
+
+  session = new Session(
+    new AgentSessionProvider({
+      sql: <T = Record<string, string | number | boolean | null>>(
+        strings: TemplateStringsArray,
+        ...values: (string | number | boolean | null)[]
+      ): T[] => {
+        if (strings.some((s) => s.includes("LEFT JOIN assistant_messages c"))) {
+          this.antiJoinCount++;
+        }
+        return this.sql<T>(strings, ...values);
+      }
+    })
+  );
+
+  async getAntiJoinCountForTest(): Promise<number> {
+    return this.antiJoinCount;
+  }
+
+  async resetAntiJoinCountForTest(): Promise<void> {
+    this.antiJoinCount = 0;
+  }
 
   // ── Messages ────────────────────────────────────────────────────
 
@@ -105,6 +133,29 @@ export class TestSessionAgent extends Agent {
     }
   }
 
+  /**
+   * Insert a child row directly via SQL, bypassing the provider (and its leaf
+   * cache) — simulates another writer mutating the cached tip so tests can
+   * prove the validation path self-heals.
+   */
+  async rawInsertChildForTest(parentId: string, id: string): Promise<void> {
+    const content = JSON.stringify({
+      id,
+      role: "assistant",
+      parts: [{ type: "text", text: id }]
+    });
+    this.sql`
+      INSERT INTO assistant_messages (id, session_id, parent_id, role, content)
+      VALUES (${id}, ${""}, ${parentId}, ${"assistant"}, ${content})
+    `;
+  }
+
+  /** Delete a row directly via SQL, bypassing the provider and its cache. */
+  async rawDeleteForTest(id: string): Promise<void> {
+    this
+      .sql`DELETE FROM assistant_messages WHERE id = ${id} AND session_id = ${""}`;
+  }
+
   /** Overwrite a stored message's content with invalid JSON. */
   async corruptMessageForTest(id: string): Promise<void> {
     const invalid = "{ this is not valid json";
@@ -140,6 +191,85 @@ export class TestSessionAgent extends Agent {
       id: m.id,
       textLength: (m.parts[0] as { text: string }).text.length
     }));
+  }
+
+  // ── ResumableStream legacy migration helpers ────────────────────
+
+  /**
+   * Recreate `cf_ai_chat_stream_metadata` with the pre-#1691/#1733 schema
+   * (no `message_id` / `is_continuation`) and seed one in-flight row, so a
+   * fresh `ResumableStream` exercises the legacy lazy-migration path on a
+   * real workerd SQLite (validates the runtime's actual error strings).
+   */
+  async setupLegacyStreamTableForTest(): Promise<void> {
+    this.sql`drop table if exists cf_ai_chat_stream_metadata`;
+    this.sql`drop table if exists cf_ai_chat_stream_chunks`;
+    this.sql`create table cf_ai_chat_stream_metadata (
+      id text primary key,
+      request_id text not null,
+      status text not null,
+      created_at integer not null,
+      completed_at integer
+    )`;
+    this
+      .sql`insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at)
+      values ('legacy-stream', 'legacy-req', 'streaming', ${Date.now()})`;
+  }
+
+  private streamMetadataColumnsForTest(): string[] {
+    return this.sql<{ name: string }>`
+      select name from pragma_table_info('cf_ai_chat_stream_metadata')
+    `.map((c) => c.name);
+  }
+
+  /**
+   * Drive a `ResumableStream` over a legacy metadata table and report what
+   * happened, so the test can assert the lazy migration recovered instead of
+   * throwing. Construction itself exercises `restore()` (a `SELECT *` that
+   * must tolerate the missing columns).
+   */
+  async resumableLegacyMigrationForTest(): Promise<{
+    columnsBefore: string[];
+    legacyMessageId: string | null;
+    startThrew: boolean;
+    columnsAfter: string[];
+    newStreamMessageId: string | null;
+  }> {
+    const stream = new ResumableStream(
+      <T = Record<string, unknown>>(
+        strings: TemplateStringsArray,
+        ...values: (string | number | boolean | null)[]
+      ): T[] => this.sql<T>(strings, ...values)
+    );
+
+    const columnsBefore = this.streamMetadataColumnsForTest();
+    // SELECT of the new column on a legacy row: guarded → null, no throw.
+    const legacyMessageId = stream.getStreamMessageId("legacy-stream");
+
+    // INSERT naming the new columns on a legacy table: must migrate + retry.
+    let startThrew = false;
+    let newStreamId = "";
+    try {
+      newStreamId = stream.start("req-x", {
+        messageId: "msg-1",
+        continuation: true
+      });
+    } catch {
+      startThrew = true;
+    }
+
+    const columnsAfter = this.streamMetadataColumnsForTest();
+    const newStreamMessageId = newStreamId
+      ? stream.getStreamMessageId(newStreamId)
+      : null;
+
+    return {
+      columnsBefore,
+      legacyMessageId,
+      startThrew,
+      columnsAfter,
+      newStreamMessageId
+    };
   }
 }
 

--- a/packages/agents/src/tests/experimental/memory/session/provider.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/provider.test.ts
@@ -48,6 +48,10 @@ interface SessionAgentStub {
     role: string;
     bytes: number;
   }> | null>;
+  getAntiJoinCountForTest(): Promise<number>;
+  resetAntiJoinCountForTest(): Promise<void>;
+  rawInsertChildForTest(parentId: string, id: string): Promise<void>;
+  rawDeleteForTest(id: string): Promise<void>;
 }
 
 async function getAgent(name: string): Promise<SessionAgentStub> {
@@ -715,5 +719,148 @@ describe("AgentSessionProvider — byte-budgeted recent history (#1710)", () => 
     for (const row of lengths) {
       expect(row.textLength).toBeGreaterThanOrEqual(1_500_000);
     }
+  });
+});
+
+/**
+ * The active branch tip is cached so finding it doesn't re-scan the whole
+ * session (an anti-join over every row) on every hydration and append.
+ */
+describe("AgentSessionProvider — active-leaf cache", () => {
+  let name: string;
+  beforeEach(() => {
+    name = `leaf-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  });
+
+  it("repeated leaf reads and auto-parent appends never re-run the anti-join", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(20);
+
+    // The chain's first auto-parent append warmed the cache; everything after
+    // is served from it.
+    await agent.resetAntiJoinCountForTest();
+
+    for (let i = 0; i < 5; i++) {
+      expect((await agent.getLatestLeaf())?.id).toBe("m19");
+    }
+    await agent.appendMessage({
+      id: "x0",
+      role: "user",
+      parts: [{ type: "text", text: "next" }]
+    });
+    await agent.appendMessage({
+      id: "x1",
+      role: "assistant",
+      parts: [{ type: "text", text: "reply" }]
+    });
+
+    expect((await agent.getLatestLeaf())?.id).toBe("x1");
+    expect(await agent.getAntiJoinCountForTest()).toBe(0);
+  });
+
+  it("at most one anti-join per cold start, regardless of history length", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(30);
+
+    // Across many reads the scan happens at most once (the first cold lookup);
+    // here the cache is already warm from the append chain, so it's zero.
+    await agent.resetAntiJoinCountForTest();
+    await agent.getHistory();
+    await agent.getRecentHistory(10 * 1024 * 1024);
+    await agent.getHistoryRowStats();
+    await agent.getPathLength();
+    expect(await agent.getAntiJoinCountForTest()).toBe(0);
+  });
+
+  it("tracks the tip across a branch append", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "root",
+      role: "user",
+      parts: [{ type: "text", text: "root" }]
+    });
+    await agent.appendMessage({
+      id: "a",
+      role: "assistant",
+      parts: [{ type: "text", text: "a" }]
+    });
+    // Branch off root: the new node is childless and most recent → new tip.
+    await agent.appendMessage(
+      { id: "b", role: "assistant", parts: [{ type: "text", text: "b" }] },
+      "root"
+    );
+    expect((await agent.getLatestLeaf())?.id).toBe("b");
+    expect((await agent.getHistory()).map((m) => m.id)).toEqual(["root", "b"]);
+  });
+
+  it("recomputes the tip after the leaf is deleted", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(3); // m0 → m1 → m2
+
+    await agent.resetAntiJoinCountForTest();
+    await agent.deleteMessages(["m2"]);
+    // The cache was invalidated, so the next lookup pays exactly one scan and
+    // returns the new tip.
+    expect((await agent.getLatestLeaf())?.id).toBe("m1");
+    expect(await agent.getAntiJoinCountForTest()).toBe(1);
+
+    // …and is cached again afterward.
+    await agent.resetAntiJoinCountForTest();
+    expect((await agent.getLatestLeaf())?.id).toBe("m1");
+    expect(await agent.getAntiJoinCountForTest()).toBe(0);
+  });
+
+  it("deleting an interior (non-tip) message keeps the cached tip", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(3); // m0 → m1 → m2
+
+    await agent.resetAntiJoinCountForTest();
+    await agent.deleteMessages(["m0"]);
+    expect((await agent.getLatestLeaf())?.id).toBe("m2");
+    expect(await agent.getAntiJoinCountForTest()).toBe(0);
+  });
+
+  it("returns null after clear", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(3);
+
+    await agent.clearMessages();
+    expect(await agent.getLatestLeaf()).toBeNull();
+  });
+
+  it("self-heals when another writer gives the cached tip a child", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(3); // m0 → m1 → m2
+    // Warm the cache on m2.
+    expect((await agent.getLatestLeaf())?.id).toBe("m2");
+
+    // A second writer attaches a child to the cached tip, bypassing the
+    // provider — the cache is now stale.
+    await agent.rawInsertChildForTest("m2", "ext-child");
+
+    await agent.resetAntiJoinCountForTest();
+    // The validation check sees m2 is no longer childless and recomputes.
+    expect((await agent.getLatestLeaf())?.id).toBe("ext-child");
+    expect(await agent.getAntiJoinCountForTest()).toBe(1);
+    expect((await agent.getHistory()).map((m) => m.id)).toEqual([
+      "m0",
+      "m1",
+      "m2",
+      "ext-child"
+    ]);
+  });
+
+  it("self-heals when another writer deletes the cached tip", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(3); // m0 → m1 → m2
+    expect((await agent.getLatestLeaf())?.id).toBe("m2");
+
+    // A second writer deletes the cached tip, bypassing the provider.
+    await agent.rawDeleteForTest("m2");
+
+    await agent.resetAntiJoinCountForTest();
+    // The validation check sees m2 is gone and recomputes the new tip.
+    expect((await agent.getLatestLeaf())?.id).toBe("m1");
+    expect(await agent.getAntiJoinCountForTest()).toBe(1);
   });
 });

--- a/packages/agents/src/tests/resumable-stream-migration.test.ts
+++ b/packages/agents/src/tests/resumable-stream-migration.test.ts
@@ -1,0 +1,63 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it, beforeEach } from "vitest";
+import { getAgentByName } from "..";
+
+/**
+ * ResumableStream lazy metadata-column migration (#1691, #1733).
+ *
+ * New tables are created with `message_id` / `is_continuation` up front, so
+ * most wakes never migrate. Tables created by an older release lack those
+ * columns and must migrate lazily — on the first stream write that needs
+ * them — instead of paying a schema-introspection read on every construction.
+ *
+ * The recovery hinges on `isMissingMetadataColumnError` matching the SQLite
+ * error text the runtime actually emits, which only a real workerd SQLite can
+ * verify. These tests drive the legacy path end to end against it.
+ */
+
+interface LegacyMigrationStub {
+  setupLegacyStreamTableForTest(): Promise<void>;
+  resumableLegacyMigrationForTest(): Promise<{
+    columnsBefore: string[];
+    legacyMessageId: string | null;
+    startThrew: boolean;
+    columnsAfter: string[];
+    newStreamMessageId: string | null;
+  }>;
+}
+
+async function getAgent(name: string): Promise<LegacyMigrationStub> {
+  return getAgentByName(
+    env.TestSessionAgent,
+    name
+  ) as unknown as Promise<LegacyMigrationStub>;
+}
+
+describe("ResumableStream — legacy metadata-column migration", () => {
+  let name: string;
+  beforeEach(() => {
+    name = `rs-migrate-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  });
+
+  it("migrates a legacy table on first stream write instead of throwing", async () => {
+    const agent = await getAgent(name);
+    await agent.setupLegacyStreamTableForTest();
+
+    const result = await agent.resumableLegacyMigrationForTest();
+
+    // Precondition: the seeded table really is the old schema.
+    expect(result.columnsBefore).not.toContain("message_id");
+    expect(result.columnsBefore).not.toContain("is_continuation");
+
+    // Reading the new column off a legacy row is guarded → null, no throw.
+    expect(result.legacyMessageId).toBeNull();
+
+    // start() hit the missing columns, migrated, and retried successfully.
+    expect(result.startThrew).toBe(false);
+    expect(result.columnsAfter).toContain("message_id");
+    expect(result.columnsAfter).toContain("is_continuation");
+
+    // The migrated row round-trips the value start() wrote.
+    expect(result.newStreamMessageId).toBe("msg-1");
+  });
+});

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -173,7 +173,8 @@ import { truncateOlderMessages } from "agents/experimental/memory/utils";
 import {
   evictLargeMediaFromMessage,
   resolveMediaEvictionConfig,
-  type MediaEvictionConfig
+  type MediaEvictionConfig,
+  type ResolvedMediaEvictionConfig
 } from "./media-eviction";
 
 /**
@@ -1945,8 +1946,10 @@ export class Think<
               this._upsertCachedMessage(event.message as UIMessage);
             }
             // The conversation grew — older messages may have aged out of
-            // the keep-recent window; evict their inline media (#1710).
-            this._scheduleMediaEvictionPass();
+            // the keep-recent window. Only schedule the maintenance scan once
+            // this session has actually observed oversized media; otherwise a
+            // normal text-only chat would pay a row-stat read after every turn.
+            this._scheduleMediaEvictionAfterAppend(event.message as UIMessage);
             break;
           case "update":
             this._patchCachedMessage(event.message as UIMessage);
@@ -1986,6 +1989,7 @@ export class Think<
       if (!hydrated) {
         this._replaceCachedMessages([]);
       }
+      this._refreshMediaEvictionSignalFromCache();
 
       // 3-6. Extension initialization (if extensionLoader is set)
       if (this.extensionLoader) {
@@ -2033,10 +2037,12 @@ export class Think<
           "this wake; the next successful wake will recover them."
       );
 
-      // 11. Background bound on the persisted transcript: evict aged inline
-      // media so the hydration footprint stops growing with session age
+      // 11. Background bound on the persisted transcript: if hydration was
+      // windowed, evict aged inline media so the footprint can converge down
       // (#1710). Runs after `blockConcurrencyWhile` releases — no boot cost.
-      this._scheduleMediaEvictionPass();
+      if (this._lastHydration?.truncated) {
+        this._scheduleMediaEvictionPass({ force: true });
+      }
     };
   }
 
@@ -2336,6 +2342,7 @@ export class Think<
 
   private _mediaEvictionRunning = false;
   private _mediaEvictionScheduled = false;
+  private _mediaEvictionObservedOversized = false;
 
   /**
    * Schedule a background media-eviction pass (see `mediaEviction`).
@@ -2343,14 +2350,51 @@ export class Think<
    * event-loop work (and after `onStart`'s `blockConcurrencyWhile`), so
    * boot and turn latency are unaffected.
    */
-  private _scheduleMediaEvictionPass(): void {
+  private _scheduleMediaEvictionPass(options?: { force?: boolean }): void {
     if (this._mediaEvictionScheduled || this._mediaEvictionRunning) return;
-    if (!resolveMediaEvictionConfig(this.mediaEviction)) return;
+    const config = resolveMediaEvictionConfig(this.mediaEviction);
+    if (!config) return;
+    if (!options?.force && !this._mediaEvictionObservedOversized) return;
     this._mediaEvictionScheduled = true;
     setTimeout(() => {
       this._mediaEvictionScheduled = false;
       void this._evictAgedMediaBestEffort();
     }, 0);
+  }
+
+  private _scheduleMediaEvictionAfterAppend(message: UIMessage): void {
+    const config = resolveMediaEvictionConfig(this.mediaEviction);
+    if (!config) return;
+    if (!this._mediaEvictionObservedOversized) {
+      this._mediaEvictionObservedOversized = this._messageMayNeedMediaEviction(
+        message,
+        config
+      );
+    }
+    if (!this._mediaEvictionObservedOversized) return;
+
+    const keepRecent = Math.max(config.keepRecentMessages, MODEL_RECENT_WINDOW);
+    if (this._cachedMessages.length > keepRecent) {
+      this._scheduleMediaEvictionPass({ force: true });
+    }
+  }
+
+  private _refreshMediaEvictionSignalFromCache(): void {
+    const config = resolveMediaEvictionConfig(this.mediaEviction);
+    if (!config) {
+      this._mediaEvictionObservedOversized = false;
+      return;
+    }
+    this._mediaEvictionObservedOversized = this._cachedMessages.some(
+      (message) => this._messageMayNeedMediaEviction(message, config)
+    );
+  }
+
+  private _messageMayNeedMediaEviction(
+    message: UIMessage,
+    config: ResolvedMediaEvictionConfig
+  ): boolean {
+    return JSON.stringify(message).length >= config.minPartBytes;
   }
 
   private _warnedEvictionUnsupported = false;
@@ -2460,7 +2504,7 @@ export class Think<
       return null;
     } finally {
       this._mediaEvictionRunning = false;
-      if (backlogRemains) this._scheduleMediaEvictionPass();
+      if (backlogRemains) this._scheduleMediaEvictionPass({ force: true });
     }
   }
 


### PR DESCRIPTION
## Summary
- Gate Think media-eviction scans so text-only sessions no longer pay row-stat reads on every wake/append; forced eviction still runs after windowed hydration or observed oversized content.
- Cache and validate the active `AgentSessionProvider` leaf so recent-history hydration and auto-parent appends avoid the O(rows) latest-leaf anti-join on long transcripts.
- Remove eager resumable-stream metadata schema introspection on construction; new tables include current columns and legacy tables migrate lazily on first missing-column read/write.

## Why
Reports showed Durable Object SQLite reads increased significantly for Think in 0.16.0 versus 0.14.3. The biggest new read amplifiers were eager maintenance work around media eviction and stream metadata migration, plus repeated latest-leaf scans on long session histories. This keeps the memory-safety work from #1710 while avoiding reads when there is no oversized content or schema migration to do.

## Notes / Risk
- `totalContentBytes` and `truncated` semantics are unchanged: windowed hydration still reports the full stored transcript size.
- The active-leaf cache re-validates cached tips with an O(1) existence/childless check and falls back to the previous full anti-join when stale or cold.
- The lazy stream migration path is covered against workerd SQLite error strings with a legacy-table test.

## Test plan
- `pnpm exec vitest --run -c packages/agents/src/tests/vitest.config.ts packages/agents/src/tests/experimental/memory/session/provider.test.ts packages/agents/src/tests/resumable-stream-migration.test.ts`
- `pnpm exec vitest --run -c packages/agents/src/tests/vitest.config.ts`
- `pnpm exec vitest --run -c packages/think/src/tests/vitest.config.ts`
- `pnpm run check`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->