### PR TITLE
feat(codemode): add durable execution retries

### DIFF
--- a/.changeset/codemode-runtime-retries.md
+++ b/.changeset/codemode-runtime-retries.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Add durable execution retries to `runtime.tool()`. Connectors can throw `RetryableError` with an optional delay; by default the runtime makes three total attempts, honors that delay or uses bounded exponential backoff, and can be customized or disabled with `retry`. Failed passes restart under the same execution id, replaying applied calls from the log and re-executing only the failure boundary. Dynamic-worker timeouts are surfaced as structured failures but are not retried by default, so applications can conservatively decide which executions are safe to retry. Attempt fencing prevents calls or results from a superseded timed-out sandbox from mutating the replay log, and connector execute contexts receive a pass-scoped `AbortSignal` for cooperatively cancelling old work before the runtime moves on.

--- a/docs/codemode/connectors.md
+++ b/docs/codemode/connectors.md
@@ -60,7 +60,10 @@ export class MyConnector extends CodemodeConnector<Env> {
 ### Each tool
 
 ```ts
-type ToolExecuteContext = { executionId: string };
+type ToolExecuteContext = {
+  executionId: string;
+  signal?: AbortSignal;
+};
 
 type ConnectorTool = {
   description?: string;
@@ -79,7 +82,7 @@ type ConnectorTool = {
 };
 ```
 
-`execute`/`revert` receive an optional `ctx` carrying the `executionId` of the run they belong to. The id is stable across a run's pause/resume passes, so it's the key to use for any resource scoped to the whole execution (see [Per-execution resources](#per-execution-resources)).
+`execute`/`revert` receive an optional `ctx` carrying the stable `executionId` and an operation-scoped `AbortSignal`. Both fields remain optional for compatibility with AI SDK toolsets and direct connector tests; the Code Mode runtime supplies both on real calls. The runtime aborts the signal when the pass or rollback operation ends. Connectors should pass it to cancellable I/O such as `fetch(..., { signal: ctx?.signal })`. Cancellation is cooperative and cannot roll back an operation already committed by a remote service.
 
 `requiresApproval: true` pauses the run for [approval](./approvals.md). `revert` enables [rollback](./runtime.md#rollback). Everything else executes immediately and is recorded in the durable log.
 
@@ -109,7 +112,7 @@ The proxy tool talks to connectors over Workers RPC. The base class derives this
 
 Some connectors own a resource that must live for the lifetime of one run — a browser/CDP session, a database transaction, a temp workspace. Two pieces of the contract make this work:
 
-1. **`execute(args, ctx)`** receives the `executionId`. Use it to lazily acquire (or reconnect to) the resource on first use, keyed by that id. Because the id is stable across pause/resume, the resource is addressable even after a run pauses for approval and resumes in a later Worker invocation. `ctx` is typed optional (so AI SDK toolsets stay shape-compatible), so read it as `ctx?.executionId` — the runtime always provides it on a real call.
+1. **`execute(args, ctx)`** receives the stable `executionId` plus a pass-scoped `signal`. Use the id to lazily acquire (or reconnect to) per-execution resources, and use the signal to stop per-pass work when the runtime moves on. Because the id is stable across pause/resume, the resource remains addressable in a later Worker invocation. `ctx` is typed optional (so AI SDK toolsets stay shape-compatible), but the runtime always provides it on a real call.
 2. **`disposeExecution(executionId, status)`** is called when the run reaches a **terminal** state, so you can tear the resource down.
 
 ```ts
@@ -124,7 +127,7 @@ export class BrowserConnector extends CodemodeConnector<Env> {
         description: "Open a URL in the run's browser session.",
         execute: async ({ url }, ctx) => {
           const session = await this.sessionFor(ctx?.executionId);
-          return session.goto(url);
+          return session.goto(url, { signal: ctx?.signal });
         }
       }
     };
@@ -171,7 +174,7 @@ override async onPassEnd(executionId: string, _status: PassEndStatus) {
 
 The same implementation rules as `disposeExecution` apply: idempotent, no instance memory, never throws.
 
-> **AI SDK toolsets:** when `tools()` returns an AI SDK `ToolSet`, codemode passes `{ executionId }` as the tool's second `execute` argument — the slot the AI SDK uses for its own call options. Inside codemode those options aren't otherwise populated, but a tool authored against the AI SDK's `toolCallId`/`messages` won't receive them here.
+> **AI SDK toolsets:** when `tools()` returns an AI SDK `ToolSet`, codemode passes `{ executionId, signal }` as the tool's second `execute` argument — the slot the AI SDK uses for its own call options. A tool authored against the AI SDK's `toolCallId`/`messages` won't receive them here.
 
 ## Replay policy
 

--- a/docs/codemode/runtime.md
+++ b/docs/codemode/runtime.md
@@ -23,7 +23,7 @@ const runtime = createCodemodeRuntime({
 
 | Handle method                                        | Purpose                                                                                                                                    |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `runtime.tool(options?)`                             | The single model-facing AI SDK tool, `codemode({ code })`                                                                                  |
+| `runtime.tool(options?)`                             | The framework-independent model-facing tool, `codemode({ code })`                                                                          |
 | `runtime.pending(executionId?)`                      | Actions awaiting approval — drives approval UIs; no id aggregates all paused runs                                                          |
 | `runtime.approve({ executionId })`                   | Approve the pending action and continue via replay                                                                                         |
 | `runtime.reject({ seq, executionId })`               | Reject a pending action; ends the execution. Returns `false` if it was a no-op (action no longer pending — approved or rejected elsewhere) |
@@ -148,6 +148,32 @@ A tool can opt out of result recording with [`replay: "reexecute"`](./connectors
 ### Size limits
 
 Any single recorded value (a call's arguments, a recorded result, the final result) is capped at 1 MB serialized (`MAX_DURABLE_VALUE_BYTES`). Truncating a logged value is never an option — replay would feed resumed code corrupted data — so an oversized argument or call result **fails the run** with a model-actionable error suggesting the data be written to a file/workspace and passed by reference. An oversized **final** result does not fail the run (replay never needs it): the run completes, the model receives the real value, and the audit trail stores a placeholder note.
+
+## Retrying failed passes
+
+A connector requests a retry by throwing `RetryableError`. By default the runtime makes three total attempts, honoring `retryAfterMs` when present and otherwise using bounded exponential backoff (500ms, 1s, up to 10s). A retry keeps the same execution id and re-runs the stored code: applied calls replay from the durable log, while the call left `executing` at the failure boundary executes again. No configuration is needed for this default.
+
+```ts
+const runtime = createCodemodeRuntime({ ctx, executor, connectors });
+```
+
+Customize the policy when needed, or pass `retry: false` to disable automatic retries:
+
+```ts
+const runtime = createCodemodeRuntime({
+  ctx,
+  executor,
+  connectors,
+  retry: {
+    maxAttempts: 4,
+    shouldRetry: ({ failure }) => failure.kind === "retryable"
+  }
+});
+```
+
+The error message and optional `retryAfterMs` cross the connector RPC and sandbox boundaries as structured metadata. Dynamic-worker timeouts also arrive as `failure.kind === "timeout"`, but are not retried by default: an operation may have succeeded remotely before its response was lost, so the application must decide whether that boundary is safe to repeat.
+
+Before retry policy or delay callbacks run, the runtime advances a durable attempt fence. Late calls and results from the superseded sandbox are inert and cannot overwrite the newer pass.
 
 ## Rollback
 

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -380,6 +380,49 @@ The `tool(name, t)` decoration hook adjusts tools you didn't author inline (used
 
 The agent drives approvals through the runtime: `runtime.pending()`, `runtime.approve({ executionId })`, `runtime.reject({ seq, executionId })`, `runtime.rollback({ executionId })` (see [docs/codemode/approvals.md](../../docs/codemode/approvals.md)).
 
+### Durable retries
+
+A runtime automatically retries `RetryableError` under the same execution id, up to three total attempts. Applied connector calls replay from the durable log; the call at the failure boundary executes again. `retryAfterMs` is honored when present, otherwise retries use bounded exponential backoff (500ms, 1s, up to 10s).
+
+```ts
+import { RetryableError } from "@cloudflare/codemode";
+
+// Connector code can signal a transient, safe-to-repeat failure.
+throw new RetryableError("Rate limited", { retryAfterMs: 2_000 });
+
+const runtime = createCodemodeRuntime({
+  ctx,
+  executor,
+  connectors
+  // No retry configuration needed for RetryableError.
+});
+
+// Customize the policy when needed — for example, to opt safe reads into
+// timeout retries. Timeout retries are off by default because a timed-out
+// mutation may already have succeeded remotely.
+const customized = createCodemodeRuntime({
+  ctx,
+  executor,
+  connectors,
+  retry: {
+    maxAttempts: 4,
+    shouldRetry: ({ failure, execution }) =>
+      failure.kind === "retryable" ||
+      (failure.kind === "timeout" && timeoutIsSafe(execution))
+  }
+});
+
+// Or disable automatic retries entirely.
+const noRetries = createCodemodeRuntime({
+  ctx,
+  executor,
+  connectors,
+  retry: false
+});
+```
+
+Each pass has a durable attempt fence. If a timed-out old sandbox finishes after its retry started, its later calls and results are ignored rather than corrupting the replay log. Connector `execute` callbacks also receive a pass-scoped `AbortSignal` through their context; pass it to cancellable I/O so the old operation stops when the runtime moves on. Cancellation is cooperative and cannot roll back a remote write that already committed.
+
 ### Snippets
 
 Snippets are durable, addressable saved scripts. The model writes and runs scripts; the developer promotes the ones worth keeping (`runtime.saveSnippet`), and the model reuses them (`codemode.run`). No authoring step, no skill-source interface.

--- a/packages/codemode/src/connectors/types.ts
+++ b/packages/codemode/src/connectors/types.ts
@@ -22,14 +22,16 @@ export type ToolAnnotations = {
 // ---------------------------------------------------------------------------
 
 /**
- * Passed to a tool's `execute`/`revert` so a connector knows which codemode
- * execution the call belongs to. The id is stable across a run's pause/resume
- * passes, so it's the right key for a per-execution resource (e.g. a browser
- * session) that must survive a pause.
+ * Passed to a tool's `execute` so a connector knows which codemode execution
+ * and pass the call belongs to. The execution id is stable across pause/resume;
+ * the signal is scoped to one pass and aborts when that pass stops making
+ * progress (completion, pause, error, timeout, or retry).
  */
 export type ToolExecuteContext = {
   /** The codemode execution this call belongs to. Stable across pause/resume. */
   executionId: string;
+  /** Cooperative cancellation for work still running when this pass ends. */
+  signal?: AbortSignal;
 };
 
 /**
@@ -57,7 +59,7 @@ export type ExecutionEndStatus =
  * resources (an open socket, a lease) should be released even though
  * per-execution resources (a session) must survive.
  */
-export type PassEndStatus = ExecutionEndStatus | "paused";
+export type PassEndStatus = ExecutionEndStatus | "paused" | "retrying";
 
 // ---------------------------------------------------------------------------
 // Connector description — returned by describe() RPC.

--- a/packages/codemode/src/executor-types.ts
+++ b/packages/codemode/src/executor-types.ts
@@ -3,11 +3,22 @@
  * code in a sandbox (DynamicWorkerExecutor, IframeSandboxExecutor, ...).
  */
 
-export interface ExecuteResult {
-  result: unknown;
-  error?: string;
-  logs?: string[];
-}
+import type { ExecuteFailure } from "./retry";
+
+export type ExecuteResult =
+  | {
+      result: unknown;
+      error?: never;
+      failure?: never;
+      logs?: string[];
+    }
+  | {
+      result?: undefined;
+      error: string;
+      /** Machine-readable failure metadata when the executor can classify it. */
+      failure?: ExecuteFailure;
+      logs?: string[];
+    };
 
 /**
  * Internal resolved form of a tool provider, ready for execution.

--- a/packages/codemode/src/executor.ts
+++ b/packages/codemode/src/executor.ts
@@ -372,6 +372,11 @@ export class DynamicWorkerExecutor implements Executor {
         `          if (__r && typeof __r === "object") {\n` +
         `            if (__r.${CONNECTOR_CONTROL_KEY} === "pause") throw new Error("${PAUSE_SENTINEL_LITERAL}");\n` +
         `            if (__r.${CONNECTOR_CONTROL_KEY} === "error") throw new Error(String(__r.message));\n` +
+        `            if (__r.${CONNECTOR_CONTROL_KEY} === "retryable") {\n` +
+        `              const __e = new Error(String(__r.message));\n` +
+        `              __e.__codemode_failure__ = { kind: "retryable", message: String(__r.message), retryAfterMs: __r.retryAfterMs };\n` +
+        `              throw __e;\n` +
+        `            }\n` +
         `          }\n` +
         `          return __r;\n` +
         `        };\n` +
@@ -400,13 +405,13 @@ export class DynamicWorkerExecutor implements Executor {
       .concat([normalized])
       .concat([
         ")(),",
-        '        new Promise((_, reject) => setTimeout(() => reject(new Error("Execution timed out")), ' +
+        '        new Promise((_, reject) => setTimeout(() => { const e = new Error("Execution timed out"); e.__codemode_failure__ = { kind: "timeout", message: "Execution timed out" }; reject(e); }, ' +
           timeoutMs +
           "))",
         "      ]);",
         "      return { result, logs: __logs };",
         "    } catch (err) {",
-        "      return { result: undefined, error: err.message, logs: __logs };",
+        "      return { result: undefined, error: err.message, failure: err.__codemode_failure__, logs: __logs };",
         "    }",
         "  }",
         "}"
@@ -472,13 +477,20 @@ export class DynamicWorkerExecutor implements Executor {
       ): Promise<{
         result: unknown;
         error?: string;
+        failure?: import("./retry").ExecuteFailure;
         logs?: string[];
       }>;
     };
     const response = await entrypoint.evaluate(dispatchers, connectorBindings);
 
-    if (response.error) {
-      return { result: undefined, error: response.error, logs: response.logs };
+    if (response.error || response.failure) {
+      return {
+        result: undefined,
+        error:
+          response.error ?? response.failure?.message ?? "Execution failed",
+        failure: response.failure,
+        logs: response.logs
+      };
     }
 
     return { result: response.result, logs: response.logs };

--- a/packages/codemode/src/index.ts
+++ b/packages/codemode/src/index.ts
@@ -38,6 +38,13 @@ export {
 } from "./runtime";
 export { type Snippet, type SaveSnippetOptions } from "./snippet";
 export {
+  RetryableError,
+  type ExecuteFailure,
+  type CodemodeRetryContext,
+  type CodemodeRetryOptions,
+  type CodemodeRetryPolicy
+} from "./retry";
+export {
   createCodemodeRuntime,
   type CreateCodemodeRuntimeOptions,
   type CodemodeRuntimeHandle,

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -18,80 +18,24 @@
  * in-memory cursor, so runs are safe across hibernation and can run
  * concurrently without clobbering one another.
  */
-import { RpcTarget } from "cloudflare:workers";
-import type { Executor, ResolvedProvider, ConnectorBinding } from "./executor";
-import { runCode } from "./run-code";
-import { normalizeCode } from "./normalize";
-import type { CodemodeConnector, ConnectorDescription } from "./connectors";
-import type {
-  ExecutionEndStatus,
-  PassEndStatus,
-  ToolAnnotations
-} from "./connectors";
-import { searchConnectors, describeTarget } from "./connectors";
+import type { Executor } from "./executor";
+import type { CodemodeConnector } from "./connectors";
 import {
   CodemodeRuntime,
   MAX_DURABLE_VALUE_BYTES,
-  STEP_CONNECTOR,
   tooLargeMessage,
-  type BeginOptions,
-  type PendingAction,
-  type ToolDecision,
-  type ToolLogEntry,
-  type ExecutionState
+  type PendingAction
 } from "./runtime";
-import type { Snippet, SaveSnippetOptions } from "./snippet";
-import type { CodeOutput } from "./shared";
-
-// Connector annotations, flattened to "connector.method" → annotation.
-type AnnotationMap = Record<string, ToolAnnotations>;
-
-/**
- * The RPC surface of the CodemodeRuntime facet, as the proxy tool uses it.
- *
- * Declared explicitly rather than relying on `Fetcher<CodemodeRuntime>`: the
- * RPC type transform collapses discriminated unions like `ToolDecision`
- * (the `unknown` payload doesn't survive serialization inference), which would
- * break `decision.kind` narrowing. This interface keeps the domain types intact.
- */
-interface RuntimeStub {
-  begin(code: string, options?: BeginOptions): Promise<string>;
-  resume(id: string): Promise<ExecutionState | null>;
-  decide(
-    executionId: string,
-    seq: number,
-    connector: string,
-    method: string,
-    args: unknown,
-    requiresApproval: boolean,
-    ephemeral?: boolean
-  ): Promise<ToolDecision>;
-  recordResult(
-    executionId: string,
-    seq: number,
-    result: unknown
-  ): Promise<void>;
-  complete(
-    executionId: string,
-    result: unknown,
-    logs?: string[]
-  ): Promise<void>;
-  fail(executionId: string, error: string, logs?: string[]): Promise<void>;
-  listPending(executionId?: string): Promise<PendingAction[]>;
-  reject(seq: number, executionId: string): Promise<boolean>;
-  expirePaused(maxAgeMs?: number): Promise<string[]>;
-  actionsToRevert(executionId: string): Promise<ToolLogEntry[]>;
-  markReverted(seq: number, executionId: string): Promise<void>;
-  markRolledBack(executionId: string): Promise<void>;
-  getExecution(id: string): Promise<ExecutionState | null>;
-  listExecutions(limit?: number): Promise<ExecutionState[]>;
-  deleteExecution(id: string): Promise<boolean>;
-  pruneExecutions(keep?: number): Promise<number>;
-  saveSnippet(name: string, options: SaveSnippetOptions): Promise<Snippet>;
-  getSnippet(name: string): Promise<Snippet | null>;
-  listSnippets(): Promise<Snippet[]>;
-  deleteSnippet(name: string): Promise<boolean>;
-}
+import {
+  disposeConnectors,
+  loadSetup,
+  missingConnectors,
+  runPass,
+  validateConnectorNames,
+  type RuntimeStub,
+  type Setup
+} from "./runtime-execution";
+import type { CodemodeRetryPolicy } from "./retry";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -155,6 +99,8 @@ export type CreateProxyToolOptions = {
   maxExecutions?: number;
   /** Optionally reshape the model-facing result (e.g. truncate). */
   transformResult?: TransformResult;
+  /** Durable retry policy. Explicit RetryableErrors retry by default. */
+  retry?: CodemodeRetryPolicy;
 };
 
 // ---------------------------------------------------------------------------
@@ -220,324 +166,6 @@ const proxySchema: ProxyToolInputSchema = {
   }
 };
 
-// Sandbox-side marker thrown to abort the run on a pause. The proxy tool
-// detects the pause via the facet's recorded state, not this message.
-const PAUSE_SENTINEL = "__CODEMODE_PAUSE__";
-
-// Sandbox-side definition of `codemode.step(name, fn)`. Assigned as an own
-// property on the codemode namespace so it shadows the dispatch proxy. It
-// wraps the local closure: ask the host whether to replay (return recorded
-// value) or execute (run fn, record the result). This is the explicit
-// side-effect boundary that makes replay correct for arbitrary work.
-const STEP_PRELUDE = String.raw`
-    codemode.step = async (name, fn) => {
-      const decision = await codemode.__stepDecide(name);
-      if (decision.kind === "replay") return decision.result;
-      // Anything other than "execute" (i.e. a pause from divergence) aborts
-      // the run; the reason is recorded on the execution.
-      if (decision.kind !== "execute") throw new Error("${PAUSE_SENTINEL}");
-      const value = await fn();
-      await codemode.__stepRecord(decision.seq, value);
-      return value;
-    };`;
-
-// Connector bindings return a control marker — `{ [CONTROL_KEY]: "pause" }` or
-// `{ [CONTROL_KEY]: "error", message }` — rather than throwing across RPC. The
-// sandbox connector proxy (see executor.ts CONNECTOR_CONTROL_KEY) detects it and
-// throws locally. Keep these two in sync.
-const CONTROL_KEY = "__codemode_control__";
-
-// ---------------------------------------------------------------------------
-// Host-side replay cursor — allocates seq per call/step, in order.
-// ---------------------------------------------------------------------------
-
-type Cursor = { next(): number };
-
-function createCursor(): Cursor {
-  let n = 0;
-  return { next: () => n++ };
-}
-
-// ---------------------------------------------------------------------------
-// Connector binding — an RpcTarget the sandbox calls via Workers RPC.
-//
-// Live RPC references can only be serialized as RPC call arguments (not via
-// Worker env), and a plain object with a function property can't be cloned at
-// all — so the binding MUST be an RpcTarget passed as an evaluate() argument.
-// ---------------------------------------------------------------------------
-
-class ConnectorCallTarget extends RpcTarget {
-  #handle: (method: string, args: unknown) => Promise<unknown>;
-  constructor(handle: (method: string, args: unknown) => Promise<unknown>) {
-    super();
-    this.#handle = handle;
-  }
-  callTool(method: string, args: unknown): Promise<unknown> {
-    return this.#handle(method, args);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Setup — connectors + runtime facet
-// ---------------------------------------------------------------------------
-
-type Setup = {
-  connectorsByName: Map<string, CodemodeConnector>;
-  descriptions: ConnectorDescription[];
-  annotations: AnnotationMap;
-};
-
-async function loadSetup(connectors: CodemodeConnector[]): Promise<Setup> {
-  const connectorsByName = new Map<string, CodemodeConnector>();
-  const descriptions: ConnectorDescription[] = [];
-  const annotations: AnnotationMap = {};
-
-  for (const connector of connectors) {
-    const name = connector.name();
-    const description = await connector.describe();
-    connectorsByName.set(name, connector);
-    descriptions.push(description);
-    for (const [method, annotation] of Object.entries(
-      description.annotations ?? {}
-    )) {
-      annotations[`${name}.${method}`] = annotation;
-    }
-  }
-
-  return { connectorsByName, descriptions, annotations };
-}
-
-// ---------------------------------------------------------------------------
-// Execution teardown — fire the connector lifecycle hook on a terminal status
-// ---------------------------------------------------------------------------
-
-/**
- * Notify every connector that an execution reached a terminal state so it can
- * dispose any per-execution resource (e.g. a browser session). Deliberately
- * *not* called on pause — a paused run may resume later. Hook rejections are
- * swallowed: teardown must never turn a finished run into a failure.
- *
- * Fires for every connector regardless of whether it took part in the run —
- * connectors that own no per-execution state default to a no-op.
- */
-export async function disposeConnectors(
-  connectors: Iterable<CodemodeConnector>,
-  executionId: string,
-  status: ExecutionEndStatus
-): Promise<void> {
-  await Promise.all(
-    [...connectors].map(async (connector) => {
-      try {
-        await connector.disposeExecution(executionId, status);
-      } catch {
-        // Intentionally ignored — see doc comment.
-      }
-    })
-  );
-}
-
-/**
- * Notify every connector that an execution pass ended — including a pause,
- * where `disposeExecution` deliberately does not fire — so per-pass resources
- * (open sockets, leases) can be released. Rejections are swallowed for the
- * same reason as `disposeConnectors`.
- */
-async function notifyPassEnd(
-  connectors: Iterable<CodemodeConnector>,
-  executionId: string,
-  status: PassEndStatus
-): Promise<void> {
-  await Promise.all(
-    [...connectors].map(async (connector) => {
-      try {
-        await connector.onPassEnd(executionId, status);
-      } catch {
-        // Intentionally ignored — see doc comment.
-      }
-    })
-  );
-}
-
-/**
- * Reject reserved and duplicate connector namespaces up front. Duplicates
- * would silently shadow each other in the sandbox (last one wins).
- */
-export function validateConnectorNames(
-  connectors: Iterable<CodemodeConnector>
-): void {
-  const seen = new Set<string>();
-  for (const connector of connectors) {
-    const name = connector.name();
-    if (name === "codemode") {
-      throw new Error(
-        'Connector name "codemode" is reserved for the codemode platform SDK.'
-      );
-    }
-    if (seen.has(name)) {
-      throw new Error(
-        `Duplicate connector name "${name}" — each connector needs a unique ` +
-          `namespace (pass a distinct \`name\` option).`
-      );
-    }
-    seen.add(name);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Connector bindings — every call routes through the runtime for a decision
-// ---------------------------------------------------------------------------
-
-function buildConnectorBindings(
-  setup: Setup,
-  runtime: RuntimeStub,
-  executionId: string,
-  cursor: Cursor
-): ConnectorBinding[] {
-  return setup.descriptions.map((desc) => ({
-    name: desc.name,
-    binding: new ConnectorCallTarget(async (method, args) => {
-      // The RpcTarget method must ALWAYS resolve — never reject. A rejection
-      // across the sandbox→host RPC boundary is tracked as an unhandled
-      // rejection on the host even though the sandbox awaits it. So every
-      // outcome, including a genuine error, is returned as a value: a result, a
-      // pause marker, or an error marker. The sandbox proxy turns the pause/
-      // error markers into a local throw, which the run's own try/catch handles
-      // (and which surfaces as an "error" execution exactly as a raw throw did).
-      try {
-        const seq = cursor.next();
-        const annotation = setup.annotations[`${desc.name}.${method}`];
-        const requiresApproval = annotation?.requiresApproval ?? false;
-        const ephemeral = annotation?.replay === "reexecute";
-        const decision = await runtime.decide(
-          executionId,
-          seq,
-          desc.name,
-          method,
-          args,
-          requiresApproval,
-          ephemeral
-        );
-
-        if (decision.kind === "replay") return decision.result;
-        if (decision.kind === "pause") return { [CONTROL_KEY]: "pause" };
-
-        const connector = setup.connectorsByName.get(desc.name);
-        if (!connector) throw new Error(`Unknown connector: ${desc.name}`);
-        const result = await connector.executeTool(method, args, {
-          executionId
-        });
-        await runtime.recordResult(executionId, decision.seq, result);
-        return result;
-      } catch (err) {
-        // Log the original error (with its stack) on the host: returning a
-        // marker keeps the RPC call from rejecting, but a genuine failure still
-        // deserves a host-side trace for debugging. The message also reaches the
-        // model and the audit trail via the run's "error" outcome.
-        console.error(
-          `codemode: ${desc.name}.${method} failed (execution ${executionId})`,
-          err
-        );
-        return {
-          [CONTROL_KEY]: "error",
-          message: err instanceof Error ? err.message : String(err)
-        };
-      }
-    })
-  }));
-}
-
-// ---------------------------------------------------------------------------
-// Platform provider — codemode namespace
-// ---------------------------------------------------------------------------
-
-function createPlatformProvider(
-  setup: Setup,
-  bindings: ConnectorBinding[],
-  runtime: RuntimeStub,
-  executor: Executor,
-  executionId: string,
-  cursor: Cursor
-): ResolvedProvider {
-  const { descriptions } = setup;
-  const provider: ResolvedProvider = {
-    name: "codemode",
-    prelude: STEP_PRELUDE,
-    fns: {
-      // Discovery
-      search: async (query: unknown) =>
-        searchConnectors(
-          String(query),
-          descriptions,
-          await runtime.listSnippets()
-        ),
-
-      describe: async (target: unknown) =>
-        describeTarget(
-          String(target),
-          descriptions,
-          await runtime.listSnippets()
-        ),
-
-      // Snippets — durable saved scripts the developer promoted
-      run: async (...args: unknown[]) => {
-        const snippet = await runtime.getSnippet(String(args[0]));
-        if (!snippet) return { error: `Snippet "${args[0]}" not found.` };
-        // The snippet recorded the connectors its source execution ran with;
-        // refuse with a clear error when one is no longer configured rather
-        // than failing partway through the script.
-        const missing = missingConnectors(
-          snippet.connectors,
-          new Set(setup.connectorsByName.keys())
-        );
-        if (missing.length > 0) {
-          return {
-            error:
-              `Snippet "${args[0]}" requires connector(s) ` +
-              `${missing.map((m) => `"${m}"`).join(", ")} that are not ` +
-              `configured on this runtime.`
-          };
-        }
-        // Snippets are saved execution code, so they may use the codemode
-        // SDK (e.g. codemode.step) — run them with this same provider, which
-        // shares the cursor so the snippet's calls continue this run's log.
-        //
-        // The stored snippet is the model's raw code, which may carry markdown
-        // fences or be a statement block — embedding it directly as an
-        // expression would be a syntax error. Normalize it to a valid arrow
-        // expression first (the same transform the executor applies to a fresh
-        // run); `runCode` then normalizes the outer wrapper as usual.
-        const snippetExpr = normalizeCode(snippet.code);
-        const result = await runCode({
-          code: `async () => {\n  const snippet = (${snippetExpr});\n  return await snippet(${JSON.stringify(args[1])});\n}`,
-          executor,
-          providers: [provider],
-          connectors: bindings
-        });
-        return result.result;
-      },
-
-      // Host primitives backing the codemode.step() prelude. The closure
-      // can't cross the RPC boundary, so step decides + records here while the
-      // sandbox runs the closure locally only when told to execute.
-      __stepDecide: async (name: unknown) =>
-        runtime.decide(
-          executionId,
-          cursor.next(),
-          STEP_CONNECTOR,
-          String(name),
-          undefined,
-          false
-        ),
-
-      __stepRecord: async (seq: unknown, value: unknown) => {
-        await runtime.recordResult(executionId, Number(seq), value);
-        return true;
-      }
-    }
-  };
-  return provider;
-}
-
 // ---------------------------------------------------------------------------
 // Tool description
 // ---------------------------------------------------------------------------
@@ -591,144 +219,6 @@ function buildDescription(
   ];
 
   return lines.join("\n");
-}
-
-// ---------------------------------------------------------------------------
-// Run one pass of the code through the executor.
-// ---------------------------------------------------------------------------
-
-async function runPass(
-  executionId: string,
-  code: string,
-  setup: Setup,
-  runtime: RuntimeStub,
-  executor: Executor,
-  transformResult?: TransformResult
-): Promise<ProxyToolOutput> {
-  const cursor = createCursor();
-  const bindings = buildConnectorBindings(setup, runtime, executionId, cursor);
-  const platformProvider = createPlatformProvider(
-    setup,
-    bindings,
-    runtime,
-    executor,
-    executionId,
-    cursor
-  );
-
-  const connectors = [...setup.connectorsByName.values()];
-
-  // Every pass — paused, completed, or errored — must end with onPassEnd so
-  // connectors can release per-pass resources (sockets, leases). On terminal
-  // outcomes, disposeExecution follows. `ended` makes the finally a safety net
-  // for crashes inside this function itself (e.g. a facet RPC failure), not a
-  // double-fire.
-  let ended = false;
-  const endPass = async (status: PassEndStatus) => {
-    ended = true;
-    await notifyPassEnd(connectors, executionId, status);
-    if (status !== "paused") {
-      await disposeConnectors(connectors, executionId, status);
-    }
-  };
-
-  try {
-    let output: CodeOutput | undefined;
-    let threw: unknown;
-    try {
-      output = await runCode({
-        code,
-        executor,
-        providers: [platformProvider],
-        connectors: bindings
-      });
-    } catch (err) {
-      threw = err;
-    }
-
-    // The facet status is the source of truth: a pause (approval or
-    // divergence) records itself there before aborting the run. The
-    // PAUSE_SENTINEL only stops the sandbox; it is never the deciding signal
-    // here.
-    const execution = await runtime.getExecution(executionId);
-    if (execution?.status === "paused") {
-      // Not terminal — the run may resume, so per-execution connector
-      // resources stay open. Per-pass resources are still released.
-      await endPass("paused");
-      return {
-        status: "paused",
-        executionId,
-        pending: await runtime.listPending(executionId)
-      };
-    }
-    if (execution?.status === "error") {
-      // A replay divergence (or an in-run durable-log failure), already
-      // recorded on the execution by the facet.
-      await endPass("error");
-      return {
-        status: "error",
-        executionId,
-        error: execution.error ?? "Codemode execution failed"
-      };
-    }
-
-    if (threw) {
-      const raw = threw instanceof Error ? threw.message : String(threw);
-      const message = withGlobalsHint(raw, setup);
-      await runtime.fail(executionId, message);
-      await endPass("error");
-      return { status: "error", executionId, error: message };
-    }
-
-    const result = output?.result;
-    await runtime.complete(executionId, result, output?.logs);
-    await endPass("completed");
-    return {
-      status: "completed",
-      executionId,
-      result: await applyTransform(transformResult, result),
-      logs: output?.logs
-    };
-  } finally {
-    if (!ended) {
-      // Something inside runPass itself threw before any labeled exit — make
-      // sure connectors still hear about the pass ending.
-      await endPass("error");
-    }
-  }
-}
-
-/**
- * A sandbox `ReferenceError` usually means the model invented a global (e.g.
- * `host.writeFile(...)`). Append the real globals so the retry is informed
- * instead of another guess.
- */
-function withGlobalsHint(message: string, setup: Setup): string {
-  if (!/\bis not defined\b/.test(message)) return message;
-  const names = [...setup.connectorsByName.keys(), "codemode"].join(", ");
-  return `${message} (the only globals available in the sandbox are: ${names})`;
-}
-
-/**
- * Apply the result transform, defending against a buggy transform: the run has
- * already completed and its resources are disposed, so a throwing transform
- * must not turn a successful run into a thrown tool error. Fall back to the raw
- * result (and warn) instead.
- */
-async function applyTransform(
-  transformResult: TransformResult | undefined,
-  result: unknown
-): Promise<unknown> {
-  if (!transformResult) return result;
-  try {
-    return await transformResult(result);
-  } catch (err) {
-    console.warn(
-      "codemode: transformResult threw; returning the raw result.",
-      err
-    );
-    return result;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -789,7 +279,8 @@ export function createProxyTool(options: CreateProxyToolOptions): CodemodeTool {
         setup,
         runtime,
         options.executor,
-        options.transformResult
+        options.transformResult,
+        options.retry
       );
     }
   };
@@ -858,15 +349,9 @@ export type ResumeCodemodeOptions = {
   maxExecutions?: number;
   /** Optionally reshape the model-facing result (e.g. truncate). */
   transformResult?: TransformResult;
+  /** Durable retry policy for the resumed pass. */
+  retry?: CodemodeRetryPolicy;
 };
-
-/** Connectors an execution/snippet recorded but the runtime no longer has. */
-function missingConnectors(
-  required: string[] | undefined,
-  available: Set<string>
-): string[] {
-  return (required ?? []).filter((name) => !available.has(name));
-}
 
 /**
  * Approve a pending action and continue the paused execution. Re-runs the
@@ -921,7 +406,8 @@ export async function resumeCodemode(
     setup,
     runtime,
     options.executor,
-    options.transformResult
+    options.transformResult,
+    options.retry
   );
 }
 
@@ -1012,53 +498,58 @@ export async function rollbackCodemode(options: {
 }): Promise<void> {
   const runtime = getRuntime(options.ctx, options.name);
 
-  const byName = new Map(options.connectors.map((c) => [c.name(), c]));
-  const actions = await runtime.actionsToRevert(options.executionId);
+  const abortController = new AbortController();
+  try {
+    const byName = new Map(options.connectors.map((c) => [c.name(), c]));
+    const actions = await runtime.actionsToRevert(options.executionId);
 
-  // Attempt every revert, in reverse order, even if some fail — a failing
-  // compensation must not strand the actions after it as un-reverted. Failures
-  // are collected and surfaced after the whole pass rather than aborting it.
-  let reverted = 0;
-  const failures: string[] = [];
-  for (const action of actions) {
-    const connector = byName.get(action.connector);
-    if (!connector) continue;
-    try {
-      // revertAction no-ops (returns false) for reads / tools without a revert.
-      const didRevert = await connector.revertAction(
-        action.method,
-        action.args,
-        action.result,
-        { executionId: options.executionId }
-      );
-      if (didRevert) {
-        await runtime.markReverted(action.seq, options.executionId);
-        reverted++;
+    // Attempt every revert, in reverse order, even if some fail — a failing
+    // compensation must not strand the actions after it as un-reverted. Failures
+    // are collected and surfaced after the whole pass rather than aborting it.
+    let reverted = 0;
+    const failures: string[] = [];
+    for (const action of actions) {
+      const connector = byName.get(action.connector);
+      if (!connector) continue;
+      try {
+        // revertAction no-ops (returns false) for reads / tools without a revert.
+        const didRevert = await connector.revertAction(
+          action.method,
+          action.args,
+          action.result,
+          { executionId: options.executionId, signal: abortController.signal }
+        );
+        if (didRevert) {
+          await runtime.markReverted(action.seq, options.executionId);
+          reverted++;
+        }
+      } catch (err) {
+        failures.push(
+          `${action.connector}.${action.method}: ` +
+            (err instanceof Error ? err.message : String(err))
+        );
       }
-    } catch (err) {
-      failures.push(
-        `${action.connector}.${action.method}: ` +
-          (err instanceof Error ? err.message : String(err))
+    }
+
+    // Reflect the rollback in the execution status so the audit trail doesn't
+    // keep showing "completed" after the run's effects were undone.
+    if (reverted > 0) {
+      await runtime.markRolledBack(options.executionId);
+      // Rolling back is terminal — dispose per-execution connector resources.
+      await disposeConnectors(
+        options.connectors,
+        options.executionId,
+        "rolled_back"
       );
     }
-  }
 
-  // Reflect the rollback in the execution status so the audit trail doesn't
-  // keep showing "completed" after the run's effects were undone.
-  if (reverted > 0) {
-    await runtime.markRolledBack(options.executionId);
-    // Rolling back is terminal — dispose per-execution connector resources.
-    await disposeConnectors(
-      options.connectors,
-      options.executionId,
-      "rolled_back"
-    );
-  }
-
-  if (failures.length > 0) {
-    throw new Error(
-      `Rollback reverted ${reverted} action(s) but ${failures.length} failed: ` +
-        failures.join("; ")
-    );
+    if (failures.length > 0) {
+      throw new Error(
+        `Rollback reverted ${reverted} action(s) but ${failures.length} failed: ` +
+          failures.join("; ")
+      );
+    }
+  } finally {
+    abortController.abort();
   }
 }

--- a/packages/codemode/src/retry.ts
+++ b/packages/codemode/src/retry.ts
@@ -1,0 +1,122 @@
+import type { ExecutionState } from "./runtime";
+
+/** Machine-readable reason an executor pass failed. */
+export type ExecuteFailure = {
+  /** Ordinary sandbox failure, an explicitly retryable connector failure, or a timeout. */
+  kind: "error" | "retryable" | "timeout";
+  message: string;
+  /** Optional server-provided delay, for example from Retry-After. */
+  retryAfterMs?: number;
+};
+
+export type CodemodeRetryContext = {
+  executionId: string;
+  /** One-based attempt number that just failed. */
+  attempt: number;
+  failure: ExecuteFailure;
+  /** Durable execution snapshot at the failure boundary. */
+  execution: ExecutionState;
+};
+
+export const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+export const DEFAULT_RETRY_BASE_DELAY_MS = 500;
+export const DEFAULT_RETRY_MAX_DELAY_MS = 10_000;
+
+export type CodemodeRetryOptions = {
+  /** Total execution attempts, including the initial attempt. Defaults to 3. */
+  maxAttempts?: number;
+  /**
+   * Decide whether a failed pass is safe to retry. By default only failures
+   * raised with RetryableError are retried; timeouts require an explicit policy
+   * because a timed-out mutation may have succeeded remotely.
+   */
+  shouldRetry?: (context: CodemodeRetryContext) => boolean | Promise<boolean>;
+  /**
+   * Delay before the next pass. Defaults to failure.retryAfterMs, then bounded
+   * exponential backoff (500ms, 1s, up to 10s). The failed pass is fenced
+   * before this delay starts.
+   */
+  delayMs?: (context: CodemodeRetryContext) => number | Promise<number>;
+};
+
+/** Pass `false` to disable the default RetryableError policy. */
+export type CodemodeRetryPolicy = CodemodeRetryOptions | false;
+
+export type ResolvedRetryPolicy = {
+  maxAttempts: number;
+  shouldRetry: (context: CodemodeRetryContext) => boolean | Promise<boolean>;
+  delayMs: (context: CodemodeRetryContext) => number | Promise<number>;
+};
+
+export function resolveRetryPolicy(
+  policy: CodemodeRetryPolicy | undefined
+): ResolvedRetryPolicy {
+  if (policy === false) {
+    return {
+      maxAttempts: 1,
+      shouldRetry: () => false,
+      delayMs: () => 0
+    };
+  }
+
+  const configuredAttempts = policy?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
+  return {
+    maxAttempts: Number.isFinite(configuredAttempts)
+      ? Math.max(1, Math.floor(configuredAttempts))
+      : 1,
+    shouldRetry:
+      policy?.shouldRetry ?? (({ failure }) => failure.kind === "retryable"),
+    delayMs: policy?.delayMs ?? defaultRetryDelayMs
+  };
+}
+
+export function defaultRetryDelayMs(context: CodemodeRetryContext): number {
+  if (context.failure.retryAfterMs !== undefined) {
+    return Math.max(0, context.failure.retryAfterMs);
+  }
+  return Math.min(
+    DEFAULT_RETRY_BASE_DELAY_MS * 2 ** (context.attempt - 1),
+    DEFAULT_RETRY_MAX_DELAY_MS
+  );
+}
+
+/**
+ * Throw from a connector to request retry of the current durable execution.
+ * The signal crosses the connector RPC and sandbox boundaries as structured
+ * metadata; callers never need to match an error message.
+ */
+export class RetryableError extends Error {
+  readonly retryAfterMs?: number;
+
+  constructor(
+    message: string,
+    options?: { retryAfterMs?: number; cause?: unknown }
+  ) {
+    super(
+      message,
+      options?.cause === undefined ? undefined : { cause: options.cause }
+    );
+    this.name = "RetryableError";
+    this.retryAfterMs = options?.retryAfterMs;
+  }
+}
+
+export function isRetryableError(error: unknown): error is RetryableError {
+  return error instanceof RetryableError;
+}
+
+/** Error thrown by runCode while retaining the executor's structured failure. */
+export class CodemodeExecutionError extends Error {
+  readonly failure: ExecuteFailure;
+  readonly logs?: string[];
+
+  constructor(failure: ExecuteFailure, logs?: string[]) {
+    const logContext = logs?.length
+      ? `\n\nConsole output:\n${logs.join("\n")}`
+      : "";
+    super(`Code execution failed: ${failure.message}${logContext}`);
+    this.name = "CodemodeExecutionError";
+    this.failure = failure;
+    this.logs = logs;
+  }
+}

--- a/packages/codemode/src/run-code.ts
+++ b/packages/codemode/src/run-code.ts
@@ -1,6 +1,7 @@
 import type { CodeOutput } from "./shared";
 import type { Executor, ResolvedProvider, ConnectorBinding } from "./executor";
 import { normalizeCode } from "./normalize";
+import { CodemodeExecutionError } from "./retry";
 
 export async function runCode({
   code,
@@ -19,11 +20,12 @@ export async function runCode({
     connectors?.length ? { connectors } : undefined
   );
 
-  if (executeResult.error) {
-    const logCtx = executeResult.logs?.length
-      ? `\n\nConsole output:\n${executeResult.logs.join("\n")}`
-      : "";
-    throw new Error(`Code execution failed: ${executeResult.error}${logCtx}`);
+  if (executeResult.error !== undefined) {
+    const failure = executeResult.failure ?? {
+      kind: "error" as const,
+      message: executeResult.error
+    };
+    throw new CodemodeExecutionError(failure, executeResult.logs);
   }
 
   return executeResult.logs?.length

--- a/packages/codemode/src/runtime-attempts.ts
+++ b/packages/codemode/src/runtime-attempts.ts
@@ -1,0 +1,98 @@
+/** Internal durable generation fence for Code Mode execution passes. */
+export class ExecutionAttemptStore {
+  constructor(private readonly sql: SqlStorage) {
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS cm_attempts (
+        execution_id TEXT PRIMARY KEY,
+        attempt INTEGER NOT NULL
+      );
+      INSERT OR IGNORE INTO cm_attempts (execution_id, attempt)
+        SELECT id, 0 FROM cm_executions;
+    `);
+  }
+
+  begin(executionId: string): void {
+    this.sql.exec(
+      `INSERT INTO cm_attempts (execution_id, attempt) VALUES (?, 0)`,
+      executionId
+    );
+  }
+
+  current(executionId: string): number {
+    const row = this.sql
+      .exec<{ attempt: number }>(
+        `SELECT attempt FROM cm_attempts WHERE execution_id = ?`,
+        executionId
+      )
+      .toArray()[0];
+    if (!row) throw new Error(`No execution "${executionId}"`);
+    return row.attempt;
+  }
+
+  advance(executionId: string, expectedAttempt: number): number | null {
+    const next = expectedAttempt + 1;
+    const updated = this.sql.exec(
+      `UPDATE cm_attempts SET attempt = ?
+        WHERE execution_id = ? AND attempt = ?
+          AND EXISTS (
+            SELECT 1 FROM cm_executions
+            WHERE id = cm_attempts.execution_id AND status = 'running'
+          )`,
+      next,
+      executionId,
+      expectedAttempt
+    );
+    return updated.rowsWritten > 0 ? next : null;
+  }
+
+  isCurrentRunning(executionId: string, attempt: number): boolean {
+    return (
+      this.sql
+        .exec(
+          `SELECT 1 FROM cm_executions
+            WHERE id = ? AND status = 'running'
+              AND EXISTS (
+                SELECT 1 FROM cm_attempts
+                WHERE execution_id = cm_executions.id AND attempt = ?
+              )`,
+          executionId,
+          attempt
+        )
+        .toArray().length > 0
+    );
+  }
+
+  recordResult(
+    executionId: string,
+    seq: number,
+    result: string | null,
+    attempt: number
+  ): boolean {
+    const updated = this.sql.exec(
+      `UPDATE cm_log SET result = ?, state = 'applied'
+        WHERE execution_id = ? AND seq = ?
+          AND (state = 'executing' OR (state = 'applied' AND ephemeral = 1))
+          AND EXISTS (
+            SELECT 1 FROM cm_executions
+            WHERE id = ? AND status = 'running'
+              AND EXISTS (
+                SELECT 1 FROM cm_attempts
+                WHERE execution_id = cm_executions.id AND attempt = ?
+              )
+          )`,
+      result,
+      executionId,
+      seq,
+      executionId,
+      attempt
+    );
+    return updated.rowsWritten > 0;
+  }
+
+  delete(executionId: string): void {
+    this.sql.exec(
+      `DELETE FROM cm_attempts WHERE execution_id = ?`,
+      executionId
+    );
+  }
+}

--- a/packages/codemode/src/runtime-execution.ts
+++ b/packages/codemode/src/runtime-execution.ts
@@ -1,0 +1,698 @@
+/** Internal durable execution orchestration for the Code Mode runtime. */
+import { RpcTarget } from "cloudflare:workers";
+import type { Executor, ResolvedProvider, ConnectorBinding } from "./executor";
+import { runCode } from "./run-code";
+import { normalizeCode } from "./normalize";
+import type { CodemodeConnector, ConnectorDescription } from "./connectors";
+import type {
+  ExecutionEndStatus,
+  PassEndStatus,
+  ToolAnnotations
+} from "./connectors";
+import { searchConnectors, describeTarget } from "./connectors";
+import {
+  STEP_CONNECTOR,
+  type BeginOptions,
+  type PendingAction,
+  type ToolDecision,
+  type ToolLogEntry,
+  type ExecutionState
+} from "./runtime";
+import type { Snippet, SaveSnippetOptions } from "./snippet";
+import type { CodeOutput } from "./shared";
+import type { ProxyToolOutput, TransformResult } from "./proxy-tool";
+import {
+  CodemodeExecutionError,
+  isRetryableError,
+  resolveRetryPolicy,
+  type CodemodeRetryContext,
+  type CodemodeRetryPolicy,
+  type ExecuteFailure
+} from "./retry";
+
+// Connector annotations, flattened to "connector.method" → annotation.
+type AnnotationMap = Record<string, ToolAnnotations>;
+
+/**
+ * The RPC surface of the CodemodeRuntime facet, as the proxy tool uses it.
+ *
+ * Declared explicitly rather than relying on `Fetcher<CodemodeRuntime>`: the
+ * RPC type transform collapses discriminated unions like `ToolDecision`
+ * (the `unknown` payload doesn't survive serialization inference), which would
+ * break `decision.kind` narrowing. This interface keeps the domain types intact.
+ */
+export interface RuntimeStub {
+  begin(code: string, options?: BeginOptions): Promise<string>;
+  currentAttempt(id: string): Promise<number>;
+  beginRetry(id: string, expectedAttempt: number): Promise<number | null>;
+  resume(id: string): Promise<ExecutionState | null>;
+  decide(
+    executionId: string,
+    seq: number,
+    connector: string,
+    method: string,
+    args: unknown,
+    requiresApproval: boolean,
+    ephemeral: boolean,
+    attempt: number
+  ): Promise<ToolDecision>;
+  recordResult(
+    executionId: string,
+    seq: number,
+    result: unknown,
+    attempt: number
+  ): Promise<boolean>;
+  complete(
+    executionId: string,
+    result: unknown,
+    logs?: string[]
+  ): Promise<void>;
+  fail(executionId: string, error: string, logs?: string[]): Promise<void>;
+  listPending(executionId?: string): Promise<PendingAction[]>;
+  reject(seq: number, executionId: string): Promise<boolean>;
+  expirePaused(maxAgeMs?: number): Promise<string[]>;
+  actionsToRevert(executionId: string): Promise<ToolLogEntry[]>;
+  markReverted(seq: number, executionId: string): Promise<void>;
+  markRolledBack(executionId: string): Promise<void>;
+  getExecution(id: string): Promise<ExecutionState | null>;
+  listExecutions(limit?: number): Promise<ExecutionState[]>;
+  deleteExecution(id: string): Promise<boolean>;
+  pruneExecutions(keep?: number): Promise<number>;
+  saveSnippet(name: string, options: SaveSnippetOptions): Promise<Snippet>;
+  getSnippet(name: string): Promise<Snippet | null>;
+  listSnippets(): Promise<Snippet[]>;
+  deleteSnippet(name: string): Promise<boolean>;
+}
+
+// Sandbox-side marker thrown to abort the run on a pause. The proxy tool
+// detects the pause via the facet's recorded state, not this message.
+const PAUSE_SENTINEL = "__CODEMODE_PAUSE__";
+
+// Sandbox-side definition of `codemode.step(name, fn)`. Assigned as an own
+// property on the codemode namespace so it shadows the dispatch proxy. It
+// wraps the local closure: ask the host whether to replay (return recorded
+// value) or execute (run fn, record the result). This is the explicit
+// side-effect boundary that makes replay correct for arbitrary work.
+const STEP_PRELUDE = String.raw`
+    codemode.step = async (name, fn) => {
+      const decision = await codemode.__stepDecide(name);
+      if (decision.kind === "replay") return decision.result;
+      // Anything other than "execute" (i.e. a pause from divergence) aborts
+      // the run; the reason is recorded on the execution.
+      if (decision.kind !== "execute") throw new Error("${PAUSE_SENTINEL}");
+      const value = await fn();
+      await codemode.__stepRecord(decision.seq, value);
+      return value;
+    };`;
+
+// Connector bindings return a control marker — `{ [CONTROL_KEY]: "pause" }` or
+// `{ [CONTROL_KEY]: "error", message }` — rather than throwing across RPC. The
+// sandbox connector proxy (see executor.ts CONNECTOR_CONTROL_KEY) detects it and
+// throws locally. Keep these two in sync.
+const CONTROL_KEY = "__codemode_control__";
+
+// ---------------------------------------------------------------------------
+// Host-side replay cursor — allocates seq per call/step, in order.
+// ---------------------------------------------------------------------------
+
+type Cursor = { next(): number };
+type PassControl = { failure?: ExecuteFailure };
+
+function createCursor(): Cursor {
+  let n = 0;
+  return { next: () => n++ };
+}
+
+// ---------------------------------------------------------------------------
+// Connector binding — an RpcTarget the sandbox calls via Workers RPC.
+//
+// Live RPC references can only be serialized as RPC call arguments (not via
+// Worker env), and a plain object with a function property can't be cloned at
+// all — so the binding MUST be an RpcTarget passed as an evaluate() argument.
+// ---------------------------------------------------------------------------
+
+class ConnectorCallTarget extends RpcTarget {
+  #handle: (method: string, args: unknown) => Promise<unknown>;
+  constructor(handle: (method: string, args: unknown) => Promise<unknown>) {
+    super();
+    this.#handle = handle;
+  }
+  callTool(method: string, args: unknown): Promise<unknown> {
+    return this.#handle(method, args);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup — connectors + runtime facet
+// ---------------------------------------------------------------------------
+
+export type Setup = {
+  connectorsByName: Map<string, CodemodeConnector>;
+  descriptions: ConnectorDescription[];
+  annotations: AnnotationMap;
+};
+
+export async function loadSetup(
+  connectors: CodemodeConnector[]
+): Promise<Setup> {
+  const connectorsByName = new Map<string, CodemodeConnector>();
+  const descriptions: ConnectorDescription[] = [];
+  const annotations: AnnotationMap = {};
+
+  for (const connector of connectors) {
+    const name = connector.name();
+    const description = await connector.describe();
+    connectorsByName.set(name, connector);
+    descriptions.push(description);
+    for (const [method, annotation] of Object.entries(
+      description.annotations ?? {}
+    )) {
+      annotations[`${name}.${method}`] = annotation;
+    }
+  }
+
+  return { connectorsByName, descriptions, annotations };
+}
+
+// ---------------------------------------------------------------------------
+// Execution teardown — fire the connector lifecycle hook on a terminal status
+// ---------------------------------------------------------------------------
+
+/**
+ * Notify every connector that an execution reached a terminal state so it can
+ * dispose any per-execution resource (e.g. a browser session). Deliberately
+ * *not* called on pause — a paused run may resume later. Hook rejections are
+ * swallowed: teardown must never turn a finished run into a failure.
+ *
+ * Fires for every connector regardless of whether it took part in the run —
+ * connectors that own no per-execution state default to a no-op.
+ */
+export async function disposeConnectors(
+  connectors: Iterable<CodemodeConnector>,
+  executionId: string,
+  status: ExecutionEndStatus
+): Promise<void> {
+  await Promise.all(
+    [...connectors].map(async (connector) => {
+      try {
+        await connector.disposeExecution(executionId, status);
+      } catch {
+        // Intentionally ignored — see doc comment.
+      }
+    })
+  );
+}
+
+/**
+ * Notify every connector that an execution pass ended — including a pause,
+ * where `disposeExecution` deliberately does not fire — so per-pass resources
+ * (open sockets, leases) can be released. Rejections are swallowed for the
+ * same reason as `disposeConnectors`.
+ */
+async function notifyPassEnd(
+  connectors: Iterable<CodemodeConnector>,
+  executionId: string,
+  status: PassEndStatus
+): Promise<void> {
+  await Promise.all(
+    [...connectors].map(async (connector) => {
+      try {
+        await connector.onPassEnd(executionId, status);
+      } catch {
+        // Intentionally ignored — see doc comment.
+      }
+    })
+  );
+}
+
+/**
+ * Reject reserved and duplicate connector namespaces up front. Duplicates
+ * would silently shadow each other in the sandbox (last one wins).
+ */
+export function validateConnectorNames(
+  connectors: Iterable<CodemodeConnector>
+): void {
+  const seen = new Set<string>();
+  for (const connector of connectors) {
+    const name = connector.name();
+    if (name === "codemode") {
+      throw new Error(
+        'Connector name "codemode" is reserved for the codemode platform SDK.'
+      );
+    }
+    if (seen.has(name)) {
+      throw new Error(
+        `Duplicate connector name "${name}" — each connector needs a unique ` +
+          `namespace (pass a distinct \`name\` option).`
+      );
+    }
+    seen.add(name);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connector bindings — every call routes through the runtime for a decision
+// ---------------------------------------------------------------------------
+
+function buildConnectorBindings(
+  setup: Setup,
+  runtime: RuntimeStub,
+  executionId: string,
+  cursor: Cursor,
+  attempt: number,
+  control: PassControl,
+  signal: AbortSignal
+): ConnectorBinding[] {
+  return setup.descriptions.map((desc) => ({
+    name: desc.name,
+    binding: new ConnectorCallTarget(async (method, args) => {
+      // A caught retry signal must not let model code drive more effects in the
+      // failed pass. Keep returning the same signal until the sandbox exits.
+      if (control.failure) {
+        return {
+          [CONTROL_KEY]: "retryable",
+          message: control.failure.message,
+          retryAfterMs: control.failure.retryAfterMs
+        };
+      }
+
+      // The RpcTarget method must ALWAYS resolve — never reject. A rejection
+      // across the sandbox→host RPC boundary is tracked as an unhandled
+      // rejection on the host even though the sandbox awaits it. So every
+      // outcome, including a genuine error, is returned as a value: a result, a
+      // pause marker, or an error marker. The sandbox proxy turns the pause/
+      // error markers into a local throw, which the run's own try/catch handles
+      // (and which surfaces as an "error" execution exactly as a raw throw did).
+      try {
+        const seq = cursor.next();
+        const annotation = setup.annotations[`${desc.name}.${method}`];
+        const requiresApproval = annotation?.requiresApproval ?? false;
+        const ephemeral = annotation?.replay === "reexecute";
+        const decision = await runtime.decide(
+          executionId,
+          seq,
+          desc.name,
+          method,
+          args,
+          requiresApproval,
+          ephemeral,
+          attempt
+        );
+
+        if (decision.kind === "replay") return decision.result;
+        if (decision.kind === "pause") return { [CONTROL_KEY]: "pause" };
+
+        const connector = setup.connectorsByName.get(desc.name);
+        if (!connector) throw new Error(`Unknown connector: ${desc.name}`);
+        const result = await connector.executeTool(method, args, {
+          executionId,
+          signal
+        });
+        const recorded = await runtime.recordResult(
+          executionId,
+          decision.seq,
+          result,
+          decision.attempt
+        );
+        return recorded ? result : { [CONTROL_KEY]: "pause" };
+      } catch (err) {
+        if (isRetryableError(err)) {
+          control.failure = {
+            kind: "retryable",
+            message: err.message,
+            retryAfterMs: err.retryAfterMs
+          };
+          return {
+            [CONTROL_KEY]: "retryable",
+            message: err.message,
+            retryAfterMs: err.retryAfterMs
+          };
+        }
+        // Log the original error (with its stack) on the host: returning a
+        // marker keeps the RPC call from rejecting, but a genuine failure still
+        // deserves a host-side trace for debugging. The message also reaches the
+        // model and the audit trail via the run's "error" outcome.
+        console.error(
+          `codemode: ${desc.name}.${method} failed (execution ${executionId})`,
+          err
+        );
+        return {
+          [CONTROL_KEY]: "error",
+          message: err instanceof Error ? err.message : String(err)
+        };
+      }
+    })
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Platform provider — codemode namespace
+// ---------------------------------------------------------------------------
+
+function createPlatformProvider(
+  setup: Setup,
+  bindings: ConnectorBinding[],
+  runtime: RuntimeStub,
+  executor: Executor,
+  executionId: string,
+  cursor: Cursor,
+  attempt: number,
+  control: PassControl
+): ResolvedProvider {
+  const { descriptions } = setup;
+  const provider: ResolvedProvider = {
+    name: "codemode",
+    prelude: STEP_PRELUDE,
+    fns: {
+      // Discovery
+      search: async (query: unknown) =>
+        searchConnectors(
+          String(query),
+          descriptions,
+          await runtime.listSnippets()
+        ),
+
+      describe: async (target: unknown) =>
+        describeTarget(
+          String(target),
+          descriptions,
+          await runtime.listSnippets()
+        ),
+
+      // Snippets — durable saved scripts the developer promoted
+      run: async (...args: unknown[]) => {
+        const snippet = await runtime.getSnippet(String(args[0]));
+        if (!snippet) return { error: `Snippet "${args[0]}" not found.` };
+        // The snippet recorded the connectors its source execution ran with;
+        // refuse with a clear error when one is no longer configured rather
+        // than failing partway through the script.
+        const missing = missingConnectors(
+          snippet.connectors,
+          new Set(setup.connectorsByName.keys())
+        );
+        if (missing.length > 0) {
+          return {
+            error:
+              `Snippet "${args[0]}" requires connector(s) ` +
+              `${missing.map((m) => `"${m}"`).join(", ")} that are not ` +
+              `configured on this runtime.`
+          };
+        }
+        // Snippets are saved execution code, so they may use the codemode
+        // SDK (e.g. codemode.step) — run them with this same provider, which
+        // shares the cursor so the snippet's calls continue this run's log.
+        //
+        // The stored snippet is the model's raw code, which may carry markdown
+        // fences or be a statement block — embedding it directly as an
+        // expression would be a syntax error. Normalize it to a valid arrow
+        // expression first (the same transform the executor applies to a fresh
+        // run); `runCode` then normalizes the outer wrapper as usual.
+        const snippetExpr = normalizeCode(snippet.code);
+        const result = await runCode({
+          code: `async () => {\n  const snippet = (${snippetExpr});\n  return await snippet(${JSON.stringify(args[1])});\n}`,
+          executor,
+          providers: [provider],
+          connectors: bindings
+        });
+        return result.result;
+      },
+
+      // Host primitives backing the codemode.step() prelude. The closure
+      // can't cross the RPC boundary, so step decides + records here while the
+      // sandbox runs the closure locally only when told to execute.
+      __stepDecide: async (name: unknown) => {
+        const seq = cursor.next();
+        if (control.failure) return { kind: "pause" as const, seq };
+        return runtime.decide(
+          executionId,
+          seq,
+          STEP_CONNECTOR,
+          String(name),
+          undefined,
+          false,
+          false,
+          attempt
+        );
+      },
+
+      __stepRecord: async (seq: unknown, value: unknown) =>
+        runtime.recordResult(executionId, Number(seq), value, attempt)
+    }
+  };
+  return provider;
+}
+
+// ---------------------------------------------------------------------------
+// Run one pass of the code through the executor.
+// ---------------------------------------------------------------------------
+
+export async function runPass(
+  executionId: string,
+  code: string,
+  setup: Setup,
+  runtime: RuntimeStub,
+  executor: Executor,
+  transformResult?: TransformResult,
+  retry?: CodemodeRetryPolicy
+): Promise<ProxyToolOutput> {
+  const connectors = [...setup.connectorsByName.values()];
+  try {
+    return await runPasses(
+      executionId,
+      code,
+      setup,
+      runtime,
+      executor,
+      connectors,
+      transformResult,
+      retry
+    );
+  } catch (error) {
+    // Facet RPCs and application retry callbacks can fail outside the sandbox.
+    // Keep the model-facing contract data-only and make a best effort to leave
+    // the execution terminal rather than stranded as "running".
+    const message = error instanceof Error ? error.message : String(error);
+    const logs =
+      error instanceof CodemodeExecutionError ? error.logs : undefined;
+    try {
+      await runtime.fail(executionId, message, logs);
+    } catch {
+      // The facet itself may be unavailable; the original failure is clearer.
+    }
+    await notifyPassEnd(connectors, executionId, "error");
+    await disposeConnectors(connectors, executionId, "error");
+    return { status: "error", executionId, error: message, logs };
+  }
+}
+
+async function runPasses(
+  executionId: string,
+  code: string,
+  setup: Setup,
+  runtime: RuntimeStub,
+  executor: Executor,
+  connectors: CodemodeConnector[],
+  transformResult?: TransformResult,
+  retry?: CodemodeRetryPolicy
+): Promise<ProxyToolOutput> {
+  const retryPolicy = resolveRetryPolicy(retry);
+  let attempts = 0;
+
+  while (true) {
+    attempts++;
+    const attempt = await runtime.currentAttempt(executionId);
+    const cursor = createCursor();
+    const control: PassControl = {};
+    const abortController = new AbortController();
+    const bindings = buildConnectorBindings(
+      setup,
+      runtime,
+      executionId,
+      cursor,
+      attempt,
+      control,
+      abortController.signal
+    );
+    const platformProvider = createPlatformProvider(
+      setup,
+      bindings,
+      runtime,
+      executor,
+      executionId,
+      cursor,
+      attempt,
+      control
+    );
+
+    let output: CodeOutput | undefined;
+    let threw: unknown;
+    try {
+      output = await runCode({
+        code,
+        executor,
+        providers: [platformProvider],
+        connectors: bindings
+      });
+    } catch (err) {
+      threw = err;
+    } finally {
+      // The sandbox pass no longer has a consumer for connector work. Abort
+      // cooperatively before retry policy, lifecycle hooks, or disposal run.
+      abortController.abort();
+    }
+    if (control.failure) {
+      // The sandbox may catch the local retry marker. Host retry intent is
+      // authoritative: discard that apparent success and restart the pass.
+      // Preserve logs from either path: a caught marker returns output, while
+      // an uncaught marker already carries logs on CodemodeExecutionError.
+      const logs =
+        output?.logs ??
+        (threw instanceof CodemodeExecutionError ? threw.logs : undefined);
+      threw = new CodemodeExecutionError(control.failure, logs);
+    }
+
+    // The facet status is the source of truth for pauses and in-run durable
+    // failures. Retryable executor failures deliberately leave it running.
+    const execution = await runtime.getExecution(executionId);
+    if (execution?.status === "paused") {
+      await notifyPassEnd(connectors, executionId, "paused");
+      return {
+        status: "paused",
+        executionId,
+        pending: await runtime.listPending(executionId)
+      };
+    }
+    if (execution?.status === "error") {
+      await notifyPassEnd(connectors, executionId, "error");
+      await disposeConnectors(connectors, executionId, "error");
+      return {
+        status: "error",
+        executionId,
+        error: execution.error ?? "Codemode execution failed"
+      };
+    }
+
+    if (threw) {
+      const failure = failureFromThrown(threw);
+      const snapshot = execution ?? (await runtime.getExecution(executionId));
+      if (snapshot && attempts < retryPolicy.maxAttempts) {
+        // Fence first: shouldRetry and delay are application callbacks and may
+        // await. A timed-out sandbox must become stale before either runs.
+        const nextAttempt = await runtime.beginRetry(executionId, attempt);
+        if (nextAttempt !== null) {
+          const context: CodemodeRetryContext = {
+            executionId,
+            attempt: attempts,
+            failure,
+            execution: snapshot
+          };
+          let shouldRetry: boolean;
+          try {
+            shouldRetry = await retryPolicy.shouldRetry(context);
+          } catch (error) {
+            throw executionCallbackError(error, threw);
+          }
+          if (shouldRetry) {
+            await notifyPassEnd(connectors, executionId, "retrying");
+            let delay: number;
+            try {
+              delay = await retryPolicy.delayMs(context);
+            } catch (error) {
+              throw executionCallbackError(error, threw);
+            }
+            if (delay > 0) await sleep(delay);
+            continue;
+          }
+        }
+      }
+
+      const raw = threw instanceof Error ? threw.message : String(threw);
+      const message = withGlobalsHint(raw, setup);
+      const logs =
+        threw instanceof CodemodeExecutionError ? threw.logs : undefined;
+      await runtime.fail(executionId, message, logs);
+      await notifyPassEnd(connectors, executionId, "error");
+      await disposeConnectors(connectors, executionId, "error");
+      return { status: "error", executionId, error: message, logs };
+    }
+
+    const result = output?.result;
+    await runtime.complete(executionId, result, output?.logs);
+    await notifyPassEnd(connectors, executionId, "completed");
+    await disposeConnectors(connectors, executionId, "completed");
+    return {
+      status: "completed",
+      executionId,
+      result: await applyTransform(transformResult, result),
+      logs: output?.logs
+    };
+  }
+}
+
+function executionCallbackError(
+  error: unknown,
+  executionError: unknown
+): CodemodeExecutionError {
+  return new CodemodeExecutionError(
+    {
+      kind: "error",
+      message: error instanceof Error ? error.message : String(error)
+    },
+    executionError instanceof CodemodeExecutionError
+      ? executionError.logs
+      : undefined
+  );
+}
+
+function failureFromThrown(error: unknown): ExecuteFailure {
+  if (error instanceof CodemodeExecutionError) return error.failure;
+  return {
+    kind: "error",
+    message: error instanceof Error ? error.message : String(error)
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A sandbox `ReferenceError` usually means the model invented a global (e.g.
+ * `host.writeFile(...)`). Append the real globals so the retry is informed
+ * instead of another guess.
+ */
+function withGlobalsHint(message: string, setup: Setup): string {
+  if (!/\bis not defined\b/.test(message)) return message;
+  const names = [...setup.connectorsByName.keys(), "codemode"].join(", ");
+  return `${message} (the only globals available in the sandbox are: ${names})`;
+}
+
+/**
+ * Apply the result transform, defending against a buggy transform: the run has
+ * already completed and its resources are disposed, so a throwing transform
+ * must not turn a successful run into a thrown tool error. Fall back to the raw
+ * result (and warn) instead.
+ */
+async function applyTransform(
+  transformResult: TransformResult | undefined,
+  result: unknown
+): Promise<unknown> {
+  if (!transformResult) return result;
+  try {
+    return await transformResult(result);
+  } catch (err) {
+    console.warn(
+      "codemode: transformResult threw; returning the raw result.",
+      err
+    );
+    return result;
+  }
+}
+
+/** Connectors an execution/snippet recorded but the runtime no longer has. */
+export function missingConnectors(
+  required: string[] | undefined,
+  available: Set<string>
+): string[] {
+  return (required ?? []).filter((name) => !available.has(name));
+}

--- a/packages/codemode/src/runtime-handle.ts
+++ b/packages/codemode/src/runtime-handle.ts
@@ -2,18 +2,18 @@ import type { CodemodeConnector } from "./connectors";
 import type { Executor } from "./executor";
 import {
   createProxyTool,
-  disposeConnectors,
   expireCodemode,
   getCodemodeRuntime,
   pendingCodemode,
   rejectCodemode,
   resumeCodemode,
   rollbackCodemode,
-  validateConnectorNames,
   type CodemodeTool,
   type ProxyToolOutput,
   type TransformResult
 } from "./proxy-tool";
+import { disposeConnectors, validateConnectorNames } from "./runtime-execution";
+import type { CodemodeRetryPolicy } from "./retry";
 import type { ExecutionState, PendingAction } from "./runtime";
 import type { SaveSnippetOptions, Snippet } from "./snippet";
 
@@ -43,6 +43,8 @@ export type CreateCodemodeRuntimeOptions = {
    * Applies to both the initial run and a resume after approval.
    */
   transformResult?: TransformResult;
+  /** Durable retry policy. Explicit RetryableErrors retry by default. */
+  retry?: CodemodeRetryPolicy;
 };
 
 export type CodemodeRuntimeToolOptions = {
@@ -136,7 +138,8 @@ class DefaultCodemodeRuntimeHandle implements CodemodeRuntimeHandle {
       description: options?.description,
       connectorHints: options?.connectorHints,
       maxExecutions: this.#options.maxExecutions,
-      transformResult: this.#options.transformResult
+      transformResult: this.#options.transformResult,
+      retry: this.#options.retry
     });
   }
 
@@ -148,7 +151,8 @@ class DefaultCodemodeRuntimeHandle implements CodemodeRuntimeHandle {
       name: this.#options.name,
       executionId: options.executionId,
       maxExecutions: this.#options.maxExecutions,
-      transformResult: this.#options.transformResult
+      transformResult: this.#options.transformResult,
+      retry: this.#options.retry
     });
   }
 

--- a/packages/codemode/src/runtime-tests/runtime.test.ts
+++ b/packages/codemode/src/runtime-tests/runtime.test.ts
@@ -30,6 +30,39 @@ interface Host {
     code: string,
     options?: { maxExecutions?: number; name?: string }
   ): Promise<ProxyToolOutput>;
+  attemptStoreLifecycle(): Promise<{
+    initial: number;
+    advanced: number | null;
+    terminalAdvance: number | null;
+    missingThrows: boolean;
+  }>;
+  backfillReleasedExecutionAttempt(): Promise<{
+    initial?: number;
+    afterRepeat?: number;
+  }>;
+  runWithRetry(code: string): Promise<ProxyToolOutput>;
+  retryCounts(): Promise<{ checkpointReads: number; retryableCalls: number }>;
+  retryAlwaysCalls(): Promise<number>;
+  runWithoutRetries(code: string): Promise<ProxyToolOutput>;
+  runWithTimeoutRetry(code: string): Promise<ProxyToolOutput>;
+  runWithRetryScenario(
+    code: string,
+    scenario: "decline" | "throw-policy" | "throw-delay"
+  ): Promise<ProxyToolOutput>;
+  slowCalls(): Promise<number>;
+  abortCounts(): Promise<{
+    calls: number;
+    active: number;
+    passes: number;
+    reverts: number;
+  }>;
+  lateResultAfterTerminal(status: "completed" | "error"): Promise<{
+    recorded: boolean;
+    status?: string;
+    result?: unknown;
+    logState?: string;
+    logResult?: unknown;
+  }>;
   approve(executionId: string): Promise<ProxyToolOutput>;
   approveWithoutItems(executionId: string): Promise<ProxyToolOutput>;
   runSnippetWithoutItems(snippet: string): Promise<ProxyToolOutput>;
@@ -78,6 +111,24 @@ function host(): Host {
 }
 
 describe("codemode durable runtime (e2e)", () => {
+  it("owns the complete attempt lifecycle", async () => {
+    const h = host();
+    await expect(h.attemptStoreLifecycle()).resolves.toEqual({
+      initial: 0,
+      advanced: 1,
+      terminalAdvance: null,
+      missingThrows: true
+    });
+  });
+
+  it("backfills attempt zero for released executions exactly once", async () => {
+    const h = host();
+    await expect(h.backfillReleasedExecutionAttempt()).resolves.toEqual({
+      initial: 0,
+      afterRepeat: 2
+    });
+  });
+
   it("runs a read-only connector call to completion over real RPC", async () => {
     const h = host();
     const out = (await h.run(
@@ -87,6 +138,238 @@ describe("codemode durable runtime (e2e)", () => {
     expect(out.status).toBe("completed");
     if (out.status === "completed") expect(out.result).toEqual([]);
   });
+
+  it("retries RetryableError by default without configuration", async () => {
+    const h = host();
+    const out = await h.run(`async () => await items.retry_once()`);
+
+    expect(out.status).toBe("completed");
+    if (out.status === "completed") expect(out.result).toEqual({ calls: 2 });
+    expect((await h.retryCounts()).retryableCalls).toBe(2);
+  });
+
+  it("persists console logs when retry attempts are exhausted", async () => {
+    const h = host();
+    const out = await h.run(`async () => {
+      console.log("before exhausted retry");
+      return items.retry_always();
+    }`);
+
+    expect(out).toMatchObject({
+      status: "error",
+      logs: ["before exhausted retry"]
+    });
+    expect(await h.retryAlwaysCalls()).toBe(3);
+    expect((await h.executions())[0]).toMatchObject({
+      status: "error",
+      logs: ["before exhausted retry"]
+    });
+  });
+
+  it("ends without retry when a custom policy declines", async () => {
+    const h = host();
+    const out = await h.runWithRetryScenario(
+      `async () => items.retry_always()`,
+      "decline"
+    );
+
+    expect(out.status).toBe("error");
+    expect(await h.retryAlwaysCalls()).toBe(1);
+  });
+
+  it.each([
+    ["throw-policy", "retry policy crashed"],
+    ["throw-delay", "retry delay crashed"]
+  ] as const)(
+    "terminalizes and preserves logs when %s throws",
+    async (scenario, message) => {
+      const h = host();
+      const out = await h.runWithRetryScenario(
+        `async () => {
+          console.log("before callback failure");
+          return items.retry_always();
+        }`,
+        scenario
+      );
+
+      expect(out).toMatchObject({
+        status: "error",
+        error: `Code execution failed: ${message}\n\nConsole output:\nbefore callback failure`,
+        logs: ["before callback failure"]
+      });
+      expect((await h.executions())[0]).toMatchObject({
+        status: "error",
+        logs: ["before callback failure"]
+      });
+    }
+  );
+
+  it("allows default retries to be disabled", async () => {
+    const h = host();
+    const out = await h.runWithoutRetries(
+      `async () => await items.retry_once()`
+    );
+
+    expect(out.status).toBe("error");
+    expect((await h.retryCounts()).retryableCalls).toBe(1);
+  });
+
+  it("retries from the durable checkpoint through runtime.tool()", async () => {
+    const h = host();
+    const out = await h.runWithRetry(`async () => {
+      const before = await items.checkpoint_read();
+      const retried = await items.retry_once();
+      return { before, retried };
+    }`);
+
+    expect(out.status).toBe("completed");
+    if (out.status === "completed") {
+      expect(out.result).toEqual({
+        before: { reads: 1 },
+        retried: { calls: 2 }
+      });
+    }
+    expect(await h.retryCounts()).toEqual({
+      checkpointReads: 1,
+      retryableCalls: 2
+    });
+    expect((await h.executions())[0].log.map((entry) => entry.state)).toEqual([
+      "applied",
+      "applied"
+    ]);
+    expect(await h.passEnds()).toEqual([
+      { executionId: out.executionId, status: "retrying" },
+      { executionId: out.executionId, status: "completed" }
+    ]);
+  });
+
+  it("retries even when model code catches the connector error", async () => {
+    const h = host();
+    const out = await h.runWithRetry(`async () => {
+      try {
+        return await items.retry_once();
+      } catch {
+        return { caught: true };
+      }
+    }`);
+
+    expect(out.status).toBe("completed");
+    if (out.status === "completed") expect(out.result).toEqual({ calls: 2 });
+    expect((await h.retryCounts()).retryableCalls).toBe(2);
+  });
+
+  it("blocks codemode.step after a caught retry signal", async () => {
+    const h = host();
+    const out = await h.runWithRetry(`async () => {
+      try {
+        return await items.retry_once();
+      } catch {
+        await codemode.step("post-failure", () => "must not run");
+        return { continued: true };
+      }
+    }`);
+
+    expect(out.status).toBe("completed");
+    if (out.status === "completed") expect(out.result).toEqual({ calls: 2 });
+    const execution = (await h.executions())[0];
+    expect(execution.log).toHaveLength(1);
+    expect(execution.log[0]).toMatchObject({
+      connector: "items",
+      method: "retry_once",
+      state: "applied"
+    });
+  });
+
+  it("aborts the in-flight connector call before retrying a timed-out pass", async () => {
+    const h = host();
+    const out = await h.runWithTimeoutRetry(
+      `async () => await items.abortable_slow_once()`
+    );
+
+    expect(out.status).toBe("completed");
+    if (out.status === "completed") expect(out.result).toEqual({ call: 2 });
+    expect(await h.abortCounts()).toEqual({
+      calls: 2,
+      active: 1,
+      passes: 0,
+      reverts: 0
+    });
+  });
+
+  it.each([
+    [
+      "completed",
+      `async () => {
+        await items.observe_abort();
+        return "done";
+      }`
+    ],
+    [
+      "error",
+      `async () => {
+        await items.observe_abort();
+        throw new Error("done with error");
+      }`
+    ],
+    [
+      "paused",
+      `async () => {
+        await items.observe_abort();
+        return items.create_item({ title: "pause" });
+      }`
+    ]
+  ] as const)(
+    "aborts the pass signal when it ends %s",
+    async (status, code) => {
+      const h = host();
+      const out = await h.run(code);
+
+      expect(out.status).toBe(status);
+      expect(await h.abortCounts()).toEqual({
+        calls: 0,
+        active: 0,
+        passes: 1,
+        reverts: 0
+      });
+    }
+  );
+
+  it("fences a timed-out pass so its late result cannot overwrite the retry", async () => {
+    const h = host();
+    const out = await h.runWithTimeoutRetry(
+      `async () => await items.slow_once()`
+    );
+
+    expect(out.status).toBe("completed");
+    if (out.status === "completed") expect(out.result).toEqual({ call: 2 });
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    expect(await h.slowCalls()).toBe(2);
+    const execution = (await h.executions())[0];
+    expect(execution.result).toEqual({ call: 2 });
+    expect(execution.log[0]).toMatchObject({
+      state: "applied",
+      result: { call: 2 }
+    });
+  });
+
+  it.each([
+    ["completed", { winner: true }],
+    ["error", undefined]
+  ] as const)(
+    "rejects a late connector result after the execution is %s",
+    async (status, expectedResult) => {
+      const h = host();
+      const state = await h.lateResultAfterTerminal(status);
+
+      expect(state).toMatchObject({
+        recorded: false,
+        status,
+        result: expectedResult,
+        logState: "executing",
+        logResult: undefined
+      });
+    }
+  );
 
   it("names the connector globals (and renders hints) in the tool description", async () => {
     const h = host();
@@ -235,6 +518,7 @@ describe("codemode durable runtime (e2e)", () => {
     expect(execs.find((e) => e.id === first.executionId)?.status).toBe(
       "rolled_back"
     );
+    expect((await h.abortCounts()).reverts).toBe(1);
   });
 
   it("does not apply anything when model code swallows the pause", async () => {

--- a/packages/codemode/src/runtime-tests/worker.ts
+++ b/packages/codemode/src/runtime-tests/worker.ts
@@ -14,13 +14,20 @@ import {
   type ExecutionEndStatus,
   type PassEndStatus
 } from "../connectors";
+import { RetryableError } from "../retry";
 import { DynamicWorkerExecutor } from "../executor";
-import { createCodemodeRuntime } from "../runtime-handle";
+import {
+  createCodemodeRuntime,
+  type CodemodeRuntimeHandle
+} from "../runtime-handle";
 import {
   getCodemodeRuntime,
   type ProxyToolInput,
   type ProxyToolOutput
 } from "../proxy-tool";
+
+import { initializeRuntimeSchema } from "../runtime";
+import { ExecutionAttemptStore } from "../runtime-attempts";
 
 // Re-export the facet class so the runtime can spawn it (and so vitest's
 // pool-workers can resolve a facet-compatible class value).
@@ -49,6 +56,14 @@ class ItemsConnector extends CodemodeConnector<Env> {
   passEnds: Array<{ executionId: string; status: PassEndStatus }> = [];
   // Counts real executions of the ephemeral read — replays must re-execute.
   ephemeralReads = 0;
+  checkpointReads = 0;
+  retryableCalls = 0;
+  retryAlwaysCalls = 0;
+  slowCalls = 0;
+  abortableCalls = 0;
+  activeAborts = 0;
+  passAborts = 0;
+  revertAborts = 0;
 
   name() {
     return "items";
@@ -59,6 +74,71 @@ class ItemsConnector extends CodemodeConnector<Env> {
       list_items: {
         description: "List all items.",
         execute: () => [...this.created]
+      },
+      checkpoint_read: {
+        description: "Count executions before a retry boundary.",
+        execute: () => ({ reads: ++this.checkpointReads })
+      },
+      retry_once: {
+        description: "Fail retryably once, then succeed.",
+        execute: () => {
+          this.retryableCalls++;
+          if (this.retryableCalls === 1) {
+            throw new RetryableError("try again", { retryAfterMs: 0 });
+          }
+          return { calls: this.retryableCalls };
+        }
+      },
+      retry_always: {
+        description: "Always fail retryably.",
+        execute: () => {
+          this.retryAlwaysCalls++;
+          throw new RetryableError("still busy", { retryAfterMs: 0 });
+        }
+      },
+      slow_once: {
+        description: "Finish the first call after its sandbox timed out.",
+        execute: async () => {
+          const call = ++this.slowCalls;
+          if (call === 1)
+            await new Promise((resolve) => setTimeout(resolve, 50));
+          return { call };
+        }
+      },
+      abortable_slow_once: {
+        description: "Abort the first slow call when its pass times out.",
+        execute: async (_args, ctx) => {
+          if (!ctx?.signal) throw new Error("missing execution signal");
+          const signal = ctx.signal;
+          const call = ++this.abortableCalls;
+          if (call > 1) return { call };
+          return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => resolve({ call }), 1_000);
+            signal.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(timer);
+                this.activeAborts++;
+                reject(signal.reason);
+              },
+              { once: true }
+            );
+          });
+        }
+      },
+      observe_abort: {
+        description: "Observe the pass signal after returning.",
+        execute: (_args, ctx) => {
+          if (!ctx?.signal) throw new Error("missing execution signal");
+          ctx.signal.addEventListener(
+            "abort",
+            () => {
+              this.passAborts++;
+            },
+            { once: true }
+          );
+          return { observed: true };
+        }
       },
       read_counter: {
         // Ephemeral read: result is never stored in the durable log; replay
@@ -96,7 +176,14 @@ class ItemsConnector extends CodemodeConnector<Env> {
           this.created.push(item);
           return { id: this.created.length, title: item.title };
         },
-        revert: (_args, result) => {
+        revert: (_args, result, ctx) => {
+          ctx?.signal?.addEventListener(
+            "abort",
+            () => {
+              this.revertAborts++;
+            },
+            { once: true }
+          );
           this.deleted.push(result);
         }
       },
@@ -153,20 +240,107 @@ export class CodemodeTestHost extends DurableObject<Env> {
     return this.#connector;
   }
 
-  #runtime(options?: RunOptions & { name?: string; noConnectors?: boolean }) {
-    const executor = new DynamicWorkerExecutor({ loader: this.env.LOADER });
+  #runtime(
+    options?: RunOptions & {
+      name?: string;
+      noConnectors?: boolean;
+      retry?: boolean;
+      disableRetry?: boolean;
+      timeoutRetry?: boolean;
+      retryScenario?: "decline" | "throw-policy" | "throw-delay";
+    }
+  ) {
+    const executor = new DynamicWorkerExecutor({
+      loader: this.env.LOADER,
+      timeout: options?.timeoutRetry ? 10 : undefined
+    });
     return createCodemodeRuntime({
       ctx: this.ctx,
       executor,
       connectors: options?.noConnectors ? [] : [this.#items()],
       name: options?.name,
       maxExecutions: options?.maxExecutions,
-      transformResult: this.#shape ? (r) => ({ shaped: r }) : undefined
+      transformResult: this.#shape ? (r) => ({ shaped: r }) : undefined,
+      retry: options?.disableRetry
+        ? false
+        : options?.retryScenario
+          ? retryScenario(options.retryScenario)
+          : options?.retry || options?.timeoutRetry
+            ? {
+                maxAttempts: 2,
+                shouldRetry: ({ failure }) =>
+                  failure.kind === "retryable" || failure.kind === "timeout"
+              }
+            : undefined
     });
   }
 
   enableShaping() {
     this.#shape = true;
+  }
+
+  attemptStoreLifecycle() {
+    initializeRuntimeSchema(this.ctx.storage.sql);
+    const attempts = new ExecutionAttemptStore(this.ctx.storage.sql);
+    this.ctx.storage.sql.exec(
+      `INSERT INTO cm_executions
+        (id, code, status, created_at, updated_at)
+        VALUES ('lifecycle', 'async () => {}', 'running', 1, 1)`
+    );
+    attempts.begin("lifecycle");
+    const initial = attempts.current("lifecycle");
+    const advanced = attempts.advance("lifecycle", initial);
+    this.ctx.storage.sql.exec(
+      `UPDATE cm_executions SET status = 'error' WHERE id = 'lifecycle'`
+    );
+    const terminalAdvance = attempts.advance("lifecycle", advanced ?? initial);
+    attempts.delete("lifecycle");
+    let missingThrows = false;
+    try {
+      attempts.current("lifecycle");
+    } catch {
+      missingThrows = true;
+    }
+    return { initial, advanced, terminalAdvance, missingThrows };
+  }
+
+  /** Exercise initialization against the exact schema released in 0.4.1. */
+  backfillReleasedExecutionAttempt() {
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE cm_executions (
+        id TEXT PRIMARY KEY,
+        code TEXT NOT NULL,
+        status TEXT NOT NULL,
+        result TEXT,
+        error TEXT,
+        logs TEXT,
+        connectors TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO cm_executions
+        (id, code, status, created_at, updated_at)
+        VALUES ('released', 'async () => {}', 'paused', 1, 1);
+    `);
+    initializeRuntimeSchema(this.ctx.storage.sql);
+    new ExecutionAttemptStore(this.ctx.storage.sql);
+    const initial = this.ctx.storage.sql
+      .exec<{ attempt: number }>(
+        `SELECT attempt FROM cm_attempts WHERE execution_id = 'released'`
+      )
+      .toArray()[0]?.attempt;
+
+    this.ctx.storage.sql.exec(
+      `UPDATE cm_attempts SET attempt = 2 WHERE execution_id = 'released'`
+    );
+    initializeRuntimeSchema(this.ctx.storage.sql);
+    new ExecutionAttemptStore(this.ctx.storage.sql);
+    const afterRepeat = this.ctx.storage.sql
+      .exec<{ attempt: number }>(
+        `SELECT attempt FROM cm_attempts WHERE execution_id = 'released'`
+      )
+      .toArray()[0]?.attempt;
+    return { initial, afterRepeat };
   }
 
   async run(
@@ -178,6 +352,94 @@ export class CodemodeTestHost extends DurableObject<Env> {
       input: ProxyToolInput,
       ctx: unknown
     ) => Promise<ProxyToolOutput>;
+    return execute({ code }, { toolCallId: "test", messages: [] });
+  }
+
+  async runWithRetry(code: string): Promise<ProxyToolOutput> {
+    return this.#execute(this.#runtime({ retry: true }), code);
+  }
+
+  retryCounts() {
+    return {
+      checkpointReads: this.#items().checkpointReads,
+      retryableCalls: this.#items().retryableCalls
+    };
+  }
+
+  retryAlwaysCalls() {
+    return this.#items().retryAlwaysCalls;
+  }
+
+  async runWithoutRetries(code: string): Promise<ProxyToolOutput> {
+    return this.#execute(this.#runtime({ disableRetry: true }), code);
+  }
+
+  async runWithTimeoutRetry(code: string): Promise<ProxyToolOutput> {
+    return this.#execute(this.#runtime({ timeoutRetry: true }), code);
+  }
+
+  async runWithRetryScenario(
+    code: string,
+    scenario: "decline" | "throw-policy" | "throw-delay"
+  ): Promise<ProxyToolOutput> {
+    return this.#execute(this.#runtime({ retryScenario: scenario }), code);
+  }
+
+  slowCalls() {
+    return this.#items().slowCalls;
+  }
+
+  abortCounts() {
+    const connector = this.#items();
+    return {
+      calls: connector.abortableCalls,
+      active: connector.activeAborts,
+      passes: connector.passAborts,
+      reverts: connector.revertAborts
+    };
+  }
+
+  /** Prove terminal executions reject a connector result that arrives late. */
+  async lateResultAfterTerminal(status: "completed" | "error") {
+    const facet = getCodemodeRuntime(this.ctx);
+    const id = await facet.begin("async () => {}");
+    const attempt = await facet.currentAttempt(id);
+    const decision = await facet.decide(
+      id,
+      0,
+      "items",
+      "slow_once",
+      undefined,
+      false,
+      false,
+      attempt
+    );
+    if (status === "completed") {
+      await facet.complete(id, { winner: true });
+    } else {
+      await facet.fail(id, "terminal failure");
+    }
+    const recorded = await facet.recordResult(
+      id,
+      0,
+      { late: true },
+      decision.kind === "execute" ? decision.attempt : attempt
+    );
+    const execution = await facet.getExecution(id);
+    return {
+      recorded,
+      status: execution?.status,
+      result: execution?.result,
+      logState: execution?.log[0]?.state,
+      logResult: execution?.log[0]?.result
+    };
+  }
+
+  #execute(
+    runtime: CodemodeRuntimeHandle,
+    code: string
+  ): Promise<ProxyToolOutput> {
+    const execute = runtime.tool().execute;
     return execute({ code }, { toolCallId: "test", messages: [] });
   }
 
@@ -276,8 +538,18 @@ export class CodemodeTestHost extends DurableObject<Env> {
     const id = await facet.begin("async () => {}");
     const args = { title: "race" };
 
+    const attempt = await facet.currentAttempt(id);
     // First pass: the approval-gated call pauses.
-    await facet.decide(id, 0, "items", "create_item", args, true);
+    await facet.decide(
+      id,
+      0,
+      "items",
+      "create_item",
+      args,
+      true,
+      false,
+      attempt
+    );
     // Approve → resume returns the run to "running".
     await facet.resume(id);
     // Replay reaches the approved call: it must transition to "executing".
@@ -287,14 +559,16 @@ export class CodemodeTestHost extends DurableObject<Env> {
       "items",
       "create_item",
       args,
-      true
+      true,
+      false,
+      attempt
     );
     const duringExecute = (await facet.getExecution(id))?.log[0]?.state;
     // A concurrent reject lands during execution: must no-op.
     const rejected = await facet.reject(0, id);
     const afterReject = await facet.getExecution(id);
     // Execution finishes and records its result.
-    await facet.recordResult(id, 0, { id: 1 });
+    await facet.recordResult(id, 0, { id: 1 }, attempt);
     const final = await facet.getExecution(id);
 
     return {
@@ -306,6 +580,25 @@ export class CodemodeTestHost extends DurableObject<Env> {
       stateFinal: final?.log[0]?.state
     };
   }
+}
+
+function retryScenario(scenario: "decline" | "throw-policy" | "throw-delay") {
+  if (scenario === "decline") {
+    return { shouldRetry: () => false };
+  }
+  if (scenario === "throw-policy") {
+    return {
+      shouldRetry: () => {
+        throw new Error("retry policy crashed");
+      }
+    };
+  }
+  return {
+    shouldRetry: () => true,
+    delayMs: () => {
+      throw new Error("retry delay crashed");
+    }
+  };
 }
 
 export default {

--- a/packages/codemode/src/runtime.ts
+++ b/packages/codemode/src/runtime.ts
@@ -50,6 +50,7 @@
  */
 import { DurableObject } from "cloudflare:workers";
 import { stringifyForStorage, parseForStorage } from "./codec";
+import { ExecutionAttemptStore } from "./runtime-attempts";
 import type { Snippet, SaveSnippetOptions } from "./snippet";
 
 // ---------------------------------------------------------------------------
@@ -126,7 +127,7 @@ export type PendingAction = {
  */
 export type ToolDecision =
   | { kind: "replay"; result: unknown }
-  | { kind: "execute"; seq: number }
+  | { kind: "execute"; seq: number; attempt: number }
   // "pause" tells the host to abort the sandbox run. The reason lives on the
   // execution: status "paused" (awaiting approval) or "error" (replay
   // divergence). Routing divergence through the execution record rather than a
@@ -296,10 +297,9 @@ function toStored(what: string, value: unknown): string | null {
 // CodemodeRuntime facet
 // ---------------------------------------------------------------------------
 
-export class CodemodeRuntime extends DurableObject<unknown> {
-  constructor(ctx: DurableObjectState, env: unknown) {
-    super(ctx, env);
-    this.ctx.storage.sql.exec(`
+/** @internal Initialize the facet schema and backfill retry generations. */
+export function initializeRuntimeSchema(sql: SqlStorage): void {
+  sql.exec(`
       CREATE TABLE IF NOT EXISTS cm_executions (
         id TEXT PRIMARY KEY,
         code TEXT NOT NULL,
@@ -333,7 +333,16 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         input_schema TEXT,
         connectors TEXT
       );
-    `);
+  `);
+}
+
+export class CodemodeRuntime extends DurableObject<unknown> {
+  readonly #attempts: ExecutionAttemptStore;
+
+  constructor(ctx: DurableObjectState, env: unknown) {
+    super(ctx, env);
+    initializeRuntimeSchema(this.ctx.storage.sql);
+    this.#attempts = new ExecutionAttemptStore(this.ctx.storage.sql);
   }
 
   // -----------------------------------------------------------------------
@@ -368,8 +377,27 @@ export class CodemodeRuntime extends DurableObject<unknown> {
       now,
       now
     );
+    this.#attempts.begin(id);
     this.#pruneTerminal(options?.maxExecutions ?? DEFAULT_MAX_EXECUTIONS, id);
     return id;
+  }
+
+  /** Current fenced pass number for an execution, starting at zero. */
+  async currentAttempt(id: string): Promise<number> {
+    return this.#attempts.current(id);
+  }
+
+  /**
+   * Fence a failed pass and begin its retry. Late calls/results carrying the
+   * old attempt number become inert before the retry delay begins.
+   */
+  async beginRetry(
+    id: string,
+    expectedAttempt: number
+  ): Promise<number | null> {
+    const next = this.#attempts.advance(id, expectedAttempt);
+    if (next !== null) this.#touch(id);
+    return next;
   }
 
   /**
@@ -415,9 +443,18 @@ export class CodemodeRuntime extends DurableObject<unknown> {
     method: string,
     args: unknown,
     requiresApproval: boolean,
-    ephemeral = false
+    ephemeral: boolean,
+    attempt: number
   ): Promise<ToolDecision> {
     const row = this.#requireRow(executionId);
+    const currentAttempt = await this.currentAttempt(executionId);
+
+    // A timed-out/retried pass may still have live RPC calls. Fence it before
+    // inspecting or mutating the log so it cannot apply work after a retry has
+    // begun.
+    if (attempt !== currentAttempt) {
+      return { kind: "pause", seq };
+    }
 
     // Once a run has paused (awaiting approval) or terminated (divergence,
     // rejection), refuse to make any further progress: every subsequent
@@ -459,7 +496,7 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         // connector/method/args only), but the value may legitimately have
         // changed underneath (e.g. a file edited between pause and resume).
         if (existing.ephemeral) {
-          return { kind: "execute", seq };
+          return { kind: "execute", seq, attempt: currentAttempt };
         }
         return { kind: "replay", result: existing.result };
       }
@@ -472,13 +509,13 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         // fresh-call path below.
         this.#setEntryState(executionId, seq, "executing");
         this.#touch(executionId);
-        return { kind: "execute", seq };
+        return { kind: "execute", seq, attempt: currentAttempt };
       }
       if (existing.state === "executing") {
         // Decided to run on a previous pass but crashed before recordResult
         // landed — re-execute. Do NOT re-pause even for an approval action: it
         // was already approved when it first reached "executing".
-        return { kind: "execute", seq };
+        return { kind: "execute", seq, attempt: currentAttempt };
       }
       // "reverted" — fall through and re-execute as a fresh call.
     }
@@ -524,7 +561,7 @@ export class CodemodeRuntime extends DurableObject<unknown> {
       return { kind: "pause", seq };
     }
     this.#touch(executionId);
-    return { kind: "execute", seq };
+    return { kind: "execute", seq, attempt: currentAttempt };
   }
 
   /**
@@ -543,8 +580,15 @@ export class CodemodeRuntime extends DurableObject<unknown> {
   async recordResult(
     executionId: string,
     seq: number,
-    result: unknown
-  ): Promise<void> {
+    result: unknown,
+    attempt: number
+  ): Promise<boolean> {
+    // A connector can finish after its pass timed out or after the execution
+    // reached a terminal state. Reject that result before serializing it, then
+    // repeat the same guard atomically on the UPDATE below to close the race
+    // between this check and persistence.
+    if (!this.#isCurrentRunning(executionId, attempt)) return false;
+
     const row = this.#logRow(executionId, seq);
     if (!row) throw new Error(`No log entry at step ${seq}`);
     let stored: string | null;
@@ -554,21 +598,24 @@ export class CodemodeRuntime extends DurableObject<unknown> {
           ? null
           : toStored(`The result of ${row.connector}.${row.method}`, result);
     } catch (err) {
-      this.#fail(
+      this.#failCurrent(
         executionId,
         seq,
-        err instanceof Error ? err.message : String(err)
+        err instanceof Error ? err.message : String(err),
+        attempt
       );
-      return;
+      return false;
     }
-    this.ctx.storage.sql.exec(
-      `UPDATE cm_log SET result = ?, state = 'applied'
-        WHERE execution_id = ? AND seq = ?`,
-      stored,
+
+    const updated = this.#updateResultIfCurrent(
       executionId,
-      seq
+      seq,
+      stored,
+      attempt
     );
+    if (!updated) return false;
     this.#touch(executionId);
+    return true;
   }
 
   /**
@@ -797,6 +844,7 @@ export class CodemodeRuntime extends DurableObject<unknown> {
   async deleteExecution(id: string): Promise<boolean> {
     const existed = this.#executionRow(id) !== null;
     this.ctx.storage.sql.exec(`DELETE FROM cm_log WHERE execution_id = ?`, id);
+    this.#attempts.delete(id);
     this.ctx.storage.sql.exec(`DELETE FROM cm_executions WHERE id = ?`, id);
     return existed;
   }
@@ -898,6 +946,17 @@ export class CodemodeRuntime extends DurableObject<unknown> {
     );
   }
 
+  #failCurrent(
+    executionId: string,
+    seq: number,
+    error: string,
+    attempt: number
+  ): boolean {
+    if (!this.#isCurrentRunning(executionId, attempt)) return false;
+    this.#fail(executionId, seq, error);
+    return true;
+  }
+
   #fail(executionId: string, seq: number, error: string): ToolDecision {
     // Mark the triggering log entry too (when one exists): an entry left
     // "executing"/"pending" under an errored execution misreads as a crash
@@ -936,6 +995,7 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         `DELETE FROM cm_log WHERE execution_id = ?`,
         id
       );
+      this.#attempts.delete(id);
       this.ctx.storage.sql.exec(`DELETE FROM cm_executions WHERE id = ?`, id);
     }
     return toDelete.length;
@@ -978,6 +1038,19 @@ export class CodemodeRuntime extends DurableObject<unknown> {
       )
       .toArray();
     return rows.length > 0 ? rows[0] : null;
+  }
+
+  #isCurrentRunning(executionId: string, attempt: number): boolean {
+    return this.#attempts.isCurrentRunning(executionId, attempt);
+  }
+
+  #updateResultIfCurrent(
+    executionId: string,
+    seq: number,
+    result: string | null,
+    attempt: number
+  ): boolean {
+    return this.#attempts.recordResult(executionId, seq, result, attempt);
   }
 
   #setEntryState(

--- a/packages/codemode/src/tests/retry.test.ts
+++ b/packages/codemode/src/tests/retry.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_RETRY_MAX_ATTEMPTS,
+  DEFAULT_RETRY_MAX_DELAY_MS,
+  defaultRetryDelayMs,
+  resolveRetryPolicy,
+  type CodemodeRetryContext,
+  type ExecuteFailure
+} from "../retry";
+
+function context(failure: ExecuteFailure, attempt = 1): CodemodeRetryContext {
+  return {
+    executionId: "exec_1",
+    attempt,
+    failure,
+    execution: {
+      id: "exec_1",
+      code: "async () => {}",
+      status: "running",
+      log: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+  };
+}
+
+describe("retry policy", () => {
+  it("uses the default attempt limit and retries only explicit transient failures", async () => {
+    const policy = resolveRetryPolicy(undefined);
+
+    expect(policy.maxAttempts).toBe(DEFAULT_RETRY_MAX_ATTEMPTS);
+    await expect(
+      Promise.resolve(
+        policy.shouldRetry(context({ kind: "retryable", message: "busy" }))
+      )
+    ).resolves.toBe(true);
+    await expect(
+      Promise.resolve(
+        policy.shouldRetry(context({ kind: "timeout", message: "timed out" }))
+      )
+    ).resolves.toBe(false);
+    await expect(
+      Promise.resolve(
+        policy.shouldRetry(context({ kind: "error", message: "broken" }))
+      )
+    ).resolves.toBe(false);
+  });
+
+  it.each([
+    [0, 1],
+    [-3, 1],
+    [2.9, 2],
+    [Number.POSITIVE_INFINITY, 1],
+    [Number.NaN, 1]
+  ])("normalizes maxAttempts %s to %s", (configured, expected) => {
+    expect(resolveRetryPolicy({ maxAttempts: configured }).maxAttempts).toBe(
+      expected
+    );
+  });
+
+  it("disables retries explicitly", async () => {
+    const policy = resolveRetryPolicy(false);
+
+    expect(policy.maxAttempts).toBe(1);
+    await expect(
+      Promise.resolve(
+        policy.shouldRetry(context({ kind: "retryable", message: "busy" }))
+      )
+    ).resolves.toBe(false);
+    await expect(
+      Promise.resolve(
+        policy.delayMs(context({ kind: "retryable", message: "busy" }))
+      )
+    ).resolves.toBe(0);
+  });
+
+  it("uses custom retry and delay callbacks", async () => {
+    const shouldRetry = vi.fn(() => true);
+    const delayMs = vi.fn(() => 123);
+    const policy = resolveRetryPolicy({ shouldRetry, delayMs });
+    const ctx = context({ kind: "timeout", message: "timed out" });
+
+    await expect(Promise.resolve(policy.shouldRetry(ctx))).resolves.toBe(true);
+    await expect(Promise.resolve(policy.delayMs(ctx))).resolves.toBe(123);
+    expect(shouldRetry).toHaveBeenCalledWith(ctx);
+    expect(delayMs).toHaveBeenCalledWith(ctx);
+  });
+});
+
+describe("defaultRetryDelayMs", () => {
+  it("honors and clamps server-provided retry delays", () => {
+    expect(
+      defaultRetryDelayMs(
+        context({ kind: "retryable", message: "busy", retryAfterMs: 250 })
+      )
+    ).toBe(250);
+    expect(
+      defaultRetryDelayMs(
+        context({ kind: "retryable", message: "busy", retryAfterMs: -1 })
+      )
+    ).toBe(0);
+  });
+
+  it("uses bounded exponential backoff", () => {
+    const failure = { kind: "retryable", message: "busy" } as const;
+
+    expect(defaultRetryDelayMs(context(failure, 1))).toBe(500);
+    expect(defaultRetryDelayMs(context(failure, 2))).toBe(1_000);
+    expect(defaultRetryDelayMs(context(failure, 20))).toBe(
+      DEFAULT_RETRY_MAX_DELAY_MS
+    );
+  });
+});

--- a/packages/codemode/src/tests/run-code.test.ts
+++ b/packages/codemode/src/tests/run-code.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { Executor } from "../executor";
+import { runCode } from "../run-code";
+import { CodemodeExecutionError } from "../retry";
+
+function executorWith(
+  result: Awaited<ReturnType<Executor["execute"]>>
+): Executor {
+  return { execute: async () => result };
+}
+
+describe("runCode executor boundary", () => {
+  it("returns successful results and logs", async () => {
+    await expect(
+      runCode({
+        code: "async () => 42",
+        executor: executorWith({ result: 42, logs: ["done"] }),
+        providers: []
+      })
+    ).resolves.toEqual({ result: 42, logs: ["done"] });
+  });
+
+  it("normalizes an unclassified executor error", async () => {
+    await expect(
+      runCode({
+        code: "async () => 42",
+        executor: executorWith({
+          result: undefined,
+          error: "sandbox failed",
+          logs: ["before failure"]
+        }),
+        providers: []
+      })
+    ).rejects.toMatchObject({
+      message:
+        "Code execution failed: sandbox failed\n\nConsole output:\nbefore failure",
+      failure: { kind: "error", message: "sandbox failed" },
+      logs: ["before failure"]
+    } satisfies Partial<CodemodeExecutionError>);
+  });
+
+  it("preserves a structured retryable failure", async () => {
+    await expect(
+      runCode({
+        code: "async () => 42",
+        executor: executorWith({
+          result: undefined,
+          error: "rate limited",
+          failure: {
+            kind: "retryable",
+            message: "rate limited",
+            retryAfterMs: 250
+          }
+        }),
+        providers: []
+      })
+    ).rejects.toMatchObject({
+      failure: {
+        kind: "retryable",
+        message: "rate limited",
+        retryAfterMs: 250
+      }
+    } satisfies Partial<CodemodeExecutionError>);
+  });
+});

--- a/packages/codemode/src/tests/runtime-handle.test.ts
+++ b/packages/codemode/src/tests/runtime-handle.test.ts
@@ -82,6 +82,7 @@ describe("createCodemodeRuntime", () => {
   it("executes as a plain tool through AI SDK streamText", async () => {
     const runtimeStub = {
       begin: vi.fn(async () => "exec_1"),
+      currentAttempt: vi.fn(async () => 0),
       getExecution: vi.fn(async () => null),
       complete: vi.fn(async () => undefined)
     };
@@ -158,6 +159,7 @@ describe("createCodemodeRuntime", () => {
     };
     const runtimeStub = {
       resume: vi.fn(async () => execution),
+      currentAttempt: vi.fn(async () => 0),
       getExecution: vi.fn(async () => execution),
       complete: vi.fn(async () => undefined)
     };


### PR DESCRIPTION
## Summary

Adds durable execution retries to `@cloudflare/codemode`'s `runtime.tool()` path.

A connector can now throw `RetryableError` to explicitly tell Code Mode that a failed tool boundary is safe to retry. The runtime retries inside the same durable execution, replays already-applied calls from the durable log, and re-executes only the failed boundary. This gives callers resilient Code Mode executions without making every application build its own replay/retry runtime.

This also adds attempt fencing and cooperative cancellation so stale work from timed-out or superseded sandbox passes cannot mutate the durable log.

## Default retry policy

By default, `runtime.tool()` retries only failures that are explicitly marked retryable with `RetryableError`.

Default behavior:

- `3` total attempts.
- If the `RetryableError` includes `retryAfterMs`, the runtime honors it.
- Otherwise the runtime uses bounded exponential backoff.
- `retry: false` disables retries completely.
- `retry: { ... }` allows callers to provide a custom retry policy.

The default policy intentionally does **not** retry arbitrary thrown errors, executor failures, or timeouts. Those may represent bugs, validation errors, non-idempotent writes, or ambiguous remote state.

## How the runtime knows an error is retryable

The SDK does not infer retryability from tool names, HTTP methods, response codes, or exception messages.

A failure is retryable by default only when connector code explicitly throws `RetryableError`.

That keeps the semantic decision at the connector boundary, where the implementation actually understands the protocol. For example, a connector may know that a server explicitly rejected a request and asked the client to retry, but the generic Code Mode runtime cannot safely infer that from the outside.

Normal errors remain terminal unless the application opts into a custom retry policy.

## Durable retry behavior

Retries happen inside the same Code Mode execution:

- The execution ID stays stable.
- Calls already recorded as applied are replayed from the durable log.
- The failed boundary is re-executed.
- Later calls are not run until the failed boundary succeeds.
- If retries are exhausted, the execution becomes `error` and the durable log is preserved for audit/debugging.

For example, if this code runs:

```ts
await api.first();
await api.flaky();
await api.after();
```

and `api.flaky()` throws `RetryableError` once, the runtime behaves as follows:

1. `first` runs and is logged.
2. `flaky` fails with `RetryableError`.
3. The next attempt replays `first` from the log.
4. `flaky` runs again.
5. `after` runs only after `flaky` succeeds.

## What happens on execution timeout

Executor timeouts are surfaced as structured failures, but they are **not retried by default**.

Timeouts are ambiguous: the sandbox stopped waiting, but the runtime cannot prove whether an in-flight connector operation committed externally. Retrying a timed-out write automatically could duplicate side effects.

Applications that know a timeout is safe may opt into retrying it with a custom retry policy, but the SDK default remains conservative.

To make timeout/custom-retry behavior safe, this PR adds durable attempt fencing:

- Every connector decision/result is tied to an execution attempt.
- The runtime only records results for the currently active attempt.
- Late results from a timed-out or superseded pass are atomically rejected.
- A stale sandbox cannot corrupt the replay log or overwrite the final result.

## Cooperative cancellation

Connector `execute` contexts now include an optional pass-scoped `AbortSignal`:

```ts
execute: async (args, ctx) => {
  return fetch(url, { signal: ctx?.signal });
}
```

The runtime aborts the signal when a pass completes, pauses, errors, times out, or moves to a retry. This lets connectors cancel in-flight work from old passes before the runtime continues.

Cancellation is cooperative only. It reduces overlap and wasted work, but it does not prove that a remote write was rolled back or never committed. Timeout retry policy remains conservative for that reason.

## Storage changes

Adds a durable attempts store/table used to fence retries by execution attempt.

The migration is additive. Existing released Code Mode execution state is backfilled into the attempt table with `INSERT OR IGNORE`.

## Public API

Adds:

- `RetryableError`
- retry configuration on Code Mode runtime creation
- optional `signal` on connector execute context

No retry configuration is required for normal `RetryableError` usage.

## Tests

Added coverage for:

- default retry policy
- custom retry policy
- disabled retries
- declined retries
- throwing retry policies
- invalid attempt limits
- `retryAfterMs` handling
- bounded backoff behavior
- executor success/error/retryable boundaries
- durable same-execution retry
- replay of prior applied calls
- re-execution of failed boundary only
- exhausted retry log preservation
- callback failure log preservation
- terminal late-result fencing after completion/error
- timeout stale-result fencing
- caught `RetryableError` not allowing `codemode.step()` to persist
- attempt-store lifecycle and backfill
- pass-scoped abort signals on completion/error/pause/timeout/retry
- rollback/revert signal behavior

Local validation:

```sh
pnpm --filter @cloudflare/codemode test
pnpm --filter @cloudflare/codemode build
pnpm run check
```
