### PR TITLE
feat(think): add multi-surface messenger ingress primitives

### DIFF
--- a/.changeset/discord-messenger-foundation.md
+++ b/.changeset/discord-messenger-foundation.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": minor
+---
+
+Add Think messenger command and reaction event primitives, plus channel-backed delivery surfaces for future Discord support.

--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -92,6 +92,7 @@ Keep it concise. A few paragraphs is fine. These are records, not essays.
 | `rfc-chat-recovery-work-budget.md`      | RFC        | Decouple chat-recovery duration from the runaway guard — work budget + `shouldKeepRecovering` (accepted)    |
 | `rfc-chat-recovery-foundation.md`       | RFC        | Shared chat recovery foundation — internal engine, adapters, behavior convergence, and testing strategy     |
 | `rfc-ai-chat-maintenance.md`            | RFC        | AIChatAgent first-class stance, shared chat toolkit, multi-session example direction                        |
+| `rfc-discord-messengers.md`             | RFC        | Discord Think messenger design — Interactions plus Gateway ingress                                          |
 | `loopback.md`                           | design doc | Loopback pattern — cross-boundary RPC for sub-agents and dynamic isolates                                   |
 | `worker-bundler.md`                     | design doc | Worker bundler — host-side assets, no code generation, mounting is caller's concern                         |
 | `rfc-workers-ai-gateway-merge.md`       | RFC        | Merge ai-gateway-provider into workers-ai-provider — registry routing, universal run API, resume (proposed) |

--- a/design/rfc-discord-messengers.md
+++ b/design/rfc-discord-messengers.md
@@ -1,0 +1,895 @@
+# RFC: Discord messengers for Think
+
+Status: proposed
+
+Related:
+
+- [`docs/think/messengers.md`](../docs/think/messengers.md) - current
+  Think messenger user-facing docs.
+- [`ideas/messengers.md`](../ideas/messengers.md) - original cross-platform
+  messenger exploration.
+
+## Summary
+
+Add a first-class Discord provider at
+`@cloudflare/think/messengers/discord` that supports both Discord ingress
+surfaces:
+
+1. **Interactions** - signed HTTP callbacks for slash commands, buttons, and
+   select menus.
+2. **Gateway** - a persistent Discord Gateway connection for DMs, mentions,
+   subscribed channel/thread messages, reactions, and other real-time events.
+
+Both surfaces feed the same Chat SDK runtime and the same Think messenger
+delivery path. Interactions are not a temporary MVP that excludes Gateway;
+Gateway is part of the core design because normal Discord messages do not
+arrive through HTTP webhooks.
+
+The design takes the official `@chat-adapter/discord` package as the semantic
+reference for Discord-specific behavior. Direct dependency reuse is not the
+implementation path for Workers: a browser/Worker-style bundle validation fails
+on Node-only imports from `@chat-adapter/discord`, `@chat-adapter/shared`, and
+`discord.js` (`async_hooks`, `crypto`, `node:events`, `node:path`,
+`node:process`). The package does bundle for Node, but the resulting graph is a
+large `discord.js`-based runtime. Think should provide a Workers-native Discord
+adapter that implements the Chat SDK `Adapter` contract and mirrors the official
+adapter's event normalization, command parsing, card rendering, and thread ID
+semantics.
+
+## Problem
+
+The current Think messenger runtime is webhook-first. Telegram fits that model:
+Telegram sends message updates to one HTTP endpoint, Chat SDK normalizes them,
+and Think routes direct messages, mentions, subscribed-thread messages, and
+actions into durable reply fibers.
+
+Discord splits bot ingress across two APIs:
+
+- Interactions arrive over a signed HTTP endpoint and require a response or
+  deferred response within roughly three seconds.
+- Normal messages, DMs, mentions, reactions, member events, and thread events
+  arrive over the Discord Gateway WebSocket.
+
+If the SDK only implements Interactions, Discord agents cannot behave like the
+Telegram messenger path. They cannot respond naturally to DMs or mentions. If
+the SDK only implements Gateway, it misses slash commands and component actions,
+and it does not satisfy Discord's recommended command UX.
+
+## Goals
+
+- Keep the user-facing Think API parallel to `telegramMessenger()`.
+- Allow Interactions-only, Gateway-only, or both in one `discordMessenger()`
+  definition.
+- Route slash commands, buttons, DMs, mentions, and subscribed thread messages
+  through one provider definition, one Chat SDK state adapter, and one Think
+  delivery implementation.
+- Reuse Chat SDK primitives for dispatch, dedupe, locking, callback URLs,
+  slash commands, reactions, cards, formatted content, and thread serialization
+  instead of adding parallel Think-only abstractions.
+- Keep the Discord implementation Workers-native: no `discord.js`, no Node
+  crypto, no Node event emitter stack, and no cron-overlap Gateway listener.
+- Support durable Gateway reconnect/resume, heartbeats, sharding, and Identify
+  rate limits.
+- Preserve the existing provider-neutral messenger context shape where possible.
+- Make Discord-specific limits explicit through capabilities and delivery
+  policy.
+
+## Non-goals
+
+- Discord OAuth, bot installation, command registration, or application setup
+  flows.
+- Discord voice.
+- A general-purpose Gateway framework for non-Discord providers.
+- Modal UX as a Think messenger turn primitive. Discord modal support is a
+  provider/card concern, not part of model-turn routing.
+- Exactly-once processing across all Gateway reconnect races. The design uses
+  stable idempotency keys and accepts at-least-once delivery from Discord.
+
+## Proposed API
+
+```ts
+import { Think } from "@cloudflare/think";
+import {
+  defineMessengers,
+  ThinkMessengerStateAgent
+} from "@cloudflare/think/messengers";
+import discordMessenger, {
+  ThinkDiscordGatewayShardAgent
+} from "@cloudflare/think/messengers/discord";
+
+export { ThinkMessengerStateAgent, ThinkDiscordGatewayShardAgent };
+
+export class SupportAgent extends Think<Env> {
+  getMessengers() {
+    return defineMessengers({
+      discord: discordMessenger({
+        token: this.env.DISCORD_BOT_TOKEN,
+        applicationId: this.env.DISCORD_APPLICATION_ID,
+        publicKey: this.env.DISCORD_PUBLIC_KEY,
+        mentionRoleIds: ["123456789012345678"],
+        userName: "support-bot",
+        interactions: {
+          defaultVisibility: "public",
+          enabled: true
+        },
+        gateway: {
+          intents: ["GuildMessages", "DirectMessages", "MessageContent"],
+          shards: "auto"
+        },
+        guildMentions: {
+          createThread: true
+        },
+        allowedMentions: {
+          parse: []
+        },
+        respondTo: [
+          "command",
+          "direct-message",
+          "mention",
+          "subscribed-thread",
+          "action",
+          "reaction"
+        ]
+      })
+    });
+  }
+}
+```
+
+`interactions.enabled: true` enables the HTTP endpoint at the normal messenger
+path, `/messengers/discord/webhook`. `gateway` enables background Gateway shards
+for real-time events. Users can set either one independently.
+
+The provider helper should default to Interactions when `publicKey` is present
+and Gateway when `gateway` is provided. Gateway should never turn on implicitly
+from only `token`; it needs explicit intents.
+
+## User Setup Workflow
+
+Discord setup is part of the integration surface because the runtime cannot work
+until the application, bot, commands, endpoint, permissions, and intents line up.
+User-facing docs and examples should walk through this sequence:
+
+1. Create a Discord application in the Developer Portal.
+2. Copy the Application ID and Public Key from **General Information**.
+3. Reset and store the bot token from **Bot** as a Worker secret.
+4. Choose installation contexts: guild install, user install, or both.
+5. Configure install scopes:
+   - `applications.commands` for slash commands.
+   - `bot` for Gateway messages, DMs, channel posting, reactions, and thread
+     participation.
+6. Configure bot permissions for guild installs:
+   - `VIEW_CHANNEL`
+   - `SEND_MESSAGES`
+   - `SEND_MESSAGES_IN_THREADS`
+   - `CREATE_PUBLIC_THREADS` when `guildMentions.createThread` is true.
+   - `CREATE_PRIVATE_THREADS` only when private thread creation is enabled.
+   - `READ_MESSAGE_HISTORY`
+   - `ADD_REACTIONS` when reaction APIs are used.
+   - `ATTACH_FILES` when file uploads are enabled.
+   - `EMBED_LINKS` when cards render as embeds.
+7. Enable privileged intents in the Bot settings when configured:
+   - `MESSAGE_CONTENT` for non-mentioned guild message content, especially
+     subscribed-thread follow-ups.
+   - `GUILD_MEMBERS` only if the application needs member data beyond the
+     message payloads Discord already sends.
+8. Export `ThinkMessengerStateAgent` and `ThinkDiscordGatewayShardAgent` from
+   the Worker module.
+9. Add `discordMessenger()` to `getMessengers()` with `token`, `applicationId`,
+   `publicKey`, explicit Gateway intents, and any role mention IDs.
+10. Deploy the Worker before configuring the Interactions endpoint, because
+    Discord verifies the endpoint with a signed `PING`.
+11. Set the Interactions Endpoint URL to
+    `https://<worker>/messengers/discord/webhook` when using HTTP
+    Interactions.
+12. Register slash commands through Discord's HTTP API. Use guild commands for
+    development because they update immediately; use global commands for
+    production after testing.
+13. Wake the root Think agent to start Gateway shards. Interactions can do this
+    on first request; Gateway-only deployments need a scheduled Worker trigger
+    or authenticated control-plane call.
+14. Test slash commands, buttons/selects, DMs, guild mentions,
+    subscribed-thread follow-ups, reactions, Gateway reconnect, and Worker
+    deploy disconnect recovery.
+
+## Public Type Changes
+
+Add a command event kind and response selector:
+
+```ts
+export type MessengerEventKind =
+  | "action"
+  | "command"
+  | "delivery-event"
+  | "direct-message"
+  | "mention"
+  | "reaction"
+  | "subscribed-message";
+
+export type MessengerRespondTo =
+  | "action"
+  | "command"
+  | "direct-message"
+  | "mention"
+  | "reaction"
+  | "subscribed-thread";
+```
+
+Add command and reaction context without overloading `message`:
+
+```ts
+export interface MessengerCommand {
+  command: string;
+  providerCommandId?: string;
+  raw?: unknown;
+  text?: string;
+  user?: MessengerAuthor;
+  values?: Record<string, unknown>;
+}
+
+export interface MessengerReaction {
+  added: boolean;
+  emoji: string;
+  messageId: string;
+  raw?: unknown;
+  user?: MessengerAuthor;
+}
+
+export interface MessengerContext {
+  action?: MessengerAction;
+  author?: MessengerAuthor;
+  capabilities: MessengerCapabilities;
+  command?: MessengerCommand;
+  kind: MessengerEventKind;
+  message?: MessengerMessage;
+  messengerId: string;
+  provider: string;
+  reaction?: MessengerReaction;
+  thread: MessengerThread;
+}
+```
+
+`toMessengerUserMessage()` should render commands as a user message such as:
+
+```text
+Slash command: /ask
+Text: summarize the incident
+```
+
+If the command has an initiating user, include the display name in group
+contexts in the same way normal group messages are attributed today.
+
+Reactions are opt-in, matching actions. A reaction event should become a Think
+user message only when `respondTo` includes `"reaction"`; otherwise the provider
+can still expose reactions through lower-level Chat SDK handlers without
+starting a model turn.
+
+## Messenger Runtime Changes
+
+The current runtime assumes every messenger has one HTTP webhook path. Discord
+needs optional HTTP ingress plus background ingress. Extend
+`MessengerDefinition` additively:
+
+```ts
+export interface MessengerDefinition {
+  adapter: Adapter;
+  adapterName: string;
+  background?: MessengerBackgroundIngress;
+  path?: string | false;
+  verifyWebhook?:
+    | false
+    | ((request: Request) => boolean | Response | Promise<boolean | Response>);
+  // existing fields unchanged
+}
+
+export interface MessengerBackgroundIngress {
+  start(context: MessengerBackgroundContext): Promise<void> | void;
+}
+
+export interface MessengerBackgroundContext {
+  chat: Chat<Record<string, Adapter>>;
+  definition: NormalizedMessengerDefinition;
+  host: MessengerThinkHost;
+  messengerId: string;
+}
+```
+
+Rules:
+
+- Existing providers keep the default HTTP path and still require an explicit
+  verification posture.
+- `path: false` disables HTTP route registration and removes the verification
+  requirement for Gateway-only providers. `path: false` is only valid when the
+  messenger also provides `background` ingress; otherwise the provider has no
+  way to receive events.
+- Background ingress starts only on the root Think agent, matching existing
+  messenger route ownership.
+- The runtime must pass a `waitUntil`-style hook to Chat SDK webhook handling
+  when the host can provide one. Discord Interactions need this so the adapter
+  can acknowledge quickly and continue processing in the background.
+
+The runtime should also register `chat.onSlashCommand()` when any definition
+responds to `command`, parallel to `onDirectMessage`, `onNewMention`,
+`onSubscribedMessage`, and `onAction`.
+
+Chat SDK already exposes slash command primitives (`onSlashCommand()` and
+`processSlashCommand()`). The Think change is to translate those existing Chat
+SDK events into `MessengerEvent`/`MessengerContext`, not to add a new command
+abstraction below Chat SDK.
+
+The runtime should also register `chat.onReaction()` when any definition
+responds to `reaction`. Chat SDK already normalizes `ReactionEvent` and handles
+self-filtering; Think only needs to convert the event into messenger context and
+durable reply routing.
+
+Commands are channel-originated in Chat SDK: `SlashCommandEvent` exposes
+`event.channel`, not `event.thread`. Generic messenger delivery therefore
+should accept any Chat SDK `Postable` surface with `post()` and `startTyping()`
+rather than only `Thread`. The public `MessengerContext.thread` remains a
+normalized conversation reference derived from the channel id so existing Think
+conversation routing still has a stable key.
+
+## Discord Installation Modes
+
+Discord has two installation contexts that affect what the integration can do:
+
+| Installation context                            | What works                                                               | Runtime implications                                                                   |
+| ----------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Guild install with `bot` scope                  | Gateway messages, DMs, channel posts, reactions, threads, slash commands | Required for natural bots that respond to mentions and subscribed threads in servers.  |
+| User install with `applications.commands` scope | Commands in supported contexts                                           | Useful for command-only experiences. Does not grant the bot guild message permissions. |
+
+The Think Discord docs should recommend guild install with both `bot` and
+`applications.commands` for the default messenger experience. User install is a
+valid command-only setup, but it should not be presented as equivalent to a
+Gateway-capable bot.
+
+## Command Registration
+
+Discord commands can only be registered through Discord's HTTP API. Runtime
+ingress must not register commands implicitly during request handling, but the
+SDK should provide a small helper or example script for command registration so
+users can complete setup without writing raw REST calls.
+
+The registration story should follow Discord's constraints:
+
+- Use guild commands during development because they update immediately.
+- Use global commands for production after validation.
+- Include `integration_types` and `contexts` when commands should support user
+  installs, guild installs, DMs, or private channels.
+- Preserve Discord's limits: command names 1-32 characters, descriptions 1-100
+  characters, at most 25 options, required options before optional options, and
+  100 global chat input commands.
+- Document the 200 application command creates per day per guild limit. Helpers
+  should prefer bulk overwrite/update semantics and avoid repeated create loops.
+- Command permissions that target users, roles, or channels require Bearer token
+  flows and are outside the bot-token helper. Default member permissions can be
+  included in command payloads.
+
+## Message Content Intent Matrix
+
+Discord's `MESSAGE_CONTENT` privileged intent affects whether message content is
+present on Gateway events. The provider should document and enforce behavior as:
+
+| Event source                                                | Content availability                | Think behavior                                                                     |
+| ----------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------- |
+| DM with the bot                                             | Available without `MESSAGE_CONTENT` | `direct-message` works without the privileged intent.                              |
+| Guild message that mentions the app                         | Available without `MESSAGE_CONTENT` | `mention` works without the privileged intent.                                     |
+| Subscribed guild thread/channel follow-up without a mention | Requires `MESSAGE_CONTENT`          | `subscribed-thread` should warn at startup if configured without `MessageContent`. |
+| Bot-authored message                                        | Available, but filtered as self     | Never starts a model turn.                                                         |
+
+If `respondTo` includes `"subscribed-thread"` for guild messages and Gateway
+intents do not include `MessageContent`, startup should emit a clear warning. If
+Discord omits content anyway, the adapter should not synthesize fake text; it
+should skip the event or produce a safe empty-content event that does not start a
+model turn.
+
+## Discord Interactions Ingress
+
+Interactions use the normal messenger HTTP route. The Discord adapter verifies:
+
+- `X-Signature-Ed25519`
+- `X-Signature-Timestamp`
+- Raw request body bytes
+- Configured Discord application public key
+
+The verifier should reject stale timestamps to reduce replay risk. The helper
+requires `publicKey` when Interactions are enabled unless the user supplies a
+custom `verifyWebhook` or explicitly sets `verifyWebhook: false`.
+
+Interaction handling maps Discord payloads into Chat SDK events:
+
+| Discord interaction             | Chat SDK event       | Think event kind |
+| ------------------------------- | -------------------- | ---------------- |
+| `PING`                          | HTTP `PONG` response | none             |
+| Application command             | slash command        | `command`        |
+| Message component button/select | action               | `action`         |
+
+Discord sends interactions through either an Interactions Endpoint URL or
+Gateway `INTERACTION_CREATE`, not both for the same configured application
+delivery mode. The supported modes are:
+
+| Mode                                 | User setup                                                         | Think behavior                                                                                                           |
+| ------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| HTTP Interactions + Gateway messages | Set the Interactions Endpoint URL and start Gateway shards         | Commands/actions arrive over HTTP; messages/reactions arrive over Gateway. This is the recommended full messenger setup. |
+| HTTP Interactions only               | Set the Interactions Endpoint URL and omit Gateway                 | Commands/actions work; DMs, mentions, reactions, and subscribed messages do not.                                         |
+| Gateway-only                         | Leave the Interactions Endpoint URL unset and start Gateway shards | Commands/actions/messages/reactions arrive over Gateway; interaction responses still use Discord HTTP callbacks.         |
+
+Long-running model replies must defer the interaction within Discord's response
+deadline, then edit the original response or post follow-ups through Discord's
+interaction webhook token. The Chat SDK adapter should own this because it is a
+Discord delivery concern, not a Think concern.
+
+The Workers-native adapter should mirror the official adapter's request-local
+slash command response behavior: during a slash command handler, the first
+`post()` to the command's channel edits the deferred original interaction
+response, and subsequent posts use follow-up interaction webhooks. This keeps
+Think delivery generic while producing the correct Discord UX.
+
+`interactions.defaultVisibility` controls the initial command response flag:
+
+| Value         | Behavior                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `"public"`    | Defer and edit a public original interaction response. Default.                                                                |
+| `"ephemeral"` | Defer with Discord's `EPHEMERAL` flag and edit an ephemeral original response. Only applies to interaction-originated replies. |
+
+This is intentionally separate from generic `supportsEphemeral`, which remains
+false because Discord does not expose a general cross-surface ephemeral posting
+primitive.
+
+Button and select payloads should use Chat SDK's callback-token pattern. Chat
+SDK rewrites `Button callbackUrl` into a short state-backed token before
+rendering, then resolves that token when the action arrives. Discord `custom_id`
+is limited to 100 characters, so long workflow callback URLs and long action
+payloads must not be embedded directly in Discord components. The Discord
+renderer should validate the encoded `custom_id` and fail before posting when an
+action id/value cannot fit.
+
+Select menus use the same action event path as buttons. `MessengerAction.value`
+should contain the selected value for single-select inputs and a serialized
+representation for multi-select inputs. The raw interaction keeps the original
+`values` array and resolved users/roles/channels for applications that need the
+full Discord payload.
+
+Signature verification must use Workers-native Web Crypto. Cloudflare Workers
+supports Ed25519 in `crypto.subtle`, so the provider can verify Discord's raw
+body bytes with the configured public key without `discord-interactions` or Node
+crypto. Verification must use the raw request body, reject missing signature
+headers, and reject stale timestamps.
+
+## Chat SDK Semantics to Mirror
+
+The Workers-native Discord adapter should mirror these official Chat SDK
+Discord adapter semantics:
+
+- `adapter.name` is `"discord"`; `botUserId` is the application id; `userName`
+  is configurable.
+- `mentionRoleIds` augments direct bot mentions, so role mentions can trigger
+  `onNewMention` and Think `mention` events.
+- Slash commands normalize to command paths with subcommands included, for
+  example `/project issue create`, while leaf option values flatten into
+  `text`. The raw command option tree remains available on `raw`.
+- Buttons and select menus normalize to Chat SDK action events with `actionId`,
+  `value`, `messageId`, `threadId`, `user`, `triggerId`, and `raw` when
+  available.
+- Reactions normalize to Chat SDK reaction events with `added`, normalized emoji,
+  raw emoji, `messageId`, `threadId`, `user`, and `raw`.
+- Cards render as Discord embeds plus action rows. Action rows contain at most
+  five components. Link buttons use URL buttons. GFM tables render in embed text
+  as GFM tables. Unsupported card children fall back to readable text.
+- Message content uses Discord markdown. `{ markdown }` converts from Chat SDK's
+  formatted AST; bare strings remain plain text except for safe emoji/mention
+  conversion.
+- `openDM(userId)` creates or resolves `discord:@me:{channelId}`.
+- `getUser(userId)` returns Discord profile fields available to bot tokens and
+  never claims to provide email.
+- `fetchMessages`, `fetchChannelMessages`, `listThreads`, `fetchThread`, and
+  `fetchChannelInfo` should exist because Think tools and scheduled work can use
+  them outside inbound handlers.
+
+## Discord Gateway Ingress
+
+Gateway is implemented as provider-owned Durable Object sub-agents, not as a
+long-lived loop inside the root Think agent and not as a cron-overlap listener.
+This keeps each shard isolated, lets shards reconnect independently, and keeps
+Gateway protocol state separate from Think conversation state.
+
+The Discord provider exports `ThinkDiscordGatewayShardAgent`. Applications that
+enable Gateway export it from the Worker entry point, just like
+`ThinkMessengerStateAgent`:
+
+```ts
+export { ThinkMessengerStateAgent } from "@cloudflare/think/messengers";
+export { ThinkDiscordGatewayShardAgent } from "@cloudflare/think/messengers/discord";
+```
+
+The root messenger runtime owns a lightweight Gateway manager:
+
+1. Resolve shard count from `gateway.shards` or Discord's `/gateway/bot` API.
+2. Create one `ThinkDiscordGatewayShardAgent` sub-agent per configured shard.
+3. Pass serializable shard configuration to each shard.
+4. Let shards own WebSocket connect, heartbeat, resume, backoff, and alarms.
+5. Forward accepted Discord dispatches back to the root runtime as internal
+   provider events.
+6. The root runtime calls the Discord adapter's dispatch processor, which uses
+   Chat SDK `processMessage`, `processReaction`, `processAction`, and
+   `processSlashCommand` APIs.
+
+The root remains the only place that registers Think reply handlers. Shards do
+not run model turns and do not own Think conversation state.
+
+The official adapter's serverless Gateway forwarder is still a useful boundary:
+it forwards normalized events like `GATEWAY_MESSAGE_CREATE`,
+`GATEWAY_MESSAGE_REACTION_ADD`, and `GATEWAY_MESSAGE_REACTION_REMOVE` into the
+same webhook handler. The Workers design should keep that internal event shape
+but deliver it through typed Agent/facet calls, not public HTTP, and never use
+the Discord bot token as an internal forwarding credential.
+
+Outgoing Gateway WebSockets do not use Durable Object hibernation. The shard DO
+is active while connected, persists session/sequence state before updating
+in-memory state, and uses alarms for reconnects. Each shard owns one alarm;
+setting a reconnect alarm replaces any previous reconnect alarm for that shard.
+
+### Gateway Shard State
+
+Each shard stores:
+
+- Shard id and total shard count.
+- Gateway URL and `resume_gateway_url`.
+- Discord `session_id`.
+- Last sequence number.
+- Last heartbeat send time and ACK time.
+- Identify backoff state.
+- Last fatal close code, if any.
+
+Shard alarms reconnect when the socket closes unexpectedly. Resume is attempted
+when Discord allows it. Invalid sessions fall back to Identify after the
+required delay. Fatal close codes such as disallowed intents should stop the
+shard and surface a clear diagnostic instead of looping.
+
+### Gateway Connection Mechanics
+
+Gateway shards should implement Discord's documented lifecycle directly with
+Workers WebSockets:
+
+- Fetch `/gateway/bot` with the bot token to resolve the recommended shard count,
+  Gateway URL, session start limit, and `max_concurrency`.
+- Connect with `v=10&encoding=json` and no compression. JSON without compression
+  avoids zlib/zstd streaming state in the first Workers-native implementation.
+- On Hello (`op: 10`), wait `heartbeat_interval * jitter` before the first
+  heartbeat, then heartbeat every interval with the latest sequence number.
+- If a heartbeat ACK (`op: 11`) is not received before the next heartbeat window,
+  close the socket with a non-1000/non-1001 code and attempt Resume.
+- Store every non-null dispatch sequence (`s`) before dispatching the event.
+- On Ready, persist `session_id` and `resume_gateway_url`.
+- On Reconnect (`op: 7`), reconnect and send Resume (`op: 6`) when session data
+  exists.
+- On Invalid Session (`op: 9`), Resume only when Discord marks the session
+  resumable; otherwise reconnect and Identify after the required delay.
+- Respect close codes: invalid shard and disallowed intents are fatal until
+  configuration changes; resumable disconnects should use Resume first.
+- Identify requests are started in `shard_id % max_concurrency` buckets. Buckets
+  start in order, and each bucket waits the Discord-required interval before the
+  next bucket.
+- Track daily Identify usage. Discord's 1000 Identifies per 24 hours limit is
+  global across shards and excludes Resume calls; reconnect policy should prefer
+  Resume whenever possible.
+
+### Gateway Intents
+
+The user must opt in to intents explicitly:
+
+```ts
+gateway: {
+  intents: ["GuildMessages", "DirectMessages", "MessageContent"];
+}
+```
+
+`MessageContent` is privileged for many bots. Without it, guild message text may
+be unavailable. The adapter should still process mentions and events that
+Discord includes, but it should not pretend to have message text when Discord
+omits it.
+
+### Gateway Dispatch Mapping
+
+Gateway support covers:
+
+| Discord dispatch                           | Chat SDK event     | Think event kind     |
+| ------------------------------------------ | ------------------ | -------------------- |
+| `MESSAGE_CREATE` in DM                     | direct message     | `direct-message`     |
+| `MESSAGE_CREATE` mention                   | new mention        | `mention`            |
+| `MESSAGE_CREATE` subscribed channel/thread | subscribed message | `subscribed-message` |
+| `MESSAGE_REACTION_ADD` / remove            | reaction           | `reaction`           |
+| Gateway interaction command                | slash command      | `command`            |
+| Gateway interaction component              | action             | `action`             |
+| `THREAD_CREATE` / update                   | thread metadata    | no model turn        |
+
+## Thread and Message Identity
+
+Use stable, provider-prefixed IDs compatible with Chat SDK's official Discord
+adapter:
+
+| Discord context        | Thread id shape                            |
+| ---------------------- | ------------------------------------------ |
+| DM channel             | `discord:@me:{channelId}`                  |
+| Guild channel          | `discord:{guildId}:{channelId}`            |
+| Discord thread channel | `discord:{guildId}:{channelId}:{threadId}` |
+
+`channelIdFromThreadId()` maps guild channel and thread conversations to the
+Discord channel/thread id that should receive replies. `providerThreadId` in the
+Think context remains the encoded Discord thread id. `providerMessageId` remains
+the Discord snowflake message id.
+
+Conversation routing stays unchanged: the default Think conversation name is
+`messenger:{messengerId}:{stable thread id}`. Applications can still provide a
+custom `conversation(event)` resolver for tenant, guild, channel, or user based
+routing.
+
+### Guild Mention Threading
+
+Discord guild mentions should create a Discord thread by default when the
+mention happens in a normal text channel and not in an existing thread:
+
+```ts
+guildMentions: {
+  createThread: true;
+}
+```
+
+This mirrors the official Chat SDK Discord adapter and gives Think a stable
+conversation container for subscribed follow-ups. It requires
+`CREATE_PUBLIC_THREADS` and `SEND_MESSAGES_IN_THREADS`. If thread creation
+fails because permissions are missing, the adapter should fall back to the parent
+channel, post a safe diagnostic when possible, and emit a structured warning so
+the developer can fix bot permissions.
+
+Applications can set `guildMentions.createThread: false` to keep mention
+conversations in the parent channel. That mode should be documented as noisier
+for shared channels because subscribed follow-ups use the channel as the
+conversation surface.
+
+## Delivery Policy
+
+Discord delivery defaults:
+
+```ts
+capabilities: {
+  canEditMessages: true,
+  canStream: true,
+  maxMessageLength: 2000,
+  supportsActions: true,
+  supportsAttachments: true,
+  supportsEphemeral: false
+}
+
+delivery: {
+  splitText: splitDiscordMessageText,
+  visibleSoftLimit: 1800
+}
+```
+
+The adapter should use post-and-edit streaming for normal channel messages. For
+Interactions, it should defer quickly and stream by editing the original
+interaction response when possible, then post follow-up messages for overflow.
+
+Discord does not have the same generalized ephemeral surface as Slack in Chat
+SDK. The official Discord adapter uses DM fallback for ephemeral-style sends.
+Think does not advertise native ephemeral support. If command-only responses
+need private replies, that is an explicit Discord delivery option separate from
+generic `supportsEphemeral`.
+
+Discord has strict REST rate limits. The adapter owns route-level 429 handling,
+global 429 handling, and safe retry-after behavior. Think should only see a
+delivery error after the adapter exhausts safe retries or receives a permanent
+Discord error.
+
+### Allowed Mentions
+
+Model output is untrusted text and can contain `@everyone`, role mentions, or
+user mentions. Discord responses should default to safe `allowed_mentions`:
+
+```ts
+allowedMentions: {
+  parse: [];
+}
+```
+
+Applications can opt into selected user or role mentions, but `everyone` should
+remain disabled unless explicitly configured. This applies to normal messages,
+interaction responses, follow-ups, and edited messages.
+
+### Permissions and Invalid Requests
+
+Discord counts repeated `401`, `403`, and `429` responses toward its invalid
+request limit. The adapter should reduce invalid requests by design:
+
+- Use interaction `app_permissions` when present to detect missing send, embed,
+  attach, thread, and reaction permissions before attempting API calls.
+- Parse rate-limit headers and 429 bodies; do not hardcode route limits.
+- Track global 429 responses separately from route buckets.
+- Stop retrying after permanent `401` token failures until configuration changes.
+- Treat missing permissions as actionable diagnostics, not generic delivery
+  failures.
+- Avoid repeated calls to deleted or inaccessible webhook/message resources after
+  a `404` or permanent `403`.
+
+## Activation and Operations
+
+Gateway connections cannot start at deploy time because Workers only run when
+invoked. Gateway startup therefore needs an activation path:
+
+- If Interactions are enabled, the first Discord interaction can wake the root
+  agent and start Gateway shards.
+- Gateway-only bots should use a scheduled Worker trigger or an explicit
+  application control-plane call that wakes the root agent and lets the gateway
+  manager start shards.
+- Once started, shard DO alarms keep reconnecting after socket closures or DO
+  eviction.
+
+The user-facing docs should call this out clearly so Gateway-only bots do not
+appear idle simply because no request has awakened their root agent yet.
+
+### Local Development
+
+Local development needs two paths:
+
+- Interactions require a public HTTPS URL because Discord verifies the endpoint
+  by sending a signed `PING`. The docs should use the same local tunnel pattern
+  as existing Worker examples and point the Discord Interactions Endpoint URL at
+  `/messengers/discord/webhook`.
+- Gateway can connect outbound from local dev once the root agent is awake. For
+  local testing, provide an explicit setup action or route in the example that
+  calls the root agent's Gateway startup method, instead of requiring users to
+  wait for a scheduled trigger.
+
+The local checklist should test both surfaces: a slash command/button through
+the public tunnel and a DM/mention through the Gateway connection.
+
+## Security
+
+- Treat all Discord HTTP payloads and Gateway dispatches as untrusted input.
+- Verify Interaction signatures against the raw request body before parsing JSON.
+- Reject stale Interaction timestamps.
+- Never log bot tokens, interaction tokens, authorization headers, or full raw
+  payloads by default. Do not log public keys, signature prefixes, request body
+  prefixes, or interaction webhook tokens during verification failures.
+- Require explicit Gateway intents and document the risk of the privileged
+  `MessageContent` intent.
+- Drop messages authored by the bot itself before dispatching to Think.
+- Use idempotency keys based on Discord snowflakes for messages and interaction
+  ids for commands/actions.
+- Use `crypto.subtle` for Ed25519 verification and `crypto.timingSafeEqual` for
+  fixed-length internal token comparisons.
+
+## Package Shape
+
+`@cloudflare/think` should expose a provider-specific subpath:
+
+```jsonc
+{
+  "exports": {
+    "./messengers/discord": {
+      "types": "./dist/messengers/discord.d.ts",
+      "import": "./dist/messengers/discord.js"
+    }
+  }
+}
+```
+
+As with Telegram, Discord adapter code should be optional so users who do not
+import the Discord subpath do not bundle it. The implementation should not
+depend directly on `@chat-adapter/discord` because the published adapter imports
+Node-only modules and `discord.js`. Instead, the Think subpath should provide a
+Workers-native Chat SDK adapter that mirrors the official adapter's public
+semantics and avoids Node runtime dependencies.
+
+## Validation
+
+- `npm view @chat-adapter/discord@4.30.0` confirms an official Chat SDK Discord
+  adapter exists with dependencies on `discord-api-types`,
+  `discord-interactions`, `discord.js`, `@chat-adapter/shared`, and `chat`.
+- A browser/Worker-style esbuild bundle of `createDiscordAdapter()` fails on
+  Node-only imports: `async_hooks`, `crypto`, `node:events`, `node:path`, and
+  `node:process`.
+- A Node-platform bundle succeeds, but produces a large `discord.js` graph. That
+  validates the package for Node/serverless use, not as a Workers-native
+  dependency.
+- Cloudflare Workers Web Crypto supports Ed25519 verification through
+  `crypto.subtle`, so Interaction verification can be implemented without Node
+  crypto or `discord-interactions`.
+- Cloudflare Durable Objects support outbound WebSockets, alarms, and persistent
+  SQLite state, which are the primitives needed for Gateway shard ownership.
+- Discord docs confirm Interactions Endpoint delivery and Gateway
+  `INTERACTION_CREATE` delivery are mutually exclusive delivery modes, while
+  Gateway-received interactions still respond through HTTP callbacks.
+- Discord docs require an initial interaction response within three seconds,
+  expose interaction tokens for follow-ups for 15 minutes, require explicit
+  Gateway intents, and define Identify/sharding/session-start limits that the DO
+  shard manager must enforce.
+
+## Implementation Plan
+
+1. Add command and reaction event types, then wire Chat SDK's existing slash
+   command and reaction events into the generic Think messenger runtime.
+2. Generalize messenger delivery surfaces from `Thread` only to Chat SDK
+   `Postable` surfaces so slash commands can reply through channels.
+3. Add optional `path: false` and `background` ingress support to
+   `MessengerDefinition`.
+4. Implement a Workers-native Discord Chat SDK adapter inside the Think Discord
+   subpath, using the official adapter as the behavior reference but avoiding
+   Node-only dependencies.
+5. Implement Discord command registration helpers/examples for guild and global
+   commands, including contexts, integration types, default member permissions,
+   and safe update/bulk-overwrite behavior.
+6. Implement Interactions support with Web Crypto signature verification,
+   timestamp freshness checks, fast ACK/defer behavior, action mapping, command
+   mapping, select mapping, callback-token component ids, and Discord delivery
+   limits.
+7. Implement `ThinkDiscordGatewayShardAgent`, Gateway shard state, reconnect,
+   resume, heartbeats, alarms, session start limit handling, shard Identify
+   bucket scheduling, and internal Gateway event forwarding.
+8. Add Gateway dispatch normalization for DMs, mentions, reactions, subscribed
+   channel/thread messages, and Gateway-delivered interactions.
+9. Implement guild mention auto-threading, safe `allowed_mentions`, permission
+   diagnostics, route/global rate-limit handling, and invalid request tracking.
+10. Add tests for command registration payloads, command routing, action/select
+    routing, reaction routing, Interaction verification, timestamp rejection,
+    thread id encoding, auto-thread fallback, safe allowed mentions, card
+    rendering, custom id length validation, Gateway dispatch idempotency, and
+    recovery behavior.
+11. Add user-facing docs and a Discord example that covers application setup,
+    command registration, local tunnel testing, Interactions, Gateway activation,
+    and permissions/intents troubleshooting.
+
+## Alternatives Considered
+
+### Interactions-only first
+
+Rejected as the complete design. It is a useful slice, but it excludes DMs and
+natural mention-based bots. Discord users expect bots to respond in channels and
+DMs without requiring every turn to start as a slash command.
+
+### Gateway-only first
+
+Rejected. Slash commands and component interactions are core Discord bot UX, and
+Interactions have a different security and delivery model. Excluding them would
+make buttons and commands second-class.
+
+### Separate cross-platform `packages/messengers`
+
+Rejected. The current repo already has a Think-native messenger architecture
+backed by Chat SDK. Discord should extend that path rather than restart the
+older standalone package idea.
+
+### Run Gateway sockets inside the root Think agent only
+
+Rejected for the full design. It is simpler for a single-shard prototype, but it
+mixes Gateway protocol state with Think conversation state and does not scale
+cleanly to multiple shards. Provider-owned shard sub-agents keep the boundaries
+clear.
+
+### Depend directly on `@chat-adapter/discord`
+
+Rejected for Workers. The package is the right semantic reference, but direct
+reuse pulls in Node-only modules and `discord.js`. Think's Discord subpath needs
+a Workers-native adapter that speaks the Chat SDK `Adapter` contract.
+
+### Use a cron-overlap Gateway listener
+
+Rejected for Workers. The official adapter's cron pattern is a pragmatic
+serverless Node workaround. Durable Object shard agents provide a stronger
+ownership model for Cloudflare: one coordination atom per Discord shard,
+durable resume state, alarms for reconnect, and no public HTTP forwarding loop.
+
+## Decisions Closed By Validation
+
+- Command routing uses Chat SDK's existing slash command primitives and is
+  documented in Think messenger docs only where Think adds messenger context and
+  model-turn routing.
+- Gateway startup is explicit. The root Think agent starts shards when it wakes;
+  Gateway-only deployments configure a scheduled Worker trigger or authenticated
+  application control-plane call to wake the root. The SDK should not add an
+  unauthenticated built-in HTTP control route.
+- Command registration remains outside runtime ingress. The SDK should provide a
+  helper or example script for guild/global command registration, while docs
+  show the minimum Discord Developer Portal setup and link to Discord's full
+  registration docs rather than becoming an application setup framework.

--- a/packages/think/src/messengers/chat-sdk.ts
+++ b/packages/think/src/messengers/chat-sdk.ts
@@ -4,8 +4,11 @@ import type {
   ActionEvent as ChatActionEvent,
   Attachment as ChatAttachment,
   Author as ChatAuthor,
+  Channel as ChatChannel,
   ChatConfig,
   Message as ChatMessage,
+  ReactionEvent as ChatReactionEvent,
+  SlashCommandEvent as ChatSlashCommandEvent,
   Thread as ChatThread
 } from "chat";
 import { Chat } from "chat";
@@ -27,9 +30,11 @@ import type {
   MessengerAction,
   MessengerAuthor,
   MessengerCapabilities,
+  MessengerCommand,
   MessengerEvent,
   MessengerEventKind,
   MessengerMessage,
+  MessengerReaction,
   MessengerThread
 } from "./events";
 import { serializableMessengerEvent, toMessengerUserMessage } from "./events";
@@ -46,10 +51,27 @@ import {
 
 export class ThinkMessengerStateAgent extends ChatSdkStateAgent {}
 
+interface ChatThreadReference {
+  channel: { name: string | null };
+  channelId: string;
+  id: string;
+  isDM: boolean;
+  toJSON(): unknown;
+}
+
+interface ChatChannelReference {
+  id: string;
+  isDM: boolean;
+  name: string | null;
+  toJSON(): unknown;
+}
+
 export type MessengerRespondTo =
   | "action"
+  | "command"
   | "direct-message"
   | "mention"
+  | "reaction"
   | "subscribed-thread";
 
 export type MessengerConversationMode = "self" | "thread";
@@ -66,14 +88,26 @@ export type MessengerConversationResolver = (
   event: MessengerEvent
 ) => MessengerConversationTarget | Promise<MessengerConversationTarget>;
 
+export interface MessengerBackgroundContext {
+  chat: Chat<Record<string, Adapter>>;
+  definition: NormalizedMessengerDefinition;
+  host: MessengerThinkHost;
+  messengerId: string;
+}
+
+export interface MessengerBackgroundIngress {
+  start(context: MessengerBackgroundContext): Promise<void> | void;
+}
+
 export interface MessengerDefinition {
   adapter: Adapter;
   adapterName: string;
+  background?: MessengerBackgroundIngress;
   capabilities?: MessengerCapabilities;
   conversation?: MessengerConversationMode | MessengerConversationResolver;
   delivery?: MessengerDeliveryPolicy;
   keyShard?: ChatSdkStateAdapterOptions["keyShard"];
-  path?: string;
+  path?: string | false;
   provider: string;
   respondTo?: readonly MessengerRespondTo[];
   shardKey?: ChatSdkStateAdapterOptions["shardKey"];
@@ -91,7 +125,7 @@ export type ThinkMessengers = Record<string, MessengerDefinition>;
 
 export interface NormalizedMessengerDefinition extends MessengerDefinition {
   id: string;
-  path: string;
+  path: string | false;
   respondTo: readonly MessengerRespondTo[];
   subscribeOnMention: boolean;
   verifyWebhook:
@@ -108,10 +142,13 @@ export interface ChatSdkMessengerOptions extends Omit<
 
 export interface ChatSdkMessengerEventInput {
   action?: ChatActionEvent;
+  channel?: ChatChannel;
+  command?: ChatSlashCommandEvent;
   eventKind: MessengerEventKind;
   message?: ChatMessage;
   raw?: unknown;
-  thread: ChatThread;
+  reaction?: ChatReactionEvent;
+  thread?: ChatThread;
 }
 
 export interface MessengerThinkTarget {
@@ -167,6 +204,7 @@ export function chatSdkMessenger(
 }
 
 export class ThinkMessengerRuntime {
+  private readonly backgroundStartTasks = new Map<string, Promise<void>>();
   private chat?: Chat<Record<string, Adapter>>;
   private readonly definitionsByAdapterName = new Map<
     string,
@@ -198,7 +236,7 @@ export class ThinkMessengerRuntime {
       return;
     }
 
-    this.chat = this.createChat();
+    void this.startBackgroundIngress(this.getOrCreateChat());
   }
 
   async handleRequest(request: Request): Promise<Response | undefined> {
@@ -208,7 +246,7 @@ export class ThinkMessengerRuntime {
 
     const url = new URL(request.url);
     const definition = this.definitions.find(
-      (candidate) => candidate.path === url.pathname
+      (candidate) => candidate.path !== false && candidate.path === url.pathname
     );
     if (!definition) {
       return undefined;
@@ -230,8 +268,8 @@ export class ThinkMessengerRuntime {
       }
     }
 
-    const chat = this.chat ?? this.createChat();
-    this.chat = chat;
+    const chat = this.getOrCreateChat();
+    void this.startBackgroundIngress(chat);
     return chat.webhooks[definition.adapterName](request);
   }
 
@@ -252,14 +290,17 @@ export class ThinkMessengerRuntime {
       );
     }
 
-    const thread = this.reviveChatObject<ChatThread>(snapshot.thread);
+    const surface = this.reviveChatObject<MessengerDeliverySurface>(
+      snapshot.thread
+    );
     const mode = messengerReplyRecoveryMode(snapshot);
 
     if (mode === "answer") {
       await this.answer(
         definition,
         snapshot.event,
-        thread,
+        surface,
+        snapshot.thread,
         undefined,
         snapshot.event,
         async (nextSnapshot) => {
@@ -274,7 +315,7 @@ export class ThinkMessengerRuntime {
     }
 
     if (mode === "apologize") {
-      await thread.post(
+      await surface.post(
         definition.delivery?.interruptedResponseText ??
           "Sorry, my reply was interrupted. Please send your message again if you'd like me to retry."
       );
@@ -306,7 +347,7 @@ export class ThinkMessengerRuntime {
     } satisfies ChatConfig<Record<string, Adapter>>);
 
     chat.onDirectMessage(async (thread, message) => {
-      const definition = this.definitionForThread(thread);
+      const definition = this.definitionForChatObject(thread);
       if (!definition) return;
       if (definition.respondTo.includes("direct-message")) {
         await this.enqueueReply(
@@ -316,13 +357,14 @@ export class ThinkMessengerRuntime {
             message,
             thread
           }),
-          thread
+          thread,
+          thread.toJSON()
         );
       }
     });
 
     chat.onNewMention(async (thread, message) => {
-      const definition = this.definitionForThread(thread);
+      const definition = this.definitionForChatObject(thread);
       if (!definition) return;
       if (definition.subscribeOnMention) {
         await thread.subscribe();
@@ -335,13 +377,14 @@ export class ThinkMessengerRuntime {
             message,
             thread
           }),
-          thread
+          thread,
+          thread.toJSON()
         );
       }
     });
 
     chat.onSubscribedMessage(async (thread, message) => {
-      const definition = this.definitionForThread(thread);
+      const definition = this.definitionForChatObject(thread);
       if (!definition) return;
       if (
         definition.respondTo.includes("subscribed-thread") ||
@@ -354,7 +397,8 @@ export class ThinkMessengerRuntime {
             message,
             thread
           }),
-          thread
+          thread,
+          thread.toJSON()
         );
       }
     });
@@ -362,7 +406,7 @@ export class ThinkMessengerRuntime {
     chat.onAction(async (event) => {
       if (!event.thread) return;
       const thread = event.thread as ChatThread;
-      const definition = this.definitionForThread(thread);
+      const definition = this.definitionForChatObject(thread);
       if (!definition) return;
       if (definition.respondTo.includes("action")) {
         await this.enqueueReply(
@@ -373,7 +417,46 @@ export class ThinkMessengerRuntime {
             raw: event.raw,
             thread
           }),
-          thread
+          thread,
+          thread.toJSON()
+        );
+      }
+    });
+
+    chat.onSlashCommand(async (event) => {
+      const definition = this.definitionForChatObject(event.channel);
+      if (!definition) return;
+      if (definition.respondTo.includes("command")) {
+        const channel = event.channel as MessengerDeliverySurface;
+        await this.enqueueReply(
+          definition,
+          await this.toEvent(definition, {
+            channel: event.channel,
+            command: event,
+            eventKind: "command",
+            raw: event.raw
+          }),
+          channel,
+          event.channel.toJSON()
+        );
+      }
+    });
+
+    chat.onReaction(async (event) => {
+      const thread = event.thread as ChatThread;
+      const definition = this.definitionForChatObject(thread);
+      if (!definition) return;
+      if (definition.respondTo.includes("reaction")) {
+        await this.enqueueReply(
+          definition,
+          await this.toEvent(definition, {
+            eventKind: "reaction",
+            raw: event.raw,
+            reaction: event,
+            thread
+          }),
+          thread,
+          thread.toJSON()
         );
       }
     });
@@ -384,17 +467,24 @@ export class ThinkMessengerRuntime {
   private async enqueueReply(
     definition: NormalizedMessengerDefinition,
     event: MessengerEvent,
-    thread: ChatThread
+    surface: MessengerDeliverySurface,
+    snapshotSurface: unknown
   ): Promise<void> {
     const snapshotEvent = serializableMessengerEvent(event);
-    const snapshotThread = thread.toJSON();
     const result = await this.host.startFiber(
       MESSENGER_REPLY_FIBER_NAME,
       async (fiber) => {
         fiber.stash(
-          messengerReplySnapshot("accepted", snapshotEvent, snapshotThread)
+          messengerReplySnapshot("accepted", snapshotEvent, snapshotSurface)
         );
-        await this.answer(definition, event, thread, fiber, snapshotEvent);
+        await this.answer(
+          definition,
+          event,
+          surface,
+          snapshotSurface,
+          fiber,
+          snapshotEvent
+        );
       },
       {
         idempotencyKey: idempotencyKeyForEvent(event),
@@ -422,7 +512,8 @@ export class ThinkMessengerRuntime {
       await this.answer(
         definition,
         snapshot.event,
-        thread,
+        surface,
+        snapshotSurface,
         undefined,
         snapshot.event,
         async (nextSnapshot) => {
@@ -437,7 +528,7 @@ export class ThinkMessengerRuntime {
     }
 
     if (mode === "apologize") {
-      await thread
+      await surface
         .post(
           definition.delivery?.interruptedResponseText ??
             "Sorry, my reply was interrupted. Please send your message again if you'd like me to retry."
@@ -450,7 +541,8 @@ export class ThinkMessengerRuntime {
   private async answer(
     definition: NormalizedMessengerDefinition,
     event: MessengerEvent,
-    thread: ChatThread,
+    surface: MessengerDeliverySurface,
+    snapshotSurface: unknown,
     fiber?: FiberContext,
     snapshotEvent = serializableMessengerEvent(event),
     checkpoint?: (
@@ -464,8 +556,8 @@ export class ThinkMessengerRuntime {
       fiber,
       policy: definition.delivery,
       snapshotEvent,
-      snapshotThread: thread.toJSON(),
-      surface: thread satisfies MessengerDeliverySurface,
+      snapshotThread: snapshotSurface,
+      surface,
       target,
       userMessage: toMessengerUserMessage(event)
     });
@@ -501,13 +593,22 @@ export class ThinkMessengerRuntime {
     )) as unknown as MessengerDeliveryTarget;
   }
 
-  private definitionForThread(
-    thread: ChatThread
+  private definitionForChatObject(
+    chatObject: ChatThreadReference | ChatChannelReference
   ): NormalizedMessengerDefinition | undefined {
+    const serialized = chatObject.toJSON() as { adapterName?: unknown };
+    const adapterName =
+      typeof serialized.adapterName === "string"
+        ? serialized.adapterName
+        : undefined;
     return (
-      this.definitionsByAdapterName.get(thread.toJSON().adapterName) ??
-      this.definitionForThreadId(thread.id) ??
-      this.definitionForThreadId(thread.channelId)
+      (adapterName
+        ? this.definitionsByAdapterName.get(adapterName)
+        : undefined) ??
+      this.definitionForThreadId(chatObject.id) ??
+      this.definitionForThreadId(
+        "channelId" in chatObject ? chatObject.channelId : undefined
+      )
     );
   }
 
@@ -567,9 +668,59 @@ export class ThinkMessengerRuntime {
         "Messenger recovery snapshot is missing chat object data"
       );
     }
+    const chat = this.getOrCreateChat();
+    void this.startBackgroundIngress(chat);
+    return JSON.parse(JSON.stringify(value), chat.reviver()) as T;
+  }
+
+  private getOrCreateChat(): Chat<Record<string, Adapter>> {
     const chat = this.chat ?? this.createChat();
     this.chat = chat;
-    return JSON.parse(JSON.stringify(value), chat.reviver()) as T;
+    return chat;
+  }
+
+  private async startBackgroundIngress(
+    chat: Chat<Record<string, Adapter>>
+  ): Promise<void> {
+    if (this.host.parentPath.length > 0) return;
+    for (const definition of this.definitions) {
+      if (!definition.background) {
+        continue;
+      }
+
+      void this.startBackgroundDefinition(chat, definition);
+    }
+  }
+
+  private startBackgroundDefinition(
+    chat: Chat<Record<string, Adapter>>,
+    definition: NormalizedMessengerDefinition
+  ): Promise<void> {
+    const existing = this.backgroundStartTasks.get(definition.id);
+    if (existing) {
+      return existing;
+    }
+
+    const task = (async () => {
+      try {
+        await chat.initialize();
+        await definition.background?.start({
+          chat,
+          definition,
+          host: this.host,
+          messengerId: definition.id
+        });
+      } catch (error) {
+        this.backgroundStartTasks.delete(definition.id);
+        console.error(
+          `Messenger ${definition.id} background ingress failed`,
+          error
+        );
+      }
+    })();
+
+    this.backgroundStartTasks.set(definition.id, task);
+    return task;
   }
 
   private async toEvent(
@@ -598,23 +749,32 @@ export function normalizeMessengers(
     ids.add(id);
 
     const path = definition.path ?? `/messengers/${id}/webhook`;
-    validatePath(path, id);
-    if (definition.verifyWebhook === undefined) {
+    if (path === false && !definition.background) {
+      throw new Error(
+        `Messenger ${id} with path: false requires background ingress`
+      );
+    }
+    if (path !== false) {
+      validatePath(path, id);
+    }
+    if (path !== false && definition.verifyWebhook === undefined) {
       throw new Error(
         `Messenger ${id} requires verifyWebhook, or verifyWebhook: false to opt out explicitly`
       );
     }
-    const verifyWebhook = definition.verifyWebhook;
+    const verifyWebhook = path === false ? false : definition.verifyWebhook!;
     if (adapterNames.has(definition.adapterName)) {
       throw new Error(
         `Duplicate messenger adapter name: ${definition.adapterName}`
       );
     }
     adapterNames.add(definition.adapterName);
-    if (paths.has(path)) {
+    if (path !== false && paths.has(path)) {
       throw new Error(`Duplicate messenger path: ${path}`);
     }
-    paths.add(path);
+    if (path !== false) {
+      paths.add(path);
+    }
 
     normalized.push({
       ...definition,
@@ -648,6 +808,20 @@ function idempotencyEventPart(event: MessengerEvent): string {
     return event.message.id;
   }
 
+  if (event.command) {
+    return [
+      "command",
+      stableNamePart(
+        event.command.providerCommandId ??
+          providerRawId(event.command.raw) ??
+          event.command.command
+      ),
+      stableNamePart(event.command.command),
+      stableNamePart(event.command.user?.userId ?? "unknown-user"),
+      stableNamePart(event.command.text ?? "no-text")
+    ].join(":");
+  }
+
   if (event.action) {
     return [
       "action",
@@ -658,6 +832,16 @@ function idempotencyEventPart(event: MessengerEvent): string {
     ].join(":");
   }
 
+  if (event.reaction) {
+    return [
+      "reaction",
+      stableNamePart(event.reaction.messageId),
+      stableNamePart(event.reaction.emoji),
+      stableNamePart(event.reaction.user?.userId ?? "unknown-user"),
+      event.reaction.added ? "added" : "removed"
+    ].join(":");
+  }
+
   return event.kind;
 }
 
@@ -665,15 +849,35 @@ export function defaultChatSdkEvent(
   definition: NormalizedMessengerDefinition,
   input: ChatSdkMessengerEventInput
 ): MessengerEvent {
+  const thread = input.thread
+    ? toMessengerThread(input.thread)
+    : input.channel
+      ? toMessengerThreadFromChannel(input.channel)
+      : input.command
+        ? toMessengerThreadFromChannel(input.command.channel)
+        : input.reaction
+          ? toMessengerThread(input.reaction.thread)
+          : undefined;
+  if (!thread) {
+    throw new Error(`Messenger event ${input.eventKind} is missing a surface`);
+  }
+
   return {
     capabilities: definition.capabilities ?? {},
     action: input.action && toMessengerAction(input.action),
+    command: input.command && toMessengerCommand(input.command),
     kind: input.eventKind,
     message: input.message && toMessengerMessage(input.message),
     messengerId: definition.id,
     provider: definition.provider,
-    raw: input.raw ?? input.message?.raw,
-    thread: toMessengerThread(input.thread)
+    raw:
+      input.raw ??
+      input.message?.raw ??
+      input.action?.raw ??
+      input.command?.raw ??
+      input.reaction?.raw,
+    reaction: input.reaction && toMessengerReaction(input.reaction),
+    thread
   };
 }
 
@@ -687,13 +891,51 @@ export function toMessengerAction(action: ChatActionEvent): MessengerAction {
   };
 }
 
-export function toMessengerThread(thread: ChatThread): MessengerThread {
+export function toMessengerCommand(
+  command: ChatSlashCommandEvent
+): MessengerCommand {
+  return {
+    command: command.command,
+    providerCommandId: providerRawId(command.raw),
+    raw: command.raw,
+    text: command.text || undefined,
+    user: toMessengerAuthor(command.user)
+  };
+}
+
+export function toMessengerReaction(
+  reaction: ChatReactionEvent
+): MessengerReaction {
+  return {
+    added: reaction.added,
+    emoji: reaction.emoji.name || reaction.rawEmoji,
+    messageId: reaction.messageId,
+    raw: reaction.raw,
+    user: toMessengerAuthor(reaction.user)
+  };
+}
+
+export function toMessengerThread(
+  thread: ChatThreadReference
+): MessengerThread {
   return {
     channelId: thread.channelId,
     channelName: thread.channel.name ?? undefined,
     id: thread.id,
     isDirectMessage: thread.isDM,
     providerThreadId: thread.id
+  };
+}
+
+export function toMessengerThreadFromChannel(
+  channel: ChatChannelReference
+): MessengerThread {
+  return {
+    channelId: channel.id,
+    channelName: channel.name ?? undefined,
+    id: channel.id,
+    isDirectMessage: channel.isDM,
+    providerThreadId: channel.id
   };
 }
 
@@ -743,6 +985,15 @@ export function toMessengerAttachment(
     size: attachment.size,
     url: attachment.url
   };
+}
+
+function providerRawId(raw: unknown): string | undefined {
+  if (raw === null || typeof raw !== "object") {
+    return undefined;
+  }
+
+  const candidate = raw as { id?: unknown };
+  return typeof candidate.id === "string" ? candidate.id : undefined;
 }
 
 function stableNamePart(value: string): string {

--- a/packages/think/src/messengers/chat-sdk.ts
+++ b/packages/think/src/messengers/chat-sdk.ts
@@ -96,6 +96,11 @@ export interface MessengerBackgroundContext {
 }
 
 export interface MessengerBackgroundIngress {
+  /**
+   * Start provider-owned ingress after Chat SDK state and adapters are ready.
+   * The runtime retries startup failures, but a successful start means the
+   * provider has taken durable ownership of reconnects/retries from there.
+   */
   start(context: MessengerBackgroundContext): Promise<void> | void;
 }
 
@@ -443,6 +448,7 @@ export class ThinkMessengerRuntime {
     });
 
     chat.onReaction(async (event) => {
+      if (!event.thread) return;
       const thread = event.thread as ChatThread;
       const definition = this.definitionForChatObject(thread);
       if (!definition) return;

--- a/packages/think/src/messengers/events.ts
+++ b/packages/think/src/messengers/events.ts
@@ -4,7 +4,9 @@ export type MessengerEventKind =
   | "direct-message"
   | "mention"
   | "subscribed-message"
+  | "command"
   | "action"
+  | "reaction"
   | "delivery-event";
 
 export interface MessengerAuthor {
@@ -55,6 +57,23 @@ export interface MessengerAction {
   value?: string;
 }
 
+export interface MessengerCommand {
+  command: string;
+  providerCommandId?: string;
+  raw?: unknown;
+  text?: string;
+  user?: MessengerAuthor;
+  values?: Record<string, unknown>;
+}
+
+export interface MessengerReaction {
+  added: boolean;
+  emoji: string;
+  messageId: string;
+  raw?: unknown;
+  user?: MessengerAuthor;
+}
+
 export interface MessengerCapabilities {
   canEditMessages?: boolean;
   canStream?: boolean;
@@ -68,10 +87,12 @@ export interface MessengerContext {
   action?: MessengerAction;
   author?: MessengerAuthor;
   capabilities: MessengerCapabilities;
+  command?: MessengerCommand;
   kind: MessengerEventKind;
   message?: MessengerMessage;
   messengerId: string;
   provider: string;
+  reaction?: MessengerReaction;
   thread: MessengerThread;
 }
 
@@ -84,12 +105,18 @@ export function messengerContextFromEvent(
 ): MessengerContext {
   return {
     action: event.action,
-    author: event.message?.author ?? event.action?.user,
+    author:
+      event.message?.author ??
+      event.action?.user ??
+      event.command?.user ??
+      event.reaction?.user,
     capabilities: event.capabilities,
+    command: event.command,
     kind: event.kind,
     message: event.message,
     messengerId: event.messengerId,
     provider: event.provider,
+    reaction: event.reaction,
     thread: event.thread
   };
 }
@@ -111,6 +138,15 @@ export function serializableMessengerEvent(
           value: event.action.value
         }
       : undefined,
+    command: event.command
+      ? {
+          command: event.command.command,
+          providerCommandId: event.command.providerCommandId,
+          text: event.command.text,
+          user: event.command.user ? { ...event.command.user } : undefined,
+          values: event.command.values ? { ...event.command.values } : undefined
+        }
+      : undefined,
     message: event.message
       ? {
           attachments: event.message.attachments.map((attachment) => ({
@@ -127,6 +163,14 @@ export function serializableMessengerEvent(
           isMention: event.message.isMention,
           providerMessageId: event.message.providerMessageId,
           text: event.message.text
+        }
+      : undefined,
+    reaction: event.reaction
+      ? {
+          added: event.reaction.added,
+          emoji: event.reaction.emoji,
+          messageId: event.reaction.messageId,
+          user: event.reaction.user ? { ...event.reaction.user } : undefined
         }
       : undefined
   };
@@ -166,6 +210,63 @@ export function toMessengerUserMessage(event: MessengerEvent): UIMessage {
     } as UIMessage;
   }
 
+  if (event.command) {
+    const user = event.command.user;
+    const displayName = user?.fullName || user?.userName || user?.userId;
+    const details = [
+      `Slash command: ${event.command.command}`,
+      event.command.text ? `Text: ${event.command.text}` : undefined
+    ].filter(Boolean);
+    const text = displayName
+      ? `${displayName}: ${details.join("\n")}`
+      : details.join("\n");
+
+    return {
+      id: [
+        event.messengerId,
+        "command",
+        event.thread.id,
+        commandEventId(event.command)
+      ]
+        .filter(Boolean)
+        .join(":"),
+      role: "user",
+      parts: [{ type: "text", text }],
+      metadata: {
+        messenger: messengerContextFromEvent(event)
+      }
+    } as UIMessage;
+  }
+
+  if (event.reaction) {
+    const user = event.reaction.user;
+    const displayName = user?.fullName || user?.userName || user?.userId;
+    const details = [
+      `Reaction ${event.reaction.added ? "added" : "removed"}: ${event.reaction.emoji}`,
+      `Source message: ${event.reaction.messageId}`
+    ];
+    const text = displayName
+      ? `${displayName}: ${details.join("\n")}`
+      : details.join("\n");
+
+    return {
+      id: [
+        event.messengerId,
+        "reaction",
+        event.thread.id,
+        event.reaction.messageId,
+        event.reaction.emoji,
+        event.reaction.user?.userId ?? "unknown-user",
+        event.reaction.added ? "added" : "removed"
+      ].join(":"),
+      role: "user",
+      parts: [{ type: "text", text }],
+      metadata: {
+        messenger: messengerContextFromEvent(event)
+      }
+    } as UIMessage;
+  }
+
   if (!message) {
     throw new Error(`Messenger event ${event.kind} does not contain a message`);
   }
@@ -190,6 +291,44 @@ export function toMessengerUserMessage(event: MessengerEvent): UIMessage {
       messenger: messengerContextFromEvent(event)
     }
   } as UIMessage;
+}
+
+function commandEventId(command: MessengerCommand): string {
+  return [
+    stableIdPart(command.providerCommandId ?? rawStringId(command.raw)),
+    stableIdPart(command.command),
+    command.user?.userId ?? "unknown-user",
+    stableIdPart(command.text ?? "no-text")
+  ].join(":");
+}
+
+function stableIdPart(value: string | undefined): string {
+  if (!value) {
+    return "unknown";
+  }
+
+  const safe = value.replace(/[^a-zA-Z0-9:_/-]/g, "_");
+  if (safe.length <= 80) {
+    return safe;
+  }
+  return `${safe.slice(0, 48)}_${hashString(value)}`;
+}
+
+function hashString(value: string): string {
+  let hash = 5381;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(index);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function rawStringId(raw: unknown): string | undefined {
+  if (raw === null || typeof raw !== "object") {
+    return undefined;
+  }
+
+  const candidate = raw as { id?: unknown };
+  return typeof candidate.id === "string" ? candidate.id : undefined;
 }
 
 function describeAttachments(attachments: MessengerAttachment[]): string {

--- a/packages/think/src/messengers/index.ts
+++ b/packages/think/src/messengers/index.ts
@@ -9,13 +9,18 @@ export {
   ThinkMessengerStateAgent,
   toMessengerAttachment,
   toMessengerAuthor,
+  toMessengerCommand,
   toMessengerMessage,
+  toMessengerReaction,
+  toMessengerThreadFromChannel,
   toMessengerThread
 } from "./chat-sdk";
 
 export type {
   ChatSdkMessengerEventInput,
   ChatSdkMessengerOptions,
+  MessengerBackgroundContext,
+  MessengerBackgroundIngress,
   MessengerConversationMode,
   MessengerConversationResolver,
   MessengerConversationTarget,
@@ -62,9 +67,11 @@ export type {
   MessengerAttachment,
   MessengerAuthor,
   MessengerCapabilities,
+  MessengerCommand,
   MessengerContext,
   MessengerEvent,
   MessengerEventKind,
   MessengerMessage,
+  MessengerReaction,
   MessengerThread
 } from "./events";

--- a/packages/think/src/tests/messengers.test.ts
+++ b/packages/think/src/tests/messengers.test.ts
@@ -6,7 +6,7 @@ import type {
 } from "agents";
 import { getAgentByName } from "agents";
 import type { Adapter } from "chat";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   chatSdkMessenger,
   defaultChatSdkEvent,
@@ -28,6 +28,7 @@ import {
   textDeltaFromStreamChunk,
   ThinkMessengerRuntime,
   toMessengerUserMessage,
+  type MessengerBackgroundContext,
   type MessengerEvent,
   type MessengerThinkHost
 } from "../messengers";
@@ -161,6 +162,168 @@ describe("think messengers core", () => {
     ).toThrow("requires verifyWebhook");
   });
 
+  it("rejects path false without background ingress", () => {
+    expect(() =>
+      normalizeMessengers({
+        dead: chatSdkMessenger({
+          adapter: fakeAdapter(),
+          path: false,
+          provider: "fake",
+          userName: "fake_bot"
+        })
+      })
+    ).toThrow("requires background ingress");
+  });
+
+  it("allows background-only messengers without webhook verification", async () => {
+    const starts: Array<{
+      messengerId: string;
+      path: string | false;
+    }> = [];
+    const started = deferred<void>();
+    const messengers = defineMessengers({
+      gateway: chatSdkMessenger({
+        adapter: fakeAdapter(),
+        background: {
+          start(context: MessengerBackgroundContext) {
+            starts.push({
+              messengerId: context.messengerId,
+              path: context.definition.path
+            });
+            started.resolve();
+          }
+        },
+        path: false,
+        provider: "fake",
+        userName: "fake_bot"
+      })
+    });
+    const [definition] = normalizeMessengers(messengers);
+
+    expect(definition?.path).toBe(false);
+    expect(definition?.verifyWebhook).toBe(false);
+
+    const runtime = new ThinkMessengerRuntime(messengers, fakeHost([]));
+    runtime.initialize();
+    await started.promise;
+
+    expect(starts).toEqual([{ messengerId: "gateway", path: false }]);
+    await expect(
+      runtime.handleRequest(
+        new Request("https://example.com/messengers/gateway/webhook", {
+          method: "POST"
+        })
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("starts background ingress once when the shared Chat runtime is created", async () => {
+    const starts: string[] = [];
+    const started = deferred<void>();
+    const adapter = fakeAdapter({
+      initialize() {
+        starts.push("adapter-initialize");
+        return Promise.resolve();
+      }
+    });
+    const runtime = new ThinkMessengerRuntime(
+      defineMessengers({
+        fake: chatSdkMessenger({
+          adapter,
+          background: {
+            start(context: MessengerBackgroundContext) {
+              starts.push(context.messengerId);
+              started.resolve();
+            }
+          },
+          provider: "fake",
+          userName: "fake_bot",
+          verifyWebhook: false
+        })
+      }),
+      fakeHost([])
+    );
+
+    await runtime.handleRequest(
+      new Request("https://example.com/messengers/fake/webhook", {
+        method: "POST"
+      })
+    );
+    await started.promise;
+    await runtime.handleRequest(
+      new Request("https://example.com/messengers/fake/webhook", {
+        method: "POST"
+      })
+    );
+
+    expect(starts).toEqual(["adapter-initialize", "fake"]);
+  });
+
+  it("retries background ingress after a failed start", async () => {
+    const starts: string[] = [];
+    const firstStart = deferred<void>();
+    const secondStart = deferred<void>();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const runtime = new ThinkMessengerRuntime(
+        defineMessengers({
+          fake: chatSdkMessenger({
+            adapter: fakeAdapter(),
+            background: {
+              start() {
+                starts.push("start");
+                if (starts.length === 1) {
+                  firstStart.resolve();
+                  throw new Error("temporary failure");
+                }
+                secondStart.resolve();
+              }
+            },
+            provider: "fake",
+            userName: "fake_bot",
+            verifyWebhook: false
+          })
+        }),
+        fakeHost([])
+      );
+
+      runtime.initialize();
+      await firstStart.promise;
+      await waitFor(() => error.mock.calls.length === 1);
+      runtime.initialize();
+      await secondStart.promise;
+
+      expect(starts).toEqual(["start", "start"]);
+      expect(error).toHaveBeenCalledOnce();
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  it("does not start background ingress on sub-agent hosts", () => {
+    const starts: string[] = [];
+    const runtime = new ThinkMessengerRuntime(
+      defineMessengers({
+        fake: chatSdkMessenger({
+          adapter: fakeAdapter(),
+          background: {
+            start(context: MessengerBackgroundContext) {
+              starts.push(context.messengerId);
+            }
+          },
+          provider: "fake",
+          userName: "fake_bot",
+          verifyWebhook: false
+        })
+      }),
+      fakeHost([], [{ className: "Parent", name: "parent" }])
+    );
+
+    runtime.initialize();
+
+    expect(starts).toEqual([]);
+  });
+
   it("honors custom webhook verifier responses before Chat SDK handling", async () => {
     const runtime = new ThinkMessengerRuntime(
       defineMessengers({
@@ -273,6 +436,37 @@ describe("think messengers core", () => {
         }
       })
     ).not.toBe(idempotencyKeyForEvent(actionEvent));
+
+    const commandEvent: MessengerEvent = {
+      ...baseEvent,
+      kind: "command",
+      message: undefined,
+      command: {
+        command: "/ask",
+        providerCommandId: "interaction-1",
+        raw: { id: "interaction-1" },
+        text: "status",
+        user: { userId: "user-1" }
+      }
+    };
+    expect(idempotencyKeyForEvent(commandEvent)).toBe(
+      "messenger:telegram:message:telegram:-100123:42:command:interaction-1:_ask:user-1:status"
+    );
+
+    const reactionEvent: MessengerEvent = {
+      ...baseEvent,
+      kind: "reaction",
+      message: undefined,
+      reaction: {
+        added: true,
+        emoji: "thumbs_up",
+        messageId: "source-message",
+        user: { userId: "user-1" }
+      }
+    };
+    expect(idempotencyKeyForEvent(reactionEvent)).toBe(
+      "messenger:telegram:message:telegram:-100123:42:reaction:source-message:thumbs_up:user-1:added"
+    );
   });
 
   it("converts messenger events to Think user messages with attachments", () => {
@@ -336,6 +530,166 @@ describe("think messengers core", () => {
         text: [
           "Ada Lovelace: Action selected: approve",
           "Value: ship-it",
+          "Source message: source-message"
+        ].join("\n")
+      }
+    ]);
+  });
+
+  it("converts messenger commands to Think user messages", () => {
+    const event = defaultChatSdkEvent(
+      normalizeMessengers({
+        fake: chatSdkMessenger({
+          adapter: fakeAdapter(),
+          provider: "fake",
+          userName: "fake_bot",
+          verifyWebhook: false
+        })
+      })[0]!,
+      {
+        channel: fakeChannel("fake:channel"),
+        command: {
+          adapter: fakeAdapter(),
+          channel: fakeChannel("fake:channel"),
+          command: "/ask",
+          raw: { id: "interaction-1" },
+          text: "status please",
+          user: {
+            fullName: "Ada Lovelace",
+            isBot: false,
+            isMe: false,
+            userId: "fake:user",
+            userName: "ada"
+          }
+        } as never,
+        eventKind: "command"
+      }
+    );
+
+    expect(event.thread).toMatchObject({
+      id: "fake:channel",
+      providerThreadId: "fake:channel"
+    });
+    expect(event.command).toMatchObject({
+      command: "/ask",
+      text: "status please"
+    });
+    expect(toMessengerUserMessage(event).parts).toEqual([
+      {
+        type: "text",
+        text: ["Ada Lovelace: Slash command: /ask", "Text: status please"].join(
+          "\n"
+        )
+      }
+    ]);
+    expect(toMessengerUserMessage(event).id).toBe(
+      "fake:command:fake:channel:interaction-1:/ask:fake:user:status_please"
+    );
+  });
+
+  it("keeps command user message IDs stable after recovery serialization", () => {
+    const event = defaultChatSdkEvent(
+      normalizeMessengers({
+        fake: chatSdkMessenger({
+          adapter: fakeAdapter(),
+          provider: "fake",
+          userName: "fake_bot",
+          verifyWebhook: false
+        })
+      })[0]!,
+      {
+        channel: fakeChannel("fake:channel"),
+        command: {
+          adapter: fakeAdapter(),
+          channel: fakeChannel("fake:channel"),
+          command: "/ask",
+          raw: { id: "interaction-1" },
+          text: "status please",
+          user: {
+            fullName: "Ada Lovelace",
+            isBot: false,
+            isMe: false,
+            userId: "fake:user",
+            userName: "ada"
+          }
+        } as never,
+        eventKind: "command"
+      }
+    );
+    const restored = serializableMessengerEvent(event);
+
+    expect(restored.command?.raw).toBeUndefined();
+    expect(restored.command?.providerCommandId).toBe("interaction-1");
+    expect(toMessengerUserMessage(restored).id).toBe(
+      toMessengerUserMessage(event).id
+    );
+  });
+
+  it("bounds command user message IDs when provider ids are unavailable", () => {
+    const event: MessengerEvent = {
+      ...baseEvent,
+      kind: "command",
+      message: undefined,
+      command: {
+        command: "/ask",
+        text: "x".repeat(500),
+        user: { userId: "fake:user" }
+      },
+      messengerId: "fake",
+      provider: "fake",
+      thread: {
+        id: "fake:channel",
+        isDirectMessage: false,
+        providerThreadId: "fake:channel"
+      }
+    };
+
+    expect(toMessengerUserMessage(event).id.length).toBeLessThan(180);
+  });
+
+  it("converts messenger reactions to Think user messages", () => {
+    const event = defaultChatSdkEvent(
+      normalizeMessengers({
+        fake: chatSdkMessenger({
+          adapter: fakeAdapter(),
+          provider: "fake",
+          userName: "fake_bot",
+          verifyWebhook: false
+        })
+      })[0]!,
+      {
+        eventKind: "reaction",
+        reaction: {
+          adapter: fakeAdapter(),
+          added: true,
+          emoji: { name: "thumbs_up" },
+          messageId: "source-message",
+          raw: { event: true },
+          rawEmoji: "👍",
+          thread: fakeThread("fake:thread"),
+          threadId: "fake:thread",
+          user: {
+            fullName: "Ada Lovelace",
+            isBot: false,
+            isMe: false,
+            userId: "fake:user",
+            userName: "ada"
+          }
+        } as never,
+        thread: fakeThread("fake:thread")
+      }
+    );
+
+    expect(event.reaction).toMatchObject({
+      added: true,
+      emoji: "thumbs_up",
+      messageId: "source-message"
+    });
+    expect(toMessengerUserMessage(event).parts).toEqual([
+      {
+        type: "text",
+        text: [
+          "Ada Lovelace: Reaction added: thumbs_up",
           "Source message: source-message"
         ].join("\n")
       }
@@ -822,7 +1176,32 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<string> {
   );
 }
 
-function fakeHost(resolved: FiberRecoveryResult[]): MessengerThinkHost {
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+function fakeHost(
+  resolved: FiberRecoveryResult[],
+  parentPath: ReadonlyArray<{ className: string; name: string }> = []
+): MessengerThinkHost {
   return {
     cancelChat() {
       return Promise.resolve(true);
@@ -832,7 +1211,7 @@ function fakeHost(resolved: FiberRecoveryResult[]): MessengerThinkHost {
     },
     constructor: { name: "FakeHost" },
     name: "fake-host",
-    parentPath: [],
+    parentPath,
     resolveFiber(_id, result) {
       resolved.push(result);
       return Promise.resolve(true);
@@ -904,5 +1283,13 @@ function fakeThread(id: string) {
     channelId: id,
     id,
     isDM: false
+  } as never;
+}
+
+function fakeChannel(id: string) {
+  return {
+    id,
+    isDM: false,
+    name: "Fake"
   } as never;
 }


### PR DESCRIPTION
## Summary

Adds provider-neutral Think messenger primitives for messengers that are not just thread-message webhooks.

This introduces background ingress, command events, reaction events, and channel-backed delivery surfaces so providers like Discord, Slack, Google Chat, and others can route mixed webhook/background/command/reaction surfaces through the same durable Think reply pipeline.

Also adds a Discord messenger RFC that captures the full planned Discord provider architecture.

## What changed

- Add `MessengerBackgroundIngress` and `MessengerBackgroundContext`.
- Allow messenger providers to disable HTTP route registration when they provide background ingress.
- Add `command` and `reaction` messenger event kinds.
- Add `MessengerCommand` and `MessengerReaction` context types.
- Wire Chat SDK `onSlashCommand()` and `onReaction()` into Think messenger routing.
- Generalize messenger delivery from `Thread` to Chat SDK postable surfaces so command replies can target channels.
- Preserve provider command IDs across recovery snapshots.
- Add validation to reject no-ingress messenger definitions.
- Add tests for background ingress, command/reaction conversion, idempotency, recovery-stable command IDs, and route behavior.
- Add a changeset for `@cloudflare/think`.

## Why

Discord needs this for Gateway and Interactions, but the primitives are broader than Discord. Slack slash commands/interactivity, Google Chat events, and other messenger providers can use the same shape without adding provider-specific special cases to Think core.

## Notes / Risk

- Existing Telegram messenger behavior is unchanged.
- Background ingress startup is root-agent only and retryable after startup failures.
- The Discord RFC is design-only; this PR does not add the Discord provider yet.

## Test plan

- `pnpm --filter @cloudflare/think run build`
- `pnpm --filter @cloudflare/think exec vitest --run -c src/tests/vitest.config.ts src/tests/messengers.test.ts --reporter=dot`
- `pnpm --filter @cloudflare/think exec vitest --run -c src/tests/vitest.config.ts --reporter=dot`
- `pnpm run check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->