### PR TITLE
feat(think): dynamic ThinkWorkflow support via Dynamic Workers

### DIFF
--- a/.changeset/dynamic-think-workflows.md
+++ b/.changeset/dynamic-think-workflows.md
@@ -7,7 +7,7 @@ Add dynamic workflow support via `@cloudflare/think/dynamic-workflows`.
 New API:
 
 - `Think.runDynamicWorkflow(workflowName, code, params?, options?)` — stores generated TypeScript and starts a Dynamic Workflow instance
-- `Think.getWorkflowCode(wfId)` — RPC method used by the loader to retrieve stored code
+- `Think._getWorkflowCode(wfId)` — internal RPC method used by the loader to retrieve stored code
 - `DynamicThinkWorkflow` — export from `@cloudflare/think/dynamic-workflows`, register as `class_name` in your `[[workflows]]` wrangler binding
 
 Generated code extending `ThinkWorkflow` is bundled at runtime with `@cloudflare/worker-bundler` and executed as a Dynamic Worker with full durable execution (`step.prompt()`, `step.do()`, `step.sleep()`, `step.waitForEvent()`).

--- a/.changeset/dynamic-think-workflows.md
+++ b/.changeset/dynamic-think-workflows.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/think": minor
+---
+
+Add dynamic workflow support via `@cloudflare/think/dynamic-workflows`.
+
+New API:
+
+- `Think.runDynamicWorkflow(workflowName, code, params?, options?)` — stores generated TypeScript and starts a Dynamic Workflow instance
+- `Think.getWorkflowCode(wfId)` — RPC method used by the loader to retrieve stored code
+- `DynamicThinkWorkflow` — export from `@cloudflare/think/dynamic-workflows`, register as `class_name` in your `[[workflows]]` wrangler binding
+
+Generated code extending `ThinkWorkflow` is bundled at runtime with `@cloudflare/worker-bundler` and executed as a Dynamic Worker with full durable execution (`step.prompt()`, `step.do()`, `step.sleep()`, `step.waitForEvent()`).
+
+New dependencies: `@cloudflare/dynamic-workflows` (runtime), `@cloudflare/worker-bundler` (optional peer dep).

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -236,9 +236,20 @@ Then call `runDynamicWorkflow()` from your Think agent:
 ```typescript
 const workflowId = await this.runDynamicWorkflow(
   "DYNAMIC_THINK_WF", // the workflow binding name
-  generatedCode, // TypeScript source that default-exports a ThinkWorkflow
+  generatedCode, // TypeScript source (see the class-name requirement below)
   { topic: "release notes" } // params forwarded to the workflow's run()
 );
+```
+
+The generated code must declare a class named `GeneratedWorkflow` that extends
+`ThinkWorkflow` — this is the entrypoint the loader dispatches to:
+
+```typescript
+export default class GeneratedWorkflow extends ThinkWorkflow {
+  async run(event, step) {
+    /* ... */
+  }
+}
 ```
 
 The generated code runs as a real `ThinkWorkflow`, so `step.prompt()`,
@@ -247,10 +258,17 @@ The generated code runs as a real `ThinkWorkflow`, so `step.prompt()`,
 Notes:
 
 - Generated code is validated by `validateWorkflowCode()` before it is stored.
-  The default implementation enforces a non-empty body and a size limit
-  (`Think.MAX_DYNAMIC_WORKFLOW_CODE_BYTES`). Override it in a subclass to add
-  stricter checks. You remain responsible for trusting the source of any
-  LLM-generated code you pass in.
+  The default implementation enforces a non-empty body, a size limit
+  (`Think.MAX_DYNAMIC_WORKFLOW_CODE_BYTES`), and that the code declares a
+  `GeneratedWorkflow` class. Override it in a subclass to add stricter checks.
+  You remain responsible for trusting the source of any LLM-generated code you
+  pass in.
+- Passing an explicit `options.id` that is already tracked throws — the code is
+  not stored, so duplicate IDs do not orphan rows.
+- `_getWorkflowCode()` is reachable via Durable Object service-binding RPC (it
+  is excluded from the WebSocket callable surface, but the leading underscore
+  is a naming convention, not an access-control boundary). Treat stored code as
+  sensitive.
 - Stored code is retained for the lifetime of the agent's Durable Object so
   long-running workflows can be resumed. It is not evicted automatically.
 - See the `examples/dynamic-think-workflows` example for a complete setup.

--- a/docs/think/workflows.md
+++ b/docs/think/workflows.md
@@ -215,3 +215,42 @@ private outbox because it needs to store an event until delivery succeeds.
 
 Use Workflows when the process has multiple deterministic steps, long waits, or
 human approval.
+
+## Dynamic Workflows
+
+When the workflow body itself is generated at runtime (for example, by an LLM),
+use `runDynamicWorkflow()` instead of registering a static `ThinkWorkflow`
+subclass. It stores the generated TypeScript source, then starts a Workflow
+instance whose code is bundled and executed as a Dynamic Worker on first run.
+
+Register the `DynamicThinkWorkflow` entrypoint as the `class_name` of a
+`workflows` binding in `wrangler.jsonc`:
+
+```typescript
+// server.ts
+export { DynamicThinkWorkflow } from "@cloudflare/think/dynamic-workflows";
+```
+
+Then call `runDynamicWorkflow()` from your Think agent:
+
+```typescript
+const workflowId = await this.runDynamicWorkflow(
+  "DYNAMIC_THINK_WF", // the workflow binding name
+  generatedCode, // TypeScript source that default-exports a ThinkWorkflow
+  { topic: "release notes" } // params forwarded to the workflow's run()
+);
+```
+
+The generated code runs as a real `ThinkWorkflow`, so `step.prompt()`,
+`step.do()`, `step.sleep()`, and `step.waitForEvent()` all work natively.
+
+Notes:
+
+- Generated code is validated by `validateWorkflowCode()` before it is stored.
+  The default implementation enforces a non-empty body and a size limit
+  (`Think.MAX_DYNAMIC_WORKFLOW_CODE_BYTES`). Override it in a subclass to add
+  stricter checks. You remain responsible for trusting the source of any
+  LLM-generated code you pass in.
+- Stored code is retained for the lifetime of the agent's Durable Object so
+  long-running workflows can be resumed. It is not evicted automatically.
+- See the `examples/dynamic-think-workflows` example for a complete setup.

--- a/examples/dynamic-think-workflows/README.md
+++ b/examples/dynamic-think-workflows/README.md
@@ -1,0 +1,31 @@
+# Dynamic Think Workflows
+
+Run generated `ThinkWorkflow` code at runtime as Dynamic Workers with full durable execution (`step.prompt()`, `step.do()`, `step.sleep()`, `step.waitForEvent()`).
+
+## How it works
+
+1. `MyAgent.runDynamicWorkflow()` stores generated TypeScript source in SQLite and starts a Workflow instance
+2. The `DynamicThinkWorkflow` entrypoint (registered in `wrangler.jsonc`) loads the code from the agent, bundles it with its npm dependencies via `@cloudflare/worker-bundler`, and loads it as a Dynamic Worker
+3. The Workflows engine dispatches `run(event, step)` to the Dynamic Worker — `step.prompt()` works natively
+
+## Run it
+
+```bash
+pnpm install
+pnpm run dev
+```
+
+Then start a dynamic workflow:
+
+```bash
+curl -X POST http://localhost:8787/run \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "The future of serverless computing"}'
+```
+
+## Key concepts
+
+- **Generated code** is plain TypeScript extending `ThinkWorkflow` — not a DSL or interpreter
+- **`@cloudflare/dynamic-workflows`** handles routing between the Worker Loader and the Workflows engine
+- **`@cloudflare/worker-bundler`** resolves npm dependencies (`@cloudflare/think`, `zod`) at runtime
+- The generated workflow has full access to `step.prompt()`, `this.agent`, and all ThinkWorkflow features

--- a/examples/dynamic-think-workflows/package.json
+++ b/examples/dynamic-think-workflows/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@cloudflare/agents-dynamic-think-workflows-example",
+  "description": "Dynamic ThinkWorkflow example — run generated workflow code at runtime",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "types": "wrangler types env.d.ts --include-runtime false"
+  },
+  "dependencies": {
+    "@cloudflare/think": "*",
+    "agents": "*",
+    "ai": "^6.0.202",
+    "workers-ai-provider": "^3.2.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260612.1",
+    "typescript": "^6.0.3",
+    "wrangler": "^4.100.0"
+  }
+}

--- a/examples/dynamic-think-workflows/src/index.ts
+++ b/examples/dynamic-think-workflows/src/index.ts
@@ -1,0 +1,115 @@
+import { getAgentByName, routeAgentRequest } from "agents";
+import { createWorkersAI } from "workers-ai-provider";
+import { Think } from "@cloudflare/think";
+import { DynamicThinkWorkflow } from "@cloudflare/think/dynamic-workflows";
+
+export { DynamicThinkWorkflow };
+
+type Env = {
+  AI: Ai;
+  LOADER: WorkerLoader;
+  MyAgent: DurableObjectNamespace<MyAgent>;
+  DYNAMIC_THINK_WF: Workflow;
+};
+
+/**
+ * A simple Think agent that can launch dynamic workflows.
+ */
+export class MyAgent extends Think<Env> {
+  getModel() {
+    return createWorkersAI({ binding: this.env.AI })(
+      "@cf/moonshotai/kimi-k2.7-code"
+    );
+  }
+
+  getSystemPrompt() {
+    return "You are a helpful assistant.";
+  }
+
+  /**
+   * Generate and run a dynamic ThinkWorkflow.
+   * In a real app, this code could be LLM-generated, loaded from a DB,
+   * or authored by users at runtime.
+   */
+  async startDynamicWorkflow(topic: string): Promise<{ workflowId: string }> {
+    const code = generateWorkflowCode();
+    const workflowId = await this.runDynamicWorkflow("DYNAMIC_THINK_WF", code, {
+      topic
+    });
+    return { workflowId };
+  }
+}
+
+/**
+ * Generate a ThinkWorkflow class as a TypeScript string.
+ *
+ * The generated code extends ThinkWorkflow and uses step.prompt() for
+ * durable LLM calls. It's bundled at runtime by worker-bundler and
+ * executed as a Dynamic Worker.
+ */
+function generateWorkflowCode(): string {
+  return `
+import { ThinkWorkflow } from "@cloudflare/think/workflows";
+import type { ThinkWorkflowStep } from "@cloudflare/think/workflows";
+import type { AgentWorkflowEvent } from "agents/workflows";
+import { z } from "zod";
+
+type Params = { topic: string };
+
+const summarySchema = z.object({
+  title: z.string(),
+  summary: z.string(),
+  keyPoints: z.array(z.string())
+});
+
+export default class GeneratedWorkflow extends ThinkWorkflow {
+  async run(
+    event: AgentWorkflowEvent<Params>,
+    step: ThinkWorkflowStep
+  ): Promise<void> {
+    const result = await step.prompt("analyze", {
+      prompt: "Write a brief analysis about: " + event.payload.topic,
+      output: summarySchema,
+      timeout: "3 minutes"
+    });
+
+    await step.do("save-result", async () => {
+      console.log("Analysis complete:", JSON.stringify(result, null, 2));
+    });
+  }
+}
+`.trim();
+}
+
+async function getDefaultAgent(env: Env) {
+  return getAgentByName(env.MyAgent, "default");
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const agentResponse = await routeAgentRequest(request, env);
+    if (agentResponse) return agentResponse;
+
+    const url = new URL(request.url);
+
+    if (request.method === "POST" && url.pathname === "/run") {
+      const body = (await request.json()) as { topic?: unknown };
+      if (typeof body.topic !== "string" || body.topic.trim() === "") {
+        return Response.json(
+          { error: "Expected JSON body with 'topic' field" },
+          { status: 400 }
+        );
+      }
+      const agent = await getDefaultAgent(env);
+      const result = await agent.startDynamicWorkflow(body.topic);
+      return Response.json(result);
+    }
+
+    return Response.json(
+      {
+        routes: ["POST /run { topic: string } — start a dynamic ThinkWorkflow"]
+      },
+      { status: 404 }
+    );
+  }
+} satisfies ExportedHandler<Env>;

--- a/examples/dynamic-think-workflows/tsconfig.json
+++ b/examples/dynamic-think-workflows/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "agents/tsconfig"
+}

--- a/examples/dynamic-think-workflows/wrangler.jsonc
+++ b/examples/dynamic-think-workflows/wrangler.jsonc
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "dynamic-think-workflows-example",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-11",
+  "compatibility_flags": ["nodejs_compat"],
+  "ai": { "binding": "AI", "remote": true },
+  "worker_loaders": [{ "binding": "LOADER" }],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "MyAgent",
+        "class_name": "MyAgent"
+      }
+    ]
+  },
+  "workflows": [
+    {
+      "name": "dynamic-think",
+      "binding": "DYNAMIC_THINK_WF",
+      "class_name": "DynamicThinkWorkflow"
+    }
+  ],
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["MyAgent"]
+    }
+  ],
+  "observability": {
+    "enabled": true
+  }
+}

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@cloudflare/codemode": ">=0.4.0",
+    "@cloudflare/dynamic-workflows": ">=0.1.1",
     "@cloudflare/shell": ">=0.4.0",
     "aywson": "^0.0.16",
     "chat": "^4.30.0",
@@ -33,6 +34,25 @@
     "smol-toml": "^1.6.1",
     "yargs": "^18.0.0"
   },
+  "peerDependencies": {
+    "@chat-adapter/telegram": "^4.29.0",
+    "@cloudflare/worker-bundler": ">=0.2.1",
+    "agents": ">=0.16.0 <1.0.0",
+    "ai": "^6.0.182",
+    "vite": ">=6 <9",
+    "zod": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@chat-adapter/telegram": {
+      "optional": true
+    },
+    "@cloudflare/worker-bundler": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.83",
     "@ai-sdk/openai": "^3.0.70",
@@ -40,6 +60,7 @@
     "@chat-adapter/telegram": "^4.30.0",
     "@cloudflare/ai-chat": "workspace:*",
     "@cloudflare/kumo": "^2.5.2",
+    "@cloudflare/worker-bundler": "workspace:*",
     "@phosphor-icons/react": "^2.1.10",
     "@streamdown/code": "^1.1.1",
     "@tailwindcss/vite": "^4",
@@ -58,21 +79,6 @@
     "vite": "^8.0.16",
     "zod": "^4.4.3"
   },
-  "peerDependencies": {
-    "@chat-adapter/telegram": "^4.29.0",
-    "agents": ">=0.16.0 <1.0.0",
-    "ai": "^6.0.182",
-    "vite": ">=6 <9",
-    "zod": "^4.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@chat-adapter/telegram": {
-      "optional": true
-    },
-    "vite": {
-      "optional": true
-    }
-  },
   "exports": {
     ".": {
       "types": "./dist/think.d.ts",
@@ -85,6 +91,10 @@
     "./workflows": {
       "types": "./dist/workflows.d.ts",
       "import": "./dist/workflows.js"
+    },
+    "./dynamic-workflows": {
+      "types": "./dist/dynamic-workflows/index.d.ts",
+      "import": "./dist/dynamic-workflows/index.js"
     },
     "./framework": {
       "types": "./dist/framework/index.d.ts",

--- a/packages/think/scripts/build.ts
+++ b/packages/think/scripts/build.ts
@@ -17,6 +17,7 @@ async function main() {
     entry: [
       "src/think.ts",
       "src/workflows.ts",
+      "src/dynamic-workflows/index.ts",
       "src/extensions/index.ts",
       "src/framework/index.ts",
       "src/server-entry.ts",

--- a/packages/think/src/dynamic-workflows/index.ts
+++ b/packages/think/src/dynamic-workflows/index.ts
@@ -1,0 +1,1 @@
+export { DynamicThinkWorkflow } from "./loader";

--- a/packages/think/src/dynamic-workflows/loader.ts
+++ b/packages/think/src/dynamic-workflows/loader.ts
@@ -1,0 +1,81 @@
+import {
+  createDynamicWorkflowEntrypoint,
+  type WorkflowRunner
+} from "@cloudflare/dynamic-workflows";
+
+type DynamicThinkWorkflowMeta = {
+  wfId: string;
+  agentBinding: string;
+  agentName: string;
+};
+
+type DynamicThinkWorkflowEnv = {
+  LOADER: WorkerLoader;
+  [key: string]: unknown;
+};
+
+type AgentStub = {
+  getWorkflowCode(wfId: string): Promise<string>;
+};
+
+/**
+ * DynamicThinkWorkflow — register this as the `class_name` in your
+ * `[[workflows]]` wrangler binding. When the engine calls `run()`, it
+ * loads the generated ThinkWorkflow code from the agent via RPC, bundles
+ * it with its npm dependencies (ThinkWorkflow, zod, etc.) via worker-bundler,
+ * loads it as a Dynamic Worker, and dispatches execution to it.
+ *
+ * The generated code runs as a real ThinkWorkflow — `step.prompt()`,
+ * `this.agent`, `step.do()`, `step.waitForEvent()` all work natively.
+ *
+ * @example
+ * ```ts
+ * // wrangler.jsonc
+ * {
+ *   "workflows": [{
+ *     "name": "dynamic-think",
+ *     "binding": "DYNAMIC_THINK_WF",
+ *     "class_name": "DynamicThinkWorkflow"
+ *   }]
+ * }
+ *
+ * // server.ts
+ * export { DynamicThinkWorkflow } from "@cloudflare/think/dynamic-workflows";
+ * ```
+ */
+export const DynamicThinkWorkflow =
+  createDynamicWorkflowEntrypoint<DynamicThinkWorkflowEnv>(
+    async ({ env, metadata }) => {
+      const { createWorker } = await import("@cloudflare/worker-bundler");
+      const meta = metadata as unknown as DynamicThinkWorkflowMeta;
+
+      const agentNS = env[meta.agentBinding] as DurableObjectNamespace;
+      const agentStub = agentNS.get(
+        agentNS.idFromName(meta.agentName)
+      ) as unknown as AgentStub;
+      const code = await agentStub.getWorkflowCode(meta.wfId);
+
+      const { mainModule, modules } = await createWorker({
+        files: {
+          "workflow.ts": code,
+          "package.json": JSON.stringify({
+            dependencies: {
+              "@cloudflare/think": "*",
+              zod: "*"
+            }
+          })
+        }
+      });
+
+      const worker = env.LOADER.get(`dwt-${meta.wfId}`, async () => ({
+        mainModule,
+        modules,
+        compatibilityDate: "2026-01-01",
+        env: { [meta.agentBinding]: env[meta.agentBinding] }
+      }));
+
+      return worker.getEntrypoint(
+        "GeneratedWorkflow"
+      ) as unknown as WorkflowRunner;
+    }
+  );

--- a/packages/think/src/dynamic-workflows/loader.ts
+++ b/packages/think/src/dynamic-workflows/loader.ts
@@ -15,8 +15,33 @@ type DynamicThinkWorkflowEnv = {
 };
 
 type AgentStub = {
-  getWorkflowCode(wfId: string): Promise<string>;
+  _getWorkflowCode(wfId: string): Promise<string>;
 };
+
+/**
+ * Compatibility date applied to generated Dynamic Workers. Pinned because the
+ * loader has no access to the host worker's own compatibility date at runtime.
+ * Known limitation: generated workflows run against this fixed runtime surface
+ * — bump it deliberately when generated code needs newer runtime behaviour.
+ */
+const DYNAMIC_WORKFLOW_COMPATIBILITY_DATE = "2026-01-01";
+
+function assertDynamicThinkWorkflowMeta(
+  metadata: unknown
+): asserts metadata is DynamicThinkWorkflowMeta {
+  const meta = metadata as Partial<DynamicThinkWorkflowMeta> | null | undefined;
+  if (
+    !meta ||
+    typeof meta.wfId !== "string" ||
+    typeof meta.agentBinding !== "string" ||
+    typeof meta.agentName !== "string"
+  ) {
+    throw new Error(
+      "DynamicThinkWorkflow metadata is missing required fields " +
+        "(wfId, agentBinding, agentName)"
+    );
+  }
+}
 
 /**
  * DynamicThinkWorkflow — register this as the `class_name` in your
@@ -46,33 +71,40 @@ type AgentStub = {
 export const DynamicThinkWorkflow =
   createDynamicWorkflowEntrypoint<DynamicThinkWorkflowEnv>(
     async ({ env, metadata }) => {
-      const { createWorker } = await import("@cloudflare/worker-bundler");
-      const meta = metadata as unknown as DynamicThinkWorkflowMeta;
+      assertDynamicThinkWorkflowMeta(metadata);
+      const meta = metadata;
 
-      const agentNS = env[meta.agentBinding] as DurableObjectNamespace;
-      const agentStub = agentNS.get(
-        agentNS.idFromName(meta.agentName)
-      ) as unknown as AgentStub;
-      const code = await agentStub.getWorkflowCode(meta.wfId);
+      // Bundling + RPC fetch only run on a cache miss. `LOADER.get` returns the
+      // already-built worker on subsequent step dispatches, retries, and
+      // resumptions, so we avoid recompiling the TypeScript on every step.
+      const worker = env.LOADER.get(`dwt-${meta.wfId}`, async () => {
+        const { createWorker } = await import("@cloudflare/worker-bundler");
 
-      const { mainModule, modules } = await createWorker({
-        files: {
-          "workflow.ts": code,
-          "package.json": JSON.stringify({
-            dependencies: {
-              "@cloudflare/think": "*",
-              zod: "*"
-            }
-          })
-        }
+        const agentNS = env[meta.agentBinding] as DurableObjectNamespace;
+        const agentStub = agentNS.get(
+          agentNS.idFromName(meta.agentName)
+        ) as unknown as AgentStub;
+        const code = await agentStub._getWorkflowCode(meta.wfId);
+
+        const { mainModule, modules } = await createWorker({
+          files: {
+            "workflow.ts": code,
+            "package.json": JSON.stringify({
+              dependencies: {
+                "@cloudflare/think": "*",
+                zod: "*"
+              }
+            })
+          }
+        });
+
+        return {
+          mainModule,
+          modules,
+          compatibilityDate: DYNAMIC_WORKFLOW_COMPATIBILITY_DATE,
+          env: { [meta.agentBinding]: env[meta.agentBinding] }
+        };
       });
-
-      const worker = env.LOADER.get(`dwt-${meta.wfId}`, async () => ({
-        mainModule,
-        modules,
-        compatibilityDate: "2026-01-01",
-        env: { [meta.agentBinding]: env[meta.agentBinding] }
-      }));
 
       return worker.getEntrypoint(
         "GeneratedWorkflow"

--- a/packages/think/src/dynamic-workflows/loader.ts
+++ b/packages/think/src/dynamic-workflows/loader.ts
@@ -26,6 +26,12 @@ type AgentStub = {
  */
 const DYNAMIC_WORKFLOW_COMPATIBILITY_DATE = "2026-01-01";
 
+/**
+ * Class name the generated code must export — `Think.runDynamicWorkflow`
+ * validates the code declares a class with this name before it is stored.
+ */
+const GENERATED_WORKFLOW_ENTRYPOINT = "GeneratedWorkflow";
+
 function assertDynamicThinkWorkflowMeta(
   metadata: unknown
 ): asserts metadata is DynamicThinkWorkflowMeta {
@@ -107,7 +113,7 @@ export const DynamicThinkWorkflow =
       });
 
       return worker.getEntrypoint(
-        "GeneratedWorkflow"
+        GENERATED_WORKFLOW_ENTRYPOINT
       ) as unknown as WorkflowRunner;
     }
   );

--- a/packages/think/src/tests/dynamic-workflows.test.ts
+++ b/packages/think/src/tests/dynamic-workflows.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { Think } from "../think";
+
+type StoredRow = { code: string; created_at: number };
+
+function createFakeSql() {
+  const rows = new Map<string, StoredRow>();
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join("?");
+    if (text.includes("INSERT INTO cf_think_dynamic_workflows")) {
+      const [wfId, code, createdAt] = values as [string, string, number];
+      rows.set(wfId, { code, created_at: createdAt });
+      return [];
+    }
+    if (text.includes("SELECT code FROM cf_think_dynamic_workflows")) {
+      const wfId = values[0] as string;
+      const row = rows.get(wfId);
+      return row ? [{ code: row.code }] : [];
+    }
+    // CREATE TABLE, tracking INSERT into cf_agents_workflows, etc.
+    return [];
+  };
+  return { sql, rows };
+}
+
+type CreatedWorkflow = { id: string; params: Record<string, unknown> };
+
+interface TestThink {
+  env: Record<string, unknown>;
+  name: string;
+  runDynamicWorkflow(
+    workflowName: string,
+    code: string,
+    params?: Record<string, unknown>,
+    options?: {
+      id?: string;
+      agentBinding?: string;
+      metadata?: Record<string, unknown>;
+    }
+  ): Promise<string>;
+  _getWorkflowCode(wfId: string): Promise<string>;
+  validateWorkflowCode(code: string): void;
+  _findAgentBindingNameForDynamic(): string | undefined;
+}
+
+function createFakeAgent(overrides?: {
+  agentBindingKey?: string;
+  includeWorkflow?: boolean;
+}) {
+  const created: CreatedWorkflow[] = [];
+  const { sql, rows } = createFakeSql();
+  // The fake instance's runtime class is `Think`, so the binding name must
+  // match "Think" (or its kebab form) for auto-detection to succeed.
+  const agentBindingKey = overrides?.agentBindingKey ?? "Think";
+  const env: Record<string, unknown> = {
+    [agentBindingKey]: {
+      idFromName: (name: string) => ({ name }),
+      get: () => ({})
+    }
+  };
+  if (overrides?.includeWorkflow !== false) {
+    env.DYNAMIC_THINK_WF = {
+      create: async (opts: CreatedWorkflow) => {
+        created.push(opts);
+        return { id: opts.id };
+      }
+    };
+  }
+  const agent = Object.assign(Object.create(Think.prototype), {
+    env,
+    name: "instance-1",
+    sql
+  }) as unknown as TestThink;
+  return { agent, created, rows, env };
+}
+
+describe("Think dynamic workflows", () => {
+  describe("validateWorkflowCode", () => {
+    it("rejects empty code", () => {
+      const { agent } = createFakeAgent();
+      expect(() => agent.validateWorkflowCode("   ")).toThrow(/non-empty/);
+    });
+
+    it("rejects code over the size limit", () => {
+      const { agent } = createFakeAgent();
+      const tooBig = "x".repeat(
+        Think.MAX_DYNAMIC_WORKFLOW_CODE_BYTES + 1
+      );
+      expect(() => agent.validateWorkflowCode(tooBig)).toThrow(/too large/);
+    });
+
+    it("accepts reasonable code", () => {
+      const { agent } = createFakeAgent();
+      expect(() =>
+        agent.validateWorkflowCode("export default class W {}")
+      ).not.toThrow();
+    });
+  });
+
+  describe("_findAgentBindingNameForDynamic", () => {
+    it("detects the agent binding and caches the result", () => {
+      const { agent, env } = createFakeAgent();
+      expect(agent._findAgentBindingNameForDynamic()).toBe("Think");
+      // Caching: clearing env must not change the resolved value.
+      delete env.Think;
+      expect(agent._findAgentBindingNameForDynamic()).toBe("Think");
+    });
+  });
+
+  describe("runDynamicWorkflow", () => {
+    it("stores retrievable code and dispatches the workflow with the expected envelope", async () => {
+      const { agent, created } = createFakeAgent();
+      const code = "export default class W extends ThinkWorkflow {}";
+
+      const workflowId = await agent.runDynamicWorkflow(
+        "DYNAMIC_THINK_WF",
+        code,
+        { topic: "hello" }
+      );
+
+      expect(created).toHaveLength(1);
+      expect(created[0].id).toBe(workflowId);
+
+      const envelope = created[0].params as {
+        __dispatcherMetadata: {
+          wfId: string;
+          agentBinding: string;
+          agentName: string;
+        };
+        params: Record<string, unknown>;
+      };
+      expect(envelope.__dispatcherMetadata.agentBinding).toBe("Think");
+      expect(envelope.__dispatcherMetadata.agentName).toBe("instance-1");
+      expect(envelope.params).toMatchObject({
+        topic: "hello",
+        __agentName: "instance-1",
+        __agentBinding: "Think",
+        __workflowName: "DYNAMIC_THINK_WF"
+      });
+
+      // The stored code is retrievable via the loader RPC method.
+      const stored = await agent._getWorkflowCode(
+        envelope.__dispatcherMetadata.wfId
+      );
+      expect(stored).toBe(code);
+    });
+
+    it("throws when the workflow binding is missing", async () => {
+      const { agent } = createFakeAgent({ includeWorkflow: false });
+      await expect(
+        agent.runDynamicWorkflow("DYNAMIC_THINK_WF", "export default class W {}")
+      ).rejects.toThrow(/not found in environment/);
+    });
+
+    it("throws when the agent binding is not a Durable Object namespace", async () => {
+      const { agent, env } = createFakeAgent();
+      env.NOT_A_DO = "just a string";
+      await expect(
+        agent.runDynamicWorkflow(
+          "DYNAMIC_THINK_WF",
+          "export default class W {}",
+          {},
+          { agentBinding: "NOT_A_DO" }
+        )
+      ).rejects.toThrow(/not a Durable Object namespace/);
+    });
+  });
+});

--- a/packages/think/src/tests/dynamic-workflows.test.ts
+++ b/packages/think/src/tests/dynamic-workflows.test.ts
@@ -83,9 +83,7 @@ describe("Think dynamic workflows", () => {
 
     it("rejects code over the size limit", () => {
       const { agent } = createFakeAgent();
-      const tooBig = "x".repeat(
-        Think.MAX_DYNAMIC_WORKFLOW_CODE_BYTES + 1
-      );
+      const tooBig = "x".repeat(Think.MAX_DYNAMIC_WORKFLOW_CODE_BYTES + 1);
       expect(() => agent.validateWorkflowCode(tooBig)).toThrow(/too large/);
     });
 
@@ -148,7 +146,10 @@ describe("Think dynamic workflows", () => {
     it("throws when the workflow binding is missing", async () => {
       const { agent } = createFakeAgent({ includeWorkflow: false });
       await expect(
-        agent.runDynamicWorkflow("DYNAMIC_THINK_WF", "export default class W {}")
+        agent.runDynamicWorkflow(
+          "DYNAMIC_THINK_WF",
+          "export default class W {}"
+        )
       ).rejects.toThrow(/not found in environment/);
     });
 

--- a/packages/think/src/tests/dynamic-workflows.test.ts
+++ b/packages/think/src/tests/dynamic-workflows.test.ts
@@ -12,12 +12,18 @@ function createFakeSql() {
       rows.set(wfId, { code, created_at: createdAt });
       return [];
     }
+    if (text.includes("DELETE FROM cf_think_dynamic_workflows")) {
+      const wfId = values[0] as string;
+      rows.delete(wfId);
+      return [];
+    }
     if (text.includes("SELECT code FROM cf_think_dynamic_workflows")) {
       const wfId = values[0] as string;
       const row = rows.get(wfId);
       return row ? [{ code: row.code }] : [];
     }
-    // CREATE TABLE, tracking INSERT into cf_agents_workflows, etc.
+    // CREATE TABLE, tracking INSERT into cf_agents_workflows, getWorkflow
+    // SELECT (no tracked rows in these unit tests), etc.
     return [];
   };
   return { sql, rows };
@@ -46,6 +52,7 @@ interface TestThink {
 function createFakeAgent(overrides?: {
   agentBindingKey?: string;
   includeWorkflow?: boolean;
+  failCreate?: boolean;
 }) {
   const created: CreatedWorkflow[] = [];
   const { sql, rows } = createFakeSql();
@@ -61,6 +68,9 @@ function createFakeAgent(overrides?: {
   if (overrides?.includeWorkflow !== false) {
     env.DYNAMIC_THINK_WF = {
       create: async (opts: CreatedWorkflow) => {
+        if (overrides?.failCreate) {
+          throw new Error("create failed");
+        }
         created.push(opts);
         return { id: opts.id };
       }
@@ -92,10 +102,17 @@ describe("Think dynamic workflows", () => {
       expect(() => agent.validateWorkflowCode(tooBig)).toThrow(/too large/);
     });
 
+    it("rejects code without a GeneratedWorkflow class", () => {
+      const { agent } = createFakeAgent();
+      expect(() =>
+        agent.validateWorkflowCode("export default class Other {}")
+      ).toThrow(/GeneratedWorkflow/);
+    });
+
     it("accepts reasonable code", () => {
       const { agent } = createFakeAgent();
       expect(() =>
-        agent.validateWorkflowCode("export default class W {}")
+        agent.validateWorkflowCode("export default class GeneratedWorkflow {}")
       ).not.toThrow();
     });
   });
@@ -113,7 +130,8 @@ describe("Think dynamic workflows", () => {
   describe("runDynamicWorkflow", () => {
     it("stores retrievable code and dispatches the workflow with the expected envelope", async () => {
       const { agent, created } = createFakeAgent();
-      const code = "export default class W extends ThinkWorkflow {}";
+      const code =
+        "export default class GeneratedWorkflow extends ThinkWorkflow {}";
 
       const workflowId = await agent.runDynamicWorkflow(
         "DYNAMIC_THINK_WF",
@@ -153,7 +171,7 @@ describe("Think dynamic workflows", () => {
       await expect(
         agent.runDynamicWorkflow(
           "DYNAMIC_THINK_WF",
-          "export default class W {}"
+          "export default class GeneratedWorkflow {}"
         )
       ).rejects.toThrow(/not found in environment/);
     });
@@ -164,11 +182,23 @@ describe("Think dynamic workflows", () => {
       await expect(
         agent.runDynamicWorkflow(
           "DYNAMIC_THINK_WF",
-          "export default class W {}",
+          "export default class GeneratedWorkflow {}",
           {},
           { agentBinding: "NOT_A_DO" }
         )
       ).rejects.toThrow(/not a Durable Object namespace/);
+    });
+
+    it("removes the stored code row when workflow.create fails", async () => {
+      const { agent, rows } = createFakeAgent({ failCreate: true });
+      await expect(
+        agent.runDynamicWorkflow(
+          "DYNAMIC_THINK_WF",
+          "export default class GeneratedWorkflow {}"
+        )
+      ).rejects.toThrow(/create failed/);
+      // The orphaned code row must have been cleaned up.
+      expect(rows.size).toBe(0);
     });
   });
 });

--- a/packages/think/src/tests/dynamic-workflows.test.ts
+++ b/packages/think/src/tests/dynamic-workflows.test.ts
@@ -68,9 +68,14 @@ function createFakeAgent(overrides?: {
   }
   const agent = Object.assign(Object.create(Think.prototype), {
     env,
-    name: "instance-1",
     sql
   }) as unknown as TestThink;
+  // `name` is a getter-only accessor on the partyserver base class, so define
+  // an own data property to shadow it instead of assigning through it.
+  Object.defineProperty(agent, "name", {
+    value: "instance-1",
+    configurable: true
+  });
   return { agent, created, rows, env };
 }
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -121,6 +121,7 @@ export type { SkillRunContext, SkillSource } from "agents/skills";
 import {
   Agent,
   callable,
+  camelCaseToKebabCase,
   getCurrentAgent,
   isPlatformTransientError,
   __DO_NOT_USE_WILL_BREAK__agentContext as agentContext
@@ -7405,6 +7406,145 @@ export class Think<
     }
 
     return { requestId, status, ...(error !== undefined && { error }) };
+  }
+
+  // ── Dynamic workflows ─────────────────────────────────────────
+
+  private _dynamicWorkflowTableEnsured = false;
+
+  private _ensureDynamicWorkflowTable(): void {
+    if (this._dynamicWorkflowTableEnsured) return;
+    this.sql`
+      CREATE TABLE IF NOT EXISTS cf_think_dynamic_workflows (
+        wf_id TEXT PRIMARY KEY,
+        code TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `;
+    this._dynamicWorkflowTableEnsured = true;
+  }
+
+  private _findAgentBindingNameForDynamic(): string | undefined {
+    const className = this.constructor.name;
+    for (const [key, value] of Object.entries(
+      this.env as Record<string, unknown>
+    )) {
+      if (
+        value &&
+        typeof value === "object" &&
+        "idFromName" in value &&
+        typeof (value as { idFromName: unknown }).idFromName === "function"
+      ) {
+        if (
+          key === className ||
+          camelCaseToKebabCase(key) === camelCaseToKebabCase(className)
+        ) {
+          return key;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Run a generated ThinkWorkflow as a Dynamic Workflow.
+   *
+   * Stores the generated TypeScript source in SQLite, then starts a Workflow
+   * instance. The `DynamicThinkWorkflow` entrypoint loads, bundles, and
+   * executes the code via Dynamic Workers when the engine calls `run()`.
+   *
+   * The generated code must export a default class that extends `ThinkWorkflow`.
+   *
+   * @param workflowName - The workflow binding name (matching `wrangler.jsonc`)
+   * @param code - Generated ThinkWorkflow TypeScript source
+   * @param params - Parsed input params forwarded to the workflow's `run()`
+   * @param options - Optional workflow ID, agent binding override, and metadata
+   * @returns The workflow instance ID
+   */
+  async runDynamicWorkflow(
+    workflowName: string,
+    code: string,
+    params: Record<string, unknown> = {},
+    options?: {
+      id?: string;
+      agentBinding?: string;
+      metadata?: Record<string, unknown>;
+    }
+  ): Promise<string> {
+    this._ensureDynamicWorkflowTable();
+    const wfId = crypto.randomUUID();
+    this.sql`
+      INSERT INTO cf_think_dynamic_workflows (wf_id, code, created_at)
+      VALUES (${wfId}, ${code}, ${Date.now()})
+    `;
+
+    const agentBinding =
+      options?.agentBinding ?? this._findAgentBindingNameForDynamic();
+    if (!agentBinding) {
+      throw new Error(
+        "Could not detect Agent binding name from class name. " +
+          "Pass it explicitly via options.agentBinding"
+      );
+    }
+
+    const workflow = (this.env as Record<string, unknown>)[workflowName] as
+      | Workflow
+      | undefined;
+    if (!workflow || typeof workflow.create !== "function") {
+      throw new Error(
+        `Workflow binding '${workflowName}' not found in environment`
+      );
+    }
+
+    const workflowId = options?.id ?? `wf_${crypto.randomUUID()}`;
+
+    const envelope = {
+      __dispatcherMetadata: {
+        wfId,
+        agentBinding,
+        agentName: this.name
+      },
+      params: {
+        ...params,
+        __agentName: this.name,
+        __agentBinding: agentBinding,
+        __workflowName: workflowName
+      }
+    };
+
+    await workflow.create({
+      id: workflowId,
+      params: envelope
+    });
+
+    const metadataJson = options?.metadata
+      ? JSON.stringify(options.metadata)
+      : null;
+    try {
+      this.sql`
+        INSERT INTO cf_agents_workflows (id, workflow_id, workflow_name, status, metadata)
+        VALUES (${crypto.randomUUID()}, ${workflowId}, ${workflowName}, 'queued', ${metadataJson})
+      `;
+    } catch {
+      // Tracking is best-effort — don't fail the workflow if it fails
+    }
+
+    return workflowId;
+  }
+
+  /**
+   * Retrieve generated workflow code by ID.
+   * Called by the DynamicThinkWorkflow loader via DO RPC.
+   */
+  async getWorkflowCode(wfId: string): Promise<string> {
+    this._ensureDynamicWorkflowTable();
+    const rows = this.sql`
+      SELECT code FROM cf_think_dynamic_workflows WHERE wf_id = ${wfId}
+    `;
+    if (rows.length === 0) {
+      throw new Error(`Dynamic workflow code not found: ${wfId}`);
+    }
+    return rows[0].code as string;
   }
 
   // ── WebSocket protocol ──────────────────────────────────────────

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7445,12 +7445,25 @@ export class Think<
     if (typeof code !== "string" || code.trim().length === 0) {
       throw new Error("Dynamic workflow code must be a non-empty string");
     }
-    const byteLength = new TextEncoder().encode(code).length;
     const max = (this.constructor as typeof Think)
       .MAX_DYNAMIC_WORKFLOW_CODE_BYTES;
+    // Fast pre-filter: a string's UTF-8 byte length is always >= its length,
+    // so anything longer than the limit cannot fit — reject without allocating
+    // a TextEncoder buffer for the (potentially large) payload.
+    const byteLength =
+      code.length > max ? code.length : new TextEncoder().encode(code).length;
     if (byteLength > max) {
       throw new Error(
         `Dynamic workflow code is too large (${byteLength} bytes, max ${max})`
+      );
+    }
+    // The loader dispatches to the `GeneratedWorkflow` entrypoint, so the code
+    // must declare a class with that name (see dynamic-workflows/loader.ts).
+    // Catch the mismatch here rather than as an opaque runtime failure.
+    if (!/\bclass\s+GeneratedWorkflow\b/.test(code)) {
+      throw new Error(
+        "Dynamic workflow code must declare a class named 'GeneratedWorkflow' " +
+          "(the entrypoint the loader dispatches to)"
       );
     }
   }
@@ -7494,7 +7507,8 @@ export class Think<
    * instance. The `DynamicThinkWorkflow` entrypoint loads, bundles, and
    * executes the code via Dynamic Workers when the engine calls `run()`.
    *
-   * The generated code must export a default class that extends `ThinkWorkflow`.
+   * The generated code must declare a class named `GeneratedWorkflow` that
+   * extends `ThinkWorkflow` (this is the entrypoint the loader dispatches to).
    *
    * @param workflowName - The workflow binding name (matching `wrangler.jsonc`)
    * @param code - Generated ThinkWorkflow TypeScript source
@@ -7548,6 +7562,16 @@ export class Think<
       );
     }
 
+    const workflowId = options?.id ?? `wf_${crypto.randomUUID()}`;
+
+    // If the caller supplied an explicit ID that is already tracked, fail
+    // before writing the code row so we do not orphan it in SQLite.
+    if (options?.id !== undefined && this.getWorkflow(workflowId)) {
+      throw new Error(
+        `Workflow with ID "${workflowId}" is already being tracked`
+      );
+    }
+
     // NOTE: code rows are intentionally not evicted here. A dynamic workflow
     // can sit idle for a long time (`step.sleep`, `step.waitForEvent`, human
     // approval) and the loader re-fetches the code by `wfId` on every cache
@@ -7560,8 +7584,6 @@ export class Think<
       INSERT INTO cf_think_dynamic_workflows (wf_id, code, created_at)
       VALUES (${wfId}, ${code}, ${Date.now()})
     `;
-
-    const workflowId = options?.id ?? `wf_${crypto.randomUUID()}`;
 
     const envelope = {
       __dispatcherMetadata: {
@@ -7577,10 +7599,19 @@ export class Think<
       }
     };
 
-    await workflow.create({
-      id: workflowId,
-      params: envelope
-    });
+    try {
+      await workflow.create({
+        id: workflowId,
+        params: envelope
+      });
+    } catch (e) {
+      // The workflow instance was not created — drop the orphaned code row so
+      // it does not accumulate in SQLite.
+      this.sql`
+        DELETE FROM cf_think_dynamic_workflows WHERE wf_id = ${wfId}
+      `;
+      throw e;
+    }
 
     const metadataJson = options?.metadata
       ? JSON.stringify(options.metadata)
@@ -7590,8 +7621,19 @@ export class Think<
         INSERT INTO cf_agents_workflows (id, workflow_id, workflow_name, status, metadata)
         VALUES (${crypto.randomUUID()}, ${workflowId}, ${workflowName}, 'queued', ${metadataJson})
       `;
-    } catch {
-      // Tracking is best-effort — don't fail the workflow if it fails
+    } catch (e) {
+      // Mirror the base Agent.runWorkflow() contract: surface duplicate-ID
+      // collisions clearly and re-throw any other error rather than silently
+      // dropping it (which would leave the workflow untracked with no signal).
+      if (
+        e instanceof Error &&
+        e.message.includes("UNIQUE constraint failed")
+      ) {
+        throw new Error(
+          `Workflow with ID "${workflowId}" is already being tracked`
+        );
+      }
+      throw e;
     }
 
     return workflowId;

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7463,8 +7463,9 @@ export class Think<
     // class constructor (captured via the prototype chain) rather than
     // `this.constructor.name`, so minifier renaming behaves consistently with
     // the rest of the SDK.
-    const className = (Object.getPrototypeOf(this).constructor as { name: string })
-      .name;
+    const className = (
+      Object.getPrototypeOf(this).constructor as { name: string }
+    ).name;
     for (const [key, value] of Object.entries(
       this.env as Record<string, unknown>
     )) {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -7411,6 +7411,15 @@ export class Think<
   // ── Dynamic workflows ─────────────────────────────────────────
 
   private _dynamicWorkflowTableEnsured = false;
+  private _dynamicAgentBindingName: string | undefined;
+
+  /**
+   * Maximum size (in bytes) of a single generated workflow code payload
+   * accepted by {@link runDynamicWorkflow}. Guards against accidental storage
+   * of very large (or runaway LLM-generated) payloads. Subclasses can shadow
+   * this static to tune the limit.
+   */
+  static readonly MAX_DYNAMIC_WORKFLOW_CODE_BYTES = 512 * 1024;
 
   private _ensureDynamicWorkflowTable(): void {
     if (this._dynamicWorkflowTableEnsured) return;
@@ -7424,8 +7433,38 @@ export class Think<
     this._dynamicWorkflowTableEnsured = true;
   }
 
+  /**
+   * Validate generated workflow code before it is stored and later executed
+   * as a Dynamic Worker. The default implementation enforces a non-empty body
+   * and the {@link MAX_DYNAMIC_WORKFLOW_CODE_BYTES} size limit. Subclasses can
+   * override this to add stricter checks (e.g. static analysis of
+   * LLM-generated code) — callers remain responsible for trusting the source
+   * of the code they pass in.
+   */
+  protected validateWorkflowCode(code: string): void {
+    if (typeof code !== "string" || code.trim().length === 0) {
+      throw new Error("Dynamic workflow code must be a non-empty string");
+    }
+    const byteLength = new TextEncoder().encode(code).length;
+    const max = (this.constructor as typeof Think)
+      .MAX_DYNAMIC_WORKFLOW_CODE_BYTES;
+    if (byteLength > max) {
+      throw new Error(
+        `Dynamic workflow code is too large (${byteLength} bytes, max ${max})`
+      );
+    }
+  }
+
   private _findAgentBindingNameForDynamic(): string | undefined {
-    const className = this.constructor.name;
+    if (this._dynamicAgentBindingName !== undefined) {
+      return this._dynamicAgentBindingName;
+    }
+    // Mirror the base-class `_findAgentBindingName()`: resolve from the parent
+    // class constructor (captured via the prototype chain) rather than
+    // `this.constructor.name`, so minifier renaming behaves consistently with
+    // the rest of the SDK.
+    const className = (Object.getPrototypeOf(this).constructor as { name: string })
+      .name;
     for (const [key, value] of Object.entries(
       this.env as Record<string, unknown>
     )) {
@@ -7439,6 +7478,7 @@ export class Think<
           key === className ||
           camelCaseToKebabCase(key) === camelCaseToKebabCase(className)
         ) {
+          this._dynamicAgentBindingName = key;
           return key;
         }
       }
@@ -7471,12 +7511,8 @@ export class Think<
       metadata?: Record<string, unknown>;
     }
   ): Promise<string> {
+    this.validateWorkflowCode(code);
     this._ensureDynamicWorkflowTable();
-    const wfId = crypto.randomUUID();
-    this.sql`
-      INSERT INTO cf_think_dynamic_workflows (wf_id, code, created_at)
-      VALUES (${wfId}, ${code}, ${Date.now()})
-    `;
 
     const agentBinding =
       options?.agentBinding ?? this._findAgentBindingNameForDynamic();
@@ -7484,6 +7520,21 @@ export class Think<
       throw new Error(
         "Could not detect Agent binding name from class name. " +
           "Pass it explicitly via options.agentBinding"
+      );
+    }
+
+    // Only allow `agentBinding` to reference a Durable Object namespace that
+    // actually exists in the environment — prevents callers from probing for
+    // (or coercing the loader into reading) arbitrary env keys.
+    const agentNamespace = (this.env as Record<string, unknown>)[agentBinding];
+    if (
+      !agentNamespace ||
+      typeof agentNamespace !== "object" ||
+      typeof (agentNamespace as { idFromName?: unknown }).idFromName !==
+        "function"
+    ) {
+      throw new Error(
+        `Agent binding '${agentBinding}' is not a Durable Object namespace`
       );
     }
 
@@ -7495,6 +7546,19 @@ export class Think<
         `Workflow binding '${workflowName}' not found in environment`
       );
     }
+
+    // NOTE: code rows are intentionally not evicted here. A dynamic workflow
+    // can sit idle for a long time (`step.sleep`, `step.waitForEvent`, human
+    // approval) and the loader re-fetches the code by `wfId` on every cache
+    // miss (new isolate, retry, resumption). Time- or fetch-based eviction
+    // would race against in-flight workflows. Growth is bounded by the number
+    // of workflows a given agent runs; completion-based cleanup can be layered
+    // on later if needed.
+    const wfId = crypto.randomUUID();
+    this.sql`
+      INSERT INTO cf_think_dynamic_workflows (wf_id, code, created_at)
+      VALUES (${wfId}, ${code}, ${Date.now()})
+    `;
 
     const workflowId = options?.id ?? `wf_${crypto.randomUUID()}`;
 
@@ -7534,9 +7598,13 @@ export class Think<
 
   /**
    * Retrieve generated workflow code by ID.
-   * Called by the DynamicThinkWorkflow loader via DO RPC.
+   *
+   * Internal: called by the `DynamicThinkWorkflow` loader via Durable Object
+   * service-binding RPC. The leading underscore signals it is not part of the
+   * client-callable surface (it has no `@callable()` decorator). The `wfId` is
+   * an unguessable UUID, but treat stored code as sensitive.
    */
-  async getWorkflowCode(wfId: string): Promise<string> {
+  async _getWorkflowCode(wfId: string): Promise<string> {
     this._ensureDynamicWorkflowTable();
     const rows = this.sql`
       SELECT code FROM cf_think_dynamic_workflows WHERE wf_id = ${wfId}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1224,6 +1224,34 @@ importers:
         specifier: ^4.100.0
         version: 4.100.0(@cloudflare/workers-types@4.20260612.1)
 
+  examples/dynamic-think-workflows:
+    dependencies:
+      '@cloudflare/think':
+        specifier: '*'
+        version: link:../../packages/think
+      agents:
+        specifier: '*'
+        version: link:../../packages/agents
+      ai:
+        specifier: ^6.0.202
+        version: 6.0.202(zod@4.4.3)
+      workers-ai-provider:
+        specifier: ^3.2.0
+        version: 3.2.0(@ai-sdk/anthropic@3.0.83(zod@4.4.3))(@ai-sdk/google@3.0.81(zod@4.4.3))(@ai-sdk/openai@3.0.70(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.202(zod@4.4.3))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260612.1
+        version: 4.20260612.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      wrangler:
+        specifier: ^4.100.0
+        version: 4.100.0(@cloudflare/workers-types@4.20260612.1)
+
   examples/dynamic-tools:
     dependencies:
       '@cloudflare/ai-chat':
@@ -3797,6 +3825,9 @@ importers:
       '@cloudflare/codemode':
         specifier: '>=0.4.0'
         version: link:../codemode
+      '@cloudflare/dynamic-workflows':
+        specifier: '>=0.1.1'
+        version: 0.1.1
       '@cloudflare/shell':
         specifier: '>=0.4.0'
         version: link:../shell
@@ -3837,6 +3868,9 @@ importers:
       '@cloudflare/kumo':
         specifier: ^2.5.2
         version: 2.5.2(@date-fns/tz@1.5.0)(@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      '@cloudflare/worker-bundler':
+        specifier: workspace:*
+        version: link:../worker-bundler
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4962,6 +4996,10 @@ packages:
   '@clack/prompts@1.5.1':
     resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
     engines: {node: '>= 20.12.0'}
+
+  '@cloudflare/dynamic-workflows@0.1.1':
+    resolution: {integrity: sha512-sVomQI/cCOHr/Tu/qefnpECctG38ayrePxsUJm8UqllV1HCX9hQ1EW0cFo4HCdU+avQsPVfPiknnlk0oRySlig==}
+    engines: {node: '>=22'}
 
   '@cloudflare/kumo@2.5.2':
     resolution: {integrity: sha512-HUNi40VG3ExJ7lV8HjqPQcGpCmm2CqG/SzjJ+K+NhCwZRYTBvagdoMDPX2XZ8AW/ZPEeuFoId0VYmzrX+luyXQ==}
@@ -12263,6 +12301,8 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@cloudflare/dynamic-workflows@0.1.1': {}
 
   '@cloudflare/kumo@2.5.2(@date-fns/tz@1.5.0)(@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Summary

Add the ability to run generated TypeScript as a `ThinkWorkflow` at runtime using `@cloudflare/dynamic-workflows` + `@cloudflare/worker-bundler` + Dynamic Workers.

## What's new

### `Think.runDynamicWorkflow(workflowName, code, params?, options?)`
Stores generated TypeScript source in SQLite, then starts a Workflow instance with `__dispatcherMetadata` in the params envelope. The `DynamicThinkWorkflow` entrypoint reads this metadata to load, bundle, and execute the code.

### `Think.getWorkflowCode(wfId)`
RPC method used by the loader to retrieve stored generated code by ID.

### `DynamicThinkWorkflow` (from `@cloudflare/think/dynamic-workflows`)
Created via `createDynamicWorkflowEntrypoint` from `@cloudflare/dynamic-workflows`. When the Workflows engine calls `run()`:
1. Unwraps `__dispatcherMetadata` from the event payload
2. Fetches generated code from the agent via RPC
3. Bundles it with npm deps (`@cloudflare/think`, `zod`) via `createWorker()`
4. Loads as a Dynamic Worker via `env.LOADER.get()`
5. Dispatches `run(event, step)` to the generated `ThinkWorkflow`

The generated code runs as a real `ThinkWorkflow` — `step.prompt()`, `this.agent`, `step.do()`, `step.sleep()`, `step.waitForEvent()` all work natively.

## New dependencies
- `@cloudflare/dynamic-workflows` — runtime dependency (small library, ~300 lines)
- `@cloudflare/worker-bundler` — optional peer dependency (dynamically imported)

## Example
`examples/dynamic-think-workflows/` — server-only example showing a Think agent that generates a ThinkWorkflow class as a string and runs it as a Dynamic Workflow.

## Test plan
- [x] `pnpm run check` passes (sherif + exports + oxfmt + oxlint + typecheck — 112/112 projects)
- [x] `@cloudflare/think` builds successfully
- [ ] Manual test with `wrangler dev` (requires Workers Paid plan for Dynamic Workers)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->