### PR TITLE
feat(think): add Discord interactions messenger

### DIFF
--- a/.changeset/discord-provider-skeleton.md
+++ b/.changeset/discord-provider-skeleton.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": minor
+---
+
+Add a Workers-native Discord messenger provider entrypoint with signed Interactions PING verification.

--- a/design/rfc-discord-messengers.md
+++ b/design/rfc-discord-messengers.md
@@ -840,6 +840,223 @@ semantics and avoids Node runtime dependencies.
     command registration, local tunnel testing, Interactions, Gateway activation,
     and permissions/intents troubleshooting.
 
+## Future Capability Slices
+
+The initial provider slice can land with signed Interactions, command/action
+normalization, and short-lived interaction webhook delivery. The remaining
+Discord surface should land as independent, reviewable slices in this order.
+
+### Slice 1: Durable Channel Delivery
+
+Goal: allow Think to post to Discord channels, threads, and DMs outside the
+15-minute interaction token window.
+
+Scope:
+
+- Implement bot-token REST delivery for `postMessage()` to encoded Discord thread
+  ids, including guild channels, Discord thread channels, and DMs.
+- Implement `openDM(userId)` or an equivalent internal helper so application code
+  can resolve `discord:@me:{channelId}` before posting.
+- Preserve current interaction response behavior: interaction-originated replies
+  still use the deferred original response first, then follow-up webhooks while
+  the interaction token is valid.
+- Fall back from expired/missing interaction response contexts to bot-token
+  channel delivery when the adapter has a real Discord thread id.
+- Centralize REST request handling so later edit/delete/fetch/attachment work can
+  share auth headers, JSON parsing, error shaping, and rate-limit handling.
+
+Tests:
+
+- Posting to `discord:{guildId}:{channelId}` calls `POST /channels/{channelId}/messages`.
+- Posting to `discord:{guildId}:{channelId}:{threadId}` targets the Discord
+  thread id, not the parent channel id.
+- Expired interaction contexts are deleted and do not reuse stale webhook tokens.
+- `allowed_mentions: { parse: [] }` remains the default on every REST send.
+- Permanent `401`/`403` responses surface actionable delivery errors without
+  unsafe retries.
+
+Non-goals:
+
+- Gateway ingress.
+- File uploads.
+- Edit/delete/fetch parity beyond what channel delivery needs internally.
+
+### Slice 2: Gateway Background Ingress
+
+Goal: receive normal Discord messages, DMs, mentions, subscribed-thread messages,
+and reactions without relying on slash commands.
+
+Scope:
+
+- Export `ThinkDiscordGatewayShardAgent` and wire `discordMessenger({ gateway })`
+  to a `MessengerBackgroundIngress` manager.
+- Resolve shard count and session-start limits from `/gateway/bot` when configured
+  with `shards: "auto"`.
+- Store shard session state in the shard Durable Object: shard id/count,
+  `session_id`, `resume_gateway_url`, last sequence, heartbeat state, and
+  identify backoff state.
+- Implement Gateway connect, Hello, jittered heartbeat, heartbeat ACK timeout,
+  dispatch sequence persistence, Ready, Resume, Reconnect, Invalid Session,
+  close-code handling, and alarm-based reconnect.
+- Forward accepted dispatches back to the root runtime through typed Agent/facet
+  calls, then normalize them through Chat SDK `processMessage()`,
+  `processReaction()`, `processAction()`, and `processSlashCommand()`.
+- Drop self-authored messages before they reach Think routing.
+- Warn when `respondTo` includes subscribed guild messages but Gateway intents do
+  not include `MessageContent`.
+
+Tests:
+
+- Shard state persists sequence before dispatch normalization.
+- Resume is attempted after resumable disconnects and Identify is used after
+  invalid sessions that cannot resume.
+- Fatal close codes stop reconnect loops and surface diagnostics.
+- DM `MESSAGE_CREATE` routes to `direct-message`; guild mentions route to
+  `mention`; subscribed messages route only when configured.
+- Duplicate Gateway dispatches use stable idempotency keys and do not start
+  duplicate reply fibers.
+
+Non-goals:
+
+- Command registration.
+- Rich component rendering.
+- Native WebSocket hibernation for outgoing Discord Gateway sockets.
+
+### Slice 3: Command Registration Tooling
+
+Goal: let users register Discord commands without hand-writing raw REST calls,
+while keeping registration out of runtime request handling.
+
+Scope:
+
+- Provide a small helper or example script for guild command create/update/bulk
+  overwrite and global command create/update/bulk overwrite.
+- Support command names, descriptions, options, subcommands, default member
+  permissions, `integration_types`, and `contexts`.
+- Prefer update/bulk-overwrite workflows that avoid repeated create loops and
+  respect Discord's daily create limits.
+- Keep Bearer-token command permission flows out of the bot-token helper; document
+  them as an advanced setup concern.
+- Include a dry-run/print mode in the example so users can inspect payloads before
+  sending them to Discord.
+
+Tests:
+
+- Payload generation enforces Discord command shape limits and required-before-
+  optional option ordering.
+- Guild and global registration hit the correct API routes.
+- Bulk overwrite does not issue per-command create calls.
+- `integration_types`, `contexts`, and `default_member_permissions` round-trip in
+  generated payloads.
+
+Non-goals:
+
+- Developer Portal application creation.
+- OAuth installation flows.
+- Automatic registration during Worker startup or webhook handling.
+
+### Slice 4: Attachments
+
+Goal: expose inbound Discord attachments in messenger context and support outbound
+file uploads when explicitly enabled.
+
+Scope:
+
+- Map Discord message attachments into `MessengerAttachment` with id, name,
+  media type, size, URL, and lazy `fetch()`.
+- Keep attachment bytes lazy so normal text-only turns do not fetch files.
+- Add outbound multipart upload support for `AdapterPostableMessage` attachments
+  and model/tool-produced file parts when the Think delivery path can represent
+  them.
+- Respect Discord file size limits and bot permissions before uploading.
+- Preserve safe defaults: do not fetch arbitrary attachment URLs unless caller
+  code asks through the attachment `fetch()` function.
+
+Tests:
+
+- Inbound Gateway messages with attachments produce serializable attachment
+  metadata without eager byte loading.
+- `fetch()` downloads bytes only when invoked and handles non-OK responses.
+- Outbound file sends use multipart form data and include `allowed_mentions`.
+- Missing `ATTACH_FILES` permission fails before repeated invalid REST calls.
+- Oversized files fail with a clear error before upload.
+
+Non-goals:
+
+- Virus scanning or content moderation.
+- Persisting attachment bytes in Think state by default.
+- Provider-neutral binary delivery redesign beyond Discord's needs.
+
+### Slice 5: Reactions, Edit/Delete, And Fetch APIs
+
+Goal: complete the Discord adapter methods that Think tools and scheduled work
+need after initial reply delivery works.
+
+Scope:
+
+- Implement `addReaction()` and `removeReaction()` using Discord emoji route
+  encoding for unicode and custom emoji values.
+- Implement `editMessage()` and `deleteMessage()` for bot-authored messages and
+  interaction-originated original responses where the adapter still has a valid
+  interaction context.
+- Implement `fetchMessages()`, `fetchChannelMessages()`, `fetchThread()`,
+  `fetchChannelInfo()`, and thread listing helpers needed by tools.
+- Normalize fetched Discord messages into Chat SDK message/thread/channel shapes
+  with stable encoded ids.
+- Share REST rate-limit handling with the durable channel delivery slice.
+
+Tests:
+
+- Unicode and custom emoji reactions are encoded correctly in REST routes.
+- Editing a normal channel message targets `/channels/{channelId}/messages/{id}`.
+- Editing an interaction original response uses the webhook route only while the
+  context is valid.
+- Deleting and fetching inaccessible messages produce permanent errors without
+  unsafe retry loops.
+- Fetched Discord threads preserve `discord:{guildId}:{channelId}:{threadId}`
+  identity.
+
+Non-goals:
+
+- Moderation actions beyond message delete.
+- Full Discord audit-log integration.
+- Cross-provider fetch API redesign.
+
+### Slice 6: Ephemeral Replies And Rich Components
+
+Goal: improve Discord-specific UX for command responses and cards without
+claiming a provider-neutral ephemeral primitive.
+
+Scope:
+
+- Add `interactions.defaultVisibility: "public" | "ephemeral"` and set the
+  initial defer response flags accordingly.
+- Keep `supportsEphemeral` false unless a provider-neutral contract exists;
+  ephemeral replies are interaction-originated Discord delivery options.
+- Render Chat SDK cards to Discord embeds and action rows, respecting Discord
+  limits for embeds, fields, rows, buttons, select menus, and component
+  `custom_id` length.
+- Use Chat SDK callback-token state for component `custom_id` values rather than
+  embedding long callback URLs or payloads directly.
+- Support link buttons as Discord URL buttons and reject unsupported component
+  shapes with readable errors before posting.
+
+Tests:
+
+- Ephemeral command defer responses include Discord's ephemeral flag and still
+  edit the original response for the first reply.
+- Public command replies remain the default.
+- Card rendering respects embed/action-row/component count limits.
+- Long callback URLs are tokenized before they enter `custom_id`.
+- Invalid component payloads fail before REST delivery, not after Discord rejects
+  the request.
+
+Non-goals:
+
+- Discord modals as a model-turn primitive.
+- General ephemeral posting to arbitrary channels.
+- A complete Discord UI framework beyond Chat SDK card rendering.
+
 ## Alternatives Considered
 
 ### Interactions-only first

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -98,6 +98,10 @@
       "types": "./dist/messengers/index.d.ts",
       "import": "./dist/messengers/index.js"
     },
+    "./messengers/discord": {
+      "types": "./dist/messengers/discord.d.ts",
+      "import": "./dist/messengers/discord.js"
+    },
     "./messengers/telegram": {
       "types": "./dist/messengers/telegram.d.ts",
       "import": "./dist/messengers/telegram.js"

--- a/packages/think/scripts/build.ts
+++ b/packages/think/scripts/build.ts
@@ -21,6 +21,7 @@ async function main() {
       "src/framework/index.ts",
       "src/server-entry.ts",
       "src/messengers/index.ts",
+      "src/messengers/discord.ts",
       "src/messengers/telegram.ts",
       "src/tools/workspace.ts",
       "src/tools/execute.ts",

--- a/packages/think/src/messengers/chat-sdk.ts
+++ b/packages/think/src/messengers/chat-sdk.ts
@@ -9,7 +9,8 @@ import type {
   Message as ChatMessage,
   ReactionEvent as ChatReactionEvent,
   SlashCommandEvent as ChatSlashCommandEvent,
-  Thread as ChatThread
+  Thread as ChatThread,
+  WebhookOptions
 } from "chat";
 import { Chat } from "chat";
 import type {
@@ -118,7 +119,8 @@ export interface MessengerDefinition {
   shardKey?: ChatSdkStateAdapterOptions["shardKey"];
   subscribeOnMention?: boolean;
   toEvent?: (
-    input: ChatSdkMessengerEventInput
+    input: ChatSdkMessengerEventInput,
+    definition: NormalizedMessengerDefinition
   ) => MessengerEvent | Promise<MessengerEvent>;
   userName: string;
   verifyWebhook?:
@@ -186,6 +188,7 @@ export interface MessengerThinkHost extends MessengerThinkTarget {
     agentClass: SubAgentClass<T>,
     name: string
   ): Promise<SubAgentStub<T>>;
+  waitUntil?(task: Promise<unknown>): void;
 }
 
 export interface MessengerFiberStartResult {
@@ -275,7 +278,10 @@ export class ThinkMessengerRuntime {
 
     const chat = this.getOrCreateChat();
     void this.startBackgroundIngress(chat);
-    return chat.webhooks[definition.adapterName](request);
+    return chat.webhooks[definition.adapterName](
+      request,
+      this.webhookOptions()
+    );
   }
 
   async handleFiberRecovery(ctx: FiberRecoveryContext): Promise<boolean> {
@@ -729,12 +735,23 @@ export class ThinkMessengerRuntime {
     return task;
   }
 
+  private webhookOptions(): WebhookOptions | undefined {
+    if (!this.host.waitUntil) {
+      return undefined;
+    }
+    return {
+      waitUntil: (task) => {
+        this.host.waitUntil?.(task);
+      }
+    };
+  }
+
   private async toEvent(
     definition: NormalizedMessengerDefinition,
     input: ChatSdkMessengerEventInput
   ): Promise<MessengerEvent> {
     return (
-      (await definition.toEvent?.(input)) ??
+      (await definition.toEvent?.(input, definition)) ??
       defaultChatSdkEvent(definition, input)
     );
   }
@@ -831,6 +848,11 @@ function idempotencyEventPart(event: MessengerEvent): string {
   if (event.action) {
     return [
       "action",
+      stableNamePart(
+        event.action.providerActionId ??
+          providerRawId(event.action.raw) ??
+          "no-provider-action"
+      ),
       stableNamePart(event.action.messageId ?? "unknown-message"),
       stableNamePart(event.action.actionId),
       stableNamePart(event.action.user?.userId ?? "unknown-user"),
@@ -891,6 +913,7 @@ export function toMessengerAction(action: ChatActionEvent): MessengerAction {
   return {
     actionId: action.actionId,
     messageId: action.messageId,
+    providerActionId: providerRawId(action.raw),
     raw: action.raw,
     user: toMessengerAuthor(action.user),
     value: action.value

--- a/packages/think/src/messengers/discord.ts
+++ b/packages/think/src/messengers/discord.ts
@@ -1,0 +1,983 @@
+import type {
+  Adapter,
+  AdapterPostableMessage,
+  ChannelInfo,
+  ChatInstance,
+  EmojiValue,
+  FetchOptions,
+  FetchResult,
+  FormattedContent,
+  RawMessage,
+  StreamChunk,
+  ThreadInfo,
+  WebhookOptions
+} from "chat";
+import { stringifyMarkdown } from "chat";
+import type {
+  ChatSdkMessengerEventInput,
+  ChatSdkMessengerOptions,
+  MessengerDefinition,
+  NormalizedMessengerDefinition
+} from "./chat-sdk";
+import { chatSdkMessenger, defaultChatSdkEvent } from "./chat-sdk";
+
+export const DISCORD_API_BASE_URL = "https://discord.com/api/v10";
+export const DISCORD_STREAM_SOFT_LIMIT = 1_800;
+export const DISCORD_FOLLOWUP_CHUNK_LIMIT = 1_900;
+export const DISCORD_INTERACTION_TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1_000;
+export const DISCORD_INTERACTION_TOKEN_TTL_MS = 15 * 60 * 1_000;
+export const DISCORD_INTERACTION_BODY_LIMIT_BYTES = 64 * 1_024;
+
+const DISCORD_PUBLIC_KEY_PATTERN = /^[a-fA-F0-9]{64}$/;
+const DISCORD_SIGNATURE_PATTERN = /^[a-fA-F0-9]{128}$/;
+
+export interface DiscordMessengerOptions extends Omit<
+  ChatSdkMessengerOptions,
+  "adapter" | "provider" | "userName" | "verifyWebhook"
+> {
+  apiUrl?: string;
+  applicationId: string;
+  fetch?: typeof fetch;
+  interactions?: boolean | DiscordInteractionsOptions;
+  publicKey?: string;
+  token?: string;
+  userName: string;
+}
+
+export interface DiscordInteractionsOptions {
+  enabled?: boolean;
+  timestampToleranceMs?: number;
+}
+
+interface DiscordAdapterConfig {
+  adapterName: string;
+  apiUrl?: string;
+  applicationId: string;
+  fetch?: typeof fetch;
+  publicKey?: string;
+  timestampToleranceMs?: number;
+  userName?: string;
+}
+
+interface DiscordMessagePayload {
+  allowed_mentions?: DiscordAllowedMentions;
+  content?: string;
+}
+
+interface DiscordAllowedMentions {
+  parse?: ("everyone" | "roles" | "users")[];
+  replied_user?: boolean;
+  roles?: string[];
+  users?: string[];
+}
+
+interface DiscordInteractionResponseContext {
+  channelId: string;
+  expiresAt: number;
+  initialResponseSent: boolean;
+  token: string;
+}
+
+export interface DiscordThreadId {
+  channelId: string;
+  guildId: string;
+  threadId?: string;
+}
+
+export interface DiscordInteraction {
+  application_id: string;
+  channel?: DiscordInteractionChannel;
+  channel_id?: string;
+  data?: DiscordInteractionData;
+  guild_id?: string;
+  id: string;
+  member?: { user?: DiscordUser };
+  message?: { id?: string };
+  token: string;
+  type: number;
+  user?: DiscordUser;
+  version: number;
+}
+
+export interface DiscordInteractionChannel {
+  id: string;
+  name?: string;
+  parent_id?: string;
+  type: number;
+}
+
+export interface DiscordInteractionData {
+  custom_id?: string;
+  name?: string;
+  options?: DiscordCommandOption[];
+  values?: string[];
+}
+
+export interface DiscordCommandOption {
+  name: string;
+  options?: DiscordCommandOption[];
+  value?: boolean | number | string;
+}
+
+export interface DiscordUser {
+  bot?: boolean;
+  global_name?: string | null;
+  id: string;
+  username: string;
+}
+
+export interface DiscordCustomId {
+  actionId: string;
+  value?: string;
+}
+
+const DISCORD_INTERACTION_TYPE = {
+  APPLICATION_COMMAND: 2,
+  MESSAGE_COMPONENT: 3,
+  PING: 1
+} as const;
+
+const DISCORD_RESPONSE_TYPE = {
+  DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE: 5,
+  DEFERRED_UPDATE_MESSAGE: 6,
+  PONG: 1
+} as const;
+
+const DISCORD_THREAD_CHANNEL_TYPES = new Set([10, 11, 12]);
+const DISCORD_CUSTOM_ID_MAX_LENGTH = 100;
+const DISCORD_CUSTOM_ID_SEPARATOR = "\n";
+const DISCORD_CONTENT_MAX_LENGTH = 2_000;
+
+class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
+  readonly name: string;
+  readonly botUserId: string;
+  readonly userName: string;
+  protected chat?: ChatInstance;
+  protected readonly apiUrl: string;
+  protected readonly applicationId: string;
+  protected readonly fetcher: typeof fetch;
+  protected readonly publicKey: string;
+  protected readonly timestampToleranceMs: number;
+
+  constructor(config: DiscordAdapterConfig) {
+    this.apiUrl = config.apiUrl ?? DISCORD_API_BASE_URL;
+    this.applicationId = config.applicationId;
+    this.botUserId = config.applicationId;
+    this.fetcher = config.fetch ?? fetch;
+    this.name = config.adapterName;
+    this.publicKey = config.publicKey
+      ? normalizeDiscordPublicKey(config.publicKey)
+      : "";
+    this.timestampToleranceMs = normalizeDiscordTimestampTolerance(
+      config.timestampToleranceMs
+    );
+    this.userName = config.userName ?? "discord";
+  }
+
+  async initialize(chat: ChatInstance): Promise<void> {
+    this.chat = chat;
+  }
+
+  async handleWebhook(
+    request: Request,
+    options?: WebhookOptions
+  ): Promise<Response> {
+    if (!this.publicKey) {
+      return new Response("Discord public key is not configured", {
+        status: 500
+      });
+    }
+    const bodyResult = await readDiscordInteractionBody(request);
+    if (bodyResult instanceof Response) {
+      return bodyResult;
+    }
+    const body = bodyResult;
+    const signature = request.headers.get("x-signature-ed25519");
+    const timestamp = request.headers.get("x-signature-timestamp");
+    const verified = await verifyDiscordInteractionRequest({
+      body,
+      publicKey: this.publicKey,
+      signature,
+      timestamp,
+      timestampToleranceMs: this.timestampToleranceMs
+    });
+    if (!verified) {
+      return new Response("Invalid signature", { status: 401 });
+    }
+
+    let interaction: DiscordInteraction;
+    try {
+      interaction = JSON.parse(new TextDecoder().decode(body));
+    } catch {
+      return new Response("Invalid JSON", { status: 400 });
+    }
+
+    if (interaction.application_id !== this.applicationId) {
+      return new Response("Application mismatch", { status: 401 });
+    }
+
+    if (interaction.type === DISCORD_INTERACTION_TYPE.PING) {
+      return Response.json({ type: DISCORD_RESPONSE_TYPE.PONG });
+    }
+
+    if (interaction.type === DISCORD_INTERACTION_TYPE.APPLICATION_COMMAND) {
+      if (!(await this.handleApplicationCommand(interaction, options))) {
+        return new Response("Invalid application command", { status: 400 });
+      }
+      return Response.json({
+        type: DISCORD_RESPONSE_TYPE.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+      });
+    }
+
+    if (interaction.type === DISCORD_INTERACTION_TYPE.MESSAGE_COMPONENT) {
+      if (!(await this.handleMessageComponent(interaction, options))) {
+        return Response.json({
+          type: DISCORD_RESPONSE_TYPE.DEFERRED_UPDATE_MESSAGE
+        });
+      }
+      return Response.json({
+        type: DISCORD_RESPONSE_TYPE.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+      });
+    }
+
+    return new Response("Unsupported Discord interaction type", {
+      status: 501
+    });
+  }
+
+  addReaction(
+    _threadId: string,
+    _messageId: string,
+    _emoji: EmojiValue | string
+  ): Promise<void> {
+    throw new Error("Discord addReaction is not implemented yet");
+  }
+
+  channelIdFromThreadId(threadId: string): string {
+    return threadId.split(":").slice(0, 3).join(":");
+  }
+
+  decodeThreadId(threadId: string): DiscordThreadId {
+    const [provider, guildId, channelId, discordThreadId] = threadId.split(":");
+    if (provider !== "discord" || !guildId || !channelId) {
+      throw new Error(`Invalid Discord thread id: ${threadId}`);
+    }
+    return { channelId, guildId, threadId: discordThreadId };
+  }
+
+  deleteMessage(_threadId: string, _messageId: string): Promise<void> {
+    throw new Error("Discord deleteMessage is not implemented yet");
+  }
+
+  editMessage(
+    _threadId: string,
+    _messageId: string,
+    _message: AdapterPostableMessage
+  ): Promise<RawMessage<unknown>> {
+    throw new Error("Discord editMessage is not implemented yet");
+  }
+
+  encodeThreadId(platformData: DiscordThreadId): string {
+    return [
+      "discord",
+      platformData.guildId,
+      platformData.channelId,
+      platformData.threadId
+    ]
+      .filter(Boolean)
+      .join(":");
+  }
+
+  fetchChannelInfo(_channelId: string): Promise<ChannelInfo> {
+    throw new Error("Discord fetchChannelInfo is not implemented yet");
+  }
+
+  fetchMessages(
+    _threadId: string,
+    _options?: FetchOptions
+  ): Promise<FetchResult<unknown>> {
+    throw new Error("Discord fetchMessages is not implemented yet");
+  }
+
+  fetchThread(_threadId: string): Promise<ThreadInfo> {
+    throw new Error("Discord fetchThread is not implemented yet");
+  }
+
+  isDM(threadId: string): boolean {
+    return this.decodeThreadId(threadId).guildId === "@me";
+  }
+
+  parseMessage(_raw: unknown): never {
+    throw new Error("Discord parseMessage is not implemented yet");
+  }
+
+  postMessage(
+    threadId: string,
+    message: AdapterPostableMessage
+  ): Promise<RawMessage<unknown>> {
+    return this.postInteractionResponse(threadId, message);
+  }
+
+  removeReaction(
+    _threadId: string,
+    _messageId: string,
+    _emoji: EmojiValue | string
+  ): Promise<void> {
+    throw new Error("Discord removeReaction is not implemented yet");
+  }
+
+  renderFormatted(content: FormattedContent): string {
+    return stringifyMarkdown(content);
+  }
+
+  startTyping(_threadId: string, _status?: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async stream(
+    threadId: string,
+    textStream: AsyncIterable<string | StreamChunk>
+  ): Promise<RawMessage<unknown> | null> {
+    let text = "";
+    for await (const chunk of textStream) {
+      if (typeof chunk === "string") {
+        text += chunk;
+      } else if (chunk.type === "markdown_text") {
+        text += chunk.text;
+      }
+    }
+    return this.postMessage(threadId, { markdown: text });
+  }
+
+  protected async handleApplicationCommand(
+    interaction: DiscordInteraction,
+    options?: WebhookOptions
+  ): Promise<boolean> {
+    if (!this.chat) return false;
+    const commandName = interaction.data?.name;
+    const user = interaction.member?.user ?? interaction.user;
+    const channelId = this.threadIdForInteraction(interaction);
+    if (!commandName || !user || !channelId) return false;
+
+    const { command, text } = parseDiscordSlashCommand(
+      commandName,
+      interaction.data?.options
+    );
+    const surfaceId = interactionSurfaceId(interaction.id);
+    const chat = this.chat;
+    this.runInteractionTask(options, async () => {
+      await this.storeInteractionResponseContext(surfaceId, {
+        channelId,
+        expiresAt: Date.now() + DISCORD_INTERACTION_TOKEN_TTL_MS,
+        initialResponseSent: false,
+        token: interaction.token
+      });
+
+      chat.processSlashCommand(
+        {
+          adapter: this,
+          channelId: surfaceId,
+          command,
+          raw: redactDiscordInteraction(interaction),
+          text,
+          user: toDiscordAuthor(user)
+        },
+        options
+      );
+    });
+    return true;
+  }
+
+  protected async handleMessageComponent(
+    interaction: DiscordInteraction,
+    options?: WebhookOptions
+  ): Promise<boolean> {
+    if (!this.chat) return false;
+    const customId = interaction.data?.custom_id;
+    const user = interaction.member?.user ?? interaction.user;
+    const messageId = interaction.message?.id;
+    const threadId = this.threadIdForInteraction(interaction);
+    if (!customId || !user || !messageId || !threadId) return false;
+
+    let decoded: DiscordCustomId;
+    try {
+      decoded = decodeDiscordCustomId(customId);
+    } catch {
+      return false;
+    }
+    const selectedValue = selectedDiscordComponentValue(interaction.data);
+    const surfaceId = interactionSurfaceId(interaction.id);
+    const chat = this.chat;
+    this.runInteractionTask(options, async () => {
+      await this.storeInteractionResponseContext(surfaceId, {
+        channelId: threadId,
+        expiresAt: Date.now() + DISCORD_INTERACTION_TOKEN_TTL_MS,
+        initialResponseSent: false,
+        token: interaction.token
+      });
+      chat.processAction(
+        {
+          actionId: decoded.actionId,
+          adapter: this,
+          messageId,
+          raw: redactDiscordInteraction(interaction),
+          threadId: surfaceId,
+          user: toDiscordAuthor(user),
+          value: selectedValue ?? decoded.value
+        },
+        options
+      );
+    });
+    return true;
+  }
+
+  protected runInteractionTask(
+    options: WebhookOptions | undefined,
+    work: () => Promise<void>
+  ): void {
+    const task = work().catch((error) => {
+      console.error("Discord interaction processing failed", error);
+    });
+    options?.waitUntil?.(task);
+  }
+
+  protected threadIdForInteraction(
+    interaction: DiscordInteraction
+  ): string | undefined {
+    const interactionChannelId =
+      interaction.channel_id ?? interaction.channel?.id;
+    if (!interactionChannelId) return undefined;
+    const guildId = interaction.guild_id ?? "@me";
+    const channel = interaction.channel;
+    const isThread = channel
+      ? DISCORD_THREAD_CHANNEL_TYPES.has(channel.type)
+      : false;
+    const parentChannelId =
+      isThread && channel?.parent_id ? channel.parent_id : interactionChannelId;
+    return this.encodeThreadId({
+      channelId: parentChannelId,
+      guildId,
+      threadId: isThread ? interactionChannelId : undefined
+    });
+  }
+
+  protected async postInteractionResponse(
+    surfaceId: string,
+    message: AdapterPostableMessage
+  ): Promise<RawMessage<unknown>> {
+    const context = await this.getInteractionResponseContext(surfaceId);
+    if (!context) {
+      throw new Error(
+        "Discord channel message delivery is not implemented yet"
+      );
+    }
+
+    const payload = this.toDiscordMessagePayload(message);
+    const initial = !context.initialResponseSent;
+    const applicationId = encodeURIComponent(this.applicationId);
+    const token = encodeURIComponent(context.token);
+    const path = initial
+      ? `/webhooks/${applicationId}/${token}/messages/@original`
+      : `/webhooks/${applicationId}/${token}?wait=true`;
+    const response = await this.discordInteractionFetch(
+      path,
+      initial ? "PATCH" : "POST",
+      payload
+    );
+    if (initial) {
+      await this.storeInteractionResponseContext(surfaceId, {
+        ...context,
+        initialResponseSent: true
+      });
+    }
+    const raw = (await response.json()) as { id?: unknown };
+    return {
+      id: typeof raw.id === "string" ? raw.id : surfaceId,
+      raw,
+      threadId: context.channelId
+    };
+  }
+
+  protected async getInteractionResponseContext(
+    surfaceId: string
+  ): Promise<DiscordInteractionResponseContext | null> {
+    const state = this.chat?.getState();
+    if (!state) return null;
+    const context = await state.get<DiscordInteractionResponseContext>(
+      interactionResponseContextKey(surfaceId)
+    );
+    if (!context) return null;
+    if (Date.now() >= context.expiresAt) {
+      await state.delete(interactionResponseContextKey(surfaceId));
+      return null;
+    }
+    return context;
+  }
+
+  protected async storeInteractionResponseContext(
+    surfaceId: string,
+    context: DiscordInteractionResponseContext
+  ): Promise<void> {
+    const state = this.chat?.getState();
+    if (!state) return;
+    const ttlMs = Math.max(1, context.expiresAt - Date.now());
+    await state.set(interactionResponseContextKey(surfaceId), context, ttlMs);
+  }
+
+  protected toDiscordMessagePayload(
+    message: AdapterPostableMessage
+  ): DiscordMessagePayload {
+    const rendered = this.renderPostable(message);
+    return {
+      allowed_mentions: { parse: [] },
+      content:
+        rendered.length <= DISCORD_CONTENT_MAX_LENGTH
+          ? rendered
+          : `${rendered.slice(0, DISCORD_CONTENT_MAX_LENGTH - 3)}...`
+    };
+  }
+
+  protected renderPostable(message: AdapterPostableMessage): string {
+    if (typeof message === "string") {
+      return message;
+    }
+    if ("raw" in message && typeof message.raw === "string") {
+      return message.raw;
+    }
+    if ("markdown" in message && typeof message.markdown === "string") {
+      return message.markdown;
+    }
+    if ("ast" in message) {
+      return this.renderFormatted(message.ast);
+    }
+    return "";
+  }
+
+  protected async discordInteractionFetch(
+    path: string,
+    method: string,
+    body: unknown
+  ): Promise<Response> {
+    const response = await this.fetcher(`${this.apiUrl}${path}`, {
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+      method
+    });
+    if (!response.ok) {
+      throw new Error(`Discord interaction request failed: ${response.status}`);
+    }
+    return response;
+  }
+}
+
+export function discordMessenger(
+  options: DiscordMessengerOptions
+): MessengerDefinition {
+  const interactions = resolveDiscordInteractionsOptions(options.interactions);
+  if (interactions.enabled && !options.publicKey) {
+    throw new Error("discordMessenger requires publicKey for Interactions");
+  }
+  if (!interactions.enabled && !options.background) {
+    throw new Error(
+      "discordMessenger with interactions disabled requires background ingress"
+    );
+  }
+  const {
+    apiUrl: _apiUrl,
+    applicationId: _applicationId,
+    fetch: _fetch,
+    interactions: _interactions,
+    publicKey: _publicKey,
+    token: _token,
+    ...messengerOptions
+  } = options;
+  const adapterName = options.adapterName ?? "discord";
+  const adapter = new DiscordAdapter({
+    adapterName,
+    apiUrl: options.apiUrl,
+    applicationId: options.applicationId,
+    fetch: options.fetch,
+    publicKey: options.publicKey,
+    timestampToleranceMs: interactions.timestampToleranceMs,
+    userName: options.userName
+  });
+
+  return chatSdkMessenger({
+    ...messengerOptions,
+    adapter,
+    adapterName,
+    capabilities: {
+      canEditMessages: false,
+      canStream: false,
+      maxMessageLength: 2_000,
+      supportsActions: false,
+      supportsAttachments: false,
+      supportsEphemeral: false,
+      ...options.capabilities
+    },
+    delivery: {
+      splitText: splitDiscordMessageText,
+      visibleSoftLimit: DISCORD_STREAM_SOFT_LIMIT,
+      ...options.delivery
+    },
+    path: interactions.enabled ? options.path : false,
+    provider: "discord",
+    respondTo:
+      options.respondTo ??
+      (interactions.enabled ? ["command", "action"] : undefined),
+    toEvent: options.toEvent ?? discordMessengerEvent,
+    userName: options.userName,
+    // Discord Interactions verification needs the raw request body, so the
+    // adapter handles it internally instead of the generic runtime preflight.
+    verifyWebhook: false
+  });
+}
+
+export default discordMessenger;
+
+export function encodeDiscordCustomId(
+  actionId: string,
+  value?: string
+): string {
+  if (!actionId || actionId.includes(DISCORD_CUSTOM_ID_SEPARATOR)) {
+    throw new Error("Discord custom_id action id is invalid");
+  }
+  const customId =
+    value !== undefined
+      ? `${actionId}${DISCORD_CUSTOM_ID_SEPARATOR}${value}`
+      : actionId;
+  validateDiscordCustomId(customId);
+  return customId;
+}
+
+export function decodeDiscordCustomId(customId: string): DiscordCustomId {
+  validateDiscordCustomId(customId);
+  const separator = customId.indexOf(DISCORD_CUSTOM_ID_SEPARATOR);
+  if (separator === -1) {
+    return { actionId: customId };
+  }
+  const actionId = customId.slice(0, separator);
+  if (!actionId) {
+    throw new Error("Discord custom_id action id is invalid");
+  }
+  return {
+    actionId,
+    value: customId.slice(separator + DISCORD_CUSTOM_ID_SEPARATOR.length)
+  };
+}
+
+export function discordMessengerEvent(
+  input: ChatSdkMessengerEventInput,
+  definition: NormalizedMessengerDefinition
+) {
+  const event = defaultDiscordMessengerEvent(definition, input);
+  const raw = interactionFromRaw(input.command?.raw ?? input.action?.raw);
+  if (raw) {
+    const thread = messengerThreadFromInteraction(raw);
+    if (thread) {
+      return { ...event, thread };
+    }
+  }
+  return event;
+}
+
+export function parseDiscordSlashCommand(
+  name: string,
+  options: DiscordCommandOption[] = []
+): { command: string; text: string } {
+  const commandParts = [name.startsWith("/") ? name : `/${name}`];
+  const valueParts: string[] = [];
+
+  const collect = (items: DiscordCommandOption[]) => {
+    for (const option of items) {
+      if (option.value !== undefined) {
+        valueParts.push(String(option.value));
+        continue;
+      }
+      if (option.options && option.options.length > 0) {
+        commandParts.push(option.name);
+        collect(option.options);
+      }
+    }
+  };
+
+  collect(options);
+  return { command: commandParts.join(" "), text: valueParts.join(" ") };
+}
+
+export interface VerifyDiscordInteractionRequestOptions {
+  body: ArrayBuffer;
+  publicKey: string;
+  signature: string | null;
+  timestamp: string | null;
+  timestampToleranceMs?: number;
+}
+
+export async function verifyDiscordInteractionRequest(
+  options: VerifyDiscordInteractionRequestOptions
+): Promise<boolean> {
+  if (!options.signature || !options.timestamp) return false;
+  if (!DISCORD_SIGNATURE_PATTERN.test(options.signature)) return false;
+  const timestampSeconds = Number(options.timestamp);
+  if (!Number.isFinite(timestampSeconds)) return false;
+
+  const toleranceMs = normalizeDiscordTimestampTolerance(
+    options.timestampToleranceMs
+  );
+  if (toleranceMs > 0) {
+    const ageMs = Math.abs(Date.now() - timestampSeconds * 1_000);
+    if (ageMs > toleranceMs) return false;
+  }
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    bytesToArrayBuffer(
+      hexToBytes(normalizeDiscordPublicKey(options.publicKey))
+    ),
+    { name: "Ed25519" },
+    false,
+    ["verify"]
+  );
+  const timestampBytes = new TextEncoder().encode(options.timestamp);
+  const bodyBytes = new Uint8Array(options.body);
+  const signed = new Uint8Array(timestampBytes.length + bodyBytes.length);
+  signed.set(timestampBytes);
+  signed.set(bodyBytes, timestampBytes.length);
+
+  return crypto.subtle.verify(
+    { name: "Ed25519" },
+    key,
+    bytesToArrayBuffer(hexToBytes(options.signature)),
+    bytesToArrayBuffer(signed)
+  );
+}
+
+export function normalizeDiscordPublicKey(publicKey: string): string {
+  const normalized = publicKey.trim().toLowerCase();
+  if (!DISCORD_PUBLIC_KEY_PATTERN.test(normalized)) {
+    throw new Error("Discord publicKey must be a 64-character hex string");
+  }
+  return normalized;
+}
+
+export function splitDiscordMessageText(
+  text: string,
+  limit = DISCORD_FOLLOWUP_CHUNK_LIMIT
+): string[] {
+  if (!text.trim()) {
+    return [];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > limit) {
+    let splitAt = remaining.lastIndexOf("\n\n", limit);
+    if (splitAt < Math.floor(limit * 0.5)) {
+      splitAt = remaining.lastIndexOf("\n", limit);
+    }
+    if (splitAt < Math.floor(limit * 0.5)) {
+      splitAt = remaining.lastIndexOf(" ", limit);
+    }
+    if (splitAt < Math.floor(limit * 0.5)) {
+      splitAt = limit;
+    }
+
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}
+
+function resolveDiscordInteractionsOptions(
+  options: DiscordMessengerOptions["interactions"]
+): Required<DiscordInteractionsOptions> {
+  if (options === false) {
+    return {
+      enabled: false,
+      timestampToleranceMs: DISCORD_INTERACTION_TIMESTAMP_TOLERANCE_MS
+    };
+  }
+  if (options === true || options === undefined) {
+    return {
+      enabled: true,
+      timestampToleranceMs: DISCORD_INTERACTION_TIMESTAMP_TOLERANCE_MS
+    };
+  }
+
+  return {
+    enabled: options.enabled ?? true,
+    timestampToleranceMs:
+      options.timestampToleranceMs ?? DISCORD_INTERACTION_TIMESTAMP_TOLERANCE_MS
+  };
+}
+
+function normalizeDiscordTimestampTolerance(value: number | undefined): number {
+  const tolerance = value ?? DISCORD_INTERACTION_TIMESTAMP_TOLERANCE_MS;
+  if (!Number.isFinite(tolerance) || tolerance <= 0) {
+    throw new Error("Discord timestampToleranceMs must be a positive number");
+  }
+  return tolerance;
+}
+
+async function readDiscordInteractionBody(
+  request: Request
+): Promise<ArrayBuffer | Response> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength) {
+    const size = Number(contentLength);
+    if (!Number.isFinite(size) || size > DISCORD_INTERACTION_BODY_LIMIT_BYTES) {
+      return new Response("Discord interaction body too large", {
+        status: 413
+      });
+    }
+  }
+
+  if (!request.body) {
+    const body = await request.arrayBuffer();
+    if (body.byteLength > DISCORD_INTERACTION_BODY_LIMIT_BYTES) {
+      return new Response("Discord interaction body too large", {
+        status: 413
+      });
+    }
+    return body;
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > DISCORD_INTERACTION_BODY_LIMIT_BYTES) {
+      await reader.cancel();
+      return new Response("Discord interaction body too large", {
+        status: 413
+      });
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytesToArrayBuffer(body);
+}
+
+function selectedDiscordComponentValue(
+  data: DiscordInteractionData | undefined
+): string | undefined {
+  if (!data?.values || data.values.length === 0) {
+    return undefined;
+  }
+  return data.values.length === 1
+    ? data.values[0]
+    : JSON.stringify(data.values);
+}
+
+function interactionSurfaceId(interactionId: string): string {
+  return `discord:interaction:${interactionId}`;
+}
+
+function interactionResponseContextKey(surfaceId: string): string {
+  return `discord:interaction-response:${surfaceId}`;
+}
+
+function validateDiscordCustomId(customId: string): void {
+  if (customId.length === 0 || customId.length > DISCORD_CUSTOM_ID_MAX_LENGTH) {
+    throw new Error(
+      `Discord custom_id must be 1-${DISCORD_CUSTOM_ID_MAX_LENGTH} characters`
+    );
+  }
+}
+
+function toDiscordAuthor(user: DiscordUser) {
+  return {
+    fullName: user.global_name || user.username,
+    isBot: user.bot ?? false,
+    isMe: false,
+    userId: user.id,
+    userName: user.username
+  };
+}
+
+function redactDiscordInteraction(
+  interaction: DiscordInteraction
+): Omit<DiscordInteraction, "token"> {
+  const { token: _token, ...redacted } = interaction;
+  return redacted;
+}
+
+function interactionFromRaw(raw: unknown): DiscordInteraction | null {
+  if (raw === null || typeof raw !== "object") {
+    return null;
+  }
+  const candidate = raw as Partial<DiscordInteraction>;
+  if (typeof candidate.id !== "string" || typeof candidate.type !== "number") {
+    return null;
+  }
+  return candidate as DiscordInteraction;
+}
+
+function messengerThreadFromInteraction(interaction: DiscordInteraction): {
+  channelId?: string;
+  id: string;
+  isDirectMessage: boolean;
+  providerThreadId: string;
+} | null {
+  const interactionChannelId =
+    interaction.channel_id ?? interaction.channel?.id;
+  if (!interactionChannelId) return null;
+  const guildId = interaction.guild_id ?? "@me";
+  const channel = interaction.channel;
+  const isThread = channel
+    ? DISCORD_THREAD_CHANNEL_TYPES.has(channel.type)
+    : false;
+  const parentChannelId =
+    isThread && channel?.parent_id ? channel.parent_id : interactionChannelId;
+  const id = [
+    "discord",
+    guildId,
+    parentChannelId,
+    isThread ? interactionChannelId : undefined
+  ]
+    .filter(Boolean)
+    .join(":");
+  return {
+    channelId: ["discord", guildId, parentChannelId].join(":"),
+    id,
+    isDirectMessage: guildId === "@me",
+    providerThreadId: id
+  };
+}
+
+function defaultDiscordMessengerEvent(
+  definition: NormalizedMessengerDefinition,
+  input: ChatSdkMessengerEventInput
+) {
+  return defaultChatSdkEvent(definition, input);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}

--- a/packages/think/src/messengers/events.ts
+++ b/packages/think/src/messengers/events.ts
@@ -52,6 +52,7 @@ export interface MessengerMessage {
 export interface MessengerAction {
   actionId: string;
   messageId?: string;
+  providerActionId?: string;
   raw?: unknown;
   user?: MessengerAuthor;
   value?: string;
@@ -134,6 +135,7 @@ export function serializableMessengerEvent(
       ? {
           actionId: event.action.actionId,
           messageId: event.action.messageId,
+          providerActionId: event.action.providerActionId,
           user: event.action.user ? { ...event.action.user } : undefined,
           value: event.action.value
         }
@@ -197,6 +199,7 @@ export function toMessengerUserMessage(event: MessengerEvent): UIMessage {
         event.messengerId,
         "action",
         event.thread.id,
+        event.action.providerActionId,
         event.action.messageId,
         event.action.actionId
       ]

--- a/packages/think/src/tests/messengers.test.ts
+++ b/packages/think/src/tests/messengers.test.ts
@@ -39,6 +39,14 @@ import telegramMessenger, {
   splitTelegramMessageText,
   telegramSecretTokenVerifier
 } from "../messengers/telegram";
+import discordMessenger, {
+  decodeDiscordCustomId,
+  encodeDiscordCustomId,
+  normalizeDiscordPublicKey,
+  parseDiscordSlashCommand,
+  splitDiscordMessageText,
+  verifyDiscordInteractionRequest
+} from "../messengers/discord";
 
 const baseEvent: MessengerEvent = {
   capabilities: { canStream: true },
@@ -425,7 +433,18 @@ describe("think messengers core", () => {
       }
     };
     expect(idempotencyKeyForEvent(actionEvent)).toBe(
-      "messenger:telegram:message:telegram:-100123:42:action:source-message:approve:user-1:ship-it"
+      "messenger:telegram:message:telegram:-100123:42:action:no-provider-action:source-message:approve:user-1:ship-it"
+    );
+    expect(
+      idempotencyKeyForEvent({
+        ...actionEvent,
+        action: {
+          ...actionEvent.action!,
+          providerActionId: "interaction-1"
+        }
+      })
+    ).toBe(
+      "messenger:telegram:message:telegram:-100123:42:action:interaction-1:source-message:approve:user-1:ship-it"
     );
     expect(
       idempotencyKeyForEvent({
@@ -534,6 +553,48 @@ describe("think messengers core", () => {
         ].join("\n")
       }
     ]);
+  });
+
+  it("keeps action user message IDs stable after recovery serialization", () => {
+    const event = defaultChatSdkEvent(
+      normalizeMessengers({
+        fake: chatSdkMessenger({
+          adapter: fakeAdapter(),
+          capabilities: { supportsActions: true },
+          provider: "fake",
+          userName: "fake_bot",
+          verifyWebhook: false
+        })
+      })[0]!,
+      {
+        action: {
+          actionId: "approve",
+          adapter: fakeAdapter(),
+          messageId: "source-message",
+          raw: { id: "interaction-1", token: "secret-token" },
+          thread: null,
+          threadId: "fake:thread",
+          user: {
+            fullName: "Ada Lovelace",
+            isBot: false,
+            isMe: false,
+            userId: "fake:user",
+            userName: "ada"
+          },
+          value: "ship-it"
+        } as never,
+        eventKind: "action",
+        thread: fakeThread("fake:thread")
+      }
+    );
+    const restored = serializableMessengerEvent(event);
+
+    expect(restored.action?.raw).toBeUndefined();
+    expect(restored.action?.providerActionId).toBe("interaction-1");
+    expect(toMessengerUserMessage(restored).id).toBe(
+      toMessengerUserMessage(event).id
+    );
+    expect(JSON.stringify(restored)).not.toContain("secret-token");
   });
 
   it("converts messenger commands to Think user messages", () => {
@@ -1162,6 +1223,442 @@ describe("telegram messenger provider", () => {
   });
 });
 
+describe("discord messenger provider", () => {
+  it("normalizes provider defaults", () => {
+    const [definition] = normalizeMessengers({
+      discord: discordMessenger({
+        applicationId: "123456789012345678",
+        publicKey: validDiscordPublicKey(),
+        userName: "fake_bot"
+      })
+    });
+
+    expect(definition?.adapterName).toBe("discord");
+    expect(definition?.path).toBe("/messengers/discord/webhook");
+    expect(definition?.provider).toBe("discord");
+    expect(definition?.verifyWebhook).toBe(false);
+    expect(definition?.respondTo).toEqual(["command", "action"]);
+    expect(definition?.capabilities).toMatchObject({
+      canEditMessages: false,
+      canStream: false,
+      maxMessageLength: 2_000,
+      supportsActions: false,
+      supportsAttachments: false,
+      supportsEphemeral: false
+    });
+    expect(JSON.stringify(definition)).not.toContain("token");
+  });
+
+  it("propagates custom adapter names to the Discord adapter", () => {
+    const [definition] = normalizeMessengers({
+      first: discordMessenger({
+        adapterName: "discord-support",
+        applicationId: "123456789012345678",
+        publicKey: validDiscordPublicKey(),
+        token: "token",
+        userName: "fake_bot"
+      })
+    });
+
+    expect(definition?.adapterName).toBe("discord-support");
+    expect(definition?.adapter.name).toBe("discord-support");
+  });
+
+  it("requires background ingress when Discord interactions are disabled", () => {
+    expect(() =>
+      discordMessenger({
+        applicationId: "123456789012345678",
+        interactions: false,
+        token: "token",
+        userName: "fake_bot"
+      })
+    ).toThrow("requires background ingress");
+  });
+
+  it("requires a valid public key", () => {
+    expect(() => normalizeDiscordPublicKey("not-a-key")).toThrow(
+      "64-character hex"
+    );
+  });
+
+  it("verifies signed Discord interaction requests", async () => {
+    const body = JSON.stringify({ type: 1 });
+    const { publicKey, signature, timestamp } = await signDiscordBody(body);
+
+    await expect(
+      verifyDiscordInteractionRequest({
+        body: new TextEncoder().encode(body).buffer,
+        publicKey,
+        signature,
+        timestamp
+      })
+    ).resolves.toBe(true);
+
+    await expect(
+      verifyDiscordInteractionRequest({
+        body: new TextEncoder().encode(body).buffer,
+        publicKey,
+        signature: `${signature.slice(0, -2)}00`,
+        timestamp
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("parses Discord slash command paths and text", () => {
+    expect(
+      parseDiscordSlashCommand("project", [
+        {
+          name: "issue",
+          options: [
+            {
+              name: "create",
+              options: [{ name: "title", value: "Login fails" }]
+            }
+          ]
+        }
+      ])
+    ).toEqual({
+      command: "/project issue create",
+      text: "Login fails"
+    });
+  });
+
+  it("encodes and decodes Discord custom IDs", () => {
+    expect(decodeDiscordCustomId(encodeDiscordCustomId("approve"))).toEqual({
+      actionId: "approve"
+    });
+    expect(
+      decodeDiscordCustomId(encodeDiscordCustomId("approve", "ship-it"))
+    ).toEqual({
+      actionId: "approve",
+      value: "ship-it"
+    });
+    expect(() => encodeDiscordCustomId("x".repeat(101))).toThrow("custom_id");
+  });
+
+  it("handles signed Discord PING interactions", async () => {
+    const body = JSON.stringify({
+      application_id: "123456789012345678",
+      id: "interaction-1",
+      token: "interaction-token",
+      type: 1,
+      version: 1
+    });
+    const { publicKey, signature, timestamp } = await signDiscordBody(body);
+    const runtime = new ThinkMessengerRuntime(
+      defineMessengers({
+        discord: discordMessenger({
+          applicationId: "123456789012345678",
+          publicKey,
+          token: "token",
+          userName: "fake_bot"
+        })
+      }),
+      fakeHost([])
+    );
+
+    const response = await runtime.handleRequest(
+      new Request("https://example.com/messengers/discord/webhook", {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-signature-ed25519": signature,
+          "x-signature-timestamp": timestamp
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response?.status).toBe(200);
+    await expect(response?.json()).resolves.toEqual({ type: 1 });
+  });
+
+  it("normalizes signed Discord application commands", async () => {
+    const commands: unknown[] = [];
+    const body = JSON.stringify({
+      application_id: "123456789012345678",
+      channel: { id: "channel-1", type: 0 },
+      channel_id: "channel-1",
+      data: {
+        name: "project",
+        options: [
+          {
+            name: "issue",
+            options: [
+              {
+                name: "create",
+                options: [{ name: "title", value: "Login fails" }]
+              }
+            ]
+          }
+        ]
+      },
+      guild_id: "guild-1",
+      id: "interaction-1",
+      member: { user: discordUser() },
+      token: "interaction-token",
+      type: 2,
+      version: 1
+    });
+    const { publicKey, signature, timestamp } = await signDiscordBody(body);
+    const adapter = discordMessenger({
+      applicationId: "123456789012345678",
+      publicKey,
+      token: "token",
+      userName: "fake_bot"
+    }).adapter;
+    const state = memoryStateAdapter();
+    await adapter.initialize({
+      getState() {
+        return state;
+      },
+      processSlashCommand(event: unknown) {
+        commands.push(event);
+      }
+    } as never);
+
+    const response = await adapter.handleWebhook(
+      signedDiscordRequest(body, signature, timestamp)
+    );
+
+    expect(await response.json()).toEqual({ type: 5 });
+    await waitFor(() => commands.length === 1);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({
+      channelId: "discord:interaction:interaction-1",
+      command: "/project issue create",
+      text: "Login fails",
+      user: {
+        fullName: "Ada Lovelace",
+        isBot: false,
+        userId: "user-1",
+        userName: "ada"
+      }
+    });
+    expect(
+      (commands[0] as { raw?: { token?: unknown } }).raw
+    ).not.toHaveProperty("token");
+  });
+
+  it("passes waitUntil to Discord interaction processing", async () => {
+    const waited: Promise<unknown>[] = [];
+    const body = JSON.stringify({
+      application_id: "123456789012345678",
+      channel: { id: "channel-1", type: 0 },
+      channel_id: "channel-1",
+      data: { name: "ask" },
+      guild_id: "guild-1",
+      id: "interaction-1",
+      member: { user: discordUser() },
+      token: "interaction-token",
+      type: 2,
+      version: 1
+    });
+    const { publicKey, signature, timestamp } = await signDiscordBody(body);
+    const runtime = new ThinkMessengerRuntime(
+      defineMessengers({
+        discord: discordMessenger({
+          applicationId: "123456789012345678",
+          publicKey,
+          respondTo: [],
+          token: "token",
+          userName: "fake_bot"
+        })
+      }),
+      fakeHost([], [], (task) => waited.push(task), fakeStateSubAgent())
+    );
+
+    await runtime.handleRequest(
+      signedDiscordRequest(body, signature, timestamp)
+    );
+
+    expect(waited.length).toBeGreaterThan(0);
+    await Promise.all(waited);
+  });
+
+  it("delivers Discord command replies through interaction webhooks", async () => {
+    const calls: Array<{ body: unknown; method: string; url: string }> = [];
+    const body = JSON.stringify({
+      application_id: "123456789012345678",
+      channel: { id: "channel-1", type: 0 },
+      channel_id: "channel-1",
+      data: { name: "ask" },
+      guild_id: "guild-1",
+      id: "interaction-1",
+      member: { user: discordUser() },
+      token: "interaction/token",
+      type: 2,
+      version: 1
+    });
+    const { publicKey, signature, timestamp } = await signDiscordBody(body);
+    const adapter = discordMessenger({
+      applicationId: "123456789012345678",
+      fetch: async (input, init) => {
+        calls.push({
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+          method: init?.method ?? "GET",
+          url: String(input)
+        });
+        return Response.json({ id: `reply-${calls.length}` });
+      },
+      publicKey,
+      token: "token",
+      userName: "fake_bot"
+    }).adapter;
+    const state = memoryStateAdapter();
+    await adapter.initialize({
+      getState() {
+        return state;
+      },
+      processSlashCommand(event: { adapter: Adapter; channelId: string }) {
+        void event.adapter.postMessage(event.channelId, {
+          markdown: "hello **discord**"
+        });
+      }
+    } as never);
+
+    const response = await adapter.handleWebhook(
+      signedDiscordRequest(body, signature, timestamp)
+    );
+    await waitFor(() => calls.length === 1);
+
+    expect(await response.json()).toEqual({ type: 5 });
+    expect(calls).toEqual([
+      {
+        body: {
+          allowed_mentions: { parse: [] },
+          content: "hello **discord**"
+        },
+        method: "PATCH",
+        url: "https://discord.com/api/v10/webhooks/123456789012345678/interaction%2Ftoken/messages/@original"
+      }
+    ]);
+  });
+
+  it("normalizes signed Discord component actions", async () => {
+    const actions: unknown[] = [];
+    const body = JSON.stringify({
+      application_id: "123456789012345678",
+      channel: { id: "thread-1", parent_id: "channel-1", type: 11 },
+      channel_id: "thread-1",
+      data: {
+        custom_id: encodeDiscordCustomId("approve", "fallback-value"),
+        values: ["selected-value"]
+      },
+      guild_id: "guild-1",
+      id: "interaction-1",
+      member: { user: discordUser() },
+      message: { id: "message-1" },
+      token: "interaction-token",
+      type: 3,
+      version: 1
+    });
+    const { publicKey, signature, timestamp } = await signDiscordBody(body);
+    const adapter = discordMessenger({
+      applicationId: "123456789012345678",
+      publicKey,
+      token: "token",
+      userName: "fake_bot"
+    }).adapter;
+    const state = memoryStateAdapter();
+    await adapter.initialize({
+      getState() {
+        return state;
+      },
+      processAction(event: unknown) {
+        actions.push(event);
+      }
+    } as never);
+
+    const response = await adapter.handleWebhook(
+      signedDiscordRequest(body, signature, timestamp)
+    );
+
+    expect(await response.json()).toEqual({ type: 5 });
+    await waitFor(() => actions.length === 1);
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      actionId: "approve",
+      messageId: "message-1",
+      threadId: "discord:interaction:interaction-1",
+      user: { userId: "user-1" },
+      value: "selected-value"
+    });
+    expect(
+      (actions[0] as { raw?: { token?: unknown } }).raw
+    ).not.toHaveProperty("token");
+  });
+
+  it("acknowledges invalid Discord component custom IDs without routing", async () => {
+    const actions: unknown[] = [];
+    const body = JSON.stringify({
+      application_id: "123456789012345678",
+      channel: { id: "channel-1", type: 0 },
+      channel_id: "channel-1",
+      data: { custom_id: "" },
+      guild_id: "guild-1",
+      id: "interaction-1",
+      member: { user: discordUser() },
+      message: { id: "message-1" },
+      token: "interaction-token",
+      type: 3,
+      version: 1
+    });
+    const { publicKey, signature, timestamp } = await signDiscordBody(body);
+    const adapter = discordMessenger({
+      applicationId: "123456789012345678",
+      publicKey,
+      token: "token",
+      userName: "fake_bot"
+    }).adapter;
+    await adapter.initialize({
+      getState() {
+        return memoryStateAdapter();
+      },
+      processAction(event: unknown) {
+        actions.push(event);
+      }
+    } as never);
+
+    const response = await adapter.handleWebhook(
+      signedDiscordRequest(body, signature, timestamp)
+    );
+
+    expect(await response.json()).toEqual({ type: 6 });
+    expect(actions).toEqual([]);
+  });
+
+  it("rejects unsigned Discord interactions", async () => {
+    const runtime = new ThinkMessengerRuntime(
+      defineMessengers({
+        discord: discordMessenger({
+          applicationId: "123456789012345678",
+          publicKey: validDiscordPublicKey(),
+          token: "token",
+          userName: "fake_bot"
+        })
+      }),
+      fakeHost([])
+    );
+
+    const response = await runtime.handleRequest(
+      new Request("https://example.com/messengers/discord/webhook", {
+        body: JSON.stringify({ type: 1 }),
+        method: "POST"
+      })
+    );
+
+    expect(response?.status).toBe(401);
+  });
+
+  it("splits long Discord follow-up text without dropping content", () => {
+    const text = "alpha beta\n\ngamma delta epsilon";
+    const chunks = splitDiscordMessageText(text, 12);
+    expect(chunks.every((chunk) => chunk.length <= 12)).toBe(true);
+    expect(chunks.join("")).toBe(text);
+  });
+});
+
 async function collectText(stream: AsyncIterable<string>): Promise<string[]> {
   const chunks: string[] = [];
   for await (const chunk of stream) {
@@ -1200,7 +1697,9 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 
 function fakeHost(
   resolved: FiberRecoveryResult[],
-  parentPath: ReadonlyArray<{ className: string; name: string }> = []
+  parentPath: ReadonlyArray<{ className: string; name: string }> = [],
+  waitUntil?: (task: Promise<unknown>) => void,
+  subAgent?: unknown
 ): MessengerThinkHost {
   return {
     cancelChat() {
@@ -1220,8 +1719,12 @@ function fakeHost(
       throw new Error("startFiber is not used by this test");
     },
     subAgent() {
+      if (subAgent) {
+        return Promise.resolve(subAgent as never);
+      }
       throw new Error("subAgent is not used by this test");
-    }
+    },
+    waitUntil
   };
 }
 
@@ -1292,4 +1795,87 @@ function fakeChannel(id: string) {
     isDM: false,
     name: "Fake"
   } as never;
+}
+
+function fakeStateSubAgent() {
+  return {
+    cacheSet() {
+      return Promise.resolve();
+    }
+  };
+}
+
+function memoryStateAdapter() {
+  const values = new Map<string, unknown>();
+  return {
+    delete(key: string) {
+      values.delete(key);
+      return Promise.resolve();
+    },
+    get<T = unknown>(key: string): Promise<T | null> {
+      return Promise.resolve((values.get(key) as T | undefined) ?? null);
+    },
+    set(key: string, value: unknown) {
+      values.set(key, value);
+      return Promise.resolve();
+    }
+  };
+}
+
+function validDiscordPublicKey(): string {
+  return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+}
+
+async function signDiscordBody(body: string): Promise<{
+  publicKey: string;
+  signature: string;
+  timestamp: string;
+}> {
+  const keyPair = (await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify"
+  ])) as CryptoKeyPair;
+  const timestamp = String(Math.floor(Date.now() / 1_000));
+  const signed = new TextEncoder().encode(`${timestamp}${body}`);
+  const signature = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    keyPair.privateKey,
+    signed
+  );
+  const publicKey = await crypto.subtle.exportKey("raw", keyPair.publicKey);
+
+  return {
+    publicKey: bytesToHex(new Uint8Array(publicKey)),
+    signature: bytesToHex(new Uint8Array(signature)),
+    timestamp
+  };
+}
+
+function signedDiscordRequest(
+  body: string,
+  signature: string,
+  timestamp: string
+): Request {
+  return new Request("https://example.com/messengers/discord/webhook", {
+    body,
+    headers: {
+      "content-type": "application/json",
+      "x-signature-ed25519": signature,
+      "x-signature-timestamp": timestamp
+    },
+    method: "POST"
+  });
+}
+
+function discordUser() {
+  return {
+    bot: false,
+    global_name: "Ada Lovelace",
+    id: "user-1",
+    username: "ada"
+  };
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -3022,6 +3022,10 @@ export class Think<
     }
   }
 
+  waitUntil(task: Promise<unknown>): void {
+    this.ctx.waitUntil(task);
+  }
+
   private _initializeMessengers(): void {
     if (this.parentPath.length > 0) {
       return;


### PR DESCRIPTION
## Summary

Adds Discord slash-command support for Think agents.

Out of the box, a Think agent can now be connected to a Discord application Interactions endpoint and answer Discord slash commands from an HTTP callback, without discord.js or Node-only runtime dependencies.

For example, after configuring a Discord application endpoint, users can type a slash command like `/ask summarize this incident` in Discord. Think verifies the Discord signature, acknowledges the interaction, routes the command into the agent as a messenger turn, and sends the agent reply back through Discord interaction response webhooks.

This also supports Discord button and select interactions as inbound action events, so interactions attached to Discord messages can be routed back into the same Think conversation flow.

## What Works Now

- Discord can verify the Worker as an Interactions endpoint with `PING`.
- Discord slash commands can start Think messenger turns.
- Discord button and select component interactions can start Think action turns.
- Agent replies to slash commands and actions are delivered through Discord interaction webhooks.
- Discord interaction tokens are redacted from persisted messenger metadata.
- Multiple Discord messenger definitions can use distinct adapter names.
- The implementation runs on Workers without `discord.js`.

## What Users Still Need To Do

- Create a Discord application.
- Configure the Interactions Endpoint URL to the Worker messenger path.
- Register slash commands with Discord.
- Store the Discord public key and application ID in Worker config or secrets.

## Not Included Yet

- Reading normal Discord messages, DMs, or mentions.
- Gateway/WebSocket support.
- Posting to Discord channels outside the interaction response window.
- Command registration helpers.
- Attachments.
- Rich Discord component/card rendering.
- Reactions/edit/delete/fetch APIs.

## Verification

- `pnpm --filter @cloudflare/think exec vitest --run -c src/tests/vitest.config.ts src/tests/messengers.test.ts --reporter=dot`
- `pnpm --filter @cloudflare/think run build`
- `pnpm run check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->