### PR TITLE
fix(codemode): keep optional AI peer out of root entry

### DIFF
--- a/.changeset/codemode-optional-ai-peer.md
+++ b/.changeset/codemode-optional-ai-peer.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Remove the root entry's runtime dependency on the optional `ai` and `zod` peers. Executor and runtime imports now bundle without either framework package installed.

--- a/packages/codemode/scripts/build.ts
+++ b/packages/codemode/scripts/build.ts
@@ -1,5 +1,27 @@
+import { readFileSync } from "node:fs";
 import { build } from "tsdown";
 import { formatDeclarationFiles } from "../../../scripts/format-declarations";
+
+function assertFrameworkFreeRootEntry() {
+  const optionalFrameworkPeers = ["ai", "zod", "@tanstack/ai"];
+
+  for (const file of ["dist/index.js", "dist/index.d.ts"]) {
+    const rootEntry = readFileSync(file, "utf8");
+    const frameworkImport = optionalFrameworkPeers.find(
+      (peer) =>
+        rootEntry.includes(`from "${peer}"`) ||
+        rootEntry.includes(`from '${peer}'`) ||
+        rootEntry.includes(`import("${peer}")`) ||
+        rootEntry.includes(`import('${peer}')`)
+    );
+
+    if (frameworkImport) {
+      throw new Error(
+        `${file} must not import optional framework peer "${frameworkImport}"`
+      );
+    }
+  }
+}
 
 async function main() {
   await build({
@@ -21,6 +43,8 @@ async function main() {
     sourcemap: true,
     fixedExtension: false
   });
+
+  assertFrameworkFreeRootEntry();
 
   // then run oxfmt on the generated .d.ts files
   formatDeclarationFiles();

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -19,8 +19,6 @@
  * concurrently without clobbering one another.
  */
 import { RpcTarget } from "cloudflare:workers";
-import { tool, type Tool } from "ai";
-import { z } from "zod";
 import type { Executor, ResolvedProvider, ConnectorBinding } from "./executor";
 import { runCode } from "./run-code";
 import { normalizeCode } from "./normalize";
@@ -163,7 +161,64 @@ export type CreateProxyToolOptions = {
 // Schema + pause sentinel
 // ---------------------------------------------------------------------------
 
-const proxySchema = z.object({ code: z.string() });
+type StandardSchemaIssue = {
+  readonly message: string;
+  readonly path?: ReadonlyArray<PropertyKey>;
+};
+
+type ProxyToolInputSchema = {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: "@cloudflare/codemode";
+    readonly validate: (
+      value: unknown
+    ) =>
+      | { readonly value: ProxyToolInput }
+      | { readonly issues: ReadonlyArray<StandardSchemaIssue> };
+    readonly jsonSchema: {
+      readonly input: (options: {
+        readonly target: string;
+      }) => Record<string, unknown>;
+      readonly output: (options: {
+        readonly target: string;
+      }) => Record<string, unknown>;
+    };
+  };
+};
+
+const proxyJsonSchema = {
+  type: "object",
+  properties: {
+    code: { type: "string" }
+  },
+  required: ["code"],
+  additionalProperties: false
+};
+
+const proxySchema: ProxyToolInputSchema = {
+  "~standard": {
+    version: 1,
+    vendor: "@cloudflare/codemode",
+    validate: (value) => {
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        "code" in value &&
+        typeof value.code === "string"
+      ) {
+        return { value: { code: value.code } };
+      }
+
+      return {
+        issues: [{ message: "Expected an object with a string code property" }]
+      };
+    },
+    jsonSchema: {
+      input: (_options) => proxyJsonSchema,
+      output: (_options) => proxyJsonSchema
+    }
+  }
+};
 
 // Sandbox-side marker thrown to abort the run on a pause. The proxy tool
 // detects the pause via the facet's recorded state, not this message.
@@ -680,9 +735,16 @@ async function applyTransform(
 // createProxyTool
 // ---------------------------------------------------------------------------
 
-export function createProxyTool(
-  options: CreateProxyToolOptions
-): Tool<ProxyToolInput, ProxyToolOutput> {
+export type CodemodeTool = {
+  description: string;
+  inputSchema: ProxyToolInputSchema;
+  execute: (
+    input: ProxyToolInput,
+    options: unknown
+  ) => Promise<ProxyToolOutput>;
+};
+
+export function createProxyTool(options: CreateProxyToolOptions): CodemodeTool {
   const connectors = options.connectors;
   validateConnectorNames(connectors);
 
@@ -698,7 +760,7 @@ export function createProxyTool(
     return (setupPromise ??= loadSetup(connectors));
   }
 
-  return tool({
+  return {
     description: buildDescription(
       connectors,
       options.description,
@@ -730,7 +792,7 @@ export function createProxyTool(
         options.transformResult
       );
     }
-  });
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/codemode/src/runtime-handle.ts
+++ b/packages/codemode/src/runtime-handle.ts
@@ -1,4 +1,3 @@
-import type { Tool } from "ai";
 import type { CodemodeConnector } from "./connectors";
 import type { Executor } from "./executor";
 import {
@@ -11,7 +10,7 @@ import {
   resumeCodemode,
   rollbackCodemode,
   validateConnectorNames,
-  type ProxyToolInput,
+  type CodemodeTool,
   type ProxyToolOutput,
   type TransformResult
 } from "./proxy-tool";
@@ -81,9 +80,7 @@ export type CodemodeExpireOptions = {
 };
 
 export interface CodemodeRuntimeHandle {
-  tool(
-    options?: CodemodeRuntimeToolOptions
-  ): Tool<ProxyToolInput, ProxyToolOutput>;
+  tool(options?: CodemodeRuntimeToolOptions): CodemodeTool;
   approve(options: CodemodeApproveOptions): Promise<ProxyToolOutput>;
   /**
    * Reject a pending action, ending the run. Returns whether the reject
@@ -130,9 +127,7 @@ class DefaultCodemodeRuntimeHandle implements CodemodeRuntimeHandle {
     this.#options = options;
   }
 
-  tool(
-    options?: CodemodeRuntimeToolOptions
-  ): Tool<ProxyToolInput, ProxyToolOutput> {
+  tool(options?: CodemodeRuntimeToolOptions): CodemodeTool {
     return createProxyTool({
       ctx: this.#options.ctx,
       executor: this.#options.executor,

--- a/packages/codemode/src/tests/runtime-handle.test.ts
+++ b/packages/codemode/src/tests/runtime-handle.test.ts
@@ -1,4 +1,5 @@
-import { asSchema } from "ai";
+import { asSchema, streamText } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { describe, expect, it, vi } from "vitest";
 import type { Executor } from "../executor";
 import { createCodemodeRuntime } from "../runtime-handle";
@@ -76,6 +77,74 @@ describe("createCodemodeRuntime", () => {
     await expect(inputSchema.validate?.({ code: 1 })).resolves.toMatchObject({
       success: false
     });
+  });
+
+  it("executes as a plain tool through AI SDK streamText", async () => {
+    const runtimeStub = {
+      begin: vi.fn(async () => "exec_1"),
+      getExecution: vi.fn(async () => null),
+      complete: vi.fn(async () => undefined)
+    };
+    const executor = createMockExecutor("executed");
+    const runtime = createCodemodeRuntime({
+      ctx: createMockCtx(runtimeStub),
+      executor,
+      connectors: []
+    });
+    const model = new MockLanguageModelV3({
+      doStream: {
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            {
+              type: "tool-call",
+              toolCallId: "call_1",
+              toolName: "codemode",
+              input: JSON.stringify({ code: "return 1" })
+            },
+            {
+              type: "finish",
+              finishReason: { unified: "tool-calls", raw: undefined },
+              usage: {
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: 0,
+                  cacheWrite: 0
+                },
+                outputTokens: { total: 1, text: 1, reasoning: 0 }
+              }
+            }
+          ]
+        })
+      }
+    });
+
+    const result = streamText({
+      model,
+      prompt: "Execute the code",
+      tools: { codemode: runtime.tool() }
+    });
+
+    await expect(result.toolResults).resolves.toEqual([
+      expect.objectContaining({
+        toolCallId: "call_1",
+        toolName: "codemode",
+        input: { code: "return 1" },
+        output: {
+          status: "completed",
+          executionId: "exec_1",
+          result: "executed",
+          logs: undefined
+        }
+      })
+    ]);
+    expect(executor.execute).toHaveBeenCalled();
+    expect(runtimeStub.complete).toHaveBeenCalledWith(
+      "exec_1",
+      "executed",
+      undefined
+    );
   });
 
   it("approves a paused execution using the runtime's executor and connectors", async () => {

--- a/packages/codemode/src/tests/runtime-handle.test.ts
+++ b/packages/codemode/src/tests/runtime-handle.test.ts
@@ -1,3 +1,4 @@
+import { asSchema } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import type { Executor } from "../executor";
 import { createCodemodeRuntime } from "../runtime-handle";
@@ -46,7 +47,7 @@ describe("createCodemodeRuntime", () => {
     ).not.toThrow();
   });
 
-  it("exposes the model-facing tool from the runtime handle", () => {
+  it("exposes the model-facing tool from the runtime handle", async () => {
     const runtimeStub = {};
     const ctx = createMockCtx(runtimeStub);
     const executor = createMockExecutor();
@@ -61,6 +62,20 @@ describe("createCodemodeRuntime", () => {
 
     expect(codemode).toBeDefined();
     expect(codemode.execute).toBeDefined();
+
+    const inputSchema = asSchema(codemode.inputSchema);
+    expect(inputSchema.jsonSchema).toEqual({
+      type: "object",
+      properties: { code: { type: "string" } },
+      required: ["code"],
+      additionalProperties: false
+    });
+    await expect(inputSchema.validate?.({ code: "return 1" })).resolves.toEqual(
+      { success: true, value: { code: "return 1" } }
+    );
+    await expect(inputSchema.validate?.({ code: 1 })).resolves.toMatchObject({
+      success: false
+    });
   });
 
   it("approves a paused execution using the runtime's executor and connectors", async () => {


### PR DESCRIPTION
## Summary

- remove the root `@cloudflare/codemode` entry's runtime imports of the optional `ai` and `zod` peers
- return the runtime tool as the same plain AI SDK-compatible object that `tool()` already returned, with a dependency-free Standard Schema input validator
- fail the codemode build if the root JS or declaration entrypoint regains a framework-peer import
- cover `runtime.tool()` end to end through AI SDK `streamText`, including schema conversion, input validation, and execution
- add a patch changeset

Closes #1779.

## Testing

- packed `@cloudflare/codemode` and built an isolated Vite + `@cloudflare/vite-plugin` Worker fixture without `ai` installed
- `pnpm --filter @cloudflare/codemode run build`
- `pnpm --dir packages/codemode test` (297 unit/Workers, 38 runtime, 33 browser tests)
- `pnpm run build` (24 projects)
- `pnpm run check` (113 TypeScript projects)
