### PR TITLE
fix(codemode): preserve MCP request context

### DIFF
--- a/.changeset/codemode-mcp-request-context.md
+++ b/.changeset/codemode-mcp-request-context.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Pass the outer MCP tool-call context to `openApiMcpServer` request callbacks so server-to-client requests and notifications can be associated with the originating response stream.

--- a/examples/codemode-mcp-openapi/README.md
+++ b/examples/codemode-mcp-openapi/README.md
@@ -9,7 +9,7 @@ Demonstrates how to turn any OpenAPI spec into a pair of MCP tools (`search` + `
 - **`search`** — the LLM queries the spec as a JavaScript object to find endpoints, parameters, and schemas
 - **`execute`** — the LLM calls the API via a host-side `request()` function you provide
 
-Auth tokens and base URLs live in your `request()` function on the host. The sandbox that runs LLM-generated code has no outbound network access and never sees secrets.
+Auth tokens and base URLs live in your `request()` function on the host. The sandbox has no outbound network access and never sees secrets. The callback's second argument is the MCP context for the outer `execute` tool call. Use it when an elicitation, sampling request, roots request, or notification belongs to that call.
 
 This example connects to the live [Cloudflare API](https://api.cloudflare.com/) using the official OpenAPI spec. Pass a Cloudflare API token via the `Authorization` header.
 
@@ -36,9 +36,9 @@ import { openApiMcpServer } from "@cloudflare/codemode/mcp";
 const server = openApiMcpServer({
   spec,
   executor,
-  request: async (opts) => {
-    // Runs on the host — put auth, base URL, and headers here.
-    // The sandbox never sees the token.
+  request: async (opts, context) => {
+    // Runs on the host. Put auth, base URL, and headers here.
+    // The sandbox sees neither the token nor the MCP context.
     const url = new URL(`https://api.example.com${opts.path}`);
     const res = await fetch(url, {
       method: opts.method,
@@ -49,6 +49,35 @@ const server = openApiMcpServer({
   }
 });
 ```
+
+The second argument is the MCP SDK's request-scoped context. For example, a host callback can elicit confirmation through the same response stream as the outer tool call:
+
+```ts
+request: async (opts, context) => {
+  const result = await server.server.elicitInput(
+    {
+      message: `Allow ${opts.method} ${opts.path}?`,
+      requestedSchema: {
+        type: "object",
+        properties: { approved: { type: "boolean" } },
+        required: ["approved"]
+      }
+    },
+    {
+      relatedRequestId: context.requestId,
+      signal: context.signal
+    }
+  );
+
+  if (result.action !== "accept" || !result.content?.approved) {
+    throw new Error("Request declined");
+  }
+
+  return callApi(opts);
+};
+```
+
+The context stays in trusted host code and should only be used while the outer tool call is active. Existing callbacks that only accept `opts` continue to work.
 
 The LLM first searches the spec:
 

--- a/examples/codemode-mcp-openapi/README.md
+++ b/examples/codemode-mcp-openapi/README.md
@@ -79,6 +79,28 @@ request: async (opts, context) => {
 
 The context stays in trusted host code and should only be used while the outer tool call is active. Existing callbacks that only accept `opts` continue to work.
 
+### Timeouts: keep the sandbox budget at or above the elicitation timeout
+
+The `request()` callback runs while the sandbox is still suspended on its
+`codemode.request()` call — that call is a blocking RPC round-trip, so the
+executor's timeout covers the whole wait, including the time a human spends
+answering the elicitation. The default `DynamicWorkerExecutor` timeout is
+**60s**, which matches the MCP elicitation timeout (both the SDK's
+`DEFAULT_REQUEST_TIMEOUT_MSEC` and `McpAgent.elicitInput` default to 60s), so
+the default config already lets an elicitation run to completion.
+
+If you lower the executor timeout, a tool that elicits user input (or samples,
+or lists roots) will abort with `Execution timed out` once the sandbox budget
+expires, before the user can respond. Keep the executor timeout at least as
+long as the elicitation timeout:
+
+```ts
+const executor = new DynamicWorkerExecutor({
+  loader: env.LOADER,
+  timeout: 60_000 // do not drop below the 60s elicitation timeout
+});
+```
+
 The LLM first searches the spec:
 
 ```js

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -1,4 +1,5 @@
 export {
+  TestCodemodeMcpAgent,
   TestMcpAgent,
   TestMcpJurisdiction,
   TestAddMcpServerAgent,

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -6,6 +6,8 @@ import type {
   ServerNotification,
   ServerRequest
 } from "@modelcontextprotocol/sdk/types.js";
+import { DynamicWorkerExecutor } from "@cloudflare/codemode";
+import { openApiMcpServer } from "@cloudflare/codemode/mcp";
 import { z } from "zod";
 import { McpAgent } from "../../mcp/index.ts";
 import {
@@ -36,6 +38,36 @@ type EchoResponseData = {
 type Props = {
   testValue: string;
 };
+
+export class TestCodemodeMcpAgent extends McpAgent<
+  Cloudflare.Env & { LOADER: WorkerLoader }
+> {
+  server!: McpServer;
+
+  async init() {
+    this.server = openApiMcpServer({
+      spec: {
+        openapi: "3.1.0",
+        info: { title: "Codemode MCP test", version: "1.0.0" },
+        paths: { "/protected": { delete: { summary: "Protected action" } } }
+      },
+      executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+      request: async (options, context) => {
+        return this.elicitInput(
+          {
+            message: `Allow ${options.method} ${options.path}?`,
+            requestedSchema: {
+              type: "object",
+              properties: { approved: { type: "boolean" } },
+              required: ["approved"]
+            }
+          },
+          { relatedRequestId: context.requestId }
+        );
+      }
+    });
+  }
+}
 
 export class TestMcpAgent extends McpAgent<Cloudflare.Env, unknown, Props> {
   private tempToolHandle?: { remove: () => void };

--- a/packages/agents/src/tests/mcp/codemode-context.test.ts
+++ b/packages/agents/src/tests/mcp/codemode-context.test.ts
@@ -1,0 +1,119 @@
+import { env } from "cloudflare:workers";
+import { createExecutionContext, runInDurableObject } from "cloudflare:test";
+import type {
+  CallToolResult,
+  JSONRPCMessage,
+  JSONRPCRequest,
+  JSONRPCResultResponse
+} from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+import type { TestCodemodeMcpAgent } from "../agents/mcp";
+import {
+  initializeStreamableHTTPServer,
+  parseSSEData,
+  sendPostRequest
+} from "../shared/test-utils";
+
+async function readOneFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>
+): Promise<string> {
+  const { value } = await reader.read();
+  if (!value) throw new Error("SSE stream ended before a frame arrived");
+  return new TextDecoder().decode(value);
+}
+
+async function getKeepAliveRefs(sessionId: string): Promise<number> {
+  const id = env.TestCodemodeMcpAgent.idFromName(
+    `streamable-http:${sessionId}`
+  );
+  const stub = env.TestCodemodeMcpAgent.get(id);
+  return runInDurableObject(stub, (instance: TestCodemodeMcpAgent) => {
+    return (
+      instance as unknown as {
+        _keepAliveRefs: number;
+      }
+    )._keepAliveRefs;
+  });
+}
+
+describe("Codemode MCP request context", () => {
+  const baseUrl = "http://example.com/codemode-mcp";
+
+  it("completes an elicitation over the originating POST after Worker Loader RPC", async () => {
+    const ctx = createExecutionContext();
+    const sessionId = await initializeStreamableHTTPServer(ctx, baseUrl);
+
+    const toolCall: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      id: "codemode-call-1",
+      method: "tools/call",
+      params: {
+        name: "execute",
+        arguments: {
+          code: `async () => codemode.request({
+            method: "DELETE",
+            path: "/protected"
+          })`
+        }
+      }
+    };
+
+    const toolResponse = await sendPostRequest(
+      ctx,
+      baseUrl,
+      toolCall,
+      sessionId
+    );
+    expect(toolResponse.status).toBe(200);
+
+    const reader = toolResponse.body?.getReader();
+    if (!reader) throw new Error("No reader available for POST stream");
+
+    const elicitRequest = parseSSEData(
+      await readOneFrame(reader)
+    ) as JSONRPCRequest;
+    expect(elicitRequest).toMatchObject({
+      method: "elicitation/create",
+      params: { message: "Allow DELETE /protected?" }
+    });
+
+    // McpAgent.elicitInput holds a keepAlive lease while its in-memory
+    // response resolver is pending. Without it, an unresolved Promise alone
+    // would not prevent the Durable Object from hibernating.
+    expect(await getKeepAliveRefs(sessionId)).toBe(1);
+
+    const elicitResponse: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      id: elicitRequest.id,
+      result: { action: "accept", content: { approved: true } }
+    } as JSONRPCMessage;
+    const response = await sendPostRequest(
+      ctx,
+      baseUrl,
+      elicitResponse,
+      sessionId
+    );
+    expect(response.status).toBe(202);
+
+    const toolResult = parseSSEData(
+      await readOneFrame(reader)
+    ) as JSONRPCResultResponse;
+    expect(toolResult.id).toBe("codemode-call-1");
+    expect(toolResult.result as CallToolResult).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { action: "accept", content: { approved: true } },
+            null,
+            2
+          )
+        }
+      ]
+    });
+
+    await vi.waitFor(async () => {
+      expect(await getKeepAliveRefs(sessionId)).toBe(0);
+    });
+  });
+});

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -8,6 +8,7 @@ import {
 // Re-export all test agents so existing imports (e.g. `import { type Env } from "./worker"`)
 // and wrangler bindings continue to work.
 export {
+  TestCodemodeMcpAgent,
   TestMcpAgent,
   TestMcpJurisdiction,
   TestAddMcpServerAgent,
@@ -95,6 +96,7 @@ export {
 // circular dependencies.
 
 import type {
+  TestCodemodeMcpAgent,
   TestRpcMcpClientAgent,
   TestEmailAgent,
   TestCaseSensitiveAgent,
@@ -146,6 +148,7 @@ import type {
 export type Env = {
   LOADER: WorkerLoader;
   MCP_OBJECT: DurableObjectNamespace<McpAgent>;
+  TestCodemodeMcpAgent: DurableObjectNamespace<TestCodemodeMcpAgent>;
   EmailAgent: DurableObjectNamespace<TestEmailAgent>;
   CaseSensitiveAgent: DurableObjectNamespace<TestCaseSensitiveAgent>;
   UserNotificationAgent: DurableObjectNamespace<TestUserNotificationAgent>;
@@ -209,7 +212,10 @@ export type Env = {
 
 // ── Fetch handler ────────────────────────────────────────────────────
 
-import { TestMcpAgent as McpAgentImpl } from "./agents";
+import {
+  TestCodemodeMcpAgent as CodemodeMcpAgentImpl,
+  TestMcpAgent as McpAgentImpl
+} from "./agents";
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
@@ -227,6 +233,12 @@ export default {
 
     if (url.pathname === "/mcp") {
       return McpAgentImpl.serve("/mcp").fetch(request, env, ctx);
+    }
+
+    if (url.pathname === "/codemode-mcp") {
+      return CodemodeMcpAgentImpl.serve("/codemode-mcp", {
+        binding: "TestCodemodeMcpAgent"
+      }).fetch(request, env, ctx);
     }
 
     if (url.pathname === "/auto" || url.pathname === "/auto/message") {

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -17,6 +17,10 @@
         "name": "MCP_OBJECT"
       },
       {
+        "class_name": "TestCodemodeMcpAgent",
+        "name": "TestCodemodeMcpAgent"
+      },
+      {
         "class_name": "TestEmailAgent",
         "name": "EmailAgent"
       },
@@ -317,6 +321,7 @@
     {
       "new_sqlite_classes": [
         "TestMcpAgent",
+        "TestCodemodeMcpAgent",
         "TestEmailAgent",
         "TestCaseSensitiveAgent",
         "TestUserNotificationAgent",

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -2,6 +2,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  ServerNotification,
+  ServerRequest
+} from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import {
   generateTypesFromJsonSchema,
@@ -254,10 +259,31 @@ export interface RequestOptions {
   rawBody?: boolean;
 }
 
+/**
+ * MCP context for the outer `execute` tool call.
+ *
+ * This remains in trusted host code and is never exposed to the sandbox.
+ * Use it only while the outer tool call is active.
+ */
+export type OpenApiMcpRequestContext = RequestHandlerExtra<
+  ServerRequest,
+  ServerNotification
+>;
+
 export interface OpenApiMcpServerOptions {
   spec: Record<string, unknown>;
   executor: Executor;
-  request: (options: RequestOptions) => Promise<unknown>;
+  /**
+   * Handle an API request from sandbox code on the trusted host.
+   *
+   * The context belongs to the outer MCP `execute` tool call. It can be used
+   * to associate elicitation, sampling, roots, and notifications with that
+   * call's response stream.
+   */
+  request: (
+    options: RequestOptions,
+    context: OpenApiMcpRequestContext
+  ) => Promise<unknown>;
   name?: string;
   version?: string;
   description?: string;
@@ -510,7 +536,7 @@ async () => {
         code: z.string().describe("JavaScript async arrow function to execute")
       }
     },
-    async ({ code }) => {
+    async ({ code }, context) => {
       try {
         const result = await executor.execute(
           createOpenApiSandboxCode(code, spec, true),
@@ -518,7 +544,8 @@ async () => {
             {
               name: "__openapiHost",
               fns: {
-                request: (args: unknown) => requestFn(args as RequestOptions)
+                request: (args: unknown) =>
+                  requestFn(args as RequestOptions, context)
               }
             }
           ]

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -279,6 +279,13 @@ export interface OpenApiMcpServerOptions {
    * The context belongs to the outer MCP `execute` tool call. It can be used
    * to associate elicitation, sampling, roots, and notifications with that
    * call's response stream.
+   *
+   * This callback runs while the sandbox is still suspended on its
+   * `codemode.request()` call, so the executor timeout covers the whole wait.
+   * The default executor timeout (60s) matches the elicitation timeout, so the
+   * default config already lets an elicitation finish. If you lower the
+   * executor timeout below the elicitation timeout, the sandbox aborts the
+   * call before the user can respond.
    */
   request: (
     options: RequestOptions,

--- a/packages/codemode/src/tests/mcp.test.ts
+++ b/packages/codemode/src/tests/mcp.test.ts
@@ -3,6 +3,7 @@ import { env } from "cloudflare:workers";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { DynamicWorkerExecutor } from "../executor";
 import { codeMcpServer, openApiMcpServer } from "../mcp";
@@ -552,6 +553,161 @@ describe("openApiMcpServer", () => {
     });
 
     expect(callText(result)).toBe("List users");
+
+    await client.close();
+  });
+
+  it("execute request callback receives the originating MCP request context", async () => {
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    let callbackRequestId: string | number | undefined;
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async (opts, context) => {
+        callbackRequestId = context.requestId;
+        return {
+          method: opts.method,
+          path: opts.path,
+          requestId: context.requestId,
+          hasSignal: context.signal instanceof AbortSignal
+        };
+      }
+    });
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const originalSend = clientTransport.send.bind(clientTransport);
+    let toolCallRequestId: string | number | undefined;
+    clientTransport.send = async (message, options) => {
+      if (
+        "method" in message &&
+        message.method === "tools/call" &&
+        "id" in message
+      ) {
+        toolCallRequestId = message.id;
+      }
+      return originalSend(message, options);
+    };
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(clientTransport);
+
+    const result = await client.callTool({
+      name: "execute",
+      arguments: {
+        code: 'async () => await codemode.request({ method: "GET", path: "/users" })'
+      }
+    });
+
+    expect(callbackRequestId).toBe(toolCallRequestId);
+    expect(JSON.parse(callText(result))).toEqual({
+      method: "GET",
+      path: "/users",
+      requestId: toolCallRequestId,
+      hasSignal: true
+    });
+
+    await client.close();
+  });
+
+  it("keeps request contexts isolated across concurrent executions", async () => {
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    const callbackRequestIds = new Map<string, string | number>();
+    let arrivals = 0;
+    let releaseCallbacks: (() => void) | undefined;
+    const bothCallbacksArrived = new Promise<void>((resolve) => {
+      releaseCallbacks = resolve;
+    });
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async (opts, context) => {
+        callbackRequestIds.set(opts.path, context.requestId);
+        arrivals += 1;
+        if (arrivals === 2) releaseCallbacks?.();
+        await bothCallbacksArrived;
+        return { path: opts.path, requestId: context.requestId };
+      }
+    });
+
+    const client = await connectClient(server);
+
+    const [a, b] = await Promise.all(
+      ["/a", "/b"].map((path) =>
+        client.callTool({
+          name: "execute",
+          arguments: {
+            code: `async () => await codemode.request({ method: "GET", path: "${path}" })`
+          }
+        })
+      )
+    );
+
+    const aRequestId = callbackRequestIds.get("/a");
+    const bRequestId = callbackRequestIds.get("/b");
+    expect(aRequestId).toBeDefined();
+    expect(bRequestId).toBeDefined();
+    expect(aRequestId).not.toBe(bRequestId);
+    expect([JSON.parse(callText(a)), JSON.parse(callText(b))]).toEqual([
+      { path: "/a", requestId: aRequestId },
+      { path: "/b", requestId: bRequestId }
+    ]);
+
+    await client.close();
+  });
+
+  it("lets request callbacks elicit input for the originating tool call", async () => {
+    const executor = new DynamicWorkerExecutor({ loader: env.LOADER });
+    let server: McpServer;
+    server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async (opts, context) => {
+        const elicitation = await server.server.elicitInput(
+          {
+            message: `Allow ${opts.method} ${opts.path}?`,
+            requestedSchema: {
+              type: "object",
+              properties: { approved: { type: "boolean" } },
+              required: ["approved"]
+            }
+          },
+          {
+            relatedRequestId: context.requestId,
+            signal: context.signal
+          }
+        );
+        return elicitation;
+      }
+    });
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client(
+      { name: "test-client", version: "1.0.0" },
+      { capabilities: { elicitation: { form: {} } } }
+    );
+    client.setRequestHandler(ElicitRequestSchema, async (request) => {
+      expect(request.params.message).toBe("Allow DELETE /users/123?");
+      return { action: "accept", content: { approved: true } };
+    });
+    await client.connect(clientTransport);
+
+    const result = await client.callTool({
+      name: "execute",
+      arguments: {
+        code: `async () => await codemode.request({
+          method: "DELETE",
+          path: "/users/123"
+        })`
+      }
+    });
+
+    expect(JSON.parse(callText(result))).toEqual({
+      action: "accept",
+      content: { approved: true }
+    });
 
     await client.close();
   });


### PR DESCRIPTION
## Summary

`openApiMcpServer` now passes the outer MCP `execute` tool-call context to its host-side request callback:

```ts
request: async (options, context) => {
  // context.requestId, context.signal, context.sendRequest(), ...
}
```

This lets host callbacks associate elicitation, sampling, roots, and notifications with the originating tool call instead of sending them as standalone messages. The context stays in trusted host code and is not exposed to generated sandbox code. Existing callbacks that only accept `options` remain compatible.

## Why

In #1510 tool registration is delegated to `@cloudflare/codemode`'s `openApiMcpServer`. The MCP SDK supplies `RequestHandlerExtra` to every tool handler, but Codemode previously discarded that second argument before invoking the application's request callback. The callback therefore had no request id to pass as `relatedRequestId`, so server-to-client requests could not use the originating POST response stream. This PR preserves that SDK context in the per-execution host closure and exports it as `OpenApiMcpRequestContext`.

## Relationship to #1734 (now merged)

The `McpAgent.serve()` + Dynamic Worker RPC path reported in #1510 needs both halves:

- #1734 (merged) lets `StreamableHTTPServerTransport` send after the child-to-host RPC boundary drops agent ALS.
- this PR preserves the semantic parent request id so the transport can route the elicitation onto the originating POST.

`createMcpHandler` / `WorkerTransport` only needs this PR.

## Hibernation note

For the `McpAgent` deployment, prefer `McpAgent.elicitInput(params, { relatedRequestId: context.requestId })`. It wraps the wait in `keepAliveWhile`, which holds an alarm-backed keepAlive lease so the Durable Object is not evicted mid-elicitation. The pending elicitation resolver is in-memory by design: an elicitation cannot be resumed across a hard eviction, so the contract is to prevent hibernation during the bounded wait, not to persist the pending request. The new integration test asserts that lease is held during the wait and released after.

## Tests

Codemode unit/contract (`packages/codemode/src/tests/mcp.test.ts`, in-memory transport + real `DynamicWorkerExecutor`):

- the callback receives the exact outer JSON-RPC request id and cancellation signal;
- overlapping Dynamic Worker executions retain separate request contexts;
- a callback elicits input associated with the outer tool call and receives the client's answer.

Real `McpAgent` integration (`packages/agents/src/tests/mcp/codemode-context.test.ts`), no mocks of the transport, executor, or RPC boundary:

- a `TestCodemodeMcpAgent` registers `openApiMcpServer` and elicits via `McpAgent.elicitInput`;
- a real Streamable HTTP POST with **no** standalone GET stream goes through the Worker Loader executor;
- the `elicitation/create` request arrives on the originating POST stream;
- the client's response POST is accepted and the final tool result follows on the same stream;
- the keepAlive lease is `1` while waiting and returns to `0` after completion.

Validation on the rebased branch:

- agents MCP suite: 493 passed (includes the new integration test)
- codemode: 299 unit/Workers + 38 runtime + 33 browser
- `pnpm run build` (24 projects)
- `pnpm run check` (exports, format, lint, 113 TypeScript projects)

Related: #1510, #1490, #1734
