### PR TITLE
Recovery-engine convergence: ai-chat recovers interrupted server tools like Think

### DIFF
--- a/.changeset/ai-chat-recovery-transcript-repair.md
+++ b/.changeset/ai-chat-recovery-transcript-repair.md
@@ -1,0 +1,36 @@
+---
+"@cloudflare/ai-chat": minor
+---
+
+Recover interrupted server-tool calls on resume instead of abandoning them.
+
+When a turn is interrupted mid tool call (e.g. a server tool whose `execute()`
+died with an evicted isolate, leaving an `input-available` orphan that nothing
+will ever resolve), `AIChatAgent` now repairs the transcript before re-entering
+inference on the recovered turn — the same behavior `@cloudflare/think` already
+has. The interrupted tool part is flipped to an errored tool-result through the
+shared `agents/chat` repair primitive, so the next `convertToModelMessages` no
+longer 400s with `AI_MissingToolResultsError` and the turn continues.
+
+Adds an overridable `repairInterruptedToolPart(part)` hook (default: flip to an
+`output-error` result) so apps can customize the repaired shape for
+client-resolved tools (e.g. preserve an interrupted question tool as text).
+Repair only ever reshapes assistant tool parts; the corrected transcript is
+persisted and broadcast through the normal write path.
+
+Repair runs before EVERY inference chokepoint — live submit, tool
+auto-continuation, `continueLastTurn`, `saveMessages`/retry, and the chat
+recovery callbacks — mirroring how `@cloudflare/think` repairs before every
+inference (the app owns `convertToModelMessages`, so the framework repairs
+`this.messages` right before handing control to `onChatMessage`). This closes
+the cases a recovery-only repair missed: a mixed client+server orphan whose
+client replay drives an auto-continuation, and any agent running with
+`chatRecovery` disabled. A guard restricts repair to when no client interaction
+is genuinely pending, so a tool the user may still answer is never clobbered; it
+is a no-op (no write, no broadcast) for a healthy transcript.
+
+The recovery-path stability wait (`waitUntilStable`) now gates on the narrower
+client-resolvable predicate so a dead server-tool orphan no longer blocks
+stability — it is repaired and the turn continues. `waitUntilStable` gains an
+optional `pendingInteraction` predicate; its default (and the documented
+semantics for app overrides) is unchanged.

--- a/.changeset/ai-chat-recovery-transcript-repair.md
+++ b/.changeset/ai-chat-recovery-transcript-repair.md
@@ -25,9 +25,12 @@ inference (the app owns `convertToModelMessages`, so the framework repairs
 `this.messages` right before handing control to `onChatMessage`). This closes
 the cases a recovery-only repair missed: a mixed client+server orphan whose
 client replay drives an auto-continuation, and any agent running with
-`chatRecovery` disabled. A guard restricts repair to when no client interaction
-is genuinely pending, so a tool the user may still answer is never clobbered; it
-is a no-op (no write, no broadcast) for a healthy transcript.
+`chatRecovery` disabled. Repair is scoped per-part to dead SERVER orphans: a
+part still legitimately awaiting a client (an `input-available` client tool or an
+`approval-requested` part the user may still answer) is left verbatim, so a fresh
+dead-server orphan at the leaf is repaired even when an unrelated abandoned client
+orphan sits earlier in history. It is a no-op (no write, no broadcast) for a
+healthy transcript.
 
 The recovery-path stability wait (`waitUntilStable`) now gates on the narrower
 client-resolvable predicate so a dead server-tool orphan no longer blocks

--- a/.changeset/orphan-persist-core-dedup.md
+++ b/.changeset/orphan-persist-core-dedup.md
@@ -1,0 +1,20 @@
+---
+"agents": patch
+---
+
+De-duplicate the orphan-persist core shared by `@cloudflare/ai-chat` and
+`@cloudflare/think` into `agents/chat`.
+
+The genuinely-common skeleton of both hosts' `_persistOrphanedStream` — the
+accumulate loop plus the `getMessage → updateMessage(merge) XOR appendMessage`
+upsert — now lives once as the `@internal` `persistReconstructedOrphan` helper.
+The deliberately host-specific bits stay in the callers: the buffer flush, the
+fallback id, the `prepare` hook (Think strips internal parts and may skip;
+ai-chat resolves the persist-target id), the `merge` hook (Think replaces;
+ai-chat reconciles partials), and broadcast (Think after; ai-chat inside its
+store's `persistMessages`).
+
+Pure internal de-duplication with no observable behavior or API change: the new
+symbol is `@internal` sibling-package support, not public API, and both hosts'
+recovery suites pass unchanged. `@cloudflare/ai-chat` and `@cloudflare/think`
+need no changeset for this extraction.

--- a/.changeset/repair-transcript-shared-primitive.md
+++ b/.changeset/repair-transcript-shared-primitive.md
@@ -15,7 +15,11 @@ terminal-state check) in `agents/chat`.
 
 The primitive is pure (returns a new messages array plus repair stats; never
 touches storage, broadcast, or events) and is parameterized by an overridable
-`repairPart` hook, so both AI-SDK chat hosts can run identical repair logic
-before re-entering inference on a recovered turn. `@cloudflare/think` delegates
-to it through its existing `repairInterruptedToolPart` hook — a pure internal
-refactor with no observable behavior or API change; its suites pass unchanged.
+`repairPart` hook plus an optional `shouldRepair(part)` skip predicate (defaults
+to repairing every interrupted part), so both AI-SDK chat hosts can run repair
+logic before re-entering inference on a recovered turn — a host whose default
+errors the part (ai-chat) uses `shouldRepair` to leave a part still awaiting a
+client interaction verbatim. `@cloudflare/think` delegates through its existing
+`repairInterruptedToolPart` hook with no `shouldRepair` (repairs everything) — a
+pure internal refactor with no observable behavior or API change; its suites pass
+unchanged.

--- a/.changeset/repair-transcript-shared-primitive.md
+++ b/.changeset/repair-transcript-shared-primitive.md
@@ -1,0 +1,21 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+---
+
+Extract transcript repair into a shared `agents/chat` primitive.
+
+`@cloudflare/think`'s `_repairToolTranscriptParts` — which flips an interrupted
+tool call (a `tool-*` / `dynamic-tool` part with no settled result, left behind
+when a stream was cut off mid-flight) into an errored tool-result so the next
+provider call doesn't 400 with `AI_MissingToolResultsError`, and normalizes
+malformed tool `input` — now lives once as the shared, `@internal`
+`repairInterruptedToolParts` primitive (plus the `toolPartHasSettledResult`
+terminal-state check) in `agents/chat`.
+
+The primitive is pure (returns a new messages array plus repair stats; never
+touches storage, broadcast, or events) and is parameterized by an overridable
+`repairPart` hook, so both AI-SDK chat hosts can run identical repair logic
+before re-entering inference on a recovered turn. `@cloudflare/think` delegates
+to it through its existing `repairInterruptedToolPart` hook — a pure internal
+refactor with no observable behavior or API change; its suites pass unchanged.

--- a/design/rfc-chat-recovery-foundation-progress.md
+++ b/design/rfc-chat-recovery-foundation-progress.md
@@ -9,6 +9,94 @@
 Running record of completed steps (newest first). Each entry links the phase,
 the change, and the key review findings.
 
+- _Recovery-engine convergence finish — ai-chat recovers interrupted server-tool
+  calls like Think (LANDED), plus orphan-persist core dedup_ — Closed the last
+  real behavior gap between the two AI-SDK chat hosts, restoring the
+  ai-chat-as-subset-of-Think north star after an earlier review pass had drifted
+  toward "keep the predicate split divergent."
+  - **The gap (bucket 1, Think better).** On an interrupted **server tool** (its
+    `execute()` died with the evicted isolate, leaving a dead `input-available`
+    orphan nothing will ever resolve), Think **recovers** the turn but ai-chat
+    **gave up**: Think excludes the dead orphan from its (client-only) stability
+    predicate AND repairs the transcript before inference, so
+    `convertToModelMessages` doesn't 400 with `AI_MissingToolResultsError`;
+    ai-chat used the **broad** `hasPendingInteraction()` for its recovery wait and
+    had no repair pass, so it rescheduled until the budget was spent and
+    terminalized via `onExhausted`.
+  - **A.1 — shared `repairInterruptedToolParts` primitive (behavior-neutral).**
+    Extracted Think's `_repairToolTranscriptParts` into a new `@internal`
+    `agents/chat/repair-transcript.ts` (plus the `toolPartHasSettledResult`
+    terminal-state check), parameterized by an overridable `repairPart` hook and
+    reusing the already-shared `normalizeToolInput`. Preserves the
+    `approval-responded` passthrough (an approved server tool waiting for its
+    continuation is NOT abandoned). Think delegates through its existing
+    `repairInterruptedToolPart` hook — pure refactor, suites unchanged. 11 unit
+    tests. `agents` + `think` patches.
+  - **A.2 — ai-chat adopts repair.** Added an overridable
+    `AIChatAgent.repairInterruptedToolPart` hook (default: flip to
+    `output-error`) and a private `_repairInterruptedToolsBeforeTurn()` that runs
+    the shared primitive over `this.messages` before re-invoking `onChatMessage`
+    and persists+broadcasts via the normal `persistMessages` write path.
+    `@cloudflare/ai-chat` minor.
+  - **A.3 — narrow the recovery predicate.** `waitUntilStable` gained an optional
+    `pendingInteraction` predicate; the two recovery call sites
+    (`_chatRecoveryContinue` / `_chatRecoveryRetry` — the only callers, both
+    recovery, no live path) pass the narrow `hasPendingClientInteraction()` so a
+    dead server-tool orphan no longer blocks stability. The broad default — and
+    the documented semantics for app overrides — are unchanged.
+  - **Hard constraint honored.** Repair only ever reshapes **assistant** tool
+    parts; user messages (and their `metadata.channel`, re-resolved on wake) are
+    structurally untouched — pinned with comments at the repair seam.
+  - **A.4 — e2e.** New `durable-chat-recovery` test: a dead server-tool
+    `input-available` orphan now **recovers** (repairs to errored, continues,
+    incident completes) instead of waiting-then-`onExhausted`, contrasting the
+    existing CLIENT-interaction park test. Think e2e unchanged.
+  - **A.5 — repair at all pre-inference chokepoints (deep-review follow-up).**
+    A post-implementation deep review found the recovery-only repair left a
+    residual gap vs Think, which repairs in `_assembleModelMessages` before
+    **every** inference: (1) a **mixed** client+server orphan parks for the
+    client, then the client replay drives `_fireAutoContinuation` (which calls
+    `onChatMessage` directly, **not** `continueLastTurn`), so the dead server
+    orphan reached `convertToModelMessages` unrepaired; and (2) agents with
+    `chatRecovery` **disabled** never hit a recovery callback at all. ai-chat
+    can't repair "inside" inference (the app owns `convertToModelMessages`), so
+    `_repairInterruptedToolsBeforeTurn()` is now invoked at all four
+    `onChatMessage` chokepoints — live submit (`chatTurnBody`), auto-continuation
+    (`autoContinuationBody`), `_runProgrammaticChatTurn` (saveMessages/retry),
+    and `continueLastTurn` — and the two now-redundant explicit recovery-callback
+    calls were removed (those bodies self-repair). A **guard**
+    (`!hasPendingClientInteraction()`) restricts repair to states where every
+    unsettled tool part is a dead server orphan, so a tool the user may still
+    answer is never clobbered; repair is a no-op (no write/broadcast) for a
+    healthy transcript. Two `continue-last-turn` tests added (repairs a dead
+    server orphan on a direct `continueLastTurn`; leaves a pending client tool
+    untouched). Full ai-chat suite (612) green.
+  - **C2 — orphan-persist core dedup (behavior-neutral).** Extracted the
+    genuinely-shared skeleton of both `_persistOrphanedStream` bodies (the
+    accumulate loop + `getMessage → updateMessage(merge) XOR appendMessage` upsert)
+    into a new `@internal` `agents/chat/orphan-persist.ts`
+    `persistReconstructedOrphan(chunks, { store, fallbackId, prepare, merge })` —
+    exactly two hooks. The host-specific bits stay in the wrappers: flush (Think
+    only), fallback id, `prepare` (Think `_strippedForPersist`+null skip; ai-chat
+    `_resolveOrphanTargetId`), `merge` (Think replace; ai-chat
+    `reconcileOrphanPartial`), and broadcast (Think after via `_broadcastMessages`;
+    ai-chat inside `persistMessages`). `agents` patch; both hosts' recovery suites
+    green.
+  - **C1 — already enforced (verify only).** Both hosts annotate
+    `_orphanStore(): OrphanPersistStore` (`ai-chat:1482`, `think:3182`);
+    compiler-enforced, nothing to implement.
+  - **D — auto-continuation lift (doc-only).** `AutoContinuationController`,
+    `hasIncompleteToolBatch`, and `_hasArmedContinuation` are already shared; the
+    remainder of each host's auto-continuation is coupled to its own streaming
+    driver / turn loop (Think's submission-aware turn spine vs ai-chat's
+    `TurnQueue`), so there is no further host-agnostic algorithm to lift. Deferred
+    Tier-3 follow-up **closed** as no-op.
+  - **B — finding #4 second-decode (deferred, tracked).** Threading the
+    already-decoded `RecoveryPartial` into the orphan write still collides with the
+    vocabulary-agnostic seam (no message id; the codec uses `getPartialStreamText`
+    while the hosts reconstruct via `StreamAccumulator`), for negligible payoff and
+    no behavior drift. Left tracked; it falls out naturally if a future
+    engine-owned orphan writer subsumes the host wrappers.
 - _Cross-RFC breadcrumb — Channels v1 persists channel id in turn metadata (docs,
   no code)_ — The [Channels RFC](./rfc-think-channels.md) shipped per-channel
   policy (instructions / tool-narrowing / `maxTurns`) as a turn-scoped

--- a/design/rfc-chat-recovery-foundation-progress.md
+++ b/design/rfc-chat-recovery-foundation-progress.md
@@ -9,6 +9,41 @@
 Running record of completed steps (newest first). Each entry links the phase,
 the change, and the key review findings.
 
+- _Convergence lock-in — server-only repair scope, cross-host conformance suite,
+  stale-RFC sweep_ — Follow-up to the recovery-engine convergence: cements the
+  shared seams and pays down the one edge the deep review found.
+  - **Server-only repair scope (refinement of A.5).** The whole-transcript guard
+    (`!hasPendingClientInteraction()`) the lock-in PR added was correct but coarse:
+    an abandoned client orphan buried in history would suppress repairing a fresh
+    dead-server orphan at the leaf. Replaced with a **per-part** skip: the shared
+    `repairInterruptedToolParts` gained an optional `shouldRepair(part)` predicate
+    (default `true` = repair all, so **Think is unchanged**); ai-chat passes
+    `shouldRepair = !partAwaitsClientInteraction(part, clientResolvable)` so it
+    repairs dead server orphans anywhere while leaving any part still awaiting a
+    client (`input-available` client tool / `approval-requested`) verbatim. New
+    unit test for the skip; new ai-chat test for the buried-client + leaf-server
+    case. `agents` + `@cloudflare/ai-chat`.
+  - **Cross-host recovery conformance suite.** New
+    `agents/chat/__tests__/recovery-conformance.test.ts` runs the REAL shared
+    primitives (`repairInterruptedToolParts` + the `partAwaitsClientInteraction` /
+    `clientResolvableToolNames` predicate) under **both** host wirings side by
+    side over a canonical scenario table (dead server orphan, pending client
+    orphan, mixed, approval-requested, approval-responded). It pins the **subset**
+    relationship — identical for server orphans; intentional divergence for
+    client orphans (ai-chat parks/skips, Think repairs-to-proceed) — and asserts
+    the invariant "ai-chat never repairs more than Think." This is the convergence
+    seam where the two hosts actually meet; a literal dual-driver e2e harness was
+    rejected because Think's recovery test agent is structurally different (Session
+    tree, no orphan-seeding hooks) and plumbing it would add fragile surface for
+    no extra coverage the shared-primitive suite doesn't already give. Each host's
+    own e2e suite (ai-chat `durable-chat-recovery` + `continue-last-turn`; Think
+    `think-session`) continues to cover its side end to end.
+  - **Stale-RFC sweep.** Corrected the §Cutover claim that the
+    `ChatRecoveryIncident` shape / keys / id formula are "duplicated verbatim …
+    not yet in `agents/chat`" — they have lived in shared
+    `recovery-incident.ts` since the engine landed. (Matrix cells are left as the
+    historical record per the doc's own note; the 2026-06 re-classification block
+    remains the authoritative status.)
 - _Recovery-engine convergence finish — ai-chat recovers interrupted server-tool
   calls like Think (LANDED), plus orphan-persist core dedup_ — Closed the last
   real behavior gap between the two AI-SDK chat hosts, restoring the

--- a/design/rfc-chat-recovery-foundation.md
+++ b/design/rfc-chat-recovery-foundation.md
@@ -1451,9 +1451,16 @@ records.
 The deploy that ships this refactor is itself a deploy-mid-recovery event. When
 the new engine boots, it can find incidents, snapshots, and schedule rows written
 by the old per-package code. The refactor must round-trip every persisted artifact
-without a data migration. Today the `ChatRecoveryIncident` shape, its keys, and
-the incident-id formula are duplicated verbatim in both packages and are not yet
-in `agents/chat`; moving them must preserve the exact serialized contract.
+without a data migration.
+
+> **Status correction (2026-06).** The `ChatRecoveryIncident` shape, its keys,
+> and the incident-id formula are **no longer duplicated** — they now live in the
+> shared `agents/chat/recovery-incident.ts` (`ChatRecoveryIncident`,
+> `CHAT_RECOVERY_INCIDENT_KEY_PREFIX`, `chatRecoveryIncidentId`,
+> `evaluateChatRecoveryIncident`), which both hosts call. The serialized contract
+> below was preserved through that move and remains the authority for cutover
+> round-tripping; the original "duplicated verbatim in both packages" wording was
+> the pre-cutover state.
 
 ### Cutover invariants
 

--- a/design/rfc-chat-recovery-foundation.md
+++ b/design/rfc-chat-recovery-foundation.md
@@ -1075,6 +1075,28 @@ cells are left as the original record; this is the authoritative status):
   `chatStreamStallTimeoutMs` defaulting to `0` (disabled), so the rollout is a pure
   capability addition with no silent behavior change (parity with Think). **DONE**,
   bucket 1. See the corrected "Adopt shared stall recovery" decision below.
+- **Pending interaction predicates** — **DONE**, **bucket 1 (behavior drift, Think
+  better)** — correcting an earlier review pass that had drifted toward "bucket 3,
+  keep divergent." The real gap: on an interrupted **server tool** (its `execute()`
+  died with the evicted isolate, leaving a dead `input-available` orphan nothing
+  will ever resolve), Think **recovers** the turn while ai-chat **gave up**. Think's
+  recovery-path stability wait excludes the dead orphan (its predicate is
+  client-only by construction) AND it repairs the transcript before inference, so
+  `convertToModelMessages` doesn't 400 with `AI_MissingToolResultsError`. ai-chat's
+  recovery wait used the **broad** `hasPendingInteraction()` and had no repair pass,
+  so it rescheduled until the budget was spent and terminalized via `onExhausted`.
+  Converged in three sub-slices: (A.1) extracted Think's `_repairToolTranscriptParts`
+  into the shared `@internal` `agents/chat` `repairInterruptedToolParts` primitive
+  (Think delegates, behavior-neutral; `agents`/`think` patches); (A.2) ai-chat
+  adopts it on the recovery-continue/retry path via a new overridable
+  `repairInterruptedToolPart` hook (`@cloudflare/ai-chat` minor); (A.3) ai-chat's
+  recovery-scoped stability wait now gates on the narrow client-resolvable predicate
+  (an optional `pendingInteraction` arg to `waitUntilStable`; the broad default —
+  and the documented app-override semantics — are unchanged). Repair only ever
+  reshapes **assistant** tool parts, so per-channel policy on the **user** message
+  (`metadata.channel`, re-resolved on wake) is structurally untouched. e2e: a
+  dead-server-tool orphan now **recovers** (repairs to errored, continues) instead
+  of waiting-then-`onExhausted`.
 
 Going forward, new matrix rows should carry an explicit **status** (proposed /
 DONE) and **litmus bucket** (1 behavior-drift / 2 bug-asymmetry / 3 product) so the

--- a/packages/agents/src/chat/__tests__/recovery-conformance.test.ts
+++ b/packages/agents/src/chat/__tests__/recovery-conformance.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Cross-host recovery conformance.
+ *
+ * The two AI-SDK chat hosts (`@cloudflare/think` and `@cloudflare/ai-chat`)
+ * converge their interrupted-turn recovery onto the SAME shared primitives:
+ * `repairInterruptedToolParts` (transcript repair before inference) and the
+ * `partAwaitsClientInteraction` / `clientResolvableToolNames` predicate (is a
+ * tool part still legitimately awaiting the client?). This suite pins the
+ * behavioral contract of those seams under each host's wiring, side by side, so
+ * the convergence can't silently drift.
+ *
+ * It deliberately encodes the **subset** relationship, not naive "identical":
+ *
+ *   - **ai-chat wiring** repairs ONLY dead SERVER orphans and SKIPS a part still
+ *     awaiting a client (`shouldRepair = !partAwaitsClientInteraction`), because
+ *     ai-chat's default repair errors the part and the app owns inference — a
+ *     pending client tool must be left for the client to replay (the turn parks).
+ *   - **Think wiring** repairs everything before its own inference (no
+ *     `shouldRepair`); its real `repairPart` may convert a client tool to text
+ *     rather than error it, but either way the part ends SETTLED so the next
+ *     provider call doesn't 400.
+ *
+ * So for a dead server orphan both hosts recover identically; for a pending
+ * client orphan they intentionally differ (ai-chat ⊆ Think: ai-chat does less —
+ * it parks). Each scenario states which.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { UIMessage } from "ai";
+import {
+  repairInterruptedToolParts,
+  type RepairInterruptedToolPartsOptions
+} from "../repair-transcript";
+import {
+  partAwaitsClientInteraction,
+  clientResolvableToolNames
+} from "../tool-state";
+
+type ChatMessage = UIMessage;
+
+/** ai-chat's default: flip an interrupted tool part to a settled errored result. */
+function flipToError(
+  part: UIMessage["parts"][number]
+): UIMessage["parts"][number] {
+  return {
+    ...part,
+    state: "output-error",
+    errorText: "The tool call was interrupted before a result was recorded."
+  } as UIMessage["parts"][number];
+}
+
+/** How each host wires the shared `repairInterruptedToolParts`. */
+function aiChatWiring(
+  clientTools: string[]
+): RepairInterruptedToolPartsOptions {
+  const clientResolvable = clientResolvableToolNames(
+    clientTools.map((name) => ({ name }))
+  );
+  return {
+    repairPart: flipToError,
+    shouldRepair: (part) => !partAwaitsClientInteraction(part, clientResolvable)
+  };
+}
+function thinkWiring(): RepairInterruptedToolPartsOptions {
+  // Think repairs every interrupted part before inference (no shouldRepair). Its
+  // real `repairPart` can convert a client tool to text; we model only the
+  // settled-ness outcome, which is what avoids the provider 400.
+  return { repairPart: flipToError };
+}
+
+type Outcome =
+  | "output-error"
+  | "input-available"
+  | "approval-requested"
+  | "approval-responded";
+
+interface Scenario {
+  name: string;
+  /** Tool names the client offered this turn (server tools are everything else). */
+  clientTools: string[];
+  messages: ChatMessage[];
+  /** Expected post-repair state per `toolCallId`, under each host wiring. */
+  expected: Record<string, { aiChat: Outcome; think: Outcome }>;
+  /** Whether the two hosts agree here (documentation for the reader). */
+  relationship: "identical" | "intentional-divergence (ai-chat ⊆ Think)";
+}
+
+function assistant(id: string, parts: Record<string, unknown>[]): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: parts as unknown as ChatMessage["parts"]
+  } as ChatMessage;
+}
+function toolPart(
+  toolName: string,
+  toolCallId: string,
+  state: string
+): Record<string, unknown> {
+  return { type: `tool-${toolName}`, toolCallId, toolName, state, input: {} };
+}
+
+function stateOf(
+  messages: ChatMessage[],
+  toolCallId: string
+): string | undefined {
+  for (const m of messages) {
+    for (const p of m.parts) {
+      const r = p as Record<string, unknown>;
+      if (r.toolCallId === toolCallId) {
+        return typeof r.state === "string" ? r.state : undefined;
+      }
+    }
+  }
+  return undefined;
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: "dead server-tool orphan recovers (both hosts)",
+    clientTools: [],
+    messages: [
+      assistant("a1", [toolPart("previewTool", "srv", "input-available")])
+    ],
+    expected: { srv: { aiChat: "output-error", think: "output-error" } },
+    relationship: "identical"
+  },
+  {
+    name: "pending client-tool orphan: ai-chat parks (skips), Think repairs",
+    clientTools: ["chooseOption"],
+    messages: [
+      assistant("a1", [toolPart("chooseOption", "cli", "input-available")])
+    ],
+    expected: { cli: { aiChat: "input-available", think: "output-error" } },
+    relationship: "intentional-divergence (ai-chat ⊆ Think)"
+  },
+  {
+    name: "mixed: buried client orphan + leaf server orphan",
+    clientTools: ["chooseOption"],
+    messages: [
+      assistant("a1", [toolPart("chooseOption", "cli", "input-available")]),
+      assistant("a2", [toolPart("previewTool", "srv", "input-available")])
+    ],
+    expected: {
+      // ai-chat keeps the buried client orphan, repairs the leaf server one.
+      cli: { aiChat: "input-available", think: "output-error" },
+      srv: { aiChat: "output-error", think: "output-error" }
+    },
+    relationship: "intentional-divergence (ai-chat ⊆ Think)"
+  },
+  {
+    name: "approval-requested client part is preserved by ai-chat, repaired by Think",
+    clientTools: ["deploy"],
+    messages: [
+      assistant("a1", [toolPart("deploy", "appr", "approval-requested")])
+    ],
+    expected: {
+      appr: { aiChat: "approval-requested", think: "output-error" }
+    },
+    relationship: "intentional-divergence (ai-chat ⊆ Think)"
+  },
+  {
+    name: "approval-responded is preserved verbatim by both (awaiting continuation)",
+    clientTools: [],
+    messages: [
+      assistant("a1", [toolPart("deploy", "appr2", "approval-responded")])
+    ],
+    // Neither wiring repairs approval-responded; assert it stays as-is.
+    expected: {
+      appr2: { aiChat: "approval-responded", think: "approval-responded" }
+    },
+    relationship: "identical"
+  }
+];
+
+describe("recovery conformance (shared repair primitive, both host wirings)", () => {
+  for (const scenario of scenarios) {
+    it(scenario.name, () => {
+      const aiChat = repairInterruptedToolParts(
+        scenario.messages,
+        aiChatWiring(scenario.clientTools)
+      );
+      const think = repairInterruptedToolParts(
+        scenario.messages,
+        thinkWiring()
+      );
+
+      for (const [toolCallId, want] of Object.entries(scenario.expected)) {
+        expect(stateOf(aiChat.messages, toolCallId)).toBe(want.aiChat);
+        expect(stateOf(think.messages, toolCallId)).toBe(want.think);
+      }
+
+      // The subset invariant: anything ai-chat repairs, Think also repairs
+      // (ai-chat never repairs MORE than Think).
+      for (const toolCallId of Object.keys(scenario.expected)) {
+        const aiChatRepaired =
+          stateOf(aiChat.messages, toolCallId) === "output-error";
+        const thinkRepaired =
+          stateOf(think.messages, toolCallId) === "output-error";
+        if (aiChatRepaired) expect(thinkRepaired).toBe(true);
+      }
+
+      // The declared relationship must match the data: "identical" iff every
+      // part has the same outcome under both wirings.
+      const allIdentical = Object.values(scenario.expected).every(
+        (want) => want.aiChat === want.think
+      );
+      expect(allIdentical).toBe(scenario.relationship === "identical");
+    });
+  }
+
+  it("server-orphan recovery is byte-for-byte identical across wirings", () => {
+    const messages = [
+      assistant("a1", [toolPart("previewTool", "srv", "input-available")])
+    ];
+    const aiChat = repairInterruptedToolParts(messages, aiChatWiring([]));
+    const think = repairInterruptedToolParts(messages, thinkWiring());
+    expect(aiChat.messages).toEqual(think.messages);
+    expect(aiChat.removedToolCalls).toBe(1);
+    expect(think.removedToolCalls).toBe(1);
+  });
+});

--- a/packages/agents/src/chat/__tests__/repair-transcript.test.ts
+++ b/packages/agents/src/chat/__tests__/repair-transcript.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import type { UIMessage } from "ai";
+import {
+  repairInterruptedToolParts,
+  toolPartHasSettledResult
+} from "../repair-transcript";
+
+type ChatMessage = UIMessage;
+
+function flipToError(
+  part: UIMessage["parts"][number]
+): UIMessage["parts"][number] {
+  return {
+    ...part,
+    state: "output-error",
+    errorText: "The tool call was interrupted before a result was recorded."
+  } as UIMessage["parts"][number];
+}
+
+function repair(messages: ChatMessage[]) {
+  return repairInterruptedToolParts(messages, { repairPart: flipToError });
+}
+
+function toolMsg(
+  id: string,
+  part: Record<string, unknown>,
+  role: "assistant" | "user" = "assistant"
+): ChatMessage {
+  return {
+    id,
+    role,
+    parts: [part as unknown as ChatMessage["parts"][number]]
+  } as ChatMessage;
+}
+
+describe("toolPartHasSettledResult", () => {
+  it("treats output/result fields and terminal states as settled", () => {
+    expect(toolPartHasSettledResult({ output: 1 })).toBe(true);
+    expect(toolPartHasSettledResult({ result: 1 })).toBe(true);
+    expect(toolPartHasSettledResult({ state: "output-available" })).toBe(true);
+    expect(toolPartHasSettledResult({ state: "output-error" })).toBe(true);
+    expect(toolPartHasSettledResult({ state: "output-denied" })).toBe(true);
+  });
+
+  it("treats in-flight states as unsettled", () => {
+    expect(toolPartHasSettledResult({ state: "input-available" })).toBe(false);
+    expect(toolPartHasSettledResult({ state: "input-streaming" })).toBe(false);
+    expect(toolPartHasSettledResult({})).toBe(false);
+  });
+});
+
+describe("repairInterruptedToolParts", () => {
+  it("flips an interrupted (input-available) tool call to the repaired shape", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-search",
+        toolCallId: "tc1",
+        toolName: "search",
+        state: "input-available",
+        input: { q: "cats" }
+      })
+    ];
+    const result = repair(messages);
+    expect(result.removedToolCalls).toBe(1);
+    expect(result.toolCallIds).toEqual(["tc1"]);
+    const part = result.messages[0].parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toContain("interrupted");
+    // Input preserved (already a valid object).
+    expect(part.input).toEqual({ q: "cats" });
+  });
+
+  it("leaves settled tool calls untouched and returns the original reference", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-search",
+        toolCallId: "tc1",
+        toolName: "search",
+        state: "output-available",
+        input: { q: "cats" },
+        output: { hits: 1 }
+      })
+    ];
+    const result = repair(messages);
+    expect(result.removedToolCalls).toBe(0);
+    expect(result.normalizedInputs).toBe(0);
+    // Unchanged message keeps its identity for cheap persist diffing.
+    expect(result.messages[0]).toBe(messages[0]);
+  });
+
+  it("preserves an approval-responded tool call verbatim", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-deploy",
+        toolCallId: "tc1",
+        toolName: "deploy",
+        state: "approval-responded",
+        input: { env: "prod" }
+      })
+    ];
+    const result = repair(messages);
+    expect(result.removedToolCalls).toBe(0);
+    expect(result.messages[0]).toBe(messages[0]);
+    const part = result.messages[0].parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("approval-responded");
+  });
+
+  it("normalizes a malformed input on a settled tool call without re-erroring it", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-search",
+        toolCallId: "tc1",
+        toolName: "search",
+        state: "output-available",
+        input: '{"q":"cats"}',
+        output: { hits: 1 }
+      })
+    ];
+    const result = repair(messages);
+    expect(result.removedToolCalls).toBe(0);
+    expect(result.normalizedInputs).toBe(1);
+    const part = result.messages[0].parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("output-available");
+    expect(part.input).toEqual({ q: "cats" });
+  });
+
+  it("normalizes a non-object input on an interrupted tool call before repairing", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-search",
+        toolCallId: "tc1",
+        toolName: "search",
+        state: "input-available",
+        input: ""
+      })
+    ];
+    const result = repair(messages);
+    expect(result.removedToolCalls).toBe(1);
+    expect(result.normalizedInputs).toBe(1);
+    const part = result.messages[0].parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("output-error");
+    expect(part.input).toEqual({});
+  });
+
+  it("handles dynamic-tool parts", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "dynamic-tool",
+        toolCallId: "tc1",
+        toolName: "whatever",
+        state: "input-available",
+        input: {}
+      })
+    ];
+    const result = repair(messages);
+    expect(result.removedToolCalls).toBe(1);
+    const part = result.messages[0].parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("output-error");
+  });
+
+  it("leaves non-tool parts untouched", () => {
+    const messages = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "hello" },
+          {
+            type: "tool-search",
+            toolCallId: "tc1",
+            toolName: "search",
+            state: "input-available",
+            input: {}
+          }
+        ]
+      } as unknown as ChatMessage
+    ];
+    const result = repair(messages);
+    const parts = result.messages[0].parts as Record<string, unknown>[];
+    expect(parts[0]).toEqual({ type: "text", text: "hello" });
+    expect(parts[1].state).toBe("output-error");
+  });
+
+  it("supports a custom repairPart hook (e.g. converting to a text part)", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-ask_user",
+        toolCallId: "tc1",
+        toolName: "ask_user",
+        state: "input-available",
+        input: { question: "Which file?" }
+      })
+    ];
+    const result = repairInterruptedToolParts(messages, {
+      repairPart: (part) => {
+        const record = part as Record<string, unknown>;
+        const input = record.input as { question?: string };
+        return {
+          type: "text",
+          text: input.question ?? ""
+        } as unknown as UIMessage["parts"][number];
+      }
+    });
+    expect(result.removedToolCalls).toBe(1);
+    const part = result.messages[0].parts[0] as Record<string, unknown>;
+    expect(part.type).toBe("text");
+    expect(part.text).toBe("Which file?");
+  });
+
+  it("repairs across multiple messages and reports all ids", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-a",
+        toolCallId: "tc1",
+        toolName: "a",
+        state: "input-available",
+        input: {}
+      }),
+      toolMsg("a2", {
+        type: "tool-b",
+        toolCallId: "tc2",
+        toolName: "b",
+        state: "output-available",
+        input: {},
+        output: {}
+      }),
+      toolMsg("a3", {
+        type: "tool-c",
+        toolCallId: "tc3",
+        toolName: "c",
+        state: "input-streaming",
+        input: {}
+      })
+    ];
+    const result = repair(messages);
+    expect(result.removedToolCalls).toBe(2);
+    expect(result.toolCallIds).toEqual(["tc1", "tc3"]);
+    // The settled one keeps identity; repaired ones are new objects.
+    expect(result.messages[1]).toBe(messages[1]);
+  });
+});

--- a/packages/agents/src/chat/__tests__/repair-transcript.test.ts
+++ b/packages/agents/src/chat/__tests__/repair-transcript.test.ts
@@ -207,6 +207,42 @@ describe("repairInterruptedToolParts", () => {
     expect(part.text).toBe("Which file?");
   });
 
+  it("skips an interrupted part when shouldRepair returns false (left verbatim)", () => {
+    const messages = [
+      toolMsg("a1", {
+        type: "tool-chooseOption",
+        toolCallId: "client-1",
+        toolName: "chooseOption",
+        state: "input-available",
+        input: {}
+      }),
+      toolMsg("a2", {
+        type: "tool-previewTool",
+        toolCallId: "server-1",
+        toolName: "previewTool",
+        state: "input-available",
+        input: {}
+      })
+    ];
+    const result = repairInterruptedToolParts(messages, {
+      repairPart: flipToError,
+      // Skip the client tool; repair only the server one.
+      shouldRepair: (part) =>
+        (part as Record<string, unknown>).toolName !== "chooseOption"
+    });
+    expect(result.removedToolCalls).toBe(1);
+    expect(result.toolCallIds).toEqual(["server-1"]);
+    // Skipped client part kept verbatim (message identity preserved).
+    expect(result.messages[0]).toBe(messages[0]);
+    expect((result.messages[0].parts[0] as Record<string, unknown>).state).toBe(
+      "input-available"
+    );
+    // Server part repaired.
+    expect((result.messages[1].parts[0] as Record<string, unknown>).state).toBe(
+      "output-error"
+    );
+  });
+
   it("repairs across multiple messages and reports all ids", () => {
     const messages = [
       toolMsg("a1", {

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -116,7 +116,31 @@ export {
   reconcileOrphanPartial
 } from "./message-reconciler";
 
+/**
+ * @internal Shared transcript-repair primitive — flips interrupted tool calls
+ * to a settled shape so a recovered turn's next provider call doesn't 400 with
+ * `AI_MissingToolResultsError`. Sibling-package support for `@cloudflare/think`
+ * and `@cloudflare/ai-chat`, not a public API. See `repair-transcript.ts`.
+ */
+export {
+  repairInterruptedToolParts,
+  toolPartHasSettledResult,
+  type RepairInterruptedToolPartsOptions,
+  type RepairInterruptedToolPartsResult
+} from "./repair-transcript";
+
 export type { OrphanPersistStore } from "./orphan-store";
+
+/**
+ * @internal Shared orphan-persist core — reconstruct an interrupted stream's
+ * message and upsert it through an `OrphanPersistStore`. Sibling-package support
+ * for `@cloudflare/think` and `@cloudflare/ai-chat`, not a public API. See
+ * `orphan-persist.ts`.
+ */
+export {
+  persistReconstructedOrphan,
+  type PersistReconstructedOrphanOptions
+} from "./orphan-persist";
 
 export { sendIfOpen, type ChatConnection } from "./connection";
 

--- a/packages/agents/src/chat/orphan-persist.ts
+++ b/packages/agents/src/chat/orphan-persist.ts
@@ -1,0 +1,90 @@
+/**
+ * Orphan-persist core — reconstruct a message from an interrupted stream's
+ * buffered chunks and upsert it through an {@link OrphanPersistStore}.
+ *
+ * This is the genuinely-shared skeleton extracted from the two AI-SDK chat
+ * hosts' `_persistOrphanedStream` (`@cloudflare/think` and
+ * `@cloudflare/ai-chat`): the accumulate loop plus the
+ * `getMessage → updateMessage(merge) XOR appendMessage` upsert. The
+ * deliberately host-specific bits stay in the callers:
+ *
+ *   - buffer flush (Think flushes defensively first; ai-chat doesn't);
+ *   - the fallback message id;
+ *   - `prepare` — Think strips internal parts and may skip (`null`); ai-chat
+ *     resolves the persist-target id from stream metadata;
+ *   - `merge` — Think replaces the whole message; ai-chat reconciles partials
+ *     so an in-place tool result isn't re-advanced by a replayed chunk; and
+ *   - broadcast (Think broadcasts after; ai-chat broadcasts inside its store's
+ *     `persistMessages`).
+ *
+ * Pure orchestration: it performs exactly one store write (update XOR append),
+ * never touches the buffer, and never broadcasts.
+ *
+ * @internal Shared chat-recovery internals; not a public API.
+ */
+
+import type { UIMessage } from "ai";
+import { StreamAccumulator } from "./stream-accumulator";
+import type { StreamChunkData } from "./message-builder";
+import type { OrphanPersistStore } from "./orphan-store";
+
+export interface PersistReconstructedOrphanOptions<
+  TMessage extends UIMessage = UIMessage
+> {
+  /** The store seam to upsert through (a `SessionProvider` write-subset). */
+  store: OrphanPersistStore<TMessage>;
+  /**
+   * Id for the reconstructed message when the stream carried no provider
+   * `start.messageId` to adopt. The accumulator still adopts a provider id when
+   * present.
+   */
+  fallbackId: string;
+  /**
+   * Finalize the reconstructed message before upsert — e.g. strip internal
+   * parts or resolve the persist-target id. Return `null` to skip persistence
+   * entirely (e.g. an empty structural-only message).
+   */
+  prepare: (message: TMessage) => TMessage | null;
+  /**
+   * Combine an existing row with the reconstructed message when a row already
+   * owns the id (replace, or reconcile partials).
+   */
+  merge: (existing: TMessage, incoming: TMessage) => TMessage;
+}
+
+/**
+ * Reconstruct a message from `chunks` and upsert it via the store. Returns
+ * `true` when a write happened (so a caller that broadcasts after — Think — can
+ * gate its broadcast on it), `false` when there was nothing to persist (no
+ * parts, or `prepare` returned `null`).
+ */
+export async function persistReconstructedOrphan<
+  TMessage extends UIMessage = UIMessage
+>(
+  chunks: ReadonlyArray<{ body: string }>,
+  options: PersistReconstructedOrphanOptions<TMessage>
+): Promise<boolean> {
+  if (chunks.length === 0) return false;
+
+  const accumulator = new StreamAccumulator({ messageId: options.fallbackId });
+  for (const chunk of chunks) {
+    try {
+      accumulator.applyChunk(JSON.parse(chunk.body) as StreamChunkData);
+    } catch {
+      // Skip malformed chunk bodies.
+    }
+  }
+
+  if (accumulator.parts.length === 0) return false;
+
+  const prepared = options.prepare(accumulator.toMessage() as TMessage);
+  if (prepared === null) return false;
+
+  const existing = await options.store.getMessage(prepared.id);
+  if (existing) {
+    await options.store.updateMessage(options.merge(existing, prepared));
+  } else {
+    await options.store.appendMessage(prepared);
+  }
+  return true;
+}

--- a/packages/agents/src/chat/repair-transcript.ts
+++ b/packages/agents/src/chat/repair-transcript.ts
@@ -1,0 +1,181 @@
+/**
+ * Transcript repair — flip interrupted tool calls (a `tool-*` / `dynamic-tool`
+ * part with no settled result, left behind when a stream was cut off mid-flight)
+ * into a settled shape so the next provider call does not 400 with
+ * `AI_MissingToolResultsError`, and normalize malformed tool `input`.
+ *
+ * This is the shared, host-agnostic core extracted from `@cloudflare/think`'s
+ * `_repairToolTranscriptParts`. Both AI-SDK chat hosts (`@cloudflare/think` and
+ * `@cloudflare/ai-chat`) run it before re-entering inference on a recovered turn
+ * so an interrupted SERVER tool (whose `execute()` died with the evicted
+ * isolate, leaving an `input-available` orphan that nothing will ever resolve)
+ * is converted to an errored tool-result and the turn can continue, instead of
+ * being abandoned.
+ *
+ * Pure: it returns a new messages array plus repair stats and never touches
+ * storage, broadcast, or events — the host owns those side effects.
+ *
+ * @internal Shared chat-recovery internals; not a public API.
+ */
+
+import type { UIMessage } from "ai";
+import { normalizeToolInput } from "./message-builder";
+
+/**
+ * Whether a tool part already has a settled result the provider accepts, so it
+ * must NOT be re-repaired into an errored result.
+ *
+ * Single source of truth for the terminal tool states. Mirrors the AI SDK's
+ * terminal states: `convertToModelMessages` emits a `tool-result` for
+ * `output-available`, `output-error`, AND `output-denied` (a user-denied
+ * approval — its denial reason becomes the tool-result). Omitting any of these
+ * makes repair re-flip the part every turn — clobbering a real `errorText` /
+ * denial with the generic "interrupted" message.
+ */
+export function toolPartHasSettledResult(
+  record: Record<string, unknown>
+): boolean {
+  if ("output" in record || "result" in record) return true;
+  const state = typeof record.state === "string" ? record.state : "";
+  return (
+    state === "output-available" ||
+    state === "output-error" ||
+    state === "output-denied"
+  );
+}
+
+export interface RepairInterruptedToolPartsOptions {
+  /**
+   * Decide the replacement for an interrupted tool part (no settled result, not
+   * `approval-responded`). Its `input` has already been normalized to a valid
+   * object. The default host behavior flips it to an errored tool-result; hosts
+   * expose this as an overridable `repairInterruptedToolPart` hook so a subclass
+   * can, e.g., convert an interrupted client-resolved tool into a text part.
+   */
+  repairPart: (part: UIMessage["parts"][number]) => UIMessage["parts"][number];
+  /**
+   * Whether a tool part already carries a settled result (defaults to
+   * {@link toolPartHasSettledResult}).
+   */
+  isSettled?: (record: Record<string, unknown>) => boolean;
+  /**
+   * Normalize a tool part's `input` (defaults to the shared
+   * {@link normalizeToolInput}).
+   */
+  normalizeInput?: (input: unknown) => { input: unknown; changed: boolean };
+}
+
+export interface RepairInterruptedToolPartsResult {
+  /** A new messages array; unchanged messages keep their original reference. */
+  messages: UIMessage[];
+  /** Count of interrupted tool calls flipped to a repaired shape. */
+  removedToolCalls: number;
+  /** Count of tool parts whose malformed `input` was normalized. */
+  normalizedInputs: number;
+  /** The tool-call ids that were repaired. */
+  toolCallIds: string[];
+}
+
+/**
+ * Repair interrupted tool calls and normalize malformed tool inputs across a
+ * transcript. Behavior mirrors `@cloudflare/think`'s original
+ * `_repairToolTranscriptParts`:
+ *
+ *   - a tool part with NO settled result and state `approval-responded` is kept
+ *     verbatim (an approved server tool waiting for its continuation to run
+ *     `execute()` — not abandoned);
+ *   - any other tool part with no settled result is normalized then handed to
+ *     `repairPart` (default: flipped to an errored result);
+ *   - a tool part WITH a settled result only has its `input` normalized.
+ *
+ * Messages with no changed part keep their original object reference so callers
+ * can cheaply detect what to persist.
+ */
+export function repairInterruptedToolParts(
+  messages: UIMessage[],
+  options: RepairInterruptedToolPartsOptions
+): RepairInterruptedToolPartsResult {
+  const isSettled = options.isSettled ?? toolPartHasSettledResult;
+  const normalizeInput = options.normalizeInput ?? normalizeToolInput;
+  const { repairPart } = options;
+
+  let removedToolCalls = 0;
+  let normalizedInputs = 0;
+  const toolCallIds: string[] = [];
+  const repaired: UIMessage[] = [];
+
+  for (const message of messages) {
+    const parts: UIMessage["parts"] = [];
+    let messageChanged = false;
+    for (const part of message.parts) {
+      const record = part as Record<string, unknown>;
+      const toolCallId =
+        typeof record.toolCallId === "string" ? record.toolCallId : undefined;
+      const isToolPart =
+        typeof record.type === "string" &&
+        (record.type.startsWith("tool-") || record.type === "dynamic-tool") &&
+        toolCallId;
+      if (!isToolPart) {
+        parts.push(part);
+        continue;
+      }
+
+      if (!isSettled(record)) {
+        const state = typeof record.state === "string" ? record.state : "";
+        // An approved server tool waits at `approval-responded` until its
+        // scheduled continuation runs `execute()`. It is not abandoned, so
+        // preserve it verbatim — flipping it to an error (or removing it) would
+        // strand the approval and prevent the real result from ever being
+        // produced by the continuation.
+        if (state === "approval-responded") {
+          parts.push(part);
+          continue;
+        }
+        // Preserve the interrupted/abandoned tool call instead of deleting it.
+        // Deleting makes the call "disappear" from the (broadcast) transcript
+        // and lets the model silently re-run it. `input` is normalized to a
+        // valid object first, then `repairPart` decides the replacement shape
+        // (default: an errored result, so conversion still gets a tool-result
+        // and the provider doesn't 400 with AI_MissingToolResultsError).
+        const normalized = normalizeInput(
+          "input" in record ? record.input : undefined
+        );
+        parts.push(
+          repairPart({
+            ...part,
+            input: normalized.input
+          } as UIMessage["parts"][number])
+        );
+        if (normalized.changed) normalizedInputs++;
+        removedToolCalls++;
+        messageChanged = true;
+        toolCallIds.push(toolCallId);
+        continue;
+      }
+
+      const normalized = normalizeInput(
+        "input" in record ? record.input : undefined
+      );
+      if (normalized.changed) {
+        parts.push({
+          ...part,
+          input: normalized.input
+        } as UIMessage["parts"][number]);
+        normalizedInputs++;
+        messageChanged = true;
+        continue;
+      }
+
+      parts.push(part);
+    }
+
+    repaired.push(messageChanged ? { ...message, parts } : message);
+  }
+
+  return {
+    messages: repaired,
+    removedToolCalls,
+    normalizedInputs,
+    toolCallIds
+  };
+}

--- a/packages/agents/src/chat/repair-transcript.ts
+++ b/packages/agents/src/chat/repair-transcript.ts
@@ -63,6 +63,17 @@ export interface RepairInterruptedToolPartsOptions {
    * {@link normalizeToolInput}).
    */
   normalizeInput?: (input: unknown) => { input: unknown; changed: boolean };
+  /**
+   * Whether an interrupted tool part (no settled result, not
+   * `approval-responded`) should be repaired at all. Defaults to `true` (repair
+   * everything, like Think — which converts even client tools via its
+   * `repairPart` override). A host whose default `repairPart` errors the part
+   * (ai-chat) passes this to SKIP a part still legitimately awaiting a CLIENT
+   * interaction (an `input-available` client tool or an `approval-requested`
+   * part the user may still answer) so it is left verbatim rather than clobbered
+   * with an error. Skipped parts are not counted in `removedToolCalls`.
+   */
+  shouldRepair?: (part: UIMessage["parts"][number]) => boolean;
 }
 
 export interface RepairInterruptedToolPartsResult {
@@ -84,6 +95,8 @@ export interface RepairInterruptedToolPartsResult {
  *   - a tool part with NO settled result and state `approval-responded` is kept
  *     verbatim (an approved server tool waiting for its continuation to run
  *     `execute()` — not abandoned);
+ *   - a tool part with NO settled result for which `shouldRepair` returns false
+ *     is kept verbatim (a part still awaiting a CLIENT interaction; see option);
  *   - any other tool part with no settled result is normalized then handed to
  *     `repairPart` (default: flipped to an errored result);
  *   - a tool part WITH a settled result only has its `input` normalized.
@@ -98,6 +111,7 @@ export function repairInterruptedToolParts(
   const isSettled = options.isSettled ?? toolPartHasSettledResult;
   const normalizeInput = options.normalizeInput ?? normalizeToolInput;
   const { repairPart } = options;
+  const shouldRepair = options.shouldRepair ?? (() => true);
 
   let removedToolCalls = 0;
   let normalizedInputs = 0;
@@ -128,6 +142,15 @@ export function repairInterruptedToolParts(
         // strand the approval and prevent the real result from ever being
         // produced by the continuation.
         if (state === "approval-responded") {
+          parts.push(part);
+          continue;
+        }
+        // A part still legitimately awaiting a CLIENT interaction (the host's
+        // `shouldRepair` returns false) is left verbatim — erroring it would
+        // clobber a tool-result / approval the client may still replay. Only
+        // hosts whose default repair ERRORS the part opt into this; Think keeps
+        // the default (repair everything, converting client tools via its hook).
+        if (!shouldRepair(part)) {
           parts.push(part);
           continue;
         }

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -23,6 +23,8 @@ import {
   reconcileMessages,
   resolveToolMergeId,
   reconcileOrphanPartial,
+  repairInterruptedToolParts,
+  persistReconstructedOrphan,
   createChatFiberSnapshot,
   unwrapChatFiberSnapshot,
   wrapChatFiberSnapshot,
@@ -30,7 +32,6 @@ import {
 } from "agents/chat";
 import {
   applyChunkToParts,
-  StreamAccumulator,
   aiSdkRecoveryCodec,
   ResumeHandshake,
   isReplayChunk,
@@ -929,6 +930,7 @@ export class AIChatAgent<
                   async () => {
                     const chatTurnBody = async () => {
                       try {
+                        await this._repairInterruptedToolsBeforeTurn();
                         const response = await this.onChatMessage(
                           async (_finishResult) => {
                             // User-provided hook. Cleanup is now handled by _reply,
@@ -1401,41 +1403,37 @@ export class AIChatAgent<
     const chunks = this._resumableStream.getStreamChunks(streamId);
     if (!chunks.length) return;
 
-    // (a) Reconstruct. A provider `start.messageId` is adopted as the id (the
-    // live path adopts it for new turns too); continuations have it stripped
-    // before storage (#1229), so the accumulator's unconditional adopt matches
-    // the live path.
-    const fallbackId = `assistant_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
-    const accumulator = new StreamAccumulator({ messageId: fallbackId });
-    for (const chunk of chunks) {
-      try {
-        accumulator.applyChunk(JSON.parse(chunk.body) as StreamChunkData);
-      } catch {
-        // Skip malformed chunk bodies
-      }
-    }
-
-    const message: UIMessage = accumulator.toMessage();
-    if (message.parts.length === 0) return;
-
-    // (b) Resolve the persist target id (the one per-package step).
-    message.id = this._resolveOrphanTargetId(streamId, message.id, fallbackId);
-
-    // (c)+(d) Upsert by id through the shared `OrphanPersistStore` seam. A row
-    // may already own this id (an early persist during tool approval, or a
-    // continuation resuming the last assistant message) — merge onto it via the
-    // shared `reconcileOrphanPartial`; otherwise append. Exactly one write
-    // (update XOR append) → one `persistMessages` → one broadcast.
-    const store = this._orphanStore();
-    const existing = await store.getMessage(message.id);
-    if (existing) {
-      await store.updateMessage(reconcileOrphanPartial(existing, message));
-    } else {
-      await store.appendMessage(message);
-    }
+    // The accumulate loop and the `getMessage → update(merge) XOR append` upsert
+    // are the shared `persistReconstructedOrphan` core. ai-chat supplies the two
+    // host-specific hooks:
+    //   - prepare: resolve the persist-target id (#1691) — the one per-package
+    //     step (a flat array can't express the tree a Session uses). A provider
+    //     `start.messageId` is adopted by the accumulator (the live path adopts
+    //     it for new turns too); continuations have it stripped before storage
+    //     (#1229), so the unconditional adopt matches the live path.
+    //   - merge: a row may already own this id (an early persist during tool
+    //     approval, or a continuation resuming the last assistant message) —
+    //     reconcile onto it via the shared `reconcileOrphanPartial` so an
+    //     in-place tool result isn't re-advanced by a replayed chunk.
+    // The store routes each write through `persistMessages` (exactly one write →
+    // one `persistMessages` → one broadcast), so no explicit broadcast here.
     // NOTE: progress is bumped at production/flush time in `_storeStreamChunk`
-    // (#1637), NOT here — persisting on recovery or a client reconnect must
-    // not be miscounted as new forward progress.
+    // (#1637), NOT here — persisting on recovery or a client reconnect must not
+    // be miscounted as new forward progress.
+    const fallbackId = `assistant_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+    await persistReconstructedOrphan(chunks, {
+      store: this._orphanStore(),
+      fallbackId,
+      prepare: (message) => {
+        message.id = this._resolveOrphanTargetId(
+          streamId,
+          message.id,
+          fallbackId
+        );
+        return message;
+      },
+      merge: (existing, incoming) => reconcileOrphanPartial(existing, incoming)
+    });
   }
 
   /**
@@ -1492,6 +1490,82 @@ export class AIChatAgent<
           this.messages.map((m) => (m.id === message.id ? message : m))
         )
     };
+  }
+
+  /**
+   * Repair a single interrupted tool call — a tool part with no settled result,
+   * left behind when a stream was cut off mid-flight (e.g. a SERVER tool whose
+   * `execute()` died with an evicted isolate, leaving an `input-available`
+   * orphan that nothing will ever resolve). Returns the replacement part that
+   * takes its place in the transcript; `input` has already been normalized to a
+   * valid object.
+   *
+   * The default flips it to an errored tool result so the record survives (no
+   * "disappearing" tool call) and `convertToModelMessages` still gets a
+   * tool-result for it, avoiding `AI_MissingToolResultsError` on the next
+   * provider call. This mirrors `@cloudflare/think` so ai-chat RECOVERS an
+   * interrupted server tool (repairs, then continues) instead of waiting on a
+   * dead orphan until its budget is spent.
+   *
+   * Override to customize the repaired shape for client-resolved tools — e.g.
+   * convert an interrupted question tool (no server `execute`, normally answered
+   * by the user's next message) into a plain text part so the model sees it as
+   * ordinary conversation rather than a tool error. A returned tool part MUST
+   * carry a settled result (`output-available` / `output-error` /
+   * `output-denied` or an `output` / `result` field); returning a non-tool part
+   * (e.g. text) is fine.
+   */
+  protected repairInterruptedToolPart(
+    part: UIMessage["parts"][number]
+  ): UIMessage["parts"][number] {
+    return {
+      ...part,
+      state: "output-error",
+      errorText: "The tool call was interrupted before a result was recorded."
+    } as UIMessage["parts"][number];
+  }
+
+  /**
+   * Transcript repair, run before EVERY inference chokepoint (live submit, tool
+   * auto-continuation, `continueLastTurn`, `saveMessages`/retry, and the chat
+   * recovery callbacks). An interrupted server-tool orphan is flipped to a
+   * settled (errored) result — via the shared `agents/chat`
+   * `repairInterruptedToolParts` primitive, the SAME logic `@cloudflare/think`
+   * runs before its own inference (`_assembleModelMessages`) — so the app's next
+   * `convertToModelMessages(this.messages)` doesn't 400 with
+   * `AI_MissingToolResultsError`. Because the app owns the inference call, the
+   * framework can't repair "inside" it the way Think does; it repairs
+   * `this.messages` at each point right before handing control to
+   * `onChatMessage` instead. This reaches the cases the recovery-only repair
+   * missed: a mixed client+server orphan whose client replay drives an
+   * auto-continuation, and any agent running with `chatRecovery` disabled.
+   *
+   * Guard: repair runs ONLY when no client interaction is genuinely pending. In
+   * that state every unsettled tool part is a dead SERVER orphan (its
+   * `execute()` died with the evicted isolate), so flipping it to an errored
+   * result is always safe. While a client tool is still awaiting the user the
+   * guard skips repair — flipping it would clobber a result the client may still
+   * replay. (On the recovery-continue path this mirrors the narrow predicate
+   * that already let `waitUntilStable` converge.)
+   *
+   * Repair only ever reshapes ASSISTANT tool parts; it never touches user
+   * messages, so per-channel policy carried on the user message's
+   * `metadata.channel` (re-resolved on wake) is structurally untouched. It is a
+   * no-op (no write, no broadcast) when nothing needs repair — the common case
+   * for a healthy transcript. When anything changes, the corrected transcript is
+   * persisted and broadcast through the normal `persistMessages` write path (one
+   * write, one broadcast), which also refreshes `this.messages`.
+   * @internal
+   */
+  private async _repairInterruptedToolsBeforeTurn(): Promise<void> {
+    if (this.hasPendingClientInteraction()) return;
+    const repaired = repairInterruptedToolParts(this.messages, {
+      repairPart: (part) => this.repairInterruptedToolPart(part)
+    });
+    if (repaired.removedToolCalls === 0 && repaired.normalizedInputs === 0) {
+      return;
+    }
+    await this.persistMessages(repaired.messages);
   }
 
   /**
@@ -1898,12 +1972,26 @@ export class AIChatAgent<
    * Returns `true` when stable. Returns `false` if `timeout` expires before
    * a pending interaction resolves. Safe to call at any time; if there is
    * nothing pending it returns immediately.
+   *
+   * `pendingInteraction` overrides which "still waiting" predicate gates
+   * stability. It defaults to the broad {@link hasPendingInteraction} (any
+   * `input-available` / `approval-requested` part) to preserve the documented
+   * semantics for app overrides. The recovery paths pass the narrower
+   * {@link hasPendingClientInteraction} so a DEAD server-tool `input-available`
+   * orphan (its `execute()` died with the evicted isolate; nothing will resolve
+   * it) does NOT block stability — recovery then repairs it to an errored
+   * result and continues, instead of waiting until the budget is spent. This
+   * mirrors `@cloudflare/think`, whose single pending predicate is already
+   * client-only by construction.
    */
   protected async waitUntilStable(options?: {
     timeout?: number;
+    pendingInteraction?: () => boolean;
   }): Promise<boolean> {
     const deadline =
       options?.timeout != null ? Date.now() + options.timeout : null;
+    const hasPendingInteraction =
+      options?.pendingInteraction ?? (() => this.hasPendingInteraction());
 
     while (true) {
       // Drain active turns AND any in-flight submits past the concurrency
@@ -1932,7 +2020,7 @@ export class AIChatAgent<
         }
       }
 
-      if (!this.hasPendingInteraction()) {
+      if (!hasPendingInteraction()) {
         if (!this._hasArmedContinuation()) {
           return true;
         }
@@ -2327,6 +2415,7 @@ export class AIChatAgent<
               async () => {
                 const autoContinuationBody = async () => {
                   try {
+                    await this._repairInterruptedToolsBeforeTurn();
                     const response = await this.onChatMessage(
                       async (_finishResult) => {},
                       {
@@ -2425,6 +2514,7 @@ export class AIChatAgent<
           );
           try {
             const programmaticBody = async () => {
+              await this._repairInterruptedToolsBeforeTurn();
               const response = await this.onChatMessage(() => {}, {
                 requestId,
                 abortSignal,
@@ -3280,6 +3370,7 @@ export class AIChatAgent<
                   options?.signal
                 );
                 try {
+                  await this._repairInterruptedToolsBeforeTurn();
                   const response = await this.onChatMessage(() => {}, {
                     requestId,
                     abortSignal,
@@ -3911,7 +4002,12 @@ export class AIChatAgent<
     try {
       const recoveryConfig = this._resolveChatRecoveryConfig();
       const ready = await this.waitUntilStable({
-        timeout: recoveryConfig.stableTimeoutMs
+        timeout: recoveryConfig.stableTimeoutMs,
+        // Recovery-scoped: a DEAD server-tool `input-available` orphan must not
+        // block stability (A.2 repairs it below), so gate on the client-
+        // resolvable predicate. A genuinely-pending CLIENT interaction still
+        // keeps it unstable and parks via the `!ready` branch.
+        pendingInteraction: () => this.hasPendingClientInteraction()
       });
       if (!ready) {
         // PARK, don't burn the budget: a stable-state timeout while a CLIENT
@@ -3970,6 +4066,10 @@ export class AIChatAgent<
       }
 
       this._applyRecoveredRequestContext(data);
+      // `continueLastTurn` repairs interrupted server-tool orphans before it
+      // re-enters inference (`_repairInterruptedToolsBeforeTurn`), so the
+      // recovered transcript is settled and the next `convertToModelMessages`
+      // doesn't 400 with `AI_MissingToolResultsError`.
       const result = await this.continueLastTurn();
       await this._updateChatRecoveryIncident(
         data?.incidentId,
@@ -4221,7 +4321,11 @@ export class AIChatAgent<
     try {
       const recoveryConfig = this._resolveChatRecoveryConfig();
       const ready = await this.waitUntilStable({
-        timeout: recoveryConfig.stableTimeoutMs
+        timeout: recoveryConfig.stableTimeoutMs,
+        // Recovery-scoped narrow predicate (see `_chatRecoveryContinue`): a dead
+        // server-tool orphan must not block stability; a real client
+        // interaction still parks via the `!ready` branch.
+        pendingInteraction: () => this.hasPendingClientInteraction()
       });
       if (!ready) {
         // PARK while a CLIENT interaction is pending — the turn is waiting for
@@ -4276,6 +4380,11 @@ export class AIChatAgent<
       }
 
       this._applyRecoveredRequestContext(data);
+      // The retry runs through `_runProgrammaticChatTurn`, which repairs any
+      // interrupted tool orphan before re-entering inference
+      // (`_repairInterruptedToolsBeforeTurn`). The retry path normally re-runs
+      // an unanswered user-message tail (no assistant orphan to repair), so that
+      // is a defensive no-op here, but keeps both recovery entrypoints converged.
       const result = await this._retryLastUserTurn(
         this._lastClientTools,
         this._lastBody

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -1540,13 +1540,14 @@ export class AIChatAgent<
    * missed: a mixed client+server orphan whose client replay drives an
    * auto-continuation, and any agent running with `chatRecovery` disabled.
    *
-   * Guard: repair runs ONLY when no client interaction is genuinely pending. In
-   * that state every unsettled tool part is a dead SERVER orphan (its
-   * `execute()` died with the evicted isolate), so flipping it to an errored
-   * result is always safe. While a client tool is still awaiting the user the
-   * guard skips repair — flipping it would clobber a result the client may still
-   * replay. (On the recovery-continue path this mirrors the narrow predicate
-   * that already let `waitUntilStable` converge.)
+   * Scope: repair only ever flips a DEAD SERVER orphan (an interrupted tool with
+   * no settled result whose `execute()` died with the evicted isolate). A part
+   * still legitimately awaiting a CLIENT interaction — an `input-available`
+   * client tool the SPA replays, or an `approval-requested` part the user may
+   * still answer — is left verbatim via the shared `shouldRepair` skip, so it is
+   * never clobbered with an error. This is per-part (not a whole-transcript
+   * guard), so a fresh dead-server orphan at the leaf is still repaired even if
+   * an unrelated abandoned client orphan sits earlier in history.
    *
    * Repair only ever reshapes ASSISTANT tool parts; it never touches user
    * messages, so per-channel policy carried on the user message's
@@ -1558,9 +1559,11 @@ export class AIChatAgent<
    * @internal
    */
   private async _repairInterruptedToolsBeforeTurn(): Promise<void> {
-    if (this.hasPendingClientInteraction()) return;
+    const clientResolvable = this._clientResolvableToolNames();
     const repaired = repairInterruptedToolParts(this.messages, {
-      repairPart: (part) => this.repairInterruptedToolPart(part)
+      repairPart: (part) => this.repairInterruptedToolPart(part),
+      shouldRepair: (part) =>
+        !this._partAwaitsClientInteraction(part, clientResolvable)
     });
     if (repaired.removedToolCalls === 0 && repaired.normalizedInputs === 0) {
       return;

--- a/packages/ai-chat/src/tests/continue-last-turn.test.ts
+++ b/packages/ai-chat/src/tests/continue-last-turn.test.ts
@@ -38,6 +38,10 @@ interface ChatRecoveryTestStub {
     persist?: boolean;
     continue?: boolean;
   }): Promise<void>;
+  setRequestContextForTest(
+    body: Record<string, unknown> | undefined,
+    clientTools: Array<{ name: string }>
+  ): Promise<void>;
   setIncludeReasoning(value: boolean): Promise<void>;
   insertInterruptedStream(
     streamId: string,
@@ -593,6 +597,104 @@ describe("continueLastTurn", () => {
     expect(
       messages.filter((m: ChatMessage) => m.role === "assistant")
     ).toHaveLength(1);
+  });
+
+  it("repairs a dead server-tool orphan before continuing (pre-inference chokepoint, no recovery callback)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+
+    // Seed an assistant turn that was cut off mid-flight: a SERVER tool left at
+    // `input-available` (its `execute()` died with the isolate, nothing will
+    // resolve it). `previewTool` is NOT a client tool and no clientTools are set
+    // for this agent, so `hasPendingClientInteraction()` is false — the repair
+    // guard lets it through. This drives `continueLastTurn` DIRECTLY (not via a
+    // chat-recovery callback), proving the repair runs at the pre-inference
+    // chokepoint, so the next `convertToModelMessages` won't 400 with
+    // `AI_MissingToolResultsError`. Mirrors `@cloudflare/think` repairing before
+    // every inference, independent of `chatRecovery`.
+    await agentStub.persistMessages([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Preview it" }]
+      },
+      {
+        id: "assistant-orphan",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Working on it" },
+          {
+            type: "tool-previewTool",
+            toolCallId: "call_assistant-orphan",
+            state: "input-available",
+            input: {}
+          }
+        ] as ChatMessage["parts"]
+      }
+    ] as ChatMessage[]);
+
+    await agentStub.callContinueLastTurn();
+    await agentStub.waitForIdleForTest();
+
+    const messages = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const orphan = messages.find((m) => m.id === "assistant-orphan")!;
+    const toolPart = orphan.parts.find(
+      (p) =>
+        "toolCallId" in p &&
+        (p as { toolCallId?: string }).toolCallId === "call_assistant-orphan"
+    ) as { state?: string } | undefined;
+    // The dead orphan was flipped to a settled (errored) result.
+    expect(toolPart?.state).toBe("output-error");
+
+    // It actually CONTINUED (ran inference once) rather than wedging on the
+    // dangling tool call.
+    expect(await agentStub.getOnChatMessageCallCount()).toBe(1);
+  });
+
+  it("does NOT repair a pending CLIENT-tool interaction on continue (guard skips it)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+
+    // A CLIENT tool genuinely awaiting the user must NOT be repaired — flipping
+    // it to an error would clobber a result the client may still replay. Mark
+    // `chooseOption` as a registered client tool, then leave it at
+    // `input-available`: the guard (`hasPendingClientInteraction()`) must skip
+    // repair so the part stays pending.
+    await agentStub.setRequestContextForTest(undefined, [
+      { name: "chooseOption" }
+    ]);
+    await agentStub.persistMessages([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Pick one" }]
+      },
+      {
+        id: "assistant-client",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-chooseOption",
+            toolCallId: "call_assistant-client",
+            state: "input-available",
+            input: {}
+          }
+        ] as ChatMessage["parts"]
+      }
+    ] as ChatMessage[]);
+
+    await agentStub.callContinueLastTurn();
+    await agentStub.waitForIdleForTest();
+
+    const messages = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const assistant = messages.find((m) => m.id === "assistant-client")!;
+    const toolPart = assistant.parts.find(
+      (p) =>
+        "toolCallId" in p &&
+        (p as { toolCallId?: string }).toolCallId === "call_assistant-client"
+    ) as { state?: string } | undefined;
+    // Still pending — the guard left the client interaction untouched.
+    expect(toolPart?.state).toBe("input-available");
   });
 
   it("should not recurse infinitely — recovery converges", async () => {

--- a/packages/ai-chat/src/tests/continue-last-turn.test.ts
+++ b/packages/ai-chat/src/tests/continue-last-turn.test.ts
@@ -651,15 +651,15 @@ describe("continueLastTurn", () => {
     expect(await agentStub.getOnChatMessageCallCount()).toBe(1);
   });
 
-  it("does NOT repair a pending CLIENT-tool interaction on continue (guard skips it)", async () => {
+  it("does NOT repair a pending CLIENT-tool interaction on continue (per-part skip)", async () => {
     const room = crypto.randomUUID();
     const agentStub = await getTestAgent(room);
 
     // A CLIENT tool genuinely awaiting the user must NOT be repaired — flipping
     // it to an error would clobber a result the client may still replay. Mark
     // `chooseOption` as a registered client tool, then leave it at
-    // `input-available`: the guard (`hasPendingClientInteraction()`) must skip
-    // repair so the part stays pending.
+    // `input-available`: the shared `shouldRepair` skip leaves that part verbatim
+    // so it stays pending.
     await agentStub.setRequestContextForTest(undefined, [
       { name: "chooseOption" }
     ]);
@@ -693,8 +693,82 @@ describe("continueLastTurn", () => {
         "toolCallId" in p &&
         (p as { toolCallId?: string }).toolCallId === "call_assistant-client"
     ) as { state?: string } | undefined;
-    // Still pending — the guard left the client interaction untouched.
+    // Still pending — the per-part skip left the client interaction untouched.
     expect(toolPart?.state).toBe("input-available");
+  });
+
+  it("repairs a leaf server orphan even when an abandoned client orphan sits earlier (per-part, not whole-transcript)", async () => {
+    const room = crypto.randomUUID();
+    const agentStub = await getTestAgent(room);
+
+    // `chooseOption` is a registered client tool; `previewTool` is not (server).
+    // An EARLIER assistant message holds an abandoned client orphan
+    // (`input-available` chooseOption), and the LEAF assistant holds a fresh dead
+    // SERVER orphan. A whole-transcript guard would skip ALL repair because a
+    // client interaction is "pending" somewhere; the per-part `shouldRepair` skip
+    // must instead leave the buried client orphan alone AND still repair the leaf
+    // server orphan so the next inference doesn't 400.
+    await agentStub.setRequestContextForTest(undefined, [
+      { name: "chooseOption" }
+    ]);
+    await agentStub.persistMessages([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "First" }]
+      },
+      {
+        id: "assistant-buried-client",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-chooseOption",
+            toolCallId: "call_buried-client",
+            state: "input-available",
+            input: {}
+          }
+        ] as ChatMessage["parts"]
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Second" }]
+      },
+      {
+        id: "assistant-leaf-server",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-previewTool",
+            toolCallId: "call_leaf-server",
+            state: "input-available",
+            input: {}
+          }
+        ] as ChatMessage["parts"]
+      }
+    ] as ChatMessage[]);
+
+    await agentStub.callContinueLastTurn();
+    await agentStub.waitForIdleForTest();
+
+    const messages = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const partState = (messageId: string, toolCallId: string) => {
+      const m = messages.find((msg) => msg.id === messageId)!;
+      const p = m.parts.find(
+        (part) =>
+          "toolCallId" in part &&
+          (part as { toolCallId?: string }).toolCallId === toolCallId
+      ) as { state?: string } | undefined;
+      return p?.state;
+    };
+
+    // Buried client orphan untouched; leaf server orphan repaired.
+    expect(partState("assistant-buried-client", "call_buried-client")).toBe(
+      "input-available"
+    );
+    expect(partState("assistant-leaf-server", "call_leaf-server")).toBe(
+      "output-error"
+    );
   });
 
   it("should not recurse infinitely — recovery converges", async () => {

--- a/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/durable-chat-recovery.test.ts
@@ -1944,6 +1944,65 @@ describe("onChatRecovery", () => {
     expect(parked?.reason).toBe("awaiting_client_interaction");
   });
 
+  it("RECOVERS a dead SERVER-tool orphan on continue (repairs to errored, then continues) instead of waiting-then-exhausting", async () => {
+    const agentStub = await getTestAgent(
+      `stable-recover-${crypto.randomUUID()}`
+    );
+    // Real stability wait (NOT forced): the narrow recovery predicate must let a
+    // dead server-tool orphan through as "stable" so it is repaired + continued,
+    // converging ai-chat with `@cloudflare/think` (which already recovers here).
+    await agentStub.setForceStableTimeoutForTest(false);
+
+    // `previewTool` is NOT a registered client tool, so its `input-available`
+    // part is a dead SERVER orphan (its `execute()` died with the isolate). The
+    // contrast with the CLIENT-interaction park test above is the whole point:
+    // a client orphan parks, a dead server orphan recovers.
+    await agentStub.setRequestContextForTest(undefined, [
+      { name: "chooseOption" }
+    ]);
+    await agentStub.persistPendingToolCallForTest(
+      "assistant-recover",
+      "previewTool"
+    );
+
+    await agentStub.seedIncidentForTest({
+      incidentId: "inc-recover",
+      requestId: "root-recover",
+      recoveryKind: "continue",
+      attempt: 1,
+      maxAttempts: 6,
+      status: "scheduled",
+      firstSeenAt: Date.now(),
+      lastAttemptAt: Date.now()
+    });
+
+    await agentStub.runChatRecoveryContinueDirectForTest({
+      incidentId: "inc-recover",
+      originalRequestId: "root-recover",
+      targetAssistantId: "assistant-recover"
+    });
+    await agentStub.waitForIdleForTest();
+
+    // The orphaned server-tool part was repaired to an errored result (no longer
+    // `input-available`), so the next provider call won't 400 with
+    // `AI_MissingToolResultsError`.
+    const messages = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const orphan = messages.find((m) => m.id === "assistant-recover");
+    const toolPart = orphan?.parts.find(
+      (p) =>
+        "toolCallId" in p &&
+        (p as { toolCallId?: string }).toolCallId === "call_assistant-recover"
+    ) as { state?: string } | undefined;
+    expect(toolPart?.state).toBe("output-error");
+
+    // It CONTINUED (ran inference) rather than parking/exhausting on a dead
+    // orphan, and the incident terminalized as completed (deleted), NOT a
+    // stable-timeout give-up.
+    expect(await agentStub.getOnChatMessageCallCount()).toBe(1);
+    const incident = await agentStub.getIncidentForTest("inc-recover");
+    expect(incident).toBeNull();
+  });
+
   it("PARKS a retry (no reschedule, no budget spent) while a CLIENT interaction is pending", async () => {
     const agentStub = await getTestAgent(
       `stable-retry-park-${crypto.randomUUID()}`

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -2290,6 +2290,7 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 
   override async waitUntilStable(options?: {
     timeout?: number;
+    pendingInteraction?: () => boolean;
   }): Promise<boolean> {
     if (this._forceStableTimeout) return false;
     return super.waitUntilStable(options);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -166,6 +166,9 @@ import {
   aiSdkRecoveryCodec,
   ResumeHandshake,
   normalizeToolInput,
+  repairInterruptedToolParts,
+  toolPartHasSettledResult,
+  persistReconstructedOrphan,
   reconcileMessages,
   resolveToolMergeId,
   createChatFiberSnapshot,
@@ -2700,45 +2703,14 @@ export class Think<
   }
 
   /**
-   * Normalize a tool part's `input` into something the provider will accept.
-   *
-   * Malformed shapes 400 modern providers and persist forever once written:
-   * a stringified-JSON `input` (e.g. `'{"prompt":"a cat"}'` instead of the
-   * object), and any non-object `input` — `null`, `undefined`, `""`, an array,
-   * or a primitive — on a settled or interrupted tool call (Anthropic rejects
-   * a `tool_use` block whose `input` is not an object). We parse the former and
-   * default the latter to an empty object so the tool-call/tool-result pair
-   * stays valid. Delegates to the shared `normalizeToolInput` so the read-side
-   * repair and the write-side accumulator guard enforce the same invariant.
-   */
-  private _normalizeToolInput(record: Record<string, unknown>): {
-    input: unknown;
-    changed: boolean;
-  } {
-    return normalizeToolInput("input" in record ? record.input : undefined);
-  }
-
-  /**
    * Whether a tool part already has a settled result the provider accepts, so
-   * it must NOT be re-repaired into an errored result.
-   *
-   * Single source of truth for the terminal tool states, shared by the repair
-   * pass and the backstop detector so they cannot drift. Mirror the AI SDK's
-   * terminal states: `convertToModelMessages` emits a `tool-result` for
-   * `output-available`, `output-error`, AND `output-denied` (a user-denied
-   * approval — its denial reason becomes the tool-result). Omitting any of
-   * these makes repair re-flip the part every turn — clobbering a real
-   * `errorText`/denial with the generic "interrupted" message — and makes the
-   * backstop falsely drop a valid call.
+   * it must NOT be re-repaired into an errored result. Delegates to the shared
+   * `agents/chat` primitive so the repair pass and the backstop detector
+   * (`_incompleteToolCallIds`) share the single source of truth for terminal
+   * tool states.
    */
   private _toolPartHasSettledResult(record: Record<string, unknown>): boolean {
-    if ("output" in record || "result" in record) return true;
-    const state = typeof record.state === "string" ? record.state : "";
-    return (
-      state === "output-available" ||
-      state === "output-error" ||
-      state === "output-denied"
-    );
+    return toolPartHasSettledResult(record);
   }
 
   /**
@@ -2809,83 +2781,16 @@ export class Think<
     normalizedInputs: number;
     toolCallIds: string[];
   } {
-    let removedToolCalls = 0;
-    let normalizedInputs = 0;
-    const toolCallIds: string[] = [];
-    const repaired: UIMessage[] = [];
-
-    for (const message of messages) {
-      const parts: UIMessage["parts"] = [];
-      let messageChanged = false;
-      for (const part of message.parts) {
-        const record = part as Record<string, unknown>;
-        const toolCallId =
-          typeof record.toolCallId === "string" ? record.toolCallId : undefined;
-        const isToolPart =
-          typeof record.type === "string" &&
-          (record.type.startsWith("tool-") || record.type === "dynamic-tool") &&
-          toolCallId;
-        if (!isToolPart) {
-          parts.push(part);
-          continue;
-        }
-
-        if (!this._toolPartHasSettledResult(record)) {
-          const state = typeof record.state === "string" ? record.state : "";
-          // An approved server tool waits at `approval-responded` until its
-          // scheduled continuation runs `execute()`. It is not abandoned, so
-          // preserve it verbatim — flipping it to an error (or removing it)
-          // would strand the approval and prevent the real result from ever
-          // being produced by the continuation.
-          if (state === "approval-responded") {
-            parts.push(part);
-            continue;
-          }
-          // Preserve the interrupted/abandoned tool call instead of deleting
-          // it. Deleting makes the call "disappear" from the (broadcast)
-          // transcript and lets the model silently re-run it. `input` is
-          // normalized to a valid object first, then `repairInterruptedToolPart`
-          // decides the replacement shape (default: an errored result, so
-          // conversion still gets a tool-result and the provider doesn't 400
-          // with AI_MissingToolResultsError). Subclasses can override it to
-          // preserve client-resolved tools (e.g. `ask_user`) as text.
-          const normalized = this._normalizeToolInput(record);
-          parts.push(
-            this.repairInterruptedToolPart({
-              ...part,
-              input: normalized.input
-            } as UIMessage["parts"][number])
-          );
-          if (normalized.changed) normalizedInputs++;
-          removedToolCalls++;
-          messageChanged = true;
-          toolCallIds.push(toolCallId);
-          continue;
-        }
-
-        const normalized = this._normalizeToolInput(record);
-        if (normalized.changed) {
-          parts.push({
-            ...part,
-            input: normalized.input
-          } as UIMessage["parts"][number]);
-          normalizedInputs++;
-          messageChanged = true;
-          continue;
-        }
-
-        parts.push(part);
-      }
-
-      repaired.push(messageChanged ? { ...message, parts } : message);
-    }
-
-    return {
-      messages: repaired,
-      removedToolCalls,
-      normalizedInputs,
-      toolCallIds
-    };
+    // Delegates to the shared `agents/chat` primitive so Think and ai-chat run
+    // identical repair logic. The overridable `repairInterruptedToolPart` hook
+    // (default: flip to an errored result; subclasses can preserve a
+    // client-resolved tool such as `ask_user` as text) is threaded through, and
+    // the settled-result / input-normalization helpers are the shared defaults.
+    return repairInterruptedToolParts(messages, {
+      repairPart: (part) => this.repairInterruptedToolPart(part),
+      isSettled: (record) => this._toolPartHasSettledResult(record),
+      normalizeInput: (input) => normalizeToolInput(input)
+    });
   }
 
   private async _repairTranscriptForProvider(
@@ -14115,40 +14020,23 @@ export class Think<
     const chunks = this._resumableStream.getStreamChunks(streamId);
     if (chunks.length === 0) return;
 
-    const accumulator = new StreamAccumulator({
-      messageId: crypto.randomUUID()
-    });
-    for (const chunk of chunks) {
-      try {
-        accumulator.applyChunk(JSON.parse(chunk.body) as StreamChunkData);
-      } catch {
-        // skip malformed chunks
-      }
-    }
-
-    if (accumulator.parts.length === 0) return;
-
-    // Preserve Think's product-specific strip + empty-skip via the shared
-    // `_strippedForPersist` rule (same as `_persistAssistantMessage`): drop the
-    // internal final-answer parts, and skip persisting an empty structural-only
-    // assistant message.
-    const stripped = this._strippedForPersist(accumulator.toMessage());
-    if (stripped === null) return;
-
-    // (c)/(d) Upsert by id through the shared `OrphanPersistStore` seam. Think
-    // replaces the whole message (no partial merge), so resolve append-vs-update
-    // purely by existence.
-    const store = this._orphanStore();
-    const existing = await store.getMessage(stripped.id);
-    if (existing) {
-      await store.updateMessage(stripped);
-    } else {
-      await store.appendMessage(stripped);
-    }
+    // The accumulate loop and the `getMessage → update(merge) XOR append` upsert
+    // are the shared `persistReconstructedOrphan` core. Think supplies the two
+    // host-specific hooks:
+    //   - prepare: `_strippedForPersist` (same as `_persistAssistantMessage`) —
+    //     drop the internal final-answer parts and skip (`null`) an empty
+    //     structural-only assistant message.
+    //   - merge: Think replaces the whole message (no partial merge).
     // NOTE: progress is bumped at production/flush time in `_storeChunkDurably`
-    // (#1637), NOT here — persisting on recovery or a client reconnect must
-    // not be miscounted as new forward progress.
-    this._broadcastMessages();
+    // (#1637), NOT here — persisting on recovery or a client reconnect must not
+    // be miscounted as new forward progress.
+    const wrote = await persistReconstructedOrphan(chunks, {
+      store: this._orphanStore(),
+      fallbackId: crypto.randomUUID(),
+      prepare: (message) => this._strippedForPersist(message),
+      merge: (_existing, incoming) => incoming
+    });
+    if (wrote) this._broadcastMessages();
   }
 
   private _broadcastChat(message: Record<string, unknown>, exclude?: string[]) {


### PR DESCRIPTION
## Summary

Finishes the **recovery-engine convergence** between the two AI-SDK chat hosts so `@cloudflare/ai-chat`'s interrupted-turn recovery becomes a strict **subset of `@cloudflare/think`**'s, sharing one implementation rather than two drifting copies. The hard constraint from the Channels work is preserved: repair only ever reshapes **assistant** tool parts, so per-channel policy carried on the user message's `metadata.channel` (re-resolved on wake) is structurally untouched.

Two commits:
1. `feat(ai-chat): recover interrupted server-tool calls like Think` — the convergence.
2. `feat(ai-chat): server-only repair scope + cross-host recovery conformance suite` — lock-in follow-up from a deep review.

## The gap this closes

On an interrupted **server tool** (its `execute()` died with an evicted isolate, leaving a dead `input-available` orphan nothing will ever resolve), Think **recovered** the turn but ai-chat **gave up**:

- Think excludes the dead orphan from its (client-only) stability predicate **and** repairs the transcript before inference, so `convertToModelMessages` doesn't 400 with `AI_MissingToolResultsError`.
- ai-chat used the **broad** `hasPendingInteraction()` for its recovery wait and had **no repair pass**, so it rescheduled until the budget was spent and terminalized via `onExhausted`.

## What changed

### Shared primitives (`agents/chat`)
- **`repair-transcript.ts`** — extracted Think's `_repairToolTranscriptParts` into the shared `@internal` `repairInterruptedToolParts` primitive (+ `toolPartHasSettledResult`), parameterized by an overridable `repairPart` hook and an optional `shouldRepair(part)` skip predicate (default: repair everything, so **Think is behavior-neutral**). Think delegates to it.
- **`orphan-persist.ts`** — extracted the shared skeleton of both hosts' `_persistOrphanedStream` (accumulate loop + `getMessage → updateMessage(merge) XOR appendMessage` upsert) into `persistReconstructedOrphan(chunks, { store, fallbackId, prepare, merge })`. Exactly two host hooks; flush/fallback-id/broadcast stay in the wrappers.

### `@cloudflare/ai-chat`
- Adopts the shared repair via a new overridable `repairInterruptedToolPart(part)` hook (default: flip to `output-error`).
- Repairs **before every inference chokepoint** — live submit, tool auto-continuation, `continueLastTurn`, `saveMessages`/retry, and the chat recovery callbacks — mirroring how Think repairs before every inference. (ai-chat can't repair *inside* inference because the app owns `convertToModelMessages`, so the framework repairs `this.messages` right before handing control to `onChatMessage`.) This closes the cases a recovery-only repair missed: a mixed client+server orphan whose client replay drives an auto-continuation, and any agent running with `chatRecovery` disabled.
- Repair is scoped **per-part to dead SERVER orphans** via `shouldRepair = !partAwaitsClientInteraction(...)`: a part still legitimately awaiting a client (`input-available` client tool / `approval-requested`) is left verbatim, so a fresh dead-server orphan at the leaf is repaired even when an unrelated abandoned client orphan sits earlier in history.
- `waitUntilStable` gains an optional `pendingInteraction` predicate; the recovery paths pass the narrow client-only predicate so a dead server orphan no longer blocks stability. The broad default (and documented app-override semantics) are unchanged.

### `@cloudflare/think`
- Delegates transcript repair and orphan persistence to the shared primitives. Pure internal refactor, no observable behavior or API change.

## Tests
- **`agents/chat/__tests__/repair-transcript.test.ts`** — unit tests for the shared repair primitive incl. the `shouldRepair` skip.
- **`agents/chat/__tests__/recovery-conformance.test.ts`** — cross-host conformance: runs the real shared repair + predicate primitives under **both host wirings** over a canonical scenario table (dead server orphan, pending client orphan, mixed, approval-requested, approval-responded). Pins the **subset** relationship (identical for server orphans; intentional divergence for client orphans where ai-chat parks/skips and Think repairs-to-proceed) and the invariant "ai-chat never repairs more than Think."
- **ai-chat** — e2e: a dead server-tool orphan now **recovers** (repairs to errored, continues, incident completes) instead of waiting-then-`onExhausted`; chokepoint repair + per-part skip + buried-client/leaf-server tests.

A literal dual-driver e2e harness was deliberately *not* plumbed into Think's Session-tree test agent — fragile surface for no coverage the shared-primitive conformance suite + each host's own e2e suite don't already provide.

## Why not unify storage
This is **not** a storage-model unification. ai-chat's flat array vs Think's Session tree stays divergent by design (a flat list is a degenerate Session tree); the RFC treats that as a separate product-direction call. The orphan store seam (`OrphanPersistStore`) is the deliberately-narrow write-subset of `SessionProvider`, not a general store.

## Docs
- Updated `design/rfc-chat-recovery-foundation.md` (matrix re-classification; corrected a stale §Cutover claim — the incident shape/id/keys have been shared in `recovery-incident.ts` since the engine landed) and the progress log.

## Changesets
- `agents` patch — shared repair + orphan-persist primitives.
- `@cloudflare/think` patch — delegation refactor.
- `@cloudflare/ai-chat` minor — recover interrupted server-tool calls.

## Test plan
- [x] `pnpm run check` (sherif + exports + format + lint + typecheck; 113 projects)
- [x] Full `@cloudflare/ai-chat` suite (613)
- [x] Full `@cloudflare/think` suite (791)
- [x] `agents/chat` unit suite (477, incl. repair-transcript + recovery-conformance)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->