### PR TITLE
fix(agents): make AI SDK peer optional

### DIFF
--- a/.changeset/agents-optional-ai-peer.md
+++ b/.changeset/agents-optional-ai-peer.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Make the `ai` peer optional again. The root `agents` runtime and declaration graph no longer reference AI SDK types; AI-specific entry points still require the peer when imported.

--- a/examples/agents-as-tools/src/client.tsx
+++ b/examples/agents-as-tools/src/client.tsx
@@ -132,7 +132,9 @@ type HelperState = {
   error?: string;
 };
 
-function toHelperState(run: AgentToolRunState): HelperState {
+function toHelperState(
+  run: AgentToolRunState<UIMessage["parts"][number]>
+): HelperState {
   const label = run.display?.name ?? run.agentType;
   const preview =
     typeof run.inputPreview === "string"
@@ -795,7 +797,7 @@ export default function App() {
     agent,
     experimental_throttle: 100
   });
-  const agentTools = useAgentToolEvents({ agent });
+  const agentTools = useAgentToolEvents<UIMessage["parts"][number]>({ agent });
   const { runsByToolCallId, resetLocalState } = agentTools;
   const helperStateByToolCall = useMemo<Record<string, HelperBucket>>(() => {
     return Object.fromEntries(

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -79,6 +79,9 @@
     "@x402/evm": {
       "optional": true
     },
+    "ai": {
+      "optional": true
+    },
     "chat": {
       "optional": true
     },

--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -1,7 +1,6 @@
 import { build } from "tsdown";
 import { globSync } from "glob";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
 import { formatDeclarationFiles } from "../../../scripts/format-declarations";
 
 const entries = [
@@ -55,66 +54,6 @@ function injectSkillsTypeReference(): void {
   }
 }
 
-function moduleSpecifiers(source: string): string[] {
-  const specifiers = new Set<string>();
-  for (const pattern of [
-    /\bfrom\s+["']([^"']+)["']/g,
-    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
-    /\bimport\s+["']([^"']+)["']/g
-  ]) {
-    for (const match of source.matchAll(pattern)) {
-      const specifier = match[1];
-      if (specifier) specifiers.add(specifier);
-    }
-  }
-  return [...specifiers];
-}
-
-function resolveEmittedImport(
-  importer: string,
-  specifier: string,
-  declarationGraph: boolean
-): string | undefined {
-  if (!specifier.startsWith(".")) return undefined;
-  const imported = resolve(dirname(importer), specifier);
-  const candidates = declarationGraph
-    ? [
-        imported.replace(/\.(?:m?js)$/, ".d.ts"),
-        `${imported}.d.ts`,
-        resolve(imported, "index.d.ts")
-      ]
-    : [imported, `${imported}.js`, resolve(imported, "index.js")];
-  return candidates.find((candidate) => existsSync(candidate));
-}
-
-function assertRootHasNoAIFrameworkDependency(): void {
-  for (const entry of ["dist/index.js", "dist/index.d.ts"]) {
-    const declarationGraph = entry.endsWith(".d.ts");
-    const pending = [resolve(entry)];
-    const visited = new Set<string>();
-
-    while (pending.length > 0) {
-      const file = pending.pop();
-      if (!file || visited.has(file)) continue;
-      visited.add(file);
-
-      for (const specifier of moduleSpecifiers(readFileSync(file, "utf8"))) {
-        if (specifier === "ai" || specifier.startsWith("@ai-sdk/")) {
-          throw new Error(
-            `${entry} reaches AI framework import "${specifier}" through ${file}`
-          );
-        }
-        const imported = resolveEmittedImport(
-          file,
-          specifier,
-          declarationGraph
-        );
-        if (imported) pending.push(imported);
-      }
-    }
-  }
-}
-
 async function main() {
   await build({
     clean: true,
@@ -134,7 +73,6 @@ async function main() {
   formatDeclarationFiles();
 
   injectSkillsTypeReference();
-  assertRootHasNoAIFrameworkDependency();
 
   process.exit(0);
 }

--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -1,6 +1,7 @@
 import { build } from "tsdown";
 import { globSync } from "glob";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { formatDeclarationFiles } from "../../../scripts/format-declarations";
 
 const entries = [
@@ -54,6 +55,66 @@ function injectSkillsTypeReference(): void {
   }
 }
 
+function moduleSpecifiers(source: string): string[] {
+  const specifiers = new Set<string>();
+  for (const pattern of [
+    /\bfrom\s+["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\bimport\s+["']([^"']+)["']/g
+  ]) {
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1];
+      if (specifier) specifiers.add(specifier);
+    }
+  }
+  return [...specifiers];
+}
+
+function resolveEmittedImport(
+  importer: string,
+  specifier: string,
+  declarationGraph: boolean
+): string | undefined {
+  if (!specifier.startsWith(".")) return undefined;
+  const imported = resolve(dirname(importer), specifier);
+  const candidates = declarationGraph
+    ? [
+        imported.replace(/\.(?:m?js)$/, ".d.ts"),
+        `${imported}.d.ts`,
+        resolve(imported, "index.d.ts")
+      ]
+    : [imported, `${imported}.js`, resolve(imported, "index.js")];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function assertRootHasNoAIFrameworkDependency(): void {
+  for (const entry of ["dist/index.js", "dist/index.d.ts"]) {
+    const declarationGraph = entry.endsWith(".d.ts");
+    const pending = [resolve(entry)];
+    const visited = new Set<string>();
+
+    while (pending.length > 0) {
+      const file = pending.pop();
+      if (!file || visited.has(file)) continue;
+      visited.add(file);
+
+      for (const specifier of moduleSpecifiers(readFileSync(file, "utf8"))) {
+        if (specifier === "ai" || specifier.startsWith("@ai-sdk/")) {
+          throw new Error(
+            `${entry} reaches AI framework import "${specifier}" through ${file}`
+          );
+        }
+        const imported = resolveEmittedImport(
+          file,
+          specifier,
+          declarationGraph
+        );
+        if (imported) pending.push(imported);
+      }
+    }
+  }
+}
+
 async function main() {
   await build({
     clean: true,
@@ -73,6 +134,7 @@ async function main() {
   formatDeclarationFiles();
 
   injectSkillsTypeReference();
+  assertRootHasNoAIFrameworkDependency();
 
   process.exit(0);
 }

--- a/packages/agents/src/agent-tool-types.ts
+++ b/packages/agents/src/agent-tool-types.ts
@@ -218,9 +218,11 @@ export type AgentToolEventMessage = {
   event: AgentToolEvent;
 };
 
-export type AgentToolRunPart = object;
+export type AgentToolRunPart = { type: string };
 
-export type AgentToolRunState<Part extends object = AgentToolRunPart> = {
+export type AgentToolRunState<
+  Part extends AgentToolRunPart = AgentToolRunPart
+> = {
   runId: string;
   agentType: string;
   parentToolCallId?: string;
@@ -249,7 +251,9 @@ export type AgentToolRunState<Part extends object = AgentToolRunPart> = {
   subAgent: { agent: string; name: string };
 };
 
-export type AgentToolEventState<Part extends object = AgentToolRunPart> = {
+export type AgentToolEventState<
+  Part extends AgentToolRunPart = AgentToolRunPart
+> = {
   runsById: Record<string, AgentToolRunState<Part>>;
   runsByToolCallId: Record<string, AgentToolRunState<Part>[]>;
   unboundRuns: AgentToolRunState<Part>[];

--- a/packages/agents/src/agent-tool-types.ts
+++ b/packages/agents/src/agent-tool-types.ts
@@ -1,4 +1,3 @@
-import type { UIMessage } from "ai";
 import type { Agent, SubAgentClass } from "./index";
 
 export type AgentToolRunStatus =
@@ -219,7 +218,9 @@ export type AgentToolEventMessage = {
   event: AgentToolEvent;
 };
 
-export type AgentToolRunState = {
+export type AgentToolRunPart = object;
+
+export type AgentToolRunState<Part extends object = AgentToolRunPart> = {
   runId: string;
   agentType: string;
   parentToolCallId?: string;
@@ -227,7 +228,15 @@ export type AgentToolRunState = {
   order: number;
   display?: AgentToolDisplayMetadata;
   status: "running" | "completed" | "error" | "aborted" | "interrupted";
-  parts: UIMessage["parts"];
+  /**
+   * Message parts reconstructed from the child agent's streamed chunks.
+   *
+   * The default stays framework-neutral so importing `agents` does not require
+   * an AI SDK peer. AI SDK consumers can use
+   * `AgentToolRunState<UIMessage["parts"][number]>` when they need its exact
+   * discriminated union.
+   */
+  parts: Part[];
   summary?: string;
   error?: string;
   /**
@@ -240,8 +249,8 @@ export type AgentToolRunState = {
   subAgent: { agent: string; name: string };
 };
 
-export type AgentToolEventState = {
-  runsById: Record<string, AgentToolRunState>;
-  runsByToolCallId: Record<string, AgentToolRunState[]>;
-  unboundRuns: AgentToolRunState[];
+export type AgentToolEventState<Part extends object = AgentToolRunPart> = {
+  runsById: Record<string, AgentToolRunState<Part>>;
+  runsByToolCallId: Record<string, AgentToolRunState<Part>[]>;
+  unboundRuns: AgentToolRunState<Part>[];
 };

--- a/packages/agents/src/agent-tools.ts
+++ b/packages/agents/src/agent-tools.ts
@@ -171,6 +171,7 @@ export type {
   AgentToolLifecycleResult,
   AgentToolRunInfo,
   AgentToolRunInspection,
+  AgentToolRunPart,
   AgentToolRunState,
   AgentToolRunStatus,
   AgentToolStoredChunk,

--- a/packages/agents/src/chat/agent-tools.ts
+++ b/packages/agents/src/chat/agent-tools.ts
@@ -1,23 +1,26 @@
-import { applyChunkToParts } from "./message-builder";
+import { applyChunkToParts, type MessagePart } from "./message-builder";
 import type {
   AgentToolEventMessage,
   AgentToolEventState,
+  AgentToolRunPart,
   AgentToolRunState,
   AgentToolStoredChunk
 } from "../agent-tool-types";
 
-function sortRuns(runs: AgentToolRunState[]): AgentToolRunState[] {
+function sortRuns<Part extends object>(
+  runs: AgentToolRunState<Part>[]
+): AgentToolRunState<Part>[] {
   return [...runs].sort((a, b) => {
     if (a.order !== b.order) return a.order - b.order;
     return a.runId.localeCompare(b.runId);
   });
 }
 
-function rebuildIndexes(
-  runsById: Record<string, AgentToolRunState>
-): Pick<AgentToolEventState, "runsByToolCallId" | "unboundRuns"> {
-  const grouped: Record<string, AgentToolRunState[]> = {};
-  const unboundRuns: AgentToolRunState[] = [];
+function rebuildIndexes<Part extends object>(
+  runsById: Record<string, AgentToolRunState<Part>>
+): Pick<AgentToolEventState<Part>, "runsByToolCallId" | "unboundRuns"> {
+  const grouped: Record<string, AgentToolRunState<Part>[]> = {};
+  const unboundRuns: AgentToolRunState<Part>[] = [];
   for (const run of Object.values(runsById)) {
     if (run.parentToolCallId) {
       grouped[run.parentToolCallId] = grouped[run.parentToolCallId] ?? [];
@@ -32,9 +35,9 @@ function rebuildIndexes(
   return { runsByToolCallId: grouped, unboundRuns: sortRuns(unboundRuns) };
 }
 
-function emptyRun(
+function emptyRun<Part extends object>(
   message: AgentToolEventMessage
-): AgentToolRunState | undefined {
+): AgentToolRunState<Part> | undefined {
   const { event } = message;
   if (event.kind === "started") {
     return {
@@ -52,10 +55,10 @@ function emptyRun(
   return undefined;
 }
 
-function applyToRun(
-  prev: AgentToolRunState | undefined,
+function applyToRun<Part extends object>(
+  prev: AgentToolRunState<Part> | undefined,
   message: AgentToolEventMessage
-): AgentToolRunState | undefined {
+): AgentToolRunState<Part> | undefined {
   const seeded = prev ?? emptyRun(message);
   const { event } = message;
 
@@ -85,7 +88,7 @@ function applyToRun(
       if (!seeded) return undefined;
       const parts = [...seeded.parts];
       try {
-        applyChunkToParts(parts, JSON.parse(event.body));
+        applyChunkToParts(parts as MessagePart[], JSON.parse(event.body));
       } catch {
         return seeded;
       }
@@ -117,7 +120,9 @@ function applyToRun(
   }
 }
 
-export function createAgentToolEventState(): AgentToolEventState {
+export function createAgentToolEventState<
+  Part extends object = AgentToolRunPart
+>(): AgentToolEventState<Part> {
   return {
     runsById: {},
     runsByToolCallId: {},
@@ -125,10 +130,10 @@ export function createAgentToolEventState(): AgentToolEventState {
   };
 }
 
-export function applyAgentToolEvent(
-  state: AgentToolEventState,
+export function applyAgentToolEvent<Part extends object = AgentToolRunPart>(
+  state: AgentToolEventState<Part>,
   message: AgentToolEventMessage
-): AgentToolEventState {
+): AgentToolEventState<Part> {
   if (message.type !== "agent-tool-event") return state;
   const runId = message.event.runId;
   const nextRun = applyToRun(state.runsById[runId], message);
@@ -142,6 +147,7 @@ export type {
   AgentToolEvent,
   AgentToolEventMessage,
   AgentToolEventState,
+  AgentToolRunPart,
   AgentToolRunState
 } from "../agent-tool-types";
 

--- a/packages/agents/src/chat/agent-tools.ts
+++ b/packages/agents/src/chat/agent-tools.ts
@@ -7,7 +7,7 @@ import type {
   AgentToolStoredChunk
 } from "../agent-tool-types";
 
-function sortRuns<Part extends object>(
+function sortRuns<Part extends AgentToolRunPart>(
   runs: AgentToolRunState<Part>[]
 ): AgentToolRunState<Part>[] {
   return [...runs].sort((a, b) => {
@@ -16,7 +16,7 @@ function sortRuns<Part extends object>(
   });
 }
 
-function rebuildIndexes<Part extends object>(
+function rebuildIndexes<Part extends AgentToolRunPart>(
   runsById: Record<string, AgentToolRunState<Part>>
 ): Pick<AgentToolEventState<Part>, "runsByToolCallId" | "unboundRuns"> {
   const grouped: Record<string, AgentToolRunState<Part>[]> = {};
@@ -35,7 +35,7 @@ function rebuildIndexes<Part extends object>(
   return { runsByToolCallId: grouped, unboundRuns: sortRuns(unboundRuns) };
 }
 
-function emptyRun<Part extends object>(
+function emptyRun<Part extends AgentToolRunPart>(
   message: AgentToolEventMessage
 ): AgentToolRunState<Part> | undefined {
   const { event } = message;
@@ -55,7 +55,7 @@ function emptyRun<Part extends object>(
   return undefined;
 }
 
-function applyToRun<Part extends object>(
+function applyToRun<Part extends AgentToolRunPart>(
   prev: AgentToolRunState<Part> | undefined,
   message: AgentToolEventMessage
 ): AgentToolRunState<Part> | undefined {
@@ -121,7 +121,7 @@ function applyToRun<Part extends object>(
 }
 
 export function createAgentToolEventState<
-  Part extends object = AgentToolRunPart
+  Part extends AgentToolRunPart = AgentToolRunPart
 >(): AgentToolEventState<Part> {
   return {
     runsById: {},
@@ -130,7 +130,9 @@ export function createAgentToolEventState<
   };
 }
 
-export function applyAgentToolEvent<Part extends object = AgentToolRunPart>(
+export function applyAgentToolEvent<
+  Part extends AgentToolRunPart = AgentToolRunPart
+>(
   state: AgentToolEventState<Part>,
   message: AgentToolEventMessage
 ): AgentToolEventState<Part> {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -109,6 +109,7 @@ export type {
   AgentToolLifecycleResult,
   AgentToolRunInfo,
   AgentToolRunInspection,
+  AgentToolRunPart,
   AgentToolRunState,
   AgentToolRunStatus,
   AgentToolStoredChunk,
@@ -834,7 +835,12 @@ function getNextCronTime(cron: string) {
 
 export type { TransportType } from "./mcp/types";
 export type { RetryOptions } from "./retries";
-export { normalizeServerId, MCP_SERVER_ID_MAX_LENGTH } from "./mcp/client";
+export {
+  normalizeServerId,
+  MCP_SERVER_ID_MAX_LENGTH,
+  type MCPAITool,
+  type MCPAIToolSet
+} from "./mcp/client";
 export {
   DurableObjectOAuthClientProvider,
   type AgentMcpOAuthProvider,

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -13,7 +13,6 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker-provider.js";
 import { type RetryOptions, tryN } from "../retries";
-import type { ToolSet } from "ai";
 import { z } from "zod";
 import { nanoid } from "nanoid";
 import { Emitter, type Event, DisposableStore } from "../core/events";
@@ -33,6 +32,24 @@ import { DurableObjectOAuthClientProvider } from "./do-oauth-client-provider";
 const defaultClientOptions: ConstructorParameters<typeof Client>[1] = {
   jsonSchemaValidator: new CfWorkerJsonSchemaValidator()
 };
+
+export type MCPAITool = {
+  description?: string;
+  title?: string;
+  execute: (
+    args: Record<string, unknown>,
+    options?: unknown
+  ) => Promise<unknown>;
+  inputSchema: z.ZodType;
+  outputSchema?: z.ZodType;
+};
+
+/**
+ * Structural tool set returned by {@link MCPClientManager.getAITools}.
+ * Compatible with the AI SDK without importing its types into the core
+ * `agents` declaration graph.
+ */
+export type MCPAIToolSet = Record<string, MCPAITool>;
 
 /** Maximum length of a normalized MCP server id. */
 export const MCP_SERVER_ID_MAX_LENGTH = 64;
@@ -1606,7 +1623,7 @@ export class MCPClientManager {
    * @param filter - Optional filter to scope results to specific servers
    * @returns a set of tools that you can use with the AI SDK
    */
-  getAITools(filter?: MCPServerFilter): ToolSet {
+  getAITools(filter?: MCPServerFilter): MCPAIToolSet {
     const connections = this.filterConnections(filter);
 
     for (const [id, conn] of Object.entries(connections)) {
@@ -1620,7 +1637,7 @@ export class MCPClientManager {
       }
     }
 
-    const entries: [string, ToolSet[string]][] = [];
+    const entries: [string, MCPAITool][] = [];
     for (const tool of getNamespacedData(connections, "tools")) {
       try {
         const toolKey = `tool_${tool.serverId.replace(/-/g, "")}_${tool.name}`;
@@ -1675,7 +1692,7 @@ export class MCPClientManager {
    * @param filter - Optional filter to scope results to specific servers
    * @returns a set of tools that you can use with the AI SDK
    */
-  unstable_getAITools(filter?: MCPServerFilter): ToolSet {
+  unstable_getAITools(filter?: MCPServerFilter): MCPAIToolSet {
     if (!this._didWarnAboutUnstableGetAITools) {
       this._didWarnAboutUnstableGetAITools = true;
       console.warn(

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -20,6 +20,7 @@ import {
   createAgentToolEventState,
   type AgentToolEventMessage,
   type AgentToolEventState,
+  type AgentToolRunPart,
   type AgentToolRunState
 } from "./chat/agent-tools";
 
@@ -1002,16 +1003,20 @@ function agentToolDedupeKey(message: AgentToolEventMessage): string {
   ].join("\0");
 }
 
-export function useAgentToolEvents(options: { agent: AgentToolEventAgent }): {
-  runsById: Record<string, AgentToolRunState>;
-  runsByToolCallId: Record<string, AgentToolRunState[]>;
-  unboundRuns: AgentToolRunState[];
-  getRunsForToolCall(toolCallId: string): AgentToolRunState[];
+export function useAgentToolEvents<
+  Part extends object = AgentToolRunPart
+>(options: {
+  agent: AgentToolEventAgent;
+}): {
+  runsById: Record<string, AgentToolRunState<Part>>;
+  runsByToolCallId: Record<string, AgentToolRunState<Part>[]>;
+  unboundRuns: AgentToolRunState<Part>[];
+  getRunsForToolCall(toolCallId: string): AgentToolRunState<Part>[];
   resetLocalState(): void;
 } {
   const { agent } = options;
-  const [state, setState] = useState<AgentToolEventState>(() =>
-    createAgentToolEventState()
+  const [state, setState] = useState<AgentToolEventState<Part>>(() =>
+    createAgentToolEventState<Part>()
   );
   const seenRef = useRef(new Set<string>());
 
@@ -1028,7 +1033,7 @@ export function useAgentToolEvents(options: { agent: AgentToolEventAgent }): {
       const key = agentToolDedupeKey(message);
       if (seenRef.current.has(key)) return;
       seenRef.current.add(key);
-      setState((prev) => applyAgentToolEvent(prev, message));
+      setState((prev) => applyAgentToolEvent<Part>(prev, message));
     };
 
     agent.addEventListener("message", onMessage);
@@ -1037,7 +1042,7 @@ export function useAgentToolEvents(options: { agent: AgentToolEventAgent }): {
 
   const resetLocalState = useCallback(() => {
     seenRef.current.clear();
-    setState(createAgentToolEventState());
+    setState(createAgentToolEventState<Part>());
   }, []);
 
   const getRunsForToolCall = useCallback(

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -1004,7 +1004,7 @@ function agentToolDedupeKey(message: AgentToolEventMessage): string {
 }
 
 export function useAgentToolEvents<
-  Part extends object = AgentToolRunPart
+  Part extends AgentToolRunPart = AgentToolRunPart
 >(options: {
   agent: AgentToolEventAgent;
 }): {

--- a/packages/agents/src/tests-d/optional-ai-peer.test-d.ts
+++ b/packages/agents/src/tests-d/optional-ai-peer.test-d.ts
@@ -1,0 +1,21 @@
+import type { ToolSet, UIMessage } from "ai";
+import type { AgentToolRunState, MCPAIToolSet } from "../index";
+import type { useAgentToolEvents } from "../react";
+
+// MCP tools remain structurally compatible with AI SDK ToolSet without making
+// AI SDK types part of the published root declaration graph.
+declare const mcpTools: MCPAIToolSet;
+const aiTools: ToolSet = mcpTools;
+void aiTools;
+
+// Agent-tool event consumers can opt into their framework's exact message-part
+// union while the default published state remains framework-neutral.
+type UIMessagePart = UIMessage["parts"][number];
+declare const run: AgentToolRunState<UIMessagePart>;
+const parts: UIMessage["parts"] = run.parts;
+void parts;
+
+type AIEventState = ReturnType<typeof useAgentToolEvents<UIMessagePart>>;
+declare const eventState: AIEventState;
+const eventParts: UIMessage["parts"] = eventState.unboundRuns[0].parts;
+void eventParts;

--- a/packages/agents/src/tests-d/optional-ai-peer.test-d.ts
+++ b/packages/agents/src/tests-d/optional-ai-peer.test-d.ts
@@ -1,21 +1,23 @@
-import type { ToolSet, UIMessage } from "ai";
-import type { AgentToolRunState, MCPAIToolSet } from "../index";
+import type { Tool, ToolSet, UIMessage } from "ai";
+import type { AgentToolRunState, MCPAITool, MCPAIToolSet } from "../index";
 import type { useAgentToolEvents } from "../react";
 
-// MCP tools remain structurally compatible with AI SDK ToolSet without making
-// AI SDK types part of the published root declaration graph.
+// MCP tools remain structurally compatible with AI SDK Tool and ToolSet without
+// making AI SDK types part of the published root declaration graph.
+declare const mcpTool: MCPAITool;
+mcpTool satisfies Tool;
+
 declare const mcpTools: MCPAIToolSet;
-const aiTools: ToolSet = mcpTools;
-void aiTools;
+mcpTools satisfies ToolSet;
 
 // Agent-tool event consumers can opt into their framework's exact message-part
 // union while the default published state remains framework-neutral.
 type UIMessagePart = UIMessage["parts"][number];
 declare const run: AgentToolRunState<UIMessagePart>;
-const parts: UIMessage["parts"] = run.parts;
-void parts;
+run.parts satisfies UIMessage["parts"];
 
 type AIEventState = ReturnType<typeof useAgentToolEvents<UIMessagePart>>;
 declare const eventState: AIEventState;
-const eventParts: UIMessage["parts"] = eventState.unboundRuns[0].parts;
-void eventParts;
+eventState.unboundRuns[0].parts satisfies UIMessage["parts"];
+eventState.runsById.example.parts satisfies UIMessage["parts"];
+eventState.runsByToolCallId.example[0].parts satisfies UIMessage["parts"];


### PR DESCRIPTION
## Summary

- mark the `ai` peer optional again
- remove AI SDK types from the emitted `agents` root declaration graph while preserving structural `ToolSet` compatibility for MCP tools
- make agent-tool streamed parts generic so AI SDK callers can opt into `UIMessage["parts"][number]` without forcing that type on every `agents` consumer

## Why

`ai` became required in `agents@0.3.1` to fix #751. At the time, every root `Agent` constructed `MCPClientManager`, whose module contained a literal `import("ai")` for `jsonSchema()`. Bundlers resolved that dynamic import even when applications never called `getAITools()`.

That runtime dependency is gone: MCP schema conversion now uses Zod, and the old chat implementation moved to `@cloudflare/ai-chat`. The remaining root coupling was type-only: `MCPClientManager.getAITools()` returned AI SDK `ToolSet`, and `AgentToolRunState.parts` referenced `UIMessage["parts"]`.

This removes those final declaration references and restores the optional peer. AI-specific entry points still require `ai` when imported.

## Compatibility

`MCPAIToolSet` is structurally assignable to AI SDK `ToolSet`. `AgentToolRunState` and `useAgentToolEvents` now accept an optional part generic; AI SDK consumers can use `UIMessage["parts"][number]` for the previous exact union.

## Validation

- `pnpm run build`: 24 projects pass
- `pnpm run check`: format, lint, exports, and all 113 TypeScript projects pass
- `pnpm --filter agents test:chat`: 477 tests pass
- focused MCP client manager: 149 tests pass
- focused agent-tool reducer: 16 tests pass
- full Workers suite: 1,456 pass / 7 skip; five unrelated Python skill tests timed out fetching the external Pyodide bundle
