### PR TITLE
fix: preserve tool approval ids

### DIFF
--- a/.changeset/approval-id-fallback.md
+++ b/.changeset/approval-id-fallback.md
@@ -1,0 +1,12 @@
+---
+"agents": patch
+---
+
+Ensure tool approval updates always retain a provider-facing approval id.
+
+Older or hand-seeded transcripts can contain an `approval-requested` tool part
+without an `approval.id`. When that part is approved and auto-continuation
+re-enters inference, the AI SDK requires a matching approval id in the converted
+model messages. Approval updates now synthesize a stable id from the
+`toolCallId` when the transcript is missing one, preventing invalid prompt
+errors while preserving existing approval metadata.

--- a/.changeset/approval-id-fallback.md
+++ b/.changeset/approval-id-fallback.md
@@ -1,5 +1,6 @@
 ---
 "agents": patch
+"@cloudflare/ai-chat": patch
 ---
 
 Ensure tool approval updates always retain a provider-facing approval id.
@@ -9,4 +10,6 @@ without an `approval.id`. When that part is approved and auto-continuation
 re-enters inference, the AI SDK requires a matching approval id in the converted
 model messages. Approval updates now synthesize a stable id from the
 `toolCallId` when the transcript is missing one, preventing invalid prompt
-errors while preserving existing approval metadata.
+errors while preserving existing approval metadata. `@cloudflare/ai-chat` now
+routes its approval merge through the shared `toolApprovalUpdate` builder so it
+benefits from the same fallback instead of its own divergent copy.

--- a/packages/agents/src/chat/__tests__/tool-state.test.ts
+++ b/packages/agents/src/chat/__tests__/tool-state.test.ts
@@ -267,6 +267,20 @@ describe("toolApprovalUpdate", () => {
     expect(applied.state).toBe("output-denied");
     expect(applied.approval).toEqual({ id: "a1", approved: false });
   });
+
+  it("synthesizes an approval id when an older transcript is missing one", () => {
+    const update = toolApprovalUpdate("tc-missing-id", true);
+    const applied = update.apply({
+      toolCallId: "tc-missing-id",
+      state: "approval-requested"
+    });
+
+    expect(applied.state).toBe("approval-responded");
+    expect(applied.approval).toEqual({
+      id: "tc-missing-id",
+      approved: true
+    });
+  });
 });
 
 describe("applyToolUpdate", () => {

--- a/packages/agents/src/chat/tool-state.ts
+++ b/packages/agents/src/chat/tool-state.ts
@@ -199,14 +199,26 @@ export function toolApprovalUpdate(
   return {
     toolCallId,
     matchStates: ["input-available", "approval-requested"],
-    apply: (part) => ({
-      ...part,
-      state: approved ? "approval-responded" : "output-denied",
-      approval: {
-        ...(part.approval as Record<string, unknown> | undefined),
-        approved
-      }
-    })
+    apply: (part) => {
+      const approval =
+        typeof part.approval === "object" &&
+        part.approval !== null &&
+        !Array.isArray(part.approval)
+          ? (part.approval as Record<string, unknown>)
+          : undefined;
+      const approvalId =
+        typeof approval?.id === "string" ? approval.id : toolCallId;
+
+      return {
+        ...part,
+        state: approved ? "approval-responded" : "output-denied",
+        approval: {
+          ...approval,
+          id: approvalId,
+          approved
+        }
+      };
+    }
   };
 }
 

--- a/packages/ai-chat/e2e/client-tools.spec.ts
+++ b/packages/ai-chat/e2e/client-tools.spec.ts
@@ -520,6 +520,9 @@ test.describe("Tool approval auto-continuation e2e", () => {
     );
     expect(toolPart).toBeTruthy();
     expect(toolPart.state).toBe("approval-responded");
-    expect(toolPart.approval).toEqual({ approved: true });
+    expect(toolPart.approval).toEqual({
+      id: result.toolCallId,
+      approved: true
+    });
   });
 });

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -44,6 +44,7 @@ import {
   hasIncompleteToolBatch,
   partAwaitsClientInteraction,
   clientResolvableToolNames,
+  toolApprovalUpdate,
   type TurnResult,
   type MessagePart,
   type StreamChunkData,
@@ -5851,21 +5852,17 @@ export class AIChatAgent<
     toolCallId: string,
     approved: boolean
   ): Promise<boolean> {
+    // Use the shared `agents/chat` builder so the approval merge — including
+    // the fallback that synthesizes `approval.id` from `toolCallId` when an
+    // older / hand-seeded transcript lacks one — stays identical to Think.
+    // convertToModelMessages needs `approval.id` to produce a valid
+    // tool-approval-request content part with `approvalId`.
+    const update = toolApprovalUpdate(toolCallId, approved);
     return this._findAndUpdateToolPart(
       toolCallId,
       "_applyToolApproval",
-      ["input-available", "approval-requested"],
-      (part) => ({
-        ...part,
-        state: approved ? "approval-responded" : "output-denied",
-        // Merge with existing approval data to preserve the id field.
-        // convertToModelMessages needs approval.id to produce a valid
-        // tool-approval-request content part with approvalId.
-        approval: {
-          ...(part.approval as Record<string, unknown> | undefined),
-          approved
-        }
-      })
+      update.matchStates,
+      update.apply
     );
   }
 

--- a/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
+++ b/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
@@ -954,7 +954,7 @@ describe("Tool approval (needsApproval) duplicate message prevention", () => {
       approval?: { approved: boolean };
     };
     expect(toolPart.state).toBe("approval-responded");
-    expect(toolPart.approval).toEqual({ approved: true });
+    expect(toolPart.approval).toEqual({ id: toolCallId, approved: true });
 
     ws.close(1000);
   });
@@ -1015,7 +1015,7 @@ describe("Tool approval (needsApproval) duplicate message prevention", () => {
       approval?: { approved: boolean };
     };
     expect(toolPart.state).toBe("output-denied");
-    expect(toolPart.approval).toEqual({ approved: false });
+    expect(toolPart.approval).toEqual({ id: toolCallId, approved: false });
 
     ws.close(1000);
   });
@@ -1316,7 +1316,7 @@ describe("Tool approval auto-continuation (needsApproval)", () => {
       approval?: { approved: boolean };
     };
     expect(toolPart.state).toBe("approval-responded");
-    expect(toolPart.approval).toEqual({ approved: true });
+    expect(toolPart.approval).toEqual({ id: toolCallId, approved: true });
     expect(assistantMsg.parts.length).toBe(1);
 
     ws.close(1000);
@@ -1384,7 +1384,7 @@ describe("Tool approval auto-continuation (needsApproval)", () => {
       approval?: { approved: boolean };
     };
     expect(toolPart.state).toBe("approval-responded");
-    expect(toolPart.approval).toEqual({ approved: true });
+    expect(toolPart.approval).toEqual({ id: toolCallId, approved: true });
 
     // Continuation parts should be appended (TestChatAgent returns text response)
     expect(assistantMsg.parts.length).toBeGreaterThan(1);
@@ -1447,7 +1447,7 @@ describe("Tool approval auto-continuation (needsApproval)", () => {
       approval?: { approved: boolean };
     };
     expect(toolPart.state).toBe("output-denied");
-    expect(toolPart.approval).toEqual({ approved: false });
+    expect(toolPart.approval).toEqual({ id: toolCallId, approved: false });
 
     // Continuation parts should be appended (LLM sees denial and responds)
     expect(assistantMsg.parts.length).toBeGreaterThan(1);


### PR DESCRIPTION
## Summary
- Synthesizes a stable approval id from `toolCallId` when applying approval updates to older or hand-seeded transcripts that lack `approval.id`.
- Prevents Think auto-continuations from feeding provider-invalid `tool-approval-*` parts into AI SDK model-message conversion.
- Adds shared `toolApprovalUpdate` regression coverage and a patch changeset for `agents`.

## Test plan
- `npx vitest --run src/chat/__tests__/tool-state.test.ts`
- `CI=true npx vitest --run -c src/tests/vitest.config.ts src/tests/client-tools.test.ts -t "holds the parallel barrier for an approval-requested sibling"`
- `pnpm run check`

## Notes
- A full local `CI=true npm test` in `packages/think` hit an unrelated recovery-test retry/idempotency flake (`UNIQUE constraint failed: cf_ai_chat_stream_metadata.id`); the failed test passed when rerun alone.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->