### PR TITLE
fix(chat): keep AI SDK status correct when reconnect races the pre-stream window (#1784)

### DIFF
--- a/.changeset/prestream-resume-keep-waiting.md
+++ b/.changeset/prestream-resume-keep-waiting.md
@@ -1,0 +1,41 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Fix AI SDK `status` getting stuck after a reconnect that races a turn's
+pre-stream window (#1784).
+
+A turn is "accepted but pre-stream" while it is queued, debouncing, or awaiting
+async setup before its resumable stream starts. A client that connected or sent
+a `STREAM_RESUME_REQUEST` in that window was answered with `STREAM_RESUME_NONE`
+("nothing to resume"), so its short resume probe resolved `null` and AI SDK
+`status` settled on `ready` even though the server went on to stream — leaving
+the UI unable to render the in-flight turn until a full remount.
+
+This adds a shared `PreStreamTurns` tracker (`agents/chat`) and a new
+server→client `cf_agent_stream_pending` frame:
+
+- The resume handshake now parks resume requests that arrive during the
+  pre-stream window and emits `STREAM_PENDING` ("keep waiting") instead of
+  `STREAM_RESUME_NONE`, then flushes parked connections into the normal
+  `STREAM_RESUMING` handshake once the stream actually starts (and releases them
+  with `STREAM_RESUME_NONE` if the turn is superseded/cleared before streaming).
+- On `STREAM_PENDING` the client transport extends its resume probe from the
+  5s fast-path to a 60s backstop so the probe stays open across the gap.
+- `useAgentChat` re-probes the stream on a transparent socket reopen (e.g. a
+  1006 reconnect that does not remount the component) so `status` recovers.
+- Continuation affinity is relaxed via an optional `isConnectionPresent` host
+  hook so a transparent reconnect (whose connection id changed) can resume a
+  continuation whose original owner connection is gone.
+
+Wired into both `AIChatAgent` and `@cloudflare/think`.
+
+The pre-stream tracker is in-memory only; it is hibernation-safe because a turn
+in its pre-stream window is an unresolved message-handler promise that pins the
+Durable Object in memory, so eviction only happens once a stream is durably
+recorded (and resumes via `ResumableStream`) or the turn has finished. Skipped
+turns (supersede/generation change) settle without releasing parked
+connections, so a client parked during the window survives onto the successor
+turn instead of being cut loose by a premature `STREAM_RESUME_NONE`.

--- a/packages/agents/src/chat/__tests__/pre-stream-turns.test.ts
+++ b/packages/agents/src/chat/__tests__/pre-stream-turns.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+import { PreStreamTurns } from "../pre-stream-turns";
+import type { ChatConnection } from "../connection";
+
+type SentFrame = Record<string, unknown>;
+
+function makeConnection(
+  id: string,
+  sink?: SentFrame[]
+): ChatConnection & { send: ReturnType<typeof vi.fn> } {
+  return {
+    id,
+    send: vi.fn((message: string) => {
+      sink?.push(JSON.parse(message) as SentFrame);
+    })
+  };
+}
+
+describe("PreStreamTurns (#1784)", () => {
+  it("starts idle: nothing in flight, park is a no-op that sends no frame", () => {
+    const pre = new PreStreamTurns();
+    expect(pre.hasInFlight()).toBe(false);
+
+    const conn = makeConnection("c1");
+    expect(pre.park(conn)).toBe(false);
+    expect(conn.send).not.toHaveBeenCalled();
+    expect(pre.awaitingConnections.size).toBe(0);
+  });
+
+  it("begin marks in flight and exposes the latest request id", () => {
+    const pre = new PreStreamTurns();
+    pre.begin("req-1");
+    expect(pre.hasInFlight()).toBe(true);
+    expect(pre.latestRequestId).toBe("req-1");
+  });
+
+  it("park enrolls a connection and sends STREAM_PENDING with the request id", () => {
+    const frames: SentFrame[] = [];
+    const pre = new PreStreamTurns();
+    pre.begin("req-1");
+
+    const conn = makeConnection("c1", frames);
+    expect(pre.park(conn)).toBe(true);
+    expect(pre.awaitingConnections.get("c1")).toBe(conn);
+    expect(frames).toEqual([{ type: "cf_agent_stream_pending", id: "req-1" }]);
+  });
+
+  it("flushOnStreamStart notifies each parked connection then clears the map (keeps accepted)", () => {
+    const pre = new PreStreamTurns();
+    pre.begin("req-1");
+    const c1 = makeConnection("c1");
+    const c2 = makeConnection("c2");
+    pre.park(c1);
+    pre.park(c2);
+
+    const notified: string[] = [];
+    pre.flushOnStreamStart((c) => notified.push(c.id));
+
+    expect(notified.sort()).toEqual(["c1", "c2"]);
+    expect(pre.awaitingConnections.size).toBe(0);
+    // The turn is still running until settle() — accepted set untouched.
+    expect(pre.hasInFlight()).toBe(true);
+  });
+
+  it("releaseAwaiting sends STREAM_RESUME_NONE to each parked connection then clears", () => {
+    const frames: SentFrame[] = [];
+    const pre = new PreStreamTurns();
+    pre.begin("req-1");
+    const c1 = makeConnection("c1", frames);
+    pre.park(c1);
+    frames.length = 0;
+
+    pre.releaseAwaiting();
+
+    expect(frames).toEqual([{ type: "cf_agent_stream_resume_none" }]);
+    expect(pre.awaitingConnections.size).toBe(0);
+  });
+
+  it("settle returns true only when the last accepted turn settles", () => {
+    const pre = new PreStreamTurns();
+    pre.begin("a");
+    pre.begin("b");
+
+    expect(pre.settle("a")).toBe(false);
+    expect(pre.hasInFlight()).toBe(true);
+    expect(pre.settle("b")).toBe(true);
+    expect(pre.hasInFlight()).toBe(false);
+    expect(pre.latestRequestId).toBeNull();
+  });
+
+  it("settling an unknown id is safe and reports idle when nothing else is in flight", () => {
+    const pre = new PreStreamTurns();
+    expect(pre.settle("never-began")).toBe(true);
+  });
+
+  it("a connection parked during the gap between queued turns survives the first turn's settle", () => {
+    // A begins, streams, settles while B is still queued (begin'd). A reconnect
+    // that parked must NOT be released until B also settles with no stream.
+    const pre = new PreStreamTurns();
+    pre.begin("a");
+    pre.begin("b");
+    const conn = makeConnection("c1");
+    pre.park(conn);
+
+    // A finishes first: not idle (B still in flight) → caller would NOT release.
+    expect(pre.settle("a")).toBe(false);
+    expect(pre.awaitingConnections.get("c1")).toBe(conn);
+
+    // B finishes: now idle.
+    expect(pre.settle("b")).toBe(true);
+  });
+
+  it("models the skip-path contract: settle WITHOUT releaseAwaiting keeps a parked client for the successor (#1784)", () => {
+    // Mirrors the host `_completeSkippedRequest` flow: a superseded turn settles
+    // out of the accepted set but must NOT release parked connections, so a
+    // client parked during the pre-stream window survives onto the turn that
+    // actually streams — even if the set momentarily empties before the
+    // successor's `begin()` runs (the supersede/settle microtask race).
+    const pre = new PreStreamTurns();
+    pre.begin("superseded");
+    const conn = makeConnection("c1");
+    pre.park(conn);
+
+    // The superseded turn settles. The host does NOT call releaseAwaiting here.
+    expect(pre.settle("superseded")).toBe(true); // set momentarily empty
+    expect(pre.awaitingConnections.get("c1")).toBe(conn); // still parked
+
+    // The successor turn begins and starts streaming → the parked client is
+    // flushed into the normal resume handshake rather than stranded.
+    pre.begin("successor");
+    const notified: string[] = [];
+    pre.flushOnStreamStart((c) => notified.push(c.id));
+    expect(notified).toEqual(["c1"]);
+    expect(pre.awaitingConnections.size).toBe(0);
+  });
+
+  it("release drops a single connection without touching the rest", () => {
+    const pre = new PreStreamTurns();
+    pre.begin("req-1");
+    const c1 = makeConnection("c1");
+    const c2 = makeConnection("c2");
+    pre.park(c1);
+    pre.park(c2);
+
+    pre.release("c1");
+
+    expect(pre.awaitingConnections.has("c1")).toBe(false);
+    expect(pre.awaitingConnections.get("c2")).toBe(c2);
+  });
+
+  it("park without a known request id omits the id from the keep-waiting frame", () => {
+    const frames: SentFrame[] = [];
+    const pre = new PreStreamTurns();
+    // settle the only id so latestRequestId is null but force in-flight via a
+    // second begin with an empty-ish id path: emulate by beginning then parking.
+    pre.begin("");
+    const conn = makeConnection("c1", frames);
+    pre.park(conn);
+    expect(frames).toEqual([{ type: "cf_agent_stream_pending" }]);
+  });
+
+  it("reset drops all state and sends no frames", () => {
+    const pre = new PreStreamTurns();
+    pre.begin("req-1");
+    const c1 = makeConnection("c1");
+    pre.park(c1);
+    c1.send.mockClear();
+
+    pre.reset();
+
+    expect(pre.hasInFlight()).toBe(false);
+    expect(pre.awaitingConnections.size).toBe(0);
+    expect(pre.latestRequestId).toBeNull();
+    expect(c1.send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agents/src/chat/__tests__/resume-handshake-frames.test.ts
+++ b/packages/agents/src/chat/__tests__/resume-handshake-frames.test.ts
@@ -4,6 +4,7 @@ import {
   HANDSHAKE_INVARIANTS,
   recoveringFrame,
   replayDoneFrame,
+  streamPendingFrame,
   streamResumeNoneFrame,
   streamResumingFrame,
   terminalErrorFrame
@@ -54,6 +55,16 @@ describe("resume-handshake golden frames", () => {
     expect("replay" in frame).toBe(false);
   });
 
+  it("STREAM_PENDING includes the id only when present (#1784)", () => {
+    expect(streamPendingFrame("req-1")).toEqual({
+      type: "cf_agent_stream_pending",
+      id: "req-1"
+    });
+    const noId = streamPendingFrame();
+    expect(noId).toEqual({ type: "cf_agent_stream_pending" });
+    expect("id" in noId).toBe(false);
+  });
+
   it("recovering frame includes the id only when present", () => {
     expect(recoveringFrame("req-1")).toEqual({
       type: "cf_agent_chat_recovering",
@@ -82,6 +93,9 @@ describe("resume-handshake golden frames", () => {
       CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE
     );
     expect(recoveringFrame("x").type).toBe(CHAT_MESSAGE_TYPES.CHAT_RECOVERING);
+    expect(streamPendingFrame("x").type).toBe(
+      CHAT_MESSAGE_TYPES.STREAM_PENDING
+    );
   });
 
   it("a host with a distinct use-chat-response constant is honored", () => {

--- a/packages/agents/src/chat/__tests__/resume-handshake-frames.ts
+++ b/packages/agents/src/chat/__tests__/resume-handshake-frames.ts
@@ -55,6 +55,20 @@ export function streamResumeNoneFrame() {
 }
 
 /**
+ * Server -> client `STREAM_PENDING` keep-waiting frame (#1784): a turn is
+ * accepted but its resumable stream has not started yet. Carries `id` only when
+ * the accepted request id is known. The client cancels its short resume probe
+ * timeout and waits for a later `STREAM_RESUMING` or `STREAM_RESUME_NONE`.
+ * Emitted by `PreStreamTurns.park`.
+ */
+export function streamPendingFrame(requestId?: string) {
+  return {
+    type: CHAT_MESSAGE_TYPES.STREAM_PENDING,
+    ...(requestId ? { id: requestId } : {})
+  };
+}
+
+/**
  * Server -> client terminal replay-done frame: the ACK fallback when no live or
  * completed chunks remain to replay, closing the resumed stream cleanly.
  * `replay: true`, never `error`. `responseType` is the host's use-chat-response

--- a/packages/agents/src/chat/__tests__/resume-handshake.test.ts
+++ b/packages/agents/src/chat/__tests__/resume-handshake.test.ts
@@ -7,8 +7,10 @@ import {
 } from "../resume-handshake";
 import { ContinuationState } from "../continuation-state";
 import type { ResumableStream } from "../resumable-stream";
+import { PreStreamTurns } from "../pre-stream-turns";
 import {
   replayDoneFrame,
+  streamPendingFrame,
   streamResumeNoneFrame,
   streamResumingFrame,
   terminalErrorFrame
@@ -91,20 +93,26 @@ function makeStream(over: Partial<FakeStreamState> = {}): {
 function makeHost(opts: {
   resumableStream: ResumableStream;
   continuation?: ContinuationState<Connection>;
+  preStream?: PreStreamTurns<Connection>;
   pendingTerminal?: PendingChatTerminal | null;
   pendingResumeConnections?: Set<string>;
   persistCalls?: string[];
+  presentConnectionIds?: Set<string>;
 }): ResumeHandshakeHost {
   return {
     responseMessageType: RESPONSE_TYPE,
     resumableStream: opts.resumableStream,
     continuation: opts.continuation ?? new ContinuationState<Connection>(),
+    preStream: opts.preStream,
     pendingResumeConnections:
       opts.pendingResumeConnections ?? new Set<string>(),
     pendingChatTerminal: async () => opts.pendingTerminal ?? null,
     persistOrphanedStream: async (id: string) => {
       opts.persistCalls?.push(id);
-    }
+    },
+    isConnectionPresent: opts.presentConnectionIds
+      ? (id: string) => opts.presentConnectionIds!.has(id)
+      : undefined
   };
 }
 
@@ -182,13 +190,15 @@ describe("ResumeHandshake (driver → golden frames)", () => {
     expect(frames).toEqual([streamResumeNoneFrame()]);
   });
 
-  it("REQUEST with no active stream but a matching pending continuation parks (no frame)", async () => {
+  it("REQUEST with no active stream but a matching pending continuation parks + keeps waiting (#1784)", async () => {
     const frames: SentFrame[] = [];
     const { resumableStream } = makeStream({ active: false });
     const continuation = new ContinuationState<Connection>();
-    // Only `connectionId` is read by the driver's pending check.
+    // `connectionId` is read by the driver's pending check; `requestId` is
+    // echoed into the keep-waiting frame.
     continuation.pending = {
-      connectionId: null
+      connectionId: null,
+      requestId: "cont-1"
     } as ContinuationState<Connection>["pending"];
     const handshake = new ResumeHandshake(
       makeHost({ resumableStream, continuation })
@@ -197,7 +207,9 @@ describe("ResumeHandshake (driver → golden frames)", () => {
 
     await handshake.handleResumeRequest(conn);
 
-    expect(frames).toEqual([]);
+    // Now parks AND tells the client to keep waiting so its short resume probe
+    // doesn't resolve "no stream" before the continuation stream starts.
+    expect(frames).toEqual([streamPendingFrame("cont-1")]);
     expect(continuation.awaitingConnections.get("c1")).toBe(conn);
   });
 
@@ -220,6 +232,81 @@ describe("ResumeHandshake (driver → golden frames)", () => {
     const frames: SentFrame[] = [];
     const { resumableStream } = makeStream({ active: false });
     const handshake = new ResumeHandshake(makeHost({ resumableStream }));
+
+    await handshake.handleResumeRequest(makeConnection("c1", frames));
+
+    expect(frames).toEqual([streamResumeNoneFrame()]);
+  });
+
+  it("REQUEST with no active stream but a pre-stream turn in flight parks + keeps waiting (#1784)", async () => {
+    const frames: SentFrame[] = [];
+    const { resumableStream } = makeStream({ active: false });
+    const preStream = new PreStreamTurns<Connection>();
+    preStream.begin("req-pre");
+    const handshake = new ResumeHandshake(
+      makeHost({ resumableStream, preStream })
+    );
+    const conn = makeConnection("c1", frames);
+
+    await handshake.handleResumeRequest(conn);
+
+    expect(frames).toEqual([streamPendingFrame("req-pre")]);
+    expect(preStream.awaitingConnections.get("c1")).toBe(conn);
+  });
+
+  it("REQUEST with an idle pre-stream tracker → RESUME_NONE (nothing in flight)", async () => {
+    const frames: SentFrame[] = [];
+    const { resumableStream } = makeStream({ active: false });
+    const preStream = new PreStreamTurns<Connection>();
+    const handshake = new ResumeHandshake(
+      makeHost({ resumableStream, preStream })
+    );
+
+    await handshake.handleResumeRequest(makeConnection("c1", frames));
+
+    expect(frames).toEqual([streamResumeNoneFrame()]);
+    expect(preStream.awaitingConnections.size).toBe(0);
+  });
+
+  it("active continuation owned by an ABSENT connection can be resumed by a new one (#1784)", async () => {
+    const frames: SentFrame[] = [];
+    const { resumableStream } = makeStream({
+      active: true,
+      activeRequestId: "req-1"
+    });
+    const continuation = new ContinuationState<Connection>();
+    continuation.activeRequestId = "req-1";
+    continuation.activeConnectionId = "old-owner";
+    const handshake = new ResumeHandshake(
+      makeHost({
+        resumableStream,
+        continuation,
+        // "old-owner" is NOT present → the new connection may take over.
+        presentConnectionIds: new Set<string>(["c1"])
+      })
+    );
+
+    await handshake.handleResumeRequest(makeConnection("c1", frames));
+
+    expect(frames).toEqual([streamResumingFrame("req-1")]);
+  });
+
+  it("active continuation owned by a PRESENT connection is NOT hijacked → RESUME_NONE", async () => {
+    const frames: SentFrame[] = [];
+    const { resumableStream } = makeStream({
+      active: true,
+      activeRequestId: "req-1"
+    });
+    const continuation = new ContinuationState<Connection>();
+    continuation.activeRequestId = "req-1";
+    continuation.activeConnectionId = "old-owner";
+    const handshake = new ResumeHandshake(
+      makeHost({
+        resumableStream,
+        continuation,
+        presentConnectionIds: new Set<string>(["old-owner", "c1"])
+      })
+    );
 
     await handshake.handleResumeRequest(makeConnection("c1", frames));
 

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -76,6 +76,15 @@ export {
 } from "./continuation-state";
 
 /**
+ * @internal Shared pre-stream-turn tracker (#1784) — represents the window
+ * between a turn being accepted and its resumable stream starting so a
+ * reconnecting client keeps waiting instead of giving up. Sibling-package
+ * support for `@cloudflare/ai-chat` and `@cloudflare/think`, not a public API.
+ * See `pre-stream-turns.ts`.
+ */
+export { PreStreamTurns } from "./pre-stream-turns";
+
+/**
  * @internal Shared auto-continuation barrier (the tool-result → auto-continue
  * flow, #1649 / #1650) — sibling-package support for `@cloudflare/ai-chat` and
  * `@cloudflare/think`, not a public API. See `auto-continuation-controller.ts`.

--- a/packages/agents/src/chat/pre-stream-turns.ts
+++ b/packages/agents/src/chat/pre-stream-turns.ts
@@ -1,0 +1,142 @@
+/**
+ * PreStreamTurns — tracks accepted chat turns that have not yet started a
+ * resumable stream, and the connections parked waiting for one.
+ *
+ * The resume handshake can resume an ACTIVE stream (chunks buffering) and can
+ * replay a TERMINAL outcome, but a normal turn spends a window between "request
+ * accepted" and "first chunk produced" in neither state: it is queued, waiting
+ * on `waitForMcpConnections`, debouncing, or simply running async setup inside
+ * `onChatMessage` before a stream object exists. A client that reconnects or
+ * re-mounts in that window used to get `cf_agent_stream_resume_none` and give
+ * up, so the turn the server went on to complete normally never drove the
+ * client's AI-SDK `status` (issue #1784).
+ *
+ * This container lets a host represent that window as resumable: the handshake
+ * parks the reconnecting connection here (and tells it to keep waiting), and the
+ * host flushes the parked connections into the normal `STREAM_RESUMING` path the
+ * moment a stream actually starts — or releases them with `resume_none` if the
+ * turn settles without ever streaming.
+ *
+ * Concurrency-safe under queued turns via an accepted-request set: parked
+ * connections are only released with `resume_none` once EVERY accepted turn has
+ * settled with no active stream, so a client parked during the gap between one
+ * turn finishing and the next starting still resumes onto the next stream.
+ *
+ * Pure data + send-through-callback, mirroring {@link ContinuationState}: the
+ * host owns the actual frame sends and the stream-start / turn-settle wiring.
+ *
+ * @internal Sibling-package support for `@cloudflare/ai-chat` and
+ * `@cloudflare/think`, not a public API.
+ */
+
+import { sendIfOpen, type ChatConnection } from "./connection";
+import { CHAT_MESSAGE_TYPES } from "./protocol";
+
+const MSG_STREAM_PENDING = CHAT_MESSAGE_TYPES.STREAM_PENDING;
+const MSG_STREAM_RESUME_NONE = CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE;
+
+export class PreStreamTurns<
+  TConnection extends ChatConnection = ChatConnection
+> {
+  /**
+   * Accepted-but-not-yet-streamed request ids. A turn enters on `begin()` and
+   * leaves on `settle()`; the set being non-empty means "pre-stream work is in
+   * flight", which gates parking and the eventual `resume_none` release.
+   */
+  private readonly _accepted = new Set<string>();
+
+  /** Connections parked waiting for a stream to start. */
+  readonly awaitingConnections = new Map<string, TConnection>();
+
+  /** The most recently accepted pre-stream request id (for the keep-waiting frame). */
+  private _latestRequestId: string | null = null;
+
+  /** Mark a freshly-accepted turn as in flight (pre-stream). */
+  begin(requestId: string): void {
+    this._accepted.add(requestId);
+    this._latestRequestId = requestId;
+  }
+
+  /**
+   * Mark an accepted turn as settled. Returns `true` when no accepted turn
+   * remains in flight (the caller should release parked connections if no
+   * stream is active).
+   */
+  settle(requestId: string): boolean {
+    this._accepted.delete(requestId);
+    if (this._accepted.size === 0) {
+      this._latestRequestId = null;
+      return true;
+    }
+    return false;
+  }
+
+  /** Whether any accepted turn is still pre-stream. */
+  hasInFlight(): boolean {
+    return this._accepted.size > 0;
+  }
+
+  /** The request id to advertise in the keep-waiting frame, if known. */
+  get latestRequestId(): string | null {
+    return this._latestRequestId;
+  }
+
+  /**
+   * Park a reconnecting connection and tell it to keep waiting (so its
+   * transport does not resolve `reconnectToStream` early). No-op when nothing
+   * is in flight. Parked connections are deliberately NOT added to the host's
+   * `pendingResumeConnections` — they must keep receiving any live broadcast —
+   * until the host flushes them through `notifyStreamResuming` on stream start.
+   */
+  park(connection: TConnection): boolean {
+    if (!this.hasInFlight()) return false;
+    this.awaitingConnections.set(connection.id, connection);
+    sendIfOpen(
+      connection,
+      JSON.stringify({
+        type: MSG_STREAM_PENDING,
+        ...(this._latestRequestId ? { id: this._latestRequestId } : {})
+      })
+    );
+    return true;
+  }
+
+  /** Drop a single connection (e.g. on socket close) without releasing others. */
+  release(connectionId: string): void {
+    this.awaitingConnections.delete(connectionId);
+  }
+
+  /**
+   * A stream has started: hand every parked connection to `notify` (the host's
+   * `notifyStreamResuming`, which sends `STREAM_RESUMING` and excludes the
+   * connection from live broadcast until it ACKs), then clear the awaiting map.
+   * The accepted set is untouched — the turn is still running.
+   */
+  flushOnStreamStart(notify: (connection: TConnection) => void): void {
+    for (const connection of this.awaitingConnections.values()) {
+      notify(connection);
+    }
+    this.awaitingConnections.clear();
+  }
+
+  /**
+   * Release every parked connection with `STREAM_RESUME_NONE` (the turn settled
+   * without ever starting a stream) and clear the awaiting map. Safe to call
+   * when the map is empty (no-op), so the host can call it liberally from a
+   * turn-settle path.
+   */
+  releaseAwaiting(): void {
+    const msg = JSON.stringify({ type: MSG_STREAM_RESUME_NONE });
+    for (const connection of this.awaitingConnections.values()) {
+      sendIfOpen(connection, msg);
+    }
+    this.awaitingConnections.clear();
+  }
+
+  /** Drop all state (chat clear / destroy). Does not send any frames. */
+  reset(): void {
+    this._accepted.clear();
+    this.awaitingConnections.clear();
+    this._latestRequestId = null;
+  }
+}

--- a/packages/agents/src/chat/protocol.ts
+++ b/packages/agents/src/chat/protocol.ts
@@ -15,6 +15,15 @@ export const CHAT_MESSAGE_TYPES = {
   STREAM_RESUME_ACK: "cf_agent_stream_resume_ack",
   STREAM_RESUME_REQUEST: "cf_agent_stream_resume_request",
   STREAM_RESUME_NONE: "cf_agent_stream_resume_none",
+  // Server→client: a turn has been accepted but its resumable stream has not
+  // started yet (queued, debouncing, waiting on MCP setup, or running async
+  // work in `onChatMessage`). Sent in response to a resume request (or on
+  // connect) so a reconnecting/re-mounting client keeps its expectation instead
+  // of resolving its resume probe to "no stream" and then false-timing-out the
+  // turn. Resolved by a later `STREAM_RESUMING` (stream started) or
+  // `STREAM_RESUME_NONE` (turn settled without streaming). Backward-compatible —
+  // clients that don't understand it ignore it. See issue #1784.
+  STREAM_PENDING: "cf_agent_stream_pending",
   TOOL_RESULT: "cf_agent_tool_result",
   TOOL_APPROVAL: "cf_agent_tool_approval",
   MESSAGE_UPDATED: "cf_agent_message_updated",

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -1043,6 +1043,17 @@ export function useAgentChat<
   const statusRef = useRef(status);
   statusRef.current = status;
 
+  // Latest resumeStream, read by the reconnect re-probe effect without making
+  // it a dependency (it would re-register the socket listeners on every render).
+  const resumeStreamRef = useRef(resumeStream);
+  resumeStreamRef.current = resumeStream;
+
+  // Whether the socket has opened at least once. The AI SDK fires its own
+  // resume on mount, so we only re-probe on SUBSEQUENT opens (transparent 1006
+  // reconnects that don't remount the component) — see the reconnect re-probe
+  // in the socket effect below (#1784).
+  const hasConnectedOnceRef = useRef(false);
+
   const resumingToolContinuationRef = useRef(false);
   const pendingToolContinuationRef = useRef(false);
   const observedToolContinuationRequestIdRef = useRef<string | null>(null);
@@ -1896,6 +1907,15 @@ export function useAgentChat<
           customTransport.handleStreamResumeNone();
           break;
 
+        case MessageType.CF_AGENT_STREAM_PENDING:
+          // Server accepted a turn but its stream hasn't started yet (#1784):
+          // tell the transport to keep waiting so its resume probe doesn't
+          // resolve "no stream" mid pre-stream window. A later STREAM_RESUMING
+          // (stream started) or STREAM_RESUME_NONE (settled without streaming)
+          // resolves it. Advisory for clients not awaiting a resume.
+          customTransport.handleStreamPending();
+          break;
+
         case MessageType.CF_AGENT_STREAM_RESUMING: {
           const isEarlyToolContinuation =
             resumingToolContinuationRef.current &&
@@ -2153,8 +2173,33 @@ export function useAgentChat<
       fallbackAckedResumeRequestIds.clear();
     }
 
+    // Reconnect re-probe (#1784): a transparent socket reconnect (e.g. a 1006
+    // drop) does NOT remount the component, so the AI SDK's mount-time resume
+    // never re-fires and a turn that was still pre-stream when the socket
+    // dropped would leave AI SDK `status` stuck at "ready" even after the
+    // server starts streaming. On every reconnect (not the first open) re-probe
+    // through the transport so `status` recovers, mirroring a fresh mount. The
+    // proactive STREAM_RESUMING the server also sends on connect is reconciled
+    // with this probe by the existing #1733 dual-notify dedupe.
+    function onAgentOpen() {
+      if (!hasConnectedOnceRef.current) {
+        hasConnectedOnceRef.current = true;
+        return;
+      }
+      if (
+        !resume ||
+        statusRef.current !== "ready" ||
+        resumingToolContinuationRef.current ||
+        customTransport.isAwaitingResume()
+      ) {
+        return;
+      }
+      void Promise.resolve(resumeStreamRef.current?.()).catch(() => {});
+    }
+
     agent.addEventListener("message", onAgentMessage);
     agent.addEventListener("close", onAgentClose);
+    agent.addEventListener("open", onAgentOpen);
 
     // Stream resume is now primarily handled by the transport's
     // reconnectToStream (which sends CF_AGENT_STREAM_RESUME_REQUEST).
@@ -2164,6 +2209,7 @@ export function useAgentChat<
     return () => {
       agent.removeEventListener("message", onAgentMessage);
       agent.removeEventListener("close", onAgentClose);
+      agent.removeEventListener("open", onAgentOpen);
       fallbackAckedResumeRequestIds.clear();
       streamStateRef.current = { status: "idle" };
       setIsServerStreaming(false);

--- a/packages/agents/src/chat/resume-handshake.ts
+++ b/packages/agents/src/chat/resume-handshake.ts
@@ -22,6 +22,7 @@ import type { Connection } from "agents";
 import { sendIfOpen } from "./connection";
 import { CHAT_MESSAGE_TYPES } from "./protocol";
 import type { ContinuationState } from "./continuation-state";
+import type { PreStreamTurns } from "./pre-stream-turns";
 import type { ResumableStream } from "./resumable-stream";
 
 /** A pending terminal outcome captured before connect (#1645). */
@@ -42,6 +43,14 @@ export interface ResumeHandshakeHost {
   readonly resumableStream: ResumableStream;
   readonly continuation: ContinuationState<Connection>;
   /**
+   * Accepted-but-not-yet-streamed turns (#1784). Optional: experimental
+   * recovery adapters that don't track a pre-stream window omit it and keep the
+   * legacy `resume_none` behavior. When present, the handshake parks a
+   * reconnecting client here (sending a keep-waiting `STREAM_PENDING`) instead
+   * of telling it there is nothing to resume.
+   */
+  readonly preStream?: PreStreamTurns<Connection>;
+  /**
    * Connections notified of a resumable stream, excluded from live broadcast
    * until they ACK. Host-owned (shared with the streaming loop).
    */
@@ -50,6 +59,14 @@ export interface ResumeHandshakeHost {
   pendingChatTerminal(): Promise<PendingChatTerminal | null>;
   /** Materialize an orphaned stream's partial into a persisted assistant message. */
   persistOrphanedStream(streamId: string): Promise<void>;
+  /**
+   * Whether the connection that owns the active continuation stream is still
+   * connected. Optional: when omitted the handshake assumes it is (legacy
+   * behavior). Hosts wire their live connection registry so a continuation
+   * stream whose owner vanished on an abrupt (1006) reconnect can still be
+   * resumed by the replacement connection (#1784).
+   */
+  isConnectionPresent?(connectionId: string): boolean;
 }
 
 /**
@@ -97,12 +114,13 @@ export class ResumeHandshake {
    * `STREAM_RESUMING` from onConnect arrives before the handler is ready.
    */
   async handleResumeRequest(connection: Connection): Promise<void> {
-    const { resumableStream, continuation } = this.host;
+    const { resumableStream, continuation, preStream } = this.host;
     if (resumableStream.hasActiveStream()) {
       if (
         continuation.activeRequestId === resumableStream.activeRequestId &&
         continuation.activeConnectionId !== null &&
-        continuation.activeConnectionId !== connection.id
+        continuation.activeConnectionId !== connection.id &&
+        this._ownerStillPresent(continuation.activeConnectionId)
       ) {
         sendIfOpen(
           connection,
@@ -116,18 +134,46 @@ export class ResumeHandshake {
       (continuation.pending.connectionId === null ||
         continuation.pending.connectionId === connection.id)
     ) {
+      // A continuation turn is accepted but its stream has not started yet.
+      // Park the connection AND tell it to keep waiting (#1784) so its resume
+      // probe does not time out before the continuation stream begins; the host
+      // flushes `awaitingConnections` into `STREAM_RESUMING` on stream start.
       continuation.awaitingConnections.set(connection.id, connection);
+      this._sendStreamPending(connection, continuation.pending.requestId);
     } else if (await this._replayTerminalOnResume(connection)) {
       // A turn terminalized while no client was connected (#1645): drive the
       // resume handshake so the terminal error frame can be delivered on the
       // resumed stream (the only path that surfaces as an error on the client)
       // once this connection ACKs — see `_replayTerminalOnAck`.
+    } else if (preStream?.park(connection)) {
+      // A normal turn is accepted but its resumable stream has not started yet
+      // (#1784). `park` enrolled the connection and sent `STREAM_PENDING`; the
+      // host flushes it into `STREAM_RESUMING` on stream start, or releases it
+      // with `STREAM_RESUME_NONE` if the turn settles without streaming.
     } else {
       sendIfOpen(
         connection,
         JSON.stringify({ type: CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE })
       );
     }
+  }
+
+  /** Send a keep-waiting `STREAM_PENDING` frame (#1784). */
+  private _sendStreamPending(connection: Connection, requestId?: string): void {
+    sendIfOpen(
+      connection,
+      JSON.stringify({
+        type: CHAT_MESSAGE_TYPES.STREAM_PENDING,
+        ...(requestId ? { id: requestId } : {})
+      })
+    );
+  }
+
+  /** Whether the active continuation's owner connection is still present. */
+  private _ownerStillPresent(connectionId: string): boolean {
+    return this.host.isConnectionPresent
+      ? this.host.isConnectionPresent(connectionId)
+      : true;
   }
 
   /** Handle a client `STREAM_RESUME_ACK` for `requestId`. */

--- a/packages/agents/src/chat/wire-types.ts
+++ b/packages/agents/src/chat/wire-types.ts
@@ -18,6 +18,14 @@ export enum MessageType {
   CF_AGENT_STREAM_RESUME_REQUEST = "cf_agent_stream_resume_request",
   /** Sent by server when client requests resume but no active stream exists */
   CF_AGENT_STREAM_RESUME_NONE = "cf_agent_stream_resume_none",
+  /**
+   * Sent by server when a turn is accepted but its resumable stream has not
+   * started yet (queued / debouncing / waiting on MCP / async setup). Tells a
+   * reconnecting client to keep waiting rather than resolve its resume probe to
+   * "no stream". Resolved by a later `CF_AGENT_STREAM_RESUMING` (stream started)
+   * or `CF_AGENT_STREAM_RESUME_NONE` (settled without streaming). See #1784.
+   */
+  CF_AGENT_STREAM_PENDING = "cf_agent_stream_pending",
 
   /** Client sends tool result to server (for client-side tools) */
   CF_AGENT_TOOL_RESULT = "cf_agent_tool_result",
@@ -84,6 +92,16 @@ export type OutgoingMessage<ChatMessage extends UIMessage = UIMessage> =
   | {
       /** Server responds to resume request when no active stream exists */
       type: MessageType.CF_AGENT_STREAM_RESUME_NONE;
+    }
+  | {
+      /**
+       * Server signals an accepted turn whose resumable stream has not started
+       * yet — the client should keep waiting for `STREAM_RESUMING` (or a later
+       * `STREAM_RESUME_NONE`) rather than give up. See #1784.
+       */
+      type: MessageType.CF_AGENT_STREAM_PENDING;
+      /** The accepted request id, when known. */
+      id?: string;
     }
   | {
       /**

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -13,6 +13,23 @@ import { nanoid } from "nanoid";
 import { MessageType, type OutgoingMessage } from "./wire-types";
 
 /**
+ * Short safety-net timeout for a resume probe when the server has said nothing.
+ * Under normal operation the server answers a `STREAM_RESUME_REQUEST` with
+ * `STREAM_RESUMING`, `STREAM_RESUME_NONE`, or `STREAM_PENDING` well before this.
+ */
+const RESUME_PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * Extended backstop applied once the server says a turn is pending
+ * (`STREAM_PENDING`, #1784). The pre-stream window (queueing, MCP setup,
+ * debounce, model latency) can exceed the short probe timeout, and the server
+ * guarantees a follow-up `STREAM_RESUMING` or `STREAM_RESUME_NONE` — so we wait
+ * much longer (refreshed on every keep-waiting frame) but still cap it so a
+ * dropped follow-up degrades to a null resolve instead of hanging forever.
+ */
+const RESUME_PENDING_TIMEOUT_MS = 60000;
+
+/**
  * Agent-like interface for sending/receiving WebSocket messages.
  * Matches the shape returned by useAgent from agents/react.
  */
@@ -77,6 +94,11 @@ export class WebSocketChatTransport<
   // Pending "no stream" resolver — called by handleStreamResumeNone
   // when onAgentMessage sees CF_AGENT_STREAM_RESUME_NONE.
   private _resumeNoneResolver: (() => void) | null = null;
+  // Keep-waiting hook (#1784) — set by whichever resume path is currently
+  // awaiting, called by handleStreamPending when onAgentMessage sees
+  // CF_AGENT_STREAM_PENDING. Extends the path's probe timeout so a slow
+  // pre-stream window (queue / MCP / model latency) does not resolve early.
+  private _onStreamPending: (() => void) | null = null;
   // Set when a client-side tool result/approval is expected to trigger
   // a new continuation stream. In this mode reconnectToStream() returns
   // a deferred ReadableStream immediately so AI SDK status can transition
@@ -188,6 +210,19 @@ export class WebSocketChatTransport<
   handleStreamResumeNone(): boolean {
     if (!this._resumeNoneResolver) return false;
     this._resumeNoneResolver();
+    return true;
+  }
+
+  /**
+   * Called by onAgentMessage when it receives CF_AGENT_STREAM_PENDING (#1784):
+   * the server accepted a turn but its stream has not started yet. If a resume
+   * path is awaiting, extend its probe timeout (so it keeps waiting for the
+   * eventual STREAM_RESUMING / STREAM_RESUME_NONE instead of resolving null
+   * after the short window). Returns true if a waiting path consumed it.
+   */
+  handleStreamPending(): boolean {
+    if (!this._onStreamPending) return false;
+    this._onStreamPending();
     return true;
   }
 
@@ -413,8 +448,19 @@ export class WebSocketChatTransport<
         resolved = true;
         this._resumeResolver = null;
         this._resumeNoneResolver = null;
+        this._onStreamPending = null;
         if (timeout) clearTimeout(timeout);
         resolve(value);
+      };
+
+      // Keep-waiting (#1784): the server says a turn is accepted but its stream
+      // hasn't started. Extend the short probe timeout to the longer backstop so
+      // we wait for the eventual STREAM_RESUMING (or STREAM_RESUME_NONE) instead
+      // of resolving null mid pre-stream window. Refreshed on every frame.
+      this._onStreamPending = () => {
+        if (resolved) return;
+        if (timeout) clearTimeout(timeout);
+        timeout = setTimeout(() => done(null), RESUME_PENDING_TIMEOUT_MS);
       };
 
       // Set the "no stream" resolver that handleStreamResumeNone() will call.
@@ -461,9 +507,9 @@ export class WebSocketChatTransport<
 
       // Safety-net timeout: if the WebSocket never connects or the
       // server is unreachable, resolve null. Under normal operation
-      // the server responds with STREAM_RESUMING or STREAM_RESUME_NONE
-      // well before this fires.
-      timeout = setTimeout(() => done(null), 5000);
+      // the server responds with STREAM_RESUMING, STREAM_RESUME_NONE, or
+      // STREAM_PENDING (which extends this) well before this fires.
+      timeout = setTimeout(() => done(null), RESUME_PROBE_TIMEOUT_MS);
     });
   }
 
@@ -515,6 +561,7 @@ export class WebSocketChatTransport<
       if (completed) return;
       completed = true;
       this._abortToolContinuation = null;
+      this._onStreamPending = null;
       clearHandshakeResolvers(resumeResolver, resumeNoneResolver);
       try {
         action();
@@ -585,6 +632,7 @@ export class WebSocketChatTransport<
           requestId = data.id;
           activeIds?.add(requestId);
           clearHandshakeResolvers(onResume, onResumeNone);
+          transport._onStreamPending = null;
           if (timeout) clearTimeout(timeout);
 
           agent.send(
@@ -600,8 +648,19 @@ export class WebSocketChatTransport<
 
         timeout = setTimeout(
           () => finish(() => controller.close(), onResume, onResumeNone),
-          5000
+          RESUME_PROBE_TIMEOUT_MS
         );
+
+        // Keep-waiting (#1784): extend the probe window when the server reports
+        // the continuation turn is accepted but its stream hasn't started.
+        transport._onStreamPending = () => {
+          if (completed) return;
+          if (timeout) clearTimeout(timeout);
+          timeout = setTimeout(
+            () => finish(() => controller.close(), onResume, onResumeNone),
+            RESUME_PENDING_TIMEOUT_MS
+          );
+        };
 
         transport._resumeResolver = onResume;
         transport._resumeNoneResolver = onResumeNone;

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -906,75 +906,48 @@ export class AIChatAgent<
           // flushed into STREAM_RESUMING on _startStream or released on settle.
           this._preStream.begin(chatMessageId);
 
-          // Track that this request is past the concurrency decision but
-          // not yet enqueued in _turnQueue. Decremented synchronously
-          // before _runExclusiveChatTurn (which increments queuedCount).
-          const releasePendingEnqueue = this._submitConcurrency.beginEnqueue();
+          // Outer finally so the accepted pre-stream turn ALWAYS settles
+          // (#1784). begin() runs before the pre-turn-body steps below
+          // (persistMessages, _mergeQueuedUserMessages, and inside the queued
+          // execute callback mcp.waitForConnections / _setRequestContext); if
+          // any of those throws, chatTurnBody's own finally never runs. Without
+          // this backstop the request id would stay stuck in _preStream —
+          // hasInFlight() true forever — so every future client would be parked
+          // on STREAM_PENDING (60s) instead of getting an immediate
+          // STREAM_RESUME_NONE, until chat clear or DO eviction. Mirrors
+          // @cloudflare/think's _handleChatRequest.
           try {
-            // Persist and broadcast user messages before entering the turn
-            // queue so other tabs see the new message immediately and so
-            // overlapping submits under latest/merge/debounce can inspect
-            // the full message list when their turn starts.
-            this._broadcastChatMessage(
-              {
-                messages: transformedMessages,
-                type: MessageType.CF_AGENT_CHAT_MESSAGES
-              },
-              [connection.id]
-            );
+            // Track that this request is past the concurrency decision but
+            // not yet enqueued in _turnQueue. Decremented synchronously
+            // before _runExclusiveChatTurn (which increments queuedCount).
+            const releasePendingEnqueue =
+              this._submitConcurrency.beginEnqueue();
+            try {
+              // Persist and broadcast user messages before entering the turn
+              // queue so other tabs see the new message immediately and so
+              // overlapping submits under latest/merge/debounce can inspect
+              // the full message list when their turn starts.
+              this._broadcastChatMessage(
+                {
+                  messages: transformedMessages,
+                  type: MessageType.CF_AGENT_CHAT_MESSAGES
+                },
+                [connection.id]
+              );
 
-            await this.persistMessages(transformedMessages, [connection.id], {
-              _deleteStaleRows: true
-            });
+              await this.persistMessages(transformedMessages, [connection.id], {
+                _deleteStaleRows: true
+              });
 
-            if (concurrencyDecision.strategy === "merge") {
-              await this._mergeQueuedUserMessages(epoch);
-            }
-          } finally {
-            releasePendingEnqueue();
-          }
-          return this._runExclusiveChatTurn(
-            chatMessageId,
-            async () => {
-              if (
-                this._submitConcurrency.isSuperseded(
-                  concurrencyDecision.submitSequence
-                )
-              ) {
-                this._completeSkippedRequest(connection, chatMessageId);
-                return;
-              }
-
-              if (concurrencyDecision.debounceUntilMs !== null) {
-                await this._submitConcurrency.waitForTimestamp(
-                  concurrencyDecision.debounceUntilMs
-                );
-
-                if (this._turnQueue.generation !== epoch) {
-                  this._completeSkippedRequest(connection, chatMessageId);
-                  return;
-                }
-
-                if (
-                  this._submitConcurrency.isSuperseded(
-                    concurrencyDecision.submitSequence
-                  )
-                ) {
-                  this._completeSkippedRequest(connection, chatMessageId);
-                  return;
-                }
-              }
-
-              // Re-merge inside the lock: more overlapping submits may have
-              // persisted additional user messages while this turn was queued.
               if (concurrencyDecision.strategy === "merge") {
                 await this._mergeQueuedUserMessages(epoch);
-
-                if (this._turnQueue.generation !== epoch) {
-                  this._completeSkippedRequest(connection, chatMessageId);
-                  return;
-                }
-
+              }
+            } finally {
+              releasePendingEnqueue();
+            }
+            await this._runExclusiveChatTurn(
+              chatMessageId,
+              async () => {
                 if (
                   this._submitConcurrency.isSuperseded(
                     concurrencyDecision.submitSequence
@@ -983,106 +956,155 @@ export class AIChatAgent<
                   this._completeSkippedRequest(connection, chatMessageId);
                   return;
                 }
-              }
 
-              // Optionally wait for in-flight MCP connections to settle (e.g. after hibernation restore)
-              // so that getAITools() returns the full set of tools in onChatMessage
-              if (this.waitForMcpConnections) {
-                const timeout =
-                  typeof this.waitForMcpConnections === "object"
-                    ? this.waitForMcpConnections.timeout
-                    : undefined;
-                await this.mcp.waitForConnections(
-                  timeout != null ? { timeout } : undefined
-                );
-              }
+                if (concurrencyDecision.debounceUntilMs !== null) {
+                  await this._submitConcurrency.waitForTimestamp(
+                    concurrencyDecision.debounceUntilMs
+                  );
 
-              this._setRequestContext(requestClientTools, requestBody);
+                  if (this._turnQueue.generation !== epoch) {
+                    this._completeSkippedRequest(connection, chatMessageId);
+                    return;
+                  }
 
-              this._emit("message:request");
+                  if (
+                    this._submitConcurrency.isSuperseded(
+                      concurrencyDecision.submitSequence
+                    )
+                  ) {
+                    this._completeSkippedRequest(connection, chatMessageId);
+                    return;
+                  }
+                }
 
-              const abortSignal = this._abortRegistry.getSignal(chatMessageId);
+                // Re-merge inside the lock: more overlapping submits may have
+                // persisted additional user messages while this turn was queued.
+                if (concurrencyDecision.strategy === "merge") {
+                  await this._mergeQueuedUserMessages(epoch);
 
-              return this._tryCatchChat(async () => {
-                // Wrap in agentContext.run() to propagate connection context to onChatMessage
-                // This ensures getCurrentAgent() returns the connection inside tool execute functions
-                return agentContext.run(
-                  {
-                    agent: this,
-                    connection,
-                    request: undefined,
-                    email: undefined
-                  },
-                  async () => {
-                    const chatTurnBody = async () => {
-                      try {
-                        await this._repairInterruptedToolsBeforeTurn();
-                        const response = await this.onChatMessage(
-                          async (_finishResult) => {
-                            // User-provided hook. Cleanup is now handled by _reply,
-                            // so this is optional for the user to pass to streamText.
-                          },
-                          {
-                            requestId: chatMessageId,
-                            abortSignal,
-                            clientTools: requestClientTools,
-                            body: requestBody,
-                            continuation: false
-                          }
-                        );
+                  if (this._turnQueue.generation !== epoch) {
+                    this._completeSkippedRequest(connection, chatMessageId);
+                    return;
+                  }
 
-                        if (response) {
-                          await this._reply(
-                            chatMessageId,
-                            response,
-                            [connection.id],
+                  if (
+                    this._submitConcurrency.isSuperseded(
+                      concurrencyDecision.submitSequence
+                    )
+                  ) {
+                    this._completeSkippedRequest(connection, chatMessageId);
+                    return;
+                  }
+                }
+
+                // Optionally wait for in-flight MCP connections to settle (e.g. after hibernation restore)
+                // so that getAITools() returns the full set of tools in onChatMessage
+                if (this.waitForMcpConnections) {
+                  const timeout =
+                    typeof this.waitForMcpConnections === "object"
+                      ? this.waitForMcpConnections.timeout
+                      : undefined;
+                  await this.mcp.waitForConnections(
+                    timeout != null ? { timeout } : undefined
+                  );
+                }
+
+                this._setRequestContext(requestClientTools, requestBody);
+
+                this._emit("message:request");
+
+                const abortSignal =
+                  this._abortRegistry.getSignal(chatMessageId);
+
+                return this._tryCatchChat(async () => {
+                  // Wrap in agentContext.run() to propagate connection context to onChatMessage
+                  // This ensures getCurrentAgent() returns the connection inside tool execute functions
+                  return agentContext.run(
+                    {
+                      agent: this,
+                      connection,
+                      request: undefined,
+                      email: undefined
+                    },
+                    async () => {
+                      const chatTurnBody = async () => {
+                        try {
+                          await this._repairInterruptedToolsBeforeTurn();
+                          const response = await this.onChatMessage(
+                            async (_finishResult) => {
+                              // User-provided hook. Cleanup is now handled by _reply,
+                              // so this is optional for the user to pass to streamText.
+                            },
                             {
-                              chatMessageId
+                              requestId: chatMessageId,
+                              abortSignal,
+                              clientTools: requestClientTools,
+                              body: requestBody,
+                              continuation: false
                             }
                           );
-                        } else {
-                          console.warn(
-                            `[AIChatAgent] onChatMessage returned no response for chatMessageId: ${chatMessageId}`
-                          );
-                          this._broadcastChatMessage(
-                            {
-                              body: "No response was generated by the agent.",
-                              done: true,
-                              id: chatMessageId,
-                              type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
-                            },
-                            [connection.id]
-                          );
-                        }
-                      } finally {
-                        this._abortRegistry.remove(chatMessageId);
-                        // Release any pre-stream parked connections (#1784).
-                        // A no-op when the turn streamed (they were flushed into
-                        // STREAM_RESUMING on _startStream); covers the
-                        // no-response / pre-stream-throw paths.
-                        this._settlePreStreamTurn(chatMessageId);
-                      }
-                    };
 
-                    if (this.chatRecovery) {
-                      await this._runChatRecoveryFiber(
-                        chatMessageId,
-                        false,
-                        chatTurnBody
-                      );
-                    } else {
-                      await chatTurnBody();
+                          if (response) {
+                            await this._reply(
+                              chatMessageId,
+                              response,
+                              [connection.id],
+                              {
+                                chatMessageId
+                              }
+                            );
+                          } else {
+                            console.warn(
+                              `[AIChatAgent] onChatMessage returned no response for chatMessageId: ${chatMessageId}`
+                            );
+                            this._broadcastChatMessage(
+                              {
+                                body: "No response was generated by the agent.",
+                                done: true,
+                                id: chatMessageId,
+                                type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
+                              },
+                              [connection.id]
+                            );
+                          }
+                        } finally {
+                          this._abortRegistry.remove(chatMessageId);
+                          // Settle the pre-stream turn on the normal path (#1784):
+                          // a no-op release when the turn streamed (already flushed
+                          // into STREAM_RESUMING on _startStream) or a release on
+                          // the no-response path. A throw BEFORE chatTurnBody runs
+                          // is caught by the outer finally instead.
+                          this._settlePreStreamTurn(chatMessageId);
+                        }
+                      };
+
+                      if (this.chatRecovery) {
+                        await this._runChatRecoveryFiber(
+                          chatMessageId,
+                          false,
+                          chatTurnBody
+                        );
+                      } else {
+                        await chatTurnBody();
+                      }
                     }
-                  }
-                );
-              });
-            },
-            {
-              epoch,
-              onStale: () =>
-                this._completeSkippedRequest(connection, chatMessageId)
-            }
-          );
+                  );
+                });
+              },
+              {
+                epoch,
+                onStale: () =>
+                  this._completeSkippedRequest(connection, chatMessageId)
+              }
+            );
+          } finally {
+            // Guaranteed settle (#1784): on the happy path chatTurnBody /
+            // _completeSkippedRequest already settled (idempotent here); this
+            // covers a throw in a pre-turn-body step before chatTurnBody's
+            // finally could run.
+            this._settlePreStreamTurn(chatMessageId);
+          }
+          return;
         }
 
         // Handle clear chat

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -58,6 +58,7 @@ import {
 import { MAX_BOUND_PARAMS, buildInClauseStrings } from "agents/chat";
 import {
   ContinuationState,
+  PreStreamTurns,
   AutoContinuationController,
   AbortRegistry,
   TIMED_OUT,
@@ -452,6 +453,23 @@ export class AIChatAgent<
    * connections awaiting a continuation stream to start.
    */
   private _continuation = new ContinuationState<Connection>();
+
+  /**
+   * Accepted-but-not-yet-streamed turns and the connections parked waiting for
+   * one (#1784). Lets a client that reconnects/re-mounts during a turn's
+   * pre-stream window (queue, MCP wait, model latency) keep waiting instead of
+   * giving up — see the {@link ResumeHandshake} `preStream` seam.
+   *
+   * HIBERNATION INVARIANT: this is in-memory only and is NOT persisted. It is
+   * safe precisely because the pre-stream window cannot overlap hibernation: a
+   * turn between `begin()` and `_startStream()` is an unresolved `onMessage`
+   * handler promise (queue/debounce/MCP/model awaits) that pins the DO in
+   * memory, so the DO is only evicted once the turn either recorded a durable
+   * stream (resumed via `ResumableStream` on wake) or finished. This breaks if a
+   * pre-stream wait is ever moved onto a durable alarm that releases the DO; if
+   * that changes, this state must become durable.
+   */
+  private _preStream = new PreStreamTurns<Connection>();
   private _agentToolForwarders = new Map<
     string,
     Set<(chunk: AgentToolStoredChunk) => void>
@@ -767,6 +785,11 @@ export class AIChatAgent<
       // Notify client about active streams that can be resumed
       if (this._resumableStream.hasActiveStream()) {
         this._notifyStreamResuming(connection);
+      } else if (this._preStream.park(connection)) {
+        // A turn is accepted but its stream hasn't started yet (#1784): park
+        // this connection and tell it to keep waiting. `park` sent the
+        // keep-waiting frame; the turn flushes it into STREAM_RESUMING on
+        // _startStream or releases it with STREAM_RESUME_NONE on settle.
       } else {
         // No active stream to resume: if a recovery is in progress (between
         // attempts — the interrupted stream ended and the continuation hasn't
@@ -796,6 +819,7 @@ export class AIChatAgent<
       // Clean up pending resume state for this connection
       this._pendingResumeConnections.delete(connection.id);
       this._continuation.releaseConnection(connection.id);
+      this._preStream.release(connection.id);
       // Call consumer's onClose
       return _onClose(connection, code, reason, wasClean);
     };
@@ -875,6 +899,12 @@ export class AIChatAgent<
           // so a stale exhaustion can't replay on a later reconnect once the
           // user has moved on.
           await this._clearChatTerminal();
+
+          // Mark this turn as accepted-but-not-yet-streamed (#1784) so a client
+          // that reconnects/re-mounts before the stream starts is parked and
+          // told to keep waiting (see _resumeHandshake / onConnect), then
+          // flushed into STREAM_RESUMING on _startStream or released on settle.
+          this._preStream.begin(chatMessageId);
 
           // Track that this request is past the concurrency decision but
           // not yet enqueued in _turnQueue. Decremented synchronously
@@ -1026,6 +1056,11 @@ export class AIChatAgent<
                         }
                       } finally {
                         this._abortRegistry.remove(chatMessageId);
+                        // Release any pre-stream parked connections (#1784).
+                        // A no-op when the turn streamed (they were flushed into
+                        // STREAM_RESUMING on _startStream); covers the
+                        // no-response / pre-stream-throw paths.
+                        this._settlePreStreamTurn(chatMessageId);
                       }
                     };
 
@@ -1060,6 +1095,8 @@ export class AIChatAgent<
           await this._clearChatTerminal();
           this._resumableStream.clearAll();
           this._pendingResumeConnections.clear();
+          this._preStream.releaseAwaiting();
+          this._preStream.reset();
           this._lastClientTools = undefined;
           this._lastBody = undefined;
           this._persistRequestContext();
@@ -1267,9 +1304,13 @@ export class AIChatAgent<
       responseMessageType: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
       resumableStream: this._resumableStream,
       continuation: this._continuation,
+      preStream: this._preStream,
       pendingResumeConnections: this._pendingResumeConnections,
       pendingChatTerminal: () => this._pendingChatTerminal(),
-      persistOrphanedStream: (streamId) => this._persistOrphanedStream(streamId)
+      persistOrphanedStream: (streamId) =>
+        this._persistOrphanedStream(streamId),
+      isConnectionPresent: (connectionId) =>
+        this._isConnectionPresent(connectionId)
     }));
   }
 
@@ -1304,6 +1345,12 @@ export class AIChatAgent<
     options: { messageId?: string; continuation?: boolean } = {}
   ): string {
     const streamId = this._resumableStream.start(requestId, options);
+    // Flush connections parked during this turn's pre-stream window (#1784)
+    // into the normal STREAM_RESUMING path now that a stream exists. Safe for
+    // every turn — the awaiting set is empty unless a client reconnected before
+    // the first chunk. (Continuation-turn parks live in `_continuation` and are
+    // flushed below.)
+    this._preStream.flushOnStreamStart((c) => this._notifyStreamResuming(c));
     if (this._continuation.pending?.requestId === requestId) {
       this._continuation.activatePending();
       this._flushAwaitingStreamStartConnections();
@@ -1999,6 +2046,40 @@ export class AIChatAgent<
       id: requestId,
       type: MessageType.CF_AGENT_USE_CHAT_RESPONSE
     });
+    // A skipped turn settles out of the pre-stream set, but must NOT release
+    // parked connections (#1784): a skip happens because a NEWER turn was
+    // admitted (latest/merge supersede) or the queue generation advanced. The
+    // earliest "successor exists" signal (`SubmitConcurrencyController.decide`)
+    // fires before the successor's `_preStream.begin()`, so releasing here would
+    // race a `begin()` that hasn't run yet and cut a parked client loose right
+    // before the successor streams. Leave it parked: the successor flushes it on
+    // `_startStream`, or the final surviving turn's settle releases it. (Chat
+    // clear releases parked connections explicitly via `resetTurnState`.)
+    this._settlePreStreamTurn(requestId, { releaseParked: false });
+  }
+
+  /** Whether a connection with this id is still attached. */
+  private _isConnectionPresent(connectionId: string): boolean {
+    return this.getConnection(connectionId) !== undefined;
+  }
+
+  /**
+   * Mark an accepted turn (#1784) as settled. When `releaseParked` (the default)
+   * and no accepted turn remains in flight and no stream is active, release every
+   * parked connection with STREAM_RESUME_NONE so a client that reconnected during
+   * the pre-stream window stops waiting. A no-op when the parked set was already
+   * flushed on stream start. Skip paths pass `releaseParked: false` so a parked
+   * client survives onto the successor turn (see `_completeSkippedRequest`).
+   */
+  private _settlePreStreamTurn(
+    requestId: string,
+    options: { releaseParked?: boolean } = {}
+  ): void {
+    const idle = this._preStream.settle(requestId);
+    const releaseParked = options.releaseParked ?? true;
+    if (releaseParked && idle && !this._resumableStream.hasActiveStream()) {
+      this._preStream.releaseAwaiting();
+    }
   }
 
   private _rollbackDroppedSubmit(connection: Connection) {
@@ -2156,6 +2237,8 @@ export class AIChatAgent<
     this._streamingTurnActive = false;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();
+    this._preStream.releaseAwaiting();
+    this._preStream.reset();
     this._pendingChatResponseResults.length = 0;
   }
 

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -6542,3 +6542,169 @@ describe("useAgentChat overlapping submits (issue #1231)", () => {
       .toHaveTextContent("user,user");
   });
 });
+
+describe("useAgentChat transparent reconnect re-probe (#1784)", () => {
+  function createAgentWithTarget({ name, url }: { name: string; url: string }) {
+    const target = new EventTarget();
+    const sentMessages: string[] = [];
+    const agent = createAgent({
+      name,
+      url,
+      send: (data: string) => sentMessages.push(data)
+    });
+    (agent as unknown as Record<string, unknown>).addEventListener =
+      target.addEventListener.bind(target);
+    (agent as unknown as Record<string, unknown>).removeEventListener =
+      target.removeEventListener.bind(target);
+    return { agent, target, sentMessages };
+  }
+
+  function dispatch(target: EventTarget, data: Record<string, unknown>) {
+    target.dispatchEvent(
+      new MessageEvent("message", { data: JSON.stringify(data) })
+    );
+  }
+
+  const RESUME_REQUEST = "cf_agent_stream_resume_request";
+
+  it("re-probes the stream on a SUBSEQUENT socket open, but not the first", async () => {
+    const { agent, target, sentMessages } = createAgentWithTarget({
+      name: "reconnect-reprobe",
+      url: "ws://localhost:3000/agents/chat/reconnect-reprobe?_pk=abc"
+    });
+
+    const resumeRequests = () =>
+      sentMessages.filter(
+        (m) => (JSON.parse(m) as { type?: string }).type === RESUME_REQUEST
+      ).length;
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        resume: true
+      });
+      return <div data-testid="status">{chat.status}</div>;
+    };
+
+    await act(async () => {
+      render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(20);
+    });
+
+    // Settle any mount-time resume probe so the transport is no longer awaiting.
+    await act(async () => {
+      dispatch(target, { type: "cf_agent_stream_resume_none" });
+      await sleep(20);
+    });
+
+    const baseline = resumeRequests();
+
+    // First "open" is treated as the initial connect — no re-probe.
+    await act(async () => {
+      target.dispatchEvent(new Event("open"));
+      await sleep(20);
+    });
+    expect(resumeRequests()).toBe(baseline);
+
+    // A SUBSEQUENT open is a transparent reconnect (e.g. 1006) that does NOT
+    // remount the component → the hook must re-probe so AI SDK status recovers.
+    await act(async () => {
+      target.dispatchEvent(new Event("open"));
+      await sleep(20);
+    });
+    expect(resumeRequests()).toBe(baseline + 1);
+  });
+
+  it("keeps the resume probe alive on STREAM_PENDING and still resolves a later STREAM_RESUMING", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { agent, target, sentMessages } = createAgentWithTarget({
+      name: "stream-pending-keepalive",
+      url: "ws://localhost:3000/agents/chat/stream-pending-keepalive?_pk=abc"
+    });
+
+    const sentTypes = () =>
+      sentMessages.map((m) => (JSON.parse(m) as { type?: string }).type);
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        resume: true
+      });
+      return <div data-testid="status">{chat.status}</div>;
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(20);
+      return screen;
+    });
+
+    // Server says "accepted, not streaming yet" — the probe must NOT resolve to
+    // "no stream" and must keep waiting.
+    await act(async () => {
+      dispatch(target, { type: "cf_agent_stream_pending", id: "pending-1" });
+      await sleep(20);
+    });
+    // A pending frame must not produce an ACK or a RESUME_NONE-driven teardown.
+    expect(sentTypes()).not.toContain("cf_agent_stream_resume_ack");
+
+    // The stream finally starts; the still-open probe resolves into the normal
+    // resume handshake (ACK + replay).
+    await act(async () => {
+      dispatch(target, { type: "cf_agent_stream_resuming", id: "pending-1" });
+      await sleep(10);
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "pending-1",
+        body: '{"type":"text-start","id":"t1"}',
+        done: false
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "pending-1",
+        body: '{"type":"text-delta","id":"t1","delta":"Hello"}',
+        done: false
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("streaming");
+    expect(sentTypes()).toContain("cf_agent_stream_resume_ack");
+
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: "pending-1",
+        body: "",
+        done: true
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("ready");
+    expect(sawActiveResponseError(consoleErrorSpy)).toBe(false);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/ai-chat/src/tests/pre-stream-resume.test.ts
+++ b/packages/ai-chat/src/tests/pre-stream-resume.test.ts
@@ -1,0 +1,233 @@
+import { env } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+import { getAgentByName } from "agents";
+import { MessageType, type OutgoingMessage } from "../types";
+import { connectChatWS } from "./test-utils";
+
+/**
+ * Integration coverage for the pre-stream resume window (#1784): a turn is
+ * accepted (`_preStream.begin`) but its resumable stream has not started yet
+ * (here, `SlowStreamAgent`'s `responseDelayMs` holds `onChatMessage` before it
+ * returns a response). A client that connects or sends a resume request in that
+ * window must be told to KEEP WAITING (`STREAM_PENDING`) rather than "nothing to
+ * resume" (`STREAM_RESUME_NONE`), then flushed into `STREAM_RESUMING` once the
+ * stream actually starts.
+ *
+ * Runs inside the Workers runtime against the real `AIChatAgent` so the whole
+ * server path (chat-request accept → begin → onConnect/handleResumeRequest park
+ * → _startStream flush) is exercised end to end.
+ */
+
+function hasType(m: unknown, type: string): boolean {
+  return typeof m === "object" && m !== null && "type" in m && m.type === type;
+}
+
+function collectMessages(ws: WebSocket): OutgoingMessage[] {
+  const messages: OutgoingMessage[] = [];
+  ws.addEventListener("message", (e: MessageEvent) => {
+    try {
+      messages.push(JSON.parse(e.data as string) as OutgoingMessage);
+    } catch {
+      // ignore non-JSON
+    }
+  });
+  return messages;
+}
+
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 4000,
+  intervalMs = 25
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await condition())) {
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+function sendChatRequest(
+  ws: WebSocket,
+  requestId: string,
+  extraBody: Record<string, unknown>
+) {
+  ws.send(
+    JSON.stringify({
+      type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+      id: requestId,
+      init: {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "u1",
+              role: "user",
+              parts: [{ type: "text", text: "hi" }]
+            }
+          ],
+          ...extraBody
+        })
+      }
+    })
+  );
+}
+
+describe("Pre-stream resume window (#1784)", () => {
+  it("onConnect during the pre-stream window parks the client with STREAM_PENDING, then STREAM_RESUMING when the stream starts", async () => {
+    const room = crypto.randomUUID();
+    const { ws: ws1 } = await connectChatWS(
+      `/agents/slow-stream-agent/${room}`
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    // Accept a turn whose stream is delayed ~1s — the pre-stream window.
+    const requestId = "req-pre-stream-connect";
+    sendChatRequest(ws1, requestId, {
+      responseDelayMs: 1000,
+      chunkCount: 1,
+      chunkDelayMs: 10
+    });
+
+    // Barrier: onChatMessage has entered (pushes the id) and is now delaying,
+    // so the turn is accepted but no stream exists yet.
+    await waitFor(async () => {
+      const started = (await agentStub.getStartedRequestIds()) as string[];
+      return started.includes(requestId);
+    });
+
+    // A NEW connection joins mid pre-stream window.
+    const { ws: ws2 } = await connectChatWS(
+      `/agents/slow-stream-agent/${room}`
+    );
+    const messages2 = collectMessages(ws2);
+
+    // It should be told to keep waiting (STREAM_PENDING), never "nothing".
+    await waitFor(() =>
+      messages2.some((m) => hasType(m, MessageType.CF_AGENT_STREAM_PENDING))
+    );
+    expect(
+      messages2.some((m) => hasType(m, MessageType.CF_AGENT_STREAM_RESUME_NONE))
+    ).toBe(false);
+
+    // Once the delay elapses and the stream starts, the parked connection is
+    // flushed into the normal resume handshake.
+    await waitFor(
+      () =>
+        messages2.some((m) => hasType(m, MessageType.CF_AGENT_STREAM_RESUMING)),
+      4000
+    );
+
+    ws1.close(1000);
+    ws2.close(1000);
+  });
+
+  it("a resume request during the pre-stream window gets STREAM_PENDING (not RESUME_NONE)", async () => {
+    const room = crypto.randomUUID();
+    const { ws: ws1 } = await connectChatWS(
+      `/agents/slow-stream-agent/${room}`
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(env.SlowStreamAgent, room);
+
+    const requestId = "req-pre-stream-request";
+    sendChatRequest(ws1, requestId, {
+      responseDelayMs: 1000,
+      chunkCount: 1,
+      chunkDelayMs: 10
+    });
+
+    await waitFor(async () => {
+      const started = (await agentStub.getStartedRequestIds()) as string[];
+      return started.includes(requestId);
+    });
+
+    const { ws: ws2 } = await connectChatWS(
+      `/agents/slow-stream-agent/${room}`
+    );
+    const messages2 = collectMessages(ws2);
+    await new Promise((r) => setTimeout(r, 30));
+
+    ws2.send(
+      JSON.stringify({ type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST })
+    );
+
+    await waitFor(() =>
+      messages2.some((m) => hasType(m, MessageType.CF_AGENT_STREAM_PENDING))
+    );
+    expect(
+      messages2.some((m) => hasType(m, MessageType.CF_AGENT_STREAM_RESUME_NONE))
+    ).toBe(false);
+
+    ws1.close(1000);
+    ws2.close(1000);
+  });
+
+  it("keeps a client parked across overlapping submits until a turn streams, never cutting it loose early (#1784)", async () => {
+    const room = crypto.randomUUID();
+    const { ws: ws1 } = await connectChatWS(
+      `/agents/latest-message-concurrency-agent/${room}`
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    const agentStub = await getAgentByName(
+      env.LatestMessageConcurrencyAgent,
+      room
+    );
+
+    // First submit is accepted and delays in the pre-stream window.
+    const firstId = "req-first";
+    sendChatRequest(ws1, firstId, {
+      responseDelayMs: 1000,
+      chunkCount: 1,
+      chunkDelayMs: 10
+    });
+    await waitFor(async () => {
+      const started = (await agentStub.getStartedRequestIds()) as string[];
+      return started.includes(firstId);
+    });
+
+    // A client connects and parks while a turn is in flight pre-stream.
+    const { ws: ws2 } = await connectChatWS(
+      `/agents/latest-message-concurrency-agent/${room}`
+    );
+    const messages2 = collectMessages(ws2);
+    await waitFor(() =>
+      messages2.some((m) => hasType(m, MessageType.CF_AGENT_STREAM_PENDING))
+    );
+
+    // A second overlapping submit lands while the first is still pre-stream.
+    // Whatever the concurrency policy decides, the parked client must resume
+    // onto whichever turn actually streams — it must NOT receive a premature
+    // STREAM_RESUME_NONE while a turn is still in flight (the supersede/settle
+    // race the `releaseParked: false` skip-path guard closes).
+    sendChatRequest(ws1, "req-second", {
+      responseDelayMs: 10,
+      chunkCount: 1,
+      chunkDelayMs: 10
+    });
+
+    await waitFor(
+      () =>
+        messages2.some((m) => hasType(m, MessageType.CF_AGENT_STREAM_RESUMING)),
+      4000
+    );
+
+    // The parked client went straight from PENDING to RESUMING: no spurious
+    // "nothing to resume" was emitted while turns were still in flight.
+    const firstResuming = messages2.findIndex((m) =>
+      hasType(m, MessageType.CF_AGENT_STREAM_RESUMING)
+    );
+    const resumeNoneBeforeResuming = messages2
+      .slice(0, firstResuming)
+      .some((m) => hasType(m, MessageType.CF_AGENT_STREAM_RESUME_NONE));
+    expect(resumeNoneBeforeResuming).toBe(false);
+
+    ws1.close(1000);
+    ws2.close(1000);
+  });
+});

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -1005,3 +1005,114 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(activeRequestIds.has("req-full")).toBe(false);
   });
 });
+
+describe("WebSocketChatTransport STREAM_PENDING keep-waiting (#1784)", () => {
+  let agent: ReturnType<typeof createMockAgent>;
+  let activeRequestIds: Set<string>;
+  let transport: WebSocketChatTransport<ChatMessage>;
+
+  beforeEach(() => {
+    agent = createMockAgent();
+    activeRequestIds = new Set();
+    transport = new WebSocketChatTransport<ChatMessage>({
+      agent,
+      activeRequestIds
+    });
+  });
+
+  it("handleStreamPending returns false when no resume is pending", () => {
+    expect(transport.handleStreamPending()).toBe(false);
+  });
+
+  it("extends the short probe timeout: a pending turn does not resolve null at 5s", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = transport.reconnectToStream({ chatId: "chat-1" });
+
+      // Server says "accepted, not streaming yet".
+      expect(transport.handleStreamPending()).toBe(true);
+
+      // The original 5s probe window passes — must NOT resolve yet.
+      vi.advanceTimersByTime(5001);
+      let settled = false;
+      void promise.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      // A later STREAM_RESUMING still resolves with a live stream.
+      transport.handleStreamResuming({ id: "req-pending" });
+      const stream = await promise;
+      expect(stream).toBeInstanceOf(ReadableStream);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still resolves null at the extended backstop if the server never follows up", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = transport.reconnectToStream({ chatId: "chat-1" });
+      expect(transport.handleStreamPending()).toBe(true);
+
+      // Past the short window but before the backstop: still waiting.
+      vi.advanceTimersByTime(5001);
+      // Past the 60s backstop: degrade to null rather than hang forever.
+      vi.advanceTimersByTime(60000);
+
+      const result = await promise;
+      expect(result).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a STREAM_RESUME_NONE after a pending frame still resolves null immediately", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+    expect(transport.handleStreamPending()).toBe(true);
+    expect(transport.handleStreamResumeNone()).toBe(true);
+
+    const result = await promise;
+    expect(result).toBeNull();
+  });
+
+  it("clears the keep-waiting hook once resolved", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+    transport.handleStreamResuming({ id: "req-x" });
+    await promise;
+
+    expect(transport.handleStreamPending()).toBe(false);
+  });
+
+  it("extends the tool-continuation probe window too", async () => {
+    vi.useFakeTimers();
+    try {
+      transport.expectToolContinuation();
+      const stream = (await transport.reconnectToStream({
+        chatId: "chat-1"
+      })) as ReadableStream<UIMessageChunk>;
+      const reader = stream.getReader();
+
+      expect(transport.handleStreamPending()).toBe(true);
+
+      // The 5s window passes without closing the (deferred) stream.
+      vi.advanceTimersByTime(5001);
+
+      // STREAM_RESUMING then completes the handshake and the stream flows.
+      expect(transport.handleStreamResuming({ id: "req-cont" })).toBe(true);
+      agent.dispatch({
+        type: MessageType.CF_AGENT_USE_CHAT_RESPONSE,
+        id: "req-cont",
+        body: '{"type":"text-start","id":"t1"}',
+        done: false
+      });
+      await expect(reader.read()).resolves.toEqual({
+        done: false,
+        value: { type: "text-start", id: "t1" }
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -146,6 +146,7 @@ import {
   cleanupStreamBuffers,
   STREAM_CLEANUP_DELAY_SECONDS,
   ContinuationState,
+  PreStreamTurns,
   AutoContinuationController,
   TIMED_OUT,
   awaitWithDeadline,
@@ -3237,6 +3238,18 @@ export class Think<
   private _lastClientTools: ClientToolSchema[] | undefined;
   private _lastBody: Record<string, unknown> | undefined;
   private _continuation = new ContinuationState<Connection>();
+  /**
+   * Accepted-but-not-yet-streamed turns and the connections parked waiting for
+   * one (#1784). See {@link ResumeHandshake} `preStream`.
+   *
+   * HIBERNATION INVARIANT: in-memory only, NOT persisted. Safe because the
+   * pre-stream window cannot overlap hibernation — a turn between `begin()` and
+   * stream start is an unresolved `onMessage` handler promise that pins the DO,
+   * so eviction only happens once a durable stream exists (resumed via
+   * `ResumableStream`) or the turn finished. Breaks if a pre-stream wait is ever
+   * moved onto a durable alarm that releases the DO; if so, persist this state.
+   */
+  private _preStream = new PreStreamTurns<Connection>();
   // Shared auto-continuation barrier (#1649 / #1650): owns the coalesce timer
   // and the double-fire guard. Parameterized by this agent's stream-active
   // signal, apply-drain, and continuation-turn pipeline (`_fireAutoContinuation`).
@@ -9756,6 +9769,12 @@ export class Think<
         // until the stream finishes.
         this._notifyStreamResuming(connection);
       } else {
+        // No active stream. If a turn is accepted but its stream hasn't started
+        // yet (#1784), park this connection and tell it to keep waiting (`park`
+        // sends the keep-waiting frame; no-op otherwise). Either way send the
+        // idle-connect transcript so the client renders the user message it
+        // just submitted while it waits for the stream to begin.
+        this._preStream.park(connection);
         for (const message of await this._buildIdleConnectMessages()) {
           connection.send(JSON.stringify(message));
         }
@@ -9772,6 +9791,7 @@ export class Think<
     ) => {
       this._pendingResumeConnections.delete(connection.id);
       this._continuation.releaseConnection(connection.id);
+      this._preStream.release(connection.id);
       return _onClose(connection, code, reason, wasClean);
     };
 
@@ -9966,6 +9986,12 @@ export class Think<
     // has already moved on. Completion clears it too, but only once the turn
     // resolves — which leaves the gap open.
     await this._clearChatTerminal();
+
+    // Mark this turn as accepted-but-not-yet-streamed (#1784) so a client that
+    // reconnects/re-mounts before the stream starts is parked and told to keep
+    // waiting (see _resumeHandshake / onConnect), then flushed into
+    // STREAM_RESUMING on _startResumableStream or released on settle.
+    this._preStream.begin(requestId);
 
     const releasePendingEnqueue = this._submitConcurrency.beginEnqueue();
     let pendingEnqueue = true;
@@ -10219,6 +10245,10 @@ export class Think<
     } finally {
       releaseIfPending();
       this._aborts.remove(requestId);
+      // Release any pre-stream parked connections (#1784). No-op when the turn
+      // streamed (flushed on _startResumableStream); covers the no-response /
+      // pre-stream-failure paths.
+      this._settlePreStreamTurn(requestId);
     }
   }
 
@@ -10257,6 +10287,8 @@ export class Think<
     this._streamingAssistant = null;
     this._continuation.sendResumeNone();
     this._continuation.clearAll();
+    this._preStream.releaseAwaiting();
+    this._preStream.reset();
   }
 
   /**
@@ -13579,6 +13611,35 @@ export class Think<
         done: true
       })
     );
+    // A skipped turn settles out of the pre-stream set, but must NOT release
+    // parked connections (#1784): a skip happens because a NEWER turn was
+    // admitted (latest/merge supersede) or the queue generation advanced. The
+    // earliest "successor exists" signal (`SubmitConcurrencyController.decide`)
+    // fires before the successor's `_preStream.begin()`, so releasing here would
+    // race a `begin()` that hasn't run yet and cut a parked client loose right
+    // before the successor streams. Leave it parked: the successor flushes it on
+    // stream start, or the final surviving turn's settle releases it. (Chat
+    // clear releases parked connections explicitly via `resetTurnState`.)
+    this._settlePreStreamTurn(requestId, { releaseParked: false });
+  }
+
+  /**
+   * Mark an accepted turn (#1784) as settled. When `releaseParked` (the default)
+   * and no accepted turn remains in flight and no stream is active, release every
+   * connection parked on the pre-stream window with STREAM_RESUME_NONE. No-op once
+   * they were flushed into STREAM_RESUMING on stream start. Skip paths pass
+   * `releaseParked: false` so a parked client survives onto the successor turn
+   * (see `_completeSkippedRequest`).
+   */
+  private _settlePreStreamTurn(
+    requestId: string,
+    options: { releaseParked?: boolean } = {}
+  ): void {
+    const idle = this._preStream.settle(requestId);
+    const releaseParked = options.releaseParked ?? true;
+    if (releaseParked && idle && !this._resumableStream.hasActiveStream()) {
+      this._preStream.releaseAwaiting();
+    }
   }
 
   private _rollbackDroppedSubmit(connection: Connection): void {
@@ -14023,9 +14084,13 @@ export class Think<
       responseMessageType: MSG_CHAT_RESPONSE,
       resumableStream: this._resumableStream,
       continuation: this._continuation,
+      preStream: this._preStream,
       pendingResumeConnections: this._pendingResumeConnections,
       pendingChatTerminal: () => this._pendingChatTerminal(),
-      persistOrphanedStream: (streamId) => this._persistOrphanedStream(streamId)
+      persistOrphanedStream: (streamId) =>
+        this._persistOrphanedStream(streamId),
+      isConnectionPresent: (connectionId) =>
+        this.getConnection(connectionId) !== undefined
     }));
   }
 
@@ -14058,6 +14123,11 @@ export class Think<
     options?: { messageId?: string }
   ): string {
     const streamId = this._resumableStream.start(requestId, options);
+    // Flush connections parked during this turn's pre-stream window (#1784)
+    // into STREAM_RESUMING now that a stream exists. No-op unless a client
+    // reconnected before the first chunk. (Continuation-turn parks live in
+    // `_continuation` and are flushed by the caller.)
+    this._preStream.flushOnStreamStart((c) => this._notifyStreamResuming(c));
     void this._ensureStreamCleanupScheduled();
     return streamId;
   }


### PR DESCRIPTION
## Summary

Fixes #1784. A chat turn spends a window between **"request accepted"** and **"first chunk produced"** in neither the active-stream nor terminal-replay state — it is queued, debouncing, waiting on `waitForMcpConnections`, or running async setup inside `onChatMessage` before a stream object exists. A client that **reconnected or re-mounted in that window** was answered with `cf_agent_stream_resume_none` and gave up, so the turn the server went on to stream never drove the client's AI SDK `status`. The UI stayed stuck at `ready` until a full remount.

This represents that window as resumable, adds a "keep waiting" signal, and makes the client recover `status` on transparent reconnects.

### Server (`agents/chat`)
- **`PreStreamTurns`** (`pre-stream-turns.ts`): a shared tracker for accepted-but-not-yet-streamed turns and the connections parked waiting on them. Pure data + send-through-callback, mirroring `ContinuationState`.
- **`cf_agent_stream_pending`** frame (protocol + wire-types + golden builder): server→client "accepted, not streaming yet".
- **`ResumeHandshake`** now parks resume requests that arrive during the pre-stream window and emits `STREAM_PENDING` instead of `RESUME_NONE`, then flushes parked connections into the normal `STREAM_RESUMING` handshake on stream start. Continuation affinity is relaxed via an optional `isConnectionPresent` host hook so a transparent reconnect (whose connection id changed) can resume a continuation whose original owner connection is gone.

### Client
- **`ws-chat-transport`**: `handleStreamPending()` extends the resume probe from the 5s fast path to a 60s backstop so the probe stays open across the gap.
- **`useAgentChat`**: re-probes the stream on a transparent socket reopen (e.g. a 1006 reconnect that does not remount the component) so `status` recovers.

### Hosts
- Wired the begin/park/flush/settle lifecycle into both `AIChatAgent` and `@cloudflare/think`.
- Skipped turns (supersede / queue generation change) settle **without** releasing parked connections (`releaseParked: false`), so a client parked during the window survives onto the successor turn instead of being cut loose by a premature `RESUME_NONE` in the supersede/settle microtask race.

## Hibernation

`PreStreamTurns` is in-memory only and is **hibernation-safe by construction**: a turn between `begin()` and stream start is an unresolved message-handler promise that pins the Durable Object in memory, so eviction only happens once a stream is durably recorded (and resumes via `ResumableStream` on wake) or the turn has finished. Documented as an invariant on each `_preStream` field. The only thing that would break it is moving a pre-stream wait onto a durable alarm that releases the DO — called out in the comment.

## Test plan

- [x] Unit (`agents/chat`): `PreStreamTurns` incl. the skip-path "stay parked for the successor" contract; handshake park/pending/flush/affinity; golden `STREAM_PENDING` frame.
- [x] Transport (`ai-chat`): `STREAM_PENDING` keep-waiting timeout extension, incl. the tool-continuation path.
- [x] Integration (workers runtime, real `AIChatAgent`): onConnect/resume-request park -> `pending` -> `resuming`; parked client survives overlapping submits with no premature `RESUME_NONE`.
- [x] React hook (`ai-chat`): transparent reconnect re-probe (first open suppressed, subsequent open re-probes) + `STREAM_PENDING` keepalive resolving a later `STREAM_RESUMING`.
- [x] Full suites pass: ai-chat 707, agents/chat 493, think workers 825, ai-chat react 81, think react 5.
- [x] `pnpm run check` (sherif, exports, oxfmt, oxlint, typecheck across 113 projects).
- [x] Changeset added (`patch` for `agents`, `@cloudflare/ai-chat`, `@cloudflare/think`).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->