### PR TITLE
test(chat-recovery): cover mid-tool-input interruption recovery (#1781)

### DIFF
--- a/packages/ai-chat/src/tests/chat-recovery.test.ts
+++ b/packages/ai-chat/src/tests/chat-recovery.test.ts
@@ -949,4 +949,88 @@ describe("chatRecovery", () => {
       ws.close(1000);
     });
   });
+
+  // Reproduction for #1781: a turn interrupted mid-tool-input (the trailing
+  // persisted assistant part is a tool call still in `input-streaming` — input
+  // never finalized, tool never dispatched). The "continue" strategy has no
+  // resumption point for a non-finalized tool call; recovery must instead repair
+  // the dead orphan and regenerate, rather than spinning to a stable-timeout.
+  describe("recovery from a mid-tool-input interruption (#1781)", () => {
+    it("repairs the input-streaming orphan and regenerates instead of exhausting", async () => {
+      const room = crypto.randomUUID();
+      const stub = (await getAgentByName(
+        env.ChatRecoveryTestAgent,
+        room
+      )) as unknown as ChatTestStub;
+
+      // The interrupted stream ends ON a tool call still in `input-streaming`:
+      // `tool-input-start` (+ a partial `tool-input-delta`) with NO
+      // `tool-input-available` — the model began emitting a tool-use block but
+      // never finished streaming its input, so the call was never finalized or
+      // executed.
+      await stub.insertInterruptedStream("stream-mid", "req-mid", [
+        {
+          body: JSON.stringify({ type: "start", messageId: "a-mid" }),
+          index: 0
+        },
+        { body: JSON.stringify({ type: "text-start" }), index: 1 },
+        {
+          body: JSON.stringify({
+            type: "text-delta",
+            delta: "Let me write that file"
+          }),
+          index: 2
+        },
+        {
+          body: JSON.stringify({
+            type: "tool-input-start",
+            toolCallId: "tc-mid",
+            toolName: "writeFile"
+          }),
+          index: 3
+        },
+        {
+          body: JSON.stringify({
+            type: "tool-input-delta",
+            toolCallId: "tc-mid",
+            inputTextDelta: '{"path":"ou'
+          }),
+          index: 4
+        }
+      ]);
+      await stub.insertInterruptedFiber("__cf_internal_chat_turn:req-mid");
+
+      await stub.triggerFiberRecovery();
+      await stub.waitForIdleForTest();
+
+      // Progress was made: the continuation re-ran inference and produced new
+      // tokens (NOT zero-progress → stable-timeout, the #1781 symptom).
+      expect(await stub.getOnChatMessageCallCount()).toBe(1);
+
+      const messages = await stub.getPersistedMessages();
+      const assistantMsgs = messages.filter((m) => m.role === "assistant");
+      expect(assistantMsgs).toHaveLength(1);
+      expect(extractAssistantText(messages)).toContain("Continued response.");
+
+      // The non-finalized tool call is no longer dangling in `input-streaming`:
+      // it has a settled (errored) result so the next provider call cannot 400.
+      const toolPart = assistantMsgs[0]?.parts?.find((p) => {
+        const part = p as { type?: unknown; toolCallId?: unknown };
+        return (
+          typeof part.type === "string" &&
+          part.type.startsWith("tool-") &&
+          part.toolCallId === "tc-mid"
+        );
+      }) as { state?: string } | undefined;
+      expect(toolPart).toBeDefined();
+      expect(toolPart?.state).not.toBe("input-streaming");
+
+      // The turn settled — the incident did not dead-end on a stable-timeout.
+      const incidents = await stub.getChatRecoveryIncidentsForTest();
+      expect(incidents.every((i) => i.status !== "exhausted")).toBe(true);
+
+      const fibers = await stub.getActiveFibers();
+      expect(fibers).toHaveLength(0);
+    });
+  });
 });

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3441,6 +3441,129 @@ describe("Think — onChatRecovery", () => {
     );
   });
 
+  // Reproduction for #1781: a turn interrupted mid-tool-input (the trailing
+  // persisted assistant part is a tool call still in `input-streaming` — input
+  // never finalized, tool never dispatched). The "continue" strategy has no
+  // resumption point for a non-finalized tool call; recovery must instead repair
+  // the dead orphan and regenerate, rather than spinning to a stable-timeout.
+  it("repairs an input-streaming orphan on recovery and regenerates (#1781)", async () => {
+    const agent = await freshRecoveryAgent(
+      `mid-tool-input-${crypto.randomUUID()}`
+    );
+
+    await agent.persistTestMessage({
+      id: "u-mid",
+      role: "user",
+      parts: [{ type: "text", text: "Write that file" }]
+    });
+    // The durable state at interruption: the assistant message ends ON a tool
+    // call still in `input-streaming` — the model began emitting a tool-use
+    // block but never finished streaming its input (no `tool-input-available`),
+    // so the call was never finalized or executed.
+    await agent.persistTestMessage({
+      id: "a-mid",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Let me write that file" },
+        {
+          type: "tool-writeFile",
+          toolCallId: "tc-mid",
+          state: "input-streaming",
+          input: undefined
+        } as unknown as UIMessage["parts"][number]
+      ]
+    });
+
+    await agent.insertInterruptedStream("stream-mid", "req-mid", [
+      {
+        body: JSON.stringify({ type: "start", messageId: "a-mid" }),
+        index: 0
+      },
+      { body: JSON.stringify({ type: "text-start" }), index: 1 },
+      {
+        body: JSON.stringify({
+          type: "text-delta",
+          delta: "Let me write that file"
+        }),
+        index: 2
+      },
+      {
+        body: JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "tc-mid",
+          toolName: "writeFile"
+        }),
+        index: 3
+      },
+      {
+        body: JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "tc-mid",
+          inputTextDelta: '{"path":"ou'
+        }),
+        index: 4
+      }
+    ]);
+    await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-mid", {
+      __cfThinkChatFiberSnapshot: {
+        kind: "think-chat-turn",
+        version: 1,
+        requestId: "req-mid",
+        continuation: false,
+        latestMessageId: "a-mid",
+        latestMessageRole: "assistant",
+        latestUserMessageId: "u-mid",
+        startedAt: Date.now()
+      },
+      user: null
+    });
+
+    await agent.triggerFiberRecovery();
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
+    ).toBe(1);
+    await agent.runScheduledRecoveryContinueForTest();
+
+    // Progress was made: the continuation re-ran inference and produced new
+    // tokens (NOT zero-progress → stable-timeout, the #1781 symptom).
+    expect(await agent.getTurnCallCount()).toBe(1);
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    // The regenerated step produced new tokens (Think appends a fresh assistant
+    // message for the new step rather than merging, but either way the turn
+    // advanced — not the #1781 zero-progress stall).
+    const allAssistantText = messages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => m.parts)
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    expect(allAssistantText).toContain("Continued response.");
+
+    // The non-finalized tool call is no longer dangling in `input-streaming`:
+    // it has a settled (errored) result so the next provider call cannot 400.
+    const toolPart = messages
+      .flatMap((m) => m.parts)
+      .find((p) => {
+        const part = p as { type?: unknown; toolCallId?: unknown };
+        return (
+          typeof part.type === "string" &&
+          part.type.startsWith("tool-") &&
+          part.toolCallId === "tc-mid"
+        );
+      }) as { state?: string } | undefined;
+    expect(toolPart).toBeDefined();
+    expect(toolPart?.state).not.toBe("input-streaming");
+
+    // The turn settled — the incident did not dead-end on a stable-timeout.
+    const incidents = (await agent.getChatRecoveryIncidentsForTest()) as Array<{
+      status: string;
+    }>;
+    expect(incidents.every((i) => i.status !== "exhausted")).toBe(true);
+
+    expect(await agent.getActiveFibers()).toHaveLength(0);
+  });
+
   it("{ continue: false } persists but does not schedule continuation", async () => {
     const agent = await freshRecoveryAgent("no-continue");
 


### PR DESCRIPTION
## Summary

Regression coverage for [#1781](https://github.com/cloudflare/agents/issues/1781): recovering a turn that was interrupted while the trailing persisted assistant part is a tool call still in `input-streaming` — the model began emitting a tool-use block but never finished streaming its input, so the call was never finalized or dispatched.

The issue reported that the `continue` recovery strategy has no resumption point for a non-finalized tool call, so it yields zero new tokens, is judged "no progress", and exhausts to a stable-timeout. Investigating current `main`, this is **already mitigated**: before re-entering inference, both hosts run the shared `repairInterruptedToolParts` primitive, which flips the dead `input-streaming` orphan to a settled (errored) result, and the turn regenerates normally. `input-streaming` also never trips `hasPendingClientInteraction`/`hasPendingInteraction`, so it doesn't park or burn the budget.

These tests lock in that behavior so a future change can't silently reintroduce the dead-end.

- **ai-chat** (`chat-recovery.test.ts`): inject an interrupted stream ending on `tool-input-start` + partial `tool-input-delta` (no `tool-input-available`), trigger fiber recovery, and assert the continuation re-runs inference (`Continued response.`), the `input-streaming` orphan is repaired to a non-`input-streaming` state, and no incident reaches `exhausted`.
- **think** (`think-session.test.ts`): mirrored scenario through Think's recovery-continue path. Think repairs the orphan in place and appends a fresh step for the regenerated tokens (vs. ai-chat's merge), but the #1781 invariants hold identically via the same shared primitive.

No production code changes — test-only.

## Test plan

- [x] `vitest run src/tests/chat-recovery.test.ts` (ai-chat) — 83 passed
- [x] `vitest --run -c src/tests/vitest.config.ts src/tests/think-session.test.ts -t onChatRecovery` (think) — 65 passed
- [x] oxfmt + oxlint clean on both files

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->