### PR TITLE
fix(chat): don't reorder terminal HITL snapshots with a later assistant (#1778)

### DIFF
--- a/.changeset/chat-protected-assistant-terminal-snapshot.md
+++ b/.changeset/chat-protected-assistant-terminal-snapshot.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix `useAgentChat` reordering a terminal/authoritative `CF_AGENT_CHAT_MESSAGES` snapshot when a protected streaming assistant is followed by a later assistant message (#1778). The protected-tail merge is still applied for stale mid-stream snapshots, but when the incoming snapshot already contains the protected assistant followed by a newer assistant (e.g. a Think HITL denial that persists the denied tool message and then appends a follow-up assistant response), protection is cleared and the snapshot is rendered in its authoritative order instead of moving the protected assistant to the end.

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -1244,6 +1244,28 @@ export function useAgentChat<
         return [...messages];
       }
 
+      // If the incoming snapshot already contains the protected assistant AND a
+      // later assistant message, the server transcript has advanced past the
+      // message we were protecting — the snapshot is terminal/authoritative
+      // (e.g. a Think HITL denial persisted the denied tool message, then
+      // appended a follow-up assistant response explaining the denial).
+      // Appending our protected copy to the tail would reorder the transcript
+      // (#1778). Clear protection and trust the snapshot as-is; if a stream is
+      // still active for the newer assistant it re-arms protection via its own
+      // `start` chunk.
+      const protectedIndex = messages.findIndex(
+        (message) => message.id === protection.assistantId
+      );
+      if (
+        protectedIndex >= 0 &&
+        messages
+          .slice(protectedIndex + 1)
+          .some((message) => message.role === "assistant")
+      ) {
+        protectedStreamingAssistantRef.current = null;
+        return [...messages];
+      }
+
       const protectedAssistant =
         messagesRef.current.find(
           (message) => message.id === protection.assistantId

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -6541,6 +6541,134 @@ describe("useAgentChat overlapping submits (issue #1231)", () => {
       .element(screen.getByTestId("role-order"))
       .toHaveTextContent("user,user");
   });
+
+  it("does not reorder a terminal snapshot that already has a later assistant (#1778)", async () => {
+    // Think HITL denial flow: the streaming assistant emits a tool that needs
+    // approval, so the turn pauses WITHOUT a `done` chunk and protection stays
+    // armed to that assistant. The user denies, and the server persists the
+    // denied tool message then appends a follow-up assistant response. Think
+    // broadcasts the full authoritative `cf_agent_chat_messages` snapshot
+    // (user, assistant-with-denied-tool, assistant-terminal-response). The
+    // protected-tail merge must NOT move the denied assistant to the end.
+    const { agent, target, sentMessages } = createAgentWithTarget({
+      name: "terminal-snapshot-order",
+      url: "ws://localhost:3000/agents/chat/terminal-snapshot-order?_pk=abc"
+    });
+
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        resume: false
+      });
+      chatInstance = chat;
+
+      return (
+        <div>
+          <div data-testid="role-order">
+            {chat.messages.map((m) => m.role).join(",")}
+          </div>
+          <div data-testid="ids">
+            {chat.messages.map((m) => m.id).join(",")}
+          </div>
+        </div>
+      );
+    };
+
+    const screen = await act(async () => {
+      const screen = render(<TestComponent />, {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </StrictMode>
+        )
+      });
+      await sleep(10);
+      return screen;
+    });
+
+    await act(async () => {
+      chatInstance!.sendMessage({ text: "delete everything" });
+      await sleep(10);
+    });
+
+    const reqId = sentMessages
+      .map((m) => JSON.parse(m) as Record<string, unknown>)
+      .find((m) => m.type === "cf_agent_use_chat_request")?.id;
+
+    // Stream the assistant that carries the tool requiring approval. The turn
+    // pauses for the approval, so there is intentionally NO `done` chunk here —
+    // protection remains armed to `assistant-denied`.
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: reqId,
+        body: '{"type":"start","messageId":"assistant-denied"}',
+        done: false
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: reqId,
+        body: '{"type":"text-start","id":"t1"}',
+        done: false
+      });
+      dispatch(target, {
+        type: "cf_agent_use_chat_response",
+        id: reqId,
+        body: '{"type":"text-delta","id":"t1","delta":"About to run a dangerous tool"}',
+        done: false
+      });
+      await sleep(10);
+    });
+
+    await expect
+      .element(screen.getByTestId("role-order"))
+      .toHaveTextContent("user,assistant");
+
+    const user1 = chatInstance!.messages.find((m) => m.role === "user")!;
+
+    // Authoritative snapshot after the user denies: the denied assistant is
+    // followed by a NEW terminal assistant explaining the denial.
+    await act(async () => {
+      dispatch(target, {
+        type: "cf_agent_chat_messages",
+        messages: [
+          user1,
+          {
+            id: "assistant-denied",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-runDangerousThing",
+                toolCallId: "tc-1",
+                state: "output-error",
+                input: { command: "rm -rf /" },
+                errorText: "Denied by user"
+              }
+            ]
+          },
+          {
+            id: "assistant-terminal",
+            role: "assistant",
+            parts: [{ type: "text", text: "I won't run that — it was denied." }]
+          }
+        ]
+      });
+      await sleep(10);
+    });
+
+    // The transcript order must match the authoritative snapshot exactly, NOT
+    // move the protected (denied) assistant to the tail.
+    await expect
+      .element(screen.getByTestId("role-order"))
+      .toHaveTextContent("user,assistant,assistant");
+    await expect
+      .element(screen.getByTestId("ids"))
+      .toHaveTextContent(`${user1.id},assistant-denied,assistant-terminal`);
+  });
 });
 
 describe("useAgentChat transparent reconnect re-probe (#1784)", () => {


### PR DESCRIPTION
## Summary

Fixes #1778. `useAgentChat` (`agents/chat/react`, re-exported by `@cloudflare/ai-chat/react` and `@cloudflare/think`) could **reorder messages** when a protected streaming assistant was merged over a terminal/authoritative `CF_AGENT_CHAT_MESSAGES` snapshot that already contained a *later* assistant message.

Expected server snapshot order:

```
user
assistant-with-denied-tool
assistant-terminal-response
```

Buggy client render:

```
user
assistant-terminal-response
assistant-with-denied-tool
```

This is most visible in **Think HITL approval/denial flows**: after a user denies a tool approval, the server persists the denied tool message and then appends a follow-up assistant response explaining the denial. The client should treat that full snapshot as authoritative instead of moving the denied assistant to the end.

## Root cause

`preserveProtectedStreamingAssistant()` unconditionally filtered the protected assistant out of the incoming snapshot and re-appended it to the tail:

```ts
return [
  ...messages.filter((message) => message.id !== protection.assistantId),
  protectedAssistant
];
```

That tail merge is correct while a snapshot is **stale relative to an active stream** (the streaming assistant is genuinely the newest message, so it must stay last and keep its live parts/tool cards). It is incorrect once the snapshot is **terminal/authoritative** and the protected assistant is no longer the newest message.

### Why protection stays armed across the denial

1. The streaming assistant emits a tool requiring approval. Protection arms to it via the non-continuation `start` chunk. The turn then **pauses for approval without a `done` chunk**, so `restoreProtectedStreamingAssistant` never fires — protection stays armed.
2. The user denies. The follow-up assistant streams as a `continuation: true` stream, and the `start`-chunk re-arm is deliberately skipped for continuations — so protection *remains* on the denied assistant.
3. Think broadcasts the authoritative snapshot `[user, assistant-denied, assistant-terminal]`, and the tail merge moves `assistant-denied` to the end.

## Fix

Before the tail merge, detect the terminal case: the incoming snapshot contains the protected assistant **and** a later message with `role === "assistant"`. When true, clear protection and return the snapshot unchanged. A still-active stream for the newer assistant re-arms protection via its own `start` chunk.

```ts
const protectedIndex = messages.findIndex(
  (message) => message.id === protection.assistantId
);
if (
  protectedIndex >= 0 &&
  messages.slice(protectedIndex + 1).some((m) => m.role === "assistant")
) {
  protectedStreamingAssistantRef.current = null;
  return [...messages];
}
```

### Edge cases considered

- **Later *user* message (the "second submit mid-stream" case)** — intentionally not matched. There the temporary move-to-end is correct and is undone later by the anchor-based `restoreProtectedStreamingAssistant`. The fix is scoped to a later *assistant*, which is the real "server has advanced" signal.
- **Protected assistant only in local state, not in the snapshot** (`protectedIndex < 0`) — falls through to the original append (correct for a not-yet-persisted turn).
- **Losing live parts** — if a later assistant exists, the protected one is finalized server-side, so the snapshot copy is complete.
- **Double-move on a later `done`** — after clearing, `restoreProtectedStreamingAssistant` sees `null` and no-ops.
- **Cross-tab observer path** — the observed-accumulator re-merge runs only while `observing` and targets the currently observed (follow-up) assistant; unaffected.

## Test plan

- [x] Added a hook-level regression test (`does not reorder a terminal snapshot that already has a later assistant (#1778)`) that mirrors the HITL denial flow (arm protection via a `start` chunk with no `done`, then deliver the authoritative snapshot with a later assistant). Verified it **fails on `main`** (`...,assistant-terminal,assistant-denied`) and **passes with the fix**.
- [x] `@cloudflare/ai-chat` react suite: 82/82 pass.
- [x] `@cloudflare/think` react suite: 5/5 pass.
- [x] Existing protection / overlapping-submits suite (issue #1231): 9/9 pass.
- [x] Lint + format clean; changeset added (`agents` patch).

> Note: the React tests resolve `agents/chat/react` from `dist`, so the `agents` package must be built before running them locally (`pnpm exec nx run agents:build`). CI builds before testing.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->