### PR TITLE
fix(codemode): extend default dynamic worker timeout

### DIFF
--- a/.changeset/tender-owls-execute-longer.md
+++ b/.changeset/tender-owls-execute-longer.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Increase the default DynamicWorkerExecutor timeout from 30 seconds to 60 seconds to better support longer-running codemode executions.

--- a/docs/codemode.md
+++ b/docs/codemode.md
@@ -370,7 +370,7 @@ Executes code in an isolated Cloudflare Worker via `WorkerLoader`.
 | Option           | Type              | Default  | Description                                                  |
 | ---------------- | ----------------- | -------- | ------------------------------------------------------------ |
 | `loader`         | `WorkerLoader`    | required | Worker Loader binding from `env.LOADER`                      |
-| `timeout`        | `number`          | `30000`  | Execution timeout in ms                                      |
+| `timeout`        | `number`          | `60000`  | Execution timeout in ms                                      |
 | `globalOutbound` | `Fetcher \| null` | `null`   | Network access control. `null` = blocked, `Fetcher` = routed |
 
 ### `IframeSandboxExecutor`
@@ -413,7 +413,7 @@ sanitizeToolName("delete"); // "delete_"
 - Code runs in **isolated Worker sandboxes** — each execution gets its own Worker instance
 - External network access (`fetch`, `connect`) is **blocked by default** at the runtime level
 - Tool calls are dispatched via Workers RPC, not network requests
-- Execution has a configurable **timeout** (default 30 seconds)
+- Execution has a configurable **timeout** (default 60 seconds)
 - Console output is captured separately and does not leak to the host
 - Browser iframe execution runs in a sandboxed iframe with a restrictive CSP by
   default. It uses nonce-scoped internal messages, but its timeout cannot preempt

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -533,7 +533,7 @@ class NodeVMExecutor implements Executor {
 | Option           | Type                     | Default  | Description                                                  |
 | ---------------- | ------------------------ | -------- | ------------------------------------------------------------ |
 | `loader`         | `WorkerLoader`           | required | Worker Loader binding from `env.LOADER`                      |
-| `timeout`        | `number`                 | `30000`  | Execution timeout in ms                                      |
+| `timeout`        | `number`                 | `60000`  | Execution timeout in ms                                      |
 | `globalOutbound` | `Fetcher \| null`        | `null`   | Network access control. `null` = blocked, `Fetcher` = routed |
 | `modules`        | `Record<string, string>` | `{}`     | Extra modules importable in the sandbox                      |
 

--- a/packages/codemode/src/executor.ts
+++ b/packages/codemode/src/executor.ts
@@ -159,10 +159,12 @@ export class ToolDispatcher extends RpcTarget {
 
 // ── DynamicWorkerExecutor ─────────────────────────────────────────────
 
+const DEFAULT_DYNAMIC_WORKER_EXECUTION_TIMEOUT_MS = 60_000;
+
 export interface DynamicWorkerExecutorOptions {
   loader: WorkerLoader;
   /**
-   * Timeout in milliseconds for code execution. Defaults to 30000 (30s).
+   * Timeout in milliseconds for code execution. Defaults to 60000 (60s).
    */
   timeout?: number;
   /**
@@ -216,7 +218,8 @@ export class DynamicWorkerExecutor implements Executor {
 
   constructor(options: DynamicWorkerExecutorOptions) {
     this.#loader = options.loader;
-    this.#timeout = options.timeout ?? 30000;
+    this.#timeout =
+      options.timeout ?? DEFAULT_DYNAMIC_WORKER_EXECUTION_TIMEOUT_MS;
     this.#globalOutbound = options.globalOutbound ?? null;
     const { "executor.js": _, ...safeModules } = options.modules ?? {};
     this.#modules = safeModules;


### PR DESCRIPTION
## Summary
- increase the default DynamicWorkerExecutor timeout from 30 seconds to 60 seconds
- update codemode docs/README default timeout references
- add a patch changeset for @cloudflare/codemode

## Verification
- pnpm exec nx run @cloudflare/codemode:build
- pnpm exec oxfmt --check packages/codemode/src/executor.ts packages/codemode/README.md docs/codemode.md .changeset/tender-owls-execute-longer.md
- pnpm exec oxlint packages/codemode/src/executor.ts
- deployed a throwaway production Worker using this branch's local @cloudflare/codemode build and verified DynamicWorkerExecutor worked fine through the 60-second default window:
  - curl /sleep?ms=59000
  - response: ok=true, wallTimeMs=59009, result.sleptMs=59000

Note: no example changes are included in this PR; the deployment smoke check used a separate throwaway Worker, which has since been deleted.