### PR TITLE
Use real Workers resources in browser tools tests

### DIFF
--- a/packages/think/src/tests/browser-tools.test.ts
+++ b/packages/think/src/tests/browser-tools.test.ts
@@ -1,89 +1,59 @@
+import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
-import { createBrowserRuntime, createBrowserTools } from "../tools/browser";
+import type { BrowserToolsHost } from "./worker";
 
-// Shape-only tests: nothing here executes against the facet, storage, or the
-// browser binding — those paths are exercised by the agents browser e2e
-// suite. The facet stub satisfies the runtime's eager `ctx.facets.get`, and
-// the export mirrors a Worker entry that re-exports CodemodeRuntime.
-const fakeCtx = {
-  storage: {},
-  facets: { get: () => ({}) },
-  exports: { CodemodeRuntime: class MockCodemodeRuntime {} }
-} as unknown as DurableObjectState;
+function host() {
+  const id = env.BrowserToolsHost.idFromName("browser-tools");
+  return env.BrowserToolsHost.get(id) as DurableObjectStub<BrowserToolsHost>;
+}
 
 describe("createBrowserTools", () => {
-  it("returns browser_execute plus the default Quick Action tools when a binding is present", () => {
-    const tools = createBrowserTools({
-      ctx: fakeCtx,
-      browser: {} as Fetcher,
-      loader: {} as WorkerLoader
-    });
+  it("returns browser_execute plus the default Quick Action tools when a binding is present", async () => {
+    const tools = await host().toolsWithBinding();
 
-    expect(Object.keys(tools).sort()).toEqual([
+    expect(tools.keys).toEqual([
       "browser_execute",
       "browser_extract",
       "browser_links",
       "browser_markdown",
       "browser_scrape"
     ]);
-    expect(typeof tools.browser_execute.execute).toBe("function");
+    expect(tools.hasExecute).toBe(true);
     // The runtime tool description lists the cdp connector namespace.
-    expect(tools.browser_execute.description).toContain("`cdp`");
+    expect(tools.description).toContain("`cdp`");
   });
 
-  it("omits Quick Action tools when quickActions is false", () => {
-    const tools = createBrowserTools({
-      ctx: fakeCtx,
-      browser: {} as Fetcher,
-      loader: {} as WorkerLoader,
-      quickActions: false
+  it("omits Quick Action tools when quickActions is false", async () => {
+    await expect(host().toolsWithoutQuickActions()).resolves.toMatchObject({
+      keys: ["browser_execute"]
     });
-
-    expect(Object.keys(tools)).toEqual(["browser_execute"]);
   });
 
-  it("accepts cdpUrl instead of browser binding (Quick Actions skipped without a binding)", () => {
-    const tools = createBrowserTools({
-      ctx: fakeCtx,
-      cdpUrl: "http://localhost:9222",
-      loader: {} as WorkerLoader
+  it("accepts cdpUrl instead of browser binding (Quick Actions skipped without a binding)", async () => {
+    await expect(host().toolsWithCdpUrl()).resolves.toMatchObject({
+      keys: ["browser_execute"]
     });
-
-    expect(Object.keys(tools)).toEqual(["browser_execute"]);
   });
 
-  it("accepts optional timeout and session mode", () => {
-    const tools = createBrowserTools({
-      ctx: fakeCtx,
-      browser: {} as Fetcher,
-      loader: {} as WorkerLoader,
-      timeout: 60_000,
-      session: { mode: "dynamic" }
+  it("accepts optional timeout and session mode", async () => {
+    await expect(host().toolsWithOptions()).resolves.toMatchObject({
+      keys: expect.arrayContaining(["browser_execute"])
     });
-
-    expect(tools).toHaveProperty("browser_execute");
   });
 
-  it("requires a browser binding or cdpUrl", () => {
-    expect(() =>
-      createBrowserTools({
-        ctx: fakeCtx,
-        loader: {} as WorkerLoader
-      })
-    ).toThrow("must be provided");
+  it("requires a browser binding or cdpUrl", async () => {
+    await expect(host().missingBrowserOrCdpUrlError()).resolves.toContain(
+      "must be provided"
+    );
   });
 
-  it("exposes the runtime handle and connector via createBrowserRuntime", () => {
-    const { runtime, connector, tools } = createBrowserRuntime({
-      ctx: fakeCtx,
-      browser: {} as Fetcher,
-      loader: {} as WorkerLoader
+  it("exposes the runtime handle and connector via createBrowserRuntime", async () => {
+    await expect(host().runtimeShape()).resolves.toEqual({
+      connectorName: "cdp",
+      runtimeApprove: "function",
+      runtimeExpirePaused: "function",
+      connectorSweep: "function",
+      hasExecute: true
     });
-
-    expect(connector.name()).toBe("cdp");
-    expect(typeof runtime.approve).toBe("function");
-    expect(typeof runtime.expirePaused).toBe("function");
-    expect(typeof connector.sweep).toBe("function");
-    expect(tools).toHaveProperty("browser_execute");
   });
 });

--- a/packages/think/src/tests/tsconfig.json
+++ b/packages/think/src/tests/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "agents/tsconfig",
   "compilerOptions": {
     "types": [
-      "@cloudflare/workers-types",
+      "@cloudflare/workers-types/latest",
       "@cloudflare/vitest-pool-workers/types"
     ]
   },

--- a/packages/think/src/tests/worker.ts
+++ b/packages/think/src/tests/worker.ts
@@ -1,4 +1,6 @@
+import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
 import { routeAgentRequest } from "agents";
+import { createBrowserRuntime, createBrowserTools } from "../tools/browser";
 
 export { HostBridgeLoopback } from "../extensions";
 
@@ -75,6 +77,110 @@ import type {
   ThinkMediaEvictionAutoAgent
 } from "./agents";
 
+type BrowserRunTestBinding = Fetcher & {
+  quickAction(action: string, options: unknown): Promise<Response>;
+};
+
+export class TestBrowserRunBinding extends WorkerEntrypoint<Env> {
+  fetch(): Response {
+    return Response.json({ ok: true });
+  }
+
+  quickAction(action: string): Response {
+    const result =
+      action === "links" || action === "scrape" || action === "json" ? [] : "";
+    return Response.json({ success: true, result });
+  }
+}
+
+function browserToolSummary(tools: Record<string, unknown>) {
+  const execute = tools.browser_execute as
+    | { execute?: unknown; description?: string }
+    | undefined;
+  return {
+    keys: Object.keys(tools).sort(),
+    hasExecute: typeof execute?.execute === "function",
+    description: execute?.description ?? ""
+  };
+}
+
+export class BrowserToolsHost extends DurableObject<Env> {
+  #browser(): BrowserRunTestBinding {
+    return this.ctx.exports.TestBrowserRunBinding as BrowserRunTestBinding;
+  }
+
+  toolsWithBinding() {
+    return browserToolSummary(
+      createBrowserTools({
+        ctx: this.ctx,
+        browser: this.#browser(),
+        loader: this.env.LOADER
+      })
+    );
+  }
+
+  toolsWithoutQuickActions() {
+    return browserToolSummary(
+      createBrowserTools({
+        ctx: this.ctx,
+        browser: this.#browser(),
+        loader: this.env.LOADER,
+        quickActions: false
+      })
+    );
+  }
+
+  toolsWithCdpUrl() {
+    return browserToolSummary(
+      createBrowserTools({
+        ctx: this.ctx,
+        cdpUrl: "http://localhost:9222",
+        loader: this.env.LOADER
+      })
+    );
+  }
+
+  toolsWithOptions() {
+    return browserToolSummary(
+      createBrowserTools({
+        ctx: this.ctx,
+        browser: this.#browser(),
+        loader: this.env.LOADER,
+        timeout: 60_000,
+        session: { mode: "dynamic" }
+      })
+    );
+  }
+
+  missingBrowserOrCdpUrlError() {
+    try {
+      createBrowserTools({
+        ctx: this.ctx,
+        loader: this.env.LOADER
+      });
+      return "";
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  runtimeShape() {
+    const { runtime, connector, tools } = createBrowserRuntime({
+      ctx: this.ctx,
+      browser: this.#browser(),
+      loader: this.env.LOADER
+    });
+
+    return {
+      connectorName: connector.name(),
+      runtimeApprove: typeof runtime.approve,
+      runtimeExpirePaused: typeof runtime.expirePaused,
+      connectorSweep: typeof connector.sweep,
+      hasExecute: "browser_execute" in tools
+    };
+  }
+}
+
 export type Env = {
   TestAssistantToolsAgent: DurableObjectNamespace<TestAssistantToolsAgent>;
   TestAssistantAgentAgent: DurableObjectNamespace<TestAssistantAgentAgent>;
@@ -108,6 +214,7 @@ export type Env = {
   ThinkWindowedHydrationAgent: DurableObjectNamespace<ThinkWindowedHydrationAgent>;
   ThinkMediaEvictionAgent: DurableObjectNamespace<ThinkMediaEvictionAgent>;
   ThinkMediaEvictionAutoAgent: DurableObjectNamespace<ThinkMediaEvictionAutoAgent>;
+  BrowserToolsHost: DurableObjectNamespace<BrowserToolsHost>;
   LOADER: WorkerLoader;
 };
 

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -139,6 +139,10 @@
         "class_name": "ThinkMediaEvictionAutoAgent",
         "name": "ThinkMediaEvictionAutoAgent"
       },
+      {
+        "class_name": "BrowserToolsHost",
+        "name": "BrowserToolsHost"
+      },
       // Facet-only class. vitest-pool-workers needs it listed as a binding so
       // a facet-compatible class value resolves; it stays out of
       // new_sqlite_classes below (the host agent owns the SQLite store).
@@ -184,7 +188,8 @@
         "ThinkOnStartHydrationFailureAgent",
         "ThinkWindowedHydrationAgent",
         "ThinkMediaEvictionAgent",
-        "ThinkMediaEvictionAutoAgent"
+        "ThinkMediaEvictionAutoAgent",
+        "BrowserToolsHost"
       ],
       "tag": "v1"
     }


### PR DESCRIPTION
## Summary
- replace the Think browser-tools test's fake DurableObjectState/Fetcher/WorkerLoader with real Workers-pool resources
- add a test-only Durable Object host so `createBrowserTools` runs with real DO ctx, `ctx.exports`, facets, and `env.LOADER`
- add a test-only loopback WorkerEntrypoint to stand in for a Browser Run binding without raw object mocks

## Validation
- `pnpm --filter @cloudflare/think exec vitest --run -c src/tests/vitest.config.ts src/tests/browser-tools.test.ts`
- `pnpm exec nx run @cloudflare/think:test`
- `pnpm --filter @cloudflare/think exec tsc --noEmit`
