### PR TITLE
docs: sync agents SDK docs since 115b3285

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -292,11 +292,151 @@ watching within budget", never as a terminal failure. Only a non-`null`
 inspection with a terminal `status` (`completed` / `error` / `aborted`)
 finalizes a run.
 
+## Report progress and milestones
+
+A sub-agent running as an agent tool — awaited or detached — can report mid-run
+progress so a parent can render a live status line, meter the run server-side, or
+react to a named checkpoint before the run finishes. Call `reportProgress()` from
+inside the child (for example, from a tool's `execute`):
+
+```ts
+export class ImportAgent extends Think<Env> {
+  getTools() {
+    return {
+      ingest: tool({
+        inputSchema: z.object({ url: z.string() }),
+        execute: async ({ url }) => {
+          // Ephemeral progress: drives a generic bar / phase / status line.
+          await this.reportProgress({
+            fraction: 0.6,
+            phase: "ingesting",
+            message: "Ingested 40k/80k rows"
+          });
+          // ...
+        }
+      })
+    };
+  }
+}
+```
+
+`reportProgress()` is available on chat agents (`@cloudflare/think` and
+`AIChatAgent`). It is a no-op with a development warning on the base `Agent`
+class and when called outside an active agent-tool run, so the same child code is
+safe to run standalone. The framework resolves the active run from the current
+turn — you never thread a run id.
+
+```ts
+reportProgress<T>(
+  progress: {
+    fraction?: number; // 0..1 — drives a progress bar
+    message?: string; // human-readable status line
+    phase?: string; // coarse phase label, e.g. "ingesting"
+    milestone?: string; // present ⇒ a durable milestone (see below)
+    data?: T; // app-specific payload; live-only unless persisted
+  },
+  options?: { persist?: boolean }
+): Promise<void>;
+```
+
+Ephemeral signals ride the child's own turn stream as a transient
+`data-agent-progress` part, so they re-broadcast to the parent's connected
+clients and surface on `AgentToolRunState.progress` through `useAgentToolEvents()`
+— a background-runs tray can render a live bar, phase, and status line without
+drilling in. Bursts are coalesced (latest-wins; a `fraction >= 1` frame always
+flushes). The `data` field is live-only unless you pass `{ persist: true }`.
+
+### Observe progress on the parent
+
+Override `onProgress()` to meter, steer, or surface progress server-side. It
+fires best-effort whenever a child progress signal is forwarded through the
+parent, for both awaited and detached runs:
+
+```ts
+export class Assistant extends Think<Env> {
+  override async onProgress(
+    run: AgentToolRunInfo,
+    progress: AgentToolProgressSnapshot
+  ) {
+    if (progress.milestone) {
+      // A durable milestone landed — branch on it.
+    }
+    console.log(run.runId, progress.phase, progress.fraction);
+  }
+}
+```
+
+`onProgress()` is not durable: after eviction a detached run's latest snapshot is
+reconstructed from `inspectAgentToolRun().progress` on reconcile rather than
+re-firing the hook. The latest snapshot is also persisted on the child run row,
+so a rehydrated parent can answer "where is this run" without having tailed the
+live stream.
+
+### Durable milestones
+
+Naming a `milestone` promotes a signal from the ephemeral tier to a **durable**
+one — there is still only one emit method:
+
+```ts
+await this.reportProgress({
+  milestone: "sources-gathered",
+  data: { sources: 2 }
+});
+```
+
+A milestone is persisted as one row on the child with a monotonic per-run
+`sequence`, and rides the stream as a **persisted** `data-agent-milestone` part
+(unlike transient progress). It therefore survives eviction, replays on drill-in,
+and is surfaced — deduped by `sequence` — on `AgentToolRunState.milestones` and
+`inspectAgentToolRun().milestones`. `onProgress()` fires for milestones too, with
+`progress.milestone` set, so a consumer can branch on milestone versus ephemeral
+progress.
+
+### Notify the chat on a milestone (Think / AIChatAgent)
+
+For a detached run on a chat agent, `detached: { onMilestones }` surfaces a chat
+message when a configured milestone lands, _before_ the run finishes. Each
+`(runId, name)` fires at most once — whether observed live or reconciled after
+eviction — so the deterministic id collapses warm and cold delivery to
+at-most-once:
+
+```ts
+// "narrate" (default): inject a synthetic assistant status line — no model turn.
+await this.runAgentTool(Researcher, {
+  input,
+  detached: { onMilestones: ["sources-gathered"] }
+});
+
+// "react": post a user-role turn so the model responds (steer, start dependent
+// work). Costs a model turn.
+await this.runAgentTool(Researcher, {
+  input,
+  detached: { onMilestones: { names: ["needs-approval"], mode: "react" } }
+});
+```
+
+Override `formatDetachedMilestone(run, milestone)` to customize the wording, or
+return an empty string to suppress a given milestone. Synthetic narrate messages
+carry `metadata.source`, so clients can render them as an agent event rather than
+a human turn.
+
+### Resetting no-progress budget for detached runs
+
+Once a detached child has reported at least one signal, the reconcile backbone
+gives up if the run then goes silent for `detachedNoProgressBudgetMs` (default 1
+hour; per-run override via `detached: { noProgressBudgetMs }`). This surfaces as
+`status: "interrupted"`, `reason: "no-progress"`. A child that never reports is
+bounded only by the absolute `detachedMaxBudgetMs` ceiling — a run is never
+given up on merely for being slow. Set `noProgressBudgetMs` to `0` or `Infinity`
+to disable the resetting window for a run.
+
 ## Render child timelines in React
 
 `useAgentToolEvents()` is a headless hook. It subscribes to the existing parent
 connection, deduplicates replay/live races, applies child `UIMessageChunk`
-bodies to message parts, and groups sibling runs by parent tool call id.
+bodies to message parts, and groups sibling runs by parent tool call id. Each
+run state carries `progress` and `milestones`, so a background-runs tray can
+render a live bar, phase, and milestone chips without drilling in.
 
 ```tsx
 import { useAgent, useAgentToolEvents } from "agents/react";

--- a/docs/chat-agents.md
+++ b/docs/chat-agents.md
@@ -878,17 +878,18 @@ function Chat() {
 
 ### Options
 
-| Option                        | Type                                            | Default  | Description                                                                                                              |
-| ----------------------------- | ----------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `agent`                       | `ReturnType<typeof useAgent>`                   | Required | Agent connection from `useAgent`                                                                                         |
-| `onToolCall`                  | `({ toolCall, addToolOutput }) => void`         | —        | Handle client-side tool execution                                                                                        |
-| `autoContinueAfterToolResult` | `boolean`                                       | `true`   | Auto-continue conversation after client tool results and approvals                                                       |
-| `resume`                      | `boolean`                                       | `true`   | Enable automatic stream resumption on reconnect                                                                          |
-| `cancelOnClientAbort`         | `boolean`                                       | `false`  | Cancel the server turn when generic client stream abort/cleanup occurs. Explicit `stop()` always cancels the server turn |
-| `body`                        | `object \| () => object`                        | —        | Custom data sent with every request                                                                                      |
-| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`              | —        | Advanced per-request customization                                                                                       |
-| `tools`                       | `Record<string, AITool>`                        | —        | Dynamic client-defined tools for SDK/platform use cases. Schemas are sent to the server automatically                    |
-| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>` or `null` | —        | Custom initial message loader. Set to `null` to skip the HTTP fetch entirely (useful when providing `messages` directly) |
+| Option                        | Type                                            | Default  | Description                                                                                                                                                                        |
+| ----------------------------- | ----------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                       | `ReturnType<typeof useAgent>`                   | Required | Agent connection from `useAgent`                                                                                                                                                   |
+| `onToolCall`                  | `({ toolCall, addToolOutput }) => void`         | —        | Handle client-side tool execution                                                                                                                                                  |
+| `autoContinueAfterToolResult` | `boolean`                                       | `true`   | Auto-continue conversation after client tool results and approvals                                                                                                                 |
+| `resume`                      | `boolean`                                       | `true`   | Enable automatic stream resumption on reconnect                                                                                                                                    |
+| `cancelOnClientAbort`         | `boolean`                                       | `false`  | Cancel the server turn when generic client stream abort/cleanup occurs. Explicit `stop()` always cancels the server turn                                                           |
+| `body`                        | `object \| () => object`                        | —        | Custom data sent with every request                                                                                                                                                |
+| `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`              | —        | Advanced per-request customization                                                                                                                                                 |
+| `tools`                       | `Record<string, AITool>`                        | —        | Dynamic client-defined tools for SDK/platform use cases. Schemas are sent to the server automatically                                                                              |
+| `getInitialMessages`          | `(options) => Promise<ChatMessage[]>` or `null` | —        | Custom initial message loader. Set to `null` to skip the HTTP fetch entirely (useful when providing `messages` directly)                                                           |
+| `syncMessagesToServer`        | `boolean`                                       | `true`   | When `true`, `setMessages` pushes the transcript to the server. Set to `false` for hosts with server-authoritative transcript storage so `setMessages` updates the local view only |
 
 ### Return Values
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,8 @@ The differentiator is not "we have durable state" — it is what happens when a 
 - [Getting Started](./think/getting-started.md) - Build your first Think agent step by step
 - [Lifecycle Hooks](./think/lifecycle-hooks.md) - `beforeTurn`, `onStepFinish`, `onChunk`, `onChatResponse`, and more
 - [Tools](./think/tools.md) - Workspace tools, code execution, extensions
+- [Actions](./think/actions.md) - Server actions with idempotency, approvals, authorization, and reply attachments
+- [Channels](./think/channels.md) - Per-channel policy, channel selection, and out-of-band notices
 - [Messengers](./think/messengers.md) - Receive and reply to Chat SDK messenger webhooks from Think
 - [Client Tools](./think/client-tools.md) - Browser-side tools, approvals, and concurrency
 - [Sub-agents and Programmatic Turns](./think/sub-agents.md) - RPC streaming, `saveMessages`, recovery

--- a/docs/think/actions.md
+++ b/docs/think/actions.md
@@ -1,0 +1,297 @@
+# Actions
+
+> **Experimental.** The API surface may evolve before Think graduates out of
+> experimental.
+
+Actions are server-side tools with batteries included. Where a plain AI SDK
+`tool()` is just a description, a schema, and an `execute` function, an
+`action()` adds the things that are tedious and dangerous to get right by hand
+for a tool that has real side effects:
+
+- **Idempotency** — a durable ledger replays a settled result by a stable key
+  instead of re-running the side effect on a recovery retry.
+- **Approvals** — gate a call behind a human, either inline (the turn waits) or
+  durably (the turn parks and resumes later, even from a dashboard with no live
+  socket).
+- **Authorization** — declare the permissions a call requires and grant them
+  per-turn.
+- **Reply attachments** — record advisory delivery metadata (a drafted email, a
+  card, a voice note) without changing what the model sees.
+
+Actions compile into Think tools, so the model calls them exactly like any other
+tool. Return them from `getActions()`; Think merges them into the tool set
+alongside `getTools()`, workspace tools, extensions, and MCP tools.
+
+## Define an action
+
+Use the `action()` descriptor factory and return a map of actions from
+`getActions()`. The map key is the tool name the model sees (unless you set
+`name`). The `execute` input type is inferred from `inputSchema`:
+
+```typescript
+import { Think, action } from "@cloudflare/think";
+import { z } from "zod";
+
+export class Support extends Think<Env> {
+  getActions() {
+    return {
+      refundOrder: action({
+        description: "Refund a customer order.",
+        inputSchema: z.object({
+          orderId: z.string(),
+          amountCents: z.number().int().positive()
+        }),
+        execute: async ({ orderId, amountCents }, ctx) => {
+          const result = await refund(orderId, amountCents);
+          return { refundId: result.id, status: result.status };
+        }
+      })
+    };
+  }
+}
+```
+
+The `execute` callback receives the validated input and an `ActionContext`:
+
+```typescript
+type ActionContext = {
+  agent: Think;
+  env: Cloudflare.Env;
+  requestId: string;
+  toolCallId: string;
+  messages: ReadonlyArray<ModelMessage>;
+  signal: AbortSignal; // aborts on turn cancel or after `timeoutMs`
+  attachReply(attachment: ReplyAttachment): void;
+};
+```
+
+The action output is normalized to JSON and truncated before it is shown to the
+model (long outputs are capped). Anything thrown from `execute` becomes a
+structured `{ error: { name, message } }` tool result rather than crashing the
+turn. Each action has a default timeout of 30 seconds; override it per action
+with `timeoutMs`.
+
+### Actions versus plain tools
+
+A plain `tool()` from `getTools()` still works and is the right choice for a
+read-only or trivial tool. Reach for `action()` when a tool has side effects you
+must not run twice, needs human approval, or needs declarative authorization —
+the ledger, approval descriptors, default timeout, and structured error mapping
+only apply to actions.
+
+## Idempotency and the action ledger
+
+When an action declares an `idempotencyKey`, Think records the settled result in
+a durable ledger keyed by `action:<name>:<key>`. If the same key is seen again —
+on a recovery retry, a reconnect, or a duplicate inbound event — Think returns
+the stored result **without** re-running `execute`, so the side effect happens
+at most once on the happy path.
+
+```typescript
+chargeInvoice: action({
+  description: "Charge an invoice.",
+  inputSchema: z.object({ invoiceId: z.string() }),
+  // Use a stable domain identifier — never a timestamp, request id, or random value.
+  idempotencyKey: ({ input }) => `invoice:${input.invoiceId}`,
+  execute: async ({ invoiceId }) => charge(invoiceId)
+});
+```
+
+`idempotencyKey` is a string, or a function `({ input, ctx }) => string`. Choose
+a key that survives recovery retries — an order id, an inbound event id — and
+not a value that changes per attempt. An action with no `idempotencyKey` falls
+back to a per-`toolCallId` key, which only deduplicates within the same tool
+call, not across retries.
+
+### Pending rows and the retry lease
+
+A ledger row is written as `pending` before `execute` runs and flipped to
+`settled` on success (a thrown or timed-out `execute` deletes the row so the
+call can be retried cleanly). If the isolate dies mid-execute, the row is left
+`pending`. By default such a stale row is reclaimed and the action re-run once
+the row is older than `actionLedgerPendingRetryLeaseMs` (default 5 minutes) —
+**but only for actions that declare an explicit `idempotencyKey`**, since that
+key is your assertion that re-running the keyed side effect is safe. A fresh
+pending row (or one without an explicit key) instead returns an
+`ActionPendingError` result so the model does not blindly retry an unknown
+state. Set `actionLedgerPendingRetryLeaseMs = false` to disable reclaim entirely
+and always surface `ActionPendingError` for a stale row.
+
+## Approvals
+
+Gate an action behind a human with `approval`. There are two mechanisms,
+selected by `kind`.
+
+### Approval-gated (the turn waits)
+
+The default when you set `approval` without a `kind`. The action compiles to a
+tool with the AI SDK `needsApproval` flag: the stream pauses with an
+`approval-requested` part, the client approves or rejects, and the turn
+continues inline. `execute` runs only after approval.
+
+```typescript
+deleteAccount: action({
+  description: "Permanently delete a user account.",
+  inputSchema: z.object({ userId: z.string() }),
+  approval: true, // or ({ input }) => input.userId !== currentUser
+  approvalSummary: "Delete an account",
+  approvalRisk: "high",
+  execute: async ({ userId }) => deleteAccount(userId)
+});
+```
+
+`approval` is a boolean or a predicate `({ input, ctx }) => boolean`, so you can
+require approval only for risky inputs. `approvalSummary` and `approvalRisk`
+(`"low" | "medium" | "high"`) populate the approval descriptor your UI renders.
+
+### Durable-pause (the turn parks and resumes later)
+
+Set `kind: "durable-pause"` when approval may take minutes or days and you do not
+want to hold a connection open. The action parks into a durable store and the
+turn ends; `execute` does not run yet. Resume later — from anywhere, including a
+dashboard with no live WebSocket — with `approveExecution()` or
+`rejectExecution()`:
+
+```typescript
+deploy: action({
+  description: "Deploy to production.",
+  inputSchema: z.object({ ref: z.string() }),
+  kind: "durable-pause",
+  approvalSummary: "Deploy to production",
+  approvalRisk: "high",
+  permissions: ["deploy:run"],
+  execute: async ({ ref }) => deploy(ref)
+});
+```
+
+```typescript
+// List everything waiting on a human (cold-load reconciliation):
+const pending = await agent.pendingApprovals();
+// [{ executionId, source: "action" | "codemode", descriptor }]
+
+// Approve or reject by execution id (idempotent — a second call is a no-op):
+await agent.approveExecution(executionId);
+await agent.rejectExecution(executionId, "Not this release");
+```
+
+`approveExecution()` runs `execute` once and auto-continues the turn even if no
+client is connected; `rejectExecution()` resolves the action without running it.
+`pendingApprovals()` merges parked actions and paused Codemode executions, so a
+single approval UI can drive both. (`durable-pause` requires an `approval`
+policy — an action that would never park is rejected at definition time.)
+
+Both approval-gated and durable-pause parts carry a stable
+`ActionApprovalDescriptor` (`{ requestId, toolCallId, action, summary, input,
+permissions, risk, kind }`) so your UI has everything it needs to render the
+prompt.
+
+## Authorization
+
+Declare the permissions an action requires with `permissions`, then grant them
+per turn. By default every turn is fully authorized, so authorization is opt-in.
+
+```typescript
+refundOrder: action({
+  description: "Refund a customer order.",
+  inputSchema: z.object({ orderId: z.string() }),
+  permissions: ["billing:refund"], // or ({ input }) => [...]
+  execute: async ({ orderId }) => refund(orderId)
+});
+```
+
+Override `authorizeTurn()` to decide, once per turn, which permissions are
+granted. Returning a list narrows the grant; any action requiring a permission
+outside the set is denied with a structured `ActionAuthorizationError` (the model
+never calls `execute`):
+
+```typescript
+export class Support extends Think<Env> {
+  override authorizeTurn(ctx: TurnContext): ActionAuthorizationDecision {
+    const role = (ctx.body as { role?: string })?.role;
+    if (role === "admin") return true; // full grant (the default)
+    return { allowed: true, grantedPermissions: ["billing:read"] };
+  }
+}
+```
+
+`authorizeTurn()` returns `true` (full grant), `false` (deny all), or
+`{ allowed, reason?, grantedPermissions? }`. For per-call logic, override
+`authorizeAction(ctx)` instead — it receives the action name, kind, input, and
+required and granted permissions.
+
+## Reply attachments
+
+An action can record advisory delivery metadata for the turn — a drafted email,
+a card, a voice note — with `ctx.attachReply()`. Attachments never change the
+tool output the model sees; they ride alongside the response for your delivery
+layer to render.
+
+```typescript
+draftReply: action({
+  description: "Draft an email reply.",
+  inputSchema: z.object({ to: z.string(), subject: z.string() }),
+  execute: async ({ to, subject }, ctx) => {
+    ctx.attachReply({ type: "email_draft", to: [to], subject });
+    return { drafted: true };
+  }
+});
+```
+
+Read the attachments after the turn from the `onChatResponse()` hook, or from the
+`replyAttachments(requestId?)` getter:
+
+```typescript
+override async onChatResponse(result: ChatResponseResult) {
+  for (const attachment of result.attachments ?? []) {
+    // attachment.type === "email_draft" | "card" | "voice_note" | custom
+  }
+}
+```
+
+Attachments are JSON-normalized and deep-copied on read, capped per turn, and
+discarded if the `execute` that recorded them fails. A ledger replay does not
+re-fire attachments (the side effect already happened), and `attachReply()` is a
+no-op when called from a `permissions`, `approval`, or `idempotencyKey` callback
+— record attachments from `execute`.
+
+A built-in `ReplyAttachment` covers `email_draft`, `card`, and `voice_note`; any
+`{ type: string; ... }` shape is allowed for custom delivery. Override
+[`renderAttachment()`](./channels.md#deliver-out-of-band) to turn an attachment
+into a channel notice.
+
+## Reference
+
+### `action(config)`
+
+| Field             | Type                                                         | Required | Default       | Description                                                                             |
+| ----------------- | ------------------------------------------------------------ | -------- | ------------- | --------------------------------------------------------------------------------------- |
+| `description`     | `string`                                                     | Yes      | —             | Tool description shown to the model.                                                    |
+| `inputSchema`     | `FlexibleSchema` (Zod or AI SDK `jsonSchema`)                | Yes      | —             | Validates and types the `execute` input.                                                |
+| `execute`         | `(input, ctx) => Output \| Promise<Output>`                  | Yes      | —             | The action body. Receives validated input and an `ActionContext`.                       |
+| `name`            | `string`                                                     | No       | map key       | Overrides the tool name.                                                                |
+| `idempotencyKey`  | `string \| ({ input, ctx }) => string`                       | No       | per tool call | Stable key for ledger replay. Use a domain identifier.                                  |
+| `permissions`     | `readonly string[] \| ({ input, ctx }) => readonly string[]` | No       | none          | Permissions this call requires (see Authorization).                                     |
+| `approval`        | `boolean \| ({ input, ctx }) => boolean`                     | No       | none          | Gate the call behind a human.                                                           |
+| `approvalSummary` | `string`                                                     | No       | `description` | Human-readable summary in the approval descriptor.                                      |
+| `approvalRisk`    | `"low" \| "medium" \| "high"`                                | No       | —             | Risk hint in the approval descriptor.                                                   |
+| `kind`            | `"server" \| "approval-gated" \| "durable-pause"`            | No       | inferred      | `approval-gated` when `approval` is set, else `server`; set `durable-pause` explicitly. |
+| `timeoutMs`       | `number`                                                     | No       | `30000`       | Per-action execution timeout (also drives `ctx.signal`).                                |
+
+### Hooks and methods on the agent
+
+| Member                                  | Description                                                                        |
+| --------------------------------------- | ---------------------------------------------------------------------------------- |
+| `getActions()`                          | Return the action descriptors to compile into tools.                               |
+| `authorizeTurn(ctx)`                    | Decide granted permissions once per turn. Defaults to full grant.                  |
+| `authorizeAction(ctx)`                  | Decide authorization per action call. Defaults to checking `authorizeTurn` grants. |
+| `pendingApprovals(executionId?)`        | List parked actions and paused Codemode executions awaiting approval.              |
+| `approveExecution(executionId)`         | Approve a parked execution; runs `execute` and auto-continues the turn.            |
+| `rejectExecution(executionId, reason?)` | Reject a parked execution without running it.                                      |
+| `replyAttachments(requestId?)`          | Read the advisory attachments recorded during a turn.                              |
+| `actionLedgerPendingRetryLeaseMs`       | Stale-pending reclaim window (default `300000`; `false` to disable).               |
+
+## Related
+
+- [Tools](./tools.md) — workspace tools, code execution, and extensions.
+- [Human in the Loop](../human-in-the-loop.md) — the approval flow end to end.
+- [Channels](./channels.md) — deliver attachments and out-of-band notices.

--- a/docs/think/channels.md
+++ b/docs/think/channels.md
@@ -1,0 +1,187 @@
+# Channels
+
+> **Experimental.** The API surface may evolve before Think graduates out of
+> experimental.
+
+A channel is a surface a Think agent talks over: the browser WebSocket, a
+messenger webhook (Telegram, Slack, and so on), voice, or your own custom
+transport. Channels generalize [messengers](./messengers.md) into one vocabulary
+so you can apply per-channel policy (a different system prompt, a narrowed tool
+set, a step cap) and deliver out-of-band notices, regardless of the surface a
+turn arrived on.
+
+Every Think agent always has an implicit `web` channel (the WebSocket chat your
+browser clients use). You declare additional channels — and override the `web`
+policy — with `configureChannels()`. Messengers returned from `getMessengers()`
+are automatically absorbed as `messenger` channels, so existing messenger apps
+keep working unchanged.
+
+## Configure channels
+
+Override `configureChannels()` to return a map of channel id to
+`ChannelDefinition`. The id is how you select the channel on a turn:
+
+```typescript
+import { Think, messengerChannel } from "@cloudflare/think";
+import { telegram } from "@chat-adapter/telegram";
+
+export class Assistant extends Think<Env> {
+  configureChannels() {
+    return {
+      // Override policy for the built-in web channel.
+      web: {
+        kind: "web",
+        ingress: { transport: "websocket" },
+        instructions: "You are chatting in a web app. Use markdown freely."
+      },
+      // A voice channel with tighter limits.
+      voice: {
+        kind: "voice",
+        ingress: { transport: "voice" },
+        instructions: "Keep replies short and speakable. No markdown.",
+        maxTurns: 3
+      },
+      // A messenger channel (Chat SDK webhook).
+      telegram: messengerChannel(
+        telegram({
+          /* adapter config */
+        })
+      )
+    };
+  }
+}
+```
+
+A `ChannelDefinition` has these fields:
+
+| Field          | Type                                                                | Description                                                                         |
+| -------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `kind`         | `"web" \| "messenger" \| "voice" \| "custom"`                       | The surface category.                                                               |
+| `ingress`      | `{ transport: "websocket" \| "voice" }` or a webhook messenger spec | How turns arrive. `messengerChannel()` builds the webhook form for you.             |
+| `instructions` | `string \| (ctx: ChannelContext) => string \| Promise<string>`      | Prepended to the system prompt for turns on this channel.                           |
+| `tools`        | `(all: ToolSet) => ToolSet`                                         | Narrow the assembled tool set for this channel (filter only — it cannot add tools). |
+| `maxTurns`     | `number`                                                            | Per-channel cap on model steps for a turn.                                          |
+| `capabilities` | `ChannelCapabilities`                                               | Surface capabilities (streaming, message editing). Defaulted for `web`.             |
+| `conversation` | messenger conversation mode or resolver                             | Messenger thread routing (see [Messengers](./messengers.md)).                       |
+| `delivery`     | channel delivery policy                                             | Messenger delivery policy.                                                          |
+
+Use the `defineChannels()` helper for type inference, and `messengerChannel()` to
+wrap a Chat SDK adapter definition as a `kind: "messenger"` channel.
+
+### Channel kinds
+
+| Kind        | Ingress                           | Notes                                                                                         |
+| ----------- | --------------------------------- | --------------------------------------------------------------------------------------------- |
+| `web`       | `{ transport: "websocket" }`      | Always present. Declare it in `configureChannels()` only to set policy; you cannot remove it. |
+| `messenger` | webhook (`messengerChannel(...)`) | Fed into the messenger runtime. Equivalent to a `getMessengers()` entry.                      |
+| `voice`     | `{ transport: "voice" }`          | Applies policy and turn context; out-of-band delivery is not yet wired.                       |
+| `custom`    | app-defined                       | For your own transport. Same delivery limitations as `voice` today.                           |
+
+## Per-channel policy
+
+Channel policy is applied as an **overridable default** before
+[`beforeTurn`](./lifecycle-hooks.md) runs, so a `beforeTurn` override still wins:
+
+- `instructions` is prepended to the base system prompt for the turn.
+- `tools` filters the assembled tool set (it can only remove tools — the
+  `getTools()` seam adds them).
+- `maxTurns` caps model steps: `beforeTurn`'s `maxSteps` wins, then the channel
+  `maxTurns`, then the instance `maxSteps` default.
+
+## Select a channel on a turn
+
+Pass `channel` to [`runTurn()`](./index.md#runturn) (or `chat()`) to run a turn
+on a specific channel. The channel id is stamped onto the user message, so a
+continued or recovered turn re-resolves the same channel and re-applies its
+policy:
+
+```typescript
+await this.runTurn({ input: "Read this out loud", channel: "voice" });
+```
+
+Inside a turn, the active channel is available as `this.activeChannel` (a
+`ChannelContext` with `channelId`, `kind`, and messenger details when relevant).
+A turn with no `channel` runs without a channel context and applies no channel
+policy.
+
+## Deliver out of band
+
+`deliverNotice()` sends a message to a channel **without** starting a model turn.
+Use it for status updates ("your import finished") or to surface an action's
+[reply attachment](./actions.md#reply-attachments) — it does not run inference,
+does not enter the turn queue, and is therefore safe to call from inside a tool's
+`execute`:
+
+```typescript
+await this.deliverNotice("Your export is ready to download.");
+
+await this.deliverNotice("Background research finished.", {
+  informModel: true // also record it in the transcript so the next turn knows
+});
+```
+
+```typescript
+type DeliverNoticeOptions = {
+  channel?: string; // defaults to the active turn's channel, else "web"
+  informModel?: boolean; // also write to the model-visible transcript (default false)
+  kind?: "final" | "interim" | "notice" | "command"; // wire tag (default "notice")
+  thread?: string; // required for out-of-turn delivery to a multi-thread messenger
+};
+```
+
+Behavior depends on the target channel:
+
+- **`web`** — the notice is always appended to the transcript (that is its only
+  render path). `informModel` then only controls the phrasing.
+- **`messenger`** — the notice is posted to the provider. Out of turn, pass
+  `thread` to target a conversation. With `informModel: true`, it is also written
+  to the transcript.
+- **`voice` / `custom`** — out-of-turn delivery throws, because these surfaces
+  have no delivery target yet.
+
+Override `renderAttachment(attachment)` to turn an action reply attachment into a
+notice; Think calls it at the end of a turn and delivers the rendered text as a
+trailing `interim` notice. Return `undefined` to skip an attachment type.
+
+## Relationship to messengers
+
+`configureChannels()` wraps `getMessengers()` — it does not replace it. Each
+`getMessengers()` entry becomes a `kind: "messenger"` channel, and everything in
+the [Messengers](./messengers.md) guide (Telegram setup, webhook routing,
+conversation targets, delivery and recovery) continues to apply. A channel id in
+`configureChannels()` that collides with a `getMessengers()` id is an error. Keep
+using `getMessengers()` for messenger-only apps; reach for `configureChannels()`
+when you also want `web`/`voice`/`custom` policy or out-of-band notices.
+
+## Observability
+
+Channel activity is reported on the `channel` observability channel:
+
+```typescript
+import { subscribe } from "agents/observability";
+
+const unsubscribe = subscribe("channel", (event) => {
+  // event.type is one of:
+  //   "channel:resolved"  — a turn resolved a registered channel
+  //   "channel:delivered" — a turn's final reply was delivered
+  //   "notice:delivered"  — deliverNotice() succeeded
+  //   "notice:failed"     — deliverNotice() threw
+});
+```
+
+## Reference
+
+| Member                          | Description                                                                 |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| `configureChannels()`           | Return the channel map. Defaults to `{}` (the implicit `web` channel only). |
+| `deliverNotice(text, options?)` | Send an out-of-band message to a channel with no model turn.                |
+| `activeChannel`                 | The `ChannelContext` for the in-flight turn, or `undefined`.                |
+| `renderAttachment(attachment)`  | Map a reply attachment to channel notice text (or `undefined` to skip).     |
+| `defineChannels(channels)`      | Identity helper for channel-map type inference.                             |
+| `messengerChannel(definition)`  | Wrap a Chat SDK adapter as a `kind: "messenger"` channel.                   |
+
+## Related
+
+- [Messengers](./messengers.md) — Chat SDK webhook setup and delivery in depth.
+- [Actions](./actions.md) — record reply attachments for `renderAttachment()`.
+- [Voice Agents](../voice.md) — real-time speech surfaces.

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -677,8 +677,88 @@ Both Think and [`AIChatAgent`](../chat-agents.md) extend `Agent` and speak the s
 
 ## Choosing a Turn API
 
-Think has several ways to start or continue a turn. Choose based on who is
-driving the work and what the caller needs back.
+Think has several ways to start or continue a turn. They all funnel through one
+public entry point — `runTurn(options)` — and the older methods remain as
+convenience shortcuts.
+
+### `runTurn()`
+
+> **Experimental.** Stable in shape, but may evolve before Think graduates.
+
+`runTurn()` is the unified turn-admission API. One method, three modes, selected
+by `options.mode`:
+
+| Mode               | Use when                                                     | Returns                         | Shortcut for       |
+| ------------------ | ------------------------------------------------------------ | ------------------------------- | ------------------ |
+| `"wait"` (default) | The caller can block until the model response is finished    | `Promise<TurnResult>`           | `saveMessages()`   |
+| `"submit"`         | The caller needs fast, durable acceptance and a later status | `Promise<SubmitMessagesResult>` | `submitMessages()` |
+| `"stream"`         | The caller wants the response streamed to a callback (RPC)   | `Promise<void>`                 | `chat()`           |
+
+The `input` accepts a string, a `UIMessage`, an array of messages, or — in
+`wait` and `stream` modes — a function `(current) => UIMessage[]` evaluated at
+admission. (`submit` does not accept function input.)
+
+```typescript
+// wait — block for the result
+const result = await this.runTurn({ input: "Summarize the latest thread" });
+if (result.status === "completed") {
+  // result.message is the assistant SessionMessage; result.continuation is false
+}
+
+// submit — durable acceptance, check status later
+const submission = await this.runTurn({
+  mode: "submit",
+  input: "Process this webhook",
+  idempotencyKey: inboundEventId // dedupe; safe to retry
+});
+// submission.accepted is true on first accept; submission.status is "pending"
+
+// stream — drive a callback (the same surface as chat())
+await this.runTurn({
+  mode: "stream",
+  input: "Stream me",
+  callback: {
+    onStart({ requestId }) {},
+    onEvent(json) {}, // UIMessageChunk JSON
+    onDone() {},
+    onError(error) {}
+  }
+});
+```
+
+Continue the last assistant turn (instead of sending new input) by passing
+`continuation: true` in `wait` mode — pass exactly one of `input` or
+`continuation`:
+
+```typescript
+await this.runTurn({ continuation: true });
+```
+
+Key behaviors:
+
+- **Blocking modes cannot nest.** Calling `wait`/`stream`/`continuation` (or the
+  equivalent shortcut) from _inside_ an active turn — for example, from a tool's
+  `execute` — throws, because it would deadlock the turn queue. From inside a
+  turn, use `runTurn({ mode: "submit" })` (durable, runs after the current turn
+  frees the queue) or [`addMessages()`](#adding-messages-without-a-turn)
+  (transcript only, no inference).
+- **`submit` is idempotent.** Pass `submissionId` and/or `idempotencyKey`;
+  re-submitting a known key returns the existing record with `accepted: false`
+  instead of starting a second turn. See [Programmatic
+  Submissions](./programmatic-submissions.md).
+- **Recovery-safe.** When `chatRecovery` is enabled, the `wait`, `stream`, and
+  drained `submit` paths all run inference inside a recovery fiber, so an
+  interrupted turn resumes after eviction.
+
+`runTurn` is exported alongside its option and result types: `RunTurnOptions`,
+`RunTurnWait`, `RunTurnSubmit`, `RunTurnStream`, `TurnInputMessages`, and
+`TurnResult`.
+
+### Picking a shortcut
+
+The table below maps each scenario to the most direct call. Each shortcut has an
+unchanged signature; reach for them when you want the narrower surface, or use
+`runTurn()` when you want one mental model.
 
 | Use case                                                       | API                                             |
 | -------------------------------------------------------------- | ----------------------------------------------- |
@@ -759,6 +839,8 @@ path.
 | `getScheduledTasks()`      | `{}`                             | Code-declared recurring prompts or handlers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `getDefaultTimezone()`     | `undefined`                      | Default timezone for wall-clock scheduled tasks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `getMessengers()`          | `{}`                             | Messenger ingress and delivery declarations — see [Messengers](./messengers.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `getActions()`             | `{}`                             | Server actions (idempotency, approvals, authorization) compiled into tools — see [Actions](./actions.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `configureChannels()`      | `{}`                             | Per-channel policy and surfaces beyond the implicit `web` channel — see [Channels](./channels.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `maxSteps`                 | `10`                             | Max tool-call rounds per turn                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `sendReasoning`            | `true`                           | Send reasoning chunks to chat clients                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `configureSession()`       | identity                         | Add context blocks, compaction, search, skills — see [Sessions](../sessions.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -1175,6 +1257,8 @@ The Agent Skills engine and its script runner live in
 - [Getting Started](./getting-started.md) — Build a Think agent step by step
 - [Lifecycle Hooks](./lifecycle-hooks.md) — `beforeTurn`, `beforeStep`, `onStepFinish`, `onChunk`, `onChatResponse`, and more
 - [Tools](./tools.md) — Workspace tools, code execution, extensions
+- [Actions](./actions.md) — Server actions with idempotency, approvals, authorization, and reply attachments
+- [Channels](./channels.md) — Per-channel policy, channel selection, and out-of-band notices
 - [Messengers](./messengers.md) — Chat SDK messenger ingress and delivery
 - [Client Tools](./client-tools.md) — Browser-side tools, approvals, and concurrency
 - [Sub-agents and Programmatic Turns](./sub-agents.md) — RPC streaming, `saveMessages`, recovery


### PR DESCRIPTION
## Summary

Syncs the in-repo `docs/` with user-facing features shipped since `115b3285`.

- **Agent tools** — detached (background) runs, progress reporting, and durable milestones (`reportProgress`, `onProgress`, `onMilestones`, no-progress budget).
- **Chat agents** — `useAgentChat`'s `syncMessagesToServer` option and the shared `agents/chat/react` entry.
- **Think `runTurn()`** — documents the unified turn-admission API (`wait`/`submit`/`stream`) and the `addMessages()` transcript-only path.
- **Think Actions (new doc)** — `action()`/`getActions()`, the idempotency ledger, approvals (approval-gated and durable-pause), authorization, and reply attachments.
- **Think Channels (new doc)** — `configureChannels()`, per-channel policy, channel selection on a turn, and out-of-band `deliverNotice()`.
- **Nav** — links the new Actions and Channels docs.

Excludes the Think Vite plugin, CLI, and starters per current scope.

## Test plan

- [ ] Docs are Markdown only (no package/code changes); render review on the upstream cloudflare-docs PR.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->