### PR TITLE
fix(codemode): dispose dynamic worker and entrypoint stub after execute

### DIFF
--- a/.changeset/codemode-dispose-dynamic-worker.md
+++ b/.changeset/codemode-dispose-dynamic-worker.md
@@ -1,0 +1,19 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Dispose the dynamically-loaded Worker and its RPC entrypoint stub after each
+`DynamicWorkerExecutor.execute()` run.
+
+Each execution spins up a child Worker via `loader.load()` and obtains an RPC
+`Fetcher` stub via `getEntrypoint()`. These own native handles, and the code
+previously left them for the garbage collector. When such a handle is finalized
+late — for example during isolate shutdown under
+`@cloudflare/vitest-pool-workers` — workerd raises a fatal assertion ("tried to
+defer destruction during isolate shutdown") that kills the worker, surfacing as
+a flaky "Worker exited unexpectedly" with no failing assertion. The milder
+manifestation is workerd's "An RPC result was not disposed properly" warning.
+
+The executor now disposes the entrypoint stub and the loaded worker in `finally`
+blocks (best-effort, via `Symbol.dispose`), releasing the handles while the
+isolate is still alive. No behavior or API change for callers.

--- a/packages/codemode/src/executor.ts
+++ b/packages/codemode/src/executor.ts
@@ -35,6 +35,35 @@ import { stringifyForCodemode, parseForCodemode } from "./codec";
 const CONNECTOR_CONTROL_KEY = "__codemode_control__";
 const PAUSE_SENTINEL_LITERAL = "__CODEMODE_PAUSE__";
 
+/**
+ * Best-effort synchronous disposal of a disposable resource.
+ *
+ * Dynamically-loaded Workers and the RPC `Fetcher` stubs returned by
+ * `getEntrypoint()` own native handles. Left to GC, they can be finalized
+ * after the isolate's destruction queue has closed — under the
+ * `@cloudflare/vitest-pool-workers` teardown matrix this trips a fatal
+ * workerd assertion ("tried to defer destruction during isolate shutdown")
+ * that kills the worker. Disposing them eagerly releases the handle while the
+ * isolate is still alive. Disposal must never mask the execution result, so
+ * failures are swallowed.
+ */
+function disposeQuietly(resource: unknown): void {
+  if (
+    typeof resource !== "object" ||
+    resource === null ||
+    !(Symbol.dispose in resource)
+  ) {
+    return;
+  }
+  const dispose = (resource as { [Symbol.dispose]?: unknown })[Symbol.dispose];
+  if (typeof dispose !== "function") return;
+  try {
+    (dispose as () => void).call(resource);
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
 const SANDBOX_CODEC = String.raw`
     const __CODEMODE_BINARY_TAG = "__codemode_binary_v1__";
     function __bytesToBase64(bytes) {
@@ -468,22 +497,41 @@ export class DynamicWorkerExecutor implements Executor {
       env: hasEnv ? env : undefined
     });
 
-    const entrypoint = worker.getEntrypoint() as unknown as {
-      evaluate(
-        dispatchers: Record<string, ToolDispatcher>,
-        connectors: Record<string, unknown>
-      ): Promise<{
-        result: unknown;
-        error?: string;
-        logs?: string[];
-      }>;
-    };
-    const response = await entrypoint.evaluate(dispatchers, connectorBindings);
+    // `worker` (the loaded child Worker) and `entrypoint` (its RPC stub) own
+    // native handles. Dispose both once `evaluate` settles so they are not left
+    // for GC — a finalize during isolate shutdown trips a fatal workerd
+    // assertion under vitest-pool-workers (see `disposeQuietly`).
+    try {
+      const entrypoint = worker.getEntrypoint() as unknown as {
+        evaluate(
+          dispatchers: Record<string, ToolDispatcher>,
+          connectors: Record<string, unknown>
+        ): Promise<{
+          result: unknown;
+          error?: string;
+          logs?: string[];
+        }>;
+      };
+      try {
+        const response = await entrypoint.evaluate(
+          dispatchers,
+          connectorBindings
+        );
 
-    if (response.error) {
-      return { result: undefined, error: response.error, logs: response.logs };
+        if (response.error) {
+          return {
+            result: undefined,
+            error: response.error,
+            logs: response.logs
+          };
+        }
+
+        return { result: response.result, logs: response.logs };
+      } finally {
+        disposeQuietly(entrypoint);
+      }
+    } finally {
+      disposeQuietly(worker);
     }
-
-    return { result: response.result, logs: response.logs };
   }
 }


### PR DESCRIPTION
## Summary

Fixes a flaky `@cloudflare/think` workers-test failure that surfaces in CI as an uncatchable **"Worker exited unexpectedly"** ([example release run](https://github.com/cloudflare/agents/actions/runs/28168433982/job/83427061665)). The underlying crash is a fatal workerd assertion during isolate teardown:

```
*** Fatal uncaught kj::Exception: workerd/jsg/setup.c++:235: failed:
    expected queueState == QueueState::ACTIVE [1 == 0];
    tried to defer destruction during isolate shutdown; queueState = 1
⎯ Unhandled Errors ⎯  Caused by: Error: Worker exited unexpectedly
Test Files  40 passed (41)
```

`40 passed (41)` = every assertion passed, but one file's worker process died before reporting, so vitest reds the whole run. Because it's a process crash (not an assertion failure or timeout), the suite's existing `retry: 3` / `teardownTimeout: 60_000` can't catch it.

### Root cause

`DynamicWorkerExecutor.execute()` spins up a child Worker via `loader.load()` and gets an RPC `Fetcher` stub via `getEntrypoint()`, but left **both for the garbage collector**. These own native handles; when one is finalized late (e.g. during isolate shutdown under `@cloudflare/vitest-pool-workers`) workerd trips the deferred-destruction assertion and kills the worker. The milder, nondeterministic manifestation of the same leak is workerd's `An RPC result was not disposed properly` warning, which I also observed in the `@cloudflare/codemode` suite.

This is the only production `loader.load()` / `getEntrypoint()` call site in the repo; `@cloudflare/shell` reuses this same executor, so both are covered.

### Fix

Dispose the entrypoint stub and the loaded worker in `finally` blocks (best-effort via `Symbol.dispose`), releasing the handles while the isolate is still alive. No behavior or API change for callers.

## Test plan

- [x] `pnpm run typecheck` (all 113 projects)
- [x] oxlint clean on `executor.ts`
- [x] `@cloudflare/codemode` suite passes; runtime tests run clean (no RPC-not-disposed warning)
- [x] Repro before fix: full `@cloudflare/think` `test:workers` crashed ~1-in-2 full runs
- [ ] Validation in progress: looping the full `test:workers` suite with the rebuilt codemode (iter 1 = `41 passed (41)`, no crash)

Note: dependency bumps (`workerd` / `@cloudflare/vitest-pool-workers`) will be handled separately and should further harden this teardown path.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->