### PR TITLE
fix(voice): rebuild playback bridge after idle to stop slow new turns

### DIFF
--- a/.changeset/voice-playback-bridge-idle-rebuild.md
+++ b/.changeset/voice-playback-bridge-idle-rebuild.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/voice": patch
+---
+
+Fix assistant speech playing back slow on a new turn after an idle gap. `VoiceClient` routes playback through a `MediaStreamAudioDestinationNode` -> `HTMLAudioElement` bridge, and reusing that element for a fresh burst after it had been idle between turns made the new turn resume at the wrong rate (audible as slow-motion that re-converges to normal over the turn). The bridge is now torn down and rebuilt once it has fully drained and been idle past a short threshold, so each turn plays through a freshly created element. Rebuilds never happen mid-turn, since chunks within a turn keep at least one source scheduled on the playback cursor.

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -732,3 +732,78 @@ describe("VoiceClient gapless playback", () => {
     expect(sources[1].startedAt).toBe(2);
   });
 });
+
+describe("VoiceClient playback bridge reuse", () => {
+  // The audible symptom (a new turn plays back slow, then re-converges) lives
+  // inside the HTMLAudioElement's playout and is not observable from JS, so we
+  // cannot assert playback speed. Instead we lock in the mechanism the fix
+  // relies on: a bridge that has gone idle between turns is rebuilt, not reused,
+  // and is never rebuilt mid-turn.
+  function pcm16Chunk(): ArrayBuffer {
+    // 1600 samples of 16-bit PCM = 0.1s at 16kHz
+    return new ArrayBuffer(1600 * 2);
+  }
+
+  function startPcm16Call(): { transport: MockTransport; client: VoiceClient } {
+    const transport = new MockTransport();
+    const client = new VoiceClient({ agent: "test-agent", transport });
+    client.connect();
+    transport.receive(
+      JSON.stringify({ type: "audio_config", format: "pcm16" })
+    );
+    return { transport, client };
+  }
+
+  it("reuses the playback bridge for consecutive chunks within a turn", async () => {
+    const { transport } = startPcm16Call();
+    audioContext.currentTime = 5;
+
+    transport.receive(pcm16Chunk());
+    transport.receive(pcm16Chunk());
+    await waitForSourceCount(2);
+
+    // Chunks within a turn stay scheduled ahead on the cursor, so the bridge
+    // must not be torn down between them.
+    expect(audioContext.mediaStreamDestinationCount).toBe(1);
+    expect(audioElement.playCount).toBe(1);
+  });
+
+  it("rebuilds the playback bridge for a new turn after it has gone idle", async () => {
+    const { transport } = startPcm16Call();
+
+    // Turn 1: one chunk ending at t=5.1.
+    audioContext.currentTime = 5;
+    transport.receive(pcm16Chunk());
+    const [first] = await waitForSourceCount(1);
+    expect(audioContext.mediaStreamDestinationCount).toBe(1);
+
+    // Turn 1 finishes playing and the bridge drains.
+    first.stop();
+
+    // A gap longer than the idle threshold passes before the next turn.
+    audioContext.currentTime = 5.5; // 0.4s past the last chunk's end (5.1)
+    transport.receive(pcm16Chunk());
+    await waitForSourceCount(2);
+
+    // The idle bridge is torn down and a fresh one is built for turn 2.
+    expect(audioContext.mediaStreamDestinationCount).toBe(2);
+    expect(audioElement.playCount).toBe(2);
+  });
+
+  it("reuses the playback bridge when the next turn follows within the idle threshold", async () => {
+    const { transport } = startPcm16Call();
+
+    audioContext.currentTime = 5;
+    transport.receive(pcm16Chunk());
+    const [first] = await waitForSourceCount(1);
+    first.stop();
+
+    // Next chunk arrives only 0.1s after the previous chunk's end (< 0.3s).
+    audioContext.currentTime = 5.2;
+    transport.receive(pcm16Chunk());
+    await waitForSourceCount(2);
+
+    expect(audioContext.mediaStreamDestinationCount).toBe(1);
+    expect(audioElement.playCount).toBe(1);
+  });
+});

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -790,6 +790,27 @@ describe("VoiceClient playback bridge reuse", () => {
     expect(audioElement.playCount).toBe(2);
   });
 
+  it("rebuilds the playback bridge for a new turn after an interrupt and idle gap", async () => {
+    const { transport } = startPcm16Call();
+
+    // Turn 1 starts playing, then is interrupted mid-playback (abrupt stop,
+    // not a natural drain).
+    audioContext.currentTime = 5;
+    transport.receive(pcm16Chunk());
+    await waitForSourceCount(1);
+    expect(audioContext.mediaStreamDestinationCount).toBe(1);
+    transport.receive(JSON.stringify({ type: "playback_interrupt" }));
+
+    // A gap longer than the idle threshold passes before the next turn.
+    audioContext.currentTime = 6; // 1s after the interrupt
+    transport.receive(pcm16Chunk());
+    await waitForSourceCount(2);
+
+    // The bridge went idle at the interrupt, so the next turn must rebuild it.
+    expect(audioContext.mediaStreamDestinationCount).toBe(2);
+    expect(audioElement.playCount).toBe(2);
+  });
+
   it("reuses the playback bridge when the next turn follows within the idle threshold", async () => {
     const { transport } = startPcm16Call();
 

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -296,6 +296,10 @@ export class VoiceClient {
   #isScheduling = false;
   #scheduledSources = new Set<AudioBufferSourceNode>();
   #playbackCursor = 0;
+  // End time (on the AudioContext clock) of the most recently scheduled chunk.
+  // Used to detect when the playback bridge has been idle across the gap
+  // between turns so it can be rebuilt (see #playAudio).
+  #lastPlaybackEnd: number | null = null;
   #playbackElement: HTMLAudioElement | null = null;
   #playbackDestination: MediaStreamAudioDestinationNode | null = null;
   #playbackDestinationPromise: Promise<AudioNode> | null = null;
@@ -905,6 +909,28 @@ export class VoiceClient {
       }
       if (generation !== this.#playbackGeneration) return;
 
+      // Assistant playback is routed through a MediaStreamAudioDestinationNode
+      // -> HTMLAudioElement bridge (so a selected output device can be honored
+      // via HTMLMediaElement.setSinkId). That bridge is a live playout path:
+      // when it is reused for a new turn after sitting idle through the gap
+      // between turns, the element resumes the fresh burst at the wrong rate and
+      // the new turn plays back noticeably slow (it then re-converges to normal
+      // over the turn). A freshly created element does not show this, so once
+      // the bridge has fully drained and been idle past a short threshold, tear
+      // it down; #getPlaybackDestination rebuilds a fresh element for this turn.
+      // The scheduledSources.size === 0 guard means this never fires mid-turn:
+      // chunks within a turn are scheduled ahead on the cursor, keeping at least
+      // one source live until the turn finishes.
+      const BRIDGE_IDLE_REBUILD_SECONDS = 0.3;
+      if (
+        this.#playbackElement &&
+        this.#scheduledSources.size === 0 &&
+        this.#lastPlaybackEnd !== null &&
+        ctx.currentTime - this.#lastPlaybackEnd > BRIDGE_IDLE_REBUILD_SECONDS
+      ) {
+        this.#closePlaybackOutput();
+      }
+
       const destination = await this.#getPlaybackDestination(ctx);
       if (generation !== this.#playbackGeneration) return;
 
@@ -930,6 +956,7 @@ export class VoiceClient {
       // a periodic click during agent speech.
       const startAt = Math.max(ctx.currentTime, this.#playbackCursor);
       this.#playbackCursor = startAt + audioBuffer.duration;
+      this.#lastPlaybackEnd = this.#playbackCursor;
       source.start(startAt);
     } catch (err) {
       console.error("[VoiceClient] Audio playback error:", err);
@@ -973,6 +1000,7 @@ export class VoiceClient {
     this.#isPlaying = false;
     this.#isScheduling = false;
     this.#playbackCursor = 0;
+    this.#lastPlaybackEnd = null;
   }
 
   // --- Mic capture ---

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -1000,7 +1000,15 @@ export class VoiceClient {
     this.#isPlaying = false;
     this.#isScheduling = false;
     this.#playbackCursor = 0;
-    this.#lastPlaybackEnd = null;
+    // An interrupt (barge-in or a user transcript) stops playback abruptly, so
+    // the bridge goes idle from now, not from the cut chunk's scheduled end.
+    // Record the current audio-clock time as the idle start so the next turn's
+    // rebuild check in #playAudio still fires after interrupt -> long pause ->
+    // new turn. Nulling this here would disable that check and let the slow-
+    // playback symptom reappear on the post-interrupt turn.
+    this.#lastPlaybackEnd = this.#audioContext
+      ? this.#audioContext.currentTime
+      : null;
   }
 
   // --- Mic capture ---


### PR DESCRIPTION
This PR fixes assistant speech playing back slow on a new turn after an idle gap in `@cloudflare/voice`. It was reported against a booth demo built on the voice agent: ask two separate questions with a pause between them and the second reply plays in slow motion, then re-converges to normal speed over the turn.

## Why

- `VoiceClient` routes assistant playback through a `MediaStreamAudioDestinationNode` -> `HTMLAudioElement` bridge so a selected output device can be honored via `HTMLMediaElement.setSinkId`. That bridge is a live playout path with its own clock.
- Reusing the same element for a new turn after it has sat idle through the gap between turns makes it resume the fresh burst at the wrong rate, audible as slow-motion that re-converges over the turn. A freshly created element does not show this. Decode and scheduling were ruled out: the decoded buffer is correct and scheduled at the right time. The artifact lives in the element's playout and is not observable from JS.
- Keeping the element warm with continuous silence between turns was considered: it removed the slow-down but introduced its own start-of-turn artifacts, so rebuilding a fresh element per turn was chosen instead.
- Routing the default sink straight to `ctx.destination` (skipping the bridge) was also considered and rejected here: the existing design intentionally routes all playback through the bridge so runtime `setOutputDevice()` keeps working, and the per-turn rebuild fixes every sink on its own. That lower-latency routing can be a separate change.

## Code Changes

- `packages/voice/src/voice-client.ts`: track the end time of the last scheduled chunk in `#lastPlaybackEnd`. In `#playAudio`, before resolving the destination, tear the bridge down if it exists, has fully drained (`#scheduledSources.size === 0`), and has been idle past 0.3s; `#getPlaybackDestination` then builds a fresh element for the turn. The drained guard means this never fires mid-turn, since chunks within a turn keep a source scheduled on the cursor. `#lastPlaybackEnd` is reset in `#stopPlayback`.
- Regression tests cover within-turn reuse, after-idle rebuild, and sub-threshold reuse. They assert the rebuild mechanism, since the audible speed itself is not observable from JS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->