### PR TITLE
fix(chat): guard tool-output-denied clobber + harden nightly e2e jobs

### DIFF
--- a/.changeset/guard-tool-output-denied-clobber.md
+++ b/.changeset/guard-tool-output-denied-clobber.md
@@ -14,3 +14,16 @@ AI SDK deems unneeded (e.g. a tool without `needsApproval`); previously that
 silently turned a granted approval into a denial in the persisted message. This
 matches the first-write-wins guards already on the `tool-input-*` handlers and
 benefits both `@cloudflare/ai-chat` and `@cloudflare/think`.
+
+`isReplayChunk` now recognizes the same replayed `tool-output-denied` (for a
+part already settled or in `approval-responded`). The server-side guard only
+protects the persisted message; without this, the stale denial chunk was still
+stored in the resumable-stream buffer and broadcast to connected clients, where
+AI SDK v6's in-place `updateToolPart` would regress the rendered tool part back
+to `output-denied` (and replay it on reconnect). Filtering it at the broadcast
+boundary keeps the client UI consistent with the persisted state.
+
+`tool-approval-request` gains a matching first-write-wins guard: a continuation
+that replays a prior tool round-trip can re-emit the approval request, which
+previously regressed an already-`approval-responded` (or settled) part back to
+`approval-requested`, discarding the user's decision.

--- a/.changeset/guard-tool-output-denied-clobber.md
+++ b/.changeset/guard-tool-output-denied-clobber.md
@@ -1,0 +1,16 @@
+---
+"agents": patch
+---
+
+Stop a `tool-output-denied` chunk from clobbering a settled or user-approved
+tool part in `agents/chat`.
+
+`applyChunkToParts` now treats `tool-output-denied` as first-write-wins: it
+leaves a part already in `output-available` / `output-error` / `output-denied`
+untouched, and — importantly — no longer flips an `approval-responded`
+(user-approved) part to `output-denied`. An auto-continuation that re-validates
+the transcript can legitimately emit `tool-output-denied` for an approval the
+AI SDK deems unneeded (e.g. a tool without `needsApproval`); previously that
+silently turned a granted approval into a denial in the persisted message. This
+matches the first-write-wins guards already on the `tool-input-*` handlers and
+benefits both `@cloudflare/ai-chat` and `@cloudflare/think`.

--- a/.changeset/guard-tool-output-denied-clobber.md
+++ b/.changeset/guard-tool-output-denied-clobber.md
@@ -23,7 +23,10 @@ AI SDK v6's in-place `updateToolPart` would regress the rendered tool part back
 to `output-denied` (and replay it on reconnect). Filtering it at the broadcast
 boundary keeps the client UI consistent with the persisted state.
 
-`tool-approval-request` gains a matching first-write-wins guard: a continuation
-that replays a prior tool round-trip can re-emit the approval request, which
-previously regressed an already-`approval-responded` (or settled) part back to
-`approval-requested`, discarding the user's decision.
+`tool-approval-request` gains the same treatment on both paths: a
+first-write-wins guard in `applyChunkToParts` (so a replayed approval request
+can't regress an already-`approval-responded` or settled part back to
+`approval-requested`, discarding the user's decision) and a matching
+`isReplayChunk` branch (so the replayed request isn't stored or broadcast,
+which would otherwise revert an approved tool to re-showing Approve/Reject on
+the client and on reconnect).

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -6,6 +6,14 @@ inputs:
     description: Registry URL for setup-node (set this when publishing).
     required: false
     default: ""
+  node-version:
+    description: >-
+      Node version for setup-node. Defaults to the latest 24.x. Pin an exact
+      patch (e.g. 24.15.0) for jobs that download a browser via
+      @puppeteer/browsers, whose extract-zip dependency silently corrupts the
+      extraction on Node 24.16+ (see puppeteer/puppeteer#14957).
+    required: false
+    default: "24"
 
 runs:
   using: composite
@@ -16,7 +24,7 @@ runs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 24
+        node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
         cache: pnpm
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -194,9 +194,11 @@ jobs:
         working-directory: experimental/tanstack-recovery
 
   # Deterministic codemode Playwright suite (Layer 4b). Drives the dynamic
-  # Worker-loader code-generation flow in a real browser; offline, no Cloudflare
-  # credentials. Mirrors `e2e-ai-chat`. A `globalTimeout` in its
-  # playwright.config.ts bounds it so a hang can never silently run to the cap.
+  # Worker-loader code-generation flow (executor.spec.ts) against an AI-free
+  # worker; offline, no Cloudflare credentials. Mirrors `e2e-ai-chat`. A
+  # `globalTimeout` in its playwright.config.ts bounds it so a hang can never
+  # silently run to the cap. (The Workers-AI codemode specs run in the separate
+  # `e2e-codemode-llm` job below.)
   e2e-codemode:
     name: "E2E: codemode (Playwright)"
     timeout-minutes: 30
@@ -224,8 +226,46 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Run codemode e2e tests
+      - name: Run codemode deterministic e2e tests
         run: pnpm run test:e2e
+        working-directory: packages/codemode
+
+  # Workers-AI codemode Playwright suite. Needs the remote `ai` binding
+  # (wrangler.jsonc) and a healthy Workers AI edge connection, so it gets
+  # credentials. Real-model latency/flakiness is bounded by a hard globalTimeout
+  # in playwright.llm.config.ts so this can never silently run to the cap.
+  e2e-codemode-llm:
+    name: "E2E: codemode (Playwright, Workers AI)"
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/install
+
+      - run: pnpm run build
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run codemode Workers AI e2e tests
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pnpm run test:e2e:llm
         working-directory: packages/codemode
 
   # Browser-connector e2e (Layer 3c). Spawns a real `wrangler dev` (local Browser

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -241,7 +241,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Pin an exact pre-bug Node patch. Wrangler's local Browser Rendering
+      # simulator downloads its own Chrome via @puppeteer/browsers, whose
+      # extract-zip dep silently aborts mid-extraction on Node 24.16+
+      # (puppeteer/puppeteer#14957). That leaves a partial Chrome cache, which
+      # Wrangler then "clears and retries" on every test — a re-corrupting loop
+      # that, with retry:3 + a 120s test timeout, ran this job to the 30m cancel.
       - uses: ./.github/actions/install
+        with:
+          node-version: 24.15.0
 
       - run: pnpm run build
 
@@ -259,11 +267,26 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
+      # Persist Wrangler's auto-downloaded Chrome (separate from the Playwright
+      # cache above) so it's fetched once and reused, keeping the one-time
+      # ~hundreds-of-MB download out of the timed test window. Keyed on the
+      # lockfile so a Wrangler bump (which can change the pinned Chrome build)
+      # busts it.
+      - name: Cache Wrangler Chrome
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/.wrangler/chrome
+          key: ${{ runner.os }}-wrangler-chrome-${{ hashFiles('pnpm-lock.yaml') }}
+
+      # Wall-clock guard (20m, below the 30m job cap) mirroring the Playwright
+      # suites' globalTimeout: a future environmental stall fails WITH logs
+      # instead of being silently cancelled at the cap. The suite's own bail:1
+      # already turns a real failure into a fast, reported one.
       - name: Run agents browser-connector e2e tests
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: pnpm run test:browser
+        run: timeout --kill-after=30s 20m pnpm run test:browser
         working-directory: packages/agents
 
   # ── DEPLOYED (Layer-5) recovery suites ──────────────────────────────────────

--- a/packages/agents/src/browser-tests/vitest.config.ts
+++ b/packages/agents/src/browser-tests/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
   test: {
     name: "browser",
     retry: 3,
+    // Stop after the first test fails all its retries. This suite spawns a real
+    // `wrangler dev` + local Browser Rendering simulator; if the environment
+    // degrades (e.g. a corrupted Chrome download), bailing turns what was a
+    // silent run to the CI job's 30-minute cancel into a fast, reported failure
+    // instead of grinding every test through retry:3 × the 120s timeout.
+    bail: 1,
     include: [path.join(import.meta.dirname, "**/*.test.ts")],
     testTimeout: 120_000,
     hookTimeout: 60_000

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -376,6 +376,21 @@ export function applyChunkToParts(
       const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
       if (toolPart) {
         const p = toolPart as Record<string, unknown>;
+        // First-write-wins: a tool that's already terminal must not be
+        // regressed by a later/replayed chunk. Also preserve an
+        // `approval-responded` (user-approved) part — a continuation that
+        // re-validates the transcript can emit `tool-output-denied` for an
+        // approval the SDK deems unneeded (e.g. a tool without
+        // `needsApproval`); that must not silently flip a granted approval
+        // into a denial.
+        if (
+          p.state === "output-available" ||
+          p.state === "output-error" ||
+          p.state === "output-denied" ||
+          p.state === "approval-responded"
+        ) {
+          return true;
+        }
         p.state = "output-denied";
       }
       return true;

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -361,6 +361,20 @@ export function applyChunkToParts(
       const toolPart = findToolPartByCallId(parts, chunk.toolCallId);
       if (toolPart) {
         const p = toolPart as Record<string, unknown>;
+        // First-write-wins: a continuation can replay the prior tool
+        // round-trip and re-emit `tool-approval-request`. Never regress a part
+        // the user has already responded to (`approval-responded`) or that has
+        // otherwise settled — that would silently discard the approval
+        // decision. Matches the guards on the `tool-input-*` /
+        // `tool-output-denied` handlers.
+        if (
+          p.state === "approval-responded" ||
+          p.state === "output-available" ||
+          p.state === "output-error" ||
+          p.state === "output-denied"
+        ) {
+          return true;
+        }
         p.state = "approval-requested";
         p.approval = {
           id: chunk.approvalId,
@@ -488,11 +502,32 @@ export function applyChunkToParts(
  * - `tool-input-available` for a `toolCallId` whose existing part is no
  *   longer `input-streaming` (i.e. has already advanced to `input-available`
  *   or any terminal state).
+ * - `tool-output-denied` for a `toolCallId` whose existing part is already
+ *   settled (`output-available` / `output-error` / `output-denied`) or
+ *   user-approved (`approval-responded`). A continuation that re-validates
+ *   the transcript can re-emit a denial for an approval the SDK now deems
+ *   unneeded; `applyChunkToParts` already drops it server-side, and this stops
+ *   it reaching the client (where the in-place `updateToolPart` would flip the
+ *   part to `output-denied`) and the replay buffer. Mirrors the
+ *   first-write-wins guard in `applyChunkToParts`.
  */
 export function isReplayChunk(
   parts: MessagePart[],
   chunk: StreamChunkData
 ): boolean {
+  if (chunk.type === "tool-output-denied") {
+    if (!chunk.toolCallId) return false;
+    const existing = findToolPartByCallId(parts, chunk.toolCallId);
+    if (!existing) return false;
+    const state = (existing as Record<string, unknown>).state;
+    return (
+      state === "output-available" ||
+      state === "output-error" ||
+      state === "output-denied" ||
+      state === "approval-responded"
+    );
+  }
+
   if (
     chunk.type !== "tool-input-start" &&
     chunk.type !== "tool-input-delta" &&

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -510,12 +510,21 @@ export function applyChunkToParts(
  *   it reaching the client (where the in-place `updateToolPart` would flip the
  *   part to `output-denied`) and the replay buffer. Mirrors the
  *   first-write-wins guard in `applyChunkToParts`.
+ * - `tool-approval-request` for a `toolCallId` whose existing part is already
+ *   `approval-responded` or settled. A continuation replaying a prior tool
+ *   round-trip can re-emit the approval request; left unfiltered it would
+ *   revert an already-approved tool back to `approval-requested` on the client
+ *   (re-showing Approve/Reject) and replay that regression on reconnect. Same
+ *   pattern and rationale as `tool-output-denied`.
  */
 export function isReplayChunk(
   parts: MessagePart[],
   chunk: StreamChunkData
 ): boolean {
-  if (chunk.type === "tool-output-denied") {
+  if (
+    chunk.type === "tool-output-denied" ||
+    chunk.type === "tool-approval-request"
+  ) {
     if (!chunk.toolCallId) return false;
     const existing = findToolPartByCallId(parts, chunk.toolCallId);
     if (!existing) return false;

--- a/packages/ai-chat/e2e/client-tools.spec.ts
+++ b/packages/ai-chat/e2e/client-tools.spec.ts
@@ -352,7 +352,10 @@ test.describe("Tool approval auto-continuation e2e", () => {
     baseURL
   }) => {
     const room = crypto.randomUUID();
-    const wsUrl = agentPath(baseURL!, room);
+    // Use the approval-required agent so the LLM emits a real tool-approval
+    // request (the tool declares needsApproval) — approving it keeps the part
+    // in approval-responded instead of the SDK re-validating it as unneeded.
+    const wsUrl = `${baseURL!.replace("http", "ws")}/agents/client-tool-approval-agent/${room}`;
 
     // This test:
     // 1. Sends a message that triggers the LLM to call getUserLocation
@@ -365,11 +368,13 @@ test.describe("Tool approval auto-continuation e2e", () => {
           allMessages: WSMessage[];
           continuationStreamId: string | null;
           toolCallId: string | null;
+          approvalId: string | null;
           approvalSent: boolean;
         }>((resolve) => {
           const ws = new WebSocket(url);
           const allMessages: WSMessage[] = [];
           let toolCallId: string | null = null;
+          let approvalId: string | null = null;
           let sentApproval = false;
           let doneCount = 0;
           let continuationStreamId: string | null = null;
@@ -391,6 +396,27 @@ test.describe("Tool approval auto-continuation e2e", () => {
               }
 
               if (data.type === MT.CF_AGENT_USE_CHAT_RESPONSE) {
+                // Capture the SDK-issued approvalId from the approval-request
+                // chunk (the tool declares needsApproval, so the part's
+                // approval.id is this id, distinct from the toolCallId).
+                if (
+                  !approvalId &&
+                  typeof data.body === "string" &&
+                  data.body.includes("tool-approval-request")
+                ) {
+                  try {
+                    const chunk = JSON.parse(data.body as string);
+                    if (
+                      chunk.type === "tool-approval-request" &&
+                      chunk.approvalId
+                    ) {
+                      approvalId = chunk.approvalId;
+                    }
+                  } catch {
+                    // not JSON
+                  }
+                }
+
                 // Look for tool-input-available
                 if (
                   !sentApproval &&
@@ -433,6 +459,7 @@ test.describe("Tool approval auto-continuation e2e", () => {
                         allMessages,
                         continuationStreamId,
                         toolCallId,
+                        approvalId,
                         approvalSent: sentApproval
                       });
                     }, 500);
@@ -476,6 +503,7 @@ test.describe("Tool approval auto-continuation e2e", () => {
               allMessages,
               continuationStreamId,
               toolCallId,
+              approvalId,
               approvalSent: sentApproval
             });
           }, 25000);
@@ -504,7 +532,7 @@ test.describe("Tool approval auto-continuation e2e", () => {
 
     // Verify persistence
     const res = await page.request.get(
-      `${baseURL}/agents/client-tool-agent/${room}/get-messages`
+      `${baseURL}/agents/client-tool-approval-agent/${room}/get-messages`
     );
     expect(res.ok()).toBe(true);
     const persisted = await res.json();
@@ -520,8 +548,12 @@ test.describe("Tool approval auto-continuation e2e", () => {
     );
     expect(toolPart).toBeTruthy();
     expect(toolPart.state).toBe("approval-responded");
+    // The tool declares needsApproval, so the SDK issues a distinct approvalId
+    // (carried on the approval-request chunk) rather than reusing the
+    // toolCallId. The persisted approval preserves that id plus approved: true.
+    expect(result.approvalId).toBeTruthy();
     expect(toolPart.approval).toEqual({
-      id: result.toolCallId,
+      id: result.approvalId,
       approved: true
     });
   });

--- a/packages/ai-chat/e2e/client-tools.spec.ts
+++ b/packages/ai-chat/e2e/client-tools.spec.ts
@@ -396,30 +396,14 @@ test.describe("Tool approval auto-continuation e2e", () => {
               }
 
               if (data.type === MT.CF_AGENT_USE_CHAT_RESPONSE) {
-                // Capture the SDK-issued approvalId from the approval-request
-                // chunk (the tool declares needsApproval, so the part's
-                // approval.id is this id, distinct from the toolCallId).
+                // Capture the toolCallId from tool-input-available, but do NOT
+                // approve yet. For a needsApproval tool the AI SDK emits
+                // tool-input-available *before* tool-approval-request; approving
+                // on input-available races the server's approval-request chunk.
+                // We wait for tool-approval-request (below) — the realistic
+                // moment a client surfaces the Approve/Reject decision.
                 if (
-                  !approvalId &&
-                  typeof data.body === "string" &&
-                  data.body.includes("tool-approval-request")
-                ) {
-                  try {
-                    const chunk = JSON.parse(data.body as string);
-                    if (
-                      chunk.type === "tool-approval-request" &&
-                      chunk.approvalId
-                    ) {
-                      approvalId = chunk.approvalId;
-                    }
-                  } catch {
-                    // not JSON
-                  }
-                }
-
-                // Look for tool-input-available
-                if (
-                  !sentApproval &&
+                  !toolCallId &&
                   typeof data.body === "string" &&
                   data.body.includes("tool-input-available")
                 ) {
@@ -430,16 +414,41 @@ test.describe("Tool approval auto-continuation e2e", () => {
                       chunk.toolCallId
                     ) {
                       toolCallId = chunk.toolCallId;
-                      // Send tool APPROVAL with autoContinue
-                      ws.send(
-                        JSON.stringify({
-                          type: MT.CF_AGENT_TOOL_APPROVAL,
-                          toolCallId: chunk.toolCallId,
-                          approved: true,
-                          autoContinue: true
-                        })
-                      );
-                      sentApproval = true;
+                    }
+                  } catch {
+                    // not JSON
+                  }
+                }
+
+                // Approve only once the server has emitted the approval request
+                // (carrying the SDK-issued approvalId, distinct from the
+                // toolCallId). This avoids racing the tool-approval-request
+                // chunk and mirrors a real client's approval flow.
+                if (
+                  !sentApproval &&
+                  typeof data.body === "string" &&
+                  data.body.includes("tool-approval-request")
+                ) {
+                  try {
+                    const chunk = JSON.parse(data.body as string);
+                    if (
+                      chunk.type === "tool-approval-request" &&
+                      chunk.approvalId
+                    ) {
+                      approvalId = chunk.approvalId;
+                      const approvedToolCallId = chunk.toolCallId ?? toolCallId;
+                      if (approvedToolCallId) {
+                        toolCallId = approvedToolCallId;
+                        ws.send(
+                          JSON.stringify({
+                            type: MT.CF_AGENT_TOOL_APPROVAL,
+                            toolCallId: approvedToolCallId,
+                            approved: true,
+                            autoContinue: true
+                          })
+                        );
+                        sentApproval = true;
+                      }
                     }
                   } catch {
                     // not JSON

--- a/packages/ai-chat/e2e/worker.ts
+++ b/packages/ai-chat/e2e/worker.ts
@@ -15,6 +15,7 @@ export type Env = {
   ChatAgent: DurableObjectNamespace<ChatAgent>;
   LlmChatAgent: DurableObjectNamespace<LlmChatAgent>;
   ClientToolAgent: DurableObjectNamespace<ClientToolAgent>;
+  ClientToolApprovalAgent: DurableObjectNamespace<ClientToolApprovalAgent>;
   SlowAgent: DurableObjectNamespace<SlowAgent>;
   BadKeyAgent: DurableObjectNamespace<BadKeyAgent>;
   SanitizeAgent: DurableObjectNamespace<SanitizeAgent>;
@@ -108,6 +109,42 @@ export class ClientToolAgent extends AIChatAgent<Env> {
           description: "Get the user's current location from the browser",
           inputSchema: z.object({})
           // No execute — client must handle via CF_AGENT_TOOL_RESULT
+        })
+      },
+      stopWhen: stepCountIs(3)
+    });
+
+    return result.toUIMessageStreamResponse();
+  }
+}
+
+/**
+ * Agent with a client-side tool that REQUIRES approval (no execute function).
+ * The LLM calls the tool, the stream pauses at approval-requested, and the
+ * test sends CF_AGENT_TOOL_APPROVAL. Kept separate from `ClientToolAgent` so
+ * the approval flow doesn't perturb the tool-result/continuation tests that
+ * agent's plain (no-approval) tool drives.
+ */
+export class ClientToolApprovalAgent extends AIChatAgent<Env> {
+  async onChatMessage() {
+    const workersai = createWorkersAI({ binding: this.env.AI });
+
+    const result = streamText({
+      model: workersai("@cf/moonshotai/kimi-k2.7-code", {
+        sessionAffinity: this.sessionAffinity
+      }),
+      system:
+        "You are a test assistant. Always use the getUserLocation tool when asked about location.",
+      messages: await convertToModelMessages(this.messages),
+      tools: {
+        getUserLocation: tool({
+          description: "Get the user's current location from the browser",
+          inputSchema: z.object({}),
+          // Requires approval: an approved continuation keeps the part in
+          // `approval-responded` (awaiting the client result) rather than the
+          // SDK re-validating it as an unneeded approval and denying it.
+          needsApproval: true
+          // No execute — client resolves via CF_AGENT_TOOL_RESULT after approval
         })
       },
       stopWhen: stepCountIs(3)

--- a/packages/ai-chat/e2e/wrangler.jsonc
+++ b/packages/ai-chat/e2e/wrangler.jsonc
@@ -7,6 +7,10 @@
       { "class_name": "ChatAgent", "name": "ChatAgent" },
       { "class_name": "LlmChatAgent", "name": "LlmChatAgent" },
       { "class_name": "ClientToolAgent", "name": "ClientToolAgent" },
+      {
+        "class_name": "ClientToolApprovalAgent",
+        "name": "ClientToolApprovalAgent"
+      },
       { "class_name": "SlowAgent", "name": "SlowAgent" },
       { "class_name": "BadKeyAgent", "name": "BadKeyAgent" },
       { "class_name": "SanitizeAgent", "name": "SanitizeAgent" },
@@ -35,6 +39,7 @@
     {
       "new_sqlite_classes": ["ResponseLlmAgent", "ResponseChainAgent"],
       "tag": "v5"
-    }
+    },
+    { "new_sqlite_classes": ["ClientToolApprovalAgent"], "tag": "v6" }
   ]
 }

--- a/packages/ai-chat/e2e/wrangler.mock.jsonc
+++ b/packages/ai-chat/e2e/wrangler.mock.jsonc
@@ -11,6 +11,10 @@
       { "class_name": "ChatAgent", "name": "ChatAgent" },
       { "class_name": "LlmChatAgent", "name": "LlmChatAgent" },
       { "class_name": "ClientToolAgent", "name": "ClientToolAgent" },
+      {
+        "class_name": "ClientToolApprovalAgent",
+        "name": "ClientToolApprovalAgent"
+      },
       { "class_name": "SlowAgent", "name": "SlowAgent" },
       { "class_name": "BadKeyAgent", "name": "BadKeyAgent" },
       { "class_name": "SanitizeAgent", "name": "SanitizeAgent" },
@@ -39,6 +43,7 @@
     {
       "new_sqlite_classes": ["ResponseLlmAgent", "ResponseChainAgent"],
       "tag": "v5"
-    }
+    },
+    { "new_sqlite_classes": ["ClientToolApprovalAgent"], "tag": "v6" }
   ]
 }

--- a/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
+++ b/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
@@ -1589,6 +1589,55 @@ describe("applyChunkToParts: tool-output-denied", () => {
     expect(part.input).toEqual({ a: 5000, b: 3, operator: "*" });
     expect(part.approval).toEqual({ id: "approval-xyz" });
   });
+
+  it("does not regress an approval-responded (approved) part to output-denied", () => {
+    // A continuation that re-validates the transcript can emit
+    // tool-output-denied for an approval the SDK deems unneeded. A granted
+    // approval (approval-responded) must not be silently flipped to a denial.
+    const parts: MessageParts = [
+      {
+        type: "tool-calculate",
+        toolCallId: "call_789",
+        toolName: "calculate",
+        state: "approval-responded",
+        input: { a: 5000, b: 3, operator: "*" },
+        approval: { id: "approval-xyz", approved: true }
+      } as MessageParts[number]
+    ];
+
+    const handled = applyChunkToParts(parts, {
+      type: "tool-output-denied",
+      toolCallId: "call_789"
+    } as StreamChunkData);
+
+    expect(handled).toBe(true);
+    const part = parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("approval-responded");
+    expect(part.approval).toEqual({ id: "approval-xyz", approved: true });
+  });
+
+  it("does not regress a terminal output-available part to output-denied", () => {
+    const parts: MessageParts = [
+      {
+        type: "tool-calculate",
+        toolCallId: "call_terminal",
+        toolName: "calculate",
+        state: "output-available",
+        input: { a: 2, b: 2, operator: "+" },
+        output: { result: 4 }
+      } as MessageParts[number]
+    ];
+
+    const handled = applyChunkToParts(parts, {
+      type: "tool-output-denied",
+      toolCallId: "call_terminal"
+    } as StreamChunkData);
+
+    expect(handled).toBe(true);
+    const part = parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("output-available");
+    expect(part.output).toEqual({ result: 4 });
+  });
 });
 
 describe("Tool approval persistence across reconnect", () => {

--- a/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
+++ b/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
@@ -1562,6 +1562,57 @@ describe("applyChunkToParts: tool-approval-request", () => {
     expect(handled).toBe(true);
     expect(parts.length).toBe(0);
   });
+
+  it("does not regress an approval-responded (approved) part to approval-requested", () => {
+    // A continuation can replay the prior tool round-trip and re-emit
+    // tool-approval-request. That must not discard a decision the user already
+    // made (approval-responded) by flipping it back to approval-requested.
+    const parts: MessageParts = [
+      {
+        type: "tool-calculate",
+        toolCallId: "call_123",
+        toolName: "calculate",
+        state: "approval-responded",
+        input: { a: 5000, b: 3, operator: "*" },
+        approval: { id: "approval-abc", approved: true }
+      } as MessageParts[number]
+    ];
+
+    const handled = applyChunkToParts(parts, {
+      type: "tool-approval-request",
+      approvalId: "approval-abc",
+      toolCallId: "call_123"
+    } as StreamChunkData);
+
+    expect(handled).toBe(true);
+    const part = parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("approval-responded");
+    expect(part.approval).toEqual({ id: "approval-abc", approved: true });
+  });
+
+  it("does not regress a terminal output-available part to approval-requested", () => {
+    const parts: MessageParts = [
+      {
+        type: "tool-calculate",
+        toolCallId: "call_terminal",
+        toolName: "calculate",
+        state: "output-available",
+        input: { a: 2, b: 2, operator: "+" },
+        output: { result: 4 }
+      } as MessageParts[number]
+    ];
+
+    const handled = applyChunkToParts(parts, {
+      type: "tool-approval-request",
+      approvalId: "approval-late",
+      toolCallId: "call_terminal"
+    } as StreamChunkData);
+
+    expect(handled).toBe(true);
+    const part = parts[0] as Record<string, unknown>;
+    expect(part.state).toBe("output-available");
+    expect(part.output).toEqual({ result: 4 });
+  });
 });
 
 describe("applyChunkToParts: tool-output-denied", () => {

--- a/packages/ai-chat/src/tests/message-builder.test.ts
+++ b/packages/ai-chat/src/tests/message-builder.test.ts
@@ -1487,6 +1487,81 @@ describe("applyChunkToParts", () => {
         })
       ).toBe(false);
     });
+
+    it("returns true for tool-output-denied on an approval-responded part", () => {
+      // A continuation that re-validates the transcript can re-emit a denial
+      // for an approval the user already granted. The chunk must not reach the
+      // client, where the in-place updateToolPart would flip the rendered part
+      // from approval-responded back to output-denied.
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      applyChunkToParts(parts, {
+        type: "tool-approval-request",
+        toolCallId: "call_1",
+        approvalId: "appr-1"
+      });
+      (parts[0] as Record<string, unknown>).state = "approval-responded";
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-output-denied",
+          toolCallId: "call_1"
+        })
+      ).toBe(true);
+    });
+
+    it("returns true for tool-output-denied on a terminal part", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      applyChunkToParts(parts, {
+        type: "tool-output-available",
+        toolCallId: "call_1",
+        output: "Sunny"
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-output-denied",
+          toolCallId: "call_1"
+        })
+      ).toBe(true);
+    });
+
+    it("returns false for a genuine first tool-output-denied (input-available)", () => {
+      // The first denial of a still-pending tool must pass through so the
+      // client sees the denial.
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-output-denied",
+          toolCallId: "call_1"
+        })
+      ).toBe(false);
+    });
+
+    it("returns false for tool-output-denied when no existing part matches", () => {
+      const parts = makeParts();
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-output-denied",
+          toolCallId: "call_unknown"
+        })
+      ).toBe(false);
+    });
   });
 });
 

--- a/packages/ai-chat/src/tests/message-builder.test.ts
+++ b/packages/ai-chat/src/tests/message-builder.test.ts
@@ -1562,6 +1562,85 @@ describe("applyChunkToParts", () => {
         })
       ).toBe(false);
     });
+
+    it("returns true for tool-approval-request on an approval-responded part", () => {
+      // A continuation replaying a prior tool round-trip can re-emit the
+      // approval request. The chunk must not reach the client, where the
+      // in-place updateToolPart would revert an approved tool back to
+      // approval-requested (re-showing Approve/Reject).
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      applyChunkToParts(parts, {
+        type: "tool-approval-request",
+        toolCallId: "call_1",
+        approvalId: "appr-1"
+      });
+      (parts[0] as Record<string, unknown>).state = "approval-responded";
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-approval-request",
+          toolCallId: "call_1",
+          approvalId: "appr-1"
+        })
+      ).toBe(true);
+    });
+
+    it("returns true for tool-approval-request on a terminal part", () => {
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      applyChunkToParts(parts, {
+        type: "tool-output-available",
+        toolCallId: "call_1",
+        output: "Sunny"
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-approval-request",
+          toolCallId: "call_1",
+          approvalId: "appr-late"
+        })
+      ).toBe(true);
+    });
+
+    it("returns false for a genuine first tool-approval-request (input-available)", () => {
+      // The first approval request of a still-pending tool must pass through so
+      // the client renders the Approve/Reject decision.
+      const parts = makeParts();
+      applyChunkToParts(parts, {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "getWeather",
+        input: { city: "London" }
+      });
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-approval-request",
+          toolCallId: "call_1",
+          approvalId: "appr-1"
+        })
+      ).toBe(false);
+    });
+
+    it("returns false for tool-approval-request when no existing part matches", () => {
+      const parts = makeParts();
+      expect(
+        isReplayChunk(parts, {
+          type: "tool-approval-request",
+          toolCallId: "call_unknown",
+          approvalId: "appr-1"
+        })
+      ).toBe(false);
+    });
   });
 });
 

--- a/packages/codemode/e2e/playwright.config.ts
+++ b/packages/codemode/e2e/playwright.config.ts
@@ -2,17 +2,25 @@ import { defineConfig } from "@playwright/test";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+/**
+ * Deterministic codemode e2e suite. Drives only `executor.spec.ts`, which POSTs
+ * raw code to /execute and /mcp/execute and never touches Workers AI, against an
+ * AI-free worker (`wrangler.mock.jsonc`). It boots offline/instantly and needs
+ * no Cloudflare credentials. The Workers-AI specs (codemode.spec.ts via /run and
+ * llm-codemode.spec.ts via /run-multi) run in playwright.llm.config.ts. Mirrors
+ * the ai-chat e2e split.
+ */
 const PORT = 8798;
 const e2eDir = dirname(fileURLToPath(import.meta.url));
-const configPath = join(e2eDir, "wrangler.jsonc");
+const configPath = join(e2eDir, "wrangler.mock.jsonc");
 
 export default defineConfig({
   testDir: e2eDir,
-  testMatch: "*.spec.ts",
+  testMatch: "executor.spec.ts",
   timeout: 60_000,
-  // Hard wall-clock cap so a slow/flaky run (e.g. the Workers-AI llm spec) fails
-  // WITH a Playwright report instead of being silently killed by a CI job's hard
-  // cancel, which produces no actionable output. Mirrors the ai-chat e2e config.
+  // Hard wall-clock cap so a hang fails WITH a Playwright report instead of being
+  // silently killed by a CI job's hard cancel, which produces no actionable
+  // output. Mirrors the ai-chat e2e config.
   globalTimeout: 15 * 60_000,
   retries: 2,
   workers: 1,

--- a/packages/codemode/e2e/playwright.llm.config.ts
+++ b/packages/codemode/e2e/playwright.llm.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig } from "@playwright/test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Workers-AI codemode e2e suite — exercises the full LLM pipeline (user prompt →
+ * model generates code → DynamicWorkerExecutor → sandboxed Worker → tool
+ * dispatch → result) for codemode.spec.ts (/run) and llm-codemode.spec.ts
+ * (/run-multi, /types/multi).
+ *
+ * Split out from the deterministic suite (playwright.config.ts) because it
+ * requires the remote `ai` binding (wrangler.jsonc) and a healthy Workers AI
+ * edge connection. Real-model latency/flakiness is bounded by a hard
+ * `globalTimeout` so this job can never silently run to a CI job's hard cancel.
+ * Mirrors the ai-chat playwright.llm.config.ts.
+ */
+const PORT = 8799;
+const e2eDir = dirname(fileURLToPath(import.meta.url));
+const configPath = join(e2eDir, "wrangler.jsonc");
+
+export default defineConfig({
+  testDir: e2eDir,
+  testMatch: ["codemode.spec.ts", "llm-codemode.spec.ts"],
+  // Real model turns are slower than the deterministic executor specs.
+  timeout: 90_000,
+  globalTimeout: 15 * 60_000,
+  // Real-model output is nondeterministic — the small Workers AI model
+  // occasionally varies wording and trips a strict assertion. Re-runs recover
+  // these reliably, so allow extra retries (only fire on failure).
+  retries: process.env.CI ? 3 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  use: {
+    baseURL: `http://localhost:${PORT}`
+  },
+  webServer: {
+    command: `lsof -ti tcp:${PORT} | xargs kill -9 2>/dev/null; npx wrangler dev --config ${configPath} --port ${PORT} --inspector-port 0`,
+    // Wait for the worker to actually serve — i.e. once the remote `ai`
+    // connection is established and `wrangler dev` is past "Establishing remote
+    // connection...". A port-only check would race ahead and every spec would
+    // fail before the remote binding is ready.
+    url: `http://localhost:${PORT}/`,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 90_000
+  }
+});

--- a/packages/codemode/e2e/wrangler.mock.jsonc
+++ b/packages/codemode/e2e/wrangler.mock.jsonc
@@ -1,0 +1,20 @@
+{
+  // Deterministic config for the offline executor e2e (executor.spec.ts), which
+  // POSTs raw code to /execute and /mcp/execute and never touches Workers AI.
+  // Intentionally has NO `ai` binding: a `remote: true` binding makes
+  // `wrangler dev` eagerly open a remote proxy session at startup, which needs
+  // Cloudflare credentials. The LLM specs (codemode.spec.ts, llm-codemode.spec.ts)
+  // use `wrangler.jsonc` (which keeps the remote `ai` binding) via
+  // playwright.llm.config.ts.
+  "compatibility_date": "2026-06-11",
+  "compatibility_flags": ["nodejs_compat"],
+  "define": {
+    "__filename": "'index.ts'"
+  },
+  "durable_objects": {
+    "bindings": [{ "class_name": "CodemodeAgent", "name": "CodemodeAgent" }]
+  },
+  "main": "worker.ts",
+  "migrations": [{ "new_sqlite_classes": ["CodemodeAgent"], "tag": "v1" }],
+  "worker_loaders": [{ "binding": "LOADER" }]
+}

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -79,6 +79,7 @@
     "build": "tsx ./scripts/build.ts",
     "test": "vitest run && vitest run --config vitest.runtime.config.ts && vitest run --config vitest.browser.config.ts",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
+    "test:e2e:llm": "playwright test --config e2e/playwright.llm.config.ts",
     "test:watch": "vitest",
     "test:browser": "vitest run --config vitest.browser.config.ts"
   },


### PR DESCRIPTION
## Summary

This PR fixes one real SDK bug surfaced by the nightly e2e suite and hardens three nightly e2e jobs that were failing or hanging in CI. The work came out of debugging three distinct nightly failures.

### 1. `fix(chat)`: don't let `tool-output-denied` clobber an approved/terminal tool part

`applyChunkToParts` in `packages/agents/src/chat/message-builder.ts` unconditionally flipped a tool part to `output-denied` on a `tool-output-denied` chunk. During an auto-continuation that re-validates the transcript, the AI SDK can legitimately emit `tool-output-denied` for an approval it now deems unneeded (e.g. a tool without `needsApproval`). That silently turned a **granted approval** (`approval-responded`) — or an already-settled part — into a denial in the persisted message.

The handler is now **first-write-wins**: a part already in `output-available` / `output-error` / `output-denied` / `approval-responded` is left untouched. This matches the guards already on the `tool-input-*` handlers and benefits both `@cloudflare/ai-chat` and `@cloudflare/think`. Ships as a patch changeset (`agents`).

To exercise a realistic approval flow, the ai-chat e2e gains a dedicated `ClientToolApprovalAgent` (with `needsApproval: true`) so the approval test is isolated from the plain `getUserLocation` client-tool test. New unit tests cover the guard for both `approval-responded` and terminal `output-available` parts.

### 2. `ci`: stop the browser-connector nightly from looping on a corrupted Chrome cache

The `E2E: agents (browser connector)` job kept hitting its 30-minute cap. Root cause: `wrangler dev`'s Browser Rendering simulator repeatedly hit a corrupted Chrome cache caused by an `extract-zip` bug on Node 24.16+. Wrangler would clear + re-download, the Node bug re-corrupted it, and the loop exhausted the job.

- Pin the job to Node `24.15.0` (via a new `node-version` input on the shared install action).
- Cache `~/.cache/.wrangler/chrome` to avoid repeated downloads.
- `bail: 1` in the browser-tests vitest config so the suite stops after the first full failure (incl. retries).
- Wrap the run in `timeout --kill-after=30s 20m` as a wall-clock guard below the job cap.

### 3. `ci(codemode)`: split e2e into offline + Workers-AI jobs

A wrangler bump (4.105.0) changed remote-binding init from lazy to eager, so `wrangler dev` now opens a remote proxy session at startup. The codemode e2e's `ai: { remote: true }` binding therefore needed Cloudflare credentials the deterministic CI job didn't have, failing at boot.

Mirrors the ai-chat split:
- `wrangler.mock.jsonc` (no `ai` binding) + `playwright.config.ts` runs the deterministic `executor.spec.ts` — no credentials needed (`e2e-codemode`).
- `playwright.llm.config.ts` (remote `ai` binding, higher timeouts, CI retries) runs `codemode.spec.ts` + `llm-codemode.spec.ts` against real Workers AI in a new credentialed `e2e-codemode-llm` job.

## Test plan

- [x] `pnpm run typecheck` — all 113 projects pass
- [x] ai-chat guard unit tests (`client-tool-duplicate-message.test.ts`) — 37/37 pass
- [x] LLM codemode e2e (`test:e2e:llm`) — 8/8 pass against real Workers AI locally
- [ ] Nightly: `e2e-agents-browser` completes without looping on Chrome cache
- [ ] Nightly: `e2e-codemode` (deterministic) runs without credentials
- [ ] Nightly: `e2e-codemode-llm` authenticates and passes
- [ ] Nightly: ai-chat tool-approval e2e passes against `ClientToolApprovalAgent`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->