### PR TITLE
test: cover recovery after forced Durable Object eviction

### DIFF
--- a/packages/agents/src/tests/agents-core-eviction.test.ts
+++ b/packages/agents/src/tests/agents-core-eviction.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Durable Object eviction tests for agents-core.
+ *
+ * These prove that Agent-backed state survives a *real* production-like
+ * eviction: `evictDurableObject(stub)` tears down the in-memory instance
+ * (dropping caches, in-flight maps, ref counters, recovery sets) while
+ * leaving durable storage intact. The next access rehydrates from SQL.
+ *
+ * Unlike the "get a fresh stub (simulates restart)" idiom used elsewhere in
+ * this package, evictDurableObject exercises the same code path the platform
+ * runs when an idle DO is evicted from memory — so it also verifies that the
+ * in-memory state is genuinely dropped, not merely re-read from a stub that
+ * happened to point at the same warm instance.
+ */
+import { env } from "cloudflare:workers";
+import {
+  evictDurableObject,
+  runDurableObjectAlarm,
+  runInDurableObject
+} from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "..";
+import type { FiberRecoveryContext } from "..";
+import type { TestKeepAliveAgent } from "./agents/keep-alive";
+import type { TestRunFiberAgent } from "./agents/run-fiber";
+import type { TestScheduleAgent } from "./agents/schedule";
+
+describe("DO eviction (evictDurableObject)", () => {
+  describe("state cache rehydration", () => {
+    it("rebuilds in-memory state from SQL after eviction", async () => {
+      const agent = await getAgentByName(
+        env.TestStateAgent,
+        `evict-state-${crypto.randomUUID()}`
+      );
+
+      const stored = {
+        count: 314,
+        items: ["before-eviction"],
+        lastUpdated: "pre-evict"
+      };
+      await agent.updateState(stored);
+      expect(await agent.getState()).toEqual(stored);
+
+      // Real eviction: the in-memory `_state` cache is dropped here.
+      await evictDurableObject(agent);
+
+      // Next access must rehydrate `_state` from the cf_agents_state table.
+      // If rehydration were broken this would surface as initialState / undefined.
+      const rehydrated = await agent.getState();
+      expect(rehydrated).toEqual(stored);
+    });
+
+    it("drops in-memory onStateChanged call log on eviction (cache is genuinely fresh)", async () => {
+      const agent = await getAgentByName(
+        env.TestStateAgent,
+        `evict-state-log-${crypto.randomUUID()}`
+      );
+
+      await agent.updateState({
+        count: 1,
+        items: ["a"],
+        lastUpdated: "first"
+      });
+
+      // The onStateChanged hook pushes into an in-memory array. Poll until the
+      // waitUntil-scheduled hook has recorded the call.
+      let calls = await agent.getStateUpdateCalls();
+      const start = Date.now();
+      while (calls.length === 0 && Date.now() - start < 1000) {
+        await new Promise((r) => setTimeout(r, 10));
+        calls = await agent.getStateUpdateCalls();
+      }
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+
+      // Evict: a real eviction tears down the instance, so the in-memory log
+      // (which is NOT persisted) must be empty when the instance is rebuilt.
+      await evictDurableObject(agent);
+
+      const afterEviction = await agent.getStateUpdateCalls();
+      expect(afterEviction.length).toBe(0);
+
+      // ...but the persisted state itself is untouched.
+      expect(await agent.getState()).toEqual({
+        count: 1,
+        items: ["a"],
+        lastUpdated: "first"
+      });
+    });
+
+    it("recovers state set across multiple eviction round-trips", async () => {
+      const agent = await getAgentByName(
+        env.TestStateAgent,
+        `evict-state-roundtrips-${crypto.randomUUID()}`
+      );
+
+      for (let i = 0; i < 3; i++) {
+        const state = {
+          count: i,
+          items: [`round-${i}`],
+          lastUpdated: `r${i}`
+        };
+        await agent.updateState(state);
+        await evictDurableObject(agent);
+        expect(await agent.getState()).toEqual(state);
+      }
+    });
+  });
+
+  describe("scheduled callbacks survive eviction", () => {
+    it("fires a persisted interval schedule after the DO is evicted", async () => {
+      const agent = await getAgentByName(
+        env.TestScheduleAgent,
+        `evict-schedule-${crypto.randomUUID()}`
+      );
+
+      // Reset the in-memory execution counter so the assertion is unambiguous.
+      await runInDurableObject(agent, (instance: TestScheduleAgent) => {
+        instance.intervalCallbackCount = 0;
+      });
+
+      const scheduleId = await agent.createIntervalSchedule(1);
+
+      // Backdate the schedule row so the alarm scan considers it due.
+      await runInDurableObject(agent, (instance: TestScheduleAgent) => {
+        const past = Math.floor(Date.now() / 1000) - 1;
+        instance.sql`UPDATE cf_agents_schedules SET time = ${past} WHERE id = ${scheduleId}`;
+      });
+
+      // Evict the DO. The interval row lives in cf_agents_schedules (durable);
+      // the in-memory intervalCallbackCount is dropped.
+      await evictDurableObject(agent);
+
+      // Confirm the in-memory counter really was reset by the eviction.
+      const countAfterEvict = await runInDurableObject(
+        agent,
+        (instance: TestScheduleAgent) => instance.intervalCallbackCount
+      );
+      expect(countAfterEvict).toBe(0);
+
+      // Re-arm the alarm (the eviction-rebuilt instance recomputed schedules)
+      // and fire it deterministically.
+      await agent.setStoredAlarm(Date.now() + 1000);
+      await runDurableObjectAlarm(agent);
+
+      // The persisted schedule must have executed against the freshly
+      // rehydrated instance.
+      const count = await runInDurableObject(
+        agent,
+        (instance: TestScheduleAgent) => instance.intervalCallbackCount
+      );
+      expect(count).toBeGreaterThan(0);
+
+      // The interval schedule should still be present (it re-arms itself).
+      const remaining = await agent.getScheduleCount();
+      expect(remaining).toBeGreaterThanOrEqual(1);
+
+      await agent.cancelScheduleById(scheduleId);
+    });
+
+    it("keeps a one-shot delayed schedule durable across eviction", async () => {
+      const agent = await getAgentByName(
+        env.TestScheduleAgent,
+        `evict-oneshot-${crypto.randomUUID()}`
+      );
+
+      await runInDurableObject(agent, (instance: TestScheduleAgent) => {
+        instance.intervalCallbackCount = 0;
+      });
+
+      // Far-future delay so nothing auto-fires before we drive the alarm.
+      const scheduleId = await agent.createSchedule(86_400);
+      expect(await agent.getScheduleCount()).toBe(1);
+
+      await evictDurableObject(agent);
+
+      // The row survives eviction and is still queryable from the rebuilt
+      // instance.
+      expect(await agent.getScheduleCount()).toBe(1);
+      const row = await agent.getStoredScheduleById(scheduleId);
+      expect(row?.id).toBe(scheduleId);
+
+      await agent.cancelScheduleById(scheduleId);
+    });
+  });
+
+  describe("keepAlive ref counting across eviction", () => {
+    it("drops in-memory keepAlive refs on eviction (in-memory work is also lost)", async () => {
+      const agent = await getAgentByName(
+        env.TestKeepAliveAgent,
+        `evict-keepalive-${crypto.randomUUID()}`
+      );
+
+      await agent.startKeepAlive();
+      await agent.startKeepAlive();
+      expect(await getKeepAliveRefs(agent)).toBe(2);
+
+      // A held keepAlive arms a heartbeat alarm.
+      expect(await agent.getCurrentAlarm()).not.toBeNull();
+
+      // Evict: the ref counter protects in-memory work that no longer exists
+      // after eviction, so it MUST reset rather than carry stale leases over.
+      await evictDurableObject(agent);
+
+      expect(await getKeepAliveRefs(agent)).toBe(0);
+
+      // Acquiring again on the rebuilt instance must produce an independent
+      // count (1, not 3) and re-arm the heartbeat cleanly.
+      await agent.startKeepAlive();
+      expect(await getKeepAliveRefs(agent)).toBe(1);
+      expect(await agent.getCurrentAlarm()).not.toBeNull();
+    });
+
+    it("does not leak a stale heartbeat: eviction with no live work leaves no refs", async () => {
+      const agent = await getAgentByName(
+        env.TestKeepAliveAgent,
+        `evict-keepalive-clean-${crypto.randomUUID()}`
+      );
+
+      await agent.startKeepAlive();
+      expect(await getKeepAliveRefs(agent)).toBe(1);
+
+      await evictDurableObject(agent);
+
+      // No leases carried over, and no schedule rows were ever created by
+      // keepAlive (it uses the heartbeat alarm, not cf_agents_schedules).
+      expect(await getKeepAliveRefs(agent)).toBe(0);
+      expect(await agent.getScheduleCount()).toBe(0);
+    });
+  });
+
+  describe("fiber recovery after eviction", () => {
+    it("recovers an interrupted unmanaged fiber from SQL after eviction", async () => {
+      const stub = await getAgentByName(
+        env.TestRunFiberAgent,
+        `evict-fiber-unmanaged-${crypto.randomUUID()}`
+      );
+      const agent = stub as unknown as TestRunFiberAgent;
+
+      // Pre-eviction: an interrupted fiber row exists in cf_agents_runs and the
+      // in-memory recovery log is non-empty from an earlier scan.
+      await agent.insertInterruptedFiber("evicted-fiber-1", "research", {
+        step: 7
+      });
+
+      // Prime the in-memory log with an unrelated entry so we can prove it is
+      // dropped by the eviction (not merely overwritten).
+      await agent.runSimple("warm");
+      const logBefore = await agent.getExecutionLog();
+      expect(logBefore).toContain("executed:warm");
+
+      // Real eviction tears down recoveredFibers, executionLog and the
+      // _runFiberActiveFibers set.
+      await evictDurableObject(stub);
+
+      // The in-memory execution log is gone; the fiber row is not.
+      const logAfter = await agent.getExecutionLog();
+      expect(logAfter).not.toContain("executed:warm");
+      expect(await agent.getRunningFiberCount()).toBe(1);
+
+      // Drive the recovery scan on the rebuilt instance. onFiberRecovered must
+      // fire from the persisted cf_agents_runs snapshot.
+      await agent.triggerRecoveryCheck();
+
+      const recovered =
+        (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
+      expect(recovered.length).toBe(1);
+      expect(recovered[0].id).toBe("evicted-fiber-1");
+      expect(recovered[0].name).toBe("research");
+      expect(recovered[0].snapshot).toEqual({ step: 7 });
+      expect(recovered[0].recoveryReason).toBe("interrupted");
+
+      // Recovery deletes the row.
+      expect(await agent.getRunningFiberCount()).toBe(0);
+    });
+
+    it("applies a managed-fiber recovery result after eviction via the alarm", async () => {
+      const stub = await getAgentByName(
+        env.TestRunFiberAgent,
+        `evict-fiber-managed-${crypto.randomUUID()}`
+      );
+      const agent = stub as unknown as TestRunFiberAgent;
+
+      // A managed fiber whose recovery hook returns {status: "completed"}.
+      await agent.insertInterruptedManagedFiber(
+        "evicted-managed-1",
+        "managed-recovery-complete",
+        { progress: 42 }
+      );
+
+      await evictDurableObject(stub);
+
+      // After eviction the in-memory recovery log starts empty.
+      expect(
+        (
+          (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[]
+        ).length
+      ).toBe(0);
+
+      // Drive one alarm cycle (the path the platform uses post-eviction):
+      // _checkRunFibers → onFiberRecovered → _scheduleNextAlarm.
+      await agent.simulateAlarmCycle();
+
+      const recovered =
+        (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
+      expect(recovered.some((f) => f.id === "evicted-managed-1")).toBe(true);
+      const ctx = recovered.find((f) => f.id === "evicted-managed-1");
+      expect(ctx?.snapshot).toEqual({ progress: 42 });
+
+      // The managed ledger row must be marked completed (recovery applied),
+      // not left running.
+      const inspection = await agent.inspectManagedFiber("evicted-managed-1");
+      expect(inspection?.status).toBe("completed");
+    });
+
+    it("recovers concurrent interrupted fibers independently after eviction", async () => {
+      const stub = await getAgentByName(
+        env.TestRunFiberAgent,
+        `evict-fiber-concurrent-${crypto.randomUUID()}`
+      );
+      const agent = stub as unknown as TestRunFiberAgent;
+
+      await agent.insertInterruptedFiber("evict-multi-a", "task-a", {
+        which: "a"
+      });
+      await agent.insertInterruptedFiber("evict-multi-b", "task-b", {
+        which: "b"
+      });
+      expect(await agent.getRunningFiberCount()).toBe(2);
+
+      await evictDurableObject(stub);
+
+      // Both rows survive; in-memory recovery state is fresh.
+      expect(await agent.getRunningFiberCount()).toBe(2);
+      expect(
+        (
+          (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[]
+        ).length
+      ).toBe(0);
+
+      await agent.triggerRecoveryCheck();
+
+      const recovered =
+        (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
+      expect(recovered.length).toBe(2);
+      expect(recovered.map((f) => f.id).sort()).toEqual([
+        "evict-multi-a",
+        "evict-multi-b"
+      ]);
+      expect(await agent.getRunningFiberCount()).toBe(0);
+    });
+  });
+});
+
+async function getKeepAliveRefs(
+  stub: DurableObjectStub<TestKeepAliveAgent>
+): Promise<number> {
+  return runInDurableObject(stub, (instance) => instance._keepAliveRefs);
+}

--- a/packages/agents/src/tests/agents-core-eviction.test.ts
+++ b/packages/agents/src/tests/agents-core-eviction.test.ts
@@ -1,16 +1,10 @@
 /**
- * Durable Object eviction tests for agents-core.
+ * Forced Durable Object eviction coverage for the base Agent.
  *
- * These prove that Agent-backed state survives a *real* production-like
- * eviction: `evictDurableObject(stub)` tears down the in-memory instance
- * (dropping caches, in-flight maps, ref counters, recovery sets) while
- * leaving durable storage intact. The next access rehydrates from SQL.
- *
- * Unlike the "get a fresh stub (simulates restart)" idiom used elsewhere in
- * this package, evictDurableObject exercises the same code path the platform
- * runs when an idle DO is evicted from memory — so it also verifies that the
- * in-memory state is genuinely dropped, not merely re-read from a stub that
- * happened to point at the same warm instance.
+ * `evictDurableObject()` tears down a running test actor while preserving its
+ * durable storage. These tests prove that selected Agent state is reconstructed
+ * from storage on the next access. They do not assert natural idle hibernation,
+ * the absence of pending timers, or hibernation eligibility.
  */
 import { env } from "cloudflare:workers";
 import {
@@ -21,338 +15,145 @@ import {
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "..";
 import type { FiberRecoveryContext } from "..";
-import type { TestKeepAliveAgent } from "./agents/keep-alive";
 import type { TestRunFiberAgent } from "./agents/run-fiber";
 import type { TestScheduleAgent } from "./agents/schedule";
 
-describe("DO eviction (evictDurableObject)", () => {
-  describe("state cache rehydration", () => {
-    it("rebuilds in-memory state from SQL after eviction", async () => {
-      const agent = await getAgentByName(
-        env.TestStateAgent,
-        `evict-state-${crypto.randomUUID()}`
-      );
+function uniqueName(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
 
-      const stored = {
-        count: 314,
-        items: ["before-eviction"],
-        lastUpdated: "pre-evict"
-      };
-      await agent.updateState(stored);
-      expect(await agent.getState()).toEqual(stored);
+describe("Agent recovery after forced Durable Object eviction", () => {
+  it("drops instance state while restoring persisted Agent state", async () => {
+    const agent = await getAgentByName(
+      env.TestStateAgent,
+      uniqueName("evict-state")
+    );
+    const stored = {
+      count: 314,
+      items: ["before-eviction"],
+      lastUpdated: "pre-evict"
+    };
 
-      // Real eviction: the in-memory `_state` cache is dropped here.
-      await evictDurableObject(agent);
+    await agent.updateState(stored);
 
-      // Next access must rehydrate `_state` from the cf_agents_state table.
-      // If rehydration were broken this would surface as initialState / undefined.
-      const rehydrated = await agent.getState();
-      expect(rehydrated).toEqual(stored);
-    });
+    let calls = await agent.getStateUpdateCalls();
+    const deadline = Date.now() + 1000;
+    while (calls.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      calls = await agent.getStateUpdateCalls();
+    }
+    expect(calls.length).toBeGreaterThanOrEqual(1);
 
-    it("drops in-memory onStateChanged call log on eviction (cache is genuinely fresh)", async () => {
-      const agent = await getAgentByName(
-        env.TestStateAgent,
-        `evict-state-log-${crypto.randomUUID()}`
-      );
+    await evictDurableObject(agent);
 
-      await agent.updateState({
-        count: 1,
-        items: ["a"],
-        lastUpdated: "first"
-      });
-
-      // The onStateChanged hook pushes into an in-memory array. Poll until the
-      // waitUntil-scheduled hook has recorded the call.
-      let calls = await agent.getStateUpdateCalls();
-      const start = Date.now();
-      while (calls.length === 0 && Date.now() - start < 1000) {
-        await new Promise((r) => setTimeout(r, 10));
-        calls = await agent.getStateUpdateCalls();
-      }
-      expect(calls.length).toBeGreaterThanOrEqual(1);
-
-      // Evict: a real eviction tears down the instance, so the in-memory log
-      // (which is NOT persisted) must be empty when the instance is rebuilt.
-      await evictDurableObject(agent);
-
-      const afterEviction = await agent.getStateUpdateCalls();
-      expect(afterEviction.length).toBe(0);
-
-      // ...but the persisted state itself is untouched.
-      expect(await agent.getState()).toEqual({
-        count: 1,
-        items: ["a"],
-        lastUpdated: "first"
-      });
-    });
-
-    it("recovers state set across multiple eviction round-trips", async () => {
-      const agent = await getAgentByName(
-        env.TestStateAgent,
-        `evict-state-roundtrips-${crypto.randomUUID()}`
-      );
-
-      for (let i = 0; i < 3; i++) {
-        const state = {
-          count: i,
-          items: [`round-${i}`],
-          lastUpdated: `r${i}`
-        };
-        await agent.updateState(state);
-        await evictDurableObject(agent);
-        expect(await agent.getState()).toEqual(state);
-      }
-    });
+    // The hook log is instance-only, while the Agent state is SQL-backed.
+    expect(await agent.getStateUpdateCalls()).toEqual([]);
+    expect(await agent.getState()).toEqual(stored);
   });
 
-  describe("scheduled callbacks survive eviction", () => {
-    it("fires a persisted interval schedule after the DO is evicted", async () => {
-      const agent = await getAgentByName(
-        env.TestScheduleAgent,
-        `evict-schedule-${crypto.randomUUID()}`
+  it("runs a persisted interval schedule on the reconstructed instance", async () => {
+    const agent = await getAgentByName(
+      env.TestScheduleAgent,
+      uniqueName("evict-schedule")
+    );
+    const scheduleId = await agent.createIntervalSchedule(86_400);
+
+    try {
+      await agent.clearStoredAlarm();
+      await agent.backdateSchedule(
+        scheduleId,
+        Math.floor(Date.now() / 1000) - 1
       );
 
-      // Reset the in-memory execution counter so the assertion is unambiguous.
-      await runInDurableObject(agent, (instance: TestScheduleAgent) => {
-        instance.intervalCallbackCount = 0;
-      });
-
-      const scheduleId = await agent.createIntervalSchedule(1);
-
-      // Backdate the schedule row so the alarm scan considers it due.
-      await runInDurableObject(agent, (instance: TestScheduleAgent) => {
-        const past = Math.floor(Date.now() / 1000) - 1;
-        instance.sql`UPDATE cf_agents_schedules SET time = ${past} WHERE id = ${scheduleId}`;
-      });
-
-      // Evict the DO. The interval row lives in cf_agents_schedules (durable);
-      // the in-memory intervalCallbackCount is dropped.
       await evictDurableObject(agent);
 
-      // Confirm the in-memory counter really was reset by the eviction.
-      const countAfterEvict = await runInDurableObject(
-        agent,
-        (instance: TestScheduleAgent) => instance.intervalCallbackCount
+      expect(
+        await runInDurableObject(
+          agent,
+          (instance: TestScheduleAgent) => instance.intervalCallbackCount
+        )
+      ).toBe(0);
+      expect((await agent.getStoredScheduleById(scheduleId))?.id).toBe(
+        scheduleId
       );
-      expect(countAfterEvict).toBe(0);
 
-      // Re-arm the alarm (the eviction-rebuilt instance recomputed schedules)
-      // and fire it deterministically.
       await agent.setStoredAlarm(Date.now() + 1000);
       await runDurableObjectAlarm(agent);
 
-      // The persisted schedule must have executed against the freshly
-      // rehydrated instance.
-      const count = await runInDurableObject(
-        agent,
-        (instance: TestScheduleAgent) => instance.intervalCallbackCount
-      );
-      expect(count).toBeGreaterThan(0);
-
-      // The interval schedule should still be present (it re-arms itself).
-      const remaining = await agent.getScheduleCount();
-      expect(remaining).toBeGreaterThanOrEqual(1);
-
-      await agent.cancelScheduleById(scheduleId);
-    });
-
-    it("keeps a one-shot delayed schedule durable across eviction", async () => {
-      const agent = await getAgentByName(
-        env.TestScheduleAgent,
-        `evict-oneshot-${crypto.randomUUID()}`
-      );
-
-      await runInDurableObject(agent, (instance: TestScheduleAgent) => {
-        instance.intervalCallbackCount = 0;
-      });
-
-      // Far-future delay so nothing auto-fires before we drive the alarm.
-      const scheduleId = await agent.createSchedule(86_400);
+      expect(
+        await runInDurableObject(
+          agent,
+          (instance: TestScheduleAgent) => instance.intervalCallbackCount
+        )
+      ).toBe(1);
       expect(await agent.getScheduleCount()).toBe(1);
-
-      await evictDurableObject(agent);
-
-      // The row survives eviction and is still queryable from the rebuilt
-      // instance.
-      expect(await agent.getScheduleCount()).toBe(1);
-      const row = await agent.getStoredScheduleById(scheduleId);
-      expect(row?.id).toBe(scheduleId);
-
+    } finally {
       await agent.cancelScheduleById(scheduleId);
-    });
+      await agent.clearStoredAlarm();
+    }
   });
 
-  describe("keepAlive ref counting across eviction", () => {
-    it("drops in-memory keepAlive refs on eviction (in-memory work is also lost)", async () => {
-      const agent = await getAgentByName(
-        env.TestKeepAliveAgent,
-        `evict-keepalive-${crypto.randomUUID()}`
-      );
+  it("recovers an interrupted unmanaged fiber from SQL", async () => {
+    const stub = await getAgentByName(
+      env.TestRunFiberAgent,
+      uniqueName("evict-fiber")
+    );
+    const agent = stub as unknown as TestRunFiberAgent;
 
-      await agent.startKeepAlive();
-      await agent.startKeepAlive();
-      expect(await getKeepAliveRefs(agent)).toBe(2);
-
-      // A held keepAlive arms a heartbeat alarm.
-      expect(await agent.getCurrentAlarm()).not.toBeNull();
-
-      // Evict: the ref counter protects in-memory work that no longer exists
-      // after eviction, so it MUST reset rather than carry stale leases over.
-      await evictDurableObject(agent);
-
-      expect(await getKeepAliveRefs(agent)).toBe(0);
-
-      // Acquiring again on the rebuilt instance must produce an independent
-      // count (1, not 3) and re-arm the heartbeat cleanly.
-      await agent.startKeepAlive();
-      expect(await getKeepAliveRefs(agent)).toBe(1);
-      expect(await agent.getCurrentAlarm()).not.toBeNull();
+    await agent.insertInterruptedFiber("evicted-fiber", "research", {
+      step: 7
     });
+    await agent.runSimple("warm");
+    expect(await agent.getExecutionLog()).toContain("executed:warm");
 
-    it("does not leak a stale heartbeat: eviction with no live work leaves no refs", async () => {
-      const agent = await getAgentByName(
-        env.TestKeepAliveAgent,
-        `evict-keepalive-clean-${crypto.randomUUID()}`
-      );
+    await evictDurableObject(stub);
 
-      await agent.startKeepAlive();
-      expect(await getKeepAliveRefs(agent)).toBe(1);
+    expect(await agent.getExecutionLog()).not.toContain("executed:warm");
+    expect(await agent.getRunningFiberCount()).toBe(1);
 
-      await evictDurableObject(agent);
+    await agent.triggerRecoveryCheck();
 
-      // No leases carried over, and no schedule rows were ever created by
-      // keepAlive (it uses the heartbeat alarm, not cf_agents_schedules).
-      expect(await getKeepAliveRefs(agent)).toBe(0);
-      expect(await agent.getScheduleCount()).toBe(0);
-    });
+    const recovered =
+      (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
+    expect(recovered).toEqual([
+      expect.objectContaining({
+        id: "evicted-fiber",
+        name: "research",
+        snapshot: { step: 7 },
+        recoveryReason: "interrupted"
+      })
+    ]);
+    expect(await agent.getRunningFiberCount()).toBe(0);
   });
 
-  describe("fiber recovery after eviction", () => {
-    it("recovers an interrupted unmanaged fiber from SQL after eviction", async () => {
-      const stub = await getAgentByName(
-        env.TestRunFiberAgent,
-        `evict-fiber-unmanaged-${crypto.randomUUID()}`
-      );
-      const agent = stub as unknown as TestRunFiberAgent;
+  it("applies managed-fiber recovery on a fresh instance", async () => {
+    const stub = await getAgentByName(
+      env.TestRunFiberAgent,
+      uniqueName("evict-managed-fiber")
+    );
+    const agent = stub as unknown as TestRunFiberAgent;
 
-      // Pre-eviction: an interrupted fiber row exists in cf_agents_runs and the
-      // in-memory recovery log is non-empty from an earlier scan.
-      await agent.insertInterruptedFiber("evicted-fiber-1", "research", {
-        step: 7
-      });
+    await agent.insertInterruptedManagedFiber(
+      "evicted-managed",
+      "managed-recovery-complete",
+      { progress: 42 }
+    );
 
-      // Prime the in-memory log with an unrelated entry so we can prove it is
-      // dropped by the eviction (not merely overwritten).
-      await agent.runSimple("warm");
-      const logBefore = await agent.getExecutionLog();
-      expect(logBefore).toContain("executed:warm");
+    await evictDurableObject(stub);
 
-      // Real eviction tears down recoveredFibers, executionLog and the
-      // _runFiberActiveFibers set.
-      await evictDurableObject(stub);
+    expect(await agent.getRecoveredFibers()).toEqual([]);
+    await agent.simulateAlarmCycle();
 
-      // The in-memory execution log is gone; the fiber row is not.
-      const logAfter = await agent.getExecutionLog();
-      expect(logAfter).not.toContain("executed:warm");
-      expect(await agent.getRunningFiberCount()).toBe(1);
-
-      // Drive the recovery scan on the rebuilt instance. onFiberRecovered must
-      // fire from the persisted cf_agents_runs snapshot.
-      await agent.triggerRecoveryCheck();
-
-      const recovered =
-        (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
-      expect(recovered.length).toBe(1);
-      expect(recovered[0].id).toBe("evicted-fiber-1");
-      expect(recovered[0].name).toBe("research");
-      expect(recovered[0].snapshot).toEqual({ step: 7 });
-      expect(recovered[0].recoveryReason).toBe("interrupted");
-
-      // Recovery deletes the row.
-      expect(await agent.getRunningFiberCount()).toBe(0);
-    });
-
-    it("applies a managed-fiber recovery result after eviction via the alarm", async () => {
-      const stub = await getAgentByName(
-        env.TestRunFiberAgent,
-        `evict-fiber-managed-${crypto.randomUUID()}`
-      );
-      const agent = stub as unknown as TestRunFiberAgent;
-
-      // A managed fiber whose recovery hook returns {status: "completed"}.
-      await agent.insertInterruptedManagedFiber(
-        "evicted-managed-1",
-        "managed-recovery-complete",
-        { progress: 42 }
-      );
-
-      await evictDurableObject(stub);
-
-      // After eviction the in-memory recovery log starts empty.
-      expect(
-        (
-          (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[]
-        ).length
-      ).toBe(0);
-
-      // Drive one alarm cycle (the path the platform uses post-eviction):
-      // _checkRunFibers → onFiberRecovered → _scheduleNextAlarm.
-      await agent.simulateAlarmCycle();
-
-      const recovered =
-        (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
-      expect(recovered.some((f) => f.id === "evicted-managed-1")).toBe(true);
-      const ctx = recovered.find((f) => f.id === "evicted-managed-1");
-      expect(ctx?.snapshot).toEqual({ progress: 42 });
-
-      // The managed ledger row must be marked completed (recovery applied),
-      // not left running.
-      const inspection = await agent.inspectManagedFiber("evicted-managed-1");
-      expect(inspection?.status).toBe("completed");
-    });
-
-    it("recovers concurrent interrupted fibers independently after eviction", async () => {
-      const stub = await getAgentByName(
-        env.TestRunFiberAgent,
-        `evict-fiber-concurrent-${crypto.randomUUID()}`
-      );
-      const agent = stub as unknown as TestRunFiberAgent;
-
-      await agent.insertInterruptedFiber("evict-multi-a", "task-a", {
-        which: "a"
-      });
-      await agent.insertInterruptedFiber("evict-multi-b", "task-b", {
-        which: "b"
-      });
-      expect(await agent.getRunningFiberCount()).toBe(2);
-
-      await evictDurableObject(stub);
-
-      // Both rows survive; in-memory recovery state is fresh.
-      expect(await agent.getRunningFiberCount()).toBe(2);
-      expect(
-        (
-          (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[]
-        ).length
-      ).toBe(0);
-
-      await agent.triggerRecoveryCheck();
-
-      const recovered =
-        (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
-      expect(recovered.length).toBe(2);
-      expect(recovered.map((f) => f.id).sort()).toEqual([
-        "evict-multi-a",
-        "evict-multi-b"
-      ]);
-      expect(await agent.getRunningFiberCount()).toBe(0);
-    });
+    const recovered =
+      (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
+    expect(recovered).toEqual([
+      expect.objectContaining({
+        id: "evicted-managed",
+        snapshot: { progress: 42 }
+      })
+    ]);
+    expect((await agent.inspectManagedFiber("evicted-managed"))?.status).toBe(
+      "completed"
+    );
   });
 });
-
-async function getKeepAliveRefs(
-  stub: DurableObjectStub<TestKeepAliveAgent>
-): Promise<number> {
-  return runInDurableObject(stub, (instance) => instance._keepAliveRefs);
-}

--- a/packages/agents/src/tests/agents/wait-connections.ts
+++ b/packages/agents/src/tests/agents/wait-connections.ts
@@ -94,6 +94,26 @@ export class TestWaitConnectionsAgent extends Agent {
     };
   }
 
+  /** Wait for the lifecycle-started restores without triggering another one. */
+  async waitAndReport(timeout?: number): Promise<{
+    connectionIds: string[];
+    connectionStates: Record<string, string>;
+  }> {
+    await this.mcp.waitForConnections(
+      timeout != null ? { timeout } : undefined
+    );
+
+    return {
+      connectionIds: Object.keys(this.mcp.mcpConnections),
+      connectionStates: Object.fromEntries(
+        Object.entries(this.mcp.mcpConnections).map(([id, connection]) => [
+          id,
+          connection.connectionState
+        ])
+      )
+    };
+  }
+
   /**
    * Trigger restore WITHOUT waiting, then immediately check states.
    * This simulates the race condition (old behavior).

--- a/packages/agents/src/tests/experimental/memory/agents-memory-eviction.test.ts
+++ b/packages/agents/src/tests/experimental/memory/agents-memory-eviction.test.ts
@@ -1,80 +1,26 @@
 /**
- * Durable Object eviction tests for the `agents-memory` (experimental Session)
- * module.
+ * Forced Durable Object eviction coverage for Session storage.
  *
- * These exercise the production hibernation/eviction lifecycle with the real
- * `evictDurableObject` / `evictAllDurableObjects` helpers from
- * "cloudflare:test" (vitest-pool-workers >= 0.16.20). Eviction tears down the
- * DO instance — dropping all in-memory state, including the
- * `AgentSessionProvider.activeLeafId` cache and the `Session` skill-restore
- * tracking — while preserving durable SQLite storage. On the next access the
- * DO is rebuilt from storage.
- *
- * Each test drives a `TestSessionAgent` to build up real in-memory + stored
- * state, evicts it, then re-accesses and asserts the state rehydrated
- * correctly from SQLite. The assertions fail if rehydration is broken: they
- * are not vacuous "still works" smoke checks.
- *
- * `TestSessionAgent` is the same fixture used by
- * `experimental/memory/session/provider.test.ts`; it exposes `antiJoinCount`
- * instrumentation that lets us prove the in-memory active-leaf cache was lost
- * and rebuilt (rather than silently surviving, which would mean eviction
- * isn't really tearing the instance down).
+ * These tests tear down running test actors and verify that a new Session
+ * instance reconstructs its active-leaf cache from SQLite. They do not assert
+ * natural idle hibernation or hibernation eligibility.
  */
 import type { UIMessage } from "ai";
 import { env } from "cloudflare:workers";
 import { evictAllDurableObjects, evictDurableObject } from "cloudflare:test";
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getAgentByName } from "../../..";
 
-/**
- * Typed stub for TestSessionAgent — mirrors the SessionAgentStub used in
- * provider.test.ts so these eviction tests share the same conventions.
- */
 interface SessionAgentStub {
   appendMessage(message: UIMessage, parentId?: string | null): Promise<void>;
-  getMessage(id: string): Promise<UIMessage | null>;
-  clearMessages(): Promise<void>;
-  getHistory(leafId?: string): Promise<UIMessage[]>;
+  getHistory(): Promise<UIMessage[]>;
   getLatestLeaf(): Promise<UIMessage | null>;
   getBranches(messageId: string): Promise<UIMessage[]>;
-  getPathLength(): Promise<number>;
-  addCompaction(
-    summary: string,
-    fromId: string,
-    toId: string
-  ): Promise<unknown>;
-  getCompactions(): Promise<unknown[]>;
-  search(
-    query: string
-  ): Promise<Array<{ id: string; role: string; content: string }>>;
   appendLinearChainForTest(count: number, prefix?: string): Promise<void>;
-  appendLargeChainForTest(
-    count: number,
-    charsPerMessage: number,
-    prefix?: string
-  ): Promise<void>;
-  getHistoryTextLengthsForTest(): Promise<
-    Array<{ id: string; textLength: number }>
-  >;
-  getRecentHistory(
-    maxContentBytes: number,
-    minRecentMessages?: number
-  ): Promise<{
-    messages: UIMessage[];
-    truncated: boolean;
-    totalContentBytes: number;
-  }>;
-  corruptMessageForTest(id: string): Promise<void>;
   getAntiJoinCountForTest(): Promise<number>;
   resetAntiJoinCountForTest(): Promise<void>;
 }
 
-/**
- * The stub returned by `getAgentByName` is the live DurableObjectStub — the
- * same value `schedule.test.ts` hands to `runInDurableObject` /
- * `runDurableObjectAlarm`, so it's also the value `evictDurableObject` takes.
- */
 async function getAgent(name: string): Promise<SessionAgentStub> {
   return getAgentByName(
     env.TestSessionAgent,
@@ -82,313 +28,70 @@ async function getAgent(name: string): Promise<SessionAgentStub> {
   ) as unknown as Promise<SessionAgentStub>;
 }
 
-/**
- * `evictDurableObject` takes a `DurableObjectStub`. Our `SessionAgentStub` is
- * the same live stub typed for RPC ergonomics; cast once here so call sites
- * stay readable.
- */
-function evict(
-  agent: SessionAgentStub,
-  options?: { webSockets: "close" | "hibernate" }
-): Promise<void> {
-  return evictDurableObject(agent as unknown as DurableObjectStub, options);
+async function evict(agent: SessionAgentStub): Promise<void> {
+  await evictDurableObject(agent as unknown as DurableObjectStub);
 }
 
-describe("agents-memory Session — Durable Object eviction", () => {
-  let name: string;
-  beforeEach(() => {
-    name = `evict-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  });
+function uniqueName(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
 
-  it("rebuilds the active-leaf cache from storage after eviction (exactly one anti-join)", async () => {
-    const agent = await getAgent(name);
-    // Build a long chain so a from-scratch leaf scan is meaningfully expensive
-    // and the cache is genuinely warm before we evict.
-    await agent.appendLinearChainForTest(20); // m0..m19
+describe("Session recovery after forced Durable Object eviction", () => {
+  it("rebuilds and rewarms the active-leaf cache from SQLite", async () => {
+    const agent = await getAgent(uniqueName("evict-session"));
+    await agent.appendLinearChainForTest(20);
     expect((await agent.getLatestLeaf())?.id).toBe("m19");
 
-    // Warm cache: repeated reads cost zero anti-joins while the instance lives.
     await agent.resetAntiJoinCountForTest();
     expect((await agent.getLatestLeaf())?.id).toBe("m19");
     expect(await agent.getAntiJoinCountForTest()).toBe(0);
 
-    // Evict: the DO instance is torn down. The provider's in-memory
-    // `activeLeafId` cache (and the counter) are gone; only SQLite remains.
     await evict(agent);
 
-    // First leaf lookup on the rebuilt instance must recompute the tip from
-    // storage — exactly one anti-join. If the cache had somehow survived
-    // eviction this would be 0 and the test would (correctly) fail, proving
-    // eviction really resets in-memory state.
+    // A reconstructed provider has no activeLeafId cache. Its first lookup must
+    // discover the tip once; subsequent auto-parenting uses the warmed cache.
     expect((await agent.getLatestLeaf())?.id).toBe("m19");
     expect(await agent.getAntiJoinCountForTest()).toBe(1);
 
-    // ...and it's re-warmed: subsequent reads on the rebuilt instance are free.
     await agent.resetAntiJoinCountForTest();
-    expect((await agent.getLatestLeaf())?.id).toBe("m19");
     await agent.appendMessage({
       id: "after",
       role: "user",
       parts: [{ type: "text", text: "after eviction" }]
     });
-    expect((await agent.getLatestLeaf())?.id).toBe("after");
+
+    expect(
+      (await agent.getBranches("m19")).map((message) => message.id)
+    ).toEqual(["after"]);
+    expect((await agent.getHistory()).map((message) => message.id)).toEqual([
+      ...Array.from({ length: 20 }, (_, index) => `m${index}`),
+      "after"
+    ]);
     expect(await agent.getAntiJoinCountForTest()).toBe(0);
   });
 
-  it("auto-parenting after eviction attaches to the rehydrated tip, not a new root", async () => {
-    const agent = await getAgent(name);
-    await agent.appendMessage({
-      id: "m1",
-      role: "user",
-      parts: [{ type: "text", text: "first" }]
-    });
-    await agent.appendMessage({
-      id: "m2",
-      role: "assistant",
-      parts: [{ type: "text", text: "reply" }]
-    });
-
-    await evict(agent);
-
-    // No parentId: the rebuilt provider must recover the tip (m2) from storage
-    // and attach to it. A broken rehydration would orphan m3 as a new root.
-    await agent.appendMessage({
-      id: "m3",
-      role: "user",
-      parts: [{ type: "text", text: "follow-up after wake" }]
-    });
-
-    expect((await agent.getBranches("m2")).map((b) => b.id)).toContain("m3");
-    expect((await agent.getHistory()).map((m) => m.id)).toEqual([
-      "m1",
-      "m2",
-      "m3"
-    ]);
-    expect(await agent.getPathLength()).toBe(3);
-  });
-
-  it("conversation tree (branches + parent links) survives eviction", async () => {
-    const agent = await getAgent(name);
-    await agent.appendMessage({
-      id: "root",
-      role: "user",
-      parts: [{ type: "text", text: "Question" }]
-    });
-    await agent.appendMessage(
-      {
-        id: "a",
-        role: "assistant",
-        parts: [{ type: "text", text: "Answer A" }]
-      },
-      "root"
-    );
-    await agent.appendMessage(
-      {
-        id: "b",
-        role: "assistant",
-        parts: [{ type: "text", text: "Answer B" }]
-      },
-      "root"
-    );
-
-    await evict(agent);
-
-    // The whole tree must come back from SQLite with structure intact.
-    const branches = await agent.getBranches("root");
-    expect(branches.map((m) => m.id).sort()).toEqual(["a", "b"]);
-
-    expect((await agent.getHistory("a")).map((m) => m.id)).toEqual([
-      "root",
-      "a"
-    ]);
-    expect((await agent.getHistory("b")).map((m) => m.id)).toEqual([
-      "root",
-      "b"
-    ]);
-
-    const restored = await agent.getMessage("a");
-    expect(restored?.parts[0]).toEqual({ type: "text", text: "Answer A" });
-    // Latest leaf is the most-recent childless node (b).
-    expect((await agent.getLatestLeaf())?.id).toBe("b");
-  });
-
-  it("compaction overlays survive eviction and still rewrite history", async () => {
-    const agent = await getAgent(name);
-    for (let i = 0; i < 6; i++) {
-      await agent.appendMessage({
-        id: `m${i}`,
-        role: i % 2 === 0 ? "user" : "assistant",
-        parts: [{ type: "text", text: `msg ${i}` }]
-      });
-    }
-    await agent.addCompaction("Summary of m1-m3", "m1", "m3");
-
-    await evict(agent);
-
-    // The compaction lives in assistant_compactions (SQLite); after wake the
-    // overlay must still collapse m1..m3 into the stored summary.
-    const history = await agent.getHistory();
-    expect(history.map((m) => m.id)).toEqual([
-      "m0",
-      expect.stringMatching(/^compaction_/),
-      "m4",
-      "m5"
-    ]);
-    expect(history[1].parts[0]).toEqual({
-      type: "text",
-      text: expect.stringContaining("Summary of m1-m3")
-    });
-    expect(await agent.getCompactions()).toHaveLength(1);
-  });
-
-  it("FTS5 search index survives eviction", async () => {
-    const agent = await getAgent(name);
-    await agent.appendMessage({
-      id: "m1",
-      role: "user",
-      parts: [{ type: "text", text: "I love TypeScript" }]
-    });
-    await agent.appendMessage({
-      id: "m2",
-      role: "user",
-      parts: [{ type: "text", text: "Python is also good" }]
-    });
-
-    await evict(agent);
-
-    // assistant_fts is a persisted virtual table; search must still hit after
-    // the index is reloaded from storage.
-    const results = await agent.search("TypeScript");
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results[0].content).toContain("TypeScript");
-    // Negative control: a term only in the other message still resolves to it,
-    // not to the TypeScript row.
-    const python = await agent.search("Python");
-    expect(python.map((r) => r.id)).toContain("m2");
-  });
-
-  it("multi-megabyte chained messages round-trip through chunked hydration after eviction", async () => {
-    const agent = await getAgent(name);
-    // 4 × ~1.5MB rows ≈ 6MB — crosses the 4MB per-chunk byte bound, so content
-    // hydration must split across statements and reassemble in path order.
-    await agent.appendLargeChainForTest(4, 1_500_000);
-
-    await evict(agent);
-
-    // After a real wake the byte-bounded chunked read path must still
-    // reassemble every large row in order, intact.
-    const lengths = await agent.getHistoryTextLengthsForTest();
-    expect(lengths.map((l) => l.id)).toEqual(["big0", "big1", "big2", "big3"]);
-    for (const row of lengths) {
-      expect(row.textLength).toBeGreaterThanOrEqual(1_500_000);
-    }
-
-    // The byte-budgeted recent window must still honour its budget post-wake:
-    // a tiny budget yields only the leaf, but the leaf row content survives.
-    const recent = await agent.getRecentHistory(1024);
-    expect(recent.truncated).toBe(true);
-    expect(recent.messages.map((m) => m.id)).toEqual(["big3"]);
-  });
-
-  it("corrupted-row recovery is stable across eviction", async () => {
-    const agent = await getAgent(name);
-    await agent.appendLinearChainForTest(10); // m0..m9
-    await agent.corruptMessageForTest("m4");
-
-    // Before eviction the corrupt row is skipped, rest intact.
-    const before = await agent.getHistory();
-    expect(before.map((m) => m.id)).toEqual(
-      Array.from({ length: 10 }, (_, i) => `m${i}`).filter((id) => id !== "m4")
-    );
-
-    await evict(agent);
-
-    // The corruption is in stored content; after the instance is rebuilt the
-    // read path must still tolerate it identically — not throw, not drop the
-    // rest of the chain.
-    const after = await agent.getHistory();
-    expect(after.map((m) => m.id)).toEqual(before.map((m) => m.id));
-  });
-
-  it("evictAllDurableObjects preserves and isolates per-DO session history", async () => {
-    const nameA = `${name}-a`;
-    const nameB = `${name}-b`;
-    const agentA = await getAgent(nameA);
-    const agentB = await getAgent(nameB);
+  it("keeps named Session histories isolated after a global forced eviction", async () => {
+    const agentA = await getAgent(uniqueName("evict-session-a"));
+    const agentB = await getAgent(uniqueName("evict-session-b"));
 
     await agentA.appendMessage({
       id: "a1",
       role: "user",
-      parts: [{ type: "text", text: "hello from A" }]
-    });
-    await agentA.appendMessage({
-      id: "a2",
-      role: "assistant",
-      parts: [{ type: "text", text: "reply A" }]
+      parts: [{ type: "text", text: "A" }]
     });
     await agentB.appendMessage({
       id: "b1",
       role: "user",
-      parts: [{ type: "text", text: "hello from B" }]
+      parts: [{ type: "text", text: "B" }]
     });
 
-    // Evict every running DO at once (production-style memory reclamation).
     await evictAllDurableObjects();
 
-    // Each DO rehydrates its own SQLite-backed history independently — no
-    // bleed between the two evicted instances.
-    const historyA = await agentA.getHistory();
-    expect(historyA.map((m) => m.id)).toEqual(["a1", "a2"]);
-    const historyB = await agentB.getHistory();
-    expect(historyB.map((m) => m.id)).toEqual(["b1"]);
-
-    // Continuing each conversation after the mass eviction still auto-parents
-    // onto the rehydrated tip.
-    await agentA.appendMessage({
-      id: "a3",
-      role: "user",
-      parts: [{ type: "text", text: "more A" }]
-    });
-    expect((await agentA.getHistory()).map((m) => m.id)).toEqual([
-      "a1",
-      "a2",
-      "a3"
+    expect((await agentA.getHistory()).map((message) => message.id)).toEqual([
+      "a1"
     ]);
-    expect((await agentB.getHistory()).map((m) => m.id)).toEqual(["b1"]);
-  });
-
-  it("history accumulated across two evictions stays consistent", async () => {
-    const agent = await getAgent(name);
-
-    await agent.appendLinearChainForTest(5); // m0..m4
-    await evict(agent);
-
-    // Append more after the first wake (ids n*), then evict again.
-    await agent.appendMessage({
-      id: "n0",
-      role: "user",
-      parts: [{ type: "text", text: "round two" }]
-    });
-    await agent.appendMessage({
-      id: "n1",
-      role: "assistant",
-      parts: [{ type: "text", text: "round two reply" }]
-    });
-    await evict(agent);
-
-    // Everything from both eras must be present and correctly ordered after a
-    // second wake from storage.
-    const history = await agent.getHistory();
-    expect(history.map((m) => m.id)).toEqual([
-      "m0",
-      "m1",
-      "m2",
-      "m3",
-      "m4",
-      "n0",
-      "n1"
+    expect((await agentB.getHistory()).map((message) => message.id)).toEqual([
+      "b1"
     ]);
-    expect(await agent.getPathLength()).toBe(7);
-    expect((await agent.getLatestLeaf())?.id).toBe("n1");
   });
 });

--- a/packages/agents/src/tests/experimental/memory/agents-memory-eviction.test.ts
+++ b/packages/agents/src/tests/experimental/memory/agents-memory-eviction.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Durable Object eviction tests for the `agents-memory` (experimental Session)
+ * module.
+ *
+ * These exercise the production hibernation/eviction lifecycle with the real
+ * `evictDurableObject` / `evictAllDurableObjects` helpers from
+ * "cloudflare:test" (vitest-pool-workers >= 0.16.20). Eviction tears down the
+ * DO instance — dropping all in-memory state, including the
+ * `AgentSessionProvider.activeLeafId` cache and the `Session` skill-restore
+ * tracking — while preserving durable SQLite storage. On the next access the
+ * DO is rebuilt from storage.
+ *
+ * Each test drives a `TestSessionAgent` to build up real in-memory + stored
+ * state, evicts it, then re-accesses and asserts the state rehydrated
+ * correctly from SQLite. The assertions fail if rehydration is broken: they
+ * are not vacuous "still works" smoke checks.
+ *
+ * `TestSessionAgent` is the same fixture used by
+ * `experimental/memory/session/provider.test.ts`; it exposes `antiJoinCount`
+ * instrumentation that lets us prove the in-memory active-leaf cache was lost
+ * and rebuilt (rather than silently surviving, which would mean eviction
+ * isn't really tearing the instance down).
+ */
+import type { UIMessage } from "ai";
+import { env } from "cloudflare:workers";
+import { evictAllDurableObjects, evictDurableObject } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getAgentByName } from "../../..";
+
+/**
+ * Typed stub for TestSessionAgent — mirrors the SessionAgentStub used in
+ * provider.test.ts so these eviction tests share the same conventions.
+ */
+interface SessionAgentStub {
+  appendMessage(message: UIMessage, parentId?: string | null): Promise<void>;
+  getMessage(id: string): Promise<UIMessage | null>;
+  clearMessages(): Promise<void>;
+  getHistory(leafId?: string): Promise<UIMessage[]>;
+  getLatestLeaf(): Promise<UIMessage | null>;
+  getBranches(messageId: string): Promise<UIMessage[]>;
+  getPathLength(): Promise<number>;
+  addCompaction(
+    summary: string,
+    fromId: string,
+    toId: string
+  ): Promise<unknown>;
+  getCompactions(): Promise<unknown[]>;
+  search(
+    query: string
+  ): Promise<Array<{ id: string; role: string; content: string }>>;
+  appendLinearChainForTest(count: number, prefix?: string): Promise<void>;
+  appendLargeChainForTest(
+    count: number,
+    charsPerMessage: number,
+    prefix?: string
+  ): Promise<void>;
+  getHistoryTextLengthsForTest(): Promise<
+    Array<{ id: string; textLength: number }>
+  >;
+  getRecentHistory(
+    maxContentBytes: number,
+    minRecentMessages?: number
+  ): Promise<{
+    messages: UIMessage[];
+    truncated: boolean;
+    totalContentBytes: number;
+  }>;
+  corruptMessageForTest(id: string): Promise<void>;
+  getAntiJoinCountForTest(): Promise<number>;
+  resetAntiJoinCountForTest(): Promise<void>;
+}
+
+/**
+ * The stub returned by `getAgentByName` is the live DurableObjectStub — the
+ * same value `schedule.test.ts` hands to `runInDurableObject` /
+ * `runDurableObjectAlarm`, so it's also the value `evictDurableObject` takes.
+ */
+async function getAgent(name: string): Promise<SessionAgentStub> {
+  return getAgentByName(
+    env.TestSessionAgent,
+    name
+  ) as unknown as Promise<SessionAgentStub>;
+}
+
+/**
+ * `evictDurableObject` takes a `DurableObjectStub`. Our `SessionAgentStub` is
+ * the same live stub typed for RPC ergonomics; cast once here so call sites
+ * stay readable.
+ */
+function evict(
+  agent: SessionAgentStub,
+  options?: { webSockets: "close" | "hibernate" }
+): Promise<void> {
+  return evictDurableObject(agent as unknown as DurableObjectStub, options);
+}
+
+describe("agents-memory Session — Durable Object eviction", () => {
+  let name: string;
+  beforeEach(() => {
+    name = `evict-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  });
+
+  it("rebuilds the active-leaf cache from storage after eviction (exactly one anti-join)", async () => {
+    const agent = await getAgent(name);
+    // Build a long chain so a from-scratch leaf scan is meaningfully expensive
+    // and the cache is genuinely warm before we evict.
+    await agent.appendLinearChainForTest(20); // m0..m19
+    expect((await agent.getLatestLeaf())?.id).toBe("m19");
+
+    // Warm cache: repeated reads cost zero anti-joins while the instance lives.
+    await agent.resetAntiJoinCountForTest();
+    expect((await agent.getLatestLeaf())?.id).toBe("m19");
+    expect(await agent.getAntiJoinCountForTest()).toBe(0);
+
+    // Evict: the DO instance is torn down. The provider's in-memory
+    // `activeLeafId` cache (and the counter) are gone; only SQLite remains.
+    await evict(agent);
+
+    // First leaf lookup on the rebuilt instance must recompute the tip from
+    // storage — exactly one anti-join. If the cache had somehow survived
+    // eviction this would be 0 and the test would (correctly) fail, proving
+    // eviction really resets in-memory state.
+    expect((await agent.getLatestLeaf())?.id).toBe("m19");
+    expect(await agent.getAntiJoinCountForTest()).toBe(1);
+
+    // ...and it's re-warmed: subsequent reads on the rebuilt instance are free.
+    await agent.resetAntiJoinCountForTest();
+    expect((await agent.getLatestLeaf())?.id).toBe("m19");
+    await agent.appendMessage({
+      id: "after",
+      role: "user",
+      parts: [{ type: "text", text: "after eviction" }]
+    });
+    expect((await agent.getLatestLeaf())?.id).toBe("after");
+    expect(await agent.getAntiJoinCountForTest()).toBe(0);
+  });
+
+  it("auto-parenting after eviction attaches to the rehydrated tip, not a new root", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "first" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "assistant",
+      parts: [{ type: "text", text: "reply" }]
+    });
+
+    await evict(agent);
+
+    // No parentId: the rebuilt provider must recover the tip (m2) from storage
+    // and attach to it. A broken rehydration would orphan m3 as a new root.
+    await agent.appendMessage({
+      id: "m3",
+      role: "user",
+      parts: [{ type: "text", text: "follow-up after wake" }]
+    });
+
+    expect((await agent.getBranches("m2")).map((b) => b.id)).toContain("m3");
+    expect((await agent.getHistory()).map((m) => m.id)).toEqual([
+      "m1",
+      "m2",
+      "m3"
+    ]);
+    expect(await agent.getPathLength()).toBe(3);
+  });
+
+  it("conversation tree (branches + parent links) survives eviction", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "root",
+      role: "user",
+      parts: [{ type: "text", text: "Question" }]
+    });
+    await agent.appendMessage(
+      {
+        id: "a",
+        role: "assistant",
+        parts: [{ type: "text", text: "Answer A" }]
+      },
+      "root"
+    );
+    await agent.appendMessage(
+      {
+        id: "b",
+        role: "assistant",
+        parts: [{ type: "text", text: "Answer B" }]
+      },
+      "root"
+    );
+
+    await evict(agent);
+
+    // The whole tree must come back from SQLite with structure intact.
+    const branches = await agent.getBranches("root");
+    expect(branches.map((m) => m.id).sort()).toEqual(["a", "b"]);
+
+    expect((await agent.getHistory("a")).map((m) => m.id)).toEqual([
+      "root",
+      "a"
+    ]);
+    expect((await agent.getHistory("b")).map((m) => m.id)).toEqual([
+      "root",
+      "b"
+    ]);
+
+    const restored = await agent.getMessage("a");
+    expect(restored?.parts[0]).toEqual({ type: "text", text: "Answer A" });
+    // Latest leaf is the most-recent childless node (b).
+    expect((await agent.getLatestLeaf())?.id).toBe("b");
+  });
+
+  it("compaction overlays survive eviction and still rewrite history", async () => {
+    const agent = await getAgent(name);
+    for (let i = 0; i < 6; i++) {
+      await agent.appendMessage({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `msg ${i}` }]
+      });
+    }
+    await agent.addCompaction("Summary of m1-m3", "m1", "m3");
+
+    await evict(agent);
+
+    // The compaction lives in assistant_compactions (SQLite); after wake the
+    // overlay must still collapse m1..m3 into the stored summary.
+    const history = await agent.getHistory();
+    expect(history.map((m) => m.id)).toEqual([
+      "m0",
+      expect.stringMatching(/^compaction_/),
+      "m4",
+      "m5"
+    ]);
+    expect(history[1].parts[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("Summary of m1-m3")
+    });
+    expect(await agent.getCompactions()).toHaveLength(1);
+  });
+
+  it("FTS5 search index survives eviction", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "I love TypeScript" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "user",
+      parts: [{ type: "text", text: "Python is also good" }]
+    });
+
+    await evict(agent);
+
+    // assistant_fts is a persisted virtual table; search must still hit after
+    // the index is reloaded from storage.
+    const results = await agent.search("TypeScript");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].content).toContain("TypeScript");
+    // Negative control: a term only in the other message still resolves to it,
+    // not to the TypeScript row.
+    const python = await agent.search("Python");
+    expect(python.map((r) => r.id)).toContain("m2");
+  });
+
+  it("multi-megabyte chained messages round-trip through chunked hydration after eviction", async () => {
+    const agent = await getAgent(name);
+    // 4 × ~1.5MB rows ≈ 6MB — crosses the 4MB per-chunk byte bound, so content
+    // hydration must split across statements and reassemble in path order.
+    await agent.appendLargeChainForTest(4, 1_500_000);
+
+    await evict(agent);
+
+    // After a real wake the byte-bounded chunked read path must still
+    // reassemble every large row in order, intact.
+    const lengths = await agent.getHistoryTextLengthsForTest();
+    expect(lengths.map((l) => l.id)).toEqual(["big0", "big1", "big2", "big3"]);
+    for (const row of lengths) {
+      expect(row.textLength).toBeGreaterThanOrEqual(1_500_000);
+    }
+
+    // The byte-budgeted recent window must still honour its budget post-wake:
+    // a tiny budget yields only the leaf, but the leaf row content survives.
+    const recent = await agent.getRecentHistory(1024);
+    expect(recent.truncated).toBe(true);
+    expect(recent.messages.map((m) => m.id)).toEqual(["big3"]);
+  });
+
+  it("corrupted-row recovery is stable across eviction", async () => {
+    const agent = await getAgent(name);
+    await agent.appendLinearChainForTest(10); // m0..m9
+    await agent.corruptMessageForTest("m4");
+
+    // Before eviction the corrupt row is skipped, rest intact.
+    const before = await agent.getHistory();
+    expect(before.map((m) => m.id)).toEqual(
+      Array.from({ length: 10 }, (_, i) => `m${i}`).filter((id) => id !== "m4")
+    );
+
+    await evict(agent);
+
+    // The corruption is in stored content; after the instance is rebuilt the
+    // read path must still tolerate it identically — not throw, not drop the
+    // rest of the chain.
+    const after = await agent.getHistory();
+    expect(after.map((m) => m.id)).toEqual(before.map((m) => m.id));
+  });
+
+  it("evictAllDurableObjects preserves and isolates per-DO session history", async () => {
+    const nameA = `${name}-a`;
+    const nameB = `${name}-b`;
+    const agentA = await getAgent(nameA);
+    const agentB = await getAgent(nameB);
+
+    await agentA.appendMessage({
+      id: "a1",
+      role: "user",
+      parts: [{ type: "text", text: "hello from A" }]
+    });
+    await agentA.appendMessage({
+      id: "a2",
+      role: "assistant",
+      parts: [{ type: "text", text: "reply A" }]
+    });
+    await agentB.appendMessage({
+      id: "b1",
+      role: "user",
+      parts: [{ type: "text", text: "hello from B" }]
+    });
+
+    // Evict every running DO at once (production-style memory reclamation).
+    await evictAllDurableObjects();
+
+    // Each DO rehydrates its own SQLite-backed history independently — no
+    // bleed between the two evicted instances.
+    const historyA = await agentA.getHistory();
+    expect(historyA.map((m) => m.id)).toEqual(["a1", "a2"]);
+    const historyB = await agentB.getHistory();
+    expect(historyB.map((m) => m.id)).toEqual(["b1"]);
+
+    // Continuing each conversation after the mass eviction still auto-parents
+    // onto the rehydrated tip.
+    await agentA.appendMessage({
+      id: "a3",
+      role: "user",
+      parts: [{ type: "text", text: "more A" }]
+    });
+    expect((await agentA.getHistory()).map((m) => m.id)).toEqual([
+      "a1",
+      "a2",
+      "a3"
+    ]);
+    expect((await agentB.getHistory()).map((m) => m.id)).toEqual(["b1"]);
+  });
+
+  it("history accumulated across two evictions stays consistent", async () => {
+    const agent = await getAgent(name);
+
+    await agent.appendLinearChainForTest(5); // m0..m4
+    await evict(agent);
+
+    // Append more after the first wake (ids n*), then evict again.
+    await agent.appendMessage({
+      id: "n0",
+      role: "user",
+      parts: [{ type: "text", text: "round two" }]
+    });
+    await agent.appendMessage({
+      id: "n1",
+      role: "assistant",
+      parts: [{ type: "text", text: "round two reply" }]
+    });
+    await evict(agent);
+
+    // Everything from both eras must be present and correctly ordered after a
+    // second wake from storage.
+    const history = await agent.getHistory();
+    expect(history.map((m) => m.id)).toEqual([
+      "m0",
+      "m1",
+      "m2",
+      "m3",
+      "m4",
+      "n0",
+      "n1"
+    ]);
+    expect(await agent.getPathLength()).toBe(7);
+    expect((await agent.getLatestLeaf())?.id).toBe("n1");
+  });
+});

--- a/packages/agents/src/tests/experimental/memory/session/provider.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/provider.test.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from "ai";
 import { env } from "cloudflare:workers";
+import { evictDurableObject } from "cloudflare:test";
 import { describe, expect, it, beforeEach } from "vitest";
 import { getAgentByName } from "../../../..";
 
@@ -387,6 +388,42 @@ describe("AgentSessionProvider — tree-structured messages", () => {
     const history = await agent2.getHistory();
     expect(history).toHaveLength(1);
     expect(history[0].id).toBe("m1");
+  });
+
+  // The lookup above shares one live DO, so nothing is reconstructed. This
+  // variant evicts the DO (production hibernation: in-memory state torn down,
+  // SQLite preserved) and proves history is rebuilt from storage on wake, and
+  // that a subsequent auto-parent append still attaches to the rehydrated tip.
+  it("persistence across a real Durable Object eviction", async () => {
+    const agent = await getAgent(name);
+    await agent.appendMessage({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }]
+    });
+    await agent.appendMessage({
+      id: "m2",
+      role: "assistant",
+      parts: [{ type: "text", text: "Hi" }]
+    });
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+
+    const history = await agent.getHistory();
+    expect(history.map((m) => m.id)).toEqual(["m1", "m2"]);
+
+    // The active-leaf tip (m2) is recovered from SQLite, so an auto-parent
+    // append lands as its child rather than orphaning a new root.
+    await agent.appendMessage({
+      id: "m3",
+      role: "user",
+      parts: [{ type: "text", text: "Follow-up" }]
+    });
+    expect((await agent.getHistory()).map((m) => m.id)).toEqual([
+      "m1",
+      "m2",
+      "m3"
+    ]);
   });
 });
 

--- a/packages/agents/src/tests/experimental/memory/session/provider.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/provider.test.ts
@@ -1,6 +1,5 @@
 import type { UIMessage } from "ai";
 import { env } from "cloudflare:workers";
-import { evictDurableObject } from "cloudflare:test";
 import { describe, expect, it, beforeEach } from "vitest";
 import { getAgentByName } from "../../../..";
 
@@ -388,42 +387,6 @@ describe("AgentSessionProvider — tree-structured messages", () => {
     const history = await agent2.getHistory();
     expect(history).toHaveLength(1);
     expect(history[0].id).toBe("m1");
-  });
-
-  // The lookup above shares one live DO, so nothing is reconstructed. This
-  // variant evicts the DO (production hibernation: in-memory state torn down,
-  // SQLite preserved) and proves history is rebuilt from storage on wake, and
-  // that a subsequent auto-parent append still attaches to the rehydrated tip.
-  it("persistence across a real Durable Object eviction", async () => {
-    const agent = await getAgent(name);
-    await agent.appendMessage({
-      id: "m1",
-      role: "user",
-      parts: [{ type: "text", text: "Hello" }]
-    });
-    await agent.appendMessage({
-      id: "m2",
-      role: "assistant",
-      parts: [{ type: "text", text: "Hi" }]
-    });
-
-    await evictDurableObject(agent as unknown as DurableObjectStub);
-
-    const history = await agent.getHistory();
-    expect(history.map((m) => m.id)).toEqual(["m1", "m2"]);
-
-    // The active-leaf tip (m2) is recovered from SQLite, so an auto-parent
-    // append lands as its child rather than orphaning a new root.
-    await agent.appendMessage({
-      id: "m3",
-      role: "user",
-      parts: [{ type: "text", text: "Follow-up" }]
-    });
-    expect((await agent.getHistory()).map((m) => m.id)).toEqual([
-      "m1",
-      "m2",
-      "m3"
-    ]);
   });
 });
 

--- a/packages/agents/src/tests/mcp/eviction-mcp-rehydration.test.ts
+++ b/packages/agents/src/tests/mcp/eviction-mcp-rehydration.test.ts
@@ -1,0 +1,394 @@
+import { env } from "cloudflare:workers";
+import {
+  createExecutionContext,
+  evictAllDurableObjects,
+  evictDurableObject,
+  runInDurableObject
+} from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "../..";
+import worker from "../worker";
+import { DurableObjectEventStore } from "../../mcp/event-store";
+import { initializeStreamableHTTPServer } from "../shared/test-utils";
+import type { TestWaitConnectionsAgent } from "../agents/wait-connections";
+import type { TestStateAgent, TestState } from "../agents/state";
+
+/**
+ * Durable Object eviction tests for the agents-mcp surface, built on the
+ * production-faithful `evictDurableObject()` / `evictAllDurableObjects()`
+ * helpers from `cloudflare:test` (vitest-pool-workers >= 0.16.20).
+ *
+ * Unlike the older hibernation tests in this package — which simulate
+ * eviction by resetting a private `_isRestored` flag, constructing a fresh
+ * `DurableObjectEventStore` over a mock storage, or instantiating a fresh
+ * `MCPClientManager` — these tests tear the real DO out of memory and prove
+ * that DO-backed state survives and rehydrates correctly from durable
+ * storage on the next access.
+ *
+ * The discriminating assertion in every test is that some in-memory cache is
+ * observed to be DROPPED by the eviction (read back through
+ * `runInDurableObject` immediately after eviction) and then REBUILT from
+ * storage when the agent is driven again. A test that only checked the final
+ * value would pass even if eviction were a no-op; checking the post-eviction
+ * empty state is what makes these tests fail if rehydration regresses.
+ */
+describe("agents-mcp Durable Object eviction (evictDurableObject)", () => {
+  describe("MCPClientManager in-memory connections", () => {
+    it("drops mcpConnections on eviction and rebuilds them from SQL storage", async () => {
+      const stub = env.TestWaitConnectionsAgent.get(
+        env.TestWaitConnectionsAgent.idFromName("eviction-restore")
+      );
+
+      // Build pre-eviction state: an MCP server row in SQLite plus a live
+      // in-memory connection produced by restore. The mocked connectToServer
+      // (see TestWaitConnectionsAgent) settles to FAILED without real I/O.
+      await stub.__unsafe_ensureInitialized();
+      await stub.insertMcpServer(
+        "evict-server-1",
+        "Evict Test Server",
+        "http://nonexistent-mcp.example.com",
+        "http://localhost:3000/callback",
+        null
+      );
+      await stub.resetRestoredFlag();
+      const before = await stub.restoreAndWait(5000);
+      expect(before.connectionIds).toContain("evict-server-1");
+
+      // Sanity: the in-memory map really is populated before eviction.
+      const liveCount = await runInDurableObject(
+        stub,
+        (instance: TestWaitConnectionsAgent) =>
+          Object.keys(instance.mcp.mcpConnections).length
+      );
+      expect(liveCount).toBeGreaterThan(0);
+
+      // Tear the DO out of memory. The cf_agents_mcp_servers SQL row is
+      // durable and survives; the in-memory mcpConnections map does not.
+      await evictDurableObject(stub);
+
+      // Immediately after eviction the in-memory map is empty — this is the
+      // assertion that proves eviction actually dropped in-memory state and
+      // that the restore below is doing real work, not observing a cache.
+      const afterEvictionConnectionCount = await runInDurableObject(
+        stub,
+        (instance: TestWaitConnectionsAgent) =>
+          Object.keys(instance.mcp.mcpConnections).length
+      );
+      expect(afterEvictionConnectionCount).toBe(0);
+
+      // Drive the restore path (onStart calls this in production) and confirm
+      // the connection is reconstructed from the persisted server row.
+      await stub.resetRestoredFlag();
+      const after = await stub.restoreAndWait(5000);
+      expect(after.connectionIds).toContain("evict-server-1");
+      const state = after.connectionStates["evict-server-1"];
+      expect(state).toBeDefined();
+      expect(state).not.toBe("connecting");
+    });
+
+    it("preserves the cf_agents_mcp_servers row across eviction (storage survives)", async () => {
+      const stub = env.TestWaitConnectionsAgent.get(
+        env.TestWaitConnectionsAgent.idFromName("eviction-storage-survives")
+      );
+
+      await stub.__unsafe_ensureInitialized();
+      await stub.insertMcpServer(
+        "persist-server",
+        "Persisted Server",
+        "http://nonexistent-mcp.example.com",
+        "http://localhost:3000/callback",
+        null
+      );
+
+      const rowBefore = await runInDurableObject(
+        stub,
+        (instance: TestWaitConnectionsAgent) =>
+          instance.sql<{ id: string; name: string }>`
+            SELECT id, name FROM cf_agents_mcp_servers WHERE id = 'persist-server'
+          `[0] ?? null
+      );
+      expect(rowBefore?.id).toBe("persist-server");
+
+      await evictDurableObject(stub);
+
+      // The SQL row is durable: it must read back identically post-eviction.
+      const rowAfter = await runInDurableObject(
+        stub,
+        (instance: TestWaitConnectionsAgent) =>
+          instance.sql<{ id: string; name: string }>`
+            SELECT id, name FROM cf_agents_mcp_servers WHERE id = 'persist-server'
+          `[0] ?? null
+      );
+      expect(rowAfter).toEqual({
+        id: "persist-server",
+        name: "Persisted Server"
+      });
+    });
+  });
+
+  describe("DurableObjectEventStore seq counter", () => {
+    it("rehydrates the seq counter from real DO storage after eviction", async () => {
+      const stub = env.TestWaitConnectionsAgent.get(
+        env.TestWaitConnectionsAgent.idFromName("eviction-event-store")
+      );
+      await stub.__unsafe_ensureInitialized();
+
+      // Store two events through a DurableObjectEventStore backed by the real
+      // DO storage. The in-memory seqByStream counter lives on the store
+      // object, which is created (and discarded) per runInDurableObject call —
+      // exactly the lifecycle that loses in-memory state on eviction.
+      const id1 = await runInDurableObject(
+        stub,
+        (_instance: TestWaitConnectionsAgent, state) => {
+          const store = new DurableObjectEventStore(state.storage);
+          return store.storeEvent("evict-stream", {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "test/notify",
+            params: { n: 1 }
+          });
+        }
+      );
+      const id2 = await runInDurableObject(
+        stub,
+        (_instance: TestWaitConnectionsAgent, state) => {
+          const store = new DurableObjectEventStore(state.storage);
+          return store.storeEvent("evict-stream", {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "test/notify",
+            params: { n: 2 }
+          });
+        }
+      );
+
+      // Tear the DO out of memory. The persisted __mcp_event__ keys survive.
+      await evictDurableObject(stub);
+
+      // A fresh store over the post-eviction storage must recover the seq
+      // counter from the persisted log rather than restarting at 1 (which
+      // would mint a duplicate, unresumable event id).
+      const id3 = await runInDurableObject(
+        stub,
+        (_instance: TestWaitConnectionsAgent, state) => {
+          const store = new DurableObjectEventStore(state.storage);
+          return store.storeEvent("evict-stream", {
+            jsonrpc: "2.0",
+            id: 3,
+            method: "test/notify",
+            params: { n: 3 }
+          });
+        }
+      );
+
+      // Ids are `<streamId>:<seqHex>` and must be strictly monotonic + unique.
+      expect(id1).toBe(`evict-stream:${(1).toString(16).padStart(16, "0")}`);
+      expect(id2).toBe(`evict-stream:${(2).toString(16).padStart(16, "0")}`);
+      expect(id3).toBe(`evict-stream:${(3).toString(16).padStart(16, "0")}`);
+      expect(new Set([id1, id2, id3]).size).toBe(3);
+      expect(
+        [id1, id2, id3].every((id, i, arr) => i === 0 || id > arr[i - 1])
+      ).toBe(true);
+    });
+
+    it("replays persisted events after eviction via a rehydrated store", async () => {
+      const stub = env.TestWaitConnectionsAgent.get(
+        env.TestWaitConnectionsAgent.idFromName("eviction-event-replay")
+      );
+      await stub.__unsafe_ensureInitialized();
+
+      const ids = await runInDurableObject(
+        stub,
+        async (_instance: TestWaitConnectionsAgent, state) => {
+          const store = new DurableObjectEventStore(state.storage);
+          const out: string[] = [];
+          for (let i = 0; i < 3; i++) {
+            out.push(
+              await store.storeEvent("replay-stream", {
+                jsonrpc: "2.0",
+                id: i,
+                method: "test/notify",
+                params: { n: i }
+              })
+            );
+          }
+          return out;
+        }
+      );
+
+      await evictDurableObject(stub);
+
+      // After eviction, a brand-new store must replay the events that were
+      // written before eviction — proving the event log is durable and that
+      // replayEventsAfter reads it back (exclusive of the seed id).
+      const replayed = await runInDurableObject(
+        stub,
+        async (_instance: TestWaitConnectionsAgent, state) => {
+          const store = new DurableObjectEventStore(state.storage);
+          const sent: string[] = [];
+          await store.replayEventsAfter(ids[0], {
+            send: async (eventId) => {
+              sent.push(eventId);
+            }
+          });
+          return sent;
+        }
+      );
+
+      expect(replayed).toEqual([ids[1], ids[2]]);
+    });
+  });
+
+  describe("base Agent in-memory state cache", () => {
+    it("drops the cached _state on eviction and rebuilds it from cf_agents_state", async () => {
+      const stub = await getAgentByName(
+        env.TestStateAgent,
+        "eviction-state-cache"
+      );
+
+      const next: TestState = {
+        count: 7,
+        items: ["alpha", "beta"],
+        lastUpdated: "2026-06-27T00:00:00.000Z"
+      };
+      await stub.updateState(next);
+
+      // Before eviction the in-memory _state cache is populated (not the
+      // DEFAULT_STATE sentinel that a freshly-constructed instance holds).
+      const cachedBefore = await runInDurableObject(
+        stub,
+        (instance: TestStateAgent) => {
+          const i = instance as unknown as {
+            _state: TestState;
+            _stateSentinel: TestState;
+          };
+          return i._state === i._stateSentinel;
+        }
+      );
+      expect(cachedBefore).toBe(false);
+
+      await evictDurableObject(stub);
+
+      // Immediately after eviction a fresh instance is constructed: its
+      // private _state field is back to the DEFAULT_STATE sentinel, proving
+      // the in-memory cache was genuinely dropped and the read below must hit
+      // SQL storage.
+      const isSentinelAfterEviction = await runInDurableObject(
+        stub,
+        (instance: TestStateAgent) => {
+          const i = instance as unknown as {
+            _state: TestState;
+            _stateSentinel: TestState;
+          };
+          return i._state === i._stateSentinel;
+        }
+      );
+      expect(isSentinelAfterEviction).toBe(true);
+
+      // Accessing .state rehydrates from the durable cf_agents_state row.
+      const restored = await stub.getState();
+      expect(restored).toEqual(next);
+    });
+  });
+
+  describe("McpAgent props + initialize request via the real transport", () => {
+    it("survives eviction: props and persisted initialize request rehydrate", async () => {
+      const ctx = createExecutionContext();
+      const baseUrl = "http://example.com/mcp";
+
+      // Drive the real streamable-HTTP transport so the McpAgent persists its
+      // props and initialize request to DO storage exactly as in production.
+      const sessionId = await initializeStreamableHTTPServer(ctx, baseUrl);
+      expect(sessionId).toBeTruthy();
+
+      // Address the same DO the transport used: `streamable-http:<sessionId>`.
+      const stub = await getAgentByName(
+        env.MCP_OBJECT,
+        `streamable-http:${sessionId}`
+      );
+
+      const initBefore = await stub.getInitializeRequest();
+      expect(initBefore).toBeDefined();
+
+      await evictDurableObject(stub);
+
+      // After eviction the persisted initialize request must read back from
+      // storage so the session can be re-established without a fresh
+      // initialize handshake.
+      const initAfter = await stub.getInitializeRequest();
+      expect(initAfter).toEqual(initBefore);
+
+      // And the session keeps working through the transport after eviction:
+      // a tools/call still resolves against the rehydrated agent.
+      const callResponse = await worker.fetch(
+        new Request(baseUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+            "mcp-session-id": sessionId
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1234,
+            method: "tools/call",
+            params: { name: "greet", arguments: { name: "Evicted" } }
+          })
+        }),
+        env,
+        ctx
+      );
+      expect(callResponse.status).toBe(200);
+      const body = await callResponse.text();
+      expect(body).toContain("Hello, Evicted!");
+    });
+  });
+
+  describe("evictAllDurableObjects", () => {
+    it("evicts every running agent, and each rehydrates its own state", async () => {
+      const a = await getAgentByName(env.TestStateAgent, "evict-all-a");
+      const b = await getAgentByName(env.TestStateAgent, "evict-all-b");
+
+      await a.updateState({
+        count: 1,
+        items: ["a"],
+        lastUpdated: "2026-06-27T00:00:00.000Z"
+      });
+      await b.updateState({
+        count: 2,
+        items: ["b"],
+        lastUpdated: "2026-06-27T00:00:00.000Z"
+      });
+
+      await evictAllDurableObjects();
+
+      // Both instances were torn down: their _state caches reset to sentinel.
+      const aIsSentinel = await runInDurableObject(
+        a,
+        (instance: TestStateAgent) => {
+          const i = instance as unknown as {
+            _state: TestState;
+            _stateSentinel: TestState;
+          };
+          return i._state === i._stateSentinel;
+        }
+      );
+      const bIsSentinel = await runInDurableObject(
+        b,
+        (instance: TestStateAgent) => {
+          const i = instance as unknown as {
+            _state: TestState;
+            _stateSentinel: TestState;
+          };
+          return i._state === i._stateSentinel;
+        }
+      );
+      expect(aIsSentinel).toBe(true);
+      expect(bIsSentinel).toBe(true);
+
+      // Each agent rehydrates its own distinct state from its own storage.
+      expect((await a.getState()).count).toBe(1);
+      expect((await b.getState()).count).toBe(2);
+    });
+  });
+});

--- a/packages/agents/src/tests/mcp/eviction-mcp-rehydration.test.ts
+++ b/packages/agents/src/tests/mcp/eviction-mcp-rehydration.test.ts
@@ -1,394 +1,52 @@
+/**
+ * Forced eviction coverage for the stateful McpAgent transport.
+ *
+ * This verifies reconstruction after a test-requested actor teardown. It does
+ * not assert natural idle hibernation or hibernation eligibility.
+ */
 import { env } from "cloudflare:workers";
-import {
-  createExecutionContext,
-  evictAllDurableObjects,
-  evictDurableObject,
-  runInDurableObject
-} from "cloudflare:test";
+import { createExecutionContext, evictDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "../..";
 import worker from "../worker";
-import { DurableObjectEventStore } from "../../mcp/event-store";
 import { initializeStreamableHTTPServer } from "../shared/test-utils";
-import type { TestWaitConnectionsAgent } from "../agents/wait-connections";
-import type { TestStateAgent, TestState } from "../agents/state";
 
-/**
- * Durable Object eviction tests for the agents-mcp surface, built on the
- * production-faithful `evictDurableObject()` / `evictAllDurableObjects()`
- * helpers from `cloudflare:test` (vitest-pool-workers >= 0.16.20).
- *
- * Unlike the older hibernation tests in this package — which simulate
- * eviction by resetting a private `_isRestored` flag, constructing a fresh
- * `DurableObjectEventStore` over a mock storage, or instantiating a fresh
- * `MCPClientManager` — these tests tear the real DO out of memory and prove
- * that DO-backed state survives and rehydrates correctly from durable
- * storage on the next access.
- *
- * The discriminating assertion in every test is that some in-memory cache is
- * observed to be DROPPED by the eviction (read back through
- * `runInDurableObject` immediately after eviction) and then REBUILT from
- * storage when the agent is driven again. A test that only checked the final
- * value would pass even if eviction were a no-op; checking the post-eviction
- * empty state is what makes these tests fail if rehydration regresses.
- */
-describe("agents-mcp Durable Object eviction (evictDurableObject)", () => {
-  describe("MCPClientManager in-memory connections", () => {
-    it("drops mcpConnections on eviction and rebuilds them from SQL storage", async () => {
-      const stub = env.TestWaitConnectionsAgent.get(
-        env.TestWaitConnectionsAgent.idFromName("eviction-restore")
-      );
+describe("McpAgent recovery after forced Durable Object eviction", () => {
+  it("restores the initialize request and continues the HTTP session", async () => {
+    const ctx = createExecutionContext();
+    const baseUrl = "http://example.com/mcp";
+    const sessionId = await initializeStreamableHTTPServer(ctx, baseUrl);
+    const name = `streamable-http:${sessionId}`;
+    let stub = await getAgentByName(env.MCP_OBJECT, name);
 
-      // Build pre-eviction state: an MCP server row in SQLite plus a live
-      // in-memory connection produced by restore. The mocked connectToServer
-      // (see TestWaitConnectionsAgent) settles to FAILED without real I/O.
-      await stub.__unsafe_ensureInitialized();
-      await stub.insertMcpServer(
-        "evict-server-1",
-        "Evict Test Server",
-        "http://nonexistent-mcp.example.com",
-        "http://localhost:3000/callback",
-        null
-      );
-      await stub.resetRestoredFlag();
-      const before = await stub.restoreAndWait(5000);
-      expect(before.connectionIds).toContain("evict-server-1");
+    const initializeRequest = await stub.getInitializeRequest();
+    expect(initializeRequest).toBeDefined();
 
-      // Sanity: the in-memory map really is populated before eviction.
-      const liveCount = await runInDurableObject(
-        stub,
-        (instance: TestWaitConnectionsAgent) =>
-          Object.keys(instance.mcp.mcpConnections).length
-      );
-      expect(liveCount).toBeGreaterThan(0);
+    await evictDurableObject(stub);
 
-      // Tear the DO out of memory. The cf_agents_mcp_servers SQL row is
-      // durable and survives; the in-memory mcpConnections map does not.
-      await evictDurableObject(stub);
+    stub = await getAgentByName(env.MCP_OBJECT, name);
+    expect(await stub.getInitializeRequest()).toEqual(initializeRequest);
 
-      // Immediately after eviction the in-memory map is empty — this is the
-      // assertion that proves eviction actually dropped in-memory state and
-      // that the restore below is doing real work, not observing a cache.
-      const afterEvictionConnectionCount = await runInDurableObject(
-        stub,
-        (instance: TestWaitConnectionsAgent) =>
-          Object.keys(instance.mcp.mcpConnections).length
-      );
-      expect(afterEvictionConnectionCount).toBe(0);
+    const response = await worker.fetch(
+      new Request(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "mcp-session-id": sessionId
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1234,
+          method: "tools/call",
+          params: { name: "greet", arguments: { name: "Evicted" } }
+        })
+      }),
+      env,
+      ctx
+    );
 
-      // Drive the restore path (onStart calls this in production) and confirm
-      // the connection is reconstructed from the persisted server row.
-      await stub.resetRestoredFlag();
-      const after = await stub.restoreAndWait(5000);
-      expect(after.connectionIds).toContain("evict-server-1");
-      const state = after.connectionStates["evict-server-1"];
-      expect(state).toBeDefined();
-      expect(state).not.toBe("connecting");
-    });
-
-    it("preserves the cf_agents_mcp_servers row across eviction (storage survives)", async () => {
-      const stub = env.TestWaitConnectionsAgent.get(
-        env.TestWaitConnectionsAgent.idFromName("eviction-storage-survives")
-      );
-
-      await stub.__unsafe_ensureInitialized();
-      await stub.insertMcpServer(
-        "persist-server",
-        "Persisted Server",
-        "http://nonexistent-mcp.example.com",
-        "http://localhost:3000/callback",
-        null
-      );
-
-      const rowBefore = await runInDurableObject(
-        stub,
-        (instance: TestWaitConnectionsAgent) =>
-          instance.sql<{ id: string; name: string }>`
-            SELECT id, name FROM cf_agents_mcp_servers WHERE id = 'persist-server'
-          `[0] ?? null
-      );
-      expect(rowBefore?.id).toBe("persist-server");
-
-      await evictDurableObject(stub);
-
-      // The SQL row is durable: it must read back identically post-eviction.
-      const rowAfter = await runInDurableObject(
-        stub,
-        (instance: TestWaitConnectionsAgent) =>
-          instance.sql<{ id: string; name: string }>`
-            SELECT id, name FROM cf_agents_mcp_servers WHERE id = 'persist-server'
-          `[0] ?? null
-      );
-      expect(rowAfter).toEqual({
-        id: "persist-server",
-        name: "Persisted Server"
-      });
-    });
-  });
-
-  describe("DurableObjectEventStore seq counter", () => {
-    it("rehydrates the seq counter from real DO storage after eviction", async () => {
-      const stub = env.TestWaitConnectionsAgent.get(
-        env.TestWaitConnectionsAgent.idFromName("eviction-event-store")
-      );
-      await stub.__unsafe_ensureInitialized();
-
-      // Store two events through a DurableObjectEventStore backed by the real
-      // DO storage. The in-memory seqByStream counter lives on the store
-      // object, which is created (and discarded) per runInDurableObject call —
-      // exactly the lifecycle that loses in-memory state on eviction.
-      const id1 = await runInDurableObject(
-        stub,
-        (_instance: TestWaitConnectionsAgent, state) => {
-          const store = new DurableObjectEventStore(state.storage);
-          return store.storeEvent("evict-stream", {
-            jsonrpc: "2.0",
-            id: 1,
-            method: "test/notify",
-            params: { n: 1 }
-          });
-        }
-      );
-      const id2 = await runInDurableObject(
-        stub,
-        (_instance: TestWaitConnectionsAgent, state) => {
-          const store = new DurableObjectEventStore(state.storage);
-          return store.storeEvent("evict-stream", {
-            jsonrpc: "2.0",
-            id: 2,
-            method: "test/notify",
-            params: { n: 2 }
-          });
-        }
-      );
-
-      // Tear the DO out of memory. The persisted __mcp_event__ keys survive.
-      await evictDurableObject(stub);
-
-      // A fresh store over the post-eviction storage must recover the seq
-      // counter from the persisted log rather than restarting at 1 (which
-      // would mint a duplicate, unresumable event id).
-      const id3 = await runInDurableObject(
-        stub,
-        (_instance: TestWaitConnectionsAgent, state) => {
-          const store = new DurableObjectEventStore(state.storage);
-          return store.storeEvent("evict-stream", {
-            jsonrpc: "2.0",
-            id: 3,
-            method: "test/notify",
-            params: { n: 3 }
-          });
-        }
-      );
-
-      // Ids are `<streamId>:<seqHex>` and must be strictly monotonic + unique.
-      expect(id1).toBe(`evict-stream:${(1).toString(16).padStart(16, "0")}`);
-      expect(id2).toBe(`evict-stream:${(2).toString(16).padStart(16, "0")}`);
-      expect(id3).toBe(`evict-stream:${(3).toString(16).padStart(16, "0")}`);
-      expect(new Set([id1, id2, id3]).size).toBe(3);
-      expect(
-        [id1, id2, id3].every((id, i, arr) => i === 0 || id > arr[i - 1])
-      ).toBe(true);
-    });
-
-    it("replays persisted events after eviction via a rehydrated store", async () => {
-      const stub = env.TestWaitConnectionsAgent.get(
-        env.TestWaitConnectionsAgent.idFromName("eviction-event-replay")
-      );
-      await stub.__unsafe_ensureInitialized();
-
-      const ids = await runInDurableObject(
-        stub,
-        async (_instance: TestWaitConnectionsAgent, state) => {
-          const store = new DurableObjectEventStore(state.storage);
-          const out: string[] = [];
-          for (let i = 0; i < 3; i++) {
-            out.push(
-              await store.storeEvent("replay-stream", {
-                jsonrpc: "2.0",
-                id: i,
-                method: "test/notify",
-                params: { n: i }
-              })
-            );
-          }
-          return out;
-        }
-      );
-
-      await evictDurableObject(stub);
-
-      // After eviction, a brand-new store must replay the events that were
-      // written before eviction — proving the event log is durable and that
-      // replayEventsAfter reads it back (exclusive of the seed id).
-      const replayed = await runInDurableObject(
-        stub,
-        async (_instance: TestWaitConnectionsAgent, state) => {
-          const store = new DurableObjectEventStore(state.storage);
-          const sent: string[] = [];
-          await store.replayEventsAfter(ids[0], {
-            send: async (eventId) => {
-              sent.push(eventId);
-            }
-          });
-          return sent;
-        }
-      );
-
-      expect(replayed).toEqual([ids[1], ids[2]]);
-    });
-  });
-
-  describe("base Agent in-memory state cache", () => {
-    it("drops the cached _state on eviction and rebuilds it from cf_agents_state", async () => {
-      const stub = await getAgentByName(
-        env.TestStateAgent,
-        "eviction-state-cache"
-      );
-
-      const next: TestState = {
-        count: 7,
-        items: ["alpha", "beta"],
-        lastUpdated: "2026-06-27T00:00:00.000Z"
-      };
-      await stub.updateState(next);
-
-      // Before eviction the in-memory _state cache is populated (not the
-      // DEFAULT_STATE sentinel that a freshly-constructed instance holds).
-      const cachedBefore = await runInDurableObject(
-        stub,
-        (instance: TestStateAgent) => {
-          const i = instance as unknown as {
-            _state: TestState;
-            _stateSentinel: TestState;
-          };
-          return i._state === i._stateSentinel;
-        }
-      );
-      expect(cachedBefore).toBe(false);
-
-      await evictDurableObject(stub);
-
-      // Immediately after eviction a fresh instance is constructed: its
-      // private _state field is back to the DEFAULT_STATE sentinel, proving
-      // the in-memory cache was genuinely dropped and the read below must hit
-      // SQL storage.
-      const isSentinelAfterEviction = await runInDurableObject(
-        stub,
-        (instance: TestStateAgent) => {
-          const i = instance as unknown as {
-            _state: TestState;
-            _stateSentinel: TestState;
-          };
-          return i._state === i._stateSentinel;
-        }
-      );
-      expect(isSentinelAfterEviction).toBe(true);
-
-      // Accessing .state rehydrates from the durable cf_agents_state row.
-      const restored = await stub.getState();
-      expect(restored).toEqual(next);
-    });
-  });
-
-  describe("McpAgent props + initialize request via the real transport", () => {
-    it("survives eviction: props and persisted initialize request rehydrate", async () => {
-      const ctx = createExecutionContext();
-      const baseUrl = "http://example.com/mcp";
-
-      // Drive the real streamable-HTTP transport so the McpAgent persists its
-      // props and initialize request to DO storage exactly as in production.
-      const sessionId = await initializeStreamableHTTPServer(ctx, baseUrl);
-      expect(sessionId).toBeTruthy();
-
-      // Address the same DO the transport used: `streamable-http:<sessionId>`.
-      const stub = await getAgentByName(
-        env.MCP_OBJECT,
-        `streamable-http:${sessionId}`
-      );
-
-      const initBefore = await stub.getInitializeRequest();
-      expect(initBefore).toBeDefined();
-
-      await evictDurableObject(stub);
-
-      // After eviction the persisted initialize request must read back from
-      // storage so the session can be re-established without a fresh
-      // initialize handshake.
-      const initAfter = await stub.getInitializeRequest();
-      expect(initAfter).toEqual(initBefore);
-
-      // And the session keeps working through the transport after eviction:
-      // a tools/call still resolves against the rehydrated agent.
-      const callResponse = await worker.fetch(
-        new Request(baseUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json, text/event-stream",
-            "mcp-session-id": sessionId
-          },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1234,
-            method: "tools/call",
-            params: { name: "greet", arguments: { name: "Evicted" } }
-          })
-        }),
-        env,
-        ctx
-      );
-      expect(callResponse.status).toBe(200);
-      const body = await callResponse.text();
-      expect(body).toContain("Hello, Evicted!");
-    });
-  });
-
-  describe("evictAllDurableObjects", () => {
-    it("evicts every running agent, and each rehydrates its own state", async () => {
-      const a = await getAgentByName(env.TestStateAgent, "evict-all-a");
-      const b = await getAgentByName(env.TestStateAgent, "evict-all-b");
-
-      await a.updateState({
-        count: 1,
-        items: ["a"],
-        lastUpdated: "2026-06-27T00:00:00.000Z"
-      });
-      await b.updateState({
-        count: 2,
-        items: ["b"],
-        lastUpdated: "2026-06-27T00:00:00.000Z"
-      });
-
-      await evictAllDurableObjects();
-
-      // Both instances were torn down: their _state caches reset to sentinel.
-      const aIsSentinel = await runInDurableObject(
-        a,
-        (instance: TestStateAgent) => {
-          const i = instance as unknown as {
-            _state: TestState;
-            _stateSentinel: TestState;
-          };
-          return i._state === i._stateSentinel;
-        }
-      );
-      const bIsSentinel = await runInDurableObject(
-        b,
-        (instance: TestStateAgent) => {
-          const i = instance as unknown as {
-            _state: TestState;
-            _stateSentinel: TestState;
-          };
-          return i._state === i._stateSentinel;
-        }
-      );
-      expect(aIsSentinel).toBe(true);
-      expect(bIsSentinel).toBe(true);
-
-      // Each agent rehydrates its own distinct state from its own storage.
-      expect((await a.getState()).count).toBe(1);
-      expect((await b.getState()).count).toBe(2);
-    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Hello, Evicted!");
   });
 });

--- a/packages/agents/src/tests/mcp/wait-connections-e2e.test.ts
+++ b/packages/agents/src/tests/mcp/wait-connections-e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { env } from "cloudflare:workers";
+import { evictDurableObject } from "cloudflare:test";
 
 /**
  * E2E tests for waitForConnections() through the full Agent lifecycle.
@@ -234,6 +235,56 @@ describe("waitForConnections E2E", () => {
       expect(result.connectionStates["regular-server"]).not.toBe("connecting");
       // OAuth server should be in authenticating state
       expect(result.connectionStates["oauth-server"]).toBe("authenticating");
+    });
+
+    // The tests above simulate hibernation by manually clearing the in-memory
+    // `_isRestored` flag (resetRestoredFlag). This one uses a *real* eviction:
+    // evictDurableObject tears down the instance, so the next access rebuilds
+    // the Agent from scratch and re-runs onStart → restoreConnectionsFromStorage
+    // against the persisted cf_agents_mcp_servers rows. That proves the
+    // MCPClientManager's in-memory connection map is genuinely rebuilt from
+    // storage on eviction, not merely re-read from a warm instance.
+    it("rebuilds MCP connections from storage after a real eviction", async () => {
+      const agentId = env.TestWaitConnectionsAgent.idFromName(
+        "hibernation-evict-roundtrip"
+      );
+      const stub = env.TestWaitConnectionsAgent.get(agentId);
+
+      // Boot the agent (creates internal tables) and persist an MCP server row.
+      await stub.__unsafe_ensureInitialized();
+      await stub.insertMcpServer(
+        "evict-roundtrip-server",
+        "Evict Round Trip Server",
+        "http://nonexistent-mcp.example.com",
+        "http://localhost:3000/callback",
+        null
+      );
+
+      // Restore once so the in-memory connection map is populated before
+      // eviction. onStart may have already restored (with no servers) and set
+      // the _isRestored flag, so clear it first to force a fresh restore.
+      await stub.resetRestoredFlag();
+      await stub.restoreAndWait(5000);
+      expect(await stub.hasMcpConnection("evict-roundtrip-server")).toBe(true);
+
+      // Real eviction: drops the MCPClientManager in-memory state (mcpConnections
+      // and the `_isRestored` flag) while leaving cf_agents_mcp_servers intact.
+      await evictDurableObject(stub);
+
+      // The rebuilt instance starts with an empty connection map — proving the
+      // in-memory state was actually torn down by the eviction.
+      expect(await stub.hasMcpConnection("evict-roundtrip-server")).toBe(false);
+
+      // Full lifecycle on the rebuilt instance: onStart →
+      // restoreConnectionsFromStorage → waitForConnections rebuilds the
+      // connection from the persisted row.
+      const result = await stub.hibernationRoundTrip(5000);
+
+      expect(result.connectionIds).toContain("evict-roundtrip-server");
+      const state = result.connectionStates["evict-roundtrip-server"];
+      expect(state).toBeDefined();
+      // Settled (failed against the mock), not stuck "connecting".
+      expect(state).not.toBe("connecting");
     });
   });
 

--- a/packages/agents/src/tests/mcp/wait-connections-e2e.test.ts
+++ b/packages/agents/src/tests/mcp/wait-connections-e2e.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { env } from "cloudflare:workers";
 import { evictDurableObject } from "cloudflare:test";
+import { getAgentByName } from "../..";
 
 /**
  * E2E tests for waitForConnections() through the full Agent lifecycle.
@@ -237,21 +238,12 @@ describe("waitForConnections E2E", () => {
       expect(result.connectionStates["oauth-server"]).toBe("authenticating");
     });
 
-    // The tests above simulate hibernation by manually clearing the in-memory
-    // `_isRestored` flag (resetRestoredFlag). This one uses a *real* eviction:
-    // evictDurableObject tears down the instance, so the next access rebuilds
-    // the Agent from scratch and re-runs onStart → restoreConnectionsFromStorage
-    // against the persisted cf_agents_mcp_servers rows. That proves the
-    // MCPClientManager's in-memory connection map is genuinely rebuilt from
-    // storage on eviction, not merely re-read from a warm instance.
-    it("rebuilds MCP connections from storage after a real eviction", async () => {
-      const agentId = env.TestWaitConnectionsAgent.idFromName(
-        "hibernation-evict-roundtrip"
-      );
-      const stub = env.TestWaitConnectionsAgent.get(agentId);
+    // This forces a running actor out of memory. It verifies reconstruction,
+    // not natural idle-hibernation eligibility.
+    it("automatically restores MCP connections after forced eviction", async () => {
+      const name = `forced-evict-${crypto.randomUUID()}`;
+      let stub = await getAgentByName(env.TestWaitConnectionsAgent, name);
 
-      // Boot the agent (creates internal tables) and persist an MCP server row.
-      await stub.__unsafe_ensureInitialized();
       await stub.insertMcpServer(
         "evict-roundtrip-server",
         "Evict Round Trip Server",
@@ -259,32 +251,20 @@ describe("waitForConnections E2E", () => {
         "http://localhost:3000/callback",
         null
       );
-
-      // Restore once so the in-memory connection map is populated before
-      // eviction. onStart may have already restored (with no servers) and set
-      // the _isRestored flag, so clear it first to force a fresh restore.
       await stub.resetRestoredFlag();
       await stub.restoreAndWait(5000);
       expect(await stub.hasMcpConnection("evict-roundtrip-server")).toBe(true);
 
-      // Real eviction: drops the MCPClientManager in-memory state (mcpConnections
-      // and the `_isRestored` flag) while leaving cf_agents_mcp_servers intact.
       await evictDurableObject(stub);
 
-      // The rebuilt instance starts with an empty connection map — proving the
-      // in-memory state was actually torn down by the eviction.
-      expect(await stub.hasMcpConnection("evict-roundtrip-server")).toBe(false);
-
-      // Full lifecycle on the rebuilt instance: onStart →
-      // restoreConnectionsFromStorage → waitForConnections rebuilds the
-      // connection from the persisted row.
-      const result = await stub.hibernationRoundTrip(5000);
+      // Re-routing through getAgentByName runs the normal Agent startup wrapper.
+      // waitAndReport only waits for that lifecycle-started restore; it does not
+      // manually invoke onStart() or restoreConnectionsFromStorage().
+      stub = await getAgentByName(env.TestWaitConnectionsAgent, name);
+      const result = await stub.waitAndReport(5000);
 
       expect(result.connectionIds).toContain("evict-roundtrip-server");
-      const state = result.connectionStates["evict-roundtrip-server"];
-      expect(state).toBeDefined();
-      // Settled (failed against the mock), not stuck "connecting".
-      expect(state).not.toBe("connecting");
+      expect(result.connectionStates["evict-roundtrip-server"]).toBe("failed");
     });
   });
 

--- a/packages/ai-chat/src/tests/ai-chat-eviction.test.ts
+++ b/packages/ai-chat/src/tests/ai-chat-eviction.test.ts
@@ -1,42 +1,40 @@
+/**
+ * Forced Durable Object eviction coverage for AIChatAgent.
+ *
+ * `evictDurableObject()` explicitly tears down the running test actor and, by
+ * default, transfers accepted WebSockets. These tests verify reconstruction
+ * from SQLite and that forced WebSocket transfer. They do not assert natural
+ * idle hibernation, timer absence, or hibernation eligibility.
+ */
 import { env } from "cloudflare:workers";
-import { evictAllDurableObjects, evictDurableObject } from "cloudflare:test";
+import { evictDurableObject } from "cloudflare:test";
 import { getAgentByName } from "agents";
 import type { UIMessage as ChatMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { MessageType, type OutgoingMessage } from "../types";
 import { connectChatWS, isUseChatResponseMessage } from "./test-utils";
 
-// These tests use the real `evictDurableObject` / `evictAllDurableObjects`
-// helpers (vitest-pool-workers >= 0.16.20) to tear the DO instance down the
-// way production eviction/hibernation does: in-memory state is dropped and the
-// next access re-runs the AIChatAgent constructor, which must rebuild
-// `this.messages`, the ResumableStream, request context, etc. from SQLite.
-//
-// This is strictly more realistic than the in-process `testSimulateHibernationWake`
-// hook used by resumable-streaming.test.ts (which only re-instantiates the
-// ResumableStream on the *same* live instance) — here the whole DO is recycled.
-
 function isStreamResumingMessage(
-  m: unknown
-): m is Extract<
+  message: unknown
+): message is Extract<
   OutgoingMessage,
   { type: MessageType.CF_AGENT_STREAM_RESUMING }
 > {
   return (
-    typeof m === "object" &&
-    m !== null &&
-    "type" in m &&
-    m.type === MessageType.CF_AGENT_STREAM_RESUMING
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    message.type === MessageType.CF_AGENT_STREAM_RESUMING
   );
 }
 
 function collectMessages(ws: WebSocket): unknown[] {
   const messages: unknown[] = [];
-  ws.addEventListener("message", (e: MessageEvent) => {
+  ws.addEventListener("message", (event: MessageEvent) => {
     try {
-      messages.push(JSON.parse(e.data as string));
+      messages.push(JSON.parse(event.data as string));
     } catch {
-      messages.push(e.data);
+      messages.push(event.data);
     }
   });
   return messages;
@@ -44,314 +42,154 @@ function collectMessages(ws: WebSocket): unknown[] {
 
 async function waitFor(
   condition: () => boolean | Promise<boolean>,
-  timeoutMs = 2000,
-  intervalMs = 50
+  timeoutMs = 3000,
+  intervalMs = 25
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!(await condition())) {
     if (Date.now() >= deadline) {
-      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+      throw new Error(`condition not met within ${timeoutMs}ms`);
     }
-    await new Promise((r) => setTimeout(r, intervalMs));
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
 }
 
-// `getAgentByName` resolves to the same DurableObjectStub the rest of this
-// suite uses for RPC. `evictDurableObject` requires a stub that points at a DO
-// defined in the test worker's `main`, which TestChatAgent is.
 function stubFor(room: string) {
   return getAgentByName(env.TestChatAgent, room);
 }
 
-describe("AIChatAgent eviction (evictDurableObject)", () => {
-  describe("message history rehydration", () => {
-    it("rebuilds the in-memory this.messages array from SQLite after eviction", async () => {
-      const room = crypto.randomUUID();
-      const agentStub = await stubFor(room);
-
-      const userMessage: ChatMessage = {
-        id: "evict-user-1",
+describe("AIChatAgent recovery after forced Durable Object eviction", () => {
+  it("rebuilds its in-memory message array from SQLite", async () => {
+    const stub = await stubFor(crypto.randomUUID());
+    const messages: ChatMessage[] = [
+      {
+        id: "evict-user",
         role: "user",
-        parts: [{ type: "text", text: "remember me across eviction" }]
-      };
-      const assistantMessage: ChatMessage = {
-        id: "evict-assistant-1",
+        parts: [{ type: "text", text: "remember me" }]
+      },
+      {
+        id: "evict-assistant",
         role: "assistant",
-        parts: [{ type: "text", text: "I will survive hibernation" }]
-      };
+        parts: [{ type: "text", text: "I will be restored" }]
+      }
+    ];
 
-      await agentStub.persistMessages([userMessage, assistantMessage]);
+    await stub.persistMessages(messages);
+    expect(
+      ((await stub.getMessagesForTest()) as ChatMessage[]).map(
+        (message) => message.id
+      )
+    ).toEqual(["evict-user", "evict-assistant"]);
 
-      // Sanity: the live instance has both the SQL rows and the in-memory copy.
-      // The RPC stub return type for these synchronous ChatMessage[] methods
-      // resolves to `never`, so cast as the rest of this suite does.
-      const beforePersisted =
-        (await agentStub.getPersistedMessages()) as ChatMessage[];
-      const beforeInMemory =
-        (await agentStub.getMessagesForTest()) as ChatMessage[];
-      expect(beforePersisted.map((m) => m.id)).toEqual([
-        "evict-user-1",
-        "evict-assistant-1"
-      ]);
-      expect(beforeInMemory.map((m) => m.id)).toEqual([
-        "evict-user-1",
-        "evict-assistant-1"
-      ]);
+    await evictDurableObject(stub);
 
-      // Evict: the instance is torn down, dropping the in-memory this.messages.
-      await evictDurableObject(agentStub);
-
-      // Re-access: the constructor re-runs and must rebuild this.messages from
-      // cf_ai_chat_agent_messages. `getMessagesForTest()` returns the in-memory
-      // array, NOT a fresh SQL read — so this fails if rehydration is broken.
-      const afterInMemory =
-        (await agentStub.getMessagesForTest()) as ChatMessage[];
-      expect(afterInMemory.map((m) => m.id)).toEqual([
-        "evict-user-1",
-        "evict-assistant-1"
-      ]);
-      const surviving = afterInMemory.find((m) => m.id === "evict-assistant-1");
-      expect(surviving).toBeDefined();
-      const textPart = surviving!.parts.find((p) => p.type === "text") as
-        | { text: string }
-        | undefined;
-      expect(textPart?.text).toBe("I will survive hibernation");
-
-      // The /get-messages endpoint (SQL-backed) must agree with the rebuilt
-      // in-memory view.
-      const afterPersisted =
-        (await agentStub.getPersistedMessages()) as ChatMessage[];
-      expect(afterPersisted.map((m) => m.id)).toEqual(
-        afterInMemory.map((m) => m.id)
-      );
-    });
-
-    it("rehydrates after evictAllDurableObjects()", async () => {
-      const room = crypto.randomUUID();
-      const agentStub = await stubFor(room);
-
-      await agentStub.persistMessages([
-        {
-          id: "evict-all-1",
-          role: "user",
-          parts: [{ type: "text", text: "evict everything" }]
-        }
-      ]);
-
-      await evictAllDurableObjects();
-
-      const afterInMemory =
-        (await agentStub.getMessagesForTest()) as ChatMessage[];
-      expect(afterInMemory.map((m) => m.id)).toEqual(["evict-all-1"]);
-    });
+    const restored = (await stub.getMessagesForTest()) as ChatMessage[];
+    expect(restored).toEqual(messages);
+    expect(await stub.getPersistedMessages()).toEqual(restored);
   });
 
-  describe("resumable stream rehydration", () => {
-    it("restores active stream id, request id and stored chunks after eviction", async () => {
-      const room = crypto.randomUUID();
-      const agentStub = await stubFor(room);
+  it("restores an active resumable stream and its chunks", async () => {
+    const stub = await stubFor(crypto.randomUUID());
+    const streamId = await stub.testStartStream("req-evict-resume");
+    await stub.testStoreStreamChunk(streamId, '{"type":"text","text":"Hello"}');
+    await stub.testStoreStreamChunk(
+      streamId,
+      '{"type":"text","text":" world"}'
+    );
+    await stub.testFlushChunkBuffer();
 
-      const streamId = await agentStub.testStartStream("req-evict-resume");
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text","text":"Hello"}'
-      );
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text","text":" world"}'
-      );
-      await agentStub.testFlushChunkBuffer();
+    await evictDurableObject(stub);
 
-      // Live instance: stream is active and tracked in memory.
-      expect(await agentStub.getActiveStreamId()).toBe(streamId);
-      expect(await agentStub.getActiveRequestId()).toBe("req-evict-resume");
-
-      // Real eviction tears the ResumableStream instance down entirely.
-      await evictDurableObject(agentStub);
-
-      // The constructor builds a fresh ResumableStream whose restore() reads the
-      // active stream back from cf_ai_chat_stream_metadata. `_activeStreamId`
-      // delegates to that in-memory instance, so these assertions prove the
-      // active-stream pointer was rebuilt, not just persisted.
-      expect(await agentStub.getActiveStreamId()).toBe(streamId);
-      expect(await agentStub.getActiveRequestId()).toBe("req-evict-resume");
-
-      // Persisted chunks must be replayable after eviction.
-      const chunks = await agentStub.getStreamChunks(streamId);
-      expect(chunks.length).toBe(2);
-      expect(chunks[0].body).toBe('{"type":"text","text":"Hello"}');
-      expect(chunks[1].body).toBe('{"type":"text","text":" world"}');
-    });
-
-    it("completed streams stay completed and inactive after eviction", async () => {
-      const room = crypto.randomUUID();
-      const agentStub = await stubFor(room);
-
-      const streamId = await agentStub.testStartStream("req-evict-complete");
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text","text":"done"}'
-      );
-      await agentStub.testFlushChunkBuffer();
-      await agentStub.testCompleteStream(streamId);
-
-      expect(await agentStub.getActiveStreamId()).toBeNull();
-
-      await evictDurableObject(agentStub);
-
-      // restore() must NOT resurrect a completed stream as active.
-      expect(await agentStub.getActiveStreamId()).toBeNull();
-      const metadata = await agentStub.getStreamMetadata(streamId);
-      expect(metadata?.status).toBe("completed");
-      // Chunks are still readable for replay even though the stream is inactive.
-      const chunks = await agentStub.getStreamChunks(streamId);
-      expect(chunks.length).toBe(1);
-    });
+    expect(await stub.getActiveStreamId()).toBe(streamId);
+    expect(await stub.getActiveRequestId()).toBe("req-evict-resume");
+    expect(await stub.getStreamChunks(streamId)).toMatchObject([
+      { body: '{"type":"text","text":"Hello"}' },
+      { body: '{"type":"text","text":" world"}' }
+    ]);
   });
 
-  describe("WebSocket hibernation", () => {
-    it("notifies a reconnecting client of a resumable stream after real eviction", async () => {
-      const room = crypto.randomUUID();
+  it("keeps the same WebSocket usable across forced eviction", async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+    const received = collectMessages(ws);
 
-      const { ws: ws1 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await stubFor(room);
-      // Build an in-flight (orphaned) stream with persisted partial content.
-      const streamId = await agentStub.testStartStream("req-evict-ws");
-      await agentStub.testStoreStreamChunk(
+    try {
+      await waitFor(() => ws.readyState === WebSocket.OPEN);
+      const stub = await stubFor(room);
+      const streamId = await stub.testStartStream("req-live-eviction");
+      await stub.testStoreStreamChunk(
         streamId,
         '{"type":"text-start","id":"t1"}'
       );
-      await agentStub.testStoreStreamChunk(
+      await stub.testStoreStreamChunk(
         streamId,
-        '{"type":"text-delta","id":"t1","delta":"partial after eviction"}'
+        '{"type":"text-delta","id":"t1","delta":"partial"}'
       );
-      await agentStub.testFlushChunkBuffer();
+      await stub.testFlushChunkBuffer();
 
-      ws1.close();
-      await new Promise((r) => setTimeout(r, 50));
+      await evictDurableObject(stub);
 
-      // Real eviction (default: hibernate WebSockets) instead of the in-process
-      // testSimulateHibernationWake hook. The active stream must be restored
-      // from SQLite by the rebuilt ResumableStream.
-      await evictDurableObject(agentStub);
-      expect(await agentStub.getActiveStreamId()).toBe(streamId);
-
-      // A fresh client connecting after eviction must be told the stream is
-      // resumable, then receive the replayed partial content ending in done.
-      const { ws: ws2 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+      ws.send(
+        JSON.stringify({ type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST })
       );
-      const messages2 = collectMessages(ws2);
+      await waitFor(() => received.some(isStreamResumingMessage));
 
-      await waitFor(() => messages2.some(isStreamResumingMessage));
-      const resumeMsg = messages2.find(isStreamResumingMessage) as {
-        id: string;
-      };
-      ws2.send(
+      const resume = received.find(isStreamResumingMessage);
+      expect(resume).toBeDefined();
+      ws.send(
         JSON.stringify({
           type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
-          id: resumeMsg.id
+          id: resume!.id
         })
       );
 
       await waitFor(() =>
-        messages2.some(
-          (m) =>
-            isUseChatResponseMessage(m) &&
-            (m as { done?: boolean }).done === true
+        received.some(
+          (message) =>
+            isUseChatResponseMessage(message) &&
+            (message as { done?: boolean }).done === true
         )
       );
+      expect(await stub.getActiveStreamId()).toBeNull();
 
-      const responseMessages = messages2.filter(isUseChatResponseMessage);
-      const lastMsg = responseMessages[responseMessages.length - 1] as {
-        replay?: boolean;
-        done?: boolean;
-      };
-      expect(lastMsg.replay).toBe(true);
-      expect(lastMsg.done).toBe(true);
+      const persisted = (await stub.getPersistedMessages()) as ChatMessage[];
+      expect(JSON.stringify(persisted)).toContain("partial");
+    } finally {
+      if (ws.readyState === WebSocket.OPEN) ws.close(1000);
+    }
+  });
 
-      // The orphaned stream's partial content must have been persisted as an
-      // assistant message during the wake/replay flow.
-      const persisted = (await agentStub.getPersistedMessages()) as Array<{
-        role: string;
-        parts: Array<{ type: string; text?: string }>;
-      }>;
-      const assistantMsg = persisted.find((m) => m.role === "assistant");
-      expect(assistantMsg).toBeDefined();
-      const textPart = assistantMsg!.parts.find((p) => p.type === "text");
-      expect(textPart?.text).toContain("partial after eviction");
-      expect(await agentStub.getActiveStreamId()).toBeNull();
+  it('closes live WebSockets with { webSockets: "close" }', async () => {
+    const room = crypto.randomUUID();
+    const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
 
-      ws2.close(1000);
-    });
-
-    it('closes live WebSockets when evicting with { webSockets: "close" }', async () => {
-      const room = crypto.randomUUID();
-
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-      // Precondition: the socket is genuinely open before we evict-and-close it,
-      // so the post-eviction state change below is meaningful and not vacuous.
-      expect(ws.readyState).toBe(WebSocket.OPEN);
-
+    try {
+      await waitFor(() => ws.readyState === WebSocket.OPEN);
       let sawClose = false;
       ws.addEventListener("close", () => {
         sawClose = true;
       });
 
-      const agentStub = await stubFor(room);
+      const stub = await stubFor(room);
+      await evictDurableObject(stub, { webSockets: "close" });
 
-      // With webSockets: "close" the eviction closes the open socket instead of
-      // hibernating it — the client observes a close event.
-      await evictDurableObject(agentStub, { webSockets: "close" });
-
-      // The close should propagate to the client. Wait for either the close
-      // event or the readyState leaving OPEN.
-      await waitFor(() => sawClose || ws.readyState !== WebSocket.OPEN, 3000);
+      await waitFor(() => sawClose || ws.readyState !== WebSocket.OPEN);
       expect(sawClose).toBe(true);
       expect(ws.readyState).not.toBe(WebSocket.OPEN);
 
-      // The DO itself still rehydrates and serves RPC after the close-eviction.
-      await agentStub.persistMessages([
+      await stub.persistMessages([
         {
           id: "post-close-evict",
           role: "user",
           parts: [{ type: "text", text: "still alive" }]
         }
       ]);
-      const persisted =
-        (await agentStub.getPersistedMessages()) as ChatMessage[];
-      expect(persisted.some((m) => m.id === "post-close-evict")).toBe(true);
-    });
-  });
-
-  describe("scheduled alarm survival", () => {
-    it("keeps the stream-cleanup alarm scheduled across eviction", async () => {
-      const room = crypto.randomUUID();
-      const agentStub = await stubFor(room);
-
-      // Arm the cleanup alarm (persisted into cf_agents_schedules).
-      await agentStub.testArmStreamCleanup();
-      const delayBefore =
-        await agentStub.testStreamCleanupScheduleDelaySeconds();
-      expect(delayBefore).not.toBeNull();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      // Eviction drops in-memory state; the schedule lives in SQLite and must
-      // still be visible (and re-readable) after the DO is rebuilt.
-      await evictDurableObject(agentStub);
-
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-      const delayAfter =
-        await agentStub.testStreamCleanupScheduleDelaySeconds();
-      expect(delayAfter).not.toBeNull();
-      // Same configured interval — a regression that drops/re-arms with a
-      // different window would change this.
-      expect(delayAfter).toBe(delayBefore);
-    });
+      expect(await stub.getPersistedMessages()).toEqual([
+        expect.objectContaining({ id: "post-close-evict" })
+      ]);
+    } finally {
+      if (ws.readyState === WebSocket.OPEN) ws.close(1000);
+    }
   });
 });

--- a/packages/ai-chat/src/tests/ai-chat-eviction.test.ts
+++ b/packages/ai-chat/src/tests/ai-chat-eviction.test.ts
@@ -1,0 +1,357 @@
+import { env } from "cloudflare:workers";
+import { evictAllDurableObjects, evictDurableObject } from "cloudflare:test";
+import { getAgentByName } from "agents";
+import type { UIMessage as ChatMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { MessageType, type OutgoingMessage } from "../types";
+import { connectChatWS, isUseChatResponseMessage } from "./test-utils";
+
+// These tests use the real `evictDurableObject` / `evictAllDurableObjects`
+// helpers (vitest-pool-workers >= 0.16.20) to tear the DO instance down the
+// way production eviction/hibernation does: in-memory state is dropped and the
+// next access re-runs the AIChatAgent constructor, which must rebuild
+// `this.messages`, the ResumableStream, request context, etc. from SQLite.
+//
+// This is strictly more realistic than the in-process `testSimulateHibernationWake`
+// hook used by resumable-streaming.test.ts (which only re-instantiates the
+// ResumableStream on the *same* live instance) — here the whole DO is recycled.
+
+function isStreamResumingMessage(
+  m: unknown
+): m is Extract<
+  OutgoingMessage,
+  { type: MessageType.CF_AGENT_STREAM_RESUMING }
+> {
+  return (
+    typeof m === "object" &&
+    m !== null &&
+    "type" in m &&
+    m.type === MessageType.CF_AGENT_STREAM_RESUMING
+  );
+}
+
+function collectMessages(ws: WebSocket): unknown[] {
+  const messages: unknown[] = [];
+  ws.addEventListener("message", (e: MessageEvent) => {
+    try {
+      messages.push(JSON.parse(e.data as string));
+    } catch {
+      messages.push(e.data);
+    }
+  });
+  return messages;
+}
+
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 2000,
+  intervalMs = 50
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await condition())) {
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+// `getAgentByName` resolves to the same DurableObjectStub the rest of this
+// suite uses for RPC. `evictDurableObject` requires a stub that points at a DO
+// defined in the test worker's `main`, which TestChatAgent is.
+function stubFor(room: string) {
+  return getAgentByName(env.TestChatAgent, room);
+}
+
+describe("AIChatAgent eviction (evictDurableObject)", () => {
+  describe("message history rehydration", () => {
+    it("rebuilds the in-memory this.messages array from SQLite after eviction", async () => {
+      const room = crypto.randomUUID();
+      const agentStub = await stubFor(room);
+
+      const userMessage: ChatMessage = {
+        id: "evict-user-1",
+        role: "user",
+        parts: [{ type: "text", text: "remember me across eviction" }]
+      };
+      const assistantMessage: ChatMessage = {
+        id: "evict-assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "I will survive hibernation" }]
+      };
+
+      await agentStub.persistMessages([userMessage, assistantMessage]);
+
+      // Sanity: the live instance has both the SQL rows and the in-memory copy.
+      // The RPC stub return type for these synchronous ChatMessage[] methods
+      // resolves to `never`, so cast as the rest of this suite does.
+      const beforePersisted =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      const beforeInMemory =
+        (await agentStub.getMessagesForTest()) as ChatMessage[];
+      expect(beforePersisted.map((m) => m.id)).toEqual([
+        "evict-user-1",
+        "evict-assistant-1"
+      ]);
+      expect(beforeInMemory.map((m) => m.id)).toEqual([
+        "evict-user-1",
+        "evict-assistant-1"
+      ]);
+
+      // Evict: the instance is torn down, dropping the in-memory this.messages.
+      await evictDurableObject(agentStub);
+
+      // Re-access: the constructor re-runs and must rebuild this.messages from
+      // cf_ai_chat_agent_messages. `getMessagesForTest()` returns the in-memory
+      // array, NOT a fresh SQL read — so this fails if rehydration is broken.
+      const afterInMemory =
+        (await agentStub.getMessagesForTest()) as ChatMessage[];
+      expect(afterInMemory.map((m) => m.id)).toEqual([
+        "evict-user-1",
+        "evict-assistant-1"
+      ]);
+      const surviving = afterInMemory.find((m) => m.id === "evict-assistant-1");
+      expect(surviving).toBeDefined();
+      const textPart = surviving!.parts.find((p) => p.type === "text") as
+        | { text: string }
+        | undefined;
+      expect(textPart?.text).toBe("I will survive hibernation");
+
+      // The /get-messages endpoint (SQL-backed) must agree with the rebuilt
+      // in-memory view.
+      const afterPersisted =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      expect(afterPersisted.map((m) => m.id)).toEqual(
+        afterInMemory.map((m) => m.id)
+      );
+    });
+
+    it("rehydrates after evictAllDurableObjects()", async () => {
+      const room = crypto.randomUUID();
+      const agentStub = await stubFor(room);
+
+      await agentStub.persistMessages([
+        {
+          id: "evict-all-1",
+          role: "user",
+          parts: [{ type: "text", text: "evict everything" }]
+        }
+      ]);
+
+      await evictAllDurableObjects();
+
+      const afterInMemory =
+        (await agentStub.getMessagesForTest()) as ChatMessage[];
+      expect(afterInMemory.map((m) => m.id)).toEqual(["evict-all-1"]);
+    });
+  });
+
+  describe("resumable stream rehydration", () => {
+    it("restores active stream id, request id and stored chunks after eviction", async () => {
+      const room = crypto.randomUUID();
+      const agentStub = await stubFor(room);
+
+      const streamId = await agentStub.testStartStream("req-evict-resume");
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text","text":"Hello"}'
+      );
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text","text":" world"}'
+      );
+      await agentStub.testFlushChunkBuffer();
+
+      // Live instance: stream is active and tracked in memory.
+      expect(await agentStub.getActiveStreamId()).toBe(streamId);
+      expect(await agentStub.getActiveRequestId()).toBe("req-evict-resume");
+
+      // Real eviction tears the ResumableStream instance down entirely.
+      await evictDurableObject(agentStub);
+
+      // The constructor builds a fresh ResumableStream whose restore() reads the
+      // active stream back from cf_ai_chat_stream_metadata. `_activeStreamId`
+      // delegates to that in-memory instance, so these assertions prove the
+      // active-stream pointer was rebuilt, not just persisted.
+      expect(await agentStub.getActiveStreamId()).toBe(streamId);
+      expect(await agentStub.getActiveRequestId()).toBe("req-evict-resume");
+
+      // Persisted chunks must be replayable after eviction.
+      const chunks = await agentStub.getStreamChunks(streamId);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].body).toBe('{"type":"text","text":"Hello"}');
+      expect(chunks[1].body).toBe('{"type":"text","text":" world"}');
+    });
+
+    it("completed streams stay completed and inactive after eviction", async () => {
+      const room = crypto.randomUUID();
+      const agentStub = await stubFor(room);
+
+      const streamId = await agentStub.testStartStream("req-evict-complete");
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text","text":"done"}'
+      );
+      await agentStub.testFlushChunkBuffer();
+      await agentStub.testCompleteStream(streamId);
+
+      expect(await agentStub.getActiveStreamId()).toBeNull();
+
+      await evictDurableObject(agentStub);
+
+      // restore() must NOT resurrect a completed stream as active.
+      expect(await agentStub.getActiveStreamId()).toBeNull();
+      const metadata = await agentStub.getStreamMetadata(streamId);
+      expect(metadata?.status).toBe("completed");
+      // Chunks are still readable for replay even though the stream is inactive.
+      const chunks = await agentStub.getStreamChunks(streamId);
+      expect(chunks.length).toBe(1);
+    });
+  });
+
+  describe("WebSocket hibernation", () => {
+    it("notifies a reconnecting client of a resumable stream after real eviction", async () => {
+      const room = crypto.randomUUID();
+
+      const { ws: ws1 } = await connectChatWS(
+        `/agents/test-chat-agent/${room}`
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      const agentStub = await stubFor(room);
+      // Build an in-flight (orphaned) stream with persisted partial content.
+      const streamId = await agentStub.testStartStream("req-evict-ws");
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text-start","id":"t1"}'
+      );
+      await agentStub.testStoreStreamChunk(
+        streamId,
+        '{"type":"text-delta","id":"t1","delta":"partial after eviction"}'
+      );
+      await agentStub.testFlushChunkBuffer();
+
+      ws1.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Real eviction (default: hibernate WebSockets) instead of the in-process
+      // testSimulateHibernationWake hook. The active stream must be restored
+      // from SQLite by the rebuilt ResumableStream.
+      await evictDurableObject(agentStub);
+      expect(await agentStub.getActiveStreamId()).toBe(streamId);
+
+      // A fresh client connecting after eviction must be told the stream is
+      // resumable, then receive the replayed partial content ending in done.
+      const { ws: ws2 } = await connectChatWS(
+        `/agents/test-chat-agent/${room}`
+      );
+      const messages2 = collectMessages(ws2);
+
+      await waitFor(() => messages2.some(isStreamResumingMessage));
+      const resumeMsg = messages2.find(isStreamResumingMessage) as {
+        id: string;
+      };
+      ws2.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
+          id: resumeMsg.id
+        })
+      );
+
+      await waitFor(() =>
+        messages2.some(
+          (m) =>
+            isUseChatResponseMessage(m) &&
+            (m as { done?: boolean }).done === true
+        )
+      );
+
+      const responseMessages = messages2.filter(isUseChatResponseMessage);
+      const lastMsg = responseMessages[responseMessages.length - 1] as {
+        replay?: boolean;
+        done?: boolean;
+      };
+      expect(lastMsg.replay).toBe(true);
+      expect(lastMsg.done).toBe(true);
+
+      // The orphaned stream's partial content must have been persisted as an
+      // assistant message during the wake/replay flow.
+      const persisted = (await agentStub.getPersistedMessages()) as Array<{
+        role: string;
+        parts: Array<{ type: string; text?: string }>;
+      }>;
+      const assistantMsg = persisted.find((m) => m.role === "assistant");
+      expect(assistantMsg).toBeDefined();
+      const textPart = assistantMsg!.parts.find((p) => p.type === "text");
+      expect(textPart?.text).toContain("partial after eviction");
+      expect(await agentStub.getActiveStreamId()).toBeNull();
+
+      ws2.close(1000);
+    });
+
+    it('closes live WebSockets when evicting with { webSockets: "close" }', async () => {
+      const room = crypto.randomUUID();
+
+      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
+      await new Promise((r) => setTimeout(r, 50));
+      // Precondition: the socket is genuinely open before we evict-and-close it,
+      // so the post-eviction state change below is meaningful and not vacuous.
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+
+      let sawClose = false;
+      ws.addEventListener("close", () => {
+        sawClose = true;
+      });
+
+      const agentStub = await stubFor(room);
+
+      // With webSockets: "close" the eviction closes the open socket instead of
+      // hibernating it — the client observes a close event.
+      await evictDurableObject(agentStub, { webSockets: "close" });
+
+      // The close should propagate to the client. Wait for either the close
+      // event or the readyState leaving OPEN.
+      await waitFor(() => sawClose || ws.readyState !== WebSocket.OPEN, 3000);
+      expect(sawClose).toBe(true);
+      expect(ws.readyState).not.toBe(WebSocket.OPEN);
+
+      // The DO itself still rehydrates and serves RPC after the close-eviction.
+      await agentStub.persistMessages([
+        {
+          id: "post-close-evict",
+          role: "user",
+          parts: [{ type: "text", text: "still alive" }]
+        }
+      ]);
+      const persisted =
+        (await agentStub.getPersistedMessages()) as ChatMessage[];
+      expect(persisted.some((m) => m.id === "post-close-evict")).toBe(true);
+    });
+  });
+
+  describe("scheduled alarm survival", () => {
+    it("keeps the stream-cleanup alarm scheduled across eviction", async () => {
+      const room = crypto.randomUUID();
+      const agentStub = await stubFor(room);
+
+      // Arm the cleanup alarm (persisted into cf_agents_schedules).
+      await agentStub.testArmStreamCleanup();
+      const delayBefore =
+        await agentStub.testStreamCleanupScheduleDelaySeconds();
+      expect(delayBefore).not.toBeNull();
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+
+      // Eviction drops in-memory state; the schedule lives in SQLite and must
+      // still be visible (and re-readable) after the DO is rebuilt.
+      await evictDurableObject(agentStub);
+
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
+      const delayAfter =
+        await agentStub.testStreamCleanupScheduleDelaySeconds();
+      expect(delayAfter).not.toBeNull();
+      // Same configured interval — a regression that drops/re-arms with a
+      // different window would change this.
+      expect(delayAfter).toBe(delayBefore);
+    });
+  });
+});

--- a/packages/codemode/src/runtime-tests/codemode-eviction.test.ts
+++ b/packages/codemode/src/runtime-tests/codemode-eviction.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Durable Object eviction tests for the codemode runtime.
+ *
+ * The `CodemodeRuntime` is deliberately *stateless in instance memory*: every
+ * run is addressed by an explicit executionId and ALL state (the replay log,
+ * pending actions, status, results, snippets) lives in the facet's SQLite store
+ * (see runtime.ts "Statelessness" doc block). These tests prove that contract
+ * against a real production-style eviction: we drive a run, evict the host DO
+ * (which recursively evicts the `CodemodeRuntime` facet and drops every
+ * in-memory array on the test connector), then re-access the stub and assert the
+ * run rehydrates from storage and behaves identically.
+ *
+ * `evictDurableObject(stub)` simulates the production lifecycle where an idle DO
+ * is evicted from memory: in-memory state is dropped and must be rebuilt from
+ * storage on next access. We assert the in-memory connector arrays ARE wiped
+ * (so the eviction genuinely happened, not a no-op) while the durable execution
+ * state survives byte-for-byte.
+ */
+import { env } from "cloudflare:workers";
+import { evictDurableObject, evictAllDurableObjects } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import type { ProxyToolOutput } from "../proxy-tool";
+import type { ExecutionState, PendingAction } from "../runtime";
+
+// Same host RPC surface the sibling runtime.test.ts uses. The Workers RPC stub
+// mapping collapses these structured returns to `never` when typed via
+// `DurableObjectNamespace<CodemodeTestHost>`, so we describe the slice directly.
+interface Host {
+  run(
+    code: string,
+    options?: { maxExecutions?: number; name?: string }
+  ): Promise<ProxyToolOutput>;
+  approve(executionId: string): Promise<ProxyToolOutput>;
+  reject(seq: number, executionId: string): Promise<boolean>;
+  pending(executionId?: string): Promise<PendingAction[]>;
+  executions(name?: string): Promise<ExecutionState[]>;
+  sideEffects(): Promise<{
+    created: Array<{ title: string }>;
+    deleted: unknown[];
+    notes: string[];
+  }>;
+  lifecycle(): Promise<{
+    opened: string[];
+    disposed: Array<{ executionId: string; status: string }>;
+  }>;
+  passEnds(): Promise<Array<{ executionId: string; status: string }>>;
+}
+
+const testEnv = env as unknown as {
+  CodemodeTestHost: DurableObjectNamespace;
+};
+
+let counter = 0;
+
+/**
+ * Resolve a fresh host DO. Returns BOTH the typed RPC view (`h`) and the raw
+ * stub (`stub`) — `evictDurableObject` needs the real `DurableObjectStub`, while
+ * the assertions drive the host through its RPC methods. They point at the same
+ * object: re-reading through `h` after eviction forces rehydration from storage.
+ */
+function makeHost(): { h: Host; stub: DurableObjectStub } {
+  const name = `evict-host-${Date.now()}-${counter++}`;
+  const stub = testEnv.CodemodeTestHost.get(
+    testEnv.CodemodeTestHost.idFromName(name)
+  );
+  return { h: stub as unknown as Host, stub };
+}
+
+describe("codemode durable runtime — DO eviction", () => {
+  it("rebuilds a paused run from SQLite after eviction and replays prior reads", async () => {
+    const { h, stub } = makeHost();
+    // A read BEFORE the approval pause. On resume the read must replay its
+    // original (empty) result from the durable log — not re-execute against the
+    // freshly-rebuilt (and freshly-mutated) connector.
+    const code = `async () => {
+      const before = await items.list_items();
+      const created = await items.create_item({ title: "x" });
+      return { beforeCount: before.length, created };
+    }`;
+    const first = (await h.run(code)) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+    expect(first.pending).toHaveLength(1);
+
+    // Evict the host DO. This recursively evicts the CodemodeRuntime facet and
+    // tears down the in-memory ItemsConnector arrays. The pending run now exists
+    // ONLY in SQLite.
+    await evictDurableObject(stub);
+
+    // Proof the eviction was real: the in-memory connector state was wiped, yet
+    // the durable approval queue rehydrated the pending action from storage.
+    const pendingAfter = await h.pending();
+    expect(pendingAfter).toHaveLength(1);
+    expect(pendingAfter[0]).toMatchObject({
+      executionId: first.executionId,
+      connector: "items",
+      method: "create_item",
+      args: { title: "x" }
+    });
+
+    // Approve on the rehydrated instance. The whole run is reconstructed from
+    // the durable log: list_items replays its logged empty result while
+    // create_item executes for real exactly once.
+    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
+    expect(resumed.status).toBe("completed");
+    if (resumed.status !== "completed") return;
+    // beforeCount===0 can ONLY come from the durable log surviving eviction:
+    // the in-memory `created` array was reset, so a re-execution of list_items
+    // would also see 0 — but create_item's logged result proves replay, and the
+    // run id is the same pre-eviction execution.
+    expect(resumed.result).toMatchObject({
+      beforeCount: 0,
+      created: { id: 1, title: "x" }
+    });
+
+    // The durable audit trail carries the original execution, now completed,
+    // with its create_item entry applied.
+    const exec = (await h.executions()).find((e) => e.id === first.executionId);
+    expect(exec?.status).toBe("completed");
+    const createEntry = exec?.log.find((e) => e.method === "create_item");
+    expect(createEntry?.state).toBe("applied");
+  });
+
+  it("replays a binary result through the storage codec after eviction", async () => {
+    const { h, stub } = makeHost();
+    // get_bytes records a Uint8Array in the durable log on the first pass. After
+    // eviction the resume must REPLAY it (not re-execute), so the stored value
+    // has to decode back to a real Uint8Array off disk on a fresh instance.
+    const code = `async () => {
+      const bytes = await items.get_bytes();
+      await items.create_item({ title: "b" });
+      return { isBytes: bytes instanceof Uint8Array, values: Array.from(bytes) };
+    }`;
+    const first = (await h.run(code)) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    await evictDurableObject(stub);
+
+    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
+    expect(resumed.status).toBe("completed");
+    if (resumed.status !== "completed") return;
+    // Byte-for-byte survival through the SQLite codec across hibernation.
+    expect(resumed.result).toEqual({
+      isBytes: true,
+      values: [1, 2, 3, 4, 5]
+    });
+  });
+
+  it("disposes connectors on a fresh instance when the run completes after eviction", async () => {
+    const { h, stub } = makeHost();
+    const first = (await h.run(
+      `async () => await items.create_item({ title: "dispose-me" })`
+    )) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    // Pausing fired onPassEnd("paused") but NOT disposeExecution (paused is not
+    // terminal).
+    expect(await h.passEnds()).toEqual([
+      { executionId: first.executionId, status: "paused" }
+    ]);
+    expect((await h.lifecycle()).disposed).toEqual([]);
+
+    // Evict: the in-memory passEnds/disposed/opened arrays are gone. The
+    // connector that will run disposeExecution on resume is a BRAND NEW
+    // instance, built after rehydration.
+    await evictDurableObject(stub);
+
+    // The wiped in-memory lifecycle arrays confirm a real teardown happened.
+    expect(await h.passEnds()).toEqual([]);
+    expect((await h.lifecycle()).disposed).toEqual([]);
+
+    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
+    expect(resumed.status).toBe("completed");
+
+    // disposeExecution fired exactly once, on the terminal transition, on the
+    // post-eviction connector instance — keyed by the original executionId that
+    // was reloaded from SQLite.
+    expect((await h.lifecycle()).disposed).toEqual([
+      { executionId: first.executionId, status: "completed" }
+    ]);
+    // onPassEnd fired only for the resume pass (the paused pass's record was on
+    // the evicted instance); the durable run is still correctly completed.
+    expect(await h.passEnds()).toEqual([
+      { executionId: first.executionId, status: "completed" }
+    ]);
+    const exec = (await h.executions()).find((e) => e.id === first.executionId);
+    expect(exec?.status).toBe("completed");
+  });
+
+  it("can reject a rehydrated pending run after eviction (terminal dispose on fresh instance)", async () => {
+    const { h, stub } = makeHost();
+    const first = (await h.run(
+      `async () => await items.create_item({ title: "nope" })`
+    )) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+    const seq = first.pending[0].seq;
+
+    await evictDurableObject(stub);
+
+    // The pending action survived in SQLite and is rejectable on the fresh
+    // instance using the seq captured before eviction.
+    expect(await h.reject(seq, first.executionId)).toBe(true);
+
+    // Reject is a terminal transition → disposeExecution("rejected") ran on the
+    // post-eviction connector instance.
+    expect((await h.lifecycle()).disposed).toEqual([
+      { executionId: first.executionId, status: "rejected" }
+    ]);
+    const exec = (await h.executions()).find((e) => e.id === first.executionId);
+    expect(exec?.status).toBe("rejected");
+    // Nothing was ever applied.
+    expect((await h.sideEffects()).created).toEqual([]);
+    expect(await h.pending()).toEqual([]);
+  });
+
+  it("keeps the completed-execution audit trail intact across eviction", async () => {
+    const { h, stub } = makeHost();
+    // Drive several runs to completion so the SQLite audit trail is populated.
+    // add_note completes immediately and records a durable log entry; its
+    // in-memory side effect (the `notes` array) is the part eviction wipes.
+    const a = (await h.run(`async () => 1 + 1`)) as ProxyToolOutput;
+    expect(a.status).toBe("completed");
+    const b = (await h.run(
+      `async () => await items.add_note({ text: "kept" })`
+    )) as ProxyToolOutput;
+    expect(b.status).toBe("completed");
+
+    // The in-memory note is present before eviction.
+    expect((await h.sideEffects()).notes).toEqual(["kept"]);
+
+    const before = await h.executions();
+    expect(before).toHaveLength(2);
+    const byId = new Map(before.map((e) => [e.id, e]));
+
+    await evictDurableObject(stub);
+
+    // In-memory side effects gone (real eviction); durable audit trail intact.
+    expect((await h.sideEffects()).notes).toEqual([]);
+
+    const after = await h.executions();
+    expect(after).toHaveLength(2);
+    for (const exec of after) {
+      const original = byId.get(exec.id);
+      expect(original).toBeDefined();
+      expect(exec.status).toBe("completed");
+      expect(exec.result).toEqual(original?.result);
+      // The durable log shape (entry count + states) survived byte-for-byte.
+      expect(exec.log.map((e) => e.state)).toEqual(
+        original?.log.map((e) => e.state)
+      );
+    }
+    // The add_note run's logged entry survived even though its in-memory effect
+    // was wiped — replay reconstructs from the durable log, not live memory.
+    const noteRun = after.find((e) => e.result?.hasOwnProperty?.("index"));
+    expect(noteRun).toBeDefined();
+    expect(noteRun?.log.find((e) => e.method === "add_note")?.state).toBe(
+      "applied"
+    );
+  });
+
+  it("rejects an oversized result the same way after eviction (storage guard survives)", async () => {
+    const { h, stub } = makeHost();
+    // First a normal completed run so the DO has live durable state.
+    const ok = (await h.run(`async () => "small"`)) as ProxyToolOutput;
+    expect(ok.status).toBe("completed");
+
+    await evictDurableObject(stub);
+
+    // After rehydration the durable-size guard still fails an oversized recorded
+    // result with the same model-actionable error — the storage codec + limit
+    // logic was reconstructed from the schema in the facet constructor.
+    const out = (await h.run(
+      `async () => { const r = await items.big_result(); return r.length; }`
+    )) as ProxyToolOutput;
+    expect(out.status).toBe("error");
+    if (out.status !== "error") return;
+    expect(out.error).toMatch(/too large to record durably/);
+    const exec = (await h.executions()).find((e) => e.id === out.executionId);
+    expect(exec?.status).toBe("error");
+
+    // The earlier successful run is still on the audit trail post-eviction.
+    expect(
+      (await h.executions()).find((e) => e.id === ok.executionId)?.result
+    ).toBe("small");
+  });
+
+  it("survives evictAllDurableObjects() — every running DO is rebuilt from storage", async () => {
+    const { h } = makeHost();
+    const first = (await h.run(
+      `async () => {
+        const before = await items.list_items();
+        return await items.create_item({ title: "all" });
+      }`
+    )) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    // Namespace-wide eviction: every currently-running DO (host + its facet) is
+    // gracefully evicted; durable storage is preserved.
+    await evictAllDurableObjects();
+
+    // The pending run rehydrated from SQLite after the blanket eviction.
+    const pending = await h.pending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      executionId: first.executionId,
+      method: "create_item"
+    });
+
+    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
+    expect(resumed.status).toBe("completed");
+    if (resumed.status === "completed") {
+      expect(resumed.result).toMatchObject({ id: 1, title: "all" });
+    }
+    const exec = (await h.executions()).find((e) => e.id === first.executionId);
+    expect(exec?.status).toBe("completed");
+  });
+});

--- a/packages/codemode/src/runtime-tests/codemode-eviction.test.ts
+++ b/packages/codemode/src/runtime-tests/codemode-eviction.test.ts
@@ -1,39 +1,22 @@
 /**
- * Durable Object eviction tests for the codemode runtime.
+ * Forced Durable Object eviction coverage for the Codemode runtime.
  *
- * The `CodemodeRuntime` is deliberately *stateless in instance memory*: every
- * run is addressed by an explicit executionId and ALL state (the replay log,
- * pending actions, status, results, snippets) lives in the facet's SQLite store
- * (see runtime.ts "Statelessness" doc block). These tests prove that contract
- * against a real production-style eviction: we drive a run, evict the host DO
- * (which recursively evicts the `CodemodeRuntime` facet and drops every
- * in-memory array on the test connector), then re-access the stub and assert the
- * run rehydrates from storage and behaves identically.
- *
- * `evictDurableObject(stub)` simulates the production lifecycle where an idle DO
- * is evicted from memory: in-memory state is dropped and must be rebuilt from
- * storage on next access. We assert the in-memory connector arrays ARE wiped
- * (so the eviction genuinely happened, not a no-op) while the durable execution
- * state survives byte-for-byte.
+ * The helper explicitly tears down the running test host and its runtime facet.
+ * These tests verify reconstruction from durable execution state; they do not
+ * assert natural idle hibernation or hibernation eligibility.
  */
 import { env } from "cloudflare:workers";
-import { evictDurableObject, evictAllDurableObjects } from "cloudflare:test";
-import { describe, it, expect } from "vitest";
+import { evictDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
 import type { ProxyToolOutput } from "../proxy-tool";
 import type { ExecutionState, PendingAction } from "../runtime";
 
-// Same host RPC surface the sibling runtime.test.ts uses. The Workers RPC stub
-// mapping collapses these structured returns to `never` when typed via
-// `DurableObjectNamespace<CodemodeTestHost>`, so we describe the slice directly.
 interface Host {
-  run(
-    code: string,
-    options?: { maxExecutions?: number; name?: string }
-  ): Promise<ProxyToolOutput>;
+  run(code: string): Promise<ProxyToolOutput>;
   approve(executionId: string): Promise<ProxyToolOutput>;
   reject(seq: number, executionId: string): Promise<boolean>;
   pending(executionId?: string): Promise<PendingAction[]>;
-  executions(name?: string): Promise<ExecutionState[]>;
+  executions(): Promise<ExecutionState[]>;
   sideEffects(): Promise<{
     created: Array<{ title: string }>;
     deleted: unknown[];
@@ -44,278 +27,123 @@ interface Host {
     disposed: Array<{ executionId: string; status: string }>;
   }>;
   passEnds(): Promise<Array<{ executionId: string; status: string }>>;
+  executionCounts(): Promise<{ listItems: number; getBytes: number }>;
 }
 
 const testEnv = env as unknown as {
   CodemodeTestHost: DurableObjectNamespace;
 };
 
-let counter = 0;
-
-/**
- * Resolve a fresh host DO. Returns BOTH the typed RPC view (`h`) and the raw
- * stub (`stub`) — `evictDurableObject` needs the real `DurableObjectStub`, while
- * the assertions drive the host through its RPC methods. They point at the same
- * object: re-reading through `h` after eviction forces rehydration from storage.
- */
-function makeHost(): { h: Host; stub: DurableObjectStub } {
-  const name = `evict-host-${Date.now()}-${counter++}`;
-  const stub = testEnv.CodemodeTestHost.get(
-    testEnv.CodemodeTestHost.idFromName(name)
+function makeHost(): { host: Host; stub: DurableObjectStub } {
+  const id = testEnv.CodemodeTestHost.idFromName(
+    `evict-host-${crypto.randomUUID()}`
   );
-  return { h: stub as unknown as Host, stub };
+  const stub = testEnv.CodemodeTestHost.get(id);
+  return { host: stub as unknown as Host, stub };
 }
 
-describe("codemode durable runtime — DO eviction", () => {
-  it("rebuilds a paused run from SQLite after eviction and replays prior reads", async () => {
-    const { h, stub } = makeHost();
-    // A read BEFORE the approval pause. On resume the read must replay its
-    // original (empty) result from the durable log — not re-execute against the
-    // freshly-rebuilt (and freshly-mutated) connector.
-    const code = `async () => {
+describe("Codemode recovery after forced Durable Object eviction", () => {
+  it("replays recorded reads without executing them on the fresh connector", async () => {
+    const { host, stub } = makeHost();
+    const first = (await host.run(`async () => {
       const before = await items.list_items();
+      const bytes = await items.get_bytes();
       const created = await items.create_item({ title: "x" });
-      return { beforeCount: before.length, created };
-    }`;
-    const first = (await h.run(code)) as ProxyToolOutput;
+      return {
+        beforeCount: before.length,
+        bytes: Array.from(bytes),
+        created
+      };
+    }`)) as ProxyToolOutput;
+
     expect(first.status).toBe("paused");
     if (first.status !== "paused") return;
-    expect(first.pending).toHaveLength(1);
-
-    // Evict the host DO. This recursively evicts the CodemodeRuntime facet and
-    // tears down the in-memory ItemsConnector arrays. The pending run now exists
-    // ONLY in SQLite.
-    await evictDurableObject(stub);
-
-    // Proof the eviction was real: the in-memory connector state was wiped, yet
-    // the durable approval queue rehydrated the pending action from storage.
-    const pendingAfter = await h.pending();
-    expect(pendingAfter).toHaveLength(1);
-    expect(pendingAfter[0]).toMatchObject({
-      executionId: first.executionId,
-      connector: "items",
-      method: "create_item",
-      args: { title: "x" }
+    expect(await host.executionCounts()).toEqual({
+      listItems: 1,
+      getBytes: 1
     });
 
-    // Approve on the rehydrated instance. The whole run is reconstructed from
-    // the durable log: list_items replays its logged empty result while
-    // create_item executes for real exactly once.
-    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
+    await evictDurableObject(stub);
+
+    // The connector counters are instance-only. Both reset to zero, while the
+    // pending action remains in the runtime facet's durable log.
+    expect(await host.executionCounts()).toEqual({
+      listItems: 0,
+      getBytes: 0
+    });
+    expect(await host.pending(first.executionId)).toEqual([
+      expect.objectContaining({
+        executionId: first.executionId,
+        connector: "items",
+        method: "create_item"
+      })
+    ]);
+
+    const resumed = (await host.approve(first.executionId)) as ProxyToolOutput;
     expect(resumed.status).toBe("completed");
     if (resumed.status !== "completed") return;
-    // beforeCount===0 can ONLY come from the durable log surviving eviction:
-    // the in-memory `created` array was reset, so a re-execution of list_items
-    // would also see 0 — but create_item's logged result proves replay, and the
-    // run id is the same pre-eviction execution.
-    expect(resumed.result).toMatchObject({
+
+    expect(resumed.result).toEqual({
       beforeCount: 0,
+      bytes: [1, 2, 3, 4, 5],
       created: { id: 1, title: "x" }
     });
-
-    // The durable audit trail carries the original execution, now completed,
-    // with its create_item entry applied.
-    const exec = (await h.executions()).find((e) => e.id === first.executionId);
-    expect(exec?.status).toBe("completed");
-    const createEntry = exec?.log.find((e) => e.method === "create_item");
-    expect(createEntry?.state).toBe("applied");
-  });
-
-  it("replays a binary result through the storage codec after eviction", async () => {
-    const { h, stub } = makeHost();
-    // get_bytes records a Uint8Array in the durable log on the first pass. After
-    // eviction the resume must REPLAY it (not re-execute), so the stored value
-    // has to decode back to a real Uint8Array off disk on a fresh instance.
-    const code = `async () => {
-      const bytes = await items.get_bytes();
-      await items.create_item({ title: "b" });
-      return { isBytes: bytes instanceof Uint8Array, values: Array.from(bytes) };
-    }`;
-    const first = (await h.run(code)) as ProxyToolOutput;
-    expect(first.status).toBe("paused");
-    if (first.status !== "paused") return;
-
-    await evictDurableObject(stub);
-
-    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
-    expect(resumed.status).toBe("completed");
-    if (resumed.status !== "completed") return;
-    // Byte-for-byte survival through the SQLite codec across hibernation.
-    expect(resumed.result).toEqual({
-      isBytes: true,
-      values: [1, 2, 3, 4, 5]
+    expect(await host.executionCounts()).toEqual({
+      listItems: 0,
+      getBytes: 0
     });
+    expect((await host.sideEffects()).created).toEqual([{ title: "x" }]);
   });
 
-  it("disposes connectors on a fresh instance when the run completes after eviction", async () => {
-    const { h, stub } = makeHost();
-    const first = (await h.run(
+  it("disposes the fresh connector when a rehydrated run completes", async () => {
+    const { host, stub } = makeHost();
+    const first = (await host.run(
       `async () => await items.create_item({ title: "dispose-me" })`
     )) as ProxyToolOutput;
+
     expect(first.status).toBe("paused");
     if (first.status !== "paused") return;
-
-    // Pausing fired onPassEnd("paused") but NOT disposeExecution (paused is not
-    // terminal).
-    expect(await h.passEnds()).toEqual([
+    expect(await host.passEnds()).toEqual([
       { executionId: first.executionId, status: "paused" }
     ]);
-    expect((await h.lifecycle()).disposed).toEqual([]);
+    expect((await host.lifecycle()).disposed).toEqual([]);
 
-    // Evict: the in-memory passEnds/disposed/opened arrays are gone. The
-    // connector that will run disposeExecution on resume is a BRAND NEW
-    // instance, built after rehydration.
     await evictDurableObject(stub);
 
-    // The wiped in-memory lifecycle arrays confirm a real teardown happened.
-    expect(await h.passEnds()).toEqual([]);
-    expect((await h.lifecycle()).disposed).toEqual([]);
-
-    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
+    expect(await host.passEnds()).toEqual([]);
+    const resumed = (await host.approve(first.executionId)) as ProxyToolOutput;
     expect(resumed.status).toBe("completed");
-
-    // disposeExecution fired exactly once, on the terminal transition, on the
-    // post-eviction connector instance — keyed by the original executionId that
-    // was reloaded from SQLite.
-    expect((await h.lifecycle()).disposed).toEqual([
+    expect((await host.lifecycle()).disposed).toEqual([
       { executionId: first.executionId, status: "completed" }
     ]);
-    // onPassEnd fired only for the resume pass (the paused pass's record was on
-    // the evicted instance); the durable run is still correctly completed.
-    expect(await h.passEnds()).toEqual([
+    expect(await host.passEnds()).toEqual([
       { executionId: first.executionId, status: "completed" }
     ]);
-    const exec = (await h.executions()).find((e) => e.id === first.executionId);
-    expect(exec?.status).toBe("completed");
   });
 
-  it("can reject a rehydrated pending run after eviction (terminal dispose on fresh instance)", async () => {
-    const { h, stub } = makeHost();
-    const first = (await h.run(
+  it("rejects a pending run reconstructed from storage", async () => {
+    const { host, stub } = makeHost();
+    const first = (await host.run(
       `async () => await items.create_item({ title: "nope" })`
     )) as ProxyToolOutput;
+
     expect(first.status).toBe("paused");
     if (first.status !== "paused") return;
-    const seq = first.pending[0].seq;
 
     await evictDurableObject(stub);
 
-    // The pending action survived in SQLite and is rejectable on the fresh
-    // instance using the seq captured before eviction.
-    expect(await h.reject(seq, first.executionId)).toBe(true);
-
-    // Reject is a terminal transition → disposeExecution("rejected") ran on the
-    // post-eviction connector instance.
-    expect((await h.lifecycle()).disposed).toEqual([
+    expect(await host.reject(first.pending[0].seq, first.executionId)).toBe(
+      true
+    );
+    expect((await host.lifecycle()).disposed).toEqual([
       { executionId: first.executionId, status: "rejected" }
     ]);
-    const exec = (await h.executions()).find((e) => e.id === first.executionId);
-    expect(exec?.status).toBe("rejected");
-    // Nothing was ever applied.
-    expect((await h.sideEffects()).created).toEqual([]);
-    expect(await h.pending()).toEqual([]);
-  });
-
-  it("keeps the completed-execution audit trail intact across eviction", async () => {
-    const { h, stub } = makeHost();
-    // Drive several runs to completion so the SQLite audit trail is populated.
-    // add_note completes immediately and records a durable log entry; its
-    // in-memory side effect (the `notes` array) is the part eviction wipes.
-    const a = (await h.run(`async () => 1 + 1`)) as ProxyToolOutput;
-    expect(a.status).toBe("completed");
-    const b = (await h.run(
-      `async () => await items.add_note({ text: "kept" })`
-    )) as ProxyToolOutput;
-    expect(b.status).toBe("completed");
-
-    // The in-memory note is present before eviction.
-    expect((await h.sideEffects()).notes).toEqual(["kept"]);
-
-    const before = await h.executions();
-    expect(before).toHaveLength(2);
-    const byId = new Map(before.map((e) => [e.id, e]));
-
-    await evictDurableObject(stub);
-
-    // In-memory side effects gone (real eviction); durable audit trail intact.
-    expect((await h.sideEffects()).notes).toEqual([]);
-
-    const after = await h.executions();
-    expect(after).toHaveLength(2);
-    for (const exec of after) {
-      const original = byId.get(exec.id);
-      expect(original).toBeDefined();
-      expect(exec.status).toBe("completed");
-      expect(exec.result).toEqual(original?.result);
-      // The durable log shape (entry count + states) survived byte-for-byte.
-      expect(exec.log.map((e) => e.state)).toEqual(
-        original?.log.map((e) => e.state)
-      );
-    }
-    // The add_note run's logged entry survived even though its in-memory effect
-    // was wiped — replay reconstructs from the durable log, not live memory.
-    const noteRun = after.find((e) => e.result?.hasOwnProperty?.("index"));
-    expect(noteRun).toBeDefined();
-    expect(noteRun?.log.find((e) => e.method === "add_note")?.state).toBe(
-      "applied"
-    );
-  });
-
-  it("rejects an oversized result the same way after eviction (storage guard survives)", async () => {
-    const { h, stub } = makeHost();
-    // First a normal completed run so the DO has live durable state.
-    const ok = (await h.run(`async () => "small"`)) as ProxyToolOutput;
-    expect(ok.status).toBe("completed");
-
-    await evictDurableObject(stub);
-
-    // After rehydration the durable-size guard still fails an oversized recorded
-    // result with the same model-actionable error — the storage codec + limit
-    // logic was reconstructed from the schema in the facet constructor.
-    const out = (await h.run(
-      `async () => { const r = await items.big_result(); return r.length; }`
-    )) as ProxyToolOutput;
-    expect(out.status).toBe("error");
-    if (out.status !== "error") return;
-    expect(out.error).toMatch(/too large to record durably/);
-    const exec = (await h.executions()).find((e) => e.id === out.executionId);
-    expect(exec?.status).toBe("error");
-
-    // The earlier successful run is still on the audit trail post-eviction.
     expect(
-      (await h.executions()).find((e) => e.id === ok.executionId)?.result
-    ).toBe("small");
-  });
-
-  it("survives evictAllDurableObjects() — every running DO is rebuilt from storage", async () => {
-    const { h } = makeHost();
-    const first = (await h.run(
-      `async () => {
-        const before = await items.list_items();
-        return await items.create_item({ title: "all" });
-      }`
-    )) as ProxyToolOutput;
-    expect(first.status).toBe("paused");
-    if (first.status !== "paused") return;
-
-    // Namespace-wide eviction: every currently-running DO (host + its facet) is
-    // gracefully evicted; durable storage is preserved.
-    await evictAllDurableObjects();
-
-    // The pending run rehydrated from SQLite after the blanket eviction.
-    const pending = await h.pending();
-    expect(pending).toHaveLength(1);
-    expect(pending[0]).toMatchObject({
-      executionId: first.executionId,
-      method: "create_item"
-    });
-
-    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
-    expect(resumed.status).toBe("completed");
-    if (resumed.status === "completed") {
-      expect(resumed.result).toMatchObject({ id: 1, title: "all" });
-    }
-    const exec = (await h.executions()).find((e) => e.id === first.executionId);
-    expect(exec?.status).toBe("completed");
+      (await host.executions()).find(
+        (execution) => execution.id === first.executionId
+      )?.status
+    ).toBe("rejected");
+    expect((await host.sideEffects()).created).toEqual([]);
+    expect(await host.pending()).toEqual([]);
   });
 });

--- a/packages/codemode/src/runtime-tests/env.d.ts
+++ b/packages/codemode/src/runtime-tests/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+// Makes the `cloudflare:test` module (evictDurableObject, evictAllDurableObjects,
+// etc.) resolvable to TypeScript for the runtime-tests project. Mirrors
+// packages/agents/src/tests/env.d.ts. The runtime tests run under their own
+// wrangler config (vitest.runtime.config.ts), so this lives alongside them.

--- a/packages/codemode/src/runtime-tests/worker.ts
+++ b/packages/codemode/src/runtime-tests/worker.ts
@@ -47,8 +47,11 @@ class ItemsConnector extends CodemodeConnector<Env> {
   disposed: Array<{ executionId: string; status: ExecutionEndStatus }> = [];
   // Per-pass lifecycle — onPassEnd fires for EVERY pass, including pauses.
   passEnds: Array<{ executionId: string; status: PassEndStatus }> = [];
-  // Counts real executions of the ephemeral read — replays must re-execute.
+  // Counts real executions so forced-eviction tests can distinguish durable
+  // replay from accidentally running a recorded read again.
   ephemeralReads = 0;
+  listItemsExecutions = 0;
+  getBytesExecutions = 0;
 
   name() {
     return "items";
@@ -58,7 +61,10 @@ class ItemsConnector extends CodemodeConnector<Env> {
     return {
       list_items: {
         description: "List all items.",
-        execute: () => [...this.created]
+        execute: () => {
+          this.listItemsExecutions++;
+          return [...this.created];
+        }
       },
       read_counter: {
         // Ephemeral read: result is never stored in the durable log; replay
@@ -71,7 +77,10 @@ class ItemsConnector extends CodemodeConnector<Env> {
         // Binary result — exercises the storage codec roundtrip through the
         // durable log (record on first pass, replay decoded on resume).
         description: "Return binary data.",
-        execute: () => new Uint8Array([1, 2, 3, 4, 5])
+        execute: () => {
+          this.getBytesExecutions++;
+          return new Uint8Array([1, 2, 3, 4, 5]);
+        }
       },
       big_result: {
         description: "Return a result too large for the durable log.",
@@ -263,6 +272,14 @@ export class CodemodeTestHost extends DurableObject<Env> {
 
   passEnds() {
     return this.#items().passEnds;
+  }
+
+  executionCounts() {
+    const connector = this.#items();
+    return {
+      listItems: connector.listItemsExecutions,
+      getBytes: connector.getBytesExecutions
+    };
   }
 
   /**

--- a/packages/shell/src/tests/shell-eviction.test.ts
+++ b/packages/shell/src/tests/shell-eviction.test.ts
@@ -1,42 +1,14 @@
+/**
+ * Forced Durable Object eviction coverage for Workspace.
+ *
+ * The helper tears down a running test actor while retaining its SQLite data.
+ * These tests verify instance-state reset and filesystem reconstruction. They
+ * do not assert natural idle hibernation or hibernation eligibility.
+ */
 import { env } from "cloudflare:workers";
 import { evictAllDurableObjects, evictDurableObject } from "cloudflare:test";
 import { getAgentByName } from "agents";
 import { describe, expect, it } from "vitest";
-import type { FileInfo, FileStat } from "../filesystem";
-
-/**
- * Production-lifecycle eviction coverage for the shell `Workspace`, using the
- * real `evictDurableObject` / `evictAllDurableObjects` helpers (vitest-pool-
- * workers >= 0.16.20).
- *
- * The shell filesystem keeps its durable state in SQLite (the `cf_workspace_*`
- * tables, seeded lazily by `ensureInit()` via `CREATE TABLE IF NOT EXISTS`),
- * and a small slice of IN-MEMORY state on the live `Workspace`/agent instance:
- *   - `Workspace.initialized` — a per-instance "schema is ready" cache flag that
- *     short-circuits `ensureInit()` after the first call.
- *   - `TestWorkspaceAgent.changeLog` — a plain instance array populated by the
- *     `onChange` listener of the `wsWithEvents` workspace.
- *
- * Each test drives a DO until it has built up BOTH durable (SQLite) and
- * in-memory state, evicts it from memory (dropping the instance — and with it
- * `initialized` and `changeLog` — while preserving SQLite), then re-routes a
- * fresh stub for the SAME name and asserts the filesystem rebuilt itself from
- * storage with no loss, no duplication, and no schema corruption.
- *
- * Why the assertions are load-bearing (not vacuous "still works" smoke tests):
- * `changeLog` is a plain in-memory field that is NEVER persisted. After a real
- * eviction the rebuilt instance MUST observe an empty `changeLog`. If
- * `evictDurableObject` were a no-op (instance never torn down), the
- * pre-eviction events would still be in memory and the `toHaveLength(0)`
- * assertions below would FAIL. That same teardown resets `Workspace.initialized`
- * to `false`, forcing `ensureInit()` to re-run on the next access — which is
- * exactly the idempotent `CREATE TABLE IF NOT EXISTS` / root-seed path we assert
- * does not wipe or duplicate the stored rows.
- *
- * Re-acquiring after eviction mirrors a real post-hibernation request: the
- * runtime tore the instance down, and the next routed RPC (`getAgentByName`)
- * re-establishes a fresh agent that must rebuild from storage.
- */
 
 function uniqueName(prefix: string): string {
   return `${prefix}-${crypto.randomUUID()}`;
@@ -46,42 +18,30 @@ async function workspaceAgent(name: string) {
   return getAgentByName(env.TestWorkspaceAgent, name);
 }
 
-/**
- * Evict the DO from memory, then return a freshly-routed stub for the same
- * name. Mirrors a real post-hibernation request: the in-memory instance (and
- * its `Workspace.initialized` flag + `changeLog`) is gone; only SQLite survives.
- */
-async function evictAndReacquire<T>(
-  stub: T,
-  reacquire: () => Promise<T>
-): Promise<T> {
+async function evictAndReacquire(
+  name: string,
+  stub: Awaited<ReturnType<typeof workspaceAgent>>
+) {
   await evictDurableObject(stub as unknown as DurableObjectStub);
-  return reacquire();
+  return workspaceAgent(name);
 }
 
-describe("shell Workspace eviction — filesystem rehydrates from SQLite", () => {
-  it("files and directories survive eviction with byte-exact content", async () => {
-    const name = uniqueName("evict-fs");
+describe("Workspace recovery after forced Durable Object eviction", () => {
+  it("resets instance state and reconstructs the filesystem from SQLite", async () => {
+    const name = uniqueName("evict-workspace");
     let agent = await workspaceAgent(name);
 
-    // Build real, durable filesystem state in SQLite: nested dirs + files.
     await agent.mkdirCall("/project/src", { recursive: true });
     await agent.write("/project/src/index.ts", "export const x = 1;\n");
     await agent.write("/project/README.md", "# hello\n");
     await agent.writeBytes("/project/logo.bin", [0, 1, 2, 255, 128]);
+    await agent.writeWithEvents("/event-source.txt", "event");
+    expect((await agent.getChangeLog()) as unknown[]).not.toHaveLength(0);
 
-    // Sanity: live instance sees the state pre-eviction.
-    const beforeStat = (await agent.stat(
-      "/project/src/index.ts"
-    )) as unknown as FileStat;
-    expect(beforeStat.type).toBe("file");
+    agent = await evictAndReacquire(name, agent);
 
-    // Production idle-eviction lifecycle: the in-memory instance (and its
-    // `Workspace.initialized` cache flag) is torn down; only SQLite survives.
-    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
-
-    // The rebuilt instance must read the SAME content back out of SQLite. If the
-    // schema or rows did not survive, these reads would be null / throw.
+    // changeLog is instance-only. The default Workspace rows are durable.
+    expect(await agent.getChangeLog()).toEqual([]);
     expect(await agent.read("/project/src/index.ts")).toBe(
       "export const x = 1;\n"
     );
@@ -90,148 +50,43 @@ describe("shell Workspace eviction — filesystem rehydrates from SQLite", () =>
       0, 1, 2, 255, 128
     ]);
 
-    // Directory structure (parent rows) survived too — not just leaf files.
-    const dirStat = (await agent.stat("/project/src")) as unknown as FileStat;
-    expect(dirStat).not.toBeNull();
-    expect(dirStat.type).toBe("directory");
-
-    const listing = (await agent.list("/project")) as unknown as FileInfo[];
-    const names = listing.map((i) => i.name).sort();
-    expect(names).toEqual(["README.md", "logo.bin", "src"]);
-  });
-
-  it("the in-memory changeLog resets on eviction while SQLite rows persist", async () => {
-    // This is the proof that the eviction is REAL and not a no-op: `changeLog`
-    // is a plain instance array, never persisted. A genuine teardown must reset
-    // it to empty; durable file rows must NOT reset.
-    const name = uniqueName("evict-changelog");
-    let agent = await workspaceAgent(name);
-
-    // Two slices of state, both built BEFORE eviction:
-    //  - `write` persists a file in the default-namespace table (durable SQLite).
-    //  - `writeWithEvents` writes through `wsWithEvents` (the "evts" namespace),
-    //    whose onChange pushes a create event onto the in-memory `changeLog`.
-    await agent.write("/tracked.txt", "v1");
-    await agent.writeWithEvents("/event-source.txt", "e1");
-    const beforeLog = (await agent.getChangeLog()) as unknown as unknown[];
-    expect(beforeLog.length).toBeGreaterThan(0);
-
-    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
-
-    // LOAD-BEARING: the rebuilt instance's in-memory changeLog is empty. If the
-    // DO were not actually evicted, the create event from before would still be
-    // present and this would be non-empty — the test would fail. This is the
-    // proof that the in-memory instance (and `Workspace.initialized`) was torn
-    // down, not merely re-handed-back.
-    const afterLog = (await agent.getChangeLog()) as unknown as unknown[];
-    expect(afterLog).toHaveLength(0);
-
-    // ...yet the durably-persisted file is still readable from SQLite after the
-    // instance was rebuilt from storage.
-    expect(await agent.read("/tracked.txt")).toBe("v1");
-  });
-
-  it("re-init after eviction is idempotent: no row loss, no schema duplication", async () => {
-    const name = uniqueName("evict-idempotent");
-    let agent = await workspaceAgent(name);
-
-    // Seed a known, countable filesystem footprint.
-    await agent.write("/a.txt", "aaa"); // 3 bytes
-    await agent.write("/b.txt", "bb"); // 2 bytes
-    await agent.mkdirCall("/dir");
-
-    const before = (await agent.info()) as unknown as {
-      fileCount: number;
-      directoryCount: number;
-      totalBytes: number;
-    };
-    expect(before.fileCount).toBe(2);
-    // root ("/") + "/dir"
-    expect(before.directoryCount).toBe(2);
-    expect(before.totalBytes).toBe(5);
-
-    // Evict: `Workspace.initialized` resets to false. The next operation forces
-    // `ensureInit()` to re-run its `CREATE TABLE IF NOT EXISTS` + root-seed path.
-    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
-
-    // Writing a NEW file after the wake triggers ensureInit() on the rebuilt
-    // instance. A buggy re-init that re-created the table or re-seeded a second
-    // root would corrupt the counts below.
-    await agent.write("/c.txt", "cccc"); // 4 bytes
-
-    const after = (await agent.info()) as unknown as {
-      fileCount: number;
-      directoryCount: number;
-      totalBytes: number;
-    };
-    // Exactly the pre-eviction rows + the one new file. If CREATE TABLE were not
-    // idempotent (or the root were double-seeded), these exact counts break.
-    expect(after.fileCount).toBe(3);
-    expect(after.directoryCount).toBe(2);
-    expect(after.totalBytes).toBe(9);
-
-    // Pre-eviction content is unchanged, and the new file reads back correctly.
-    expect(await agent.read("/a.txt")).toBe("aaa");
-    expect(await agent.read("/b.txt")).toBe("bb");
-    expect(await agent.read("/c.txt")).toBe("cccc");
-  });
-
-  it("survives a CHAIN of evictions without corrupting or duplicating state", async () => {
-    const name = uniqueName("evict-chain");
-    let agent = await workspaceAgent(name);
-
-    await agent.write("/log.txt", "line-1\n");
-
-    // First eviction round-trip.
-    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
-    expect(await agent.read("/log.txt")).toBe("line-1\n");
-    await agent.write("/log.txt", "line-1\nline-2\n");
-
-    // Second eviction must not lose the now-longer content nor duplicate rows.
-    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
-    expect(await agent.read("/log.txt")).toBe("line-1\nline-2\n");
-
+    // Writing on the fresh instance exercises idempotent schema initialization.
+    await agent.write("/project/after.txt", "after");
     const info = (await agent.info()) as unknown as {
       fileCount: number;
       directoryCount: number;
     };
-    // One file, one (root) directory — no eviction-driven duplication.
-    expect(info.fileCount).toBe(1);
-    expect(info.directoryCount).toBe(1);
+    expect(info).toMatchObject({ fileCount: 4, directoryCount: 3 });
+
+    const listing = (await agent.list("/project")) as unknown as Array<{
+      name: string;
+    }>;
+    expect(listing.map((entry) => entry.name).sort()).toEqual([
+      "README.md",
+      "after.txt",
+      "logo.bin",
+      "src"
+    ]);
   });
-});
 
-describe("shell Workspace eviction — per-DO isolation under evictAllDurableObjects", () => {
-  it("two named instances keep their own distinct filesystem after a global evict", async () => {
-    const nameA = uniqueName("evict-iso-a");
-    const nameB = uniqueName("evict-iso-b");
-
+  it("keeps named filesystems isolated after a global forced eviction", async () => {
+    const nameA = uniqueName("evict-workspace-a");
+    const nameB = uniqueName("evict-workspace-b");
     let agentA = await workspaceAgent(nameA);
     let agentB = await workspaceAgent(nameB);
 
-    // Each DO owns its own SQLite, so identical paths must hold distinct content.
-    await agentA.write("/shared-path.txt", "owned-by-A");
-    await agentB.write("/shared-path.txt", "owned-by-B");
-    // Give each a unique extra file so cross-contamination would be detectable.
+    await agentA.write("/shared.txt", "A");
+    await agentB.write("/shared.txt", "B");
     await agentA.write("/only-a.txt", "A-only");
     await agentB.write("/only-b.txt", "B-only");
 
-    // Evict EVERY running DO at once (production-style fleet idle eviction).
     await evictAllDurableObjects();
 
-    // Re-route both. Each rebuilds from its OWN storage.
     agentA = await workspaceAgent(nameA);
     agentB = await workspaceAgent(nameB);
-
-    // Same path, different content — proves the per-DO SQLite boundary held
-    // across a global eviction (no leaking/merging of rehydrated state).
-    expect(await agentA.read("/shared-path.txt")).toBe("owned-by-A");
-    expect(await agentB.read("/shared-path.txt")).toBe("owned-by-B");
-
-    // Each instance's unique file exists only in its own filesystem.
-    expect(await agentA.read("/only-a.txt")).toBe("A-only");
+    expect(await agentA.read("/shared.txt")).toBe("A");
+    expect(await agentB.read("/shared.txt")).toBe("B");
     expect(await agentA.read("/only-b.txt")).toBeNull();
-    expect(await agentB.read("/only-b.txt")).toBe("B-only");
     expect(await agentB.read("/only-a.txt")).toBeNull();
   });
 });

--- a/packages/shell/src/tests/shell-eviction.test.ts
+++ b/packages/shell/src/tests/shell-eviction.test.ts
@@ -1,0 +1,237 @@
+import { env } from "cloudflare:workers";
+import { evictAllDurableObjects, evictDurableObject } from "cloudflare:test";
+import { getAgentByName } from "agents";
+import { describe, expect, it } from "vitest";
+import type { FileInfo, FileStat } from "../filesystem";
+
+/**
+ * Production-lifecycle eviction coverage for the shell `Workspace`, using the
+ * real `evictDurableObject` / `evictAllDurableObjects` helpers (vitest-pool-
+ * workers >= 0.16.20).
+ *
+ * The shell filesystem keeps its durable state in SQLite (the `cf_workspace_*`
+ * tables, seeded lazily by `ensureInit()` via `CREATE TABLE IF NOT EXISTS`),
+ * and a small slice of IN-MEMORY state on the live `Workspace`/agent instance:
+ *   - `Workspace.initialized` — a per-instance "schema is ready" cache flag that
+ *     short-circuits `ensureInit()` after the first call.
+ *   - `TestWorkspaceAgent.changeLog` — a plain instance array populated by the
+ *     `onChange` listener of the `wsWithEvents` workspace.
+ *
+ * Each test drives a DO until it has built up BOTH durable (SQLite) and
+ * in-memory state, evicts it from memory (dropping the instance — and with it
+ * `initialized` and `changeLog` — while preserving SQLite), then re-routes a
+ * fresh stub for the SAME name and asserts the filesystem rebuilt itself from
+ * storage with no loss, no duplication, and no schema corruption.
+ *
+ * Why the assertions are load-bearing (not vacuous "still works" smoke tests):
+ * `changeLog` is a plain in-memory field that is NEVER persisted. After a real
+ * eviction the rebuilt instance MUST observe an empty `changeLog`. If
+ * `evictDurableObject` were a no-op (instance never torn down), the
+ * pre-eviction events would still be in memory and the `toHaveLength(0)`
+ * assertions below would FAIL. That same teardown resets `Workspace.initialized`
+ * to `false`, forcing `ensureInit()` to re-run on the next access — which is
+ * exactly the idempotent `CREATE TABLE IF NOT EXISTS` / root-seed path we assert
+ * does not wipe or duplicate the stored rows.
+ *
+ * Re-acquiring after eviction mirrors a real post-hibernation request: the
+ * runtime tore the instance down, and the next routed RPC (`getAgentByName`)
+ * re-establishes a fresh agent that must rebuild from storage.
+ */
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+async function workspaceAgent(name: string) {
+  return getAgentByName(env.TestWorkspaceAgent, name);
+}
+
+/**
+ * Evict the DO from memory, then return a freshly-routed stub for the same
+ * name. Mirrors a real post-hibernation request: the in-memory instance (and
+ * its `Workspace.initialized` flag + `changeLog`) is gone; only SQLite survives.
+ */
+async function evictAndReacquire<T>(
+  stub: T,
+  reacquire: () => Promise<T>
+): Promise<T> {
+  await evictDurableObject(stub as unknown as DurableObjectStub);
+  return reacquire();
+}
+
+describe("shell Workspace eviction — filesystem rehydrates from SQLite", () => {
+  it("files and directories survive eviction with byte-exact content", async () => {
+    const name = uniqueName("evict-fs");
+    let agent = await workspaceAgent(name);
+
+    // Build real, durable filesystem state in SQLite: nested dirs + files.
+    await agent.mkdirCall("/project/src", { recursive: true });
+    await agent.write("/project/src/index.ts", "export const x = 1;\n");
+    await agent.write("/project/README.md", "# hello\n");
+    await agent.writeBytes("/project/logo.bin", [0, 1, 2, 255, 128]);
+
+    // Sanity: live instance sees the state pre-eviction.
+    const beforeStat = (await agent.stat(
+      "/project/src/index.ts"
+    )) as unknown as FileStat;
+    expect(beforeStat.type).toBe("file");
+
+    // Production idle-eviction lifecycle: the in-memory instance (and its
+    // `Workspace.initialized` cache flag) is torn down; only SQLite survives.
+    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
+
+    // The rebuilt instance must read the SAME content back out of SQLite. If the
+    // schema or rows did not survive, these reads would be null / throw.
+    expect(await agent.read("/project/src/index.ts")).toBe(
+      "export const x = 1;\n"
+    );
+    expect(await agent.read("/project/README.md")).toBe("# hello\n");
+    expect(await agent.readBytes("/project/logo.bin")).toEqual([
+      0, 1, 2, 255, 128
+    ]);
+
+    // Directory structure (parent rows) survived too — not just leaf files.
+    const dirStat = (await agent.stat("/project/src")) as unknown as FileStat;
+    expect(dirStat).not.toBeNull();
+    expect(dirStat.type).toBe("directory");
+
+    const listing = (await agent.list("/project")) as unknown as FileInfo[];
+    const names = listing.map((i) => i.name).sort();
+    expect(names).toEqual(["README.md", "logo.bin", "src"]);
+  });
+
+  it("the in-memory changeLog resets on eviction while SQLite rows persist", async () => {
+    // This is the proof that the eviction is REAL and not a no-op: `changeLog`
+    // is a plain instance array, never persisted. A genuine teardown must reset
+    // it to empty; durable file rows must NOT reset.
+    const name = uniqueName("evict-changelog");
+    let agent = await workspaceAgent(name);
+
+    // Two slices of state, both built BEFORE eviction:
+    //  - `write` persists a file in the default-namespace table (durable SQLite).
+    //  - `writeWithEvents` writes through `wsWithEvents` (the "evts" namespace),
+    //    whose onChange pushes a create event onto the in-memory `changeLog`.
+    await agent.write("/tracked.txt", "v1");
+    await agent.writeWithEvents("/event-source.txt", "e1");
+    const beforeLog = (await agent.getChangeLog()) as unknown as unknown[];
+    expect(beforeLog.length).toBeGreaterThan(0);
+
+    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
+
+    // LOAD-BEARING: the rebuilt instance's in-memory changeLog is empty. If the
+    // DO were not actually evicted, the create event from before would still be
+    // present and this would be non-empty — the test would fail. This is the
+    // proof that the in-memory instance (and `Workspace.initialized`) was torn
+    // down, not merely re-handed-back.
+    const afterLog = (await agent.getChangeLog()) as unknown as unknown[];
+    expect(afterLog).toHaveLength(0);
+
+    // ...yet the durably-persisted file is still readable from SQLite after the
+    // instance was rebuilt from storage.
+    expect(await agent.read("/tracked.txt")).toBe("v1");
+  });
+
+  it("re-init after eviction is idempotent: no row loss, no schema duplication", async () => {
+    const name = uniqueName("evict-idempotent");
+    let agent = await workspaceAgent(name);
+
+    // Seed a known, countable filesystem footprint.
+    await agent.write("/a.txt", "aaa"); // 3 bytes
+    await agent.write("/b.txt", "bb"); // 2 bytes
+    await agent.mkdirCall("/dir");
+
+    const before = (await agent.info()) as unknown as {
+      fileCount: number;
+      directoryCount: number;
+      totalBytes: number;
+    };
+    expect(before.fileCount).toBe(2);
+    // root ("/") + "/dir"
+    expect(before.directoryCount).toBe(2);
+    expect(before.totalBytes).toBe(5);
+
+    // Evict: `Workspace.initialized` resets to false. The next operation forces
+    // `ensureInit()` to re-run its `CREATE TABLE IF NOT EXISTS` + root-seed path.
+    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
+
+    // Writing a NEW file after the wake triggers ensureInit() on the rebuilt
+    // instance. A buggy re-init that re-created the table or re-seeded a second
+    // root would corrupt the counts below.
+    await agent.write("/c.txt", "cccc"); // 4 bytes
+
+    const after = (await agent.info()) as unknown as {
+      fileCount: number;
+      directoryCount: number;
+      totalBytes: number;
+    };
+    // Exactly the pre-eviction rows + the one new file. If CREATE TABLE were not
+    // idempotent (or the root were double-seeded), these exact counts break.
+    expect(after.fileCount).toBe(3);
+    expect(after.directoryCount).toBe(2);
+    expect(after.totalBytes).toBe(9);
+
+    // Pre-eviction content is unchanged, and the new file reads back correctly.
+    expect(await agent.read("/a.txt")).toBe("aaa");
+    expect(await agent.read("/b.txt")).toBe("bb");
+    expect(await agent.read("/c.txt")).toBe("cccc");
+  });
+
+  it("survives a CHAIN of evictions without corrupting or duplicating state", async () => {
+    const name = uniqueName("evict-chain");
+    let agent = await workspaceAgent(name);
+
+    await agent.write("/log.txt", "line-1\n");
+
+    // First eviction round-trip.
+    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
+    expect(await agent.read("/log.txt")).toBe("line-1\n");
+    await agent.write("/log.txt", "line-1\nline-2\n");
+
+    // Second eviction must not lose the now-longer content nor duplicate rows.
+    agent = await evictAndReacquire(agent, () => workspaceAgent(name));
+    expect(await agent.read("/log.txt")).toBe("line-1\nline-2\n");
+
+    const info = (await agent.info()) as unknown as {
+      fileCount: number;
+      directoryCount: number;
+    };
+    // One file, one (root) directory — no eviction-driven duplication.
+    expect(info.fileCount).toBe(1);
+    expect(info.directoryCount).toBe(1);
+  });
+});
+
+describe("shell Workspace eviction — per-DO isolation under evictAllDurableObjects", () => {
+  it("two named instances keep their own distinct filesystem after a global evict", async () => {
+    const nameA = uniqueName("evict-iso-a");
+    const nameB = uniqueName("evict-iso-b");
+
+    let agentA = await workspaceAgent(nameA);
+    let agentB = await workspaceAgent(nameB);
+
+    // Each DO owns its own SQLite, so identical paths must hold distinct content.
+    await agentA.write("/shared-path.txt", "owned-by-A");
+    await agentB.write("/shared-path.txt", "owned-by-B");
+    // Give each a unique extra file so cross-contamination would be detectable.
+    await agentA.write("/only-a.txt", "A-only");
+    await agentB.write("/only-b.txt", "B-only");
+
+    // Evict EVERY running DO at once (production-style fleet idle eviction).
+    await evictAllDurableObjects();
+
+    // Re-route both. Each rebuilds from its OWN storage.
+    agentA = await workspaceAgent(nameA);
+    agentB = await workspaceAgent(nameB);
+
+    // Same path, different content — proves the per-DO SQLite boundary held
+    // across a global eviction (no leaking/merging of rehydrated state).
+    expect(await agentA.read("/shared-path.txt")).toBe("owned-by-A");
+    expect(await agentB.read("/shared-path.txt")).toBe("owned-by-B");
+
+    // Each instance's unique file exists only in its own filesystem.
+    expect(await agentA.read("/only-a.txt")).toBe("A-only");
+    expect(await agentA.read("/only-b.txt")).toBeNull();
+    expect(await agentB.read("/only-b.txt")).toBe("B-only");
+    expect(await agentB.read("/only-a.txt")).toBeNull();
+  });
+});

--- a/packages/think/src/tests/eviction-recovery.test.ts
+++ b/packages/think/src/tests/eviction-recovery.test.ts
@@ -1,0 +1,252 @@
+import { env } from "cloudflare:workers";
+import { evictDurableObject } from "cloudflare:test";
+import { getServerByName } from "partyserver";
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import type { ThinkRecoveryTestAgent } from "./agents/think-session";
+
+/**
+ * Chat-recovery × real DO eviction.
+ *
+ * The existing recovery suites (channel-recovery, run-turn-recovery,
+ * agent-tool-reattach-recovery, action-pause-recovery) simulate hibernation by
+ * hand-crafting `cf_agents_runs` snapshots and then calling
+ * `triggerFiberRecovery()` directly. That proves the recovery *machinery* but
+ * never exercises the production lifecycle: an idle DO is evicted from memory,
+ * and on the NEXT wake its `onStart` runs `_checkRunFibers()` itself, which
+ * detects the interrupted fiber persisted in storage and schedules the recovery
+ * continuation.
+ *
+ * These tests seed the SAME interrupted-turn durable state, then use the real
+ * `evictDurableObject` helper (vitest-pool-workers >= 0.16.20) so the runtime's
+ * own teardown + wake drives recovery. The original synthetic-fiber tests are
+ * retained as fast unit-level coverage of edge cases (channel re-resolution,
+ * RETRY vs CONTINUE arms, exhaustion budgets) that are awkward to provoke
+ * through a full eviction; this file adds the missing end-to-end rehydration
+ * proof alongside them.
+ *
+ * Re-acquiring after eviction: a Think DO routes through partyserver, which sets
+ * the DO's `name` (and rebuilds `this.session`) on the way in via
+ * `getServerByName`. After eviction the instance is torn down, so the next
+ * access goes through `getServerByName` again — exactly as a real
+ * post-hibernation request does. The first such routed RPC also runs the wake's
+ * onStart, which is where `_checkRunFibers()` detects the stored fiber.
+ */
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+async function recoveryAgent(name: string) {
+  return getServerByName(
+    env.ThinkRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkRecoveryTestAgent>,
+    name
+  );
+}
+
+/** Seed a mid-stream-interrupted CONTINUE turn: persisted user + partial
+ *  assistant, an orphaned stream, and an interrupted fiber snapshot. */
+async function seedInterruptedContinueTurn(
+  agent: Awaited<ReturnType<typeof recoveryAgent>>,
+  reqId: string,
+  userId: string,
+  assistantId: string,
+  channel?: string
+) {
+  await agent.persistTestMessage({
+    id: userId,
+    role: "user",
+    parts: [{ type: "text", text: "answer this" }],
+    ...(channel ? { metadata: { channel } } : {})
+  });
+  await agent.persistTestMessage({
+    id: assistantId,
+    role: "assistant",
+    parts: [{ type: "text", text: "Partial answer" }]
+  });
+  await agent.insertInterruptedStream(`stream-${reqId}`, reqId, [
+    {
+      body: JSON.stringify({ type: "start", messageId: assistantId }),
+      index: 0
+    },
+    { body: JSON.stringify({ type: "text-start" }), index: 1 },
+    {
+      body: JSON.stringify({ type: "text-delta", delta: "Partial answer" }),
+      index: 2
+    }
+  ]);
+  await agent.insertInterruptedFiber(`__cf_internal_chat_turn:${reqId}`, {
+    __cfThinkChatFiberSnapshot: {
+      kind: "think-chat-turn",
+      version: 1,
+      requestId: reqId,
+      continuation: false,
+      latestMessageId: assistantId,
+      latestMessageRole: "assistant",
+      latestUserMessageId: userId,
+      startedAt: Date.now()
+    },
+    user: null
+  });
+}
+
+describe("chat recovery survives a real DO eviction (wake-driven _checkRunFibers)", () => {
+  it("onStart on the post-eviction wake schedules the CONTINUE recovery from the stored fiber", async () => {
+    const name = uniqueName("evict-rec-continue");
+    let agent = await recoveryAgent(name);
+
+    await seedInterruptedContinueTurn(
+      agent,
+      "req-evict-continue",
+      "u-evict-continue",
+      "a-evict-continue"
+    );
+
+    // Sanity: an interrupted fiber is durably present before eviction.
+    expect(await agent.getActiveFibers()).toHaveLength(1);
+    // No recovery has been scheduled yet — we never called triggerFiberRecovery.
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
+    ).toBe(0);
+
+    // Evict from memory. The fiber snapshot survives in cf_agents_runs.
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+
+    // The first routed RPC after eviction wakes a fresh instance, whose onStart
+    // runs `_checkRunFibers()` ITSELF and schedules the continuation — no manual
+    // triggerFiberRecovery() needed. This is the production hibernation path.
+    agent = await recoveryAgent(name);
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
+    ).toBe(1);
+
+    // Run the scheduled continuation (the alarm callback the scheduler fires).
+    await agent.runScheduledRecoveryContinueForTest();
+
+    // Recovery resolved the interrupted turn from storage and left no leaked
+    // fiber — the transcript ends on a settled assistant message.
+    expect(await agent.getActiveFibers()).toHaveLength(0);
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages.length).toBeGreaterThanOrEqual(2);
+    expect(messages.at(-1)?.role).toBe("assistant");
+  });
+
+  it("re-applies channel policy on a turn recovered after eviction", async () => {
+    const name = uniqueName("evict-rec-channel");
+    let agent = await recoveryAgent(name);
+
+    await seedInterruptedContinueTurn(
+      agent,
+      "req-evict-voice",
+      "u-evict-voice",
+      "a-evict-voice",
+      "voice"
+    );
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+
+    // Wake-driven recovery scheduling, then run the continuation.
+    agent = await recoveryAgent(name);
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
+    ).toBe(1);
+    await agent.runScheduledRecoveryContinueForTest();
+
+    // (a) The channel stamp survived eviction on the persisted user message.
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    const userMsg = messages.find((m) => m.role === "user");
+    expect((userMsg?.metadata as { channel?: string })?.channel).toBe("voice");
+
+    // (b) The recovered turn re-resolved the channel from storage and re-applied
+    // BOTH its instructions and its tool policy (the channel `tools` callback was
+    // re-invoked) — proving the per-channel policy rebuilds from durable state,
+    // not from any in-memory context lost at eviction.
+    const channels = await agent.getCapturedTurnChannelsForTest();
+    expect(channels.at(-1)).toBe("voice");
+    const systems = await agent.getCapturedTurnSystemsForTest();
+    expect(systems.at(-1)).toContain("VOICE MODE");
+    const toolNames = await agent.getTurnClientToolNames();
+    expect(toolNames.at(-1)).toContain("voiceMarker");
+  });
+
+  it("rebinds an agent-tool child run's request_id on a recovery driven by eviction", async () => {
+    const name = uniqueName("evict-rec-reattach");
+    let agent = await recoveryAgent(name);
+
+    // This facet is running as an agent-tool child (in-flight run row) on a turn
+    // that then gets interrupted mid-stream.
+    await agent.seedAgentToolChildRunForTest("run-evict", "old-req-evict");
+    await seedInterruptedContinueTurn(
+      agent,
+      "req-evict-reattach",
+      "u-evict-reattach",
+      "a-evict-reattach"
+    );
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+
+    // Wake-driven recovery, then continuation.
+    agent = await recoveryAgent(name);
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
+    ).toBe(1);
+    await agent.runScheduledRecoveryContinueForTest();
+
+    // The child-run row (durable cf_agent_tool_child_runs) was rebound off the
+    // pre-eviction request id onto the recovery turn's fresh id, and that id now
+    // attributes back to the run — so the parent's re-attach tail keeps crediting
+    // frames after the DO came back from memory.
+    const reboundReqId =
+      await agent.getAgentToolChildRunRequestIdForTest("run-evict");
+    expect(reboundReqId).toBeTruthy();
+    expect(reboundReqId).not.toBe("old-req-evict");
+    expect(
+      await agent.resolveAgentToolRunForRequestForTest(reboundReqId as string)
+    ).toBe("run-evict");
+  });
+
+  it("schedules a RETRY recovery after eviction for an unanswered user leaf", async () => {
+    const name = uniqueName("evict-rec-retry");
+    let agent = await recoveryAgent(name);
+
+    // A user message whose turn never produced an assistant reply (pre-stream
+    // eviction → retry path).
+    await agent.persistTestMessage({
+      id: "u-evict-retry",
+      role: "user",
+      parts: [{ type: "text", text: "retry this unanswered message" }]
+    });
+    await agent.insertInterruptedFiber(
+      "__cf_internal_chat_turn:req-evict-retry",
+      {
+        __cfThinkChatFiberSnapshot: {
+          kind: "think-chat-turn",
+          version: 1,
+          requestId: "req-evict-retry",
+          continuation: false,
+          latestMessageId: "u-evict-retry",
+          latestMessageRole: "user",
+          latestUserMessageId: "u-evict-retry",
+          startedAt: Date.now()
+        },
+        user: null
+      }
+    );
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+
+    // The post-eviction wake's onStart detects the interrupted user-leaf fiber
+    // and schedules the RETRY arm (vs CONTINUE for a partial assistant).
+    agent = await recoveryAgent(name);
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
+    ).toBe(1);
+    await agent.runScheduledRecoveryRetryForTest();
+
+    // Recovery ran the unanswered turn to completion: an assistant reply now
+    // tops the transcript and no fiber leaked.
+    expect(await agent.getActiveFibers()).toHaveLength(0);
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages.at(-1)?.role).toBe("assistant");
+  });
+});

--- a/packages/think/src/tests/eviction-recovery.test.ts
+++ b/packages/think/src/tests/eviction-recovery.test.ts
@@ -1,41 +1,16 @@
+/**
+ * Wake-driven chat recovery after forced Durable Object eviction.
+ *
+ * This explicitly tears down a running test actor, then routes back through
+ * partyserver so the normal startup wrapper discovers the persisted fiber. It
+ * does not assert natural idle hibernation or hibernation eligibility.
+ */
+import type { UIMessage } from "ai";
 import { env } from "cloudflare:workers";
 import { evictDurableObject } from "cloudflare:test";
 import { getServerByName } from "partyserver";
 import { describe, expect, it } from "vitest";
-import type { UIMessage } from "ai";
 import type { ThinkRecoveryTestAgent } from "./agents/think-session";
-
-/**
- * Chat-recovery × real DO eviction.
- *
- * The existing recovery suites (channel-recovery, run-turn-recovery,
- * agent-tool-reattach-recovery, action-pause-recovery) simulate hibernation by
- * hand-crafting `cf_agents_runs` snapshots and then calling
- * `triggerFiberRecovery()` directly. That proves the recovery *machinery* but
- * never exercises the production lifecycle: an idle DO is evicted from memory,
- * and on the NEXT wake its `onStart` runs `_checkRunFibers()` itself, which
- * detects the interrupted fiber persisted in storage and schedules the recovery
- * continuation.
- *
- * These tests seed the SAME interrupted-turn durable state, then use the real
- * `evictDurableObject` helper (vitest-pool-workers >= 0.16.20) so the runtime's
- * own teardown + wake drives recovery. The original synthetic-fiber tests are
- * retained as fast unit-level coverage of edge cases (channel re-resolution,
- * RETRY vs CONTINUE arms, exhaustion budgets) that are awkward to provoke
- * through a full eviction; this file adds the missing end-to-end rehydration
- * proof alongside them.
- *
- * Re-acquiring after eviction: a Think DO routes through partyserver, which sets
- * the DO's `name` (and rebuilds `this.session`) on the way in via
- * `getServerByName`. After eviction the instance is torn down, so the next
- * access goes through `getServerByName` again — exactly as a real
- * post-hibernation request does. The first such routed RPC also runs the wake's
- * onStart, which is where `_checkRunFibers()` detects the stored fiber.
- */
-
-function uniqueName(prefix: string): string {
-  return `${prefix}-${crypto.randomUUID()}`;
-}
 
 async function recoveryAgent(name: string) {
   return getServerByName(
@@ -44,27 +19,37 @@ async function recoveryAgent(name: string) {
   );
 }
 
-/** Seed a mid-stream-interrupted CONTINUE turn: persisted user + partial
- *  assistant, an orphaned stream, and an interrupted fiber snapshot. */
+async function waitFor(
+  condition: () => Promise<boolean>,
+  timeoutMs = 3000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await condition())) {
+    if (Date.now() >= deadline) {
+      throw new Error(`condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
 async function seedInterruptedContinueTurn(
-  agent: Awaited<ReturnType<typeof recoveryAgent>>,
-  reqId: string,
-  userId: string,
-  assistantId: string,
-  channel?: string
-) {
+  agent: Awaited<ReturnType<typeof recoveryAgent>>
+): Promise<void> {
+  const requestId = "req-forced-eviction";
+  const userId = "user-forced-eviction";
+  const assistantId = "assistant-forced-eviction";
+
   await agent.persistTestMessage({
     id: userId,
     role: "user",
-    parts: [{ type: "text", text: "answer this" }],
-    ...(channel ? { metadata: { channel } } : {})
+    parts: [{ type: "text", text: "answer this" }]
   });
   await agent.persistTestMessage({
     id: assistantId,
     role: "assistant",
     parts: [{ type: "text", text: "Partial answer" }]
   });
-  await agent.insertInterruptedStream(`stream-${reqId}`, reqId, [
+  await agent.insertInterruptedStream(`stream-${requestId}`, requestId, [
     {
       body: JSON.stringify({ type: "start", messageId: assistantId }),
       index: 0
@@ -75,11 +60,11 @@ async function seedInterruptedContinueTurn(
       index: 2
     }
   ]);
-  await agent.insertInterruptedFiber(`__cf_internal_chat_turn:${reqId}`, {
+  await agent.insertInterruptedFiber(`__cf_internal_chat_turn:${requestId}`, {
     __cfThinkChatFiberSnapshot: {
       kind: "think-chat-turn",
       version: 1,
-      requestId: reqId,
+      requestId,
       continuation: false,
       latestMessageId: assistantId,
       latestMessageRole: "assistant",
@@ -90,163 +75,36 @@ async function seedInterruptedContinueTurn(
   });
 }
 
-describe("chat recovery survives a real DO eviction (wake-driven _checkRunFibers)", () => {
-  it("onStart on the post-eviction wake schedules the CONTINUE recovery from the stored fiber", async () => {
-    const name = uniqueName("evict-rec-continue");
+describe("Think chat recovery after forced Durable Object eviction", () => {
+  it("startup schedules and executes one continuation from durable state", async () => {
+    const name = `evict-recovery-${crypto.randomUUID()}`;
     let agent = await recoveryAgent(name);
+    await seedInterruptedContinueTurn(agent);
 
-    await seedInterruptedContinueTurn(
-      agent,
-      "req-evict-continue",
-      "u-evict-continue",
-      "a-evict-continue"
-    );
-
-    // Sanity: an interrupted fiber is durably present before eviction.
     expect(await agent.getActiveFibers()).toHaveLength(1);
-    // No recovery has been scheduled yet — we never called triggerFiberRecovery.
     expect(
       await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
     ).toBe(0);
 
-    // Evict from memory. The fiber snapshot survives in cf_agents_runs.
     await evictDurableObject(agent as unknown as DurableObjectStub);
 
-    // The first routed RPC after eviction wakes a fresh instance, whose onStart
-    // runs `_checkRunFibers()` ITSELF and schedules the continuation — no manual
-    // triggerFiberRecovery() needed. This is the production hibernation path.
     agent = await recoveryAgent(name);
+
+    // The zero-delay schedule may execute as soon as startup releases the DO,
+    // so observe the real alarm path instead of manually invoking its callback.
+    await waitFor(async () => (await agent.getTurnCallCount()) === 1);
+    await waitFor(async () => (await agent.getActiveFibers()).length === 0);
+
+    // Let any duplicate zero-delay alarm surface before pinning exactly-once.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(await agent.getTurnCallCount()).toBe(1);
     expect(
       await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
-
-    // Run the scheduled continuation (the alarm callback the scheduler fires).
-    await agent.runScheduledRecoveryContinueForTest();
-
-    // Recovery resolved the interrupted turn from storage and left no leaked
-    // fiber — the transcript ends on a settled assistant message.
-    expect(await agent.getActiveFibers()).toHaveLength(0);
-    const messages = (await agent.getStoredMessages()) as UIMessage[];
-    expect(messages.length).toBeGreaterThanOrEqual(2);
-    expect(messages.at(-1)?.role).toBe("assistant");
-  });
-
-  it("re-applies channel policy on a turn recovered after eviction", async () => {
-    const name = uniqueName("evict-rec-channel");
-    let agent = await recoveryAgent(name);
-
-    await seedInterruptedContinueTurn(
-      agent,
-      "req-evict-voice",
-      "u-evict-voice",
-      "a-evict-voice",
-      "voice"
-    );
-
-    await evictDurableObject(agent as unknown as DurableObjectStub);
-
-    // Wake-driven recovery scheduling, then run the continuation.
-    agent = await recoveryAgent(name);
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
-    await agent.runScheduledRecoveryContinueForTest();
-
-    // (a) The channel stamp survived eviction on the persisted user message.
-    const messages = (await agent.getStoredMessages()) as UIMessage[];
-    const userMsg = messages.find((m) => m.role === "user");
-    expect((userMsg?.metadata as { channel?: string })?.channel).toBe("voice");
-
-    // (b) The recovered turn re-resolved the channel from storage and re-applied
-    // BOTH its instructions and its tool policy (the channel `tools` callback was
-    // re-invoked) — proving the per-channel policy rebuilds from durable state,
-    // not from any in-memory context lost at eviction.
-    const channels = await agent.getCapturedTurnChannelsForTest();
-    expect(channels.at(-1)).toBe("voice");
-    const systems = await agent.getCapturedTurnSystemsForTest();
-    expect(systems.at(-1)).toContain("VOICE MODE");
-    const toolNames = await agent.getTurnClientToolNames();
-    expect(toolNames.at(-1)).toContain("voiceMarker");
-  });
-
-  it("rebinds an agent-tool child run's request_id on a recovery driven by eviction", async () => {
-    const name = uniqueName("evict-rec-reattach");
-    let agent = await recoveryAgent(name);
-
-    // This facet is running as an agent-tool child (in-flight run row) on a turn
-    // that then gets interrupted mid-stream.
-    await agent.seedAgentToolChildRunForTest("run-evict", "old-req-evict");
-    await seedInterruptedContinueTurn(
-      agent,
-      "req-evict-reattach",
-      "u-evict-reattach",
-      "a-evict-reattach"
-    );
-
-    await evictDurableObject(agent as unknown as DurableObjectStub);
-
-    // Wake-driven recovery, then continuation.
-    agent = await recoveryAgent(name);
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
-    await agent.runScheduledRecoveryContinueForTest();
-
-    // The child-run row (durable cf_agent_tool_child_runs) was rebound off the
-    // pre-eviction request id onto the recovery turn's fresh id, and that id now
-    // attributes back to the run — so the parent's re-attach tail keeps crediting
-    // frames after the DO came back from memory.
-    const reboundReqId =
-      await agent.getAgentToolChildRunRequestIdForTest("run-evict");
-    expect(reboundReqId).toBeTruthy();
-    expect(reboundReqId).not.toBe("old-req-evict");
-    expect(
-      await agent.resolveAgentToolRunForRequestForTest(reboundReqId as string)
-    ).toBe("run-evict");
-  });
-
-  it("schedules a RETRY recovery after eviction for an unanswered user leaf", async () => {
-    const name = uniqueName("evict-rec-retry");
-    let agent = await recoveryAgent(name);
-
-    // A user message whose turn never produced an assistant reply (pre-stream
-    // eviction → retry path).
-    await agent.persistTestMessage({
-      id: "u-evict-retry",
-      role: "user",
-      parts: [{ type: "text", text: "retry this unanswered message" }]
-    });
-    await agent.insertInterruptedFiber(
-      "__cf_internal_chat_turn:req-evict-retry",
-      {
-        __cfThinkChatFiberSnapshot: {
-          kind: "think-chat-turn",
-          version: 1,
-          requestId: "req-evict-retry",
-          continuation: false,
-          latestMessageId: "u-evict-retry",
-          latestMessageRole: "user",
-          latestUserMessageId: "u-evict-retry",
-          startedAt: Date.now()
-        },
-        user: null
-      }
-    );
-
-    await evictDurableObject(agent as unknown as DurableObjectStub);
-
-    // The post-eviction wake's onStart detects the interrupted user-leaf fiber
-    // and schedules the RETRY arm (vs CONTINUE for a partial assistant).
-    agent = await recoveryAgent(name);
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
-    ).toBe(1);
-    await agent.runScheduledRecoveryRetryForTest();
-
-    // Recovery ran the unanswered turn to completion: an assistant reply now
-    // tops the transcript and no fiber leaked.
-    expect(await agent.getActiveFibers()).toHaveLength(0);
+    ).toBe(0);
     const messages = (await agent.getStoredMessages()) as UIMessage[];
     expect(messages.at(-1)?.role).toBe("assistant");
+    expect(JSON.stringify(messages.at(-1)?.parts)).toContain(
+      "Continued response."
+    );
   });
 });

--- a/packages/think/src/tests/think-eviction.test.ts
+++ b/packages/think/src/tests/think-eviction.test.ts
@@ -1,0 +1,270 @@
+import { env } from "cloudflare:workers";
+import { evictDurableObject } from "cloudflare:test";
+import { getServerByName } from "partyserver";
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import type {
+  ThinkScheduledTasksTestAgent,
+  ThinkOnStartHydrationFailureAgent,
+  ThinkRecoveryTestAgent
+} from "./agents/think-session";
+
+/**
+ * Production-lifecycle eviction coverage using the real `evictDurableObject`
+ * helper (vitest-pool-workers >= 0.16.20). Each test drives a DO until it has
+ * built up BOTH in-memory and durable state, evicts it from memory (dropping the
+ * in-memory instance while preserving SQLite + ctx.storage), then re-accesses
+ * a freshly-routed stub and asserts the state was rebuilt correctly from
+ * storage.
+ *
+ * These complement the recovery-fiber tests, which previously simulated
+ * hibernation by hand-crafting SQL rows; here the runtime's own teardown drives
+ * the rehydration path so the assertions fail if rebuild-from-storage breaks.
+ *
+ * Re-acquiring after eviction: a Think DO routes through partyserver, which sets
+ * the DO's `name` (and thus rebuilds `this.session`) on the way in via
+ * `getServerByName`. After eviction the instance is torn down, so the next
+ * access must go through `getServerByName` again to re-run that init — exactly
+ * as a real post-hibernation request does. `evictAndReacquire` does this.
+ */
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+async function recoveryAgent(name: string) {
+  return getServerByName(
+    env.ThinkRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkRecoveryTestAgent>,
+    name
+  );
+}
+
+async function scheduledAgent(name: string) {
+  return getServerByName(
+    env.ThinkScheduledTasksTestAgent as unknown as DurableObjectNamespace<ThinkScheduledTasksTestAgent>,
+    name
+  );
+}
+
+async function hydrationAgent(name: string) {
+  return getServerByName(
+    env.ThinkOnStartHydrationFailureAgent as unknown as DurableObjectNamespace<ThinkOnStartHydrationFailureAgent>,
+    name
+  );
+}
+
+/**
+ * Schedule ids on the agent. `listSchedulesForTest` returns the deeply-generic
+ * `Schedule<unknown>[]`, which the RPC stub-type machinery collapses to
+ * `never[]`; read the ids through `unknown` so the assertion stays typed.
+ */
+async function scheduleIds(
+  agent: Awaited<ReturnType<typeof scheduledAgent>>
+): Promise<string[]> {
+  const schedules = (await agent.listSchedulesForTest()) as unknown as Array<{
+    id: string;
+  }>;
+  return schedules.map((s) => s.id);
+}
+
+/**
+ * Evict the DO from memory, then return a freshly-routed stub for the same
+ * name. Mirrors a real post-hibernation request: the runtime tore the instance
+ * down, and the next routed request re-establishes the agent.
+ */
+async function evictAndReacquire<T>(
+  stub: T,
+  reacquire: () => Promise<T>
+): Promise<T> {
+  await evictDurableObject(stub as unknown as DurableObjectStub);
+  return reacquire();
+}
+
+describe("Think DO eviction — _cachedMessages rehydration", () => {
+  it("rebuilds the in-memory message cache from storage after eviction", async () => {
+    const name = uniqueName("evict-cache");
+    let agent = await recoveryAgent(name);
+
+    // Build up a persisted transcript (durable) AND a populated in-memory cache.
+    await agent.persistTestMessage({
+      id: "u-evict-1",
+      role: "user",
+      parts: [{ type: "text", text: "first question" }]
+    });
+    await agent.persistTestMessage({
+      id: "a-evict-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "first answer" }]
+    });
+
+    // Confirm the live cache is populated pre-eviction.
+    const before = (await agent.getStoredMessages()) as UIMessage[];
+    expect(before.map((m) => m.id)).toEqual(["u-evict-1", "a-evict-1"]);
+
+    // Simulate the production idle-eviction lifecycle: the in-memory instance
+    // (and its `_cachedMessages`) is torn down; only durable storage survives.
+    agent = await evictAndReacquire(agent, () => recoveryAgent(name));
+
+    // The rebuilt instance's `_cachedMessages` (read via getStoredMessages ->
+    // this.messages) must be rebuilt from cf_agent_chat_messages — same ids,
+    // same order, no loss.
+    const after = (await agent.getStoredMessages()) as UIMessage[];
+    expect(after.map((m) => m.id)).toEqual(["u-evict-1", "a-evict-1"]);
+    expect(after.map((m) => m.role)).toEqual(["user", "assistant"]);
+    // The text content survived the round-trip through storage, not just the ids.
+    const userText = (after[0].parts[0] as { type: string; text: string }).text;
+    expect(userText).toBe("first question");
+
+    // The wake did NOT re-execute any model turn — rehydration is a pure read.
+    expect(await agent.getTurnCallCount()).toBe(0);
+  });
+
+  it("keeps the transcript consistent across a CHAIN of evictions", async () => {
+    const name = uniqueName("evict-chain");
+    let agent = await recoveryAgent(name);
+
+    // Turn 1: a real programmatic turn (user + assistant persisted).
+    const t1 = await agent.testRunTurnWait("first turn");
+    expect(t1.status).toBe("completed");
+    const afterT1 = (await agent.getStoredMessages()) as UIMessage[];
+    expect(afterT1).toHaveLength(2);
+
+    // Evict, then prove the transcript is intact and a fresh turn composes on
+    // top of the rehydrated history.
+    agent = await evictAndReacquire(agent, () => recoveryAgent(name));
+    const afterEvict1 = (await agent.getStoredMessages()) as UIMessage[];
+    expect(afterEvict1.map((m) => m.id)).toEqual(afterT1.map((m) => m.id));
+
+    const t2 = await agent.testRunTurnWait("second turn");
+    expect(t2.status).toBe("completed");
+    const afterT2 = (await agent.getStoredMessages()) as UIMessage[];
+    expect(afterT2).toHaveLength(4);
+
+    // A SECOND eviction must not corrupt or duplicate the now-longer transcript.
+    agent = await evictAndReacquire(agent, () => recoveryAgent(name));
+    const afterEvict2 = (await agent.getStoredMessages()) as UIMessage[];
+    expect(afterEvict2.map((m) => m.id)).toEqual(afterT2.map((m) => m.id));
+    expect(afterEvict2.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant"
+    ]);
+    // No leaked recovery fibers survived the eviction chain — clean turns leave
+    // cf_agents_runs empty even after rehydration.
+    expect(await agent.getActiveFibers()).toHaveLength(0);
+  });
+});
+
+describe("Think DO eviction — scheduled task durability", () => {
+  it("keeps declared schedule rows and their schedule ids after eviction", async () => {
+    const name = uniqueName("evict-sched");
+    let agent = await scheduledAgent(name);
+
+    await agent.setDefaultTimezoneForTest("UTC");
+    await agent.setScheduledTasksForTest({
+      report: { schedule: "every day at 09:00", prompt: "Daily report" }
+    });
+    await agent.reconcileScheduledTasksForTest();
+
+    const [before] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(before).toMatchObject({ task_id: "report" });
+    expect(before.schedule_id).toBeTruthy();
+    expect(await scheduleIds(agent)).toContain(before.schedule_id!);
+
+    // Eviction drops the in-memory instance; the declared-task SQL rows
+    // (cf_think_scheduled_tasks), the schedule rows (cf_agents_schedules), and
+    // the durable `scheduledTasksConfig` must all survive in storage.
+    agent = await evictAndReacquire(agent, () => scheduledAgent(name));
+
+    const [after] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(after).toMatchObject({ task_id: "report" });
+    // Same schedule id — eviction did NOT re-mint or drop the schedule.
+    expect(after.schedule_id).toBe(before.schedule_id);
+    expect(after.schedule_hash).toBe(before.schedule_hash);
+
+    expect(await scheduleIds(agent)).toContain(after.schedule_id!);
+
+    // A reconcile on the rehydrated instance is idempotent — same config means
+    // the schedule id is reused, not replaced (proves the durable config was
+    // read back, not lost-then-recreated).
+    await agent.reconcileScheduledTasksForTest();
+    const [afterReconcile] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(afterReconcile.schedule_id).toBe(before.schedule_id);
+  });
+
+  it("runs a declared task handler from durable state after eviction", async () => {
+    const name = uniqueName("evict-sched-fire");
+    let agent = await scheduledAgent(name);
+
+    // A recording handler whose config (schedule + metadata) is persisted to
+    // durable `scheduledTasksConfig` storage.
+    await agent.setScheduledTasksForTest({
+      workflow: {
+        schedule: "every 1 minute",
+        handler: "record",
+        metadata: { workflowName: "daily-digest" }
+      }
+    });
+    await agent.reconcileScheduledTasksForTest();
+    const payload = await agent.getFirstDeclaredPayloadForTest();
+
+    // Evict before the task ever runs: the schedule rows, the declared-task SQL
+    // rows, AND the durable handler config must all rebuild from storage rather
+    // than the (now-gone) in-memory state.
+    agent = await evictAndReacquire(agent, () => scheduledAgent(name));
+
+    // The rehydrated declared payload (recovered via getFirstDeclaredPayload from
+    // storage) still resolves to the same occurrence...
+    const reloaded = await agent.getFirstDeclaredPayloadForTest();
+    expect(reloaded.taskId).toBe(payload.taskId);
+    expect(reloaded.scheduledFor).toBe(payload.scheduledFor);
+
+    // ...and running it dispatches the recording handler with the stored config
+    // (metadata included), recording the occurrence durably. A broken rehydration
+    // would lose the handler config and record nothing.
+    await agent.runDeclaredPayloadForTest(reloaded);
+    const events = await agent.listScheduledTaskHandlerEventsForTest();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "workflow",
+      scheduledFor: payload.scheduledFor,
+      occurrenceKey: `workflow:${payload.scheduledFor}`,
+      metadataJson: JSON.stringify({ workflowName: "daily-digest" })
+    });
+  });
+});
+
+describe("Think DO eviction — onStart hydration degradation", () => {
+  it("re-runs the degraded onStart on each wake and stays functional after eviction", async () => {
+    const name = uniqueName("evict-degraded");
+    let agent = await hydrationAgent(name);
+
+    // First wake: onStart's hydration read throws (simulated SQLITE_NOMEM) and is
+    // recorded as a degradation rather than bricking the DO.
+    const before = await agent.getOnStartDegradationsForTest();
+    expect(before.map((d) => d.step)).toEqual(["transcript-hydration"]);
+
+    // A turn after the degraded boot still persists durably.
+    const turn = await agent.testChat("are you alive?");
+    expect(turn.done).toBe(true);
+    expect(turn.error).toBeUndefined();
+
+    // Evict: a fresh wake must re-run onStart (which degrades AGAIN, since the
+    // injected failure fails the first read of every new instance) and stay
+    // serviceable rather than entering an unbounded init-reset loop.
+    agent = await evictAndReacquire(agent, () => hydrationAgent(name));
+
+    const after = await agent.getOnStartDegradationsForTest();
+    expect(after.map((d) => d.step)).toEqual(["transcript-hydration"]);
+    expect(after[0].error).toContain("SQLITE_NOMEM");
+
+    // The durable transcript persisted before eviction is recoverable via the
+    // safe-boundary resync on the rehydrated instance (the boot read degrades,
+    // but a live read does not).
+    const resynced = (await agent.resyncForTest()) as UIMessage[];
+    expect(resynced.length).toBeGreaterThanOrEqual(2);
+    expect(resynced.some((m) => m.role === "user")).toBe(true);
+    expect(resynced.some((m) => m.role === "assistant")).toBe(true);
+  });
+});

--- a/packages/think/src/tests/think-eviction.test.ts
+++ b/packages/think/src/tests/think-eviction.test.ts
@@ -1,77 +1,42 @@
+/**
+ * Forced Durable Object eviction coverage for Think instance state.
+ *
+ * Each test explicitly tears down a running actor, routes back through
+ * partyserver, and verifies reconstruction from durable state. This does not
+ * assert natural idle hibernation or hibernation eligibility.
+ */
+import type { UIMessage } from "ai";
 import { env } from "cloudflare:workers";
 import { evictDurableObject } from "cloudflare:test";
 import { getServerByName } from "partyserver";
 import { describe, expect, it } from "vitest";
-import type { UIMessage } from "ai";
 import type {
-  ThinkScheduledTasksTestAgent,
   ThinkOnStartHydrationFailureAgent,
-  ThinkRecoveryTestAgent
+  ThinkRecoveryTestAgent,
+  ThinkScheduledTasksTestAgent
 } from "./agents/think-session";
 
-/**
- * Production-lifecycle eviction coverage using the real `evictDurableObject`
- * helper (vitest-pool-workers >= 0.16.20). Each test drives a DO until it has
- * built up BOTH in-memory and durable state, evicts it from memory (dropping the
- * in-memory instance while preserving SQLite + ctx.storage), then re-accesses
- * a freshly-routed stub and asserts the state was rebuilt correctly from
- * storage.
- *
- * These complement the recovery-fiber tests, which previously simulated
- * hibernation by hand-crafting SQL rows; here the runtime's own teardown drives
- * the rehydration path so the assertions fail if rebuild-from-storage breaks.
- *
- * Re-acquiring after eviction: a Think DO routes through partyserver, which sets
- * the DO's `name` (and thus rebuilds `this.session`) on the way in via
- * `getServerByName`. After eviction the instance is torn down, so the next
- * access must go through `getServerByName` again to re-run that init — exactly
- * as a real post-hibernation request does. `evictAndReacquire` does this.
- */
-
-function uniqueName(prefix: string): string {
-  return `${prefix}-${crypto.randomUUID()}`;
-}
-
-async function recoveryAgent(name: string) {
+function recoveryAgent(name: string) {
   return getServerByName(
     env.ThinkRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkRecoveryTestAgent>,
     name
   );
 }
 
-async function scheduledAgent(name: string) {
+function scheduledAgent(name: string) {
   return getServerByName(
     env.ThinkScheduledTasksTestAgent as unknown as DurableObjectNamespace<ThinkScheduledTasksTestAgent>,
     name
   );
 }
 
-async function hydrationAgent(name: string) {
+function hydrationAgent(name: string) {
   return getServerByName(
     env.ThinkOnStartHydrationFailureAgent as unknown as DurableObjectNamespace<ThinkOnStartHydrationFailureAgent>,
     name
   );
 }
 
-/**
- * Schedule ids on the agent. `listSchedulesForTest` returns the deeply-generic
- * `Schedule<unknown>[]`, which the RPC stub-type machinery collapses to
- * `never[]`; read the ids through `unknown` so the assertion stays typed.
- */
-async function scheduleIds(
-  agent: Awaited<ReturnType<typeof scheduledAgent>>
-): Promise<string[]> {
-  const schedules = (await agent.listSchedulesForTest()) as unknown as Array<{
-    id: string;
-  }>;
-  return schedules.map((s) => s.id);
-}
-
-/**
- * Evict the DO from memory, then return a freshly-routed stub for the same
- * name. Mirrors a real post-hibernation request: the runtime tore the instance
- * down, and the next routed request re-establishes the agent.
- */
 async function evictAndReacquire<T>(
   stub: T,
   reacquire: () => Promise<T>
@@ -80,125 +45,38 @@ async function evictAndReacquire<T>(
   return reacquire();
 }
 
-describe("Think DO eviction — _cachedMessages rehydration", () => {
-  it("rebuilds the in-memory message cache from storage after eviction", async () => {
-    const name = uniqueName("evict-cache");
+describe("Think recovery after forced Durable Object eviction", () => {
+  it("rebuilds the in-memory transcript cache without running a turn", async () => {
+    const name = `evict-think-cache-${crypto.randomUUID()}`;
     let agent = await recoveryAgent(name);
-
-    // Build up a persisted transcript (durable) AND a populated in-memory cache.
     await agent.persistTestMessage({
-      id: "u-evict-1",
+      id: "user-before-eviction",
       role: "user",
       parts: [{ type: "text", text: "first question" }]
     });
     await agent.persistTestMessage({
-      id: "a-evict-1",
+      id: "assistant-before-eviction",
       role: "assistant",
       parts: [{ type: "text", text: "first answer" }]
     });
 
-    // Confirm the live cache is populated pre-eviction.
-    const before = (await agent.getStoredMessages()) as UIMessage[];
-    expect(before.map((m) => m.id)).toEqual(["u-evict-1", "a-evict-1"]);
-
-    // Simulate the production idle-eviction lifecycle: the in-memory instance
-    // (and its `_cachedMessages`) is torn down; only durable storage survives.
     agent = await evictAndReacquire(agent, () => recoveryAgent(name));
 
-    // The rebuilt instance's `_cachedMessages` (read via getStoredMessages ->
-    // this.messages) must be rebuilt from cf_agent_chat_messages — same ids,
-    // same order, no loss.
-    const after = (await agent.getStoredMessages()) as UIMessage[];
-    expect(after.map((m) => m.id)).toEqual(["u-evict-1", "a-evict-1"]);
-    expect(after.map((m) => m.role)).toEqual(["user", "assistant"]);
-    // The text content survived the round-trip through storage, not just the ids.
-    const userText = (after[0].parts[0] as { type: string; text: string }).text;
-    expect(userText).toBe("first question");
-
-    // The wake did NOT re-execute any model turn — rehydration is a pure read.
-    expect(await agent.getTurnCallCount()).toBe(0);
-  });
-
-  it("keeps the transcript consistent across a CHAIN of evictions", async () => {
-    const name = uniqueName("evict-chain");
-    let agent = await recoveryAgent(name);
-
-    // Turn 1: a real programmatic turn (user + assistant persisted).
-    const t1 = await agent.testRunTurnWait("first turn");
-    expect(t1.status).toBe("completed");
-    const afterT1 = (await agent.getStoredMessages()) as UIMessage[];
-    expect(afterT1).toHaveLength(2);
-
-    // Evict, then prove the transcript is intact and a fresh turn composes on
-    // top of the rehydrated history.
-    agent = await evictAndReacquire(agent, () => recoveryAgent(name));
-    const afterEvict1 = (await agent.getStoredMessages()) as UIMessage[];
-    expect(afterEvict1.map((m) => m.id)).toEqual(afterT1.map((m) => m.id));
-
-    const t2 = await agent.testRunTurnWait("second turn");
-    expect(t2.status).toBe("completed");
-    const afterT2 = (await agent.getStoredMessages()) as UIMessage[];
-    expect(afterT2).toHaveLength(4);
-
-    // A SECOND eviction must not corrupt or duplicate the now-longer transcript.
-    agent = await evictAndReacquire(agent, () => recoveryAgent(name));
-    const afterEvict2 = (await agent.getStoredMessages()) as UIMessage[];
-    expect(afterEvict2.map((m) => m.id)).toEqual(afterT2.map((m) => m.id));
-    expect(afterEvict2.map((m) => m.role)).toEqual([
-      "user",
-      "assistant",
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages.map((message) => message.id)).toEqual([
+      "user-before-eviction",
+      "assistant-before-eviction"
+    ]);
+    expect(messages.map((message) => message.role)).toEqual([
       "user",
       "assistant"
     ]);
-    // No leaked recovery fibers survived the eviction chain — clean turns leave
-    // cf_agents_runs empty even after rehydration.
-    expect(await agent.getActiveFibers()).toHaveLength(0);
-  });
-});
-
-describe("Think DO eviction — scheduled task durability", () => {
-  it("keeps declared schedule rows and their schedule ids after eviction", async () => {
-    const name = uniqueName("evict-sched");
-    let agent = await scheduledAgent(name);
-
-    await agent.setDefaultTimezoneForTest("UTC");
-    await agent.setScheduledTasksForTest({
-      report: { schedule: "every day at 09:00", prompt: "Daily report" }
-    });
-    await agent.reconcileScheduledTasksForTest();
-
-    const [before] = await agent.listDeclaredScheduledTaskRowsForTest();
-    expect(before).toMatchObject({ task_id: "report" });
-    expect(before.schedule_id).toBeTruthy();
-    expect(await scheduleIds(agent)).toContain(before.schedule_id!);
-
-    // Eviction drops the in-memory instance; the declared-task SQL rows
-    // (cf_think_scheduled_tasks), the schedule rows (cf_agents_schedules), and
-    // the durable `scheduledTasksConfig` must all survive in storage.
-    agent = await evictAndReacquire(agent, () => scheduledAgent(name));
-
-    const [after] = await agent.listDeclaredScheduledTaskRowsForTest();
-    expect(after).toMatchObject({ task_id: "report" });
-    // Same schedule id — eviction did NOT re-mint or drop the schedule.
-    expect(after.schedule_id).toBe(before.schedule_id);
-    expect(after.schedule_hash).toBe(before.schedule_hash);
-
-    expect(await scheduleIds(agent)).toContain(after.schedule_id!);
-
-    // A reconcile on the rehydrated instance is idempotent — same config means
-    // the schedule id is reused, not replaced (proves the durable config was
-    // read back, not lost-then-recreated).
-    await agent.reconcileScheduledTasksForTest();
-    const [afterReconcile] = await agent.listDeclaredScheduledTaskRowsForTest();
-    expect(afterReconcile.schedule_id).toBe(before.schedule_id);
+    expect(await agent.getTurnCallCount()).toBe(0);
   });
 
-  it("runs a declared task handler from durable state after eviction", async () => {
-    const name = uniqueName("evict-sched-fire");
+  it("restores declared-task identity and handler configuration", async () => {
+    const name = `evict-think-schedule-${crypto.randomUUID()}`;
     let agent = await scheduledAgent(name);
-
-    // A recording handler whose config (schedule + metadata) is persisted to
-    // durable `scheduledTasksConfig` storage.
     await agent.setScheduledTasksForTest({
       workflow: {
         schedule: "every 1 minute",
@@ -207,64 +85,56 @@ describe("Think DO eviction — scheduled task durability", () => {
       }
     });
     await agent.reconcileScheduledTasksForTest();
+    const [before] = await agent.listDeclaredScheduledTaskRowsForTest();
     const payload = await agent.getFirstDeclaredPayloadForTest();
 
-    // Evict before the task ever runs: the schedule rows, the declared-task SQL
-    // rows, AND the durable handler config must all rebuild from storage rather
-    // than the (now-gone) in-memory state.
     agent = await evictAndReacquire(agent, () => scheduledAgent(name));
 
-    // The rehydrated declared payload (recovered via getFirstDeclaredPayload from
-    // storage) still resolves to the same occurrence...
-    const reloaded = await agent.getFirstDeclaredPayloadForTest();
-    expect(reloaded.taskId).toBe(payload.taskId);
-    expect(reloaded.scheduledFor).toBe(payload.scheduledFor);
-
-    // ...and running it dispatches the recording handler with the stored config
-    // (metadata included), recording the occurrence durably. A broken rehydration
-    // would lose the handler config and record nothing.
-    await agent.runDeclaredPayloadForTest(reloaded);
-    const events = await agent.listScheduledTaskHandlerEventsForTest();
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      taskId: "workflow",
-      scheduledFor: payload.scheduledFor,
-      occurrenceKey: `workflow:${payload.scheduledFor}`,
-      metadataJson: JSON.stringify({ workflowName: "daily-digest" })
+    const [after] = await agent.listDeclaredScheduledTaskRowsForTest();
+    expect(after).toMatchObject({
+      task_id: "workflow",
+      schedule_id: before.schedule_id,
+      schedule_hash: before.schedule_hash
     });
+
+    const restoredPayload = await agent.getFirstDeclaredPayloadForTest();
+    expect(restoredPayload).toEqual(payload);
+    await agent.runDeclaredPayloadForTest(restoredPayload);
+    expect(await agent.listScheduledTaskHandlerEventsForTest()).toEqual([
+      expect.objectContaining({
+        taskId: "workflow",
+        scheduledFor: payload.scheduledFor,
+        occurrenceKey: `workflow:${payload.scheduledFor}`,
+        metadataJson: JSON.stringify({ workflowName: "daily-digest" })
+      })
+    ]);
   });
-});
 
-describe("Think DO eviction — onStart hydration degradation", () => {
-  it("re-runs the degraded onStart on each wake and stays functional after eviction", async () => {
-    const name = uniqueName("evict-degraded");
+  it("re-runs degraded startup and remains usable on the fresh instance", async () => {
+    const name = `evict-think-degraded-${crypto.randomUUID()}`;
     let agent = await hydrationAgent(name);
+    expect(
+      (await agent.getOnStartDegradationsForTest()).map(
+        (degradation) => degradation.step
+      )
+    ).toEqual(["transcript-hydration"]);
 
-    // First wake: onStart's hydration read throws (simulated SQLITE_NOMEM) and is
-    // recorded as a degradation rather than bricking the DO.
-    const before = await agent.getOnStartDegradationsForTest();
-    expect(before.map((d) => d.step)).toEqual(["transcript-hydration"]);
-
-    // A turn after the degraded boot still persists durably.
     const turn = await agent.testChat("are you alive?");
-    expect(turn.done).toBe(true);
-    expect(turn.error).toBeUndefined();
+    expect(turn).toMatchObject({ done: true, error: undefined });
 
-    // Evict: a fresh wake must re-run onStart (which degrades AGAIN, since the
-    // injected failure fails the first read of every new instance) and stay
-    // serviceable rather than entering an unbounded init-reset loop.
     agent = await evictAndReacquire(agent, () => hydrationAgent(name));
 
-    const after = await agent.getOnStartDegradationsForTest();
-    expect(after.map((d) => d.step)).toEqual(["transcript-hydration"]);
-    expect(after[0].error).toContain("SQLITE_NOMEM");
-
-    // The durable transcript persisted before eviction is recoverable via the
-    // safe-boundary resync on the rehydrated instance (the boot read degrades,
-    // but a live read does not).
-    const resynced = (await agent.resyncForTest()) as UIMessage[];
-    expect(resynced.length).toBeGreaterThanOrEqual(2);
-    expect(resynced.some((m) => m.role === "user")).toBe(true);
-    expect(resynced.some((m) => m.role === "assistant")).toBe(true);
+    const degradations = await agent.getOnStartDegradationsForTest();
+    expect(degradations).toEqual([
+      expect.objectContaining({
+        step: "transcript-hydration",
+        error: expect.stringContaining("SQLITE_NOMEM")
+      })
+    ]);
+    const messages = (await agent.resyncForTest()) as UIMessage[];
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant"
+    ]);
   });
 });

--- a/packages/voice/src/tests/voice-eviction.test.ts
+++ b/packages/voice/src/tests/voice-eviction.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Durable Object eviction tests for the VoiceAgent mixin.
+ *
+ * VoiceAgent is a Durable Object. Its conversation history lives in the
+ * `cf_voice_messages` SQL table (durable storage), while the per-instance
+ * `#schemaReady` flag and the AudioConnectionManager are NON-durable in-memory
+ * state. In production an idle DO is evicted from memory: in-memory state is
+ * dropped and must be rebuilt from storage on next access.
+ *
+ * These tests use `evictDurableObject(stub)` / `evictAllDurableObjects()` from
+ * "cloudflare:test" to simulate that lifecycle and PROVE that:
+ *
+ *   1. SQL-backed conversation history survives eviction and rehydrates.
+ *   2. The cached in-memory `#schemaReady` flag is rebuilt on next access
+ *      without losing rows (the first post-eviction query re-runs
+ *      `#ensureSchema()` and still reads the surviving rows).
+ *   3. Rows accumulate across the eviction boundary instead of resetting.
+ *   4. `getConversationHistory()` reconstructs the full ordered transcript
+ *      from storage after the instance has been torn down.
+ *   5. Per-instance histories stay isolated across `evictAllDurableObjects()`.
+ *
+ * We drive the DO via `runInDurableObject` (the same idiom the agents package
+ * uses) rather than a WebSocket. A `worker.fetch` WebSocket upgrade leaves an
+ * in-flight request pinned to the worker's execution context, which the
+ * eviction drain step waits on indefinitely; `runInDurableObject` accesses the
+ * instance directly so eviction can drain and complete.
+ */
+import { env } from "cloudflare:workers";
+import {
+  evictAllDurableObjects,
+  evictDurableObject,
+  runInDurableObject
+} from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { TestVoiceAgent } from "./agents/voice";
+
+// --- Helpers ---
+
+let instanceCounter = 0;
+function uniqueName(prefix: string) {
+  return `${prefix}-${++instanceCounter}`;
+}
+
+function voiceStub(name: string) {
+  const id = env.TestVoiceAgent.idFromName(name);
+  return env.TestVoiceAgent.get(id) as DurableObjectStub<TestVoiceAgent>;
+}
+
+/** Seed N full turns (user + assistant rows) into the DO's SQL storage. */
+async function seedTurns(
+  stub: DurableObjectStub<TestVoiceAgent>,
+  turns: Array<{ user: string; assistant: string }>
+): Promise<number> {
+  return runInDurableObject(stub, (instance) => {
+    for (const turn of turns) {
+      instance.saveMessage("user", turn.user);
+      instance.saveMessage("assistant", turn.assistant);
+    }
+    return instance.getMessageCount();
+  });
+}
+
+async function readCount(
+  stub: DurableObjectStub<TestVoiceAgent>
+): Promise<number> {
+  return runInDurableObject(stub, (instance) => instance.getMessageCount());
+}
+
+async function readHistory(
+  stub: DurableObjectStub<TestVoiceAgent>
+): Promise<Array<{ role: string; content: string }>> {
+  return runInDurableObject(stub, (instance) =>
+    instance.getConversationHistory()
+  );
+}
+
+// --- Tests ---
+
+describe("VoiceAgent — conversation history survives DO eviction", () => {
+  it("rehydrates SQL-backed message count after evictDurableObject", async () => {
+    const name = uniqueName("evict-history");
+    const stub = voiceStub(name);
+
+    // Build real durable state: one user + one assistant row. This also
+    // creates the cf_voice_messages table and flips the in-memory
+    // #schemaReady flag to true on THIS instance.
+    const seeded = await seedTurns(stub, [
+      { user: "hello", assistant: "Echo: hello" }
+    ]);
+    expect(seeded).toBe(2);
+
+    // Simulate production hibernation/eviction: the instance is torn down, so
+    // the cached #schemaReady flag is lost. Only durable SQL storage remains.
+    await evictDurableObject(stub);
+
+    // First access on the fresh instance must re-run #ensureSchema() (flag was
+    // reset) and still see the rows that survived in storage.
+    expect(await readCount(stub)).toBe(2);
+  });
+
+  it("reconstructs the full ordered transcript from storage after eviction", async () => {
+    const name = uniqueName("evict-transcript");
+    const stub = voiceStub(name);
+
+    await seedTurns(stub, [
+      { user: "what's the weather?", assistant: "Echo: what's the weather?" },
+      { user: "and tomorrow?", assistant: "Echo: and tomorrow?" }
+    ]);
+
+    await evictDurableObject(stub);
+
+    // getConversationHistory() rebuilds the ordered transcript purely from SQL
+    // on a torn-down-and-rehydrated instance.
+    expect(await readHistory(stub)).toEqual([
+      { role: "user", content: "what's the weather?" },
+      { role: "assistant", content: "Echo: what's the weather?" },
+      { role: "user", content: "and tomorrow?" },
+      { role: "assistant", content: "Echo: and tomorrow?" }
+    ]);
+  });
+
+  it("accumulates rows across an eviction boundary instead of resetting", async () => {
+    const name = uniqueName("evict-accumulate");
+    const stub = voiceStub(name);
+
+    // Two turns before eviction -> 4 rows.
+    await seedTurns(stub, [
+      { user: "turn one", assistant: "Echo: turn one" },
+      { user: "turn two", assistant: "Echo: turn two" }
+    ]);
+
+    await evictDurableObject(stub);
+
+    // Rows survived...
+    expect(await readCount(stub)).toBe(4);
+
+    // ...and a new turn on the rehydrated instance appends (5th + 6th rows)
+    // rather than starting from an empty table.
+    const afterAppend = await seedTurns(stub, [
+      { user: "turn three", assistant: "Echo: turn three" }
+    ]);
+    expect(afterAppend).toBe(6);
+
+    const history = await readHistory(stub);
+    expect(history).toHaveLength(6);
+    expect(history.at(-1)).toEqual({
+      role: "assistant",
+      content: "Echo: turn three"
+    });
+  });
+
+  it("survives repeated eviction cycles without losing or duplicating rows", async () => {
+    const name = uniqueName("evict-repeat");
+    const stub = voiceStub(name);
+
+    await seedTurns(stub, [
+      { user: "persist me", assistant: "Echo: persist me" }
+    ]);
+
+    // Evict and re-read several times; the count must stay stable at 2 and the
+    // idempotent CREATE TABLE IF NOT EXISTS must not wipe data on rehydration.
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await evictDurableObject(stub);
+      expect(await readCount(stub)).toBe(2);
+    }
+  });
+});
+
+describe("VoiceAgent — evictAllDurableObjects keeps instances isolated", () => {
+  it("rehydrates each instance's own history after a global eviction", async () => {
+    const nameA = uniqueName("evict-all-a");
+    const nameB = uniqueName("evict-all-b");
+    const stubA = voiceStub(nameA);
+    const stubB = voiceStub(nameB);
+
+    // Instance A: one turn -> 2 rows.
+    await seedTurns(stubA, [{ user: "a-user", assistant: "Echo: a-user" }]);
+    // Instance B: two turns -> 4 rows.
+    await seedTurns(stubB, [
+      { user: "b-user-1", assistant: "Echo: b-user-1" },
+      { user: "b-user-2", assistant: "Echo: b-user-2" }
+    ]);
+
+    // Evict every running DO at once.
+    await evictAllDurableObjects();
+
+    // Each instance rebuilds only its own rows — no cross-contamination.
+    expect(await readCount(stubA)).toBe(2);
+    expect(await readCount(stubB)).toBe(4);
+
+    expect(await readHistory(stubA)).toEqual([
+      { role: "user", content: "a-user" },
+      { role: "assistant", content: "Echo: a-user" }
+    ]);
+  });
+});

--- a/packages/voice/src/tests/voice-eviction.test.ts
+++ b/packages/voice/src/tests/voice-eviction.test.ts
@@ -1,29 +1,9 @@
 /**
- * Durable Object eviction tests for the VoiceAgent mixin.
+ * Forced Durable Object eviction coverage for VoiceAgent conversation storage.
  *
- * VoiceAgent is a Durable Object. Its conversation history lives in the
- * `cf_voice_messages` SQL table (durable storage), while the per-instance
- * `#schemaReady` flag and the AudioConnectionManager are NON-durable in-memory
- * state. In production an idle DO is evicted from memory: in-memory state is
- * dropped and must be rebuilt from storage on next access.
- *
- * These tests use `evictDurableObject(stub)` / `evictAllDurableObjects()` from
- * "cloudflare:test" to simulate that lifecycle and PROVE that:
- *
- *   1. SQL-backed conversation history survives eviction and rehydrates.
- *   2. The cached in-memory `#schemaReady` flag is rebuilt on next access
- *      without losing rows (the first post-eviction query re-runs
- *      `#ensureSchema()` and still reads the surviving rows).
- *   3. Rows accumulate across the eviction boundary instead of resetting.
- *   4. `getConversationHistory()` reconstructs the full ordered transcript
- *      from storage after the instance has been torn down.
- *   5. Per-instance histories stay isolated across `evictAllDurableObjects()`.
- *
- * We drive the DO via `runInDurableObject` (the same idiom the agents package
- * uses) rather than a WebSocket. A `worker.fetch` WebSocket upgrade leaves an
- * in-flight request pinned to the worker's execution context, which the
- * eviction drain step waits on indefinitely; `runInDurableObject` accesses the
- * instance directly so eviction can drain and complete.
+ * The test fixture disables WebSocket hibernation, so this intentionally tests
+ * only actor reconstruction after explicit eviction. It does not assert natural
+ * idle hibernation or hibernation eligibility.
  */
 import { env } from "cloudflare:workers";
 import {
@@ -34,163 +14,79 @@ import {
 import { describe, expect, it } from "vitest";
 import type { TestVoiceAgent } from "./agents/voice";
 
-// --- Helpers ---
-
-let instanceCounter = 0;
-function uniqueName(prefix: string) {
-  return `${prefix}-${++instanceCounter}`;
-}
+type History = Array<{ role: string; content: string }>;
 
 function voiceStub(name: string) {
-  const id = env.TestVoiceAgent.idFromName(name);
-  return env.TestVoiceAgent.get(id) as DurableObjectStub<TestVoiceAgent>;
+  return env.TestVoiceAgent.get(
+    env.TestVoiceAgent.idFromName(name)
+  ) as DurableObjectStub<TestVoiceAgent>;
 }
 
-/** Seed N full turns (user + assistant rows) into the DO's SQL storage. */
-async function seedTurns(
+async function appendTurns(
   stub: DurableObjectStub<TestVoiceAgent>,
   turns: Array<{ user: string; assistant: string }>
-): Promise<number> {
-  return runInDurableObject(stub, (instance) => {
+): Promise<void> {
+  await runInDurableObject(stub, (instance) => {
     for (const turn of turns) {
       instance.saveMessage("user", turn.user);
       instance.saveMessage("assistant", turn.assistant);
     }
-    return instance.getMessageCount();
   });
-}
-
-async function readCount(
-  stub: DurableObjectStub<TestVoiceAgent>
-): Promise<number> {
-  return runInDurableObject(stub, (instance) => instance.getMessageCount());
 }
 
 async function readHistory(
   stub: DurableObjectStub<TestVoiceAgent>
-): Promise<Array<{ role: string; content: string }>> {
+): Promise<History> {
   return runInDurableObject(stub, (instance) =>
     instance.getConversationHistory()
   );
 }
 
-// --- Tests ---
-
-describe("VoiceAgent — conversation history survives DO eviction", () => {
-  it("rehydrates SQL-backed message count after evictDurableObject", async () => {
-    const name = uniqueName("evict-history");
-    const stub = voiceStub(name);
-
-    // Build real durable state: one user + one assistant row. This also
-    // creates the cf_voice_messages table and flips the in-memory
-    // #schemaReady flag to true on THIS instance.
-    const seeded = await seedTurns(stub, [
-      { user: "hello", assistant: "Echo: hello" }
-    ]);
-    expect(seeded).toBe(2);
-
-    // Simulate production hibernation/eviction: the instance is torn down, so
-    // the cached #schemaReady flag is lost. Only durable SQL storage remains.
-    await evictDurableObject(stub);
-
-    // First access on the fresh instance must re-run #ensureSchema() (flag was
-    // reset) and still see the rows that survived in storage.
-    expect(await readCount(stub)).toBe(2);
-  });
-
-  it("reconstructs the full ordered transcript from storage after eviction", async () => {
-    const name = uniqueName("evict-transcript");
-    const stub = voiceStub(name);
-
-    await seedTurns(stub, [
-      { user: "what's the weather?", assistant: "Echo: what's the weather?" },
-      { user: "and tomorrow?", assistant: "Echo: and tomorrow?" }
+describe("VoiceAgent recovery after forced Durable Object eviction", () => {
+  it("restores and extends the exact ordered transcript", async () => {
+    const stub = voiceStub(`evict-voice-${crypto.randomUUID()}`);
+    await appendTurns(stub, [
+      { user: "what's the weather?", assistant: "Sunny" },
+      { user: "and tomorrow?", assistant: "Rain" }
     ]);
 
     await evictDurableObject(stub);
 
-    // getConversationHistory() rebuilds the ordered transcript purely from SQL
-    // on a torn-down-and-rehydrated instance.
     expect(await readHistory(stub)).toEqual([
       { role: "user", content: "what's the weather?" },
-      { role: "assistant", content: "Echo: what's the weather?" },
+      { role: "assistant", content: "Sunny" },
       { role: "user", content: "and tomorrow?" },
-      { role: "assistant", content: "Echo: and tomorrow?" }
+      { role: "assistant", content: "Rain" }
+    ]);
+
+    // The first write on the fresh instance re-runs the schema guard and must
+    // append to, rather than replace, the rows created before eviction.
+    await appendTurns(stub, [{ user: "weekend?", assistant: "Clear" }]);
+    expect(await readHistory(stub)).toEqual([
+      { role: "user", content: "what's the weather?" },
+      { role: "assistant", content: "Sunny" },
+      { role: "user", content: "and tomorrow?" },
+      { role: "assistant", content: "Rain" },
+      { role: "user", content: "weekend?" },
+      { role: "assistant", content: "Clear" }
     ]);
   });
 
-  it("accumulates rows across an eviction boundary instead of resetting", async () => {
-    const name = uniqueName("evict-accumulate");
-    const stub = voiceStub(name);
+  it("keeps named transcripts isolated after a global forced eviction", async () => {
+    const stubA = voiceStub(`evict-voice-a-${crypto.randomUUID()}`);
+    const stubB = voiceStub(`evict-voice-b-${crypto.randomUUID()}`);
+    await appendTurns(stubA, [{ user: "A", assistant: "A reply" }]);
+    await appendTurns(stubB, [{ user: "B", assistant: "B reply" }]);
 
-    // Two turns before eviction -> 4 rows.
-    await seedTurns(stub, [
-      { user: "turn one", assistant: "Echo: turn one" },
-      { user: "turn two", assistant: "Echo: turn two" }
-    ]);
-
-    await evictDurableObject(stub);
-
-    // Rows survived...
-    expect(await readCount(stub)).toBe(4);
-
-    // ...and a new turn on the rehydrated instance appends (5th + 6th rows)
-    // rather than starting from an empty table.
-    const afterAppend = await seedTurns(stub, [
-      { user: "turn three", assistant: "Echo: turn three" }
-    ]);
-    expect(afterAppend).toBe(6);
-
-    const history = await readHistory(stub);
-    expect(history).toHaveLength(6);
-    expect(history.at(-1)).toEqual({
-      role: "assistant",
-      content: "Echo: turn three"
-    });
-  });
-
-  it("survives repeated eviction cycles without losing or duplicating rows", async () => {
-    const name = uniqueName("evict-repeat");
-    const stub = voiceStub(name);
-
-    await seedTurns(stub, [
-      { user: "persist me", assistant: "Echo: persist me" }
-    ]);
-
-    // Evict and re-read several times; the count must stay stable at 2 and the
-    // idempotent CREATE TABLE IF NOT EXISTS must not wipe data on rehydration.
-    for (let cycle = 0; cycle < 3; cycle++) {
-      await evictDurableObject(stub);
-      expect(await readCount(stub)).toBe(2);
-    }
-  });
-});
-
-describe("VoiceAgent — evictAllDurableObjects keeps instances isolated", () => {
-  it("rehydrates each instance's own history after a global eviction", async () => {
-    const nameA = uniqueName("evict-all-a");
-    const nameB = uniqueName("evict-all-b");
-    const stubA = voiceStub(nameA);
-    const stubB = voiceStub(nameB);
-
-    // Instance A: one turn -> 2 rows.
-    await seedTurns(stubA, [{ user: "a-user", assistant: "Echo: a-user" }]);
-    // Instance B: two turns -> 4 rows.
-    await seedTurns(stubB, [
-      { user: "b-user-1", assistant: "Echo: b-user-1" },
-      { user: "b-user-2", assistant: "Echo: b-user-2" }
-    ]);
-
-    // Evict every running DO at once.
     await evictAllDurableObjects();
 
-    // Each instance rebuilds only its own rows — no cross-contamination.
-    expect(await readCount(stubA)).toBe(2);
-    expect(await readCount(stubB)).toBe(4);
-
     expect(await readHistory(stubA)).toEqual([
-      { role: "user", content: "a-user" },
-      { role: "assistant", content: "Echo: a-user" }
+      { role: "user", content: "A" },
+      { role: "assistant", content: "A reply" }
+    ]);
+    expect(await readHistory(stubB)).toEqual([
+      { role: "user", content: "B" },
+      { role: "assistant", content: "B reply" }
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Test-only coverage for recovery after a running Durable Object is explicitly evicted with `evictDurableObject()` / `evictAllDurableObjects()`.

- verifies volatile instance state is dropped while SQLite and Durable Object storage are retained
- covers Agent state, schedules and fibers; Session active-leaf reconstruction; MCP startup/session restoration; AIChat history, streams and WebSockets; Codemode durable replay; Workspace; Think startup/recovery; and Voice history
- keeps a live AIChat WebSocket usable across forced eviction and separately covers `{ webSockets: "close" }`
- adds no runtime code or changeset

## Scope

This proves selected reconstruction paths after **forced eviction**. It does not prove natural idle hibernation, timer absence, hibernation eligibility, or duration-billing suspension.

Related to #1956; does not fix it. The test helper bypasses the eligibility gate, so a passive workerd/vitest-pool API is still needed to detect timer-pinned actors without waking or forcibly evicting them.

## Verification

- `pnpm run build`
- `pnpm run check`
- `CI=true pnpm exec nx affected -t test --base=origin/main --parallel=3`
