### PR TITLE
feat(think): bundle workers-ai-provider and accept model id strings

### DIFF
--- a/.changeset/think-default-model-provider.md
+++ b/.changeset/think-default-model-provider.md
@@ -1,0 +1,26 @@
+---
+"@cloudflare/think": minor
+---
+
+`getModel()` now accepts a model id string, resolved through a built-in `workers-ai-provider` instance — no separate provider package to install, import, or wire up for the common case.
+
+Think now depends on `workers-ai-provider` (plus the `@ai-sdk/openai` and `@ai-sdk/anthropic` wire-format plugins) directly. When `getModel()` returns a string, Think resolves it off your `AI` binding:
+
+- A `@cf/...` id hits Workers AI directly (with `sessionAffinity` wired in automatically for prefix-cache hits).
+- Any other `"<provider>/<model>"` slug — e.g. `"openai/gpt-5.5"`, `"anthropic/claude-sonnet-4-5"`, `"google/gemini-2.5-pro"`, `"xai/grok-4"`, `"groq/..."` — is routed through AI Gateway.
+
+```typescript
+export class MyAgent extends Think<Env> {
+  getModel() {
+    return "@cf/moonshotai/kimi-k2.7-code"; // or "openai/gpt-5.5"
+  }
+}
+```
+
+Returning a fully-constructed AI SDK `LanguageModel` from `getModel()` still works unchanged for any other provider or for full control over provider/gateway options. A new `getAIBinding()` override (default `this.env.AI`) controls which binding the string resolver uses.
+
+Because `getModel()` may now return a bare string, a new public `resolveModel(model?)` method (defaults to resolving `getModel()`) returns a concrete `LanguageModel`. Use it for side inference calls — e.g. summarization/compaction `generateText` — instead of passing `getModel()` straight to the AI SDK.
+
+The per-turn override `TurnConfig.model` (returned from `beforeTurn`) also accepts a `ThinkModel` now, so you can switch models for a turn with a plain string (e.g. a cheaper model for continuations). The per-step override `StepConfig.model` (returned from `beforeStep`) accepts a `ThinkModel` too — Think resolves a string back into a `LanguageModel` before handing the step to the AI SDK.
+
+`getModel()` is typed to return `ThinkModel` (a newly exported alias for `LanguageModel | ThinkModelId`). `ThinkModelId` (also exported) gives editor autocomplete for the Workers AI text-generation catalog (`@cf/...`, derived from the installed `@cloudflare/workers-types`) while still accepting any string — gateway catalog slugs like `"openai/gpt-5.5"` are validated at runtime, since the catalog lives server-side and is not knowable from types.

--- a/docs/think/getting-started.md
+++ b/docs/think/getting-started.md
@@ -25,9 +25,11 @@ npm init -y
 Install dependencies:
 
 ```sh
-npm install @cloudflare/think agents ai @cloudflare/shell zod workers-ai-provider react react-dom
+npm install @cloudflare/think agents ai @cloudflare/shell zod react react-dom
 npm install -D wrangler @cloudflare/vite-plugin @cloudflare/workers-types @vitejs/plugin-react @tailwindcss/vite tailwindcss typescript vite
 ```
+
+Think bundles [`workers-ai-provider`](https://www.npmjs.com/package/workers-ai-provider), so you do not need to install or import it for the common case — `getModel()` can return a model id string (see below).
 
 ## 2. Configure wrangler
 
@@ -78,14 +80,14 @@ Create `src/server.ts`:
 
 ```typescript
 import { Think } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 import { routeAgentRequest } from "agents";
 
 export class MyAgent extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+    // A string is resolved through Think's built-in workers-ai-provider off the
+    // `AI` binding. Use a "@cf/..." id for Workers AI, or a "provider/model"
+    // slug like "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   getSystemPrompt() {
@@ -202,10 +204,8 @@ Override `configureSession` to give the model writable memory that survives rest
 
 ```typescript
 export class MyAgent extends Think<Env> {
-  getModel(): LanguageModel {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+  getModel() {
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   configureSession(session: Session) {
@@ -240,7 +240,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 export class MyAgent extends Think<Env> {
-  getModel(): LanguageModel {
+  getModel() {
     /* ... */
   }
   configureSession(session: Session) {
@@ -287,7 +287,7 @@ import type {
 } from "@cloudflare/think";
 
 export class MyAgent extends Think<Env> {
-  getModel(): LanguageModel {
+  getModel() {
     /* ... */
   }
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -32,21 +32,23 @@ If you only need a chat-protocol adapter where you own the loop and the `Respons
 ### Install
 
 ```sh
-npm install @cloudflare/think agents ai @cloudflare/shell zod workers-ai-provider
+npm install @cloudflare/think agents ai @cloudflare/shell zod
 ```
+
+`workers-ai-provider` is bundled with Think, so the common case needs no extra provider package — `getModel()` can return a model id string.
 
 ### Server
 
 ```typescript
 import { Think } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 import { routeAgentRequest } from "agents";
 
 export class MyAgent extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+    // Resolved via Think's built-in workers-ai-provider off the `AI` binding.
+    // Use a "@cf/..." id for Workers AI, or a "provider/model" slug like
+    // "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 }
 
@@ -838,7 +840,8 @@ path.
 
 | Method / Property          | Default                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | -------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `getModel()`               | throws                           | Return the `LanguageModel` to use                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `getModel()`               | throws                           | Return a model id `string` (resolved via the bundled `workers-ai-provider` off `getAIBinding()` — a `@cf/...` id hits Workers AI, a `"provider/model"` slug routes through AI Gateway) or a `LanguageModel`                                                                                                                                                                                                                                                                                                                                                      |
+| `getAIBinding()`           | `this.env.AI`                    | Workers AI binding used to resolve string models from `getModel()`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `getSystemPrompt()`        | `"You are a helpful assistant."` | System prompt (fallback when no context blocks)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `getTools()`               | `{}`                             | AI SDK `ToolSet` for the agentic loop                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `getScheduledTasks()`      | `{}`                             | Code-declared recurring prompts or handlers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -1087,7 +1090,7 @@ export class MyAgent extends Think<Env> {
       fast: "@cf/moonshotai/kimi-k2.7-code",
       capable: "@cf/meta/llama-4-scout-17b-16e-instruct"
     };
-    return createWorkersAI({ binding: this.env.AI })(models[tier]);
+    return models[tier];
   }
 }
 ```

--- a/docs/think/lifecycle-hooks.md
+++ b/docs/think/lifecycle-hooks.md
@@ -81,7 +81,9 @@ export class MyAgent extends Think<Env> {
       .onCompaction(
         createCompactFunction({
           summarize: (prompt) =>
-            generateText({ model: this.getModel(), prompt }).then((r) => r.text)
+            generateText({ model: this.resolveModel(), prompt }).then(
+              (r) => r.text
+            )
         })
       )
       .compactAfter(100_000)
@@ -109,7 +111,7 @@ beforeTurn(ctx: TurnContext): TurnConfig | void | Promise<TurnConfig | void>
 | `system`       | `string`                  | Assembled system prompt (from context blocks or `getSystemPrompt()`)     |
 | `messages`     | `ModelMessage[]`          | Assembled model messages (truncated)                                     |
 | `tools`        | `ToolSet`                 | Merged tool set (workspace + getTools + session + MCP + client + caller) |
-| `model`        | `LanguageModel`           | The model from `getModel()`                                              |
+| `model`        | `LanguageModel`           | The resolved model (a string from `getModel()` is already resolved here) |
 | `continuation` | `boolean`                 | Whether this is a continuation turn (auto-continue after tool result)    |
 | `body`         | `Record<string, unknown>` | Custom body fields from the client request                               |
 
@@ -119,7 +121,7 @@ All fields are optional. Return only what you want to change.
 
 | Field                      | Type                                           | Description                                                                                                                                                                       |
 | -------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                    | `LanguageModel`                                | Override the model for this turn                                                                                                                                                  |
+| `model`                    | `ThinkModel`                                   | Override the model for this turn — a model id string or a `LanguageModel`                                                                                                         |
 | `system`                   | `string`                                       | Override the system prompt                                                                                                                                                        |
 | `messages`                 | `ModelMessage[]`                               | Override the assembled messages                                                                                                                                                   |
 | `tools`                    | `ToolSet`                                      | Extra tools to merge (additive)                                                                                                                                                   |
@@ -314,15 +316,15 @@ onStepFinish(step 1)
 
 `StepConfig<TOOLS>` is the AI SDK's `PrepareStepResult<TOOLS>`. Return only the fields to override for the current step.
 
-| Field                  | Type                                                   | Description                                                 |
-| ---------------------- | ------------------------------------------------------ | ----------------------------------------------------------- |
-| `model`                | `LanguageModel`                                        | Override the model for this step                            |
-| `toolChoice`           | `ToolChoice<TOOLS>`                                    | Force or disable tool calling for this step                 |
-| `activeTools`          | `Array<keyof TOOLS>`                                   | Limit which tools are available for this step               |
-| `system`               | `string \| SystemModelMessage \| SystemModelMessage[]` | Override the system message for this step                   |
-| `messages`             | `ModelMessage[]`                                       | Override the full message list for this step                |
-| `experimental_context` | `unknown`                                              | Override context passed to tool execution from this step on |
-| `providerOptions`      | `ProviderOptions`                                      | Provider-specific options for this step                     |
+| Field                  | Type                                                   | Description                                                               |
+| ---------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `model`                | `ThinkModel`                                           | Override the model for this step — a model id string or a `LanguageModel` |
+| `toolChoice`           | `ToolChoice<TOOLS>`                                    | Force or disable tool calling for this step                               |
+| `activeTools`          | `Array<keyof TOOLS>`                                   | Limit which tools are available for this step                             |
+| `system`               | `string \| SystemModelMessage \| SystemModelMessage[]` | Override the system message for this step                                 |
+| `messages`             | `ModelMessage[]`                                       | Override the full message list for this step                              |
+| `experimental_context` | `unknown`                                              | Override context passed to tool execution from this step on               |
+| `providerOptions`      | `ProviderOptions`                                      | Provider-specific options for this step                                   |
 
 ### Examples
 

--- a/examples/agent-skills/package.json
+++ b/examples/agent-skills/package.json
@@ -16,8 +16,7 @@
     "agents": "*",
     "ai": "^6.0.202",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "workers-ai-provider": "^3.2.1"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/examples/agent-skills/src/server.ts
+++ b/examples/agent-skills/src/server.ts
@@ -1,6 +1,5 @@
 import { callable, routeAgentRequest } from "agents";
 import { Think, skills } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 import bundledSkills from "agents:skills";
 
 type Env = {
@@ -11,10 +10,7 @@ type Env = {
 
 export class SkillsAgent extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      { sessionAffinity: this.sessionAffinity }
-    );
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   getSystemPrompt() {

--- a/examples/agents-as-tools/package.json
+++ b/examples/agents-as-tools/package.json
@@ -22,7 +22,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/examples/agents-as-tools/src/server.ts
+++ b/examples/agents-as-tools/src/server.ts
@@ -10,9 +10,8 @@
 import { callable, routeAgentRequest } from "agents";
 import { agentTool } from "agents/agent-tools";
 import { Think } from "@cloudflare/think";
-import type { LanguageModel, ToolSet } from "ai";
+import type { ToolSet } from "ai";
 import { tool } from "ai";
-import { createWorkersAI } from "workers-ai-provider";
 import { z } from "zod";
 
 type ResearchInput = { query: string };
@@ -31,11 +30,8 @@ function inputText(input: unknown): string {
 class DemoToolAgent extends Think<Env> {
   override chatRecovery = true;
 
-  override getModel(): LanguageModel {
-    const workersai = createWorkersAI({ binding: this.env.AI });
-    return workersai("@cf/moonshotai/kimi-k2.7-code", {
-      sessionAffinity: this.sessionAffinity
-    });
+  override getModel() {
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   formatAgentToolInput(input: unknown) {
@@ -176,11 +172,8 @@ export class Planner extends DemoToolAgent {
 export class Assistant extends Think<Env> {
   override maxConcurrentAgentTools = 4;
 
-  override getModel(): LanguageModel {
-    const workersai = createWorkersAI({ binding: this.env.AI });
-    return workersai("@cf/moonshotai/kimi-k2.7-code", {
-      sessionAffinity: this.sessionAffinity
-    });
+  override getModel() {
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt(): string {

--- a/examples/assistant/agents/assistant/agent.ts
+++ b/examples/assistant/agents/assistant/agent.ts
@@ -1,9 +1,7 @@
 import { callable } from "agents";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { createWorkersAI } from "workers-ai-provider";
 import { Think, Workspace } from "@cloudflare/think";
 import type { ThinkScheduledTasks } from "@cloudflare/think";
-import type { LanguageModel } from "ai";
 import type { FileInfo, WorkspaceChangeEvent } from "@cloudflare/shell";
 import { nanoid } from "nanoid";
 import { MyAssistant } from "./agents/my-assistant/agent";
@@ -34,11 +32,8 @@ export class AssistantDirectory extends Think<Env, DirectoryState> {
   // (see `getScheduledTasks`) and leaves room for top-level agentic work
   // later. `getModel()` is a stub for that future use — nothing in the
   // accumulator role calls it.
-  override getModel(): LanguageModel {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      { sessionAffinity: this.sessionAffinity }
-    );
+  override getModel() {
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   /**

--- a/examples/assistant/agents/assistant/agents/my-assistant/agent.ts
+++ b/examples/assistant/agents/assistant/agents/my-assistant/agent.ts
@@ -1,4 +1,3 @@
-import { createWorkersAI } from "workers-ai-provider";
 import { callable } from "agents";
 import {
   Think,
@@ -23,7 +22,7 @@ import type {
   StepContext
 } from "@cloudflare/think";
 import { tool, generateText } from "ai";
-import type { LanguageModel, ToolSet } from "ai";
+import type { ToolSet } from "ai";
 import { z } from "zod";
 import { AssistantDirectory } from "../../agent";
 import { SharedMCPClient } from "../../shared-mcp-client";
@@ -101,16 +100,13 @@ export class MyAssistant extends Think<Env> {
    */
   sharedMcp = new SharedMCPClient(() => this.parentAgent(AssistantDirectory));
 
-  getModel(): LanguageModel {
+  getModel() {
     const tier = this.getConfig<AgentConfig>()?.modelTier ?? "fast";
     const models: Record<string, string> = {
       fast: "@cf/moonshotai/kimi-k2.7-code",
       capable: "@cf/moonshotai/kimi-k2.7-code"
     };
-    return createWorkersAI({ binding: this.env.AI })(
-      models[tier] ?? models.fast,
-      { sessionAffinity: this.sessionAffinity }
-    );
+    return models[tier] ?? models.fast;
   }
 
   // Recover from a turn that overflows the context window mid-flight: compaction
@@ -169,7 +165,9 @@ When you learn something about the user or their project, save it to memory.`
       .onCompaction(
         createCompactFunction({
           summarize: (prompt) =>
-            generateText({ model: this.getModel(), prompt }).then((r) => r.text)
+            generateText({ model: this.resolveModel(), prompt }).then(
+              (r) => r.text
+            )
         })
       )
       .compactAfter(50000)

--- a/examples/assistant/package.json
+++ b/examples/assistant/package.json
@@ -23,7 +23,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/examples/browser-live-view/package.json
+++ b/examples/browser-live-view/package.json
@@ -18,8 +18,7 @@
     "ai": "^6.0.202",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1"
+    "streamdown": "^2.5.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/examples/browser-live-view/src/server.ts
+++ b/examples/browser-live-view/src/server.ts
@@ -6,7 +6,6 @@ import {
   DurableBrowserSessionStore,
   type BrowserLiveView
 } from "agents/browser";
-import { createWorkersAI } from "workers-ai-provider";
 import type { ToolSet } from "ai";
 
 // The execute tool runs sandboxed code on a durable codemode runtime that
@@ -25,9 +24,7 @@ const BROWSER_SESSION_KEY = "main";
 
 export class LiveViewAgent extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   getSystemPrompt() {

--- a/examples/chat-sdk-messenger/package.json
+++ b/examples/chat-sdk-messenger/package.json
@@ -20,8 +20,7 @@
     "ai": "^6.0.202",
     "chat": "^4.31.0",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "workers-ai-provider": "^3.2.1"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/examples/chat-sdk-messenger/src/intelligence/conversation-agent.ts
+++ b/examples/chat-sdk-messenger/src/intelligence/conversation-agent.ts
@@ -1,13 +1,9 @@
 import { Think } from "@cloudflare/think";
-import type { LanguageModel, ToolSet } from "ai";
-import { createWorkersAI } from "workers-ai-provider";
+import type { ToolSet } from "ai";
 
 export class ConversationAgent extends Think {
-  override getModel(): LanguageModel {
-    const workersai = createWorkersAI({ binding: this.env.AI });
-    return workersai("@cf/moonshotai/kimi-k2.7-code", {
-      sessionAffinity: this.sessionAffinity
-    });
+  override getModel() {
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt(): string {

--- a/examples/context-overflow-recovery/package.json
+++ b/examples/context-overflow-recovery/package.json
@@ -16,8 +16,7 @@
     "agents": "*",
     "ai": "^6.0.202",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "workers-ai-provider": "^3.2.1"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/examples/context-overflow-recovery/src/server.ts
+++ b/examples/context-overflow-recovery/src/server.ts
@@ -4,7 +4,6 @@ import {
   defaultContextOverflowClassifier,
   type Session
 } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 
 type Env = {
   AI: Ai;
@@ -48,10 +47,7 @@ export class ContextOverflowAgent extends Think<Env> {
   override classifyChatError = defaultContextOverflowClassifier;
 
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/meta/llama-3.1-8b-instruct",
-      { sessionAffinity: this.sessionAffinity }
-    );
+    return "@cf/meta/llama-3.1-8b-instruct";
   }
 
   getSystemPrompt() {

--- a/examples/playground/src/demos/ai/ThinkShellDemo.tsx
+++ b/examples/playground/src/demos/ai/ThinkShellDemo.tsx
@@ -82,13 +82,10 @@ const codeSections: CodeSection[] = [
     description:
       "Think is the high-level agent base class: chat protocol, persistence, stream resumption, client tools, workspace tools, and lifecycle hooks.",
     code: `import { Think } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 
 export class Assistant extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   getSystemPrompt() {

--- a/examples/sandbox-coding-agent/package.json
+++ b/examples/sandbox-coding-agent/package.json
@@ -21,7 +21,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/examples/sandbox-coding-agent/src/server.ts
+++ b/examples/sandbox-coding-agent/src/server.ts
@@ -18,8 +18,7 @@ import { getSandbox, Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 import { Think, type TurnConfig } from "@cloudflare/think";
 import { callable, routeAgentRequest } from "agents";
 import { agentTool } from "agents/agent-tools";
-import { tool, type LanguageModel, type ToolSet, type UIMessage } from "ai";
-import { createWorkersAI } from "workers-ai-provider";
+import { tool, type ToolSet, type UIMessage } from "ai";
 import { z } from "zod";
 import { runClaudeCode } from "./claude-code";
 import { snapshotDiff, type WorkspaceDiff } from "./diff";
@@ -181,11 +180,8 @@ export class CodingOrchestrator extends Think<Env> {
   // Cap how many containers run at once (also bounded by container max_instances).
   override maxConcurrentAgentTools = 3;
 
-  override getModel(): LanguageModel {
-    const workersai = createWorkersAI({ binding: this.env.AI });
-    return workersai("@cf/moonshotai/kimi-k2.7-code", {
-      sessionAffinity: this.sessionAffinity
-    });
+  override getModel() {
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt(): string {

--- a/examples/think-chat-sdk/package.json
+++ b/examples/think-chat-sdk/package.json
@@ -19,8 +19,7 @@
     "agents": "*",
     "ai": "^6.0.202",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "workers-ai-provider": "^3.2.1"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/examples/think-chat-sdk/src/index.ts
+++ b/examples/think-chat-sdk/src/index.ts
@@ -1,5 +1,4 @@
 import { getAgentByName, routeAgentRequest } from "agents";
-import { createWorkersAI } from "workers-ai-provider";
 import { Think } from "@cloudflare/think";
 import {
   ThinkMessengerStateAgent,
@@ -33,9 +32,7 @@ export type TelegramWebhookSetupResult = {
 
 export class SupportAgent extends Think<Env> {
   override getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt() {

--- a/examples/think-submissions/package.json
+++ b/examples/think-submissions/package.json
@@ -16,8 +16,7 @@
     "agents": "*",
     "ai": "^6.0.202",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "workers-ai-provider": "^3.2.1"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/examples/think-submissions/src/server.ts
+++ b/examples/think-submissions/src/server.ts
@@ -1,5 +1,4 @@
 import { callable, routeAgentRequest } from "agents";
-import { createWorkersAI } from "workers-ai-provider";
 import { Think } from "@cloudflare/think";
 import type {
   ThinkScheduledTasks,
@@ -14,9 +13,7 @@ type Env = {
 
 export class TaskAgent extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   getSystemPrompt() {

--- a/examples/think-workflows/package.json
+++ b/examples/think-workflows/package.json
@@ -13,7 +13,6 @@
     "@cloudflare/think": "*",
     "agents": "*",
     "ai": "^6.0.202",
-    "workers-ai-provider": "^3.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/examples/think-workflows/src/index.ts
+++ b/examples/think-workflows/src/index.ts
@@ -1,5 +1,4 @@
 import { getAgentByName, routeAgentRequest } from "agents";
-import { createWorkersAI } from "workers-ai-provider";
 import { z } from "zod";
 import { Think } from "@cloudflare/think";
 import { ThinkWorkflow } from "@cloudflare/think/workflows";
@@ -33,9 +32,7 @@ const reportDraftSchema = z.object({
 
 export class ReportAgent extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code"
-    );
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   getSystemPrompt() {

--- a/experimental/ops-approval-agent/package.json
+++ b/experimental/ops-approval-agent/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@cloudflare/think": "*",
     "agents": "*",
-    "ai": "^6.0.202",
-    "workers-ai-provider": "^3.2.1"
+    "ai": "^6.0.202"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260625.1",

--- a/experimental/ops-approval-agent/src/server.ts
+++ b/experimental/ops-approval-agent/src/server.ts
@@ -22,7 +22,6 @@
 import { getAgentByName, routeAgentRequest } from "agents";
 import { Think } from "@cloudflare/think";
 import { jsonSchema, tool, type ToolSet } from "ai";
-import { createWorkersAI } from "workers-ai-provider";
 import type { ThinkScheduledTasks } from "@cloudflare/think";
 
 type Env = {
@@ -60,7 +59,7 @@ export class OpsApprovalAgent extends Think<Env, OpsState> {
   }
 
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(MODEL_ID);
+    return MODEL_ID;
   }
 
   getSystemPrompt() {

--- a/experimental/session-skills/package.json
+++ b/experimental/session-skills/package.json
@@ -16,8 +16,7 @@
     "agents": "*",
     "ai": "^6.0.202",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "workers-ai-provider": "^3.2.1"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4",

--- a/experimental/session-skills/src/server.ts
+++ b/experimental/session-skills/src/server.ts
@@ -13,7 +13,6 @@ import { createCompactFunction } from "agents/experimental/memory/utils";
 import { generateText } from "ai";
 import type { Session } from "@cloudflare/think";
 import { Think } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 
 export interface Skill {
   key: string;
@@ -23,10 +22,7 @@ export interface Skill {
 
 export class SkillsAgent extends Think<Env> {
   getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      { sessionAffinity: this.sessionAffinity }
-    );
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   configureSession(session: Session) {
@@ -55,9 +51,7 @@ export class SkillsAgent extends Think<Env> {
         createCompactFunction({
           summarize: (prompt) =>
             generateText({
-              model: createWorkersAI({ binding: this.env.AI })(
-                "@cf/zai-org/glm-4.7-flash"
-              ),
+              model: this.resolveModel("@cf/zai-org/glm-4.7-flash"),
               prompt
             }).then((r) => r.text),
           tailTokenBudget: 150,

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -24,6 +24,8 @@
     "think": "dist/cli/index.js"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.83",
+    "@ai-sdk/openai": "^3.0.70",
     "@cloudflare/codemode": ">=0.4.0",
     "@cloudflare/shell": ">=0.4.0",
     "aywson": "^0.0.16",
@@ -31,11 +33,10 @@
     "create-think": "workspace:*",
     "just-bash": "^3.0.2",
     "smol-toml": "^1.7.0",
+    "workers-ai-provider": "^3.2.1",
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^3.0.83",
-    "@ai-sdk/openai": "^3.0.70",
     "@ai-sdk/react": "^3.0.204",
     "@chat-adapter/telegram": "^4.31.0",
     "@cloudflare/ai-chat": "workspace:*",

--- a/packages/think/src/cli/init.ts
+++ b/packages/think/src/cli/init.ts
@@ -341,9 +341,12 @@ const FRAMEWORK_DEPENDENCIES: Record<string, string> = {
 // `think-starters/basic/package.json`). This avoids fresh projects pulling an
 // untested major (e.g. a new `vite`/`ai`/`wrangler`). Kept in sync with the
 // starter by a test in `src/cli-tests/cli.test.ts`.
+// `workers-ai-provider` is intentionally NOT listed here: `@cloudflare/think`
+// depends on it directly and resolves string models through it, so scaffolded
+// projects get it transitively. Add it explicitly only if you import
+// `createWorkersAI` yourself.
 export const THIRD_PARTY_DEPENDENCIES: Record<string, string> = {
-  ai: "^6.0.202",
-  "workers-ai-provider": "^3.2.1"
+  ai: "^6.0.202"
 };
 
 export const THIRD_PARTY_DEV_DEPENDENCIES: Record<string, string> = {
@@ -405,7 +408,6 @@ function viteConfig(routePrefix: string | undefined): string {
 function agentSource(): string {
   return [
     `import { Think, skills } from "@cloudflare/think";`,
-    `import { createWorkersAI } from "workers-ai-provider";`,
     `import bundledSkills from "agents:skills";`,
     "",
     "type Env = Cloudflare.Env & {",
@@ -415,10 +417,10 @@ function agentSource(): string {
     "",
     "export class Assistant extends Think<Env> {",
     "  override getModel() {",
-    "    return createWorkersAI({ binding: this.env.AI })(",
-    '      "@cf/moonshotai/kimi-k2.7-code",',
-    "      { sessionAffinity: this.sessionAffinity }",
-    "    );",
+    "    // Resolved via the built-in workers-ai-provider off env.AI. Use a",
+    '    // "@cf/..." id for Workers AI, or a "provider/model" slug like',
+    '    // "openai/gpt-5.5" to route through AI Gateway.',
+    '    return "@cf/moonshotai/kimi-k2.7-code";',
     "  }",
     "",
     "  override getSystemPrompt() {",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -10,7 +10,8 @@
  * multi-session support.
  *
  * Configuration overrides:
- *   - getModel()            — return the LanguageModel to use
+ *   - getModel()            — return a model id string (resolved via the
+ *                             built-in workers-ai-provider) or a LanguageModel
  *   - getSystemPrompt()     — return the system prompt (fallback when no context blocks)
  *   - getTools()            — return the ToolSet for the agentic loop
  *   - maxSteps              — max tool-call rounds per turn (default: 10)
@@ -44,11 +45,13 @@
  * @example
  * ```typescript
  * import { Think } from "@cloudflare/think";
- * import { createWorkersAI } from "workers-ai-provider";
  *
  * export class MyAgent extends Think<Env> {
  *   getModel() {
- *     return createWorkersAI({ binding: this.env.AI })("@cf/moonshotai/kimi-k2.7-code");
+ *     // A string is resolved via the built-in workers-ai-provider off env.AI.
+ *     // Use a "@cf/..." id for Workers AI, or a "provider/model" slug like
+ *     // "openai/gpt-5.5" to route through AI Gateway.
+ *     return "@cf/moonshotai/kimi-k2.7-code";
  *   }
  *
  *   getSystemPrompt() {
@@ -105,6 +108,9 @@ import {
   streamText,
   tool
 } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+import { anthropic } from "workers-ai-provider/anthropic";
+import { openai } from "workers-ai-provider/openai";
 import * as skills from "agents/skills";
 import { SkillRegistry } from "agents/skills";
 import type { SkillScriptRunner, SkillSource } from "agents/skills";
@@ -1905,8 +1911,12 @@ export interface TurnContext {
  * All fields are optional — return only what you want to change.
  */
 export interface TurnConfig {
-  /** Override the model for this turn (e.g. cheap model for continuations). */
-  model?: LanguageModel;
+  /**
+   * Override the model for this turn (e.g. cheap model for continuations).
+   * Accepts a model id string (resolved via the built-in provider, same rules
+   * as {@link Think.getModel}) or a `LanguageModel`.
+   */
+  model?: ThinkModel;
   /** Override the assembled system prompt. */
   system?: string;
   /** Override the assembled messages. */
@@ -2172,9 +2182,17 @@ export type PrepareStepContext<TOOLS extends ToolSet = ToolSet> = Parameters<
  * return only the fields you want to override (`model`, `toolChoice`,
  * `activeTools`, `system`, `messages`, `experimental_context`,
  * `providerOptions`).
+ *
+ * `model` is widened to {@link ThinkModel}: like {@link Think.getModel}, you
+ * can return a model id string (resolved via the built-in provider) instead of
+ * a `LanguageModel`. Think resolves it before handing the step to the AI SDK.
  */
-export type StepConfig<TOOLS extends ToolSet = ToolSet> =
-  PrepareStepResult<TOOLS>;
+export type StepConfig<TOOLS extends ToolSet = ToolSet> = Omit<
+  PrepareStepResult<TOOLS>,
+  "model"
+> & {
+  model?: ThinkModel;
+};
 
 /**
  * Context passed to the `beforeToolCall` hook **before** the tool's
@@ -2388,6 +2406,39 @@ type ToolDecisionOptions = {
  *
  * @experimental The API surface may change before stabilizing.
  */
+/**
+ * Keys of the global `AiModels` interface (from `@cloudflare/workers-types`)
+ * whose model type extends `T`. Mirrors the derivation `workers-ai-provider`
+ * uses, so the set stays in sync with the installed workers-types version.
+ */
+type WorkersAIModelIdsExtending<T> = {
+  [K in keyof AiModels]: AiModels[K] extends T ? K : never;
+}[keyof AiModels];
+
+/**
+ * A model id accepted by {@link Think.getModel}.
+ *
+ * Provides editor autocomplete for the Workers AI text-generation catalog
+ * (`@cf/...`) while still accepting **any** string — including
+ * `"<provider>/<model>"` AI Gateway slugs like `"openai/gpt-5.5"`, whose
+ * validity is only known at runtime (the catalog is server-side and changes
+ * independently of these types). The `(string & {})` arm is what keeps
+ * arbitrary strings assignable without collapsing the autocomplete union.
+ */
+export type ThinkModelId =
+  | Exclude<
+      WorkersAIModelIdsExtending<BaseAiTextGeneration>,
+      WorkersAIModelIdsExtending<BaseAiTextToImage>
+    >
+  | (string & {});
+
+/**
+ * What {@link Think.getModel} may return: either a fully-constructed AI SDK
+ * `LanguageModel`, or a {@link ThinkModelId} string resolved through Think's
+ * built-in `workers-ai-provider`. Also the input type of {@link Think.resolveModel}.
+ */
+export type ThinkModel = LanguageModel | ThinkModelId;
+
 export class Think<
   Env extends Cloudflare.Env = Cloudflare.Env,
   State = unknown,
@@ -3622,11 +3673,100 @@ export class Think<
   // ── Configuration overrides ─────────────────────────────────────
 
   /**
-   * Return the language model to use for inference.
-   * Must be overridden by subclasses.
+   * Return the model to use for inference. Must be overridden by subclasses.
+   *
+   * The return value can be either:
+   *
+   * - A **string** model id, resolved through the built-in
+   *   {@link https://www.npmjs.com/package/workers-ai-provider | workers-ai-provider}
+   *   off your `AI` binding (see {@link getAIBinding}). A `@cf/...` id hits
+   *   Workers AI directly; any other `"<provider>/<model>"` slug — e.g.
+   *   `"openai/gpt-5.5"`, `"anthropic/claude-sonnet-4-5"`, `"google/gemini-2.5-pro"`
+   *   — is routed through AI Gateway with resumable streaming on by default.
+   *   This is the common case: no extra package to install, no provider to wire.
+   * - A fully-constructed AI SDK `LanguageModel`, for any other provider or for
+   *   full control over provider/gateway options.
+   *
+   * @example String (Workers AI)
+   * ```typescript
+   * getModel() {
+   *   return "@cf/moonshotai/kimi-k2.7-code";
+   * }
+   * ```
+   *
+   * @example String (third-party via AI Gateway)
+   * ```typescript
+   * getModel() {
+   *   return "openai/gpt-5.5";
+   * }
+   * ```
+   *
+   * @example Bring your own provider
+   * ```typescript
+   * import { createOpenAI } from "@ai-sdk/openai";
+   * getModel() {
+   *   return createOpenAI({ apiKey: this.env.OPENAI_API_KEY })("gpt-5.5");
+   * }
+   * ```
    */
-  getModel(): LanguageModel {
-    throw new Error("Override getModel() to return a LanguageModel.");
+  getModel(): ThinkModel {
+    throw new Error(
+      "Override getModel() to return a model id string (e.g. " +
+        '"@cf/moonshotai/kimi-k2.7-code" or "openai/gpt-5.5") or a LanguageModel.'
+    );
+  }
+
+  /**
+   * Return the Workers AI binding used by the built-in default provider when
+   * {@link getModel} returns a string. Defaults to `this.env.AI`. Override if
+   * your binding is named something other than `AI`.
+   */
+  getAIBinding(): Ai {
+    const binding = (this.env as { AI?: Ai }).AI;
+    if (!binding) {
+      throw new Error(
+        "Think's default model provider needs a Workers AI binding named " +
+          '"AI". Add `"ai": { "binding": "AI" }` to wrangler.jsonc, override ' +
+          "getAIBinding() to return your binding, or override getModel() to " +
+          "return a LanguageModel."
+      );
+    }
+    return binding;
+  }
+
+  /**
+   * Lazily-constructed, instance-cached default provider. Bundles the `openai`
+   * and `anthropic` wire-format plugins so a `"<provider>/<model>"` slug routes
+   * through AI Gateway out of the box (covers OpenAI, Anthropic, Google,
+   * xAI/Grok, Groq, and the OpenAI-compatible long tail).
+   *
+   * Cached per instance, which assumes {@link getAIBinding} is stable for the
+   * lifetime of the agent (the default `this.env.AI` always is).
+   */
+  private _defaultProvider?: ReturnType<typeof createWorkersAI>;
+
+  /**
+   * Resolve a model value into a concrete AI SDK `LanguageModel`.
+   *
+   * Defaults to resolving {@link getModel}. A `LanguageModel` is returned as-is;
+   * a string is built through the bundled default provider (see {@link getModel}
+   * for the slug rules). Use this whenever you need a usable model outside the
+   * main turn — e.g. a side `generateText` call for summarization/compaction —
+   * since `getModel()` may return a bare string.
+   */
+  resolveModel(model: ThinkModel = this.getModel()): LanguageModel {
+    if (typeof model !== "string") return model;
+    this._defaultProvider ??= createWorkersAI({
+      binding: this.getAIBinding(),
+      providers: [openai, anthropic]
+    });
+    // `@cf/...` ids take Workers AI chat settings (sessionAffinity improves
+    // prefix-cache hits). Any other slug is a catalog model routed through AI
+    // Gateway; we pass no per-call settings, which avoids forcing options a
+    // given provider/transport would reject.
+    return model.startsWith("@cf/")
+      ? this._defaultProvider(model, { sessionAffinity: this.sessionAffinity })
+      : this._defaultProvider(model);
   }
 
   /**
@@ -5023,7 +5163,7 @@ export class Think<
       );
     }
 
-    const model = this.getModel();
+    const model = this.resolveModel();
     const ctx: TurnContext = {
       system,
       messages,
@@ -5045,7 +5185,8 @@ export class Think<
       : undefined;
     const wantsStructuredOutput = structuredOutputSchema !== undefined;
 
-    const finalModel = config.model ?? model;
+    const finalModel =
+      config.model != null ? this.resolveModel(config.model) : model;
     const finalSystem =
       config.system ??
       this._systemPromptForTurn(
@@ -5223,21 +5364,29 @@ export class Think<
         // force the model to call `final_answer` so the turn always terminates
         // with a schema-shaped result instead of running out of steps. Respect a
         // `toolChoice` the subclass already set for this step.
-        if (
+        const stepResult =
           wantsStructuredOutput &&
           event.stepNumber >= finalMaxSteps - 1 &&
           (withMessages as { toolChoice?: unknown }).toolChoice === undefined
-        ) {
+            ? {
+                ...withMessages,
+                toolChoice: {
+                  type: "tool" as const,
+                  toolName: finalAnswerToolName
+                },
+                activeTools: [finalAnswerToolName]
+              }
+            : withMessages;
+        // `beforeStep` may return a string `model` (StepConfig widens it to
+        // ThinkModel); the AI SDK needs a concrete LanguageModel, so resolve it.
+        const stepModel = (stepResult as { model?: ThinkModel }).model;
+        if (typeof stepModel === "string") {
           return {
-            ...withMessages,
-            toolChoice: {
-              type: "tool" as const,
-              toolName: finalAnswerToolName
-            },
-            activeTools: [finalAnswerToolName]
-          };
+            ...stepResult,
+            model: this.resolveModel(stepModel)
+          } as PrepareStepResult<ToolSet>;
         }
-        return withMessages;
+        return stepResult as PrepareStepResult<ToolSet>;
       }) satisfies PrepareStepFunction<ToolSet>,
       onChunk: async (event) => {
         // Pass the AI SDK's chunk event through unchanged — gives users

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -308,9 +305,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -466,9 +460,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -597,9 +588,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -722,9 +710,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -1058,9 +1043,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -2183,9 +2165,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2378,9 +2357,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -2488,9 +2464,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -2589,9 +2562,6 @@ importers:
       ai:
         specifier: ^6.0.202
         version: 6.0.208(zod@4.4.3)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3395,9 +3365,6 @@ importers:
       ai:
         specifier: ^6.0.202
         version: 6.0.208(zod@4.4.3)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260625.1
@@ -3596,9 +3563,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
@@ -3923,6 +3887,12 @@ importers:
 
   packages/think:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.83
+        version: 3.0.85(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^3.0.70
+        version: 3.0.74(zod@4.4.3)
       '@cloudflare/codemode':
         specifier: '>=0.4.0'
         version: link:../codemode
@@ -3944,16 +3914,13 @@ importers:
       smol-toml:
         specifier: ^1.7.0
         version: 1.7.0
+      workers-ai-provider:
+        specifier: ^3.2.1
+        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
     devDependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^3.0.83
-        version: 3.0.85(zod@4.4.3)
-      '@ai-sdk/openai':
-        specifier: ^3.0.70
-        version: 3.0.74(zod@4.4.3)
       '@ai-sdk/react':
         specifier: ^3.0.204
         version: 3.0.210(react@19.2.7)(zod@4.4.3)
@@ -4179,9 +4146,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -4252,9 +4216,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4328,9 +4289,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -4401,9 +4359,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4477,9 +4432,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.42.3
@@ -4550,9 +4502,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      workers-ai-provider:
-        specifier: ^3.2.1
-        version: 3.2.1(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@3.0.83(zod@4.4.3))(@ai-sdk/openai@3.0.74(zod@4.4.3))(@ai-sdk/provider@3.0.10)(ai@6.0.208(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/think-starters/basic/agents/assistant/agent.ts
+++ b/think-starters/basic/agents/assistant/agent.ts
@@ -1,5 +1,4 @@
 import { Think } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 
 type Env = Cloudflare.Env & {
   AI: Ai;
@@ -14,12 +13,10 @@ type Env = Cloudflare.Env & {
  */
 export class Assistant extends Think<Env> {
   override getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      {
-        sessionAffinity: this.sessionAffinity
-      }
-    );
+    // Resolved via the built-in workers-ai-provider off env.AI. Use a
+    // "@cf/..." id for Workers AI, or a "provider/model" slug like
+    // "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt() {

--- a/think-starters/basic/package.json
+++ b/think-starters/basic/package.json
@@ -26,8 +26,7 @@
     "ai": "^6.0.202",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1"
+    "streamdown": "^2.5.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/think-starters/business-workflow/agents/operations/agent.ts
+++ b/think-starters/business-workflow/agents/operations/agent.ts
@@ -1,6 +1,5 @@
 import { Think } from "@cloudflare/think";
 import type { ThinkScheduledTasks } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 import { tool } from "ai";
 import { z } from "zod";
 
@@ -21,12 +20,10 @@ type Env = Cloudflare.Env & {
  */
 export class Operations extends Think<Env> {
   override getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      {
-        sessionAffinity: this.sessionAffinity
-      }
-    );
+    // Resolved via the built-in workers-ai-provider off env.AI. Use a
+    // "@cf/..." id for Workers AI, or a "provider/model" slug like
+    // "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt() {

--- a/think-starters/business-workflow/package.json
+++ b/think-starters/business-workflow/package.json
@@ -27,7 +27,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/think-starters/coding-agent/agents/coder/agent.ts
+++ b/think-starters/coding-agent/agents/coder/agent.ts
@@ -1,6 +1,5 @@
 import { Think, skills } from "@cloudflare/think";
 import { createExecuteTool } from "@cloudflare/think/tools/execute";
-import { createWorkersAI } from "workers-ai-provider";
 import bundledSkills from "agents:skills";
 
 type Env = Cloudflare.Env & {
@@ -19,12 +18,10 @@ type Env = Cloudflare.Env & {
  */
 export class Coder extends Think<Env> {
   override getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      {
-        sessionAffinity: this.sessionAffinity
-      }
-    );
+    // Resolved via the built-in workers-ai-provider off env.AI. Use a
+    // "@cf/..." id for Workers AI, or a "provider/model" slug like
+    // "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt() {

--- a/think-starters/coding-agent/package.json
+++ b/think-starters/coding-agent/package.json
@@ -26,8 +26,7 @@
     "ai": "^6.0.202",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1"
+    "streamdown": "^2.5.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/think-starters/customer-support/agents/support/agent.ts
+++ b/think-starters/customer-support/agents/support/agent.ts
@@ -1,5 +1,4 @@
 import { Think, skills } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 import bundledSkills from "agents:skills";
 import { tool } from "ai";
 import { z } from "zod";
@@ -19,12 +18,10 @@ type Env = Cloudflare.Env & {
  */
 export class Support extends Think<Env> {
   override getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      {
-        sessionAffinity: this.sessionAffinity
-      }
-    );
+    // Resolved via the built-in workers-ai-provider off env.AI. Use a
+    // "@cf/..." id for Workers AI, or a "provider/model" slug like
+    // "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override getSystemPrompt() {

--- a/think-starters/customer-support/package.json
+++ b/think-starters/customer-support/package.json
@@ -27,7 +27,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/think-starters/personal-assistant/agents/assistant/agent.ts
+++ b/think-starters/personal-assistant/agents/assistant/agent.ts
@@ -1,6 +1,5 @@
 import { Think } from "@cloudflare/think";
 import type { Session, ThinkScheduledTasks } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 
 type Env = Cloudflare.Env & {
   AI: Ai;
@@ -16,12 +15,10 @@ type Env = Cloudflare.Env & {
  */
 export class Assistant extends Think<Env> {
   override getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      {
-        sessionAffinity: this.sessionAffinity
-      }
-    );
+    // Resolved via the built-in workers-ai-provider off env.AI. Use a
+    // "@cf/..." id for Workers AI, or a "provider/model" slug like
+    // "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   override configureSession(session: Session) {

--- a/think-starters/personal-assistant/package.json
+++ b/think-starters/personal-assistant/package.json
@@ -26,8 +26,7 @@
     "ai": "^6.0.202",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1"
+    "streamdown": "^2.5.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.42.3",

--- a/think-starters/webhook-agent/agents/inbox/agent.ts
+++ b/think-starters/webhook-agent/agents/inbox/agent.ts
@@ -1,5 +1,4 @@
 import { Think } from "@cloudflare/think";
-import { createWorkersAI } from "workers-ai-provider";
 import { tool } from "ai";
 import { z } from "zod";
 
@@ -18,12 +17,10 @@ type Env = Cloudflare.Env & {
  */
 export class Inbox extends Think<Env> {
   override getModel() {
-    return createWorkersAI({ binding: this.env.AI })(
-      "@cf/moonshotai/kimi-k2.7-code",
-      {
-        sessionAffinity: this.sessionAffinity
-      }
-    );
+    // Resolved via the built-in workers-ai-provider off env.AI. Use a
+    // "@cf/..." id for Workers AI, or a "provider/model" slug like
+    // "openai/gpt-5.5" to route through AI Gateway.
+    return "@cf/moonshotai/kimi-k2.7-code";
   }
 
   /**

--- a/think-starters/webhook-agent/package.json
+++ b/think-starters/webhook-agent/package.json
@@ -27,7 +27,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "streamdown": "^2.5.0",
-    "workers-ai-provider": "^3.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Makes the common model-configuration case in `@cloudflare/think` zero-boilerplate. Instead of installing `workers-ai-provider`, importing `createWorkersAI`, and wiring it up in every agent, `getModel()` can now just return a **model id string**:

```typescript
export class MyAgent extends Think<Env> {
  getModel() {
    return "@cf/moonshotai/kimi-k2.7-code"; // or "openai/gpt-5.5"
  }
}
```

Think bundles `workers-ai-provider` (plus the `@ai-sdk/openai` / `@ai-sdk/anthropic` wire-format plugins) and resolves the string off your `AI` binding:

- `@cf/...` ids hit Workers AI directly, with `sessionAffinity` wired in automatically for prefix-cache hits.
- Any other `"<provider>/<model>"` slug (`openai/gpt-5.5`, `anthropic/claude-sonnet-4-5`, `google/gemini-2.5-pro`, `xai/grok-4`, `groq/...`) routes through AI Gateway.

Returning a fully-constructed `LanguageModel` from `getModel()` still works unchanged for full control over provider/gateway options.

## What's included

**Core (`packages/think`)**
- `getModel()` is typed to return `ThinkModel` — a newly exported alias for `LanguageModel | ThinkModelId`. `ThinkModelId` (also exported) gives editor autocomplete for the Workers AI text-generation catalog while still accepting any string (gateway slugs are validated server-side at runtime).
- New `getAIBinding()` override (default `this.env.AI`) controls which binding the string resolver uses.
- New public `resolveModel(model?)` (defaults to resolving `getModel()`) returns a concrete `LanguageModel`. Use it for side inference calls (summarization/compaction `generateText`) instead of passing a possibly-string `getModel()` straight to the AI SDK.
- Per-turn override `TurnConfig.model` (from `beforeTurn`) and per-step override `StepConfig.model` (from `beforeStep`) now accept `ThinkModel` too; string overrides are resolved before the step is handed to the AI SDK.
- `workers-ai-provider` + `@ai-sdk/openai` + `@ai-sdk/anthropic` are now direct dependencies of `@cloudflare/think`.

**Scaffolder + templates + docs**
- `think init` scaffolds a string-returning `getModel()`; `workers-ai-provider` removed from `THIRD_PARTY_DEPENDENCIES`.
- All starter templates and non-starter examples that used the `createWorkersAI(...)("@cf/...")` boilerplate now return strings, with `workers-ai-provider` dropped from their `package.json`.
- Docs (`getting-started`, `index`, `lifecycle-hooks`) updated to the string pattern.

Deliberately left using `createWorkersAI` directly: examples/experiments that exist to exercise low-level provider behavior (`deploy-churn` mock + BYOK recovery harness, `gateway-resume-think` capture/re-attach models, `wip/issue-1691-live` multi-provider switch, raw `Agent` + `generateText` session-* experiments).

> Note: `resume: true` is intentionally **not** set as a provider-level default — that capability hasn't rolled out to everyone yet. Users who want it can return a fully-constructed `LanguageModel` with their own `resume` setting.

## Test plan

- [x] `pnpm run check` (sherif + export checks + oxfmt + oxlint + typecheck, 114 projects) passes
- [x] `pnpm exec nx run think:test` (CLI + workers + react suites) passes
- [x] Type-level autocomplete works for `@cf/...` ids while arbitrary gateway slugs remain assignable
- [ ] Manual smoke: a scaffolded agent returning `"@cf/..."` and one returning `"openai/gpt-5.5"` both run a turn end-to-end

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->