### PR TITLE
fix(agent-tools): clone run parts so StrictMode doesn't double streamed text (#1835)

### DIFF
--- a/.changeset/fix-agent-tool-events-strictmode-double-text.md
+++ b/.changeset/fix-agent-tool-events-strictmode-double-text.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Fix `useAgentToolEvents` doubling streamed text in React StrictMode / SSR frameworks (#1835).
+
+The agent-tool-event reducer (`applyAgentToolEvent` → `applyToRun`) shallow-copied a run's `parts` array with `[...seeded.parts]` and then handed it to `applyChunkToParts`, which mutates part objects in place (e.g. `lastTextPart.text += delta`). Because the copied array still shared its element references with the previous state, those in-place mutations leaked back into `prev`. React double-invokes `setState` updaters in StrictMode and during dev hydration, so each `text-delta` chunk was applied twice against the same already-mutated `prev`, doubling every word. Affected Next.js, TanStack Start, Remix, and any `<React.StrictMode>` app. The reducer now clones each part before mutating, keeping it pure.

--- a/packages/agents/src/chat/__tests__/agent-tools.test.ts
+++ b/packages/agents/src/chat/__tests__/agent-tools.test.ts
@@ -82,6 +82,45 @@ describe("agent tool event reducer", () => {
     });
   });
 
+  it("is a pure reducer: replaying a text-delta chunk against the same prev does not double text (#1835)", () => {
+    let state = createAgentToolEventState();
+    state = applyAgentToolEvent(
+      state,
+      frame(0, {
+        kind: "started",
+        runId: "r",
+        agentType: "Researcher",
+        order: 0
+      })
+    );
+    state = applyAgentToolEvent(
+      state,
+      frame(1, {
+        kind: "chunk",
+        runId: "r",
+        body: JSON.stringify({ type: "text-delta", delta: "hello" })
+      })
+    );
+
+    const prev = state;
+    const deltaFrame = frame(2, {
+      kind: "chunk",
+      runId: "r",
+      body: JSON.stringify({ type: "text-delta", delta: " world" })
+    });
+
+    // React StrictMode / dev hydration double-invokes setState updaters with the
+    // SAME prev. A pure reducer must produce the same result both times and must
+    // never mutate prev — otherwise the second pass appends the delta twice.
+    const first = applyAgentToolEvent(prev, deltaFrame);
+    const second = applyAgentToolEvent(prev, deltaFrame);
+
+    expect(first.runsById.r.parts[0]).toMatchObject({ text: "hello world" });
+    expect(second.runsById.r.parts[0]).toMatchObject({ text: "hello world" });
+    // prev must be untouched by either invocation.
+    expect(prev.runsById.r.parts[0]).toMatchObject({ text: "hello" });
+  });
+
   it("projects a transient data-agent-progress chunk onto run.progress without persisting a part", () => {
     let state = createAgentToolEventState();
     state = applyAgentToolEvent(

--- a/packages/agents/src/chat/agent-tools.ts
+++ b/packages/agents/src/chat/agent-tools.ts
@@ -306,7 +306,15 @@ function applyToRun<Part extends AgentToolRunPart>(
       };
     case "chunk": {
       if (!seeded) return undefined;
-      const parts = [...seeded.parts];
+      // `applyChunkToParts` mutates part objects in place (e.g.
+      // `lastTextPart.text += delta`). A shallow array copy (`[...seeded.parts]`)
+      // keeps the *element* references shared with the previous state, so those
+      // in-place mutations leak back into `prev`. React double-invokes setState
+      // updaters in StrictMode / dev hydration, replaying each chunk against the
+      // same (already-mutated) `prev` and doubling the text (#1835). Clone each
+      // part so the reducer stays pure — every mutation here is to a top-level
+      // field, so a per-part shallow copy is sufficient.
+      const parts = seeded.parts.map((part) => ({ ...part }) as Part);
       let parsed: unknown;
       try {
         parsed = JSON.parse(event.body);


### PR DESCRIPTION
## Summary

Fixes #1835 — `useAgentToolEvents` doubles every word of streamed text in React StrictMode / SSR frameworks (Next.js, TanStack Start, Remix).

### Root cause

The agent-tool-event reducer is impure. In `applyToRun` (`packages/agents/src/chat/agent-tools.ts`), the `chunk` case did:

```ts
const parts = [...seeded.parts];
```

This is a **shallow array copy** — the new array's elements are the *same object references* as `prev.parts`. It then calls `applyChunkToParts`, which mutates part objects in place (e.g. `lastTextPart.text += delta`). So the mutation leaks back into the previous state object.

React double-invokes `setState` updaters in StrictMode and during dev hydration (`hydrateRoot`). Because `useAgentToolEvents` updates via `setState((prev) => applyAgentToolEvent(prev, message))`, each `text-delta` is applied **twice against the same, already-mutated `prev`** → doubled text.

### Fix

Clone each part before mutating, so the reducer stays pure:

```ts
const parts = seeded.parts.map((part) => ({ ...part }) as Part);
```

Every mutation in `applyChunkToParts` targets a top-level field of a part (`text`, `state`, `input`, `output`, `data`, …), so a per-part shallow copy is sufficient — no deep clone needed. This matches the one-line fix proposed in the issue, with a typed cast for the generic `Part`.

### Validity / accuracy of the report

Confirmed valid and accurate: the mechanism (shared references + in-place mutation + StrictMode double-invoke) is exactly as described, and the proposed fix resolves it.

## Test plan

- [x] Added a regression test in `packages/agents/src/chat/__tests__/agent-tools.test.ts` that replays a `text-delta` against the same `prev` twice (simulating StrictMode) and asserts the result is not doubled and `prev` is left untouched.
- [x] `vitest --project chat` — all 24 tests pass.
- [x] `oxlint` + `oxfmt --check` clean on edited files.
- [x] `tsc --noEmit` clean for the `agents` package.
- [x] Changeset added (`agents` patch).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->