### PR TITLE
fix(think): preserve attachment fetchMetadata through messenger serialization

### DIFF
--- a/.changeset/think-messenger-attachment-fetchmetadata.md
+++ b/.changeset/think-messenger-attachment-fetchmetadata.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/think": patch
+---
+
+Preserve attachment `fetchMetadata` through messenger event serialization so sub-agents can re-fetch files.
+
+When a conversation resolver routes a thread to a sub-agent Durable Object, the messenger event is run through `serializableMessengerEvent()` before crossing the DO boundary. That serialization previously dropped everything except `id`, `mediaType`, `name`, `size`, `text`, and `url` from each attachment — discarding `fetch`, `raw`, and (for adapters that store their platform identifier there) the only remaining handle on the file.
+
+For adapters like `@chat-adapter/telegram`, the file identifier lives exclusively in `fetchMetadata.fileId` and the top-level `id` is never populated, so photos became irretrievable inside a sub-agent (`attachment.id` and `attachment.fetch` were both missing).
+
+`MessengerAttachment` now carries a serialization-safe `fetchMetadata?: Record<string, string>` field that survives the sub-agent hop. `toMessengerAttachment()` copies `fetchMetadata` from the underlying Chat SDK attachment and backfills the top-level `id` from a known metadata key (`id`, `fileId`, `mediaId`, `fileUniqueId`) when the adapter doesn't set one. A downstream agent can use `fetchMetadata` together with the adapter's `rehydrateAttachment()` to reconstruct the download closure.

--- a/packages/think/src/messengers/chat-sdk.ts
+++ b/packages/think/src/messengers/chat-sdk.ts
@@ -740,6 +740,7 @@ export function toMessengerAuthor(author: ChatAuthor): MessengerAuthor {
 export function toMessengerAttachment(
   attachment: ChatAttachment
 ): MessengerAttachment {
+  const fetchMetadata = attachment.fetchMetadata;
   return {
     fetch: attachment.fetchData
       ? async () => {
@@ -754,12 +755,37 @@ export function toMessengerAttachment(
           return copy instanceof ArrayBuffer ? copy : new ArrayBuffer(0);
         }
       : undefined,
+    fetchMetadata: fetchMetadata ? { ...fetchMetadata } : undefined,
+    id: identifierFromFetchMetadata(fetchMetadata),
     mediaType: attachment.mimeType,
     name: attachment.name,
     raw: attachment,
     size: attachment.size,
     url: attachment.url
   };
+}
+
+const FETCH_METADATA_ID_KEYS = ["id", "fileId", "mediaId", "fileUniqueId"];
+
+/**
+ * Best-effort top-level id for an attachment whose adapter only records its
+ * identifier in `fetchMetadata` (e.g. Telegram `fileId`). This keeps id-based
+ * consumers working without per-adapter knowledge, while the full
+ * `fetchMetadata` is preserved verbatim for precise re-fetching.
+ */
+function identifierFromFetchMetadata(
+  fetchMetadata: Record<string, string> | undefined
+): string | undefined {
+  if (!fetchMetadata) {
+    return undefined;
+  }
+  for (const key of FETCH_METADATA_ID_KEYS) {
+    const value = fetchMetadata[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function stableNamePart(value: string): string {

--- a/packages/think/src/messengers/events.ts
+++ b/packages/think/src/messengers/events.ts
@@ -18,6 +18,14 @@ export interface MessengerAuthor {
 export interface MessengerAttachment {
   data?: ArrayBuffer;
   fetch?: () => Promise<ArrayBuffer>;
+  /**
+   * Platform-specific metadata needed to re-fetch the attachment after the
+   * event has been serialized (e.g. across a sub-agent Durable Object hop).
+   * Adapters store identifiers here — Telegram `fileId`, WhatsApp `mediaId`,
+   * etc. — that survive serialization even when `fetch`, `data`, and `raw`
+   * cannot, so a downstream agent can reconstruct the download closure.
+   */
+  fetchMetadata?: Record<string, string>;
   id?: string;
   mediaType?: string;
   name?: string;
@@ -114,6 +122,9 @@ export function serializableMessengerEvent(
     message: event.message
       ? {
           attachments: event.message.attachments.map((attachment) => ({
+            fetchMetadata: attachment.fetchMetadata
+              ? { ...attachment.fetchMetadata }
+              : undefined,
             id: attachment.id,
             mediaType: attachment.mediaType,
             name: attachment.name,

--- a/packages/think/src/tests/messengers.test.ts
+++ b/packages/think/src/tests/messengers.test.ts
@@ -26,6 +26,7 @@ import {
   TextStreamCallback,
   textDeltaFromStreamChunk,
   ThinkMessengerRuntime,
+  toMessengerAttachment,
   toMessengerUserMessage,
   type MessengerEvent,
   type MessengerThinkHost
@@ -349,6 +350,7 @@ describe("think messengers core", () => {
           {
             data: new ArrayBuffer(1),
             fetch: () => Promise.resolve(new ArrayBuffer(1)),
+            fetchMetadata: { fileId: "AgACAgIfileid" },
             mediaType: "text/plain",
             name: "notes.txt",
             raw: { providerFile: true },
@@ -372,7 +374,39 @@ describe("think messengers core", () => {
     expect(cloned.event.message.attachments[0].raw).toBeUndefined();
     expect(cloned.event.message.attachments[0].data).toBeUndefined();
     expect(cloned.event.message.attachments[0].fetch).toBeUndefined();
+    expect(cloned.event.message.attachments[0].fetchMetadata).toEqual({
+      fileId: "AgACAgIfileid"
+    });
     expect(cloned.thread._type).toBe("chat:Thread");
+  });
+
+  it("preserves attachment fetchMetadata and backfills id when converting", () => {
+    const attachment = toMessengerAttachment({
+      fetchData: () => Promise.resolve(Buffer.from("hello")),
+      fetchMetadata: { fileId: "AgACAgItelegram" },
+      mimeType: "image/jpeg",
+      name: "photo.jpg",
+      size: 1024,
+      type: "image",
+      url: "https://example.com/photo.jpg"
+    });
+
+    expect(attachment.fetchMetadata).toEqual({ fileId: "AgACAgItelegram" });
+    expect(attachment.id).toBe("AgACAgItelegram");
+    expect(attachment.raw).toBeDefined();
+  });
+
+  it("leaves attachment id undefined when fetchMetadata has no known id key", () => {
+    const attachment = toMessengerAttachment({
+      fetchMetadata: { region: "us-east" },
+      mimeType: "image/jpeg",
+      name: "photo.jpg",
+      type: "image",
+      url: "https://example.com/photo.jpg"
+    });
+
+    expect(attachment.fetchMetadata).toEqual({ region: "us-east" });
+    expect(attachment.id).toBeUndefined();
   });
 
   it("parses and classifies messenger recovery snapshots", () => {


### PR DESCRIPTION
## Summary

Fixes #1833.

When a conversation resolver routes a thread to a sub-agent Durable Object, the messenger event is run through `serializableMessengerEvent()` before crossing the DO boundary. That serialization dropped everything except `id`, `mediaType`, `name`, `size`, `text`, and `url` from each attachment — discarding `fetch`, `raw`, and the platform identifier.

For adapters like `@chat-adapter/telegram`, the file id lives exclusively in `fetchMetadata.fileId` and the top-level `id` is never populated, so photos became irretrievable inside a sub-agent (`attachment.id` and `attachment.fetch` were both missing).

This change:

- Adds a serialization-safe `fetchMetadata?: Record<string, string>` field to `MessengerAttachment`.
- Preserves `fetchMetadata` through `serializableMessengerEvent` (the exact spot identified in the issue), while still dropping the non-cloneable `fetch`/`raw`/`data`.
- Carries `fetchMetadata` through `toMessengerAttachment`, and backfills the top-level `id` from a known, adapter-agnostic metadata key (`id`/`fileId`/`mediaId`/`fileUniqueId`).

This implements both options the issue suggested (preserve `fetchMetadata` **and** backfill `id`), so a downstream sub-agent has the data needed to re-fetch via the adapter's `rehydrateAttachment()`.

## Test plan

- [x] Extended the serialization-snapshot test to assert `fetchMetadata` survives JSON round-tripping while `raw`/`fetch`/`data` are still stripped.
- [x] Added focused `toMessengerAttachment` tests: id backfill from `fetchMetadata.fileId`, and id staying `undefined` when no known id key is present.
- [x] `pnpm run check` (sherif + export checks + format + lint + typecheck, all 114 projects) passes.
- [x] `@cloudflare/think` test suite passes (894 unit/integration + generated/vite/cli/react).
- [x] Added a `@cloudflare/think` patch changeset.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->