### PR TITLE
fix: addMcpServer returns READY for a restored connection stuck AUTHENTICATING

### DIFF
--- a/.changeset/spotty-pandas-refuse.md
+++ b/.changeset/spotty-pandas-refuse.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+---
+
+fix: `addMcpServer` no longer reports `ready` for a restored connection that is still awaiting OAuth.
+
+A connection restored after a Durable Object wake (hibernation, eviction, redeploy) keeps its persisted `AUTHENTICATING` state, but the OAuth provider's in-memory `authUrl` was never rehydrated. The existing-connection early return in `addMcpServer` required that in-memory URL to report `authenticating`, so it fell through to `ready` — while `getMcpServers()` correctly reported `authenticating` for the same server. Callers driving OAuth off the return value stopped re-surfacing the sign-in link and the flow wedged silently.
+
+`addMcpServer` now falls back to the persisted `auth_url` for authenticating connections, so its return value matches `getMcpServers()`. If no auth URL exists in memory or storage, it re-runs the connect flow to mint a fresh one instead of reporting `ready`. Re-adding a known server also reuses its existing id on the HTTP path (as the RPC path already did) instead of generating a new one.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -12259,22 +12259,30 @@ export class Agent<
 
     if (existingServer && this.mcp.mcpConnections[existingServer.id]) {
       const conn = this.mcp.mcpConnections[existingServer.id];
-      if (
-        conn.connectionState === MCPConnectionState.AUTHENTICATING &&
-        conn.options.transport.authProvider?.authUrl
-      ) {
-        return {
-          id: existingServer.id,
-          state: MCPConnectionState.AUTHENTICATING,
-          authUrl: conn.options.transport.authProvider.authUrl
-        };
-      }
-      if (conn.connectionState === MCPConnectionState.FAILED) {
+      if (conn.connectionState === MCPConnectionState.AUTHENTICATING) {
+        // Prefer the in-memory authUrl from a live OAuth flow; fall back to
+        // the persisted auth_url for a connection restored after hibernation,
+        // where the provider's in-memory URL is lost.
+        const authUrl =
+          conn.options.transport.authProvider?.authUrl ??
+          existingServer.auth_url;
+        if (authUrl) {
+          return {
+            id: existingServer.id,
+            state: MCPConnectionState.AUTHENTICATING,
+            authUrl
+          };
+        }
+        // No auth URL in memory or storage: fall through to re-run the
+        // connect flow and mint a fresh one, rather than reporting READY
+        // for an unauthenticated server.
+      } else if (conn.connectionState === MCPConnectionState.FAILED) {
         throw new Error(
           `MCP server "${serverName}" is in failed state: ${conn.connectionError}`
         );
+      } else {
+        return { id: existingServer.id, state: MCPConnectionState.READY };
       }
-      return { id: existingServer.id, state: MCPConnectionState.READY };
     }
 
     // RPC transport path: second argument is a DurableObjectNamespace
@@ -12402,7 +12410,10 @@ export class Agent<
         : `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
     }
 
-    const id = requestedId ?? nanoid(8);
+    // Reuse the existing server's id (restore-through-addMcpServer, matching
+    // the RPC path above) before generating a new one, so re-adding a known
+    // server never orphans its storage row.
+    const id = requestedId ?? existingServer?.id ?? nanoid(8);
 
     // Only create authProvider if we have a callbackUrl (needed for OAuth servers)
     let authProvider:

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -204,6 +204,26 @@ export class TestOAuthAgent extends Agent {
     }
   }
 
+  // Wrapper because DurableObjectStub RPC typing doesn't preserve
+  // addMcpServer's overloaded return type through the boundary.
+  async testAddMcpServer(
+    serverName: string,
+    url: string
+  ): Promise<{ id: string; state: string; authUrl?: string }> {
+    const result = await this.addMcpServer(serverName, url, {
+      callbackHost: "http://example.com"
+    });
+    return {
+      id: result.id,
+      state: result.state,
+      authUrl: "authUrl" in result ? result.authUrl : undefined
+    };
+  }
+
+  testGetMcpServerState(serverId: string): string | undefined {
+    return this.getMcpServers().servers[serverId]?.state;
+  }
+
   getMcpServerFromDb(serverId: string) {
     const servers = this.sql<{
       id: string;

--- a/packages/agents/src/tests/mcp/oauth2-mcp-client.test.ts
+++ b/packages/agents/src/tests/mcp/oauth2-mcp-client.test.ts
@@ -80,6 +80,90 @@ describe("OAuth2 MCP Client - Hibernation", () => {
   });
 });
 
+describe("OAuth2 MCP Client - addMcpServer on restored connections", () => {
+  // Regression test for #1855: a connection restored from storage mid-OAuth
+  // has connectionState AUTHENTICATING but no in-memory authProvider.authUrl,
+  // and addMcpServer used to fall through to reporting READY for it.
+  it("returns authenticating with the persisted authUrl for a restored connection awaiting OAuth", async () => {
+    // Unique per attempt: connection restore runs once per DO instance, so a
+    // reused instance (e.g. on test retry) would skip it.
+    const agentName = `test-add-mcp-server-after-wake-${nanoid(8)}`;
+    const agentId = env.TestOAuthAgent.idFromName(agentName);
+    const agentStub = env.TestOAuthAgent.get(agentId);
+    const serverId = nanoid(8);
+    const serverUrl = "http://example.com/mcp";
+    const authUrl = "http://example.com/oauth/authorize";
+    const callbackUrl = `http://example.com/agents/test-o-auth-agent/${agentId.toString()}/callback`;
+
+    await agentStub.sql`
+      CREATE TABLE IF NOT EXISTS cf_agents_mcp_servers (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        server_url TEXT NOT NULL,
+        callback_url TEXT NOT NULL,
+        client_id TEXT,
+        auth_url TEXT,
+        server_options TEXT
+      )
+    `;
+
+    // A server left mid-OAuth: auth_url was persisted, consent never completed.
+    await agentStub.sql`
+      INSERT INTO cf_agents_mcp_servers (id, name, server_url, client_id, auth_url, callback_url, server_options)
+      VALUES (${serverId}, ${"test-oauth-server"}, ${serverUrl}, ${"test-client-id"}, ${authUrl}, ${callbackUrl}, ${null})
+    `;
+
+    // Wake the agent so the connection is restored from storage.
+    await agentStub.setName(agentName);
+
+    // The restored connection is in-memory and awaiting the OAuth callback.
+    expect(await agentStub.hasMcpConnection(serverId)).toBe(true);
+
+    const result = await agentStub.testAddMcpServer(
+      "test-oauth-server",
+      serverUrl
+    );
+
+    expect(result.id).toBe(serverId);
+    expect(result.state).toBe("authenticating");
+    expect(result.authUrl).toBe(authUrl);
+
+    // addMcpServer's return value and getMcpServers() must agree on the
+    // state of the same connection in the same tick.
+    expect(result.state).toBe(await agentStub.testGetMcpServerState(serverId));
+  });
+
+  it("prefers the live in-memory authUrl during an in-flight OAuth flow", async () => {
+    const agentId = env.TestOAuthAgent.newUniqueId();
+    const agentStub = env.TestOAuthAgent.get(agentId);
+    const serverId = nanoid(8);
+    const serverUrl = "http://example.com/mcp";
+    const callbackUrl = `http://example.com/agents/test-o-auth-agent/${agentId.toString()}/callback`;
+
+    await agentStub.setName("default");
+
+    // Live dance: in-memory authUrl is set on the connection's authProvider
+    // while the stored auth_url is still NULL.
+    await agentStub.setupMockMcpConnection(
+      serverId,
+      "live-oauth-server",
+      serverUrl,
+      callbackUrl,
+      "client-id"
+    );
+    await agentStub.setupMockOAuthState(serverId, "test-code", "test-state");
+
+    const result = await agentStub.testAddMcpServer(
+      "live-oauth-server",
+      serverUrl
+    );
+
+    expect(result.id).toBe(serverId);
+    expect(result.state).toBe("authenticating");
+    expect(result.authUrl).toBe("http://example.com/oauth/authorize");
+  });
+});
+
 describe("OAuth2 MCP Client - Callback Handling", () => {
   it("should process OAuth callback with valid connection", async () => {
     const agentId = env.TestOAuthAgent.newUniqueId();


### PR DESCRIPTION
Fixes #1855

## Problem

`addMcpServer()` returns `{ state: "ready" }` for an existing connection that is actually stuck in `AUTHENTICATING`, whenever that connection has no in-memory `authProvider.authUrl` — which is exactly the state after any Durable Object wake (hibernation / eviction / redeploy). A caller that drives OAuth off the return value believes the server is connected and never re-surfaces the sign-in link, so the flow wedges silently. Meanwhile `getMcpServers()` (which reads persisted state) reports `authenticating` for the same server in the same tick.

## Root cause

1. When a connection enters `AUTHENTICATING`, `connectToServer()` persists `auth_url` to the `cf_agents_mcp_servers` table.
2. On wake, `restoreConnectionsFromStorage()` sees the stored `auth_url`, recreates the connection, and sets `connectionState = AUTHENTICATING` — but the provider's in-memory `authUrl` is only ever assigned inside `redirectToAuthorization()` during a live authorize dance, so it comes back `undefined`.
3. `addMcpServer`'s existing-connection early return required `connectionState === AUTHENTICATING && authProvider?.authUrl` to report `authenticating`; the restored connection failed the second condition and fell through to `READY`.

## Fix

- For an existing connection in `AUTHENTICATING`, fall back to the persisted `auth_url` (already in scope from `listServers()`) when the in-memory URL is missing, so `addMcpServer`'s return value agrees with `getMcpServers()`.
- If no auth URL exists in memory **or** storage, fall through to re-run the connect flow and mint a fresh one — never report `READY` for a connection whose state is `AUTHENTICATING`. (`MCPClientConnection.init()` is explicitly re-enterable after a 401 → OAuth cycle, and if stored tokens turn out valid this self-heals to `READY` through the normal discover path.)
- Supporting change for that fall-through: the HTTP path now reuses the existing server's id (`requestedId ?? existingServer?.id ?? nanoid(8)`), matching what the RPC path already did, so re-adding a known server never orphans its storage row under a freshly generated id.

## Tests (TDD)

- `returns authenticating with the persisted authUrl for a restored connection awaiting OAuth` — reproduces the issue's exact scenario (persisted `auth_url` row → wake → duplicate `addMcpServer`); failed with `"ready"` before the fix. Also pins the invariant that `addMcpServer`'s return state agrees with `getMcpServers()` in the same tick.
- `prefers the live in-memory authUrl during an in-flight OAuth flow` — pins the existing fast path (in-memory URL wins over persisted state).

`packages/agents` workers suite: 1510 tests pass; repo `npm run check` (sherif, exports, oxfmt, oxlint, typecheck) green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->