### PR TITLE
feat(agent-think): GPT-5.5 with medium reasoning effort

### DIFF
--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -62,13 +62,14 @@ const CONTEXT_KEY = "agent-think-context";
 // this is the grace window for that ack, not a tuning knob.
 const RESET_ABORT_DELAY_MS = 100;
 const REPO_ROOT = "/workspace/repo";
-// Kimi K2.7 Code on Workers AI (bills via Workers AI, NOT Unified Billing —
-// switched back 2026-07-03 after unified-billing credits ran dry mid-run;
-// gpt-5.5 burned ~200k input tokens/call once tool outputs bloated the
-// thread). To go back: MODEL_ID = "openai/gpt-5.5" — the gateway delegate
-// plumbing (`providers: [openai]`) is already in place and inert for @cf/
-// models.
-const MODEL_ID = "@cf/moonshotai/kimi-k2.7-code";
+// GPT-5.5 (medium reasoning) through AI Gateway's model catalog — Unified
+// Billing over the AI binding, no provider key. `reasoning_effort` is a
+// first-class workers-ai-provider model setting forwarded into the request
+// (verified live: completion_tokens_details.reasoning_tokens > 0).
+// Fallback if unified-billing credits run dry (gateway 402s):
+// MODEL_ID = "@cf/moonshotai/kimi-k2.7-code" bills via Workers AI instead.
+const MODEL_ID = "openai/gpt-5.5";
+const REASONING_EFFORT = "medium";
 
 /** Per-issue run context, set by `dispatch` before the turn is submitted. */
 export interface RunContext {
@@ -386,7 +387,12 @@ export class ThinkAgent extends ThinkBase {
       binding: this.env.AI,
       gateway: { id: "default" },
       providers: [openai]
-    })(MODEL_ID);
+      // DelegateCallOptions' typing lags the runtime: the model reads
+      // settings.reasoning_effort and forwards it into the request (verified
+      // live — completion_tokens_details.reasoning_tokens > 0 at "medium").
+    })(MODEL_ID, {
+      reasoning_effort: REASONING_EFFORT
+    } as Parameters<ReturnType<typeof createWorkersAI>>[1]);
   }
 
   override async beforeTurn() {


### PR DESCRIPTION
Switches agent-think's model from the Kimi fallback back to `openai/gpt-5.5`, now with `reasoning_effort: "medium"` — a first-class workers-ai-provider model setting forwarded through the gateway delegate (the `DelegateCallOptions` typing lags that runtime, hence the narrow cast with a comment).

The Kimi fallback (`@cf/moonshotai/kimi-k2.7-code`, Workers AI billing) remains a one-line switch documented at the constant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->