### PR TITLE
fix(agent-think): keep workspace files in container

### DIFF
--- a/agent-think/AGENTS.md
+++ b/agent-think/AGENTS.md
@@ -40,8 +40,8 @@ agent-think  (this dir — PUBLIC-safe, holds no App creds)
    ├─ AgentThink WorkerEntrypoint.dispatch  (src/index.ts)
    │     getAgentByName(env.ThinkAgent, session) → setContext → start()
    │     start() ONLY submits the durable turn — returns in ~1s
-   ├─ ThinkAgent DO  (src/agent.ts) — owns the Workspace (SQLite VFS) + the turn
-   │     gh/git auth runs INSIDE the turn (beforeTurn → #ensureGitAuth);
+   ├─ ThinkAgent DO  (src/agent.ts) — owns durable turn state + Workspace transport
+   │     /workspace is authoritative in the container (backend sync is disabled);
    │     container backend dials the warm pool per-connect:
    │        resolveContainerId(env, id) → env.Sandbox.get(idFromName(uuid))
    ├─ Sandbox DO  (src/sandbox.ts)   — container host (wsd); handed out by pool
@@ -67,8 +67,8 @@ verbs on one issue reuse the same DO/workspace/thread, and `submitMessages`
 uses idempotency key `repo#issue`, so webhook redeliveries and repeat mentions
 join the existing turn instead of forking a second one.
 
-Skills are mounted read-only from R2 at `/workspace/.agents/skills`; the model
-picks the skill(s) matching the free-form instruction — there is no fixed verb.
+Skills use Think's native R2 SkillSource and activation tools, independent of
+the container's coding filesystem.
 
 ## Rules we hold ourselves to
 
@@ -88,13 +88,12 @@ picks the skill(s) matching the free-form instruction — there is no fixed verb
 - **No Cloudflare Workflow.** An earlier shape wrapped the turn in a Workflow;
   its 10-min step timeout + retry-from-scratch was the main death mode. Think's
   native durable `submitMessages` is the durability layer.
-- **Compute is decoupled from state** (Aron's hackspace pattern:
-  github.com/aron/cloudflare-workspaces-prototype, `hackspace` branch). The
-  Agent DO owns the Workspace; containers are separate warm-pooled Sandbox DOs.
-  When container behavior surprises you, diff against that prototype first.
-- **Everything real runs on the `container` backend** (the only one with a
-  toolchain + network). The `shell` backend is a just-bash isolate for cheap
-  text ops. The skills + system prompt enforce this split.
+- **The container owns `/workspace`.** Workspace's transport still connects the
+  ThinkAgent to its warm-pooled Sandbox, but `sync: "none"` prevents repo data,
+  `.git`, `node_modules`, builds, and logs from entering DO SQLite. The DO owns
+  only durable turn/recovery state. Skills use Think's native R2 source.
+- **Everything runs on the `container` backend.** It provides the real Linux
+  filesystem, toolchain, and network used by bash and the file tools.
 - **Repros must be clickable.** The reproduce skill mandates a minimal
   Vite + React page (exact 7-file recipe in the skill) so maintainers see the
   failing behavior without cloning anything.
@@ -145,13 +144,10 @@ picks the skill(s) matching the free-form instruction — there is no fixed verb
   in `run_worker_first`. Symptom: the UI's HTTP calls work while every
   `wss://` connect fails. (This bit us on the command center; the repro-skill
   recipe carries the same rule.)
-- **Unbounded bash output can kill a session irrecoverably.** Command output
-  streams through the DO; a chatty command (full monorepo `pnpm install`)
-  OOMed the isolate, and the persisted backlog then CPU-death-looped every
-  wake before recovery could run (see PLANS/agents/agent-think-1845-rca.md).
-  Skills + the bash tool description mandate redirect-to-file + tail for
-  noisy commands. Operator escape hatch: `AgentThink.resetSession(session)`
-  RPC wipes the session clean.
+- **Never re-enable container Workspace sync.** Pulling a monorepo install
+  (roughly 1.9 GB / 158k entries) into the ThinkAgent DO causes a memory-reset
+  loop on every container `/ws` reconnect. Noisy output must still be redirected
+  to `/workspace/temp` and tailed so tool results stay bounded.
 - **Deploys reset in-flight turns.** A deploy lazily resets every DO onto the
   new code; a running turn loses its container connection and burns minutes on
   Think's (working) recovery — it re-auths and resumes, but don't deploy while

--- a/agent-think/scripts/seed-skills.mjs
+++ b/agent-think/scripts/seed-skills.mjs
@@ -2,9 +2,8 @@
  * Seed the agent-think-skills R2 bucket from ./skills.
  *
  * Uploads every skills/<name>/SKILL.md to the bucket under the
- * `.agents/skills/<name>/SKILL.md` key, matching the mount prefix in
- * wrangler.jsonc (R2Bucket(env.R2_SKILLS, { prefix: ".agents/" }) →
- * /workspace/.agents). Run after editing a skill:
+ * `.agents/skills/<name>/SKILL.md` key consumed by Think's native
+ * `skills.r2(...)` source. Run after editing a skill:
  *
  *   npm run seed:r2            # remote bucket
  *   npm run seed:r2 -- --local # local (wrangler dev) bucket

--- a/agent-think/skills/open-pr/SKILL.md
+++ b/agent-think/skills/open-pr/SKILL.md
@@ -3,26 +3,33 @@ name: open-pr
 description: Take a cloudflare/agents GitHub issue plus any repro findings and one-shot a fix PR — branch, change, test, push, and open the PR linked to the issue.
 ---
 
-You are given `issueNumber`, `repo`, and `context` in the arguments. Produce a focused fix PR, authored as **yourself** — the agent-think GitHub App. Do not impersonate any user.
+The agent system prompt gives you `issueNumber`, `repo`, and the user's
+instruction. Use those values directly; there is no separate arguments object.
+Produce a focused fix PR, authored as **yourself** — the agent-think GitHub App.
+Do not impersonate any user.
 
-`context` is any free-form text the user typed after the `@agent-think pr`
-command (it may be empty). Treat it as a direct instruction — e.g. constraints
+The instruction is the free-form text the user typed after `@agent-think` (it
+may be empty). Treat it as a direct instruction — e.g. constraints
 on the fix, a preferred approach, or a pointer to the suspect area — and weight
 it highly, but stay within the scope of the issue.
 
 All `gh`, `git`, `npm`, `curl`, and `wrangler` commands must run on the
 `container` backend (`bash({ command, backend: "container" })`) — the `shell`
 backend has no real binaries or network. `gh` is already authenticated as the
-app; use it directly (no token handling). Work only under `/workspace` (the
-shared filesystem), except for temporary files in `/tmp`.
+app; use it directly (no token handling). Work under `/workspace`; use
+`/workspace/temp` for scratch files.
 
 ## 0. Clone the repo
 
-The workspace starts empty. Clone the target repo into `/workspace/repo`:
+Clone the target repo directly under `/workspace` using its repository name
+(`cloudflare/agents` → `/workspace/agents`):
 
 ```bash
-git clone https://github.com/<repo>.git /workspace/repo
-cd /workspace/repo
+REPO_DIR="/workspace/$(basename <repo>)"
+if [ ! -d "$REPO_DIR/.git" ]; then
+  git clone https://github.com/<repo>.git "$REPO_DIR"
+fi
+cd "$REPO_DIR"
 ```
 
 ## 1. Gather everything known
@@ -45,7 +52,7 @@ skipping it and what additional detail would help.
 
 ## 2. Locate the root cause
 
-With the repo cloned at `/workspace/repo`, read the relevant code in
+With the repo cloned at `$REPO_DIR`, read the relevant code in
 `packages/agents`, `packages/think`, etc. Confirm the hypothesis (or form your
 own) by reading the actual implementation. Identify the smallest change that
 fixes the reported behavior.
@@ -80,18 +87,19 @@ Install and run the affected package's checks (monorepo uses pnpm + Nx):
 # NOISY commands (installs, builds, test suites) MUST be redirected to a
 # container-local file and tailed — streaming megabytes of live output
 # through the session can kill it irrecoverably:
+mkdir -p /workspace/temp
 CI=1 pnpm install --frozen-lockfile --reporter=append-only \
-  > /tmp/install.log 2>&1 || (tail -40 /tmp/install.log; false)
-tail -20 /tmp/install.log
+  > /workspace/temp/install.log 2>&1 || (tail -40 /workspace/temp/install.log; false)
+tail -20 /workspace/temp/install.log
 # Prefer scoped/affected runs; fall back to package scripts.
 pnpm -w exec oxfmt --check . || pnpm -w exec oxfmt --write .
 pnpm -w exec oxlint . || true
 # Run the relevant package's typecheck + tests, redirected the same way:
-pnpm --filter <package> typecheck > /tmp/typecheck.log 2>&1; tail -30 /tmp/typecheck.log
-pnpm --filter <package> test > /tmp/test.log 2>&1; tail -40 /tmp/test.log
+pnpm --filter <package> typecheck > /workspace/temp/typecheck.log 2>&1; tail -30 /workspace/temp/typecheck.log
+pnpm --filter <package> test > /workspace/temp/test.log 2>&1; tail -40 /workspace/temp/test.log
 ```
 
-(`/tmp` is fine for temporary files that the container creates and consumes.)
+(`/workspace/temp` is container-local and never enters Agent DO storage.)
 
 Record whether tests passed in `testsPassed`. If you cannot make tests pass and
 the failure is your change's fault, fix it; if tests are unrelated/flaky, note
@@ -110,9 +118,9 @@ pnpm --filter <package> build
 ```
 
 2. Build a minimal demo app in `/workspace/demo-<issueNumber>` that exercises
-   the fixed path. Follow the **"Minimal frontend (required)"** recipe from the
-   reproduce skill (`/workspace/.agents/skills/reproduce/SKILL.md`) — same 7
-   files — but install the packed tarball so the demo runs YOUR fix:
+   the fixed path. Follow the activated reproduce skill's **"Minimal frontend
+   (required)"** recipe — same 7 files — but install the packed tarball so the
+   demo runs YOUR fix:
 
 ```bash
 npm install /workspace/<package>-x.y.z.tgz
@@ -148,10 +156,10 @@ gh pr create --repo <repo> \
   --base main \
   --head "$BRANCH" \
   --title "fix: <concise description> (#<issueNumber>)" \
-  --body-file /tmp/pr-body.md
+  --body-file /workspace/temp/pr-body.md
 ```
 
-Write the PR body outside the workspace at `/tmp/pr-body.md`. It must include:
+Write the PR body outside the checkout at `/workspace/temp/pr-body.md`. It must include:
 
 - `Closes #<issueNumber>` so the issue auto-links.
 - **What was wrong** (root cause, citing the file/line).

--- a/agent-think/skills/reproduce/SKILL.md
+++ b/agent-think/skills/reproduce/SKILL.md
@@ -3,10 +3,12 @@ name: reproduce
 description: Reproduce a cloudflare/agents GitHub issue by scaffolding a minimal Agents/Worker project and deploying it to a temporary Cloudflare account, then report findings back on the issue.
 ---
 
-You are given `issueNumber`, `repo`, and `context` in the arguments. Reproduce the bug end-to-end and post your findings as an issue comment.
+The agent system prompt gives you `issueNumber`, `repo`, and the user's
+instruction. Use those values directly; there is no separate arguments object.
+Reproduce the bug end-to-end and post your findings as an issue comment.
 
-`context` is any free-form text the user typed after the `@agent-think repro`
-command (it may be empty). Treat it as an extra hint from the triggering user
+The instruction is the free-form text the user typed after `@agent-think` (it
+may be empty). Treat it as an extra hint from the triggering user
 — e.g. additional reproduction steps, a specific version, or a pointer to the
 suspect area. Let it guide your reproduction, but the issue itself remains the
 source of truth.
@@ -18,10 +20,14 @@ app; use it directly (no token handling).
 
 ## 0. Clone the repo
 
-The workspace starts empty. Clone the target repo into `/workspace/repo` first:
+Clone the target repo directly under `/workspace` using its repository name
+(`cloudflare/agents` → `/workspace/agents`):
 
 ```bash
-git clone --depth=1 https://github.com/<repo>.git /workspace/repo
+REPO_DIR="/workspace/$(basename <repo>)"
+if [ ! -d "$REPO_DIR/.git" ]; then
+  git clone --depth=1 https://github.com/<repo>.git "$REPO_DIR"
+fi
 ```
 
 ## 1. Understand the issue
@@ -43,17 +49,16 @@ a short, polite comment saying the repro-agent skipped it and why.
 
 ## 2. Understand the relevant code
 
-With the repo cloned at `/workspace/repo`, read the relevant parts of
+With the repo cloned at `$REPO_DIR`, read the relevant parts of
 `packages/agents`, `packages/think`, or the matching `think-starters/` template
 to understand the area the issue touches. Match the user's versions where it
 matters.
 
 ## 3. Scaffold a minimal reproduction
 
-Work in a scratch dir **under `/workspace`**, never touch the checkout. Do NOT
-use `/tmp` or any path outside `/workspace`: only `/workspace` is the shared
-filesystem that both the container shell AND the `read`/`write`/`edit` tools
-see. Files written elsewhere are invisible to those tools.
+Work in a scratch dir under `/workspace`, never touch the checkout. The entire
+workspace is container-local; `/workspace/temp` is available for logs and other
+scratch files. The shell and `read`/`write`/`edit` tools see the same files.
 
 ```bash
 REPRO_DIR="/workspace/repro-<issueNumber>"
@@ -81,7 +86,7 @@ Every repro deploy MUST ship a minimal Vite + React page at the Worker's root UR
 **Steps**
 
 1. In `$REPRO_DIR`, create the 7 files below.
-2. `npm install > /tmp/install.log 2>&1; tail -15 /tmp/install.log` (pin `agents` to the exact version under test if the bug is version-specific). Always redirect noisy commands to a container-local file like this — streaming megabytes of live output through the session can kill it.
+2. `mkdir -p /workspace/temp && npm install > /workspace/temp/install.log 2>&1; tail -15 /workspace/temp/install.log` (pin `agents` to the exact version under test if the bug is version-specific). Always redirect noisy commands to a container-local file like this — streaming megabytes of live output through the session can kill it.
 3. Sanity-check the build before deploying: `npx vite build` (catches config errors cheaply; do NOT run `vite dev` — it blocks waiting for a browser).
 4. Deploy per the **Deploy** step below (`vite build` first is mandatory; the build writes `dist/` plus a `.wrangler/deploy/config.json` redirect that `wrangler deploy` follows).
 5. After deploy, confirm the root URL serves the page (the **Verify** step) and include the URL + click instructions in your report (the **Report back** step).
@@ -268,7 +273,7 @@ human should look at.
 Publish the repro project as an **orphan branch on the target repo** so anyone
 (human or agent) can pull exactly what you built and run it:
 
-Never do this inside `/workspace/repo` — the clone must stay intact for the
+Never do this inside `$REPO_DIR` — the clone must stay intact for the
 root-cause hypothesis and any follow-up PR work. Publish from a scratch dir:
 
 ```bash

--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -1,17 +1,9 @@
 /**
  * ThinkAgent — one Think Durable Object per GitHub issue.
  *
- * Owns a `@cloudflare/workspace.Workspace` with two backends behind a
- * single `shell.exec`:
- *
- *   - "container" (default) CloudflareContainerBackend — wsd over
- *                 capnweb. Full Linux with a real toolchain and
- *                 network: `gh` + `git` (authenticated as the app),
- *                 `npm`, `node`, `curl`, `jq`, `wrangler`. All GitHub,
- *                 network, and build/deploy work happens here.
- *   - "shell"     WorkerBackend — just-bash in a Dynamic Worker.
- *                 Cold-start fast, but NO real binaries and no public
- *                 network. Only cheap text tooling (cat/grep/sed/jq).
+ * Owns a `@cloudflare/workspace.Workspace` whose container backend has sync
+ * disabled. The container's /workspace is authoritative: repos, .git,
+ * node_modules, builds, logs, and scratch data never enter the ThinkAgent DO.
  *
  * gh-app calls `dispatch()` (see index.ts) with the issue
  * coordinates, a free-form `instruction` ("reproduce this", "open a
@@ -19,27 +11,24 @@
  * `setContext` stores it; `start` authenticates `gh`/`git` in the
  * container with the token, then runs one agent turn.
  *
- * Skills are mounted read-only from R2 at /workspace/.agents/skills;
- * both `reproduce` and `open-pr` ship in the bucket, and the model
- * picks the matching one(s) from the instruction — there is no fixed
- * verb.
+ * Skills use Think's native R2 SkillSource and activation tools, independent
+ * of the coding Workspace filesystem.
  */
 
 import type {
   ToolCallResultContext,
+  TurnContext,
   WorkspaceLike as ThinkWorkspaceLike
 } from "@cloudflare/think";
-import { Think } from "@cloudflare/think";
+import { skills, Think } from "@cloudflare/think";
 import {
   type DurableObjectStorageLike,
-  R2Bucket,
   Workspace,
   WorkspaceProxy,
   WorkspaceServiceProxy,
   type WorkspaceStub
 } from "@cloudflare/workspace";
 import { CloudflareContainerBackend } from "@cloudflare/workspace/backends/container";
-import { WorkerBackend } from "@cloudflare/workspace/backends/worker";
 import { type ToolSet } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
 import { openai } from "workers-ai-provider/openai";
@@ -48,11 +37,15 @@ import type { CommandCenterAgent } from "./command-center";
 import { releaseContainer, resolveContainerId } from "./pool";
 import { createBashTool } from "./tools/bash";
 import {
+  ContainerFileStore,
+  ContainerLocalBackend,
+  quote,
+  repoDirectory
+} from "./container-workspace";
+import {
   createEditTool,
   createReadTool,
-  createWriteTool,
-  type WorkspaceLike as FsWorkspaceLike,
-  WorkspaceFileStore
+  createWriteTool
 } from "./tools/fs/index";
 
 export { WorkspaceProxy, WorkspaceServiceProxy };
@@ -61,7 +54,6 @@ const CONTEXT_KEY = "agent-think-context";
 // resetSession aborts the isolate AFTER its RPC response has been delivered;
 // this is the grace window for that ack, not a tuning knob.
 const RESET_ABORT_DELAY_MS = 100;
-const REPO_ROOT = "/workspace/repo";
 // GPT-5.5 (medium reasoning) through AI Gateway's model catalog — Unified
 // Billing over the AI binding, no provider key. `reasoning_effort` is a
 // first-class workers-ai-provider model setting forwarded into the request
@@ -135,21 +127,7 @@ export class ThinkAgent extends ThinkBase {
     });
     this.#workspaceFs = new Workspace({
       storage: ctx.storage as unknown as DurableObjectStorageLike,
-      backends: [
-        new WorkerBackend({
-          id: "shell",
-          loader: env.LOADER,
-          workspace: workspaceRef,
-          ctx
-        }),
-        this.#containerBackend
-      ],
-      // Skills mounted read-only. R2 keys live under `.agents/`, e.g.
-      // `.agents/skills/reproduce/SKILL.md`; the prefix is stripped so
-      // the agent reads /workspace/.agents/skills/reproduce/SKILL.md.
-      mounts: {
-        "/workspace/.agents": R2Bucket(env.R2_SKILLS, { prefix: ".agents/" })
-      }
+      backends: [new ContainerLocalBackend(this.#containerBackend)]
     });
 
     this.workspace = adaptToThinkWorkspace(
@@ -254,9 +232,9 @@ export class ThinkAgent extends ThinkBase {
             {
               type: "text",
               text:
-                "Carry out the user's instruction for this issue now. Read the matching " +
-                "skill under /workspace/.agents/skills first and follow it end to end, " +
-                "then reply with the structured result that skill specifies."
+                "Carry out the user's instruction for this issue now. Activate the " +
+                "matching skill first and follow it end to end, then reply with the " +
+                "structured result that skill specifies."
             }
           ]
         }
@@ -328,8 +306,43 @@ export class ThinkAgent extends ThinkBase {
   }
 
   async gitDiff(): Promise<string> {
-    await this.#workspaceFs.ready();
-    return this.#workspaceFs.git.diff({ dir: REPO_ROOT });
+    const handle = await this.#workspaceFs.shell.exec(
+      `git -C ${quote(repoDirectory(this.#context?.repo))} diff --no-ext-diff`,
+      { encoding: "utf8", backend: "container" }
+    );
+    const result = await handle.result();
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout || "git diff failed");
+    }
+    return result.stdout;
+  }
+
+  /** Dev/e2e proof that container files are not pulled into the host DO VFS. */
+  async debugWorkspaceIsolation(): Promise<{
+    containerFileExists: boolean;
+    hostVfsContainsFile: boolean;
+  }> {
+    const path = `/workspace/temp/isolation-${crypto.randomUUID()}/node_modules/probe.txt`;
+    const handle = await this.#workspaceFs.shell.exec(
+      `mkdir -p ${quote(path.slice(0, path.lastIndexOf("/")))} && printf container-only > ${quote(path)}`,
+      { encoding: "utf8", backend: "container" }
+    );
+    const result = await handle.result();
+    if (result.exitCode !== 0) throw new Error(result.stderr || result.stdout);
+
+    const verify = await this.#workspaceFs.shell.exec(
+      `test -f ${quote(path)}`,
+      { encoding: "utf8", backend: "container" }
+    );
+    const containerFileExists = (await verify.result()).exitCode === 0;
+
+    let hostVfsContainsFile = true;
+    try {
+      await this.#workspaceFs.fs.stat(path);
+    } catch (error) {
+      hostVfsContainsFile = !isEnoent(error);
+    }
+    return { containerFileExists, hostVfsContainsFile };
   }
 
   /** Dev/e2e readback: the current message log for this session. */
@@ -395,7 +408,16 @@ export class ThinkAgent extends ThinkBase {
     } as Parameters<ReturnType<typeof createWorkersAI>>[1]);
   }
 
-  override async beforeTurn() {
+  override getSkills() {
+    return [
+      skills.r2(this.env.R2_SKILLS, {
+        prefix: ".agents/skills/",
+        refreshIntervalMs: 0
+      })
+    ];
+  }
+
+  override async beforeTurn(ctx: TurnContext) {
     // Container gh/git auth runs here — inside the durable turn — rather
     // than in start(), so dispatch stays fast and a slow container attach
     // can't be killed by the caller's cancellation (see start()).
@@ -407,8 +429,14 @@ export class ThinkAgent extends ThinkBase {
       // built-ins (list/find/grep/delete) unconditionally; this allowlist
       // makes the AI SDK drop their definitions from the provider request
       // entirely (~600 prompt tokens reclaimed per call). ls/grep/rm/find
-      // happen through `bash`.
-      activeTools: Object.keys(this.getTools())
+      // happen through `bash`. Keep Think's native skill activation tools when
+      // its R2 catalog is available.
+      activeTools: [
+        ...Object.keys(this.getTools()),
+        ...["activate_skill", "read_skill_resource"].filter(
+          (name) => name in ctx.tools
+        )
+      ]
     };
   }
 
@@ -490,66 +518,48 @@ export class ThinkAgent extends ThinkBase {
             ""
           ]
         : []),
-      "Two skills are available under /workspace/.agents/skills:",
-      "  - reproduce/SKILL.md — reproduce the issue in a minimal project,",
-      "    deploy it, verify the symptom, and report findings on the issue.",
-      "  - open-pr/SKILL.md   — locate the root cause, make the minimal fix,",
-      "    verify it, and open a PR that closes the issue.",
+      "Two skills are available through Think's skill catalog:",
+      "  - reproduce — reproduce and report an issue.",
+      "  - open-pr   — locate, fix, verify, and open a PR.",
       "",
-      "Decide from the instruction which skill(s) to follow (one, or reproduce",
-      "then open-pr if asked to fix what you repro). Read the matching SKILL.md",
-      "first and follow it exactly, including the structured result it specifies.",
+      "Decide which skill matches the instruction and activate it before acting.",
+      "Follow it exactly, including the structured result it specifies.",
       "",
       "Environment:",
-      `  - The repo should be worked on under ${REPO_ROOT}.`,
-      "  - `gh`, `git`, `curl`, `npm`, `node`, `wrangler` all live on the",
-      "    `container` backend, which is the only one with a real toolchain and",
-      "    network. `gh` and `git` are ALREADY AUTHENTICATED there as the app",
+      `  - Clone ${ctx?.repo ?? "the repo"} to ${repoDirectory(ctx?.repo)}.`,
+      "    Keep .git, node_modules, builds, and logs in their normal locations",
+      "    there. /workspace/temp is available for scratch data.",
+      "  - /workspace is container-local and is NEVER synchronized through the",
+      "    Agent Durable Object.",
+      "  - `gh`, `git`, `curl`, `npm`, `node`, and `wrangler` run in the",
+      "    container. `gh` and `git` are ALREADY AUTHENTICATED there as the app",
       "    (via `gh auth login` + `gh auth setup-git`). Do NOT print, echo, or",
       "    re-configure the token.",
-      "  - IMPORTANT: run every `gh`, `git`, `npm`, `curl`, and `wrangler`",
-      '    command on the `container` backend — bash({ command, backend: "container" }).',
-      "    The `shell` backend has none of them and no network; it is only for",
-      "    cat/grep/sed/jq-style text work.",
-      "  - The dedicated read/write/edit tools operate on the same workspace",
-      "    files the container sees, so prefer them for file I/O.",
+      "  - The dedicated read/write/edit tools operate on the same container",
+      "    filesystem, so prefer them for file content operations.",
       "",
       "When done, reply with the structured summary the skill specifies."
     ].join("\n");
   }
 
   override getTools(): ToolSet {
-    const ctx = this.#context;
-    if (!ctx) return {} as ToolSet;
-    const store = new WorkspaceFileStore(adaptToFsWorkspace(this.#workspaceFs));
-    const ws = this.#workspaceFs;
+    if (!this.#context) return {} as ToolSet;
+    const store = new ContainerFileStore(this.#workspaceFs.shell);
     return {
       read: createReadTool({ store, maxBytes: 32 * 1024, maxLines: 800 }),
       write: createWriteTool({ store }),
       edit: createEditTool({ store }),
       bash: createBashTool({
-        workspace: ws,
+        workspace: this.#workspaceFs,
         maxBytes: 32 * 1024,
         backends: {
-          shell: {
-            description:
-              "just-bash in a Dynamic Worker. Cold-start fast, no container, no " +
-              "public network, and NO real binaries. Only cat/grep/sed/awk/jq/" +
-              "find-style text tooling. It has NO `gh`, `git`, `npm`, `curl`, or " +
-              "`wrangler` — do not use it for those."
-          },
           container: {
             description:
               "Cloudflare Container (full Linux) with a real toolchain and public " +
-              "network: `gh` and `git` (already authenticated as the app), plus " +
-              "`npm`, `node`, `curl`, `jq`, `wrangler`. Use this for EVERYTHING " +
-              "that touches GitHub, the network, or a real binary — cloning, " +
-              "`gh issue`/`gh pr`, `npm install`, `wrangler deploy`, test runs."
+              "network. /workspace is container-local: .git, node_modules, build " +
+              "outputs, logs, and scratch data never enter the Agent DO."
           }
         },
-        // Default to the container: repro/pr work is almost entirely real
-        // toolchain + network, so the shell backend is the exception, not the
-        // rule. (It's still available for cheap text munging.)
         defaultBackend: "container"
       })
     };
@@ -557,10 +567,6 @@ export class ThinkAgent extends ThinkBase {
 }
 
 // ── Adapters (from examples/think) ─────────────────────────────────
-
-function adaptToFsWorkspace(ws: Workspace): FsWorkspaceLike {
-  return ws as unknown as FsWorkspaceLike;
-}
 
 function adaptToThinkWorkspace(ws: Workspace) {
   return {

--- a/agent-think/src/container-workspace.ts
+++ b/agent-think/src/container-workspace.ts
@@ -1,0 +1,191 @@
+import type { BackendHandle, WorkspaceBackend } from "@cloudflare/workspace";
+import type { FileStat, FileStore } from "./tools/fs/index";
+
+/**
+ * Preserve @cloudflare/workspace's container transport while disabling its
+ * automatic DO-VFS ↔ container-VFS push/pull bracket. The container's
+ * /workspace is authoritative.
+ */
+export class ContainerLocalBackend implements WorkspaceBackend {
+  readonly id: string;
+  readonly type = "container-local";
+
+  constructor(private readonly backend: WorkspaceBackend) {
+    this.id = backend.id;
+  }
+
+  async connect(): Promise<BackendHandle> {
+    const handle = await this.backend.connect();
+    handle.sync = "none";
+    return handle;
+  }
+}
+
+interface ContainerShell {
+  exec(
+    command: string,
+    options: { encoding: "utf8"; backend: string }
+  ): Promise<{
+    result(): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  }>;
+}
+
+const READ_CHUNK_BYTES = 64 * 1024;
+const WRITE_CHUNK_BYTES = 48 * 1024;
+
+/** FileStore backed entirely by the container's local /workspace filesystem. */
+export class ContainerFileStore implements FileStore {
+  constructor(private readonly shell: ContainerShell) {}
+
+  async stat(path: string): Promise<FileStat | null> {
+    const result = await this.run(
+      `if [ -f ${quote(path)} ]; then stat -c '%s\t%Y\t%f' -- ${quote(path)}; else exit 44; fi`,
+      [0, 44]
+    );
+    if (result.exitCode === 44) return null;
+
+    const [size, mtimeSeconds, modeHex] = result.stdout.trim().split("\t");
+    if (!size || !mtimeSeconds || !modeHex) {
+      throw new Error(`Unable to parse stat output for ${path}`);
+    }
+    return {
+      size: Number(size),
+      mtime: Number(mtimeSeconds) * 1000,
+      mode: Number.parseInt(modeHex, 16)
+    };
+  }
+
+  async readAll(path: string): Promise<Uint8Array | null> {
+    const stat = await this.stat(path);
+    if (!stat) return null;
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for await (const chunk of this.readChunks(path, 0, stat.size)) {
+      chunks.push(chunk);
+      total += chunk.byteLength;
+    }
+    return concat(chunks, total);
+  }
+
+  async *readChunks(
+    path: string,
+    byteOffset = 0,
+    byteLength?: number
+  ): AsyncIterable<Uint8Array> {
+    const stat = await this.stat(path);
+    if (!stat) throw enoent(path);
+
+    const end = Math.min(
+      stat.size,
+      byteLength === undefined ? stat.size : byteOffset + byteLength
+    );
+    for (let offset = byteOffset; offset < end; offset += READ_CHUNK_BYTES) {
+      const count = Math.min(READ_CHUNK_BYTES, end - offset);
+      const result = await this.run(
+        `dd if=${quote(path)} iflag=skip_bytes,count_bytes skip=${offset} count=${count} status=none | base64 -w0`
+      );
+      const bytes = decodeBase64(result.stdout.trim());
+      if (bytes.byteLength === 0) break;
+      yield bytes;
+    }
+  }
+
+  async write(
+    path: string,
+    content: Uint8Array,
+    opts?: { mode?: number }
+  ): Promise<void> {
+    const parent = parentDir(path);
+    const temp = `/workspace/temp/.agent-write-${crypto.randomUUID()}`;
+    let committed = false;
+    try {
+      await this.run(
+        `set -e; mkdir -p ${quote(parent)} /workspace/temp; : > ${quote(temp)}`
+      );
+      for (
+        let offset = 0;
+        offset < content.byteLength;
+        offset += WRITE_CHUNK_BYTES
+      ) {
+        const encoded = encodeBase64(
+          content.subarray(offset, offset + WRITE_CHUNK_BYTES)
+        );
+        await this.run(
+          `printf %s ${quote(encoded)} | base64 -d >> ${quote(temp)}`
+        );
+      }
+      const mode = (opts?.mode ?? 0o644) & 0o7777;
+      await this.run(
+        `set -e; chmod ${mode.toString(8)} ${quote(temp)}; mv -f ${quote(temp)} ${quote(path)}`
+      );
+      committed = true;
+    } finally {
+      if (!committed) {
+        await this.run(`rm -f ${quote(temp)}`, [0]).catch(() => {});
+      }
+    }
+  }
+
+  private async run(command: string, allowedExitCodes = [0]) {
+    const handle = await this.shell.exec(command, {
+      encoding: "utf8",
+      backend: "container"
+    });
+    const result = await handle.result();
+    if (!allowedExitCodes.includes(result.exitCode)) {
+      throw new Error(
+        `Container filesystem command failed (${result.exitCode}): ${result.stderr || result.stdout}`
+      );
+    }
+    return result;
+  }
+}
+
+export function repoDirectory(repo: string | undefined): string {
+  const name = repo?.split("/").filter(Boolean).at(-1) ?? "repo";
+  const safe = name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "repo";
+  return `/workspace/${safe}`;
+}
+
+export function quote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function parentDir(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index <= 0 ? "/workspace" : path.slice(0, index);
+}
+
+function enoent(path: string): Error & { code: string } {
+  return Object.assign(new Error(`ENOENT: no such file, open '${path}'`), {
+    code: "ENOENT"
+  });
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let offset = 0; offset < bytes.byteLength; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary);
+}
+
+function decodeBase64(value: string): Uint8Array {
+  if (!value) return new Uint8Array();
+  const binary = atob(value);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function concat(chunks: Uint8Array[], total: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0];
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}

--- a/agent-think/src/index.ts
+++ b/agent-think/src/index.ts
@@ -187,6 +187,16 @@ export default {
         );
         return Response.json(await agent.debugMessages());
       }
+      const isolation = url.pathname.match(
+        /^\/dev\/workspace-isolation\/([^/]+)$/
+      );
+      if (request.method === "GET" && isolation) {
+        const agent = await getAgentByName<Env, ThinkAgent>(
+          env.ThinkAgent,
+          decodeURIComponent(isolation[1])
+        );
+        return Response.json(await agent.debugWorkspaceIsolation());
+      }
     }
 
     // Read-only state snapshot for the command-center UI: instant hydration

--- a/agent-think/src/tools/bash.ts
+++ b/agent-think/src/tools/bash.ts
@@ -33,21 +33,24 @@ import { z } from "zod";
  * Minimal subset of `@cloudflare/workspace.Workspace` we depend on:
  * the shell facade exposes `exec(command, { cwd, encoding, backend })`
  * and the returned handle resolves to a `{ exitCode, stdout, stderr }`
- * result. `kill` is present on local handles (it is missing from the
- * cross-RPC stub flavor), so it is feature-detected before use.
+ * result. Command timeouts are enforced by Workspace/wsd via `timeoutMs`.
  */
 export interface BashWorkspaceLike {
   shell: {
     exec(
       command: string,
-      options: { cwd?: string; encoding: "utf8"; backend?: string }
+      options: {
+        cwd?: string;
+        encoding: "utf8";
+        backend?: string;
+        timeoutMs?: number;
+      }
     ): Promise<{
       result(): Promise<{
         exitCode: number;
         stdout: string;
         stderr: string;
       }>;
-      kill?(signal?: string): Promise<void>;
     }>;
   };
 }
@@ -81,8 +84,6 @@ export interface BashToolOptions {
   headBytes?: number;
 }
 
-const TIMED_OUT: unique symbol = Symbol("bash-timeout");
-
 const DEFAULT_MAX_BYTES = 32 * 1024; // per stream
 const DEFAULT_HEAD_BYTES = 4 * 1024;
 /** Exit code reported when `timeout` expires — GNU timeout(1) convention. */
@@ -110,7 +111,7 @@ export function createBashTool(opts: BashToolOptions) {
     "",
     "IMPORTANT: redirect NOISY commands (installs, builds, test",
     "suites) to a container-local file and tail it, e.g.:",
-    "  CI=1 pnpm install --reporter=append-only > /tmp/install.log 2>&1; tail -30 /tmp/install.log",
+    "  mkdir -p /workspace/temp; CI=1 pnpm install --reporter=append-only > /workspace/temp/install.log 2>&1; tail -30 /workspace/temp/install.log",
     "Streaming megabytes of live output through the session can",
     "kill it irrecoverably.",
     "",
@@ -160,7 +161,8 @@ export function createBashTool(opts: BashToolOptions) {
       const handle = await opts.workspace.shell.exec(command, {
         cwd,
         encoding: "utf8",
-        backend
+        backend,
+        ...(timeout !== undefined ? { timeoutMs: timeout * 1000 } : {})
       });
 
       const meta = {
@@ -169,40 +171,18 @@ export function createBashTool(opts: BashToolOptions) {
         backend: backend ?? opts.defaultBackend
       };
 
-      const result =
-        timeout === undefined
-          ? await handle.result()
-          : await Promise.race([
-              handle.result(),
-              sleep(timeout * 1000).then((): typeof TIMED_OUT => TIMED_OUT)
-            ]);
-
-      if (result === TIMED_OUT) {
-        // Best-effort: local handles expose kill; cross-RPC stubs may not,
-        // in which case the process can outlive the timeout.
-        await handle.kill?.("SIGTERM").catch(() => {});
-        return {
-          ...meta,
-          exitCode: TIMEOUT_EXIT_CODE,
-          timedOut: true,
-          stdout: "",
-          stderr: `command timed out after ${timeout}s (SIGTERM sent)`
-        };
-      }
+      const result = await handle.result();
 
       return {
         ...meta,
         exitCode: result.exitCode,
-        timedOut: false,
+        timedOut:
+          timeout !== undefined && result.exitCode === TIMEOUT_EXIT_CODE,
         stdout: truncate(result.stdout, maxBytes, headBytes),
         stderr: truncate(result.stderr, maxBytes, headBytes)
       };
     }
   });
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**

--- a/agent-think/test/bash.test.ts
+++ b/agent-think/test/bash.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createBashTool } from "../src/tools/bash";
+
+describe("bash tool", () => {
+  it("forwards the requested timeout to Workspace/wsd", async () => {
+    let received:
+      | {
+          cwd?: string;
+          encoding: "utf8";
+          backend?: string;
+          timeoutMs?: number;
+        }
+      | undefined;
+    const tool = createBashTool({
+      workspace: {
+        shell: {
+          async exec(_command, options) {
+            received = options;
+            return {
+              async result() {
+                return { exitCode: 0, stdout: "ok", stderr: "" };
+              }
+            };
+          }
+        }
+      },
+      backends: { container: { description: "test" } },
+      defaultBackend: "container"
+    });
+
+    await tool.execute!(
+      { command: "pnpm install", timeout: 1200 },
+      undefined as never
+    );
+
+    expect(received).toMatchObject({
+      encoding: "utf8",
+      timeoutMs: 1_200_000
+    });
+  });
+});

--- a/agent-think/test/container-workspace.test.ts
+++ b/agent-think/test/container-workspace.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import type { BackendHandle, WorkspaceBackend } from "@cloudflare/workspace";
+import {
+  ContainerLocalBackend,
+  repoDirectory
+} from "../src/container-workspace";
+
+describe("container-local workspace", () => {
+  it("disables Workspace push/pull sync", async () => {
+    const handle = {
+      rpc: {},
+      sync: "remote",
+      close: async () => {}
+    } as unknown as BackendHandle;
+    const backend: WorkspaceBackend = {
+      id: "container",
+      type: "test",
+      connect: async () => handle
+    };
+
+    expect(await new ContainerLocalBackend(backend).connect()).toBe(handle);
+    expect(handle.sync).toBe("none");
+  });
+
+  it("uses the repository name directly under /workspace", () => {
+    expect(repoDirectory("cloudflare/agents")).toBe("/workspace/agents");
+    expect(repoDirectory("owner/my repo")).toBe("/workspace/my-repo");
+  });
+});

--- a/agent-think/tests-e2e/flow.test.ts
+++ b/agent-think/tests-e2e/flow.test.ts
@@ -49,6 +49,17 @@ function turnProgressed(messages: DebugMessage[]): boolean {
 }
 
 describe("E2E: agent-think dispatch → durable turn", () => {
+  it("keeps /workspace container-local instead of syncing it to the DO VFS", async () => {
+    const isolation = await fetch(
+      `${BASE_URL}/dev/workspace-isolation/${crypto.randomUUID()}`
+    );
+    expect(isolation.status).toBe(200);
+    expect(await isolation.json()).toEqual({
+      containerFileExists: true,
+      hostVfsContainsFile: false
+    });
+  }, 120_000);
+
   it("comes up, dispatches a real run, and the turn progresses", async () => {
     // 1. Worker up.
     const health = await fetch(`${BASE_URL}/`);
@@ -62,9 +73,9 @@ describe("E2E: agent-think dispatch → durable turn", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         repo: "cloudflare/agents",
-        issueNumber: 1854,
+        issueNumber: 1859,
         instruction:
-          "just clone the repo into /workspace/repo and run ls — do not deploy or comment",
+          "just clone the repo into /workspace/agents and run ls — do not deploy or comment",
         // Optional: a real GH token lets the clone succeed. Absent, the clone
         // may fail — but the turn should still visibly progress (tool calls /
         // assistant text), which is what we assert on.

--- a/agent-think/tests-e2e/vitest.config.ts
+++ b/agent-think/tests-e2e/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 /**
@@ -9,10 +10,12 @@ import { defineConfig } from "vitest/config";
  * Slow (~30s+ boot for cold docker, then minutes for a real model turn). Kept
  * separate from the default vitest run so `npm test` stays fast.
  */
+const testDir = import.meta.dirname;
+
 export default defineConfig({
   test: {
-    include: ["**/*.test.ts"],
-    globalSetup: "./setup.ts",
+    include: [path.join(testDir, "**/*.test.ts")],
+    globalSetup: path.join(testDir, "setup.ts"),
     testTimeout: 60_000,
     hookTimeout: 240_000,
     pool: "forks"


### PR DESCRIPTION
## Summary

Keep agent-think's coding filesystem entirely inside its Cloudflare Container:

- mark the existing `CloudflareContainerBackend` handle `sync: "none"`, so Workspace no longer pushes/pulls `/workspace` through the ThinkAgent DO VFS
- route `read`, `write`, `edit`, `bash`, and `gitDiff` to the container-local filesystem
- use Think's existing `skills.r2(...)` implementation instead of mounting skills into `/workspace`
- clone repos at `/workspace/<repo-name>` and use `/workspace/temp` for scratch data
- forward bash `timeout` to Workspace/wsd's native `timeoutMs` instead of maintaining a second outer timer

## Why

A full Agents monorepo install creates roughly 1.9 GB / 158k filesystem entries. Pulling that back into the ThinkAgent's SQLite VFS caused repeated 128 MB Durable Object memory-limit resets. The model transcript was only ~214 KB; filesystem synchronization was the poison.

Long commands also hit wsd's default ~300-second timeout because agent-think accepted a bash timeout but did not forward it to Workspace.

## Validation

- agent-think typecheck passed
- agent-think unit suite passed (7 tests)
- lint and formatting passed
- Wrangler Worker/container dry run passed
- real-container E2E passed: a `node_modules`-shaped file existed in `/workspace` inside the container and was absent from the host DO VFS
- production smoke: cloned `/workspace/agents` and materialized 1.4 GB of `node_modules` with zero Durable Object memory-limit resets
- production timeout regression: a single command slept 330 seconds under `timeout=420` and returned `exitCode: 0`, `timedOut: false`, `elapsed=330`

Deployed version: `27f55e17-e48d-41e4-a968-89e5b923f2cf`.

## Scope guard

Every changed path is under `agent-think/`. This PR changes no SDK package or other repository path.
