### PR TITLE
chore(agent-think): remove unused gitDiff RPC

### DIFF
--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -305,18 +305,6 @@ export class ThinkAgent extends ThinkBase {
     this.#log("git-auth-exit", { exitCode: result.exitCode });
   }
 
-  async gitDiff(): Promise<string> {
-    const handle = await this.#workspaceFs.shell.exec(
-      `git -C ${quote(repoDirectory(this.#context?.repo))} diff --no-ext-diff`,
-      { encoding: "utf8", backend: "container" }
-    );
-    const result = await handle.result();
-    if (result.exitCode !== 0) {
-      throw new Error(result.stderr || result.stdout || "git diff failed");
-    }
-    return result.stdout;
-  }
-
   /** Dev/e2e proof that container files are not pulled into the host DO VFS. */
   async debugWorkspaceIsolation(): Promise<{
     containerFileExists: boolean;


### PR DESCRIPTION
## Summary

Remove the unused `ThinkAgent.gitDiff()` RPC method.

It had no callers, route, or operator surface; agent-think's skills inspect changes with `git diff` through the bash tool instead.

## Validation

- agent-think typecheck passed
- agent-think unit tests passed (7 tests)
- lint and formatting passed

All changed paths are under `agent-think/`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->