### PR TITLE
refactor(agents): extract state subsystem into agent/state.ts

### DIFF
--- a/packages/agents/src/agent/state.ts
+++ b/packages/agents/src/agent/state.ts
@@ -1,0 +1,760 @@
+/**
+ * Agent state subsystem.
+ *
+ * "State" is a single JSON-serializable value owned by one Agent instance
+ * (one Durable Object). It is read with `agent.state` and replaced wholesale
+ * with `agent.setState(next)` — there are no partial updates.
+ *
+ * What makes it more than a plain field is that it is durable and live:
+ * - Durable: persisted as one row in the `cf_agents_state` SQLite table and
+ *   lazily rehydrated into an in-memory cache on the first read of a cold
+ *   isolate, so it survives hibernation and reconnects.
+ * - Live: `setState` (from the server or from a connected client) persists the
+ *   value and broadcasts it over WebSocket so the server and every connected
+ *   client stay in agreement, with the browser `useAgent` hook re-rendering on
+ *   each change.
+ *
+ * Use it for the small, canonical snapshot clients should watch update in real
+ * time (session/task status, progress, collaborative counters). For large or
+ * relational data (message history, logs) use the agent's raw SQL instead;
+ * `state` is loaded and rewritten whole and broadcast on every change, so keep
+ * it small.
+ *
+ * This module owns that behaviour (`AgentState`), the connection-state flag
+ * machinery (readonly / no-protocol), and the state-change hook dispatch. The
+ * `Agent` class holds an `AgentState` instance and delegates to it; see
+ * `AgentStateApi` for the curated, public-ready subset.
+ */
+import type { AgentEmail } from "../internal_context";
+import { __DO_NOT_USE_WILL_BREAK__agentContext as agentContext } from "../internal_context";
+import { MessageType } from "../types";
+import type { Connection } from "partyserver";
+
+// Row id for the agent's user-visible state in cf_agents_state.
+// A separate SCHEMA_VERSION_ROW_ID row in the same table tracks migrations.
+const STATE_ROW_ID = "cf_state_row_id";
+
+/**
+ * Sentinel used as the initial value of the in-memory state cache.
+ * Comparing against this object (by reference) is how we detect that state
+ * has never been set in this isolate and needs to be loaded from SQLite.
+ *
+ * Exported so Agent can initialise its own `initialState` field to the same
+ * sentinel and so the strangler-pattern `_state` bridge accessor can read it.
+ */
+export const DEFAULT_STATE = {} as unknown;
+
+/**
+ * Internal key used to store the readonly flag in connection state.
+ * Prefixed with _cf_ to avoid collision with user state keys.
+ */
+const CF_READONLY_KEY = "_cf_readonly";
+
+/**
+ * Internal key used to store the no-protocol flag in connection state.
+ * When set, protocol messages (identity, state sync, MCP servers) are not
+ * sent to this connection — neither on connect nor via broadcasts.
+ */
+const CF_NO_PROTOCOL_KEY = "_cf_no_protocol";
+
+/**
+ * Internal key used to store voice call state in connection state.
+ * Used by the voice mixin to track whether a connection is in an active call.
+ */
+const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
+
+/**
+ * Internal key used to remember the outer `/sub/...` URL for a
+ * WebSocket accepted by the parent on behalf of a child facet.
+ * Hibernated events then wake the parent, which forwards frames to
+ * the child over serializable RPC while keeping native WebSocket I/O
+ * parent-owned.
+ */
+const CF_SUB_AGENT_OUTER_URL_KEY = "_cf_subAgentOuterUrl";
+const CF_SUB_AGENT_TAGS_KEY = "_cf_subAgentTags";
+
+/**
+ * The set of all internal keys stored in connection state that must be
+ * hidden from user code and preserved across setState calls.
+ */
+const CF_INTERNAL_KEYS: ReadonlySet<string> = new Set([
+  CF_READONLY_KEY,
+  CF_NO_PROTOCOL_KEY,
+  CF_VOICE_IN_CALL_KEY,
+  CF_SUB_AGENT_OUTER_URL_KEY,
+  CF_SUB_AGENT_TAGS_KEY
+]);
+
+// ── Connection-state key helpers ──────────────────────────────────────────────
+
+type StateSource = Connection | "server";
+
+/** Raw getter/setter pair captured from a connection before we override it. */
+type RawConnectionStateAccessors = {
+  getRaw: () => Record<string, unknown> | null;
+  setRaw: (state: unknown) => unknown;
+};
+
+/** Check if a raw connection state object contains any internal keys. */
+function rawHasInternalKeys(raw: Record<string, unknown>): boolean {
+  for (const key of Object.keys(raw)) {
+    if (CF_INTERNAL_KEYS.has(key)) return true;
+  }
+  return false;
+}
+
+/** Return a copy of `raw` with all internal keys removed, or null if no user keys remain. */
+function stripInternalKeys(
+  raw: Record<string, unknown>
+): Record<string, unknown> | null {
+  const result: Record<string, unknown> = {};
+  let hasUserKeys = false;
+  for (const key of Object.keys(raw)) {
+    if (!CF_INTERNAL_KEYS.has(key)) {
+      result[key] = raw[key];
+      hasUserKeys = true;
+    }
+  }
+  return hasUserKeys ? result : null;
+}
+
+/** Return a copy containing only the internal keys present in `raw`. */
+function extractInternalFlags(
+  raw: Record<string, unknown>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(raw)) {
+    if (CF_INTERNAL_KEYS.has(key)) {
+      result[key] = raw[key];
+    }
+  }
+  return result;
+}
+
+// ── AgentStateHost ────────────────────────────────────────────────────────────
+
+/**
+ * Which state-change notification hook to invoke after a state change is
+ * persisted and broadcast.
+ *
+ * The "persistence hook" is the user-overridable callback an Agent subclass can
+ * define to react to state changes: `onStateChanged(state, source)` (current
+ * name) or `onStateUpdate(state, source)` (the deprecated alias, kept for
+ * backwards compatibility). It runs after the new state has already been
+ * written to SQLite and broadcast to clients, so it is a notification, not a
+ * gate — throwing from it cannot undo the change (contrast `validateStateChange`,
+ * which runs before and can reject).
+ *
+ * Rather than walk the prototype chain on every `setState` to discover whether
+ * a subclass overrode either hook, the Agent constructor resolves this once and
+ * stores the result. The dispatch on the hot path is then a single switch:
+ *
+ * - "new"  → the subclass overrode `onStateChanged`; call it.
+ * - "old"  → the subclass overrode only the deprecated `onStateUpdate`; call it.
+ * - "none" → neither hook is overridden; skip the call entirely.
+ */
+export type StatePersistenceHookMode = "new" | "old" | "none";
+
+/**
+ * Narrow interface that `AgentState` uses to call back into `Agent`.
+ * Keeping this small avoids coupling state logic to the full Agent class.
+ */
+export type AgentStateHost<State> = {
+  /** The agent instance — used to restore agentContext when running hooks. */
+  agent: unknown;
+  ctx: DurableObjectState;
+  /** The user-declared initial state, or DEFAULT_STATE if none was provided. */
+  initialState: State;
+  sql<T = Record<string, string | number | boolean | null>>(
+    strings: TemplateStringsArray,
+    ...values: (string | number | boolean | null)[]
+  ): T[];
+  getConnections(): Iterable<Connection>;
+  broadcast(message: string, without?: string[]): void;
+  validateStateChange(nextState: State, source: StateSource): void;
+  onStateChanged(state: State | undefined, source: StateSource): unknown;
+  onStateUpdate(state: State | undefined, source: StateSource): unknown;
+  onError(error: unknown): unknown;
+  _emit(type: "state:update", payload?: Record<string, unknown>): void;
+};
+
+// ── AgentStateApi (public-ready surface) ──────────────────────────────────────
+
+/**
+ * The curated, user-facing subset of `AgentState`.
+ *
+ * `AgentState` implements this interface. Everything not listed here
+ * (persistence-hook wiring, the ungated `setInternal` write path,
+ * protocol-broadcast internals, connection wrapping, and the `unsafe*` flag
+ * accessors) is framework plumbing and deliberately excluded.
+ *
+ * This type is not part of the package's published API yet. It exists so that
+ * a future major version can expose the state subsystem as `agent.stateOps`
+ * typed as `AgentStateApi<State>` — dropping the thin `state` / `setState`
+ * wrappers from the `Agent` class — without leaking the internal methods that
+ * currently live on the same object.
+ */
+export interface AgentStateApi<State> {
+  /**
+   * The current agent state. Lazily loaded from SQLite on first access within
+   * a cold isolate; falls back to the declared `initialState` when unset.
+   */
+  readonly state: State;
+
+  /**
+   * Update the agent state. Persists to SQLite, broadcasts to connected
+   * clients, and fires the state-change hook.
+   *
+   * @throws Error if called from a readonly connection context.
+   */
+  setState(state: State): void;
+
+  /** Mark a connection as readonly or readwrite (default: readonly). */
+  setConnectionReadonly(connection: Connection, readonly?: boolean): void;
+
+  /** Whether a connection is marked readonly. */
+  isConnectionReadonly(connection: Connection): boolean;
+
+  /**
+   * Whether a connection receives protocol messages (identity, state sync,
+   * MCP server lists).
+   */
+  isConnectionProtocolEnabled(connection: Connection): boolean;
+}
+
+// ── AgentState ────────────────────────────────────────────────────────────────
+
+/**
+ * Encapsulates all state-management behaviour for an Agent instance.
+ *
+ * Owns:
+ * - The in-memory state cache (`#state`)
+ * - The raw connection-state accessor map used to read/write internal flags
+ *   without going through the user-facing connection.state wrapper
+ * - The persistence-hook dispatch mode (new / old / none)
+ * - The set of connection IDs that are temporarily excluded from protocol
+ *   broadcasts (used during initial state sync on connect)
+ *
+ * `Agent` holds a `_state` field of this type and delegates to it. The
+ * `AgentStateHost` callback interface keeps this class decoupled from the full
+ * Agent class.
+ *
+ * The public-ready subset of this class is described by `AgentStateApi`; the
+ * remaining methods are marked `@internal` and grouped after it.
+ */
+export class AgentState<State> implements AgentStateApi<State> {
+  #host: AgentStateHost<State>;
+
+  /** In-memory state cache. DEFAULT_STATE means "not yet loaded from SQLite". */
+  #state = DEFAULT_STATE as State;
+
+  /**
+   * Stores raw state accessors for wrapped connections.
+   * Used by internal flag methods (readonly, no-protocol) to read/write
+   * _cf_-prefixed keys without going through the user-facing state/setState.
+   */
+  #rawStateAccessors = new WeakMap<Connection, RawConnectionStateAccessors>();
+
+  /**
+   * Which state-change notification hook to fire after a change is persisted.
+   * Resolved once by the Agent constructor (see `setPersistenceHookMode`) so
+   * the hot path never walks the prototype chain. Defaults to "none" until the
+   * constructor detects an overridden hook. See {@link StatePersistenceHookMode}.
+   */
+  #persistenceHookMode: StatePersistenceHookMode = "none";
+
+  /**
+   * Connection IDs to skip during `broadcastProtocol`. Populated temporarily
+   * during initial state sync on connect to avoid double-sending state to the
+   * connecting client.
+   */
+  #protocolBroadcastExcludeIds = new Set<string>();
+
+  constructor(host: AgentStateHost<State>) {
+    this.#host = host;
+  }
+
+  // ── Public API (future `agent.stateOps`, see AgentStateApi) ───────────────────
+
+  /**
+   * Return the current agent state.
+   *
+   * On first access within a cold isolate, checks the in-memory cache; if that
+   * holds the DEFAULT_STATE sentinel, reads from SQLite. Row existence in
+   * cf_agents_state is the signal that state was previously set — this handles
+   * all values including falsy ones (null, 0, false, ""). If no row exists and
+   * `initialState` was provided, persists and returns that.
+   */
+  get state(): State {
+    if (this.#state !== DEFAULT_STATE) {
+      return this.#state;
+    }
+
+    const result = this.#host.sql<{ state: State | undefined }>`
+      SELECT state FROM cf_agents_state WHERE id = ${STATE_ROW_ID}
+    `;
+
+    if (result.length > 0) {
+      const state = result[0].state as string;
+
+      try {
+        this.#state = JSON.parse(state);
+      } catch (e) {
+        console.error(
+          "Failed to parse stored state, falling back to initialState:",
+          e
+        );
+        if (this.#host.initialState !== DEFAULT_STATE) {
+          this.#state = this.#host.initialState;
+          // Persist the fixed state to prevent future parse errors
+          this.setInternal(this.#host.initialState);
+        } else {
+          // No initialState defined — clear corrupted data to prevent infinite retry loop
+          this.#host
+            .sql`DELETE FROM cf_agents_state WHERE id = ${STATE_ROW_ID}`;
+          return undefined as State;
+        }
+      }
+      return this.#state;
+    }
+
+    if (this.#host.initialState === DEFAULT_STATE) {
+      return undefined as State;
+    }
+
+    // First access with no prior state — persist initialState and return it.
+    this.setInternal(this.#host.initialState);
+    return this.#host.initialState;
+  }
+
+  /**
+   * Public entry point for `Agent.setState()`.
+   * Checks the current agentContext for a readonly connection before delegating
+   * to `setInternal`.
+   */
+  setState(state: State): void {
+    const store = agentContext.getStore();
+    if (store?.connection && this.isConnectionReadonly(store.connection)) {
+      throw new Error("Connection is readonly");
+    }
+    this.setInternal(state, "server");
+  }
+
+  // ── State persistence internals (not part of AgentStateApi) ───────────────────
+
+  /**
+   * @internal Called once from the Agent constructor after it detects which
+   * state-change hook (if any) the subclass overrode, fixing which hook
+   * `setInternal` fires. See {@link StatePersistenceHookMode}.
+   */
+  setPersistenceHookMode(mode: StatePersistenceHookMode): void {
+    this.#persistenceHookMode = mode;
+  }
+
+  /**
+   * @internal Read the raw cached state value.
+   * Used by the strangler-pattern `_state` accessor bridge on Agent so that
+   * existing code that reads `this._state` (including test helpers) keeps
+   * working without modification during the extraction.
+   */
+  getCachedState(): State {
+    return this.#state;
+  }
+
+  /**
+   * @internal Overwrite the raw cached state value without persisting or
+   * broadcasting.
+   * Used by the strangler-pattern `_state` accessor bridge on Agent so that
+   * test helpers that force-reset `this._state` to the DEFAULT_STATE sentinel
+   * (to simulate a "lazy init" path) can still do so.
+   */
+  setCachedState(state: State): void {
+    this.#state = state;
+  }
+
+  /**
+   * @internal
+   * Persist, broadcast, and fire hooks for a state change.
+   *
+   * - Calls `validateStateChange` (sync gating hook — may throw to reject).
+   * - Writes the new value to the in-memory cache and SQLite.
+   * - Broadcasts the new state to all protocol-enabled connections except the
+   *   source connection (if the update came from a client).
+   * - Schedules the notification hook (`onStateChanged` / `onStateUpdate`) via
+   *   `waitUntil` so it runs reliably even if the handler has already returned.
+   *   Errors in the hook are routed to `onError` and do not affect the persist
+   *   or broadcast that already happened.
+   */
+  setInternal(nextState: State, source: StateSource = "server"): void {
+    // Validation/gating hook (sync only)
+    this.#host.validateStateChange(nextState, source);
+
+    // Persist state — row existence in cf_agents_state is the signal that
+    // state was set (no separate wasChanged flag needed).
+    this.#state = nextState;
+    this.#host.sql`
+      INSERT OR REPLACE INTO cf_agents_state (id, state)
+      VALUES (${STATE_ROW_ID}, ${JSON.stringify(nextState)})
+    `;
+
+    // Broadcast state to protocol-enabled connections, excluding the source
+    this.broadcastProtocol(
+      JSON.stringify({
+        state: nextState,
+        type: MessageType.CF_AGENT_STATE
+      }),
+      source !== "server" ? [source.id] : []
+    );
+
+    // Notification hook (non-gating). Run after broadcast and do not block.
+    // Use waitUntil for reliability after the handler returns.
+    const { connection, request, email } = agentContext.getStore() || {};
+    this.#host.ctx.waitUntil(
+      this.#runPersistenceHook(nextState, source, {
+        connection,
+        request,
+        email
+      })
+    );
+  }
+
+  /**
+   * @internal Broadcast a protocol message only to connections that have
+   * protocol messages enabled. Connections where `shouldSendProtocolMessages`
+   * returned false are excluded automatically, as are any IDs in
+   * `#protocolBroadcastExcludeIds` and the `excludeIds` argument.
+   */
+  broadcastProtocol(msg: string, excludeIds: string[] = []): void {
+    const exclude = [...excludeIds, ...this.#protocolBroadcastExcludeIds];
+    for (const conn of this.#host.getConnections()) {
+      if (!this.isConnectionProtocolEnabled(conn)) {
+        exclude.push(conn.id);
+      }
+    }
+    this.#host.broadcast(msg, exclude);
+  }
+
+  /**
+   * @internal
+   * Temporarily exclude a connection from protocol broadcasts for the duration
+   * of `callback`, then restore the previous exclusion state.
+   *
+   * Used during initial state sync on connect: reading `this.state` can trigger
+   * lazy persistence of `initialState`, which in turn calls `setInternal` and
+   * broadcasts — but we want to send the state to the connecting client in a
+   * single targeted message, not via the broadcast path.
+   */
+  excludeConnectionFromProtocolBroadcast<T>(
+    connectionId: string,
+    callback: () => T
+  ): T {
+    const wasExcluded = this.#protocolBroadcastExcludeIds.has(connectionId);
+    this.#protocolBroadcastExcludeIds.add(connectionId);
+    try {
+      return callback();
+    } finally {
+      if (!wasExcluded) {
+        this.#protocolBroadcastExcludeIds.delete(connectionId);
+      }
+    }
+  }
+
+  // ── Connection state (readonly + protocol flags) ─────────────────────────────
+
+  /**
+   * @internal
+   * Wraps `connection.state` and `connection.setState` so that internal
+   * `_cf_`-prefixed flags (readonly, no-protocol, sub-agent URL, etc.) are
+   * hidden from user code and cannot be accidentally overwritten.
+   *
+   * Idempotent — safe to call multiple times on the same connection.
+   * After hibernation, `#rawStateAccessors` is empty but the connection's state
+   * getter still reads from the persisted WebSocket attachment. Calling this
+   * method re-captures the raw getter so that predicate methods
+   * (`isConnectionReadonly`, `isConnectionProtocolEnabled`) work correctly
+   * post-hibernation.
+   */
+  ensureConnectionWrapped(connection: Connection): void {
+    if (this.#rawStateAccessors.has(connection)) return;
+
+    // As of compatibility date 2026-03-17 the runtime defaults a server-side
+    // WebSocket's `binaryType` to "blob" (the `websocket_standard_binary_type`
+    // flag), so binary frames arrive as `Blob` instead of `ArrayBuffer`. The
+    // Agent protocol and every downstream consumer (e.g. voice audio frames,
+    // user-defined `onMessage` handlers that do `message instanceof ArrayBuffer`)
+    // have always relied on binary frames being delivered as `ArrayBuffer`.
+    //
+    // For non-hibernating agents (`static options = { hibernate: false }`)
+    // messages are delivered through `addEventListener("message", ...)`, where
+    // this new default applies and would silently break binary handling. Pin
+    // it back to "arraybuffer" so the contract holds regardless of the app's
+    // compatibility date. This first runs in `onConnect` before the client can
+    // send any frame, so it takes effect for every message on the connection.
+    //
+    // This is defense-in-depth: partyserver >= 0.5.7 also pins `binaryType` in
+    // `accept()`, but agents may run against an older partyserver or a custom
+    // connection, so we keep our own pin. It runs once per connection per
+    // isolate lifetime (gated by the `#rawStateAccessors` check above); after a
+    // hibernation wake that in-memory map is empty, so it re-pins on the first
+    // call. The hibernatable `webSocketMessage` handler always delivers
+    // `ArrayBuffer` regardless of this flag, so for hibernating agents this is a
+    // harmless no-op.
+    try {
+      if (connection.binaryType !== "arraybuffer") {
+        connection.binaryType = "arraybuffer";
+      }
+    } catch {
+      // Some connection shims may not expose a settable `binaryType`; the
+      // protocol still works for string frames, so ignore and continue.
+    }
+
+    // Determine whether `state` is an accessor (getter) or a data property.
+    // partyserver always defines `state` as a getter via Object.defineProperties,
+    // but we handle the data-property case to stay robust for hibernate: false
+    // and any future connection implementations.
+    const descriptor = Object.getOwnPropertyDescriptor(connection, "state");
+
+    let getRaw: () => Record<string, unknown> | null;
+    let setRaw: (state: unknown) => unknown;
+
+    if (descriptor?.get) {
+      // Accessor property — bind the original getter directly.
+      // The getter reads from the serialized WebSocket attachment, so it
+      // always returns the latest value even after setState updates it.
+      getRaw = descriptor.get.bind(connection) as () => Record<
+        string,
+        unknown
+      > | null;
+      setRaw = connection.setState.bind(connection);
+    } else {
+      // Data property — track raw state in a closure variable.
+      // Reading `connection.state` after our override would call our filtered
+      // getter (circular), so we snapshot the value here and keep it in sync.
+      let rawState = (connection.state ?? null) as Record<
+        string,
+        unknown
+      > | null;
+      getRaw = () => rawState;
+      setRaw = (state: unknown) => {
+        rawState = state as Record<string, unknown> | null;
+        return rawState;
+      };
+    }
+
+    this.#rawStateAccessors.set(connection, { getRaw, setRaw });
+
+    // Override state getter to hide all internal _cf_ flags from user code
+    Object.defineProperty(connection, "state", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        const raw = getRaw();
+        if (raw != null && typeof raw === "object" && rawHasInternalKeys(raw)) {
+          return stripInternalKeys(raw);
+        }
+        return raw;
+      }
+    });
+
+    // Override setState to preserve internal flags when user sets state
+    Object.defineProperty(connection, "setState", {
+      configurable: true,
+      writable: true,
+      value(stateOrFn: unknown | ((prev: unknown) => unknown)) {
+        const raw = getRaw();
+        const flags =
+          raw != null && typeof raw === "object"
+            ? extractInternalFlags(raw as Record<string, unknown>)
+            : {};
+        const hasFlags = Object.keys(flags).length > 0;
+
+        let newUserState: unknown;
+        if (typeof stateOrFn === "function") {
+          // Pass only the user-visible state (without internal flags) to the callback
+          const userVisible = hasFlags
+            ? stripInternalKeys(raw as Record<string, unknown>)
+            : raw;
+          newUserState = (stateOrFn as (prev: unknown) => unknown)(userVisible);
+        } else {
+          newUserState = stateOrFn;
+        }
+
+        // Merge back internal flags if any were set
+        if (hasFlags) {
+          if (newUserState != null && typeof newUserState === "object") {
+            return setRaw({
+              ...(newUserState as Record<string, unknown>),
+              ...flags
+            });
+          }
+          // User set null — store just the flags
+          return setRaw(flags);
+        }
+        return setRaw(newUserState);
+      }
+    });
+  }
+
+  /**
+   * Part of AgentStateApi.
+   * Mark a connection as readonly or readwrite.
+   * Removes the key entirely when clearing readonly to avoid dead keys
+   * accumulating in the connection attachment.
+   */
+  setConnectionReadonly(connection: Connection, readonly = true): void {
+    this.ensureConnectionWrapped(connection);
+    const accessors = this.#rawStateAccessors.get(connection)!;
+    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
+    if (readonly) {
+      accessors.setRaw({ ...raw, [CF_READONLY_KEY]: true });
+    } else {
+      const { [CF_READONLY_KEY]: _, ...rest } = raw;
+      accessors.setRaw(Object.keys(rest).length > 0 ? rest : null);
+    }
+  }
+
+  /**
+   * Part of AgentStateApi.
+   * Check if a connection is marked as readonly.
+   * Safe to call after hibernation — re-wraps the connection if the
+   * in-memory accessor cache was cleared.
+   */
+  isConnectionReadonly(connection: Connection): boolean {
+    this.ensureConnectionWrapped(connection);
+    const raw = this.#rawStateAccessors.get(connection)!.getRaw() as Record<
+      string,
+      unknown
+    > | null;
+    return !!raw?.[CF_READONLY_KEY];
+  }
+
+  /**
+   * @internal
+   * Read an internal `_cf_`-prefixed flag from the raw connection state,
+   * bypassing the user-facing state wrapper that strips internal keys.
+   *
+   * This exists for framework mixins (e.g. voice) that need to persist
+   * flags in the connection attachment across hibernation. Application
+   * code should use `connection.state` and `connection.setState()` instead.
+   * Exposed on Agent as `_unsafe_getConnectionFlag`.
+   */
+  unsafeGetConnectionFlag(connection: Connection, key: string): unknown {
+    this.ensureConnectionWrapped(connection);
+    const raw = this.#rawStateAccessors.get(connection)!.getRaw() as Record<
+      string,
+      unknown
+    > | null;
+    return raw?.[key];
+  }
+
+  /**
+   * @internal
+   * Write an internal `_cf_`-prefixed flag to the raw connection state,
+   * bypassing the user-facing state wrapper. The key must be registered in
+   * `CF_INTERNAL_KEYS` so it is preserved across user `setState` calls and
+   * hidden from `connection.state`. Pass `undefined` to remove the key.
+   * Exposed on Agent as `_unsafe_setConnectionFlag`.
+   */
+  unsafeSetConnectionFlag(
+    connection: Connection,
+    key: string,
+    value: unknown
+  ): void {
+    this.ensureConnectionWrapped(connection);
+    const accessors = this.#rawStateAccessors.get(connection)!;
+    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
+    if (value === undefined) {
+      const { [key]: _, ...rest } = raw;
+      accessors.setRaw(Object.keys(rest).length > 0 ? rest : null);
+    } else {
+      accessors.setRaw({ ...raw, [key]: value });
+    }
+  }
+
+  /**
+   * @internal
+   * Return the full raw connection state including internal `_cf_` flags.
+   * Used by sub-agent forwarding code that needs to read flags like
+   * `_cf_subAgentOuterUrl` without stripping them.
+   */
+  getRawConnectionState(connection: Connection): unknown {
+    this.ensureConnectionWrapped(connection);
+    return this.#rawStateAccessors.get(connection)?.getRaw() ?? null;
+  }
+
+  /**
+   * Part of AgentStateApi.
+   * Check if a connection has protocol messages enabled.
+   * Protocol messages include identity, state sync, and MCP server lists.
+   * Safe to call after hibernation — re-wraps the connection if the
+   * in-memory accessor cache was cleared.
+   */
+  isConnectionProtocolEnabled(connection: Connection): boolean {
+    this.ensureConnectionWrapped(connection);
+    const raw = this.#rawStateAccessors.get(connection)!.getRaw() as Record<
+      string,
+      unknown
+    > | null;
+    return !raw?.[CF_NO_PROTOCOL_KEY];
+  }
+
+  /**
+   * @internal
+   * Mark a connection as having protocol messages disabled.
+   * Called internally when `shouldSendProtocolMessages` returns false.
+   */
+  setConnectionNoProtocol(connection: Connection): void {
+    this.ensureConnectionWrapped(connection);
+    const accessors = this.#rawStateAccessors.get(connection)!;
+    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
+    accessors.setRaw({ ...raw, [CF_NO_PROTOCOL_KEY]: true });
+  }
+
+  /**
+   * Dispatch to whichever state-change notification hook the subclass defined,
+   * using the mode resolved at construction time so there is no prototype walk
+   * at call time. See {@link StatePersistenceHookMode}.
+   */
+  #callPersistenceHook(state: State | undefined, source: StateSource) {
+    switch (this.#persistenceHookMode) {
+      case "new":
+        return this.#host.onStateChanged(state, source);
+      case "old":
+        return this.#host.onStateUpdate(state, source);
+      case "none":
+        return undefined;
+    }
+  }
+
+  /**
+   * Run the persistence hook inside the saved agentContext so that
+   * `getCurrentAgent()` returns the correct agent during the hook.
+   * Errors are routed to `onError` and do not affect the persist or broadcast
+   * that already happened.
+   */
+  async #runPersistenceHook(
+    state: State | undefined,
+    source: StateSource,
+    context: {
+      connection: Connection | undefined;
+      request: Request | undefined;
+      email: AgentEmail | undefined;
+    }
+  ): Promise<void> {
+    try {
+      await agentContext.run(
+        { agent: this.#host.agent, ...context },
+        async () => {
+          this.#host._emit("state:update");
+          await this.#callPersistenceHook(state, source);
+        }
+      );
+    } catch (e) {
+      try {
+        await this.#host.onError(e);
+      } catch {
+        // onStateChanged/onStateUpdate errors should not affect state or broadcasts.
+      }
+    }
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -83,6 +83,7 @@ import {
 } from "./observability";
 import { DisposableStore } from "./core/events";
 import { MessageType } from "./types";
+import { AgentState, DEFAULT_STATE, type AgentStateHost } from "./agent/state";
 import { RPC_DO_PREFIX } from "./mcp/rpc";
 import type { McpAgent } from "./mcp";
 export {
@@ -1095,12 +1096,9 @@ type AgentToolRecoveryInspection =
 const CURRENT_SCHEMA_VERSION = 11;
 
 const SCHEMA_VERSION_ROW_ID = "cf_schema_version";
-const STATE_ROW_ID = "cf_state_row_id";
 // Legacy key — no longer written, but read for backward compatibility with
 // DOs that were created before the single-row state optimization.
 const STATE_WAS_CHANGED = "cf_state_was_changed";
-
-const DEFAULT_STATE = {} as unknown;
 
 async function sha256Hex(value: string): Promise<string> {
   const bytes = new TextEncoder().encode(value);
@@ -1147,25 +1145,6 @@ function isValidParentPath(
 }
 
 /**
- * Internal key used to store the readonly flag in connection state.
- * Prefixed with _cf_ to avoid collision with user state keys.
- */
-const CF_READONLY_KEY = "_cf_readonly";
-
-/**
- * Internal key used to store the no-protocol flag in connection state.
- * When set, protocol messages (identity, state sync, MCP servers) are not
- * sent to this connection — neither on connect nor via broadcasts.
- */
-const CF_NO_PROTOCOL_KEY = "_cf_no_protocol";
-
-/**
- * Internal key used to store voice call state in connection state.
- * Used by the voice mixin to track whether a connection is in an active call.
- */
-const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
-
-/**
  * Internal key used to remember the outer `/sub/...` URL for a
  * WebSocket accepted by the parent on behalf of a child facet.
  * Hibernated events then wake the parent, which forwards frames to
@@ -1176,54 +1155,6 @@ const CF_SUB_AGENT_OUTER_URL_KEY = "_cf_subAgentOuterUrl";
 const CF_SUB_AGENT_TAGS_KEY = "_cf_subAgentTags";
 
 const SUB_AGENT_OUTER_URL_HEADER = "x-cf-agents-subagent-url";
-
-/**
- * The set of all internal keys stored in connection state that must be
- * hidden from user code and preserved across setState calls.
- */
-const CF_INTERNAL_KEYS: ReadonlySet<string> = new Set([
-  CF_READONLY_KEY,
-  CF_NO_PROTOCOL_KEY,
-  CF_VOICE_IN_CALL_KEY,
-  CF_SUB_AGENT_OUTER_URL_KEY,
-  CF_SUB_AGENT_TAGS_KEY
-]);
-
-/** Check if a raw connection state object contains any internal keys. */
-function rawHasInternalKeys(raw: Record<string, unknown>): boolean {
-  for (const key of Object.keys(raw)) {
-    if (CF_INTERNAL_KEYS.has(key)) return true;
-  }
-  return false;
-}
-
-/** Return a copy of `raw` with all internal keys removed, or null if no user keys remain. */
-function stripInternalKeys(
-  raw: Record<string, unknown>
-): Record<string, unknown> | null {
-  const result: Record<string, unknown> = {};
-  let hasUserKeys = false;
-  for (const key of Object.keys(raw)) {
-    if (!CF_INTERNAL_KEYS.has(key)) {
-      result[key] = raw[key];
-      hasUserKeys = true;
-    }
-  }
-  return hasUserKeys ? result : null;
-}
-
-/** Return a copy containing only the internal keys present in `raw`. */
-function extractInternalFlags(
-  raw: Record<string, unknown>
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const key of Object.keys(raw)) {
-    if (CF_INTERNAL_KEYS.has(key)) {
-      result[key] = raw[key];
-    }
-  }
-  return result;
-}
 
 /** Max length for error strings broadcast to clients. */
 const MAX_ERROR_STRING_LENGTH = 500;
@@ -1576,35 +1507,12 @@ export class Agent<
   State = unknown,
   Props extends Record<string, unknown> = Record<string, unknown>
 > extends Server<Env, Props> {
-  private _state = DEFAULT_STATE as State;
   private _disposables = new DisposableStore();
   private _destroyed = false;
-
-  /**
-   * Stores raw state accessors for wrapped connections.
-   * Used by internal flag methods (readonly, no-protocol) to read/write
-   * _cf_-prefixed keys without going through the user-facing state/setState.
-   */
-  private _rawStateAccessors = new WeakMap<
-    Connection,
-    {
-      getRaw: () => Record<string, unknown> | null;
-      setRaw: (state: unknown) => unknown;
-    }
-  >();
-
-  /**
-   * Cached persistence-hook dispatch mode, computed once in the constructor.
-   * - "new"  → call onStateChanged
-   * - "old"  → call onStateUpdate (deprecated)
-   * - "none" → neither hook is overridden, skip entirely
-   */
-  private _persistenceHookMode: "new" | "old" | "none" = "none";
 
   /** True when this agent runs as a facet (sub-agent) inside a parent. */
   private _isFacet = false;
 
-  private _protocolBroadcastExcludeIds = new Set<string>();
   private _cf_currentSubAgentBridge?: SubAgentConnectionBridgeLike;
   private _cf_virtualSubAgentConnections = new Map<
     string,
@@ -1688,6 +1596,16 @@ export class Agent<
    */
   initialState: State = DEFAULT_STATE as State;
 
+  private readonly _state = new AgentState<State>(this._createStateHost());
+
+  private get _cachedState(): State {
+    return this._state.getCachedState();
+  }
+
+  private set _cachedState(state: State) {
+    this._state.setCachedState(state);
+  }
+
   /**
    * Stable key for Workers AI session affinity (prefix-cache optimization).
    *
@@ -1713,52 +1631,7 @@ export class Agent<
    * Current state of the Agent
    */
   get state(): State {
-    if (this._state !== DEFAULT_STATE) {
-      // state was previously set, and populated internal state
-      return this._state;
-    }
-    // looks like this is the first time the state is being accessed
-    // check if the state was set in a previous life
-    const result = this.sql<{ state: State | undefined }>`
-      SELECT state FROM cf_agents_state WHERE id = ${STATE_ROW_ID}
-    `;
-
-    // Row existence is the signal that state was previously set.
-    // This handles all values including falsy ones (null, 0, false, "").
-    if (result.length > 0) {
-      const state = result[0].state as string;
-
-      try {
-        this._state = JSON.parse(state);
-      } catch (e) {
-        console.error(
-          "Failed to parse stored state, falling back to initialState:",
-          e
-        );
-        if (this.initialState !== DEFAULT_STATE) {
-          this._state = this.initialState;
-          // Persist the fixed state to prevent future parse errors
-          this._setStateInternal(this.initialState);
-        } else {
-          // No initialState defined - clear corrupted data to prevent infinite retry loop
-          this.sql`DELETE FROM cf_agents_state WHERE id = ${STATE_ROW_ID}`;
-          return undefined as State;
-        }
-      }
-      return this._state;
-    }
-
-    // ok, this is the first time the state is being accessed
-    // and the state was not set in a previous life
-    // so we need to set the initial state (if provided)
-    if (this.initialState === DEFAULT_STATE) {
-      // no initial state provided, so we return undefined
-      return undefined as State;
-    }
-    // initial state provided, so we set the state,
-    // update db and return the initial state
-    this._setStateInternal(this.initialState);
-    return this.initialState;
+    return this._state.state;
   }
 
   /**
@@ -1851,6 +1724,29 @@ export class Agent<
       payload,
       timestamp: Date.now()
     } as ObservabilityEvent);
+  }
+
+  private _createStateHost(): AgentStateHost<State> {
+    const thisAgent = this;
+    return {
+      agent: this,
+      ctx: this.ctx,
+      get initialState() {
+        return thisAgent.initialState;
+      },
+      sql: <T = Record<string, string | number | boolean | null>>(
+        strings: TemplateStringsArray,
+        ...values: (string | number | boolean | null)[]
+      ) => this.sql<T>(strings, ...values),
+      getConnections: () => this.getConnections(),
+      broadcast: (message, without) => this.broadcast(message, without),
+      validateStateChange: (nextState, source) =>
+        this.validateStateChange(nextState, source),
+      onStateChanged: (state, source) => this.onStateChanged(state, source),
+      onStateUpdate: (state, source) => this.onStateUpdate(state, source),
+      onError: (error) => this.onError(error),
+      _emit: (type, payload) => this._emit(type, payload)
+    };
   }
 
   /**
@@ -2305,9 +2201,9 @@ export class Agent<
 
       const base = Agent.prototype;
       if (proto.onStateChanged !== base.onStateChanged) {
-        this._persistenceHookMode = "new";
+        this._state.setPersistenceHookMode("new");
       } else if (proto.onStateUpdate !== base.onStateUpdate) {
-        this._persistenceHookMode = "old";
+        this._state.setPersistenceHookMode("old");
       }
       // default "none" already set in field initializer
     }
@@ -2333,7 +2229,7 @@ export class Agent<
       if (await this._cf_forwardSubAgentWebSocketMessage(connection, message)) {
         return;
       }
-      this._ensureConnectionWrapped(connection);
+      this._state.ensureConnectionWrapped(connection);
       return agentContext.run(
         { agent: this, connection, request: undefined, email: undefined },
         async () => {
@@ -2362,7 +2258,7 @@ export class Agent<
               return;
             }
             try {
-              this._setStateInternal(parsed.state as State, connection);
+              this._state.setInternal(parsed.state as State, connection);
             } catch (e) {
               // validateStateChange (or another sync error) rejected the update.
               // Log the full error server-side, send a generic message to the client.
@@ -2456,12 +2352,12 @@ export class Agent<
 
     const _onConnect = this.onConnect.bind(this);
     this.onConnect = async (connection: Connection, ctx: ConnectionContext) => {
-      this._ensureConnectionWrapped(connection);
+      this._state.ensureConnectionWrapped(connection);
       const subAgentOuterUrl = ctx.request.headers.get(
         SUB_AGENT_OUTER_URL_HEADER
       );
       if (subAgentOuterUrl) {
-        this._unsafe_setConnectionFlag(
+        this._state.unsafeSetConnectionFlag(
           connection,
           CF_SUB_AGENT_OUTER_URL_KEY,
           subAgentOuterUrl
@@ -2532,17 +2428,11 @@ export class Agent<
               );
             }
 
-            const wasExcludedFromStateInitBroadcast =
-              this._protocolBroadcastExcludeIds.has(connection.id);
-            let currentState: State | undefined;
-            this._protocolBroadcastExcludeIds.add(connection.id);
-            try {
-              currentState = this.state;
-            } finally {
-              if (!wasExcludedFromStateInitBroadcast) {
-                this._protocolBroadcastExcludeIds.delete(connection.id);
-              }
-            }
+            const currentState =
+              this._state.excludeConnectionFromProtocolBroadcast(
+                connection.id,
+                () => this.state
+              );
 
             if (currentState !== undefined) {
               connection.send(
@@ -2560,7 +2450,7 @@ export class Agent<
               })
             );
           } else {
-            this._setConnectionNoProtocol(connection);
+            this._state.setConnectionNoProtocol(connection);
           }
 
           this._emit("connect", { connectionId: connection.id });
@@ -2755,216 +2645,12 @@ export class Agent<
   }
 
   /**
-   * Broadcast a protocol message only to connections that have protocol
-   * messages enabled. Connections where shouldSendProtocolMessages returned
-   * false are excluded automatically.
-   * @param msg The JSON-encoded protocol message
-   * @param excludeIds Additional connection IDs to exclude (e.g. the source)
-   */
-  private _broadcastProtocol(msg: string, excludeIds: string[] = []) {
-    const exclude = [...excludeIds, ...this._protocolBroadcastExcludeIds];
-    for (const conn of this.getConnections()) {
-      if (!this.isConnectionProtocolEnabled(conn)) {
-        exclude.push(conn.id);
-      }
-    }
-    this.broadcast(msg, exclude);
-  }
-
-  private _setStateInternal(
-    nextState: State,
-    source: Connection | "server" = "server"
-  ): void {
-    // Validation/gating hook (sync only)
-    this.validateStateChange(nextState, source);
-
-    // Persist state — row existence in cf_agents_state is the signal that
-    // state was set (no separate wasChanged flag needed).
-    this._state = nextState;
-    this.sql`
-      INSERT OR REPLACE INTO cf_agents_state (id, state)
-      VALUES (${STATE_ROW_ID}, ${JSON.stringify(nextState)})
-    `;
-
-    // Broadcast state to protocol-enabled connections, excluding the source
-    this._broadcastProtocol(
-      JSON.stringify({
-        state: nextState,
-        type: MessageType.CF_AGENT_STATE
-      }),
-      source !== "server" ? [source.id] : []
-    );
-
-    // Notification hook (non-gating). Run after broadcast and do not block.
-    // Use waitUntil for reliability after the handler returns.
-    const { connection, request, email } = agentContext.getStore() || {};
-    this.ctx.waitUntil(
-      (async () => {
-        try {
-          await agentContext.run(
-            { agent: this, connection, request, email },
-            async () => {
-              this._emit("state:update");
-              await this._callStatePersistenceHook(nextState, source);
-            }
-          );
-        } catch (e) {
-          // onStateChanged/onStateUpdate errors should not affect state or broadcasts
-          try {
-            await this.onError(e);
-          } catch {
-            // swallow
-          }
-        }
-      })()
-    );
-  }
-
-  /**
    * Update the Agent's state
    * @param state New state to set
    * @throws Error if called from a readonly connection context
    */
   setState(state: State): void {
-    // Check if the current context has a readonly connection
-    const store = agentContext.getStore();
-    if (store?.connection && this.isConnectionReadonly(store.connection)) {
-      throw new Error("Connection is readonly");
-    }
-    this._setStateInternal(state, "server");
-  }
-
-  /**
-   * Wraps connection.state and connection.setState so that internal
-   * _cf_-prefixed flags (readonly, no-protocol) are hidden from user code
-   * and cannot be accidentally overwritten.
-   *
-   * Idempotent — safe to call multiple times on the same connection.
-   * After hibernation, the _rawStateAccessors WeakMap is empty but the
-   * connection's state getter still reads from the persisted WebSocket
-   * attachment. Calling this method re-captures the raw getter so that
-   * predicate methods (isConnectionReadonly, isConnectionProtocolEnabled)
-   * work correctly post-hibernation.
-   */
-  private _ensureConnectionWrapped(connection: Connection) {
-    if (this._rawStateAccessors.has(connection)) return;
-
-    // As of compatibility date 2026-03-17 the runtime defaults a server-side
-    // WebSocket's `binaryType` to "blob" (the `websocket_standard_binary_type`
-    // flag), so binary frames arrive as `Blob` instead of `ArrayBuffer`. The
-    // Agent protocol and every downstream consumer (e.g. voice audio frames,
-    // user-defined `onMessage` handlers that do `message instanceof ArrayBuffer`)
-    // have always relied on binary frames being delivered as `ArrayBuffer`.
-    //
-    // For non-hibernating agents (`static options = { hibernate: false }`)
-    // messages are delivered through `addEventListener("message", ...)`, where
-    // this new default applies and would silently break binary handling. Pin
-    // it back to "arraybuffer" so the contract holds regardless of the app's
-    // compatibility date. This first runs in `onConnect` before the client can
-    // send any frame, so it takes effect for every message on the connection.
-    //
-    // This is defense-in-depth: partyserver >= 0.5.7 also pins `binaryType` in
-    // `accept()`, but agents may run against an older partyserver or a custom
-    // connection, so we keep our own pin. It runs once per connection per
-    // isolate lifetime (gated by the `_rawStateAccessors` check above); after a
-    // hibernation wake that in-memory map is empty, so it re-pins on the first
-    // call. The hibernatable `webSocketMessage` handler always delivers
-    // `ArrayBuffer` regardless of this flag, so for hibernating agents this is a
-    // harmless no-op.
-    try {
-      if (connection.binaryType !== "arraybuffer") {
-        connection.binaryType = "arraybuffer";
-      }
-    } catch {
-      // Some connection shims may not expose a settable `binaryType`; the
-      // protocol still works for string frames, so ignore and continue.
-    }
-
-    // Determine whether `state` is an accessor (getter) or a data property.
-    // partyserver always defines `state` as a getter via Object.defineProperties,
-    // but we handle the data-property case to stay robust for hibernate: false
-    // and any future connection implementations.
-    const descriptor = Object.getOwnPropertyDescriptor(connection, "state");
-
-    let getRaw: () => Record<string, unknown> | null;
-    let setRaw: (state: unknown) => unknown;
-
-    if (descriptor?.get) {
-      // Accessor property — bind the original getter directly.
-      // The getter reads from the serialized WebSocket attachment, so it
-      // always returns the latest value even after setState updates it.
-      getRaw = descriptor.get.bind(connection) as () => Record<
-        string,
-        unknown
-      > | null;
-      setRaw = connection.setState.bind(connection);
-    } else {
-      // Data property — track raw state in a closure variable.
-      // Reading `connection.state` after our override would call our filtered
-      // getter (circular), so we snapshot the value here and keep it in sync.
-      let rawState = (connection.state ?? null) as Record<
-        string,
-        unknown
-      > | null;
-      getRaw = () => rawState;
-      setRaw = (state: unknown) => {
-        rawState = state as Record<string, unknown> | null;
-        return rawState;
-      };
-    }
-
-    this._rawStateAccessors.set(connection, { getRaw, setRaw });
-
-    // Override state getter to hide all internal _cf_ flags from user code
-    Object.defineProperty(connection, "state", {
-      configurable: true,
-      enumerable: true,
-      get() {
-        const raw = getRaw();
-        if (raw != null && typeof raw === "object" && rawHasInternalKeys(raw)) {
-          return stripInternalKeys(raw);
-        }
-        return raw;
-      }
-    });
-
-    // Override setState to preserve internal flags when user sets state
-    Object.defineProperty(connection, "setState", {
-      configurable: true,
-      writable: true,
-      value(stateOrFn: unknown | ((prev: unknown) => unknown)) {
-        const raw = getRaw();
-        const flags =
-          raw != null && typeof raw === "object"
-            ? extractInternalFlags(raw as Record<string, unknown>)
-            : {};
-        const hasFlags = Object.keys(flags).length > 0;
-
-        let newUserState: unknown;
-        if (typeof stateOrFn === "function") {
-          // Pass only the user-visible state (without internal flags) to the callback
-          const userVisible = hasFlags
-            ? stripInternalKeys(raw as Record<string, unknown>)
-            : raw;
-          newUserState = (stateOrFn as (prev: unknown) => unknown)(userVisible);
-        } else {
-          newUserState = stateOrFn;
-        }
-
-        // Merge back internal flags if any were set
-        if (hasFlags) {
-          if (newUserState != null && typeof newUserState === "object") {
-            return setRaw({
-              ...(newUserState as Record<string, unknown>),
-              ...flags
-            });
-          }
-          // User set null — store just the flags
-          return setRaw(flags);
-        }
-        return setRaw(newUserState);
-      }
-    });
+    this._state.setState(state);
   }
 
   /**
@@ -2973,17 +2659,7 @@ export class Agent<
    * @param readonly Whether the connection should be readonly (default: true)
    */
   setConnectionReadonly(connection: Connection, readonly = true) {
-    this._ensureConnectionWrapped(connection);
-    const accessors = this._rawStateAccessors.get(connection)!;
-    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
-    if (readonly) {
-      accessors.setRaw({ ...raw, [CF_READONLY_KEY]: true });
-    } else {
-      // Remove the key entirely instead of storing false — avoids dead keys
-      // accumulating in the connection attachment.
-      const { [CF_READONLY_KEY]: _, ...rest } = raw;
-      accessors.setRaw(Object.keys(rest).length > 0 ? rest : null);
-    }
+    this._state.setConnectionReadonly(connection, readonly);
   }
 
   /**
@@ -2995,12 +2671,7 @@ export class Agent<
    * @returns True if the connection is readonly
    */
   isConnectionReadonly(connection: Connection): boolean {
-    this._ensureConnectionWrapped(connection);
-    const raw = this._rawStateAccessors.get(connection)!.getRaw() as Record<
-      string,
-      unknown
-    > | null;
-    return !!raw?.[CF_READONLY_KEY];
+    return this._state.isConnectionReadonly(connection);
   }
 
   /**
@@ -3014,14 +2685,13 @@ export class Agent<
    * code should use `connection.state` and `connection.setState()` instead.
    *
    * @internal
+   * @deprecated Tombstone — this forwarder will be removed in a future major.
+   * The behaviour now lives on `AgentState.unsafeGetConnectionFlag`; the
+   * state subsystem is slated to be exposed as `agent.stateOps` (see
+   * `AgentStateApi`). Do not add new callers.
    */
   _unsafe_getConnectionFlag(connection: Connection, key: string): unknown {
-    this._ensureConnectionWrapped(connection);
-    const raw = this._rawStateAccessors.get(connection)!.getRaw() as Record<
-      string,
-      unknown
-    > | null;
-    return raw?.[key];
+    return this._state.unsafeGetConnectionFlag(connection, key);
   }
 
   /**
@@ -3033,21 +2703,17 @@ export class Agent<
    * and hidden from `connection.state`.
    *
    * @internal
+   * @deprecated Tombstone — this forwarder will be removed in a future major.
+   * The behaviour now lives on `AgentState.unsafeSetConnectionFlag`; the
+   * state subsystem is slated to be exposed as `agent.stateOps` (see
+   * `AgentStateApi`). Do not add new callers.
    */
   _unsafe_setConnectionFlag(
     connection: Connection,
     key: string,
     value: unknown
   ): void {
-    this._ensureConnectionWrapped(connection);
-    const accessors = this._rawStateAccessors.get(connection)!;
-    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
-    if (value === undefined) {
-      const { [key]: _, ...rest } = raw;
-      accessors.setRaw(Object.keys(rest).length > 0 ? rest : null);
-    } else {
-      accessors.setRaw({ ...raw, [key]: value });
-    }
+    this._state.unsafeSetConnectionFlag(connection, key, value);
   }
 
   /**
@@ -3097,23 +2763,7 @@ export class Agent<
    * @returns True if the connection receives protocol messages
    */
   isConnectionProtocolEnabled(connection: Connection): boolean {
-    this._ensureConnectionWrapped(connection);
-    const raw = this._rawStateAccessors.get(connection)!.getRaw() as Record<
-      string,
-      unknown
-    > | null;
-    return !raw?.[CF_NO_PROTOCOL_KEY];
-  }
-
-  /**
-   * Mark a connection as having protocol messages disabled.
-   * Called internally when shouldSendProtocolMessages returns false.
-   */
-  private _setConnectionNoProtocol(connection: Connection) {
-    this._ensureConnectionWrapped(connection);
-    const accessors = this._rawStateAccessors.get(connection)!;
-    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
-    accessors.setRaw({ ...raw, [CF_NO_PROTOCOL_KEY]: true });
+    return this._state.isConnectionProtocolEnabled(connection);
   }
 
   /**
@@ -3154,25 +2804,6 @@ export class Agent<
   // oxlint-disable-next-line eslint(no-unused-vars) -- params used by subclass overrides
   onStateUpdate(_state: State | undefined, _source: Connection | "server") {
     // override this to handle state updates (deprecated — use onStateChanged)
-  }
-
-  /**
-   * Dispatch to the appropriate persistence hook based on the mode
-   * cached in the constructor. No prototype walks at call time.
-   */
-  private async _callStatePersistenceHook(
-    state: State | undefined,
-    source: Connection | "server"
-  ): Promise<void> {
-    switch (this._persistenceHookMode) {
-      case "new":
-        await this.onStateChanged(state, source);
-        break;
-      case "old":
-        await this.onStateUpdate(state, source);
-        break;
-      // "none": neither hook overridden — skip
-    }
   }
 
   /**
@@ -6976,7 +6607,7 @@ export class Agent<
     if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
       return null;
     }
-    this._ensureConnectionWrapped(connection);
+    this._state.ensureConnectionWrapped(connection);
     connection.setState(state);
     return this._cf_getForwardedSubAgentState(connection);
   }
@@ -6985,8 +6616,8 @@ export class Agent<
     connection: Connection,
     ownerPath: ReadonlyArray<AgentPathStep>
   ): SubAgentConnectionMeta | null {
-    this._ensureConnectionWrapped(connection);
-    const outerUri = this._unsafe_getConnectionFlag(
+    this._state.ensureConnectionWrapped(connection);
+    const outerUri = this._state.unsafeGetConnectionFlag(
       connection,
       CF_SUB_AGENT_OUTER_URL_KEY
     );
@@ -6995,7 +6626,7 @@ export class Agent<
     const target = this._cf_subAgentPathFromOuterUri(outerUri, ownerPath);
     if (!target) return null;
 
-    const raw = this._cf_getRawConnectionState(connection);
+    const raw = this._state.getRawConnectionState(connection);
     const rawTags =
       raw != null && typeof raw === "object"
         ? (raw as Record<string, unknown>)[CF_SUB_AGENT_TAGS_KEY]
@@ -7014,8 +6645,8 @@ export class Agent<
   private _cf_subAgentTargetPath(
     connection: Connection
   ): ReadonlyArray<AgentPathStep> | null {
-    this._ensureConnectionWrapped(connection);
-    const outerUri = this._unsafe_getConnectionFlag(
+    this._state.ensureConnectionWrapped(connection);
+    const outerUri = this._state.unsafeGetConnectionFlag(
       connection,
       CF_SUB_AGENT_OUTER_URL_KEY
     );
@@ -7062,9 +6693,9 @@ export class Agent<
   }
 
   private _cf_connectionHasSubAgentTarget(connection: Connection): boolean {
-    this._ensureConnectionWrapped(connection);
+    this._state.ensureConnectionWrapped(connection);
     return (
-      typeof this._unsafe_getConnectionFlag(
+      typeof this._state.unsafeGetConnectionFlag(
         connection,
         CF_SUB_AGENT_OUTER_URL_KEY
       ) === "string"
@@ -7170,8 +6801,8 @@ export class Agent<
     child: SubAgentWebSocketEndpoint;
     meta: SubAgentConnectionMeta;
   } | null> {
-    this._ensureConnectionWrapped(connection);
-    const outerUri = this._unsafe_getConnectionFlag(
+    this._state.ensureConnectionWrapped(connection);
+    const outerUri = this._state.unsafeGetConnectionFlag(
       connection,
       CF_SUB_AGENT_OUTER_URL_KEY
     );
@@ -7215,7 +6846,7 @@ export class Agent<
 
     const childUri = new URL(forwardReq?.url ?? uri);
     childUri.pathname = match.remainingPath;
-    const raw = this._cf_getRawConnectionState(connection);
+    const raw = this._state.getRawConnectionState(connection);
     const rawTags =
       raw != null && typeof raw === "object"
         ? (raw as Record<string, unknown>)[CF_SUB_AGENT_TAGS_KEY]
@@ -7257,7 +6888,7 @@ export class Agent<
         this.setConnectionReadonly(connection, true);
       }
       if (!this.shouldSendProtocolMessages(connection, { request })) {
-        this._setConnectionNoProtocol(connection);
+        this._state.setConnectionNoProtocol(connection);
       }
 
       const childTags = await this.getConnectionTags(connection, { request });
@@ -7374,7 +7005,7 @@ export class Agent<
     } as unknown as Connection;
 
     stored.connection = connection;
-    this._ensureConnectionWrapped(connection);
+    this._state.ensureConnectionWrapped(connection);
     return connection;
   }
 
@@ -7382,7 +7013,7 @@ export class Agent<
     bridge: SubAgentConnectionBridgeLike,
     connection: Connection
   ): void {
-    this._unsafe_setConnectionFlag(connection, CF_SUB_AGENT_TAGS_KEY, [
+    this._state.unsafeSetConnectionFlag(connection, CF_SUB_AGENT_TAGS_KEY, [
       ...connection.tags
     ]);
     const stored = this._cf_virtualSubAgentConnections.get(connection.id);
@@ -7392,7 +7023,7 @@ export class Agent<
         id: connection.id,
         uri: connection.uri,
         tags: [...connection.tags],
-        state: this._cf_getRawConnectionState(connection)
+        state: this._state.getRawConnectionState(connection)
       },
       connection: stored?.connection ?? connection
     });
@@ -7418,13 +7049,8 @@ export class Agent<
     }
   }
 
-  private _cf_getRawConnectionState(connection: Connection): unknown {
-    this._ensureConnectionWrapped(connection);
-    return this._rawStateAccessors.get(connection)?.getRaw() ?? null;
-  }
-
   private _cf_getForwardedSubAgentState(connection: Connection): unknown {
-    const raw = this._cf_getRawConnectionState(connection);
+    const raw = this._state.getRawConnectionState(connection);
     if (raw == null || typeof raw !== "object") return raw;
     const { [CF_SUB_AGENT_OUTER_URL_KEY]: _, ...rest } = raw as Record<
       string,
@@ -12552,7 +12178,7 @@ export class Agent<
   }
 
   private broadcastMcpServers() {
-    this._broadcastProtocol(
+    this._state.broadcastProtocol(
       JSON.stringify({
         mcp: this.getMcpServers(),
         type: MessageType.CF_AGENT_MCP_SERVERS

--- a/packages/agents/src/tests/agents/protocol-messages.ts
+++ b/packages/agents/src/tests/agents/protocol-messages.ts
@@ -19,9 +19,9 @@ export class TestProtocolMessagesAgent extends Agent<
   { count: number }
 > {
   // Capture the DEFAULT_STATE sentinel reference for cache reset in tests.
-  // Child field initializers run after super(), at which point _state is DEFAULT_STATE.
+  // Child field initializers run after super(), at which point _cachedState is DEFAULT_STATE.
   // @ts-expect-error - accessing private field for testing
-  private _stateSentinel: { count: number } = this._state;
+  private _stateSentinel: { count: number } = this._cachedState;
 
   initialState = { count: 0 };
   static options = { hibernate: true };
@@ -57,7 +57,7 @@ export class TestProtocolMessagesAgent extends Agent<
   async resetStateForLazyInitTest() {
     this.sql`DELETE FROM cf_agents_state WHERE id = ${"cf_state_row_id"}`;
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
   }
 
   @callable()

--- a/packages/agents/src/tests/agents/state.ts
+++ b/packages/agents/src/tests/agents/state.ts
@@ -10,9 +10,9 @@ export type TestState = {
 
 export class TestStateAgent extends Agent<Cloudflare.Env, TestState> {
   // Capture the DEFAULT_STATE sentinel reference for cache reset in tests.
-  // Child field initializers run after super(), at which point _state is DEFAULT_STATE.
+  // Child field initializers run after super(), at which point _cachedState is DEFAULT_STATE.
   // @ts-expect-error - accessing private field for testing
-  private _stateSentinel: TestState = this._state;
+  private _stateSentinel: TestState = this._cachedState;
 
   initialState: TestState = {
     count: 0,
@@ -89,7 +89,7 @@ export class TestStateAgent extends Agent<Cloudflare.Env, TestState> {
   getStateAfterCorruption(): TestState {
     // Reset the in-memory cache so the getter re-reads from DB
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
     // This should trigger the try-catch and fallback to initialState
     return this.state;
   }
@@ -184,7 +184,7 @@ export class TestStateAgent extends Agent<Cloudflare.Env, TestState> {
     );
     // Reset in-memory cache to sentinel so getter re-reads from DB
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
   }
 
   // Simulate orphaned wasChanged: legacy DO crashed during corruption recovery,
@@ -197,7 +197,7 @@ export class TestStateAgent extends Agent<Cloudflare.Env, TestState> {
       `INSERT OR REPLACE INTO cf_agents_state (id, state) VALUES ('cf_state_was_changed', 'true')`
     );
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
   }
 }
 
@@ -205,7 +205,7 @@ export class TestStateAgent extends Agent<Cloudflare.Env, TestState> {
 export class TestStateAgentNoInitial extends Agent {
   // Capture the DEFAULT_STATE sentinel reference for cache reset in tests.
   // @ts-expect-error - accessing private field for testing
-  private _stateSentinel: unknown = this._state;
+  private _stateSentinel: unknown = this._cachedState;
 
   // No initialState defined - should return undefined
 
@@ -254,7 +254,7 @@ export class TestStateAgentNoInitial extends Agent {
   // Reset in-memory cache and read from DB
   getStateAfterCorruption() {
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
     return this.state;
   }
 
@@ -266,7 +266,7 @@ export class TestStateAgentNoInitial extends Agent {
     );
     // Reset in-memory cache to sentinel so getter re-reads from DB
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
   }
 
   // Simulate orphaned wasChanged: legacy DO crashed during corruption recovery,
@@ -279,7 +279,7 @@ export class TestStateAgentNoInitial extends Agent {
       `INSERT OR REPLACE INTO cf_agents_state (id, state) VALUES ('cf_state_was_changed', 'true')`
     );
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
   }
 
   // Simulate legacy state row without wasChanged: old SDK version that only wrote
@@ -293,7 +293,7 @@ export class TestStateAgentNoInitial extends Agent {
       value
     );
     // @ts-expect-error - accessing private field for testing
-    this._state = this._stateSentinel;
+    this._cachedState = this._stateSentinel;
   }
 
   // Reset schema version to 0 (simulates a pre-versioning DO)


### PR DESCRIPTION
This PR pulls the Agent state machinery out of the monolithic Agent class in `packages/agents/src/index.ts` and into a dedicated `packages/agents/src/agent/state.ts` module (`AgentState`). It is a surface-level extraction: behaviour and the public API are unchanged.

## Why

- `index.ts` is ~12k lines and the state logic (in-memory cache, SQLite persistence, protocol broadcast, connection readonly/no-protocol flags, state-change hook dispatch) was interleaved with everything else, making it hard for humans and agents to reason about in isolation.
- Grouping that logic in one documented module shrinks `index.ts` substantially and gives the state subsystem a single place to read and edit.
- The extraction uses a narrow `AgentStateHost<State>` callback interface rather than handing `AgentState` the whole Agent, so the boundary is explicit instead of "everything can reach everything". Passing the full Agent would have been less churn but would have preserved the coupling this change is meant to expose.
- This is deliberately not a functional or lower-layer extraction. `AgentState` still depends on Agent-only facilities, so it is not yet usable on a bare partyserver `Server`; see the couplings listed below.

## Architectural Changes

Before: state cache, persistence, broadcast, connection flags, and hook dispatch lived as methods and fields directly on `Agent`.

After: `Agent` holds a private `_state: AgentState<State>` and delegates to it. `AgentState` calls back into `Agent` only through the `AgentStateHost<State>` interface. `AgentStateApi<State>` describes the curated user-facing subset that `AgentState` implements, so a future major could expose the subsystem without leaking internal plumbing.

Still Agent-only (why it is not yet reusable on a lower layer). partyserver already provides `ctx`, `broadcast`, `getConnections`, `onError`, connections, and hibernation, so those are not blockers. The remaining couplings are:

- Ambient agent context: `state.ts` imports the `agentContext` AsyncLocalStorage directly and uses it for readonly-connection gating and to run the hook so `getCurrentAgent()` works. This must become host-provided context.
- Schema ownership: the `cf_agents_state` table is created by the Agent constructor (not by `AgentState`), the `sql` tagged-template helper is an Agent method, and the `cf_schema_version` migration framework co-inhabits the same table. `AgentState` is currently a tenant of a table the Agent layer owns.
- State-sync protocol/client: the live half depends on the `CF_AGENT_STATE` message type and a client that understands it (`useAgent` / `AgentClient`).
- Typed hook surface: `initialState`, `validateStateChange`, `onStateChanged` / `onStateUpdate` are Agent's user-facing override points.
- Observability: `_emit("state:update")` is Agent's event bus.
- Connection-flag semantics: the wrapping mechanism is pure partyserver, but the meanings (readonly = block writes, no-protocol = suppress `CF_AGENT_*` frames) are Agent-layer policy.

## Code Changes

- New `AgentState<State>` in `agent/state.ts` owns the state cache, persistence, broadcast, connection-flag machinery, and hook dispatch, talking back to Agent via `AgentStateHost<State>`.
- `Agent` delegates its state methods to `_state`. Public API (`state`, `setState`, `setConnectionReadonly`, `isConnectionReadonly`, `isConnectionProtocolEnabled`) is unchanged and still declared on `Agent.prototype`; `agent.state` still returns the state value.
- Removed five private pass-through wrappers on Agent (`_broadcastProtocol`, `_setStateInternal`, `_ensureConnectionWrapped`, `_setConnectionNoProtocol`, `_cf_getRawConnectionState`) and inlined their call sites to `_state`.
- Tombstoned `_unsafe_getConnectionFlag` / `_unsafe_setConnectionFlag` as `@deprecated` forwarders with no remaining in-repo callers.
- Documented the module: a top-level overview of what "state" is, and an expanded explanation of the persistence-hook dispatch mode.
- Test helpers that force the in-memory cache now go through the renamed private `_cachedState` accessor.

No changeset is included: `AgentStateApi` is exported from the module but not from the package's public entry points, and no published behaviour changes.

## Compatibility

Nothing user-facing changes. `_unsafe_getConnectionFlag` / `_unsafe_setConnectionFlag` remain on the prototype but are now `@deprecated` internal forwarders slated for removal in a future major; they were never part of the documented API.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->