### PR TITLE
fix(think): preserve system prompt when skills are enabled

### DIFF
--- a/.changeset/tidy-skills-keep-prompts.md
+++ b/.changeset/tidy-skills-keep-prompts.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Keep `getSystemPrompt()` in the assembled model prompt when `getSkills()` registers its catalog context.

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -209,8 +209,8 @@ export class MyAgent extends Think<Env> {
 
 Think supports the [Agent Skills](https://agentskills.io/) directory format as
 a first-class API. Return one or more `SkillSource` objects from `getSkills()`;
-Think adds the skill catalog to the prompt and exposes `activate_skill` and
-`read_skill_resource` tools when skills are available.
+Think appends the skill catalog to `getSystemPrompt()` and exposes
+`activate_skill` and `read_skill_resource` tools when skills are available.
 
 ```ts
 import { Think, skills } from "@cloudflare/think";
@@ -268,9 +268,10 @@ can read `{ name, path }` or a qualified path such as
 from other skills.
 
 Skills are on-demand instructions, not always-on system prompt text. The model
-sees the catalog first, then calls `activate_skill` when a user task matches a
-skill description. Use `getSystemPrompt()` or a Session context block for
-behavior that should apply to every turn.
+sees their catalog alongside the base prompt, then calls `activate_skill` when a
+user task matches a skill description. Enabling skills does not replace
+`getSystemPrompt()`. Use that method or a Session context block for behavior that
+should apply to every turn.
 
 Script execution is opt-in and **experimental**. `getSkillScriptRunner()`
 enables `run_skill_script`, which can run JavaScript, TypeScript, Python, and
@@ -334,7 +335,7 @@ Script execution requires a Worker Loader binding:
 | Method / Property          | Default                            | Description                                                                                                                                                                                                                  |
 | -------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `getModel()`               | throws                             | Return the `LanguageModel` to use                                                                                                                                                                                            |
-| `getSystemPrompt()`        | careful assistant operating prompt | System prompt (fallback when no context blocks)                                                                                                                                                                              |
+| `getSystemPrompt()`        | careful assistant operating prompt | Base prompt; skill catalogs augment it, otherwise it is the fallback when no context blocks exist                                                                                                                            |
 | `getTools()`               | `{}`                               | AI SDK `ToolSet` for the agentic loop                                                                                                                                                                                        |
 | `getMessengers()`          | `{}`                               | Messenger ingress and delivery declarations                                                                                                                                                                                  |
 | `getScheduledTasks()`      | `{}`                               | Code-declared recurring prompts                                                                                                                                                                                              |

--- a/packages/think/src/tests/agents/index.ts
+++ b/packages/think/src/tests/agents/index.ts
@@ -10,6 +10,7 @@ export {
   ThinkTestAgent,
   ThinkToolsTestAgent,
   ThinkSessionTestAgent,
+  ThinkSkillsPromptTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
   ThinkLegacyConfigMigrationAgent,

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -42,7 +42,8 @@ import type {
   ActionAuthorizationContext,
   ActionAuthorizationDecision,
   StepContext,
-  ChunkContext
+  ChunkContext,
+  SkillSource
 } from "../../think";
 import {
   sanitizeMessage,
@@ -3185,6 +3186,7 @@ export class ThinkAgentToolParent extends Agent {
 
 export class ThinkSessionTestAgent extends Think {
   private _response = "Hello from session agent!";
+  private _capturedSystem = "";
 
   override configureSession(session: Session) {
     return session
@@ -3197,6 +3199,10 @@ export class ThinkSessionTestAgent extends Think {
 
   override getModel(): LanguageModel {
     return createMockModel(this._response);
+  }
+
+  override beforeTurn(ctx: TurnContext): void {
+    this._capturedSystem = ctx.system;
   }
 
   async setResponse(response: string): Promise<void> {
@@ -3216,6 +3222,10 @@ export class ThinkSessionTestAgent extends Think {
 
   async getStoredMessages(): Promise<UIMessage[]> {
     return this.getMessages();
+  }
+
+  async getCapturedSystem(): Promise<string> {
+    return this._capturedSystem;
   }
 
   async getContextBlockContent(label: string): Promise<string | null> {
@@ -3271,6 +3281,66 @@ export class ThinkSessionTestAgent extends Think {
 
   async hostGetContext(label: string): Promise<string | null> {
     return this._hostGetContext(label);
+  }
+}
+
+// ── ThinkSkillsPromptTestAgent ───────────────────────────────
+// Exercises first-class skills and base-system-prompt composition together.
+
+const promptTestSkillSource: SkillSource = {
+  id: "prompt-test-skills",
+  fingerprint: "prompt-test-skills-v1",
+  async list() {
+    return [
+      {
+        name: "prompt-test",
+        description: "Verify skill catalog prompt composition."
+      }
+    ];
+  },
+  async load(name) {
+    return name === "prompt-test"
+      ? {
+          name,
+          description: "Verify skill catalog prompt composition.",
+          body: "Follow the prompt composition test procedure."
+        }
+      : null;
+  }
+};
+
+export class ThinkSkillsPromptTestAgent extends Think {
+  private _capturedSystem = "";
+
+  override getSystemPrompt(): string {
+    return "CUSTOM SKILLS AGENT SYSTEM PROMPT";
+  }
+
+  override getSkills(): SkillSource[] {
+    return [promptTestSkillSource];
+  }
+
+  override getModel(): LanguageModel {
+    return createMockModel("Skills prompt test response");
+  }
+
+  override beforeTurn(ctx: TurnContext): void {
+    this._capturedSystem = ctx.system;
+  }
+
+  async testChat(message: string): Promise<TestChatResult> {
+    const cb = new TestCollectingCallback();
+    await this.chat(message, cb);
+    return {
+      events: cb.events,
+      done: cb.doneCalled,
+      error: cb.errorMessage,
+      interruptedCalls: cb.interruptedCalls
+    };
+  }
+
+  async getCapturedSystem(): Promise<string> {
+    return this._capturedSystem;
   }
 }
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -6,6 +6,7 @@ import { subscribe } from "agents/observability";
 import type {
   ThinkTestAgent,
   ThinkSessionTestAgent,
+  ThinkSkillsPromptTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
   ThinkLegacyConfigMigrationAgent,
@@ -88,6 +89,13 @@ function closeWS(ws: WebSocket): Promise<void> {
 async function freshSessionAgent(name: string) {
   return getServerByName(
     env.ThinkSessionTestAgent as unknown as DurableObjectNamespace<ThinkSessionTestAgent>,
+    name
+  );
+}
+
+async function freshSkillsPromptAgent(name: string) {
+  return getServerByName(
+    env.ThinkSkillsPromptTestAgent as unknown as DurableObjectNamespace<ThinkSkillsPromptTestAgent>,
     name
   );
 }
@@ -960,6 +968,29 @@ describe("Think — Session integration", () => {
 // ── Context blocks ───────────────────────────────────────────────
 
 describe("Think — context blocks", () => {
+  it("keeps getSystemPrompt when getSkills registers its catalog context", async () => {
+    const agent = await freshSkillsPromptAgent("ctx-skills-base-prompt");
+
+    const result = await agent.testChat("Use the prompt test skill.");
+    expect(result.done).toBe(true);
+
+    const system = await agent.getCapturedSystem();
+    expect(system).toContain("CUSTOM SKILLS AGENT SYSTEM PROMPT");
+    expect(system).toContain("prompt-test");
+    expect(system).toContain("Verify skill catalog prompt composition.");
+  });
+
+  it("keeps replacement semantics for context blocks when skills are disabled", async () => {
+    const agent = await freshSessionAgent("ctx-replaces-base-prompt");
+
+    const result = await agent.testChat("Hello!");
+    expect(result.done).toBe(true);
+
+    const system = await agent.getCapturedSystem();
+    expect(system).toContain("MEMORY");
+    expect(system).not.toContain("You are a careful, capable assistant");
+  });
+
   it("should configure session with context blocks", async () => {
     const agent = await freshSessionAgent("ctx-basic");
 

--- a/packages/think/src/tests/worker.ts
+++ b/packages/think/src/tests/worker.ts
@@ -19,6 +19,7 @@ export {
   ThinkFiberTestAgent,
   ThinkClientToolsAgent,
   ThinkSessionTestAgent,
+  ThinkSkillsPromptTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
   ThinkLegacyConfigMigrationAgent,
@@ -55,6 +56,7 @@ import type {
   ThinkFiberTestAgent,
   ThinkClientToolsAgent,
   ThinkSessionTestAgent,
+  ThinkSkillsPromptTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
   ThinkLegacyConfigMigrationAgent,
@@ -195,6 +197,7 @@ export type Env = {
   ThinkFiberTestAgent: DurableObjectNamespace<ThinkFiberTestAgent>;
   ThinkClientToolsAgent: DurableObjectNamespace<ThinkClientToolsAgent>;
   ThinkSessionTestAgent: DurableObjectNamespace<ThinkSessionTestAgent>;
+  ThinkSkillsPromptTestAgent: DurableObjectNamespace<ThinkSkillsPromptTestAgent>;
   ThinkAsyncConfigSessionAgent: DurableObjectNamespace<ThinkAsyncConfigSessionAgent>;
   ThinkConfigTestAgent: DurableObjectNamespace<ThinkConfigTestAgent>;
   ThinkLegacyConfigMigrationAgent: DurableObjectNamespace<ThinkLegacyConfigMigrationAgent>;

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -56,6 +56,10 @@
         "name": "ThinkSessionTestAgent"
       },
       {
+        "class_name": "ThinkSkillsPromptTestAgent",
+        "name": "ThinkSkillsPromptTestAgent"
+      },
+      {
         "class_name": "ThinkAsyncConfigSessionAgent",
         "name": "ThinkAsyncConfigSessionAgent"
       },
@@ -172,6 +176,7 @@
         "ThinkFiberTestAgent",
         "ThinkClientToolsAgent",
         "ThinkSessionTestAgent",
+        "ThinkSkillsPromptTestAgent",
         "ThinkAsyncConfigSessionAgent",
         "ThinkConfigTestAgent",
         "ThinkLegacyConfigMigrationAgent",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -12,7 +12,7 @@
  * Configuration overrides:
  *   - getModel()            — return a model id string (resolved via the
  *                             built-in workers-ai-provider) or a LanguageModel
- *   - getSystemPrompt()     — return the system prompt (fallback when no context blocks)
+ *   - getSystemPrompt()     — return the base system prompt (fallback when no context blocks)
  *   - getTools()            — return the ToolSet for the agentic loop
  *   - maxSteps              — max tool-call rounds per turn (default: 10)
  *   - configureSession()    — add context blocks, compaction, search, skills
@@ -1892,7 +1892,7 @@ export interface TurnInput {
  * Contains everything Think assembled — the hook can inspect and override.
  */
 export interface TurnContext {
-  /** Assembled system prompt (from context blocks or getSystemPrompt fallback). */
+  /** Assembled system prompt (context blocks plus the base prompt when skills are enabled). */
   system: string;
   /** Assembled model messages (truncated, pruned). */
   messages: ModelMessage[];
@@ -3770,8 +3770,9 @@ export class Think<
   }
 
   /**
-   * Return the system prompt for the assistant.
+   * Return the base system prompt for the assistant.
    * Used as fallback when no context blocks are configured via `configureSession`.
+   * A catalog registered by `getSkills()` augments rather than replaces it.
    */
   getSystemPrompt(): string {
     return [
@@ -5148,7 +5149,12 @@ export class Think<
         : undefined;
 
     const frozenPrompt = await this.session.freezeSystemPrompt();
-    const rawBaseSystem = frozenPrompt || this.getSystemPrompt();
+    // User-configured context retains its existing replacement semantics, but
+    // first-class skills are framework-added context: their catalog must not
+    // silently erase the agent's identity and always-on instructions.
+    const rawBaseSystem = this._skillRegistry
+      ? [this.getSystemPrompt(), frozenPrompt].filter(Boolean).join("\n\n")
+      : frozenPrompt || this.getSystemPrompt();
     const baseSystem = channelInstructions
       ? `${channelInstructions}\n\n${rawBaseSystem}`
       : rawBaseSystem;


### PR DESCRIPTION
## Summary

- keep `getSystemPrompt()` in the assembled prompt when `getSkills()` registers the Think skills catalog
- preserve the existing replacement behavior for ordinary Session context blocks when skills are not enabled
- document the composition rule and add a patch changeset

Closes #1871.

## Testing

- `pnpm --filter @cloudflare/think test`
  - 42 Workers test files / 896 tests
  - generated-entry: 10 tests
  - Vite: 10 tests
  - CLI: 55 tests
  - React: 5 tests
- `tsc --noEmit -p packages/think/tsconfig.json`
- `tsc --noEmit -p packages/think/src/tests/tsconfig.json`
- repo-wide export, formatting, and lint checks pass

`pnpm run check` reaches the repo-wide typecheck, where three existing voice example projects fail against the current voice types (`examples/telnyx-voice-agent`, `examples/voice-agent`, and `examples/playground`). The affected Think package and test TypeScript projects pass.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->