### PR TITLE
fix(agent-think): scope lifecycle to active runs

### DIFF
--- a/agent-think/AGENTS.md
+++ b/agent-think/AGENTS.md
@@ -92,6 +92,15 @@ the container's coding filesystem.
   ThinkAgent to its warm-pooled Sandbox, but `sync: "none"` prevents repo data,
   `.git`, `node_modules`, builds, and logs from entering DO SQLite. The DO owns
   only durable turn/recovery state. Skills use Think's native R2 source.
+- **Run identity is durable input, not prompt configuration.** The first user
+  message carries an `<agent-think-run>` JSON envelope (repo, issue,
+  instruction, requester, triggering comment). Skills fail closed without it.
+  This survives context-block prompt assembly, eviction, and continuation.
+- **Workspace transport is scoped.** Container auth and every file/bash tool
+  run through `RunLifecycle.withWorkspace`; the last concurrent user closes the
+  RPC/WebSocket handle. A bounded, renewable WarmPool lease protects the
+  assigned container while the durable turn is active, then idle eviction owns
+  cleanup after terminal completion.
 - **Everything runs on the `container` backend.** It provides the real Linux
   filesystem, toolchain, and network used by bash and the file tools.
 - **Repros must be clickable.** The reproduce skill mandates a minimal
@@ -165,9 +174,10 @@ pnpm run deploy  # vite build (thread UI) + wrangler deploy (worker + image)
 npm run seed:r2  # push skills/** to the R2 bucket (add -- --local for dev)
 ```
 
-- Vitest configs live next to their suites: `test/vitest.config.ts` (unit) and
-  `tests-e2e/vitest.config.ts` (e2e). `vite.config.ts` at the root builds only
-  the thread UI into `dist/client`.
+- Vitest configs live next to their suites: `test/vitest.config.ts` (Workers
+  runtime module/DO tests) and `tests-e2e/vitest.config.ts` (real Wrangler +
+  Docker infrastructure, with only inference replaced by a test subclass).
+  `vite.config.ts` at the root builds only the thread UI into `dist/client`.
 - Local-only HTTP surface (gated on `LOCAL_DEV=1`, set automatically by the
   e2e harness): `POST /dev/dispatch` and `GET /dev/messages/:session` — drive
   the full agent path without gh-app or webhooks.

--- a/agent-think/package.json
+++ b/agent-think/package.json
@@ -9,7 +9,7 @@
     "dev": "wrangler dev --ip 0.0.0.0",
     "build:client": "vite build",
     "deploy": "vite build && wrangler deploy",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tests-e2e/tsconfig.json",
     "gen-types": "wrangler types",
     "seed:r2": "node ./scripts/seed-skills.mjs",
     "test": "vitest run --config test/vitest.config.ts",

--- a/agent-think/skills/open-pr/SKILL.md
+++ b/agent-think/skills/open-pr/SKILL.md
@@ -3,8 +3,19 @@ name: open-pr
 description: Take a cloudflare/agents GitHub issue plus any repro findings and one-shot a fix PR — branch, change, test, push, and open the PR linked to the issue.
 ---
 
-The agent system prompt gives you `issueNumber`, `repo`, and the user's
-instruction. Use those values directly; there is no separate arguments object.
+The first user message contains an `<agent-think-run>` envelope with `repository`,
+`issue`, `instruction`, `requested-by`, and (when available) `trigger-comment-id`.
+Use those values exactly. Never infer or substitute another target from examples,
+workspace contents, GitHub searches, or concurrent issues. If the envelope or a
+required field is absent, stop without cloning/editing/pushing/posting and return a
+structured skipped result. When `trigger-comment-id` is present, your first
+container action is the liveness reaction:
+
+```bash
+gh api repos/<repository>/issues/comments/<trigger-comment-id>/reactions \
+  -f content=rocket
+```
+
 Produce a focused fix PR, authored as **yourself** — the agent-think GitHub App.
 Do not impersonate any user.
 
@@ -48,7 +59,8 @@ known.
 needing design, is too vague, spans many subsystems, or you cannot locate a
 confident root cause, stop: return `prOpened: false`, `skipped: true`, and a
 `summary` explaining why. Post a brief, polite comment saying the pr-agent is
-skipping it and what additional detail would help.
+skipping it and what additional detail would help; begin it with
+`Requested by @<requestedBy>` when the run envelope has a requester.
 
 ## 2. Locate the root cause
 
@@ -161,6 +173,8 @@ gh pr create --repo <repo> \
 
 Write the PR body outside the checkout at `/workspace/temp/pr-body.md`. It must include:
 
+- `Requested by @<requestedBy>` near the top, using the exact sanitized
+  `requested-by` mention from the run envelope (omit only when it is `unknown`).
 - `Closes #<issueNumber>` so the issue auto-links.
 - **What was wrong** (root cause, citing the file/line).
 - **What changed** and why this is the minimal fix.

--- a/agent-think/skills/reproduce/SKILL.md
+++ b/agent-think/skills/reproduce/SKILL.md
@@ -3,8 +3,19 @@ name: reproduce
 description: Reproduce a cloudflare/agents GitHub issue by scaffolding a minimal Agents/Worker project and deploying it to a temporary Cloudflare account, then report findings back on the issue.
 ---
 
-The agent system prompt gives you `issueNumber`, `repo`, and the user's
-instruction. Use those values directly; there is no separate arguments object.
+The first user message contains an `<agent-think-run>` envelope with `repository`,
+`issue`, `instruction`, `requested-by`, and (when available) `trigger-comment-id`.
+Use those values exactly. Never infer or substitute another target from examples,
+workspace contents, GitHub searches, or concurrent issues. If the envelope or a
+required field is absent, stop without cloning/editing/posting and return a
+structured skipped result. When `trigger-comment-id` is present, your first
+container action is the liveness reaction:
+
+```bash
+gh api repos/<repository>/issues/comments/<trigger-comment-id>/reactions \
+  -f content=rocket
+```
+
 Reproduce the bug end-to-end and post your findings as an issue comment.
 
 The instruction is the free-form text the user typed after `@agent-think` (it
@@ -45,7 +56,8 @@ Read it carefully. Extract:
 **Decide if it is reproducible at all.** If it is a feature request, a question,
 a pure-docs issue, or has no concrete runnable behavior, stop here: return
 `skipped: true`, `reproduced: false`, and a `summary` explaining why. Still post
-a short, polite comment saying the repro-agent skipped it and why.
+a short, polite comment saying the repro-agent skipped it and why; begin it with
+`Requested by @<requestedBy>` when the run envelope has a requester.
 
 ## 2. Understand the relevant code
 
@@ -307,6 +319,8 @@ gh issue comment <issueNumber> --repo <repo> --body-file comment.md
 
 The comment should contain:
 
+- `Requested by @<requestedBy>` near the top, using the exact sanitized
+  `requested-by` mention from the run envelope (omit only when it is `unknown`).
 - **Verdict**: reproduced / could not reproduce / skipped, with one-line reason.
 - **Live URL** plus one line of click instructions ("open it, press _Trigger
   bug_, watch the log") — the page is the demo. Phrase it exactly like:

--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -49,7 +49,11 @@ import {
   createReadTool,
   createWriteTool
 } from "./tools/fs/index";
-import { buildRunEnvelope, type RunTarget } from "./run-context";
+import {
+  buildRunEnvelope,
+  buildRunTelemetry,
+  type RunTarget
+} from "./run-context";
 import {
   classifyRunOutcome,
   RunLifecycle,
@@ -427,6 +431,15 @@ export class ThinkAgent extends ThinkBase {
     await this.#runLifecycle.withWorkspace(() => this.#ensureGitAuth());
     return {
       maxOutputTokens: 16384,
+      ...(this.#context
+        ? {
+            experimental_telemetry: buildRunTelemetry(
+              this.#context,
+              this.name,
+              this.constructor.name
+            )
+          }
+        : {}),
       // Only our four tools reach the model (read/write/edit/bash — pi's
       // codingTools shape, Claude Code's names). Think merges its workspace
       // built-ins (list/find/grep/delete) unconditionally; this allowlist

--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -113,6 +113,7 @@ export class ThinkAgent extends ThinkBase {
    * issue (new short-lived token) re-authenticates automatically.
    */
   #authedToken: string | null = null;
+  #reportTail: Promise<void> = Promise.resolve();
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -227,18 +228,16 @@ export class ThinkAgent extends ThinkBase {
       issue: ctx.issueNumber,
       instruction: ctx.instruction
     });
-    const commandCenter = await getAgentByName<Env, CommandCenterAgent>(
-      this.env.CommandCenter,
-      "main"
+    this.#report((commandCenter) =>
+      commandCenter.recordDispatch({
+        session: this.name,
+        repo: ctx.repo,
+        issueNumber: ctx.issueNumber,
+        instruction: ctx.instruction,
+        issueTitle: ctx.issueTitle,
+        requestedBy: ctx.requestedBy
+      })
     );
-    await commandCenter.recordDispatch({
-      session: this.name,
-      repo: ctx.repo,
-      issueNumber: ctx.issueNumber,
-      instruction: ctx.instruction,
-      issueTitle: ctx.issueTitle,
-      requestedBy: ctx.requestedBy
-    });
     const submission = await this.submitMessages(
       [
         {
@@ -379,15 +378,19 @@ export class ThinkAgent extends ThinkBase {
       cc: Awaited<ReturnType<typeof getAgentByName<Env, CommandCenterAgent>>>
     ) => Promise<unknown>
   ): void {
-    this.ctx.waitUntil(
-      getAgentByName<Env, CommandCenterAgent>(this.env.CommandCenter, "main")
-        .then(fn)
-        .catch((err) =>
-          // Log-only: reporting must never break the run, but a silent
-          // failure here made the command center undebuggable.
-          this.#log("report-error", { error: String(err).slice(0, 200) })
-        )
-    );
+    // Serialize observer updates without awaiting them on the run path. This
+    // preserves dispatch → tools → terminal ordering for fast turns while a
+    // slow/broken Command Center can never block or fail the actual run.
+    this.#reportTail = this.#reportTail
+      .then(() =>
+        getAgentByName<Env, CommandCenterAgent>(this.env.CommandCenter, "main")
+      )
+      .then(fn)
+      .then(() => undefined)
+      .catch((err) =>
+        this.#log("report-error", { error: String(err).slice(0, 200) })
+      );
+    this.ctx.waitUntil(this.#reportTail);
   }
 
   // ── Think hooks ────────────────────────────────────────────────
@@ -466,17 +469,15 @@ export class ThinkAgent extends ThinkBase {
   }
 
   async #recordTerminal(outcome: RunOutcome): Promise<void> {
-    const cc = await getAgentByName<Env, CommandCenterAgent>(
-      this.env.CommandCenter,
-      "main"
+    this.#report((commandCenter) =>
+      commandCenter.recordTurn({
+        session: this.name,
+        outcome: outcome.status,
+        ...(outcome.status === "error"
+          ? { error: outcome.error.slice(0, 300) }
+          : {})
+      })
     );
-    await cc.recordTurn({
-      session: this.name,
-      outcome: outcome.status,
-      ...(outcome.status === "error"
-        ? { error: outcome.error.slice(0, 300) }
-        : {})
-    });
   }
 
   // ── Lifecycle logging: reconstruct a run from the deployed logs ──

--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -16,6 +16,8 @@
  */
 
 import type {
+  ChatRecoveryExhaustedContext,
+  ChatResponseResult,
   ToolCallResultContext,
   TurnContext,
   WorkspaceLike as ThinkWorkspaceLike
@@ -29,7 +31,7 @@ import {
   type WorkspaceStub
 } from "@cloudflare/workspace";
 import { CloudflareContainerBackend } from "@cloudflare/workspace/backends/container";
-import { type ToolSet } from "ai";
+import type { LanguageModel, ToolSet } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
 import { openai } from "workers-ai-provider/openai";
 import { getAgentByName } from "agents";
@@ -47,6 +49,12 @@ import {
   createReadTool,
   createWriteTool
 } from "./tools/fs/index";
+import { buildRunEnvelope, type RunTarget } from "./run-context";
+import {
+  classifyRunOutcome,
+  RunLifecycle,
+  type RunOutcome
+} from "./run-lifecycle";
 
 export { WorkspaceProxy, WorkspaceServiceProxy };
 
@@ -64,27 +72,23 @@ const MODEL_ID = "openai/gpt-5.5";
 const REASONING_EFFORT = "medium";
 
 /** Per-issue run context, set by `dispatch` before the turn is submitted. */
-export interface RunContext {
-  repo: string;
-  issueNumber: number;
-  /** Free-form instruction the user typed after `@agent-think`. */
-  instruction: string;
+export interface RunContext extends RunTarget {
   /** Short-lived GitHub App installation token. */
   installationToken: string;
-  /** Triggering comment id — see DispatchInput.commentId. */
-  commentId?: number;
-  /** GitHub issue title, forwarded to the command center. */
-  issueTitle?: string;
-  /** Who mentioned @agent-think, forwarded to the command center. */
-  requestedBy?: { login: string; avatarUrl?: string };
 }
 
 class ThinkBase extends Think<Env> {}
 
 export class ThinkAgent extends ThinkBase {
-  // Think's own chat recovery IS the durability layer now (no Workflow):
-  // submitMessages persists the turn and Think resumes it across a DO
-  // eviction. Left at the default (enabled).
+  /** Agent-think has no media attachment store; drop aged inline media. */
+  override mediaEviction = { externalizeToWorkspace: false };
+
+  // Think's own chat recovery is the durability layer. Its terminal hook must
+  // also release agent-think's external resources and command-center status.
+  override chatRecovery = {
+    onExhausted: (ctx: ChatRecoveryExhaustedContext) =>
+      this.#finishRun("error", `Recovery exhausted: ${ctx.reason}`)
+  };
 
   /** repro/pr can be long: clone, install, deploy or fix, verify. */
   override maxSteps = 60;
@@ -99,6 +103,7 @@ export class ThinkAgent extends ThinkBase {
 
   readonly #containerBackend: CloudflareContainerBackend;
   readonly #workspaceFs: Workspace;
+  readonly #runLifecycle: RunLifecycle;
   #context: RunContext | null = null;
   /**
    * The installation token the container's `gh`/`git` is currently
@@ -133,6 +138,14 @@ export class ThinkAgent extends ThinkBase {
     this.workspace = adaptToThinkWorkspace(
       this.#workspaceFs
     ) as unknown as ThinkWorkspaceLike;
+    this.#runLifecycle = new RunLifecycle({
+      env,
+      sessionId: ctx.id.toString(),
+      workspace: this.#workspaceFs,
+      reportTerminal: (outcome) => this.#recordTerminal(outcome),
+      log: (event, data) => this.#log(event, data),
+      fork: (effect) => this.ctx.waitUntil(effect)
+    });
 
     this.ctx.blockConcurrencyWhile(async () => {
       this.#context =
@@ -180,6 +193,7 @@ export class ThinkAgent extends ThinkBase {
    */
   async resetSession(): Promise<void> {
     this.#log("session-reset", {});
+    await this.#workspaceFs.close();
     await releaseContainer(this.env, this.ctx.id.toString());
     await this.ctx.storage.deleteAlarm();
     await this.ctx.storage.deleteAll();
@@ -213,16 +227,18 @@ export class ThinkAgent extends ThinkBase {
       issue: ctx.issueNumber,
       instruction: ctx.instruction
     });
-    this.#report((cc) =>
-      cc.recordDispatch({
-        session: this.name,
-        repo: ctx.repo,
-        issueNumber: ctx.issueNumber,
-        instruction: ctx.instruction,
-        issueTitle: ctx.issueTitle,
-        requestedBy: ctx.requestedBy
-      })
+    const commandCenter = await getAgentByName<Env, CommandCenterAgent>(
+      this.env.CommandCenter,
+      "main"
     );
+    await commandCenter.recordDispatch({
+      session: this.name,
+      repo: ctx.repo,
+      issueNumber: ctx.issueNumber,
+      instruction: ctx.instruction,
+      issueTitle: ctx.issueTitle,
+      requestedBy: ctx.requestedBy
+    });
     const submission = await this.submitMessages(
       [
         {
@@ -231,10 +247,7 @@ export class ThinkAgent extends ThinkBase {
           parts: [
             {
               type: "text",
-              text:
-                "Carry out the user's instruction for this issue now. Activate the " +
-                "matching skill first and follow it end to end, then reply with the " +
-                "structured result that skill specifies."
+              text: buildRunEnvelope(ctx)
             }
           ]
         }
@@ -379,7 +392,7 @@ export class ThinkAgent extends ThinkBase {
 
   // ── Think hooks ────────────────────────────────────────────────
 
-  override getModel() {
+  override getModel(): LanguageModel {
     // Route through the account's default AI Gateway so model calls get
     // Gateway-side retries, caching, and observability. The `openai` provider
     // plugin lets the `openai/...` catalog slug dispatch through the gateway
@@ -406,10 +419,9 @@ export class ThinkAgent extends ThinkBase {
   }
 
   override async beforeTurn(ctx: TurnContext) {
-    // Container gh/git auth runs here — inside the durable turn — rather
-    // than in start(), so dispatch stays fast and a slow container attach
-    // can't be killed by the caller's cancellation (see start()).
-    await this.#ensureGitAuth();
+    // Container auth is scoped: no Workspace transport remains open while the
+    // model is thinking, so infrastructure /ws cannot become the turn root.
+    await this.#runLifecycle.withWorkspace(() => this.#ensureGitAuth());
     return {
       maxOutputTokens: 16384,
       // Only our four tools reach the model (read/write/edit/bash — pi's
@@ -445,6 +457,28 @@ export class ThinkAgent extends ThinkBase {
     this.#log("git-auth-ok", {});
   }
 
+  async #finishRun(outcome: "done" | "error", error?: string): Promise<void> {
+    await this.#runLifecycle.finish(
+      outcome === "done"
+        ? { status: "done" }
+        : { status: "error", error: error ?? "Agent run failed" }
+    );
+  }
+
+  async #recordTerminal(outcome: RunOutcome): Promise<void> {
+    const cc = await getAgentByName<Env, CommandCenterAgent>(
+      this.env.CommandCenter,
+      "main"
+    );
+    await cc.recordTurn({
+      session: this.name,
+      outcome: outcome.status,
+      ...(outcome.status === "error"
+        ? { error: outcome.error.slice(0, 300) }
+        : {})
+    });
+  }
+
   // ── Lifecycle logging: reconstruct a run from the deployed logs ──
   //
   // These are the Think turn-lifecycle overrides (not the submission-observer
@@ -463,26 +497,39 @@ export class ThinkAgent extends ThinkBase {
     });
   }
 
-  override async onChatResponse(): Promise<void> {
-    this.#report((cc) =>
-      cc.recordTurn({ session: this.name, outcome: "done" })
-    );
-    this.#log("turn:done", {
-      assistantChars: collectAssistantText(this.messages).length
+  override async onChatResponse(result: ChatResponseResult): Promise<void> {
+    const assistantText = collectAssistantText([result.message]);
+    const outcome = classifyRunOutcome({
+      status: result.status,
+      assistantText,
+      error: result.error
     });
+    await this.#runLifecycle.finish(outcome);
+    if (outcome.status === "done") {
+      this.#log("turn:done", { assistantChars: assistantText.length });
+    } else {
+      this.#log("turn:error", {
+        stage: "response",
+        error: outcome.error.slice(0, 800)
+      });
+    }
   }
 
   override onChatError(error: unknown, ctx?: { stage?: string }): unknown {
-    this.#report((cc) =>
-      cc.recordTurn({
-        session: this.name,
-        outcome: "error",
-        error: String(error).slice(0, 300)
-      })
+    const message = String(error);
+    // Some setup failures never reach onChatResponse. Cleanup immediately;
+    // a later durable recovery begins a fresh lease and may overwrite the
+    // command-center status with success.
+    this.ctx.waitUntil(
+      this.#finishRun("error", message).catch((cleanupError) =>
+        this.#log("turn-cleanup-error", {
+          error: String(cleanupError).slice(0, 300)
+        })
+      )
     );
     this.#log("turn:error", {
       stage: ctx?.stage,
-      error: String(error).slice(0, 800)
+      error: message.slice(0, 800)
     });
     return error;
   }
@@ -496,16 +543,6 @@ export class ThinkAgent extends ThinkBase {
       "The user invoked you with this instruction:",
       `  ${ctx?.instruction || "(no instruction — default to reproducing the issue)"}`,
       "",
-      ...(ctx?.commentId
-        ? [
-            "FIRST ACTION — prove you are alive: add a 🚀 reaction to the",
-            "comment that triggered you, then continue with the task:",
-            `  bash({ command: "gh api repos/${ctx.repo}/issues/comments/${ctx.commentId}/reactions -f content=rocket", backend: "container" })`,
-            "(👀 was added when your trigger was seen; your 🚀 tells the",
-            "humans the agent itself is running.)",
-            ""
-          ]
-        : []),
       "Two skills are available through Think's skill catalog:",
       "  - reproduce — reproduce and report an issue.",
       "  - open-pr   — locate, fix, verify, and open a PR.",
@@ -533,7 +570,7 @@ export class ThinkAgent extends ThinkBase {
   override getTools(): ToolSet {
     if (!this.#context) return {} as ToolSet;
     const store = new ContainerFileStore(this.#workspaceFs.shell);
-    return {
+    return this.#runLifecycle.scopeTools({
       read: createReadTool({ store, maxBytes: 32 * 1024, maxLines: 800 }),
       write: createWriteTool({ store }),
       edit: createEditTool({ store }),
@@ -550,7 +587,7 @@ export class ThinkAgent extends ThinkBase {
         },
         defaultBackend: "container"
       })
-    };
+    });
   }
 }
 

--- a/agent-think/src/index.ts
+++ b/agent-think/src/index.ts
@@ -151,6 +151,9 @@ export default {
           issueNumber?: number;
           instruction?: string;
           installationToken?: string;
+          commentId?: number;
+          issueTitle?: string;
+          requestedBy?: { login: string; avatarUrl?: string };
         };
         if (!body.repo || typeof body.issueNumber !== "number") {
           return Response.json(
@@ -163,7 +166,10 @@ export default {
             repo: body.repo,
             issueNumber: body.issueNumber,
             instruction: body.instruction ?? "reproduce this issue",
-            installationToken: body.installationToken ?? ""
+            installationToken: body.installationToken ?? "",
+            commentId: body.commentId,
+            issueTitle: body.issueTitle,
+            requestedBy: body.requestedBy
           });
           return Response.json(result, { status: 202 });
         } catch (error) {

--- a/agent-think/src/pool.ts
+++ b/agent-think/src/pool.ts
@@ -15,7 +15,7 @@
 import type { WarmPool, WarmPoolConfig } from "./warm-pool";
 import type { Sandbox } from "./sandbox";
 
-interface PoolEnv {
+export interface PoolEnv {
   WarmPool: DurableObjectNamespace<WarmPool>;
   Sandbox: DurableObjectNamespace<Sandbox>;
   WARM_POOL_TARGET?: string;
@@ -52,6 +52,36 @@ export async function resolveContainerId(
   const stub = poolStub(env);
   await stub.configure(readConfig(env));
   return stub.getContainer(sessionId);
+}
+
+/** Allocate/touch a container and protect it while a durable run is active. */
+export async function beginContainerActivity(
+  env: PoolEnv,
+  sessionId: string,
+  leaseId: string,
+  leaseMs: number
+): Promise<void> {
+  await resolveContainerId(env, sessionId);
+  await poolStub(env).beginActivity(sessionId, leaseId, leaseMs);
+}
+
+/** Renew a live run lease without reconnecting Workspace. */
+export async function renewContainerActivity(
+  env: PoolEnv,
+  sessionId: string,
+  leaseId: string,
+  leaseMs: number
+): Promise<boolean> {
+  return poolStub(env).renewActivity(sessionId, leaseId, leaseMs);
+}
+
+/** End a live run lease; the sticky assignment remains until normal idle eviction. */
+export async function endContainerActivity(
+  env: PoolEnv,
+  sessionId: string,
+  leaseId: string
+): Promise<boolean> {
+  return poolStub(env).endActivity(sessionId, leaseId);
 }
 
 /**

--- a/agent-think/src/run-context.ts
+++ b/agent-think/src/run-context.ts
@@ -1,0 +1,67 @@
+const GITHUB_LOGIN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const CLOUDFLARE_REPO = /^cloudflare\/[A-Za-z0-9_.-]+$/;
+
+export interface RequestedBy {
+  login: string;
+  avatarUrl?: string;
+}
+
+export interface RunTarget {
+  repo: string;
+  issueNumber: number;
+  instruction: string;
+  commentId?: number;
+  issueTitle?: string;
+  requestedBy?: RequestedBy;
+}
+
+export function validateRunTarget(target: RunTarget): RunTarget {
+  if (
+    !CLOUDFLARE_REPO.test(target.repo) ||
+    target.repo.endsWith("/.") ||
+    target.repo.endsWith("/..")
+  ) {
+    throw new Error(`Invalid Cloudflare repository: ${target.repo}`);
+  }
+  if (!Number.isSafeInteger(target.issueNumber) || target.issueNumber <= 0) {
+    throw new Error(`Invalid issue number: ${target.issueNumber}`);
+  }
+  if (
+    target.commentId !== undefined &&
+    (!Number.isSafeInteger(target.commentId) || target.commentId <= 0)
+  ) {
+    throw new Error(`Invalid comment id: ${target.commentId}`);
+  }
+  if (target.requestedBy && !GITHUB_LOGIN.test(target.requestedBy.login)) {
+    throw new Error(`Invalid GitHub login: ${target.requestedBy.login}`);
+  }
+  return target;
+}
+
+/**
+ * Durable, model-visible run identity. This deliberately duplicates the
+ * system prompt: context blocks may change prompt assembly, but a submitted
+ * user message is persisted with the turn and survives every continuation.
+ */
+export function buildRunEnvelope(target: RunTarget): string {
+  validateRunTarget(target);
+  const envelope = {
+    repository: target.repo,
+    issue: target.issueNumber,
+    ...(target.issueTitle ? { "issue-title": target.issueTitle } : {}),
+    instruction: target.instruction || "reproduce this issue",
+    "requested-by": target.requestedBy
+      ? `@${target.requestedBy.login}`
+      : "unknown",
+    ...(target.commentId !== undefined
+      ? { "trigger-comment-id": target.commentId }
+      : {})
+  };
+  return [
+    "<agent-think-run>",
+    JSON.stringify(envelope),
+    "</agent-think-run>",
+    "Use exactly this repository and issue. Never infer or substitute another target.",
+    "Activate the matching skill, follow it end to end, and return its structured result."
+  ].join("\n");
+}

--- a/agent-think/src/run-context.ts
+++ b/agent-think/src/run-context.ts
@@ -43,6 +43,24 @@ export function validateRunTarget(target: RunTarget): RunTarget {
  * system prompt: context blocks may change prompt assembly, but a submitted
  * user message is persisted with the turn and survives every continuation.
  */
+export function buildRunTelemetry(
+  target: RunTarget,
+  agentId: string,
+  agentName: string
+) {
+  validateRunTarget(target);
+  return {
+    metadata: {
+      agentId,
+      agentName,
+      conversationId: agentId,
+      repository: target.repo,
+      issueNumber: target.issueNumber,
+      ...(target.requestedBy ? { requestedBy: target.requestedBy.login } : {})
+    }
+  };
+}
+
 export function buildRunEnvelope(target: RunTarget): string {
   validateRunTarget(target);
   const envelope = {

--- a/agent-think/src/run-lifecycle.ts
+++ b/agent-think/src/run-lifecycle.ts
@@ -1,0 +1,242 @@
+import type { Workspace } from "@cloudflare/workspace";
+import type { ToolSet } from "ai";
+import {
+  beginContainerActivity,
+  endContainerActivity,
+  renewContainerActivity,
+  type PoolEnv
+} from "./pool";
+
+const DEFAULT_LEASE_MS = 20 * 60 * 1000;
+const DEFAULT_RENEW_MS = 60 * 1000;
+
+export type RunOutcome =
+  | { status: "done" }
+  | { status: "error"; error: string };
+
+export function classifyRunOutcome(input: {
+  status: "completed" | "error" | "aborted";
+  assistantText: string;
+  error?: string;
+}): RunOutcome {
+  if (input.status === "completed" && input.assistantText.trim().length > 0) {
+    return { status: "done" };
+  }
+  return {
+    status: "error",
+    error:
+      input.error ??
+      (input.assistantText.trim().length === 0
+        ? "Turn ended without a final assistant report (step budget exhausted)."
+        : `Turn ended with status ${input.status}.`)
+  };
+}
+
+export class RunLifecycleError extends Error {
+  readonly _tag = "RunLifecycleError";
+
+  constructor(
+    readonly operation: "start" | "renew" | "workspace" | "finish",
+    readonly cause: unknown
+  ) {
+    super(`Run lifecycle ${operation} failed: ${String(cause)}`);
+  }
+}
+
+export interface RunLifecycleOptions {
+  env: PoolEnv;
+  sessionId: string;
+  workspace: Workspace;
+  reportTerminal(outcome: RunOutcome): Promise<void>;
+  log(event: string, data: Record<string, unknown>): void;
+  fork(effect: Promise<unknown>): void;
+  leaseMs?: number;
+  renewMs?: number;
+}
+
+/**
+ * Owns all resources for one durable agent run.
+ *
+ * Interface invariants:
+ * - `start()` acquires/renews the container assignment lease.
+ * - `withWorkspace()` is scoped: every successful acquire has a finally-release,
+ *   and the final concurrent user closes all Workspace RPC streams.
+ * - `finish()` is idempotent, closes transport before ending the lease, and
+ *   reports the terminal status even when cleanup fails.
+ * - an isolate lost without `finish()` leaves only a bounded lease, never a
+ *   permanently pinned container.
+ */
+export class RunLifecycle {
+  readonly #options: RunLifecycleOptions;
+  readonly #leaseMs: number;
+  readonly #renewMs: number;
+  #leaseId: string | null = null;
+  #renewTimer: ReturnType<typeof setInterval> | null = null;
+  #workspaceUsers = 0;
+  #phase: "idle" | "active" | "finishing" | "finished" = "idle";
+  #finishPromise: Promise<void> | null = null;
+
+  constructor(options: RunLifecycleOptions) {
+    this.#options = options;
+    this.#leaseMs = options.leaseMs ?? DEFAULT_LEASE_MS;
+    this.#renewMs = options.renewMs ?? DEFAULT_RENEW_MS;
+  }
+
+  async start(): Promise<void> {
+    if (this.#phase === "finishing" && this.#finishPromise) {
+      await this.#finishPromise;
+    }
+    if (this.#phase === "idle" || this.#phase === "finished") {
+      this.#phase = "active";
+      this.#finishPromise = null;
+      this.#leaseId = crypto.randomUUID();
+    }
+    const leaseId = this.#leaseId;
+    if (leaseId === null) {
+      throw new RunLifecycleError("start", "lease id was not initialized");
+    }
+    try {
+      await beginContainerActivity(
+        this.#options.env,
+        this.#options.sessionId,
+        leaseId,
+        this.#leaseMs
+      );
+    } catch (cause) {
+      throw new RunLifecycleError("start", cause);
+    }
+
+    if (this.#renewTimer !== null) return;
+    this.#renewTimer = setInterval(() => {
+      this.#options.fork(
+        this.renew().catch((error) =>
+          this.#options.log("lease-renew-error", {
+            error: String(error).slice(0, 300)
+          })
+        )
+      );
+    }, this.#renewMs);
+  }
+
+  async renew(): Promise<void> {
+    const leaseId = this.#leaseId;
+    if (leaseId === null) return;
+    try {
+      const renewed = await renewContainerActivity(
+        this.#options.env,
+        this.#options.sessionId,
+        leaseId,
+        this.#leaseMs
+      );
+      if (!renewed) throw new Error("active container lease was lost");
+    } catch (cause) {
+      throw new RunLifecycleError("renew", cause);
+    }
+  }
+
+  scopeTools(tools: ToolSet): ToolSet {
+    return Object.fromEntries(
+      Object.entries(tools).map(([name, definition]) => {
+        const execute = definition.execute;
+        if (!execute) return [name, definition];
+        return [
+          name,
+          {
+            ...definition,
+            execute: (input: unknown, options: unknown) =>
+              this.withWorkspace(() =>
+                Promise.resolve(
+                  execute(input as never, options as never) as unknown
+                )
+              )
+          }
+        ];
+      })
+    ) as ToolSet;
+  }
+
+  async withWorkspace<A>(use: () => Promise<A>): Promise<A> {
+    await this.start();
+    this.#workspaceUsers++;
+    let value: A | undefined;
+    let useError: unknown;
+    try {
+      value = await use();
+    } catch (error) {
+      useError = error;
+    }
+
+    let releaseError: unknown;
+    this.#workspaceUsers--;
+    if (this.#workspaceUsers === 0) {
+      try {
+        await this.#options.workspace.close();
+        await this.renew();
+      } catch (error) {
+        releaseError = error;
+      }
+    }
+
+    if (useError !== undefined && releaseError !== undefined) {
+      throw new RunLifecycleError(
+        "workspace",
+        new AggregateError([useError, releaseError])
+      );
+    }
+    if (useError !== undefined) throw useError;
+    if (releaseError !== undefined) {
+      throw new RunLifecycleError("workspace", releaseError);
+    }
+    return value as A;
+  }
+
+  finish(outcome: RunOutcome): Promise<void> {
+    if (this.#phase === "finished") return Promise.resolve();
+    if (this.#phase === "finishing" && this.#finishPromise) {
+      return this.#finishPromise;
+    }
+    this.#phase = "finishing";
+    const pending = this.#finish(outcome).finally(() => {
+      this.#phase = "finished";
+    });
+    this.#finishPromise = pending;
+    return pending;
+  }
+
+  async #finish(outcome: RunOutcome): Promise<void> {
+    if (this.#renewTimer !== null) {
+      clearInterval(this.#renewTimer);
+      this.#renewTimer = null;
+    }
+    const leaseId = this.#leaseId;
+    this.#leaseId = null;
+
+    const cleanupErrors: unknown[] = [];
+    try {
+      await this.#options.workspace.close();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (leaseId !== null) {
+      try {
+        await endContainerActivity(
+          this.#options.env,
+          this.#options.sessionId,
+          leaseId
+        );
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+
+    try {
+      await this.#options.reportTerminal(outcome);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+
+    if (cleanupErrors.length > 0) {
+      throw new RunLifecycleError("finish", new AggregateError(cleanupErrors));
+    }
+  }
+}

--- a/agent-think/src/run-lifecycle.ts
+++ b/agent-think/src/run-lifecycle.ts
@@ -61,8 +61,9 @@ export interface RunLifecycleOptions {
  * - `start()` acquires/renews the container assignment lease.
  * - `withWorkspace()` is scoped: every successful acquire has a finally-release,
  *   and the final concurrent user closes all Workspace RPC streams.
- * - `finish()` is idempotent, closes transport before ending the lease, and
- *   reports the terminal status even when cleanup fails.
+ * - `finish()` is idempotent and best-effort: it closes transport before
+ *   ending the lease, reports terminal status, logs cleanup failures, and never
+ *   turns a completed agent run into an error because observability failed.
  * - an isolate lost without `finish()` leaves only a bounded lease, never a
  *   permanently pinned container.
  */
@@ -236,7 +237,9 @@ export class RunLifecycle {
     }
 
     if (cleanupErrors.length > 0) {
-      throw new RunLifecycleError("finish", new AggregateError(cleanupErrors));
+      this.#options.log("run-lifecycle-finish-error", {
+        errors: cleanupErrors.map((error) => String(error).slice(0, 300))
+      });
     }
   }
 }

--- a/agent-think/src/warm-pool.ts
+++ b/agent-think/src/warm-pool.ts
@@ -67,11 +67,16 @@ interface ContainerWithState {
   getState(): Promise<ContainerState>;
 }
 
-/** Persisted assignment row: the container UUID plus a last-touched stamp. */
+/** Persisted assignment row: container identity, idle clock, and active run lease. */
 export interface AssignmentRecord {
   uuid: string;
-  /** Wall-clock ms of the last `getContainer` call — drives idle eviction. */
+  /** Wall-clock ms when the assignment most recently became idle. */
   touchedAt: number;
+  /**
+   * A live turn renews this bounded lease. If its isolate disappears, the
+   * lease expires and normal idle eviction eventually reclaims the container.
+   */
+  activeLease?: { id: string; expiresAt: number };
 }
 
 // ---------------------------------------------------------------------------
@@ -107,6 +112,7 @@ export function selectExpiredAssignments(
   const expired: Array<{ sandboxId: string; uuid: string; touchedAt: number }> =
     [];
   for (const [sandboxId, record] of assignments) {
+    if (record.activeLease && record.activeLease.expiresAt > now) continue;
     if (record.touchedAt <= cutoff) {
       expired.push({
         sandboxId,
@@ -246,6 +252,49 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
     throw new Error("Failed to start container");
   }
 
+  /** Mark an assigned container active for one durable turn. */
+  async beginActivity(
+    sandboxId: string,
+    leaseId: string,
+    leaseMs: number
+  ): Promise<void> {
+    await this.init();
+    const existing = this.assignments.get(sandboxId);
+    if (!existing) throw new Error(`No container assigned to ${sandboxId}`);
+    const now = this.now();
+    existing.touchedAt = now;
+    existing.activeLease = {
+      id: leaseId,
+      expiresAt: now + Math.max(1, leaseMs)
+    };
+    await this.persist();
+  }
+
+  /** Extend a lease only when the caller still owns it. */
+  async renewActivity(
+    sandboxId: string,
+    leaseId: string,
+    leaseMs: number
+  ): Promise<boolean> {
+    await this.init();
+    const existing = this.assignments.get(sandboxId);
+    if (!existing || existing.activeLease?.id !== leaseId) return false;
+    existing.activeLease.expiresAt = this.now() + Math.max(1, leaseMs);
+    await this.persist();
+    return true;
+  }
+
+  /** End a lease without destroying the sticky session container. */
+  async endActivity(sandboxId: string, leaseId: string): Promise<boolean> {
+    await this.init();
+    const existing = this.assignments.get(sandboxId);
+    if (!existing || existing.activeLease?.id !== leaseId) return false;
+    delete existing.activeLease;
+    existing.touchedAt = this.now();
+    await this.persist();
+    return true;
+  }
+
   /**
    * Look up an existing container assignment without allocating.
    * Returns the container UUID if the sandbox ID has an active assignment, null otherwise.
@@ -306,6 +355,15 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
     await this.init();
     this.config = { ...DEFAULT_CONFIG, ...config };
     await this.ctx.storage.put("config", this.config);
+
+    // init() may have scheduled with the previous/default cadence. Pull the
+    // next alarm forward when configuration asks for a shorter interval, but
+    // never postpone an alarm that is already due sooner.
+    const nextRefresh = this.now() + this.config.refreshInterval;
+    const scheduled = await this.ctx.storage.getAlarm();
+    if (scheduled === null || scheduled > nextRefresh) {
+      await this.ctx.storage.setAlarm(nextRefresh);
+    }
   }
 
   /**

--- a/agent-think/test/container-workspace.test.ts
+++ b/agent-think/test/container-workspace.test.ts
@@ -4,6 +4,7 @@ import {
   ContainerLocalBackend,
   repoDirectory
 } from "../src/container-workspace";
+import { selectExpiredAssignments } from "../src/warm-pool";
 
 describe("container-local workspace", () => {
   it("disables Workspace push/pull sync", async () => {
@@ -25,5 +26,40 @@ describe("container-local workspace", () => {
   it("uses the repository name directly under /workspace", () => {
     expect(repoDirectory("cloudflare/agents")).toBe("/workspace/agents");
     expect(repoDirectory("owner/my repo")).toBe("/workspace/my-repo");
+  });
+
+  it("does not evict an actively leased assignment", () => {
+    const assignments = new Map([
+      [
+        "active",
+        {
+          uuid: "container-active",
+          touchedAt: 0,
+          activeLease: { id: "run-1", expiresAt: 20_000 }
+        }
+      ],
+      ["idle", { uuid: "container-idle", touchedAt: 0 }]
+    ]);
+
+    expect(selectExpiredAssignments(assignments, 10_000, 1_000)).toEqual([
+      { sandboxId: "idle", uuid: "container-idle", touchedAt: 0 }
+    ]);
+  });
+
+  it("eventually evicts an abandoned expired lease", () => {
+    const assignments = new Map([
+      [
+        "stale",
+        {
+          uuid: "container-stale",
+          touchedAt: 0,
+          activeLease: { id: "dead-run", expiresAt: 9_999 }
+        }
+      ]
+    ]);
+
+    expect(selectExpiredAssignments(assignments, 10_000, 1_000)).toEqual([
+      { sandboxId: "stale", uuid: "container-stale", touchedAt: 0 }
+    ]);
   });
 });

--- a/agent-think/test/reliability.test.ts
+++ b/agent-think/test/reliability.test.ts
@@ -1,0 +1,81 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { getAgentByName } from "agents";
+import { describe, expect, it } from "vitest";
+import { ThinkAgent } from "../src/agent";
+import type { CommandCenterAgent } from "../src/command-center";
+import { WarmPool } from "../src/warm-pool";
+import { classifyRunOutcome } from "../src/run-lifecycle";
+
+describe("agent-think reliability", () => {
+  it("classifies a final assistant report as done", () => {
+    expect(
+      classifyRunOutcome({ status: "completed", assistantText: "PR opened" })
+    ).toEqual({ status: "done" });
+  });
+
+  it("classifies tool-only step exhaustion as an error", () => {
+    expect(
+      classifyRunOutcome({ status: "completed", assistantText: "" })
+    ).toEqual({
+      status: "error",
+      error:
+        "Turn ended without a final assistant report (step budget exhausted)."
+    });
+  });
+
+  it("preserves an explicit provider error", () => {
+    expect(
+      classifyRunOutcome({
+        status: "error",
+        assistantText: "partial",
+        error: "provider failed"
+      })
+    ).toEqual({ status: "error", error: "provider failed" });
+  });
+
+  it("records terminal command-center state through the real DO", async () => {
+    const session = `reliability-${crypto.randomUUID()}`;
+    const commandCenter = await getAgentByName<Env, CommandCenterAgent>(
+      env.CommandCenter,
+      session
+    );
+    await commandCenter.recordDispatch({
+      session,
+      repo: "cloudflare/agents",
+      issueNumber: 1,
+      instruction: "test"
+    });
+    await commandCenter.recordTurn({
+      session,
+      outcome: "error",
+      error: "recovery exhausted"
+    });
+
+    expect((await commandCenter.getSnapshot()).threads[session]).toMatchObject({
+      status: "error",
+      lastError: "recovery exhausted"
+    });
+  });
+
+  it("advances an existing alarm when the refresh cadence shrinks", async () => {
+    const id = env.WarmPool.idFromName(`config-${crypto.randomUUID()}`);
+    const stub = env.WarmPool.get(id);
+    const before = Date.now();
+    await stub.configure({ refreshInterval: 100, assignmentIdleTtl: 1_000 });
+
+    await runInDurableObject(stub, async (_pool: WarmPool, state) => {
+      const alarm = await state.storage.getAlarm();
+      expect(alarm).not.toBeNull();
+      expect(alarm as number).toBeLessThanOrEqual(before + 1_000);
+    });
+  });
+
+  it("does not externalize media without an attachment store", async () => {
+    const id = env.ThinkAgent.idFromName(`media-${crypto.randomUUID()}`);
+    const stub = env.ThinkAgent.get(id);
+    await runInDurableObject(stub, (agent: ThinkAgent) => {
+      expect(agent.mediaEviction).toEqual({ externalizeToWorkspace: false });
+    });
+  });
+});

--- a/agent-think/test/run-context.test.ts
+++ b/agent-think/test/run-context.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildRunEnvelope, validateRunTarget } from "../src/run-context";
+import {
+  buildRunEnvelope,
+  buildRunTelemetry,
+  validateRunTarget
+} from "../src/run-context";
 
 const target = {
   repo: "cloudflare/workers-oauth-provider",
@@ -16,6 +20,19 @@ describe("agent-think run context", () => {
     );
     expect(buildRunEnvelope(target)).toContain('"issue":209');
     expect(buildRunEnvelope(target)).toContain('"requested-by":"@mattzcarey"');
+  });
+
+  it("keeps identity on every inference and recovery continuation", () => {
+    expect(buildRunTelemetry(target, "session-209", "ThinkAgent")).toEqual({
+      metadata: {
+        agentId: "session-209",
+        agentName: "ThinkAgent",
+        conversationId: "session-209",
+        repository: "cloudflare/workers-oauth-provider",
+        issueNumber: 209,
+        requestedBy: "mattzcarey"
+      }
+    });
   });
 
   it("rejects substituted targets and unsafe requester mentions", () => {

--- a/agent-think/test/run-context.test.ts
+++ b/agent-think/test/run-context.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildRunEnvelope, validateRunTarget } from "../src/run-context";
+
+const target = {
+  repo: "cloudflare/workers-oauth-provider",
+  issueNumber: 209,
+  instruction: "fix the registered token endpoint auth method",
+  commentId: 4905306032,
+  requestedBy: { login: "mattzcarey" }
+};
+
+describe("agent-think run context", () => {
+  it("persists the immutable target and requester in the submitted envelope", () => {
+    expect(buildRunEnvelope(target)).toContain(
+      '"repository":"cloudflare/workers-oauth-provider"'
+    );
+    expect(buildRunEnvelope(target)).toContain('"issue":209');
+    expect(buildRunEnvelope(target)).toContain('"requested-by":"@mattzcarey"');
+  });
+
+  it("rejects substituted targets and unsafe requester mentions", () => {
+    expect(() => validateRunTarget({ ...target, repo: "other/repo" })).toThrow(
+      "Invalid Cloudflare repository"
+    );
+    expect(() =>
+      validateRunTarget({
+        ...target,
+        requestedBy: { login: "@mattzcarey please-run" }
+      })
+    ).toThrow("Invalid GitHub login");
+    expect(() => validateRunTarget({ ...target, commentId: -1 })).toThrow(
+      "Invalid comment id"
+    );
+  });
+});

--- a/agent-think/test/skills.test.ts
+++ b/agent-think/test/skills.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import openPrSkill from "../skills/open-pr/SKILL.md?raw";
+import reproduceSkill from "../skills/reproduce/SKILL.md?raw";
+
+const skills = [
+  ["reproduce", reproduceSkill],
+  ["open-pr", openPrSkill]
+] as const;
+
+describe("agent-think skill target contract", () => {
+  for (const [name, content] of skills) {
+    it(`${name} fails closed without immutable run context`, () => {
+      expect(content).toContain("<agent-think-run>");
+      expect(content).toContain("Never infer or substitute another target");
+    });
+
+    it(`${name} attributes posted reports to the requester`, () => {
+      expect(content).toContain("Requested by @<requestedBy>");
+    });
+
+    it(`${name} reacts to the triggering comment from durable context`, () => {
+      expect(content).toContain("<trigger-comment-id>/reactions");
+      expect(content).toContain("content=rocket");
+    });
+  }
+});

--- a/agent-think/tests-e2e/flow.test.ts
+++ b/agent-think/tests-e2e/flow.test.ts
@@ -1,54 +1,104 @@
-/**
- * End-to-end flow against a live `wrangler dev --local`.
- *
- * REQUIRES docker + wrangler dev. SLOW: a cold container build plus a real
- * model turn takes minutes. This is intentionally kept separate from the fast
- * unit tests (`npm test`) — run it with the e2e config when you need to
- * reproduce locally *why a run dies* (the silent wedge we chase).
- *
- * The flow mirrors what gh-app does over the service binding, but through the
- * LOCAL_DEV-gated HTTP surface:
- *
- *   1. GET  /                          → worker is up (health banner)
- *   2. POST /dev/dispatch              → 202, resolves the per-issue ThinkAgent
- *                                        DO, sets context, starts a durable turn
- *   3. GET  /dev/messages/:session     → poll the DO message log until the turn
- *                                        visibly progresses (assistant text or a
- *                                        recorded tool call). No progress inside
- *                                        the window IS the failure we want to
- *                                        catch — on timeout we dump every
- *                                        collected message so a human can see
- *                                        exactly where it wedged.
- *
- * Everything runs against real bindings: ThinkAgent DO, container-backed
- * Workspace (real gh/git/npm/node), R2-mounted skills. No mocks.
- */
-import { describe, it, expect } from "vitest";
-import { BASE_URL } from "./harness";
+import { describe, expect, it, vi } from "vitest";
+import { BASE_URL, wranglerOutput } from "./harness";
 
-/** One message in the DO log, as returned by ThinkAgent.debugMessages(). */
 interface DebugMessage {
   role: string;
-  parts: Array<{ type: string; text?: string }>;
+  parts: Array<{ type: string; text?: string; output?: unknown }>;
 }
 
-/**
- * The turn "progressed" once the model produced anything real: a non-empty
- * assistant text part, OR any tool-call part (static `tool-<name>` or the
- * dynamic-tool shape). That is the signal a silent wedge would starve.
- */
-function turnProgressed(messages: DebugMessage[]): boolean {
-  for (const m of messages) {
-    if (m.role !== "assistant") continue;
-    for (const p of m.parts) {
-      if (p.type === "text" && (p.text ?? "").trim().length > 0) return true;
-      if (p.type === "dynamic-tool" || p.type.startsWith("tool-")) return true;
-    }
+interface ThreadMeta {
+  status: "running" | "done" | "error";
+  lastError?: string;
+}
+
+const issueBase = 10_000 + Math.floor(Math.random() * 900_000);
+let commentSequence = 1;
+
+async function dispatch(instruction: string, issueNumber: number) {
+  const response = await fetch(`${BASE_URL}/dev/dispatch`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      repo: "cloudflare/workers-oauth-provider",
+      issueNumber,
+      instruction,
+      installationToken: "",
+      commentId: issueNumber * 1000 + commentSequence++,
+      issueTitle: "E2E lifecycle fixture",
+      requestedBy: { login: "mattzcarey" }
+    })
+  });
+  expect(response.status).toBe(202);
+  return (await response.json()) as { session: string };
+}
+
+async function messages(session: string): Promise<DebugMessage[]> {
+  const response = await fetch(
+    `${BASE_URL}/dev/messages/${encodeURIComponent(session)}`
+  );
+  expect(response.status).toBe(200);
+  return response.json() as Promise<DebugMessage[]>;
+}
+
+async function poolStats(): Promise<{ assigned: number }> {
+  const response = await fetch(`${BASE_URL}/__test/pool-stats`);
+  expect(response.status).toBe(200);
+  return response.json() as Promise<{ assigned: number }>;
+}
+
+async function runPoolAlarm(): Promise<{ assigned: number }> {
+  const response = await fetch(`${BASE_URL}/__test/pool-alarm`, {
+    method: "POST"
+  });
+  expect(response.status).toBe(200);
+  return response.json() as Promise<{ assigned: number }>;
+}
+
+async function thread(session: string): Promise<ThreadMeta | undefined> {
+  const response = await fetch(`${BASE_URL}/api/command-center`);
+  const state = (await response.json()) as {
+    threads: Record<string, ThreadMeta>;
+  };
+  return state.threads[session];
+}
+
+async function waitForThread(
+  session: string,
+  status: ThreadMeta["status"]
+): Promise<ThreadMeta> {
+  let current: ThreadMeta | undefined;
+  try {
+    await vi.waitUntil(
+      async () => {
+        current = await thread(session);
+        return current?.status === status;
+      },
+      { timeout: 60_000, interval: 200 }
+    );
+    return current as ThreadMeta;
+  } catch (error) {
+    const transcript = await messages(session).catch(() => []);
+    throw new Error(
+      `Timed out waiting for ${session}=${status}; current=${JSON.stringify(current)}\n` +
+        `transcript=${JSON.stringify(transcript, null, 2)}\n` +
+        `wrangler=${wranglerOutput().slice(-20_000)}`,
+      { cause: error }
+    );
   }
-  return false;
 }
 
-describe("E2E: agent-think dispatch → durable turn", () => {
+function transcriptText(items: DebugMessage[]): string {
+  return items
+    .flatMap((message) =>
+      message.parts.flatMap((part) => [
+        part.text ?? "",
+        JSON.stringify(part.output)
+      ])
+    )
+    .join("\n");
+}
+
+describe("E2E: production graph with inference adapter", () => {
   it("keeps /workspace container-local instead of syncing it to the DO VFS", async () => {
     const isolation = await fetch(
       `${BASE_URL}/dev/workspace-isolation/${crypto.randomUUID()}`
@@ -60,56 +110,66 @@ describe("E2E: agent-think dispatch → durable turn", () => {
     });
   }, 120_000);
 
-  it("comes up, dispatches a real run, and the turn progresses", async () => {
-    // 1. Worker up.
-    const health = await fetch(`${BASE_URL}/`);
-    expect(health.status).toBe(200);
-
-    // 2. Dispatch a real run. A deliberately tiny instruction so the container
-    //    does real network work (clone) without deploying or commenting — we
-    //    only need proof the turn moves, not a full repro.
-    const dispatch = await fetch(`${BASE_URL}/dev/dispatch`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        repo: "cloudflare/agents",
-        issueNumber: 1859,
-        instruction:
-          "just clone the repo into /workspace/agents and run ls — do not deploy or comment",
-        // Optional: a real GH token lets the clone succeed. Absent, the clone
-        // may fail — but the turn should still visibly progress (tool calls /
-        // assistant text), which is what we assert on.
-        installationToken: process.env.GH_TOKEN ?? ""
-      })
-    });
-    expect(dispatch.status).toBe(202);
-    const { session } = (await dispatch.json()) as { session: string };
-    expect(session).toBeTruthy();
-
-    // 3. Poll the DO message log until the turn progresses. Real model +
-    //    container are slow, so we give it ~4 minutes and check every 5s.
-    const deadline = Date.now() + 240_000;
-    let messages: DebugMessage[] = [];
-    while (Date.now() < deadline) {
-      const res = await fetch(
-        `${BASE_URL}/dev/messages/${encodeURIComponent(session)}`
-      );
-      if (res.ok) {
-        messages = (await res.json()) as DebugMessage[];
-        if (turnProgressed(messages)) {
-          expect(turnProgressed(messages)).toBe(true);
-          return; // success — the turn moved
-        }
-      }
-      await new Promise((r) => setTimeout(r, 5000));
-    }
-
-    // Timed out with no progress: this is the silent-wedge failure. Dump the
-    // full message log so a human can see where it died.
-    throw new Error(
-      `turn never progressed within 4 min for session "${session}".\n` +
-        `Collected ${messages.length} message(s):\n` +
-        JSON.stringify(messages, null, 2)
+  it("persists the immutable target even when skills register context", async () => {
+    const issueNumber = issueBase;
+    const { session } = await dispatch(
+      "TEST: echo immutable run envelope",
+      issueNumber
     );
-  }, 300_000); // outrun the 4-min poll + boot slack
+    await waitForThread(session, "done");
+
+    const text = transcriptText(await messages(session));
+    expect(text).toContain("<agent-think-run>");
+    expect(text).toContain(
+      '\\"repository\\":\\"cloudflare/workers-oauth-provider\\"'
+    );
+    expect(text).toContain(`\\"issue\\":${issueNumber}`);
+    expect(text).toContain('\\"requested-by\\":\\"@mattzcarey\\"');
+    expect(text).toContain("captured-run-context:");
+    expect(text).not.toContain("cloudflare/agents#1871");
+  }, 120_000);
+
+  it("holds the lease during a real command, closes RPC streams, and reconnects", async () => {
+    const issueNumber = issueBase + 1;
+    const { session } = await dispatch(
+      "TEST: hold active container lease",
+      issueNumber
+    );
+    await vi.waitUntil(async () => (await poolStats()).assigned === 1, {
+      timeout: 30_000,
+      interval: 100
+    });
+
+    // TTL is one second; an explicit real alarm during the two-second command
+    // must preserve the actively leased assignment.
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
+    expect((await runPoolAlarm()).assigned).toBe(1);
+
+    await waitForThread(session, "done");
+    expect(transcriptText(await messages(session))).toContain("lifecycle-ok");
+
+    // Once terminal cleanup ends the lease, the same alarm must evict it.
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
+    expect((await runPoolAlarm()).assigned).toBe(0);
+
+    // The same durable agent session then reconnects to a fresh container.
+    await dispatch("TEST: hold active container lease", issueNumber);
+    await waitForThread(session, "done");
+    expect(transcriptText(await messages(session))).toContain("lifecycle-ok");
+    expect(wranglerOutput()).not.toContain(
+      "WritableStream RPC stub was disposed without calling close()"
+    );
+    expect(wranglerOutput()).not.toContain(
+      "An RPC stub was not disposed properly"
+    );
+  }, 180_000);
+
+  it("marks a tool-only step-budget exhaustion as error, not done", async () => {
+    const { session } = await dispatch(
+      "TEST: exhaust step budget",
+      issueBase + 2
+    );
+    const terminal = await waitForThread(session, "error");
+    expect(terminal.lastError).toContain("without a final assistant report");
+  }, 120_000);
 });

--- a/agent-think/tests-e2e/harness.ts
+++ b/agent-think/tests-e2e/harness.ts
@@ -6,10 +6,11 @@
  *
  * Tests talk to it over HTTP as gh-app would over the service binding, so the
  * whole stack (ThinkAgent DO, container-backed Workspace, real gh/git/npm) is
- * exercised end-to-end. No mocks — this is how we reproduce locally why a run
- * silently wedges.
+ * exercised end-to-end. Only model inference is replaced by the test Worker;
+ * this is how we reproduce locally why a run silently wedges.
  */
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
@@ -17,6 +18,11 @@ const PORT = Number(process.env.E2E_PORT ?? 8799);
 export const BASE_URL = `http://127.0.0.1:${PORT}`;
 
 let proc: ChildProcess | null = null;
+const output: string[] = [];
+
+export function wranglerOutput(): string {
+  return output.join("");
+}
 
 /** Spawn wrangler dev with .env loaded. Resolves when the server is reachable. */
 export async function startWrangler(): Promise<void> {
@@ -41,22 +47,26 @@ export async function startWrangler(): Promise<void> {
     }
   }
 
-  // LOCAL_DEV=1 unlocks the /dev/dispatch + /dev/messages HTTP surface that
-  // production never exposes (see the LOCAL_DEV gate in src/index.ts).
-  env.LOCAL_DEV = "1";
+  // Build assets and seed the real local R2 binding before workerd starts.
+  execFileSync("pnpm", ["build:client"], {
+    cwd: resolve(process.cwd()),
+    env,
+    stdio: "pipe"
+  });
+  seedLocalSkills(env);
 
   const args = [
     "wrangler",
     "dev",
+    "--config",
+    "tests-e2e/wrangler.jsonc",
     "--local",
     "--port",
     String(PORT),
     "--ip",
     "127.0.0.1",
     "--inspector-port",
-    "0",
-    "--var",
-    "LOCAL_DEV:1"
+    "0"
   ];
   proc = spawn("npx", args, {
     env,
@@ -65,20 +75,22 @@ export async function startWrangler(): Promise<void> {
     detached: true // own process group so we can SIGKILL the whole tree
   });
 
-  const logs: string[] = [];
-  proc.stdout?.on("data", (chunk) => logs.push(chunk.toString()));
-  proc.stderr?.on("data", (chunk) => logs.push(chunk.toString()));
+  output.length = 0;
+  proc.stdout?.on("data", (chunk) => output.push(chunk.toString()));
+  proc.stderr?.on("data", (chunk) => output.push(chunk.toString()));
 
   const deadline = Date.now() + 180_000; // cold docker build can take a while
   while (Date.now() < deadline) {
     if (!proc || proc.exitCode !== null) {
-      throw new Error("wrangler exited during startup:\n" + logs.join(""));
+      throw new Error("wrangler exited during startup:\n" + wranglerOutput());
     }
     if (await isUp()) return;
     await sleep(1000);
   }
   await stopWrangler();
-  throw new Error("wrangler dev failed to come up in time\n" + logs.join(""));
+  throw new Error(
+    "wrangler dev failed to come up in time\n" + wranglerOutput()
+  );
 }
 
 export async function stopWrangler(): Promise<void> {
@@ -114,6 +126,33 @@ async function isUp(): Promise<boolean> {
     return res.ok;
   } catch {
     return false;
+  }
+}
+
+function seedLocalSkills(env: NodeJS.ProcessEnv): void {
+  const root = resolve(process.cwd());
+  for (const entry of readdirSync(resolve(root, "skills"), {
+    withFileTypes: true
+  })) {
+    if (!entry.isDirectory()) continue;
+    const file = resolve(root, "skills", entry.name, "SKILL.md");
+    execFileSync(
+      "pnpm",
+      [
+        "exec",
+        "wrangler",
+        "r2",
+        "object",
+        "put",
+        `agent-think-skills/.agents/skills/${entry.name}/SKILL.md`,
+        "--file",
+        file,
+        "--local",
+        "--config",
+        "tests-e2e/wrangler.jsonc"
+      ],
+      { cwd: root, env, stdio: "pipe" }
+    );
   }
 }
 

--- a/agent-think/tests-e2e/mock-inference.ts
+++ b/agent-think/tests-e2e/mock-inference.ts
@@ -1,0 +1,68 @@
+import type { LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+
+const usage = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 }
+};
+
+function finishText(text: string) {
+  return {
+    stream: simulateReadableStream({
+      chunks: [
+        { type: "stream-start" as const, warnings: [] },
+        { type: "text-start" as const, id: "text-1" },
+        { type: "text-delta" as const, id: "text-1", delta: text },
+        { type: "text-end" as const, id: "text-1" },
+        {
+          type: "finish" as const,
+          usage,
+          finishReason: { unified: "stop" as const, raw: undefined }
+        }
+      ]
+    })
+  };
+}
+
+function callBash(command: string) {
+  return {
+    stream: simulateReadableStream({
+      chunks: [
+        { type: "stream-start" as const, warnings: [] },
+        {
+          type: "tool-call" as const,
+          toolCallId: crypto.randomUUID(),
+          toolName: "bash",
+          input: JSON.stringify({ command, backend: "container", timeout: 30 })
+        },
+        {
+          type: "finish" as const,
+          usage,
+          finishReason: { unified: "tool-calls" as const, raw: undefined }
+        }
+      ]
+    })
+  };
+}
+
+/** The E2E suite's only adapter: inference. Everything else is production. */
+export function mockInference(): LanguageModel {
+  return new MockLanguageModelV3({
+    doStream: async ({ prompt }) => {
+      const serialized = JSON.stringify(prompt);
+      const hasToolResult = serialized.includes('"role":"tool"');
+      if (serialized.includes("TEST: exhaust step budget")) {
+        return callBash("true");
+      }
+      if (
+        serialized.includes("TEST: hold active container lease") &&
+        !hasToolResult
+      ) {
+        return callBash(
+          "mkdir -p /workspace/temp; sleep 2; printf lifecycle-ok > /workspace/temp/lifecycle-marker"
+        );
+      }
+      return finishText(`captured-run-context: ${serialized}`);
+    }
+  });
+}

--- a/agent-think/tests-e2e/tsconfig.json
+++ b/agent-think/tests-e2e/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vite/client", "../worker-configuration.d.ts"]
+  },
+  "include": ["./**/*.ts", "../worker-configuration.d.ts"]
+}

--- a/agent-think/tests-e2e/worker.ts
+++ b/agent-think/tests-e2e/worker.ts
@@ -1,0 +1,57 @@
+import productionWorker, {
+  AgentThink,
+  CommandCenterAgent,
+  Sandbox,
+  WarmPool as ProductionWarmPool,
+  WorkspaceProxy,
+  WorkspaceServiceProxy
+} from "../src/index";
+import { ThinkAgent as ProductionThinkAgent } from "../src/agent";
+import { mockInference } from "./mock-inference";
+
+/** Production agent with deterministic inference for real-container E2E. */
+export class ThinkAgent extends ProductionThinkAgent {
+  override maxSteps = 2;
+
+  override getModel() {
+    return mockInference();
+  }
+}
+
+/** Test adapter exposing the real maintenance operation over RPC. */
+export class WarmPool extends ProductionWarmPool {
+  async runMaintenance() {
+    await this.alarm();
+    return this.getStats();
+  }
+}
+
+export {
+  AgentThink,
+  CommandCenterAgent,
+  Sandbox,
+  WorkspaceProxy,
+  WorkspaceServiceProxy
+};
+
+function pool(env: Env) {
+  return env.WarmPool.get(env.WarmPool.idFromName("global-pool"));
+}
+
+/** Test-only HTTP adapter over real production interfaces. */
+export default {
+  async fetch(request: Request, env: Env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/__test/pool-stats") {
+      return Response.json(await pool(env).getStats());
+    }
+    if (request.method === "POST" && url.pathname === "/__test/pool-alarm") {
+      const testPool = pool(env) as unknown as {
+        runMaintenance(): Promise<unknown>;
+      };
+      return Response.json(await testPool.runMaintenance());
+    }
+    return productionWorker.fetch(request, env);
+  },
+  scheduled: productionWorker.scheduled
+} satisfies ExportedHandler<Env>;

--- a/agent-think/tests-e2e/wrangler.jsonc
+++ b/agent-think/tests-e2e/wrangler.jsonc
@@ -1,0 +1,52 @@
+{
+  "$schema": "../node_modules/wrangler/config-schema.json",
+  "name": "agent-think-e2e",
+  "main": "worker.ts",
+  "compatibility_date": "2026-06-11",
+  "compatibility_flags": ["nodejs_compat", "enable_abortsignal_rpc"],
+
+  "ai": { "binding": "AI" },
+  "worker_loaders": [{ "binding": "LOADER" }],
+
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "../Dockerfile",
+      "instance_type": "standard-2",
+      "max_instances": 10
+    }
+  ],
+
+  "durable_objects": {
+    "bindings": [
+      { "name": "ThinkAgent", "class_name": "ThinkAgent" },
+      { "name": "Sandbox", "class_name": "Sandbox" },
+      { "name": "WarmPool", "class_name": "WarmPool" },
+      { "name": "CommandCenter", "class_name": "CommandCenterAgent" }
+    ]
+  },
+
+  "r2_buckets": [
+    { "binding": "R2_SKILLS", "bucket_name": "agent-think-skills" }
+  ],
+
+  "assets": {
+    "directory": "../dist/client",
+    "binding": "ASSETS",
+    "run_worker_first": ["/thread/*", "/agents/*", "/api/*", "/__test/*"]
+  },
+
+  "vars": {
+    "LOCAL_DEV": "1",
+    "PUBLIC_BASE_URL": "http://127.0.0.1:8799",
+    "WARM_POOL_TARGET": "0",
+    "WARM_POOL_REFRESH_INTERVAL": "100",
+    "WARM_POOL_ASSIGNMENT_IDLE_TTL_MS": "1000"
+  },
+
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["ThinkAgent"] },
+    { "tag": "v2", "new_sqlite_classes": ["Sandbox", "WarmPool"] },
+    { "tag": "v3", "new_sqlite_classes": ["CommandCenterAgent"] }
+  ]
+}


### PR DESCRIPTION
## Summary

Make one agent-think dispatch a durable, target-safe, scoped run:

- persist repo, issue, instruction, requester, and triggering comment in the first user message, so skills retain their target even when Think context blocks replace `getSystemPrompt()`
- make reproduce/open-PR skills fail closed without that envelope, restore the 🚀 liveness reaction from its durable data, and tag the requester in every posted report/PR body
- add a `RunLifecycle` module that scopes Workspace acquisition/release, closes RPC/WebSocket handles after auth and each tool batch, renews a bounded WarmPool lease while the run is active, and reports terminal state in order
- prevent idle eviction from killing an active run while still reclaiming abandoned leases after their bounded expiry
- treat completed tool-only/max-step turns as errors rather than successful empty reports
- keep agent/conversation/repo/issue/requester trace identity on recovery continuations
- mark recovery exhaustion terminal in Command Center, and disable media externalization because agent-think has no attachment store

GitHub installation-token renewal is deliberately unchanged and out of scope.

## Root causes

1. Run identity lived only in `getSystemPrompt()`. Think skills register a Session context block, so current prompt assembly selected that block instead and dropped agent-think's repo/issue/instruction. Two concurrent runs therefore guessed the same unrelated issue.
2. WarmPool only touched assignments during backend connection. Workspace cached that connection, so real tool activity was invisible to the one-hour idle clock and an active run was destroyed at exactly the TTL.
3. Workspace handles remained open after useful work. Idle destruction then canceled the control WebSocket, producing misleading long error traces and disposed RPC-stream failures.
4. Recovery and max-step terminal paths did not always produce a truthful Command Center state.

## Tests

### Workers runtime (`@cloudflare/vitest-pool-workers`)

- 6 files / 24 tests passed
- immutable run-envelope validation and injection-safe JSON encoding
- skill target/requester/liveness contracts
- active, idle, and abandoned lease selection
- alarm rescheduling when pool cadence shrinks
- terminal outcome classification
- recovery telemetry identity
- real CommandCenter/ThinkAgent Durable Object state
- media-eviction policy

### Real infrastructure E2E

`wrangler dev --local` with the real Docker container, ThinkAgent/Sandbox/WarmPool/CommandCenter DOs, R2 skills, Worker Loader, Workspace/wsd, bash, and filesystem. Only model inference is replaced by a test subclass.

- 1 file / 4 tests passed
- container files remain outside DO VFS
- skills context cannot remove the immutable target
- a two-second real command survives a one-second idle TTL
- explicit real pool maintenance preserves an active lease, then evicts it after terminal release
- the same durable session reconnects to a fresh container after eviction
- repeated Workspace RPC streams close without disposal warnings
- tool-only step-budget exhaustion reports `error`, not `done`

### Other checks

- agent-think production + E2E typechecks passed
- agent-think lint and formatting passed
- client production build passed
- monorepo build passed
- root `pnpm run check` passed, including all 116 project typechecks

## Scope

All changed paths are under `agent-think/`. No SDK packages or unrelated applications are modified.
