### PR TITLE
fix: always apply the Worker-safe JSON Schema validator to MCP client connections

### DIFF
--- a/.changeset/brave-mangos-search.md
+++ b/.changeset/brave-mangos-search.md
@@ -2,6 +2,8 @@
 "agents": patch
 ---
 
-Apply the Worker-safe `CfWorkerJsonSchemaValidator` by default on the `MCPClientManager.connect()` path, matching `createConnection()`.
+Always apply the Worker-safe `CfWorkerJsonSchemaValidator` to MCP client connections by default.
 
-RPC MCP connections made via `addMcpServer(name, namespace)` previously skipped the default, so the MCP SDK fell back to its AJV validator when a server exposed tools with `outputSchema`. AJV compiles schemas with `new Function`, which Workers disallows, failing discovery with "Code generation from strings disallowed for this context". Caller-supplied `client.jsonSchemaValidator` overrides are still respected.
+`MCPClientConnection` now owns the default (merged in its constructor), so every construction path uses the Worker-safe validator unless the caller supplies their own — including the RPC `addMcpServer(name, namespace)` path via `MCPClientManager.connect()`, which previously skipped it. Without the default, the MCP SDK fell back to its AJV validator when a server exposed tools with `outputSchema`; AJV compiles schemas with `new Function`, which Workers disallows, failing discovery with "Code generation from strings disallowed for this context".
+
+`connect()` now builds connections through `createConnection()` instead of duplicating construction, so the two paths can no longer drift. Caller-supplied `client.jsonSchemaValidator` overrides are respected on the live connection; because validator instances cannot survive JSON serialization, they are no longer persisted, and a previously persisted, serialization-degraded validator is ignored on restore — after hibernation the connection falls back to the Worker-safe default instead of failing discovery.

--- a/.changeset/brave-mangos-search.md
+++ b/.changeset/brave-mangos-search.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Apply the Worker-safe `CfWorkerJsonSchemaValidator` by default on the `MCPClientManager.connect()` path, matching `createConnection()`.
+
+RPC MCP connections made via `addMcpServer(name, namespace)` previously skipped the default, so the MCP SDK fell back to its AJV validator when a server exposed tools with `outputSchema`. AJV compiles schemas with `new Function`, which Workers disallows, failing discovery with "Code generation from strings disallowed for this context". Caller-supplied `client.jsonSchemaValidator` overrides are still respected.

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -1,4 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker-provider.js";
 import {
   SSEClientTransport,
   type SSEClientTransportOptions
@@ -43,6 +44,14 @@ import type {
   TransportType,
   McpClientOptions
 } from "./types";
+
+// Workers disallows runtime code generation, so the MCP SDK's default AJV
+// validator (which compiles schemas with `new Function`) cannot run there.
+// Every connection defaults to the Worker-safe validator unless the caller
+// supplies their own.
+const defaultClientOptions: McpClientOptions = {
+  jsonSchemaValidator: new CfWorkerJsonSchemaValidator()
+};
 
 /**
  * Connection state machine for MCP client connections.
@@ -148,10 +157,15 @@ export class MCPClientConnection {
       client: McpClientOptions;
     } = { client: {}, transport: {} }
   ) {
+    this.options = {
+      ...options,
+      client: { ...defaultClientOptions, ...options.client }
+    };
+
     const clientOptions = {
-      ...options.client,
+      ...this.options.client,
       capabilities: {
-        ...options.client?.capabilities,
+        ...this.options.client?.capabilities,
         elicitation: {}
       } as ClientCapabilities
     };

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -11,7 +11,6 @@ import type {
   ResourceTemplate,
   Tool
 } from "@modelcontextprotocol/sdk/types.js";
-import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker-provider.js";
 import { type RetryOptions, tryN } from "../retries";
 import { z } from "zod";
 import { nanoid } from "nanoid";
@@ -28,10 +27,6 @@ import type { TransportType } from "./types";
 import type { MCPServerRow } from "./client-storage";
 import type { AgentMcpOAuthProvider } from "./do-oauth-client-provider";
 import { DurableObjectOAuthClientProvider } from "./do-oauth-client-provider";
-
-const defaultClientOptions: ConstructorParameters<typeof Client>[1] = {
-  jsonSchemaValidator: new CfWorkerJsonSchemaValidator()
-};
 
 export type MCPAITool = {
   description?: string;
@@ -837,6 +832,12 @@ export class MCPClientManager {
       const parsedOptions: MCPServerOptions | null = server.server_options
         ? JSON.parse(server.server_options)
         : null;
+      // A caller-supplied jsonSchemaValidator is a live instance that can't
+      // survive JSON serialization; drop whatever degraded value an older row
+      // may hold so the connection falls back to the Worker-safe default.
+      if (parsedOptions?.client) {
+        delete parsedOptions.client.jsonSchemaValidator;
+      }
 
       let authProvider: AgentMcpOAuthProvider | undefined;
       if (server.callback_url) {
@@ -1007,37 +1008,14 @@ export class MCPClientManager {
       );
     }
 
-    // During OAuth reconnect, reuse existing connection to preserve state
+    // During OAuth reconnect, reuse existing connection to preserve state;
+    // otherwise drop any existing connection and rebuild it.
     if (!options.reconnect?.oauthCode || !this.mcpConnections[id]) {
-      const normalizedTransport = {
-        ...options.transport,
-        type: options.transport?.type ?? ("auto" as TransportType)
-      };
-
-      this.mcpConnections[id] = new MCPClientConnection(
-        new URL(url),
-        {
-          name: this._name,
-          version: this._version
-        },
-        {
-          client: { ...defaultClientOptions, ...options.client },
-          transport: normalizedTransport
-        }
-      );
-
-      // Pipe connection-level observability events to the manager-level emitter
-      // and track the subscription for cleanup.
-      const store = new DisposableStore();
-      // If we somehow already had disposables for this id, clear them first
-      const existing = this._connectionDisposables.get(id);
-      if (existing) existing.dispose();
-      this._connectionDisposables.set(id, store);
-      store.add(
-        this.mcpConnections[id].onObservabilityEvent((event) => {
-          this._onObservabilityEvent.fire(event);
-        })
-      );
+      delete this.mcpConnections[id];
+      this.createConnection(id, url, {
+        client: options.client,
+        transport: options.transport ?? {}
+      });
     }
 
     // Initialize connection first. this will try connect
@@ -1146,7 +1124,7 @@ export class MCPClientManager {
         version: this._version
       },
       {
-        client: { ...defaultClientOptions, ...options.client },
+        client: options.client ?? {},
         transport: normalizedTransport
       }
     );
@@ -1192,9 +1170,13 @@ export class MCPClientManager {
       }
     });
 
-    // Save to storage (exclude authProvider since it's recreated during restore)
+    // Save to storage, excluding live instances that can't survive JSON
+    // serialization: authProvider is recreated during restore, and
+    // jsonSchemaValidator falls back to the Worker-safe default.
     const { authProvider: _, ...transportWithoutAuth } =
       options.transport ?? {};
+    const { jsonSchemaValidator: _validator, ...serializableClient } =
+      options.client ?? {};
     this.saveServerToStorage({
       id,
       name: options.name,
@@ -1203,7 +1185,7 @@ export class MCPClientManager {
       client_id: options.clientId ?? null,
       auth_url: options.authUrl ?? null,
       server_options: JSON.stringify({
-        client: options.client,
+        client: serializableClient,
         transport: transportWithoutAuth,
         retry: options.retry
       })

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -1021,7 +1021,7 @@ export class MCPClientManager {
           version: this._version
         },
         {
-          client: options.client ?? {},
+          client: { ...defaultClientOptions, ...options.client },
           transport: normalizedTransport
         }
       );

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker-provider.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
   CallToolResult,
@@ -94,6 +95,32 @@ export class TestMcpAgent extends McpAgent<Cloudflare.Env, unknown, Props> {
       },
       async ({ name }) => {
         return { content: [{ text: `Hello, ${name}!`, type: "text" }] };
+      }
+    );
+
+    // Tool with an outputSchema: the MCP SDK client compiles a JSON Schema
+    // validator for it during discovery, which requires the Worker-safe
+    // validator (the SDK's AJV fallback uses `new Function`, disallowed in
+    // Workers).
+    this.server.registerTool(
+      "structuredGreet",
+      {
+        description: "Greet and return structured output",
+        inputSchema: { name: z.string().describe("Name to greet") },
+        outputSchema: {
+          greeting: z.string(),
+          nameLength: z.number()
+        }
+      },
+      async ({ name }) => {
+        const structuredContent = {
+          greeting: `Hello, ${name}!`,
+          nameLength: name.length
+        };
+        return {
+          content: [{ text: JSON.stringify(structuredContent), type: "text" }],
+          structuredContent
+        };
       }
     );
 
@@ -483,6 +510,39 @@ export class TestRpcMcpClientAgent extends Agent {
       const toolNames = tools.map((t) => t.name);
 
       return { success: true, toolNames };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  async testRpcClientUsesWorkerSafeValidator() {
+    try {
+      const { id } = await this.addMcpServer(
+        "rpc-validator-test",
+        this.env.MCP_OBJECT as unknown as DurableObjectNamespace<McpAgent>,
+        {
+          props: { testValue: "rpc-validator-value" }
+        }
+      );
+
+      const validator =
+        this.mcp.mcpConnections[id]?.options.client?.jsonSchemaValidator;
+
+      const result = await this.mcp.callTool({
+        serverId: id,
+        name: "structuredGreet",
+        arguments: { name: "RPC User" }
+      });
+
+      return {
+        success: true,
+        usesWorkerSafeValidator:
+          validator instanceof CfWorkerJsonSchemaValidator,
+        structuredContent: result.structuredContent
+      };
     } catch (error) {
       return {
         success: false,

--- a/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
+++ b/packages/agents/src/tests/mcp/add-rpc-mcp-server.test.ts
@@ -297,3 +297,29 @@ describe("addMcpServer with RPC binding", () => {
     expect(result.result!.content[0].text).toBe("from-rpc-client");
   });
 });
+
+describe("addMcpServer with RPC binding — Worker-safe JSON Schema validator", () => {
+  it("applies CfWorkerJsonSchemaValidator by default and handles outputSchema tools", async () => {
+    const agentStub = await getAgentByName(
+      env.TestRpcMcpClientAgent,
+      "test-rpc-validator-default"
+    );
+    const result =
+      (await agentStub.testRpcClientUsesWorkerSafeValidator()) as unknown as {
+        success: boolean;
+        usesWorkerSafeValidator?: boolean;
+        structuredContent?: { greeting?: string; nameLength?: number };
+        error?: string;
+      };
+
+    if (!result.success) {
+      throw new Error(`Test failed: ${result.error}`);
+    }
+
+    expect(result.usesWorkerSafeValidator).toBe(true);
+    expect(result.structuredContent).toEqual({
+      greeting: "Hello, RPC User!",
+      nameLength: "RPC User".length
+    });
+  });
+});

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker-provider.js";
 import { MCPClientManager } from "../../mcp/client";
 import {
   MCPClientConnection,
@@ -302,6 +303,63 @@ describe("MCPClientManager OAuth Integration", () => {
         "test-auth-code"
       );
       expect(authProvider.deleteCodeVerifier).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Worker-safe JSON Schema validator defaults", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("connect() applies CfWorkerJsonSchemaValidator when no client options are provided", async () => {
+      vi.spyOn(MCPClientConnection.prototype, "init").mockResolvedValue(
+        undefined
+      );
+      vi.spyOn(manager, "discoverIfConnected").mockResolvedValue({
+        state: "ready",
+        success: true
+      });
+
+      const { id } = await manager.connect("http://example.com", {
+        transport: { type: "auto" }
+      });
+
+      expect(
+        manager.mcpConnections[id]?.options.client?.jsonSchemaValidator
+      ).toBeInstanceOf(CfWorkerJsonSchemaValidator);
+    });
+
+    it("connect() preserves a caller-supplied jsonSchemaValidator", async () => {
+      vi.spyOn(MCPClientConnection.prototype, "init").mockResolvedValue(
+        undefined
+      );
+      vi.spyOn(manager, "discoverIfConnected").mockResolvedValue({
+        state: "ready",
+        success: true
+      });
+
+      const customValidator = new CfWorkerJsonSchemaValidator();
+      const { id } = await manager.connect("http://example.com", {
+        client: { jsonSchemaValidator: customValidator },
+        transport: { type: "auto" }
+      });
+
+      expect(
+        manager.mcpConnections[id]?.options.client?.jsonSchemaValidator
+      ).toBe(customValidator);
+    });
+
+    it("registerServer() applies CfWorkerJsonSchemaValidator when no client options are provided", async () => {
+      await manager.registerServer("validator-default-id", {
+        url: "http://example.com",
+        name: "validator-default",
+        transport: { type: "auto" }
+      });
+
+      expect(
+        manager.mcpConnections["validator-default-id"]?.options.client
+          ?.jsonSchemaValidator
+      ).toBeInstanceOf(CfWorkerJsonSchemaValidator);
     });
   });
 

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -361,6 +361,52 @@ describe("MCPClientManager OAuth Integration", () => {
           ?.jsonSchemaValidator
       ).toBeInstanceOf(CfWorkerJsonSchemaValidator);
     });
+
+    it("registerServer() does not persist a caller-supplied jsonSchemaValidator", async () => {
+      const customValidator = new CfWorkerJsonSchemaValidator();
+      await manager.registerServer("validator-persist-id", {
+        url: "http://example.com",
+        name: "validator-persist",
+        client: { jsonSchemaValidator: customValidator },
+        transport: { type: "auto" }
+      });
+
+      // The live connection keeps the caller's validator...
+      expect(
+        manager.mcpConnections["validator-persist-id"]?.options.client
+          ?.jsonSchemaValidator
+      ).toBe(customValidator);
+
+      // ...but a validator instance cannot survive JSON serialization, so it
+      // must not be written to storage at all.
+      const row = mockStorageData.get("validator-persist-id");
+      const persisted = JSON.parse(row?.server_options ?? "{}");
+      expect(persisted.client).not.toHaveProperty("jsonSchemaValidator");
+    });
+
+    it("restore falls back to the Worker-safe default when persisted options contain a serialization-degraded validator", async () => {
+      // Simulate a row written by a caller that passed a custom validator:
+      // JSON.stringify degrades the instance to a plain object.
+      saveServerToMock({
+        id: "restored-degraded-validator",
+        name: "Degraded Validator Server",
+        server_url: "http://example.com",
+        callback_url: "http://localhost:3000/callback",
+        client_id: null,
+        auth_url: "https://auth.example.com/authorize",
+        server_options: JSON.stringify({
+          transport: { type: "auto" },
+          client: { jsonSchemaValidator: {} }
+        })
+      });
+
+      await manager.restoreConnectionsFromStorage("test-agent");
+
+      expect(
+        manager.mcpConnections["restored-degraded-validator"]?.options.client
+          ?.jsonSchemaValidator
+      ).toBeInstanceOf(CfWorkerJsonSchemaValidator);
+    });
   });
 
   describe("Callback URL Management", () => {


### PR DESCRIPTION
## Summary

RPC MCP connections made via `addMcpServer(name, DurableObjectNamespace, ...)` go through `MCPClientManager.connect()`, which constructed connections with `client: options.client ?? {}` — skipping the `CfWorkerJsonSchemaValidator` default that `createConnection()` applies. Without it, the MCP SDK falls back to its AJV validator when a server exposes tools with `outputSchema`; AJV compiles schemas with `new Function`, which the Workers runtime disallows, so discovery fails with:

```
Failed to discover server capabilities: Code generation from strings disallowed for this context
```

## Fix

Rather than patching the drifted copy, this removes the ways the default can be skipped at all:

- **`MCPClientConnection` owns the default.** The `CfWorkerJsonSchemaValidator` merge moved into the connection constructor (next to the existing elicitation-capabilities merge), so every construction path — present or future — gets the Worker-safe validator unless the caller supplies their own.
- **`connect()` now builds through `createConnection()`.** The two ~30-line duplicated construction blocks (transport normalization + construction + observability wiring) are collapsed into one; the duplication is what allowed the paths to drift apart in the first place. Behavior is unchanged: `connect()` still reuses the existing connection during an OAuth code reconnect and rebuilds otherwise.
- **Overrides can no longer be silently poisoned across hibernation.** A caller-supplied `jsonSchemaValidator` is a live instance and can't survive `JSON.stringify`; previously `registerServer()` persisted it anyway, and restore fed the degraded `{}` back into the merge, clobbering the safe default and breaking discovery after a Durable Object wake. Now `registerServer()` excludes it from persisted `server_options` (same treatment as `authProvider` on transport), and restore drops any degraded value held by rows written before this change. Live connections keep the caller's validator; restored ones fall back to the Worker-safe default.

## Tests (TDD, each fix red first)

- `client-manager.test.ts` — `connect()` applies the default (red pre-fix); `connect()` preserves a caller-supplied validator; `registerServer()` applies the default; `registerServer()` does not persist a caller-supplied validator (red pre-fix); restore falls back to the default when a persisted row holds a serialization-degraded validator (red pre-fix: asserted `{}` clobbering the default).
- `add-rpc-mcp-server.test.ts` — end-to-end through the real `addMcpServer(name, namespace)` RPC path: connection uses the Worker-safe validator (red pre-fix) and a tool with `outputSchema` (`structuredGreet` on `TestMcpAgent`) discovers and returns validated `structuredContent`.

Note: the AJV runtime error itself can't reproduce under vitest-pool-workers (the pool injects unsafe-eval for its module runner), so tests pin the validator instance rather than the thrown error.

Full `packages/agents` suite: 113 files, 2243 tests passing. `npm run check` clean.

Fixes #1893