### PR TITLE
feat(mcp): allow declaring url-mode elicitation capability and handling elicitation on the MCP client

### DIFF
--- a/.changeset/mcp-client-elicitation-options.md
+++ b/.changeset/mcp-client-elicitation-options.md
@@ -1,0 +1,21 @@
+---
+"agents": patch
+---
+
+MCP client: url-mode elicitation support with a real elicitation handler
+
+- Agents can now respond to server-initiated `elicitation/create` requests
+  by overriding `Agent.onElicitRequest(request, serverId)`. As a class
+  method it survives Durable Object hibernation and applies to connections
+  restored from storage. `MCPClientManager` also accepts an
+  `elicitationHandler` option, and `MCPClientConnection` an
+  `elicitationHandler` callback, for non-Agent usage.
+- Connections advertise elicitation modes based on what can actually be
+  handled: with a handler configured they advertise `{ form: {}, url: {} }`
+  (MCP spec 2025-11-25) at the initialize handshake; without one they keep
+  the previous form-mode-only default. An explicit
+  `client.capabilities.elicitation` (e.g. via `addMcpServer`) always wins,
+  is persisted with the server options, and survives hibernation — it is no
+  longer clobbered by a hardcoded value.
+- Overriding/instance-patching `MCPClientConnection.handleElicitationRequest`
+  directly is deprecated in favor of the `elicitationHandler` option.

--- a/docs/agents/mcp-client.md
+++ b/docs/agents/mcp-client.md
@@ -111,6 +111,35 @@ await this.addMcpServer("github", "https://mcp.github.com/mcp", {
 
 These options are persisted and used when reconnecting after hibernation or after OAuth completion. Default: 3 attempts, 500ms base delay, 5s max delay. See [Retries](./retries.md) for more details.
 
+### Elicitation
+
+MCP servers can request input from the client during a tool call (`elicitation/create`). To respond, override `onElicitRequest` on your agent:
+
+```typescript
+class MyAgent extends Agent<Env> {
+  async onElicitRequest(request: ElicitRequest, serverId: string) {
+    // e.g. deliver a url-mode elicitation link out-of-band
+    return { action: "accept" as const, content: {} };
+  }
+}
+```
+
+Because it is a class method, the handler survives Durable Object hibernation and applies to connections restored from storage. Without an override, elicitation requests are rejected with an error.
+
+Overriding `onElicitRequest` is all you need: when a handler is present, connections automatically advertise both form- and url-mode elicitation (MCP spec 2025-11-25 — url-mode is used for sensitive flows like OAuth URLs) at the `initialize` handshake. Without a handler, only form-mode is advertised, matching previous behavior.
+
+To narrow the advertised modes, declare them explicitly — an explicit declaration always wins and is persisted with the server options, surviving hibernation:
+
+```typescript
+await this.addMcpServer("portal", "https://portal.example.com/mcp", {
+  client: {
+    capabilities: {
+      elicitation: { form: {} } // form-mode only, even with a handler
+    }
+  }
+});
+```
+
 ### URL Security
 
 MCP server URLs are validated before connection to prevent Server-Side Request Forgery (SSRF). The following URL targets are blocked:

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -6,6 +6,7 @@ An Agent that acts as an MCP **client** — dynamically connects to remote MCP s
 
 - **`addMcpServer` / `removeMcpServer`** — managing MCP server connections from an Agent
 - **`onMcpUpdate`** — real-time state updates pushed to the React frontend via WebSocket
+- **`onElicitRequest`** — when a server requests input mid-tool-call (elicitation), the Agent broadcasts it to the browser, which renders a form from the request's schema (or a link for url-mode); the human's answer resolves the pending tool call via a `@callable` method
 - **OAuth popup flow** — `configureOAuthCallback` with a custom handler that closes the popup after auth
 - **`agentFetch`** — making HTTP requests to the Agent's custom endpoints from the client
 
@@ -16,9 +17,9 @@ npm install
 npm run dev
 ```
 
-The UI lets you add MCP server URLs, see their connection state, and browse their tools, prompts, and resources.
+The UI lets you add MCP server URLs, see their connection state, browse their tools, prompts, and resources, and run tools. If a tool call triggers an elicitation, a card appears asking for your input.
 
-To test with an authenticated server, run the [`mcp-worker-authenticated`](../mcp-worker-authenticated/) example alongside this one and add its URL.
+To test with an authenticated server, run the [`mcp-worker-authenticated`](../mcp-worker-authenticated/) example alongside this one and add its URL. To test elicitation, run the [`mcp-elicitation`](../mcp-elicitation/) example's server and run its `elicitName` tool from this UI.
 
 ## Environment variables
 

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -19,7 +19,7 @@ npm run dev
 
 The UI lets you add MCP server URLs, see their connection state, browse their tools, prompts, and resources, and run tools. If a tool call triggers an elicitation, a card appears asking for your input.
 
-To test with an authenticated server, run the [`mcp-worker-authenticated`](../mcp-worker-authenticated/) example alongside this one and add its URL. To test elicitation, run the [`mcp-elicitation`](../mcp-elicitation/) example's server and run its `elicitName` tool from this UI.
+To test with an authenticated server, run the [`mcp-worker-authenticated`](../mcp-worker-authenticated/) example alongside this one and add its URL. To test elicitation, run the [`mcp-elicitation`](../mcp-elicitation/) example's server, add it here (the MCP endpoint is at `/mcp`, e.g. `http://localhost:8787/mcp`), and run its `increase-counter` (form-mode) or `connect-account` (url-mode) tool from this UI.
 
 ## Environment variables
 

--- a/examples/mcp-client/src/client.tsx
+++ b/examples/mcp-client/src/client.tsx
@@ -49,6 +49,69 @@ type SchemaProperty = {
   default?: unknown;
 };
 
+/** Form fields generated from a JSON Schema `properties` map. */
+function SchemaFields({
+  properties,
+  values,
+  onChange
+}: {
+  properties: Record<string, SchemaProperty>;
+  values: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      {Object.entries(properties).map(([key, prop]) => (
+        <label key={key} className="block text-xs text-kumo-subtle">
+          {prop.title ?? key}
+          {prop.type === "boolean" ? (
+            <input
+              type="checkbox"
+              className="ml-2 align-middle"
+              checked={Boolean(values[key] ?? prop.default ?? false)}
+              onChange={(e) => onChange(key, e.target.checked)}
+            />
+          ) : prop.enum ? (
+            <select
+              className="w-full px-3 py-1.5 text-sm rounded-lg border border-kumo-line bg-kumo-base text-kumo-default"
+              value={String(values[key] ?? prop.default ?? "")}
+              onChange={(e) => onChange(key, e.target.value)}
+            >
+              <option value="" disabled>
+                Select…
+              </option>
+              {prop.enum.map((option) => (
+                <option key={String(option)} value={String(option)}>
+                  {String(option)}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              type={
+                prop.type === "number" || prop.type === "integer"
+                  ? "number"
+                  : "text"
+              }
+              placeholder={prop.description ?? String(prop.default ?? "")}
+              className="w-full px-3 py-1.5 text-sm rounded-lg border border-kumo-line bg-kumo-base text-kumo-default placeholder:text-kumo-inactive focus:outline-none focus:ring-1 focus:ring-kumo-accent"
+              value={String(values[key] ?? "")}
+              onChange={(e) =>
+                onChange(
+                  key,
+                  prop.type === "number" || prop.type === "integer"
+                    ? e.target.valueAsNumber
+                    : e.target.value
+                )
+              }
+            />
+          )}
+        </label>
+      ))}
+    </div>
+  );
+}
+
 /**
  * Renders one pending elicitation: a form generated from the request's
  * `requestedSchema` (form mode) or a link to open (url mode), with
@@ -109,54 +172,12 @@ function ElicitationCard({
           </Button>
         </div>
       ) : (
-        <div className="mt-3 space-y-2">
-          {Object.entries(properties).map(([key, prop]) => (
-            <label key={key} className="block text-xs text-kumo-subtle">
-              {prop.title ?? key}
-              {prop.type === "boolean" ? (
-                <input
-                  type="checkbox"
-                  className="ml-2 align-middle"
-                  checked={Boolean(values[key] ?? prop.default ?? false)}
-                  onChange={(e) => setValue(key, e.target.checked)}
-                />
-              ) : prop.enum ? (
-                <select
-                  className="w-full px-3 py-1.5 text-sm rounded-lg border border-kumo-line bg-kumo-base text-kumo-default"
-                  value={String(values[key] ?? prop.default ?? "")}
-                  onChange={(e) => setValue(key, e.target.value)}
-                >
-                  <option value="" disabled>
-                    Select…
-                  </option>
-                  {prop.enum.map((option) => (
-                    <option key={String(option)} value={String(option)}>
-                      {String(option)}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <input
-                  type={
-                    prop.type === "number" || prop.type === "integer"
-                      ? "number"
-                      : "text"
-                  }
-                  placeholder={prop.description ?? String(prop.default ?? "")}
-                  className="w-full px-3 py-1.5 text-sm rounded-lg border border-kumo-line bg-kumo-base text-kumo-default placeholder:text-kumo-inactive focus:outline-none focus:ring-1 focus:ring-kumo-accent"
-                  value={String(values[key] ?? "")}
-                  onChange={(e) =>
-                    setValue(
-                      key,
-                      prop.type === "number" || prop.type === "integer"
-                        ? e.target.valueAsNumber
-                        : e.target.value
-                    )
-                  }
-                />
-              )}
-            </label>
-          ))}
+        <div className="mt-3">
+          <SchemaFields
+            properties={properties}
+            values={values}
+            onChange={setValue}
+          />
         </div>
       )}
 
@@ -236,6 +257,72 @@ function ModeToggle() {
   );
 }
 
+/** One tool: schema dump, an args form generated from its inputSchema, Run. */
+function ToolCard({
+  tool,
+  onRun
+}: {
+  tool: { name: string; serverId: string; inputSchema?: unknown };
+  onRun: (
+    serverId: string,
+    name: string,
+    args: Record<string, unknown>
+  ) => Promise<unknown>;
+}) {
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [result, setResult] = useState<unknown>(null);
+  const properties = ((
+    tool.inputSchema as { properties?: Record<string, SchemaProperty> }
+  )?.properties ?? {}) as Record<string, SchemaProperty>;
+
+  const run = async () => {
+    setResult("Running…");
+    try {
+      setResult(await onRun(tool.serverId, tool.name, values));
+    } catch (error) {
+      setResult(String(error));
+    }
+  };
+
+  return (
+    <Surface className="p-3 rounded-xl ring ring-kumo-line">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Text size="sm" bold>
+            {tool.name}
+          </Text>
+          <Badge variant="secondary">{tool.serverId}</Badge>
+        </div>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<PlayIcon size={14} />}
+          onClick={run}
+        >
+          Run
+        </Button>
+      </div>
+      {Object.keys(properties).length > 0 && (
+        <div className="mt-2">
+          <SchemaFields
+            properties={properties}
+            values={values}
+            onChange={(key, value) => setValues((v) => ({ ...v, [key]: value }))}
+          />
+        </div>
+      )}
+      <pre className="text-xs mt-1 whitespace-pre-wrap break-words text-kumo-subtle font-mono">
+        {JSON.stringify(tool, null, 2)}
+      </pre>
+      {result !== null && (
+        <pre className="text-xs mt-2 p-2 rounded-lg bg-kumo-elevated whitespace-pre-wrap break-words text-kumo-default font-mono">
+          {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </Surface>
+  );
+}
+
 function App() {
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("connecting");
@@ -248,10 +335,6 @@ function App() {
     tools: []
   });
   const [elicitations, setElicitations] = useState<PendingElicitation[]>([]);
-  const [toolResult, setToolResult] = useState<{
-    name: string;
-    result: unknown;
-  } | null>(null);
 
   const agent = useAgent({
     agent: "my-agent",
@@ -280,15 +363,11 @@ function App() {
     await agent.call("respondToElicitation", [id, result]);
   };
 
-  const runTool = async (serverId: string, name: string) => {
-    setToolResult({ name, result: "Running…" });
-    try {
-      const result = await agent.call("callTool", [serverId, name, {}]);
-      setToolResult({ name, result });
-    } catch (error) {
-      setToolResult({ name, result: String(error) });
-    }
-  };
+  const runTool = (
+    serverId: string,
+    name: string,
+    args: Record<string, unknown>
+  ) => agent.call("callTool", [serverId, name, args]);
 
   function openPopup(authUrl: string) {
     window.open(
@@ -409,19 +488,6 @@ function App() {
             </form>
           </Surface>
 
-          {/* Pending Elicitations */}
-          {elicitations.length > 0 && (
-            <section className="space-y-2">
-              {elicitations.map((elicitation) => (
-                <ElicitationCard
-                  key={elicitation.id}
-                  elicitation={elicitation}
-                  onRespond={respondToElicitation}
-                />
-              ))}
-            </section>
-          )}
-
           {/* Connected Servers */}
           <section>
             <div className="flex items-center gap-2 mb-3">
@@ -517,37 +583,11 @@ function App() {
               </div>
               <div className="space-y-2">
                 {mcpState.tools.map((tool) => (
-                  <Surface
+                  <ToolCard
                     key={`${tool.name}-${tool.serverId}`}
-                    className="p-3 rounded-xl ring ring-kumo-line"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <Text size="sm" bold>
-                          {tool.name}
-                        </Text>
-                        <Badge variant="secondary">{tool.serverId}</Badge>
-                      </div>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        icon={<PlayIcon size={14} />}
-                        onClick={() => runTool(tool.serverId, tool.name)}
-                      >
-                        Run
-                      </Button>
-                    </div>
-                    <pre className="text-xs mt-1 whitespace-pre-wrap break-words text-kumo-subtle font-mono">
-                      {JSON.stringify(tool, null, 2)}
-                    </pre>
-                    {toolResult?.name === tool.name && (
-                      <pre className="text-xs mt-2 p-2 rounded-lg bg-kumo-elevated whitespace-pre-wrap break-words text-kumo-default font-mono">
-                        {typeof toolResult.result === "string"
-                          ? toolResult.result
-                          : JSON.stringify(toolResult.result, null, 2)}
-                      </pre>
-                    )}
-                  </Surface>
+                    tool={tool}
+                    onRun={runTool}
+                  />
                 ))}
               </div>
             </section>
@@ -616,6 +656,20 @@ function App() {
           )}
         </div>
       </main>
+
+      {/* Pending elicitations — fixed overlay so they're visible no matter
+          where on the page the tool was run from */}
+      {elicitations.length > 0 && (
+        <div className="fixed bottom-6 right-6 z-50 w-96 max-h-[80vh] overflow-auto space-y-2 shadow-lg">
+          {elicitations.map((elicitation) => (
+            <ElicitationCard
+              key={elicitation.id}
+              elicitation={elicitation}
+              onRespond={respondToElicitation}
+            />
+          ))}
+        </div>
+      )}
 
       <footer className="border-t border-kumo-line py-3">
         <div className="flex justify-center">

--- a/examples/mcp-client/src/client.tsx
+++ b/examples/mcp-client/src/client.tsx
@@ -19,11 +19,13 @@ import {
   TrashIcon,
   SignInIcon,
   InfoIcon,
+  PlayIcon,
   MoonIcon,
   SunIcon
 } from "@phosphor-icons/react";
 import type { MCPServersState } from "agents";
 import { nanoid } from "nanoid";
+import type { PendingElicitation } from "./server";
 import "./styles.css";
 
 let sessionId = localStorage.getItem("sessionId");
@@ -33,6 +35,157 @@ if (!sessionId) {
 }
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
+
+type ElicitResponse = {
+  action: "accept" | "decline" | "cancel";
+  content: Record<string, unknown>;
+};
+
+type SchemaProperty = {
+  type?: string;
+  title?: string;
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+};
+
+/**
+ * Renders one pending elicitation: a form generated from the request's
+ * `requestedSchema` (form mode) or a link to open (url mode), with
+ * accept / decline buttons that answer back to the agent.
+ */
+function ElicitationCard({
+  elicitation,
+  onRespond
+}: {
+  elicitation: PendingElicitation;
+  onRespond: (id: string, result: ElicitResponse) => void;
+}) {
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const params = elicitation.params as PendingElicitation["params"] & {
+    mode?: string;
+    url?: string;
+  };
+  const isUrlMode = params.mode === "url";
+  const properties: Record<string, SchemaProperty> = isUrlMode
+    ? {}
+    : ((params.requestedSchema?.properties ?? {}) as Record<
+        string,
+        SchemaProperty
+      >);
+
+  const setValue = (key: string, value: unknown) =>
+    setValues((v) => ({ ...v, [key]: value }));
+
+  return (
+    <Surface className="p-4 rounded-xl ring ring-kumo-accent">
+      <div className="flex items-center gap-2">
+        <Text size="sm" bold>
+          Server needs your input
+        </Text>
+        <Badge variant="secondary">{elicitation.serverId}</Badge>
+      </div>
+      <span className="mt-1 block">
+        <Text size="xs" variant="secondary">
+          {params.message}
+        </Text>
+      </span>
+
+      {isUrlMode ? (
+        <div className="mt-3 flex items-center gap-2">
+          <span className="font-mono truncate">
+            <Text size="xs" variant="secondary">
+              {params.url}
+            </Text>
+          </span>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() =>
+              window.open(params.url, "_blank", "noopener,noreferrer")
+            }
+          >
+            Open
+          </Button>
+        </div>
+      ) : (
+        <div className="mt-3 space-y-2">
+          {Object.entries(properties).map(([key, prop]) => (
+            <label key={key} className="block text-xs text-kumo-subtle">
+              {prop.title ?? key}
+              {prop.type === "boolean" ? (
+                <input
+                  type="checkbox"
+                  className="ml-2 align-middle"
+                  checked={Boolean(values[key] ?? prop.default ?? false)}
+                  onChange={(e) => setValue(key, e.target.checked)}
+                />
+              ) : prop.enum ? (
+                <select
+                  className="w-full px-3 py-1.5 text-sm rounded-lg border border-kumo-line bg-kumo-base text-kumo-default"
+                  value={String(values[key] ?? prop.default ?? "")}
+                  onChange={(e) => setValue(key, e.target.value)}
+                >
+                  <option value="" disabled>
+                    Select…
+                  </option>
+                  {prop.enum.map((option) => (
+                    <option key={String(option)} value={String(option)}>
+                      {String(option)}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type={
+                    prop.type === "number" || prop.type === "integer"
+                      ? "number"
+                      : "text"
+                  }
+                  placeholder={prop.description ?? String(prop.default ?? "")}
+                  className="w-full px-3 py-1.5 text-sm rounded-lg border border-kumo-line bg-kumo-base text-kumo-default placeholder:text-kumo-inactive focus:outline-none focus:ring-1 focus:ring-kumo-accent"
+                  value={String(values[key] ?? "")}
+                  onChange={(e) =>
+                    setValue(
+                      key,
+                      prop.type === "number" || prop.type === "integer"
+                        ? e.target.valueAsNumber
+                        : e.target.value
+                    )
+                  }
+                />
+              )}
+            </label>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-3 flex gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() =>
+            onRespond(elicitation.id, {
+              action: "accept",
+              content: isUrlMode ? {} : values
+            })
+          }
+        >
+          {isUrlMode ? "Done" : "Submit"}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            onRespond(elicitation.id, { action: "decline", content: {} })
+          }
+        >
+          Decline
+        </Button>
+      </div>
+    </Surface>
+  );
+}
 
 function ConnectionIndicator({ status }: { status: ConnectionStatus }) {
   const dot =
@@ -94,6 +247,11 @@ function App() {
     servers: {},
     tools: []
   });
+  const [elicitations, setElicitations] = useState<PendingElicitation[]>([]);
+  const [toolResult, setToolResult] = useState<{
+    name: string;
+    result: unknown;
+  } | null>(null);
 
   const agent = useAgent({
     agent: "my-agent",
@@ -102,8 +260,35 @@ function App() {
     onMcpUpdate: useCallback((mcpServers: MCPServersState) => {
       setMcpState(mcpServers);
     }, []),
+    onMessage: useCallback((event: MessageEvent) => {
+      if (typeof event.data !== "string") return;
+      let message: PendingElicitation;
+      try {
+        message = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      if (message.type === "mcp-elicitation") {
+        setElicitations((current) => [...current, message]);
+      }
+    }, []),
     onOpen: useCallback(() => setConnectionStatus("connected"), [])
   });
+
+  const respondToElicitation = async (id: string, result: ElicitResponse) => {
+    setElicitations((current) => current.filter((e) => e.id !== id));
+    await agent.call("respondToElicitation", [id, result]);
+  };
+
+  const runTool = async (serverId: string, name: string) => {
+    setToolResult({ name, result: "Running…" });
+    try {
+      const result = await agent.call("callTool", [serverId, name, {}]);
+      setToolResult({ name, result });
+    } catch (error) {
+      setToolResult({ name, result: String(error) });
+    }
+  };
 
   function openPopup(authUrl: string) {
     window.open(
@@ -224,6 +409,19 @@ function App() {
             </form>
           </Surface>
 
+          {/* Pending Elicitations */}
+          {elicitations.length > 0 && (
+            <section className="space-y-2">
+              {elicitations.map((elicitation) => (
+                <ElicitationCard
+                  key={elicitation.id}
+                  elicitation={elicitation}
+                  onRespond={respondToElicitation}
+                />
+              ))}
+            </section>
+          )}
+
           {/* Connected Servers */}
           <section>
             <div className="flex items-center gap-2 mb-3">
@@ -323,15 +521,32 @@ function App() {
                     key={`${tool.name}-${tool.serverId}`}
                     className="p-3 rounded-xl ring ring-kumo-line"
                   >
-                    <div className="flex items-center gap-2">
-                      <Text size="sm" bold>
-                        {tool.name}
-                      </Text>
-                      <Badge variant="secondary">{tool.serverId}</Badge>
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Text size="sm" bold>
+                          {tool.name}
+                        </Text>
+                        <Badge variant="secondary">{tool.serverId}</Badge>
+                      </div>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        icon={<PlayIcon size={14} />}
+                        onClick={() => runTool(tool.serverId, tool.name)}
+                      >
+                        Run
+                      </Button>
                     </div>
                     <pre className="text-xs mt-1 whitespace-pre-wrap break-words text-kumo-subtle font-mono">
                       {JSON.stringify(tool, null, 2)}
                     </pre>
+                    {toolResult?.name === tool.name && (
+                      <pre className="text-xs mt-2 p-2 rounded-lg bg-kumo-elevated whitespace-pre-wrap break-words text-kumo-default font-mono">
+                        {typeof toolResult.result === "string"
+                          ? toolResult.result
+                          : JSON.stringify(toolResult.result, null, 2)}
+                      </pre>
+                    )}
                   </Surface>
                 ))}
               </div>

--- a/examples/mcp-client/src/client.tsx
+++ b/examples/mcp-client/src/client.tsx
@@ -307,7 +307,9 @@ function ToolCard({
           <SchemaFields
             properties={properties}
             values={values}
-            onChange={(key, value) => setValues((v) => ({ ...v, [key]: value }))}
+            onChange={(key, value) =>
+              setValues((v) => ({ ...v, [key]: value }))
+            }
           />
         </div>
       )}
@@ -316,7 +318,9 @@ function ToolCard({
       </pre>
       {result !== null && (
         <pre className="text-xs mt-2 p-2 rounded-lg bg-kumo-elevated whitespace-pre-wrap break-words text-kumo-default font-mono">
-          {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
+          {typeof result === "string"
+            ? result
+            : JSON.stringify(result, null, 2)}
         </pre>
       )}
     </Surface>

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -1,6 +1,31 @@
 import { Agent, callable, routeAgentRequest } from "agents";
+import type { ElicitRequest, ElicitResult } from "agents/mcp";
+
+/**
+ * An elicitation forwarded to the browser, awaiting a human response.
+ * Shape of the `mcp-elicitation` broadcast message.
+ */
+export type PendingElicitation = {
+  type: "mcp-elicitation";
+  id: string;
+  serverId: string;
+  params: ElicitRequest["params"];
+};
+
+const ELICITATION_TIMEOUT_MS = 5 * 60 * 1000;
 
 export class MyAgent extends Agent {
+  /**
+   * Elicitations waiting on a human response, keyed by elicitation id.
+   * In-memory only: a pending elicitation does not survive hibernation,
+   * which is fine — the tool call awaiting it is a live request and would
+   * not survive hibernation either.
+   */
+  private pendingElicitations = new Map<
+    string,
+    (result: ElicitResult) => void
+  >();
+
   onStart() {
     this.mcp.configureOAuthCallback({
       customHandler: (result) => {
@@ -19,6 +44,52 @@ export class MyAgent extends Agent {
     });
   }
 
+  /**
+   * Called when a connected MCP server sends an `elicitation/create`
+   * request during a tool call. Forwards it to connected browser clients
+   * and waits for one of them to answer via `respondToElicitation`.
+   *
+   * Overriding this method is also what makes connections advertise
+   * elicitation support (form and url mode) to servers.
+   */
+  async onElicitRequest(
+    request: ElicitRequest,
+    serverId: string
+  ): Promise<ElicitResult> {
+    const id = crypto.randomUUID();
+
+    const result = new Promise<ElicitResult>((resolve) => {
+      this.pendingElicitations.set(id, resolve);
+      // Don't hold the tool call open forever if nobody answers.
+      setTimeout(() => {
+        if (this.pendingElicitations.delete(id)) {
+          resolve({ action: "cancel", content: {} });
+        }
+      }, ELICITATION_TIMEOUT_MS);
+    });
+
+    this.broadcast(
+      JSON.stringify({
+        type: "mcp-elicitation",
+        id,
+        serverId,
+        params: request.params
+      } satisfies PendingElicitation)
+    );
+
+    return result;
+  }
+
+  /** Called by the browser with the human's answer to an elicitation. */
+  @callable()
+  respondToElicitation(id: string, result: ElicitResult) {
+    const resolve = this.pendingElicitations.get(id);
+    if (resolve) {
+      this.pendingElicitations.delete(id);
+      resolve(result);
+    }
+  }
+
   @callable()
   async addServer(name: string, url: string) {
     await this.addMcpServer(name, url);
@@ -27,6 +98,15 @@ export class MyAgent extends Agent {
   @callable()
   async disconnectServer(serverId: string) {
     await this.removeMcpServer(serverId);
+  }
+
+  @callable()
+  async callTool(
+    serverId: string,
+    name: string,
+    args: Record<string, unknown>
+  ) {
+    return await this.mcp.callTool({ serverId, name, arguments: args });
   }
 }
 

--- a/examples/mcp-elicitation/README.md
+++ b/examples/mcp-elicitation/README.md
@@ -1,3 +1,10 @@
 # MCP Elicitation Demo
 
-This is a MCP server example that shows how to use elicitation support using the Agents SDK.
+An MCP server example showing elicitation with the Agents SDK. The MCP endpoint is served at `/mcp` (e.g. `http://localhost:8787/mcp` under `wrangler dev`).
+
+Two tools demonstrate the two elicitation modes:
+
+- **`increase-counter`** — form-mode: elicits an amount from the user via a `requestedSchema` form.
+- **`connect-account`** — url-mode: sends a link for the user to open out-of-band, keeping the sensitive URL out of tool-result text.
+
+Pair it with the [`mcp-client`](../mcp-client/) example, which renders both elicitation modes in a browser UI.

--- a/examples/mcp-elicitation/src/index.ts
+++ b/examples/mcp-elicitation/src/index.ts
@@ -50,6 +50,7 @@ export class MyAgent extends Agent<Cloudflare.Env, State> {
   };
 
   onStart(): void | Promise<void> {
+    this.registerUrlElicitationTool();
     this.server.registerTool(
       "increase-counter",
       {
@@ -117,6 +118,40 @@ export class MyAgent extends Agent<Cloudflare.Env, State> {
             content: [{ type: "text", text: "Counter increase failed." }]
           };
         }
+      }
+    );
+  }
+
+  registerUrlElicitationTool() {
+    this.server.registerTool(
+      "connect-account",
+      {
+        description:
+          "Pretends to link an external account. Demonstrates url-mode " +
+          "elicitation: the sensitive URL goes to the user out-of-band " +
+          "instead of into tool-result text.",
+        inputSchema: {}
+      },
+      async (_args, extra) => {
+        const result = await this.server.server.elicitInput(
+          {
+            mode: "url",
+            message:
+              "Open this link to connect your account, then come back and confirm.",
+            url: "https://example.com/oauth/authorize?demo=true",
+            elicitationId: crypto.randomUUID()
+          },
+          { relatedRequestId: extra.requestId }
+        );
+
+        if (result.action !== "accept") {
+          return {
+            content: [{ type: "text", text: "Account connection cancelled." }]
+          };
+        }
+        return {
+          content: [{ type: "text", text: "Account connected. Thanks!" }]
+        };
       }
     );
   }

--- a/packages/agents/conformance/baseline-client.yml
+++ b/packages/agents/conformance/baseline-client.yml
@@ -1,11 +1,6 @@
 # Expected failures for the MCP client conformance suite.
 # Each entry documents a known gap — remove entries as gaps are fixed.
 client:
-  # Elicitation is delegated to the platform (McpAgent.elicitInput / custom
-  # handleElicitationRequest overrides); MCPClientConnection hardcodes the
-  # `elicitation` capability without `form.applyDefaults`, so SEP-1034
-  # client-side defaults are not applied.
-  - elicitation-sep1034-client-defaults
   # SHOULD-level warning only (all checks pass): the client registers via
   # dynamic client registration instead of using a URL-based client ID
   # (client_id_metadata_document, CIMD).

--- a/packages/agents/conformance/worker.ts
+++ b/packages/agents/conformance/worker.ts
@@ -9,6 +9,7 @@ import { isUnauthorized, toErrorMessage } from "../src/mcp/errors.ts";
 import {
   createMcpHandler,
   DurableObjectEventStore,
+  type ElicitResult,
   McpAgent,
   type TransportState,
   WorkerTransport
@@ -53,6 +54,16 @@ type RunResult =
 export class ConformanceHost extends Agent<Env> {
   private _serverId: string | undefined;
 
+  /**
+   * Accept elicitation requests. Form-mode defaults are applied by the SDK
+   * client because the connection advertises `form.applyDefaults`
+   * (SEP-1034); overriding this method is also what makes connections
+   * advertise elicitation capabilities in the first place.
+   */
+  async onElicitRequest(): Promise<ElicitResult> {
+    return { action: "accept", content: {} };
+  }
+
   onStart() {
     // Respond to OAuth callbacks with an explicit status the driver can
     // assert on, instead of the default redirect-to-origin.
@@ -92,7 +103,14 @@ export class ConformanceHost extends Agent<Env> {
     try {
       if (!this._serverId) {
         const result = await this.addMcpServer(SERVER_NAME, serverUrl, {
-          transport: { type: "streamable-http" }
+          transport: { type: "streamable-http" },
+          client: {
+            capabilities: {
+              // Opt into SDK-side default application (SEP-1034) on top of
+              // the handler-driven default of `{ form: {}, url: {} }`.
+              elicitation: { form: { applyDefaults: true }, url: {} }
+            }
+          }
         });
         this._serverId = result.id;
         if (result.state === MCPConnectionState.AUTHENTICATING) {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -20,6 +20,8 @@ import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client
 import { signAgentHeaders } from "./email";
 
 import type {
+  ElicitRequest,
+  ElicitResult,
   Prompt,
   Resource,
   ServerCapabilities,
@@ -2250,10 +2252,20 @@ export class Agent<
     this._ensureSchema();
 
     // Initialize MCPClientManager AFTER tables are created
+    // Wire elicitation only when the subclass actually overrides
+    // onElicitRequest: connections advertise url-mode elicitation exactly
+    // when a handler exists, so wiring the throwing base implementation
+    // would advertise modes nothing can handle.
+    const handlesElicitation =
+      this.onElicitRequest !== Agent.prototype.onElicitRequest;
+
     this.mcp = new MCPClientManager(this._ParentClass.name, "0.0.1", {
       storage: this.ctx.storage,
       createAuthProvider: (callbackUrl) =>
-        this.createMcpOAuthProvider(callbackUrl)
+        this.createMcpOAuthProvider(callbackUrl),
+      elicitationHandler: handlesElicitation
+        ? (request, serverId) => this.onElicitRequest(request, serverId)
+        : undefined
     });
 
     // Broadcast server state whenever MCP state changes (register, connect, OAuth, remove, etc.)
@@ -3154,6 +3166,35 @@ export class Agent<
   // oxlint-disable-next-line eslint(no-unused-vars) -- params used by subclass overrides
   onStateUpdate(_state: State | undefined, _source: Connection | "server") {
     // override this to handle state updates (deprecated — use onStateChanged)
+  }
+
+  /**
+   * Called when an MCP server this agent is connected to (via
+   * {@link addMcpServer}) sends an `elicitation/create` request.
+   *
+   * Override this to respond to elicitation — e.g. deliver a url-mode
+   * elicitation link out-of-band and return `{ action: "accept" }`. Being a
+   * class method, the override survives Durable Object hibernation and
+   * applies to connections restored from storage, unlike a callback passed
+   * at connect time.
+   *
+   * When overridden, MCP client connections automatically advertise both
+   * form- and url-mode elicitation (MCP spec 2025-11-25) at the `initialize`
+   * handshake; without an override they advertise form-mode only. To narrow
+   * the advertised modes, declare `client.capabilities.elicitation`
+   * explicitly on `addMcpServer` — an explicit declaration always wins.
+   *
+   * @param _request The elicitation request from the server
+   * @param _serverId Id of the MCP server connection that sent the request
+   */
+  // oxlint-disable-next-line eslint(no-unused-vars) -- params used by subclass overrides
+  async onElicitRequest(
+    _request: ElicitRequest,
+    _serverId: string
+  ): Promise<ElicitResult> {
+    throw new Error(
+      "Elicitation is not handled by this agent. Override onElicitRequest(request, serverId) to respond to MCP elicitation requests."
+    );
   }
 
   /**

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -111,6 +111,15 @@ export type MCPDiscoveryResult = {
   error?: string;
 };
 
+/**
+ * Handler for server-initiated `elicitation/create` requests.
+ * Held in memory only — never persisted — so it must be re-supplied when a
+ * connection is recreated (e.g. after Durable Object hibernation).
+ */
+export type MCPElicitationHandler = (
+  request: ElicitRequest
+) => Promise<ElicitResult>;
+
 export class MCPClientConnection {
   client: Client;
   connectionState: MCPConnectionState = MCPConnectionState.CONNECTING;
@@ -155,6 +164,7 @@ export class MCPClientConnection {
     public options: {
       transport: MCPTransportOptions;
       client: McpClientOptions;
+      elicitationHandler?: MCPElicitationHandler;
     } = { client: {}, transport: {} }
   ) {
     this.options = {
@@ -162,11 +172,18 @@ export class MCPClientConnection {
       client: { ...defaultClientOptions, ...options.client }
     };
 
+    // Advertise elicitation modes based on what can actually be handled:
+    // with a handler configured, default to both form and url mode (MCP spec
+    // 2025-11-25); without one, keep the legacy form-mode-only `{}`. An
+    // explicit caller-declared `capabilities.elicitation` wins wholesale so
+    // callers can narrow (or widen) the advertised modes.
     const clientOptions = {
       ...this.options.client,
       capabilities: {
         ...this.options.client?.capabilities,
-        elicitation: {}
+        elicitation:
+          this.options.client?.capabilities?.elicitation ??
+          (options.elicitationHandler ? { form: {}, url: {} } : {})
       } as ClientCapabilities
     };
 
@@ -673,16 +690,23 @@ export class MCPClientConnection {
   }
 
   /**
-   * Handle elicitation request from server
-   * Automatically uses the Agent's built-in elicitation handling if available
+   * Handle elicitation request from server.
+   *
+   * Delegates to the `elicitationHandler` connection option when provided.
+   *
+   * @deprecated Overriding or instance-patching this method directly is
+   * deprecated — pass the `elicitationHandler` connection option instead
+   * (agents: override `Agent.onElicitRequest`).
    */
   async handleElicitationRequest(
-    _request: ElicitRequest
+    request: ElicitRequest
   ): Promise<ElicitResult> {
-    // Elicitation handling must be implemented by the platform
-    // For MCP servers, this should be handled by McpAgent.elicitInput()
+    const handler = this.options.elicitationHandler;
+    if (handler) {
+      return handler(request);
+    }
     throw new Error(
-      "Elicitation handler must be implemented for your platform. Override handleElicitationRequest method."
+      "Elicitation handler must be implemented for your platform. Provide the elicitationHandler connection option (agents: override onElicitRequest)."
     );
   }
 

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -4,6 +4,8 @@ import type {
   CallToolRequest,
   CallToolResultSchema,
   CompatibilityCallToolResultSchema,
+  ElicitRequest,
+  ElicitResult,
   GetPromptRequest,
   Prompt,
   ReadResourceRequest,
@@ -19,6 +21,7 @@ import type { MCPObservabilityEvent } from "../observability/mcp";
 import {
   MCPClientConnection,
   MCPConnectionState,
+  type MCPElicitationHandler,
   type MCPTransportOptions
 } from "./client-connection";
 import { toErrorMessage } from "./errors";
@@ -306,6 +309,17 @@ export type MCPClientOAuthResult =
 export type MCPClientManagerOptions = {
   storage: DurableObjectStorage;
   createAuthProvider?: (callbackUrl: string) => AgentMcpOAuthProvider;
+  /**
+   * Handler for server-initiated `elicitation/create` requests, applied to
+   * every connection this manager creates — including connections restored
+   * from storage after Durable Object hibernation. Held in memory only
+   * (never persisted), which is why it lives here rather than in the
+   * per-server persisted options.
+   */
+  elicitationHandler?: (
+    request: ElicitRequest,
+    serverId: string
+  ) => Promise<ElicitResult>;
 };
 
 /**
@@ -335,6 +349,7 @@ export class MCPClientManager {
   ) => AgentMcpOAuthProvider;
   private _isRestored = false;
   private _pendingConnections = new Map<string, Promise<void>>();
+  private _elicitationHandler?: MCPClientManagerOptions["elicitationHandler"];
 
   /** @internal Protected for testing purposes. */
   protected readonly _onObservabilityEvent =
@@ -367,6 +382,20 @@ export class MCPClientManager {
     }
     this._storage = options.storage;
     this._createAuthProviderFn = options.createAuthProvider;
+    this._elicitationHandler = options.elicitationHandler;
+  }
+
+  /**
+   * Scope the manager-level elicitation handler to a single connection.
+   * Returns undefined when no handler is configured so the connection keeps
+   * its default throwing behavior.
+   */
+  private scopedElicitationHandler(
+    serverId: string
+  ): MCPElicitationHandler | undefined {
+    const handler = this._elicitationHandler;
+    if (!handler) return undefined;
+    return (request) => handler(request, serverId);
   }
 
   // SQL helper - runs a query and returns results as array
@@ -494,6 +523,11 @@ export class MCPClientManager {
       const authProvider = conn.options.transport.authProvider;
       if (authProvider) {
         authProvider.serverId = newId;
+      }
+      // The elicitation handler closes over the server id it was created
+      // with — rescope it so elicitation requests report the new id.
+      if (conn.options.elicitationHandler) {
+        conn.options.elicitationHandler = this.scopedElicitationHandler(newId);
       }
     }
 
@@ -1125,7 +1159,8 @@ export class MCPClientManager {
       },
       {
         client: options.client ?? {},
-        transport: normalizedTransport
+        transport: normalizedTransport,
+        elicitationHandler: this.scopedElicitationHandler(id)
       }
     );
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -645,6 +645,8 @@ export type {
   MCPDiscoverResult
 } from "./client";
 
+export type { MCPElicitationHandler } from "./client-connection";
+
 export { normalizeServerId, MCP_SERVER_ID_MAX_LENGTH } from "./client";
 
 export type { McpClientOptions } from "./types";

--- a/packages/agents/src/tests/mcp/client-elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/client-elicitation.test.ts
@@ -1,0 +1,299 @@
+import { env } from "cloudflare:workers";
+import type {
+  ClientCapabilities,
+  ElicitRequest
+} from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+import { MCPClientManager } from "../../mcp/client";
+import { MCPClientConnection } from "../../mcp/client-connection";
+import type { MCPServerRow } from "../../mcp/client-storage";
+
+const elicitRequest: ElicitRequest = {
+  method: "elicitation/create",
+  params: {
+    message: "What is your name?",
+    requestedSchema: {
+      type: "object",
+      properties: { name: { type: "string" } }
+    }
+  }
+};
+
+function advertisedCapabilities(
+  connection: MCPClientConnection
+): ClientCapabilities {
+  return (connection.client as unknown as { _capabilities: ClientCapabilities })
+    ._capabilities;
+}
+
+describe("MCP client elicitation options (#1875)", () => {
+  describe("capability negotiation", () => {
+    it("defaults to form-mode-only elicitation without a handler", () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        { transport: { type: "streamable-http" }, client: {} }
+      );
+
+      expect(advertisedCapabilities(connection).elicitation).toEqual({});
+    });
+
+    it("defaults to form- and url-mode elicitation with a handler", () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {},
+          elicitationHandler: async () => ({ action: "cancel", content: {} })
+        }
+      );
+
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
+    });
+
+    it("lets an explicit declaration narrow the modes despite a handler", () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: { capabilities: { elicitation: { form: {} } } },
+          elicitationHandler: async () => ({ action: "cancel", content: {} })
+        }
+      );
+
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {}
+      });
+    });
+
+    it("honors caller-declared elicitation modes instead of clobbering them", () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {
+            capabilities: {
+              elicitation: { form: {}, url: {} },
+              sampling: {}
+            }
+          }
+        }
+      );
+
+      const capabilities = advertisedCapabilities(connection);
+      expect(capabilities.elicitation).toEqual({ form: {}, url: {} });
+      expect(capabilities.sampling).toEqual({});
+    });
+  });
+
+  describe("elicitation handler injection", () => {
+    it("delegates to the injected handler", async () => {
+      const handler = vi
+        .fn()
+        .mockResolvedValue({ action: "accept", content: { name: "Alice" } });
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {},
+          elicitationHandler: handler
+        }
+      );
+
+      const result = await connection.handleElicitationRequest(elicitRequest);
+
+      expect(result).toEqual({ action: "accept", content: { name: "Alice" } });
+      expect(handler).toHaveBeenCalledWith(elicitRequest);
+    });
+
+    it("keeps the throwing default when no handler is injected", async () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        { transport: { type: "streamable-http" }, client: {} }
+      );
+
+      await expect(
+        connection.handleElicitationRequest(elicitRequest)
+      ).rejects.toThrow("Elicitation handler must be implemented");
+    });
+
+    it("completes an elicitation round-trip via RPC using the injected handler", async () => {
+      const name = crypto.randomUUID();
+      const connection = new MCPClientConnection(
+        new URL(`rpc://${name}`),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "rpc", namespace: env.MCP_OBJECT, name },
+          client: {},
+          elicitationHandler: async () => ({
+            action: "accept",
+            content: { name: "Alice" }
+          })
+        }
+      );
+      await connection.init();
+
+      const result = await connection.client.callTool({
+        name: "elicitNameCustom",
+        arguments: {}
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: "Custom elicit: Alice" }
+      ]);
+    });
+  });
+
+  describe("MCPClientManager wiring", () => {
+    function createMockStorage() {
+      const rows = new Map<string, MCPServerRow>();
+      const kv = new Map<string, unknown>();
+      const exec = <T extends Record<string, SqlStorageValue>>(
+        query: string,
+        ...values: SqlStorageValue[]
+      ) => {
+        const results: T[] = [];
+        if (query.includes("INSERT OR REPLACE")) {
+          rows.set(values[0] as string, {
+            id: values[0] as string,
+            name: values[1] as string,
+            server_url: values[2] as string,
+            client_id: values[3] as string | null,
+            auth_url: values[4] as string | null,
+            callback_url: values[5] as string,
+            server_options: values[6] as string | null
+          });
+        } else if (query.includes("UPDATE") && query.includes("SET id = ?")) {
+          const [newId, oldId] = values as [string, string];
+          const row = rows.get(oldId);
+          if (row) {
+            rows.delete(oldId);
+            rows.set(newId, { ...row, id: newId });
+          }
+        } else if (query.includes("SELECT")) {
+          if (query.includes("WHERE id = ?")) {
+            const row = rows.get(values[0] as string);
+            if (row) results.push(row as unknown as T);
+          } else {
+            results.push(...(Array.from(rows.values()) as unknown as T[]));
+          }
+        }
+        return results[Symbol.iterator]();
+      };
+      const storage = {
+        sql: { exec },
+        get: async <T>(key: string) => kv.get(key) as T | undefined,
+        put: async (key: string, value: unknown) => {
+          kv.set(key, value);
+        },
+        list: async () => new Map(),
+        kv: {
+          get: <T>(key: string) => kv.get(key) as T | undefined,
+          put: (key: string, value: unknown) => {
+            kv.set(key, value);
+          },
+          list: vi.fn(),
+          delete: vi.fn()
+        }
+      } as unknown as DurableObjectStorage;
+      return { storage, rows };
+    }
+
+    it("scopes the manager-level handler to each connection with its server id", async () => {
+      const { storage } = createMockStorage();
+      const handler = vi
+        .fn()
+        .mockResolvedValue({ action: "decline", content: {} });
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        elicitationHandler: handler
+      });
+
+      await manager.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+
+      const connection = manager.mcpConnections["srv-1"];
+      const result = await connection.handleElicitationRequest(elicitRequest);
+
+      expect(result).toEqual({ action: "decline", content: {} });
+      expect(handler).toHaveBeenCalledWith(elicitRequest, "srv-1");
+    });
+
+    it("rescopes the handler to the new id after a server id migration", async () => {
+      const { storage } = createMockStorage();
+      const handler = vi
+        .fn()
+        .mockResolvedValue({ action: "accept", content: {} });
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        elicitationHandler: handler
+      });
+
+      await manager.registerServer("old-id", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+      await manager.migrateServerId("old-id", "github", "test-client");
+
+      const migrated = manager.mcpConnections.github;
+      await migrated.handleElicitationRequest(elicitRequest);
+
+      expect(handler).toHaveBeenCalledWith(elicitRequest, "github");
+    });
+
+    it("rewires the handler and restores declared capabilities after hibernation", async () => {
+      const { storage } = createMockStorage();
+      const handlerA = vi.fn();
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        elicitationHandler: handlerA
+      });
+
+      await managerA.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example",
+        callbackUrl: "http://example.com/callback",
+        // Auth in progress → restore recreates the connection without dialing out
+        authUrl: "http://example.com/authorize",
+        // Narrower than the handler-driven default — proves the restored
+        // connection uses the persisted declaration, not the default.
+        client: { capabilities: { elicitation: { form: {} } } }
+      });
+
+      // Simulate a hibernation wake-up: a fresh manager over the same storage
+      const handlerB = vi
+        .fn()
+        .mockResolvedValue({ action: "cancel", content: {} });
+      const managerB = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        createAuthProvider: () =>
+          ({ serverId: undefined, clientId: undefined }) as never,
+        elicitationHandler: handlerB
+      });
+      await managerB.restoreConnectionsFromStorage("test-client");
+
+      const restored = managerB.mcpConnections["srv-1"];
+      expect(restored).toBeDefined();
+
+      // Declared elicitation modes survived persistence and beat the default
+      expect(advertisedCapabilities(restored).elicitation).toEqual({
+        form: {}
+      });
+
+      // The new manager's handler is wired with the original server id
+      const result = await restored.handleElicitationRequest(elicitRequest);
+      expect(result).toEqual({ action: "cancel", content: {} });
+      expect(handlerB).toHaveBeenCalledWith(elicitRequest, "srv-1");
+    });
+  });
+});


### PR DESCRIPTION
Closes #1875

## Problem

An agent acting as an MCP client (via `addMcpServer` / `this.mcp`) could not participate in url-mode elicitation (MCP spec 2025-11-25):

1. `MCPClientConnection` hardcoded `capabilities.elicitation = {}` (form-mode only), clobbering anything the caller passed via `client.capabilities`.
2. The client-side `handleElicitationRequest` was a throwing stub with no injection point — and since capabilities are negotiated once at `initialize`, overriding it alone couldn't help.

## Fix

**Handler:** new overridable `Agent.onElicitRequest(request, serverId)`. Deliberately a class method rather than the per-call `addMcpServer` callback the issue proposed: a function option can't be persisted, so it would silently vanish when connections are recreated after Durable Object hibernation. A prototype method survives hibernation and applies to storage-restored connections; `serverId` allows per-server dispatch. Plumbing: `MCPClientManagerOptions.elicitationHandler` (scoped per connection with its server id, including the restore and id-migration paths) and a per-connection `elicitationHandler` option for non-Agent usage.

**Capabilities follow the handler:** connections advertise elicitation modes based on what can actually be handled. With a handler configured they advertise `{ form: {}, url: {} }` at the initialize handshake — so overriding `onElicitRequest` is the whole story for url-mode; no capability declaration needed. Without a handler they keep the previous form-mode-only `{}`, preserving today's server fallback behavior for handler-less agents (a capability is never claimed that nothing can handle). The `Agent` wires the handler only when `onElicitRequest` is actually overridden.

**Explicit declarations win:** `client.capabilities.elicitation` passed via `addMcpServer` is honored wholesale instead of being clobbered, letting callers narrow (or widen) the advertised modes. It is persisted in `server_options` and survives hibernation.

**Deprecation:** overriding/instance-patching `MCPClientConnection.handleElicitationRequest` directly is deprecated (still functional) in favor of the `elicitationHandler` option.

## Conformance

Enables the previously-baselined `elicitation-sep1034-client-defaults` scenario: `ConformanceHost` overrides `onElicitRequest` and declares `form.applyDefaults`, so the SDK client applies schema defaults to accepted form elicitations. The expected-failure baseline entry is removed.

## Tests

New `client-elicitation.test.ts`:
- capability defaults: form-only without a handler, `{ form, url }` with one; explicit declaration narrows despite a handler; caller-declared modes honored
- handler delegation + unchanged throwing default
- RPC end-to-end elicitation round-trip via the injected handler
- manager-level scoping (handler receives the server id)
- handler rescoped to the new id after `migrateServerId` (review finding)
- hibernation simulation: fresh manager over the same storage restores connections with the persisted (narrower-than-default) declaration intact and the new manager's handler rewired

Rebased on main (post-#1902, whose `connect()`→`createConnection()` refactor consolidated the handler threading into one construction site). Full MCP suite (516 tests) and `npm run check` green. Docs updated in `docs/agents/mcp-client.md`; changeset included (patch).