### PR TITLE
codemode: echo the execution call log on the proxy tool output

### DIFF
--- a/.changeset/spotty-taxis-report.md
+++ b/.changeset/spotty-taxis-report.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Echo the durable tool-call log on the proxy tool output. `ProxyToolOutput` now carries an optional `calls` field (the execution's `ToolLogEntry[]`) on completed, paused and error outcomes, so UIs can render an audit trail of every connector call and step — name, args, result, approval requirement and state — without a separate `executions()` round trip.

--- a/docs/codemode/approvals.md
+++ b/docs/codemode/approvals.md
@@ -61,9 +61,21 @@ type ProxyToolOutput =
       executionId: string;
       result: unknown;
       logs?: string[];
+      calls?: ToolLogEntry[];
     }
-  | { status: "paused"; executionId: string; pending: PendingAction[] }
-  | { status: "error"; executionId: string; error: string; logs?: string[] };
+  | {
+      status: "paused";
+      executionId: string;
+      pending: PendingAction[];
+      calls?: ToolLogEntry[];
+    }
+  | {
+      status: "error";
+      executionId: string;
+      error: string;
+      logs?: string[];
+      calls?: ToolLogEntry[];
+    };
 
 type PendingAction = {
   executionId: string;
@@ -73,6 +85,8 @@ type PendingAction = {
   args: unknown;
 };
 ```
+
+Every outcome also carries `calls` — the execution's [tool-call log](./runtime.md#the-tool-call-log) as it stands at the end of the pass: each connector call and `codemode.step`, with args, recorded result, approval requirement, and state. Render it to show the user what a run actually did (and what is still pending) without a separate `executions()` round trip.
 
 ## Resolving approvals
 

--- a/docs/codemode/runtime.md
+++ b/docs/codemode/runtime.md
@@ -141,6 +141,8 @@ A call is logged `executing` the moment the runtime decides to run it, and only 
 
 The log lives in the facet's SQLite database — one row per entry, so recording a call appends a row instead of rewriting the whole execution.
 
+The tool's output echoes the log on every outcome as `calls?: ToolLogEntry[]` (see [Tool output](./approvals.md#tool-output)), so a UI can render the run's audit trail directly from the tool result; `runtime.executions()` remains the durable source for past runs.
+
 ### Ephemeral entries
 
 A tool can opt out of result recording with [`replay: "reexecute"`](./connectors.md#replay-policy). Its calls are still logged (for sequencing and divergence detection) but the result is never stored: a replay **re-executes** the call instead of replaying a recorded value. Use it for idempotent reads with large results — file contents, directory listings — that would otherwise bloat the durable log.

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -104,11 +104,13 @@ export type ProxyToolOutput =
       executionId: string;
       result: unknown;
       logs?: string[];
+      calls?: ToolLogEntry[];
     }
   | {
       status: "paused";
       executionId: string;
       pending: PendingAction[];
+      calls?: ToolLogEntry[];
     }
   // Execution errors (a thrown sandbox error or a replay divergence) are
   // returned, not thrown: the model sees the failure as a tool result it can
@@ -119,6 +121,7 @@ export type ProxyToolOutput =
       executionId: string;
       error: string;
       logs?: string[];
+      calls?: ToolLogEntry[];
     };
 
 /**
@@ -650,6 +653,11 @@ async function runPass(
     // PAUSE_SENTINEL only stops the sandbox; it is never the deciding signal
     // here.
     const execution = await runtime.getExecution(executionId);
+    // The durable log as it stands at the end of this pass — every connector
+    // call and step, with args, results and approval state. Echoed on the
+    // output so UIs can render an audit trail without a separate
+    // getExecution round trip.
+    const calls = execution?.log;
     if (execution?.status === "paused") {
       // Not terminal — the run may resume, so per-execution connector
       // resources stay open. Per-pass resources are still released.
@@ -657,7 +665,8 @@ async function runPass(
       return {
         status: "paused",
         executionId,
-        pending: await runtime.listPending(executionId)
+        pending: await runtime.listPending(executionId),
+        calls
       };
     }
     if (execution?.status === "error") {
@@ -667,7 +676,8 @@ async function runPass(
       return {
         status: "error",
         executionId,
-        error: execution.error ?? "Codemode execution failed"
+        error: execution.error ?? "Codemode execution failed",
+        calls
       };
     }
 
@@ -676,7 +686,7 @@ async function runPass(
       const message = withGlobalsHint(raw, setup);
       await runtime.fail(executionId, message);
       await endPass("error");
-      return { status: "error", executionId, error: message };
+      return { status: "error", executionId, error: message, calls };
     }
 
     const result = output?.result;
@@ -686,7 +696,8 @@ async function runPass(
       status: "completed",
       executionId,
       result: await applyTransform(transformResult, result),
-      logs: output?.logs
+      logs: output?.logs,
+      calls
     };
   } finally {
     if (!ended) {

--- a/packages/codemode/src/runtime-tests/runtime.test.ts
+++ b/packages/codemode/src/runtime-tests/runtime.test.ts
@@ -142,6 +142,45 @@ describe("codemode durable runtime (e2e)", () => {
     expect((await h.sideEffects()).created).toEqual([{ title: "hello" }]);
   });
 
+  it("echoes the tool-call log on the output across pause and completion", async () => {
+    const h = host();
+    const code = `async () => {
+      const before = await items.list_items();
+      const created = await items.create_item({ title: "logged" });
+      return { beforeCount: before.length, created };
+    }`;
+    const first = (await h.run(code)) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    // The paused output carries the log so far: the applied read and the
+    // pending approval-gated action, with args and states.
+    expect(first.calls).toHaveLength(2);
+    expect(first.calls?.[0]).toMatchObject({
+      connector: "items",
+      method: "list_items",
+      requiresApproval: false,
+      state: "applied"
+    });
+    expect(first.calls?.[1]).toMatchObject({
+      connector: "items",
+      method: "create_item",
+      args: { title: "logged" },
+      requiresApproval: true,
+      state: "pending"
+    });
+
+    const resumed = (await h.approve(first.executionId)) as ProxyToolOutput;
+    expect(resumed.status).toBe("completed");
+    if (resumed.status !== "completed") return;
+    expect(resumed.calls).toHaveLength(2);
+    expect(resumed.calls?.[1]).toMatchObject({
+      method: "create_item",
+      state: "applied",
+      result: { id: 1, title: "logged" }
+    });
+  });
+
   it("replays prior reads from the log instead of re-executing them", async () => {
     const h = host();
     // A read before the approval pause. On resume the read must NOT run again.

--- a/packages/codemode/src/tests/runtime-handle.test.ts
+++ b/packages/codemode/src/tests/runtime-handle.test.ts
@@ -198,7 +198,8 @@ describe("createCodemodeRuntime", () => {
       status: "completed",
       executionId: "exec_1",
       result: "approved",
-      logs: undefined
+      logs: undefined,
+      calls: []
     });
 
     expect(runtimeStub.resume).toHaveBeenCalledWith("exec_1");


### PR DESCRIPTION
Closes #1845.

The durable codemode runtime already records every connector call and `codemode.step` in its replay log (`ToolLogEntry`: seq, connector, method, args, result, approval requirement, state). This surfaces that log on `ProxyToolOutput` as an optional `calls` field on all three outcomes (completed, paused, error), so UIs can render an audit trail of what ran — and what is pending approval — straight from the tool output, without a separate `executions()` round trip.

No new recording machinery: the field just echoes the execution's existing durable log at the end of the pass.

- `ProxyToolOutput` gains `calls?: ToolLogEntry[]` on every variant
- `runPass` attaches `execution.log` to the returned output (initial run and resume-after-approval alike)
- e2e test covering the log across a pause → approve → completion cycle
- patch changeset for `@cloudflare/codemode`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->