### PR TITLE
codemode: client-side tool calls via durable pause/resolve

### DIFF
--- a/.changeset/tidy-moons-listen.md
+++ b/.changeset/tidy-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Add client-side tool calls to codemode via durable pause/resolve. A tool annotated with `resolution: "client"` pauses the run like an approval, but is never executed server-side: the host supplies its result with the new `resolve({ executionId, seq, result })` on the runtime handle (or the standalone `resolveCodemode`), and the run resumes with the code seeing the client's value. `ToolSetConnector` gains a `clientTools: "pause"` option that exposes execute-less AI SDK tools (client-side / provider-executed) as client-resolved tools instead of skipping them.

--- a/docs/codemode/approvals.md
+++ b/docs/codemode/approvals.md
@@ -83,10 +83,13 @@ type PendingAction = {
   connector: string;
   method: string;
   args: unknown;
+  resolution?: "approval" | "client";
 };
 ```
 
 Every outcome also carries `calls` — the execution's [tool-call log](./runtime.md#the-tool-call-log) as it stands at the end of the pass: each connector call and `codemode.step`, with args, recorded result, approval requirement, and state. Render it to show the user what a run actually did (and what is still pending) without a separate `executions()` round trip.
+
+`resolution` tells the UI what kind of answer the pending action needs: `"approval"` (the default) is a yes/no — approve and the host executes the tool server-side; `"client"` means the tool never executes server-side and the run stays paused until the host supplies the tool's result via `resolve()` — see [Client-resolved tools](#client-resolved-tools).
 
 ## Resolving approvals
 
@@ -101,6 +104,10 @@ await runtime.pending();
 
 // Approve the pending action(s) and continue
 await runtime.approve({ executionId });
+
+// Supply a client-resolved call's result and continue — for pending actions
+// with resolution: "client" (see below); approve() cannot satisfy these.
+await runtime.resolve({ executionId, seq, result });
 
 // Reject — ends the execution. Does NOT undo actions already applied earlier
 // in the same run; call rollback() for that. Returns false if the action was
@@ -131,6 +138,47 @@ export class Chat extends AIChatAgent<Env> {
   }
 }
 ```
+
+## Client-resolved tools
+
+Some tools can't execute server-side at all — their result comes from the client (a browser API like `getUserTimezone`, an `ask_user` prompt, a device sensor). Mark them `resolution: "client"`: calling one pauses the run durably, exactly like an approval, but instead of approving you **supply the result**:
+
+```ts
+protected tools() {
+  return {
+    get_user_timezone: {
+      description: "The user's IANA timezone, read from the browser.",
+      requiresApproval: true,
+      resolution: "client",
+      execute: () => {
+        throw new Error("client-resolved — supplied via resolve()");
+      }
+    }
+  };
+}
+```
+
+For an AI SDK `ToolSet` wrapped in a `ToolSetConnector`, execute-less tools are skipped by default (advertising a method the sandbox can't call would send the model down a dead end). Opt them in instead with `clientTools: "pause"` — they're then exposed in the sandbox and the generated types as client-resolved tools:
+
+```ts
+new ToolSetConnector(ctx, { name: "tools", tools, clientTools: "pause" });
+```
+
+The flow mirrors approvals, with `resolve()` in place of `approve()`:
+
+```
+Model code calls tools.get_user_timezone()
+  → run pauses; pending action carries resolution: "client"
+  → agent surfaces it to the client (same channel as approvals)
+  → client computes the value and calls back
+  → runtime.resolve({ executionId, seq, result: "Europe/London" })
+  → the result is recorded as the call's value; the run replays and continues —
+    the model's code sees it as the call's ordinary return value
+```
+
+`approve()` can never satisfy a client-resolved call — on such a run it just returns the same `paused` outcome again. `resolve()` has the same safety properties as `reject()`: it only lands on an action that is still pending on a paused run, and a stale/duplicate resolve returns an error outcome rather than throwing or double-applying. A client that never answers is covered by [`expirePaused`](./runtime.md#retention), same as an approval nobody answers.
+
+The client-supplied result is recorded in the durable log and replayed as ground truth — it is **trusted**. Validate it at the agent boundary (the `@callable` method) if the client isn't.
 
 ## Rollback
 

--- a/docs/codemode/connectors.md
+++ b/docs/codemode/connectors.md
@@ -67,6 +67,7 @@ type ConnectorTool = {
   inputSchema?: JSONSchema7; // defaults to an open object
   outputSchema?: JSONSchema7;
   requiresApproval?: boolean; // omit to execute immediately
+  resolution?: "approval" | "client"; // how a paused call is satisfied
   execute: (
     args: unknown,
     ctx?: ToolExecuteContext
@@ -81,7 +82,7 @@ type ConnectorTool = {
 
 `execute`/`revert` receive an optional `ctx` carrying the `executionId` of the run they belong to. The id is stable across a run's pause/resume passes, so it's the key to use for any resource scoped to the whole execution (see [Per-execution resources](#per-execution-resources)).
 
-`requiresApproval: true` pauses the run for [approval](./approvals.md). `revert` enables [rollback](./runtime.md#rollback). Everything else executes immediately and is recorded in the durable log.
+`requiresApproval: true` pauses the run for [approval](./approvals.md). `resolution: "client"` marks a [client-resolved tool](./approvals.md#client-resolved-tools) — it never executes server-side; the run pauses until the host supplies the result via `resolve()`. `revert` enables [rollback](./runtime.md#rollback). Everything else executes immediately and is recorded in the durable log.
 
 AI SDK tools are shape-compatible — an existing `ToolSet` can be returned from `tools()` directly:
 

--- a/docs/codemode/runtime.md
+++ b/docs/codemode/runtime.md
@@ -26,6 +26,7 @@ const runtime = createCodemodeRuntime({
 | `runtime.tool(options?)`                             | The single model-facing AI SDK tool, `codemode({ code })`                                                                                  |
 | `runtime.pending(executionId?)`                      | Actions awaiting approval — drives approval UIs; no id aggregates all paused runs                                                          |
 | `runtime.approve({ executionId })`                   | Approve the pending action and continue via replay                                                                                         |
+| `runtime.resolve({ executionId, seq, result })`      | Supply a [client-resolved](./approvals.md#client-resolved-tools) call's result and continue via replay                                     |
 | `runtime.reject({ seq, executionId })`               | Reject a pending action; ends the execution. Returns `false` if it was a no-op (action no longer pending — approved or rejected elsewhere) |
 | `runtime.rollback({ executionId })`                  | Revert applied actions in reverse order via each tool's `revert`                                                                           |
 | `runtime.expirePaused({ maxAgeMs? })`                | Expire stale awaiting-approval runs and reclaim their resources                                                                            |
@@ -132,6 +133,7 @@ type ToolLogEntry = {
   args: unknown;
   result?: unknown; // recorded for replay (never for ephemeral entries)
   requiresApproval: boolean;
+  resolution?: "approval" | "client"; // how a pending entry is satisfied
   ephemeral?: boolean; // replay: "reexecute" — re-runs instead of replaying
   state: "executing" | "applied" | "pending" | "reverted";
 };

--- a/packages/codemode/src/connectors/base.ts
+++ b/packages/codemode/src/connectors/base.ts
@@ -27,6 +27,13 @@ export type ConnectorTool = {
   /** Pause for user approval before executing. Omit to execute immediately. */
   requiresApproval?: boolean;
   /**
+   * How the paused call is satisfied. `"approval"` (the default when
+   * `requiresApproval` is set) executes the tool server-side once approved;
+   * `"client"` keeps the run paused until the host supplies the result via
+   * `resolve()` — the tool's `execute` never runs server-side.
+   */
+  resolution?: "approval" | "client";
+  /**
    * Replay policy for the durable log. `"reexecute"` marks the call ephemeral:
    * its result is never stored durably, and a replay re-executes the call
    * instead of replaying a recorded result. Use it for idempotent reads whose
@@ -167,10 +174,11 @@ export abstract class CodemodeConnector<
         inputSchema: toolInputSchema(t),
         outputSchema: t.outputSchema
       };
-      if (t.requiresApproval || t.replay === "reexecute") {
+      if (t.requiresApproval || t.replay === "reexecute" || t.resolution) {
         annotations[name] = {
           ...(t.requiresApproval ? { requiresApproval: true } : {}),
-          ...(t.replay === "reexecute" ? { replay: "reexecute" as const } : {})
+          ...(t.replay === "reexecute" ? { replay: "reexecute" as const } : {}),
+          ...(t.resolution ? { resolution: t.resolution } : {})
         };
       }
     }

--- a/packages/codemode/src/connectors/toolset.ts
+++ b/packages/codemode/src/connectors/toolset.ts
@@ -29,6 +29,14 @@ export interface ToolSetConnectorOptions {
   instructions?: string;
   /** The AI SDK tools to expose. */
   tools: ToolSet;
+  /**
+   * What to do with execute-less tools (client-side / provider-executed).
+   * `"skip"` (the default) excludes them from bindings and types — calling
+   * one from the sandbox is impossible. `"pause"` includes them as
+   * client-resolved tools: calling one pauses the run durably until the host
+   * supplies the result via `resolve()` (they never execute server-side).
+   */
+  clientTools?: "skip" | "pause";
 }
 
 export class ToolSetConnector extends CodemodeConnector {
@@ -45,9 +53,11 @@ export class ToolSetConnector extends CodemodeConnector {
 
   /**
    * Only tools with an `execute` function can run inside the sandbox.
-   * Execute-less tools (client-side / provider-executed) are excluded from
-   * both the runtime bindings and the generated types — advertising a method
-   * the sandbox can't call would send the model down a dead end.
+   * By default (`clientTools: "skip"`), execute-less tools (client-side /
+   * provider-executed) are excluded from both the runtime bindings and the
+   * generated types — advertising a method the sandbox can't call would send
+   * the model down a dead end. With `clientTools: "pause"` they are exposed
+   * as client-resolved tools instead (see `#clientTools`).
    */
   #executableTools(): ToolSet {
     const executable: ToolSet = {};
@@ -59,7 +69,11 @@ export class ToolSetConnector extends CodemodeConnector {
         skipped.push(toolName);
       }
     }
-    if (skipped.length > 0 && !this.#warnedSkipped) {
+    if (
+      skipped.length > 0 &&
+      this.#options.clientTools !== "pause" &&
+      !this.#warnedSkipped
+    ) {
       this.#warnedSkipped = true;
       console.warn(
         `[codemode] ToolSetConnector "${this.name()}" skipped tools without ` +
@@ -68,6 +82,22 @@ export class ToolSetConnector extends CodemodeConnector {
       );
     }
     return executable;
+  }
+
+  /**
+   * Execute-less tools exposed as client-resolved (only with
+   * `clientTools: "pause"`). Calling one pauses the run durably; the host
+   * supplies the result via `resolve()`.
+   */
+  #clientTools(): ToolSet {
+    if (this.#options.clientTools !== "pause") return {};
+    const client: ToolSet = {};
+    for (const [toolName, t] of Object.entries(this.#options.tools)) {
+      if (!("execute" in t && typeof t.execute === "function")) {
+        client[toolName] = t;
+      }
+    }
+    return client;
   }
 
   override name(): string {
@@ -123,18 +153,60 @@ export class ToolSetConnector extends CodemodeConnector {
           : (args: unknown) => execute(args)
       };
     }
+
+    // Client-resolved tools (clientTools: "pause"): included so the sandbox
+    // can call them, but they never execute server-side — the call pauses
+    // durably and the host supplies the result via resolve(). The execute here
+    // is a safety net for a path that should be unreachable.
+    for (const [toolName, t] of Object.entries(this.#clientTools())) {
+      const name = sanitizeToolName(toolName);
+      const existing = sources.get(name);
+      if (existing !== undefined) {
+        throw new Error(
+          `Tools "${existing}" and "${toolName}" on ${this.name()} both ` +
+            `map to "${name}" — rename one of them.`
+        );
+      }
+      sources.set(name, toolName);
+
+      const rawSchema =
+        "inputSchema" in t
+          ? t.inputSchema
+          : (t as Record<string, unknown>).parameters;
+      const schema =
+        rawSchema != null
+          ? asSchema(rawSchema as Parameters<typeof asSchema>[0])
+          : undefined;
+
+      out[name] = {
+        description: t.description,
+        inputSchema: schema?.jsonSchema as JSONSchema7 | undefined,
+        requiresApproval: true,
+        resolution: "client",
+        execute: () => {
+          throw new Error(
+            `Tool "${toolName}" on ${this.name()} is client-resolved and ` +
+              `cannot execute server-side — supply its result via resolve().`
+          );
+        }
+      };
+    }
     return out;
   }
 
   /**
    * Generate the sandbox type block from the original AI SDK schemas (Zod or
    * `jsonSchema()` wrappers) rather than the converted JSON Schema, preserving
-   * field descriptions as `@param` lines. Restricted to the same executable
-   * subset that `tools()` exposes, so the types never advertise a method the
+   * field descriptions as `@param` lines. Restricted to the same subset that
+   * `tools()` exposes — executable tools plus, with `clientTools: "pause"`,
+   * the client-resolved ones — so the types never advertise a method the
    * sandbox can't call.
    */
   override async getTypeScriptTypes(): Promise<string> {
-    return generateTypes(this.#executableTools(), this.name());
+    return generateTypes(
+      { ...this.#executableTools(), ...this.#clientTools() },
+      this.name()
+    );
   }
 }
 

--- a/packages/codemode/src/connectors/types.ts
+++ b/packages/codemode/src/connectors/types.ts
@@ -8,6 +8,15 @@ export type ToolAnnotations = {
   /** Requires user approval before executing. Unannotated methods execute immediately. */
   requiresApproval?: boolean;
   /**
+   * How a paused call is satisfied. Both values imply the run pauses at the
+   * call. `"approval"` (the default when `requiresApproval` is set) means the
+   * host executes the tool server-side once approved. `"client"` means the
+   * tool never executes server-side: the run stays paused until the host
+   * supplies the tool's result via `resolve()` (e.g. a client-side tool whose
+   * result comes from the browser).
+   */
+  resolution?: "approval" | "client";
+  /**
    * Replay policy for the durable log. `"reexecute"` marks the call ephemeral:
    * its result is never stored, and a replay re-executes the call instead of
    * replaying a recorded result. Only valid for idempotent reads — the call

--- a/packages/codemode/src/index.ts
+++ b/packages/codemode/src/index.ts
@@ -43,6 +43,7 @@ export {
   type CodemodeRuntimeHandle,
   type CodemodeRuntimeToolOptions,
   type CodemodeApproveOptions,
+  type CodemodeResolveOptions,
   type CodemodeRejectOptions,
   type CodemodeRollbackOptions,
   type CodemodeExpireOptions

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -63,7 +63,8 @@ interface RuntimeStub {
     method: string,
     args: unknown,
     requiresApproval: boolean,
-    ephemeral?: boolean
+    ephemeral?: boolean,
+    resolution?: "approval" | "client"
   ): Promise<ToolDecision>;
   recordResult(
     executionId: string,
@@ -78,6 +79,7 @@ interface RuntimeStub {
   fail(executionId: string, error: string, logs?: string[]): Promise<void>;
   listPending(executionId?: string): Promise<PendingAction[]>;
   reject(seq: number, executionId: string): Promise<boolean>;
+  resolve(executionId: string, seq: number, result: unknown): Promise<boolean>;
   expirePaused(maxAgeMs?: number): Promise<string[]>;
   actionsToRevert(executionId: string): Promise<ToolLogEntry[]>;
   markReverted(seq: number, executionId: string): Promise<void>;
@@ -408,7 +410,11 @@ function buildConnectorBindings(
       try {
         const seq = cursor.next();
         const annotation = setup.annotations[`${desc.name}.${method}`];
-        const requiresApproval = annotation?.requiresApproval ?? false;
+        // A client-resolved call always pauses, whether or not the connector
+        // also set requiresApproval — resolution implies the pause.
+        const requiresApproval =
+          (annotation?.requiresApproval ?? false) ||
+          annotation?.resolution === "client";
         const ephemeral = annotation?.replay === "reexecute";
         const decision = await runtime.decide(
           executionId,
@@ -417,7 +423,8 @@ function buildConnectorBindings(
           method,
           args,
           requiresApproval,
-          ephemeral
+          ephemeral,
+          annotation?.resolution
         );
 
         if (decision.kind === "replay") return decision.result;
@@ -941,6 +948,71 @@ export async function resumeCodemode(
     options.executor,
     options.transformResult
   );
+}
+
+// ---------------------------------------------------------------------------
+// Resolve — supply a client-resolved action's result and continue via replay
+// ---------------------------------------------------------------------------
+
+export type ResolveCodemodeOptions = ResumeCodemodeOptions & {
+  /** Sequence number of the pending client-resolved action (from `pending()`). */
+  seq: number;
+  /** The result the client produced — recorded as the call's return value. */
+  result: unknown;
+};
+
+/**
+ * Supply the result of a pending client-resolved action (`resolution:
+ * "client"`) and continue the paused execution. The result is recorded on the
+ * durable log as if the tool had executed; the run then resumes and the replay
+ * serves the client's value to the code. Returns an error *outcome* (not a
+ * throw) when the action is no longer pending — the run may have been
+ * rejected, expired, or resolved from elsewhere.
+ */
+export async function resolveCodemode(
+  options: ResolveCodemodeOptions
+): Promise<ProxyToolOutput> {
+  const runtime = getRuntime(options.ctx, options.name);
+
+  let recorded: boolean;
+  try {
+    recorded = await runtime.resolve(
+      options.executionId,
+      options.seq,
+      options.result
+    );
+  } catch (err) {
+    // An unrecordable result (too large / unserializable) — surface the
+    // model-actionable message as an error outcome; the action stays pending.
+    return {
+      status: "error",
+      executionId: options.executionId,
+      error: err instanceof Error ? err.message : String(err)
+    };
+  }
+  if (!recorded) {
+    return {
+      status: "error",
+      executionId: options.executionId,
+      error:
+        `Cannot resolve step ${options.seq} of execution ` +
+        `"${options.executionId}": the call is no longer pending (it may ` +
+        `have been rejected, expired, or resolved elsewhere).`
+    };
+  }
+
+  // The entry is now "applied" with the client's result; continuing is the
+  // same replay pass an approval resume runs — the replay serves the recorded
+  // value at the resolved seq.
+  return resumeCodemode({
+    ctx: options.ctx,
+    connectors: options.connectors,
+    executor: options.executor,
+    name: options.name,
+    executionId: options.executionId,
+    maxExecutions: options.maxExecutions,
+    transformResult: options.transformResult
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/codemode/src/runtime-handle.ts
+++ b/packages/codemode/src/runtime-handle.ts
@@ -7,6 +7,7 @@ import {
   getCodemodeRuntime,
   pendingCodemode,
   rejectCodemode,
+  resolveCodemode,
   resumeCodemode,
   rollbackCodemode,
   validateConnectorNames,
@@ -60,6 +61,14 @@ export type CodemodeApproveOptions = {
   executionId: string;
 };
 
+export type CodemodeResolveOptions = {
+  /** Execution the pending client-resolved action belongs to. Get it from `pending()`. */
+  executionId: string;
+  seq: number;
+  /** The result the client produced — recorded as the call's return value. */
+  result: unknown;
+};
+
 export type CodemodeRejectOptions = {
   seq: number;
   /** Execution to reject within. Get it from `pending()`. */
@@ -89,6 +98,13 @@ export interface CodemodeRuntimeHandle {
    * was NOT rejected and the action may have executed.
    */
   reject(options: CodemodeRejectOptions): Promise<boolean>;
+  /**
+   * Supply the result of a pending client-resolved action (`resolution:
+   * "client"`) and continue the run — the code sees the client's value as the
+   * call's return. Returns an error outcome (not a throw) when the action is
+   * no longer pending.
+   */
+  resolve(options: CodemodeResolveOptions): Promise<ProxyToolOutput>;
   rollback(options: CodemodeRollbackOptions): Promise<void>;
   pending(executionId?: string): Promise<PendingAction[]>;
   /**
@@ -147,6 +163,20 @@ class DefaultCodemodeRuntimeHandle implements CodemodeRuntimeHandle {
       connectors: this.#options.connectors,
       name: this.#options.name,
       executionId: options.executionId,
+      maxExecutions: this.#options.maxExecutions,
+      transformResult: this.#options.transformResult
+    });
+  }
+
+  resolve(options: CodemodeResolveOptions): Promise<ProxyToolOutput> {
+    return resolveCodemode({
+      ctx: this.#options.ctx,
+      executor: this.#options.executor,
+      connectors: this.#options.connectors,
+      name: this.#options.name,
+      executionId: options.executionId,
+      seq: options.seq,
+      result: options.result,
       maxExecutions: this.#options.maxExecutions,
       transformResult: this.#options.transformResult
     });

--- a/packages/codemode/src/runtime-tests/runtime.test.ts
+++ b/packages/codemode/src/runtime-tests/runtime.test.ts
@@ -33,6 +33,11 @@ interface Host {
   approve(executionId: string): Promise<ProxyToolOutput>;
   approveWithoutItems(executionId: string): Promise<ProxyToolOutput>;
   runSnippetWithoutItems(snippet: string): Promise<ProxyToolOutput>;
+  resolve(
+    executionId: string,
+    seq: number,
+    result: unknown
+  ): Promise<ProxyToolOutput>;
   expirePaused(maxAgeMs?: number): Promise<string[]>;
   reject(seq: number, executionId: string): Promise<boolean>;
   rollback(executionId: string): Promise<void>;
@@ -609,6 +614,127 @@ describe("codemode durable runtime (e2e)", () => {
       { executionId: out.executionId, status: "completed" },
       { executionId: out.executionId, status: "rolled_back" }
     ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Client-resolved tools (resolution: "client") — pause until resolve()
+  // -------------------------------------------------------------------------
+
+  it("pauses on a client-resolved call and completes once resolved", async () => {
+    const h = host();
+    const first = (await h.run(
+      `async () => {
+        const answer = await items.ask_user({ question: "color?" });
+        return "answer:" + answer;
+      }`
+    )) as ProxyToolOutput;
+
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+    expect(first.pending).toHaveLength(1);
+    expect(first.pending[0]).toMatchObject({
+      connector: "items",
+      method: "ask_user",
+      args: { question: "color?" },
+      resolution: "client"
+    });
+
+    const resolved = (await h.resolve(
+      first.executionId,
+      first.pending[0].seq,
+      "blue"
+    )) as ProxyToolOutput;
+    expect(resolved.status).toBe("completed");
+    if (resolved.status === "completed") {
+      expect(resolved.result).toBe("answer:blue");
+    }
+  });
+
+  it("approve() does not execute a client-resolved call server-side", async () => {
+    const h = host();
+    const first = (await h.run(
+      `async () => await items.ask_user({ question: "sure?" })`
+    )) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    // Approving a client-resolved action must NOT flip it to executing —
+    // its execute (which would throw) never runs; the run pauses again with
+    // the same pending action awaiting resolve().
+    const approved = (await h.approve(first.executionId)) as ProxyToolOutput;
+    expect(approved.status).toBe("paused");
+    if (approved.status !== "paused") return;
+    expect(approved.pending).toHaveLength(1);
+    expect(approved.pending[0]).toMatchObject({
+      seq: first.pending[0].seq,
+      method: "ask_user",
+      resolution: "client"
+    });
+
+    // The run is still live — resolving it now completes normally.
+    const resolved = (await h.resolve(
+      first.executionId,
+      first.pending[0].seq,
+      "yes"
+    )) as ProxyToolOutput;
+    expect(resolved.status).toBe("completed");
+    if (resolved.status === "completed") expect(resolved.result).toBe("yes");
+  });
+
+  it("resolve() on a non-pending seq returns an error outcome", async () => {
+    const h = host();
+    const first = (await h.run(
+      `async () => await items.ask_user({ question: "q" })`
+    )) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    // No such seq — the run stays paused and resumable.
+    const stale = (await h.resolve(
+      first.executionId,
+      999,
+      "nope"
+    )) as ProxyToolOutput;
+    expect(stale.status).toBe("error");
+    if (stale.status === "error") {
+      expect(stale.error).toMatch(/no longer pending/);
+    }
+
+    const resolved = (await h.resolve(
+      first.executionId,
+      first.pending[0].seq,
+      "ok"
+    )) as ProxyToolOutput;
+    expect(resolved.status).toBe("completed");
+
+    // A second resolve of the already-applied seq is also stale.
+    const dupe = (await h.resolve(
+      first.executionId,
+      first.pending[0].seq,
+      "again"
+    )) as ProxyToolOutput;
+    expect(dupe.status).toBe("error");
+  });
+
+  it("detects replay divergence on a client-resolved call's args", async () => {
+    const h = host();
+    // The args are nondeterministic and not wrapped in a step — the resolved
+    // value must not be served against different args on replay.
+    const first = (await h.run(
+      `async () => await items.ask_user({ question: "q" + Math.random() })`
+    )) as ProxyToolOutput;
+    expect(first.status).toBe("paused");
+    if (first.status !== "paused") return;
+
+    const resolved = (await h.resolve(
+      first.executionId,
+      first.pending[0].seq,
+      "answer"
+    )) as ProxyToolOutput;
+    expect(resolved.status).toBe("error");
+    if (resolved.status === "error") {
+      expect(resolved.error).toMatch(/divergence/i);
+    }
   });
 
   // -------------------------------------------------------------------------

--- a/packages/codemode/src/runtime-tests/worker.ts
+++ b/packages/codemode/src/runtime-tests/worker.ts
@@ -100,6 +100,17 @@ class ItemsConnector extends CodemodeConnector<Env> {
           this.deleted.push(result);
         }
       },
+      ask_user: {
+        // Client-resolved: calling it pauses the run; only resolve() with a
+        // host-supplied result can satisfy it. The execute is a safety net
+        // that must never run.
+        description: "Ask the user a question (answered client-side).",
+        requiresApproval: true,
+        resolution: "client",
+        execute: () => {
+          throw new Error("client-resolved tool cannot execute server-side");
+        }
+      },
       boom: {
         // Always throws — exercises the host→sandbox error path: the binding
         // must return an error marker (never reject across RPC) so the run ends
@@ -212,6 +223,14 @@ export class CodemodeTestHost extends DurableObject<Env> {
 
   reject(seq: number, executionId: string): Promise<boolean> {
     return this.#runtime().reject({ seq, executionId });
+  }
+
+  resolve(
+    executionId: string,
+    seq: number,
+    result: unknown
+  ): Promise<ProxyToolOutput> {
+    return this.#runtime().resolve({ executionId, seq, result });
   }
 
   rollback(executionId: string): Promise<void> {

--- a/packages/codemode/src/runtime.ts
+++ b/packages/codemode/src/runtime.ts
@@ -80,6 +80,12 @@ export type ToolLogEntry = {
    * instead of replaying a recorded result; their result is never stored.
    */
   ephemeral?: boolean;
+  /**
+   * How a paused call is satisfied: `"approval"` executes server-side once
+   * approved; `"client"` stays pending until `resolve()` supplies the result.
+   * Only present on approval-gated entries.
+   */
+  resolution?: "approval" | "client";
   state: ToolLogEntryState;
 };
 
@@ -116,6 +122,11 @@ export type PendingAction = {
   connector: string;
   method: string;
   args: unknown;
+  /**
+   * How the action is satisfied: `"approval"` (approve → execute server-side)
+   * or `"client"` (the host must supply the result via `resolve()`).
+   */
+  resolution?: "approval" | "client";
 };
 
 /**
@@ -173,7 +184,8 @@ function pendingOf(state: ExecutionState): PendingAction[] {
       seq: e.seq,
       connector: e.connector,
       method: e.method,
-      args: e.args
+      args: e.args,
+      resolution: e.resolution
     }));
 }
 
@@ -230,6 +242,7 @@ type LogRow = {
   result: string | null;
   requires_approval: number;
   ephemeral: number;
+  resolution: string | null;
   state: string;
 };
 
@@ -251,6 +264,10 @@ function rowToEntry(row: LogRow): ToolLogEntry {
     result: parseForStorage(row.result),
     requiresApproval: row.requires_approval === 1,
     ephemeral: row.ephemeral === 1 ? true : undefined,
+    resolution:
+      row.resolution === "approval" || row.resolution === "client"
+        ? row.resolution
+        : undefined,
     state: row.state as ToolLogEntryState
   };
 }
@@ -322,6 +339,7 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         result TEXT,
         requires_approval INTEGER NOT NULL DEFAULT 0,
         ephemeral INTEGER NOT NULL DEFAULT 0,
+        resolution TEXT,
         state TEXT NOT NULL,
         PRIMARY KEY (execution_id, seq)
       );
@@ -334,6 +352,16 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         connectors TEXT
       );
     `);
+    // Additive migration: cm_log tables created before the `resolution`
+    // column existed lack it (CREATE TABLE IF NOT EXISTS won't add it).
+    const logColumns = this.ctx.storage.sql
+      .exec<{ name: string }>(`PRAGMA table_info(cm_log)`)
+      .toArray();
+    if (!logColumns.some((c) => c.name === "resolution")) {
+      this.ctx.storage.sql.exec(
+        `ALTER TABLE cm_log ADD COLUMN resolution TEXT`
+      );
+    }
   }
 
   // -----------------------------------------------------------------------
@@ -415,7 +443,8 @@ export class CodemodeRuntime extends DurableObject<unknown> {
     method: string,
     args: unknown,
     requiresApproval: boolean,
-    ephemeral = false
+    ephemeral = false,
+    resolution?: "approval" | "client"
   ): Promise<ToolDecision> {
     const row = this.#requireRow(executionId);
 
@@ -464,6 +493,18 @@ export class CodemodeRuntime extends DurableObject<unknown> {
         return { kind: "replay", result: existing.result };
       }
       if (existing.state === "pending") {
+        // A client-resolved call is never executed server-side: approval (or
+        // any replay pass reaching it) must not flip it to "executing". It
+        // stays pending — only resolve() can satisfy it with the client's
+        // result — so re-pause the run here.
+        if (existing.resolution === "client") {
+          this.ctx.storage.sql.exec(
+            `UPDATE cm_executions SET status = 'paused', updated_at = ? WHERE id = ?`,
+            Date.now(),
+            executionId
+          );
+          return { kind: "pause", seq };
+        }
         // Approved since the last run. Transition pending → executing and
         // persist BEFORE returning, so a concurrent reject() (e.g. a second UI
         // tab) sees "executing" and no-ops instead of reverting an action that
@@ -503,8 +544,8 @@ export class CodemodeRuntime extends DurableObject<unknown> {
     this.ctx.storage.sql.exec(
       `INSERT OR REPLACE INTO cm_log
         (execution_id, seq, connector, method, args, result,
-         requires_approval, ephemeral, state)
-        VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
+         requires_approval, ephemeral, resolution, state)
+        VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
       executionId,
       seq,
       connector,
@@ -512,6 +553,8 @@ export class CodemodeRuntime extends DurableObject<unknown> {
       storedArgs,
       requiresApproval ? 1 : 0,
       ephemeral ? 1 : 0,
+      // Both values imply a pause; "approval" is the default for a gated call.
+      requiresApproval ? (resolution ?? "approval") : null,
       state
     );
 
@@ -676,6 +719,43 @@ export class CodemodeRuntime extends DurableObject<unknown> {
       Date.now(),
       executionId
     );
+    return true;
+  }
+
+  /**
+   * Supply the result of a pending client-resolved action. The entry flips to
+   * "applied" with the given result, exactly as if the tool had executed —
+   * the replay pass then serves the value to the resumed code from the log.
+   * The execution stays paused; the caller resumes it (see `resolveCodemode`).
+   *
+   * Returns whether the result was recorded: `false` when the entry is no
+   * longer pending or the run is no longer paused (stale/duplicate resolve),
+   * mirroring `reject()`.
+   */
+  async resolve(
+    executionId: string,
+    seq: number,
+    result: unknown
+  ): Promise<boolean> {
+    const execution = this.#executionRow(executionId);
+    if (!execution || execution.status !== "paused") return false;
+    const entry = this.#logRow(executionId, seq);
+    if (entry?.state !== "pending") return false;
+    // The size/serializability guard applies as to any recorded result — an
+    // unrecordable client value throws a model-actionable error to the caller
+    // and leaves the entry pending.
+    const stored = toStored(
+      `The result of ${entry.connector}.${entry.method}`,
+      result
+    );
+    this.ctx.storage.sql.exec(
+      `UPDATE cm_log SET result = ?, state = 'applied'
+        WHERE execution_id = ? AND seq = ?`,
+      stored,
+      executionId,
+      seq
+    );
+    this.#touch(executionId);
     return true;
   }
 

--- a/packages/codemode/src/tests/toolset-connector.test.ts
+++ b/packages/codemode/src/tests/toolset-connector.test.ts
@@ -105,6 +105,49 @@ describe("ToolSetConnector", () => {
     expect(warn.mock.calls[0][0]).toContain("clientSide");
   });
 
+  it("includes execute-less tools as client-resolved with clientTools: 'pause'", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const connector = new ToolSetConnector(ctx, {
+      clientTools: "pause",
+      tools: {
+        serverSide: tool({
+          description: "Runs on the server",
+          inputSchema: z.object({}),
+          execute: async () => "ran"
+        }),
+        clientSide: tool({
+          description: "Forwarded to the client",
+          inputSchema: z.object({ prompt: z.string() })
+          // no execute — client-side tool
+        })
+      }
+    });
+
+    const desc = await connector.describe();
+    expect(Object.keys(desc.descriptors).sort()).toEqual([
+      "clientSide",
+      "serverSide"
+    ]);
+    expect(desc.annotations?.serverSide).toBeUndefined();
+    expect(desc.annotations?.clientSide).toEqual({
+      requiresApproval: true,
+      resolution: "client"
+    });
+
+    // The client tool IS advertised in the sandbox types.
+    const types = await connector.getTypeScriptTypes();
+    expect(types).toContain("serverSide");
+    expect(types).toContain("clientSide");
+
+    // Its server-side execute is a safety net that must never succeed.
+    await expect(
+      connector.executeTool("clientSide", { prompt: "hi" })
+    ).rejects.toThrow(/client-resolved.*cannot execute server-side/);
+
+    // No "skipped" warning — the tool wasn't skipped.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("rejects tools whose sanitized names collide", async () => {
     const connector = new ToolSetConnector(ctx, {
       tools: {


### PR DESCRIPTION
Closes #1735.

Lets generated code call client-side (execute-less) tools by generalizing the durable approval machinery into value-carrying resolution: a client tool call pauses the run as a pending log entry marked `resolution: "client"`; the client supplies the result via a new `resolve()`, which records it as applied and resumes via the existing replay — so the model just writes `const tz = await tools.getUserTimezone({})` and the run durably parks until the client answers.

## What changed
- `ToolAnnotations.resolution?: "approval" | "client"` — both imply a pause; approval stays the default for gated calls. Carried through `ToolLogEntry` and `PendingAction` so approval UIs can distinguish "approve/deny" from "compute and return".
- `CodemodeRuntime.resolve(executionId, seq, result)` — mirrors `reject()`: only a pending entry on a paused run; stores the client result (same size guard) and flips it to applied. `decide()` will never execute a client-pending entry server-side — `approve()` on such a run just re-pauses; once resolved, ordinary replay serves the value with the usual divergence check.
- `resolveCodemode()` / `handle.resolve({executionId, seq, result})` — records the result then reuses the resume path; stale/duplicate resolves return an error outcome, not a throw.
- `ToolSetConnector` opt-in `clientTools: "pause"` (default "skip" preserves today's skip-and-warn): execute-less tools are exposed in the sandbox + `getTypeScriptTypes()`, annotated client-resolved, with a throwing server-side execute as a safety net.
- e2e + toolset tests; patch changeset.

## Notes / deferred
- Client-supplied results are trusted (no output-schema validation yet) — follow-up.
- `expirePaused` already covers a client that never answers.
- No changes to the agents chat client; apps wire this like approvals (e.g. a `@callable resolveExecution` on the agent), reusing the existing `onToolCall`-style handler.

Draft — API surface up for discussion.