### PR TITLE
fix(voice): honor pcm16 audio sample rate

### DIFF
--- a/.changeset/voice-pcm16-sample-rate.md
+++ b/.changeset/voice-pcm16-sample-rate.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/voice": patch
+---
+
+Honor the configured sample rate for raw `pcm16` audio payloads.
+
+Adds a `sampleRate` option to `VoiceAgentOptions` (default `16000`) that is declared in the server `audio_config` message. `VoiceClient` reads it (exposed via a new `sampleRate` getter) and constructs `AudioBuffer` instances at that rate for raw `pcm16` playback, so providers with a native rate other than 16 kHz (e.g. 24 kHz Gemini TTS) play at the correct speed. Falls back to 16 kHz when the server omits the field.

--- a/docs/voice/index.md
+++ b/docs/voice/index.md
@@ -277,6 +277,7 @@ Pass options to `withVoice()` as the second argument:
 const VoiceAgent = withVoice(Agent, {
   historyLimit: 20, // Max messages loaded for context (default: 20)
   audioFormat: "mp3", // Audio format sent to client (default: "mp3")
+  sampleRate: 16000, // Sample rate (Hz) for raw pcm16 payloads (default: 16000)
   maxMessageCount: 1000 // Max messages in SQLite (default: 1000)
 });
 ```

--- a/packages/voice/src/tests/agents/voice.ts
+++ b/packages/voice/src/tests/agents/voice.ts
@@ -345,6 +345,10 @@ function isJsonValue(value: unknown): boolean {
 // --- Test agents ---
 
 const VoiceBase = withVoice(Agent);
+const Pcm24kVoiceBase = withVoice(Agent, {
+  audioFormat: "pcm16",
+  sampleRate: 24000
+});
 
 /**
  * Test VoiceAgent with continuous transcriber.
@@ -682,5 +686,23 @@ export class TestAiSdkTextStreamVoiceAgent extends VoiceBase {
     } catch {
       // ignore
     }
+  }
+}
+
+/**
+ * Test VoiceAgent configured for native 24kHz pcm16 payloads
+ * (e.g. Gemini TTS). Verifies sampleRate is declared in audio_config.
+ */
+export class TestPcm24kVoiceAgent extends Pcm24kVoiceBase {
+  static options = { hibernate: false };
+
+  transcriber = new TestTranscriber();
+  tts = new TestTTS();
+
+  async onTurn(
+    transcript: string,
+    _context: VoiceTurnContext
+  ): Promise<string> {
+    return `Echo: ${transcript}`;
   }
 }

--- a/packages/voice/src/tests/voice-client.test.ts
+++ b/packages/voice/src/tests/voice-client.test.ts
@@ -63,6 +63,7 @@ class FakeAudioContext {
   currentTime = 0;
   source: FakeAudioBufferSourceNode | null = null;
   sources: FakeAudioBufferSourceNode[] = [];
+  createdBuffers: Array<{ length: number; sampleRate: number }> = [];
   deferDecode = false;
   pendingDecode: (() => void) | null = null;
   destination = {};
@@ -86,6 +87,7 @@ class FakeAudioContext {
     length: number,
     sampleRate: number
   ): AudioBuffer {
+    this.createdBuffers.push({ length, sampleRate });
     return {
       duration: length / sampleRate,
       getChannelData: () => new Float32Array(length)
@@ -819,15 +821,48 @@ describe("VoiceClient gapless playback", () => {
     return new ArrayBuffer(1600 * 2);
   }
 
-  function startPcm16Call(): { transport: MockTransport; client: VoiceClient } {
+  function startPcm16Call(sampleRate?: number): {
+    transport: MockTransport;
+    client: VoiceClient;
+  } {
     const transport = new MockTransport();
     const client = new VoiceClient({ agent: "test-agent", transport });
     client.connect();
     transport.receive(
-      JSON.stringify({ type: "audio_config", format: "pcm16" })
+      JSON.stringify({
+        type: "audio_config",
+        format: "pcm16",
+        ...(sampleRate !== undefined ? { sampleRate } : {})
+      })
     );
     return { transport, client };
   }
+
+  it("uses the sampleRate from audio_config when playing pcm16", async () => {
+    const { transport, client } = startPcm16Call(24000);
+    expect(client.sampleRate).toBe(24000);
+
+    // 2400 samples at 24kHz = 0.1s
+    transport.receive(new ArrayBuffer(2400 * 2));
+    await waitForSourceCount(1);
+
+    expect(audioContext.createdBuffers).toEqual([
+      { length: 2400, sampleRate: 24000 }
+    ]);
+    expect(audioContext.sources[0]?.startedAt).toBe(0);
+  });
+
+  it("defaults pcm16 sampleRate to 16000 when audio_config omits it", async () => {
+    const { transport, client } = startPcm16Call();
+    expect(client.sampleRate).toBe(16000);
+
+    transport.receive(pcm16Chunk());
+    await waitForSourceCount(1);
+
+    expect(audioContext.createdBuffers).toEqual([
+      { length: 1600, sampleRate: 16000 }
+    ]);
+  });
 
   it("schedules consecutive chunks back-to-back instead of waiting for ended", async () => {
     const { transport } = startPcm16Call();

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -247,6 +247,23 @@ describe("VoiceAgent — protocol", () => {
       unknown
     >;
     expect(config.format).toBe("mp3");
+    expect(config.sampleRate).toBe(16000);
+    ws.close();
+  });
+
+  it("sends configured sampleRate in audio_config", async () => {
+    const { ws } = await connectWS(
+      `/agents/test-pcm24k-voice-agent/voice-test-${++instanceCounter}`
+    );
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    const config = (await waitForType(ws, "audio_config")) as Record<
+      string,
+      unknown
+    >;
+    expect(config.format).toBe("pcm16");
+    expect(config.sampleRate).toBe(24000);
     ws.close();
   });
 });

--- a/packages/voice/src/tests/worker.ts
+++ b/packages/voice/src/tests/worker.ts
@@ -4,7 +4,8 @@ export {
   TestVoiceAgent,
   TestEmptyResponseVoiceAgent,
   TestAiSdkFullStreamVoiceAgent,
-  TestAiSdkTextStreamVoiceAgent
+  TestAiSdkTextStreamVoiceAgent,
+  TestPcm24kVoiceAgent
 } from "./agents/voice";
 
 export {
@@ -17,6 +18,7 @@ export type Env = {
   TestEmptyResponseVoiceAgent: DurableObjectNamespace;
   TestAiSdkFullStreamVoiceAgent: DurableObjectNamespace;
   TestAiSdkTextStreamVoiceAgent: DurableObjectNamespace;
+  TestPcm24kVoiceAgent: DurableObjectNamespace;
   TestVoiceInputAgent: DurableObjectNamespace;
   TestRejectCallVoiceInputAgent: DurableObjectNamespace;
 };

--- a/packages/voice/src/tests/wrangler.jsonc
+++ b/packages/voice/src/tests/wrangler.jsonc
@@ -28,6 +28,10 @@
         "name": "TestAiSdkTextStreamVoiceAgent"
       },
       {
+        "class_name": "TestPcm24kVoiceAgent",
+        "name": "TestPcm24kVoiceAgent"
+      },
+      {
         "class_name": "TestVoiceInputAgent",
         "name": "TestVoiceInputAgent"
       },
@@ -45,6 +49,7 @@
         "TestEmptyResponseVoiceAgent",
         "TestAiSdkFullStreamVoiceAgent",
         "TestAiSdkTextStreamVoiceAgent",
+        "TestPcm24kVoiceAgent",
         "TestVoiceInputAgent",
         "TestRejectCallVoiceInputAgent"
       ],

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -677,9 +677,10 @@ export class VoiceClient {
       case "audio_config":
         this.#serverCallAcknowledged = true;
         this.#audioFormat = msg.format as VoiceAudioFormat;
-        if (typeof msg.sampleRate === "number" && msg.sampleRate > 0) {
-          this.#sampleRate = msg.sampleRate;
-        }
+        this.#sampleRate =
+          typeof msg.sampleRate === "number" && msg.sampleRate > 0
+            ? msg.sampleRate
+            : 16000;
         break;
       case "status":
         this.#status = msg.status as VoiceStatus;

--- a/packages/voice/src/voice-client.ts
+++ b/packages/voice/src/voice-client.ts
@@ -269,6 +269,8 @@ export class VoiceClient {
   #outputDeviceError: string | null = null;
   #lastCustomMessage: unknown = null;
   #audioFormat: VoiceAudioFormat | null = null;
+  /** Sample rate for raw pcm16 payloads; set from server `audio_config`. */
+  #sampleRate = 16000;
   #interimTranscript: string | null = null;
   #serverProtocolVersion: number | null = null;
   #inCall = false;
@@ -644,6 +646,14 @@ export class VoiceClient {
     return this.#audioFormat;
   }
 
+  /**
+   * The sample rate (Hz) the server declared for raw pcm16 payloads.
+   * Set when the server sends `audio_config` at call start. Defaults to 16000.
+   */
+  get sampleRate(): number {
+    return this.#sampleRate;
+  }
+
   // --- Voice protocol handler ---
 
   #handleJSONMessage(data: string): void {
@@ -667,6 +677,9 @@ export class VoiceClient {
       case "audio_config":
         this.#serverCallAcknowledged = true;
         this.#audioFormat = msg.format as VoiceAudioFormat;
+        if (typeof msg.sampleRate === "number" && msg.sampleRate > 0) {
+          this.#sampleRate = msg.sampleRate;
+        }
         break;
       case "status":
         this.#status = msg.status as VoiceStatus;
@@ -938,9 +951,9 @@ export class VoiceClient {
 
       let audioBuffer: AudioBuffer;
       if (this.#audioFormat === "pcm16") {
-        // Raw 16-bit LE mono PCM at 16kHz — manually construct AudioBuffer
+        // Raw 16-bit LE mono PCM — sample rate comes from server audio_config
         const int16 = new Int16Array(audioData);
-        audioBuffer = ctx.createBuffer(1, int16.length, 16000);
+        audioBuffer = ctx.createBuffer(1, int16.length, this.#sampleRate);
         const channel = audioBuffer.getChannelData(0);
         for (let i = 0; i < int16.length; i++) {
           channel[i] = int16[i] / 32768;

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -121,6 +121,14 @@ export interface VoiceAgentOptions {
   historyLimit?: number;
   /** Audio format used for binary audio payloads sent to the client. @default "mp3" */
   audioFormat?: VoiceAudioFormat;
+  /**
+   * Sample rate (Hz) of raw PCM audio payloads sent to the client.
+   * Declared in the `audio_config` message so the client can play `pcm16`
+   * at the provider's native rate (e.g. 24000 for Gemini TTS).
+   * Encoded formats (mp3/wav/opus) carry their own rate and ignore this.
+   * @default 16000
+   */
+  sampleRate?: number;
   /** Max conversation messages to keep in SQLite. Oldest are pruned. @default 1000 */
   maxMessageCount?: number;
 }
@@ -129,6 +137,7 @@ export interface VoiceAgentOptions {
 
 const DEFAULT_HISTORY_LIMIT = 20;
 const DEFAULT_MAX_MESSAGE_COUNT = 1000;
+const DEFAULT_SAMPLE_RATE = 16000;
 
 // --- Mixin ---
 
@@ -576,9 +585,11 @@ export function withVoice<TBase extends AgentLike>(
         this.#keepAliveDispose.set(connection.id, dispose);
 
         const configuredFormat = opt("audioFormat", "mp3") as VoiceAudioFormat;
+        const configuredSampleRate = opt("sampleRate", DEFAULT_SAMPLE_RATE);
         this.#sendJSON(connection, {
           type: "audio_config",
-          format: configuredFormat
+          format: configuredFormat,
+          sampleRate: configuredSampleRate
         });
       } catch (error) {
         await this.#handleStartupFailure(


### PR DESCRIPTION
## Summary

- Add a `sampleRate` option to `VoiceAgentOptions` for raw PCM output.
- Include `sampleRate` in the server `audio_config` message so clients can play `pcm16` at the provider-native rate.
- Update `VoiceClient` to read `sampleRate` from `audio_config` and use it when constructing `AudioBuffer` instances for raw `pcm16` payloads.
- Preserve the existing 16 kHz fallback when the server omits `sampleRate`.
- Add protocol and playback coverage for configured 24 kHz PCM and default 16 kHz behavior.

## Validation

- `pnpm run check`

## Diff scope

This replacement PR is based directly on `origin/main` and contains only the voice sample-rate commit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->