### PR TITLE
fix(mcp): advertise no elicitation capability when no handler is configured

### DIFF
--- a/.changeset/no-elicitation-capability-without-handler.md
+++ b/.changeset/no-elicitation-capability-without-handler.md
@@ -1,0 +1,21 @@
+---
+"agents": patch
+---
+
+MCP client: advertise no elicitation capability when no handler is configured
+
+Connections without an elicitation handler previously advertised form-mode
+elicitation while rejecting every elicitation request that arrived, so
+spec-compliant servers chose elicitation over their fallback flows and the
+tool call failed mid-flight. Connections now advertise the elicitation
+capability only when it can be handled: both form and url mode with a
+handler (an `onElicitRequest` override on `Agent`, or the
+`elicitationHandler` option), and no elicitation capability without one,
+letting servers fall back gracefully.
+
+Behavior change: code relying on the deprecated pattern of instance-patching
+`handleElicitationRequest` on a connection stops receiving elicitation
+requests, because the capability is no longer advertised. Migrate to
+`Agent.onElicitRequest` / the `elicitationHandler` option, or declare
+`client.capabilities.elicitation` explicitly — an explicit declaration is
+always honored.

--- a/docs/agents/mcp-client.md
+++ b/docs/agents/mcp-client.md
@@ -124,9 +124,9 @@ class MyAgent extends Agent<Env> {
 }
 ```
 
-Because it is a class method, the handler survives Durable Object hibernation and applies to connections restored from storage. Without an override, elicitation requests are rejected with an error.
+Because it is a class method, the handler survives Durable Object hibernation and applies to connections restored from storage.
 
-Overriding `onElicitRequest` is all you need: when a handler is present, connections automatically advertise both form- and url-mode elicitation (MCP spec 2025-11-25 — url-mode is used for sensitive flows like OAuth URLs) at the `initialize` handshake. Without a handler, only form-mode is advertised, matching previous behavior.
+Overriding `onElicitRequest` is all you need: when a handler is present, connections automatically advertise both form- and url-mode elicitation (MCP spec 2025-11-25 — url-mode is used for sensitive flows like OAuth URLs) at the `initialize` handshake. Without a handler, connections advertise no elicitation capability, so spec-compliant servers use their non-elicitation fallbacks instead of sending requests the agent cannot answer.
 
 To narrow the advertised modes, declare them explicitly — an explicit declaration always wins and is persisted with the server options, surviving hibernation:
 

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -158,6 +158,14 @@ export class MCPClientConnection {
   public readonly onObservabilityEvent: Event<MCPObservabilityEvent> =
     this._onObservabilityEvent.event;
 
+  /**
+   * Whether the connection advertised the elicitation capability. The SDK
+   * client refuses to register an `elicitation/create` request handler when
+   * the capability was not declared, so handler registration is gated on
+   * this.
+   */
+  private readonly _elicitationEnabled: boolean;
+
   constructor(
     public url: URL,
     info: ConstructorParameters<typeof Client>[0],
@@ -172,18 +180,22 @@ export class MCPClientConnection {
       client: { ...defaultClientOptions, ...options.client }
     };
 
-    // Advertise elicitation modes based on what can actually be handled:
-    // with a handler configured, default to both form and url mode (MCP spec
-    // 2025-11-25); without one, keep the legacy form-mode-only `{}`. An
-    // explicit caller-declared `capabilities.elicitation` wins wholesale so
-    // callers can narrow (or widen) the advertised modes.
+    // Advertise elicitation only when it can actually be handled: with a
+    // handler configured, default to both form and url mode (MCP spec
+    // 2025-11-25); without one, advertise no elicitation capability so
+    // spec-compliant servers use their non-elicitation fallbacks instead of
+    // sending requests that would only be rejected. An explicit
+    // caller-declared `capabilities.elicitation` wins wholesale so callers
+    // can narrow (or widen) the advertised modes.
+    const elicitation =
+      this.options.client?.capabilities?.elicitation ??
+      (options.elicitationHandler ? { form: {}, url: {} } : undefined);
+    this._elicitationEnabled = elicitation !== undefined;
     const clientOptions = {
       ...this.options.client,
       capabilities: {
         ...this.options.client?.capabilities,
-        elicitation:
-          this.options.client?.capabilities?.elicitation ??
-          (options.elicitationHandler ? { form: {}, url: {} } : {})
+        ...(elicitation ? { elicitation } : {})
       } as ClientCapabilities
     };
 
@@ -222,13 +234,17 @@ export class MCPClientConnection {
 
     // Handle the result and emit appropriate events
     if (res.state === MCPConnectionState.CONNECTED && res.transport) {
-      // Set up elicitation request handler after successful connection
-      this.client.setRequestHandler(
-        ElicitRequestSchema,
-        async (request: ElicitRequest) => {
-          return await this.handleElicitationRequest(request);
-        }
-      );
+      // Set up the elicitation request handler after a successful
+      // connection. Only when the capability was advertised — the SDK
+      // client throws on registering a handler for an undeclared capability.
+      if (this._elicitationEnabled) {
+        this.client.setRequestHandler(
+          ElicitRequestSchema,
+          async (request: ElicitRequest) => {
+            return await this.handleElicitationRequest(request);
+          }
+        );
+      }
 
       this.lastConnectedTransport = res.transport;
 

--- a/packages/agents/src/tests/mcp/client-elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/client-elicitation.test.ts
@@ -28,14 +28,14 @@ function advertisedCapabilities(
 
 describe("MCP client elicitation options (#1875)", () => {
   describe("capability negotiation", () => {
-    it("defaults to form-mode-only elicitation without a handler", () => {
+    it("advertises no elicitation capability without a handler", () => {
       const connection = new MCPClientConnection(
         new URL("http://example.com/mcp"),
         { name: "test-client", version: "1.0.0" },
         { transport: { type: "streamable-http" }, client: {} }
       );
 
-      expect(advertisedCapabilities(connection).elicitation).toEqual({});
+      expect(advertisedCapabilities(connection).elicitation).toBeUndefined();
     });
 
     it("defaults to form- and url-mode elicitation with a handler", () => {

--- a/packages/agents/src/tests/mcp/elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/elicitation.test.ts
@@ -332,12 +332,10 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
 
   describe("RPC Transport", () => {
     it("should keep a normal concurrent tool call separate from an eliciting tool call via RPC", async () => {
-      const { connection } = await establishRPCConnection();
-
-      connection.handleElicitationRequest = async () => {
+      const { connection } = await establishRPCConnection(async () => {
         await new Promise((resolve) => setTimeout(resolve, 20));
         return { action: "accept", content: { name: "Alice" } };
-      };
+      });
 
       const [elicitResult, greetResult] = await Promise.all([
         connection.client.callTool({
@@ -359,12 +357,11 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
     });
 
     it("should complete elicitation accept round-trip via RPC", async () => {
-      const { connection } = await establishRPCConnection();
-
-      // Override the elicitation handler to auto-accept with a name
-      connection.handleElicitationRequest = async () => {
-        return { action: "accept", content: { name: "Alice" } };
-      };
+      // Inject an elicitation handler that auto-accepts with a name
+      const { connection } = await establishRPCConnection(async () => ({
+        action: "accept",
+        content: { name: "Alice" }
+      }));
 
       const result = await connection.client.callTool({
         name: "elicitNameCustom",
@@ -377,11 +374,10 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
     });
 
     it("should handle elicitation cancel response via RPC", async () => {
-      const { connection } = await establishRPCConnection();
-
-      connection.handleElicitationRequest = async () => {
-        return { action: "cancel", content: {} };
-      };
+      const { connection } = await establishRPCConnection(async () => ({
+        action: "cancel",
+        content: {}
+      }));
 
       const result = await connection.client.callTool({
         name: "elicitNameCustom",
@@ -394,11 +390,10 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
     });
 
     it("should handle elicitation decline response via RPC", async () => {
-      const { connection } = await establishRPCConnection();
-
-      connection.handleElicitationRequest = async () => {
-        return { action: "decline", content: {} };
-      };
+      const { connection } = await establishRPCConnection(async () => ({
+        action: "decline",
+        content: {}
+      }));
 
       const result = await connection.client.callTool({
         name: "elicitNameCustom",

--- a/packages/agents/src/tests/shared/test-utils.ts
+++ b/packages/agents/src/tests/shared/test-utils.ts
@@ -148,18 +148,28 @@ export async function initializeMCPClientConnection(
 }
 
 /**
- * Helper to create RPC connection to TestMcpAgent
+ * Helper to create RPC connection to TestMcpAgent.
+ *
+ * Pass `elicitationHandler` when the test exercises elicitation — without a
+ * handler the connection advertises no elicitation capability, so the server
+ * refuses to elicit.
  */
-export async function establishRPCConnection(): Promise<{
+export async function establishRPCConnection(
+  elicitationHandler?: MCPClientConnection["options"]["elicitationHandler"]
+): Promise<{
   connection: MCPClientConnection;
   sessionId: string;
 }> {
   const name = crypto.randomUUID();
 
-  const connection = await initializeMCPClientConnection(
-    `rpc://${name}`,
-    "rpc",
-    { namespace: env.MCP_OBJECT, name }
+  const connection = new MCPClientConnection(
+    new URL(`rpc://${name}`),
+    { name: "test-client", version: "1.0.0" },
+    {
+      transport: { type: "rpc", namespace: env.MCP_OBJECT, name },
+      client: {},
+      elicitationHandler
+    }
   );
 
   await connection.init();


### PR DESCRIPTION
Follow-up to #1903.

## Problem

A connection without an elicitation handler advertised form-mode elicitation (`elicitation: {}`) while rejecting every elicitation request that arrived — a leftover from before #1903, when the capability was hardcoded. Spec-compliant servers gate on client capabilities, so the false advertisement made them choose elicitation over their non-elicitation fallback flows, and the tool call then failed mid-flight with an opaque error.

## Fix

Complete the "capabilities follow the handler" rule from #1903: the elicitation capability is advertised **only when it can be handled**.

- With a handler (`Agent.onElicitRequest` override or the `elicitationHandler` option): `{ form: {}, url: {} }`, unchanged.
- Without one: no elicitation capability, so servers use their fallbacks instead of sending requests the agent can only reject.
- An explicit `client.capabilities.elicitation` declaration still wins wholesale.

Handler registration is now gated on the advertisement — the MCP SDK client throws when registering a request handler for an undeclared capability.

## Behavior change

Code relying on the deprecated pattern of instance-patching `handleElicitationRequest` on a connection stops receiving elicitation requests (the capability is no longer advertised). That path was undocumented, broke across hibernation, and the client elicitation scenario was baselined as a known conformance failure until #1903 — migration is `Agent.onElicitRequest`, the `elicitationHandler` option, or an explicit capability declaration. Called out in the changeset.

## Tests

- Default-capability test updated: no handler → no elicitation capability advertised.
- RPC elicitation tests migrated from instance-patching to the `elicitationHandler` option (which also exercises the new gate end-to-end — without the advertised capability the server refuses to elicit).
- Full MCP suite (29 files / 516 tests) and `npm run check` green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->