### PR TITLE
fix(mcp): configure client elicitation handler

### DIFF
--- a/.changeset/mcp-client-elicitation-options.md
+++ b/.changeset/mcp-client-elicitation-options.md
@@ -4,16 +4,17 @@
 
 MCP client: url-mode elicitation support with a real elicitation handler
 
-- Agents can now respond to server-initiated `elicitation/create` requests
-  by overriding `Agent.onElicitRequest(request, serverId)`. As a class
-  method it survives Durable Object hibernation and applies to connections
-  restored from storage. `MCPClientManager` also accepts an
-  `elicitationHandler` option, and `MCPClientConnection` an
-  `elicitationHandler` callback, for non-Agent usage.
+- Agents can now respond to server-initiated `elicitation/create` requests by
+  calling `this.mcp.configureElicitationHandler(handler)` before MCP
+  connections are registered or restored. Agent `onStart()` now runs before
+  automatic MCP restore, so onStart configuration survives Durable Object
+  hibernation and applies to restored connections.
+  `MCPClientConnection` also accepts an `elicitationHandler` callback for
+  lower-level non-Agent usage.
 - Connections advertise elicitation modes based on what can actually be
   handled: with a handler configured they advertise `{ form: {}, url: {} }`
-  (MCP spec 2025-11-25) at the initialize handshake; without one they keep
-  the previous form-mode-only default. An explicit
+  (MCP spec 2025-11-25) at the initialize handshake; without one they
+  advertise no elicitation capability. An explicit
   `client.capabilities.elicitation` (e.g. via `addMcpServer`) always wins,
   is persisted with the server options, and survives hibernation — it is no
   longer clobbered by a hardcoded value.

--- a/.changeset/mcp-client-elicitation-options.md
+++ b/.changeset/mcp-client-elicitation-options.md
@@ -5,10 +5,10 @@
 MCP client: url-mode elicitation support with a real elicitation handler
 
 - Agents can now respond to server-initiated `elicitation/create` requests by
-  calling `this.mcp.configureElicitationHandler({ form, url })` before MCP
-  connections are registered or restored. Agent `onStart()` now runs before
-  automatic MCP restore, so onStart configuration survives Durable Object
-  hibernation and applies to restored connections.
+  calling `this.mcp.configureElicitationHandler({ form, url })`, typically in
+  `onStart()`. The advertised modes are persisted with each MCP server, so
+  connections restored after Durable Object hibernation re-advertise them at
+  the handshake and the handlers re-attach when onStart runs.
   `MCPClientConnection` also accepts `elicitationHandlers` callbacks for
   lower-level non-Agent usage.
 - Connections advertise elicitation modes based on what can actually be

--- a/.changeset/mcp-client-elicitation-options.md
+++ b/.changeset/mcp-client-elicitation-options.md
@@ -5,18 +5,18 @@
 MCP client: url-mode elicitation support with a real elicitation handler
 
 - Agents can now respond to server-initiated `elicitation/create` requests by
-  calling `this.mcp.configureElicitationHandler(handler)` before MCP
+  calling `this.mcp.configureElicitationHandler({ form, url })` before MCP
   connections are registered or restored. Agent `onStart()` now runs before
   automatic MCP restore, so onStart configuration survives Durable Object
   hibernation and applies to restored connections.
-  `MCPClientConnection` also accepts an `elicitationHandler` callback for
+  `MCPClientConnection` also accepts `elicitationHandlers` callbacks for
   lower-level non-Agent usage.
 - Connections advertise elicitation modes based on what can actually be
-  handled: with a handler configured they advertise `{ form: {}, url: {} }`
-  (MCP spec 2025-11-25) at the initialize handshake; without one they
-  advertise no elicitation capability. An explicit
+  handled: they advertise exactly the modes with configured handlers at the
+  initialize handshake; without handlers they advertise no elicitation
+  capability. An explicit
   `client.capabilities.elicitation` (e.g. via `addMcpServer`) always wins,
   is persisted with the server options, and survives hibernation — it is no
   longer clobbered by a hardcoded value.
 - Overriding/instance-patching `MCPClientConnection.handleElicitationRequest`
-  directly is deprecated in favor of the `elicitationHandler` option.
+  directly is deprecated in favor of the `elicitationHandlers` option.

--- a/.changeset/no-elicitation-capability-without-handler.md
+++ b/.changeset/no-elicitation-capability-without-handler.md
@@ -9,13 +9,14 @@ elicitation while rejecting every elicitation request that arrived, so
 spec-compliant servers chose elicitation over their fallback flows and the
 tool call failed mid-flight. Connections now advertise the elicitation
 capability only when it can be handled: both form and url mode with a
-handler (an `onElicitRequest` override on `Agent`, or the
-`elicitationHandler` option), and no elicitation capability without one,
-letting servers fall back gracefully.
+handler configured via `this.mcp.configureElicitationHandler(...)` or the
+connection `elicitationHandler` option, and no elicitation capability without
+one, letting servers fall back gracefully.
 
 Behavior change: code relying on the deprecated pattern of instance-patching
 `handleElicitationRequest` on a connection stops receiving elicitation
 requests, because the capability is no longer advertised. Migrate to
-`Agent.onElicitRequest` / the `elicitationHandler` option, or declare
+`this.mcp.configureElicitationHandler(...)` / the connection
+`elicitationHandler` option, or declare
 `client.capabilities.elicitation` explicitly — an explicit declaration is
 always honored.

--- a/.changeset/no-elicitation-capability-without-handler.md
+++ b/.changeset/no-elicitation-capability-without-handler.md
@@ -9,14 +9,15 @@ elicitation while rejecting every elicitation request that arrived, so
 spec-compliant servers chose elicitation over their fallback flows and the
 tool call failed mid-flight. Connections now advertise the elicitation
 capability only when it can be handled: both form and url mode with a
-handler configured via `this.mcp.configureElicitationHandler(...)` or the
-connection `elicitationHandler` option, and no elicitation capability without
-one, letting servers fall back gracefully.
+handlers configured via `this.mcp.configureElicitationHandler({ form, url })`
+or the connection `elicitationHandlers` option, and no elicitation capability
+without handlers, letting servers fall back gracefully. Only modes with
+configured handlers are advertised.
 
 Behavior change: code relying on the deprecated pattern of instance-patching
 `handleElicitationRequest` on a connection stops receiving elicitation
 requests, because the capability is no longer advertised. Migrate to
-`this.mcp.configureElicitationHandler(...)` / the connection
-`elicitationHandler` option, or declare
+`this.mcp.configureElicitationHandler({ form, url })` / the connection
+`elicitationHandlers` option, or declare
 `client.capabilities.elicitation` explicitly — an explicit declaration is
 always honored.

--- a/docs/agents/mcp-client.md
+++ b/docs/agents/mcp-client.md
@@ -113,20 +113,24 @@ These options are persisted and used when reconnecting after hibernation or afte
 
 ### Elicitation
 
-MCP servers can request input from the client during a tool call (`elicitation/create`). To respond, override `onElicitRequest` on your agent:
+MCP servers can request input from the client during a tool call (`elicitation/create`). To respond, configure an elicitation handler before MCP connections are registered or restored:
 
 ```typescript
+import { Agent } from "agents";
+
 class MyAgent extends Agent<Env> {
-  async onElicitRequest(request: ElicitRequest, serverId: string) {
-    // e.g. deliver a url-mode elicitation link out-of-band
-    return { action: "accept" as const, content: {} };
+  onStart() {
+    this.mcp.configureElicitationHandler(async (request, serverId) => {
+      // e.g. deliver a url-mode elicitation link out-of-band
+      return { action: "accept" as const, content: {} };
+    });
   }
 }
 ```
 
-Because it is a class method, the handler survives Durable Object hibernation and applies to connections restored from storage.
+The Agent lifecycle runs `onStart()` before automatic MCP connection restore, so handlers configured there apply to connections restored from storage. Configuring a handler after an MCP connection is already active updates the in-memory handler, but the server only sees new advertised elicitation modes after that connection reconnects.
 
-Overriding `onElicitRequest` is all you need: when a handler is present, connections automatically advertise both form- and url-mode elicitation (MCP spec 2025-11-25 — url-mode is used for sensitive flows like OAuth URLs) at the `initialize` handshake. Without a handler, connections advertise no elicitation capability, so spec-compliant servers use their non-elicitation fallbacks instead of sending requests the agent cannot answer.
+When a handler is present, connections automatically advertise both form- and url-mode elicitation (MCP spec 2025-11-25 — url-mode is used for sensitive flows like OAuth URLs) at the `initialize` handshake. Without a handler, connections advertise no elicitation capability, so spec-compliant servers use their non-elicitation fallbacks instead of sending requests the agent cannot answer.
 
 To narrow the advertised modes, declare them explicitly — an explicit declaration always wins and is persisted with the server options, surviving hibernation:
 

--- a/docs/agents/mcp-client.md
+++ b/docs/agents/mcp-client.md
@@ -134,7 +134,7 @@ class MyAgent extends Agent<Env> {
 }
 ```
 
-The Agent lifecycle runs `onStart()` before automatic MCP connection restore, so handlers configured there apply to connections restored from storage. Configuring a handler after an MCP connection is already active updates the in-memory handler, but the server only sees new advertised elicitation modes after that connection reconnects.
+The advertised modes are persisted with each MCP server, so a connection restored from storage after hibernation re-advertises the same modes at the handshake; the handlers themselves re-attach when `onStart()` runs. Configuring a handler after an MCP connection is already active updates the in-memory handler, but the server only sees new advertised elicitation modes after that connection reconnects.
 
 Connections advertise only the elicitation modes with configured handlers at the `initialize` handshake: configure `form` to advertise form-mode elicitation, `url` to advertise url-mode elicitation (MCP spec 2025-11-25 — url mode is used for sensitive flows like OAuth URLs), or both to advertise both modes. Without handlers, connections advertise no elicitation capability, so spec-compliant servers use their non-elicitation fallbacks instead of sending requests the agent cannot answer.
 

--- a/docs/agents/mcp-client.md
+++ b/docs/agents/mcp-client.md
@@ -120,9 +120,15 @@ import { Agent } from "agents";
 
 class MyAgent extends Agent<Env> {
   onStart() {
-    this.mcp.configureElicitationHandler(async (request, serverId) => {
-      // e.g. deliver a url-mode elicitation link out-of-band
-      return { action: "accept" as const, content: {} };
+    this.mcp.configureElicitationHandler({
+      url: async (request, serverId) => {
+        // Deliver a url-mode elicitation link out-of-band
+        return { action: "accept" as const, content: {} };
+      },
+      form: async (request, serverId) => {
+        // Collect values matching request.params.requestedSchema
+        return { action: "accept" as const, content: {} };
+      }
     });
   }
 }
@@ -130,15 +136,15 @@ class MyAgent extends Agent<Env> {
 
 The Agent lifecycle runs `onStart()` before automatic MCP connection restore, so handlers configured there apply to connections restored from storage. Configuring a handler after an MCP connection is already active updates the in-memory handler, but the server only sees new advertised elicitation modes after that connection reconnects.
 
-When a handler is present, connections automatically advertise both form- and url-mode elicitation (MCP spec 2025-11-25 — url-mode is used for sensitive flows like OAuth URLs) at the `initialize` handshake. Without a handler, connections advertise no elicitation capability, so spec-compliant servers use their non-elicitation fallbacks instead of sending requests the agent cannot answer.
+Connections advertise only the elicitation modes with configured handlers at the `initialize` handshake: configure `form` to advertise form-mode elicitation, `url` to advertise url-mode elicitation (MCP spec 2025-11-25 — url mode is used for sensitive flows like OAuth URLs), or both to advertise both modes. Without handlers, connections advertise no elicitation capability, so spec-compliant servers use their non-elicitation fallbacks instead of sending requests the agent cannot answer.
 
-To narrow the advertised modes, declare them explicitly — an explicit declaration always wins and is persisted with the server options, surviving hibernation:
+To override the advertised modes, declare them explicitly — an explicit declaration always wins and is persisted with the server options, surviving hibernation:
 
 ```typescript
 await this.addMcpServer("portal", "https://portal.example.com/mcp", {
   client: {
     capabilities: {
-      elicitation: { form: {} } // form-mode only, even with a handler
+      elicitation: { form: {} } // form-mode only, even with both handlers configured
     }
   }
 });

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -6,7 +6,7 @@ An Agent that acts as an MCP **client** — dynamically connects to remote MCP s
 
 - **`addMcpServer` / `removeMcpServer`** — managing MCP server connections from an Agent
 - **`onMcpUpdate`** — real-time state updates pushed to the React frontend via WebSocket
-- **`onElicitRequest`** — when a server requests input mid-tool-call (elicitation), the Agent broadcasts it to the browser, which renders a form from the request's schema (or a link for url-mode); the human's answer resolves the pending tool call via a `@callable` method
+- **`this.mcp.configureElicitationHandler`** — when a server requests input mid-tool-call (elicitation), the Agent broadcasts it to the browser, which renders a form from the request's schema (or a link for url-mode); the human's answer resolves the pending tool call via a `@callable` method
 - **OAuth popup flow** — `configureOAuthCallback` with a custom handler that closes the popup after auth
 - **`agentFetch`** — making HTTP requests to the Agent's custom endpoints from the client
 

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -6,7 +6,7 @@ An Agent that acts as an MCP **client** — dynamically connects to remote MCP s
 
 - **`addMcpServer` / `removeMcpServer`** — managing MCP server connections from an Agent
 - **`onMcpUpdate`** — real-time state updates pushed to the React frontend via WebSocket
-- **`this.mcp.configureElicitationHandler`** — when a server requests input mid-tool-call (elicitation), the Agent broadcasts it to the browser, which renders a form from the request's schema (or a link for url-mode); the human's answer resolves the pending tool call via a `@callable` method
+- **`this.mcp.configureElicitationHandler`** — when a server requests input mid-tool-call (elicitation), the Agent registers form and url handlers that broadcast requests to the browser; the human's answer resolves the pending tool call via a `@callable` method
 - **OAuth popup flow** — `configureOAuthCallback` with a custom handler that closes the popup after auth
 - **`agentFetch`** — making HTTP requests to the Agent's custom endpoints from the client
 

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -27,6 +27,10 @@ export class MyAgent extends Agent {
   >();
 
   onStart() {
+    this.mcp.configureElicitationHandler((request, serverId) =>
+      this.handleElicitationRequest(request, serverId)
+    );
+
     this.mcp.configureOAuthCallback({
       customHandler: (result) => {
         if (result.authSuccess) {
@@ -45,14 +49,11 @@ export class MyAgent extends Agent {
   }
 
   /**
-   * Called when a connected MCP server sends an `elicitation/create`
-   * request during a tool call. Forwards it to connected browser clients
-   * and waits for one of them to answer via `respondToElicitation`.
-   *
-   * Overriding this method is also what makes connections advertise
-   * elicitation support (form and url mode) to servers.
+   * Forwards a connected MCP server's `elicitation/create` request to
+   * browser clients and waits for one of them to answer via
+   * `respondToElicitation`.
    */
-  async onElicitRequest(
+  private async handleElicitationRequest(
     request: ElicitRequest,
     serverId: string
   ): Promise<ElicitResult> {

--- a/examples/mcp-client/src/server.ts
+++ b/examples/mcp-client/src/server.ts
@@ -27,9 +27,12 @@ export class MyAgent extends Agent {
   >();
 
   onStart() {
-    this.mcp.configureElicitationHandler((request, serverId) =>
-      this.handleElicitationRequest(request, serverId)
-    );
+    this.mcp.configureElicitationHandler({
+      form: (request, serverId) =>
+        this.forwardElicitationToBrowser(request, serverId),
+      url: (request, serverId) =>
+        this.forwardElicitationToBrowser(request, serverId)
+    });
 
     this.mcp.configureOAuthCallback({
       customHandler: (result) => {
@@ -53,7 +56,7 @@ export class MyAgent extends Agent {
    * browser clients and waits for one of them to answer via
    * `respondToElicitation`.
    */
-  private async handleElicitationRequest(
+  private async forwardElicitationToBrowser(
     request: ElicitRequest,
     serverId: string
   ): Promise<ElicitResult> {

--- a/packages/agents/conformance/worker.ts
+++ b/packages/agents/conformance/worker.ts
@@ -9,7 +9,6 @@ import { isUnauthorized, toErrorMessage } from "../src/mcp/errors.ts";
 import {
   createMcpHandler,
   DurableObjectEventStore,
-  type ElicitResult,
   McpAgent,
   type TransportState,
   WorkerTransport
@@ -54,17 +53,14 @@ type RunResult =
 export class ConformanceHost extends Agent<Env> {
   private _serverId: string | undefined;
 
-  /**
-   * Accept elicitation requests. Form-mode defaults are applied by the SDK
-   * client because the connection advertises `form.applyDefaults`
-   * (SEP-1034); overriding this method is also what makes connections
-   * advertise elicitation capabilities in the first place.
-   */
-  async onElicitRequest(): Promise<ElicitResult> {
-    return { action: "accept", content: {} };
-  }
-
   onStart() {
+    // Accept elicitation requests. Form-mode defaults are applied by the SDK
+    // client because the connection advertises `form.applyDefaults` (SEP-1034).
+    this.mcp.configureElicitationHandler(async () => ({
+      action: "accept",
+      content: {}
+    }));
+
     // Respond to OAuth callbacks with an explicit status the driver can
     // assert on, instead of the default redirect-to-origin.
     this.mcp.configureOAuthCallback({

--- a/packages/agents/conformance/worker.ts
+++ b/packages/agents/conformance/worker.ts
@@ -56,10 +56,16 @@ export class ConformanceHost extends Agent<Env> {
   onStart() {
     // Accept elicitation requests. Form-mode defaults are applied by the SDK
     // client because the connection advertises `form.applyDefaults` (SEP-1034).
-    this.mcp.configureElicitationHandler(async () => ({
-      action: "accept",
-      content: {}
-    }));
+    this.mcp.configureElicitationHandler({
+      form: async () => ({
+        action: "accept",
+        content: {}
+      }),
+      url: async () => ({
+        action: "accept",
+        content: {}
+      })
+    });
 
     // Respond to OAuth callbacks with an explicit status the driver can
     // assert on, instead of the default redirect-to-origin.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2639,6 +2639,14 @@ export class Agent<
           }
 
           await this._tryCatch(async () => {
+            // Restore MCP connections before fiber/chat recovery so recovered
+            // turns see MCP tools. Restored connections re-advertise the
+            // capabilities persisted from the previous session; the handlers
+            // behind them attach when onStart() configures them.
+            await this.mcp.restoreConnectionsFromStorage(this.name);
+            await this._restoreRpcMcpServers();
+            this.broadcastMcpServers();
+
             this._checkOrphanedWorkflows();
             await this._checkRunFibers();
             const startupAgentToolRunIds = this._agentToolRunRecoveryRunIds();
@@ -2689,10 +2697,6 @@ export class Agent<
                   "as a class field or in the constructor instead."
               );
             }
-
-            await this.mcp.restoreConnectionsFromStorage(this.name);
-            await this._restoreRpcMcpServers();
-            this.broadcastMcpServers();
 
             this._scheduleAgentToolRunRecovery({
               runIds: startupAgentToolRunIds

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -20,8 +20,6 @@ import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client
 import { signAgentHeaders } from "./email";
 
 import type {
-  ElicitRequest,
-  ElicitResult,
   Prompt,
   Resource,
   ServerCapabilities,
@@ -2252,20 +2250,10 @@ export class Agent<
     this._ensureSchema();
 
     // Initialize MCPClientManager AFTER tables are created
-    // Wire elicitation only when the subclass actually overrides
-    // onElicitRequest: connections advertise url-mode elicitation exactly
-    // when a handler exists, so wiring the throwing base implementation
-    // would advertise modes nothing can handle.
-    const handlesElicitation =
-      this.onElicitRequest !== Agent.prototype.onElicitRequest;
-
     this.mcp = new MCPClientManager(this._ParentClass.name, "0.0.1", {
       storage: this.ctx.storage,
       createAuthProvider: (callbackUrl) =>
-        this.createMcpOAuthProvider(callbackUrl),
-      elicitationHandler: handlesElicitation
-        ? (request, serverId) => this.onElicitRequest(request, serverId)
-        : undefined
+        this.createMcpOAuthProvider(callbackUrl)
     });
 
     // Broadcast server state whenever MCP state changes (register, connect, OAuth, remove, etc.)
@@ -2651,10 +2639,6 @@ export class Agent<
           }
 
           await this._tryCatch(async () => {
-            await this.mcp.restoreConnectionsFromStorage(this.name);
-            await this._restoreRpcMcpServers();
-            this.broadcastMcpServers();
-
             this._checkOrphanedWorkflows();
             await this._checkRunFibers();
             const startupAgentToolRunIds = this._agentToolRunRecoveryRunIds();
@@ -2705,6 +2689,10 @@ export class Agent<
                   "as a class field or in the constructor instead."
               );
             }
+
+            await this.mcp.restoreConnectionsFromStorage(this.name);
+            await this._restoreRpcMcpServers();
+            this.broadcastMcpServers();
 
             this._scheduleAgentToolRunRecovery({
               runIds: startupAgentToolRunIds
@@ -3166,35 +3154,6 @@ export class Agent<
   // oxlint-disable-next-line eslint(no-unused-vars) -- params used by subclass overrides
   onStateUpdate(_state: State | undefined, _source: Connection | "server") {
     // override this to handle state updates (deprecated — use onStateChanged)
-  }
-
-  /**
-   * Called when an MCP server this agent is connected to (via
-   * {@link addMcpServer}) sends an `elicitation/create` request.
-   *
-   * Override this to respond to elicitation — e.g. deliver a url-mode
-   * elicitation link out-of-band and return `{ action: "accept" }`. Being a
-   * class method, the override survives Durable Object hibernation and
-   * applies to connections restored from storage, unlike a callback passed
-   * at connect time.
-   *
-   * When overridden, MCP client connections automatically advertise both
-   * form- and url-mode elicitation (MCP spec 2025-11-25) at the `initialize`
-   * handshake; without an override they advertise form-mode only. To narrow
-   * the advertised modes, declare `client.capabilities.elicitation`
-   * explicitly on `addMcpServer` — an explicit declaration always wins.
-   *
-   * @param _request The elicitation request from the server
-   * @param _serverId Id of the MCP server connection that sent the request
-   */
-  // oxlint-disable-next-line eslint(no-unused-vars) -- params used by subclass overrides
-  async onElicitRequest(
-    _request: ElicitRequest,
-    _serverId: string
-  ): Promise<ElicitResult> {
-    throw new Error(
-      "Elicitation is not handled by this agent. Override onElicitRequest(request, serverId) to respond to MCP elicitation requests."
-    );
   }
 
   /**
@@ -12479,7 +12438,7 @@ export class Agent<
         : `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
     }
 
-    const id = requestedId ?? nanoid(8);
+    const id = requestedId ?? existingServer?.id ?? nanoid(8);
 
     // Only create authProvider if we have a callbackUrl (needed for OAuth servers)
     let authProvider:

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -120,6 +120,27 @@ export type MCPElicitationHandler = (
   request: ElicitRequest
 ) => Promise<ElicitResult>;
 
+export type MCPElicitationHandlers = {
+  form?: MCPElicitationHandler;
+  url?: MCPElicitationHandler;
+};
+
+function elicitationCapabilitiesFromHandlers(
+  handlers?: MCPElicitationHandlers
+): ClientCapabilities["elicitation"] | undefined {
+  if (!handlers) return undefined;
+
+  const elicitation: NonNullable<ClientCapabilities["elicitation"]> = {};
+  if (handlers.form) {
+    elicitation.form = {};
+  }
+  if (handlers.url) {
+    elicitation.url = {};
+  }
+
+  return elicitation.form || elicitation.url ? elicitation : undefined;
+}
+
 export class MCPClientConnection {
   client: Client;
   connectionState: MCPConnectionState = MCPConnectionState.CONNECTING;
@@ -172,7 +193,7 @@ export class MCPClientConnection {
     public options: {
       transport: MCPTransportOptions;
       client: McpClientOptions;
-      elicitationHandler?: MCPElicitationHandler;
+      elicitationHandlers?: MCPElicitationHandlers;
     } = { client: {}, transport: {} }
   ) {
     this.options = {
@@ -184,16 +205,15 @@ export class MCPClientConnection {
   }
 
   private createClient(): Client {
-    // Advertise elicitation only when it can actually be handled: with a
-    // handler configured, default to both form and url mode (MCP spec
-    // 2025-11-25); without one, advertise no elicitation capability so
-    // spec-compliant servers use their non-elicitation fallbacks instead of
-    // sending requests that would only be rejected. An explicit
-    // caller-declared `capabilities.elicitation` wins wholesale so callers
-    // can narrow (or widen) the advertised modes.
+    // Advertise elicitation only when it can actually be handled. Handler
+    // keys map directly to advertised modes, so a form-only handler advertises
+    // form only, a url-only handler advertises url only, and no handlers means
+    // no elicitation capability. An explicit caller-declared
+    // `capabilities.elicitation` wins wholesale so callers can narrow (or
+    // widen) the advertised modes.
     const elicitation =
       this.options.client?.capabilities?.elicitation ??
-      (this.options.elicitationHandler ? { form: {}, url: {} } : undefined);
+      elicitationCapabilitiesFromHandlers(this.options.elicitationHandlers);
     this._elicitationEnabled = elicitation !== undefined;
     const clientOptions = {
       ...this.options.client,
@@ -214,8 +234,8 @@ export class MCPClientConnection {
    * handshake. Active connections keep their negotiated capabilities until
    * they reconnect.
    */
-  configureElicitationHandler(handler?: MCPElicitationHandler): void {
-    this.options.elicitationHandler = handler;
+  configureElicitationHandler(handlers?: MCPElicitationHandlers): void {
+    this.options.elicitationHandlers = handlers;
 
     if (!this.client.transport) {
       this.client = this.createClient();
@@ -728,20 +748,26 @@ export class MCPClientConnection {
   /**
    * Handle elicitation request from server.
    *
-   * Delegates to the `elicitationHandler` connection option when provided.
+   * Delegates to the `elicitationHandlers` connection option when provided.
    *
    * @deprecated Overriding or instance-patching this method directly is
-   * deprecated — pass the `elicitationHandler` connection option instead.
+   * deprecated — pass the `elicitationHandlers` connection option instead.
    */
   async handleElicitationRequest(
     request: ElicitRequest
   ): Promise<ElicitResult> {
-    const handler = this.options.elicitationHandler;
+    const mode = request.params.mode === "url" ? "url" : "form";
+    const handler = this.options.elicitationHandlers?.[mode];
     if (handler) {
       return handler(request);
     }
+    if (this.options.elicitationHandlers) {
+      throw new Error(
+        `No MCP ${mode}-mode elicitation handler configured for this connection.`
+      );
+    }
     throw new Error(
-      "Elicitation handler must be implemented for your platform. Provide the elicitationHandler connection option or configure this.mcp.configureElicitationHandler(...)."
+      "Elicitation handler must be implemented for your platform. Provide the MCPClientConnection elicitationHandlers option, or register handlers through the MCP client manager before connecting."
     );
   }
 

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -125,9 +125,11 @@ export type MCPElicitationHandlers = {
   url?: MCPElicitationHandler;
 };
 
-function elicitationCapabilitiesFromHandlers(
-  handlers?: MCPElicitationHandlers
-): ClientCapabilities["elicitation"] | undefined {
+/** Derive the elicitation capability to advertise from the handler keys. */
+export function elicitationCapabilitiesFromHandlers(handlers?: {
+  form?: unknown;
+  url?: unknown;
+}): ClientCapabilities["elicitation"] | undefined {
   if (!handlers) return undefined;
 
   const elicitation: NonNullable<ClientCapabilities["elicitation"]> = {};
@@ -194,6 +196,13 @@ export class MCPClientConnection {
       transport: MCPTransportOptions;
       client: McpClientOptions;
       elicitationHandlers?: MCPElicitationHandlers;
+      /**
+       * Client capabilities persisted from a previous session, advertised
+       * until handlers are reconfigured after a hibernation restore. Cleared
+       * by {@link configureElicitationHandler} — reconfigured handlers are
+       * the source of truth. Explicit `client.capabilities` win per key.
+       */
+      capabilitySeed?: ClientCapabilities;
     } = { client: {}, transport: {} }
   ) {
     this.options = {
@@ -210,14 +219,18 @@ export class MCPClientConnection {
     // form only, a url-only handler advertises url only, and no handlers means
     // no elicitation capability. An explicit caller-declared
     // `capabilities.elicitation` wins wholesale so callers can narrow (or
-    // widen) the advertised modes.
+    // widen) the advertised modes. The restore seed applies last, covering
+    // the window before handlers are reconfigured after hibernation.
+    const seed = this.options.capabilitySeed;
     const elicitation =
       this.options.client?.capabilities?.elicitation ??
-      elicitationCapabilitiesFromHandlers(this.options.elicitationHandlers);
+      elicitationCapabilitiesFromHandlers(this.options.elicitationHandlers) ??
+      seed?.elicitation;
     this._elicitationEnabled = elicitation !== undefined;
     const clientOptions = {
       ...this.options.client,
       capabilities: {
+        ...seed,
         ...this.options.client?.capabilities,
         ...(elicitation ? { elicitation } : {})
       } as ClientCapabilities
@@ -238,6 +251,9 @@ export class MCPClientConnection {
    */
   configureElicitationHandler(handlers?: MCPElicitationHandlers): void {
     this.options.elicitationHandlers = handlers;
+    // Handlers are now the source of truth — drop the restore seed so
+    // clearing the handlers un-advertises the capability on rebuild.
+    this.options.capabilitySeed = undefined;
 
     if (!this.client.transport) {
       this.client = this.createClient();
@@ -259,7 +275,9 @@ export class MCPClientConnection {
     // init() can be re-entered after a mid-session 401 → OAuth → reconnect
     // cycle (e.g. scope step-up, token revocation). The SDK client refuses
     // to connect while a previous transport is still attached, so detach it
-    // first.
+    // first. Rebuild the client so the new handshake advertises the current
+    // handler-derived capabilities — reconnects are documented as the point
+    // where handler changes on a live connection take effect.
     if (this.client.transport) {
       this._transport = undefined;
       try {
@@ -267,6 +285,7 @@ export class MCPClientConnection {
       } catch {
         // Closing a transport that just failed auth is best-effort.
       }
+      this.client = this.createClient();
     }
 
     const res = await this.tryConnect(transportType);

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -231,8 +231,10 @@ export class MCPClientConnection {
    *
    * If the connection has not been initialized yet, rebuild the SDK client so
    * handler-driven elicitation capabilities are reflected in the initial
-   * handshake. Active connections keep their negotiated capabilities until
-   * they reconnect.
+   * handshake. A rebuild (rather than `Client.registerCapabilities`) is
+   * required because SDK capability registration is merge-only — it cannot
+   * un-advertise a mode when handlers are cleared before connecting. Active
+   * connections keep their negotiated capabilities until they reconnect.
    */
   configureElicitationHandler(handlers?: MCPElicitationHandlers): void {
     this.options.elicitationHandlers = handlers;

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -164,11 +164,11 @@ export class MCPClientConnection {
    * the capability was not declared, so handler registration is gated on
    * this.
    */
-  private readonly _elicitationEnabled: boolean;
+  private _elicitationEnabled = false;
 
   constructor(
     public url: URL,
-    info: ConstructorParameters<typeof Client>[0],
+    private readonly _info: ConstructorParameters<typeof Client>[0],
     public options: {
       transport: MCPTransportOptions;
       client: McpClientOptions;
@@ -180,6 +180,10 @@ export class MCPClientConnection {
       client: { ...defaultClientOptions, ...options.client }
     };
 
+    this.client = this.createClient();
+  }
+
+  private createClient(): Client {
     // Advertise elicitation only when it can actually be handled: with a
     // handler configured, default to both form and url mode (MCP spec
     // 2025-11-25); without one, advertise no elicitation capability so
@@ -189,7 +193,7 @@ export class MCPClientConnection {
     // can narrow (or widen) the advertised modes.
     const elicitation =
       this.options.client?.capabilities?.elicitation ??
-      (options.elicitationHandler ? { form: {}, url: {} } : undefined);
+      (this.options.elicitationHandler ? { form: {}, url: {} } : undefined);
     this._elicitationEnabled = elicitation !== undefined;
     const clientOptions = {
       ...this.options.client,
@@ -199,7 +203,23 @@ export class MCPClientConnection {
       } as ClientCapabilities
     };
 
-    this.client = new Client(info, clientOptions);
+    return new Client(this._info, clientOptions);
+  }
+
+  /**
+   * Configure the handler used for server-initiated elicitation requests.
+   *
+   * If the connection has not been initialized yet, rebuild the SDK client so
+   * handler-driven elicitation capabilities are reflected in the initial
+   * handshake. Active connections keep their negotiated capabilities until
+   * they reconnect.
+   */
+  configureElicitationHandler(handler?: MCPElicitationHandler): void {
+    this.options.elicitationHandler = handler;
+
+    if (!this.client.transport) {
+      this.client = this.createClient();
+    }
   }
 
   /**
@@ -711,8 +731,7 @@ export class MCPClientConnection {
    * Delegates to the `elicitationHandler` connection option when provided.
    *
    * @deprecated Overriding or instance-patching this method directly is
-   * deprecated — pass the `elicitationHandler` connection option instead
-   * (agents: override `Agent.onElicitRequest`).
+   * deprecated — pass the `elicitationHandler` connection option instead.
    */
   async handleElicitationRequest(
     request: ElicitRequest
@@ -722,7 +741,7 @@ export class MCPClientConnection {
       return handler(request);
     }
     throw new Error(
-      "Elicitation handler must be implemented for your platform. Provide the elicitationHandler connection option (agents: override onElicitRequest)."
+      "Elicitation handler must be implemented for your platform. Provide the elicitationHandler connection option or configure this.mcp.configureElicitationHandler(...)."
     );
   }
 

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -21,7 +21,7 @@ import type { MCPObservabilityEvent } from "../observability/mcp";
 import {
   MCPClientConnection,
   MCPConnectionState,
-  type MCPElicitationHandler,
+  type MCPElicitationHandlers,
   type MCPTransportOptions
 } from "./client-connection";
 import { toErrorMessage } from "./errors";
@@ -311,6 +311,11 @@ export type MCPClientElicitationHandler = (
   serverId: string
 ) => Promise<ElicitResult>;
 
+export type MCPClientElicitationHandlers = {
+  form?: MCPClientElicitationHandler;
+  url?: MCPClientElicitationHandler;
+};
+
 export type MCPClientManagerOptions = {
   storage: DurableObjectStorage;
   createAuthProvider?: (callbackUrl: string) => AgentMcpOAuthProvider;
@@ -343,7 +348,7 @@ export class MCPClientManager {
   ) => AgentMcpOAuthProvider;
   private _isRestored = false;
   private _pendingConnections = new Map<string, Promise<void>>();
-  private _elicitationHandler?: MCPClientElicitationHandler;
+  private _elicitationHandlers?: MCPClientElicitationHandlers;
 
   /** @internal Protected for testing purposes. */
   protected readonly _onObservabilityEvent =
@@ -383,12 +388,18 @@ export class MCPClientManager {
    * Returns undefined when no handler is configured so the connection keeps
    * its default throwing behavior.
    */
-  private scopedElicitationHandler(
+  private scopedElicitationHandlers(
     serverId: string
-  ): MCPElicitationHandler | undefined {
-    const handler = this._elicitationHandler;
-    if (!handler) return undefined;
-    return (request) => handler(request, serverId);
+  ): MCPElicitationHandlers | undefined {
+    const handlers = this._elicitationHandlers;
+    if (!handlers || (!handlers.form && !handlers.url)) return undefined;
+
+    const form = handlers.form;
+    const url = handlers.url;
+    return {
+      form: form ? (request) => form(request, serverId) : undefined,
+      url: url ? (request) => url(request, serverId) : undefined
+    };
   }
 
   // SQL helper - runs a query and returns results as array
@@ -519,9 +530,7 @@ export class MCPClientManager {
       }
       // The elicitation handler closes over the server id it was created
       // with — rescope it so elicitation requests report the new id.
-      if (conn.options.elicitationHandler) {
-        conn.configureElicitationHandler(this.scopedElicitationHandler(newId));
-      }
+      conn.configureElicitationHandler(this.scopedElicitationHandlers(newId));
     }
 
     const disposables = this._connectionDisposables.get(oldId);
@@ -1153,7 +1162,7 @@ export class MCPClientManager {
       {
         client: options.client ?? {},
         transport: normalizedTransport,
-        elicitationHandler: this.scopedElicitationHandler(id)
+        elicitationHandlers: this.scopedElicitationHandlers(id)
       }
     );
 
@@ -1624,13 +1633,15 @@ export class MCPClientManager {
    *
    * Pass undefined to clear the handler.
    *
-   * @param handler Elicitation handler, scoped with the server id that sent the request
+   * @param handlers Elicitation handlers keyed by mode, each scoped with the server id that sent the request
    */
-  configureElicitationHandler(handler?: MCPClientElicitationHandler): void {
-    this._elicitationHandler = handler;
-
+  configureElicitationHandler(handlers?: MCPClientElicitationHandlers): void {
+    this._elicitationHandlers =
+      handlers && (handlers.form || handlers.url) ? handlers : undefined;
     for (const [id, connection] of Object.entries(this.mcpConnections)) {
-      connection.configureElicitationHandler(this.scopedElicitationHandler(id));
+      connection.configureElicitationHandler(
+        this.scopedElicitationHandlers(id)
+      );
     }
   }
 

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -306,20 +306,14 @@ export type MCPClientOAuthResult =
       authError: string;
     };
 
+export type MCPClientElicitationHandler = (
+  request: ElicitRequest,
+  serverId: string
+) => Promise<ElicitResult>;
+
 export type MCPClientManagerOptions = {
   storage: DurableObjectStorage;
   createAuthProvider?: (callbackUrl: string) => AgentMcpOAuthProvider;
-  /**
-   * Handler for server-initiated `elicitation/create` requests, applied to
-   * every connection this manager creates — including connections restored
-   * from storage after Durable Object hibernation. Held in memory only
-   * (never persisted), which is why it lives here rather than in the
-   * per-server persisted options.
-   */
-  elicitationHandler?: (
-    request: ElicitRequest,
-    serverId: string
-  ) => Promise<ElicitResult>;
 };
 
 /**
@@ -349,7 +343,7 @@ export class MCPClientManager {
   ) => AgentMcpOAuthProvider;
   private _isRestored = false;
   private _pendingConnections = new Map<string, Promise<void>>();
-  private _elicitationHandler?: MCPClientManagerOptions["elicitationHandler"];
+  private _elicitationHandler?: MCPClientElicitationHandler;
 
   /** @internal Protected for testing purposes. */
   protected readonly _onObservabilityEvent =
@@ -382,7 +376,6 @@ export class MCPClientManager {
     }
     this._storage = options.storage;
     this._createAuthProviderFn = options.createAuthProvider;
-    this._elicitationHandler = options.elicitationHandler;
   }
 
   /**
@@ -527,7 +520,7 @@ export class MCPClientManager {
       // The elicitation handler closes over the server id it was created
       // with — rescope it so elicitation requests report the new id.
       if (conn.options.elicitationHandler) {
-        conn.options.elicitationHandler = this.scopedElicitationHandler(newId);
+        conn.configureElicitationHandler(this.scopedElicitationHandler(newId));
       }
     }
 
@@ -1618,6 +1611,27 @@ export class MCPClientManager {
    */
   configureOAuthCallback(config: MCPClientOAuthCallbackConfig): void {
     this._oauthCallbackConfig = config;
+  }
+
+  /**
+   * Configure handling for server-initiated `elicitation/create` requests.
+   *
+   * The handler is held in memory only and applied to every MCP connection
+   * created or restored by this manager. Call this before registering or
+   * restoring connections when you want the initial MCP handshake to advertise
+   * handler-driven form- and url-mode elicitation. Existing active connections
+   * keep their negotiated capabilities until they reconnect.
+   *
+   * Pass undefined to clear the handler.
+   *
+   * @param handler Elicitation handler, scoped with the server id that sent the request
+   */
+  configureElicitationHandler(handler?: MCPClientElicitationHandler): void {
+    this._elicitationHandler = handler;
+
+    for (const [id, connection] of Object.entries(this.mcpConnections)) {
+      connection.configureElicitationHandler(this.scopedElicitationHandler(id));
+    }
   }
 
   /**

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -3,6 +3,7 @@ import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.j
 import type {
   CallToolRequest,
   CallToolResultSchema,
+  ClientCapabilities,
   CompatibilityCallToolResultSchema,
   ElicitRequest,
   ElicitResult,
@@ -19,6 +20,7 @@ import { nanoid } from "nanoid";
 import { Emitter, type Event, DisposableStore } from "../core/events";
 import type { MCPObservabilityEvent } from "../observability/mcp";
 import {
+  elicitationCapabilitiesFromHandlers,
   MCPClientConnection,
   MCPConnectionState,
   type MCPElicitationHandlers,
@@ -237,6 +239,12 @@ export type MCPServerOptions = {
   };
   /** Retry options for connection and reconnection attempts */
   retry?: RetryOptions;
+  /**
+   * Client capabilities advertised from configured handlers (currently the
+   * elicitation modes). Handlers are functions and cannot be persisted, so
+   * this records what they advertised for restores after hibernation.
+   */
+  capabilities?: ClientCapabilities;
 };
 
 /**
@@ -392,7 +400,7 @@ export class MCPClientManager {
     serverId: string
   ): MCPElicitationHandlers | undefined {
     const handlers = this._elicitationHandlers;
-    if (!handlers || (!handlers.form && !handlers.url)) return undefined;
+    if (!handlers) return undefined;
 
     const form = handlers.form;
     const url = handlers.url;
@@ -529,8 +537,13 @@ export class MCPClientManager {
         authProvider.serverId = newId;
       }
       // The elicitation handler closes over the server id it was created
-      // with — rescope it so elicitation requests report the new id.
-      conn.configureElicitationHandler(this.scopedElicitationHandlers(newId));
+      // with — rescope it so elicitation requests report the new id. With no
+      // handlers there is nothing to rescope, and configuring would wipe the
+      // connection's restored capability seed.
+      const scoped = this.scopedElicitationHandlers(newId);
+      if (scoped) {
+        conn.configureElicitationHandler(scoped);
+      }
     }
 
     const disposables = this._connectionDisposables.get(oldId);
@@ -588,16 +601,51 @@ export class MCPClientManager {
   }
 
   /**
-   * Get the retry options for a server from stored server_options
+   * Get the parsed server_options for a stored server, if any.
    */
-  private getServerRetryOptions(serverId: string): RetryOptions | undefined {
+  private getStoredServerOptions(
+    serverId: string
+  ): MCPServerOptions | undefined {
     const rows = this.sql<MCPServerRow>(
       "SELECT server_options FROM cf_agents_mcp_servers WHERE id = ?",
       serverId
     );
     if (!rows.length || !rows[0].server_options) return undefined;
-    const parsed: MCPServerOptions = JSON.parse(rows[0].server_options);
-    return parsed.retry;
+    return JSON.parse(rows[0].server_options);
+  }
+
+  /**
+   * Read and clear the capabilities persisted on a stored server row. The
+   * stamp is valid for one restore: sessions that configure handlers re-stamp
+   * every row, so a deploy that stops configuring them stops advertising
+   * stale modes after its first wake instead of forever.
+   */
+  private consumeStoredCapabilities(
+    serverId: string
+  ): ClientCapabilities | undefined {
+    const rows = this.sql<MCPServerRow>(
+      "SELECT id, name, server_url, client_id, auth_url, callback_url, server_options FROM cf_agents_mcp_servers WHERE id = ?",
+      serverId
+    );
+    const row = rows[0];
+    if (!row?.server_options) return undefined;
+    const options: MCPServerOptions = JSON.parse(row.server_options);
+    const capabilities = options.capabilities;
+    if (capabilities) {
+      options.capabilities = undefined;
+      this.saveServerToStorage({
+        ...row,
+        server_options: JSON.stringify(options)
+      });
+    }
+    return capabilities;
+  }
+
+  /**
+   * Get the retry options for a server from stored server_options
+   */
+  private getServerRetryOptions(serverId: string): RetryOptions | undefined {
+    return this.getStoredServerOptions(serverId)?.retry;
   }
 
   private clearServerAuthUrl(serverId: string): void {
@@ -800,7 +848,11 @@ export class MCPClientManager {
       client_id: null,
       auth_url: null,
       callback_url: "",
-      server_options: JSON.stringify({ bindingName, props })
+      server_options: JSON.stringify({
+        bindingName,
+        props,
+        capabilities: this.advertisedHandlerCapabilities()
+      })
     });
   }
 
@@ -1162,7 +1214,11 @@ export class MCPClientManager {
       {
         client: options.client ?? {},
         transport: normalizedTransport,
-        elicitationHandlers: this.scopedElicitationHandlers(id)
+        elicitationHandlers: this.scopedElicitationHandlers(id),
+        // Stored servers re-advertise the capabilities persisted on their
+        // row (see MCPServerOptions.capabilities); fresh registrations have
+        // no row yet and rely on the handlers above.
+        capabilitySeed: this.consumeStoredCapabilities(id)
       }
     );
 
@@ -1224,7 +1280,8 @@ export class MCPClientManager {
       server_options: JSON.stringify({
         client: serializableClient,
         transport: transportWithoutAuth,
-        retry: options.retry
+        retry: options.retry,
+        capabilities: this.advertisedHandlerCapabilities()
       })
     });
 
@@ -1626,10 +1683,15 @@ export class MCPClientManager {
    * Configure handling for server-initiated `elicitation/create` requests.
    *
    * The handler is held in memory only and applied to every MCP connection
-   * created or restored by this manager. Call this before registering or
-   * restoring connections when you want the initial MCP handshake to advertise
+   * created or restored by this manager. Call this before registering
+   * connections when you want the initial MCP handshake to advertise
    * handler-driven form- and url-mode elicitation. Existing active connections
    * keep their negotiated capabilities until they reconnect.
+   *
+   * The advertised modes are persisted with each stored server, so
+   * connections restored after hibernation re-advertise them at the handshake
+   * even when this is called later in the wake-up (e.g. from onStart) — the
+   * handlers attach to the live connections as soon as this runs.
    *
    * Pass undefined to clear the handler.
    *
@@ -1638,10 +1700,43 @@ export class MCPClientManager {
   configureElicitationHandler(handlers?: MCPClientElicitationHandlers): void {
     this._elicitationHandlers =
       handlers && (handlers.form || handlers.url) ? handlers : undefined;
+    this.persistAdvertisedCapabilities();
     for (const [id, connection] of Object.entries(this.mcpConnections)) {
       connection.configureElicitationHandler(
         this.scopedElicitationHandlers(id)
       );
+    }
+  }
+
+  /** Client capabilities advertised from the currently configured handlers. */
+  private advertisedHandlerCapabilities(): ClientCapabilities | undefined {
+    const elicitation = elicitationCapabilitiesFromHandlers(
+      this._elicitationHandlers
+    );
+    return elicitation ? { elicitation } : undefined;
+  }
+
+  /**
+   * Record the handler-derived capabilities on every stored server row so a
+   * restore after hibernation re-advertises them before the handlers
+   * themselves are reconfigured.
+   */
+  private persistAdvertisedCapabilities(): void {
+    const capabilities = this.advertisedHandlerCapabilities();
+    for (const server of this.getServersFromStorage()) {
+      const options: MCPServerOptions = server.server_options
+        ? JSON.parse(server.server_options)
+        : {};
+      if (
+        JSON.stringify(options.capabilities) === JSON.stringify(capabilities)
+      ) {
+        continue;
+      }
+      options.capabilities = capabilities;
+      this.saveServerToStorage({
+        ...server,
+        server_options: JSON.stringify(options)
+      });
     }
   }
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -641,12 +641,16 @@ export type {
   MCPClientOAuthResult,
   MCPClientOAuthCallbackConfig,
   MCPClientElicitationHandler,
+  MCPClientElicitationHandlers,
   MCPServerOptions,
   MCPConnectionResult,
   MCPDiscoverResult
 } from "./client";
 
-export type { MCPElicitationHandler } from "./client-connection";
+export type {
+  MCPElicitationHandler,
+  MCPElicitationHandlers
+} from "./client-connection";
 
 export { normalizeServerId, MCP_SERVER_ID_MAX_LENGTH } from "./client";
 

--- a/packages/agents/src/mcp/index.ts
+++ b/packages/agents/src/mcp/index.ts
@@ -640,6 +640,7 @@ export {
 export type {
   MCPClientOAuthResult,
   MCPClientOAuthCallbackConfig,
+  MCPClientElicitationHandler,
   MCPServerOptions,
   MCPConnectionResult,
   MCPDiscoverResult

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -1115,6 +1115,37 @@ export class TestHttpMcpDedupAgent extends Agent {
     };
   }
 
+  async testStoredHttpServerWithoutConnectionReusesId() {
+    const id = "stored-without-connection";
+    const url = "https://mcp.example.com/stored";
+    await this.mcp.registerServer(id, {
+      url,
+      name: "stored-server",
+      transport: { type: "auto" as const }
+    });
+    delete this.mcp.mcpConnections[id];
+
+    let returnedId: string | null = null;
+    try {
+      const result = await this.addMcpServer("stored-server", url);
+      returnedId = result.id;
+    } catch (_err) {
+      returnedId =
+        this.mcp.listServers().find((s) => s.name === "stored-server")?.id ??
+        null;
+    }
+
+    const storedIds = this.mcp
+      .listServers()
+      .filter((s) => s.name === "stored-server")
+      .map((s) => s.id);
+
+    return {
+      returnedId,
+      storedIds
+    };
+  }
+
   // Test: a server first registered without `id` (under a nanoid) gets
   // migrated in place when the caller adds `{ id }` on the next call.
   async testHttpSuppliedIdMigratesNanoid() {

--- a/packages/agents/src/tests/agents/mcp.ts
+++ b/packages/agents/src/tests/agents/mcp.ts
@@ -1126,10 +1126,18 @@ export class TestHttpMcpDedupAgent extends Agent {
     delete this.mcp.mcpConnections[id];
 
     let returnedId: string | null = null;
+    let threwExpectedConnectionError = false;
+    let connectionError: string | null = null;
     try {
       const result = await this.addMcpServer("stored-server", url);
       returnedId = result.id;
-    } catch (_err) {
+    } catch (error) {
+      connectionError = error instanceof Error ? error.message : String(error);
+      const expectedPrefix = `Failed to connect to MCP server at ${new URL(url).href}:`;
+      if (!connectionError.startsWith(expectedPrefix)) {
+        throw error;
+      }
+      threwExpectedConnectionError = true;
       returnedId =
         this.mcp.listServers().find((s) => s.name === "stored-server")?.id ??
         null;
@@ -1141,8 +1149,10 @@ export class TestHttpMcpDedupAgent extends Agent {
       .map((s) => s.id);
 
     return {
+      connectionError,
       returnedId,
-      storedIds
+      storedIds,
+      threwExpectedConnectionError
     };
   }
 

--- a/packages/agents/src/tests/agents/run-fiber.ts
+++ b/packages/agents/src/tests/agents/run-fiber.ts
@@ -20,9 +20,13 @@ export class TestRunFiberAgent extends Agent {
   private _releaseIgnoredCancelManagedFiber?: () => void;
   private _releaseBlockedRecovery?: () => void;
 
+  /** MCP connection ids visible at the moment each fiber was recovered. */
+  recoveryMcpConnections: Record<string, string[]> = {};
+
   override async onFiberRecovered(
     ctx: FiberRecoveryContext
   ): Promise<void | FiberRecoveryResult> {
+    this.recoveryMcpConnections[ctx.id] = Object.keys(this.mcp.mcpConnections);
     this.recoveredFibers.push(ctx);
     if (ctx.name === "managed-recovery-block") {
       await new Promise<void>((resolve) => {
@@ -546,6 +550,36 @@ export class TestRunFiberAgent extends Agent {
   }
 
   // ── Eviction simulation ───────────────────────────────────────
+
+  /**
+   * Insert a stored MCP server pending OAuth (never dials out on restore)
+   * and reset the manager so the next wake restores it again. Clears the
+   * in-memory connections so any connection seen later provably came from
+   * that wake's restore.
+   */
+  async seedMcpServerRow(id: string): Promise<void> {
+    this.sql`
+      INSERT OR REPLACE INTO cf_agents_mcp_servers
+        (id, name, server_url, client_id, auth_url, callback_url, server_options)
+      VALUES (${id}, ${"seeded"}, ${"http://mcp.invalid/mcp"}, NULL,
+              ${"http://mcp.invalid/authorize"}, ${"http://mcp.invalid/callback"},
+              ${JSON.stringify({ capabilities: { elicitation: { form: {}, url: {} } } })})
+    `;
+    for (const connectionId of Object.keys(this.mcp.mcpConnections)) {
+      delete this.mcp.mcpConnections[connectionId];
+    }
+    // @ts-expect-error - accessing private field for testing
+    this.mcp._isRestored = false;
+  }
+
+  /** Re-run the wrapped wake sequence: MCP restore → fiber recovery → onStart. */
+  async rerunWakeSequence(): Promise<void> {
+    await this.onStart();
+  }
+
+  async getRecoveryMcpConnections(): Promise<Record<string, string[]>> {
+    return this.recoveryMcpConnections;
+  }
 
   async insertInterruptedFiber(
     id: string,

--- a/packages/agents/src/tests/mcp/client-elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/client-elicitation.test.ts
@@ -85,6 +85,60 @@ describe("MCP client elicitation options (#1875)", () => {
       });
     });
 
+    it("advertises a seeded capability when no handlers are configured", () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {},
+          capabilitySeed: { elicitation: { url: {} } }
+        }
+      );
+
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        url: {}
+      });
+    });
+
+    it("configured handlers replace the seed and clearing them un-advertises", () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: {},
+          capabilitySeed: { elicitation: { form: {}, url: {} } }
+        }
+      );
+
+      connection.configureElicitationHandler({
+        form: async () => ({ action: "accept", content: {} })
+      });
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {}
+      });
+
+      connection.configureElicitationHandler(undefined);
+      expect(advertisedCapabilities(connection).elicitation).toBeUndefined();
+    });
+
+    it("an explicit declaration wins over the seed", () => {
+      const connection = new MCPClientConnection(
+        new URL("http://example.com/mcp"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http" },
+          client: { capabilities: { elicitation: { form: {} } } },
+          capabilitySeed: { elicitation: { form: {}, url: {} } }
+        }
+      );
+
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {}
+      });
+    });
+
     it("honors caller-declared elicitation modes instead of clobbering them", () => {
       const connection = new MCPClientConnection(
         new URL("http://example.com/mcp"),
@@ -137,6 +191,41 @@ describe("MCP client elicitation options (#1875)", () => {
       await expect(
         connection.handleElicitationRequest(elicitRequest)
       ).rejects.toThrow("Elicitation handler must be implemented");
+    });
+
+    it("re-initializing a live connection picks up handler changes in the new handshake", async () => {
+      const name = crypto.randomUUID();
+      const connection = new MCPClientConnection(
+        new URL(`rpc://${name}`),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "rpc", namespace: env.MCP_OBJECT, name },
+          client: {},
+          elicitationHandlers: {
+            form: async () => ({ action: "accept", content: {} })
+          }
+        }
+      );
+      await connection.init();
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {}
+      });
+
+      // Widening handlers on a live connection takes effect on reconnect —
+      // init() re-entry rebuilds the client for the new handshake
+      connection.configureElicitationHandler({
+        form: async () => ({ action: "accept", content: {} }),
+        url: async () => ({ action: "accept", content: {} })
+      });
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {}
+      });
+
+      await connection.init();
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
     });
 
     it("completes an elicitation round-trip via RPC using the injected handler", async () => {
@@ -440,6 +529,221 @@ describe("MCP client elicitation options (#1875)", () => {
       });
       expect(formHandler).toHaveBeenCalledWith(elicitRequest, "srv-1");
       expect(urlHandler).toHaveBeenCalledWith(urlElicitRequest, "srv-1");
+    });
+
+    it("re-advertises persisted capabilities on restore before handlers are reconfigured", async () => {
+      const { storage, rows } = createMockStorage();
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerA.configureElicitationHandler({
+        form: async () => ({ action: "accept", content: {} }),
+        url: async () => ({ action: "accept", content: {} })
+      });
+      await managerA.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example",
+        callbackUrl: "http://example.com/callback",
+        // Auth in progress → restore recreates the connection without dialing out
+        authUrl: "http://example.com/authorize"
+      });
+
+      // Wake after hibernation: restore runs (before fiber/chat recovery)
+      // while no handlers are configured yet
+      const managerB = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        createAuthProvider: () =>
+          ({ serverId: undefined, clientId: undefined }) as never
+      });
+      await managerB.restoreConnectionsFromStorage("test-client");
+
+      const restored = managerB.mcpConnections["srv-1"];
+      expect(advertisedCapabilities(restored).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
+      // A request in the pre-onStart window fails loudly instead of crashing
+      await expect(
+        restored.handleElicitationRequest(elicitRequest)
+      ).rejects.toThrow("Elicitation handler must be implemented");
+
+      // onStart re-attaches handlers to the live connection
+      const handler = vi
+        .fn()
+        .mockResolvedValue({ action: "accept", content: { name: "Alice" } });
+      managerB.configureElicitationHandler({ form: handler, url: handler });
+
+      await expect(
+        restored.handleElicitationRequest(elicitRequest)
+      ).resolves.toEqual({ action: "accept", content: { name: "Alice" } });
+      expect(handler).toHaveBeenCalledWith(elicitRequest, "srv-1");
+      expect(advertisedCapabilities(restored).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
+
+      // A session that only handles form narrows the advertised modes and
+      // updates the stored row for the next wake
+      managerB.configureElicitationHandler({ form: handler });
+      expect(advertisedCapabilities(restored).elicitation).toEqual({
+        form: {}
+      });
+      const options = JSON.parse(rows.get("srv-1")?.server_options ?? "{}");
+      expect(options.capabilities).toEqual({ elicitation: { form: {} } });
+    });
+
+    it("the persisted capability survives one restore, then requires reconfiguration", async () => {
+      const { storage } = createMockStorage();
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerA.configureElicitationHandler({
+        form: async () => ({ action: "accept", content: {} })
+      });
+      await managerA.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example",
+        callbackUrl: "http://example.com/callback",
+        authUrl: "http://example.com/authorize"
+      });
+
+      // First wake after the deploy stopped configuring handlers: the stamp
+      // still seeds the connection once
+      const managerB = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        createAuthProvider: () =>
+          ({ serverId: undefined, clientId: undefined }) as never
+      });
+      await managerB.restoreConnectionsFromStorage("test-client");
+      expect(
+        advertisedCapabilities(managerB.mcpConnections["srv-1"]).elicitation
+      ).toEqual({ form: {} });
+
+      // Second wake with no configure call in between: the stale mode is no
+      // longer advertised, so servers use their non-elicitation fallbacks
+      const managerC = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        createAuthProvider: () =>
+          ({ serverId: undefined, clientId: undefined }) as never
+      });
+      await managerC.restoreConnectionsFromStorage("test-client");
+      expect(
+        advertisedCapabilities(managerC.mcpConnections["srv-1"]).elicitation
+      ).toBeUndefined();
+    });
+
+    it("a server id migration preserves the restored capability seed", async () => {
+      const { storage } = createMockStorage();
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerA.configureElicitationHandler({
+        url: async () => ({ action: "accept", content: {} })
+      });
+      await managerA.registerServer("old-id", {
+        url: "http://example.com/mcp",
+        name: "example",
+        callbackUrl: "http://example.com/callback",
+        authUrl: "http://example.com/authorize"
+      });
+
+      // Restore without configuring handlers (the pre-onStart window), then
+      // migrate the id — the seed must survive the rescope
+      const managerB = new MCPClientManager("test-client", "1.0.0", {
+        storage,
+        createAuthProvider: () =>
+          ({ serverId: undefined, clientId: undefined }) as never
+      });
+      await managerB.restoreConnectionsFromStorage("test-client");
+      await managerB.migrateServerId("old-id", "github", "test-client");
+
+      expect(
+        advertisedCapabilities(managerB.mcpConnections.github).elicitation
+      ).toEqual({ url: {} });
+    });
+
+    it("records the advertised capability on stored rows as handlers change", async () => {
+      const { storage, rows } = createMockStorage();
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      const parse = () => JSON.parse(rows.get("srv-1")?.server_options ?? "{}");
+
+      await manager.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+      expect(parse().capabilities).toBeUndefined();
+
+      manager.configureElicitationHandler({
+        url: async () => ({ action: "cancel", content: {} })
+      });
+      expect(parse().capabilities).toEqual({ elicitation: { url: {} } });
+
+      manager.configureElicitationHandler(undefined);
+      expect(parse().capabilities).toBeUndefined();
+    });
+
+    it("stamps the current capability onto rows registered after configuration", async () => {
+      const { storage, rows } = createMockStorage();
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      manager.configureElicitationHandler({
+        form: async () => ({ action: "accept", content: {} })
+      });
+
+      await manager.registerServer("srv-http", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+      manager.saveRpcServerToStorage("srv-rpc", "counter", "counter", "MCP");
+
+      for (const id of ["srv-http", "srv-rpc"]) {
+        const options = JSON.parse(rows.get(id)?.server_options ?? "{}");
+        expect(options.capabilities).toEqual({ elicitation: { form: {} } });
+      }
+    });
+
+    it("seeds capabilities on a live connection and attaches handlers after connect", async () => {
+      const { storage } = createMockStorage();
+      const name = crypto.randomUUID();
+
+      // Previous session: handlers configured, RPC server row stamped
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerA.configureElicitationHandler({
+        form: async () => ({ action: "accept", content: {} })
+      });
+      managerA.saveRpcServerToStorage("srv-rpc", "rpc-server", name, "MCP");
+
+      // Wake: the Agent RPC restore path reconnects by stored id before any
+      // handler exists — the manager seeds capabilities from its own row
+      const managerB = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      await managerB.connect(`rpc://${name}`, {
+        reconnect: { id: "srv-rpc" },
+        transport: { type: "rpc", namespace: env.MCP_OBJECT, name }
+      });
+
+      const conn = managerB.mcpConnections["srv-rpc"];
+      expect(advertisedCapabilities(conn).elicitation).toEqual({ form: {} });
+
+      // Handlers attach to the already-connected client — no rebuild
+      managerB.configureElicitationHandler({
+        form: async () => ({ action: "accept", content: { name: "Alice" } })
+      });
+      expect(advertisedCapabilities(conn).elicitation).toEqual({ form: {} });
+
+      const result = await conn.client.callTool({
+        name: "elicitNameCustom",
+        arguments: {}
+      });
+      expect(result.content).toEqual([
+        { type: "text", text: "Custom elicit: Alice" }
+      ]);
     });
 
     it("advertises only configured modes and fails loudly without a matching handler", async () => {

--- a/packages/agents/src/tests/mcp/client-elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/client-elicitation.test.ts
@@ -19,6 +19,15 @@ const elicitRequest: ElicitRequest = {
   }
 };
 
+const urlElicitRequest: ElicitRequest = {
+  method: "elicitation/create",
+  params: {
+    mode: "url",
+    message: "Connect your account",
+    url: "https://example.com/authorize"
+  }
+};
+
 function advertisedCapabilities(
   connection: MCPClientConnection
 ): ClientCapabilities {
@@ -38,19 +47,20 @@ describe("MCP client elicitation options (#1875)", () => {
       expect(advertisedCapabilities(connection).elicitation).toBeUndefined();
     });
 
-    it("defaults to form- and url-mode elicitation with a handler", () => {
+    it("advertises only the modes with configured handlers", () => {
       const connection = new MCPClientConnection(
         new URL("http://example.com/mcp"),
         { name: "test-client", version: "1.0.0" },
         {
           transport: { type: "streamable-http" },
           client: {},
-          elicitationHandler: async () => ({ action: "cancel", content: {} })
+          elicitationHandlers: {
+            url: async () => ({ action: "cancel", content: {} })
+          }
         }
       );
 
       expect(advertisedCapabilities(connection).elicitation).toEqual({
-        form: {},
         url: {}
       });
     });
@@ -62,7 +72,10 @@ describe("MCP client elicitation options (#1875)", () => {
         {
           transport: { type: "streamable-http" },
           client: { capabilities: { elicitation: { form: {} } } },
-          elicitationHandler: async () => ({ action: "cancel", content: {} })
+          elicitationHandlers: {
+            form: async () => ({ action: "cancel", content: {} }),
+            url: async () => ({ action: "cancel", content: {} })
+          }
         }
       );
 
@@ -103,7 +116,7 @@ describe("MCP client elicitation options (#1875)", () => {
         {
           transport: { type: "streamable-http" },
           client: {},
-          elicitationHandler: handler
+          elicitationHandlers: { form: handler }
         }
       );
 
@@ -133,10 +146,12 @@ describe("MCP client elicitation options (#1875)", () => {
         {
           transport: { type: "rpc", namespace: env.MCP_OBJECT, name },
           client: {},
-          elicitationHandler: async () => ({
-            action: "accept",
-            content: { name: "Alice" }
-          })
+          elicitationHandlers: {
+            form: async () => ({
+              action: "accept",
+              content: { name: "Alice" }
+            })
+          }
         }
       );
       await connection.init();
@@ -216,7 +231,7 @@ describe("MCP client elicitation options (#1875)", () => {
         storage
       });
 
-      manager.configureElicitationHandler(handler);
+      manager.configureElicitationHandler({ form: handler, url: handler });
       await manager.registerServer("srv-1", {
         url: "http://example.com/mcp",
         name: "example"
@@ -253,7 +268,7 @@ describe("MCP client elicitation options (#1875)", () => {
       const connection = manager.mcpConnections["srv-1"];
       expect(advertisedCapabilities(connection).elicitation).toBeUndefined();
 
-      manager.configureElicitationHandler(handler);
+      manager.configureElicitationHandler({ form: handler, url: handler });
 
       expect(advertisedCapabilities(connection).elicitation).toEqual({
         form: {},
@@ -270,10 +285,12 @@ describe("MCP client elicitation options (#1875)", () => {
         storage
       });
 
-      manager.configureElicitationHandler(async () => ({
-        action: "accept",
-        content: {}
-      }));
+      manager.configureElicitationHandler({
+        form: async () => ({
+          action: "accept",
+          content: {}
+        })
+      });
       await manager.registerServer("srv-1", {
         url: "http://example.com/mcp",
         name: "example"
@@ -281,8 +298,7 @@ describe("MCP client elicitation options (#1875)", () => {
 
       const connection = manager.mcpConnections["srv-1"];
       expect(advertisedCapabilities(connection).elicitation).toEqual({
-        form: {},
-        url: {}
+        form: {}
       });
 
       manager.configureElicitationHandler(undefined);
@@ -301,7 +317,7 @@ describe("MCP client elicitation options (#1875)", () => {
       const manager = new MCPClientManager("test-client", "1.0.0", {
         storage
       });
-      manager.configureElicitationHandler(handler);
+      manager.configureElicitationHandler({ form: handler, url: handler });
 
       await manager.registerServer("srv-1", {
         url: "http://example.com/mcp",
@@ -323,7 +339,7 @@ describe("MCP client elicitation options (#1875)", () => {
       const manager = new MCPClientManager("test-client", "1.0.0", {
         storage
       });
-      manager.configureElicitationHandler(handler);
+      manager.configureElicitationHandler({ form: handler, url: handler });
 
       await manager.registerServer("old-id", {
         url: "http://example.com/mcp",
@@ -343,7 +359,7 @@ describe("MCP client elicitation options (#1875)", () => {
       const managerA = new MCPClientManager("test-client", "1.0.0", {
         storage
       });
-      managerA.configureElicitationHandler(handlerA);
+      managerA.configureElicitationHandler({ form: handlerA, url: handlerA });
 
       await managerA.registerServer("srv-1", {
         url: "http://example.com/mcp",
@@ -365,7 +381,7 @@ describe("MCP client elicitation options (#1875)", () => {
         createAuthProvider: () =>
           ({ serverId: undefined, clientId: undefined }) as never
       });
-      managerB.configureElicitationHandler(handlerB);
+      managerB.configureElicitationHandler({ form: handlerB, url: handlerB });
       await managerB.restoreConnectionsFromStorage("test-client");
 
       const restored = managerB.mcpConnections["srv-1"];
@@ -380,6 +396,80 @@ describe("MCP client elicitation options (#1875)", () => {
       const result = await restored.handleElicitationRequest(elicitRequest);
       expect(result).toEqual({ action: "cancel", content: {} });
       expect(handlerB).toHaveBeenCalledWith(elicitRequest, "srv-1");
+    });
+
+    it("dispatches form and url elicitations to their configured handlers", async () => {
+      const { storage } = createMockStorage();
+      const formHandler = vi
+        .fn()
+        .mockResolvedValue({ action: "accept", content: { name: "Alice" } });
+      const urlHandler = vi
+        .fn()
+        .mockResolvedValue({ action: "accept", content: {} });
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+
+      manager.configureElicitationHandler({
+        form: formHandler,
+        url: urlHandler
+      });
+      await manager.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+
+      const connection = manager.mcpConnections["srv-1"];
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
+
+      await expect(
+        connection.handleElicitationRequest(elicitRequest)
+      ).resolves.toEqual({
+        action: "accept",
+        content: { name: "Alice" }
+      });
+      await expect(
+        connection.handleElicitationRequest(urlElicitRequest)
+      ).resolves.toEqual({
+        action: "accept",
+        content: {}
+      });
+      expect(formHandler).toHaveBeenCalledWith(elicitRequest, "srv-1");
+      expect(urlHandler).toHaveBeenCalledWith(urlElicitRequest, "srv-1");
+    });
+
+    it("advertises only configured modes and fails loudly without a matching handler", async () => {
+      const { storage } = createMockStorage();
+      const urlHandler = vi
+        .fn()
+        .mockResolvedValue({ action: "accept", content: {} });
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+
+      manager.configureElicitationHandler({ url: urlHandler });
+      await manager.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+
+      const connection = manager.mcpConnections["srv-1"];
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        url: {}
+      });
+
+      await expect(
+        connection.handleElicitationRequest(elicitRequest)
+      ).rejects.toThrow("No MCP form-mode elicitation handler configured");
+      await expect(
+        connection.handleElicitationRequest(urlElicitRequest)
+      ).resolves.toEqual({
+        action: "accept",
+        content: {}
+      });
     });
   });
 });

--- a/packages/agents/src/tests/mcp/client-elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/client-elicitation.test.ts
@@ -24,7 +24,8 @@ const urlElicitRequest: ElicitRequest = {
   params: {
     mode: "url",
     message: "Connect your account",
-    url: "https://example.com/authorize"
+    url: "https://example.com/authorize",
+    elicitationId: "elicit-1"
   }
 };
 

--- a/packages/agents/src/tests/mcp/client-elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/client-elicitation.test.ts
@@ -207,15 +207,101 @@ describe("MCP client elicitation options (#1875)", () => {
       return { storage, rows };
     }
 
+    it("configureElicitationHandler applies to future connections", async () => {
+      const { storage } = createMockStorage();
+      const handler = vi
+        .fn()
+        .mockResolvedValue({ action: "accept", content: { name: "Alice" } });
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+
+      manager.configureElicitationHandler(handler);
+      await manager.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+
+      const connection = manager.mcpConnections["srv-1"];
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
+
+      const result = await connection.handleElicitationRequest(elicitRequest);
+
+      expect(result).toEqual({
+        action: "accept",
+        content: { name: "Alice" }
+      });
+      expect(handler).toHaveBeenCalledWith(elicitRequest, "srv-1");
+    });
+
+    it("configureElicitationHandler updates existing uninitialized connections", async () => {
+      const { storage } = createMockStorage();
+      const handler = vi
+        .fn()
+        .mockResolvedValue({ action: "decline", content: {} });
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+
+      await manager.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+      const connection = manager.mcpConnections["srv-1"];
+      expect(advertisedCapabilities(connection).elicitation).toBeUndefined();
+
+      manager.configureElicitationHandler(handler);
+
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
+      const result = await connection.handleElicitationRequest(elicitRequest);
+      expect(result).toEqual({ action: "decline", content: {} });
+      expect(handler).toHaveBeenCalledWith(elicitRequest, "srv-1");
+    });
+
+    it("configureElicitationHandler can clear an uninitialized connection handler", async () => {
+      const { storage } = createMockStorage();
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+
+      manager.configureElicitationHandler(async () => ({
+        action: "accept",
+        content: {}
+      }));
+      await manager.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+
+      const connection = manager.mcpConnections["srv-1"];
+      expect(advertisedCapabilities(connection).elicitation).toEqual({
+        form: {},
+        url: {}
+      });
+
+      manager.configureElicitationHandler(undefined);
+
+      expect(advertisedCapabilities(connection).elicitation).toBeUndefined();
+      await expect(
+        connection.handleElicitationRequest(elicitRequest)
+      ).rejects.toThrow("Elicitation handler must be implemented");
+    });
+
     it("scopes the manager-level handler to each connection with its server id", async () => {
       const { storage } = createMockStorage();
       const handler = vi
         .fn()
         .mockResolvedValue({ action: "decline", content: {} });
       const manager = new MCPClientManager("test-client", "1.0.0", {
-        storage,
-        elicitationHandler: handler
+        storage
       });
+      manager.configureElicitationHandler(handler);
 
       await manager.registerServer("srv-1", {
         url: "http://example.com/mcp",
@@ -235,9 +321,9 @@ describe("MCP client elicitation options (#1875)", () => {
         .fn()
         .mockResolvedValue({ action: "accept", content: {} });
       const manager = new MCPClientManager("test-client", "1.0.0", {
-        storage,
-        elicitationHandler: handler
+        storage
       });
+      manager.configureElicitationHandler(handler);
 
       await manager.registerServer("old-id", {
         url: "http://example.com/mcp",
@@ -255,9 +341,9 @@ describe("MCP client elicitation options (#1875)", () => {
       const { storage } = createMockStorage();
       const handlerA = vi.fn();
       const managerA = new MCPClientManager("test-client", "1.0.0", {
-        storage,
-        elicitationHandler: handlerA
+        storage
       });
+      managerA.configureElicitationHandler(handlerA);
 
       await managerA.registerServer("srv-1", {
         url: "http://example.com/mcp",
@@ -277,9 +363,9 @@ describe("MCP client elicitation options (#1875)", () => {
       const managerB = new MCPClientManager("test-client", "1.0.0", {
         storage,
         createAuthProvider: () =>
-          ({ serverId: undefined, clientId: undefined }) as never,
-        elicitationHandler: handlerB
+          ({ serverId: undefined, clientId: undefined }) as never
       });
+      managerB.configureElicitationHandler(handlerB);
       await managerB.restoreConnectionsFromStorage("test-client");
 
       const restored = managerB.mcpConnections["srv-1"];

--- a/packages/agents/src/tests/mcp/elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/elicitation.test.ts
@@ -332,9 +332,11 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
 
   describe("RPC Transport", () => {
     it("should keep a normal concurrent tool call separate from an eliciting tool call via RPC", async () => {
-      const { connection } = await establishRPCConnection(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 20));
-        return { action: "accept", content: { name: "Alice" } };
+      const { connection } = await establishRPCConnection({
+        form: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          return { action: "accept", content: { name: "Alice" } };
+        }
       });
 
       const [elicitResult, greetResult] = await Promise.all([
@@ -358,10 +360,12 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
 
     it("should complete elicitation accept round-trip via RPC", async () => {
       // Inject an elicitation handler that auto-accepts with a name
-      const { connection } = await establishRPCConnection(async () => ({
-        action: "accept",
-        content: { name: "Alice" }
-      }));
+      const { connection } = await establishRPCConnection({
+        form: async () => ({
+          action: "accept",
+          content: { name: "Alice" }
+        })
+      });
 
       const result = await connection.client.callTool({
         name: "elicitNameCustom",
@@ -374,10 +378,12 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
     });
 
     it("should handle elicitation cancel response via RPC", async () => {
-      const { connection } = await establishRPCConnection(async () => ({
-        action: "cancel",
-        content: {}
-      }));
+      const { connection } = await establishRPCConnection({
+        form: async () => ({
+          action: "cancel",
+          content: {}
+        })
+      });
 
       const result = await connection.client.callTool({
         name: "elicitNameCustom",
@@ -390,10 +396,12 @@ describe("McpAgent.elicitInput() in-memory resolver", () => {
     });
 
     it("should handle elicitation decline response via RPC", async () => {
-      const { connection } = await establishRPCConnection(async () => ({
-        action: "decline",
-        content: {}
-      }));
+      const { connection } = await establishRPCConnection({
+        form: async () => ({
+          action: "decline",
+          content: {}
+        })
+      });
 
       const result = await connection.client.callTool({
         name: "elicitNameCustom",

--- a/packages/agents/src/tests/mcp/http-dedup.test.ts
+++ b/packages/agents/src/tests/mcp/http-dedup.test.ts
@@ -55,12 +55,18 @@ describe("addMcpServer HTTP dedup (name + URL)", () => {
     );
     const result =
       (await agentStub.testStoredHttpServerWithoutConnectionReusesId()) as unknown as {
+        connectionError: string | null;
         returnedId: string | null;
         storedIds: string[];
+        threwExpectedConnectionError: boolean;
       };
 
     expect(result.returnedId).toBe("stored-without-connection");
     expect(result.storedIds).toEqual(["stored-without-connection"]);
+    expect(result.threwExpectedConnectionError).toBe(true);
+    expect(result.connectionError).toContain(
+      "Failed to connect to MCP server at https://mcp.example.com/stored:"
+    );
   });
 
   it("should NOT dedup when URL matches but name differs", async () => {

--- a/packages/agents/src/tests/mcp/http-dedup.test.ts
+++ b/packages/agents/src/tests/mcp/http-dedup.test.ts
@@ -48,6 +48,21 @@ describe("addMcpServer HTTP dedup (name + URL)", () => {
     expect(result.returnedId).toBe(result.seededId);
   });
 
+  it("should reuse a stored server id even before its connection is restored", async () => {
+    const agentStub = await getAgentByName(
+      env.TestHttpMcpDedupAgent,
+      "test-stored-without-connection"
+    );
+    const result =
+      (await agentStub.testStoredHttpServerWithoutConnectionReusesId()) as unknown as {
+        returnedId: string | null;
+        storedIds: string[];
+      };
+
+    expect(result.returnedId).toBe("stored-without-connection");
+    expect(result.storedIds).toEqual(["stored-without-connection"]);
+  });
+
   it("should NOT dedup when URL matches but name differs", async () => {
     const agentStub = await getAgentByName(
       env.TestHttpMcpDedupAgent,

--- a/packages/agents/src/tests/run-fiber.test.ts
+++ b/packages/agents/src/tests/run-fiber.test.ts
@@ -212,6 +212,30 @@ describe("runFiber", () => {
   // ── Recovery ──────────────────────────────────────────────────
 
   describe("recovery", () => {
+    it("restores MCP connections before fiber recovery runs", async () => {
+      // Unique name: DO storage persists across test runs, and a leftover
+      // server row would make the ordering assertion vacuous.
+      const agent = await getAgentByName(
+        env.TestRunFiberAgent,
+        `recovery-mcp-ordering-${crypto.randomUUID()}`
+      );
+
+      // Simulate pre-eviction state: a stored MCP server and an interrupted
+      // fiber, then re-run the wake sequence the wrapped onStart performs.
+      await agent.seedMcpServerRow("mcp-seeded");
+      await agent.insertInterruptedFiber("fiber-mcp", "mcp-ordering");
+      await agent.rerunWakeSequence();
+
+      const recovered =
+        (await agent.getRecoveredFibers()) as unknown as FiberRecoveryContext[];
+      expect(recovered.some((fiber) => fiber.id === "fiber-mcp")).toBe(true);
+
+      // The recovered fiber ran with the restored connection already
+      // registered — a recovered chat turn can wait on it and see MCP tools.
+      const seen = await agent.getRecoveryMcpConnections();
+      expect(seen["fiber-mcp"]).toContain("mcp-seeded");
+    });
+
     it("should detect an interrupted fiber and call onFiberRecovered", async () => {
       const agent = await getAgentByName(
         env.TestRunFiberAgent,

--- a/packages/agents/src/tests/shared/test-utils.ts
+++ b/packages/agents/src/tests/shared/test-utils.ts
@@ -150,12 +150,12 @@ export async function initializeMCPClientConnection(
 /**
  * Helper to create RPC connection to TestMcpAgent.
  *
- * Pass `elicitationHandler` when the test exercises elicitation — without a
- * handler the connection advertises no elicitation capability, so the server
+ * Pass `elicitationHandlers` when the test exercises elicitation — without
+ * handlers the connection advertises no elicitation capability, so the server
  * refuses to elicit.
  */
 export async function establishRPCConnection(
-  elicitationHandler?: MCPClientConnection["options"]["elicitationHandler"]
+  elicitationHandlers?: MCPClientConnection["options"]["elicitationHandlers"]
 ): Promise<{
   connection: MCPClientConnection;
   sessionId: string;
@@ -168,7 +168,7 @@ export async function establishRPCConnection(
     {
       transport: { type: "rpc", namespace: env.MCP_OBJECT, name },
       client: {},
-      elicitationHandler
+      elicitationHandlers
     }
   );
 


### PR DESCRIPTION
Follow-up to #1903/#1910 (none of this has shipped — the pending Version Packages release absorbs all of it, so no compatibility path is kept).

## What changed

Elicitation handling moves off the Agent class onto the MCP client manager, matching the `configureOAuthCallback` pattern. `Agent.onElicitRequest` is removed.

## How to use

Register handlers in `onStart()`. The handler keys are the capability declaration: connections advertise exactly the modes with configured handlers at the `initialize` handshake — `form` only, `url` only, or both. No handlers → no elicitation capability advertised, so servers use their non-elicitation fallbacks.

```ts
class MyAgent extends Agent<Env> {
  onStart() {
    this.mcp.configureElicitationHandler({
      url: async (request, serverId) => {
        // deliver request.params.url to the user out-of-band
        return { action: "accept", content: {} };
      },
      form: async (request, serverId) => {
        // collect fields matching request.params.requestedSchema
        return { action: "accept", content: { /* fields */ } };
      },
    });
  }
}
```

An explicit `client.capabilities.elicitation` on `addMcpServer` still wins wholesale (persisted, survives hibernation), e.g. to declare `form: { applyDefaults: true }`.

## Surviving hibernation: persisted capabilities

Handlers are functions and cannot be persisted, but the capabilities they advertise can. Whenever handlers are configured (and whenever a server is registered), the handler-derived client capabilities are recorded on each stored server row (`server_options.capabilities`, a general `ClientCapabilities` object — only `elicitation` is populated today, but future handler-driven capabilities such as sampling reuse the same field with no storage migration).

On wake, restored connections re-advertise the same modes at the `initialize` handshake before `onStart()` has run. Elicitation dispatch looks handlers up at request time, so when `onStart()` calls `configureElicitationHandler`, the handlers attach to the already-live connections — no reconnect needed. The seeding is self-contained in the manager: `createConnection` consumes the stamp from its own stored row, so every path that recreates a known server (storage restore, the Agent RPC restore, `addMcpServer` re-adds) gets it uniformly with no parameter threading.

The stamp is valid for **one restore**: consuming it clears it, and any `configureElicitationHandler` call re-stamps every row. Apps that configure handlers each wake see no difference; a deploy that deletes the configure call stops advertising the stale modes after a single wake instead of forever (adversarial review caught the forever-stale variant). Configuring handlers also clears the in-memory seed (handlers become the source of truth). Explicit `client.capabilities` declarations win over the seed, and reconnects rebuild the SDK client so handler changes on a live connection take effect at the next handshake.

Precedence at client build: `client.capabilities.elicitation` (declared) → handler-derived → persisted seed.

## Lifecycle

Because restored connections no longer depend on handlers existing at connect time, automatic MCP restore keeps its original position: **before** fiber/chat recovery and user `onStart()`. Recovered turns (`waitForMcpConnections`) see the pending connections and run with MCP tools — an earlier revision of this PR moved restore after `onStart()` and traded that away; the persisted-capability seed removes the tradeoff. An end-to-end test replays the wake sequence and pins the ordering (mutation-tested: reordering restore after recovery fails it).

`addMcpServer` reuses the stored server id when re-adding a known server (`requestedId ?? existingServer?.id ?? nanoid(8)`), keeping registration idempotent during the onStart window and preserving OAuth token storage keyed by server id across hibernation.

Two windows remain by construction: an elicitation request arriving after a restored connection connects but before `onStart()` configures handlers (including during a recovered turn) is answered with a JSON-RPC error — servers handle elicitation failure per spec, and this equals main's behavior for form mode. And the first wake after handlers are first introduced has no stored record yet, so restored connections advertise nothing for that boot; the record is written during that wake and every later wake is correct.

## Implementation notes

- `MCPClientConnection.configureElicitationHandler` rebuilds the SDK client for not-yet-connected connections because SDK `registerCapabilities` is merge-only — a rebuild is the only way to un-advertise a mode when handlers are cleared before connecting (evaluated and rejected the `registerCapabilities` approach for exactly this reason). `init()` re-entry (mid-session 401 → OAuth → reconnect) also rebuilds, so reconnects genuinely refresh advertised capabilities.
- `migrateServerId` rescopes handlers to the new server id; when the manager has no handlers it leaves the connection untouched so an id migration cannot wipe a restored capability seed (mutation-tested).
- RPC elicitation tests use the connection-level `elicitationHandlers` option; conformance host and the mcp-client example configure via `onStart()`.

## Tests

Full agents suite (114 files / 2,267 tests), full MCP suite, `npm run check`, and all conformance jobs green. New coverage: seed precedence (seed vs handlers vs explicit declaration), capability persistence on stored rows, restore-then-configure across a simulated hibernation (the fiber-recovery window), a live RPC connection seeded at connect with handlers attached afterwards (full elicitation round-trip), and the wake-ordering test above. Verified end-to-end against the running `mcp-client` + `mcp-elicitation` examples: both form- and url-mode round-trips complete through `configureElicitationHandler`.
