### PR TITLE
fix(think): resolve messenger self-mentions

### DIFF
--- a/.changeset/messenger-self-mention-bot-name.md
+++ b/.changeset/messenger-self-mention-bot-name.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/think": patch
+---
+
+Rewrite the bot's own unresolved self-mention in messenger events to its readable handle before the model sees it.
+
+When a user @-mentions a Think messenger bot, the triggering message leads with the bot's own mention. Adapters resolve every other user's mention to `@DisplayName` but leave the bot's own as a raw user-id token (for example, Slack's `@U0BD9EYL52S`), which small models can misread as a third party the sender was trying to reach. Think now rewrites that surviving self-mention to `@<userName>` (the bot handle already required on every messenger) in `defaultChatSdkEvent`, reconstructing the `@handle` the sender originally typed.
+
+Adds the exported `resolveSelfMention` helper. Rewriting only applies when the adapter exposes a `botUserId`, so handle-based adapters (for example, Telegram) are unaffected. No new configuration is required.

--- a/docs/think/messengers.md
+++ b/docs/think/messengers.md
@@ -167,6 +167,24 @@ if (messenger?.thread.isDirectMessage === false) {
 }
 ```
 
+## Self-Mentions
+
+When a user @-mentions the bot, the triggering message leads with the bot's own
+mention. Adapters resolve every other user's mention to a readable
+`@DisplayName`, but they leave the bot's own mention as a raw user-id token (for
+example, Slack's `@U0BD9EYL52S`) because mention detection still needs it. That
+raw id is the only unresolved mention that can survive in the text, so Think
+rewrites it to `@<userName>` (the bot handle you already configure) before the
+model sees it. This reconstructs the `@handle` the sender originally typed and
+keeps a small model from reading the unexplained id as a third party the sender
+was trying to reach.
+
+Rewriting reuses the required `userName` option, so no extra configuration is
+needed. It only applies when the adapter exposes a `botUserId` (used by
+platforms that put ids in mentions). Adapters that mention the bot by handle
+(for example, Telegram's `@username`) already produce readable text and are left
+unchanged.
+
 ## Custom Chat SDK Adapters
 
 Use `chatSdkMessenger()` for providers that do not have a Think helper yet:

--- a/packages/think/src/messengers/chat-sdk.ts
+++ b/packages/think/src/messengers/chat-sdk.ts
@@ -682,16 +682,56 @@ export function defaultChatSdkEvent(
   definition: NormalizedMessengerDefinition,
   input: ChatSdkMessengerEventInput
 ): MessengerEvent {
+  const message = input.message && toMessengerMessage(input.message);
+  if (message) {
+    message.text = resolveSelfMention(
+      message.text,
+      definition.adapter.botUserId,
+      definition.userName
+    );
+  }
   return {
     capabilities: definition.capabilities ?? {},
     action: input.action && toMessengerAction(input.action),
     kind: input.eventKind,
-    message: input.message && toMessengerMessage(input.message),
+    message,
     messengerId: definition.id,
     provider: definition.provider,
     raw: input.raw ?? input.message?.raw,
     thread: toMessengerThread(input.thread)
   };
+}
+
+/**
+ * Rewrite the bot's own unresolved self-mention to `@<userName>`.
+ *
+ * Adapters resolve every user's `<@id>` mention to a readable `@DisplayName`
+ * except the bot's own, which is deliberately left as a raw id token so mention
+ * detection can still find it. That raw id is therefore the only unresolved
+ * mention that can survive in the text, so once it has served its purpose we
+ * replace it with the bot's configured handle before the model sees it —
+ * reconstructing the readable `@handle` the sender originally typed. Handles
+ * both the angle-bracket form (`<@U123>` / `<@!U123>`, Slack/Discord) and the
+ * bare `@U123` form some adapters normalize to. No-op when the adapter does not
+ * expose a `botUserId`.
+ */
+export function resolveSelfMention(
+  text: string,
+  botUserId: string | undefined,
+  userName: string
+): string {
+  if (!botUserId) {
+    return text;
+  }
+  const id = escapeRegExp(botUserId);
+  const replacement = `@${userName}`;
+  return text
+    .replace(new RegExp(`<@!?${id}>`, "g"), replacement)
+    .replace(new RegExp(`@${id}\\b`, "g"), replacement);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function toMessengerAction(action: ChatActionEvent): MessengerAction {

--- a/packages/think/src/messengers/index.ts
+++ b/packages/think/src/messengers/index.ts
@@ -4,6 +4,7 @@ export {
   defaultConversationName,
   idempotencyKeyForEvent,
   normalizeMessengers,
+  resolveSelfMention,
   ThinkMessengerRuntime,
   ThinkMessengerStateAgent,
   toMessengerAttachment,

--- a/packages/think/src/tests/messengers.test.ts
+++ b/packages/think/src/tests/messengers.test.ts
@@ -11,6 +11,7 @@ import {
   chatSdkMessenger,
   defaultChatSdkEvent,
   defaultConversationName,
+  resolveSelfMention,
   deliverMessengerReply,
   EMPTY_MESSENGER_RESPONSE,
   ERROR_MESSENGER_RESPONSE,
@@ -337,6 +338,60 @@ describe("think messengers core", () => {
           "Source message: source-message"
         ].join("\n")
       }
+    ]);
+  });
+
+  it("rewrites the bot's own self-mention to the bot handle", () => {
+    expect(
+      resolveSelfMention("@U0BD9EYL52S hi friend", "U0BD9EYL52S", "think_bot")
+    ).toBe("@think_bot hi friend");
+    expect(
+      resolveSelfMention("hey <@U0BD9EYL52S> there", "U0BD9EYL52S", "think_bot")
+    ).toBe("hey @think_bot there");
+    expect(
+      resolveSelfMention(
+        "hey <@!U0BD9EYL52S> there",
+        "U0BD9EYL52S",
+        "think_bot"
+      )
+    ).toBe("hey @think_bot there");
+  });
+
+  it("leaves other users' resolved mentions untouched", () => {
+    expect(
+      resolveSelfMention(
+        "@U0BD9EYL52S ask @Ada about it",
+        "U0BD9EYL52S",
+        "think_bot"
+      )
+    ).toBe("@think_bot ask @Ada about it");
+  });
+
+  it("is a no-op when the adapter exposes no botUserId", () => {
+    expect(resolveSelfMention("@U0BD9EYL52S hi", undefined, "think_bot")).toBe(
+      "@U0BD9EYL52S hi"
+    );
+  });
+
+  it("resolves the self-mention in default events using the bot handle", () => {
+    const [definition] = normalizeMessengers({
+      slack: chatSdkMessenger({
+        adapter: fakeAdapter({ botUserId: "U0BD9EYL52S" }),
+        provider: "slack",
+        userName: "think_bot",
+        verifyWebhook: false
+      })
+    });
+
+    const event = defaultChatSdkEvent(definition!, {
+      eventKind: "mention",
+      message: fakeMessage("@U0BD9EYL52S hi friend"),
+      thread: fakeThread("slack:C123")
+    });
+
+    expect(event.message?.text).toBe("@think_bot hi friend");
+    expect(toMessengerUserMessage(event).parts).toEqual([
+      { type: "text", text: "Ada Lovelace: @think_bot hi friend" }
     ]);
   });
 
@@ -958,6 +1013,24 @@ function fakeAdapter(overrides: Partial<Adapter> = {}): Adapter {
     userName: "fake_bot",
     ...overrides
   } as Adapter;
+}
+
+function fakeMessage(text: string) {
+  return {
+    attachments: [],
+    author: {
+      fullName: "Ada Lovelace",
+      isBot: false,
+      isMe: false,
+      userId: "slack:user",
+      userName: "ada"
+    },
+    id: "message-1",
+    isMention: true,
+    metadata: { dateSent: new Date(0), edited: false },
+    raw: {},
+    text
+  } as never;
 }
 
 function fakeThread(id: string) {


### PR DESCRIPTION
This PR rewrites Think messenger self-mentions before they reach the model. It replaces the bot's own unresolved raw user-id mention with the configured bot handle in Chat SDK messenger events.

## Why

- Mention-triggered messenger messages can start with the bot's own platform id, for example `@U0BD9EYL52S`, after adapters resolve other users to readable names.
- Small models can misread that unresolved id as a third party the sender wanted to contact, rather than as the bot mention that triggered the event.
- The existing `userName` messenger option already represents the readable bot handle, so the fix can reconstruct `@<userName>` without adding configuration.
- Rewriting is limited to adapters that expose `botUserId`; handle-based adapters already produce readable mentions and are left unchanged.

## Public API Surface

| Symbol | Kind | Notes |
| ------ | ---- | ----- |
| `resolveSelfMention` | Function | Additive export from `@cloudflare/think/messengers` that rewrites `<@id>`, `<@!id>`, and bare `@id` self-mentions to `@<userName>`. |

## Code Changes

- `defaultChatSdkEvent` now normalizes the message once, rewrites the bot self-mention, and passes the rewritten message into the messenger event.
- `resolveSelfMention` handles Slack and Discord angle-bracket mention forms plus the bare `@id` form some adapters normalize to.
- Messenger docs explain why self-mentions are rewritten and when the behavior applies.
- The changeset marks this as a patch fix for `@cloudflare/think`.