### PR TITLE
fix(mcp): recover expired HTTP sessions

### DIFF
--- a/.changeset/mcp-stale-session-self-heal.md
+++ b/.changeset/mcp-stale-session-self-heal.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Recover streamable HTTP connections when a server rejects a persisted session with HTTP 404. The client clears the stale session from memory and storage, initializes a new session, and rediscovers capabilities once.

--- a/packages/agents/src/mcp/client-connection.ts
+++ b/packages/agents/src/mcp/client-connection.ts
@@ -6,6 +6,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/sse.js";
 import {
   StreamableHTTPClientTransport,
+  StreamableHTTPError,
   type StreamableHTTPClientTransportOptions
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 // Import types directly from MCP SDK
@@ -101,15 +102,10 @@ export type MCPClientConnectionResult = {
   transport?: BaseTransportType;
 };
 
-/**
- * Result of a discovery operation.
- * success indicates whether discovery completed successfully.
- * error is present when success is false.
- */
-export type MCPDiscoveryResult = {
-  success: boolean;
-  error?: string;
-};
+/** Result of discovering server capabilities. */
+export type MCPDiscoveryResult =
+  | { success: true }
+  | { success: false; reason: "error" | "stale-session"; error: string };
 
 /**
  * Handler for server-initiated `elicitation/create` requests.
@@ -547,6 +543,7 @@ export class MCPClientConnection {
       });
       return {
         success: false,
+        reason: "error",
         error: `Discovery skipped - connection in ${this.connectionState} state`
       };
     }
@@ -619,7 +616,17 @@ export class MCPClientConnection {
       this.connectionState = MCPConnectionState.CONNECTED;
 
       const error = e instanceof Error ? e.message : String(e);
-      return { success: false, error };
+      // A restored streamable HTTP session rejected with 404 must be
+      // initialized again without its persisted session id.
+      const staleSession =
+        this._probingCapabilities &&
+        e instanceof StreamableHTTPError &&
+        e.code === 404;
+      return {
+        success: false,
+        reason: staleSession ? "stale-session" : "error",
+        error
+      };
     } finally {
       // Clean up the abort controller
       this._discoveryAbortController = undefined;
@@ -805,6 +812,13 @@ export class MCPClientConnection {
     }
 
     return undefined;
+  }
+
+  /** @internal Clear a restored session before reconnecting. */
+  clearResumedSession(): void {
+    if ("sessionId" in this.options.transport) {
+      delete this.options.transport.sessionId;
+    }
   }
 
   private getTransportName(

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -23,6 +23,7 @@ import {
   elicitationCapabilitiesFromHandlers,
   MCPClientConnection,
   MCPConnectionState,
+  type MCPDiscoveryResult,
   type MCPElicitationHandlers,
   type MCPTransportOptions
 } from "./client-connection";
@@ -1654,12 +1655,57 @@ export class MCPClientManager {
 
     // Delegate to connection's discover method which handles cancellation and timeout
     const result = await conn.discover(options);
+    if (!result.success && result.reason === "stale-session") {
+      return this._recoverStaleSession(conn, serverId, options);
+    }
     this._onServerStateChanged.fire();
 
-    return {
-      ...result,
-      state: conn.connectionState
-    };
+    return this._toDiscoverResult(conn, result);
+  }
+
+  private _toDiscoverResult(
+    conn: MCPClientConnection,
+    result: MCPDiscoveryResult
+  ): MCPDiscoverResult {
+    return result.success
+      ? { success: true, state: conn.connectionState }
+      : { success: false, error: result.error, state: conn.connectionState };
+  }
+
+  private async _recoverStaleSession(
+    conn: MCPClientConnection,
+    serverId: string,
+    options: { timeoutMs?: number }
+  ): Promise<MCPDiscoverResult> {
+    conn.clearResumedSession();
+    this.updateStoredSessionId(serverId, undefined);
+
+    let connectResult: MCPConnectionResult;
+    try {
+      connectResult = await this.connectToServer(serverId);
+    } catch (error) {
+      return {
+        success: false,
+        error: toErrorMessage(error),
+        state: conn.connectionState
+      };
+    }
+
+    if (connectResult.state !== MCPConnectionState.CONNECTED) {
+      return {
+        success: false,
+        error:
+          connectResult.state === MCPConnectionState.FAILED
+            ? connectResult.error
+            : `Connection in ${connectResult.state} state after session re-initialization`,
+        state: conn.connectionState
+      };
+    }
+
+    const result = await conn.discover(options);
+    this._onServerStateChanged.fire();
+
+    return this._toDiscoverResult(conn, result);
   }
 
   /**

--- a/packages/agents/src/tests/mcp/client-connection.test.ts
+++ b/packages/agents/src/tests/mcp/client-connection.test.ts
@@ -1,6 +1,9 @@
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ServerCapabilities } from "@modelcontextprotocol/sdk/types.js";
+import {
+  McpError,
+  type ServerCapabilities
+} from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { z } from "zod";
 import { MCPClientConnection } from "../../mcp/client-connection";
@@ -266,6 +269,43 @@ describe("MCP Client Connection Integration", () => {
       expect(connection.prompts).toEqual([]);
       expect(connection.resourceTemplates).toEqual([]);
     });
+
+    it("does not classify a JSON-RPC error code 404 as a stale session", async () => {
+      const connection = new MCPClientConnection(
+        new URL(serverUrl),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "streamable-http", sessionId: "restored-session" },
+          client: {}
+        }
+      );
+      const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+        sessionId: "restored-session"
+      });
+      Object.defineProperty(connection, "_transport", { value: transport });
+      connection.connectionState = "connected";
+      connection.client.getServerCapabilities = vi.fn();
+      connection.client.getInstructions = vi.fn();
+      connection.client.listTools = vi
+        .fn()
+        .mockRejectedValue(new McpError(404, "Application resource missing"));
+      connection.client.listResources = vi
+        .fn()
+        .mockResolvedValue({ resources: [] });
+      connection.client.listPrompts = vi
+        .fn()
+        .mockResolvedValue({ prompts: [] });
+      connection.client.listResourceTemplates = vi
+        .fn()
+        .mockResolvedValue({ resourceTemplates: [] });
+      connection.client.setNotificationHandler = vi.fn();
+
+      expect(await connection.discover()).toMatchObject({
+        success: false,
+        reason: "error",
+        error: expect.stringContaining("Application resource missing")
+      });
+    });
   });
 
   describe("Capability Discovery", () => {
@@ -523,8 +563,10 @@ describe("MCP Client Connection Integration", () => {
       // Trigger discovery - should fail and return error result
       const result = await connection.discover();
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Instructions service down");
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining("Instructions service down")
+      });
 
       // Connection should return to connected state (not failed) so user can retry
       expect(connection.connectionState).toBe("connected");
@@ -624,8 +666,10 @@ describe("MCP Client Connection Integration", () => {
       // Trigger discovery - should fail
       const result = await connection.discover();
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("All services down");
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining("All services down")
+      });
 
       // Connection should return to connected state (not failed) so user can retry
       expect(connection.connectionState).toBe("connected");

--- a/packages/agents/src/tests/mcp/session-lifecycle.integration.test.ts
+++ b/packages/agents/src/tests/mcp/session-lifecycle.integration.test.ts
@@ -88,7 +88,7 @@ function createManagerStorage() {
   return { rows, storage };
 }
 
-function createRecordedFetch(): {
+function createRecordedFetch(options?: { rejectSessionId?: string }): {
   fetch: typeof globalThis.fetch;
   requests: RecordedRequest[];
 } {
@@ -96,12 +96,17 @@ function createRecordedFetch(): {
 
   const recordedFetch: typeof globalThis.fetch = async (input, init) => {
     const request = new Request(input, init);
+    const sessionId = request.headers.get("mcp-session-id");
     requests.push({
       method: request.method,
       url: request.url,
-      sessionId: request.headers.get("mcp-session-id"),
+      sessionId,
       accept: request.headers.get("accept")
     });
+
+    if (sessionId === options?.rejectSessionId) {
+      return new Response("Session not found", { status: 404 });
+    }
 
     const ctx = createExecutionContext();
     return worker.fetch(request, env, ctx);
@@ -293,6 +298,52 @@ describe("MCP streamable-http session lifecycle integration", () => {
       if (manager2) {
         await manager2.closeAllConnections();
       }
+    }
+  });
+
+  it("reinitializes when a server rejects a restored session", async () => {
+    const { rows, storage } = createManagerStorage();
+    const staleSessionId = "expired-session";
+    const serverId = "integration-stale-session";
+    const manager1 = new MCPClientManager("test-client", "1.0.0", {
+      storage
+    });
+    let manager2: MCPClientManager | undefined;
+
+    try {
+      await manager1.registerServer(serverId, {
+        url: "http://example.com/mcp",
+        name: "Stale Session Server",
+        transport: { type: "streamable-http", sessionId: staleSessionId }
+      });
+
+      manager2 = new MCPClientManager("test-client", "1.0.0", { storage });
+      const restoredFetch = createRecordedFetch({
+        rejectSessionId: staleSessionId
+      });
+      vi.stubGlobal("fetch", restoredFetch.fetch);
+
+      await manager2.restoreConnectionsFromStorage("test-client");
+      await manager2.waitForConnections({ timeout: 5000 });
+
+      expect(manager2.mcpConnections[serverId].connectionState).toBe("ready");
+      expect(
+        restoredFetch.requests.some(
+          (request) => request.sessionId === staleSessionId
+        )
+      ).toBe(true);
+      expect(
+        restoredFetch.requests.filter(
+          (request) => request.method === "POST" && !request.sessionId
+        )
+      ).toHaveLength(1);
+
+      const options = JSON.parse(rows.get(serverId)?.server_options ?? "{}");
+      expect(options.transport.sessionId).toEqual(expect.any(String));
+      expect(options.transport.sessionId).not.toBe(staleSessionId);
+    } finally {
+      await manager1.closeAllConnections();
+      await manager2?.closeAllConnections();
     }
   });
 });


### PR DESCRIPTION
## Summary

Recover a streamable HTTP MCP connection when the server returns HTTP 404 for a session restored from storage.

The client now:

- identifies HTTP 404 only while probing a restored streamable HTTP session;
- clears that session id from memory and durable storage;
- initializes a fresh session and rediscovers capabilities once.

Application-level JSON-RPC errors with code 404 are unchanged, as are failures on sessions negotiated in the current lifetime.

## Why this is needed

The MCP SDK skips `initialize` when given a persisted session id. If the server expires that session while the Agent sleeps, restore appears connected but discovery remains wedged on 404 across later wakes.

The regression still reproduces on current `main`; the new session-lifecycle test fails there and passes with this fix.

## Validation

- `pnpm --filter agents exec vitest run src/tests/mcp` — 30 files, 548 tests passed
- focused package lint and TypeScript checks passed
- `pnpm run check` passes through exports, formatting, lint, and `packages/agents` typechecks; repo-wide typecheck is currently blocked by unchanged `main` voice errors in `examples/voice-agent` and `voice-providers/assemblyai`

Includes a patch changeset for `agents`.
