### PR TITLE
fix(mcp): harden connection recovery

### DIFF
--- a/.changeset/mcp-reconnect-hardening.md
+++ b/.changeset/mcp-reconnect-hardening.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Harden MCP connection recovery: honor retry budgets for resolved connection failures, finish in-flight restore work before stable-id migration, and close connections replaced by the legacy `connect()` path.

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -309,6 +309,13 @@ export type MCPConnectionResult =
       state: typeof MCPConnectionState.CONNECTED;
     };
 
+/** Converts a resolved connection failure into a retry signal. */
+class ConnectRetryError extends Error {
+  constructor(readonly result: MCPConnectionResult) {
+    super("MCP connection attempt failed");
+  }
+}
+
 /**
  * Result of discovering server capabilities.
  * success indicates whether discovery completed successfully.
@@ -490,6 +497,14 @@ export class MCPClientManager {
     clientName: string
   ): Promise<void> {
     if (oldId === newId) return;
+
+    // Restore work closes over oldId. Drain it before renaming, including
+    // replacement work registered while an earlier task settles.
+    while (true) {
+      const pending = this._pendingConnections.get(oldId);
+      if (!pending) break;
+      await pending.catch(() => {});
+    }
 
     const existing = this.sql<MCPServerRow>(
       "SELECT id FROM cf_agents_mcp_servers WHERE id = ?",
@@ -1039,6 +1054,34 @@ export class MCPClientManager {
     }
   }
 
+  private async _connectWithRetry(
+    serverId: string,
+    retry?: RetryOptions
+  ): Promise<MCPConnectionResult> {
+    const maxAttempts = retry?.maxAttempts ?? 3;
+    const baseDelayMs = retry?.baseDelayMs ?? 500;
+    const maxDelayMs = retry?.maxDelayMs ?? 5000;
+
+    try {
+      return await tryN(
+        maxAttempts,
+        async () => {
+          const result = await this.connectToServer(serverId);
+          if (result.state === MCPConnectionState.FAILED) {
+            throw new ConnectRetryError(result);
+          }
+          return result;
+        },
+        { baseDelayMs, maxDelayMs }
+      );
+    } catch (error) {
+      if (error instanceof ConnectRetryError) {
+        return error.result;
+      }
+      throw error;
+    }
+  }
+
   /**
    * Internal method to restore a single server connection and discovery
    */
@@ -1050,21 +1093,12 @@ export class MCPClientManager {
     // If stored OAuth tokens are valid, connection will succeed automatically
     // If tokens are missing/invalid, connection will fail with Unauthorized
     // and state will be set to "authenticating"
-    const maxAttempts = retry?.maxAttempts ?? 3;
-    const baseDelayMs = retry?.baseDelayMs ?? 500;
-    const maxDelayMs = retry?.maxDelayMs ?? 5000;
-
-    const connectResult = await tryN(
-      maxAttempts,
-      async () => this.connectToServer(serverId),
-      { baseDelayMs, maxDelayMs }
-    ).catch((error) => {
-      console.error(
-        `Error connecting to ${serverId} after ${maxAttempts} attempts:`,
-        error
-      );
-      return null;
-    });
+    const connectResult = await this._connectWithRetry(serverId, retry).catch(
+      (error) => {
+        console.error(`Error connecting to ${serverId}:`, error);
+        return null;
+      }
+    );
 
     if (connectResult?.state === MCPConnectionState.CONNECTED) {
       const discoverResult = await this.discoverIfConnected(serverId);
@@ -1123,7 +1157,13 @@ export class MCPClientManager {
     // During OAuth reconnect, reuse existing connection to preserve state;
     // otherwise drop any existing connection and rebuild it.
     if (!options.reconnect?.oauthCode || !this.mcpConnections[id]) {
-      delete this.mcpConnections[id];
+      const replaced = this.mcpConnections[id];
+      if (replaced) {
+        delete this.mcpConnections[id];
+        // Once removed from the map, nothing else can close this transport.
+        await replaced.close().catch(() => {});
+        this.updateStoredSessionId(id, undefined);
+      }
       this.createConnection(id, url, {
         client: options.client,
         transport: options.transport ?? {}
@@ -1704,15 +1744,7 @@ export class MCPClientManager {
     }
 
     const retry = this.getServerRetryOptions(serverId);
-    const maxAttempts = retry?.maxAttempts ?? 3;
-    const baseDelayMs = retry?.baseDelayMs ?? 500;
-    const maxDelayMs = retry?.maxDelayMs ?? 5000;
-
-    const connectResult = await tryN(
-      maxAttempts,
-      async () => this.connectToServer(serverId),
-      { baseDelayMs, maxDelayMs }
-    );
+    const connectResult = await this._connectWithRetry(serverId, retry);
     this._onServerStateChanged.fire();
 
     if (connectResult.state === MCPConnectionState.CONNECTED) {

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -173,6 +173,13 @@ describe("MCPClientManager OAuth Integration", () => {
           server.auth_url = null;
           mockStorageData.set(id, server);
         }
+      } else if (query.includes("UPDATE") && query.includes("SET id = ?")) {
+        const [newId, oldId] = values as [string, string];
+        const server = mockStorageData.get(oldId);
+        if (server) {
+          mockStorageData.delete(oldId);
+          mockStorageData.set(newId, { ...server, id: newId });
+        }
       } else if (query.includes("SELECT")) {
         if (query.includes("WHERE callback_url")) {
           const url = values[0] as string;
@@ -182,6 +189,9 @@ describe("MCPClientManager OAuth Integration", () => {
               break;
             }
           }
+        } else if (query.includes("WHERE id = ?")) {
+          const server = mockStorageData.get(values[0] as string);
+          if (server) results.push(server as unknown as T);
         } else {
           results.push(
             ...(Array.from(mockStorageData.values()) as unknown as T[])
@@ -201,6 +211,8 @@ describe("MCPClientManager OAuth Integration", () => {
       put: async (key: string, value: unknown) => {
         mockKVData.set(key, value);
       },
+      list: async () => new Map(),
+      delete: vi.fn(),
       kv: {
         get: <T>(key: string) => mockKVData.get(key) as T | undefined,
         put: (key: string, value: unknown) => {
@@ -2570,7 +2582,8 @@ describe("MCPClientManager OAuth Integration", () => {
         name: "Test Server",
         callbackUrl: "http://localhost:3000/callback",
         client: {},
-        transport: { type: "auto" }
+        transport: { type: "auto" },
+        retry: { maxAttempts: 1 }
       });
 
       let resolveInit!: () => void;
@@ -4838,6 +4851,170 @@ describe("MCPClientManager OAuth Integration", () => {
       resolveNew();
       await waitPromise;
       expect(waited).toBe(true);
+    });
+  });
+
+  describe("connection recovery regressions", () => {
+    function storeServer(id: string, maxAttempts = 3) {
+      saveServerToMock({
+        id,
+        name: "Test Server",
+        server_url: "http://example.com/mcp",
+        callback_url: "http://localhost:3000/callback",
+        client_id: null,
+        auth_url: null,
+        server_options: JSON.stringify({
+          retry: { maxAttempts, baseDelayMs: 1, maxDelayMs: 2 },
+          transport: { type: "streamable-http" }
+        })
+      });
+    }
+
+    async function restore() {
+      await manager.restoreConnectionsFromStorage("test-agent");
+      await manager.waitForConnections();
+    }
+
+    it("retries resolved connection failures during restore", async () => {
+      storeServer("retry-restore");
+      const connect = vi
+        .spyOn(manager, "connectToServer")
+        .mockResolvedValueOnce({ state: "failed", error: "transient" })
+        .mockResolvedValueOnce({ state: "failed", error: "transient" })
+        .mockResolvedValueOnce({ state: "connected" });
+      const discover = vi
+        .spyOn(manager, "discoverIfConnected")
+        .mockResolvedValue({ success: true, state: "ready" });
+
+      await restore();
+
+      expect(connect).toHaveBeenCalledTimes(3);
+      expect(discover).toHaveBeenCalledWith("retry-restore");
+    });
+
+    it("stops after the configured retry budget", async () => {
+      storeServer("retry-exhausted", 2);
+      const connect = vi
+        .spyOn(manager, "connectToServer")
+        .mockResolvedValue({ state: "failed", error: "offline" });
+
+      await restore();
+
+      expect(connect).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry a connection waiting for OAuth", async () => {
+      storeServer("retry-oauth");
+      const connect = vi.spyOn(manager, "connectToServer").mockResolvedValue({
+        state: "authenticating",
+        authUrl: "https://example.com/authorize"
+      });
+
+      await restore();
+
+      expect(connect).toHaveBeenCalledOnce();
+    });
+
+    it("uses the same retry budget after OAuth completion", async () => {
+      await manager.registerServer("retry-establish", {
+        url: "http://example.com/mcp",
+        name: "Test Server",
+        retry: { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 2 }
+      });
+      const connection = manager.mcpConnections["retry-establish"];
+      connection.discover = vi.fn().mockImplementation(async () => {
+        connection.connectionState = "ready";
+        return { success: true };
+      });
+      const connect = vi
+        .spyOn(manager, "connectToServer")
+        .mockResolvedValueOnce({ state: "failed", error: "transient" })
+        .mockResolvedValueOnce({ state: "connected" });
+
+      await manager.establishConnection("retry-establish");
+
+      expect(connect).toHaveBeenCalledTimes(2);
+      expect(connection.discover).toHaveBeenCalledOnce();
+    });
+
+    it("finishes restore work before migrating a server id", async () => {
+      storeServer("old-id", 1);
+      const pending = createDeferred<{
+        state: typeof MCPConnectionState.CONNECTED;
+      }>();
+      vi.spyOn(manager, "connectToServer").mockReturnValue(pending.promise);
+      await manager.restoreConnectionsFromStorage("test-agent");
+
+      const connection = manager.mcpConnections["old-id"];
+      const discover = vi.fn().mockImplementation(async () => {
+        connection.connectionState = "ready";
+        return { success: true };
+      });
+      connection.discover = discover;
+
+      const migration = manager.migrateServerId(
+        "old-id",
+        "stable-id",
+        "test-agent"
+      );
+      pending.resolve({ state: "connected" });
+      await migration;
+
+      expect(discover).toHaveBeenCalledOnce();
+      expect(manager.mcpConnections["stable-id"]).toBe(connection);
+      expect(mockStorageData.has("old-id")).toBe(false);
+    });
+
+    it("drains replacement work registered while migration waits", async () => {
+      const first = createDeferred<void>();
+      const second = createDeferred<void>();
+      manager.trackConnection("old-id", first.promise);
+
+      let migrated = false;
+      const migration = manager
+        .migrateServerId("old-id", "stable-id", "test-agent")
+        .then(() => {
+          migrated = true;
+        });
+      manager.trackConnection("old-id", second.promise);
+      first.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(migrated).toBe(false);
+
+      second.resolve();
+      await migration;
+      expect(migrated).toBe(true);
+    });
+
+    it("closes a connection replaced through connect() and clears its session", async () => {
+      await manager.registerServer("replace", {
+        url: "http://example.com/mcp",
+        name: "Test Server",
+        transport: {
+          type: "streamable-http",
+          sessionId: "old-session"
+        }
+      });
+      const replaced = manager.mcpConnections.replace;
+      replaced.close = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(MCPClientConnection.prototype, "init").mockResolvedValue(
+        undefined
+      );
+      vi.spyOn(manager, "discoverIfConnected").mockResolvedValue({
+        success: true,
+        state: "ready"
+      });
+
+      await manager.connect("http://example.com/mcp", {
+        reconnect: { id: "replace" }
+      });
+
+      expect(replaced.close).toHaveBeenCalledOnce();
+      expect(manager.mcpConnections.replace).not.toBe(replaced);
+      const options = JSON.parse(
+        mockStorageData.get("replace")?.server_options ?? "{}"
+      );
+      expect(options.transport.sessionId).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Harden three supported MCP connection-recovery paths:

- apply persisted retry budgets when `connectToServer()` reports `{ state: "failed" }` instead of throwing;
- finish in-flight restore/discovery work before migrating an auto-generated server id to a caller-supplied stable id;
- close a connection replaced through the legacy `connect()` path and clear its terminated persisted session id.

## Why this is needed

`tryN()` only retries thrown errors, while MCP connection failures normally resolve as a failed result. Documented retry options therefore stopped after one attempt. Stable-id migration could also rename a connection while restore still addressed the old id, orphaning discovery. Finally, the internally-used legacy reconnect path dropped replaced transports without closing them.

The minimized regression tests still fail on current `main` for all three symptoms and pass with this branch.

## Validation

- `pnpm --filter agents exec vitest run src/tests/mcp` — 30 files, 553 tests passed
- focused package lint and both Agents TypeScript projects passed
- build, exports, formatting, and repo lint passed
- repo-wide typecheck remains blocked by unchanged `main` voice errors in `examples/voice-agent` and `voice-providers/assemblyai`

Includes a patch changeset for `agents`.
