### PR TITLE
fix(mcp): preserve capability seeds until handshake

### DIFF
--- a/.changeset/mcp-defer-capability-seed-clear.md
+++ b/.changeset/mcp-defer-capability-seed-clear.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+---
+
+MCP client: consume the persisted capability seed at first use instead of at restore-time read
+
+The capability stamp persisted on each MCP server row (used to re-advertise elicitation modes at the handshake after Durable Object hibernation) was read-and-cleared when the connection object was created, before any connection attempt. Wakes that never reached a handshake burned it: a restore that parked on a pending OAuth flow, or a wake interrupted between restore and `onStart` re-stamping the rows, left the next wake's connections negotiating without the elicitation capability until some later reconnect.
+
+The stamp is now read without clearing and only cleared once a seeded handshake actually completes in a session that has not configured handlers, preserving the one-successful-restore semantics: after the seed is used in a completed handshake it no longer re-advertises stale modes, and any `configureElicitationHandlers` call still re-stamps every row. Sessions with handlers configured own their row stamps, so a handshake there (e.g. re-adding a server under a stable id) keeps the fresh stamp in place for the next wake.

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -615,30 +615,27 @@ export class MCPClientManager {
   }
 
   /**
-   * Read and clear the capabilities persisted on a stored server row. The
-   * stamp is valid for one restore: sessions that configure handlers re-stamp
-   * every row, so a deploy that stops configuring them stops advertising
-   * stale modes after its first wake instead of forever.
+   * Clear the capabilities persisted on a stored server row. Called once a
+   * seeded connection's handshake completes (see `createConnection`): the
+   * stamp is valid for one successful restore — sessions that configure
+   * handlers re-stamp every row, so a deploy that stops configuring them
+   * stops advertising stale modes after its first connected wake instead of
+   * forever, while wakes that never handshake don't burn the stamp.
    */
-  private consumeStoredCapabilities(
-    serverId: string
-  ): ClientCapabilities | undefined {
+  private clearStoredCapabilities(serverId: string): void {
     const rows = this.sql<MCPServerRow>(
       "SELECT id, name, server_url, client_id, auth_url, callback_url, server_options FROM cf_agents_mcp_servers WHERE id = ?",
       serverId
     );
     const row = rows[0];
-    if (!row?.server_options) return undefined;
+    if (!row?.server_options) return;
     const options: MCPServerOptions = JSON.parse(row.server_options);
-    const capabilities = options.capabilities;
-    if (capabilities) {
-      options.capabilities = undefined;
-      this.saveServerToStorage({
-        ...row,
-        server_options: JSON.stringify(options)
-      });
-    }
-    return capabilities;
+    if (!options.capabilities) return;
+    options.capabilities = undefined;
+    this.saveServerToStorage({
+      ...row,
+      server_options: JSON.stringify(options)
+    });
   }
 
   /**
@@ -1205,6 +1202,14 @@ export class MCPClientManager {
       type: options.transport?.type ?? ("auto" as TransportType)
     };
 
+    // Stored servers re-advertise the capabilities persisted on their row
+    // (see MCPServerOptions.capabilities); fresh registrations have no row
+    // yet and rely on the handlers below. The stamp is read without
+    // clearing so a wake that never handshakes (OAuth still pending, isolate
+    // death before connect) doesn't burn it — it is consumed at first use,
+    // once a seeded handshake completes.
+    const capabilitySeed = this.getStoredServerOptions(id)?.capabilities;
+
     this.mcpConnections[id] = new MCPClientConnection(
       new URL(url),
       {
@@ -1215,10 +1220,7 @@ export class MCPClientManager {
         client: options.client ?? {},
         transport: normalizedTransport,
         elicitationHandlers: this.scopedElicitationHandlers(id),
-        // Stored servers re-advertise the capabilities persisted on their
-        // row (see MCPServerOptions.capabilities); fresh registrations have
-        // no row yet and rely on the handlers above.
-        capabilitySeed: this.consumeStoredCapabilities(id)
+        capabilitySeed
       }
     );
 
@@ -1232,6 +1234,36 @@ export class MCPClientManager {
         this._onObservabilityEvent.fire(event);
       })
     );
+
+    if (capabilitySeed) {
+      const conn = this.mcpConnections[id];
+      // Every handshake reports its success through this event, so it marks
+      // the seed's first use. The burn only targets deploys that stopped
+      // configuring handlers: a session with handlers configured owns the
+      // row stamps (each configure call re-stamps them, and re-registering
+      // a server writes a fresh one), and configureElicitationHandlers
+      // drops the in-memory seed on live connections — either way a fresh
+      // stamp meant for the next wake is never wiped here.
+      const seedClear = conn.onObservabilityEvent((event) => {
+        if (
+          event.type !== "mcp:client:connect" ||
+          event.payload.state !== MCPConnectionState.CONNECTED
+        ) {
+          return;
+        }
+        seedClear.dispose();
+        if (this._elicitationHandlers || !conn.options.capabilitySeed) return;
+        // migrateServerId may have renamed the row while the handshake was
+        // in flight — clear under the connection's current id.
+        const currentId = Object.keys(this.mcpConnections).find(
+          (key) => this.mcpConnections[key] === conn
+        );
+        if (currentId) {
+          this.clearStoredCapabilities(currentId);
+        }
+      });
+      store.add(seedClear);
+    }
 
     return this.mcpConnections[id];
   }

--- a/packages/agents/src/tests/mcp/client-elicitation.test.ts
+++ b/packages/agents/src/tests/mcp/client-elicitation.test.ts
@@ -592,8 +592,119 @@ describe("MCP client elicitation options (#1875)", () => {
       expect(options.capabilities).toEqual({ elicitation: { form: {} } });
     });
 
-    it("the persisted capability survives one restore, then requires reconfiguration", async () => {
-      const { storage } = createMockStorage();
+    it("the persisted capability survives one seeded handshake, then requires reconfiguration", async () => {
+      // The stamp is consumed at first use (a completed handshake), not at
+      // restore-time read, so the wake must actually connect — done here
+      // over RPC.
+      const { storage, rows } = createMockStorage();
+      const name = crypto.randomUUID();
+
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerA.configureElicitationHandlers({
+        form: async () => ({ action: "accept", content: {} })
+      });
+      managerA.saveRpcServerToStorage("srv-rpc", "rpc-server", name, "MCP");
+
+      // First connected wake after the deploy stopped configuring handlers:
+      // the stamp still seeds the handshake once
+      const managerB = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      await managerB.connect(`rpc://${name}`, {
+        reconnect: { id: "srv-rpc" },
+        transport: { type: "rpc", namespace: env.MCP_OBJECT, name }
+      });
+      expect(
+        advertisedCapabilities(managerB.mcpConnections["srv-rpc"]).elicitation
+      ).toEqual({ form: {} });
+
+      // The completed seeded handshake consumed the stamp
+      const options = JSON.parse(rows.get("srv-rpc")?.server_options ?? "{}");
+      expect(options.capabilities).toBeUndefined();
+
+      // Next wake with no configure call in between: the stale mode is no
+      // longer advertised, so servers use their non-elicitation fallbacks
+      const managerC = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      await managerC.connect(`rpc://${name}`, {
+        reconnect: { id: "srv-rpc" },
+        transport: { type: "rpc", namespace: env.MCP_OBJECT, name }
+      });
+      expect(
+        advertisedCapabilities(managerC.mcpConnections["srv-rpc"]).elicitation
+      ).toBeUndefined();
+    });
+
+    it("a stable-id re-add in a configuring session keeps the row stamped for the next wake", async () => {
+      const { storage, rows } = createMockStorage();
+      const name = crypto.randomUUID();
+
+      // Previous session stamped the row under a stable id
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerA.configureElicitationHandlers({
+        form: async () => ({ action: "accept", content: {} })
+      });
+      managerA.saveRpcServerToStorage("srv-rpc", "rpc-server", name, "MCP");
+
+      // New session configures before the connection object exists, then
+      // re-adds the same stable id: createConnection reads the row stamp as
+      // a seed and registerServer writes a fresh one before the handshake
+      const managerB = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerB.configureElicitationHandlers({
+        form: async () => ({ action: "accept", content: {} })
+      });
+      await managerB.registerServer("srv-rpc", {
+        url: `rpc://${name}`,
+        name: "rpc-server",
+        transport: { type: "rpc", namespace: env.MCP_OBJECT, name }
+      });
+      const result = await managerB.connectToServer("srv-rpc");
+      expect(result.state).toBe("connected");
+
+      // The session configures handlers every wake, so the completed
+      // handshake must not burn the fresh stamp meant for the next wake
+      const options = JSON.parse(rows.get("srv-rpc")?.server_options ?? "{}");
+      expect(options.capabilities).toEqual({ elicitation: { form: {} } });
+    });
+
+    it("re-adding a closed server in a configuring session keeps the row stamped", async () => {
+      const { storage, rows } = createMockStorage();
+      const name = crypto.randomUUID();
+      const manager = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      manager.configureElicitationHandlers({
+        url: async () => ({ action: "accept", content: {} })
+      });
+      const register = () =>
+        manager.registerServer("srv-rpc", {
+          url: `rpc://${name}`,
+          name: "rpc-server",
+          transport: { type: "rpc", namespace: env.MCP_OBJECT, name }
+        });
+      await register();
+      await manager.connectToServer("srv-rpc");
+      // The row (and its stamp) survives the close; only removeServer deletes it
+      await manager.closeConnection("srv-rpc");
+
+      // Re-add: createConnection reads the stamped row as a seed before
+      // registerServer re-stamps it and the handshake completes
+      await register();
+      await manager.connectToServer("srv-rpc");
+
+      const options = JSON.parse(rows.get("srv-rpc")?.server_options ?? "{}");
+      expect(options.capabilities).toEqual({ elicitation: { url: {} } });
+    });
+
+    it("an OAuth-pending restore keeps the capability seed for the wake that connects", async () => {
+      const { storage, rows } = createMockStorage();
       const managerA = new MCPClientManager("test-client", "1.0.0", {
         storage
       });
@@ -607,20 +718,21 @@ describe("MCP client elicitation options (#1875)", () => {
         authUrl: "http://example.com/authorize"
       });
 
-      // First wake after the deploy stopped configuring handlers: the stamp
-      // still seeds the connection once
+      // Wake 1: OAuth is still pending, so restore parks the connection in
+      // AUTHENTICATING and never handshakes — the stamp must not be burned
       const managerB = new MCPClientManager("test-client", "1.0.0", {
         storage,
         createAuthProvider: () =>
           ({ serverId: undefined, clientId: undefined }) as never
       });
       await managerB.restoreConnectionsFromStorage("test-client");
-      expect(
-        advertisedCapabilities(managerB.mcpConnections["srv-1"]).elicitation
-      ).toEqual({ form: {} });
+      expect(managerB.mcpConnections["srv-1"].connectionState).toBe(
+        "authenticating"
+      );
+      const options = JSON.parse(rows.get("srv-1")?.server_options ?? "{}");
+      expect(options.capabilities).toEqual({ elicitation: { form: {} } });
 
-      // Second wake with no configure call in between: the stale mode is no
-      // longer advertised, so servers use their non-elicitation fallbacks
+      // Wake 2: the seed still covers the handshake
       const managerC = new MCPClientManager("test-client", "1.0.0", {
         storage,
         createAuthProvider: () =>
@@ -629,7 +741,49 @@ describe("MCP client elicitation options (#1875)", () => {
       await managerC.restoreConnectionsFromStorage("test-client");
       expect(
         advertisedCapabilities(managerC.mcpConnections["srv-1"]).elicitation
-      ).toBeUndefined();
+      ).toEqual({ form: {} });
+    });
+
+    it("a wake interrupted before the handshake does not burn the capability seed", async () => {
+      const { storage, rows } = createMockStorage();
+      const managerA = new MCPClientManager("test-client", "1.0.0", {
+        storage
+      });
+      managerA.configureElicitationHandlers({
+        url: async () => ({ action: "accept", content: {} })
+      });
+      await managerA.registerServer("srv-1", {
+        url: "http://example.com/mcp",
+        name: "example"
+      });
+
+      // Wake 1 is interrupted between restore and the handshake (deploy
+      // reset, OOM, a throw before onStart re-stamps): init never connects
+      const initSpy = vi
+        .spyOn(MCPClientConnection.prototype, "init")
+        .mockResolvedValue(undefined);
+      try {
+        const managerB = new MCPClientManager("test-client", "1.0.0", {
+          storage
+        });
+        await managerB.restoreConnectionsFromStorage("test-client");
+        await managerB.waitForConnections();
+
+        const options = JSON.parse(rows.get("srv-1")?.server_options ?? "{}");
+        expect(options.capabilities).toEqual({ elicitation: { url: {} } });
+
+        // Wake 2 still seeds the handshake with the stamped capability
+        const managerC = new MCPClientManager("test-client", "1.0.0", {
+          storage
+        });
+        await managerC.restoreConnectionsFromStorage("test-client");
+        await managerC.waitForConnections();
+        expect(
+          advertisedCapabilities(managerC.mcpConnections["srv-1"]).elicitation
+        ).toEqual({ url: {} });
+      } finally {
+        initSpy.mockRestore();
+      }
     });
 
     it("a server id migration preserves the restored capability seed", async () => {


### PR DESCRIPTION
## Summary

- read a restored MCP capability seed without immediately deleting it
- consume the seed only after it participates in a successful connection handshake
- preserve fresh row stamps when elicitation handlers are configured in the current session

## Why

The persisted capability stamp bridges the restore-to-`onStart` window after Durable Object hibernation. It was previously cleared as soon as a connection object was created, so a wake parked on OAuth or interrupted before connecting could burn the stamp without advertising it. The following wake then negotiated without the configured elicitation modes.

A seed now survives wakes that never handshake. It is cleared after one successful seeded restore when no handlers were configured, retaining the existing protection against advertising stale modes after an application removes its handlers. Configuring handlers continues to re-stamp stored rows for the next wake.

## Review follow-up

- the clear listener only consumes a seed when no handlers are configured in the current session
- stable-id re-add and close/re-add flows preserve the fresh stamp owned by configured handlers
- the repair and mutation-test rounds found no remaining issues

## Validation

- `pnpm --filter agents exec vitest run src/tests/mcp` — 29 files, 536 tests passed
- `pnpm run check` — passed
- regression coverage includes OAuth-pending restore, interruption before handshake, one-use expiry, stable-id re-add, and close/re-add with active handlers

Includes a patch changeset for `agents`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
