### PR TITLE
fix(mcp): harden OAuth callback recovery

### DIFF
--- a/.changeset/mcp-oauth-callback-robustness.md
+++ b/.changeset/mcp-oauth-callback-robustness.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Verify MCP OAuth callback state before changing a connection. Forged, expired, and replayed callbacks no longer disrupt the genuine authorization flow, and `addMcpServer()` refreshes auth URLs whose embedded state has expired.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -12426,12 +12426,18 @@ export class Agent<
     if (existingServer && this.mcp.mcpConnections[existingServer.id]) {
       const conn = this.mcp.mcpConnections[existingServer.id];
       if (conn.connectionState === MCPConnectionState.AUTHENTICATING) {
-        const liveAuthUrl = conn.options.transport.authProvider?.authUrl;
+        const authProvider = conn.options.transport.authProvider;
         const authUrl =
-          liveAuthUrl ||
-          (this._isAbsoluteHttpUrl(existingServer.auth_url)
-            ? existingServer.auth_url
-            : undefined);
+          (await this._redeemableAuthUrl(
+            existingServer.id,
+            authProvider?.authUrl,
+            authProvider
+          )) ??
+          (await this._redeemableAuthUrl(
+            existingServer.id,
+            existingServer.auth_url,
+            authProvider
+          ));
         if (authUrl) {
           return {
             id: existingServer.id,
@@ -12681,6 +12687,23 @@ export class Agent<
     }
 
     return { id, state: MCPConnectionState.READY };
+  }
+
+  private async _redeemableAuthUrl(
+    serverId: string,
+    authUrl: string | null | undefined,
+    authProvider: AgentMcpOAuthProvider | undefined
+  ): Promise<string | undefined> {
+    if (!this._isAbsoluteHttpUrl(authUrl) || !authProvider) return;
+    const state = new URL(authUrl).searchParams.get("state");
+    if (!state) return authUrl;
+
+    authProvider.serverId = serverId;
+    try {
+      return (await authProvider.checkState(state)).valid ? authUrl : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   private _isAbsoluteHttpUrl(

--- a/packages/agents/src/mcp/client.ts
+++ b/packages/agents/src/mcp/client.ts
@@ -755,6 +755,29 @@ export class MCPClientManager {
     return callback();
   }
 
+  private async hasRedeemableOAuthState(
+    serverId: string,
+    authProvider: AgentMcpOAuthProvider,
+    state: string
+  ): Promise<boolean> {
+    authProvider.serverId = serverId;
+    try {
+      return (await authProvider.checkState(state)).valid;
+    } catch {
+      return false;
+    }
+  }
+
+  private ignoreUnverifiedCallback(
+    serverId: string,
+    error: string
+  ): MCPOAuthCallbackResult {
+    console.warn(
+      `[MCPClientManager] Ignoring OAuth callback with unverified state for server "${serverId}": ${error}`
+    );
+    return { serverId, authSuccess: false, authError: error };
+  }
+
   private async consumeStaleOAuthState(
     serverId: string,
     authProvider: AgentMcpOAuthProvider,
@@ -1558,6 +1581,24 @@ export class MCPClientManager {
           }
           return this.oauthCallbackSuccess(validation.serverId, conn);
         }
+        // Only a callback carrying a genuine state nonce may fail the
+        // connection; a stray or invalid callback must not alter the
+        // connection state machine.
+        const authProvider = conn.options.transport.authProvider;
+        if (
+          validation.state &&
+          authProvider &&
+          !(await this.hasRedeemableOAuthState(
+            validation.serverId,
+            authProvider,
+            validation.state
+          ))
+        ) {
+          return this.ignoreUnverifiedCallback(
+            validation.serverId,
+            validation.error
+          );
+        }
         return this.failConnection(validation.serverId, validation.error);
       }
 
@@ -1589,7 +1630,12 @@ export class MCPClientManager {
           await this.consumeStaleOAuthState(serverId, authProvider, state);
           return this.oauthCallbackSuccess(serverId, conn);
         }
-        throw new Error(stateValidation.error || "Invalid state");
+        // Same rule as the invalid branch above: a callback whose nonce
+        // cannot be verified must not alter the connection state machine.
+        return this.ignoreUnverifiedCallback(
+          serverId,
+          stateValidation.error || "Invalid state"
+        );
       }
 
       // A stale popup can complete after another callback already exchanged tokens.
@@ -1599,12 +1645,16 @@ export class MCPClientManager {
         return this.oauthCallbackSuccess(serverId, conn);
       }
 
-      if (conn.connectionState !== MCPConnectionState.AUTHENTICATING) {
+      if (
+        conn.connectionState !== MCPConnectionState.AUTHENTICATING &&
+        conn.connectionState !== MCPConnectionState.FAILED
+      ) {
         throw new Error(
-          `Failed to authenticate: the client is in "${conn.connectionState}" state, expected "authenticating"`
+          `Failed to authenticate from "${conn.connectionState}" state`
         );
       }
 
+      // A genuine callback can recover a flow that previously entered FAILED.
       conn.connectionState = MCPConnectionState.CONNECTING;
       await authProvider.consumeState(state);
       await this.completeAuthorizationAndCleanupVerifier(

--- a/packages/agents/src/tests/agents/oauth.ts
+++ b/packages/agents/src/tests/agents/oauth.ts
@@ -155,6 +155,24 @@ export class TestOAuthAgent extends Agent {
     this.mockStateStorage.set(nonce, { serverId, createdAt: Date.now() });
   }
 
+  async seedPersistedOAuthState(
+    serverId: string,
+    nonce: string,
+    ageMs = 0
+  ): Promise<void> {
+    const provider = new DurableObjectOAuthClientProvider(
+      this.ctx.storage,
+      this.name,
+      "http://example.com/oauth/callback"
+    );
+    provider.serverId = serverId;
+    await this.ctx.storage.put(provider.stateKey(nonce), {
+      nonce,
+      serverId,
+      createdAt: Date.now() - ageMs
+    });
+  }
+
   setupMockMcpConnection(
     serverId: string,
     serverName: string,

--- a/packages/agents/src/tests/mcp/client-manager.test.ts
+++ b/packages/agents/src/tests/mcp/client-manager.test.ts
@@ -680,7 +680,7 @@ describe("MCPClientManager OAuth Integration", () => {
       expect(result.serverId).toBe(serverId);
     });
 
-    it("should fail connection when callback received for connection in failed state", async () => {
+    it("should complete a genuine callback received for a connection in failed state", async () => {
       const serverId = "test-server";
       const callbackUrl = "http://localhost:3000/callback";
       const stateStorage = createMockStateStorage();
@@ -708,6 +708,12 @@ describe("MCPClientManager OAuth Integration", () => {
       connection.init = vi.fn().mockResolvedValue(undefined);
       connection.client.close = vi.fn().mockResolvedValue(undefined);
       connection.connectionState = "failed";
+      connection.connectionError = "spurious failure";
+      const completeAuthSpy = vi
+        .spyOn(connection, "completeAuthorization")
+        .mockImplementation(async () => {
+          connection.connectionState = "connecting";
+        });
 
       manager.mcpConnections[serverId] = connection;
 
@@ -717,10 +723,11 @@ describe("MCPClientManager OAuth Integration", () => {
       );
 
       const result = await manager.handleCallbackRequest(callbackRequest);
-      expect(result.authSuccess).toBe(false);
-      expect(result.authError).toBe(
-        'Failed to authenticate: the client is in "failed" state, expected "authenticating"'
-      );
+      expect(result.authSuccess).toBe(true);
+      expect(completeAuthSpy).toHaveBeenCalledWith("test", {
+        alreadyAccepted: true
+      });
+      expect(connection.connectionError).toBe(null);
     });
 
     it("should recognize custom callback paths that do not contain '/callback'", async () => {
@@ -757,6 +764,83 @@ describe("MCPClientManager OAuth Integration", () => {
       expect(
         manager.isCallbackRequest(new Request(`${customCallbackUrl}?code=test`))
       ).toBe(false);
+    });
+  });
+
+  describe("OAuth Callback Robustness", () => {
+    const serverId = "test-server";
+    const callbackUrl = "http://localhost:3000/callback";
+    const authUrl = "https://auth.example.com/authorize";
+
+    function setupAuthenticatingConnection(
+      stateStorage: ReturnType<typeof createMockStateStorage>
+    ) {
+      saveServerToMock({
+        id: serverId,
+        name: "Test Server",
+        server_url: "http://test.com",
+        callback_url: callbackUrl,
+        client_id: null,
+        auth_url: authUrl,
+        server_options: null
+      });
+
+      const mockAuthProvider = createMockAuthProvider(stateStorage);
+      const connection = new MCPClientConnection(
+        new URL("http://test.com"),
+        { name: "test-client", version: "1.0.0" },
+        {
+          transport: { type: "auto", authProvider: mockAuthProvider },
+          client: {}
+        }
+      );
+      connection.init = vi.fn().mockResolvedValue(undefined);
+      connection.client.close = vi.fn().mockResolvedValue(undefined);
+      connection.connectionState = "authenticating";
+      manager.mcpConnections[serverId] = connection;
+      return connection;
+    }
+
+    it("ignores an error callback whose state nonce was never issued", async () => {
+      const stateStorage = createMockStateStorage();
+      const connection = setupAuthenticatingConnection(stateStorage);
+
+      const strayState = `${nanoid()}.${serverId}`;
+      const result = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?error=access_denied&state=${strayState}`)
+      );
+
+      expect(result.authSuccess).toBe(false);
+      expect(result.authError).toBe("access_denied");
+      expect(connection.connectionState).toBe("authenticating");
+      expect(mockStorageData.get(serverId)?.auth_url).toBe(authUrl);
+    });
+
+    it("completes a genuine callback after a stray code callback", async () => {
+      const stateStorage = createMockStateStorage();
+      const connection = setupAuthenticatingConnection(stateStorage);
+      const completeAuthSpy = vi
+        .spyOn(connection, "completeAuthorization")
+        .mockImplementation(async () => {
+          connection.connectionState = "connecting";
+        });
+
+      const state = stateStorage.createState(serverId);
+
+      const strayResult = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=x&state=${nanoid()}.${serverId}`)
+      );
+      expect(strayResult.authSuccess).toBe(false);
+      expect(connection.connectionState).toBe("authenticating");
+
+      const result = await manager.handleCallbackRequest(
+        new Request(`${callbackUrl}?code=auth-code&state=${state}`)
+      );
+
+      expect(result.authSuccess).toBe(true);
+      expect(completeAuthSpy).toHaveBeenCalledWith("auth-code", {
+        alreadyAccepted: true
+      });
     });
   });
 
@@ -858,6 +942,7 @@ describe("MCPClientManager OAuth Integration", () => {
       const result2 = await manager.handleCallbackRequest(callbackRequest2);
       expect(result2.authSuccess).toBe(false);
       expect(result2.authError).toBe("State not found or already used");
+      expect(connection.connectionState).toBe("authenticating");
     });
 
     it("should reject expired state (10 minute TTL)", async () => {
@@ -897,6 +982,7 @@ describe("MCPClientManager OAuth Integration", () => {
       const result = await manager.handleCallbackRequest(callbackRequest);
       expect(result.authSuccess).toBe(false);
       expect(result.authError).toBe("State expired");
+      expect(connection.connectionState).toBe("authenticating");
     });
 
     it("should only match callbacks with valid state for existing servers", async () => {

--- a/packages/agents/src/tests/mcp/oauth2-mcp-client.test.ts
+++ b/packages/agents/src/tests/mcp/oauth2-mcp-client.test.ts
@@ -343,6 +343,34 @@ describe("OAuth2 MCP Client - addMcpServer on restored connections", () => {
     ).toBe("OAuth configuration incomplete: missing authUrl");
   });
 
+  it("reconnects when a persisted auth URL embeds expired state", async () => {
+    const agentName = `test-stale-oauth-url-${nanoid(8)}`;
+    const agentStub = env.TestOAuthAgent.getByName(agentName);
+    const serverId = nanoid(8);
+    const serverUrl = "http://example.com/mcp";
+    const nonce = nanoid();
+    const staleUrl = `https://auth.example.com/authorize?state=${nonce}.${serverId}`;
+    const freshUrl = `https://auth.example.com/fresh/${serverId}`;
+
+    await restoreOAuthConnection(
+      agentStub,
+      agentName,
+      serverId,
+      serverUrl,
+      staleUrl
+    );
+    await agentStub.seedPersistedOAuthState(serverId, nonce, 11 * 60 * 1000);
+    await agentStub.configureMcpReconnect(serverId, "authenticating", freshUrl);
+
+    expect(
+      await agentStub.testAddMcpServer("test-oauth-server", serverUrl)
+    ).toEqual({
+      id: serverId,
+      state: "authenticating",
+      authUrl: freshUrl
+    });
+  });
+
   it("reconnects instead of returning unusable persisted auth URLs", async () => {
     const unusableAuthUrls = [
       "::::",


### PR DESCRIPTION
## Summary

Harden the MCP OAuth callback state machine:

- verify a callback's state nonce before it can fail or otherwise mutate a connection;
- leave the active flow unchanged for forged, expired, or replayed state;
- allow a genuine callback to complete a flow that previously entered `failed`;
- make `addMcpServer()` reconnect when an authorization URL embeds expired state, so it returns a fresh flow instead of an unusable URL.

## Why this is needed

A well-formed callback carrying an unknown nonce could move an in-flight connection from `authenticating` to `failed` and clear its authorization URL. The genuine callback was then rejected. Separately, preserving the connection on expired state requires refreshing the expired URL or the flow remains stuck.

The minimized callback tests and stale-flow integration test both fail on current `main` and pass with this branch.

## Validation

- `pnpm --filter agents exec vitest run src/tests/mcp` — 30 files, 549 tests passed
- focused package lint and both Agents TypeScript projects passed
- build, exports, and formatting passed
- repo-wide typecheck remains blocked by unchanged `main` voice errors in `examples/voice-agent` and `voice-providers/assemblyai`

Includes a patch changeset for `agents`.
