### PR TITLE
agent-think: Install Python in sandbox image

### DIFF
--- a/agent-think/Dockerfile
+++ b/agent-think/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates curl xz-utils git bash unzip \
       fuse3 libfuse2t64 \
-      build-essential \
+      build-essential python3 \
       gh jq \
  && rm -rf /var/lib/apt/lists/*
 
@@ -68,10 +68,9 @@ COPY --from=wsd /usr/local/bin/wsd /usr/local/bin/wsd
 #                          and most language runtimes honour this.
 #   - NODE_EXTRA_CA_CERTS — Node's TLS stack. Appends to its bundled
 #                          CA list (not a replacement).
-#   - REQUESTS_CA_BUNDLE  — Python's `requests`. Harmless when Python
-#                          isn't installed; cheap insurance for any
-#                          future Python add-ons or `pip` calls a
-#                          user invokes via `exec`.
+#   - REQUESTS_CA_BUNDLE  — Python's `requests`. Keeps Python add-ons
+#                          and `pip` calls made through `exec` on the
+#                          same trusted bundle.
 #
 # Setting all three before the Node/Bun install means the global
 # `npm install -g esbuild wrangler` and Bun bootstrap below also run


### PR DESCRIPTION
The agent-think sandbox includes a native compiler toolchain, but it does not include Python. Packages that fall back to `node-gyp`, including dependencies used by the Agents monorepo, fail before compilation because `node-gyp` cannot find a Python executable.

Install `python3` with the existing build tools. This lets the sandbox clone the Agents repository and complete `pnpm install`, while keeping Python network clients on the container's configured certificate bundle.

Verify by building `agent-think/Dockerfile`, then run `python3 --version` in the resulting image. A full clone and `pnpm install` of `cloudflare/agents` also completes successfully in the local container-backed end-to-end harness.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->