### PR TITLE
docs(agents): document current ctx.id.name availability and pin it with a cold-wake test

### DIFF
--- a/docs/agents/agent-class.md
+++ b/docs/agents/agent-class.md
@@ -183,7 +183,15 @@ There's also `this.broadcast` that sends a WS message to all connected clients (
 
 ### `this.name`
 
-It's hard to get a Durable Object's `name` from within it. `partyserver` tries to make it available in `this.name` but it's not a perfect solution. Read more about it [here](https://github.com/cloudflare/workerd/issues/2240).
+Since [2026-03-15](https://developers.cloudflare.com/changelog/post/2026-03-15-durable-object-id-name/), the Workers runtime populates `ctx.id.name` inside a Durable Object addressed via `idFromName()` or `getByName()` — from construction onward, including alarm handlers. `partyserver` reads `ctx.id.name` first, so for named access `this.name` resolves natively with no extra machinery.
+
+`ctx.id.name` is still `undefined` — permanently, [by design](https://developers.cloudflare.com/durable-objects/api/id/#name) — in three cases:
+
+- the object is addressed via `idFromString()` (even if the id was originally created with `idFromName()`) or `newUniqueId()`;
+- the name is longer than 1,024 bytes;
+- the alarm firing was scheduled before 2026-03-15 (reschedule it from a `fetch()` or RPC handler where the name is available).
+
+For those cases `partyserver` falls back to a legacy name record in storage (written by the `setName()` bootstrap), and `this.name` throws if no name can be resolved at all.
 
 ## Layer 2: Agent
 

--- a/docs/agents/agent-class.md
+++ b/docs/agents/agent-class.md
@@ -183,15 +183,15 @@ There's also `this.broadcast` that sends a WS message to all connected clients (
 
 ### `this.name`
 
-Since [2026-03-15](https://developers.cloudflare.com/changelog/post/2026-03-15-durable-object-id-name/), the Workers runtime populates `ctx.id.name` inside a Durable Object addressed via `idFromName()` or `getByName()` — from construction onward, including alarm handlers. `partyserver` reads `ctx.id.name` first, so for named access `this.name` resolves natively with no extra machinery.
+Since [2026-03-15](https://developers.cloudflare.com/changelog/post/2026-03-15-durable-object-id-name/), the Workers runtime populates `ctx.id.name` inside a Durable Object addressed via `idFromName()` or `getByName()`, including in alarm handlers. Constructor-time availability isn't spelled out in the docs, but workerd's own tests pin it ([workerd#6421](https://github.com/cloudflare/workerd/pull/6421)), as do `partyserver`'s runtime-contract tests. `partyserver` reads `ctx.id.name` first, so for named access `this.name` resolves natively with no extra machinery.
 
-`ctx.id.name` is still `undefined` — permanently, [by design](https://developers.cloudflare.com/durable-objects/api/id/#name) — in three cases:
+`ctx.id.name` is still `undefined` in these cases (see [the DO id docs](https://developers.cloudflare.com/durable-objects/api/id/#name)):
 
-- the object is addressed via `idFromString()` (even if the id was originally created with `idFromName()`) or `newUniqueId()`;
+- the object is addressed via `idFromString()` (even if the id was originally created with `idFromName()`) or `newUniqueId()` — deliberate design, not a gap;
 - the name is longer than 1,024 bytes;
-- the alarm firing was scheduled before 2026-03-15 (reschedule it from a `fetch()` or RPC handler where the name is available).
+- the alarm firing was scheduled before 2026-03-15, or was scheduled from a context that itself had no name (reschedule it from a `fetch()` or RPC handler where the name is available).
 
-For those cases `partyserver` falls back to a legacy name record in storage (written by the `setName()` bootstrap), and `this.name` throws if no name can be resolved at all.
+For those cases `partyserver` falls back to a legacy name record in storage (written automatically during named-access initialization, or by the `setName()` bootstrap for raw-id DOs), and `this.name` throws if no name can be resolved at all.
 
 ## Layer 2: Agent
 

--- a/docs/shell/index.md
+++ b/docs/shell/index.md
@@ -94,7 +94,7 @@ All options are passed as a single object to `new Workspace(options)`.
 
 ### Lazy name resolution
 
-In Durable Objects, `this.name` is not available at class field initialization time. Pass a function to defer evaluation:
+In Durable Objects, `this.name` may not be resolvable at class field initialization time (for example, reading it throws when the object was addressed by raw id instead of by name). Pass a function to defer evaluation:
 
 ```typescript
 class MyAgent extends Agent<Env> {

--- a/packages/agents/src/tests/name-resolution.test.ts
+++ b/packages/agents/src/tests/name-resolution.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { TEST_MESSAGES } from "./shared/test-utils";
+import type { McpAgent } from "../mcp";
+
+// Since 2026-03-15 the Workers runtime populates ctx.id.name inside a
+// Durable Object addressed via idFromName()/getByName(), from construction
+// onward — the name no longer has to be smuggled in through storage.
+// https://developers.cloudflare.com/changelog/post/2026-03-15-durable-object-id-name/
+// https://developers.cloudflare.com/durable-objects/api/id/#name
+//
+// These tests pin that behavior: a cold-woken agent whose first-ever entry
+// point is a native DO RPC call resolves this.name purely from ctx.id.name,
+// with NO __ps_name seeding and no setName() bootstrap. Contrast with the
+// "Cold Wake Initialization" tests in mcp/transports/rpc.test.ts, which seed
+// the legacy __ps_name record — those pin the fallback that still covers
+// pre-2026-03-15 alarm records and raw-id (idFromString()/newUniqueId() +
+// setName()) addressing, where ctx.id.name stays undefined by design.
+describe("this.name resolution from ctx.id.name", () => {
+  it("resolves this.name on a cold agent addressed via idFromName(), without __ps_name seeding", async () => {
+    const doName = `rpc:ctx-id-name-${crypto.randomUUID()}`;
+    const id = env.MCP_OBJECT.idFromName(doName);
+    const stub = env.MCP_OBJECT.get(id) as DurableObjectStub<McpAgent>;
+
+    // No storage seeding — the first contact with this DO is a native RPC
+    // entry point that bypasses fetch/alarm/webSocket paths. Name resolution
+    // must come from ctx.id.name alone.
+    const response = await stub.handleMcpMessage(TEST_MESSAGES.initialize);
+
+    expect(response).toBeDefined();
+    expect(response).toHaveProperty("result");
+
+    const name = await runInDurableObject(stub, (instance) => instance.name);
+    expect(name).toBe(doName);
+  });
+
+  it("resolves this.name on a cold agent addressed via getByName(), without __ps_name seeding", async () => {
+    const doName = `rpc:ctx-id-name-${crypto.randomUUID()}`;
+    const stub = env.MCP_OBJECT.getByName(
+      doName
+    ) as DurableObjectStub<McpAgent>;
+
+    const response = await stub.handleMcpMessage(TEST_MESSAGES.initialize);
+
+    expect(response).toBeDefined();
+    expect(response).toHaveProperty("result");
+
+    const name = await runInDurableObject(stub, (instance) => instance.name);
+    expect(name).toBe(doName);
+  });
+});

--- a/packages/agents/src/tests/name-resolution.test.ts
+++ b/packages/agents/src/tests/name-resolution.test.ts
@@ -12,13 +12,16 @@ import type { McpAgent } from "../mcp";
 //
 // These tests pin that behavior: a cold-woken agent whose first-ever entry
 // point is a native DO RPC call resolves this.name purely from ctx.id.name,
-// with NO __ps_name seeding and no setName() bootstrap. Contrast with the
-// "Cold Wake Initialization" tests in mcp/transports/rpc.test.ts, which seed
-// the legacy __ps_name record — those pin the fallback that still covers
-// pre-2026-03-15 alarm records and raw-id (idFromString()/newUniqueId() +
-// setName()) addressing, where ctx.id.name stays undefined by design.
+// with NO __ps_name seeding and no setName() bootstrap. (The "Cold Wake
+// Initialization" tests in mcp/transports/rpc.test.ts still seed __ps_name,
+// but they address via idFromName(), so under the current runtime the seed
+// is inert — the legacy fallback paths it would feed are pinned upstream in
+// partyserver's own test suite, not here.)
 describe("this.name resolution from ctx.id.name", () => {
   it("resolves this.name on a cold agent addressed via idFromName(), without __ps_name seeding", async () => {
+    // The "rpc:" prefix is load-bearing: McpAgent parses this.name as
+    // `${transport}:${sessionId}`, and handleMcpMessage requires the RPC
+    // transport.
     const doName = `rpc:ctx-id-name-${crypto.randomUUID()}`;
     const id = env.MCP_OBJECT.idFromName(doName);
     const stub = env.MCP_OBJECT.get(id) as DurableObjectStub<McpAgent>;


### PR DESCRIPTION
Since [2026-03-15](https://developers.cloudflare.com/changelog/post/2026-03-15-durable-object-id-name/), the Workers runtime populates `ctx.id.name` inside a Durable Object addressed via `idFromName()`/`getByName()`, including in alarm handlers (constructor-time availability is pinned by workerd's own tests, [workerd#6421](https://github.com/cloudflare/workerd/pull/6421)). Our docs still described names as effectively unavailable inside the DO (citing workerd#2240, which was closed in April).

## Changes

- **`docs/agents/agent-class.md`**: replaces the stale "it's hard / not a perfect solution" caveat on `this.name` with the actual availability matrix: populated for `idFromName()`/`getByName()`; still `undefined` — [per the DO id docs](https://developers.cloudflare.com/durable-objects/api/id/#name) — for `idFromString()`/`newUniqueId()` addressing (deliberate design), names over 1,024 bytes, and alarms scheduled before 2026-03-15 or from a nameless context.
- **`docs/shell/index.md`**: corrects the lazy-name-resolution rationale (the name *may* not be resolvable at field-init time, rather than never being available).
- **`packages/agents/src/tests/name-resolution.test.ts`** (new): pins the new runtime behavior — a cold agent whose first-ever contact is a native RPC call resolves `this.name` purely from `ctx.id.name`, with no `__ps_name` seeding and no `setName()` bootstrap, for both `idFromName()` and `getByName()` addressing. The existing cold-wake tests in `mcp/transports/rpc.test.ts` that seed `__ps_name` are deliberately untouched; note that since they address via `idFromName()`, their seeds are inert under the current runtime — the legacy fallback paths are pinned upstream in partyserver's own test suite.

## Deliberately not in this PR

- Removing the constructor-time name guards or the `__ps_name` fallback machinery — that requires a partyserver major (deprecation started in cloudflare/partykit#413).
- Bumping miniflare to ≥ 4.20260706.0 for local alarm-after-eviction name parity (separate infra change).
- A length guard for logical names approaching the 1,024-byte `ctx.id.name` cap (open design question).

## Testing

- `pnpm run check` green (exports, format, lint, all 116 TS projects).
- New test file passes locally: 2/2 under the workers pool (miniflare 4.20260625.0).