### PR TITLE
agent-think: Use team Gateway and continue failed runs

### DIFF
--- a/agent-think/.env_example
+++ b/agent-think/.env_example
@@ -8,6 +8,9 @@
 # repo read is enough to reproduce; opening PRs needs contents + pull_requests
 # write.
 GH_TOKEN=
+# Team AI Gateway token used for model inference in local agent turns.
+# Production stores this as a Worker secret; never commit the value.
+CLOUDFLARE_AIG_TOKEN=
 # LOCAL_DEV=1 unlocks the dev-only HTTP surface in src/index.ts:
 #   POST /dev/dispatch          { repo, issueNumber, instruction?, installationToken? }
 #   GET  /dev/messages/:session

--- a/agent-think/AGENTS.md
+++ b/agent-think/AGENTS.md
@@ -48,10 +48,11 @@ agent-think  (this dir — PUBLIC-safe, holds no App creds)
    ├─ WarmPool DO (src/warm-pool.ts) — keeps exactly one unassigned container warm
    ├─ CommandCenterAgent DO (src/command-center.ts) — singleton ("main")
    │     registry of every thread + per-thread counters; ThinkAgent reports
-   │     lifecycle events fire-and-forget (observing must never break a run)
-   └─ UI (React SPA, src/client.tsx): `/` command center (metrics + ChatGPT-
-      style thread sidebar, live via agents state sync); /thread/:session
-      live thread view
+   │     lifecycle events fire-and-forget; failed runs are claimed atomically
+   │     before an operator continuation
+   └─ UI (React SPA, src/client.tsx): `/` command center (metrics, failed-run
+      continuation, and ChatGPT-style thread sidebar, live via agents state
+      sync); /thread/:session live thread view
 ```
 
 Reactions are the liveness protocol (an "on it" comment was tried and removed
@@ -183,11 +184,11 @@ npm run seed:r2  # push skills/** to the R2 bucket (add -- --local for dev)
   the full agent path without gh-app or webhooks.
 - Deploys target the `agents` Cloudflare account
   (`CLOUDFLARE_ACCOUNT_ID=b8afc92c7a87f699592038b756153d22`).
-- Model: `openai/gpt-5.5` through the account's default AI Gateway
-  (`createWorkersAI({ binding, gateway, providers: [openai] })` — the catalog
-  slug routes via the gateway delegate; Unified Billing, no OpenAI key).
-  NOTE: the `providers: [openai]` plugin is REQUIRED for `{provider}/{model}`
-  slugs — without it workers-ai-provider refuses to build the model.
+- Model: `gpt-5.5` with medium reasoning through the team AI Gateway token,
+  with a client-side fallback to `claude-opus-4-8` when the primary dispatch
+  fails. Production reads `CLOUDFLARE_AIG_TOKEN` from a Worker secret and
+  attributes every request to the `agents-team-agent-think` project. Local
+  agent turns read the same variable from `.env`.
 
 ## Where the pieces live
 

--- a/agent-think/package.json
+++ b/agent-think/package.json
@@ -12,10 +12,11 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tests-e2e/tsconfig.json",
     "gen-types": "wrangler types",
     "seed:r2": "node ./scripts/seed-skills.mjs",
-    "test": "vitest run --config test/vitest.config.ts",
+    "test": "vitest run --config test/vitest.config.ts && vitest run test/model.test.ts --environment node",
     "test:e2e": "vitest run --config tests-e2e/vitest.config.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.83",
     "@ai-sdk/openai": "^3.0.70",
     "@cloudflare/ai-chat": "workspace:*",
     "@cloudflare/think": "workspace:*",

--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -34,10 +34,9 @@ import {
 import { CloudflareContainerBackend } from "@cloudflare/workspace/backends/container";
 import { WorkerBackend } from "@cloudflare/workspace/backends/worker";
 import type { LanguageModel, ToolSet } from "ai";
-import { createWorkersAI } from "workers-ai-provider";
-import { openai } from "workers-ai-provider/openai";
 import { getAgentByName } from "agents";
 import type { CommandCenterAgent } from "./command-center";
+import { createAgentThinkModel } from "./model";
 import { releaseContainer, resolveContainerId } from "./pool";
 import { createBashTool } from "./tools/bash";
 import {
@@ -60,14 +59,6 @@ const CONTEXT_KEY = "agent-think-context";
 // resetSession aborts the isolate AFTER its RPC response has been delivered;
 // this is the grace window for that ack, not a tuning knob.
 const RESET_ABORT_DELAY_MS = 100;
-// GPT-5.5 (medium reasoning) through AI Gateway's model catalog — Unified
-// Billing over the AI binding, no provider key. `reasoning_effort` is a
-// first-class workers-ai-provider model setting forwarded into the request
-// (verified live: completion_tokens_details.reasoning_tokens > 0).
-// Fallback if unified-billing credits run dry (gateway 402s):
-// MODEL_ID = "@cf/moonshotai/kimi-k2.7-code" bills via Workers AI instead.
-const MODEL_ID = "openai/gpt-5.5";
-const REASONING_EFFORT = "medium";
 
 /** Per-issue run context, set by `dispatch` before the turn is submitted. */
 export interface RunContext extends RunTarget {
@@ -136,7 +127,11 @@ function agentThinkInstructions(ctx: RunContext | null): string | null {
   ].join("\n");
 }
 
-class ThinkBase extends Think<Env> {}
+interface AgentThinkEnv extends Env {
+  CLOUDFLARE_AIG_TOKEN?: string;
+}
+
+class ThinkBase extends Think<AgentThinkEnv> {}
 
 export class ThinkAgent extends ThinkBase {
   // Think's own chat recovery is the durability layer. Its terminal hook must
@@ -171,7 +166,7 @@ export class ThinkAgent extends ThinkBase {
   #cleanupPromise: Promise<void> | null = null;
   #reportTail: Promise<void> = Promise.resolve();
 
-  constructor(ctx: DurableObjectState, env: Env) {
+  constructor(ctx: DurableObjectState, env: AgentThinkEnv) {
     super(ctx, env);
     // This Agent DO OWNS the Workspace (SQLite VFS state); the container is a
     // SEPARATE `Sandbox` DO handed out by the warm pool. The backend's
@@ -283,6 +278,35 @@ export class ThinkAgent extends ThinkBase {
    *
    * Returns the submission id so the caller can correlate logs.
    */
+  async continueRun(): Promise<string> {
+    const context = this.#context;
+    if (!context) {
+      throw new Error("Run context is unavailable for this session");
+    }
+    const submission = await this.submitMessages(
+      [
+        {
+          id: crypto.randomUUID(),
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text:
+                "Continue the interrupted run from the existing transcript and workspace. " +
+                "Inspect the last completed tool result before taking another action."
+            }
+          ]
+        }
+      ],
+      {
+        idempotencyKey: crypto.randomUUID(),
+        metadata: { source: "command-center", instruction: "continue" }
+      }
+    );
+    this.#log("continued", { submissionId: submission.submissionId });
+    return submission.submissionId;
+  }
+
   async start(): Promise<string> {
     const ctx = this.#context;
     if (!ctx) throw new Error("setContext() must be called before start()");
@@ -504,20 +528,7 @@ export class ThinkAgent extends ThinkBase {
   }
 
   override getModel(): LanguageModel {
-    // Route through the account's default AI Gateway so model calls get
-    // Gateway-side retries, caching, and observability. The `openai` provider
-    // plugin lets the `openai/...` catalog slug dispatch through the gateway
-    // delegate (OpenAI wire format over the AI binding, Unified Billing).
-    return createWorkersAI({
-      binding: this.env.AI,
-      gateway: { id: "default" },
-      providers: [openai]
-      // DelegateCallOptions' typing lags the runtime: the model reads
-      // settings.reasoning_effort and forwards it into the request (verified
-      // live — completion_tokens_details.reasoning_tokens > 0 at "medium").
-    })(MODEL_ID, {
-      reasoning_effort: REASONING_EFFORT
-    } as Parameters<ReturnType<typeof createWorkersAI>>[1]);
+    return createAgentThinkModel(this.env.CLOUDFLARE_AIG_TOKEN);
   }
 
   override getSkills() {

--- a/agent-think/src/client.tsx
+++ b/agent-think/src/client.tsx
@@ -6,8 +6,8 @@
  * left sidebar lists every thread in reverse-chronological order (ChatGPT
  * style); picking one routes to `/thread/:session`, which connects to that
  * ThinkAgent Durable Object over the agents WebSocket and renders the live
- * message stream. It is a viewer: there is no input box, because runs are
- * driven by the GitHub `@agent-think` command, not the browser.
+ * message stream. New tasks are driven by the GitHub `@agent-think` command;
+ * the command center can continue a failed durable run in place.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -248,11 +248,15 @@ function aggregateRepos(threads: ThreadMeta[]): RepoAgg[] {
 function CommandCenterView({
   threads,
   status,
-  onOpen
+  onOpen,
+  onContinue,
+  continuing
 }: {
   threads: ThreadMeta[];
   status: ConnectionStatus;
   onOpen: (session: string) => void;
+  onContinue: (thread: ThreadMeta) => void;
+  continuing: string | null;
 }) {
   const running = threads.filter((t) => t.status === "running").length;
   const errored = threads.filter((t) => t.status === "error").length;
@@ -318,27 +322,34 @@ function CommandCenterView({
         ) : (
           <div className="runs">
             {threads.map((t) => (
-              <button
-                key={t.session}
-                className="run"
-                onClick={() => onOpen(t.session)}
-              >
-                <span className={`run__dot run__dot--${t.status}`} />
-                <span className="run__title">
-                  {t.repo}#{t.issueNumber}
-                </span>
-                <span className="run__instruction">
-                  {t.status === "error" && t.lastError
-                    ? t.lastError
-                    : (t.issueTitle ?? t.instruction)}
-                </span>
-                <RequesterAvatar thread={t} />
-                <span className="run__meta">
-                  {t.tools} tools
-                  {t.toolErrors > 0 ? ` · ${t.toolErrors} err` : ""} ·{" "}
-                  {threadStatusLabel(t)} · {relativeTime(t.updatedAt)}
-                </span>
-              </button>
+              <div key={t.session} className="run">
+                <button className="run__open" onClick={() => onOpen(t.session)}>
+                  <span className={`run__dot run__dot--${t.status}`} />
+                  <span className="run__title">
+                    {t.repo}#{t.issueNumber}
+                  </span>
+                  <span className="run__instruction">
+                    {t.status === "error" && t.lastError
+                      ? t.lastError
+                      : (t.issueTitle ?? t.instruction)}
+                  </span>
+                  <RequesterAvatar thread={t} />
+                  <span className="run__meta">
+                    {t.tools} tools
+                    {t.toolErrors > 0 ? ` · ${t.toolErrors} err` : ""} ·{" "}
+                    {threadStatusLabel(t)} · {relativeTime(t.updatedAt)}
+                  </span>
+                </button>
+                {t.status === "error" && (
+                  <button
+                    className="run__continue"
+                    disabled={continuing === t.session}
+                    onClick={() => onContinue(t)}
+                  >
+                    {continuing === t.session ? "Continuing…" : "Continue"}
+                  </button>
+                )}
+              </div>
             ))}
           </div>
         )}
@@ -358,6 +369,7 @@ function App() {
   const [ccStatus, setCcStatus] = useState<ConnectionStatus>("connecting");
   const [cc, setCc] = useState<CommandCenterState>({ threads: {} });
   const [query, setQuery] = useState("");
+  const [continuing, setContinuing] = useState<string | null>(null);
 
   useAgent<CommandCenterState>({
     // Kebab-case of the DO binding `CommandCenter`; one shared instance.
@@ -400,6 +412,27 @@ function App() {
   const navigate = (to: string) => {
     window.history.pushState(null, "", to);
     setPath(to);
+  };
+
+  const continueThread = async (thread: ThreadMeta) => {
+    const accepted = window.confirm(
+      "Continue this failed run using its existing transcript and workspace? " +
+        "Older runs may still need a fresh GitHub mention if their installation token has expired."
+    );
+    if (!accepted) return;
+    setContinuing(thread.session);
+    try {
+      const response = await fetch(
+        `/api/command-center/continue/${encodeURIComponent(thread.session)}`,
+        { method: "POST" }
+      );
+      const result = (await response.json()) as { error?: string };
+      if (!response.ok) throw new Error(result.error ?? "Continuation failed");
+    } catch (error) {
+      window.alert(error instanceof Error ? error.message : String(error));
+    } finally {
+      setContinuing(null);
+    }
   };
 
   const session = sessionFromPath(path);
@@ -476,6 +509,8 @@ function App() {
           threads={threads}
           status={ccStatus}
           onOpen={(s) => navigate(`/thread/${s}`)}
+          onContinue={(thread) => void continueThread(thread)}
+          continuing={continuing}
         />
       )}
     </div>

--- a/agent-think/src/command-center.ts
+++ b/agent-think/src/command-center.ts
@@ -5,8 +5,8 @@
  * worker has ever dispatched: repo/issue coordinates, live status, and
  * per-thread tool counters. ThinkAgent reports lifecycle events here
  * fire-and-forget (see `#report` in agent.ts) — a reporting failure must
- * never break a run, and the command center never drives runs, it only
- * observes them.
+ * never break a run. The only control mutation is an atomic claim for
+ * continuing a failed run from the operator command center.
  *
  * The UI connects with `useAgent({ agent: "command-center", name: "main" })`
  * and receives every update through the agents SDK state sync, which is what
@@ -110,6 +110,25 @@ export class CommandCenterAgent extends Agent<Env, CommandCenterState> {
   /** Read-only snapshot for the HTTP fallback (see /api/command-center). */
   async getSnapshot(): Promise<CommandCenterState> {
     return this.state;
+  }
+
+  async claimContinuation(
+    session: string
+  ): Promise<
+    | { ok: true; thread: ThreadMeta }
+    | { ok: false; reason: "not_found" | "not_failed" }
+  > {
+    const thread = this.state.threads[session];
+    if (!thread) return { ok: false, reason: "not_found" };
+    if (thread.status !== "error") return { ok: false, reason: "not_failed" };
+    this.#put({
+      ...thread,
+      status: "running",
+      updatedAt: Date.now(),
+      runs: thread.runs + 1,
+      lastError: undefined
+    });
+    return { ok: true, thread };
   }
 
   #put(meta: ThreadMeta): void {

--- a/agent-think/src/index.ts
+++ b/agent-think/src/index.ts
@@ -205,6 +205,56 @@ export default {
       }
     }
 
+    const continuation = url.pathname.match(
+      /^\/api\/command-center\/continue\/([^/]+)$/
+    );
+    if (request.method === "POST" && continuation) {
+      if (request.headers.get("origin") !== url.origin) {
+        return Response.json(
+          { error: "same-origin request required" },
+          { status: 403 }
+        );
+      }
+      const session = decodeURIComponent(continuation[1]);
+      const commandCenter = await getAgentByName<Env, CommandCenterAgent>(
+        env.CommandCenter,
+        "main"
+      );
+      const claim = await commandCenter.claimContinuation(session);
+      if (!claim.ok) {
+        return claim.reason === "not_found"
+          ? Response.json({ error: "thread not found" }, { status: 404 })
+          : Response.json(
+              { error: "only failed runs can be continued" },
+              { status: 409 }
+            );
+      }
+      const agent = await getAgentByName<Env, ThinkAgent>(
+        env.ThinkAgent,
+        session
+      );
+      try {
+        const submissionId = await agent.continueRun();
+        return Response.json(
+          {
+            session,
+            submissionId,
+            warning:
+              "GitHub operations may require a new issue mention if the stored installation token has expired."
+          },
+          { status: 202 }
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        await commandCenter.recordTurn({
+          session,
+          outcome: "error",
+          error: message
+        });
+        return Response.json({ error: message }, { status: 500 });
+      }
+    }
+
     // Read-only state snapshot for the command-center UI: instant hydration
     // on page load, and a poll fallback whenever the agents WS state sync is
     // not connected.

--- a/agent-think/src/model.ts
+++ b/agent-think/src/model.ts
@@ -1,0 +1,77 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  defaultSettingsMiddleware,
+  type LanguageModel,
+  wrapLanguageModel
+} from "ai";
+import { createClientFallbackModel } from "workers-ai-provider";
+
+const AI_GATEWAY_BASE_URL =
+  "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway";
+const PROJECT_METADATA = JSON.stringify({
+  project: "agents-team-agent-think"
+});
+
+export function createAgentThinkModel(
+  token: string | undefined,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch
+): LanguageModel {
+  const normalizedToken = token?.trim() ?? "";
+  if (!normalizedToken) {
+    throw new Error("CLOUDFLARE_AIG_TOKEN is not configured");
+  }
+
+  const gatewayFetch: typeof globalThis.fetch = (input, init) => {
+    const headers = new Headers(init?.headers);
+    // Provider SDKs add upstream credentials by default. The team token
+    // authenticates AI Gateway, which supplies provider access itself.
+    headers.delete("authorization");
+    headers.delete("x-api-key");
+    headers.set("cf-aig-authorization", `Bearer ${normalizedToken}`);
+    headers.set("cf-aig-metadata", PROJECT_METADATA);
+    return fetchImpl(input, { ...init, headers });
+  };
+
+  const openai = createOpenAI({
+    apiKey: "unused",
+    baseURL: `${AI_GATEWAY_BASE_URL}/openai`,
+    fetch: gatewayFetch
+  });
+  const anthropic = createAnthropic({
+    apiKey: "unused",
+    baseURL: `${AI_GATEWAY_BASE_URL}/anthropic`,
+    fetch: gatewayFetch
+  });
+  const primary = withProviderOptions(openai.chat("gpt-5.5"), {
+    openai: { reasoningEffort: "medium" }
+  });
+  const fallback = withProviderOptions(anthropic("claude-opus-4-8"), {
+    anthropic: { thinking: { type: "adaptive" }, effort: "medium" }
+  });
+
+  return createClientFallbackModel([
+    { slug: "openai/gpt-5.5", model: primary, transport: "gateway" },
+    {
+      slug: "anthropic/claude-opus-4-8",
+      model: fallback,
+      transport: "gateway"
+    }
+  ]);
+}
+
+function withProviderOptions(
+  model: ReturnType<typeof wrapLanguageModel>,
+  providerOptions: NonNullable<
+    Parameters<
+      typeof defaultSettingsMiddleware
+    >[0]["settings"]["providerOptions"]
+  >
+): ReturnType<typeof wrapLanguageModel> {
+  return wrapLanguageModel({
+    model,
+    middleware: defaultSettingsMiddleware({
+      settings: { providerOptions }
+    })
+  });
+}

--- a/agent-think/src/styles.css
+++ b/agent-think/src/styles.css
@@ -290,20 +290,52 @@ body {
 .run {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
+  gap: 8px;
+  padding: 2px;
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 8px;
-  color: var(--text);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
   min-width: 0;
 }
 
 .run:hover {
   background: var(--panel-2);
+}
+
+.run__open {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  min-width: 0;
+  flex: 1;
+}
+
+.run__continue {
+  flex-shrink: 0;
+  margin-right: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--red);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--red);
+  font: 600 11px var(--sans);
+  cursor: pointer;
+}
+
+.run__continue:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--red) 12%, transparent);
+}
+
+.run__continue:disabled {
+  cursor: wait;
+  opacity: 0.6;
 }
 
 .run__dot {

--- a/agent-think/test/model.test.ts
+++ b/agent-think/test/model.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAgentThinkModel } from "../src/model";
+
+const completion = {
+  id: "chatcmpl-test",
+  object: "chat.completion",
+  created: 1,
+  model: "gpt-5.5",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "ok" },
+      finish_reason: "stop"
+    }
+  ],
+  usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+};
+
+const anthropicCompletion = {
+  id: "msg-test",
+  type: "message",
+  role: "assistant",
+  model: "claude-opus-4-8",
+  content: [{ type: "text", text: "fallback" }],
+  stop_reason: "end_turn",
+  stop_sequence: null,
+  usage: { input_tokens: 1, output_tokens: 1 }
+};
+
+describe("createAgentThinkModel", () => {
+  it("uses the team Gateway token and project attribution", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      Response.json(completion)
+    );
+    const model = createAgentThinkModel("team-token", fetch);
+
+    await model.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }]
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const [input, init] = fetch.mock.calls[0];
+    expect(String(input)).toBe(
+      "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/openai/chat/completions"
+    );
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("cf-aig-authorization")).toBe("Bearer team-token");
+    expect(headers.get("cf-aig-metadata")).toBe(
+      JSON.stringify({ project: "agents-team-agent-think" })
+    );
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      model: "gpt-5.5",
+      reasoning_effort: "medium"
+    });
+  });
+
+  it("falls back from a failed GPT request to Opus 4.8", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      if (String(input).includes("/openai/")) {
+        return Response.json(
+          { error: { message: "Payment Required", type: "gateway_error" } },
+          { status: 402 }
+        );
+      }
+      return Response.json(anthropicCompletion);
+    });
+    const model = createAgentThinkModel("team-token", fetch);
+
+    const result = await model.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }]
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls.map(([input]) => String(input))).toEqual([
+      "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/openai/chat/completions",
+      "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/anthropic/messages"
+    ]);
+    const fallbackInit = fetch.mock.calls[1][1];
+    const fallbackHeaders = new Headers(fallbackInit?.headers);
+    expect(fallbackHeaders.get("authorization")).toBeNull();
+    expect(fallbackHeaders.get("x-api-key")).toBeNull();
+    expect(fallbackHeaders.get("cf-aig-authorization")).toBe(
+      "Bearer team-token"
+    );
+    expect(fallbackHeaders.get("cf-aig-metadata")).toBe(
+      JSON.stringify({ project: "agents-team-agent-think" })
+    );
+    expect(JSON.parse(String(fallbackInit?.body))).toMatchObject({
+      model: "claude-opus-4-8",
+      thinking: { type: "adaptive" },
+      output_config: { effort: "medium" }
+    });
+    expect(result.content).toContainEqual({ type: "text", text: "fallback" });
+  });
+
+  it.each([undefined, "", "   "])(
+    "fails closed when the team token is unavailable (%s)",
+    (token) => {
+      expect(() => createAgentThinkModel(token, vi.fn())).toThrow(
+        "CLOUDFLARE_AIG_TOKEN is not configured"
+      );
+    }
+  );
+});

--- a/agent-think/test/reliability.test.ts
+++ b/agent-think/test/reliability.test.ts
@@ -4,6 +4,39 @@ import { describe, expect, it } from "vitest";
 import type { CommandCenterAgent } from "../src/command-center";
 
 describe("agent-think reliability", () => {
+  it("claims a failed continuation only once", async () => {
+    const session = `continuation-${crypto.randomUUID()}`;
+    const commandCenter = await getAgentByName<Env, CommandCenterAgent>(
+      env.CommandCenter,
+      "main"
+    );
+    await commandCenter.recordDispatch({
+      session,
+      repo: "cloudflare/agents",
+      issueNumber: 1,
+      instruction: "test"
+    });
+    await commandCenter.recordTurn({
+      session,
+      outcome: "error",
+      error: "payment required"
+    });
+
+    expect(await commandCenter.claimContinuation(session)).toMatchObject({
+      ok: true,
+      thread: { status: "error" }
+    });
+    expect(await commandCenter.claimContinuation(session)).toEqual({
+      ok: false,
+      reason: "not_failed"
+    });
+    expect((await commandCenter.getSnapshot()).threads[session]).toMatchObject({
+      status: "running",
+      runs: 2,
+      lastError: undefined
+    });
+  });
+
   it("records terminal command-center state through the real DO", async () => {
     const session = `reliability-${crypto.randomUUID()}`;
     const commandCenter = await getAgentByName<Env, CommandCenterAgent>(

--- a/agent-think/test/routing.test.ts
+++ b/agent-think/test/routing.test.ts
@@ -43,6 +43,28 @@ describe("agent-think HTTP surface", () => {
     expect(res.status).toBe(404);
   });
 
+  it("rejects cross-origin command-center continuation requests", async () => {
+    const res = await SELF.fetch(
+      "https://agent-think.test/api/command-center/continue/cloudflare-agents-1",
+      {
+        method: "POST",
+        headers: { origin: "https://attacker.example" }
+      }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when continuing an unknown command-center session", async () => {
+    const res = await SELF.fetch(
+      "https://agent-think.test/api/command-center/continue/cloudflare-agents-1",
+      {
+        method: "POST",
+        headers: { origin: "https://agent-think.test" }
+      }
+    );
+    expect(res.status).toBe(404);
+  });
+
   it("GET /thread/:session is handled by the SPA fallback (not the 404 tail)", async () => {
     // /thread/* is a client-side route: the worker serves index.html and lets
     // the React app read the session from the path. We assert it's *handled*

--- a/agent-think/test/vitest.config.ts
+++ b/agent-think/test/vitest.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
   test: {
     name: "unit",
     include: [path.join(testDir, "**/*.test.ts")],
+    // Provider routing is pure HTTP and runs in Node from the package test
+    // script. The Workers pool's fetch bridge cannot observe both fallback
+    // dispatches through an injected fetch implementation.
+    exclude: [path.join(testDir, "model.test.ts")],
     setupFiles: [path.join(testDir, "setup.ts")],
     // The first module resolution in the isolate has to load think + workspace;
     // 15s keeps a cold start from tripping a spurious timeout.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
 
   agent-think:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.83
+        version: 3.0.85(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.70
         version: 3.0.74(zod@4.4.3)


### PR DESCRIPTION
The existing model path uses account unified-billing credits and stops agent turns with `402 Payment Required` when those credits are unavailable. The team AI Gateway token is intended for exploratory Agents applications and requires a project tag for usage attribution.

Route model requests through the authenticated team Gateway and tag them as `agents-team-agent-think`. GPT-5.5 remains the primary model with medium reasoning. A failed primary dispatch falls back through `workers-ai-provider` to Anthropic Claude Opus 4.8 with adaptive thinking and medium effort, using the same token and project attribution. Provider SDK credentials are removed before each Gateway request.

The command center now shows a Continue action for failed runs. It atomically claims the failed thread and submits a continuation into the same durable Think session, preserving its transcript and Workspace. This does not mint a new GitHub installation token, so old sessions may still need a fresh issue mention before another GitHub operation.

Production requires the `CLOUDFLARE_AIG_TOKEN` Worker secret. For local agent turns, set the same variable in `agent-think/.env`.

Tests cover the authenticated request headers, a `402` response followed by a successful Opus 4.8 response, missing secrets, same-origin continuation routing, and atomic continuation claims. The agent-think unit suite, typecheck, lint, formatting check, Sherif dependency check, and client build pass.
