### PR TITLE
agent-think: Recover stale running threads

### DIFF
--- a/agent-think/src/client.tsx
+++ b/agent-think/src/client.tsx
@@ -16,6 +16,7 @@ import { useAgent } from "agents/react";
 import { useAgentChat } from "@cloudflare/ai-chat/react";
 import { getToolName, isToolUIPart, type UIMessage } from "ai";
 import type { CommandCenterState, ThreadMeta } from "./command-center";
+import { STALE_RUN_MS } from "./run-status";
 import "./styles.css";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected";
@@ -182,6 +183,14 @@ function ThreadView({ session }: { session: string }) {
 
 // ── Command center (the `/` route) ─────────────────────────────────
 
+function canContinueThread(thread: ThreadMeta): boolean {
+  return (
+    thread.status === "error" ||
+    (thread.status === "running" &&
+      Date.now() - thread.updatedAt >= STALE_RUN_MS)
+  );
+}
+
 function threadStatusLabel(t: ThreadMeta): string {
   return t.status === "running"
     ? "running"
@@ -340,13 +349,17 @@ function CommandCenterView({
                     {threadStatusLabel(t)} · {relativeTime(t.updatedAt)}
                   </span>
                 </button>
-                {t.status === "error" && (
+                {canContinueThread(t) && (
                   <button
                     className="run__continue"
                     disabled={continuing === t.session}
                     onClick={() => onContinue(t)}
                   >
-                    {continuing === t.session ? "Continuing…" : "Continue"}
+                    {continuing === t.session
+                      ? "Continuing…"
+                      : t.status === "running"
+                        ? "Recover stale"
+                        : "Continue"}
                   </button>
                 )}
               </div>

--- a/agent-think/src/command-center.ts
+++ b/agent-think/src/command-center.ts
@@ -14,6 +14,7 @@
  */
 
 import { Agent } from "agents";
+import { STALE_RUN_MS } from "./run-status";
 
 export type ThreadStatus = "running" | "done" | "error";
 
@@ -116,11 +117,16 @@ export class CommandCenterAgent extends Agent<Env, CommandCenterState> {
     session: string
   ): Promise<
     | { ok: true; thread: ThreadMeta }
-    | { ok: false; reason: "not_found" | "not_failed" }
+    | { ok: false; reason: "not_found" | "not_recoverable" }
   > {
     const thread = this.state.threads[session];
     if (!thread) return { ok: false, reason: "not_found" };
-    if (thread.status !== "error") return { ok: false, reason: "not_failed" };
+    const staleRunning =
+      thread.status === "running" &&
+      Date.now() - thread.updatedAt >= STALE_RUN_MS;
+    if (thread.status !== "error" && !staleRunning) {
+      return { ok: false, reason: "not_recoverable" };
+    }
     this.#put({
       ...thread,
       status: "running",

--- a/agent-think/src/index.ts
+++ b/agent-think/src/index.ts
@@ -233,7 +233,7 @@ export default {
         return claim.reason === "not_found"
           ? Response.json({ error: "thread not found" }, { status: 404 })
           : Response.json(
-              { error: "only failed runs can be continued" },
+              { error: "only failed or stale runs can be continued" },
               { status: 409 }
             );
       }

--- a/agent-think/src/run-status.ts
+++ b/agent-think/src/run-status.ts
@@ -1,0 +1,1 @@
+export const STALE_RUN_MS = 10 * 60 * 1000;

--- a/agent-think/test/reliability.test.ts
+++ b/agent-think/test/reliability.test.ts
@@ -1,9 +1,37 @@
 import { env } from "cloudflare:workers";
 import { getAgentByName } from "agents";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CommandCenterAgent } from "../src/command-center";
 
 describe("agent-think reliability", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("reclaims a stale running continuation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00Z"));
+    const session = `stale-${crypto.randomUUID()}`;
+    const commandCenter = await getAgentByName<Env, CommandCenterAgent>(
+      env.CommandCenter,
+      "main"
+    );
+    await commandCenter.recordDispatch({
+      session,
+      repo: "cloudflare/agents",
+      issueNumber: 1,
+      instruction: "test"
+    });
+
+    expect(await commandCenter.claimContinuation(session)).toEqual({
+      ok: false,
+      reason: "not_recoverable"
+    });
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    expect(await commandCenter.claimContinuation(session)).toMatchObject({
+      ok: true,
+      thread: { status: "running" }
+    });
+  });
+
   it("claims a failed continuation only once", async () => {
     const session = `continuation-${crypto.randomUUID()}`;
     const commandCenter = await getAgentByName<Env, CommandCenterAgent>(
@@ -28,7 +56,7 @@ describe("agent-think reliability", () => {
     });
     expect(await commandCenter.claimContinuation(session)).toEqual({
       ok: false,
-      reason: "not_failed"
+      reason: "not_recoverable"
     });
     expect((await commandCenter.getSnapshot()).threads[session]).toMatchObject({
       status: "running",


### PR DESCRIPTION
A continuation submission can terminalize before agent-think reports its final status, leaving the command center stuck on `running`. The existing Continue action then refuses the thread even though no work remains active.

Treat a running thread as stale after ten minutes without a lifecycle update. The command-center Durable Object claims that recovery atomically, and the UI exposes it as “Recover stale.” Fresh running threads still reject continuation, so repeated clicks cannot duplicate active work.

Tests cover fresh-running rejection, stale-running reclamation, failed-run single claims, same-origin routing, typecheck, lint, formatting, and the client build.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->