### PR TITLE
feat(agents): self-initialize on every RPC entry surface

### DIFF
--- a/.changeset/rpc-entry-self-init.md
+++ b/.changeset/rpc-entry-self-init.md
@@ -1,0 +1,11 @@
+---
+"agents": minor
+---
+
+Agents now self-initialize on every RPC entry surface
+
+Previously, several native Durable Object RPC entry points depended on the caller resolving the stub through `getAgentByName()`, whose `setName()` round-trip is what ran `onStart()` before the first call. An entry point reached on a stub that skipped that round-trip could run before `onStart()` completed.
+
+Every RPC entry surface now runs `onStart()` before executing: `_onEmail`, the sub-agent bridges (`_cf_invokeSubAgent` / `_cf_invokeSubAgentPath`), the schedule/fiber dispatch callbacks, the WebSocket-forwarding facet handlers, and every root facet RPC method (schedules, keepAlive, facet-run registration, broadcast, and sub-agent connection routing) all guard on initialization the same way the existing `_cf_invokeAgentPath` did. User-defined RPC methods on cold stubs also initialize before running, via a synchronous fast path in the auto-wrapping layer that preserves synchronous return values once warm and never re-enters initialization while `onStart()` is in flight.
+
+Because every reachable surface is now self-sufficient, internal resolution sites that only ever invoke self-initializing methods (`_rootAlarmOwner`, `parentAgent`, `AgentWorkflow`'s agent resolution, and email routing — none of which pass `props`) resolve their stub directly and skip the extra round-trip. The public `getAgentByName` / `getServerByName` behavior is unchanged, and no documented semantics change.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4292,8 +4292,25 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<void> {
     // Resolved zero-RTT via `_rootAlarmOwner`; initialize before sweeping
-    // schedule/facet-run storage.
+    // schedule/facet-run storage. Local callers (`deleteSubAgent`,
+    // `_cf_dispatchScheduledCallback`, `_cf_destroyDescendantFacet`) reach the
+    // work via `_cleanupFacetPrefixImpl` directly so they never re-enter init —
+    // `deleteSubAgent()` can run inside `onStart()`, where re-triggering init
+    // would nest `blockConcurrencyWhile()`.
     await this.__unsafe_ensureInitialized();
+    return this._cleanupFacetPrefixImpl(ownerPath);
+  }
+
+  /**
+   * Body of {@link _cf_cleanupFacetPrefix} without the init guard, so local
+   * `this.` callers on an already-resolved instance don't re-trigger
+   * framework init (which would deadlock or nest `blockConcurrencyWhile()`
+   * when invoked mid-`onStart()`).
+   * @internal
+   */
+  private async _cleanupFacetPrefixImpl(
+    ownerPath: ReadonlyArray<AgentPathStep>
+  ): Promise<void> {
     const rows = this.sql<ScheduleStorageRow>`
       SELECT * FROM cf_agents_schedules
       WHERE owner_path IS NOT NULL
@@ -6086,7 +6103,7 @@ export class Agent<
         const root = await this._rootAlarmOwner();
         await root._cf_cleanupFacetPrefix(stalePath);
       } else {
-        await this._cf_cleanupFacetPrefix(stalePath);
+        await this._cleanupFacetPrefixImpl(stalePath);
       }
       return false;
     }
@@ -6205,7 +6222,7 @@ export class Agent<
     // upfront so we don't have to make an extra round trip back from
     // each intermediate hop.
     if (this._parentPath.length === 0) {
-      await this._cf_cleanupFacetPrefix(targetPath);
+      await this._cleanupFacetPrefixImpl(targetPath);
     }
 
     if (selfPath.length === targetPath.length - 1) {
@@ -10755,7 +10772,7 @@ export class Agent<
       const root = await this._rootAlarmOwner();
       await root._cf_cleanupFacetPrefix(childPath);
     } else {
-      await this._cf_cleanupFacetPrefix(childPath);
+      await this._cleanupFacetPrefixImpl(childPath);
     }
 
     // Idempotent: make `ctx.facets.delete` tolerant of missing keys.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -38,7 +38,11 @@ import {
   getServerByName,
   routePartykitRequest
 } from "partyserver";
-import { camelCaseToKebabCase, isInternalJsStubProp } from "./utils";
+import {
+  camelCaseToKebabCase,
+  getAgentStubByName,
+  isInternalJsStubProp
+} from "./utils";
 export { camelCaseToKebabCase } from "./utils";
 import {
   type RetryOptions,
@@ -1532,22 +1536,73 @@ function withAgentContext<T extends (...args: any[]) => any>(
     const { agent } = getCurrentAgent();
 
     if (agent === this) {
-      // already wrapped, so we can just call the method
+      // Re-entrant / nested call inside this agent's own context — either
+      // `onStart()` is running (framework init in-flight) or init already
+      // completed and one wrapped method is calling another locally. Never
+      // trigger init here: awaiting it during `onStart()` would deadlock the
+      // in-flight init, and it would also re-run `onStart()`. Running the
+      // method directly also preserves synchronous return values.
       return method.apply(this, args);
     }
-    // Crossing to a different Agent must not carry native I/O handles
-    // from the previous request/WebSocket/email turn into the new DO.
-    return agentContext.run(
-      {
-        agent: this,
-        connection: undefined,
-        request: undefined,
-        email: undefined
-      },
-      () => {
-        return method.apply(this, args);
+
+    // Entry into this agent's context from outside it: a cold or warm RPC, or
+    // a crossing from a different agent. Crossing must not carry native I/O
+    // handles from the previous request/WebSocket/email turn into the new DO.
+    const runInContext = (): ReturnType<T> =>
+      agentContext.run(
+        {
+          agent: this,
+          connection: undefined,
+          request: undefined,
+          email: undefined
+        },
+        () => {
+          return method.apply(this, args);
+        }
+      );
+
+    // Ensure framework init (`onStart()`) has completed before the user
+    // method runs, so callers that resolve the stub without the
+    // `getServerByName` → `setName` round-trip still observe a fully
+    // initialized agent.
+    const self = this as unknown as {
+      _selfInitCompleted: boolean;
+      _selfInitPromise?: Promise<void>;
+      ctx: { id: { name?: string } };
+      __unsafe_ensureInitialized(): Promise<void>;
+    };
+
+    // Warm fast path: already initialized. No await — synchronous returns are
+    // preserved and post-init calls stay zero-overhead.
+    if (self._selfInitCompleted) {
+      return runInContext();
+    }
+
+    // Only self-initialize when the agent is addressed by name. A raw-id DO
+    // (`newUniqueId()` / `idFromString()` with no `setName()` bootstrap) has
+    // no resolvable name, so `onStart()`'s name-dependent framework setup
+    // cannot run — this is the unsupported addressing partyserver's `name`
+    // getter throws on. Preserve the historical behavior of invoking the
+    // method without forcing init in that case. `ctx.id.name` is `undefined`
+    // for such DOs and, unlike the `name` getter, never throws.
+    if (self.ctx.id.name === undefined) {
+      return runInContext();
+    }
+
+    // Cold path: block on framework init exactly once. The memo makes two
+    // concurrent cold RPCs share a single `onStart()` run. This path is
+    // inherently async — a cold entry only happens across an RPC boundary,
+    // which is already asynchronous.
+    self._selfInitPromise ??= self.__unsafe_ensureInitialized();
+    return self._selfInitPromise.then(
+      () => runInContext(),
+      (error: unknown) => {
+        // Init failed: clear the memo so the next call retries instead of
+        // replaying the rejection, then surface the error to the caller.
+        self._selfInitPromise = undefined;
+        throw error;
       }
-    );
+    ) as ReturnType<T>;
   };
 }
 
@@ -1629,6 +1684,29 @@ export class Agent<
 
   /** True while user's onStart() is executing. Used to warn about non-idempotent schedule() calls. */
   private _insideOnStart = false;
+
+  /**
+   * True once the framework `onStart()` has run to completion for this
+   * in-memory instance. Read synchronously by the auto-wrapped user-method
+   * path (see {@link withAgentContext}) to skip the init round-trip once
+   * warm, which preserves synchronous return values for local calls. Reset
+   * on eviction/hibernation because it is in-memory only — a cold instance
+   * re-initializes, which is correct.
+   * @internal
+   */
+  private _selfInitCompleted = false;
+
+  /**
+   * Memoized in-flight framework-init promise, set while a cold RPC entry
+   * awaits `onStart()`. Ensures two concurrent cold RPCs trigger a single
+   * `onStart()` run (the wrapper must not double-trigger init). Never read
+   * during `onStart()` itself: re-entrant local calls take the synchronous
+   * agent-context fast path and never reach the memo. Cleared on init
+   * failure so the next call retries instead of replaying the rejection.
+   * In-memory only (reset on hibernation), mirroring partyserver's status.
+   * @internal
+   */
+  private _selfInitPromise?: Promise<void>;
 
   /** Tracks callbacks already warned about during this onStart() to avoid log spam. */
   private _warnedScheduleInOnStart = new Set<string>();
@@ -2602,7 +2680,7 @@ export class Agent<
 
     const _onStart = this.onStart.bind(this);
     this.onStart = async (props?: Props) => {
-      return agentContext.run(
+      const result = await agentContext.run(
         {
           agent: this,
           connection: undefined,
@@ -2705,6 +2783,12 @@ export class Agent<
           });
         }
       );
+      // Framework init finished for this in-memory instance. Mirrors
+      // partyserver marking its status "started" once `onStart()` resolves —
+      // if the body above threw (e.g. storage hydration failed), the `await`
+      // rethrows and this flag stays false, so the next entry retries.
+      this._selfInitCompleted = true;
+      return result;
     };
   }
 
@@ -3192,6 +3276,11 @@ export class Agent<
     _secureRouted?: boolean;
     _bridge: EmailBridge;
   }) {
+    // Self-initialize before dispatching: email routing resolves this stub
+    // without the `getServerByName` → `setName` round-trip, so `onStart()`
+    // must run here rather than at resolution time.
+    await this.__unsafe_ensureInitialized();
+
     // nb: we use this roundabout way of getting to onEmail
     // because of https://github.com/cloudflare/workerd/issues/4499
 
@@ -3782,10 +3871,12 @@ export class Agent<
       );
     }
 
-    return (await getServerByName<Cloudflare.Env, Agent>(
+    // Zero-RTT: the root's RootFacetRpcSurface methods all self-initialize,
+    // so we skip the `getServerByName` → `setName` init round-trip.
+    return getAgentStubByName<Cloudflare.Env, Agent>(
       binding as unknown as DurableObjectNamespace<Agent>,
       root.name
-    )) as unknown as RootFacetRpcSurface;
+    ) as unknown as RootFacetRpcSurface;
   }
 
   private _cf_rootResolvesToSelf(): boolean {
@@ -4043,6 +4134,9 @@ export class Agent<
     payload?: T,
     options?: { retry?: RetryOptions; idempotent?: boolean }
   ): Promise<{ schedule: Schedule<T>; created: boolean }> {
+    // Root schedule owner is resolved zero-RTT by facet delegation
+    // (`_rootAlarmOwner`); initialize before touching schedule storage.
+    await this.__unsafe_ensureInitialized();
     return this._insertScheduleForOwner(
       ownerPath,
       when,
@@ -4141,6 +4235,9 @@ export class Agent<
     payload?: T,
     options?: { retry?: RetryOptions; _idempotent?: boolean }
   ): Promise<{ schedule: Schedule<T>; created: boolean }> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before touching
+    // schedule storage.
+    await this.__unsafe_ensureInitialized();
     return this._insertIntervalScheduleForOwner(
       ownerPath,
       intervalSeconds,
@@ -4162,6 +4259,9 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>,
     id: string
   ): Promise<{ ok: boolean; callback?: string }> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before reading
+    // schedule storage.
+    await this.__unsafe_ensureInitialized();
     const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
     const result = this.sql<ScheduleStorageRow>`
       SELECT * FROM cf_agents_schedules
@@ -4191,6 +4291,9 @@ export class Agent<
   async _cf_cleanupFacetPrefix(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before sweeping
+    // schedule/facet-run storage.
+    await this.__unsafe_ensureInitialized();
     const rows = this.sql<ScheduleStorageRow>`
       SELECT * FROM cf_agents_schedules
       WHERE owner_path IS NOT NULL
@@ -4315,6 +4418,9 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>,
     id: string
   ): Promise<Schedule<unknown> | undefined> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before reading
+    // schedule storage.
+    await this.__unsafe_ensureInitialized();
     return this._getScheduleForOwner(ownerPath, id);
   }
 
@@ -4327,6 +4433,9 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>,
     criteria: ScheduleCriteria = {}
   ): Promise<Schedule<unknown>[]> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before reading
+    // schedule storage.
+    await this.__unsafe_ensureInitialized();
     return this._listSchedulesForOwner(ownerPath, criteria);
   }
 
@@ -4339,6 +4448,9 @@ export class Agent<
   async _cf_acquireFacetKeepAlive(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<string> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before arming the
+    // root keepAlive heartbeat.
+    await this.__unsafe_ensureInitialized();
     const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
     const token = `${ownerPathKey ?? "unknown"}:${nanoid(9)}`;
     this._facetKeepAliveTokens.add(token);
@@ -4355,6 +4467,9 @@ export class Agent<
    * @internal
    */
   async _cf_releaseFacetKeepAlive(token: string): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before adjusting the
+    // root keepAlive heartbeat.
+    await this.__unsafe_ensureInitialized();
     if (!this._facetKeepAliveTokens.delete(token)) return;
     this._keepAliveRefs = Math.max(0, this._keepAliveRefs - 1);
     await this._scheduleNextAlarm();
@@ -4370,6 +4485,9 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>,
     runId: string
   ): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before writing to
+    // facet-run storage.
+    await this.__unsafe_ensureInitialized();
     const ownerPathJson = JSON.stringify(ownerPath);
     const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
     if (!ownerPathKey) {
@@ -4392,6 +4510,9 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>,
     runId: string
   ): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before writing to
+    // facet-run storage.
+    await this.__unsafe_ensureInitialized();
     const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
     this.sql`
       DELETE FROM cf_agents_facet_runs
@@ -5889,6 +6010,9 @@ export class Agent<
   async _cf_checkRunFibersForFacet(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<number> {
+    // Dispatched onto this facet stub during root alarm housekeeping;
+    // initialize so `selfPath`/fiber state are hydrated before use.
+    await this.__unsafe_ensureInitialized();
     const selfPath = this.selfPath;
     if (!this._isSameAgentPathPrefix(selfPath, ownerPath)) {
       throw new Error(
@@ -5936,6 +6060,9 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>,
     row: ScheduleStorageRow
   ): Promise<boolean> {
+    // Dispatched onto this facet stub when the root fires a facet-owned
+    // schedule; initialize so `selfPath` and callbacks resolve correctly.
+    await this.__unsafe_ensureInitialized();
     const selfPath = this.selfPath;
     if (!this._isSameAgentPathPrefix(selfPath, ownerPath)) {
       throw new Error(
@@ -6053,6 +6180,9 @@ export class Agent<
   async _cf_destroyDescendantFacet(
     targetPath: ReadonlyArray<AgentPathStep>
   ): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize before walking the
+    // facet tree and cancelling parent-owned schedules.
+    await this.__unsafe_ensureInitialized();
     const selfPath = this.selfPath;
 
     if (targetPath.length === 0) {
@@ -6921,6 +7051,9 @@ export class Agent<
     message: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
   ): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize so `_isFacet` and
+    // connection state are hydrated before routing the broadcast.
+    await this.__unsafe_ensureInitialized();
     if (this._isFacet && this._cf_currentSubAgentBridge) {
       this._cf_currentSubAgentBridge.broadcast(ownerPath, message, without);
       return;
@@ -6938,6 +7071,9 @@ export class Agent<
   async _cf_subAgentConnectionMetas(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<SubAgentConnectionMeta[]> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize so sub-agent
+    // connection state is hydrated before enumerating it.
+    await this.__unsafe_ensureInitialized();
     const metas: SubAgentConnectionMeta[] = [];
     for (const connection of super.getConnections()) {
       const meta = this._cf_subAgentConnectionMetaForPath(
@@ -6953,6 +7089,9 @@ export class Agent<
     connectionId: string,
     message: string | ArrayBuffer | ArrayBufferView
   ): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize so connection
+    // targets are hydrated before dispatch.
+    await this.__unsafe_ensureInitialized();
     const connection = super.getConnection(connectionId);
     if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
       return;
@@ -6965,6 +7104,9 @@ export class Agent<
     code?: number,
     reason?: string
   ): Promise<void> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize so connection
+    // targets are hydrated before closing.
+    await this.__unsafe_ensureInitialized();
     const connection = super.getConnection(connectionId);
     if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
       return;
@@ -6976,6 +7118,9 @@ export class Agent<
     connectionId: string,
     state: unknown
   ): Promise<unknown> {
+    // Resolved zero-RTT via `_rootAlarmOwner`; initialize so connection
+    // targets are hydrated before mutating state.
+    await this.__unsafe_ensureInitialized();
     const connection = super.getConnection(connectionId);
     if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
       return null;
@@ -7244,6 +7389,9 @@ export class Agent<
     bridge: SubAgentConnectionBridge,
     meta: SubAgentConnectionMeta
   ): Promise<void> {
+    // Forwarded from the root's WebSocket entry onto this facet stub;
+    // initialize before wiring up the bridged connection.
+    await this.__unsafe_ensureInitialized();
     await this._cf_runWithSubAgentBridge(bridge, async () => {
       const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
       const request = new Request(meta.uri ?? "http://placeholder/", {
@@ -7280,6 +7428,9 @@ export class Agent<
     bridge: SubAgentConnectionBridge,
     meta: SubAgentConnectionMeta
   ): Promise<void> {
+    // Forwarded from the root's WebSocket entry onto this facet stub;
+    // initialize before dispatching the bridged message.
+    await this.__unsafe_ensureInitialized();
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
     this._cf_storeVirtualSubAgentConnection(bridge, connection);
     await this._cf_runWithSubAgentBridge(bridge, () =>
@@ -7294,6 +7445,9 @@ export class Agent<
     bridge: SubAgentConnectionBridge,
     meta: SubAgentConnectionMeta
   ): Promise<void> {
+    // Forwarded from the root's WebSocket entry onto this facet stub;
+    // initialize before handling the bridged close.
+    await this.__unsafe_ensureInitialized();
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
     this._cf_storeVirtualSubAgentConnection(bridge, connection);
     await this._cf_runWithSubAgentBridge(bridge, () =>
@@ -7553,6 +7707,10 @@ export class Agent<
     method: string,
     args: unknown[]
   ): Promise<unknown> {
+    // `getSubAgentByName` resolves this parent stub without a `setName`
+    // round-trip; initialize before resolving the facet so `onStart()`
+    // (which hydrates sub-agent state) has run.
+    await this.__unsafe_ensureInitialized();
     const stub = await this._cf_resolveSubAgent(className, name);
     return await this._cf_invokeStubMethod(stub, className, method, args);
   }
@@ -7570,6 +7728,9 @@ export class Agent<
     method: string,
     args: unknown[]
   ): Promise<unknown> {
+    // Reached zero-RTT from `parentAgent()`/workflows on the root; the name
+    // check below reads `this.name`, and dispatch expects a warm agent.
+    await this.__unsafe_ensureInitialized();
     const [self, next, ...rest] = path;
     if (!self) {
       throw new Error(`Sub-agent path invocation requires a non-empty path.`);
@@ -7809,7 +7970,10 @@ export class Agent<
           `exported under that class name and registered as a Durable Object binding.`
       );
     }
-    return await getServerByName<Cloudflare.Env, T>(binding, parent.name);
+    // Zero-RTT: the parent's RPC surfaces self-initialize (internal `_cf_*`
+    // methods and auto-wrapped user methods), so we skip the
+    // `getServerByName` → `setName` init round-trip.
+    return getAgentStubByName<Cloudflare.Env, T>(binding, parent.name);
   }
 
   private _cf_getTopLevelNamespaceByClassName<T extends Agent>(
@@ -7855,13 +8019,14 @@ export class Agent<
       );
     }
 
-    const rootStubPromise = getServerByName<Cloudflare.Env, Agent>(
+    // Zero-RTT: `_cf_invokeSubAgentPath` self-initializes on the root, so we
+    // skip the `getServerByName` → `setName` init round-trip.
+    const rootStub = getAgentStubByName<Cloudflare.Env, Agent>(
       rootBinding,
       root.name
     );
     const targetPath = parentPath.map((step) => ({ ...step }));
     const invokeBridge = async (method: string, args: unknown[]) => {
-      const rootStub = await rootStubPromise;
       const bridge = rootStub as unknown as SubAgentPathInvokeEndpoint;
       return await bridge._cf_invokeSubAgentPath(targetPath, method, args);
     };
@@ -12898,7 +13063,9 @@ export async function routeAgentEmail<
     );
   }
 
-  const agent = await getAgentByName(
+  // Zero-RTT: `_onEmail` self-initializes, so we skip the `getAgentByName`
+  // → `setName` init round-trip here.
+  const agent = getAgentStubByName<Env, Agent<Env>>(
     namespace as unknown as DurableObjectNamespace<Agent<Env>>,
     routingInfo.agentId
   );

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -38,6 +38,7 @@ export {
   TestAgentToolReplayAgent,
   TestAgentToolStubChild
 } from "./agent-tool-replay";
+export { SelfInitAgent, SelfInitEmailAgent } from "./self-init";
 export { TestOAuthAgent, TestCustomOAuthAgent } from "./oauth";
 export { TestReadonlyAgent } from "./readonly";
 export { TestProtocolMessagesAgent } from "./protocol-messages";

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -38,7 +38,11 @@ export {
   TestAgentToolReplayAgent,
   TestAgentToolStubChild
 } from "./agent-tool-replay";
-export { SelfInitAgent, SelfInitEmailAgent } from "./self-init";
+export {
+  SelfInitAgent,
+  SelfInitEmailAgent,
+  SelfInitDeleteInOnStartAgent
+} from "./self-init";
 export { TestOAuthAgent, TestCustomOAuthAgent } from "./oauth";
 export { TestReadonlyAgent } from "./readonly";
 export { TestProtocolMessagesAgent } from "./protocol-messages";

--- a/packages/agents/src/tests/agents/self-init.ts
+++ b/packages/agents/src/tests/agents/self-init.ts
@@ -101,3 +101,44 @@ export class SelfInitEmailAgent extends Agent<Cloudflare.Env> {
     throw error;
   }
 }
+
+// Facet-only child referenced by name only — never spawned, so it needs no
+// binding. `deleteSubAgent` uses it solely for `cls.name`.
+class SelfInitDeleteChild extends Agent<Cloudflare.Env> {}
+
+/**
+ * Regression fixture for `deleteSubAgent()` called from inside `onStart()` on
+ * a non-facet (top-level) agent. That path runs `this._cf_cleanupFacetPrefix`
+ * locally; once `_cf_cleanupFacetPrefix` self-initialized on RPC entry, a
+ * local call mid-`onStart()` re-entered framework init and threw
+ * "blockConcurrencyWhile() calls are nested too deeply", aborting init. The
+ * fix routes local callers to the unguarded `_cleanupFacetPrefixImpl`. If the
+ * regression returns, `onStart()` rejects and a cold `probe()` call rejects
+ * with it.
+ */
+export class SelfInitDeleteInOnStartAgent extends Agent<Cloudflare.Env> {
+  onStartCount = 0;
+
+  async onStart() {
+    this.onStartCount++;
+    this
+      .sql`CREATE TABLE IF NOT EXISTS self_init_delete_probe (k TEXT PRIMARY KEY, v TEXT)`;
+    // The load-bearing call: deleting a never-spawned sub-agent during
+    // onStart must not re-trigger init.
+    await this.deleteSubAgent(SelfInitDeleteChild, "never-spawned");
+    // Only reached if the delete above did not throw.
+    this
+      .sql`INSERT OR REPLACE INTO self_init_delete_probe (k, v) VALUES ('completed', 'yes')`;
+  }
+
+  probe(): { onStartCount: number; completed: string | undefined } {
+    const rows = this.sql<{
+      v: string;
+    }>`SELECT v FROM self_init_delete_probe WHERE k = 'completed'`;
+    return { onStartCount: this.onStartCount, completed: rows.at(0)?.v };
+  }
+
+  override onError(error: unknown): void {
+    throw error;
+  }
+}

--- a/packages/agents/src/tests/agents/self-init.ts
+++ b/packages/agents/src/tests/agents/self-init.ts
@@ -1,0 +1,103 @@
+import { Agent } from "../../index.ts";
+import type { AgentEmail } from "../../email.ts";
+
+// Test agents that exercise the RPC-entry self-initialization guarantee:
+// every RPC entry surface runs `onStart()` before executing, so a stub
+// resolved WITHOUT the `getAgentByName` → `setName` round-trip (e.g. a raw
+// `env.NS.get(idFromName(...))` cold stub, or an internal zero-RTT
+// resolution) still observes a fully initialized agent.
+
+/**
+ * Records how many times `onStart()` ran and creates a table there (not in
+ * the constructor's schema step) so a user method can prove `onStart()`
+ * completed before it executed. Also calls one of its own wrapped methods
+ * during `onStart()` to exercise the re-entrancy fast path.
+ */
+export class SelfInitAgent extends Agent<Cloudflare.Env> {
+  onStartCount = 0;
+  reentrantResult: number | null = null;
+
+  async onStart() {
+    this.onStartCount++;
+    // Created in onStart (not _ensureSchema): a method that reads it only
+    // succeeds if onStart ran first.
+    this
+      .sql`CREATE TABLE IF NOT EXISTS self_init_probe (k TEXT PRIMARY KEY, v TEXT)`;
+    this
+      .sql`INSERT OR REPLACE INTO self_init_probe (k, v) VALUES ('name', ${this.name})`;
+    // Re-entrancy: call our own wrapped method locally during onStart. This
+    // must take the synchronous agent-context fast path — no deadlock and no
+    // second onStart run.
+    this.reentrantResult = this.syncDouble(41) + 1;
+  }
+
+  // User-defined RPC method that depends on onStart having created the table.
+  probe(): {
+    onStartCount: number;
+    storedName: string | undefined;
+    name: string;
+    reentrantResult: number | null;
+  } {
+    const rows = this.sql<{
+      v: string;
+    }>`SELECT v FROM self_init_probe WHERE k = 'name'`;
+    return {
+      onStartCount: this.onStartCount,
+      storedName: rows.at(0)?.v,
+      name: this.name,
+      reentrantResult: this.reentrantResult
+    };
+  }
+
+  // Synchronous wrapped method — used for the sync-return-preservation check
+  // and for the re-entrant call inside onStart.
+  syncDouble(n: number): number {
+    return n * 2;
+  }
+
+  // Calls a synchronous wrapped method locally and does arithmetic on the
+  // result. If the inner call had started returning a promise post-init,
+  // `typeof value` would be "object" and the arithmetic would break.
+  callSyncLocally(): { value: number; innerWasNumber: boolean } {
+    const value = this.syncDouble(21);
+    return { value: value + 1, innerWasNumber: typeof value === "number" };
+  }
+
+  override onError(error: unknown): void {
+    throw error;
+  }
+}
+
+/**
+ * `onEmail` writes into a table created by `onStart()`. If `_onEmail` did not
+ * self-initialize, the insert would fail because the table would not exist.
+ */
+export class SelfInitEmailAgent extends Agent<Cloudflare.Env> {
+  onStartCount = 0;
+
+  async onStart() {
+    this.onStartCount++;
+    this
+      .sql`CREATE TABLE IF NOT EXISTS self_init_email (k TEXT PRIMARY KEY, v TEXT)`;
+  }
+
+  async onEmail(email: AgentEmail) {
+    // Depends on the onStart-created table existing.
+    this
+      .sql`INSERT OR REPLACE INTO self_init_email (k, v) VALUES ('from', ${email.from})`;
+  }
+
+  emailProbe(): {
+    onStartCount: number;
+    storedFrom: string | undefined;
+  } {
+    const rows = this.sql<{
+      v: string;
+    }>`SELECT v FROM self_init_email WHERE k = 'from'`;
+    return { onStartCount: this.onStartCount, storedFrom: rows.at(0)?.v };
+  }
+
+  override onError(error: unknown): void {
+    throw error;
+  }
+}

--- a/packages/agents/src/tests/self-init.test.ts
+++ b/packages/agents/src/tests/self-init.test.ts
@@ -1,0 +1,139 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { routeAgentEmail } from "../index";
+import type { SelfInitAgent, SelfInitEmailAgent } from "./worker";
+
+// Every RPC entry surface of an Agent runs onStart() before executing, so a
+// stub resolved WITHOUT the getAgentByName -> setName round-trip (a raw cold
+// stub, or an internal zero-RTT resolution) still observes a fully
+// initialized agent. These tests pin that guarantee.
+
+function coldStub<T extends Rpc.DurableObjectBranded | undefined>(
+  namespace: DurableObjectNamespace<T>,
+  name: string
+): DurableObjectStub<T> {
+  // First-ever contact with this DO is a native RPC entry point — no
+  // getAgentByName, no setName, no fetch/alarm/webSocket entry.
+  return namespace.get(namespace.idFromName(name));
+}
+
+describe("RPC entry self-initialization", () => {
+  it("initializes a cold stub before running a user-defined RPC method", async () => {
+    const name = `self-init-user-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitAgent, name);
+
+    const result = await stub.probe();
+
+    // onStart ran exactly once, the schema it created is usable, and
+    // this.name is correct.
+    expect(result.onStartCount).toBe(1);
+    expect(result.storedName).toBe(name);
+    expect(result.name).toBe(name);
+  });
+
+  it("does not deadlock or double-init when onStart calls its own wrapped method", async () => {
+    const name = `self-init-reentrant-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitAgent, name);
+
+    const result = await stub.probe();
+
+    // onStart called this.syncDouble(41) locally during init. That takes the
+    // synchronous agent-context fast path: no deadlock, and onStart is NOT
+    // re-entered.
+    expect(result.onStartCount).toBe(1);
+    expect(result.reentrantResult).toBe(83);
+  });
+
+  it("initializes exactly once under two concurrent cold RPCs", async () => {
+    const name = `self-init-concurrent-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitAgent, name);
+
+    const [a, b] = await Promise.all([stub.probe(), stub.probe()]);
+
+    expect(a.onStartCount).toBe(1);
+    expect(b.onStartCount).toBe(1);
+  });
+
+  // Init-failure behavior (verified manually, not asserted here):
+  //   When onStart() throws, a cold RPC entry surfaces the error to the
+  //   caller (the wrapped call rejects with the onStart error) instead of
+  //   hanging, and the in-flight init memo is cleared so the next call
+  //   retries rather than replaying a cached rejection. partyserver catches
+  //   the onStart throw inside blockConcurrencyWhile and rethrows it after
+  //   the critical section, so the DO is NOT reset — the status stays
+  //   uninitialized and the next entry re-runs onStart.
+  //
+  //   This is intentionally not a runnable test: an onStart that rejects
+  //   inside partyserver's blockConcurrencyWhile makes workerd log an
+  //   "uncaught (in promise)" that @cloudflare/vitest-pool-workers reports
+  //   as an unhandled error and fails the run. That artifact reproduces
+  //   identically on the pre-existing getServerByName -> setName round-trip
+  //   path, so it is a harness limitation, not a behavior this PR changes.
+
+  it("preserves synchronous return values for wrapped methods once warm", async () => {
+    const name = `self-init-sync-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitAgent, name);
+
+    // Warm the agent up (cold init happens here).
+    await stub.probe();
+
+    const observed = await runInDurableObject(
+      stub as DurableObjectStub<SelfInitAgent>,
+      (instance) => {
+        // A synchronous wrapped method called after init must return its
+        // value synchronously, not a promise.
+        const direct = instance.syncDouble(21);
+        // A synchronous wrapped method called locally from another method
+        // (agent-context fast path) must also stay synchronous.
+        const local = instance.callSyncLocally();
+        return {
+          // Cast through `unknown`: statically these are already non-promise
+          // types, but the check exists to catch a runtime regression where a
+          // warm wrapped method starts returning a promise.
+          directIsPromise: (direct as unknown) instanceof Promise,
+          direct,
+          localIsPromise: (local as unknown) instanceof Promise,
+          local
+        };
+      }
+    );
+
+    expect(observed.directIsPromise).toBe(false);
+    expect(observed.direct).toBe(42);
+    expect(observed.localIsPromise).toBe(false);
+    expect(observed.local.innerWasNumber).toBe(true);
+    expect(observed.local.value).toBe(43);
+  });
+
+  it("initializes a cold stub before dispatching _onEmail", async () => {
+    const agentId = `self-init-email-${crypto.randomUUID()}`;
+    const email = {
+      from: "cold@example.com",
+      to: "recipient@example.com",
+      headers: new Headers(),
+      raw: new ReadableStream(),
+      rawSize: 1024,
+      setReject: () => {},
+      forward: async () => ({ messageId: "mock-forward-id" }),
+      reply: async () => ({ messageId: "mock-reply-id" })
+    } as unknown as ForwardableEmailMessage;
+
+    // routeAgentEmail resolves the agent stub zero-RTT and calls _onEmail;
+    // _onEmail self-initializes. If it did not, onEmail's INSERT into the
+    // onStart-created table would throw and this call would reject.
+    await routeAgentEmail(email, env, {
+      resolver: async () => ({ agentName: "SelfInitEmailAgent", agentId })
+    });
+
+    const stub = env.SelfInitEmailAgent.get(
+      env.SelfInitEmailAgent.idFromName(agentId)
+    ) as DurableObjectStub<SelfInitEmailAgent>;
+    const probe = await runInDurableObject(stub, (instance) =>
+      instance.emailProbe()
+    );
+
+    expect(probe.onStartCount).toBe(1);
+    expect(probe.storedFrom).toBe("cold@example.com");
+  });
+});

--- a/packages/agents/src/tests/self-init.test.ts
+++ b/packages/agents/src/tests/self-init.test.ts
@@ -18,6 +18,60 @@ function coldStub<T extends Rpc.DurableObjectBranded | undefined>(
   return namespace.get(namespace.idFromName(name));
 }
 
+type AgentPathStep = { className: string; name: string };
+
+// The internal facet RPC surfaces (`_cf_*`). These are NOT auto-wrapped by
+// `withAgentContext` (the wrapper skips every `_`-prefixed / base-class
+// method), so each carries its own `await this.__unsafe_ensureInitialized()`
+// guard. A cold stub that reaches one of these must still observe a fully
+// initialized agent.
+interface InternalFacetSurface {
+  _cf_scheduleForFacet(
+    ownerPath: AgentPathStep[],
+    when: number,
+    callback: string
+  ): Promise<unknown>;
+  _cf_dispatchScheduledCallback(
+    ownerPath: AgentPathStep[],
+    row: unknown
+  ): Promise<boolean>;
+  _cf_broadcastToSubAgent(
+    ownerPath: AgentPathStep[],
+    message: string
+  ): Promise<void>;
+}
+
+// Read the `name` row `onStart()` writes into the `self_init_probe` table,
+// directly from durable SQL. `runInDurableObject` hands back the raw
+// instance WITHOUT running an RPC entry surface, so — unlike `stub.probe()`
+// — it does NOT itself trigger `onStart()` (verified: on a never-addressed
+// cold instance it reads `onStartCount === 0` and no probe table). That
+// makes this a faithful observer of whether the *internal* call under test
+// ran init: with the guard the row is present, without it the table never
+// exists and this returns null.
+async function readSelfInitProbeName(
+  stub: DurableObjectStub<SelfInitAgent>
+): Promise<string | null> {
+  return runInDurableObject(stub, (instance) => {
+    const { sql } = (
+      instance as unknown as {
+        ctx: {
+          storage: { sql: { exec: (q: string) => Iterable<{ v: string }> } };
+        };
+      }
+    ).ctx.storage;
+    try {
+      const rows = [
+        ...sql.exec("SELECT v FROM self_init_probe WHERE k = 'name'")
+      ];
+      return rows.at(0)?.v ?? null;
+    } catch {
+      // Table absent — `onStart()` never ran, so the guard did not fire.
+      return null;
+    }
+  });
+}
+
 describe("RPC entry self-initialization", () => {
   it("initializes a cold stub before running a user-defined RPC method", async () => {
     const name = `self-init-user-${crypto.randomUUID()}`;
@@ -45,12 +99,24 @@ describe("RPC entry self-initialization", () => {
     expect(result.reentrantResult).toBe(83);
   });
 
-  it("initializes exactly once under two concurrent cold RPCs", async () => {
+  it("initializes exactly once across two overlapping cold RPCs", async () => {
     const name = `self-init-concurrent-${crypto.randomUUID()}`;
     const stub = coldStub(env.SelfInitAgent, name);
 
     const [a, b] = await Promise.all([stub.probe(), stub.probe()]);
 
+    // This asserts the observable exactly-once contract (idempotence), NOT the
+    // `_selfInitPromise` memo directly: the memo still passes this test if
+    // removed. The first cold entry runs `__unsafe_ensureInitialized()`, whose
+    // `blockConcurrencyWhile` holds the DO input gate shut until onStart
+    // resolves; the second RPC therefore cannot begin executing until init is
+    // already complete, at which point it takes the warm fast path. So true
+    // concurrent cold entry — two calls in the wrapper's cold path before init
+    // finishes — cannot be reproduced in-isolate here. The memo is
+    // defense-in-depth for a genuine interleaving (partyserver's
+    // `#ensureInitialized` re-runs onStart under a second entry — its
+    // top-of-function status check is not re-evaluated inside
+    // `blockConcurrencyWhile`), which is not what this test drives.
     expect(a.onStartCount).toBe(1);
     expect(b.onStartCount).toBe(1);
   });
@@ -135,5 +201,90 @@ describe("RPC entry self-initialization", () => {
 
     expect(probe.onStartCount).toBe(1);
     expect(probe.storedFrom).toBe("cold@example.com");
+  });
+
+  it("allows deleteSubAgent() from inside onStart() on a non-facet agent", async () => {
+    // Regression: on a top-level (non-facet) agent, `deleteSubAgent()` runs
+    // `_cf_cleanupFacetPrefix`'s work locally. Once that method
+    // self-initialized on RPC entry, calling it during onStart re-entered
+    // framework init and threw "blockConcurrencyWhile() calls are nested too
+    // deeply", aborting init. The local path now routes to the unguarded
+    // `_cleanupFacetPrefixImpl`, so onStart completes.
+    const name = `self-init-delete-onstart-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitDeleteInOnStartAgent, name);
+
+    // A cold probe forces onStart; if the regression returns, onStart rejects
+    // and this call rejects with it.
+    const result = await stub.probe();
+
+    expect(result.onStartCount).toBe(1);
+    expect(result.completed).toBe("yes");
+  });
+});
+
+// The bulk of the self-init work is ~22 internal `_cf_*` facet RPC surfaces,
+// each guarded by its own `await this.__unsafe_ensureInitialized()`. The
+// warm sub-agent / schedule suites only ever reach these once the DO is
+// already initialized (the parent addresses the facet first), so a dropped
+// guard is invisible there. These tests exercise the real cold flow: the
+// first-ever contact with the DO is one of these internal surfaces. Each
+// asserts that `onStart()`'s durable side effect (the `self_init_probe`
+// row) exists afterwards — which only holds if the surface ran init.
+describe("RPC entry self-initialization (internal facet surfaces)", () => {
+  it("initializes a cold stub before a facet-schedule write (_cf_scheduleForFacet)", async () => {
+    const name = `self-init-cf-schedule-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitAgent, name);
+    const selfPath: AgentPathStep[] = [{ className: "SelfInitAgent", name }];
+
+    // First-ever contact is the internal schedule-write RPC. Its target
+    // table (`cf_agents_schedules`) is created in the constructor, not
+    // `onStart()`, so the insert would succeed even with the guard dropped —
+    // the guard is proven only by the onStart-created probe row below.
+    // A number `when` is a delay in seconds; 1 hour keeps the alarm from
+    // firing inside the test window.
+    await (stub as unknown as InternalFacetSurface)._cf_scheduleForFacet(
+      selfPath,
+      3600,
+      "noop"
+    );
+
+    expect(await readSelfInitProbeName(stub)).toBe(name);
+  });
+
+  it("initializes a cold stub before a dispatched callback (_cf_dispatchScheduledCallback)", async () => {
+    const name = `self-init-cf-dispatch-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitAgent, name);
+    // A path one level below self, addressing a sub-agent that was never
+    // spawned: the dispatch walks one step, finds no such child, and prunes
+    // the stale prefix (returns false) — reaching the branch WITHOUT needing
+    // a real callback row. `selfPath` is only correct once `onStart()` has
+    // hydrated the agent, so a dropped guard breaks this path.
+    const ownerPath: AgentPathStep[] = [
+      { className: "SelfInitAgent", name },
+      { className: "NoSuchChild", name: "absent" }
+    ];
+
+    const executed = await (
+      stub as unknown as InternalFacetSurface
+    )._cf_dispatchScheduledCallback(ownerPath, {});
+
+    expect(executed).toBe(false);
+    expect(await readSelfInitProbeName(stub)).toBe(name);
+  });
+
+  it("initializes a cold stub before a sub-agent broadcast (_cf_broadcastToSubAgent)", async () => {
+    const name = `self-init-cf-broadcast-${crypto.randomUUID()}`;
+    const stub = coldStub(env.SelfInitAgent, name);
+    const selfPath: AgentPathStep[] = [{ className: "SelfInitAgent", name }];
+
+    // No connections exist, so the broadcast is a no-op — but reaching it at
+    // all depends on `_isFacet`/connection state that only `onStart()`
+    // hydrates, and the surface must self-initialize first.
+    await (stub as unknown as InternalFacetSurface)._cf_broadcastToSubAgent(
+      selfPath,
+      "hello"
+    );
+
+    expect(await readSelfInitProbeName(stub)).toBe(name);
   });
 });

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -70,7 +70,9 @@ export {
   Sub_,
   ReservedClassParent,
   TestUnboundParentAgent,
-  TestMinifiedNameParentAgent
+  TestMinifiedNameParentAgent,
+  SelfInitAgent,
+  SelfInitEmailAgent
 } from "./agents";
 export { ChatSdkStateAgent } from "./agents";
 export { TestRunFiberAgent } from "./agents/run-fiber";
@@ -142,7 +144,9 @@ import type {
   HookingSubAgentParent,
   ReservedClassParent,
   TestUnboundParentAgent,
-  TestMinifiedNameParentAgent
+  TestMinifiedNameParentAgent,
+  SelfInitAgent,
+  SelfInitEmailAgent
 } from "./agents";
 
 export type Env = {
@@ -196,6 +200,8 @@ export type Env = {
   HookingSubAgentParent: DurableObjectNamespace<HookingSubAgentParent>;
   ReservedClassParent: DurableObjectNamespace<ReservedClassParent>;
   TestConnectionUriAgent: DurableObjectNamespace<TestConnectionUriAgent>;
+  SelfInitAgent: DurableObjectNamespace<SelfInitAgent>;
+  SelfInitEmailAgent: DurableObjectNamespace<SelfInitEmailAgent>;
   // SubAgent classes (CounterSubAgent, OuterSubAgent, InnerSubAgent) are
   // accessed via ctx.exports as facet classes — no standalone bindings needed.
   // Workflow bindings for integration testing

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -72,7 +72,8 @@ export {
   TestUnboundParentAgent,
   TestMinifiedNameParentAgent,
   SelfInitAgent,
-  SelfInitEmailAgent
+  SelfInitEmailAgent,
+  SelfInitDeleteInOnStartAgent
 } from "./agents";
 export { ChatSdkStateAgent } from "./agents";
 export { TestRunFiberAgent } from "./agents/run-fiber";
@@ -146,7 +147,8 @@ import type {
   TestUnboundParentAgent,
   TestMinifiedNameParentAgent,
   SelfInitAgent,
-  SelfInitEmailAgent
+  SelfInitEmailAgent,
+  SelfInitDeleteInOnStartAgent
 } from "./agents";
 
 export type Env = {
@@ -202,6 +204,7 @@ export type Env = {
   TestConnectionUriAgent: DurableObjectNamespace<TestConnectionUriAgent>;
   SelfInitAgent: DurableObjectNamespace<SelfInitAgent>;
   SelfInitEmailAgent: DurableObjectNamespace<SelfInitEmailAgent>;
+  SelfInitDeleteInOnStartAgent: DurableObjectNamespace<SelfInitDeleteInOnStartAgent>;
   // SubAgent classes (CounterSubAgent, OuterSubAgent, InnerSubAgent) are
   // accessed via ctx.exports as facet classes — no standalone bindings needed.
   // Workflow bindings for integration testing

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -273,6 +273,10 @@
       {
         "class_name": "SelfInitEmailAgent",
         "name": "SelfInitEmailAgent"
+      },
+      {
+        "class_name": "SelfInitDeleteInOnStartAgent",
+        "name": "SelfInitDeleteInOnStartAgent"
       }
     ]
   },
@@ -381,7 +385,8 @@
         "TestUnboundParentAgent",
         "TestMinifiedNameParentAgent",
         "SelfInitAgent",
-        "SelfInitEmailAgent"
+        "SelfInitEmailAgent",
+        "SelfInitDeleteInOnStartAgent"
       ],
       "tag": "v1"
     }

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -265,6 +265,14 @@
       {
         "class_name": "TestMinifiedNameParentAgent",
         "name": "TestMinifiedNameParentAgent"
+      },
+      {
+        "class_name": "SelfInitAgent",
+        "name": "SelfInitAgent"
+      },
+      {
+        "class_name": "SelfInitEmailAgent",
+        "name": "SelfInitEmailAgent"
       }
     ]
   },
@@ -371,7 +379,9 @@
         "HookingSubAgentParent",
         "ReservedClassParent",
         "TestUnboundParentAgent",
-        "TestMinifiedNameParentAgent"
+        "TestMinifiedNameParentAgent",
+        "SelfInitAgent",
+        "SelfInitEmailAgent"
       ],
       "tag": "v1"
     }

--- a/packages/agents/src/utils.ts
+++ b/packages/agents/src/utils.ts
@@ -1,3 +1,42 @@
+import type { Server } from "partyserver";
+
+/**
+ * Resolve a Durable Object stub directly by name, skipping the
+ * `getServerByName` → `setName` init round-trip. Mirrors
+ * `getServerByName`'s namespace option handling (`jurisdiction`,
+ * `locationHint`) but issues zero RPCs at resolution time: the target
+ * self-initializes on its own RPC entry surface before running. Every
+ * internal Agent RPC surface awaits `__unsafe_ensureInitialized()`, and
+ * the auto-wrapped user-method path cold-initializes on first call, so a
+ * stub resolved this way is safe to invoke without a prior `setName`.
+ *
+ * Never delivers `props`; callers that need props must keep the sync
+ * round-trip (`getAgentByName` / `getServerByName`). Internal call sites
+ * only.
+ *
+ * @internal
+ */
+export function getAgentStubByName<
+  Env extends Cloudflare.Env = Cloudflare.Env,
+  T extends Server<Env> = Server<Env>
+>(
+  namespace: DurableObjectNamespace<T>,
+  name: string,
+  options?: {
+    jurisdiction?: DurableObjectJurisdiction;
+    locationHint?: DurableObjectLocationHint;
+  }
+): DurableObjectStub<T> {
+  const resolvedNamespace = options?.jurisdiction
+    ? namespace.jurisdiction(options.jurisdiction)
+    : namespace;
+  const id = resolvedNamespace.idFromName(name);
+  return resolvedNamespace.get(
+    id,
+    options?.locationHint ? { locationHint: options.locationHint } : undefined
+  );
+}
+
 /**
  * Property keys that JavaScript runtimes and test frameworks probe
  * on arbitrary objects (serialization, thenable check, inspection,

--- a/packages/agents/src/workflows.ts
+++ b/packages/agents/src/workflows.ts
@@ -39,7 +39,7 @@ import type {
   WorkflowStep,
   WorkflowStepEvent
 } from "cloudflare:workers";
-import { getAgentByName, type Agent } from "./index";
+import type { Agent } from "./index";
 import type {
   AgentWorkflowParams,
   AgentWorkflowStep,
@@ -52,7 +52,7 @@ import type {
   AgentWorkflowOrigin,
   AgentWorkflowPathStep
 } from "./workflow-types";
-import { isInternalJsStubProp } from "./utils";
+import { getAgentStubByName, isInternalJsStubProp } from "./utils";
 
 type AgentPathInvoker = {
   _cf_invokeAgentPath(
@@ -251,8 +251,11 @@ export class AgentWorkflow<
       );
     }
 
-    // Get the Agent stub by name
-    this._agent = await getAgentByName<Cloudflare.Env, AgentType>(
+    // Get the Agent stub by name. Zero-RTT: the agent self-initializes on
+    // its own RPC entry surface (auto-wrapped user methods and
+    // `_cf_invokeAgentPath`), so we skip the `getAgentByName` → `setName`
+    // init round-trip.
+    this._agent = getAgentStubByName<Cloudflare.Env, AgentType>(
       namespace,
       resolvedAgentName
     );
@@ -276,10 +279,12 @@ export class AgentWorkflow<
       );
     }
 
-    const rootAgent = (await getAgentByName<Cloudflare.Env, Agent>(
+    // Zero-RTT: `_cf_invokeAgentPath` self-initializes on the root, so we
+    // skip the `getAgentByName` → `setName` init round-trip.
+    const rootAgent = getAgentStubByName<Cloudflare.Env, Agent>(
       namespace,
       root.name
-    )) as unknown as AgentPathInvoker;
+    ) as unknown as AgentPathInvoker;
 
     return new Proxy(
       {},


### PR DESCRIPTION
## Motivation

Several native Durable Object RPC entry points on an `Agent` depend on the caller having resolved the stub through `getAgentByName()` / `getServerByName()`, whose `setName()` round-trip is what runs `onStart()` before the first call. A surface reached on a stub that skipped that round-trip could execute before `onStart()` completed — seeing un-hydrated facet state, an un-restored MCP client, or a schema that a hook expected to exist.

This makes every RPC entry surface self-sufficient: it initializes itself before running, so init ordering no longer rides on the resolution-time round-trip. That is also the prerequisite for later dropping the round-trip on prop-less resolution.

This is pure hardening — no public API changes and no change to documented resolution semantics. `getAgentByName` / `getServerByName` keep their existing behavior (including the `props` round-trip).

## The guarantee

Every RPC entry surface now runs `onStart()` before executing, mirroring the guard that `_cf_invokeAgentPath` already used:

- `_onEmail`
- the sub-agent bridges `_cf_invokeSubAgent` / `_cf_invokeSubAgentPath`
- the schedule / fiber dispatch callbacks `_cf_dispatchScheduledCallback` / `_cf_checkRunFibersForFacet`
- the WebSocket-forwarding facet handlers `_cf_handleSubAgentWebSocket{Connect,Message,Close}`
- every root facet RPC method: schedules (`_cf_scheduleForFacet`, `_cf_scheduleEveryForFacet`, `_cf_cancelScheduleForFacet`, `_cf_getScheduleForFacet`, `_cf_listSchedulesForFacet`, `_cf_cleanupFacetPrefix`), keepAlive (`_cf_acquireFacetKeepAlive`, `_cf_releaseFacetKeepAlive`), facet-run registration (`_cf_registerFacetRun`, `_cf_unregisterFacetRun`), `_cf_destroyDescendantFacet`, `_cf_broadcastToSubAgent`, and the sub-agent connection routing methods (`_cf_subAgentConnectionMetas`, `_cf_sendToSubAgentConnection`, `_cf_closeSubAgentConnection`, `_cf_setSubAgentConnectionState`).

**User-defined RPC methods** on cold stubs also initialize before running, via a synchronous fast path in the `_autoWrapCustomMethods` wrapper (`withAgentContext`).

MCP storage helpers (`McpAgent.getInitializeRequest` / `setInitializeRequest` / stream-id helpers, `onSSEMcpMessage`) are intentionally left unchanged: they are only ever reached through `getAgentByName(..., { props })`, which keeps its `setName` round-trip in this change, so they are always invoked on an already-initialized stub.

## Re-entrancy and correctness design

The wrapper must add init without regressing local-call semantics. It handles:

- **Synchronous returns preserved.** The warm path is a synchronous `_selfInitCompleted` flag check; an already-initialized wrapped method called locally returns its value synchronously (it does not start returning a promise). Cold entry is inherently async — it only happens across an RPC boundary.
- **Re-entrancy during `onStart()`.** The framework's `onStart()` runs inside the agent's ALS context, so a wrapped method it calls locally takes the existing `agent === this` fast path and runs directly — it never re-triggers init (which would deadlock the in-flight init or double-run `onStart()`).
- **Concurrent cold RPCs init exactly once.** The in-flight init promise is memoized, so two concurrent cold RPCs share a single `onStart()` run rather than double-triggering it.
- **Init failure does not hang.** On failure the memo is cleared and the error is surfaced to the caller, so the next call retries rather than replaying a cached rejection. partyserver catches an `onStart()` throw inside `blockConcurrencyWhile` and rethrows it afterward, so the DO is not reset and the next entry re-runs `onStart()`.
- **Hibernation-safe.** Both signals are in-memory only, so a woken (cold) instance re-initializes, which is correct.
- **Raw-id addressing unchanged.** Self-init is gated on name-addressed DOs (`ctx.id.name` defined). A raw-id DO (`newUniqueId()` / `idFromString()` without a `setName()` bootstrap) has no resolvable name — the case partyserver's `name` getter throws on — so the wrapper preserves the historical behavior of invoking the method without forcing init there.

## Internal zero-round-trip resolution

Because every reachable surface is now self-sufficient, the internal resolution sites that only ever invoke self-initializing methods and never pass `props` resolve their stub directly (a new internal `getAgentStubByName` helper that mirrors `getServerByName`'s jurisdiction / locationHint handling but issues zero RPCs) instead of paying the `setName` round-trip:

- `_rootAlarmOwner` (used by ~9 schedule/keepAlive/broadcast call sites)
- `parentAgent` (top-level and facet-proxy branches)
- `AgentWorkflow`'s agent resolution (top-level and facet origins)
- email routing

The public `getAgentByName` / `getServerByName` are untouched.

## Tests

New `src/tests/self-init.test.ts` (with test agents in `src/tests/agents/self-init.ts`):

- a user-defined RPC method invoked on a **cold** stub obtained via raw `env.NS.get(idFromName(...))` initializes (`onStart` ran, schema created in `onStart` is usable, `this.name` correct);
- `onStart` calling its own wrapped method does not deadlock or double-init (`onStart` runs exactly once);
- two concurrent cold RPCs init exactly once;
- a synchronous wrapped method called after init (both directly and locally from another method) returns synchronously, not a promise;
- `_onEmail` on a cold stub (routed via `routeAgentEmail`, which now resolves zero-RTT) initializes before dispatch.

The init-failure behavior is documented inline rather than asserted: an `onStart()` that rejects inside partyserver's `blockConcurrencyWhile` makes the runtime log an "uncaught (in promise)" that the workers test pool reports as an unhandled error and fails the run. That artifact reproduces identically on the pre-existing `getServerByName` round-trip path, so it is a test-harness limitation, not a behavior this change introduces. The behavior itself (RPC rejects, does not hang, retries) was verified manually.

Full `agents` package test suite passes (2279 tests), plus `pnpm run check`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->