### PR TITLE
fix(mcp): correct elicitation release guidance

### DIFF
--- a/.changeset/mcp-client-elicitation-options.md
+++ b/.changeset/mcp-client-elicitation-options.md
@@ -9,8 +9,6 @@ MCP client: url-mode elicitation support with a real elicitation handler
   `onStart()`. The advertised modes are persisted with each MCP server, so
   connections restored after Durable Object hibernation re-advertise them at
   the handshake and the handlers re-attach when onStart runs.
-  `MCPClientConnection` also accepts `elicitationHandlers` callbacks for
-  lower-level non-Agent usage.
 - Connections advertise elicitation modes based on what can actually be
   handled: they advertise exactly the modes with configured handlers at the
   initialize handshake; without handlers they advertise no elicitation
@@ -18,5 +16,3 @@ MCP client: url-mode elicitation support with a real elicitation handler
   `client.capabilities.elicitation` (e.g. via `addMcpServer`) always wins,
   is persisted with the server options, and survives hibernation — it is no
   longer clobbered by a hardcoded value.
-- Overriding/instance-patching `MCPClientConnection.handleElicitationRequest`
-  directly is deprecated in favor of the `elicitationHandlers` option.

--- a/.changeset/no-elicitation-capability-without-handler.md
+++ b/.changeset/no-elicitation-capability-without-handler.md
@@ -8,16 +8,10 @@ Connections without an elicitation handler previously advertised form-mode
 elicitation while rejecting every elicitation request that arrived, so
 spec-compliant servers chose elicitation over their fallback flows and the
 tool call failed mid-flight. Connections now advertise the elicitation
-capability only when it can be handled: both form and url mode with a
-handlers configured via `this.mcp.configureElicitationHandlers({ form, url })`
-or the connection `elicitationHandlers` option, and no elicitation capability
-without handlers, letting servers fall back gracefully. Only modes with
-configured handlers are advertised.
+capability only when it can be handled: form mode, URL mode, or both, based on
+handlers configured via `this.mcp.configureElicitationHandlers({ form, url })`.
+Connections without handlers advertise no elicitation capability, letting
+servers fall back gracefully.
 
-Behavior change: code relying on the deprecated pattern of instance-patching
-`handleElicitationRequest` on a connection stops receiving elicitation
-requests, because the capability is no longer advertised. Migrate to
-`this.mcp.configureElicitationHandlers({ form, url })` / the connection
-`elicitationHandlers` option, or declare
-`client.capabilities.elicitation` explicitly — an explicit declaration is
-always honored.
+An explicit `client.capabilities.elicitation` declaration remains authoritative.
+Only advertise modes your Agent can handle.

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -14,7 +14,7 @@ An Agent that acts as an MCP **client** — dynamically connects to remote MCP s
 
 ```sh
 npm install
-npm run dev
+npm run start
 ```
 
 The UI lets you add MCP server URLs, see their connection state, browse their tools, prompts, and resources, and run tools. If a tool call triggers an elicitation, a card appears asking for your input.

--- a/examples/mcp-elicitation/src/index.ts
+++ b/examples/mcp-elicitation/src/index.ts
@@ -150,7 +150,12 @@ export class MyAgent extends Agent<Cloudflare.Env, State> {
           };
         }
         return {
-          content: [{ type: "text", text: "Account connected. Thanks!" }]
+          content: [
+            {
+              type: "text",
+              text: "Account connection page opened. Complete it in your browser."
+            }
+          ]
         };
       }
     );


### PR DESCRIPTION
## Summary

Small release-readiness cleanup for `agents@0.17.4`:

- remove unsupported lower-level `MCPClientConnection` promises from the release changesets
- fix the `mcp-client` README command (`npm run start`)
- correct the URL-mode example result: `accept` means the user opened the external flow, not that the flow completed

No public API or runtime behavior changes.

## Verification

- `pnpm run typecheck examples/mcp-client`
- `pnpm --filter @cloudflare/agents-mcp-elicitation exec tsc --noEmit`
- the underlying elicitation implementation already passes the package tests and MCP conformance suite
