### PR TITLE
Bound Agent Workflow tracking so that local state is automatically pruned

### DIFF
--- a/.changeset/workflow-tracking-retention.md
+++ b/.changeset/workflow-tracking-retention.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Automatically bound Agent Workflow tracking rows with terminal-outcome retention and alarm-driven cleanup that survives idle Agent eviction.

--- a/.changeset/workflow-tracking-retention.md
+++ b/.changeset/workflow-tracking-retention.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Automatically bound Agent Workflow tracking rows with terminal-outcome retention and alarm-driven cleanup that survives idle Agent eviction.
+Passing `retention` to `Agent.runWorkflow(...)` both sends [`retention`](https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions) unchanged to the underlying Workflow instance and automatically cleans up the Agent's SQLite store.

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -553,11 +553,15 @@ Workflows started with `runWorkflow()` are automatically tracked in the originat
 | `created_at`                | INTEGER | Unix timestamp                    |
 | `updated_at`                | INTEGER | Unix timestamp                    |
 | `completed_at`              | INTEGER | Unix timestamp (when done)        |
+| `expires_at`                | INTEGER | Derived local cleanup timestamp   |
 | `success_retention_seconds` | INTEGER | Local success retention           |
 | `error_retention_seconds`   | INTEGER | Local error/termination retention |
-| `expires_at`                | INTEGER | Indexed local cleanup timestamp   |
 
 Note: Workflow params and output are not stored by default. Use `metadata` to store queryable information, and store large payloads in your own tables if needed.
+
+`expires_at` is derived from `completed_at` and the retention period for the
+Workflow's terminal outcome. Storing and indexing the derived value lets the
+Agent find the next row to clean up without recalculating every row's retention.
 
 ### Workflow Status Values
 

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -265,7 +265,10 @@ const instanceId = await this.runWorkflow(
 - `options.retention` - Workflow instance retention passed unchanged to
   [`Workflow.create()`](https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions).
   Use `successRetention` for successful instances and `errorRetention` for
-  errored or terminated instances.
+  errored or terminated instances. The Agent stores the normalized values in
+  SQLite so its local tracking row follows the same terminal-outcome policy.
+  When either value is omitted, local tracking uses a 30-day fallback because
+  the SDK cannot detect whether the account is Workers Free or Workers Paid.
 
 **Returns:** Workflow instance ID
 
@@ -538,18 +541,21 @@ Workflows started with `runWorkflow()` are automatically tracked in the originat
 
 ### `cf_agents_workflows` Table
 
-| Column          | Type    | Description                     |
-| --------------- | ------- | ------------------------------- |
-| `id`            | TEXT    | Internal row ID                 |
-| `workflow_id`   | TEXT    | Cloudflare workflow instance ID |
-| `workflow_name` | TEXT    | Workflow binding name           |
-| `status`        | TEXT    | Current status                  |
-| `metadata`      | TEXT    | JSON metadata (for querying)    |
-| `error_name`    | TEXT    | Error name (if failed)          |
-| `error_message` | TEXT    | Error message (if failed)       |
-| `created_at`    | INTEGER | Unix timestamp                  |
-| `updated_at`    | INTEGER | Unix timestamp                  |
-| `completed_at`  | INTEGER | Unix timestamp (when done)      |
+| Column                      | Type    | Description                       |
+| --------------------------- | ------- | --------------------------------- |
+| `id`                        | TEXT    | Internal row ID                   |
+| `workflow_id`               | TEXT    | Cloudflare workflow instance ID   |
+| `workflow_name`             | TEXT    | Workflow binding name             |
+| `status`                    | TEXT    | Current status                    |
+| `metadata`                  | TEXT    | JSON metadata (for querying)      |
+| `error_name`                | TEXT    | Error name (if failed)            |
+| `error_message`             | TEXT    | Error message (if failed)         |
+| `created_at`                | INTEGER | Unix timestamp                    |
+| `updated_at`                | INTEGER | Unix timestamp                    |
+| `completed_at`              | INTEGER | Unix timestamp (when done)        |
+| `success_retention_seconds` | INTEGER | Local success retention           |
+| `error_retention_seconds`   | INTEGER | Local error/termination retention |
+| `expires_at`                | INTEGER | Indexed local cleanup timestamp   |
 
 Note: Workflow params and output are not stored by default. Use `metadata` to store queryable information, and store large payloads in your own tables if needed.
 

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -396,6 +396,9 @@ type WorkflowPage = {
 
 Delete a single workflow tracking record.
 
+This removes only the Agent's local SQLite tracking row. It does not delete or
+terminate the underlying Workflow instance.
+
 ```typescript
 const deleted = this.deleteWorkflow(instanceId);
 // true if deleted, false if not found
@@ -403,7 +406,9 @@ const deleted = this.deleteWorkflow(instanceId);
 
 #### `deleteWorkflows(criteria?)`
 
-Delete workflow tracking records matching criteria. Useful for cleanup.
+Delete workflow tracking records matching criteria before automatic retention
+expires. This affects only local Agent SQLite tracking, not underlying Workflow
+instances or their state.
 
 ```typescript
 // Delete all completed workflows older than 7 days
@@ -845,25 +850,18 @@ const approvalData = await this.waitForApproval(step, { timeout: "7 days" });
 2. **Use meaningful step names** - Helps with debugging and observability
 3. **Report progress regularly** - Keeps users informed
 4. **Handle errors gracefully** - Use `reportError()` before throwing
-5. **Clean up completed workflows** - The `cf_agents_workflows` table can grow unbounded, so implement a retention policy:
-
-```typescript
-// Option 1: Cleanup immediately on completion
-async onWorkflowComplete(workflowName, instanceId, result) {
-  // Process result first, then delete
-  this.deleteWorkflow(instanceId);
-}
-
-// Option 2: Scheduled cleanup (keep recent history)
-// Call this periodically via a scheduled task or cron
-this.deleteWorkflows({
-  status: ["complete", "errored"],
-  createdBefore: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) // 7 days
-});
-
-// Option 3: Keep all history for compliance/auditing
-// Don't call deleteWorkflows() - query historical data as needed
-```
+5. **Treat Workflow tracking as bounded operational state** - The SDK
+   automatically deletes terminal rows from `cf_agents_workflows` after 30
+   days. It arms cleanup when tracking starts, computes expiry from the
+   terminal completion time, and recovers cleanup after Agent eviction without
+   requiring `onStart()` or `onReady()` hooks. This is a bounded local fallback
+   aligned with the maximum default Workflow retention on Workers Paid; it is
+   not indefinite audit history. Workers Free retains underlying Workflow state
+   for less time, so a local tracking row can temporarily outlive platform
+   state. Use an external durable store for compliance or long-term history.
+   `deleteWorkflow()` and `deleteWorkflows()` remain available for earlier
+   removal. Automatic and manual deletion affect only Agent SQLite tracking,
+   never the underlying Workflow instance or state.
 
 6. **Handle workflow binding renames carefully** - If you rename a workflow binding in `wrangler.jsonc`, existing tracked workflows will reference the old name. The agent will warn on startup if it detects this. Use `migrateWorkflowBinding()` to update them:
 

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -265,7 +265,10 @@ const instanceId = await this.runWorkflow(
 - [`options.retention`](https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions) - Workflow retention passed unchanged to
   `Workflow.create()`.
   Use `successRetention` for successful instances and `errorRetention` for
-  errored or terminated instances.
+  errored or terminated instances. The Agent stores the normalized values in
+  SQLite so its local tracking row follows the same terminal-outcome policy.
+  When either value is omitted, local tracking uses a 30-day fallback because
+  the SDK cannot detect whether the account is Workers Free or Workers Paid.
 
 **Returns:** Workflow instance ID
 
@@ -538,18 +541,21 @@ Workflows started with `runWorkflow()` are automatically tracked in the originat
 
 ### `cf_agents_workflows` Table
 
-| Column          | Type    | Description                     |
-| --------------- | ------- | ------------------------------- |
-| `id`            | TEXT    | Internal row ID                 |
-| `workflow_id`   | TEXT    | Cloudflare workflow instance ID |
-| `workflow_name` | TEXT    | Workflow binding name           |
-| `status`        | TEXT    | Current status                  |
-| `metadata`      | TEXT    | JSON metadata (for querying)    |
-| `error_name`    | TEXT    | Error name (if failed)          |
-| `error_message` | TEXT    | Error message (if failed)       |
-| `created_at`    | INTEGER | Unix timestamp                  |
-| `updated_at`    | INTEGER | Unix timestamp                  |
-| `completed_at`  | INTEGER | Unix timestamp (when done)      |
+| Column                      | Type    | Description                       |
+| --------------------------- | ------- | --------------------------------- |
+| `id`                        | TEXT    | Internal row ID                   |
+| `workflow_id`               | TEXT    | Cloudflare workflow instance ID   |
+| `workflow_name`             | TEXT    | Workflow binding name             |
+| `status`                    | TEXT    | Current status                    |
+| `metadata`                  | TEXT    | JSON metadata (for querying)      |
+| `error_name`                | TEXT    | Error name (if failed)            |
+| `error_message`             | TEXT    | Error message (if failed)         |
+| `created_at`                | INTEGER | Unix timestamp                    |
+| `updated_at`                | INTEGER | Unix timestamp                    |
+| `completed_at`              | INTEGER | Unix timestamp (when done)        |
+| `success_retention_seconds` | INTEGER | Local success retention           |
+| `error_retention_seconds`   | INTEGER | Local error/termination retention |
+| `expires_at`                | INTEGER | Indexed local cleanup timestamp   |
 
 Note: Workflow params and output are not stored by default. Use `metadata` to store queryable information, and store large payloads in your own tables if needed.
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -29,6 +29,7 @@
     "@rolldown/plugin-babel": "^0.2.3",
     "cron-schedule": "^6.0.0",
     "esbuild": "^0.28.1",
+    "itty-time": "2.0.1",
     "mimetext": "^3.0.28",
     "nanoid": "^5.1.16",
     "partyserver": "^0.5.9",

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -680,6 +680,11 @@ type RootFacetRpcSurface = {
     payload?: T,
     options?: { retry?: RetryOptions; _idempotent?: boolean }
   ): Promise<{ schedule: Schedule<T>; created: boolean }>;
+  _cf_rearmWorkflowCleanupForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    nextCleanupAt: number | null,
+    fired?: boolean
+  ): Promise<void>;
   _cf_cleanupFacetPrefix(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<void>;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -37,6 +37,7 @@ import {
   routePartykitRequest
 } from "partyserver";
 import { camelCaseToKebabCase, isInternalJsStubProp } from "./utils";
+import { normalizeWorkflowRetention } from "./workflow-retention";
 export { camelCaseToKebabCase } from "./utils";
 import {
   type RetryOptions,
@@ -11424,10 +11425,18 @@ export class Agent<
     const metadataJson = options?.metadata
       ? JSON.stringify(options.metadata)
       : null;
+    const { successRetentionSeconds, errorRetentionSeconds } =
+      normalizeWorkflowRetention(options?.retention);
     try {
       this.sql`
-        INSERT INTO cf_agents_workflows (id, workflow_id, workflow_name, status, metadata)
-        VALUES (${id}, ${instance.id}, ${workflowName}, 'queued', ${metadataJson})
+        INSERT INTO cf_agents_workflows (
+          id, workflow_id, workflow_name, status, metadata,
+          success_retention_seconds, error_retention_seconds
+        )
+        VALUES (
+          ${id}, ${instance.id}, ${workflowName}, 'queued', ${metadataJson},
+          ${successRetentionSeconds}, ${errorRetentionSeconds}
+        )
       `;
     } catch (e) {
       if (

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1137,7 +1137,12 @@ type AgentToolRecoveryInspection =
  * on wake to skip DDL on established DOs.
  */
 const CURRENT_SCHEMA_VERSION = 12;
+// Workflows retain completed instance state for at most 30 days on Workers
+// Paid. Free accounts retain it for 3 days.
+// https://developers.cloudflare.com/workflows/reference/limits/#_top
 const DEFAULT_WORKFLOW_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+// Recheck non-terminal tracking rows daily so a missed Workflow callback does
+// not leave local state unbounded after the platform instance finishes.
 const WORKFLOW_RECONCILIATION_SECONDS = 24 * 60 * 60;
 
 const SCHEMA_VERSION_ROW_ID = "cf_schema_version";
@@ -2151,22 +2156,21 @@ export class Agent<
           created_at INTEGER NOT NULL DEFAULT (unixepoch()),
           updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
           completed_at INTEGER,
-          success_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
-          error_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
-          expires_at INTEGER
+          expires_at INTEGER,
+          success_retention_seconds INTEGER NOT NULL DEFAULT (30 * 24 * 60 * 60),
+          error_retention_seconds INTEGER NOT NULL DEFAULT (30 * 24 * 60 * 60)
         )
       `;
 
+      addColumnIfNotExists(
+        "ALTER TABLE cf_agents_workflows ADD COLUMN expires_at INTEGER"
+      );
       addColumnIfNotExists(
         `ALTER TABLE cf_agents_workflows ADD COLUMN success_retention_seconds INTEGER NOT NULL DEFAULT ${DEFAULT_WORKFLOW_RETENTION_SECONDS}`
       );
       addColumnIfNotExists(
         `ALTER TABLE cf_agents_workflows ADD COLUMN error_retention_seconds INTEGER NOT NULL DEFAULT ${DEFAULT_WORKFLOW_RETENTION_SECONDS}`
       );
-      addColumnIfNotExists(
-        "ALTER TABLE cf_agents_workflows ADD COLUMN expires_at INTEGER"
-      );
-
       if (schemaVersion < 12) {
         this.ctx.storage.sql.exec(`
           UPDATE cf_agents_workflows
@@ -6080,6 +6084,19 @@ export class Agent<
         const status = await instance.status();
         await this._updateWorkflowTracking(row.workflow_id, status);
       } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("instance.not_found")
+        ) {
+          // The Workflow service has already removed this instance, so no
+          // later callback can supply a terminal timestamp. Remove the stale
+          // local tracking row instead of reconciling it forever.
+          this.sql`
+            DELETE FROM cf_agents_workflows
+            WHERE workflow_id = ${row.workflow_id}
+          `;
+          continue;
+        }
         // Platform state can be temporarily unavailable. Keep the local row
         // and retry on the next bounded reconciliation wake.
         console.warn(
@@ -6787,15 +6804,18 @@ export class Agent<
       return;
     }
 
-    const existing = this.sql<{ id: string }>`
+    // Facets cannot own a physical alarm. This mirrors the existing
+    // root-owned schedule pattern: one namespaced schedule row per facet feeds
+    // the root Agent's shared earliest-alarm calculation.
+    const [existing] = this.sql<{ id: string }>`
       SELECT id FROM cf_agents_schedules
       WHERE callback = ${callback} AND owner_path_key = ${ownerPathKey}
       LIMIT 1
     `;
-    if (existing[0]) {
+    if (existing) {
       this.sql`
         UPDATE cf_agents_schedules SET time = ${nextCleanupAt}
-        WHERE id = ${existing[0].id}
+        WHERE id = ${existing.id}
       `;
     } else {
       await this._insertScheduleForOwner(

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1130,7 +1130,9 @@ type AgentToolRecoveryInspection =
  * The constructor stores this as a row in cf_agents_state and checks it
  * on wake to skip DDL on established DOs.
  */
-const CURRENT_SCHEMA_VERSION = 11;
+const CURRENT_SCHEMA_VERSION = 12;
+const DEFAULT_WORKFLOW_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+const WORKFLOW_RECONCILIATION_SECONDS = 24 * 60 * 60;
 
 const SCHEMA_VERSION_ROW_ID = "cf_schema_version";
 const STATE_ROW_ID = "cf_state_row_id";
@@ -2142,9 +2144,34 @@ export class Agent<
           error_message TEXT,
           created_at INTEGER NOT NULL DEFAULT (unixepoch()),
           updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
-          completed_at INTEGER
+          completed_at INTEGER,
+          success_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
+          error_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
+          expires_at INTEGER
         )
       `;
+
+      addColumnIfNotExists(
+        `ALTER TABLE cf_agents_workflows ADD COLUMN success_retention_seconds INTEGER NOT NULL DEFAULT ${DEFAULT_WORKFLOW_RETENTION_SECONDS}`
+      );
+      addColumnIfNotExists(
+        `ALTER TABLE cf_agents_workflows ADD COLUMN error_retention_seconds INTEGER NOT NULL DEFAULT ${DEFAULT_WORKFLOW_RETENTION_SECONDS}`
+      );
+      addColumnIfNotExists(
+        "ALTER TABLE cf_agents_workflows ADD COLUMN expires_at INTEGER"
+      );
+
+      if (schemaVersion < 12) {
+        this.ctx.storage.sql.exec(`
+          UPDATE cf_agents_workflows
+          SET expires_at = completed_at + CASE
+            WHEN status = 'complete' THEN success_retention_seconds
+            WHEN status IN ('errored', 'terminated') THEN error_retention_seconds
+            ELSE NULL
+          END
+          WHERE completed_at IS NOT NULL AND expires_at IS NULL
+        `);
+      }
 
       this.sql`
         CREATE INDEX IF NOT EXISTS idx_workflows_status ON cf_agents_workflows(status)
@@ -2152,6 +2179,10 @@ export class Agent<
 
       this.sql`
         CREATE INDEX IF NOT EXISTS idx_workflows_name ON cf_agents_workflows(workflow_name)
+      `;
+
+      this.sql`
+        CREATE INDEX IF NOT EXISTS idx_workflows_expires_at ON cf_agents_workflows(expires_at)
       `;
 
       // Clean up legacy STATE_WAS_CHANGED rows from the single-row state optimization
@@ -6006,6 +6037,76 @@ export class Agent<
   async _onAlarmHousekeeping(): Promise<void> {
     await this._checkRunFibers();
     await this._checkFacetRunFibers();
+    await this._cleanupWorkflowTracking();
+  }
+
+  /** @internal */
+  protected async _cleanupWorkflowTracking(): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+    this.sql`
+      DELETE FROM cf_agents_workflows
+      WHERE expires_at IS NOT NULL AND expires_at <= ${now}
+    `;
+
+    // Rows without an expiry are still active or missed their terminal
+    // callback. Poll only when their bounded reconciliation wake is due. This
+    // gives an idle, one-shot Agent a durable recovery path after eviction.
+    const rows = this.sql<{
+      workflow_id: string;
+      workflow_name: string;
+    }>`
+      SELECT workflow_id, workflow_name
+      FROM cf_agents_workflows
+      WHERE expires_at IS NULL
+        AND updated_at + ${WORKFLOW_RECONCILIATION_SECONDS} <= ${now}
+    `;
+    for (const row of rows) {
+      const workflow = this._findWorkflowBindingByName(row.workflow_name);
+      if (!workflow) {
+        this.sql`
+          UPDATE cf_agents_workflows SET updated_at = ${now}
+          WHERE workflow_id = ${row.workflow_id}
+        `;
+        continue;
+      }
+      try {
+        const instance = await workflow.get(row.workflow_id);
+        const status = await instance.status();
+        await this._updateWorkflowTracking(row.workflow_id, status);
+      } catch (error) {
+        // Platform state can be temporarily unavailable. Keep the local row
+        // and retry on the next bounded reconciliation wake.
+        console.warn(
+          `[Agent] Could not reconcile Workflow ${row.workflow_name}/${row.workflow_id}; retrying later.`,
+          error
+        );
+        this.sql`
+          UPDATE cf_agents_workflows SET updated_at = ${now}
+          WHERE workflow_id = ${row.workflow_id}
+        `;
+      }
+    }
+
+    this.sql`
+      DELETE FROM cf_agents_workflows
+      WHERE expires_at IS NOT NULL AND expires_at <= ${now}
+    `;
+  }
+
+  /** @internal Alarm callback used when this Agent is a facet. */
+  async _cf_cleanupWorkflowTrackingAlarm(): Promise<void> {
+    await this._cleanupWorkflowTracking();
+    if (this._isFacet) {
+      await (
+        await this._rootAlarmOwner()
+      )._cf_rearmWorkflowCleanupForFacet(
+        this.selfPath,
+        this._nextWorkflowCleanupAt(),
+        true
+      );
+    } else {
+      await this._rearmWorkflowCleanup();
+    }
   }
 
   private _isSameAgentPathPrefix(
@@ -6593,6 +6694,24 @@ export class Agent<
         nextTimeMs === null ? recoveryMs : Math.min(nextTimeMs, recoveryMs);
     }
 
+    const workflowCleanup = this.sql<{ next_cleanup_at: number | null }>`
+      SELECT MIN(
+        CASE
+          WHEN expires_at IS NOT NULL THEN expires_at
+          ELSE updated_at + ${WORKFLOW_RECONCILIATION_SECONDS}
+        END
+      ) AS next_cleanup_at
+      FROM cf_agents_workflows
+    `;
+    const workflowCleanupAt = workflowCleanup[0]?.next_cleanup_at;
+    if (workflowCleanupAt !== null && workflowCleanupAt !== undefined) {
+      const workflowCleanupMs = Math.max(workflowCleanupAt * 1000, nowMs + 1);
+      nextTimeMs =
+        nextTimeMs === null
+          ? workflowCleanupMs
+          : Math.min(nextTimeMs, workflowCleanupMs);
+    }
+
     const facetRuns = this.sql<{ count: number }>`
       SELECT COUNT(*) as count FROM cf_agents_facet_runs
     `;
@@ -6609,6 +6728,79 @@ export class Agent<
     } else {
       await this.ctx.storage.deleteAlarm();
     }
+  }
+
+  /**
+   * Recompute the Agent's single physical alarm after a Workflow tracking
+   * insert or terminal update. Kept narrow so Workflow integrations can reuse
+   * the cleanup invariant without exposing a user lifecycle hook.
+   * @internal
+   */
+  protected async _rearmWorkflowCleanup(): Promise<void> {
+    if (this._isFacet) {
+      await (
+        await this._rootAlarmOwner()
+      )._cf_rearmWorkflowCleanupForFacet(
+        this.selfPath,
+        this._nextWorkflowCleanupAt()
+      );
+      return;
+    }
+    await this._scheduleNextAlarm();
+  }
+
+  private _nextWorkflowCleanupAt(): number | null {
+    const rows = this.sql<{ next_cleanup_at: number | null }>`
+      SELECT MIN(
+        CASE
+          WHEN expires_at IS NOT NULL THEN expires_at
+          ELSE updated_at + ${WORKFLOW_RECONCILIATION_SECONDS}
+        END
+      ) AS next_cleanup_at
+      FROM cf_agents_workflows
+    `;
+    return rows[0]?.next_cleanup_at ?? null;
+  }
+
+  /** @internal Root-owned alarm row for a facet's local Workflow table. */
+  async _cf_rearmWorkflowCleanupForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    nextCleanupAt: number | null,
+    fired = false
+  ): Promise<void> {
+    const callback = "_cf_cleanupWorkflowTrackingAlarm";
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    if (nextCleanupAt === null || fired) {
+      this.sql`
+        DELETE FROM cf_agents_schedules
+        WHERE callback = ${callback} AND owner_path_key = ${ownerPathKey}
+      `;
+    }
+    if (nextCleanupAt === null) {
+      await this._scheduleNextAlarm();
+      return;
+    }
+
+    const existing = this.sql<{ id: string }>`
+      SELECT id FROM cf_agents_schedules
+      WHERE callback = ${callback} AND owner_path_key = ${ownerPathKey}
+      LIMIT 1
+    `;
+    if (existing[0]) {
+      this.sql`
+        UPDATE cf_agents_schedules SET time = ${nextCleanupAt}
+        WHERE id = ${existing[0].id}
+      `;
+    } else {
+      await this._insertScheduleForOwner(
+        ownerPath,
+        new Date(nextCleanupAt * 1000),
+        callback,
+        undefined,
+        { idempotent: true }
+      );
+    }
+    await this._scheduleNextAlarm();
   }
 
   /**
@@ -11286,6 +11478,11 @@ export class Agent<
 
     this._emit("workflow:start", { workflowId: instance.id, workflowName });
 
+    // Arm from the first durable tracking write, before a terminal timestamp
+    // exists. This reconciliation wake closes the eviction/crash window where
+    // a one-shot Agent never receives (or finishes persisting) its callback.
+    await this._rearmWorkflowCleanup();
+
     return instance.id;
   }
 
@@ -11444,7 +11641,7 @@ export class Agent<
 
     // Update tracking table with new status
     const status = await instance.status();
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     this._emit("workflow:terminated", {
       workflowId,
@@ -11489,7 +11686,7 @@ export class Agent<
     });
 
     const status = await instance.status();
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     this._emit("workflow:paused", {
       workflowId,
@@ -11533,7 +11730,7 @@ export class Agent<
     });
 
     const status = await instance.status();
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     this._emit("workflow:resumed", {
       workflowId,
@@ -11597,14 +11794,16 @@ export class Agent<
             created_at = ${now},
             updated_at = ${now},
             completed_at = NULL,
+            expires_at = NULL,
             error_name = NULL,
             error_message = NULL
         WHERE workflow_id = ${workflowId}
       `;
+      await this._rearmWorkflowCleanup();
     } else {
       // Just update status from Cloudflare
       const status = await instance.status();
-      this._updateWorkflowTracking(workflowId, status);
+      await this._updateWorkflowTracking(workflowId, status);
     }
 
     this._emit("workflow:restarted", {
@@ -11673,7 +11872,7 @@ export class Agent<
     const status = await instance.status();
 
     // Update the tracking record
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     return status;
   }
@@ -11984,10 +12183,10 @@ export class Agent<
   /**
    * Update workflow tracking record from InstanceStatus
    */
-  private _updateWorkflowTracking(
+  protected async _updateWorkflowTracking(
     workflowId: string,
     status: InstanceStatus
-  ): void {
+  ): Promise<void> {
     const statusName = status.status;
     const now = Math.floor(Date.now() / 1000);
 
@@ -11998,6 +12197,9 @@ export class Agent<
       "terminated"
     ];
     const completedAt = completedStatuses.includes(statusName) ? now : null;
+    const expiresAt = completedAt
+      ? this._workflowExpiry(workflowId, statusName, completedAt)
+      : null;
 
     // Extract error info if present
     const errorName = status.error?.name ?? null;
@@ -12009,9 +12211,32 @@ export class Agent<
           error_name = ${errorName},
           error_message = ${errorMessage},
           updated_at = ${now},
-          completed_at = ${completedAt}
+          completed_at = ${completedAt},
+          expires_at = ${expiresAt}
       WHERE workflow_id = ${workflowId}
     `;
+    await this._rearmWorkflowCleanup();
+  }
+
+  private _workflowExpiry(
+    workflowId: string,
+    status: WorkflowStatus,
+    completedAt: number
+  ): number {
+    const rows = this.sql<{
+      success_retention_seconds: number;
+      error_retention_seconds: number;
+    }>`
+      SELECT success_retention_seconds, error_retention_seconds
+      FROM cf_agents_workflows
+      WHERE workflow_id = ${workflowId}
+    `;
+    const row = rows[0];
+    const retention =
+      status === "complete"
+        ? row?.success_retention_seconds
+        : row?.error_retention_seconds;
+    return completedAt + (retention ?? DEFAULT_WORKFLOW_RETENTION_SECONDS);
   }
 
   /**
@@ -12180,9 +12405,15 @@ export class Agent<
       case "complete":
         // Update tracking status to "complete"
         // Don't overwrite if already terminated/paused (race condition protection)
+        const completeExpiresAt = this._workflowExpiry(
+          callback.workflowId,
+          "complete",
+          now
+        );
         this.sql`
           UPDATE cf_agents_workflows
-          SET status = 'complete', updated_at = ${now}, completed_at = ${now}
+          SET status = 'complete', updated_at = ${now}, completed_at = ${now},
+              expires_at = ${completeExpiresAt}
           WHERE workflow_id = ${callback.workflowId}
             AND status NOT IN ('terminated', 'paused')
         `;
@@ -12191,14 +12422,21 @@ export class Agent<
           callback.workflowId,
           callback.result
         );
+        await this._rearmWorkflowCleanup();
         break;
       case "error":
         // Update tracking status to "errored"
         // Don't overwrite if already terminated/paused (race condition protection)
+        const errorExpiresAt = this._workflowExpiry(
+          callback.workflowId,
+          "errored",
+          now
+        );
         this.sql`
           UPDATE cf_agents_workflows
           SET status = 'errored', updated_at = ${now}, completed_at = ${now},
-              error_name = 'WorkflowError', error_message = ${callback.error}
+              error_name = 'WorkflowError', error_message = ${callback.error},
+              expires_at = ${errorExpiresAt}
           WHERE workflow_id = ${callback.workflowId}
             AND status NOT IN ('terminated', 'paused')
         `;
@@ -12207,6 +12445,7 @@ export class Agent<
           callback.workflowId,
           callback.error
         );
+        await this._rearmWorkflowCleanup();
         break;
       case "event":
         // No status change for events - they can occur at any stage

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -51,6 +51,7 @@ import {
   routePartykitRequest
 } from "partyserver";
 import { camelCaseToKebabCase, isInternalJsStubProp } from "./utils";
+import { normalizeWorkflowRetention } from "./workflow-retention";
 export { camelCaseToKebabCase } from "./utils";
 import {
   type RetryOptions,
@@ -11464,10 +11465,18 @@ export class Agent<
     const metadataJson = options?.metadata
       ? JSON.stringify(options.metadata)
       : null;
+    const { successRetentionSeconds, errorRetentionSeconds } =
+      normalizeWorkflowRetention(options?.retention);
     try {
       this.sql`
-        INSERT INTO cf_agents_workflows (id, workflow_id, workflow_name, status, metadata)
-        VALUES (${id}, ${instance.id}, ${workflowName}, 'queued', ${metadataJson})
+        INSERT INTO cf_agents_workflows (
+          id, workflow_id, workflow_name, status, metadata,
+          success_retention_seconds, error_retention_seconds
+        )
+        VALUES (
+          ${id}, ${instance.id}, ${workflowName}, 'queued', ${metadataJson},
+          ${successRetentionSeconds}, ${errorRetentionSeconds}
+        )
       `;
     } catch (e) {
       if (

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -708,6 +708,11 @@ type RootFacetRpcSurface = {
     payload?: T,
     options?: { retry?: RetryOptions; _idempotent?: boolean }
   ): Promise<{ schedule: Schedule<T>; created: boolean }>;
+  _cf_rearmWorkflowCleanupForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    nextCleanupAt: number | null,
+    fired?: boolean
+  ): Promise<void>;
   _cf_cleanupFacetPrefix(
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<void>;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1102,7 +1102,9 @@ type AgentToolRecoveryInspection =
  * The constructor stores this as a row in cf_agents_state and checks it
  * on wake to skip DDL on established DOs.
  */
-const CURRENT_SCHEMA_VERSION = 11;
+const CURRENT_SCHEMA_VERSION = 12;
+const DEFAULT_WORKFLOW_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+const WORKFLOW_RECONCILIATION_SECONDS = 24 * 60 * 60;
 
 const SCHEMA_VERSION_ROW_ID = "cf_schema_version";
 const STATE_ROW_ID = "cf_state_row_id";
@@ -2111,9 +2113,34 @@ export class Agent<
           error_message TEXT,
           created_at INTEGER NOT NULL DEFAULT (unixepoch()),
           updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
-          completed_at INTEGER
+          completed_at INTEGER,
+          success_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
+          error_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
+          expires_at INTEGER
         )
       `;
+
+      addColumnIfNotExists(
+        `ALTER TABLE cf_agents_workflows ADD COLUMN success_retention_seconds INTEGER NOT NULL DEFAULT ${DEFAULT_WORKFLOW_RETENTION_SECONDS}`
+      );
+      addColumnIfNotExists(
+        `ALTER TABLE cf_agents_workflows ADD COLUMN error_retention_seconds INTEGER NOT NULL DEFAULT ${DEFAULT_WORKFLOW_RETENTION_SECONDS}`
+      );
+      addColumnIfNotExists(
+        "ALTER TABLE cf_agents_workflows ADD COLUMN expires_at INTEGER"
+      );
+
+      if (schemaVersion < 12) {
+        this.ctx.storage.sql.exec(`
+          UPDATE cf_agents_workflows
+          SET expires_at = completed_at + CASE
+            WHEN status = 'complete' THEN success_retention_seconds
+            WHEN status IN ('errored', 'terminated') THEN error_retention_seconds
+            ELSE NULL
+          END
+          WHERE completed_at IS NOT NULL AND expires_at IS NULL
+        `);
+      }
 
       this.sql`
         CREATE INDEX IF NOT EXISTS idx_workflows_status ON cf_agents_workflows(status)
@@ -2121,6 +2148,10 @@ export class Agent<
 
       this.sql`
         CREATE INDEX IF NOT EXISTS idx_workflows_name ON cf_agents_workflows(workflow_name)
+      `;
+
+      this.sql`
+        CREATE INDEX IF NOT EXISTS idx_workflows_expires_at ON cf_agents_workflows(expires_at)
       `;
 
       // Clean up legacy STATE_WAS_CHANGED rows from the single-row state optimization
@@ -5969,6 +6000,76 @@ export class Agent<
   async _onAlarmHousekeeping(): Promise<void> {
     await this._checkRunFibers();
     await this._checkFacetRunFibers();
+    await this._cleanupWorkflowTracking();
+  }
+
+  /** @internal */
+  protected async _cleanupWorkflowTracking(): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+    this.sql`
+      DELETE FROM cf_agents_workflows
+      WHERE expires_at IS NOT NULL AND expires_at <= ${now}
+    `;
+
+    // Rows without an expiry are still active or missed their terminal
+    // callback. Poll only when their bounded reconciliation wake is due. This
+    // gives an idle, one-shot Agent a durable recovery path after eviction.
+    const rows = this.sql<{
+      workflow_id: string;
+      workflow_name: string;
+    }>`
+      SELECT workflow_id, workflow_name
+      FROM cf_agents_workflows
+      WHERE expires_at IS NULL
+        AND updated_at + ${WORKFLOW_RECONCILIATION_SECONDS} <= ${now}
+    `;
+    for (const row of rows) {
+      const workflow = this._findWorkflowBindingByName(row.workflow_name);
+      if (!workflow) {
+        this.sql`
+          UPDATE cf_agents_workflows SET updated_at = ${now}
+          WHERE workflow_id = ${row.workflow_id}
+        `;
+        continue;
+      }
+      try {
+        const instance = await workflow.get(row.workflow_id);
+        const status = await instance.status();
+        await this._updateWorkflowTracking(row.workflow_id, status);
+      } catch (error) {
+        // Platform state can be temporarily unavailable. Keep the local row
+        // and retry on the next bounded reconciliation wake.
+        console.warn(
+          `[Agent] Could not reconcile Workflow ${row.workflow_name}/${row.workflow_id}; retrying later.`,
+          error
+        );
+        this.sql`
+          UPDATE cf_agents_workflows SET updated_at = ${now}
+          WHERE workflow_id = ${row.workflow_id}
+        `;
+      }
+    }
+
+    this.sql`
+      DELETE FROM cf_agents_workflows
+      WHERE expires_at IS NOT NULL AND expires_at <= ${now}
+    `;
+  }
+
+  /** @internal Alarm callback used when this Agent is a facet. */
+  async _cf_cleanupWorkflowTrackingAlarm(): Promise<void> {
+    await this._cleanupWorkflowTracking();
+    if (this._isFacet) {
+      await (
+        await this._rootAlarmOwner()
+      )._cf_rearmWorkflowCleanupForFacet(
+        this.selfPath,
+        this._nextWorkflowCleanupAt(),
+        true
+      );
+    } else {
+      await this._rearmWorkflowCleanup();
+    }
   }
 
   private _isSameAgentPathPrefix(
@@ -6556,6 +6657,24 @@ export class Agent<
         nextTimeMs === null ? recoveryMs : Math.min(nextTimeMs, recoveryMs);
     }
 
+    const workflowCleanup = this.sql<{ next_cleanup_at: number | null }>`
+      SELECT MIN(
+        CASE
+          WHEN expires_at IS NOT NULL THEN expires_at
+          ELSE updated_at + ${WORKFLOW_RECONCILIATION_SECONDS}
+        END
+      ) AS next_cleanup_at
+      FROM cf_agents_workflows
+    `;
+    const workflowCleanupAt = workflowCleanup[0]?.next_cleanup_at;
+    if (workflowCleanupAt !== null && workflowCleanupAt !== undefined) {
+      const workflowCleanupMs = Math.max(workflowCleanupAt * 1000, nowMs + 1);
+      nextTimeMs =
+        nextTimeMs === null
+          ? workflowCleanupMs
+          : Math.min(nextTimeMs, workflowCleanupMs);
+    }
+
     const facetRuns = this.sql<{ count: number }>`
       SELECT COUNT(*) as count FROM cf_agents_facet_runs
     `;
@@ -6572,6 +6691,79 @@ export class Agent<
     } else {
       await this.ctx.storage.deleteAlarm();
     }
+  }
+
+  /**
+   * Recompute the Agent's single physical alarm after a Workflow tracking
+   * insert or terminal update. Kept narrow so Workflow integrations can reuse
+   * the cleanup invariant without exposing a user lifecycle hook.
+   * @internal
+   */
+  protected async _rearmWorkflowCleanup(): Promise<void> {
+    if (this._isFacet) {
+      await (
+        await this._rootAlarmOwner()
+      )._cf_rearmWorkflowCleanupForFacet(
+        this.selfPath,
+        this._nextWorkflowCleanupAt()
+      );
+      return;
+    }
+    await this._scheduleNextAlarm();
+  }
+
+  private _nextWorkflowCleanupAt(): number | null {
+    const rows = this.sql<{ next_cleanup_at: number | null }>`
+      SELECT MIN(
+        CASE
+          WHEN expires_at IS NOT NULL THEN expires_at
+          ELSE updated_at + ${WORKFLOW_RECONCILIATION_SECONDS}
+        END
+      ) AS next_cleanup_at
+      FROM cf_agents_workflows
+    `;
+    return rows[0]?.next_cleanup_at ?? null;
+  }
+
+  /** @internal Root-owned alarm row for a facet's local Workflow table. */
+  async _cf_rearmWorkflowCleanupForFacet(
+    ownerPath: ReadonlyArray<AgentPathStep>,
+    nextCleanupAt: number | null,
+    fired = false
+  ): Promise<void> {
+    const callback = "_cf_cleanupWorkflowTrackingAlarm";
+    const ownerPathKey = this._scheduleOwnerPathKey(ownerPath);
+    if (nextCleanupAt === null || fired) {
+      this.sql`
+        DELETE FROM cf_agents_schedules
+        WHERE callback = ${callback} AND owner_path_key = ${ownerPathKey}
+      `;
+    }
+    if (nextCleanupAt === null) {
+      await this._scheduleNextAlarm();
+      return;
+    }
+
+    const existing = this.sql<{ id: string }>`
+      SELECT id FROM cf_agents_schedules
+      WHERE callback = ${callback} AND owner_path_key = ${ownerPathKey}
+      LIMIT 1
+    `;
+    if (existing[0]) {
+      this.sql`
+        UPDATE cf_agents_schedules SET time = ${nextCleanupAt}
+        WHERE id = ${existing[0].id}
+      `;
+    } else {
+      await this._insertScheduleForOwner(
+        ownerPath,
+        new Date(nextCleanupAt * 1000),
+        callback,
+        undefined,
+        { idempotent: true }
+      );
+    }
+    await this._scheduleNextAlarm();
   }
 
   /**
@@ -11246,6 +11438,11 @@ export class Agent<
 
     this._emit("workflow:start", { workflowId: instance.id, workflowName });
 
+    // Arm from the first durable tracking write, before a terminal timestamp
+    // exists. This reconciliation wake closes the eviction/crash window where
+    // a one-shot Agent never receives (or finishes persisting) its callback.
+    await this._rearmWorkflowCleanup();
+
     return instance.id;
   }
 
@@ -11404,7 +11601,7 @@ export class Agent<
 
     // Update tracking table with new status
     const status = await instance.status();
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     this._emit("workflow:terminated", {
       workflowId,
@@ -11449,7 +11646,7 @@ export class Agent<
     });
 
     const status = await instance.status();
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     this._emit("workflow:paused", {
       workflowId,
@@ -11493,7 +11690,7 @@ export class Agent<
     });
 
     const status = await instance.status();
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     this._emit("workflow:resumed", {
       workflowId,
@@ -11557,14 +11754,16 @@ export class Agent<
             created_at = ${now},
             updated_at = ${now},
             completed_at = NULL,
+            expires_at = NULL,
             error_name = NULL,
             error_message = NULL
         WHERE workflow_id = ${workflowId}
       `;
+      await this._rearmWorkflowCleanup();
     } else {
       // Just update status from Cloudflare
       const status = await instance.status();
-      this._updateWorkflowTracking(workflowId, status);
+      await this._updateWorkflowTracking(workflowId, status);
     }
 
     this._emit("workflow:restarted", {
@@ -11633,7 +11832,7 @@ export class Agent<
     const status = await instance.status();
 
     // Update the tracking record
-    this._updateWorkflowTracking(workflowId, status);
+    await this._updateWorkflowTracking(workflowId, status);
 
     return status;
   }
@@ -11944,10 +12143,10 @@ export class Agent<
   /**
    * Update workflow tracking record from InstanceStatus
    */
-  private _updateWorkflowTracking(
+  protected async _updateWorkflowTracking(
     workflowId: string,
     status: InstanceStatus
-  ): void {
+  ): Promise<void> {
     const statusName = status.status;
     const now = Math.floor(Date.now() / 1000);
 
@@ -11958,6 +12157,9 @@ export class Agent<
       "terminated"
     ];
     const completedAt = completedStatuses.includes(statusName) ? now : null;
+    const expiresAt = completedAt
+      ? this._workflowExpiry(workflowId, statusName, completedAt)
+      : null;
 
     // Extract error info if present
     const errorName = status.error?.name ?? null;
@@ -11969,9 +12171,32 @@ export class Agent<
           error_name = ${errorName},
           error_message = ${errorMessage},
           updated_at = ${now},
-          completed_at = ${completedAt}
+          completed_at = ${completedAt},
+          expires_at = ${expiresAt}
       WHERE workflow_id = ${workflowId}
     `;
+    await this._rearmWorkflowCleanup();
+  }
+
+  private _workflowExpiry(
+    workflowId: string,
+    status: WorkflowStatus,
+    completedAt: number
+  ): number {
+    const rows = this.sql<{
+      success_retention_seconds: number;
+      error_retention_seconds: number;
+    }>`
+      SELECT success_retention_seconds, error_retention_seconds
+      FROM cf_agents_workflows
+      WHERE workflow_id = ${workflowId}
+    `;
+    const row = rows[0];
+    const retention =
+      status === "complete"
+        ? row?.success_retention_seconds
+        : row?.error_retention_seconds;
+    return completedAt + (retention ?? DEFAULT_WORKFLOW_RETENTION_SECONDS);
   }
 
   /**
@@ -12140,9 +12365,15 @@ export class Agent<
       case "complete":
         // Update tracking status to "complete"
         // Don't overwrite if already terminated/paused (race condition protection)
+        const completeExpiresAt = this._workflowExpiry(
+          callback.workflowId,
+          "complete",
+          now
+        );
         this.sql`
           UPDATE cf_agents_workflows
-          SET status = 'complete', updated_at = ${now}, completed_at = ${now}
+          SET status = 'complete', updated_at = ${now}, completed_at = ${now},
+              expires_at = ${completeExpiresAt}
           WHERE workflow_id = ${callback.workflowId}
             AND status NOT IN ('terminated', 'paused')
         `;
@@ -12151,14 +12382,21 @@ export class Agent<
           callback.workflowId,
           callback.result
         );
+        await this._rearmWorkflowCleanup();
         break;
       case "error":
         // Update tracking status to "errored"
         // Don't overwrite if already terminated/paused (race condition protection)
+        const errorExpiresAt = this._workflowExpiry(
+          callback.workflowId,
+          "errored",
+          now
+        );
         this.sql`
           UPDATE cf_agents_workflows
           SET status = 'errored', updated_at = ${now}, completed_at = ${now},
-              error_name = 'WorkflowError', error_message = ${callback.error}
+              error_name = 'WorkflowError', error_message = ${callback.error},
+              expires_at = ${errorExpiresAt}
           WHERE workflow_id = ${callback.workflowId}
             AND status NOT IN ('terminated', 'paused')
         `;
@@ -12167,6 +12405,7 @@ export class Agent<
           callback.workflowId,
           callback.error
         );
+        await this._rearmWorkflowCleanup();
         break;
       case "event":
         // No status change for events - they can occur at any stage

--- a/packages/agents/src/tests/agents/workflow.ts
+++ b/packages/agents/src/tests/agents/workflow.ts
@@ -364,7 +364,7 @@ export class TestWorkflowAgent extends Agent {
     expiresAt: number | null;
     alarm: number | null;
   } | null> {
-    const rows = this.sql<{
+    const [row] = this.sql<{
       success_retention_seconds: number;
       error_retention_seconds: number;
       completed_at: number | null;
@@ -374,7 +374,6 @@ export class TestWorkflowAgent extends Agent {
              completed_at, expires_at
       FROM cf_agents_workflows WHERE workflow_id = ${workflowId}
     `;
-    const row = rows[0];
     if (!row) return null;
     return {
       successRetentionSeconds: row.success_retention_seconds,
@@ -385,7 +384,7 @@ export class TestWorkflowAgent extends Agent {
     };
   }
 
-  async expireWorkflowForTest(workflowId: string): Promise<void> {
+  async expireWorkflow(workflowId: string): Promise<void> {
     const past = Math.floor(Date.now() / 1000) - 1;
     this.sql`
       UPDATE cf_agents_workflows SET expires_at = ${past}
@@ -393,12 +392,20 @@ export class TestWorkflowAgent extends Agent {
     `;
   }
 
-  async runWorkflowCleanupForTest(): Promise<void> {
+  async makeWorkflowDueForReconciliation(workflowId: string): Promise<void> {
+    const stale = Math.floor(Date.now() / 1000) - 24 * 60 * 60 - 1;
+    this.sql`
+      UPDATE cf_agents_workflows SET updated_at = ${stale}
+      WHERE workflow_id = ${workflowId}
+    `;
+  }
+
+  async runWorkflowCleanup(): Promise<void> {
     await this._cleanupWorkflowTracking();
     await this._rearmWorkflowCleanup();
   }
 
-  async setWorkflowTerminalForTest(
+  async setWorkflowTerminal(
     workflowId: string,
     status: "complete" | "errored" | "terminated"
   ): Promise<void> {

--- a/packages/agents/src/tests/agents/workflow.ts
+++ b/packages/agents/src/tests/agents/workflow.ts
@@ -353,7 +353,56 @@ export class TestWorkflowAgent extends Agent {
       INSERT INTO cf_agents_workflows (id, workflow_id, workflow_name, status, metadata)
       VALUES (${id}, ${workflowId}, ${workflowName}, ${status}, ${metadata ? JSON.stringify(metadata) : null})
     `;
+    await this._rearmWorkflowCleanup();
     return id;
+  }
+
+  async getWorkflowCleanupState(workflowId: string): Promise<{
+    successRetentionSeconds: number;
+    errorRetentionSeconds: number;
+    completedAt: number | null;
+    expiresAt: number | null;
+    alarm: number | null;
+  } | null> {
+    const rows = this.sql<{
+      success_retention_seconds: number;
+      error_retention_seconds: number;
+      completed_at: number | null;
+      expires_at: number | null;
+    }>`
+      SELECT success_retention_seconds, error_retention_seconds,
+             completed_at, expires_at
+      FROM cf_agents_workflows WHERE workflow_id = ${workflowId}
+    `;
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      successRetentionSeconds: row.success_retention_seconds,
+      errorRetentionSeconds: row.error_retention_seconds,
+      completedAt: row.completed_at,
+      expiresAt: row.expires_at,
+      alarm: await this.ctx.storage.getAlarm()
+    };
+  }
+
+  async expireWorkflowForTest(workflowId: string): Promise<void> {
+    const past = Math.floor(Date.now() / 1000) - 1;
+    this.sql`
+      UPDATE cf_agents_workflows SET expires_at = ${past}
+      WHERE workflow_id = ${workflowId}
+    `;
+  }
+
+  async runWorkflowCleanupForTest(): Promise<void> {
+    await this._cleanupWorkflowTracking();
+    await this._rearmWorkflowCleanup();
+  }
+
+  async setWorkflowTerminalForTest(
+    workflowId: string,
+    status: "complete" | "errored" | "terminated"
+  ): Promise<void> {
+    await this._updateWorkflowTracking(workflowId, { status });
   }
 
   // Expose getWorkflow for testing

--- a/packages/agents/src/tests/schema-and-state-optimization.test.ts
+++ b/packages/agents/src/tests/schema-and-state-optimization.test.ts
@@ -102,11 +102,14 @@ const EXPECTED_SCHEMA_DDL = [
           error_message TEXT,
           created_at INTEGER NOT NULL DEFAULT (unixepoch()),
           updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
-          completed_at INTEGER
+          completed_at INTEGER,
+          success_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
+          error_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
+          expires_at INTEGER
         )`
 ];
 
-const EXPECTED_SCHEMA_VERSION = 11;
+const EXPECTED_SCHEMA_VERSION = 12;
 
 describe("schema DDL snapshot", () => {
   it("should match the expected DDL for the current schema version", async () => {

--- a/packages/agents/src/tests/schema-and-state-optimization.test.ts
+++ b/packages/agents/src/tests/schema-and-state-optimization.test.ts
@@ -103,9 +103,9 @@ const EXPECTED_SCHEMA_DDL = [
           created_at INTEGER NOT NULL DEFAULT (unixepoch()),
           updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
           completed_at INTEGER,
-          success_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
-          error_retention_seconds INTEGER NOT NULL DEFAULT 2592000,
-          expires_at INTEGER
+          expires_at INTEGER,
+          success_retention_seconds INTEGER NOT NULL DEFAULT (30 * 24 * 60 * 60),
+          error_retention_seconds INTEGER NOT NULL DEFAULT (30 * 24 * 60 * 60)
         )`
 ];
 

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -75,6 +75,61 @@ describe("workflow operations", () => {
       expect(workflow).toBeNull();
     });
 
+    it("arms bounded cleanup with 30-day default retention", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-defaults");
+      await agentStub.insertTestWorkflow(
+        "wf-cleanup-defaults",
+        "TEST_WORKFLOW",
+        "queued"
+      );
+
+      const state = await agentStub.getWorkflowCleanupState(
+        "wf-cleanup-defaults"
+      );
+      expect(state?.successRetentionSeconds).toBe(30 * 24 * 60 * 60);
+      expect(state?.errorRetentionSeconds).toBe(30 * 24 * 60 * 60);
+      expect(state?.expiresAt).toBeNull();
+      expect(state?.alarm).not.toBeNull();
+    });
+
+    it.each([
+      ["complete", "successRetentionSeconds"],
+      ["errored", "errorRetentionSeconds"],
+      ["terminated", "errorRetentionSeconds"]
+    ] as const)(
+      "uses the terminal-outcome retention for %s workflows",
+      async (status, retentionKey) => {
+        const agentStub = await getTestAgent(`workflow-cleanup-${status}`);
+        const workflowId = `wf-cleanup-${status}`;
+        await agentStub.insertTestWorkflow(
+          workflowId,
+          "TEST_WORKFLOW",
+          "queued"
+        );
+
+        await agentStub.setWorkflowTerminalForTest(workflowId, status);
+        const state = await agentStub.getWorkflowCleanupState(workflowId);
+        expect(state?.completedAt).not.toBeNull();
+        expect(state?.expiresAt).toBe(
+          (state?.completedAt ?? 0) + (state?.[retentionKey] ?? 0)
+        );
+      }
+    );
+
+    it("deletes only expired local tracking rows and stops cleanup", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-expired");
+      await agentStub.insertTestWorkflow(
+        "wf-cleanup-expired",
+        "TEST_WORKFLOW",
+        "complete"
+      );
+      await agentStub.expireWorkflowForTest("wf-cleanup-expired");
+
+      await agentStub.runWorkflowCleanupForTest();
+
+      expect(await agentStub.getWorkflowById("wf-cleanup-expired")).toBeNull();
+    });
+
     it("should query workflows by status", async () => {
       const agentStub = await getTestAgent("workflow-query-test-1");
 

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -132,6 +132,49 @@ describe("workflow operations", () => {
       expect(state?.alarm).not.toBeNull();
     });
 
+    it("stores normalized retention for local outcome cleanup", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-retention");
+      const workflowId = "wf-cleanup-retention";
+
+      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
+        successRetention: "1 day",
+        errorRetention: "2 weeks"
+      });
+
+      const state = await agentStub.getWorkflowCleanupState(workflowId);
+      expect(state?.successRetentionSeconds).toBe(24 * 60 * 60);
+      expect(state?.errorRetentionSeconds).toBe(2 * 7 * 24 * 60 * 60);
+      expect(state?.expiresAt).toBeNull();
+      expect(state?.alarm).not.toBeNull();
+    });
+
+    it("rounds numeric retention up from milliseconds", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-numeric");
+      const workflowId = "wf-cleanup-numeric";
+
+      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
+        successRetention: 60_001,
+        errorRetention: 120_000
+      });
+
+      const state = await agentStub.getWorkflowCleanupState(workflowId);
+      expect(state?.successRetentionSeconds).toBe(61);
+      expect(state?.errorRetentionSeconds).toBe(120);
+    });
+
+    it("uses the 30-day fallback for an omitted outcome", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-partial");
+      const workflowId = "wf-cleanup-partial";
+
+      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
+        successRetention: "1 day"
+      });
+
+      const state = await agentStub.getWorkflowCleanupState(workflowId);
+      expect(state?.successRetentionSeconds).toBe(24 * 60 * 60);
+      expect(state?.errorRetentionSeconds).toBe(30 * 24 * 60 * 60);
+    });
+
     it.each([
       ["complete", "successRetentionSeconds"],
       ["errored", "errorRetentionSeconds"],

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -92,6 +92,49 @@ describe("workflow operations", () => {
       expect(state?.alarm).not.toBeNull();
     });
 
+    it("stores normalized retention for local outcome cleanup", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-retention");
+      const workflowId = "wf-cleanup-retention";
+
+      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
+        successRetention: "1 day",
+        errorRetention: "2 weeks"
+      });
+
+      const state = await agentStub.getWorkflowCleanupState(workflowId);
+      expect(state?.successRetentionSeconds).toBe(24 * 60 * 60);
+      expect(state?.errorRetentionSeconds).toBe(2 * 7 * 24 * 60 * 60);
+      expect(state?.expiresAt).toBeNull();
+      expect(state?.alarm).not.toBeNull();
+    });
+
+    it("rounds numeric retention up from milliseconds", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-numeric");
+      const workflowId = "wf-cleanup-numeric";
+
+      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
+        successRetention: 60_001,
+        errorRetention: 120_000
+      });
+
+      const state = await agentStub.getWorkflowCleanupState(workflowId);
+      expect(state?.successRetentionSeconds).toBe(61);
+      expect(state?.errorRetentionSeconds).toBe(120);
+    });
+
+    it("uses the 30-day fallback for an omitted outcome", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-partial");
+      const workflowId = "wf-cleanup-partial";
+
+      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
+        successRetention: "1 day"
+      });
+
+      const state = await agentStub.getWorkflowCleanupState(workflowId);
+      expect(state?.successRetentionSeconds).toBe(24 * 60 * 60);
+      expect(state?.errorRetentionSeconds).toBe(30 * 24 * 60 * 60);
+    });
+
     it.each([
       ["complete", "successRetentionSeconds"],
       ["errored", "errorRetentionSeconds"],

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -163,6 +163,18 @@ describe("workflow operations", () => {
       expect(state?.errorRetentionSeconds).toBe(120);
     });
 
+    it("uses the Workflows duration parser for calendar units", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-year");
+      const workflowId = "wf-cleanup-year";
+
+      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
+        successRetention: "1 year"
+      });
+
+      const state = await agentStub.getWorkflowCleanupState(workflowId);
+      expect(state?.successRetentionSeconds).toBe(365.25 * 24 * 60 * 60);
+    });
+
     it("uses the 30-day fallback for an omitted outcome", async () => {
       const agentStub = await getTestAgent("workflow-cleanup-partial");
       const workflowId = "wf-cleanup-partial";

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -191,7 +191,7 @@ describe("workflow operations", () => {
           "queued"
         );
 
-        await agentStub.setWorkflowTerminalForTest(workflowId, status);
+        await agentStub.setWorkflowTerminal(workflowId, status);
         const state = await agentStub.getWorkflowCleanupState(workflowId);
         expect(state?.completedAt).not.toBeNull();
         expect(state?.expiresAt).toBe(
@@ -207,11 +207,26 @@ describe("workflow operations", () => {
         "TEST_WORKFLOW",
         "complete"
       );
-      await agentStub.expireWorkflowForTest("wf-cleanup-expired");
+      await agentStub.expireWorkflow("wf-cleanup-expired");
 
-      await agentStub.runWorkflowCleanupForTest();
+      await agentStub.runWorkflowCleanup();
 
       expect(await agentStub.getWorkflowById("wf-cleanup-expired")).toBeNull();
+    });
+
+    it("deletes stale tracking when the Workflow instance no longer exists", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-missing");
+      const workflowId = "wf-cleanup-missing";
+      await agentStub.insertTestWorkflow(
+        workflowId,
+        "TEST_WORKFLOW",
+        "running"
+      );
+      await agentStub.makeWorkflowDueForReconciliation(workflowId);
+
+      await agentStub.runWorkflowCleanup();
+
+      expect(await agentStub.getWorkflowById(workflowId)).toBeNull();
     });
 
     it("should query workflows by status", async () => {

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -39,7 +39,8 @@ describe("workflow operations", () => {
           binding: "TestWorkflowAgent"
         }),
         sql: () => [],
-        _emit: vi.fn()
+        _emit: vi.fn(),
+        _rearmWorkflowCleanup: vi.fn()
       } as unknown as Agent<Cloudflare.Env>;
 
       await Agent.prototype.runWorkflow.call(

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -163,18 +163,6 @@ describe("workflow operations", () => {
       expect(state?.errorRetentionSeconds).toBe(120);
     });
 
-    it("uses the Workflows duration parser for calendar units", async () => {
-      const agentStub = await getTestAgent("workflow-cleanup-year");
-      const workflowId = "wf-cleanup-year";
-
-      await agentStub.runSimpleWorkflowWithRetentionTest(workflowId, {
-        successRetention: "1 year"
-      });
-
-      const state = await agentStub.getWorkflowCleanupState(workflowId);
-      expect(state?.successRetentionSeconds).toBe(365.25 * 24 * 60 * 60);
-    });
-
     it("uses the 30-day fallback for an omitted outcome", async () => {
       const agentStub = await getTestAgent("workflow-cleanup-partial");
       const workflowId = "wf-cleanup-partial";

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -115,6 +115,61 @@ describe("workflow operations", () => {
       expect(workflow).toBeNull();
     });
 
+    it("arms bounded cleanup with 30-day default retention", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-defaults");
+      await agentStub.insertTestWorkflow(
+        "wf-cleanup-defaults",
+        "TEST_WORKFLOW",
+        "queued"
+      );
+
+      const state = await agentStub.getWorkflowCleanupState(
+        "wf-cleanup-defaults"
+      );
+      expect(state?.successRetentionSeconds).toBe(30 * 24 * 60 * 60);
+      expect(state?.errorRetentionSeconds).toBe(30 * 24 * 60 * 60);
+      expect(state?.expiresAt).toBeNull();
+      expect(state?.alarm).not.toBeNull();
+    });
+
+    it.each([
+      ["complete", "successRetentionSeconds"],
+      ["errored", "errorRetentionSeconds"],
+      ["terminated", "errorRetentionSeconds"]
+    ] as const)(
+      "uses the terminal-outcome retention for %s workflows",
+      async (status, retentionKey) => {
+        const agentStub = await getTestAgent(`workflow-cleanup-${status}`);
+        const workflowId = `wf-cleanup-${status}`;
+        await agentStub.insertTestWorkflow(
+          workflowId,
+          "TEST_WORKFLOW",
+          "queued"
+        );
+
+        await agentStub.setWorkflowTerminalForTest(workflowId, status);
+        const state = await agentStub.getWorkflowCleanupState(workflowId);
+        expect(state?.completedAt).not.toBeNull();
+        expect(state?.expiresAt).toBe(
+          (state?.completedAt ?? 0) + (state?.[retentionKey] ?? 0)
+        );
+      }
+    );
+
+    it("deletes only expired local tracking rows and stops cleanup", async () => {
+      const agentStub = await getTestAgent("workflow-cleanup-expired");
+      await agentStub.insertTestWorkflow(
+        "wf-cleanup-expired",
+        "TEST_WORKFLOW",
+        "complete"
+      );
+      await agentStub.expireWorkflowForTest("wf-cleanup-expired");
+
+      await agentStub.runWorkflowCleanupForTest();
+
+      expect(await agentStub.getWorkflowById("wf-cleanup-expired")).toBeNull();
+    });
+
     it("should query workflows by status", async () => {
       const agentStub = await getTestAgent("workflow-query-test-1");
 

--- a/packages/agents/src/workflow-retention.ts
+++ b/packages/agents/src/workflow-retention.ts
@@ -1,0 +1,60 @@
+const DEFAULT_TRACKING_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+
+type WorkflowRetention = NonNullable<
+  WorkflowInstanceCreateOptions["retention"]
+>;
+type WorkflowRetentionDuration = NonNullable<
+  WorkflowRetention["successRetention"]
+>;
+
+const UNIT_SECONDS = {
+  second: 1,
+  minute: 60,
+  hour: 60 * 60,
+  day: 24 * 60 * 60,
+  week: 7 * 24 * 60 * 60,
+  month: 30 * 24 * 60 * 60,
+  year: 365 * 24 * 60 * 60
+} as const;
+
+function retentionSeconds(duration: WorkflowRetentionDuration): number {
+  if (typeof duration === "number") {
+    if (!Number.isFinite(duration) || duration < 0) {
+      throw new Error(`Invalid Workflow retention duration: ${duration}`);
+    }
+    return Math.ceil(duration / 1000);
+  }
+
+  const match = duration.match(
+    /^(.+) (second|minute|hour|day|week|month|year)s?$/
+  );
+  if (!match) {
+    throw new Error(`Invalid Workflow retention duration: ${duration}`);
+  }
+
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error(`Invalid Workflow retention duration: ${duration}`);
+  }
+
+  const unit = match[2] as keyof typeof UNIT_SECONDS;
+  return Math.ceil(amount * UNIT_SECONDS[unit]);
+}
+
+export function normalizeWorkflowRetention(
+  retention: WorkflowInstanceCreateOptions["retention"]
+): {
+  successRetentionSeconds: number;
+  errorRetentionSeconds: number;
+} {
+  return {
+    successRetentionSeconds:
+      retention?.successRetention === undefined
+        ? DEFAULT_TRACKING_RETENTION_SECONDS
+        : retentionSeconds(retention.successRetention),
+    errorRetentionSeconds:
+      retention?.errorRetention === undefined
+        ? DEFAULT_TRACKING_RETENTION_SECONDS
+        : retentionSeconds(retention.errorRetention)
+  };
+}

--- a/packages/agents/src/workflow-retention.ts
+++ b/packages/agents/src/workflow-retention.ts
@@ -1,9 +1,6 @@
-const DEFAULT_TRACKING_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+import { ms } from "itty-time";
 
-// Keep this parser aligned with Workerd's WorkflowRetentionDuration type.
-// Workerd does not export the binding's duration normalizer, while Agent
-// tracking needs the equivalent duration to derive its local cleanup time.
-// https://github.com/cloudflare/workerd/blob/main/types/defines/workflows.d.ts
+const DEFAULT_TRACKING_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 
 type WorkflowRetention = NonNullable<
   WorkflowInstanceCreateOptions["retention"]
@@ -12,38 +9,12 @@ type WorkflowRetentionDuration = NonNullable<
   WorkflowRetention["successRetention"]
 >;
 
-const UNIT_SECONDS = {
-  second: 1,
-  minute: 60,
-  hour: 60 * 60,
-  day: 24 * 60 * 60,
-  week: 7 * 24 * 60 * 60,
-  month: 30 * 24 * 60 * 60,
-  year: 365 * 24 * 60 * 60
-} as const;
-
 function retentionSeconds(duration: WorkflowRetentionDuration): number {
-  if (typeof duration === "number") {
-    if (!Number.isFinite(duration) || duration < 0) {
-      throw new Error(`Invalid Workflow retention duration: ${duration}`);
-    }
-    return Math.ceil(duration / 1000);
-  }
-
-  const match = duration.match(
-    /^(.+) (second|minute|hour|day|week|month|year)s?$/
-  );
-  if (!match) {
+  const durationMs = ms(duration);
+  if (!Number.isFinite(durationMs)) {
     throw new Error(`Invalid Workflow retention duration: ${duration}`);
   }
-
-  const amount = Number(match[1]);
-  if (!Number.isFinite(amount) || amount < 0) {
-    throw new Error(`Invalid Workflow retention duration: ${duration}`);
-  }
-
-  const unit = match[2] as keyof typeof UNIT_SECONDS;
-  return Math.ceil(amount * UNIT_SECONDS[unit]);
+  return Math.ceil(durationMs / 1000);
 }
 
 export function normalizeWorkflowRetention(

--- a/packages/agents/src/workflow-retention.ts
+++ b/packages/agents/src/workflow-retention.ts
@@ -1,5 +1,10 @@
 const DEFAULT_TRACKING_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 
+// Keep this parser aligned with Workerd's WorkflowRetentionDuration type.
+// Workerd does not export the binding's duration normalizer, while Agent
+// tracking needs the equivalent duration to derive its local cleanup time.
+// https://github.com/cloudflare/workerd/blob/main/types/defines/workflows.d.ts
+
 type WorkflowRetention = NonNullable<
   WorkflowInstanceCreateOptions["retention"]
 >;

--- a/packages/agents/src/workflow-types.ts
+++ b/packages/agents/src/workflow-types.ts
@@ -218,6 +218,12 @@ export type WorkflowTrackingRow = {
   updated_at: number;
   /** Unix timestamp when workflow completed (null if not complete) */
   completed_at: number | null;
+  /** Successful-instance retention in seconds */
+  success_retention_seconds: number;
+  /** Errored/terminated-instance retention in seconds */
+  error_retention_seconds: number;
+  /** Unix timestamp after which the local tracking row may be deleted */
+  expires_at: number | null;
 };
 
 /**

--- a/packages/agents/src/workflow-types.ts
+++ b/packages/agents/src/workflow-types.ts
@@ -219,6 +219,12 @@ export type WorkflowTrackingRow = {
   updated_at: number;
   /** Unix timestamp when workflow completed (null if not complete) */
   completed_at: number | null;
+  /** Successful-instance retention in seconds */
+  success_retention_seconds: number;
+  /** Errored/terminated-instance retention in seconds */
+  error_retention_seconds: number;
+  /** Unix timestamp after which the local tracking row may be deleted */
+  expires_at: number | null;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3850,6 +3850,9 @@ importers:
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
+      itty-time:
+        specifier: 2.0.1
+        version: 2.0.1
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -9405,6 +9408,9 @@ packages:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
+
+  itty-time@2.0.1:
+    resolution: {integrity: sha512-p612bgdK5YKgsg0nm8Wx4nYipHphdR+LD5yfDbIJOEEtkdrQyUcVDHlAkGmazCU4GaGx/6RhGrvucfOXifwxog==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -17506,6 +17512,8 @@ snapshots:
   isows@1.0.7(ws@8.20.1):
     dependencies:
       ws: 8.20.1
+
+  itty-time@2.0.1: {}
 
   jackspeak@4.2.3:
     dependencies:


### PR DESCRIPTION
**tl;dr – Automatically prune terminal Agent Workflow tracking rows from local SQLite.**

Agent Workflow tracking currently grows without bound even after the Workflow platform expires instance state. This persists normalized success/error retention, derives an indexed `expires_at` after the terminal outcome is known, and maintains one earliest-expiry cleanup alarm per Agent or facet owner.

Cleanup is armed when `runWorkflow()` first writes tracking state, reconciles missed terminal callbacks after eviction or crashes, deletes expired local rows, and stops when no cleanup remains. Omitted retention uses a bounded 30-day local fallback because the SDK cannot detect Workers Free versus Paid; this improves the existing unbounded behavior.

This deletes only Agent-local SQLite tracking. It never deletes Workflow platform instances, state, or logs.

---

References: [retention passthrough PR](https://github.com/cloudflare/agents/pull/1948), [Agents cleanup strategy](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#cleanup-strategy)