### PR TITLE
fix(think): forward props through onStart wrapper

### DIFF
--- a/.changeset/friendly-props-start.md
+++ b/.changeset/friendly-props-start.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Forward routing props through the Think `onStart` lifecycle wrapper.

--- a/packages/think/src/tests/agents/index.ts
+++ b/packages/think/src/tests/agents/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./assistant-agent-loop";
 export {
   ThinkTestAgent,
+  ThinkPropsTestAgent,
   ThinkToolsTestAgent,
   ThinkSessionTestAgent,
   ThinkAsyncConfigSessionAgent,

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -3216,6 +3216,26 @@ export class ThinkAgentToolParent extends Agent {
   }
 }
 
+type ThinkPropsTestProps = {
+  tenantId: string;
+};
+
+export class ThinkPropsTestAgent extends Think<
+  Cloudflare.Env,
+  unknown,
+  ThinkPropsTestProps
+> {
+  private _startProps?: ThinkPropsTestProps;
+
+  override onStart(props?: ThinkPropsTestProps): void {
+    this._startProps = props;
+  }
+
+  getStartProps(): ThinkPropsTestProps | undefined {
+    return this._startProps;
+  }
+}
+
 // ── ThinkSessionTestAgent ───────────────────────────────────
 // Extends Think with Session configuration for context block testing.
 

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -5,6 +5,7 @@ import type { UIMessage } from "ai";
 import { subscribe } from "agents/observability";
 import type {
   ThinkTestAgent,
+  ThinkPropsTestAgent,
   ThinkSessionTestAgent,
   ThinkAsyncConfigSessionAgent,
   ThinkConfigTestAgent,
@@ -25,6 +26,13 @@ const MSG_CHAT_RESPONSE = "cf_agent_use_chat_response";
 async function freshAgent(name: string) {
   return getServerByName(
     env.ThinkTestAgent as unknown as DurableObjectNamespace<ThinkTestAgent>,
+    name
+  );
+}
+
+async function freshPropsAgent(name: string) {
+  return getServerByName(
+    env.ThinkPropsTestAgent as unknown as DurableObjectNamespace<ThinkPropsTestAgent>,
     name
   );
 }
@@ -151,6 +159,25 @@ async function freshLegacyConfigMigrationAgent(name: string) {
 // ── Core chat functionality ──────────────────────────────────────
 
 describe("Think — core", () => {
+  it("should forward routed props to onStart", async () => {
+    const room = `props-${crypto.randomUUID()}`;
+    const response = await exports.default.fetch(
+      `http://example.com/agents/think-props-test-agent/${room}`,
+      { headers: { Upgrade: "websocket" } }
+    );
+    expect(response.status).toBe(101);
+    const ws = response.webSocket as WebSocket;
+    expect(ws).toBeDefined();
+    ws.accept();
+
+    try {
+      const agent = await freshPropsAgent(room);
+      expect(await agent.getStartProps()).toEqual({ tenantId: "tenant-1" });
+    } finally {
+      await closeWS(ws);
+    }
+  });
+
   it("should run a chat turn and persist messages", async () => {
     const agent = await freshAgent("chat-basic");
     const result = await agent.testChat("Hello!");

--- a/packages/think/src/tests/worker.ts
+++ b/packages/think/src/tests/worker.ts
@@ -15,6 +15,7 @@ export {
   LoopToolTestAgent,
   OverflowRecoveryTestAgent,
   ThinkTestAgent,
+  ThinkPropsTestAgent,
   ThinkToolsTestAgent,
   ThinkFiberTestAgent,
   ThinkClientToolsAgent,
@@ -51,6 +52,7 @@ import type {
   LoopToolTestAgent,
   OverflowRecoveryTestAgent,
   ThinkTestAgent,
+  ThinkPropsTestAgent,
   ThinkToolsTestAgent,
   ThinkFiberTestAgent,
   ThinkClientToolsAgent,
@@ -191,6 +193,7 @@ export type Env = {
   LoopToolTestAgent: DurableObjectNamespace<LoopToolTestAgent>;
   OverflowRecoveryTestAgent: DurableObjectNamespace<OverflowRecoveryTestAgent>;
   ThinkTestAgent: DurableObjectNamespace<ThinkTestAgent>;
+  ThinkPropsTestAgent: DurableObjectNamespace<ThinkPropsTestAgent>;
   ThinkToolsTestAgent: DurableObjectNamespace<ThinkToolsTestAgent>;
   ThinkFiberTestAgent: DurableObjectNamespace<ThinkFiberTestAgent>;
   ThinkClientToolsAgent: DurableObjectNamespace<ThinkClientToolsAgent>;
@@ -223,8 +226,13 @@ export type Env = {
 
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
+    const options = new URL(request.url).pathname.startsWith(
+      "/agents/think-props-test-agent/"
+    )
+      ? { cors: true, props: { tenantId: "tenant-1" } }
+      : { cors: true };
     return (
-      (await routeAgentRequest(request, env, { cors: true })) ||
+      (await routeAgentRequest(request, env, options)) ||
       new Response("Not found", { status: 404 })
     );
   }

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -40,6 +40,10 @@
         "name": "ThinkTestAgent"
       },
       {
+        "class_name": "ThinkPropsTestAgent",
+        "name": "ThinkPropsTestAgent"
+      },
+      {
         "class_name": "ThinkToolsTestAgent",
         "name": "ThinkToolsTestAgent"
       },
@@ -168,6 +172,7 @@
         "LoopToolTestAgent",
         "OverflowRecoveryTestAgent",
         "ThinkTestAgent",
+        "ThinkPropsTestAgent",
         "ThinkToolsTestAgent",
         "ThinkFiberTestAgent",
         "ThinkClientToolsAgent",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2707,7 +2707,7 @@ export class Think<
     super(ctx, env);
 
     const _onStart = this.onStart.bind(this);
-    this.onStart = async () => {
+    this.onStart = async (props?: Props) => {
       // 1. Workspace initialization
       if (!this.workspace) {
         this.workspace = new Workspace({
@@ -2786,7 +2786,7 @@ export class Think<
       await this._initializeChannels();
 
       // 8. User's onStart
-      await _onStart();
+      await _onStart(props);
 
       // 9. Declarative scheduled tasks are code-defined and should reconcile
       // before draining any recovered programmatic work they may enqueue.


### PR DESCRIPTION
This PR forwards routing props through the Think `onStart` wrapper so Think agents receive props passed through `routeAgentRequest`. Fixes #1936.

## Why

- `Agent` supports routing props in `onStart`, but the Think lifecycle wrapper accepts no argument and invokes the captured hook without forwarding it.
- This causes `Think<Env, State, Props>` subclasses to receive `undefined` even though the routing layer supplied props.
- We could refactor the shared lifecycle wrappers, but a targeted forwarding change is lower-risk and preserves Think initialization order.

## Code Changes

- Update the Think `onStart` wrapper to accept optional `Props` and forward it to the captured lifecycle hook.
- Add a Workers regression test that routes a Think Durable Object with props and verifies they arrive in `onStart`.
- Add a patch changeset for `@cloudflare/think`.

## Test plan

- [x] `pnpm --filter @cloudflare/think run test:workers`
- [x] `pnpm run build`
- [x] `pnpm run check`

Generated with [Devin](https://devin.ai)