### PR TITLE
fix(agents): make turndown stub diagnostic

### DIFF
--- a/.changeset/gentle-turndown-diagnostics.md
+++ b/.changeset/gentle-turndown-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Make the `agents/vite` `turndown` stub fail with a diagnostic error when app code calls it directly, and document the `stubTurndown: false` opt-out for applications that use `turndown` themselves.

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -226,6 +226,26 @@ export default defineConfig({
 
 The `agents()` plugin is safe to include even if your project does not use decorators. It only runs the transform on files that contain `@` syntax.
 
+### Turndown Stub
+
+By default, the `agents()` Vite plugin also replaces imports of the `turndown`
+package with a Worker-safe stub. This prevents `just-bash`, used by Think's
+workspace `bash` tool and skill scripts, from pulling `turndown`'s Node DOM
+fallback into the Worker bundle. That fallback expects Node's global `require()`,
+which is not available in Workers.
+
+If your app imports `turndown` directly for HTML-to-Markdown conversion, disable
+the stub so your import resolves to the real package:
+
+```typescript
+export default defineConfig({
+  plugins: [agents({ stubTurndown: false }), react(), cloudflare()]
+});
+```
+
+When the stub is enabled and app code calls `turndown()`, the stub throws an
+error that points back to this option.
+
 The starter template and all examples include this plugin by default.
 
 ## Generating Types

--- a/packages/agents/src/cli-tests/vite-skills.test.ts
+++ b/packages/agents/src/cli-tests/vite-skills.test.ts
@@ -246,6 +246,8 @@ describe("turndown stub vite plugin", () => {
 
     const code = await load(plugin, ctx)("\0agents:turndown-stub");
     expect(code).toContain("class TurndownService");
+    expect(code).toContain("throw new Error(message)");
+    expect(code).toContain("agents({ stubTurndown: false })");
     expect(code).toContain("export default TurndownService");
   });
 

--- a/packages/agents/src/vite.ts
+++ b/packages/agents/src/vite.ts
@@ -370,13 +370,17 @@ async function buildSkillsModule(
 }
 
 const TURNDOWN_STUB_ID = "\0agents:turndown-stub";
+const TURNDOWN_STUB_MESSAGE =
+  "The Agents Vite plugin stubbed the 'turndown' package to keep Workers " +
+  "bundles compatible with just-bash. If your app uses turndown directly, " +
+  "configure the plugin with agents({ stubTurndown: false }).";
 
 // `just-bash` (pulled in by the workspace bash tool / skill runner) statically
 // depends on `turndown`, whose ESM build runs a top-level `require()` on its
 // Node DOM fallback. Workers is ESM with no global `require`, so the module
 // throws at startup — even when the bash tool is never used. turndown is only
 // needed by just-bash's niche `html-to-markdown` command, so we replace it with
-// an inert stub by default to keep Workers deploys clean. Opt out with
+// a diagnostic stub by default to keep Workers deploys clean. Opt out with
 // `agents({ stubTurndown: false })` if you rely on turndown elsewhere.
 function turndownStubPlugin(): Plugin {
   return {
@@ -388,13 +392,14 @@ function turndownStubPlugin(): Plugin {
     },
     load(id) {
       if (id !== TURNDOWN_STUB_ID) return null;
-      return `class TurndownService {
+      return `const message = ${JSON.stringify(TURNDOWN_STUB_MESSAGE)};
+class TurndownService {
   constructor() {}
   use() { return this; }
   addRule() { return this; }
   keep() { return this; }
   remove() { return this; }
-  turndown() { return ""; }
+  turndown() { throw new Error(message); }
 }
 export default TurndownService;
 `;
@@ -435,10 +440,10 @@ function skillsImportPlugin(): Plugin {
 
 export interface AgentsPluginOptions {
   /**
-   * Replace `turndown` with an inert stub so `just-bash` (workspace bash tool /
-   * skill runner) doesn't drag turndown's `require()`-using DOM fallback into
-   * the Worker's module-init path and break deploys. Enabled by default. Set to
-   * `false` if your app uses turndown directly and needs the real
+   * Replace `turndown` with a diagnostic stub so `just-bash` (workspace bash
+   * tool / skill runner) doesn't drag turndown's `require()`-using DOM fallback
+   * into the Worker's module-init path and break deploys. Enabled by default.
+   * Set to `false` if your app uses turndown directly and needs the real
    * implementation.
    */
   stubTurndown?: boolean;


### PR DESCRIPTION
This PR makes the `agents/vite` `turndown` stub fail with a targeted diagnostic when app code calls it directly, and documents the `stubTurndown: false` escape hatch. Closes #1901.

## Why

- Upgraders can hit the `turndown` stub through their own app code, not only through `just-bash` internals.
- The old stub returned an empty string from `turndown()`, which made direct HTML-to-Markdown integrations fail silently and sent users looking in the wrong place.
- We could disable the stub by default, but that would reintroduce the Workers startup failure it was added to avoid when `just-bash` pulls in `turndown` transitively.
- Keeping the stub enabled while making direct use fail loudly preserves the deploy-safe default and gives apps that need real `turndown` a concrete migration path.

## Code Changes

- `packages/agents/src/vite.ts` gives the virtual `turndown` module a shared diagnostic message and throws it from `TurndownService#turndown()`.
- `docs/agents/configuration.md` documents why `agents()` stubs `turndown`, what symptom direct users will see, and how to opt out with `agents({ stubTurndown: false })`.
- `.changeset/gentle-turndown-diagnostics.md` records the patch release note for `agents`.

## Compatibility

- The `stubTurndown` default stays enabled, so Workers bundles keep the existing protection against `turndown`'s Node fallback.
- Apps that accidentally relied on the stub returning empty markdown will now get a clear runtime error. Apps that need real HTML-to-Markdown conversion should use `agents({ stubTurndown: false })`.
