### PR TITLE
Add `retention` support for workflows

### DIFF
--- a/.changeset/workflow-retention-passthrough.md
+++ b/.changeset/workflow-retention-passthrough.md
@@ -2,4 +2,4 @@
 "agents": minor
 ---
 
-Pass Workflow instance retention options through `Agent.runWorkflow()`.
+Pass Workflow [`retention`](https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions) through `Agent.runWorkflow()`.

--- a/.changeset/workflow-retention-passthrough.md
+++ b/.changeset/workflow-retention-passthrough.md
@@ -1,0 +1,5 @@
+---
+"agents": minor
+---
+
+Pass Workflow instance retention options through `Agent.runWorkflow()`.

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -262,8 +262,8 @@ const instanceId = await this.runWorkflow(
 - `options.id` - Custom workflow ID (auto-generated if not provided)
 - `options.metadata` - Optional metadata stored for querying (not passed to workflow)
 - `options.agentBinding` - Agent binding name (auto-detected from class name if not provided). When called from a sub-agent, this is the root Agent binding name.
-- `options.retention` - Workflow instance retention passed unchanged to
-  [`Workflow.create()`](https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions).
+- [`options.retention`](https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions) - Workflow retention passed unchanged to
+  `Workflow.create()`.
   Use `successRetention` for successful instances and `errorRetention` for
   errored or terminated instances.
 

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -246,7 +246,11 @@ const instanceId = await this.runWorkflow(
   {
     id: "custom-id", // optional - auto-generated if not provided
     metadata: { userId: "user-456", priority: "high" }, // optional - for querying
-    agentBinding: "MyAgent" // optional - auto-detected from class name if not provided
+    agentBinding: "MyAgent", // optional - auto-detected from class name if not provided
+    retention: {
+      successRetention: "1 day",
+      errorRetention: "7 days"
+    }
   }
 );
 ```
@@ -258,6 +262,10 @@ const instanceId = await this.runWorkflow(
 - `options.id` - Custom workflow ID (auto-generated if not provided)
 - `options.metadata` - Optional metadata stored for querying (not passed to workflow)
 - `options.agentBinding` - Agent binding name (auto-detected from class name if not provided). When called from a sub-agent, this is the root Agent binding name.
+- `options.retention` - Workflow instance retention passed unchanged to
+  [`Workflow.create()`](https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions).
+  Use `successRetention` for successful instances and `errorRetention` for
+  errored or terminated instances.
 
 **Returns:** Workflow instance ID
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -11258,7 +11258,10 @@ export class Agent<
     // Create the workflow instance
     const instance = await workflow.create({
       id: workflowId,
-      params: augmentedParams
+      params: augmentedParams,
+      ...(options?.retention === undefined
+        ? {}
+        : { retention: options.retention })
     });
 
     // Track the workflow in our database

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -11259,9 +11259,7 @@ export class Agent<
     const instance = await workflow.create({
       id: workflowId,
       params: augmentedParams,
-      ...(options?.retention === undefined
-        ? {}
-        : { retention: options.retention })
+      retention: options?.retention
     });
 
     // Track the workflow in our database

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -11216,7 +11216,10 @@ export class Agent<
     // Create the workflow instance
     const instance = await workflow.create({
       id: workflowId,
-      params: augmentedParams
+      params: augmentedParams,
+      ...(options?.retention === undefined
+        ? {}
+        : { retention: options.retention })
     });
 
     // Track the workflow in our database

--- a/packages/agents/src/tests-d/workflow-retention.test-d.ts
+++ b/packages/agents/src/tests-d/workflow-retention.test-d.ts
@@ -1,0 +1,24 @@
+import { expectTypeOf } from "vitest";
+import type { RunWorkflowOptions } from "../workflows";
+
+expectTypeOf<RunWorkflowOptions["retention"]>().toEqualTypeOf<
+  WorkflowInstanceCreateOptions["retention"]
+>();
+
+const validRetention = {
+  retention: {
+    successRetention: "1 day",
+    errorRetention: 60_000
+  }
+} satisfies RunWorkflowOptions;
+
+void validRetention;
+
+const invalidRetention = {
+  retention: {
+    // @ts-expect-error Workflow retention uses WorkflowSleepDuration units.
+    successRetention: "1 fortnight"
+  }
+} satisfies RunWorkflowOptions;
+
+void invalidRetention;

--- a/packages/agents/src/tests/agents/workflow.ts
+++ b/packages/agents/src/tests/agents/workflow.ts
@@ -1,5 +1,9 @@
 import { Agent } from "../../index.ts";
-import type { WorkflowStatus, WorkflowInfo } from "../../workflows.ts";
+import type {
+  RunWorkflowOptions,
+  WorkflowStatus,
+  WorkflowInfo
+} from "../../workflows.ts";
 
 type WorkflowSubAgentState = {
   status: string;
@@ -699,6 +703,17 @@ export class TestWorkflowAgent extends Agent {
     return this.runWorkflow("SIMPLE_WORKFLOW", params, {
       id: workflowId
     });
+  }
+
+  async runSimpleWorkflowWithRetentionTest(
+    workflowId: string,
+    retention: NonNullable<RunWorkflowOptions["retention"]>
+  ): Promise<string> {
+    return this.runWorkflow(
+      "SIMPLE_WORKFLOW",
+      { value: "retention-test" },
+      { id: workflowId, retention }
+    );
   }
 
   // Start a simple workflow using the Agent's generated default ID

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -25,6 +25,25 @@ async function getTestAgent(name: string) {
 
 describe("workflow operations", () => {
   describe("workflow tracking", () => {
+    it("starts and tracks a workflow with custom retention", async () => {
+      const agentStub = await getTestAgent("workflow-retention-test");
+      const workflowId = "workflow-with-retention";
+
+      const instanceId = await agentStub.runSimpleWorkflowWithRetentionTest(
+        workflowId,
+        {
+          successRetention: "1 day",
+          errorRetention: "2 weeks"
+        }
+      );
+
+      expect(instanceId).toBe(workflowId);
+      expect(await agentStub.getWorkflowById(workflowId)).toMatchObject({
+        workflowId,
+        workflowName: "SIMPLE_WORKFLOW"
+      });
+    });
+
     it("should insert and retrieve a workflow tracking record", async () => {
       const agentStub = await getTestAgent("workflow-tracking-test-1");
 

--- a/packages/agents/src/tests/workflow.test.ts
+++ b/packages/agents/src/tests/workflow.test.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:workers";
-import { describe, expect, it } from "vitest";
-import { getAgentByName } from "..";
+import { describe, expect, it, vi } from "vitest";
+import { Agent, getAgentByName } from "..";
 import type { WorkflowInfo } from "../workflows";
 
 // Helper type for callback records
@@ -25,6 +25,46 @@ async function getTestAgent(name: string) {
 
 describe("workflow operations", () => {
   describe("workflow tracking", () => {
+    it("forwards custom retention to workflow.create", async () => {
+      const retention = {
+        successRetention: "1 day",
+        errorRetention: "2 weeks"
+      } satisfies NonNullable<WorkflowInstanceCreateOptions["retention"]>;
+      const create = vi.fn(async () => ({ id: "workflow-with-retention" }));
+      const agent = {
+        name: "workflow-retention-test",
+        _findWorkflowBindingByName: () => ({ create }),
+        _workflowOrigin: () => ({
+          kind: "agent",
+          binding: "TestWorkflowAgent"
+        }),
+        sql: () => [],
+        _emit: vi.fn()
+      } as unknown as Agent<Cloudflare.Env>;
+
+      await Agent.prototype.runWorkflow.call(
+        agent,
+        "SIMPLE_WORKFLOW",
+        { value: "retention-test" },
+        { id: "workflow-with-retention", retention }
+      );
+
+      expect(create).toHaveBeenCalledWith({
+        id: "workflow-with-retention",
+        params: {
+          value: "retention-test",
+          __agentName: "workflow-retention-test",
+          __agentBinding: "TestWorkflowAgent",
+          __workflowName: "SIMPLE_WORKFLOW",
+          __agentOrigin: {
+            kind: "agent",
+            binding: "TestWorkflowAgent"
+          }
+        },
+        retention
+      });
+    });
+
     it("starts and tracks a workflow with custom retention", async () => {
       const agentStub = await getTestAgent("workflow-retention-test");
       const workflowId = "workflow-with-retention";

--- a/packages/agents/src/workflow-types.ts
+++ b/packages/agents/src/workflow-types.ts
@@ -231,6 +231,8 @@ export type RunWorkflowOptions = {
   metadata?: Record<string, unknown>;
   /** Agent binding name (auto-detected from class name if not provided) */
   agentBinding?: string;
+  /** Retention policy for the underlying Workflow instance */
+  retention?: WorkflowInstanceCreateOptions["retention"];
 };
 
 /**

--- a/packages/agents/src/workflow-types.ts
+++ b/packages/agents/src/workflow-types.ts
@@ -230,6 +230,8 @@ export type RunWorkflowOptions = {
   metadata?: Record<string, unknown>;
   /** Agent binding name (auto-detected from class name if not provided) */
   agentBinding?: string;
+  /** Retention policy for the underlying Workflow instance */
+  retention?: WorkflowInstanceCreateOptions["retention"];
 };
 
 /**


### PR DESCRIPTION
**tl;dr – Pass Workflow instance retention through `Agent.runWorkflow()`.**

`Workflow.create()` supports `retention` for automatically disposing of success/error instances:
> https://developers.cloudflare.com/workflows/build/workers-api/#workflowinstancecreateoptions

`Agent.runWorkflow()` does not currently support `retention`:
> https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#runworkflowworkflowname-params-options

This adds the native, strongly typed `retention` option and forwards it unchanged to the underlying Workflow binding.

**Agent-local tracking behavior is unchanged. However, a follow-up PR will automatically reconcile the Agent's DB based on `retention`.** This will remove the need for https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#cleanup-strategy based on time.
