### PR TITLE
agent-think: use GPT-5.6 Sol max reasoning

### DIFF
--- a/agent-think/AGENTS.md
+++ b/agent-think/AGENTS.md
@@ -188,9 +188,11 @@ npm run seed:r2  # push skills/** to the R2 bucket (add -- --local for dev)
   the full agent path without gh-app or webhooks.
 - Deploys target the `agents` Cloudflare account
   (`CLOUDFLARE_ACCOUNT_ID=b8afc92c7a87f699592038b756153d22`).
-- Model: `gpt-5.5` with medium reasoning through the team AI Gateway token,
-  with a client-side fallback to `claude-opus-4-8` when the primary dispatch
-  fails. Production reads `CLOUDFLARE_AIG_TOKEN` from a Worker secret and
+- Model: `gpt-5.6-sol` with max reasoning through the OpenAI Responses API
+  and team AI Gateway token, with a client-side fallback to
+  `claude-opus-4-8` when the primary dispatch fails. Responses use
+  `store: false`, so agent-think does not persist provider reasoning state.
+  Production reads `CLOUDFLARE_AIG_TOKEN` from a Worker secret and
   attributes every request to the `agents-team-agent-think` project. Local
   agent turns read the same variable from `.env`.
 

--- a/agent-think/src/model.ts
+++ b/agent-think/src/model.ts
@@ -43,15 +43,15 @@ export function createAgentThinkModel(
     baseURL: `${AI_GATEWAY_BASE_URL}/anthropic`,
     fetch: gatewayFetch
   });
-  const primary = withProviderOptions(openai.chat("gpt-5.5"), {
-    openai: { reasoningEffort: "medium" }
+  const primary = withProviderOptions(openai.responses("gpt-5.6-sol"), {
+    openai: { reasoningEffort: "max", store: false }
   });
   const fallback = withProviderOptions(anthropic("claude-opus-4-8"), {
     anthropic: { thinking: { type: "adaptive" }, effort: "medium" }
   });
 
   return createClientFallbackModel([
-    { slug: "openai/gpt-5.5", model: primary, transport: "gateway" },
+    { slug: "openai/gpt-5.6-sol", model: primary, transport: "gateway" },
     {
       slug: "anthropic/claude-opus-4-8",
       model: fallback,

--- a/agent-think/test/model.test.ts
+++ b/agent-think/test/model.test.ts
@@ -2,19 +2,68 @@ import { describe, expect, it, vi } from "vitest";
 import { createAgentThinkModel } from "../src/model";
 
 const completion = {
-  id: "chatcmpl-test",
-  object: "chat.completion",
-  created: 1,
-  model: "gpt-5.5",
-  choices: [
+  id: "resp-test",
+  created_at: 1,
+  model: "gpt-5.6-sol",
+  output: [
     {
-      index: 0,
-      message: { role: "assistant", content: "ok" },
-      finish_reason: "stop"
+      type: "message",
+      id: "msg-test",
+      role: "assistant",
+      content: [
+        { type: "output_text", text: "ok", annotations: [], logprobs: null }
+      ]
     }
   ],
-  usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+  incomplete_details: null,
+  usage: {
+    input_tokens: 1,
+    input_tokens_details: { cached_tokens: 0 },
+    output_tokens: 2,
+    output_tokens_details: { reasoning_tokens: 1 }
+  }
 };
+
+const streamEvents = [
+  {
+    type: "response.created",
+    response: {
+      id: "resp-stream",
+      created_at: 1,
+      model: "gpt-5.6-sol",
+      service_tier: null
+    }
+  },
+  {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { type: "message", id: "msg-stream", phase: null }
+  },
+  {
+    type: "response.output_text.delta",
+    item_id: "msg-stream",
+    delta: "streamed",
+    logprobs: null
+  },
+  {
+    type: "response.output_item.done",
+    output_index: 0,
+    item: { type: "message", id: "msg-stream", phase: null }
+  },
+  {
+    type: "response.completed",
+    response: {
+      incomplete_details: null,
+      usage: {
+        input_tokens: 1,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens: 2,
+        output_tokens_details: { reasoning_tokens: 1 }
+      },
+      service_tier: null
+    }
+  }
+];
 
 const anthropicCompletion = {
   id: "msg-test",
@@ -41,7 +90,7 @@ describe("createAgentThinkModel", () => {
     expect(fetch).toHaveBeenCalledOnce();
     const [input, init] = fetch.mock.calls[0];
     expect(String(input)).toBe(
-      "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/openai/chat/completions"
+      "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/openai/responses"
     );
     const headers = new Headers(init?.headers);
     expect(headers.get("authorization")).toBeNull();
@@ -49,9 +98,46 @@ describe("createAgentThinkModel", () => {
     expect(headers.get("cf-aig-metadata")).toBe(
       JSON.stringify({ project: "agents-team-agent-think" })
     );
+    const body = JSON.parse(String(init?.body));
+    expect(body).toMatchObject({
+      model: "gpt-5.6-sol",
+      reasoning: { effort: "max" },
+      store: false,
+      include: ["reasoning.encrypted_content"]
+    });
+    expect(body).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("streams through the Responses API", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(
+      async () =>
+        new Response(
+          streamEvents
+            .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+            .join("") + "data: [DONE]\n\n",
+          { headers: { "content-type": "text/event-stream" } }
+        )
+    );
+    const model = createAgentThinkModel("team-token", fetch);
+
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }]
+    });
+    const chunks = [];
+    for await (const chunk of result.stream) chunks.push(chunk);
+
+    expect(chunks).toContainEqual({
+      type: "text-delta",
+      id: "msg-stream",
+      delta: "streamed"
+    });
+    const [input, init] = fetch.mock.calls[0];
+    expect(String(input)).toContain("/openai/responses");
     expect(JSON.parse(String(init?.body))).toMatchObject({
-      model: "gpt-5.5",
-      reasoning_effort: "medium"
+      model: "gpt-5.6-sol",
+      reasoning: { effort: "max" },
+      store: false,
+      stream: true
     });
   });
 
@@ -73,7 +159,7 @@ describe("createAgentThinkModel", () => {
 
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(fetch.mock.calls.map(([input]) => String(input))).toEqual([
-      "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/openai/chat/completions",
+      "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/openai/responses",
       "https://gateway.ai.cloudflare.com/v1/27b146402af2103944379f33841b6234/project-gateway/anthropic/messages"
     ]);
     const fallbackInit = fetch.mock.calls[1][1];


### PR DESCRIPTION
## Summary

- move agent-think's primary model from GPT-5.5 Chat Completions at medium reasoning to `gpt-5.6-sol` through the OpenAI Responses API at max reasoning
- set `store: false` so agent-think does not retain provider reasoning state
- keep the existing Claude Opus 4.8 medium-effort fallback unchanged
- test non-streaming Responses parsing, SSE streaming, exact Gateway request shape, authentication/project headers, and cross-protocol fallback

## Request shape

```ts
openai.responses("gpt-5.6-sol")
```

```ts
openai: {
  reasoningEffort: "max",
  store: false
}
```

The installed AI SDK sends this as `reasoning: { effort: "max" }` to `/openai/responses` and automatically requests `reasoning.encrypted_content` for the non-stored flow.

## Verification

- agent-think: 38 tests passed
- agent-think and E2E TypeScript projects passed
- full monorepo build: 25 targets passed
- `pnpm run check`: exports, formatting, lint, and all 117 TypeScript projects passed
- production deployment and live Gateway smoke: pending

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Production verification

- deployed code-only with `--containers-rollout none`, preserving the existing container image
- final production Worker version: `7e3ef6df-a97c-4c18-9ffa-b3f57b92a628`
- live Responses smoke selected `gpt-5.6-sol`, returned `PONG`, and completed with finish reason `stop`
- the temporary Access-protected smoke endpoint was removed immediately after verification and now returns 404
- no `turn:*` activity was present in Workers Observability during the hour before deployment
