### PR TITLE
Add support for the Pyodide package index

### DIFF
--- a/packages/worker-bundler/package.json
+++ b/packages/worker-bundler/package.json
@@ -36,6 +36,7 @@
     "@typescript/vfs": "^1.6.4",
     "es-module-lexer": "^2.2.0",
     "esbuild-wasm": "0.28.1",
+    "fflate": "^0.8.2",
     "resolve.exports": "^2.0.3",
     "semver": "^7.8.5",
     "smol-toml": "^1.7.0",

--- a/packages/worker-bundler/src/app.ts
+++ b/packages/worker-bundler/src/app.ts
@@ -101,6 +101,14 @@ export interface CreateAppOptions {
   registry?: string;
 
   /**
+   * When installing Python packages declared in pyproject.toml, prefer the
+   * Pyodide package index over PyPI. Useful when the target runtime uses
+   * Pyodide's wasm32 wheel builds.
+   * @default true
+   */
+  preferPyodideIndex?: boolean;
+
+  /**
    * JSX transform mode passed to esbuild. Applied to both server and client
    * bundles.
    */
@@ -204,6 +212,7 @@ export async function createApp(
     minify = false,
     sourcemap = false,
     registry,
+    preferPyodideIndex,
     jsx,
     jsxImportSource,
     define,
@@ -226,10 +235,10 @@ export async function createApp(
   // Install npm dependencies if needed
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
-    const installResult = await installDependencies(
-      fileSystem,
-      registry ? { registry } : {}
-    );
+    const installResult = await installDependencies(fileSystem, {
+      ...(registry ? { registry } : {}),
+      ...(preferPyodideIndex !== undefined ? { preferPyodideIndex } : {})
+    });
     installWarnings.push(...installResult.warnings);
   }
 

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -8,7 +8,7 @@ import { bundleWithEsbuild, bundlerOnlyOptionsWarning } from "./bundler";
 import { hasNodejsCompat, parseWranglerConfig } from "./config";
 import { hasDependencies, installDependencies } from "./installer";
 import { transformAndResolve } from "./transformer";
-import type { CreateWorkerOptions, CreateWorkerResult } from "./types";
+import type { CreateWorkerOptions, CreateWorkerResult, Modules } from "./types";
 import {
   DEFAULT_ENTRY_POINTS,
   detectEntryPoint,
@@ -117,7 +117,7 @@ export async function createWorker(
   const wranglerConfig = parseWranglerConfig(fileSystem);
   const nodejsCompat = hasNodejsCompat(wranglerConfig);
 
-  // Auto-install dependencies if package.json has dependencies
+  // Auto-install dependencies if package.json or pyproject.toml has dependencies
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
     const installResult = await installDependencies(
@@ -141,6 +141,29 @@ export async function createWorker(
     throw new Error(
       `Entry point "${entryPoint}" was not found in \`files\`. Available files: ${formatFileListForError(fileSystem)}.`
     );
+  }
+
+  if (entryPoint.endsWith(".py")) {
+    const modules: Modules = {};
+    for (const path of fileSystem.list()) {
+      if (path === "pyproject.toml") {
+        continue;
+      }
+      const content = fileSystem.read(path);
+      if (content !== null) {
+        modules[path] = content;
+      }
+    }
+
+    return {
+      mainModule: entryPoint,
+      modules,
+      wranglerConfig: {
+        compatibilityDate: wranglerConfig?.compatibilityDate ?? "2026-07-02",
+        compatibilityFlags: wranglerConfig?.compatibilityFlags ?? []
+      },
+      warnings: installWarnings
+    };
   }
 
   if (bundle) {
@@ -171,7 +194,6 @@ export async function createWorker(
     if (installWarnings.length > 0) {
       result.warnings = [...(result.warnings ?? []), ...installWarnings];
     }
-
     return result;
   } else {
     // No bundling - transform files and resolve dependencies.

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -94,6 +94,7 @@ export async function createWorker(
     minify = false,
     sourcemap = false,
     registry,
+    preferPyodideIndex,
     jsx,
     jsxImportSource,
     define,
@@ -120,10 +121,10 @@ export async function createWorker(
   // Auto-install dependencies if package.json or pyproject.toml has dependencies
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
-    const installResult = await installDependencies(
-      fileSystem,
-      registry ? { registry } : {}
-    );
+    const installResult = await installDependencies(fileSystem, {
+      ...(registry ? { registry } : {}),
+      ...(preferPyodideIndex !== undefined ? { preferPyodideIndex } : {})
+    });
     installWarnings.push(...installResult.warnings);
   }
 

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -6,9 +6,12 @@
  */
 
 import * as semver from "semver";
+import { unzipSync } from "fflate";
 import type { FileSystem } from "./file-system";
+import { parse as parseToml } from "smol-toml";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
+const PYPI_JSON_API = "https://pypi.org/pypi";
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
 
 /**
@@ -49,6 +52,15 @@ interface PackageJson {
   dist?: {
     tarball: string;
     integrity?: string;
+  };
+}
+
+// Deliberately keeping this minimal
+interface PyprojectToml {
+  project?: {
+    name: string;
+    version: string;
+    dependencies?: string[];
   };
 }
 
@@ -106,26 +118,85 @@ export async function installDependencies(
 
   // Read package.json
   const packageJsonContent = fileSystem.read("package.json");
-  if (!packageJsonContent) {
-    return result; // No package.json, nothing to install
+  const pyprojectTomlContent = fileSystem.read("pyproject.toml");
+
+  if (packageJsonContent && pyprojectTomlContent) {
+    result.warnings.push("Cannot have package.json and pyproject.toml");
+    return result;
   }
 
-  let packageJson: PackageJson;
+  if (packageJsonContent) {
+    let packageJson: PackageJson;
+    try {
+      packageJson = JSON.parse(packageJsonContent) as PackageJson;
+    } catch {
+      result.warnings.push("Failed to parse package.json");
+      return result;
+    }
+
+    // Collect dependencies to install
+    const depsToInstall: Record<string, string> = {
+      ...packageJson.dependencies,
+      ...(dev ? packageJson.devDependencies : {})
+    };
+
+    if (Object.keys(depsToInstall).length === 0) {
+      return result; // No dependencies to install
+    }
+
+    // Track installed packages to avoid duplicates
+    const installedPackages = new Map<string, string>(); // name -> version
+    // Track in-progress installations to avoid duplicate work
+    const inProgress = new Map<string, Promise<void>>();
+
+    // Install all dependencies in parallel
+    await Promise.all(
+      Object.entries(depsToInstall).map(([name, versionRange]) =>
+        installPackage(
+          name,
+          versionRange,
+          result,
+          fileSystem,
+          installedPackages,
+          inProgress,
+          registry
+        )
+      )
+    );
+  } else if (pyprojectTomlContent) {
+    return await installDependenciesPython(fileSystem, pyprojectTomlContent);
+  }
+  return result;
+}
+
+/**
+ * Install Python dependencies declared in a pyproject.toml file.
+ */
+async function installDependenciesPython(
+  fileSystem: FileSystem,
+  pyprojectTomlContent: string
+): Promise<InstallResult> {
+  const result: InstallResult = {
+    installed: [],
+    warnings: []
+  };
+
+  let pyprojectToml: PyprojectToml;
   try {
-    packageJson = JSON.parse(packageJsonContent) as PackageJson;
+    pyprojectToml = parseToml(pyprojectTomlContent) as PyprojectToml;
   } catch {
-    result.warnings.push("Failed to parse package.json");
+    result.warnings.push("Failed to parse pyproject.toml");
     return result;
   }
 
   // Collect dependencies to install
-  const depsToInstall: Record<string, string> = {
-    ...packageJson.dependencies,
-    ...(dev ? packageJson.devDependencies : {})
-  };
+  const depsToInstall: Record<string, string> = {};
+  depsToInstall["workers-runtime-sdk"] = "*"; // TODO: Should this always take the latest?
+  for (const dep of pyprojectToml.project?.dependencies ?? []) {
+    const name = dep.trim();
+    if (!name) continue;
 
-  if (Object.keys(depsToInstall).length === 0) {
-    return result; // No dependencies to install
+    depsToInstall[name] = "*"; // in the future this should be a version specifier, if one was set
   }
 
   // Track installed packages to avoid duplicates
@@ -135,19 +206,17 @@ export async function installDependencies(
 
   // Install all dependencies in parallel
   await Promise.all(
-    Object.entries(depsToInstall).map(([name, versionRange]) =>
-      installPackage(
-        name,
-        versionRange,
+    Object.entries(depsToInstall).map(([depName]) =>
+      installPythonPackage(
+        depName,
         result,
         fileSystem,
         installedPackages,
         inProgress,
-        registry
+        PYPI_JSON_API // hardcoding this for now to keep the implementation light
       )
     )
   );
-
   return result;
 }
 
@@ -251,6 +320,113 @@ async function installPackage(
 }
 
 /**
+ * Install a single Python package from PyPI.
+ *
+ * This is a minimal implementation: it downloads the latest version of the
+ * package as a source distribution and adds it to python_modules/. It does not
+ * resolve version ranges or install transitive dependencies.
+ */
+async function installPythonPackage(
+  name: string,
+  // _versionRange: string, // remove fully if package resolver impl. ends up not going through this path
+  result: InstallResult,
+  fileSystem: FileSystem,
+  installedPackages: Map<string, string>,
+  inProgress: Map<string, Promise<void>>,
+  registry: string
+): Promise<void> {
+  // Skip if already installed in this run
+  if (installedPackages.has(name)) {
+    return;
+  }
+
+  // TODO: In the JS impl., a check is done here for whether the package already exists in the filesystem
+  // Assess in the future whether this is sensible to repeat
+
+  // If installation is already in progress, wait for it
+  const existing = inProgress.get(name);
+  if (existing) {
+    return existing;
+  }
+
+  const installPromise = (async () => {
+    try {
+      const metadata = await fetchPythonPackageMetadata(name, registry);
+
+      const version = metadata.info.version;
+      const wheel = metadata.urls.find(
+        (url) => url.packagetype === "bdist_wheel"
+      );
+      if (!wheel) {
+        throw new Error(
+          `No wheel distribution found for ${name}@${version} on PyPI`
+        );
+      }
+      const wheelUrl = wheel.url;
+
+      const response = await fetchWithTimeout(
+        wheelUrl,
+        {},
+        DEFAULT_TIMEOUT_MS * 2
+      );
+      if (!response.ok) {
+        throw new Error(
+          `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheelUrl})`
+        );
+      }
+
+      const buffer = await response.arrayBuffer();
+
+      const packageFilesWheel = stripWheelToPackage(
+        extractWheel(new Uint8Array(buffer), result)
+      );
+
+      // Mark as installed before writing to prevent cycles
+      installedPackages.set(name, version);
+      result.installed.push(`${name}@${version}`);
+
+      // Add files to python_modules
+      for (const [filePath, content] of Object.entries(packageFilesWheel)) {
+        fileSystem.write(`python_modules/${filePath}`, content);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.warnings.push(`Failed to install ${name}: ${message}`);
+    }
+  })();
+
+  inProgress.set(name, installPromise);
+
+  try {
+    await installPromise;
+  } finally {
+    inProgress.delete(name);
+  }
+}
+
+/**
+ * Strip a Python wheel down to just the package contents.
+ *
+ * Wheels contain the importable package alongside `.dist-info` metadata and
+ * `.data` directories. This removes those supporting directories and flattens
+ * the package directory so its files are at the root of the returned record.
+ */
+function stripWheelToPackage(
+  files: Record<string, string>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [path, content] of Object.entries(files)) {
+    // Skip wheel metadata and data directories
+    if (path.includes(".dist-info/") || path.includes(".data/")) {
+      continue;
+    }
+    // We'll expect that any remaining directories in the wheel are importable packages
+    result[path] = content;
+  }
+  return result;
+}
+
+/**
  * Fetch package metadata from npm registry.
  */
 async function fetchPackageMetadata(
@@ -284,6 +460,31 @@ async function fetchPackageMetadata(
   }
 
   return (await response.json()) as NpmPackageMetadata;
+}
+
+async function fetchPythonPackageMetadata(name: string, registry: string) {
+  // Fetch package metadata from PyPI JSON API
+  // TODO: Redo this to use the PyPA simple repository API
+  const metadataResponse = await fetchWithTimeout(`${registry}/${name}/json`);
+  if (!metadataResponse.ok) {
+    const hint =
+      metadataResponse.status === 404
+        ? " (package not found — check the name in pyproject.toml)"
+        : "";
+    throw new Error(
+      `PyPI returned ${metadataResponse.status} ${metadataResponse.statusText} for "${name}"${hint}`
+    );
+  }
+  const metadata = (await metadataResponse.json()) as {
+    info: { version: string };
+
+    urls: Array<{
+      filename: string;
+      url: string;
+      packagetype: string;
+    }>;
+  };
+  return metadata;
 }
 
 /**
@@ -346,6 +547,34 @@ export async function fetchPackageFiles(
 
   // Extract the tarball (npm tarballs are gzipped tar files)
   return extractTarball(new Uint8Array(buffer));
+}
+
+/**
+ * Extract files from a ZIP archive (Python wheel).
+ *
+ * Python wheels are distributed as .whl files (ZIP archives).
+ */
+function extractWheel(
+  data: Uint8Array,
+  result: InstallResult
+): Record<string, string> {
+  const unzipped = unzipSync(data);
+  const files: Record<string, string> = {};
+  const textDecoder = new TextDecoder();
+
+  for (const [path, content] of Object.entries(unzipped)) {
+    // Todo: Remove this check once it's confirmed that compiled wasm binaries are working
+    // (blocking this for now so any such packages will fail gracefully in the interim)
+    if (!isTextFile(path)) {
+      result.warnings.push(
+        `Could not install file ${path}, extension must match an approved text format type. This may corrupt this dependency.`
+      );
+      continue;
+    }
+    files[path] = textDecoder.decode(content);
+  }
+
+  return files;
 }
 
 /**
@@ -500,7 +729,8 @@ function isTextFile(path: string): boolean {
     ".map",
     ".d.ts",
     ".d.mts",
-    ".d.cts"
+    ".d.cts",
+    ".py"
   ];
 
   // Check common config files without extensions
@@ -526,17 +756,31 @@ function isTextFile(path: string): boolean {
 }
 
 /**
- * Check if files contain a package.json with dependencies that need installing.
+ * Check if files contain a package.json or pyproject.toml with dependencies that need installing.
  */
 export function hasDependencies(files: FileSystem): boolean {
+  const pyprojectToml = files.read("pyproject.toml");
   const packageJson = files.read("package.json");
-  if (!packageJson) return false;
+  if (!packageJson && !pyprojectToml) return false;
 
-  try {
-    const pkg = JSON.parse(packageJson);
-    const deps = pkg.dependencies ?? {};
-    return Object.keys(deps).length > 0;
-  } catch {
-    return false;
+  if (packageJson) {
+    try {
+      const pkg = JSON.parse(packageJson);
+      const deps = pkg.dependencies ?? {};
+      return Object.keys(deps).length > 0;
+    } catch {
+      return false;
+    }
   }
+
+  if (pyprojectToml) {
+    try {
+      const pkg = parseToml(pyprojectToml) as PyprojectToml;
+      const deps = pkg.project?.dependencies ?? [];
+      return deps.length > 0;
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -389,6 +389,20 @@ async function installPythonPackage(
       for (const [filePath, content] of Object.entries(packageFilesWheel)) {
         fileSystem.write(`python_modules/${filePath}`, content);
       }
+
+      const dependencies = [...(metadata.info.requires_dist ?? [])];
+      await Promise.all(
+        dependencies.map((dep) =>
+          installPythonPackage(
+            parsePythonVersionString(dep)["name"], // This will change (ie look nicer) after we've completely fleshed out what this should return
+            result,
+            fileSystem,
+            installedPackages,
+            inProgress,
+            PYPI_JSON_API // hardcoding this for now to keep the implementation light
+          )
+        )
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       result.warnings.push(`Failed to install ${name}: ${message}`);
@@ -476,7 +490,10 @@ async function fetchPythonPackageMetadata(name: string, registry: string) {
     );
   }
   const metadata = (await metadataResponse.json()) as {
-    info: { version: string };
+    info: {
+      version: string;
+      requires_dist?: string[];
+    };
 
     urls: Array<{
       filename: string;
@@ -753,6 +770,34 @@ function isTextFile(path: string): boolean {
   }
 
   return textExtensions.some((ext) => path.toLowerCase().endsWith(ext));
+}
+
+/**
+ * Parse a Python version specifier string (PEP 508) and extract the package name.
+ *
+ * Accepts strings as they appear in `pyproject.toml` `[project].dependencies`
+ * or in PyPI JSON API `info.requires_dist` responses. Examples:
+ *   "requests"
+ *   "requests>=2.0"
+ *   "requests[security]>=2.0"
+ *   "requests (>=2.0)"
+ *   "requests; python_version < '3.8'"
+ *   "requests[security] >= 2.0 ; python_version < '3.8'"
+ *
+ * Returns a tuple of `[package_name, null, null]`. The second and third slots
+ * are placeholders reserved for future use (e.g. extras, version specifier).
+ */
+function parsePythonVersionString(spec: string): { name: string } {
+  // Drop the PEP 508 environment marker (everything after `;`)
+  let head = spec.split(";", 1)[0] ?? "";
+
+  // The package name is the leading run of characters allowed in a PEP 508
+  // identifier: letters, digits, `.`, `-`, `_`. Stop at the first character
+  // that isn't one of those (whitespace, `[`, `(`, `<`, `>`, `=`, `!`, `~`, etc.).
+  const match = head.match(/^\s*([A-Za-z0-9][A-Za-z0-9._-]*)/);
+  const name = match ? match[1]! : head.trim();
+
+  return { name: name };
 }
 
 /**

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -866,26 +866,11 @@ function parseRequiresDist(metadata: string): string[] {
   const lines = metadata.split(/\r?\n/);
   let current: string | undefined;
 
-  for (const raw of lines) {
-    // Continuation line (starts with whitespace)
-    if (raw.startsWith(" ") || raw.startsWith("\t")) {
-      if (current !== undefined) {
-        current += " " + raw.trim();
-      }
-      continue;
-    }
-
+  for (const line of lines) {
     // Process previous header if it was Requires-Dist
-    if (current !== undefined && current.startsWith("Requires-Dist:")) {
-      requires.push(current.slice("Requires-Dist:".length).trim());
+    if (line !== undefined && line.startsWith("Requires-Dist:")) {
+      requires.push(line.slice("Requires-Dist:".length).trim());
     }
-
-    current = raw;
-  }
-
-  // Process last header
-  if (current !== undefined && current.startsWith("Requires-Dist:")) {
-    requires.push(current.slice("Requires-Dist:".length).trim());
   }
 
   return requires;

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -112,6 +112,12 @@ interface PyodideLockfilePackage {
   depends: string[];
 }
 
+interface PyodideWheelInfo {
+  package: PyodideLockfilePackage;
+  url: string;
+  file: PypiSimpleFile;
+}
+
 // Making this global so it will only need to be fetched once per invocation
 // TODO: Consider distributing this with Pyodide itself since it's not likely to change very much between runs
 let pyodideLockfile: PyodideLockfile | null = null;
@@ -640,11 +646,7 @@ function normalizePythonName(name: string): string {
  *
  * Returns `null` if the lockfile is not loaded or the package is not present.
  */
-function getPyodideWheel(name: string): {
-  package: PyodideLockfilePackage;
-  url: string;
-  file: PypiSimpleFile;
-} | null {
+function getPyodideWheel(name: string): PyodideWheelInfo | null {
   if (!pyodideLockfile) return null;
 
   const normalizedName = normalizePythonName(name);

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -11,7 +11,7 @@ import type { FileSystem } from "./file-system";
 import { parse as parseToml } from "smol-toml";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
-const PYPI_JSON_API = "https://pypi.org/pypi";
+const PYPI_SIMPLE_API = "https://pypi.org/simple";
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
 
 /**
@@ -68,6 +68,20 @@ interface NpmPackageMetadata {
   name: string;
   "dist-tags": Record<string, string>;
   versions: Record<string, PackageJson>;
+}
+
+interface PypiSimpleFile {
+  filename: string;
+  url: string;
+  hashes?: Record<string, string>;
+  "requires-python"?: string;
+  "core-metadata"?: boolean | { hash?: string; url?: string };
+  yanked?: boolean | string;
+}
+
+interface PypiSimpleMetadata {
+  name: string;
+  files: PypiSimpleFile[];
 }
 
 interface InstallOptions {
@@ -213,7 +227,7 @@ async function installDependenciesPython(
         fileSystem,
         installedPackages,
         inProgress,
-        PYPI_JSON_API // hardcoding this for now to keep the implementation light
+        PYPI_SIMPLE_API
       )
     )
   );
@@ -353,15 +367,8 @@ async function installPythonPackage(
     try {
       const metadata = await fetchPythonPackageMetadata(name, registry);
 
-      const version = metadata.info.version;
-      const wheel = metadata.urls.find(
-        (url) => url.packagetype === "bdist_wheel"
-      );
-      if (!wheel) {
-        throw new Error(
-          `No wheel distribution found for ${name}@${version} on PyPI`
-        );
-      }
+      const version = metadata.version;
+      const wheel = metadata.wheel;
       const wheelUrl = wheel.url;
 
       const response = await fetchWithTimeout(
@@ -390,16 +397,21 @@ async function installPythonPackage(
         fileSystem.write(`python_modules/${filePath}`, content);
       }
 
-      const dependencies = [...(metadata.info.requires_dist ?? [])];
+      // Fetch requires_dist from core metadata if available
+      const metadataUrl = getCoreMetadataUrl(wheel);
+      const requiresDist = metadataUrl
+        ? await fetchPythonRequiresDist(metadataUrl)
+        : [];
+
       await Promise.all(
-        dependencies.map((dep) =>
+        requiresDist.map((dep) =>
           installPythonPackage(
             parsePythonVersionString(dep)["name"], // This will change (ie look nicer) after we've completely fleshed out what this should return
             result,
             fileSystem,
             installedPackages,
             inProgress,
-            PYPI_JSON_API // hardcoding this for now to keep the implementation light
+            PYPI_SIMPLE_API
           )
         )
       );
@@ -476,10 +488,23 @@ async function fetchPackageMetadata(
   return (await response.json()) as NpmPackageMetadata;
 }
 
-async function fetchPythonPackageMetadata(name: string, registry: string) {
-  // Fetch package metadata from PyPI JSON API
-  // TODO: Redo this to use the PyPA simple repository API
-  const metadataResponse = await fetchWithTimeout(`${registry}/${name}/json`);
+async function fetchPythonPackageMetadata(
+  name: string,
+  registry: string
+): Promise<{ version: string; wheel: PypiSimpleFile }> {
+  // Normalize package name per PEP 503 (lowercase, replace [-_.] with -)
+  const normalizedName = name.toLowerCase().replace(/[-_.]+/g, "-");
+
+  // Fetch package metadata from PyPI Simple API
+  const metadataResponse = await fetchWithTimeout(
+    `${registry}/${normalizedName}/`,
+    {
+      headers: {
+        Accept: "application/vnd.pypi.simple.v1+json"
+      }
+    }
+  );
+
   if (!metadataResponse.ok) {
     const hint =
       metadataResponse.status === 404
@@ -489,19 +514,187 @@ async function fetchPythonPackageMetadata(name: string, registry: string) {
       `PyPI returned ${metadataResponse.status} ${metadataResponse.statusText} for "${name}"${hint}`
     );
   }
-  const metadata = (await metadataResponse.json()) as {
-    info: {
-      version: string;
-      requires_dist?: string[];
-    };
+  const metadata = (await metadataResponse.json()) as PypiSimpleMetadata;
 
-    urls: Array<{
-      filename: string;
-      url: string;
-      packagetype: string;
-    }>;
+  const wheel = selectWheel(metadata.files);
+  if (!wheel) {
+    throw new Error(`No compatible wheel found for ${name} on PyPI`);
+  }
+
+  const version = parseWheelVersion(wheel.filename);
+  if (!version) {
+    throw new Error(
+      `Could not parse version from wheel filename: ${wheel.filename}`
+    );
+  }
+
+  return { version, wheel };
+}
+
+/**
+ * Select a compatible wheel from PyPI Simple API files list.
+ * Prefers py3-none-any or py2.py3-none-any wheels for maximum compatibility.
+ * Selects the latest version from compatible wheels.
+ * TODO: implement proper platform/python version matching
+ */
+function selectWheel(files: PypiSimpleFile[]): PypiSimpleFile | null {
+  const wheels = files.filter((f) => f.filename.endsWith(".whl"));
+  if (wheels.length === 0) return null;
+
+  // Filter to universal wheels (py3-none-any or py2.py3-none-any)
+  const universal = wheels.filter(
+    (w) =>
+      w.filename.endsWith("-py3-none-any.whl") ||
+      w.filename.endsWith("-py2.py3-none-any.whl")
+  );
+
+  const candidates = universal.length > 0 ? universal : wheels;
+
+  // Select the wheel with the highest version
+  let latest: PypiSimpleFile | null = null;
+  let latestVersion: string | undefined;
+
+  for (const wheel of candidates) {
+    const version = parseWheelVersion(wheel.filename);
+    if (!version) continue;
+
+    if (
+      !latest ||
+      !latestVersion ||
+      comparePythonVersions(version, latestVersion) > 0
+    ) {
+      latest = wheel;
+      latestVersion = version;
+    }
+  }
+
+  return latest;
+}
+
+/**
+ * Compare two PEP 440 version strings.
+ * Returns >0 if a > b, <0 if a < b, 0 if equal.
+ *
+ * Python versions (PEP 440) are not semver-compatible (e.g. "3.6.2.1" has four
+ * release segments), so semver cannot be used here. This is a minimal
+ * comparison: it compares the dotted numeric release segments, and treats
+ * pre-release/dev versions (a/b/rc/alpha/beta/dev/pre) as lower than the same
+ * release so a stable release is preferred.
+ * TODO: full PEP 440 ordering (post-releases, local versions, epochs) if needed.
+ */
+export function comparePythonVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const releaseMatch = v.match(/^[0-9]+(?:\.[0-9]+)*/);
+    const release = (releaseMatch?.[0] ?? "0").split(".").map(Number);
+    const rest = v.slice(releaseMatch?.[0].length ?? 0);
+    const isPre = /^[.\-_]?(a|b|c|rc|alpha|beta|dev|pre)/i.test(rest);
+    return { release, isPre };
   };
-  return metadata;
+
+  const av = parse(a);
+  const bv = parse(b);
+
+  const len = Math.max(av.release.length, bv.release.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (av.release[i] ?? 0) - (bv.release[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  // Same release: a stable version outranks a pre-release/dev version
+  if (av.isPre !== bv.isPre) return av.isPre ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Parse version from a wheel filename.
+ * Wheel format: {distribution}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+ *
+ * With no build tag (5 parts): distribution-version-python-abi-platform.whl
+ * With build tag (6+ parts): distribution-version-build-python-abi-platform.whl
+ *
+ */
+function parseWheelVersion(filename: string): string | undefined {
+  const parts = filename.replace(/\.whl$/, "").split("-");
+  if (parts.length < 5) return undefined;
+
+  // The last three parts are always: python_tag, abi_tag, platform_tag
+  // For 5 parts: distribution, version, py, abi, platform -> version is parts[1]
+  // For 6+ parts: distribution, version, build?, py, abi, platform -> version is parts[1]
+  return parts[1];
+}
+
+/**
+ * Get the core metadata URL from a PyPI Simple API file entry.
+ * Returns undefined if core metadata is not available.
+ *
+ * Per PEP 714: if core-metadata is true or an object (with hash),
+ * metadata is available at {file_url}.metadata unless a separate URL is provided.
+ */
+function getCoreMetadataUrl(file: PypiSimpleFile): string | undefined {
+  const cm = file["core-metadata"];
+  if (!cm) return undefined;
+
+  // If it's an object with an explicit URL, use that
+  if (typeof cm === "object" && cm.url) return cm.url;
+
+  // Otherwise (boolean true or object with just hash), use .metadata suffix
+  if (cm === true || typeof cm === "object") return `${file.url}.metadata`;
+
+  return undefined;
+}
+
+/**
+ * Fetch and parse Requires-Dist from a Python package's core metadata.
+ * Returns empty array if metadata is unavailable or parsing fails.
+ */
+async function fetchPythonRequiresDist(url: string): Promise<string[]> {
+  try {
+    const response = await fetchWithTimeout(url);
+    if (!response.ok) return [];
+    const contentType = response.headers.get("content-type") ?? "";
+    // PyPI tends to send this as `binary/octet-stream` even though it's actually text, this avoids an unhelpful warning
+    const text = contentType.startsWith("text/")
+      ? await response.text()
+      : new TextDecoder().decode(await response.arrayBuffer());
+    return parseRequiresDist(text);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse Requires-Dist headers from Python package METADATA file (RFC 822 format).
+ * Handles continuation lines (starting with whitespace).
+ */
+function parseRequiresDist(metadata: string): string[] {
+  const requires: string[] = [];
+  const lines = metadata.split(/\r?\n/);
+  let current: string | undefined;
+
+  const requiresDistKey = "requires-dist:";
+  for (const raw of lines) {
+    // Continuation line (starts with whitespace)
+    if (raw.startsWith(" ") || raw.startsWith("\t")) {
+      if (current !== undefined) {
+        current += " " + raw.trim();
+      }
+      continue;
+    }
+
+    // Process previous header if it was Requires-Dist
+    if (current !== undefined && current.startsWith(requiresDistKey)) {
+      requires.push(current.slice(requiresDistKey.length).trim());
+    }
+
+    current = raw.toLowerCase();
+  }
+
+  // Process last header
+  if (current !== undefined && current.startsWith(requiresDistKey)) {
+    requires.push(current.slice(requiresDistKey.length).trim());
+  }
+
+  return requires;
 }
 
 /**

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -510,10 +510,10 @@ async function installPythonPackage(
   }
 }
 
-async function retrieveFromPyPI (
+async function retrieveFromPyPI(
   name: string,
   registry: string
-): Promise<[Response, PypiSimpleFile, string, string[]] | null> {
+): Promise<[Response, PypiSimpleFile, string] | null> {
   const metadata = await fetchPythonPackageMetadata(name, registry);
   const version = metadata.version;
   const wheel = metadata.wheel;
@@ -531,9 +531,9 @@ async function retrieveFromPyPI (
   return [response, wheel, version];
 }
 
-async function retrieveFromPyodide (
+async function retrieveFromPyodide(
   name: string
-): Promise<[Response, PypiSimpleFile, string, string[]] | null> {
+): Promise<[Response, PypiSimpleFile, string] | null> {
   const pyodideWheel = getPyodideWheel(name);
   if (!pyodideWheel) {
     return null;
@@ -551,7 +551,7 @@ async function retrieveFromPyodide (
   const version = pyodideWheel.package.version;
   const wheel = pyodideWheel.file;
   return [response, wheel, version];
-};
+}
 
 /**
  * Strip a Python wheel down to just the package contents.

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -431,49 +431,6 @@ async function installPythonPackage(
 
       // Putting the logic for retrieving a wheel from PyPI and the Pyodide index into their own functions here
       // This is so either one can be used as a fallback for the other in a (relatively) tidy way
-      const retrieveFromPyPI = async (
-        name: string,
-        registry: string
-      ): Promise<[Response, PypiSimpleFile, string, string[]] | null> => {
-        const metadata = await fetchPythonPackageMetadata(name, registry);
-        const version = metadata.version;
-        const wheel = metadata.wheel;
-
-        const response = await fetchWithTimeout(
-          wheel.url,
-          {},
-          DEFAULT_TIMEOUT_MS * 2
-        );
-
-        if (!response.ok) {
-          return null;
-        }
-
-        return [response, wheel, version];
-      };
-
-      const retrieveFromPyodide = async (
-        name: string
-      ): Promise<[Response, PypiSimpleFile, string, string[]] | null> => {
-        const pyodideWheel = getPyodideWheel(name);
-        if (!pyodideWheel) {
-          return null;
-        }
-
-        const response = await fetchWithTimeout(
-          pyodideWheel.url,
-          {},
-          DEFAULT_TIMEOUT_MS * 2
-        );
-        if (!response.ok) {
-          return null;
-        }
-
-        const version = pyodideWheel.package.version;
-        const wheel = pyodideWheel.file;
-        return [response, wheel, version];
-      };
-
       // Try either PyPI or the Pyodide index, then fall back to the other one if that one fails
       if (preferPyodideIndex) {
         let registryResult = await retrieveFromPyodide(name);
@@ -546,6 +503,49 @@ async function installPythonPackage(
     inProgress.delete(name);
   }
 }
+
+async function retrieveFromPyPI (
+  name: string,
+  registry: string
+): Promise<[Response, PypiSimpleFile, string, string[]] | null> {
+  const metadata = await fetchPythonPackageMetadata(name, registry);
+  const version = metadata.version;
+  const wheel = metadata.wheel;
+
+  const response = await fetchWithTimeout(
+    wheel.url,
+    {},
+    DEFAULT_TIMEOUT_MS * 2
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return [response, wheel, version];
+}
+
+async function retrieveFromPyodide (
+  name: string
+): Promise<[Response, PypiSimpleFile, string, string[]] | null> {
+  const pyodideWheel = getPyodideWheel(name);
+  if (!pyodideWheel) {
+    return null;
+  }
+
+  const response = await fetchWithTimeout(
+    pyodideWheel.url,
+    {},
+    DEFAULT_TIMEOUT_MS * 2
+  );
+  if (!response.ok) {
+    return null;
+  }
+
+  const version = pyodideWheel.package.version;
+  const wheel = pyodideWheel.file;
+  return [response, wheel, version];
+};
 
 /**
  * Strip a Python wheel down to just the package contents.

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -550,9 +550,8 @@ async function installPythonPackage(
 /**
  * Strip a Python wheel down to just the package contents.
  *
- * Wheels contain the importable package alongside `.dist-info` metadata and
- * `.data` directories. This removes those supporting directories and flattens
- * the package directory so its files are at the root of the returned record.
+ * TODO: Re-review this function once we've cleared issues with file extension limits
+ * in workerd; it excludes certain metadata files in *.dist-info/ for now but it shouldn't remain this way
  */
 function stripWheelToPackage(
   files: Record<string, string>

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -760,7 +760,7 @@ function selectWheel(files: PypiSimpleFile[]): PypiSimpleFile | undefined {
  * release so a stable release is preferred.
  * TODO: full PEP 440 ordering (post-releases, local versions, epochs) if needed.
  */
-function comparePythonVersions(a: string, b: string): number {
+export function comparePythonVersions(a: string, b: string): number {
   const parse = (v: string) => {
     const releaseMatch = v.match(/^[0-9]+(?:\.[0-9]+)*/);
     const release = (releaseMatch?.[0] ?? "0").split(".").map(Number);

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -412,7 +412,7 @@ async function installPythonPackage(
   installedPackages: Map<string, string>,
   inProgress: Map<string, Promise<void>>,
   registry: string,
-  preferPyodideIndex: boolean
+  preferPyodideIndex: boolean // TODO: Remove this / remove references to this from other files; we will always prefer the pyodide index
 ): Promise<void> {
   // Skip if already installed in this run
   if (installedPackages.has(name)) {
@@ -531,6 +531,7 @@ async function retrieveFromPyPI(
   return [response, wheel, version];
 }
 
+// TODO: Alter the flow to use the PyPA simple api (index.pyodide.org)
 async function retrieveFromPyodide(
   name: string
 ): Promise<[Response, PypiSimpleFile, string] | null> {

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -11,7 +11,8 @@ import type { FileSystem } from "./file-system";
 import { parse as parseToml } from "smol-toml";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
-const PYPI_JSON_API = "https://pypi.org/pypi";
+const PYPI_SIMPLE_API = "https://pypi.org/simple";
+const PYODIDE_VERSION = "v0.28.2"; // Used for retrieving a pyodide lockfile, which is done per Pyodide version
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
 
 /**
@@ -70,6 +71,51 @@ interface NpmPackageMetadata {
   versions: Record<string, PackageJson>;
 }
 
+interface PypiSimpleFile {
+  filename: string;
+  url: string;
+  hashes?: Record<string, string>;
+  "requires-python"?: string;
+  "core-metadata"?: boolean | { hash?: string; url?: string };
+  yanked?: boolean | string;
+}
+
+interface PypiSimpleMetadata {
+  name: string;
+  files: PypiSimpleFile[];
+}
+
+// Describes the packages that are available on the Pyodide CDN for a given Pyodide version
+interface PyodideLockfile {
+  info: {
+    abi_version: string;
+    arch: "wasm32";
+    platform: string;
+    python: string;
+    version: string;
+  };
+  packages: Record<string, PyodideLockfilePackage>;
+}
+
+interface PyodideLockfilePackage {
+  name: string;
+  version: string;
+  file_name: string;
+  sha256: string;
+  package_type:
+    | "package"
+    | "cpython_module"
+    | "shared_library"
+    | "static_library";
+  install_dir: "site" | "dynlib";
+  imports: string[];
+  depends: string[];
+}
+
+// Making this global so it will only need to be fetched once per invocation
+// TODO: Consider distributing this with Pyodide itself since it's not likely to change very much between runs
+let pyodideLockfile: PyodideLockfile | null = null;
+
 interface InstallOptions {
   /**
    * Include devDependencies (default: false)
@@ -80,6 +126,11 @@ interface InstallOptions {
    * Registry URL (default: https://registry.npmjs.org)
    */
   registry?: string;
+
+  /**
+   * If installing Python packages, set whether to prefer the Pyodide index (default: true)
+   */
+  preferPyodideIndex?: boolean;
 }
 
 export interface InstallResult {
@@ -109,7 +160,11 @@ export async function installDependencies(
   fileSystem: FileSystem,
   options: InstallOptions = {}
 ): Promise<InstallResult> {
-  const { dev = false, registry = NPM_REGISTRY } = options;
+  const {
+    dev = false,
+    registry = NPM_REGISTRY,
+    preferPyodideIndex = true
+  } = options;
 
   const result: InstallResult = {
     installed: [],
@@ -164,7 +219,11 @@ export async function installDependencies(
       )
     );
   } else if (pyprojectTomlContent) {
-    return await installDependenciesPython(fileSystem, pyprojectTomlContent);
+    return await installDependenciesPython(
+      fileSystem,
+      pyprojectTomlContent,
+      preferPyodideIndex
+    );
   }
   return result;
 }
@@ -174,7 +233,8 @@ export async function installDependencies(
  */
 async function installDependenciesPython(
   fileSystem: FileSystem,
-  pyprojectTomlContent: string
+  pyprojectTomlContent: string,
+  preferPyodideIndex: boolean
 ): Promise<InstallResult> {
   const result: InstallResult = {
     installed: [],
@@ -199,6 +259,17 @@ async function installDependenciesPython(
     depsToInstall[name] = "*"; // in the future this should be a version specifier, if one was set
   }
 
+  if (!pyodideLockfile) {
+    try {
+      pyodideLockfile = await fetchPyodideLockfile(PYODIDE_VERSION);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.warnings.push(
+        `Could not retrieve Pyodide lockfile, attempts to retrieve packages from the Pyodide CDN may fail. Error: ${message}`
+      );
+    }
+  }
+
   // Track installed packages to avoid duplicates
   const installedPackages = new Map<string, string>(); // name -> version
   // Track in-progress installations to avoid duplicate work
@@ -213,7 +284,8 @@ async function installDependenciesPython(
         fileSystem,
         installedPackages,
         inProgress,
-        PYPI_JSON_API // hardcoding this for now to keep the implementation light
+        PYPI_SIMPLE_API,
+        preferPyodideIndex
       )
     )
   );
@@ -333,7 +405,8 @@ async function installPythonPackage(
   fileSystem: FileSystem,
   installedPackages: Map<string, string>,
   inProgress: Map<string, Promise<void>>,
-  registry: string
+  registry: string,
+  preferPyodideIndex: boolean
 ): Promise<void> {
   // Skip if already installed in this run
   if (installedPackages.has(name)) {
@@ -351,35 +424,91 @@ async function installPythonPackage(
 
   const installPromise = (async () => {
     try {
-      const metadata = await fetchPythonPackageMetadata(name, registry);
+      // Setting default values since some of the errors below access these and they may not all be set in all cases
+      let response: Response = {} as Response;
+      let wheel: PypiSimpleFile = {} as PypiSimpleFile;
+      let version: string = "";
 
-      const version = metadata.info.version;
-      const wheel = metadata.urls.find(
-        (url) => url.packagetype === "bdist_wheel"
-      );
-      if (!wheel) {
-        throw new Error(
-          `No wheel distribution found for ${name}@${version} on PyPI`
+      // Putting the logic for retrieving a wheel from PyPI and the Pyodide index into their own functions here
+      // This is so either one can be used as a fallback for the other in a (relatively) tidy way
+      const retrieveFromPyPI = async (
+        name: string,
+        registry: string
+      ): Promise<[Response, PypiSimpleFile, string, string[]] | null> => {
+        const metadata = await fetchPythonPackageMetadata(name, registry);
+        const version = metadata.version;
+        const wheel = metadata.wheel;
+
+        const response = await fetchWithTimeout(
+          wheel.url,
+          {},
+          DEFAULT_TIMEOUT_MS * 2
         );
-      }
-      const wheelUrl = wheel.url;
 
-      const response = await fetchWithTimeout(
-        wheelUrl,
-        {},
-        DEFAULT_TIMEOUT_MS * 2
-      );
-      if (!response.ok) {
-        throw new Error(
-          `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheelUrl})`
+        if (!response.ok) {
+          return null;
+        }
+
+        return [response, wheel, version];
+      };
+
+      const retrieveFromPyodide = async (
+        name: string
+      ): Promise<[Response, PypiSimpleFile, string, string[]] | null> => {
+        const pyodideWheel = getPyodideWheel(name);
+        if (!pyodideWheel) {
+          return null;
+        }
+
+        const response = await fetchWithTimeout(
+          pyodideWheel.url,
+          {},
+          DEFAULT_TIMEOUT_MS * 2
         );
-      }
+        if (!response.ok) {
+          return null;
+        }
 
+        const version = pyodideWheel.package.version;
+        const wheel = pyodideWheel.file;
+        return [response, wheel, version];
+      };
+
+      // Try either PyPI or the Pyodide index, then fall back to the other one if that one fails
+      if (preferPyodideIndex) {
+        let registryResult = await retrieveFromPyodide(name);
+        if (registryResult) {
+          [response, wheel, version] = registryResult;
+        } else {
+          registryResult = await retrieveFromPyPI(name, registry);
+          if (registryResult) {
+            [response, wheel, version] = registryResult;
+          } else {
+            throw new Error(
+              `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheel.url})`
+            );
+          }
+        }
+      } else {
+        let registryResult = await retrieveFromPyPI(name, registry);
+        if (registryResult) {
+          [response, wheel, version] = registryResult;
+        } else {
+          registryResult = await retrieveFromPyodide(name);
+          if (registryResult) {
+            [response, wheel, version] = registryResult;
+          } else {
+            throw new Error(
+              `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheel.url})`
+            );
+          }
+        }
+      }
       const buffer = await response.arrayBuffer();
 
-      const packageFilesWheel = stripWheelToPackage(
-        extractWheel(new Uint8Array(buffer), result)
-      );
+      const wheelContents = extractWheel(new Uint8Array(buffer), result);
+      const dependencies = getDependenciesFromWheel(wheelContents);
+      const packageFilesWheel = stripWheelToPackage(wheelContents);
 
       // Mark as installed before writing to prevent cycles
       installedPackages.set(name, version);
@@ -390,7 +519,6 @@ async function installPythonPackage(
         fileSystem.write(`python_modules/${filePath}`, content);
       }
 
-      const dependencies = [...(metadata.info.requires_dist ?? [])];
       await Promise.all(
         dependencies.map((dep) =>
           installPythonPackage(
@@ -399,7 +527,8 @@ async function installPythonPackage(
             fileSystem,
             installedPackages,
             inProgress,
-            PYPI_JSON_API // hardcoding this for now to keep the implementation light
+            PYPI_SIMPLE_API,
+            preferPyodideIndex
           )
         )
       );
@@ -476,10 +605,85 @@ async function fetchPackageMetadata(
   return (await response.json()) as NpmPackageMetadata;
 }
 
-async function fetchPythonPackageMetadata(name: string, registry: string) {
-  // Fetch package metadata from PyPI JSON API
-  // TODO: Redo this to use the PyPA simple repository API
-  const metadataResponse = await fetchWithTimeout(`${registry}/${name}/json`);
+/**
+ * Fetch the Pyodide lockfile for a given Pyodide version.
+ *
+ * The lockfile lists all pre-built packages available in the Pyodide
+ * distribution, including their wheel URLs, hashes, and dependencies.
+ */
+async function fetchPyodideLockfile(
+  version: string
+): Promise<PyodideLockfile | null> {
+  const url = `https://cdn.jsdelivr.net/pyodide/${version}/full/pyodide-lock.json`;
+  try {
+    const response = await fetchWithTimeout(url);
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as PyodideLockfile;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize a Python package name per PEP 503.
+ *
+ * Lowercases the name and collapses runs of `-`, `_`, and `.` into a single `-`.
+ */
+function normalizePythonName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, "-");
+}
+
+/**
+ * Look up a package in the loaded Pyodide lockfile and return the URL and a
+ * Simple-API-shaped file entry for its wheel.
+ *
+ * Returns `null` if the lockfile is not loaded or the package is not present.
+ */
+function getPyodideWheel(name: string): {
+  package: PyodideLockfilePackage;
+  url: string;
+  file: PypiSimpleFile;
+} | null {
+  if (!pyodideLockfile) return null;
+
+  const normalizedName = normalizePythonName(name);
+  const pkg = pyodideLockfile.packages[normalizedName];
+  if (!pkg) return null;
+
+  const baseUrl = `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full`;
+  const url = pkg.file_name.startsWith("http")
+    ? pkg.file_name
+    : `${baseUrl}/${pkg.file_name}`;
+
+  return {
+    package: pkg,
+    url,
+    file: {
+      filename: pkg.file_name,
+      url,
+      hashes: { sha256: pkg.sha256 }
+    }
+  };
+}
+
+async function fetchPythonPackageMetadata(
+  name: string,
+  registry: string
+): Promise<{ version: string; wheel: PypiSimpleFile }> {
+  const normalizedName = normalizePythonName(name);
+
+  // Fetch package metadata from PyPI Simple API
+  const metadataResponse = await fetchWithTimeout(
+    `${registry}/${normalizedName}/`,
+    {
+      headers: {
+        Accept: "application/vnd.pypi.simple.v1+json"
+      }
+    }
+  );
+
   if (!metadataResponse.ok) {
     const hint =
       metadataResponse.status === 404
@@ -489,19 +693,202 @@ async function fetchPythonPackageMetadata(name: string, registry: string) {
       `PyPI returned ${metadataResponse.status} ${metadataResponse.statusText} for "${name}"${hint}`
     );
   }
-  const metadata = (await metadataResponse.json()) as {
-    info: {
-      version: string;
-      requires_dist?: string[];
-    };
+  const metadata = (await metadataResponse.json()) as PypiSimpleMetadata;
 
-    urls: Array<{
-      filename: string;
-      url: string;
-      packagetype: string;
-    }>;
+  const wheel = selectWheel(metadata.files);
+  if (!wheel) {
+    throw new Error(`No compatible wheel found for ${name} on PyPI`);
+  }
+
+  const version = parseWheelVersion(wheel.filename);
+  if (!version) {
+    throw new Error(
+      `Could not parse version from wheel filename: ${wheel.filename}`
+    );
+  }
+
+  return { version, wheel };
+}
+
+/**
+ * Select a compatible wheel from PyPI Simple API files list.
+ * Prefers py3-none-any or py2.py3-none-any wheels for maximum compatibility.
+ * Selects the latest version from compatible wheels.
+ * TODO: implement proper platform/python version matching
+ */
+function selectWheel(files: PypiSimpleFile[]): PypiSimpleFile | undefined {
+  const wheels = files.filter((f) => f.filename.endsWith(".whl"));
+  if (wheels.length === 0) return undefined;
+
+  // Filter to universal wheels (py3-none-any or py2.py3-none-any)
+  const universal = wheels.filter(
+    (w) =>
+      w.filename.includes("-py3-none-any.whl") ||
+      w.filename.includes("-py2.py3-none-any.whl")
+  );
+
+  const candidates = universal.length > 0 ? universal : wheels;
+
+  // Select the wheel with the highest version
+  let latest: PypiSimpleFile | undefined;
+  let latestVersion: string | undefined;
+
+  for (const wheel of candidates) {
+    const version = parseWheelVersion(wheel.filename);
+    if (!version) continue;
+
+    if (
+      !latest ||
+      !latestVersion ||
+      comparePythonVersions(version, latestVersion) > 0
+    ) {
+      latest = wheel;
+      latestVersion = version;
+    }
+  }
+
+  return latest;
+}
+
+/**
+ * Compare two PEP 440 version strings.
+ * Returns >0 if a > b, <0 if a < b, 0 if equal.
+ *
+ * Python versions (PEP 440) are not semver-compatible (e.g. "3.6.2.1" has four
+ * release segments), so semver cannot be used here. This is a minimal
+ * comparison: it compares the dotted numeric release segments, and treats
+ * pre-release/dev versions (a/b/rc/alpha/beta/dev/pre) as lower than the same
+ * release so a stable release is preferred.
+ * TODO: full PEP 440 ordering (post-releases, local versions, epochs) if needed.
+ */
+function comparePythonVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const releaseMatch = v.match(/^[0-9]+(?:\.[0-9]+)*/);
+    const release = (releaseMatch?.[0] ?? "0").split(".").map(Number);
+    const rest = v.slice(releaseMatch?.[0].length ?? 0);
+    const isPre = /^[.\-_]?(a|b|c|rc|alpha|beta|dev|pre)/i.test(rest);
+    return { release, isPre };
   };
-  return metadata;
+
+  const av = parse(a);
+  const bv = parse(b);
+
+  const len = Math.max(av.release.length, bv.release.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (av.release[i] ?? 0) - (bv.release[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  // Same release: a stable version outranks a pre-release/dev version
+  if (av.isPre !== bv.isPre) return av.isPre ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Parse version from a wheel filename.
+ * Wheel format: {distribution}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+ *
+ * With no build tag (5 parts): distribution-version-python-abi-platform.whl
+ * With build tag (6+ parts): distribution-version-build-python-abi-platform.whl
+ *
+ * TODO: handle edge cases with distribution names containing hyphens
+ */
+function parseWheelVersion(filename: string): string | undefined {
+  const parts = filename.replace(/\.whl$/, "").split("-");
+  if (parts.length < 5) return undefined;
+
+  // The last three parts are always: python_tag, abi_tag, platform_tag
+  // For 5 parts: distribution, version, py, abi, platform -> version is parts[1]
+  // For 6+ parts: distribution, version, build?, py, abi, platform -> version is parts[1]
+  return parts[1];
+}
+
+/**
+ * Get the core metadata URL from a PyPI Simple API file entry.
+ * Returns undefined if core metadata is not available.
+ *
+ * Per PEP 714: if core-metadata is true or an object (with hash),
+ * metadata is available at {file_url}.metadata unless a separate URL is provided.
+ */
+function getCoreMetadataUrl(file: PypiSimpleFile): string | undefined {
+  const cm = file["core-metadata"];
+  if (!cm) return undefined;
+
+  // If it's an object with an explicit URL, use that
+  if (typeof cm === "object" && cm.url) return cm.url;
+
+  // Otherwise (boolean true or object with just hash), use .metadata suffix
+  if (cm === true || typeof cm === "object") return `${file.url}.metadata`;
+
+  return undefined;
+}
+
+/**
+ * Fetch and parse Requires-Dist from a Python package's core metadata.
+ * Returns empty array if metadata is unavailable or parsing fails.
+ */
+async function fetchPythonRequiresDist(url: string): Promise<string[]> {
+  try {
+    const response = await fetchWithTimeout(url);
+    if (!response.ok) return [];
+    const contentType = response.headers.get("content-type") ?? "";
+    // PyPI tends to send this as `binary/octet-stream` even though it's actually text, this avoids an unhelpful warning
+    const text = contentType.startsWith("text/")
+      ? await response.text()
+      : new TextDecoder().decode(await response.arrayBuffer());
+    return parseRequiresDist(text);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract Requires-Dist entries from a wheel's *.dist-info/METADATA file.
+ * Accepts the file record returned by `extractWheel`.
+ * Returns an empty array if METADATA is missing or contains no dependencies.
+ */
+function getDependenciesFromWheel(files: Record<string, string>): string[] {
+  const metadataPath = Object.keys(files).find((path) =>
+    path.endsWith(".dist-info/METADATA")
+  );
+  if (!metadataPath) return [];
+  const metadata = files[metadataPath];
+  if (!metadata) return [];
+  return parseRequiresDist(metadata);
+}
+
+/**
+ * Parse Requires-Dist headers from Python package METADATA file (RFC 822 format).
+ * Handles continuation lines (starting with whitespace).
+ */
+function parseRequiresDist(metadata: string): string[] {
+  const requires: string[] = [];
+  const lines = metadata.split(/\r?\n/);
+  let current: string | undefined;
+
+  for (const raw of lines) {
+    // Continuation line (starts with whitespace)
+    if (raw.startsWith(" ") || raw.startsWith("\t")) {
+      if (current !== undefined) {
+        current += " " + raw.trim();
+      }
+      continue;
+    }
+
+    // Process previous header if it was Requires-Dist
+    if (current !== undefined && current.startsWith("Requires-Dist:")) {
+      requires.push(current.slice("Requires-Dist:".length).trim());
+    }
+
+    current = raw;
+  }
+
+  // Process last header
+  if (current !== undefined && current.startsWith("Requires-Dist:")) {
+    requires.push(current.slice("Requires-Dist:".length).trim());
+  }
+
+  return requires;
 }
 
 /**
@@ -580,7 +967,15 @@ function extractWheel(
   const textDecoder = new TextDecoder();
 
   for (const [path, content] of Object.entries(unzipped)) {
-    // Todo: Remove this check once it's confirmed that compiled wasm binaries are working
+    // Keep the wheel's core metadata file so callers can read Requires-Dist from it.
+    // This file has no extension, so it would otherwise be rejected by isTextFile.
+    // TODO: Remove this after we clear the other todo constraining down to just text files
+    if (path.endsWith(".dist-info/METADATA")) {
+      files[path] = textDecoder.decode(content);
+      continue;
+    }
+
+    // TODO: Remove this check once it's confirmed that compiled wasm binaries are working
     // (blocking this for now so any such packages will fail gracefully in the interim)
     if (!isTextFile(path)) {
       result.warnings.push(

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -551,7 +551,7 @@ async function installPythonPackage(
  * Strip a Python wheel down to just the package contents.
  *
  * TODO: Re-review this function once we've cleared issues with file extension limits
- * in workerd; it excludes certain metadata files in *.dist-info/ for now but it shouldn't remain this way
+ * in workerd; this function excludes certain metadata files in *.dist-info/ for now but it shouldn't remain this way
  */
 function stripWheelToPackage(
   files: Record<string, string>

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -253,7 +253,7 @@ async function installDependenciesPython(
   const depsToInstall: Record<string, string> = {};
   depsToInstall["workers-runtime-sdk"] = "*"; // TODO: Should this always take the latest?
   for (const dep of pyprojectToml.project?.dependencies ?? []) {
-    const name = parsePythonVersionString(dep.trim())["name"];
+    const { name } = parsePythonVersionString(dep.trim());
     if (!name) continue;
 
     depsToInstall[name] = "*"; // in the future this should be a version specifier, if one was set

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -859,7 +859,6 @@ function getDependenciesFromWheel(files: Record<string, string>): string[] {
 
 /**
  * Parse Requires-Dist headers from Python package METADATA file (RFC 822 format).
- * Handles continuation lines (starting with whitespace).
  */
 function parseRequiresDist(metadata: string): string[] {
   const requires: string[] = [];

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -253,7 +253,7 @@ async function installDependenciesPython(
   const depsToInstall: Record<string, string> = {};
   depsToInstall["workers-runtime-sdk"] = "*"; // TODO: Should this always take the latest?
   for (const dep of pyprojectToml.project?.dependencies ?? []) {
-    const name = dep.trim();
+    const name = parsePythonVersionString(dep.trim())["name"];
     if (!name) continue;
 
     depsToInstall[name] = "*"; // in the future this should be a version specifier, if one was set

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -394,9 +394,9 @@ async function installPackage(
 /**
  * Install a single Python package from PyPI.
  *
- * This is a minimal implementation: it downloads the latest version of the
- * package as a source distribution and adds it to python_modules/. It does not
- * resolve version ranges or install transitive dependencies.
+ * This is an in-progress minimal implementation: it downloads the
+ * latest version of the wheel and adds it to python_modules/. It does not
+ * resolve version ranges.
  */
 async function installPythonPackage(
   name: string,

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -984,3 +984,121 @@ describe("hasNodejsCompat", () => {
     expect(hasNodejsCompat(undefined)).toBe(false);
   });
 });
+
+// Longer timeout duration given since Python workers can take longer to start in the test suite
+describe("createWorker with python main", () => {
+  it("executes a Python script as the main module", async () => {
+    const dynamic_worker = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          '    return Response("hi")'
+        ].join("\n")
+      }
+    });
+    const id = "test-worker-" + testId++;
+
+    // These should both have defaults from createWorker
+    expect(dynamic_worker.wranglerConfig?.compatibilityDate).not.toBeNull();
+    expect(dynamic_worker.wranglerConfig?.compatibilityFlags).not.toBeNull();
+
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: dynamic_worker.mainModule,
+      modules: dynamic_worker.modules,
+      compatibilityDate: dynamic_worker.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: dynamic_worker.wranglerConfig!.compatibilityFlags!
+    }));
+
+    let response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("hi");
+  });
+}, 20000);
+
+describe("createWorker with pyproject.toml", () => {
+  it("accepts a dummy pyproject.toml without throwing", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          '    return Response("ok")'
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          "",
+          "[tool.setuptools]",
+          'packages = ["dummy"]'
+        ].join("\n"),
+        "python_modules/dummy/__init__.py": "",
+        "python_modules/dummy/hello.py": [
+          "def greet(name: str) -> str:",
+          '    return f"hello, {name}"'
+        ].join("\n")
+      }
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+  });
+
+  it("works with a pure python package", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import typing_extensions",
+          "import typing_inspection",
+          "import attrs, attr", // `attrs` supplies two importables, attr and attrs. If it's installed properly, both will be available
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "typing_extensions": typing_extensions.__name__,',
+          '      "typing_inspection": typing_inspection.__name__,',
+          '      "attrs": attrs.__name__,',
+          '      "attr": attr.__name__,',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          // typing_extensions has zero dependencies. typing_inspection depends on typing_extensions
+          // `attrs` has zero dependencies
+          'dependencies = ["typing_extensions", "typing_inspection", "attrs"]'
+        ].join("\n")
+      }
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.typing_extensions).toBe("typing_extensions");
+    expect(body.typing_inspection).toBe("typing_inspection");
+    expect(body.attrs).toBe("attrs");
+    expect(body.attr).toBe("attr");
+  });
+}, 20000);

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1101,4 +1101,43 @@ describe("createWorker with pyproject.toml", () => {
     expect(body.attrs).toBe("attrs");
     expect(body.attr).toBe("attr");
   });
+
+  it("automatically installs a nested dependency", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import typing_inspection",
+          "import typing_extensions",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "typing_extensions": typing_extensions.__name__,',
+          '      "typing_inspection": typing_inspection.__name__,',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          // typing_inspection depends on typing_extensions
+          'dependencies = ["typing_inspection"]'
+        ].join("\n")
+      }
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.typing_extensions).toBe("typing_extensions");
+    expect(body.typing_inspection).toBe("typing_inspection");
+  });
 }, 20000);

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1082,7 +1082,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           // typing_extensions has zero dependencies. typing_inspection depends on typing_extensions
           // `attrs` has zero dependencies
-          'dependencies = ["typing_extensions", "typing_inspection", "attrs"]'
+          'dependencies = ["typing_extensions==4.16.0", "typing_inspection==0.4.2", "attrs==26.1.0"]',
         ].join("\n")
       },
       preferPyodideIndex: false
@@ -1124,8 +1124,8 @@ describe("createWorker with pyproject.toml", () => {
           'name = "dummy"',
           'version = "0.0.0"',
           // typing_inspection depends on typing_extensions
-          'dependencies = ["typing_inspection"]'
-        ].join("\n")
+          'dependencies = ["typing_inspection==0.4.2"]'
+        ].join("\n"),
       },
       preferPyodideIndex: false
     });
@@ -1165,8 +1165,8 @@ describe("createWorker with pyproject.toml", () => {
           'name = "dummy"',
           'version = "0.0.0"',
           // typing_inspection depends on typing_extensions
-          'dependencies = ["typing_inspection"]'
-        ].join("\n")
+          'dependencies = ["typing_inspection==0.4.2"]'
+        ].join("\n"),
       },
       preferPyodideIndex: true
     });

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1020,44 +1020,6 @@ describe("createWorker with python main", () => {
 }, 20000);
 
 describe("createWorker with pyproject.toml", () => {
-  it("accepts a dummy pyproject.toml without throwing", async () => {
-    const id = "test-worker-" + testId++;
-    const createWorkerResult = await createWorker({
-      files: {
-        "index.py": [
-          "from workers import Response, WorkerEntrypoint",
-          "class Default(WorkerEntrypoint):",
-          "  async def fetch(self, request):",
-          '    return Response("ok")'
-        ].join("\n"),
-        "pyproject.toml": [
-          "[project]",
-          'name = "dummy"',
-          'version = "0.0.0"',
-          "",
-          "[tool.setuptools]",
-          'packages = ["dummy"]'
-        ].join("\n"),
-        "python_modules/dummy/__init__.py": "",
-        "python_modules/dummy/hello.py": [
-          "def greet(name: str) -> str:",
-          '    return f"hello, {name}"'
-        ].join("\n")
-      },
-      preferPyodideIndex: false
-    });
-    const worker = env.LOADER.get(id, () => ({
-      mainModule: createWorkerResult.mainModule,
-      modules: createWorkerResult.modules,
-      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
-      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
-    }));
-    const response = await worker
-      .getEntrypoint()
-      .fetch(new Request("http://worker/"));
-    expect(response.status).toBe(200);
-  });
-
   it("works with a pure python package", async () => {
     const id = "test-worker-" + testId++;
     const createWorkerResult = await createWorker({

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1043,7 +1043,8 @@ describe("createWorker with pyproject.toml", () => {
           "def greet(name: str) -> str:",
           '    return f"hello, {name}"'
         ].join("\n")
-      }
+      },
+      preferPyodideIndex: false
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1083,7 +1084,8 @@ describe("createWorker with pyproject.toml", () => {
           // `attrs` has zero dependencies
           'dependencies = ["typing_extensions", "typing_inspection", "attrs"]'
         ].join("\n")
-      }
+      },
+      preferPyodideIndex: false
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1124,7 +1126,49 @@ describe("createWorker with pyproject.toml", () => {
           // typing_inspection depends on typing_extensions
           'dependencies = ["typing_inspection"]'
         ].join("\n")
-      }
+      },
+      preferPyodideIndex: false
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.typing_extensions).toBe("typing_extensions");
+    expect(body.typing_inspection).toBe("typing_inspection");
+  });
+
+  it("works with the pyodide index", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import typing_inspection",
+          "import typing_extensions", // If nothing has gone wrong with nested deps, this will work fine
+          // TODO: Fix nested deps when resolving from pyodide so the above will work
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "typing_extensions": typing_extensions.__name__,',
+          '      "typing_inspection": typing_inspection.__name__,',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          // typing_inspection depends on typing_extensions
+          'dependencies = ["typing_inspection"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1170,4 +1170,4 @@ describe("comparePythonVersions", () => {
     expect(comparePythonVersions("2.0.0dev", "2.0.0")).toBeLessThan(0);
     expect(comparePythonVersions("2.0.0pre", "2.0.0")).toBeLessThan(0);
   });
-})
+});

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1082,7 +1082,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           // typing_extensions has zero dependencies. typing_inspection depends on typing_extensions
           // `attrs` has zero dependencies
-          'dependencies = ["typing_extensions==4.16.0", "typing_inspection==0.4.2", "attrs==26.1.0"]',
+          'dependencies = ["typing_extensions==4.16.0", "typing_inspection==0.4.2", "attrs==26.1.0"]'
         ].join("\n")
       },
       preferPyodideIndex: false
@@ -1125,7 +1125,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           // typing_inspection depends on typing_extensions
           'dependencies = ["typing_inspection==0.4.2"]'
-        ].join("\n"),
+        ].join("\n")
       },
       preferPyodideIndex: false
     });
@@ -1151,8 +1151,7 @@ describe("createWorker with pyproject.toml", () => {
         "index.py": [
           "from workers import Response, WorkerEntrypoint",
           "import typing_inspection",
-          "import typing_extensions", // If nothing has gone wrong with nested deps, this will work fine
-          // TODO: Fix nested deps when resolving from pyodide so the above will work
+          "import typing_extensions", // If nothing has gone wrong with nested deps when using the Pyodide index, this will work fine
           "class Default(WorkerEntrypoint):",
           "  async def fetch(self, request):",
           "    return Response.json({",
@@ -1166,7 +1165,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           // typing_inspection depends on typing_extensions
           'dependencies = ["typing_inspection==0.4.2"]'
-        ].join("\n"),
+        ].join("\n")
       },
       preferPyodideIndex: true
     });

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1144,6 +1144,7 @@ describe("createWorker with pyproject.toml", () => {
     expect(body.typing_inspection).toBe("typing_inspection");
   });
 
+  // Checks that the Pyodide index works the same way we expect PyPI to work
   it("works with the pyodide index", async () => {
     const id = "test-worker-" + testId++;
     const createWorkerResult = await createWorker({

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -8,6 +8,7 @@ import { runInDurableObject } from "cloudflare:test";
 import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
 import type { CreateWorkerOptions } from "../types";
 import { createTypescriptLanguageService } from "../typescript";
+import { comparePythonVersions } from "../installer";
 
 let testId = 0;
 
@@ -1147,3 +1148,26 @@ describe("createWorker with pyproject.toml", () => {
     expect(body.typing_inspection).toBe("typing_inspection");
   });
 }, 20000);
+
+describe("comparePythonVersions", () => {
+  it("accurately compares versions", () => {
+    expect(comparePythonVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(comparePythonVersions("2.0.0", "1.0.0")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("1.2.3", "1.2.4")).toBeLessThan(0);
+    expect(comparePythonVersions("1.2.4", "1.2.3")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.10.0", "1.2.0")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.0.1", "1.0")).toBeGreaterThan(0);
+  });
+
+  it("considers non-release versions (a/b/rc/alpha/beta/dev/pre) to be lower versions than numeric ones", () => {
+    expect(comparePythonVersions("2.0.0a1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0", "2.0.0a1")).toBeGreaterThan(0);
+    expect(comparePythonVersions("2.0.0b1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0rc1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0-alpha", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0beta", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0dev", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0pre", "2.0.0")).toBeLessThan(0);
+  });
+})

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -8,6 +8,7 @@ import { runInDurableObject } from "cloudflare:test";
 import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
 import type { CreateWorkerOptions } from "../types";
 import { createTypescriptLanguageService } from "../typescript";
+import { comparePythonVersions } from "../installer";
 
 let testId = 0;
 
@@ -1141,3 +1142,26 @@ describe("createWorker with pyproject.toml", () => {
     expect(body.typing_inspection).toBe("typing_inspection");
   });
 }, 20000);
+
+describe("comparePythonVersions", () => {
+  it("accurately compares versions", () => {
+    expect(comparePythonVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(comparePythonVersions("2.0.0", "1.0.0")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("1.2.3", "1.2.4")).toBeLessThan(0);
+    expect(comparePythonVersions("1.2.4", "1.2.3")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.10.0", "1.2.0")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.0.1", "1.0")).toBeGreaterThan(0);
+  });
+
+  it("considers non-release versions (a/b/rc/alpha/beta/dev/pre) to be lower versions than numeric ones", () => {
+    expect(comparePythonVersions("2.0.0a1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0", "2.0.0a1")).toBeGreaterThan(0);
+    expect(comparePythonVersions("2.0.0b1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0rc1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0-alpha", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0beta", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0dev", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0pre", "2.0.0")).toBeLessThan(0);
+  });
+})

--- a/packages/worker-bundler/src/types.ts
+++ b/packages/worker-bundler/src/types.ts
@@ -112,6 +112,13 @@ export interface CreateWorkerOptions {
   registry?: string;
 
   /**
+   * When installing Python packages declared in pyproject.toml, prefer the
+   * Pyodide package index over PyPI.
+   * @default true
+   */
+  preferPyodideIndex?: boolean;
+
+  /**
    * JSX transform mode passed to esbuild.
    * `"automatic"` enables the new JSX runtime (no need to import React).
    *

--- a/packages/worker-bundler/src/utils.ts
+++ b/packages/worker-bundler/src/utils.ts
@@ -21,6 +21,7 @@ export const DEFAULT_ENTRY_POINTS = [
   "src/index.mjs",
   "index.ts",
   "index.js",
+  "index.py",
   "src/worker.ts",
   "src/worker.js"
 ] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4090,6 +4090,9 @@ importers:
       esbuild-wasm:
         specifier: 0.28.1
         version: 0.28.1
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       resolve.exports:
         specifier: ^2.0.3
         version: 2.0.3
@@ -9164,6 +9167,9 @@ packages:
 
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -16878,6 +16884,8 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   fetchdts@0.1.7: {}
+
+  fflate@0.8.3: {}
 
   figures@3.2.0:
     dependencies:


### PR DESCRIPTION
The short description is that this adds the Pyodide package index as a possible index to retrieve packages from. The slightly longer description is that it allows either PyPI or the Pyodide index to be preferred as the main index, with the other serving as a fallback if that one fails for any reason. I moved a lot of things around to try to make that clean since they work fairly differently, so let me know if anyone sees anything that looks weird.

Addresses a comment made by @ryanking13 on #1881 and builds on #1950, putting this up as a draft until that gets merged since the number of commits will look excessive until then