### PR TITLE
fix(chat): reconcile errored reconnect streams

### DIFF
--- a/.changeset/fix-error-reconnect-streaming-state.md
+++ b/.changeset/fix-error-reconnect-streaming-state.md
@@ -1,0 +1,9 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Reconcile stale `useAgentChat` server-streaming state after an errored client reconnects.
+
+Reconnect probes now include correlation IDs, and `STREAM_RESUME_NONE` distinguishes globally idle agents from active continuations owned by another connection. The hook clears fallback streaming state only for a correlated idle response. Reconnect opens are retained while a prior resume or status transition settles, in-flight handshakes are retransmitted on replacement sockets, and all AI SDK resume entry points share one serialization gate.

--- a/packages/agents/src/chat/__tests__/parse-protocol.test.ts
+++ b/packages/agents/src/chat/__tests__/parse-protocol.test.ts
@@ -118,10 +118,14 @@ describe("parseProtocolMessage", () => {
     });
   });
 
-  it("parses stream-resume-request", () => {
+  it("parses stream-resume-request with optional probe correlation", () => {
     const msg = { type: CHAT_MESSAGE_TYPES.STREAM_RESUME_REQUEST };
-    const event = parseProtocolMessage(JSON.stringify(msg));
-    expect(event).toEqual({ type: "stream-resume-request" });
+    expect(parseProtocolMessage(JSON.stringify(msg))).toEqual({
+      type: "stream-resume-request"
+    });
+    expect(
+      parseProtocolMessage(JSON.stringify({ ...msg, probeId: "probe-1" }))
+    ).toEqual({ type: "stream-resume-request", probeId: "probe-1" });
   });
 
   it("parses stream-resume-ack", () => {

--- a/packages/agents/src/chat/__tests__/resume-handshake-frames.test.ts
+++ b/packages/agents/src/chat/__tests__/resume-handshake-frames.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { CHAT_MESSAGE_TYPES } from "../protocol";
+import { CHAT_MESSAGE_TYPES, STREAM_RESUME_NONE_REASONS } from "../protocol";
 import {
   HANDSHAKE_INVARIANTS,
   recoveringFrame,
@@ -24,10 +24,26 @@ describe("resume-handshake golden frames", () => {
     });
   });
 
-  it("STREAM_RESUME_NONE carries no id", () => {
-    const frame = streamResumeNoneFrame();
-    expect(frame).toEqual({ type: "cf_agent_stream_resume_none" });
-    expect("id" in frame).toBe(false);
+  it("STREAM_RESUME_NONE distinguishes authoritative idle from affinity denial", () => {
+    const idle = streamResumeNoneFrame();
+    expect(idle).toEqual({
+      type: "cf_agent_stream_resume_none",
+      reason: "idle"
+    });
+    expect("id" in idle).toBe(false);
+    expect(
+      streamResumeNoneFrame(STREAM_RESUME_NONE_REASONS.CONTINUATION_OWNED)
+    ).toEqual({
+      type: "cf_agent_stream_resume_none",
+      reason: "continuation-owned"
+    });
+    expect(
+      streamResumeNoneFrame(STREAM_RESUME_NONE_REASONS.IDLE, "probe-1")
+    ).toEqual({
+      type: "cf_agent_stream_resume_none",
+      reason: "idle",
+      probeId: "probe-1"
+    });
   });
 
   it("replay-done frame is a clean close: replay:true, no error", () => {

--- a/packages/agents/src/chat/__tests__/resume-handshake-frames.ts
+++ b/packages/agents/src/chat/__tests__/resume-handshake-frames.ts
@@ -23,7 +23,11 @@
  * (paired with a client + changeset).
  */
 
-import { CHAT_MESSAGE_TYPES } from "../protocol";
+import {
+  CHAT_MESSAGE_TYPES,
+  STREAM_RESUME_NONE_REASONS,
+  type StreamResumeNoneReason
+} from "../protocol";
 
 /**
  * Server -> client `STREAM_RESUMING` notify: there is a resumable stream (or a
@@ -34,23 +38,30 @@ import { CHAT_MESSAGE_TYPES } from "../protocol";
  * Load-bearing (#1733): a single connection can legitimately receive this twice
  * for one request — proactively from idle-connect AND in response to its
  * explicit `STREAM_RESUME_REQUEST`. The server must NOT dedupe; the client
- * dedupes its ACK. Both sends are byte-identical to this frame.
+ * dedupes its ACK. The explicit response additionally echoes the probe id.
  */
-export function streamResumingFrame(requestId: string) {
+export function streamResumingFrame(requestId: string, probeId?: string) {
   return {
     type: CHAT_MESSAGE_TYPES.STREAM_RESUMING,
-    id: requestId
+    id: requestId,
+    ...(probeId ? { probeId } : {})
   };
 }
 
 /**
- * Server -> client `STREAM_RESUME_NONE`: nothing to resume — no active stream
- * (and no pending continuation / terminal), or a DIFFERENT connection owns the
- * active continuation. Carries no `id`. Emitted by both REQUEST `else` branches.
+ * Server -> client `STREAM_RESUME_NONE`: no stream can be attached to this
+ * connection. `reason: idle` is authoritative global inactivity; a different
+ * live connection owning an active continuation uses `continuation-owned`.
+ * Carries no request/stream `id`.
  */
-export function streamResumeNoneFrame() {
+export function streamResumeNoneFrame(
+  reason: StreamResumeNoneReason = STREAM_RESUME_NONE_REASONS.IDLE,
+  probeId?: string
+) {
   return {
-    type: CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE
+    type: CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE,
+    reason,
+    ...(probeId ? { probeId } : {})
   };
 }
 
@@ -61,10 +72,11 @@ export function streamResumeNoneFrame() {
  * timeout and waits for a later `STREAM_RESUMING` or `STREAM_RESUME_NONE`.
  * Emitted by `PreStreamTurns.park`.
  */
-export function streamPendingFrame(requestId?: string) {
+export function streamPendingFrame(requestId?: string, probeId?: string) {
   return {
     type: CHAT_MESSAGE_TYPES.STREAM_PENDING,
-    ...(requestId ? { id: requestId } : {})
+    ...(requestId ? { id: requestId } : {}),
+    ...(probeId ? { probeId } : {})
   };
 }
 

--- a/packages/agents/src/chat/__tests__/resume-handshake.test.ts
+++ b/packages/agents/src/chat/__tests__/resume-handshake.test.ts
@@ -8,6 +8,7 @@ import {
 import { ContinuationState } from "../continuation-state";
 import type { ResumableStream } from "../resumable-stream";
 import { PreStreamTurns } from "../pre-stream-turns";
+import { STREAM_RESUME_NONE_REASONS } from "../protocol";
 import {
   replayDoneFrame,
   streamPendingFrame,
@@ -161,14 +162,14 @@ describe("ResumeHandshake (driver → golden frames)", () => {
     const handshake = new ResumeHandshake(makeHost({ resumableStream }));
     const conn = makeConnection("c1", frames);
 
-    // Proactive notify (idle-connect) followed by the client's explicit request:
-    // both must emit a byte-identical STREAM_RESUMING for the same connection.
+    // Proactive notify has no probe id; the explicit response echoes its
+    // correlation id while preserving the same stream request id.
     handshake.notifyStreamResuming(conn);
-    await handshake.handleResumeRequest(conn);
+    await handshake.handleResumeRequest(conn, "probe-1");
 
     expect(frames).toEqual([
       streamResumingFrame("req-1"),
-      streamResumingFrame("req-1")
+      streamResumingFrame("req-1", "probe-1")
     ]);
   });
 
@@ -185,9 +186,17 @@ describe("ResumeHandshake (driver → golden frames)", () => {
       makeHost({ resumableStream, continuation })
     );
 
-    await handshake.handleResumeRequest(makeConnection("c1", frames));
+    await handshake.handleResumeRequest(
+      makeConnection("c1", frames),
+      "probe-owned"
+    );
 
-    expect(frames).toEqual([streamResumeNoneFrame()]);
+    expect(frames).toEqual([
+      streamResumeNoneFrame(
+        STREAM_RESUME_NONE_REASONS.CONTINUATION_OWNED,
+        "probe-owned"
+      )
+    ]);
   });
 
   it("REQUEST with no active stream but a matching pending continuation parks + keeps waiting (#1784)", async () => {
@@ -228,14 +237,19 @@ describe("ResumeHandshake (driver → golden frames)", () => {
     expect(frames).toEqual([streamResumingFrame("req-term")]);
   });
 
-  it("REQUEST with nothing to resume → RESUME_NONE", async () => {
+  it("REQUEST with nothing to resume → correlated idle RESUME_NONE", async () => {
     const frames: SentFrame[] = [];
     const { resumableStream } = makeStream({ active: false });
     const handshake = new ResumeHandshake(makeHost({ resumableStream }));
 
-    await handshake.handleResumeRequest(makeConnection("c1", frames));
+    await handshake.handleResumeRequest(
+      makeConnection("c1", frames),
+      "probe-idle"
+    );
 
-    expect(frames).toEqual([streamResumeNoneFrame()]);
+    expect(frames).toEqual([
+      streamResumeNoneFrame(STREAM_RESUME_NONE_REASONS.IDLE, "probe-idle")
+    ]);
   });
 
   it("REQUEST with no active stream but a pre-stream turn in flight parks + keeps waiting (#1784)", async () => {
@@ -310,7 +324,9 @@ describe("ResumeHandshake (driver → golden frames)", () => {
 
     await handshake.handleResumeRequest(makeConnection("c1", frames));
 
-    expect(frames).toEqual([streamResumeNoneFrame()]);
+    expect(frames).toEqual([
+      streamResumeNoneFrame(STREAM_RESUME_NONE_REASONS.CONTINUATION_OWNED)
+    ]);
   });
 
   // ── handleResumeAck ────────────────────────────────────────────────

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -52,7 +52,11 @@ export {
   type ClientToolExecutor
 } from "./client-tools";
 
-export { CHAT_MESSAGE_TYPES } from "./protocol";
+export {
+  CHAT_MESSAGE_TYPES,
+  STREAM_RESUME_NONE_REASONS,
+  type StreamResumeNoneReason
+} from "./protocol";
 
 export { MessageType } from "./wire-types";
 export type { OutgoingMessage, IncomingMessage } from "./wire-types";

--- a/packages/agents/src/chat/parse-protocol.ts
+++ b/packages/agents/src/chat/parse-protocol.ts
@@ -41,7 +41,7 @@ export type ChatProtocolEvent =
       approved: boolean;
       autoContinue?: boolean;
     }
-  | { type: "stream-resume-request" }
+  | { type: "stream-resume-request"; probeId?: string }
   | { type: "stream-resume-ack"; id: string }
   | { type: "messages"; messages: unknown[] };
 
@@ -116,7 +116,10 @@ export function parseProtocolMessage(raw: string): ChatProtocolEvent | null {
       };
 
     case CHAT_MESSAGE_TYPES.STREAM_RESUME_REQUEST:
-      return { type: "stream-resume-request" };
+      return {
+        type: "stream-resume-request",
+        ...(typeof data.probeId === "string" ? { probeId: data.probeId } : {})
+      };
 
     case CHAT_MESSAGE_TYPES.STREAM_RESUME_ACK:
       return {

--- a/packages/agents/src/chat/pre-stream-turns.ts
+++ b/packages/agents/src/chat/pre-stream-turns.ts
@@ -88,14 +88,15 @@ export class PreStreamTurns<
    * `pendingResumeConnections` — they must keep receiving any live broadcast —
    * until the host flushes them through `notifyStreamResuming` on stream start.
    */
-  park(connection: TConnection): boolean {
+  park(connection: TConnection, probeId?: string): boolean {
     if (!this.hasInFlight()) return false;
     this.awaitingConnections.set(connection.id, connection);
     sendIfOpen(
       connection,
       JSON.stringify({
         type: MSG_STREAM_PENDING,
-        ...(this._latestRequestId ? { id: this._latestRequestId } : {})
+        ...(this._latestRequestId ? { id: this._latestRequestId } : {}),
+        ...(probeId ? { probeId } : {})
       })
     );
     return true;

--- a/packages/agents/src/chat/protocol.ts
+++ b/packages/agents/src/chat/protocol.ts
@@ -5,6 +5,16 @@
  * clients. Both @cloudflare/ai-chat (via its MessageType enum) and
  * @cloudflare/think use these values.
  */
+export const STREAM_RESUME_NONE_REASONS = {
+  /** No active, pending, or terminal stream exists for this agent. */
+  IDLE: "idle",
+  /** An active tool continuation is owned by another live connection. */
+  CONTINUATION_OWNED: "continuation-owned"
+} as const;
+
+export type StreamResumeNoneReason =
+  (typeof STREAM_RESUME_NONE_REASONS)[keyof typeof STREAM_RESUME_NONE_REASONS];
+
 export const CHAT_MESSAGE_TYPES = {
   CHAT_MESSAGES: "cf_agent_chat_messages",
   USE_CHAT_REQUEST: "cf_agent_use_chat_request",

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -10,6 +10,7 @@ import type {
 import { nanoid } from "nanoid";
 import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { OutgoingMessage } from "./wire-types";
+import { STREAM_RESUME_NONE_REASONS } from "./protocol";
 import { MessageType } from "./wire-types";
 import {
   transition as broadcastTransition,
@@ -1001,9 +1002,10 @@ export function useAgentChat<
       }
     });
   }
-  // Always point the transport at the latest socket so sends/listeners
-  // go through the current connection after _pk changes.
-  customTransportRef.current.agent = agentRef.current;
+  // Always point the transport at the latest socket so sends/listeners go
+  // through the current connection after _pk changes. setAgent also settles a
+  // handshake owned by a genuinely replaced agent/Chat generation.
+  customTransportRef.current.setAgent(agentRef.current);
   customTransportRef.current.setCancelOnClientAbort(cancelOnClientAbort);
   const customTransport = customTransportRef.current;
 
@@ -1019,9 +1021,11 @@ export function useAgentChat<
     messages: initialMessages,
     transport: customTransport,
     id: stableChatIdRef.current,
-    // Pass resume so useChat calls transport.reconnectToStream().
-    // This lets the AI SDK track status ("streaming") during resume.
-    resume
+    // useAgentChat owns the mount effect below so every resume entry point
+    // (mount, reconnect, tool continuation, and the public helper) shares one
+    // full-lifetime serialization gate. The resumed stream still flows through
+    // AI SDK and drives its normal status transitions.
+    resume: false
   });
 
   // Destructure stable method references from useChatHelpers.
@@ -1035,7 +1039,7 @@ export function useAgentChat<
     addToolResult,
     addToolApprovalResponse,
     sendMessage,
-    resumeStream,
+    resumeStream: rawResumeStream,
     status,
     stop
   } = useChatHelpers;
@@ -1043,35 +1047,56 @@ export function useAgentChat<
   const statusRef = useRef(status);
   statusRef.current = status;
 
-  // Latest resumeStream, read by the reconnect re-probe effect without making
-  // it a dependency (it would re-register the socket listeners on every render).
+  // AI SDK Chat.makeRequest has one mutable activeResponse and no resume
+  // concurrency guard (#1837). Serialize the complete AI SDK promise — not just
+  // its transport handshake — across mount, reconnect, tool, and public calls.
+  const resumeGenerationRef = useRef(0);
+  const resumeOperationRef = useRef<{
+    generation: number;
+    promise: Promise<void>;
+  } | null>(null);
+  const reconnectProbePendingRef = useRef(false);
+  const reconnectProbeRunnerRef = useRef<(() => void) | null>(null);
+  const invalidateResumeGeneration = useCallback(() => {
+    resumeGenerationRef.current++;
+    resumeOperationRef.current = null;
+  }, []);
+
+  const resumeStream = useCallback(
+    (...args: Parameters<typeof rawResumeStream>): Promise<void> => {
+      const active = resumeOperationRef.current;
+      if (active) return active.promise;
+
+      const operation = {
+        generation: resumeGenerationRef.current,
+        promise: Promise.resolve()
+      };
+      // Publish ownership before invoking the async AI SDK method, but invoke it
+      // synchronously so StrictMode cleanup can always cancel the resolver it
+      // creates (rather than leaving an untracked queued invocation behind).
+      resumeOperationRef.current = operation;
+      operation.promise = rawResumeStream(...args).finally(() => {
+        if (
+          resumeOperationRef.current !== operation ||
+          resumeGenerationRef.current !== operation.generation
+        ) {
+          return;
+        }
+        resumeOperationRef.current = null;
+        // An open event suppressed while this operation was active is an
+        // edge-triggered signal; retry it now rather than losing it forever.
+        reconnectProbeRunnerRef.current?.();
+      });
+      return operation.promise;
+    },
+    [rawResumeStream]
+  );
+
+  // Read by the socket effect without re-registering listeners on ordinary
+  // renders. A new Chat generation changes the callback and intentionally
+  // re-runs that effect.
   const resumeStreamRef = useRef(resumeStream);
   resumeStreamRef.current = resumeStream;
-
-  // Whether the socket has opened at least once. The AI SDK fires its own
-  // resume on mount, so we only re-probe on SUBSEQUENT opens (transparent 1006
-  // reconnects that don't remount the component) — see the reconnect re-probe
-  // in the socket effect below (#1784).
-  const hasConnectedOnceRef = useRef(false);
-
-  // True while a reconnect re-probe `resumeStream()` we issued is still in
-  // flight. AI SDK's `Chat.makeRequest` has no concurrency guard — every
-  // resume shares the single mutable `this.activeResponse`, and its `finally`
-  // finalizer reads `this.activeResponse.state` with a bare (unguarded) read
-  // before clearing it. Overlapping reconnect-driven resumes therefore race:
-  // a later resume clears `activeResponse` before an earlier one's finalizer
-  // runs, throwing `Cannot read properties of undefined (reading 'state')`
-  // (#1837). The `onAgentOpen` guard's `statusRef` is lagging React state and
-  // `isAwaitingResume()` only covers the handshake, so neither closes the
-  // post-handshake / pre-status-propagation window. Serialize resumes here:
-  // never issue a new re-probe `resumeStream()` while one is outstanding.
-  const resumeInFlightRef = useRef(false);
-  // Generation token for the in-flight resume. Bumped whenever the gate is
-  // force-reset (socket-effect cleanup, e.g. an agent swap on `_pk` change).
-  // A resume's `.finally` captures its generation and only clears the flag if
-  // it still matches — so a stale, orphaned resume settling after a newer one
-  // has taken over can't reopen the gate underneath it.
-  const resumeGenerationRef = useRef(0);
 
   const resumingToolContinuationRef = useRef(false);
   const pendingToolContinuationRef = useRef(false);
@@ -1123,38 +1148,49 @@ export function useAgentChat<
       return;
     }
 
-    continuationLaunchTimerRef.current = setTimeout(() => {
-      continuationLaunchTimerRef.current = null;
+    const timer = setTimeout(() => {
+      void (async () => {
+        // A mount/reconnect resume may still own AI SDK activeResponse while
+        // status is lagging at ready. Wait for that serialized operation before
+        // arming the transport's special continuation mode.
+        while (resumeOperationRef.current) {
+          await resumeOperationRef.current.promise.catch(() => {});
+        }
 
-      if (
-        !pendingToolContinuationRef.current ||
-        statusRef.current !== "ready"
-      ) {
-        return;
-      }
+        if (continuationLaunchTimerRef.current === timer) {
+          continuationLaunchTimerRef.current = null;
+        }
+        if (
+          !pendingToolContinuationRef.current ||
+          statusRef.current !== "ready"
+        ) {
+          return;
+        }
 
-      pendingToolContinuationRef.current = false;
-      const myGeneration = continuationGenerationRef.current;
-      customTransport.expectToolContinuation();
+        pendingToolContinuationRef.current = false;
+        const myGeneration = continuationGenerationRef.current;
+        customTransport.expectToolContinuation();
 
-      void resumeStream()
-        .catch((error) => {
-          console.error(
-            "[useAgentChat] Tool continuation resume failed:",
-            error
-          );
-        })
-        .finally(() => {
-          // Bail if a reset (clearHistory / cross-tab clear) or a newer
-          // continuation has taken over since we started — otherwise this
-          // stale settlement would flip the flags off while a newer
-          // continuation is still in flight, and reopen the re-entry
-          // guard spuriously.
-          if (continuationGenerationRef.current !== myGeneration) return;
-          resumingToolContinuationRef.current = false;
-          setIsToolContinuation(false);
-        });
+        await resumeStream()
+          .catch((error) => {
+            console.error(
+              "[useAgentChat] Tool continuation resume failed:",
+              error
+            );
+          })
+          .finally(() => {
+            // Bail if a reset (clearHistory / cross-tab clear) or a newer
+            // continuation has taken over since we started — otherwise this
+            // stale settlement would flip the flags off while a newer
+            // continuation is still in flight, and reopen the re-entry
+            // guard spuriously.
+            if (continuationGenerationRef.current !== myGeneration) return;
+            resumingToolContinuationRef.current = false;
+            setIsToolContinuation(false);
+          });
+      })();
     }, 0);
+    continuationLaunchTimerRef.current = timer;
   }, [customTransport, resumeStream]);
 
   const startToolContinuation = useCallback(() => {
@@ -1942,11 +1978,28 @@ export function useAgentChat<
           });
           break;
 
-        case MessageType.CF_AGENT_STREAM_RESUME_NONE:
-          // Server confirmed no active stream — let the transport
-          // resolve reconnectToStream immediately with null.
-          customTransport.handleStreamResumeNone();
+        case MessageType.CF_AGENT_STREAM_RESUME_NONE: {
+          // Every matching NONE settles the transport probe, but only a
+          // correlated idle reason proves inactivity for that probe. The same
+          // frame type also means another connection owns a continuation; older or
+          // delayed unreasoned frames are likewise non-authoritative (#1914).
+          const handled = customTransport.handleStreamResumeNone(data);
+          if (
+            handled &&
+            data.reason === STREAM_RESUME_NONE_REASONS.IDLE &&
+            typeof data.probeId === "string"
+          ) {
+            const result = broadcastTransition(streamStateRef.current, {
+              type: "clear"
+            });
+            streamStateRef.current = result.state;
+            setIsServerStreaming(result.isStreaming);
+            if (observedToolContinuationRequestIdRef.current !== null) {
+              resetToolContinuation();
+            }
+          }
           break;
+        }
 
         case MessageType.CF_AGENT_STREAM_PENDING:
           // Server accepted a turn but its stream hasn't started yet (#1784):
@@ -2102,6 +2155,9 @@ export function useAgentChat<
               localResponseIds.delete(data.id);
               localRequestIdsRef.current.delete(data.id);
               fallbackAckedResumeRequestIdsRef.current.delete(data.id);
+              if (observedToolContinuationRequestIdRef.current === data.id) {
+                resetToolContinuation();
+              }
             }
             return;
           }
@@ -2207,73 +2263,89 @@ export function useAgentChat<
     const fallbackAckedResumeRequestIds =
       fallbackAckedResumeRequestIdsRef.current;
 
-    // A closed socket invalidates the per-socket resume-ACK dedupe: after a
-    // reconnect the server sees a brand-new connection and must be ACKed
-    // (and replay) again, so the previous entries must not suppress it.
-    //
-    // NOTE: deliberately does NOT reset `resumeInFlightRef` (#1837). The flag
-    // is owned by the in-flight resume and cleared only by its own `.finally`
-    // (or invalidated via the generation bump in this effect's cleanup).
-    // Clearing it here would set it false while the resume may still be
-    // mid-flight (post-handshake, before `makeRequest`'s finalizer runs),
-    // re-coupling correctness to close/open task ordering and reopening the
-    // overlap window. It is also unnecessary: a handshake-phase drop is already
-    // gated by `isAwaitingResume()` (and the pending promise's resolver re-binds
-    // to the new socket), and a streaming-phase drop closes the resume stream,
-    // which settles `makeRequest` and clears the flag via its `.finally`.
-    function onAgentClose() {
-      fallbackAckedResumeRequestIds.clear();
-    }
+    let socketIsOpen = false;
+    let sawClose = false;
+    let disposed = false;
 
-    // Reconnect re-probe (#1784): a transparent socket reconnect (e.g. a 1006
-    // drop) does NOT remount the component, so the AI SDK's mount-time resume
-    // never re-fires and a turn that was still pre-stream when the socket
-    // dropped would leave AI SDK `status` stuck at "ready" even after the
-    // server starts streaming. On every reconnect (not the first open) re-probe
-    // through the transport so `status` recovers, mirroring a fresh mount. The
-    // proactive STREAM_RESUMING the server also sends on connect is reconciled
-    // with this probe by the existing #1733 dual-notify dedupe.
-    function onAgentOpen() {
-      if (!hasConnectedOnceRef.current) {
-        hasConnectedOnceRef.current = true;
+    const clearFallbackObserver = () => {
+      const result = broadcastTransition(streamStateRef.current, {
+        type: "clear"
+      });
+      streamStateRef.current = result.state;
+      setIsServerStreaming(result.isStreaming);
+      if (observedToolContinuationRequestIdRef.current !== null) {
+        resetToolContinuation();
+      }
+    };
+
+    // An open is an edge, not durable state. Keep it pending while AI SDK status,
+    // a tool continuation, or the #1837 full-lifetime gate is ineligible. If a
+    // handshake itself crossed the disconnect, retransmit that same request on
+    // the replacement socket instead of starting a second Chat resume.
+    const tryPendingReconnectProbe = () => {
+      if (disposed || !socketIsOpen || !reconnectProbePendingRef.current) {
         return;
       }
+      if (!resume) {
+        reconnectProbePendingRef.current = false;
+        return;
+      }
+      if (customTransport.retryPendingResume()) {
+        reconnectProbePendingRef.current = false;
+        return;
+      }
+
+      const canReconcileObservedContinuation =
+        observedToolContinuationRequestIdRef.current !== null;
       if (
-        !resume ||
-        statusRef.current !== "ready" ||
-        resumingToolContinuationRef.current ||
-        resumeInFlightRef.current ||
-        customTransport.isAwaitingResume()
+        (statusRef.current !== "ready" && statusRef.current !== "error") ||
+        (resumingToolContinuationRef.current &&
+          !canReconcileObservedContinuation) ||
+        resumeOperationRef.current !== null
       ) {
         return;
       }
-      const resumeStreamFn = resumeStreamRef.current;
-      if (!resumeStreamFn) return;
-      // Serialize resumes (#1837): hold the in-flight flag for the entire
-      // resume lifetime so a rapid second `open` (reconnect storm) can't
-      // overwrite the AI SDK's shared `activeResponse` mid-flight.
-      resumeInFlightRef.current = true;
-      const myGeneration = resumeGenerationRef.current;
-      void Promise.resolve(resumeStreamFn())
-        .catch(() => {})
-        .finally(() => {
-          // Skip if the gate was force-reset (agent swap) and a newer resume
-          // has since taken over — clearing here would reopen it spuriously.
-          if (resumeGenerationRef.current !== myGeneration) return;
-          resumeInFlightRef.current = false;
-        });
+
+      reconnectProbePendingRef.current = false;
+      void resumeStreamRef.current().catch(() => {});
+    };
+    reconnectProbeRunnerRef.current = tryPendingReconnectProbe;
+
+    // Track an actual close→open transition rather than counting open events.
+    // This correctly handles useAgentChat mounting after the parent socket was
+    // already open: its first observed open after a close is still a reconnect.
+    function onAgentClose() {
+      socketIsOpen = false;
+      sawClose = true;
+      fallbackAckedResumeRequestIds.clear();
+
+      // resume:false opts out of recovering disconnected streams. There can be
+      // no future authoritative probe, so stop claiming that a disconnected
+      // fallback observer is live; pending client tool work remains folded into
+      // the public flag independently.
+      if (!resume) {
+        clearFallbackObserver();
+      }
+    }
+
+    function onAgentOpen() {
+      socketIsOpen = true;
+      if (!sawClose) return;
+      sawClose = false;
+      reconnectProbePendingRef.current = true;
+      tryPendingReconnectProbe();
     }
 
     agent.addEventListener("message", onAgentMessage);
     agent.addEventListener("close", onAgentClose);
     agent.addEventListener("open", onAgentOpen);
 
-    // Stream resume is now primarily handled by the transport's
-    // reconnectToStream (which sends CF_AGENT_STREAM_RESUME_REQUEST).
-    // The onAgentMessage handler above serves as fallback for cross-tab
-    // broadcasts and cases where the transport didn't handle the resume.
-
     return () => {
+      disposed = true;
+      if (reconnectProbeRunnerRef.current === tryPendingReconnectProbe) {
+        reconnectProbeRunnerRef.current = null;
+      }
+      reconnectProbePendingRef.current = false;
       agent.removeEventListener("message", onAgentMessage);
       agent.removeEventListener("close", onAgentClose);
       agent.removeEventListener("open", onAgentOpen);
@@ -2283,12 +2355,12 @@ export function useAgentChat<
       setIsRecovering(false);
       protectedStreamingAssistantRef.current = null;
       localResponseIds.clear();
-      // Don't let an orphaned re-probe (e.g. agent swapped on `_pk` change)
-      // leave the serialization gate stuck closed for the next socket (#1837).
-      // Bump the generation so the orphaned resume's late `.finally` can't
-      // clear the gate out from under a newer resume on the next socket.
-      resumeGenerationRef.current++;
-      resumeInFlightRef.current = false;
+
+      // Invalidate both sides of an old agent/Chat generation. Transport
+      // callbacks/timers settle identity-safely; the token prevents its late AI
+      // SDK finalizer from reopening the serialization gate under a new Chat.
+      customTransport.resetResumeState();
+      invalidateResumeGeneration();
     };
   }, [
     agent,
@@ -2299,8 +2371,24 @@ export function useAgentChat<
     resetToolContinuation,
     resetMatchingHydratedAssistantForReplay,
     restoreProtectedStreamingAssistant,
-    resetLocalChatState
+    resetLocalChatState,
+    invalidateResumeGeneration
   ]);
+
+  // Own mount/chat-generation resumption so StrictMode, reconnects, tool
+  // continuations, and public calls all use the same #1837 serialization gate.
+  // This effect is declared after the socket handler so a synchronous server
+  // response cannot beat message-listener registration.
+  useEffect(() => {
+    if (!resume) return;
+    void resumeStream().catch(() => {});
+  }, [resume, resumeStream]);
+
+  // Flush an open edge that arrived while status/tool state was temporarily
+  // ineligible. Full-lifetime resume settlement also calls the same runner.
+  useEffect(() => {
+    reconnectProbeRunnerRef.current?.();
+  }, [isToolContinuation, status]);
 
   // ── DEPRECATED: addToolResult wrapper with confirmation batching ────
   // This wrapper is deprecated. Use addToolOutput or addToolApprovalResponse instead.
@@ -2544,6 +2632,7 @@ export function useAgentChat<
 
   return {
     ...useChatHelpers,
+    resumeStream,
     messages: messagesWithToolResults,
     isServerStreaming: effectiveIsServerStreaming,
     isStreaming,

--- a/packages/agents/src/chat/resume-handshake.ts
+++ b/packages/agents/src/chat/resume-handshake.ts
@@ -20,7 +20,11 @@
 
 import type { Connection } from "agents";
 import { sendIfOpen } from "./connection";
-import { CHAT_MESSAGE_TYPES } from "./protocol";
+import {
+  CHAT_MESSAGE_TYPES,
+  STREAM_RESUME_NONE_REASONS,
+  type StreamResumeNoneReason
+} from "./protocol";
 import type { ContinuationState } from "./continuation-state";
 import type { PreStreamTurns } from "./pre-stream-turns";
 import type { ResumableStream } from "./resumable-stream";
@@ -90,15 +94,17 @@ export class ResumeHandshake {
    * `reconnectToStream` hangs to its timeout with no replay), and the proactive
    * notify is required for clients that never send a request. The notify is one
    * tiny frame; the client dedupes its ACK so the buffer is not replayed twice.
+   * Direct responses echo the opaque probe id; proactive notifications omit it.
    */
-  notifyStreamResuming(connection: Connection): void {
+  notifyStreamResuming(connection: Connection, probeId?: string): void {
     const { resumableStream, pendingResumeConnections } = this.host;
     if (!resumableStream.hasActiveStream()) return;
     const sent = sendIfOpen(
       connection,
       JSON.stringify({
         type: CHAT_MESSAGE_TYPES.STREAM_RESUMING,
-        id: resumableStream.activeRequestId
+        id: resumableStream.activeRequestId,
+        ...(probeId ? { probeId } : {})
       })
     );
     if (sent) {
@@ -113,7 +119,10 @@ export class ResumeHandshake {
    * message handler is registered, avoiding the race where a proactive
    * `STREAM_RESUMING` from onConnect arrives before the handler is ready.
    */
-  async handleResumeRequest(connection: Connection): Promise<void> {
+  async handleResumeRequest(
+    connection: Connection,
+    probeId?: string
+  ): Promise<void> {
     const { resumableStream, continuation, preStream } = this.host;
     if (resumableStream.hasActiveStream()) {
       if (
@@ -122,12 +131,13 @@ export class ResumeHandshake {
         continuation.activeConnectionId !== connection.id &&
         this._ownerStillPresent(continuation.activeConnectionId)
       ) {
-        sendIfOpen(
+        this._sendResumeNone(
           connection,
-          JSON.stringify({ type: CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE })
+          STREAM_RESUME_NONE_REASONS.CONTINUATION_OWNED,
+          probeId
         );
       } else {
-        this.notifyStreamResuming(connection);
+        this.notifyStreamResuming(connection, probeId);
       }
     } else if (
       continuation.pending !== null &&
@@ -139,32 +149,62 @@ export class ResumeHandshake {
       // probe does not time out before the continuation stream begins; the host
       // flushes `awaitingConnections` into `STREAM_RESUMING` on stream start.
       continuation.awaitingConnections.set(connection.id, connection);
-      this._sendStreamPending(connection, continuation.pending.requestId);
-    } else if (await this._replayTerminalOnResume(connection)) {
+      this._sendStreamPending(
+        connection,
+        continuation.pending.requestId,
+        probeId
+      );
+    } else if (await this._replayTerminalOnResume(connection, probeId)) {
       // A turn terminalized while no client was connected (#1645): drive the
       // resume handshake so the terminal error frame can be delivered on the
       // resumed stream (the only path that surfaces as an error on the client)
       // once this connection ACKs — see `_replayTerminalOnAck`.
-    } else if (preStream?.park(connection)) {
+    } else if (preStream?.park(connection, probeId)) {
       // A normal turn is accepted but its resumable stream has not started yet
       // (#1784). `park` enrolled the connection and sent `STREAM_PENDING`; the
       // host flushes it into `STREAM_RESUMING` on stream start, or releases it
       // with `STREAM_RESUME_NONE` if the turn settles without streaming.
     } else {
-      sendIfOpen(
+      // This is the only direct response that proves global inactivity: every
+      // active, pending, terminal-replay, and pre-stream branch was exhausted.
+      // The reason is backward-compatible (older clients ignore it) and lets a
+      // reconnecting hook reconcile fallback streaming state without confusing
+      // continuation-affinity denial for idle (#1914).
+      this._sendResumeNone(
         connection,
-        JSON.stringify({ type: CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE })
+        STREAM_RESUME_NONE_REASONS.IDLE,
+        probeId
       );
     }
   }
 
+  private _sendResumeNone(
+    connection: Connection,
+    reason: StreamResumeNoneReason,
+    probeId?: string
+  ): void {
+    sendIfOpen(
+      connection,
+      JSON.stringify({
+        type: CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE,
+        reason,
+        ...(probeId ? { probeId } : {})
+      })
+    );
+  }
+
   /** Send a keep-waiting `STREAM_PENDING` frame (#1784). */
-  private _sendStreamPending(connection: Connection, requestId?: string): void {
+  private _sendStreamPending(
+    connection: Connection,
+    requestId?: string,
+    probeId?: string
+  ): void {
     sendIfOpen(
       connection,
       JSON.stringify({
         type: CHAT_MESSAGE_TYPES.STREAM_PENDING,
-        ...(requestId ? { id: requestId } : {})
+        ...(requestId ? { id: requestId } : {}),
+        ...(probeId ? { probeId } : {})
       })
     );
   }
@@ -230,7 +270,8 @@ export class ResumeHandshake {
    * `true` if a terminal was pending (and `STREAM_RESUMING` was sent).
    */
   private async _replayTerminalOnResume(
-    connection: Connection
+    connection: Connection,
+    probeId?: string
   ): Promise<boolean> {
     const pending = await this.host.pendingChatTerminal();
     if (!pending) return false;
@@ -238,7 +279,8 @@ export class ResumeHandshake {
       connection,
       JSON.stringify({
         type: CHAT_MESSAGE_TYPES.STREAM_RESUMING,
-        id: pending.requestId
+        id: pending.requestId,
+        ...(probeId ? { probeId } : {})
       })
     );
     return true;

--- a/packages/agents/src/chat/wire-types.ts
+++ b/packages/agents/src/chat/wire-types.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema7, UIMessage } from "ai";
+import type { StreamResumeNoneReason } from "./protocol";
 
 /**
  * Enum for message types to improve type safety and maintainability
@@ -82,6 +83,8 @@ export type OutgoingMessage<ChatMessage extends UIMessage = UIMessage> =
       type: MessageType.CF_AGENT_STREAM_RESUMING;
       /** The request ID of the stream being resumed */
       id: string;
+      /** Present when this offer directly answers a client resume probe. */
+      probeId?: string;
     }
   | {
       /** Server notifies client that a message was updated (e.g., tool result applied) */
@@ -90,8 +93,15 @@ export type OutgoingMessage<ChatMessage extends UIMessage = UIMessage> =
       message: ChatMessage;
     }
   | {
-      /** Server responds to resume request when no active stream exists */
+      /** Server responds to a resume request with no stream for this client. */
       type: MessageType.CF_AGENT_STREAM_RESUME_NONE;
+      /**
+       * Why no stream was offered. Only `idle` proves global inactivity;
+       * omitted by older servers and by non-authoritative delayed releases.
+       */
+      reason?: StreamResumeNoneReason;
+      /** Correlates an authoritative response to its client resume probe. */
+      probeId?: string;
     }
   | {
       /**
@@ -102,6 +112,8 @@ export type OutgoingMessage<ChatMessage extends UIMessage = UIMessage> =
       type: MessageType.CF_AGENT_STREAM_PENDING;
       /** The accepted request id, when known. */
       id?: string;
+      /** Correlates a direct keep-waiting response to its client probe. */
+      probeId?: string;
     }
   | {
       /**
@@ -165,6 +177,8 @@ export type IncomingMessage<ChatMessage extends UIMessage = UIMessage> =
   | {
       /** Client requests stream resume check after message handler is registered */
       type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST;
+      /** Opaque correlation id echoed by direct server responses. */
+      probeId?: string;
     }
   | {
       /** Client sends tool result to server (for client-side tools) */

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -93,12 +93,17 @@ export class WebSocketChatTransport<
   private _resumeResolver: ((data: { id: string }) => void) | null = null;
   // Pending "no stream" resolver — called by handleStreamResumeNone
   // when onAgentMessage sees CF_AGENT_STREAM_RESUME_NONE.
-  private _resumeNoneResolver: (() => void) | null = null;
+  private _resumeNoneResolver:
+    | ((data: { probeId?: string }) => boolean)
+    | null = null;
   // Keep-waiting hook (#1784) — set by whichever resume path is currently
   // awaiting, called by handleStreamPending when onAgentMessage sees
   // CF_AGENT_STREAM_PENDING. Extends the path's probe timeout so a slow
   // pre-stream window (queue / MCP / model latency) does not resolve early.
   private _onStreamPending: (() => void) | null = null;
+  // Retransmits the current handshake on a replacement socket without starting
+  // a second AI SDK resume request. Set only while a resolver is active.
+  private _retryResumeProbe: (() => void) | null = null;
   // Set when a client-side tool result/approval is expected to trigger
   // a new continuation stream. In this mode reconnectToStream() returns
   // a deferred ReadableStream immediately so AI SDK status can transition
@@ -107,12 +112,26 @@ export class WebSocketChatTransport<
   private _abortToolContinuation: (() => boolean) | null = null;
   private _activeServerTurnId: string | null = null;
   private _cancelAttachedStream: (() => boolean) | null = null;
+  // Local-only detach for a resume stream owned by an obsolete Chat/agent
+  // generation. Unlike explicit cancellation, this never cancels server work.
+  private _detachResumeStream: (() => boolean) | null = null;
 
   constructor(options: WebSocketChatTransportOptions<ChatMessage>) {
     this.agent = options.agent;
     this.prepareBody = options.prepareBody;
     this.activeRequestIds = options.activeRequestIds;
     this.cancelOnClientAbort = options.cancelOnClientAbort ?? false;
+  }
+
+  /**
+   * Point the singleton transport at a new Agent connection. A pending resolver
+   * belongs to the old Chat/socket generation and must settle before messages
+   * from the replacement connection can be consumed (#1914 review).
+   */
+  setAgent(agent: AgentConnection) {
+    if (this.agent === agent) return;
+    this.resetResumeState();
+    this.agent = agent;
   }
 
   setCancelOnClientAbort(cancelOnClientAbort: boolean) {
@@ -191,6 +210,38 @@ export class WebSocketChatTransport<
   }
 
   /**
+   * Settle and detach the current handshake without interpreting it as a
+   * server-idle response. Used when the owning hook/agent generation changes.
+   */
+  cancelPendingResume(): boolean {
+    const resolveNone = this._resumeNoneResolver;
+    if (!resolveNone) return false;
+    return resolveNone({});
+  }
+
+  /**
+   * Invalidate all client-side resume state for an obsolete hook/agent
+   * generation without cancelling its durable server turn.
+   */
+  resetResumeState(): void {
+    this._expectToolContinuation = false;
+    this.cancelPendingResume();
+    this._detachResumeStream?.();
+  }
+
+  /**
+   * Re-send the active handshake request on the latest socket generation. This
+   * preserves one AI SDK resume operation while recovering a request/reply lost
+   * with the previous WebSocket.
+   */
+  retryPendingResume(): boolean {
+    const retry = this._retryResumeProbe;
+    if (!retry) return false;
+    retry();
+    return true;
+  }
+
+  /**
    * Called by onAgentMessage when it receives CF_AGENT_STREAM_RESUMING.
    * If reconnectToStream is waiting, this handles the resume handshake
    * (ACK + stream creation) and returns true. Otherwise returns false
@@ -207,10 +258,9 @@ export class WebSocketChatTransport<
    * If reconnectToStream is waiting, resolves the promise with null
    * immediately (no 5-second timeout). Returns true if handled.
    */
-  handleStreamResumeNone(): boolean {
+  handleStreamResumeNone(data: { probeId?: string } = {}): boolean {
     if (!this._resumeNoneResolver) return false;
-    this._resumeNoneResolver();
-    return true;
+    return this._resumeNoneResolver(data);
   }
 
   /**
@@ -427,60 +477,82 @@ export class WebSocketChatTransport<
   async reconnectToStream(_options: {
     chatId: string;
   }): Promise<ReadableStream<UIMessageChunk> | null> {
+    // A transport has one handshake slot. Returning null for an unexpected
+    // concurrent caller is safer than overwriting callbacks owned by the first
+    // AI SDK request (StrictMode/manual overlap); the hook serializes its normal
+    // mount, tool, public, and reconnect entry points.
+    if (this.isAwaitingResume()) return null;
+
     if (this._expectToolContinuation) {
       this._expectToolContinuation = false;
       return this._createToolContinuationStream();
     }
 
     // Detect whether the server has an active stream for this chat.
-    // Instead of registering our own addEventListener listener (which
-    // races with onAgentMessage), we set _resumeResolver so that
-    // onAgentMessage can call handleStreamResuming() synchronously
-    // when it sees CF_AGENT_STREAM_RESUMING — eliminating the race.
+    // Instead of registering another message listener (which races with the
+    // hook), expose identity-owned callbacks consumed synchronously by the
+    // shared handler.
     const activeIds = this.activeRequestIds;
+    const probeId = nanoid(8);
 
     return new Promise<ReadableStream<UIMessageChunk> | null>((resolve) => {
       let resolved = false;
       let timeout: ReturnType<typeof setTimeout> | undefined;
+      let resumeResolver: ((data: { id: string }) => void) | null = null;
+      let resumeNoneResolver: ((data: { probeId?: string }) => boolean) | null =
+        null;
+      let onStreamPending: (() => void) | null = null;
+      let retryResumeProbe: (() => void) | null = null;
+
+      const clearOwnedCallbacks = () => {
+        if (resumeResolver && this._resumeResolver === resumeResolver) {
+          this._resumeResolver = null;
+        }
+        if (
+          resumeNoneResolver &&
+          this._resumeNoneResolver === resumeNoneResolver
+        ) {
+          this._resumeNoneResolver = null;
+        }
+        if (onStreamPending && this._onStreamPending === onStreamPending) {
+          this._onStreamPending = null;
+        }
+        if (retryResumeProbe && this._retryResumeProbe === retryResumeProbe) {
+          this._retryResumeProbe = null;
+        }
+      };
 
       const done = (value: ReadableStream<UIMessageChunk> | null) => {
         if (resolved) return;
         resolved = true;
-        this._resumeResolver = null;
-        this._resumeNoneResolver = null;
-        this._onStreamPending = null;
+        clearOwnedCallbacks();
         if (timeout) clearTimeout(timeout);
         resolve(value);
       };
 
-      // Keep-waiting (#1784): the server says a turn is accepted but its stream
-      // hasn't started. Extend the short probe timeout to the longer backstop so
-      // we wait for the eventual STREAM_RESUMING (or STREAM_RESUME_NONE) instead
-      // of resolving null mid pre-stream window. Refreshed on every frame.
-      this._onStreamPending = () => {
-        if (resolved) return;
+      const armTimeout = (delay: number) => {
         if (timeout) clearTimeout(timeout);
-        timeout = setTimeout(() => done(null), RESUME_PENDING_TIMEOUT_MS);
+        timeout = setTimeout(() => done(null), delay);
       };
 
-      // Set the "no stream" resolver that handleStreamResumeNone() will call.
-      // When onAgentMessage sees CF_AGENT_STREAM_RESUME_NONE, it calls
-      // handleStreamResumeNone() which resolves immediately with null.
-      this._resumeNoneResolver = () => done(null);
+      // Keep-waiting (#1784): the server says a turn is accepted but its stream
+      // has not started. Extend this operation's own timeout only.
+      onStreamPending = () => {
+        if (resolved) return;
+        armTimeout(RESUME_PENDING_TIMEOUT_MS);
+      };
 
-      // Set the resolver that handleStreamResuming() will call.
-      // When onAgentMessage sees CF_AGENT_STREAM_RESUMING, it calls
-      // handleStreamResuming() which invokes this callback.
-      this._resumeResolver = (data: { id: string }) => {
+      resumeNoneResolver = (data) => {
+        if (data.probeId && data.probeId !== probeId) return false;
+        done(null);
+        return true;
+      };
+
+      resumeResolver = (data: { id: string }) => {
         const requestId = data.id;
-
-        // Track this request so onAgentMessage skips subsequent chunks
         activeIds?.add(requestId);
-
         const stream = this._createResumeStream(requestId);
 
-        // Send ACK to server via the latest agent (the socket may
-        // have been replaced since reconnectToStream was called).
         this.agent.send(
           JSON.stringify({
             type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
@@ -488,28 +560,31 @@ export class WebSocketChatTransport<
           })
         );
 
-        // Return a ReadableStream fed by the replayed + live chunks
         done(stream);
       };
 
-      // Send the resume request. PartySocket queues sends when
-      // the socket isn't open yet and flushes on connect, so
-      // this works regardless of current readyState.
-      try {
-        this.agent.send(
-          JSON.stringify({
-            type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST
-          })
-        );
-      } catch {
-        // WebSocket may already be closed
-      }
+      // Re-arm both the request and timeout on each replacement socket. This is
+      // a retransmission of this resolver's handshake, not a second Chat resume.
+      retryResumeProbe = () => {
+        if (resolved) return;
+        armTimeout(RESUME_PROBE_TIMEOUT_MS);
+        try {
+          this.agent.send(
+            JSON.stringify({
+              type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST,
+              probeId
+            })
+          );
+        } catch {
+          // The next socket open retries again; the timeout remains a backstop.
+        }
+      };
 
-      // Safety-net timeout: if the WebSocket never connects or the
-      // server is unreachable, resolve null. Under normal operation
-      // the server responds with STREAM_RESUMING, STREAM_RESUME_NONE, or
-      // STREAM_PENDING (which extends this) well before this fires.
-      timeout = setTimeout(() => done(null), RESUME_PROBE_TIMEOUT_MS);
+      this._onStreamPending = onStreamPending;
+      this._resumeNoneResolver = resumeNoneResolver;
+      this._resumeResolver = resumeResolver;
+      this._retryResumeProbe = retryResumeProbe;
+      retryResumeProbe();
     });
   }
 
@@ -527,42 +602,45 @@ export class WebSocketChatTransport<
     abortError.name = "AbortError";
     let completed = false;
     let requestId: string | null = null;
-    let readerController!: ReadableStreamDefaultController<UIMessageChunk>;
+    let readerController: ReadableStreamDefaultController<UIMessageChunk> | null =
+      null;
+    const probeId = nanoid(8);
     let onResumeRef: ((data: { id: string }) => void) | null = null;
-    let onResumeNoneRef: (() => void) | null = null;
+    let onResumeNoneRef: ((data: { probeId?: string }) => boolean) | null =
+      null;
+    let onStreamPendingRef: (() => void) | null = null;
+    let retryResumeProbeRef: (() => void) | null = null;
+    let abortToolContinuationRef: (() => boolean) | null = null;
+    let detachResumeStreamRef: (() => boolean) | null = null;
 
-    const clearHandshakeResolvers = (
-      resumeResolver?: ((data: { id: string }) => void) | null,
-      resumeNoneResolver?: (() => void) | null
-    ) => {
-      if (resumeResolver === undefined && resumeNoneResolver === undefined) {
+    const clearOwnedHandshake = () => {
+      if (onResumeRef && this._resumeResolver === onResumeRef) {
         this._resumeResolver = null;
-        this._resumeNoneResolver = null;
-        return;
       }
-
-      if (resumeResolver && this._resumeResolver === resumeResolver) {
-        this._resumeResolver = null;
+      if (onResumeNoneRef && this._resumeNoneResolver === onResumeNoneRef) {
+        this._resumeNoneResolver = null;
+      }
+      if (onStreamPendingRef && this._onStreamPending === onStreamPendingRef) {
+        this._onStreamPending = null;
       }
       if (
-        resumeNoneResolver &&
-        this._resumeNoneResolver === resumeNoneResolver
+        retryResumeProbeRef &&
+        this._retryResumeProbe === retryResumeProbeRef
       ) {
-        this._resumeNoneResolver = null;
+        this._retryResumeProbe = null;
       }
     };
 
-    const finish = (
-      action: () => void,
-      resumeResolver?: ((data: { id: string }) => void) | null,
-      resumeNoneResolver?: (() => void) | null,
-      keepRequestId = false
-    ) => {
+    const finish = (action: () => void, keepRequestId = false) => {
       if (completed) return;
       completed = true;
-      this._abortToolContinuation = null;
-      this._onStreamPending = null;
-      clearHandshakeResolvers(resumeResolver, resumeNoneResolver);
+      if (this._abortToolContinuation === abortToolContinuationRef) {
+        this._abortToolContinuation = null;
+      }
+      if (this._detachResumeStream === detachResumeStreamRef) {
+        this._detachResumeStream = null;
+      }
+      clearOwnedHandshake();
       try {
         action();
       } catch {
@@ -576,20 +654,11 @@ export class WebSocketChatTransport<
 
     const transport = this;
 
-    this._abortToolContinuation = () => {
-      if (completed) {
-        return false;
-      }
+    abortToolContinuationRef = () => {
+      if (completed) return false;
 
       if (requestId === null) {
-        // Handshake hasn't completed yet — close the stream and clear
-        // resolvers so the subsequent onResume/handleStreamResuming
-        // becomes a no-op.
-        finish(
-          () => readerController.error(abortError),
-          onResumeRef,
-          onResumeNoneRef
-        );
+        finish(() => readerController?.error(abortError));
         return true;
       }
 
@@ -604,26 +673,33 @@ export class WebSocketChatTransport<
         // Ignore failures (e.g. agent already disconnected)
       }
 
-      // keepRequestId=true: keep the ID in activeIds so onAgentMessage
-      // skips in-flight chunks until the server's done:true cleans it up
-      // (same pattern as sendMessages onAbort).
-      finish(
-        () => readerController.error(abortError),
-        onResumeRef,
-        onResumeNoneRef,
-        true
-      );
+      // Keep the ID so the shared message handler ignores in-flight chunks
+      // until the server's terminal frame performs its normal cleanup.
+      finish(() => readerController?.error(abortError), true);
       return true;
     };
+    this._abortToolContinuation = abortToolContinuationRef;
+    detachResumeStreamRef = () => {
+      if (completed) return false;
+      finish(() => readerController?.close());
+      return true;
+    };
+    this._detachResumeStream = detachResumeStreamRef;
 
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
         readerController = controller;
         let timeout: ReturnType<typeof setTimeout> | undefined;
 
-        const onResumeNone = () => {
+        const armTimeout = (delay: number) => {
           if (timeout) clearTimeout(timeout);
-          finish(() => controller.close(), onResume, onResumeNone);
+          timeout = setTimeout(() => finish(() => controller.close()), delay);
+        };
+
+        const onResumeNone = (data: { probeId?: string }) => {
+          if (data.probeId && data.probeId !== probeId) return false;
+          finish(() => controller.close());
+          return true;
         };
 
         const onResume = (data: { id: string }) => {
@@ -631,8 +707,7 @@ export class WebSocketChatTransport<
 
           requestId = data.id;
           activeIds?.add(requestId);
-          clearHandshakeResolvers(onResume, onResumeNone);
-          transport._onStreamPending = null;
+          clearOwnedHandshake();
           if (timeout) clearTimeout(timeout);
 
           agent.send(
@@ -643,27 +718,35 @@ export class WebSocketChatTransport<
           );
         };
 
-        onResumeRef = onResume;
-        onResumeNoneRef = onResumeNone;
-
-        timeout = setTimeout(
-          () => finish(() => controller.close(), onResume, onResumeNone),
-          RESUME_PROBE_TIMEOUT_MS
-        );
-
-        // Keep-waiting (#1784): extend the probe window when the server reports
-        // the continuation turn is accepted but its stream hasn't started.
-        transport._onStreamPending = () => {
+        const onStreamPending = () => {
           if (completed) return;
-          if (timeout) clearTimeout(timeout);
-          timeout = setTimeout(
-            () => finish(() => controller.close(), onResume, onResumeNone),
-            RESUME_PENDING_TIMEOUT_MS
-          );
+          armTimeout(RESUME_PENDING_TIMEOUT_MS);
         };
 
+        const retryResumeProbe = () => {
+          if (completed || requestId !== null) return;
+          armTimeout(RESUME_PROBE_TIMEOUT_MS);
+          try {
+            transport.agent.send(
+              JSON.stringify({
+                type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST,
+                probeId
+              })
+            );
+          } catch {
+            // A later socket open can retry this same deferred handshake.
+          }
+        };
+
+        onResumeRef = onResume;
+        onResumeNoneRef = onResumeNone;
+        onStreamPendingRef = onStreamPending;
+        retryResumeProbeRef = retryResumeProbe;
         transport._resumeResolver = onResume;
         transport._resumeNoneResolver = onResumeNone;
+        transport._onStreamPending = onStreamPending;
+        transport._retryResumeProbe = retryResumeProbe;
+
         const onMessage = (event: MessageEvent) => {
           try {
             const data = JSON.parse(
@@ -679,10 +762,8 @@ export class WebSocketChatTransport<
             }
 
             if (data.error) {
-              finish(
-                () => controller.error(new Error(data.body || "Stream error")),
-                onResume,
-                onResumeNone
+              finish(() =>
+                controller.error(new Error(data.body || "Stream error"))
               );
               return;
             }
@@ -697,17 +778,14 @@ export class WebSocketChatTransport<
             }
 
             if (data.done) {
-              finish(() => controller.close(), onResume, onResumeNone);
+              finish(() => controller.close());
             }
           } catch {
             // Ignore non-JSON messages
           }
         };
 
-        const onClose = () => {
-          if (timeout) clearTimeout(timeout);
-          finish(() => controller.close(), onResume, onResumeNone);
-        };
+        const onClose = () => finish(() => controller.close());
 
         agent.addEventListener("message", onMessage, {
           signal: streamController.signal
@@ -716,22 +794,14 @@ export class WebSocketChatTransport<
           signal: streamController.signal
         });
 
-        try {
-          agent.send(
-            JSON.stringify({
-              type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST
-            })
-          );
-        } catch {
-          finish(() => controller.close());
-        }
+        retryResumeProbe();
       },
       cancel() {
         if (requestId && transport.cancelOnClientAbort) {
           transport.sendCancelFrame(requestId);
-          finish(() => {}, onResumeRef, onResumeNoneRef, true);
+          finish(() => {}, true);
         } else {
-          finish(() => {}, onResumeRef, onResumeNoneRef);
+          finish(() => {});
         }
       }
     });
@@ -752,6 +822,7 @@ export class WebSocketChatTransport<
     const abortError = new Error("Aborted");
     abortError.name = "AbortError";
     let completed = false;
+    let detachResumeStream: (() => boolean) | null = null;
 
     const finish = (
       action: () => void,
@@ -762,6 +833,9 @@ export class WebSocketChatTransport<
       completed = true;
       if (clearServerTurn) {
         this.clearActiveServerTurn(requestId);
+      }
+      if (this._detachResumeStream === detachResumeStream) {
+        this._detachResumeStream = null;
       }
       try {
         action();
@@ -774,15 +848,22 @@ export class WebSocketChatTransport<
       chunkController.abort();
     };
 
+    let streamController: ReadableStreamDefaultController<UIMessageChunk> | null =
+      null;
     const cancelActiveRequest = () => {
       if (completed) return false;
-      finish(() => streamController.error(abortError), true);
+      finish(() => streamController?.error(abortError), true);
       return true;
     };
     this.setActiveServerTurn(requestId, cancelActiveRequest);
 
-    let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
     const transport = this;
+    detachResumeStream = () => {
+      if (completed) return false;
+      finish(() => streamController?.close());
+      return true;
+    };
+    this._detachResumeStream = detachResumeStream;
 
     return new ReadableStream<UIMessageChunk>({
       start(controller) {

--- a/packages/agents/src/react-tests/resume-overlap-race.test.tsx
+++ b/packages/agents/src/react-tests/resume-overlap-race.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Regression test for #1837 — reconnect-driven resume overlap.
  *
- * With `resume: true` (the default), `useAgentChat` re-probes the stream from
- * its WebSocket `onAgentOpen` handler on every reconnect. The AI SDK's
+ * With `resume: true` (the default), `useAgentChat` re-probes the stream after
+ * WebSocket close→open transitions. The AI SDK's
  * `Chat.makeRequest` has NO concurrency guard: every resume shares the single
  * mutable `this.activeResponse`, and its `finally` finalizer reads
  * `this.activeResponse.state.message` with a BARE (unguarded) read before
@@ -20,8 +20,8 @@
  *
  * So a socket `open` landing in that window (a reconnect storm: flaky mobile
  * link / DO bounce on redeploy) sailed past both guards and launched an
- * overlapping resume. The fix serializes resumes via `resumeInFlightRef`: no
- * new re-probe `resumeStream()` is issued while one is still outstanding.
+ * overlapping resume. Resume calls now share one full-lifetime operation; an
+ * eligible reconnect is retried only after that operation settles.
  *
  * This drives the REAL hook through a fake `EventTarget` agent (no Worker
  * needed) using exactly the frames a reconnect storm produces.
@@ -29,6 +29,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render as _render, cleanup } from "vitest-browser-react";
 import type { UIMessage } from "ai";
+import { StrictMode } from "react";
 import type { useAgent } from "../react";
 import { useAgentChat } from "../chat/react";
 
@@ -81,6 +82,10 @@ function open(target: EventTarget) {
   target.dispatchEvent(new Event("open"));
 }
 
+function close(target: EventTarget) {
+  target.dispatchEvent(new Event("close"));
+}
+
 const RESUMING = "cf_agent_stream_resuming";
 const RESUME_NONE = "cf_agent_stream_resume_none";
 const RESUME_REQUEST = "cf_agent_stream_resume_request";
@@ -98,7 +103,26 @@ function countType(sentMessages: string[], type: string): number {
     .filter((m) => m.type === type).length;
 }
 
-describe("reconnect-driven resume overlap (#1837)", () => {
+function lastFrameOfType(
+  sentMessages: string[],
+  type: string
+): Record<string, unknown> {
+  const frame = sentMessages
+    .map((message) => JSON.parse(message) as Record<string, unknown>)
+    .filter((message) => message.type === type)
+    .at(-1);
+  if (!frame) throw new Error(`No ${type} frame was sent`);
+  return frame;
+}
+
+type AgentChatResult = ReturnType<typeof useAgentChat>;
+
+function requireChat(chat: AgentChatResult | null): AgentChatResult {
+  if (!chat) throw new Error("Chat hook was not initialized");
+  return chat;
+}
+
+describe("reconnect-driven stream resume", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -110,7 +134,7 @@ describe("reconnect-driven resume overlap (#1837)", () => {
     cleanup();
   });
 
-  it("serializes overlapping resumes and never reads a cleared activeResponse", async () => {
+  it("serializes overlapping resumes and never reads a cleared activeResponse (#1837)", async () => {
     const { agent, target, sentMessages } = createFakeAgent({
       name: "overlap",
       url: "ws://localhost:3000/agents/chat/overlap?_pk=abc"
@@ -133,20 +157,19 @@ describe("reconnect-driven resume overlap (#1837)", () => {
     dispatch(target, { type: RESUME_NONE });
     await sleep(10);
 
-    // First "open" is consumed by the hook's first-open gate (hasConnectedOnce).
+    // A bare initial open is ignored. An actual close→open then fires resume A.
     open(target);
-    await sleep(10);
-
-    // A real reconnect: the re-probe fires resume A (sends a RESUME_REQUEST).
+    close(target);
     open(target);
-    await sleep(10);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(2);
+    });
 
     // Server announces resume A. The handshake resolves SYNCHRONOUSLY here, so
     // isAwaitingResume() flips false immediately — but the AI SDK only sets
-    // status to "submitted" in a *later microtask*. A second "open" dispatched
-    // in the same synchronous turn therefore sees statusRef === "ready" AND
-    // isAwaitingResume() === false. Pre-fix this launched an overlapping resume
-    // B; post-fix `resumeInFlightRef` suppresses it.
+    // status to "submitted" in a *later microtask*. A duplicate bare "open"
+    // dispatched in the same synchronous turn used to launch an overlapping
+    // resume B. Close→open tracking and the full-lifetime gate both reject it.
     const requestsBeforeOverlap = countType(sentMessages, RESUME_REQUEST);
     dispatch(target, { type: RESUMING, id: "s1" });
     open(target); // overlapping reconnect — no await before this
@@ -177,5 +200,540 @@ describe("reconnect-driven resume overlap (#1837)", () => {
     expect(requestsAfterOverlap).toBe(requestsBeforeOverlap);
     // ...and the AI SDK finalizer must never read a cleared activeResponse.
     expect(sawStateTypeError).toBe(false);
+  });
+
+  it("re-probes a real client error and clears only an explicitly idle result (#1914)", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "error-reconnect",
+      url: "ws://localhost:3000/agents/chat/error-reconnect?_pk=abc"
+    });
+
+    function TestComponent() {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        // #1913 is a client-side failure while otherwise-valid replay keeps
+        // running on the server. Throwing from the real AI SDK onData seam
+        // reproduces that split without inventing a server error frame.
+        onData: () => {
+          throw new Error("forced client stream failure");
+        }
+      });
+      return (
+        <div>
+          <div data-testid="status">{chat.status}</div>
+          <div data-testid="is-server-streaming">
+            {String(chat.isServerStreaming)}
+          </div>
+        </div>
+      );
+    }
+
+    const { container } = await render(<TestComponent />);
+
+    const expectHookState = async (status: string, isStreaming: boolean) => {
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('[data-testid="status"]')?.textContent
+        ).toBe(status);
+        expect(
+          container.querySelector('[data-testid="is-server-streaming"]')
+            ?.textContent
+        ).toBe(String(isStreaming));
+      });
+    };
+
+    // Settle the mount-time probe. A bare initial open does not re-probe; with
+    // no transport resolver waiting, the offer below enters the fallback.
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await expectHookState("ready", false);
+    open(target);
+
+    dispatch(target, { type: RESUMING, id: "s1" });
+    await expectHookState("ready", true);
+
+    // A stale/unowned NONE must not tear down the live fallback observer.
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await expectHookState("ready", true);
+
+    // Hand the observed stream to a transport-owned resume. A valid data chunk
+    // reaches onData and fails only the client stream; the simulated server
+    // remains active and deliberately omits its terminal frame.
+    close(target);
+    const requestsBeforeHandoff = countType(sentMessages, RESUME_REQUEST);
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(
+        requestsBeforeHandoff + 1
+      );
+    });
+    dispatch(target, { type: RESUMING, id: "s1" });
+    dispatch(target, {
+      type: CHAT_RESPONSE,
+      id: "s1",
+      body: JSON.stringify({
+        type: "data-client-failure",
+        data: { valid: true },
+        transient: true
+      }),
+      done: false
+    });
+    await expectHookState("error", true);
+
+    // The server completes while disconnected. Reconnect must probe even though
+    // AI SDK status remains error.
+    close(target);
+    const requestsBeforeErrorReconnect = countType(
+      sentMessages,
+      RESUME_REQUEST
+    );
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(
+        requestsBeforeErrorReconnect + 1
+      );
+    });
+
+    const activeProbeId = lastFrameOfType(sentMessages, RESUME_REQUEST).probeId;
+
+    // A late authoritative reply for an older probe must not settle or clear
+    // the current generation.
+    dispatch(target, {
+      type: RESUME_NONE,
+      reason: "idle",
+      probeId: "stale-probe"
+    });
+    await expectHookState("error", true);
+
+    // RESUME_NONE also means "an active continuation belongs to another live
+    // connection". It resolves this probe but must not clear fallback state.
+    dispatch(target, {
+      type: RESUME_NONE,
+      reason: "continuation-owned",
+      probeId: activeProbeId
+    });
+    dispatch(target, {
+      type: CHAT_RESPONSE,
+      id: "s1",
+      body: JSON.stringify({ type: "text-start", id: "still-live" }),
+      continuation: true,
+      done: false
+    });
+    await expectHookState("error", true);
+
+    // A later reconnect receives the distinct globally-idle result. Only this
+    // correlated active probe may settle the fallback observer.
+    close(target);
+    const requestsBeforeIdle = countType(sentMessages, RESUME_REQUEST);
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(
+        requestsBeforeIdle + 1
+      );
+    });
+    dispatch(target, {
+      type: RESUME_NONE,
+      reason: "idle",
+      probeId: lastFrameOfType(sentMessages, RESUME_REQUEST).probeId
+    });
+    await expectHookState("error", false);
+
+    const captured = (errorSpy.mock.calls.flat() as unknown[]).map(
+      (a: unknown) => (a instanceof Error ? a.message : String(a))
+    );
+    expect(
+      captured.some((message: string) =>
+        /reading 'state'|Cannot read properties of undefined/.test(message)
+      )
+    ).toBe(false);
+  });
+
+  it("retransmits an in-flight probe on the replacement socket", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "probe-retransmit",
+      url: "ws://localhost:3000/agents/chat/probe-retransmit?_pk=abc"
+    });
+
+    function TestComponent() {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[]
+      });
+      return (
+        <div data-testid="is-server-streaming">
+          {String(chat.isServerStreaming)}
+        </div>
+      );
+    }
+
+    const { container } = await render(<TestComponent />);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    open(target);
+
+    dispatch(target, { type: RESUMING, id: "lost-probe-stream" });
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="is-server-streaming"]')
+          ?.textContent
+      ).toBe("true");
+    });
+
+    close(target);
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(2);
+    });
+
+    // The reply to request 2 is lost with its socket. The replacement socket
+    // must retransmit that SAME transport handshake instead of starting an
+    // overlapping AI SDK resume or waiting five seconds with no queued retry.
+    close(target);
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(3);
+    });
+
+    dispatch(target, {
+      type: RESUME_NONE,
+      reason: "idle",
+      probeId: lastFrameOfType(sentMessages, RESUME_REQUEST).probeId
+    });
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="is-server-streaming"]')
+          ?.textContent
+      ).toBe("false");
+    });
+  });
+
+  it("recognizes a reconnect after mounting against an already-open agent", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "already-open",
+      url: "ws://localhost:3000/agents/chat/already-open?_pk=abc"
+    });
+
+    function TestComponent() {
+      useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[]
+      });
+      return null;
+    }
+
+    await render(<TestComponent />);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+
+    // No initial `open` event is observed by the hook: the parent agent was
+    // already connected when useAgentChat mounted. A close→open is still a real
+    // reconnect and must not be mistaken for the initial open.
+    close(target);
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(2);
+    });
+  });
+
+  it("queues an open that arrives while a local stream is still settling", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "status-transition",
+      url: "ws://localhost:3000/agents/chat/status-transition?_pk=abc"
+    });
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+
+    function TestComponent() {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[]
+      });
+      chatInstance = chat;
+      return <div data-testid="status">{chat.status}</div>;
+    }
+
+    const { container } = await render(<TestComponent />);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+
+    void requireChat(chatInstance).sendMessage({ text: "hello" });
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="status"]')?.textContent
+      ).toMatch(/submitted|streaming/);
+    });
+
+    // close synchronously terminates the transport stream, but React/AI SDK
+    // status reaches ready in a later job. The open edge must survive that gap.
+    close(target);
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(2);
+    });
+  });
+
+  it("reconciles an early fallback-observed tool continuation after lost done", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "early-tool-reconnect",
+      url: "ws://localhost:3000/agents/chat/early-tool-reconnect?_pk=abc"
+    });
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+    const initialMessages: UIMessage[] = [
+      {
+        id: "assistant-tool",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-clientTool",
+            toolCallId: "tool-1",
+            state: "input-available",
+            input: {}
+          }
+        ]
+      }
+    ];
+
+    function TestComponent() {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: initialMessages
+      });
+      chatInstance = chat;
+      return (
+        <div>
+          <div data-testid="tool">{String(chat.isToolContinuation)}</div>
+          <div data-testid="streaming">{String(chat.isServerStreaming)}</div>
+        </div>
+      );
+    }
+
+    const { container } = await render(<TestComponent />);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+
+    // The server announces the continuation before the zero-delay launcher can
+    // attach a transport stream, so the hook intentionally takes its fallback.
+    requireChat(chatInstance).addToolOutput({
+      toolCallId: "tool-1",
+      toolName: "clientTool",
+      output: { ok: true }
+    });
+    dispatch(target, { type: RESUMING, id: "early-continuation" });
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="tool"]')?.textContent).toBe(
+        "true"
+      );
+      expect(
+        container.querySelector('[data-testid="streaming"]')?.textContent
+      ).toBe("true");
+    });
+
+    // The terminal continuation frame is lost. Reconnect after server
+    // completion must bypass only the fallback-observed continuation guard.
+    close(target);
+    const beforeReconnect = countType(sentMessages, RESUME_REQUEST);
+    open(target);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(beforeReconnect + 1);
+    });
+    dispatch(target, {
+      type: RESUME_NONE,
+      reason: "idle",
+      probeId: lastFrameOfType(sentMessages, RESUME_REQUEST).probeId
+    });
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="tool"]')?.textContent).toBe(
+        "false"
+      );
+      expect(
+        container.querySelector('[data-testid="streaming"]')?.textContent
+      ).toBe("false");
+    });
+  });
+
+  it("clears a disconnected fallback observer when resume is disabled", async () => {
+    const { agent, target } = createFakeAgent({
+      name: "resume-disabled",
+      url: "ws://localhost:3000/agents/chat/resume-disabled?_pk=abc"
+    });
+
+    function TestComponent() {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[],
+        resume: false
+      });
+      return (
+        <div data-testid="streaming">{String(chat.isServerStreaming)}</div>
+      );
+    }
+
+    const { container } = await render(<TestComponent />);
+    dispatch(target, {
+      type: CHAT_RESPONSE,
+      id: "other-tab",
+      body: JSON.stringify({ type: "text-start", id: "text-1" }),
+      done: false
+    });
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="streaming"]')?.textContent
+      ).toBe("true");
+    });
+
+    close(target);
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="streaming"]')?.textContent
+      ).toBe("false");
+    });
+  });
+
+  it("cancels an old agent handshake before the new Chat generation probes", async () => {
+    const a = createFakeAgent({
+      name: "agent-a",
+      url: "ws://localhost:3000/agents/chat/agent-a?_pk=abc"
+    });
+    const b = createFakeAgent({
+      name: "agent-b",
+      url: "ws://localhost:3000/agents/chat/agent-b?_pk=def"
+    });
+
+    function TestComponent({ agent }: { agent: ReturnType<typeof useAgent> }) {
+      useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[]
+      });
+      return null;
+    }
+
+    const screen = await render(<TestComponent agent={a.agent} />);
+    await vi.waitFor(() => {
+      expect(countType(a.sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+
+    screen.rerender(<TestComponent agent={b.agent} />);
+    await vi.waitFor(() => {
+      expect(countType(b.sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+
+    // A late offer from A has no listener/resolver ownership and cannot be ACKed
+    // through B or mark B's request ID transport-owned.
+    dispatch(a.target, { type: RESUMING, id: "stale-a" });
+    await sleep(10);
+    expect(countType(b.sentMessages, "cf_agent_stream_resume_ack")).toBe(0);
+
+    dispatch(b.target, { type: RESUMING, id: "current-b" });
+    await vi.waitFor(() => {
+      expect(countType(b.sentMessages, "cf_agent_stream_resume_ack")).toBe(1);
+    });
+    dispatch(b.target, {
+      type: CHAT_RESPONSE,
+      id: "current-b",
+      body: "",
+      done: true
+    });
+  });
+
+  it("keeps StrictMode mount generations identity-owned", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "strict-resume",
+      url: "ws://localhost:3000/agents/chat/strict-resume?_pk=abc"
+    });
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+
+    function TestComponent() {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[]
+      });
+      chatInstance = chat;
+      return null;
+    }
+
+    await render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>
+    );
+    await sleep(20);
+
+    const requests = sentMessages
+      .map((message) => JSON.parse(message) as Record<string, unknown>)
+      .filter((message) => message.type === RESUME_REQUEST);
+    expect(requests).toHaveLength(2);
+
+    // The first setup was cleaned up. Its late correlated response cannot
+    // settle the second setup's resolver or make a public call start a third.
+    dispatch(target, {
+      type: RESUME_NONE,
+      reason: "idle",
+      probeId: requests[0].probeId
+    });
+    const current = requireChat(chatInstance).resumeStream();
+    await sleep(10);
+    expect(countType(sentMessages, RESUME_REQUEST)).toBe(2);
+
+    dispatch(target, {
+      type: RESUME_NONE,
+      reason: "idle",
+      probeId: requests[1].probeId
+    });
+    await current;
+  });
+
+  it("single-flights the public resume helper with reconnect-driven resumes", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "public-resume",
+      url: "ws://localhost:3000/agents/chat/public-resume?_pk=abc"
+    });
+    let chatInstance: ReturnType<typeof useAgentChat> | null = null;
+
+    function TestComponent() {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: [] as UIMessage[]
+      });
+      chatInstance = chat;
+      return null;
+    }
+
+    await render(<TestComponent />);
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(1);
+    });
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await sleep(10);
+
+    const before = countType(sentMessages, RESUME_REQUEST);
+    const first = requireChat(chatInstance).resumeStream();
+    const second = requireChat(chatInstance).resumeStream();
+    await vi.waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBe(before + 1);
+    });
+    expect(second).toBe(first);
+
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await Promise.all([first, second]);
+    expect(countType(sentMessages, RESUME_REQUEST)).toBe(before + 1);
   });
 });

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -1162,7 +1162,10 @@ export class AIChatAgent<
         // avoiding the race condition where CF_AGENT_STREAM_RESUMING sent
         // in onConnect arrives before the client's handler is ready.
         if (event.type === "stream-resume-request") {
-          await this._resumeHandshake().handleResumeRequest(connection);
+          await this._resumeHandshake().handleResumeRequest(
+            connection,
+            event.probeId
+          );
           return;
         }
 

--- a/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
+++ b/packages/ai-chat/src/react-tests/use-agent-chat.test.tsx
@@ -6695,7 +6695,7 @@ describe("useAgentChat transparent reconnect re-probe (#1784)", () => {
 
   const RESUME_REQUEST = "cf_agent_stream_resume_request";
 
-  it("re-probes the stream on a SUBSEQUENT socket open, but not the first", async () => {
+  it("re-probes on a close-to-open transition, but not a bare initial open", async () => {
     const { agent, target, sentMessages } = createAgentWithTarget({
       name: "reconnect-reprobe",
       url: "ws://localhost:3000/agents/chat/reconnect-reprobe?_pk=abc"
@@ -6729,22 +6729,26 @@ describe("useAgentChat transparent reconnect re-probe (#1784)", () => {
 
     // Settle any mount-time resume probe so the transport is no longer awaiting.
     await act(async () => {
-      dispatch(target, { type: "cf_agent_stream_resume_none" });
+      dispatch(target, {
+        type: "cf_agent_stream_resume_none",
+        reason: "idle"
+      });
       await sleep(20);
     });
 
     const baseline = resumeRequests();
 
-    // First "open" is treated as the initial connect — no re-probe.
+    // A bare open with no observed close is the initial connect — no re-probe.
     await act(async () => {
       target.dispatchEvent(new Event("open"));
       await sleep(20);
     });
     expect(resumeRequests()).toBe(baseline);
 
-    // A SUBSEQUENT open is a transparent reconnect (e.g. 1006) that does NOT
+    // A close→open is a transparent reconnect (e.g. 1006) that does NOT
     // remount the component → the hook must re-probe so AI SDK status recovers.
     await act(async () => {
+      target.dispatchEvent(new Event("close"));
       target.dispatchEvent(new Event("open"));
       await sleep(20);
     });

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -873,7 +873,8 @@ describe("Resumable Streaming", () => {
       // Send resume request when there's no active stream
       ws.send(
         JSON.stringify({
-          type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST
+          type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST,
+          probeId: "probe-idle-ai-chat"
         })
       );
 
@@ -891,7 +892,10 @@ describe("Resumable Streaming", () => {
           "type" in m &&
           m.type === MessageType.CF_AGENT_STREAM_RESUME_NONE
       );
-      expect(noneMsg).toBeDefined();
+      expect(noneMsg).toMatchObject({
+        reason: "idle",
+        probeId: "probe-idle-ai-chat"
+      });
 
       ws.close(1000);
     });

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -106,6 +106,65 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(result).toBeInstanceOf(ReadableStream);
   });
 
+  it("does not overwrite an active handshake with a concurrent caller", async () => {
+    const first = transport.reconnectToStream({ chatId: "chat-1" });
+    const second = transport.reconnectToStream({ chatId: "chat-1" });
+
+    await expect(second).resolves.toBeNull();
+    expect(agent.sent).toHaveLength(1);
+    expect(transport.handleStreamResuming({ id: "req-owned" })).toBe(true);
+    await expect(first).resolves.toBeInstanceOf(ReadableStream);
+  });
+
+  it("retransmits the active handshake without creating another resolver", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+    expect(agent.sent).toHaveLength(1);
+
+    expect(transport.retryPendingResume()).toBe(true);
+    expect(agent.sent).toHaveLength(2);
+    expect(agent.sent.map((message) => JSON.parse(message).type)).toEqual([
+      MessageType.CF_AGENT_STREAM_RESUME_REQUEST,
+      MessageType.CF_AGENT_STREAM_RESUME_REQUEST
+    ]);
+
+    expect(transport.handleStreamResumeNone()).toBe(true);
+    await expect(promise).resolves.toBeNull();
+    expect(transport.retryPendingResume()).toBe(false);
+  });
+
+  it("settles an old agent's resolver before accepting a new generation", async () => {
+    const oldPromise = transport.reconnectToStream({ chatId: "chat-1" });
+    const replacement = createMockAgent();
+
+    transport.setAgent(replacement);
+    await expect(oldPromise).resolves.toBeNull();
+    expect(transport.handleStreamResuming({ id: "stale" })).toBe(false);
+
+    const currentPromise = transport.reconnectToStream({ chatId: "chat-1" });
+    expect(replacement.sent).toHaveLength(1);
+    expect(transport.handleStreamResuming({ id: "current" })).toBe(true);
+    await expect(currentPromise).resolves.toBeInstanceOf(ReadableStream);
+  });
+
+  it("locally detaches an attached resume stream on agent replacement", async () => {
+    const oldPromise = transport.reconnectToStream({ chatId: "chat-1" });
+    transport.handleStreamResuming({ id: "old-stream" });
+    const oldStream = (await oldPromise) as ReadableStream<UIMessageChunk>;
+    const reader = oldStream.getReader();
+    const replacement = createMockAgent();
+
+    transport.setAgent(replacement);
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined
+    });
+    expect(activeRequestIds.has("old-stream")).toBe(false);
+
+    const currentPromise = transport.reconnectToStream({ chatId: "chat-1" });
+    expect(transport.handleStreamResuming({ id: "new-stream" })).toBe(true);
+    await expect(currentPromise).resolves.toBeInstanceOf(ReadableStream);
+  });
+
   // ── handleStreamResuming resolves reconnectToStream ──────────────────
 
   it("resolves with ReadableStream when handleStreamResuming is called", async () => {
@@ -239,6 +298,22 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
     const result = await promise;
     expect(result).toBeNull();
+  });
+
+  it("rejects a correlated NONE owned by an older probe", async () => {
+    const promise = transport.reconnectToStream({ chatId: "chat-1" });
+    const requestFrame = agent.sent.at(-1);
+    if (!requestFrame) throw new Error("Expected a resume request");
+    const request = JSON.parse(requestFrame) as { probeId: string };
+
+    expect(transport.handleStreamResumeNone({ probeId: "stale-probe" })).toBe(
+      false
+    );
+    expect(transport.isAwaitingResume()).toBe(true);
+    expect(transport.handleStreamResumeNone({ probeId: request.probeId })).toBe(
+      true
+    );
+    await expect(promise).resolves.toBeNull();
   });
 
   it("tool continuation path registers handleStreamResuming resolver", async () => {
@@ -586,28 +661,16 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
   // ── Idempotency / double-call safety ─────────────────────────────────
 
-  it("only the latest reconnectToStream's resolver is active (React strict mode)", async () => {
-    vi.useFakeTimers();
-    try {
-      // Simulate React strict mode: effect runs twice
-      const promise1 = transport.reconnectToStream({ chatId: "chat-1" });
-      const promise2 = transport.reconnectToStream({ chatId: "chat-1" });
+  it("keeps the first resolver identity-owned under a StrictMode double call", async () => {
+    const promise1 = transport.reconnectToStream({ chatId: "chat-1" });
+    const promise2 = transport.reconnectToStream({ chatId: "chat-1" });
 
-      // handleStreamResuming only triggers the LATEST resolver
-      const handled = transport.handleStreamResuming({ id: "req-sm" });
-      expect(handled).toBe(true);
-
-      // Second call resolves with a stream
-      const stream2 = await promise2;
-      expect(stream2).toBeInstanceOf(ReadableStream);
-
-      // First call's resolver was overwritten — it times out
-      vi.advanceTimersByTime(5001);
-      const stream1 = await promise1;
-      expect(stream1).toBeNull();
-    } finally {
-      vi.useRealTimers();
-    }
+    // The duplicate declines immediately instead of overwriting callbacks whose
+    // older timeout could later erase the active resolver set.
+    await expect(promise2).resolves.toBeNull();
+    expect(agent.sent).toHaveLength(1);
+    expect(transport.handleStreamResuming({ id: "req-sm" })).toBe(true);
+    await expect(promise1).resolves.toBeInstanceOf(ReadableStream);
   });
 
   it("handleStreamResuming returns false after resolver is consumed", async () => {

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -2695,7 +2695,7 @@ describe("resume coordination during pending continuation", () => {
     await closeWS(ws);
   });
 
-  it("sends STREAM_RESUME_NONE to non-initiating connections during active continuation", async () => {
+  it("correlates idle STREAM_RESUME_NONE after a continuation completes", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);
     const { ws: ws1 } = await connectWS(room);
@@ -2751,10 +2751,19 @@ describe("resume coordination during pending continuation", () => {
     await delay(100);
 
     const nonePromise = waitForMessageOfType(ws2, MSG_STREAM_RESUME_NONE, 3000);
-    ws2.send(JSON.stringify({ type: MSG_STREAM_RESUME_REQUEST }));
+    ws2.send(
+      JSON.stringify({
+        type: MSG_STREAM_RESUME_REQUEST,
+        probeId: "probe-idle-continuation"
+      })
+    );
 
     const noneMsg = await nonePromise;
-    expect(noneMsg.type).toBe(MSG_STREAM_RESUME_NONE);
+    expect(noneMsg).toMatchObject({
+      type: MSG_STREAM_RESUME_NONE,
+      reason: "idle",
+      probeId: "probe-idle-continuation"
+    });
 
     await closeWS(ws1);
     await closeWS(ws2);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -10638,7 +10638,7 @@ export class Think<
   ): Promise<void> {
     switch (event.type) {
       case "stream-resume-request":
-        await this._handleStreamResumeRequest(connection);
+        await this._handleStreamResumeRequest(connection, event.probeId);
         break;
 
       case "stream-resume-ack":
@@ -10711,9 +10711,10 @@ export class Think<
   }
 
   private async _handleStreamResumeRequest(
-    connection: Connection
+    connection: Connection,
+    probeId?: string
   ): Promise<void> {
-    await this._resumeHandshake().handleResumeRequest(connection);
+    await this._resumeHandshake().handleResumeRequest(connection, probeId);
   }
 
   private async _handleStreamResumeAck(


### PR DESCRIPTION
## Summary

- allow `useAgentChat` to reconcile a server turn after the AI SDK client has entered `error`, rather than limiting reconnect probes to `ready`
- correlate resume probes across replacement sockets and distinguish globally idle agents from active continuations owned by another connection
- retain reconnect-open edges while status or an existing resume settles, retransmit an in-flight handshake on the new socket, and serialize mount/reconnect/tool/public resume entry points
- add real-hook regression coverage for the reported client-error/server-still-running split, plus reconnect races, StrictMode, tool continuations, agent replacement, and `resume: false`
- ship patch changesets for `agents`, `@cloudflare/ai-chat`, and `@cloudflare/think`

## Why

`isServerStreaming` tracks server broadcasts independently from the AI SDK chat status. If a client-side failure moved the chat to `error` and the terminal server frame was missed, every later reconnect was rejected by the `status === "ready"` re-probe guard. The server could finish normally while the client remained stuck in a streaming state until reload.

Removing that guard alone is not sufficient:

- `STREAM_RESUME_NONE` can mean either global inactivity or that another live connection owns an active continuation
- a resume request or response can be lost with the socket that carried it
- overlapping AI SDK resume operations regress the `activeResponse` race fixed in #1838

Resume requests therefore carry optional probe IDs that direct server responses echo. `STREAM_RESUME_NONE` also carries an optional reason (`idle` or `continuation-owned`). The hook clears fallback streaming state only after a correlated `idle` response. These fields are additive: older clients ignore them, while uncorrelated responses still settle the transport without being treated as authoritative global-idle evidence.

## Testing

- `pnpm --filter agents exec vitest --run --project react src/react-tests/resume-overlap-race.test.tsx`
- `pnpm --filter agents run test:react`
- `pnpm --filter agents run test:chat`
- `pnpm --filter @cloudflare/ai-chat exec vitest --run src/tests/ws-transport-resume.test.ts`
- `pnpm --filter @cloudflare/ai-chat run test:react`
- `pnpm --filter @cloudflare/think run test:react`
- `pnpm run check`

Closes #1914

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->