### PR TITLE
fix(shell): align codemode dependency version

### DIFF
--- a/.changeset/tidy-shells-wave.md
+++ b/.changeset/tidy-shells-wave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/shell": patch
+---
+
+Require `@cloudflare/codemode` 0.5.0 or newer.

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/cloudflare/agents/issues"
   },
   "dependencies": {
-    "@cloudflare/codemode": ">=0.4.0",
+    "@cloudflare/codemode": ">=0.5.0",
     "isomorphic-git": "^1.38.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3954,7 +3954,7 @@ importers:
   packages/shell:
     dependencies:
       '@cloudflare/codemode':
-        specifier: '>=0.4.0'
+        specifier: '>=0.5.0'
         version: link:../codemode
       isomorphic-git:
         specifier: ^1.38.5


### PR DESCRIPTION
This PR aligns `@cloudflare/shell` with the workspace-wide `@cloudflare/codemode` dependency floor.

## Why

- `pnpm check` fails Sherif because published workspace packages declare both `>=0.4.0` and `>=0.5.0` for `@cloudflare/codemode`.
- `agents` and `@cloudflare/think` already require `>=0.5.0`, so retaining the older floor only in `@cloudflare/shell` leaves the workspace inconsistent.

## Code Changes

- Raises the `@cloudflare/shell` runtime dependency on `@cloudflare/codemode` from `>=0.4.0` to `>=0.5.0`.
- Updates the matching lockfile importer and adds a patch changeset.

## Compatibility

Consumers of `@cloudflare/shell` must use `@cloudflare/codemode` 0.5.0 or newer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/1977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->