### PR TITLE
fix(observability): bound top-level approval spans

### DIFF
--- a/.changeset/neat-spans-nest.md
+++ b/.changeset/neat-spans-nest.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Mark asynchronously decided AI SDK v7 top-level approval spans when they outlive their invocation.

--- a/packages/agents/src/observability/ai/v6/wrap.ts
+++ b/packages/agents/src/observability/ai/v6/wrap.ts
@@ -281,7 +281,8 @@ function operationParamsForCall(
           toolApproval: wrapToolApprovalPolicy(
             tracer,
             params.toolApproval,
-            approvedToolCalls
+            approvedToolCalls,
+            boundToInvocation
           )
         }
       : {}),

--- a/packages/agents/src/tests/observability/ai-sdk-v7-integration.test.ts
+++ b/packages/agents/src/tests/observability/ai-sdk-v7-integration.test.ts
@@ -529,6 +529,41 @@ describe("wrapAISDK with the real AI SDK v7", () => {
     ).toBe(true);
   });
 
+  it("marks top-level approval spans decided after the invocation ended", async () => {
+    const tracing = new RecordingTracer();
+    const decided = deferred<"user-approval">();
+    let escaped: Promise<unknown> | undefined;
+
+    await withInvocationScope(async () => {
+      escaped = wrap(tracing).generateText({
+        [Symbol.for("cloudflare.agents.ai-sdk.invocation-bounded")]: true,
+        model: approvalRequestModel(),
+        prompt: "Deploy",
+        toolApproval: async () => decided.promise,
+        tools: {
+          deploy: ai.tool({
+            execute: async () => "deployed",
+            inputSchema: z.object({ target: z.string() })
+          })
+        }
+      } as Parameters<typeof ai.generateText>[0]);
+    });
+
+    decided.resolve("user-approval");
+    await escaped;
+
+    const approval = tracing.spans.find(
+      (span) => span.name === "tool_approval deploy"
+    );
+    expect(approval?.attributes["cloudflare.agents.tool.approval.state"]).toBe(
+      "requested"
+    );
+    expect(approval?.attributes["cloudflare.agents.span.truncated"]).toBe(true);
+    expect(
+      approval?.parent?.attributes["cloudflare.agents.span.truncated"]
+    ).toBe(true);
+  });
+
   it("leaves approval spans decided inside the invocation unmarked", async () => {
     const tracing = new RecordingTracer();
 


### PR DESCRIPTION
Follow-up to #1982.

AI SDK v7 top-level `toolApproval` policies were not receiving the invocation lifetime policy, so asynchronously-decided approval spans could be emitted as complete after their invocation had already ended. Pass the existing boundary through and cover the escaped-invocation path with the real v7 SDK.