### PR TITLE
Simplify Agents SDK trace spans

### DIFF
--- a/.changeset/tidy-agent-traces.md
+++ b/.changeset/tidy-agent-traces.md
@@ -4,4 +4,4 @@
 "@cloudflare/think": patch
 ---
 
-Reduce SDK trace noise by consolidating initialization, chat setup, and fiber lifecycle spans around semantic agent operations.
+Reduce SDK trace noise and use consistent verb-object names for agent lifecycle, request handling, turns, submissions, and response streaming.

--- a/.changeset/tidy-agent-traces.md
+++ b/.changeset/tidy-agent-traces.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Reduce SDK trace noise by consolidating initialization, chat setup, and fiber lifecycle spans around semantic agent operations.

--- a/docs/agents/observability.md
+++ b/docs/agents/observability.md
@@ -260,16 +260,22 @@ These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track
 | `email:receive` | `{ from, to, subject? }` | An email is received  |
 | `email:reply`   | `{ from, to, subject? }` | A reply email is sent |
 
-## Agent initialization span
+## Agent lifecycle spans
 
-When Worker traces are enabled, the base Agent constructor runs inside one
-`agent_initialization` span and startup runs inside one `agent_start` span.
-AIChat and Think retain one component-level initialization span so constructor
-and startup storage remains grouped, but internal setup steps do not emit
-additional spans. Each span carries `cloudflare.agents.agent.name` (the agent
-class), `cloudflare.agents.agent.id` (the named instance), and
+When Worker traces are enabled, Agent lifecycle work is grouped under stable
+verb-object span names:
+
+- `initialize_agent` covers base constructor setup.
+- `initialize_chat_agent` covers AIChat constructor setup.
+- `start_agent` covers base startup and recovery.
+- `start_agent_runtime` covers Think runtime and session startup.
+
+Internal setup steps do not emit additional spans. Each lifecycle span carries
+`cloudflare.agents.agent.name` (the agent class),
+`cloudflare.agents.agent.id` (the named instance), and
 `cloudflare.agents.operation.name`. Like the rest of the tracing in this
-package, it is a no-op when the runtime has no native tracing capability.
+package, lifecycle tracing is a no-op when the runtime has no native tracing
+capability.
 
 ## AI SDK tracing
 
@@ -282,14 +288,19 @@ integration is a no-op when the runtime has no native tracing capability.
 
 **Think agents are traced out of the box.** Enable
 `observability.traces.enabled` in `wrangler.jsonc`; no Think option is required.
-A turn gets an `invoke_agent {agent class}` operation span, `chat {model}` model
-spans, and `execute_tool {tool}` spans. Think always supplies its durable
-identity: `gen_ai.agent.name` is the class name, `gen_ai.agent.id` is the named
-instance, and `gen_ai.conversation.id` is the opaque Durable Object ID. These
-are defaults; `beforeTurn` can override `functionId` or the corresponding
-metadata fields for applications with a different identity model. Payload
-storage is off by default. Set `storeMessages` and/or `storeTools` on the Think
-agent to opt in; these are wrapper settings, not span attributes.
+A chat request is handled under `handle_chat_request`, and each admitted turn
+runs under `run_agent_turn`. The turn contains `invoke_agent {agent class}`
+operation spans, `chat {model}` model spans, `execute_tool {tool}` spans, and a
+`stream_agent_response` span while the response is consumed, broadcast, and
+persisted. Durable turns use `submit_agent_turn` when accepted and
+`run_submitted_agent_turn` when later executed. Think always supplies its
+durable identity: `gen_ai.agent.name` is the class name,
+`gen_ai.agent.id` is the named instance, and `gen_ai.conversation.id` is the
+opaque Durable Object ID. These are defaults; `beforeTurn` can override
+`functionId` or the corresponding metadata fields for applications with a
+different identity model. Payload storage is off by default. Set
+`storeMessages` and/or `storeTools` on the Think agent to opt in; these are
+wrapper settings, not span attributes.
 
 ### AI SDK v6 and v7
 

--- a/docs/agents/observability.md
+++ b/docs/agents/observability.md
@@ -262,15 +262,14 @@ These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track
 
 ## Agent initialization span
 
-When Worker traces are enabled, every `Agent` constructor runs its setup —
-method wrapping, schema creation, and MCP client manager initialization —
-inside an `agent_initialization` span. Constructor-time child spans group under
-this one stable parent instead of appearing as top-level clutter. The span
-carries `cloudflare.agents.agent.name` (the agent class),
-`cloudflare.agents.agent.id` (the named instance, omitted when the name is not
-yet readable during construction), and `cloudflare.agents.operation.name`
-(`agent_initialization`). Like the rest of the tracing in this package, it is a
-no-op when the runtime has no native tracing capability.
+When Worker traces are enabled, the base Agent startup runs inside one
+`agent_initialization` span. Internal state restoration, recovery, and user
+startup hooks do not emit additional setup spans. The span carries
+`cloudflare.agents.agent.name` (the agent class),
+`cloudflare.agents.agent.id` (the named instance), and
+`cloudflare.agents.operation.name` (`agent_initialization`). Like the rest of
+the tracing in this package, it is a no-op when the runtime has no native
+tracing capability.
 
 ## AI SDK tracing
 

--- a/docs/agents/observability.md
+++ b/docs/agents/observability.md
@@ -262,14 +262,14 @@ These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track
 
 ## Agent initialization span
 
-When Worker traces are enabled, the base Agent startup runs inside one
-`agent_initialization` span. Internal state restoration, recovery, and user
-startup hooks do not emit additional setup spans. The span carries
-`cloudflare.agents.agent.name` (the agent class),
-`cloudflare.agents.agent.id` (the named instance), and
-`cloudflare.agents.operation.name` (`agent_initialization`). Like the rest of
-the tracing in this package, it is a no-op when the runtime has no native
-tracing capability.
+When Worker traces are enabled, the base Agent constructor runs inside one
+`agent_initialization` span and startup runs inside one `agent_start` span.
+AIChat and Think retain one component-level initialization span so constructor
+and startup storage remains grouped, but internal setup steps do not emit
+additional spans. Each span carries `cloudflare.agents.agent.name` (the agent
+class), `cloudflare.agents.agent.id` (the named instance), and
+`cloudflare.agents.operation.name`. Like the rest of the tracing in this
+package, it is a no-op when the runtime has no native tracing capability.
 
 ## AI SDK tracing
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2802,7 +2802,7 @@ export class Agent<
       );
     };
     this.onStart = (props?: Props) =>
-      this._withAgentSpan("agent_initialization", "startup", {}, (update) =>
+      this._withAgentSpan("agent_start", "startup", {}, (update) =>
         startAgent(props, update)
       );
   }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2321,20 +2321,27 @@ export class Agent<
   constructor(ctx: AgentContext, env: Env) {
     super(ctx, env);
 
-    if (!wrappedClasses.has(this.constructor)) {
-      // Auto-wrap custom methods with agent context
-      this._autoWrapCustomMethods();
-      wrappedClasses.add(this.constructor);
-    }
+    this.mcp = this._withAgentSpan(
+      "agent_initialization",
+      "initialization",
+      {},
+      () => {
+        if (!wrappedClasses.has(this.constructor)) {
+          // Auto-wrap custom methods with agent context
+          this._autoWrapCustomMethods();
+          wrappedClasses.add(this.constructor);
+        }
 
-    this._ensureSchema();
+        this._ensureSchema();
 
-    // Initialize MCPClientManager AFTER tables are created
-    this.mcp = new MCPClientManager(this._ParentClass.name, "0.0.1", {
-      storage: this.ctx.storage,
-      createAuthProvider: (callbackUrl) =>
-        this.createMcpOAuthProvider(callbackUrl)
-    });
+        // Initialize MCPClientManager AFTER tables are created
+        return new MCPClientManager(this._ParentClass.name, "0.0.1", {
+          storage: this.ctx.storage,
+          createAuthProvider: (callbackUrl) =>
+            this.createMcpOAuthProvider(callbackUrl)
+        });
+      }
+    );
 
     // Broadcast server state whenever MCP state changes (register, connect, OAuth, remove, etc.)
     this._disposables.add(

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1958,14 +1958,6 @@ export class Agent<
       throw new SqlError(query, e);
     }
   }
-  private _schemaInitialization:
-    | {
-        previousVersion: number;
-        currentVersion: number;
-        migrated: boolean;
-      }
-    | undefined;
-
   /**
    * Create all internal tables and run migrations if needed.
    * Called by the constructor on every wake. Idempotent — skips DDL when
@@ -2324,55 +2316,25 @@ export class Agent<
         VALUES (${SCHEMA_VERSION_ROW_ID}, ${String(CURRENT_SCHEMA_VERSION)})
       `;
     }
-
-    this._schemaInitialization = {
-      previousVersion: schemaVersion,
-      currentVersion: CURRENT_SCHEMA_VERSION,
-      migrated: schemaVersion < CURRENT_SCHEMA_VERSION
-    };
   }
 
   constructor(ctx: AgentContext, env: Env) {
     super(ctx, env);
 
-    this.mcp = this._withAgentSpan(
-      "agent_initialization",
-      "initialization",
-      {},
-      (update) => {
-        if (!wrappedClasses.has(this.constructor)) {
-          // Auto-wrap custom methods with agent context
-          this._autoWrapCustomMethods();
-          wrappedClasses.add(this.constructor);
-        }
+    if (!wrappedClasses.has(this.constructor)) {
+      // Auto-wrap custom methods with agent context
+      this._autoWrapCustomMethods();
+      wrappedClasses.add(this.constructor);
+    }
 
-        this._withAgentSpan(
-          "initialize_agent_storage",
-          "initialization",
-          {},
-          (updateStorage) => {
-            this._ensureSchema();
-            const schemaAttributes = {
-              "cloudflare.agents.schema.version.previous":
-                this._schemaInitialization?.previousVersion,
-              "cloudflare.agents.schema.version.current":
-                this._schemaInitialization?.currentVersion,
-              "cloudflare.agents.schema.migrated":
-                this._schemaInitialization?.migrated
-            };
-            updateStorage(schemaAttributes);
-            update(schemaAttributes);
-          }
-        );
+    this._ensureSchema();
 
-        // Initialize MCPClientManager AFTER tables are created
-        return new MCPClientManager(this._ParentClass.name, "0.0.1", {
-          storage: this.ctx.storage,
-          createAuthProvider: (callbackUrl) =>
-            this.createMcpOAuthProvider(callbackUrl)
-        });
-      }
-    );
+    // Initialize MCPClientManager AFTER tables are created
+    this.mcp = new MCPClientManager(this._ParentClass.name, "0.0.1", {
+      storage: this.ctx.storage,
+      createAuthProvider: (callbackUrl) =>
+        this.createMcpOAuthProvider(callbackUrl)
+    });
 
     // Broadcast server state whenever MCP state changes (register, connect, OAuth, remove, etc.)
     this._disposables.add(
@@ -2731,67 +2693,46 @@ export class Agent<
           email: undefined
         },
         async () => {
-          await this._withAgentSpan(
-            "restore_agent_state",
-            "startup",
-            {},
-            async () => {
-              // Hydrate _isFacet from persistent storage so the flag
-              // survives hibernation (the DO constructor resets it to false).
-              const isFacet =
-                await this.ctx.storage.get<boolean>("cf_agents_is_facet");
-              if (isFacet) this._isFacet = true;
+          // Hydrate _isFacet from persistent storage so the flag survives
+          // hibernation (the DO constructor resets it to false).
+          const isFacet =
+            await this.ctx.storage.get<boolean>("cf_agents_is_facet");
+          if (isFacet) this._isFacet = true;
 
-              const storedFacetName = await this.ctx.storage.get<string>(
-                "cf_agents_facet_name"
-              );
-              if (typeof storedFacetName === "string") {
-                this._facetName = storedFacetName;
-              }
-
-              const storedParentPath = await this.ctx.storage.get<
-                Array<{ className: string; name: string }>
-              >("cf_agents_parent_path");
-              if (isValidParentPath(storedParentPath)) {
-                this._parentPath = storedParentPath;
-              }
-              try {
-                await this._cf_hydrateSubAgentConnectionsFromRoot();
-              } catch (error) {
-                console.warn(
-                  "[Agent] Unable to hydrate sub-agent WebSocket connections:",
-                  error
-                );
-              }
-            }
+          const storedFacetName = await this.ctx.storage.get<string>(
+            "cf_agents_facet_name"
           );
+          if (typeof storedFacetName === "string") {
+            this._facetName = storedFacetName;
+          }
+
+          const storedParentPath = await this.ctx.storage.get<
+            Array<{ className: string; name: string }>
+          >("cf_agents_parent_path");
+          if (isValidParentPath(storedParentPath)) {
+            this._parentPath = storedParentPath;
+          }
+          try {
+            await this._cf_hydrateSubAgentConnectionsFromRoot();
+          } catch (error) {
+            console.warn(
+              "[Agent] Unable to hydrate sub-agent WebSocket connections:",
+              error
+            );
+          }
 
           await this._tryCatch(async () => {
             // Restore MCP connections before fiber/chat recovery so recovered
             // turns see MCP tools. Restored connections re-advertise the
             // capabilities persisted from the previous session; the handlers
             // behind them attach when onStart() configures them.
-            await this._withAgentSpan(
-              "restore_mcp_connections",
-              "startup",
-              {},
-              async () => {
-                await this.mcp.restoreConnectionsFromStorage(this.name);
-                await this._restoreRpcMcpServers();
-                this.broadcastMcpServers();
-              }
-            );
+            await this.mcp.restoreConnectionsFromStorage(this.name);
+            await this._restoreRpcMcpServers();
+            this.broadcastMcpServers();
 
-            const startupAgentToolRunIds = await this._withAgentSpan(
-              "recover_agent_work",
-              "startup",
-              {},
-              async () => {
-                this._checkOrphanedWorkflows();
-                await this._checkRunFibers();
-                return this._agentToolRunRecoveryRunIds();
-              }
-            );
+            this._checkOrphanedWorkflows();
+            await this._checkRunFibers();
+            const startupAgentToolRunIds = this._agentToolRunRecoveryRunIds();
             update({
               "cloudflare.agents.start.facet": this._isFacet,
               "cloudflare.agents.recovery.agent_tools.count":
@@ -2812,12 +2753,7 @@ export class Agent<
             this._warnedScheduleInOnStart.clear();
             let result: Awaited<ReturnType<typeof _onStart>>;
             try {
-              result = await this._withAgentSpan(
-                "run_user_on_start",
-                "startup",
-                {},
-                () => _onStart(props)
-              );
+              result = await _onStart(props);
             } finally {
               this._insideOnStart = false;
             }
@@ -2859,7 +2795,7 @@ export class Agent<
       );
     };
     this.onStart = (props?: Props) =>
-      this._withAgentSpan("agent_start", "startup", {}, (update) =>
+      this._withAgentSpan("agent_initialization", "startup", {}, (update) =>
         startAgent(props, update)
       );
   }
@@ -5680,26 +5616,16 @@ export class Agent<
 
     const writeSnapshot = (data: unknown) => {
       const snapshot = JSON.stringify(data);
-      this._withAgentSpan(
-        "persist_fiber_snapshot",
-        "fiber",
-        {
-          "cloudflare.agents.fiber.id": id,
-          "cloudflare.agents.fiber.name": name
-        },
-        () => {
-          this.sql`
-            UPDATE cf_agents_runs SET snapshot = ${snapshot}
-            WHERE id = ${id}
-          `;
-          if (options?.managed) {
-            this.sql`
-              UPDATE cf_agents_fibers SET snapshot = ${snapshot}
-              WHERE fiber_id = ${id}
-            `;
-          }
-        }
-      );
+      this.sql`
+        UPDATE cf_agents_runs SET snapshot = ${snapshot}
+        WHERE id = ${id}
+      `;
+      if (options?.managed) {
+        this.sql`
+          UPDATE cf_agents_fibers SET snapshot = ${snapshot}
+          WHERE fiber_id = ${id}
+        `;
+      }
     };
 
     let root: RootFacetRpcSurface | undefined;
@@ -5746,17 +5672,7 @@ export class Agent<
       }
     } finally {
       this._runFiberActiveFibers.delete(id);
-      this._withAgentSpan(
-        "finalize_fiber",
-        "fiber",
-        {
-          "cloudflare.agents.fiber.id": id,
-          "cloudflare.agents.fiber.name": name
-        },
-        () => {
-          this.sql`DELETE FROM cf_agents_runs WHERE id = ${id}`;
-        }
-      );
+      this.sql`DELETE FROM cf_agents_runs WHERE id = ${id}`;
       dispose();
       if (root && registeredFacetRun) {
         try {
@@ -6486,12 +6402,6 @@ export class Agent<
   }
 
   private async _scheduleNextAlarm(): Promise<void> {
-    await this._withAgentSpan("schedule_agent_alarm", "alarm", {}, () =>
-      this._scheduleNextAlarmBody()
-    );
-  }
-
-  private async _scheduleNextAlarmBody(): Promise<void> {
     // A pending destroy (#1625) owns the alarm: keep it armed immediately so
     // teardown lands, and never let the "no work pending" branch below
     // delete it out from under `_cf_scheduleDestroy`.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2322,7 +2322,7 @@ export class Agent<
     super(ctx, env);
 
     this.mcp = this._withAgentSpan(
-      "agent_initialization",
+      "initialize_agent",
       "initialization",
       {},
       () => {
@@ -2802,7 +2802,7 @@ export class Agent<
       );
     };
     this.onStart = (props?: Props) =>
-      this._withAgentSpan("agent_start", "startup", {}, (update) =>
+      this._withAgentSpan("start_agent", "startup", {}, (update) =>
         startAgent(props, update)
       );
   }
@@ -5599,20 +5599,10 @@ export class Agent<
     options?: InternalFiberOptions
   ): Promise<T> {
     const signal = options?.signal ?? new AbortController().signal;
-    this._withAgentSpan(
-      "initialize_fiber",
-      "fiber",
-      {
-        "cloudflare.agents.fiber.id": id,
-        "cloudflare.agents.fiber.name": name
-      },
-      () => {
-        this.sql`
-          INSERT INTO cf_agents_runs (id, name, snapshot, created_at)
-          VALUES (${id}, ${name}, NULL, ${Date.now()})
-        `;
-      }
-    );
+    this.sql`
+      INSERT INTO cf_agents_runs (id, name, snapshot, created_at)
+      VALUES (${id}, ${name}, NULL, ${Date.now()})
+    `;
     const startedAt = Date.now();
     this._emit("fiber:run:started", {
       fiberId: id,

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -801,7 +801,7 @@ export class AIChatAgent<
     super(ctx, env);
     withAgentSpan(
       this,
-      "chat_initialization",
+      "initialize_chat_agent",
       "initialization",
       { "cloudflare.agents.component": "ai_chat" },
       () => {
@@ -954,17 +954,7 @@ export class AIChatAgent<
           // A genuinely-new turn supersedes any pending terminal record (#1645)
           // so a stale exhaustion can't replay on a later reconnect once the
           // user has moved on.
-          await withAgentSpan(
-            this,
-            "chat_interaction_setup",
-            "interaction",
-            {
-              "cloudflare.agents.component": "ai_chat",
-              "cloudflare.agents.turn.request_id": chatMessageId,
-              "cloudflare.agents.turn.trigger": requestTrigger
-            },
-            () => this._clearChatTerminal()
-          );
+          await this._clearChatTerminal();
 
           // Mark this turn as accepted-but-not-yet-streamed (#1784) so a client
           // that reconnects/re-mounts before the stream starts is parked and
@@ -1113,7 +1103,7 @@ export class AIChatAgent<
                           if (response) {
                             await withAgentSpan(
                               this,
-                              "persist_chat_result",
+                              "stream_agent_response",
                               "turn",
                               {
                                 "cloudflare.agents.component": "ai_chat",
@@ -1326,7 +1316,7 @@ export class AIChatAgent<
       if (event?.type === "chat-request") {
         return withAgentSpan(
           this,
-          "chat_interaction",
+          "handle_chat_request",
           "interaction",
           {
             "cloudflare.agents.component": "ai_chat",
@@ -2568,7 +2558,7 @@ export class AIChatAgent<
             () =>
               withAgentSpan(
                 this,
-                "chat_turn",
+                "run_agent_turn",
                 "turn",
                 {
                   "cloudflare.agents.component": "ai_chat",

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -801,7 +801,7 @@ export class AIChatAgent<
     super(ctx, env);
     withAgentSpan(
       this,
-      "agent_initialization",
+      "chat_initialization",
       "initialization",
       { "cloudflare.agents.component": "ai_chat" },
       () => {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -799,26 +799,34 @@ export class AIChatAgent<
 
   constructor(ctx: AgentContext, env: Env) {
     super(ctx, env);
-    this.sql`create table if not exists cf_ai_chat_agent_messages (
-      id text primary key,
-      message text not null,
-      created_at datetime default current_timestamp
-    )`;
+    withAgentSpan(
+      this,
+      "agent_initialization",
+      "initialization",
+      { "cloudflare.agents.component": "ai_chat" },
+      () => {
+        this.sql`create table if not exists cf_ai_chat_agent_messages (
+          id text primary key,
+          message text not null,
+          created_at datetime default current_timestamp
+        )`;
 
-    // Key-value table for request context that must survive hibernation
-    // (e.g., custom body fields, client tools from the last chat request).
-    this.sql`create table if not exists cf_ai_chat_request_context (
-      key text primary key,
-      value text not null
-    )`;
+        // Key-value table for request context that must survive hibernation
+        // (e.g., custom body fields, client tools from the last chat request).
+        this.sql`create table if not exists cf_ai_chat_request_context (
+          key text primary key,
+          value text not null
+        )`;
 
-    this._ensureAgentToolTables();
-    this._restoreRequestContext();
-    this._resumableStream = new ResumableStream(this.sql.bind(this));
+        this._ensureAgentToolTables();
+        this._restoreRequestContext();
+        this._resumableStream = new ResumableStream(this.sql.bind(this));
 
-    const rawMessages = this._loadMessagesFromDb();
-    // Automatic migration following https://jhak.im/blog/ai-sdk-migration-handling-previously-saved-messages
-    this.messages = autoTransformMessages(rawMessages);
+        const rawMessages = this._loadMessagesFromDb();
+        // Automatic migration following https://jhak.im/blog/ai-sdk-migration-handling-previously-saved-messages
+        this.messages = autoTransformMessages(rawMessages);
+      }
+    );
 
     this._abortRegistry = new AbortRegistry();
     const _onConnect = this.onConnect.bind(this);

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -799,72 +799,26 @@ export class AIChatAgent<
 
   constructor(ctx: AgentContext, env: Env) {
     super(ctx, env);
-    withAgentSpan(
-      this,
-      "chat_initialization",
-      "initialization",
-      { "cloudflare.agents.component": "ai_chat" },
-      (update) => {
-        withAgentSpan(
-          this,
-          "initialize_chat_storage",
-          "initialization",
-          { "cloudflare.agents.component": "ai_chat" },
-          () => {
-            this.sql`create table if not exists cf_ai_chat_agent_messages (
-              id text primary key,
-              message text not null,
-              created_at datetime default current_timestamp
-            )`;
+    this.sql`create table if not exists cf_ai_chat_agent_messages (
+      id text primary key,
+      message text not null,
+      created_at datetime default current_timestamp
+    )`;
 
-            // Key-value table for request context that must survive hibernation
-            // (e.g., custom body fields, client tools from the last chat request).
-            this.sql`create table if not exists cf_ai_chat_request_context (
-              key text primary key,
-              value text not null
-            )`;
+    // Key-value table for request context that must survive hibernation
+    // (e.g., custom body fields, client tools from the last chat request).
+    this.sql`create table if not exists cf_ai_chat_request_context (
+      key text primary key,
+      value text not null
+    )`;
 
-            this._ensureAgentToolTables();
-          }
-        );
+    this._ensureAgentToolTables();
+    this._restoreRequestContext();
+    this._resumableStream = new ResumableStream(this.sql.bind(this));
 
-        // Restore request context from SQLite (survives hibernation)
-        withAgentSpan(
-          this,
-          "restore_chat_request_context",
-          "initialization",
-          { "cloudflare.agents.component": "ai_chat" },
-          () => this._restoreRequestContext()
-        );
-
-        // Initialize resumable stream manager (creates its own tables + restores state)
-        withAgentSpan(
-          this,
-          "initialize_resumable_stream",
-          "initialization",
-          { "cloudflare.agents.component": "ai_chat" },
-          () => {
-            this._resumableStream = new ResumableStream(this.sql.bind(this));
-          }
-        );
-
-        const rawMessages = withAgentSpan(
-          this,
-          "load_chat_messages",
-          "initialization",
-          { "cloudflare.agents.component": "ai_chat" },
-          () => this._loadMessagesFromDb()
-        );
-
-        // Automatic migration following https://jhak.im/blog/ai-sdk-migration-handling-previously-saved-messages
-        this.messages = autoTransformMessages(rawMessages);
-        update({
-          "cloudflare.agents.chat.messages.loaded": rawMessages.length,
-          "cloudflare.agents.chat.active_stream.restored":
-            this._resumableStream.hasActiveStream()
-        });
-      }
-    );
+    const rawMessages = this._loadMessagesFromDb();
+    // Automatic migration following https://jhak.im/blog/ai-sdk-migration-handling-previously-saved-messages
+    this.messages = autoTransformMessages(rawMessages);
 
     this._abortRegistry = new AbortRegistry();
     const _onConnect = this.onConnect.bind(this);
@@ -994,7 +948,7 @@ export class AIChatAgent<
           // user has moved on.
           await withAgentSpan(
             this,
-            "clear_previous_chat_state",
+            "chat_interaction_setup",
             "interaction",
             {
               "cloudflare.agents.component": "ai_chat",
@@ -1031,35 +985,21 @@ export class AIChatAgent<
               // queue so other tabs see the new message immediately and so
               // overlapping submits under latest/merge/debounce can inspect
               // the full message list when their turn starts.
-              await withAgentSpan(
-                this,
-                "persist_incoming_messages",
-                "interaction",
+              this._broadcastChatMessage(
                 {
-                  "cloudflare.agents.component": "ai_chat",
-                  "cloudflare.agents.turn.request_id": chatMessageId,
-                  "cloudflare.agents.turn.trigger": requestTrigger
+                  messages: transformedMessages,
+                  type: MessageType.CF_AGENT_CHAT_MESSAGES
                 },
-                async () => {
-                  this._broadcastChatMessage(
-                    {
-                      messages: transformedMessages,
-                      type: MessageType.CF_AGENT_CHAT_MESSAGES
-                    },
-                    [connection.id]
-                  );
-
-                  await this.persistMessages(
-                    transformedMessages,
-                    [connection.id],
-                    { _deleteStaleRows: true }
-                  );
-
-                  if (concurrencyDecision.strategy === "merge") {
-                    await this._mergeQueuedUserMessages(epoch);
-                  }
-                }
+                [connection.id]
               );
+
+              await this.persistMessages(transformedMessages, [connection.id], {
+                _deleteStaleRows: true
+              });
+
+              if (concurrencyDecision.strategy === "merge") {
+                await this._mergeQueuedUserMessages(epoch);
+              }
             } finally {
               releasePendingEnqueue();
             }
@@ -1098,19 +1038,7 @@ export class AIChatAgent<
                 // Re-merge inside the lock: more overlapping submits may have
                 // persisted additional user messages while this turn was queued.
                 if (concurrencyDecision.strategy === "merge") {
-                  await withAgentSpan(
-                    this,
-                    "merge_queued_messages",
-                    "turn",
-                    {
-                      "cloudflare.agents.component": "ai_chat",
-                      "cloudflare.agents.turn.request_id": chatMessageId,
-                      "cloudflare.agents.turn.trigger": requestTrigger,
-                      "cloudflare.agents.turn.admission": "queue",
-                      "cloudflare.agents.turn.generation": epoch
-                    },
-                    () => this._mergeQueuedUserMessages(epoch)
-                  );
+                  await this._mergeQueuedUserMessages(epoch);
 
                   if (this._turnQueue.generation !== epoch) {
                     this._completeSkippedRequest(connection, chatMessageId);
@@ -1127,33 +1055,19 @@ export class AIChatAgent<
                   }
                 }
 
-                await withAgentSpan(
-                  this,
-                  "prepare_chat_context",
-                  "turn",
-                  {
-                    "cloudflare.agents.component": "ai_chat",
-                    "cloudflare.agents.turn.request_id": chatMessageId,
-                    "cloudflare.agents.turn.trigger": requestTrigger,
-                    "cloudflare.agents.turn.admission": "queue",
-                    "cloudflare.agents.turn.generation": epoch
-                  },
-                  async () => {
-                    // Optionally wait for in-flight MCP connections to settle (e.g. after hibernation restore)
-                    // so that getAITools() returns the full set of tools in onChatMessage
-                    if (this.waitForMcpConnections) {
-                      const timeout =
-                        typeof this.waitForMcpConnections === "object"
-                          ? this.waitForMcpConnections.timeout
-                          : undefined;
-                      await this.mcp.waitForConnections(
-                        timeout != null ? { timeout } : undefined
-                      );
-                    }
+                // Optionally wait for in-flight MCP connections to settle (e.g. after hibernation restore)
+                // so that getAITools() returns the full set of tools in onChatMessage
+                if (this.waitForMcpConnections) {
+                  const timeout =
+                    typeof this.waitForMcpConnections === "object"
+                      ? this.waitForMcpConnections.timeout
+                      : undefined;
+                  await this.mcp.waitForConnections(
+                    timeout != null ? { timeout } : undefined
+                  );
+                }
 
-                    this._setRequestContext(requestClientTools, requestBody);
-                  }
-                );
+                this._setRequestContext(requestClientTools, requestBody);
 
                 this._emit("message:request");
 
@@ -1173,20 +1087,7 @@ export class AIChatAgent<
                     async () => {
                       const chatTurnBody = async () => {
                         try {
-                          await withAgentSpan(
-                            this,
-                            "repair_interrupted_tools",
-                            "turn",
-                            {
-                              "cloudflare.agents.component": "ai_chat",
-                              "cloudflare.agents.turn.request_id":
-                                chatMessageId,
-                              "cloudflare.agents.turn.trigger": requestTrigger,
-                              "cloudflare.agents.turn.admission": "queue",
-                              "cloudflare.agents.turn.generation": epoch
-                            },
-                            () => this._repairInterruptedToolsBeforeTurn()
-                          );
+                          await this._repairInterruptedToolsBeforeTurn();
                           const response = await this.onChatMessage(
                             async (_finishResult) => {
                               // User-provided hook. Cleanup is now handled by _reply,

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -3027,7 +3027,7 @@ export class Think<
     this.onStart = (props?: Props) =>
       withAgentSpan(
         this,
-        "think_start",
+        "start_agent_runtime",
         "startup",
         { "cloudflare.agents.component": "think" },
         () => startThink(props)
@@ -7055,7 +7055,9 @@ export class Think<
       // channel context must be set here too.
       return withAgentSpan(
         this,
-        "chat_submission",
+        spec.admission === "submit"
+          ? "submit_agent_turn"
+          : "run_submitted_agent_turn",
         "submission",
         {
           "cloudflare.agents.component": "think",
@@ -7063,21 +7065,7 @@ export class Think<
           "cloudflare.agents.turn.admission": spec.admission,
           "cloudflare.agents.turn.channel": spec.channel
         },
-        () =>
-          withAgentSpan(
-            this,
-            spec.admission === "submit"
-              ? "accept_chat_submission"
-              : "execute_chat_submission",
-            "submission",
-            {
-              "cloudflare.agents.component": "think",
-              "cloudflare.agents.turn.trigger": spec.trigger,
-              "cloudflare.agents.turn.admission": spec.admission,
-              "cloudflare.agents.turn.channel": spec.channel
-            },
-            () => this._withChannelContext(spec.channel, () => spec.execute())
-          )
+        () => this._withChannelContext(spec.channel, () => spec.execute())
       );
     }
 
@@ -7117,7 +7105,7 @@ export class Think<
       () =>
         withAgentSpan(
           this,
-          "chat_turn",
+          "run_agent_turn",
           "turn",
           {
             "cloudflare.agents.component": "think",
@@ -11125,7 +11113,7 @@ export class Think<
           if (event.type === "chat-request") {
             await withAgentSpan(
               this,
-              "chat_interaction",
+              "handle_chat_request",
               "interaction",
               {
                 "cloudflare.agents.component": "think",
@@ -11315,17 +11303,7 @@ export class Think<
     // gap would surface the previous failed turn's error even though the user
     // has already moved on. Completion clears it too, but only once the turn
     // resolves — which leaves the gap open.
-    await withAgentSpan(
-      this,
-      "chat_interaction_setup",
-      "interaction",
-      {
-        "cloudflare.agents.component": "think",
-        "cloudflare.agents.turn.request_id": requestId,
-        "cloudflare.agents.turn.trigger": "ws-chat"
-      },
-      () => this._clearChatTerminal()
-    );
+    await this._clearChatTerminal();
 
     // Mark this turn as accepted-but-not-yet-streamed (#1784) so a client that
     // reconnects/re-mounts before the stream starts is parked and told to keep
@@ -11499,7 +11477,7 @@ export class Think<
 
                 await withAgentSpan(
                   this,
-                  "persist_chat_result",
+                  "stream_agent_response",
                   "turn",
                   {
                     "cloudflare.agents.component": "think",
@@ -11523,7 +11501,7 @@ export class Think<
                   ) {
                     const shortened = await withAgentSpan(
                       this,
-                      "compact_chat_history",
+                      "compact_conversation_history",
                       "turn",
                       {
                         "cloudflare.agents.component": "think",

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -3024,7 +3024,14 @@ export class Think<
         this._scheduleMediaEvictionPass({ force: true });
       }
     };
-    this.onStart = (props?: Props) => startThink(props);
+    this.onStart = (props?: Props) =>
+      withAgentSpan(
+        this,
+        "think_start",
+        "startup",
+        { "cloudflare.agents.component": "think" },
+        () => startThink(props)
+      );
   }
 
   /**

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -2903,59 +2903,46 @@ export class Think<
     super(ctx, env);
 
     const _onStart = this.onStart.bind(this);
-    const startThink = async (
-      props: Props | undefined,
-      update: UpdateAgentSpan
-    ) => {
-      await withAgentSpan(
-        this,
-        "initialize_think_session",
-        "startup",
-        { "cloudflare.agents.component": "think" },
-        async () => {
-          // 1. Workspace initialization
-          if (!this.workspace) {
-            this.workspace = new Workspace({
-              sql: this.ctx.storage.sql,
-              name: () => this.name
-            });
-          }
+    const startThink = async (props: Props | undefined) => {
+      // 1. Workspace initialization
+      if (!this.workspace) {
+        this.workspace = new Workspace({
+          sql: this.ctx.storage.sql,
+          name: () => this.name
+        });
+      }
 
-          // 2. Session configuration (builder phase — context blocks, compaction, skills)
-          const baseSession = Session.create(this);
-          this.session = await this.configureSession(baseSession);
-          this.session.internal_onMessagesChanged(async (event) => {
-            switch (event.type) {
-              case "append":
-                if (!event.inserted || event.parentId !== undefined) {
-                  await this._syncMessages();
-                } else {
-                  this._upsertCachedMessage(event.message as UIMessage);
-                }
-                // The conversation grew — older messages may have aged out of
-                // the keep-recent window. Only schedule the maintenance scan once
-                // this session has actually observed oversized media; otherwise a
-                // normal text-only chat would pay a row-stat read after every turn.
-                this._scheduleMediaEvictionAfterAppend(
-                  event.message as UIMessage
-                );
-                break;
-              case "update":
-                this._patchCachedMessage(event.message as UIMessage);
-                break;
-              case "clear":
-                this._replaceCachedMessages([]);
-                break;
-              case "delete":
-              case "compact":
-                await this._syncMessages();
-                break;
+      // 2. Session configuration (builder phase — context blocks, compaction, skills)
+      const baseSession = Session.create(this);
+      this.session = await this.configureSession(baseSession);
+      this.session.internal_onMessagesChanged(async (event) => {
+        switch (event.type) {
+          case "append":
+            if (!event.inserted || event.parentId !== undefined) {
+              await this._syncMessages();
+            } else {
+              this._upsertCachedMessage(event.message as UIMessage);
             }
-          });
-
-          await this._initializeSkills();
+            // The conversation grew — older messages may have aged out of
+            // the keep-recent window. Only schedule the maintenance scan once
+            // this session has actually observed oversized media; otherwise a
+            // normal text-only chat would pay a row-stat read after every turn.
+            this._scheduleMediaEvictionAfterAppend(event.message as UIMessage);
+            break;
+          case "update":
+            this._patchCachedMessage(event.message as UIMessage);
+            break;
+          case "clear":
+            this._replaceCachedMessages([]);
+            break;
+          case "delete":
+          case "compact":
+            await this._syncMessages();
+            break;
         }
-      );
+      });
+
+      await this._initializeSkills();
 
       // Force Session to initialize its tables (assistant_messages,
       // assistant_compactions, assistant_config, etc.) so that subsequent
@@ -2968,53 +2955,31 @@ export class Think<
       // history is untouched and the next safe-boundary `_syncMessages()`
       // retries.
       this._onStartDegradations = [];
-      await withAgentSpan(
-        this,
-        "hydrate_think_session",
-        "startup",
-        { "cloudflare.agents.component": "think" },
-        async () => {
-          const hydrated = await this._runBestEffortOnStartStep(
-            "transcript-hydration",
-            () => this._syncMessages(),
-            "The agent is starting with an empty in-memory message view; " +
-              "persisted history is untouched. If the error is SQLITE_NOMEM, " +
-              "the stored transcript is too large to hydrate (often inline " +
-              "base64 media in tool results) — compact or clear the session " +
-              "to recover."
-          );
-          if (!hydrated) {
-            this._replaceCachedMessages([]);
-          }
-          this._refreshMediaEvictionSignalFromCache();
-        }
+      const hydrated = await this._runBestEffortOnStartStep(
+        "transcript-hydration",
+        () => this._syncMessages(),
+        "The agent is starting with an empty in-memory message view; " +
+          "persisted history is untouched. If the error is SQLITE_NOMEM, " +
+          "the stored transcript is too large to hydrate (often inline " +
+          "base64 media in tool results) — compact or clear the session " +
+          "to recover."
       );
+      if (!hydrated) {
+        this._replaceCachedMessages([]);
+      }
+      this._refreshMediaEvictionSignalFromCache();
 
       // 3-6. Extension initialization (if extensionLoader is set)
       if (this.extensionLoader) {
-        await withAgentSpan(
-          this,
-          "initialize_think_extensions",
-          "startup",
-          { "cloudflare.agents.component": "think" },
-          () => this._initializeExtensions()
-        );
+        await this._initializeExtensions();
       }
 
       // 7. Protocol handlers
-      await withAgentSpan(
-        this,
-        "initialize_think_chat",
-        "startup",
-        { "cloudflare.agents.component": "think" },
-        async () => {
-          this._resumableStream = new ResumableStream(this.sql.bind(this));
-          this._restoreClientTools();
-          this._restoreBody();
-          this._setupProtocolHandlers();
-          await this._initializeChannels();
-        }
-      );
+      this._resumableStream = new ResumableStream(this.sql.bind(this));
+      this._restoreClientTools();
+      this._restoreBody();
+      this._setupProtocolHandlers();
+      await this._initializeChannels();
 
       // 8. User's onStart
       await _onStart(props);
@@ -3024,46 +2989,32 @@ export class Think<
       // Best-effort: reconcile runs after the agent is otherwise functional,
       // and a failure (user getScheduledTasks() throwing, storage pressure)
       // must not brick the DO (#1710).
-      await withAgentSpan(
-        this,
-        "reconcile_think_schedules",
-        "startup",
-        { "cloudflare.agents.component": "think" },
-        () =>
-          this._runBestEffortOnStartStep(
-            "scheduled-task-reconcile",
-            () => this._reconcileDeclaredScheduledTasks(),
-            "Declared scheduled tasks were not reconciled on this wake; the " +
-              "next successful wake will reconcile them."
-          )
+      await this._runBestEffortOnStartStep(
+        "scheduled-task-reconcile",
+        () => this._reconcileDeclaredScheduledTasks(),
+        "Declared scheduled tasks were not reconciled on this wake; the " +
+          "next successful wake will reconcile them."
       );
 
       // 10. Durable submissions may run user-defined model/hooks, so start them
       // after subclass initialization has completed. Best-effort for the same
       // reason as step 9.
-      await withAgentSpan(
-        this,
-        "recover_think_durable_work",
-        "startup",
-        { "cloudflare.agents.component": "think" },
-        () =>
-          this._runBestEffortOnStartStep(
-            "durable-work-recovery",
-            async () => {
-              await this._sweepActionLedger();
-              await this._sweepActionPendingApprovals();
-              await this._recoverSubmissionsOnStart();
-              this._recoverWorkflowNotifications();
-              if (this._hasPendingSubmissions()) {
-                await this._scheduleSubmissionDrain();
-              }
-              if (this._hasPendingWorkflowNotifications()) {
-                this._startWorkflowNotificationDrain();
-              }
-            },
-            "Pending submissions / workflow notifications were not recovered on " +
-              "this wake; the next successful wake will recover them."
-          )
+      await this._runBestEffortOnStartStep(
+        "durable-work-recovery",
+        async () => {
+          await this._sweepActionLedger();
+          await this._sweepActionPendingApprovals();
+          await this._recoverSubmissionsOnStart();
+          this._recoverWorkflowNotifications();
+          if (this._hasPendingSubmissions()) {
+            await this._scheduleSubmissionDrain();
+          }
+          if (this._hasPendingWorkflowNotifications()) {
+            this._startWorkflowNotificationDrain();
+          }
+        },
+        "Pending submissions / workflow notifications were not recovered on " +
+          "this wake; the next successful wake will recover them."
       );
 
       // 11. Background bound on the persisted transcript: if hydration was
@@ -3072,24 +3023,8 @@ export class Think<
       if (this._lastHydration?.truncated) {
         this._scheduleMediaEvictionPass({ force: true });
       }
-
-      update({
-        "cloudflare.agents.hydration.messages":
-          this._lastHydration?.hydratedMessages,
-        "cloudflare.agents.hydration.content_bytes":
-          this._lastHydration?.totalContentBytes,
-        "cloudflare.agents.hydration.truncated": this._lastHydration?.truncated,
-        "cloudflare.agents.start.degradations": this._onStartDegradations.length
-      });
     };
-    this.onStart = (props?: Props) =>
-      withAgentSpan(
-        this,
-        "think_start",
-        "startup",
-        { "cloudflare.agents.component": "think" },
-        (update) => startThink(props, update)
-      );
+    this.onStart = (props?: Props) => startThink(props);
   }
 
   /**
@@ -5552,26 +5487,7 @@ export class Think<
    * for interception, and calls streamText.
    */
   private async _runInferenceLoop(input: TurnInput): Promise<StreamableResult> {
-    const turn = admittedTurnContext.getStore();
-    const invoke = await withAgentSpan(
-      this,
-      "prepare_agent",
-      "turn",
-      {
-        "cloudflare.agents.component": "think",
-        ...(turn?.agent === this
-          ? {
-              "cloudflare.agents.turn.request_id": turn.requestId,
-              "cloudflare.agents.turn.trigger": turn.trigger,
-              "cloudflare.agents.turn.admission": turn.admission,
-              "cloudflare.agents.turn.channel": turn.channel,
-              "cloudflare.agents.turn.continuation": turn.continuation,
-              "cloudflare.agents.turn.generation": turn.generation
-            }
-          : {})
-      },
-      () => this._prepareInferenceInvocation(input)
-    );
+    const invoke = await this._prepareInferenceInvocation(input);
     return invoke();
   }
 
@@ -11394,7 +11310,7 @@ export class Think<
     // resolves — which leaves the gap open.
     await withAgentSpan(
       this,
-      "clear_previous_chat_state",
+      "chat_interaction_setup",
       "interaction",
       {
         "cloudflare.agents.component": "think",
@@ -11427,28 +11343,16 @@ export class Think<
           : undefined;
       const requestBody =
         Object.keys(customBody).length > 0 ? customBody : undefined;
-      withAgentSpan(
-        this,
-        "persist_chat_request_context",
-        "interaction",
-        {
-          "cloudflare.agents.component": "think",
-          "cloudflare.agents.turn.request_id": requestId,
-          "cloudflare.agents.turn.trigger": "ws-chat"
-        },
-        () => {
-          if (requestClientTools) {
-            this._lastClientTools = requestClientTools;
-            this._persistClientTools();
-          } else if (rawClientTools !== undefined) {
-            this._lastClientTools = undefined;
-            this._persistClientTools();
-          }
+      if (requestClientTools) {
+        this._lastClientTools = requestClientTools;
+        this._persistClientTools();
+      } else if (rawClientTools !== undefined) {
+        this._lastClientTools = undefined;
+        this._persistClientTools();
+      }
 
-          this._lastBody = requestBody;
-          this._persistBody();
-        }
-      );
+      this._lastBody = requestBody;
+      this._persistBody();
 
       // ── Reconcile, persist, and broadcast user messages ──────────
       //
@@ -11462,17 +11366,7 @@ export class Think<
       const clientToolsForTurn = this._lastClientTools;
       const bodyForTurn = this._lastBody;
 
-      const serverMessages = await withAgentSpan(
-        this,
-        "load_chat_history",
-        "interaction",
-        {
-          "cloudflare.agents.component": "think",
-          "cloudflare.agents.turn.request_id": requestId,
-          "cloudflare.agents.turn.trigger": "ws-chat"
-        },
-        () => this._readMessagesFromStorage()
-      );
+      const serverMessages = await this._readMessagesFromStorage();
       const reconciled = reconcileMessages(
         incomingMessages,
         serverMessages,
@@ -11484,28 +11378,18 @@ export class Think<
         branchParentId = reconciled[reconciled.length - 1].id;
       }
 
-      const persisted = await withAgentSpan(
-        this,
-        "persist_incoming_messages",
-        "interaction",
-        {
-          "cloudflare.agents.component": "think",
-          "cloudflare.agents.turn.request_id": requestId,
-          "cloudflare.agents.turn.trigger": "ws-chat"
-        },
-        async () => {
-          if (this._turnQueue.generation !== epoch) return false;
+      const persisted = await (async () => {
+        if (this._turnQueue.generation !== epoch) return false;
 
-          for (const msg of reconciled) {
-            if (this._turnQueue.generation !== epoch) return false;
-            await this._persistIncomingMessage(msg, serverMessages);
-          }
-
+        for (const msg of reconciled) {
           if (this._turnQueue.generation !== epoch) return false;
-          await this._syncMessages();
-          return true;
+          await this._persistIncomingMessage(msg, serverMessages);
         }
-      );
+
+        if (this._turnQueue.generation !== epoch) return false;
+        await this._syncMessages();
+        return true;
+      })();
       if (!persisted) {
         this._completeSkippedRequest(connection, requestId);
         return;


### PR DESCRIPTION
Agents SDK traces currently emit many near-zero-duration implementation spans. That adds ingestion cost and hides the agent turn and model invocation users actually need.

Collapse internal startup, request setup, and fiber lifecycle bookkeeping while retaining the lifecycle spans that group native storage operations. Use stable verb-object names for request handling, agent turns, durable submissions, and response streaming. Keep agent invocation, model calls, and tool execution visible through the OpenTelemetry GenAI hierarchy.

## Before

```text
hibernatableWebSocket (50.18s)
├── agent_initialization (0ms)
├── durable_object_storage_get (0ms)
├── think_start (0ms)
└── chat_interaction (9.64s)
    ├── clear_previous_chat_state (0ms)
    ├── persist_chat_request_context (0ms)
    ├── load_chat_history (0ms)
    ├── persist_incoming_messages (0ms)
    ├── schedule_agent_alarm (0ms)
    ├── chat_turn (9.64s)
    │   ├── initialize_fiber (0ms)
    │   ├── persist_fiber_snapshot (0ms)
    │   ├── prepare_agent (0ms)
    │   ├── invoke_agent TestbedAgent (9.64s)
    │   │   └── chat @cf/moonshotai/kimi-k2.6 (9.64s)
    │   ├── persist_chat_result (9.64s)
    │   └── finalize_fiber (0ms)
    └── schedule_agent_alarm (0ms)
```

## After

```text
hibernatableWebSocket (50.18s)
├── initialize_agent (0ms)
├── start_agent_runtime (0ms)
│   └── start_agent (0ms)
└── handle_chat_request (9.64s)
    └── run_agent_turn (9.64s)
        ├── invoke_agent TestbedAgent (9.64s)
        │   └── chat @cf/moonshotai/kimi-k2.6 (9.64s)
        └── stream_agent_response (9.64s)
```

Think durable turns use `submit_agent_turn` when accepted and `run_submitted_agent_turn` when later executed. Context overflow recovery appears as `compact_conversation_history` only when compaction runs.
