### PR TITLE
Automatically report AgentWorkflow completion so that lifecycle tracking stays synchronized

### DIFF
--- a/.changeset/automatic-agent-workflow-lifecycle.md
+++ b/.changeset/automatic-agent-workflow-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Automatically report successful `AgentWorkflow` completion and its returned result to the originating Agent. Workflows no longer need to call `step.reportComplete()` for Agent lifecycle callbacks and tracking to stay synchronized.

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -91,9 +91,7 @@ export class ProcessingWorkflow extends AgentWorkflow<MyAgent, TaskParams> {
       taskId: params.taskId
     });
 
-    // Report completion (durable via step)
-    await step.reportComplete(result);
-
+    // Returning reports completion and the result to the Agent automatically.
     return result;
   }
 }
@@ -210,14 +208,14 @@ Base class for Workflows that integrate with Agents.
 
 **Methods on `step` (durable, idempotent, won't repeat on retry):**
 
-| Method                          | Description                                    |
-| ------------------------------- | ---------------------------------------------- |
-| `step.reportComplete(result?)`  | Report successful completion                   |
-| `step.reportError(error)`       | Report an error                                |
-| `step.sendEvent(event)`         | Send a custom event to the Agent               |
-| `step.updateAgentState(state)`  | Replace Agent state (broadcasts to clients)    |
-| `step.mergeAgentState(partial)` | Merge into Agent state (broadcasts to clients) |
-| `step.resetAgentState()`        | Reset Agent state to initialState              |
+| Method                          | Description                                         |
+| ------------------------------- | --------------------------------------------------- |
+| `step.reportComplete(result?)`  | Explicitly report completion before `run()` returns |
+| `step.reportError(error)`       | Report a non-terminal error event                   |
+| `step.sendEvent(event)`         | Send a custom event to the Agent                    |
+| `step.updateAgentState(state)`  | Replace Agent state (broadcasts to clients)         |
+| `step.mergeAgentState(partial)` | Merge into Agent state (broadcasts to clients)      |
+| `step.resetAgentState()`        | Reset Agent state to initialState                   |
 
 **DefaultProgress Type:**
 
@@ -796,7 +794,8 @@ await this.reportProgress({
 });
 this.broadcastToClients({ type: "update", data });
 
-// Durable callbacks via step (idempotent, won't repeat on retry)
+// Terminal callbacks are automatic when run() returns or throws.
+// These methods remain available for explicit lifecycle notifications.
 await step.reportComplete(result);
 await step.reportError("Something went wrong");
 await step.sendEvent({ type: "custom", data: {} });
@@ -836,7 +835,7 @@ const approvalData = await this.waitForApproval(step, { timeout: "7 days" });
 1. **Keep workflows focused** - One workflow per logical task
 2. **Use meaningful step names** - Helps with debugging and observability
 3. **Report progress regularly** - Keeps users informed
-4. **Handle errors gracefully** - Use `reportError()` before throwing
+4. **Preserve error context** - Throw an `Error` with the message that `onWorkflowError()` should receive
 5. **Clean up completed workflows** - The `cf_agents_workflows` table can grow unbounded, so implement a retention policy:
 
 ```typescript

--- a/packages/agents/src/tests/test-workflow.ts
+++ b/packages/agents/src/tests/test-workflow.ts
@@ -56,10 +56,9 @@ export class TestProcessingWorkflow extends AgentWorkflow<
       }>("wait-for-approval", { type: "approval", timeout: "1 minute" });
 
       if (!approval.payload.approved) {
-        await step.reportError(
+        throw new Error(
           `Rejected: ${approval.payload.reason || "No reason given"}`
         );
-        throw new Error("Workflow rejected");
       }
     }
 
@@ -107,8 +106,6 @@ export class TestProcessingWorkflow extends AgentWorkflow<
       percent: 0.9,
       message: "Almost done"
     });
-    await step.reportComplete(result);
-
     return result;
   }
 }

--- a/packages/agents/src/tests/workflow-integration.test.ts
+++ b/packages/agents/src/tests/workflow-integration.test.ts
@@ -166,9 +166,22 @@ describe("AgentWorkflow integration", () => {
 
       const callbacks =
         (await agentStub.getCallbacksReceived()) as CallbackRecord[];
-      expect(callbacks.some((c: CallbackRecord) => c.type === "complete")).toBe(
-        true
+      const completeCallbacks = callbacks.filter(
+        (c: CallbackRecord) => c.type === "complete"
       );
+      expect(completeCallbacks).toHaveLength(1);
+      expect(completeCallbacks[0].data).toEqual({
+        result: expect.objectContaining({
+          processed: true,
+          taskId: "task-789"
+        })
+      });
+
+      const trackedWorkflow = (await agentStub.getWorkflowById(
+        "approval-test-wf-1"
+      )) as WorkflowInfo | null;
+      expect(trackedWorkflow?.status).toBe("complete");
+      expect(trackedWorkflow?.completedAt).toBeInstanceOf(Date);
     });
 
     it("should handle rejection and report error", async () => {

--- a/packages/agents/src/workflow-types.ts
+++ b/packages/agents/src/workflow-types.ts
@@ -49,13 +49,15 @@ export interface AgentWorkflowStep extends WorkflowStep {
   /**
    * Report successful completion to the Agent (durable).
    * Triggers onWorkflowComplete() on the Agent.
+   * AgentWorkflow calls this automatically with the value returned by run().
    * @param result - Optional result data
    */
   reportComplete<T = unknown>(result?: T): Promise<void>;
 
   /**
-   * Report an error to the Agent (durable).
+   * Report a non-terminal error event to the Agent (durable).
    * Triggers onWorkflowError() on the Agent.
+   * Throwing from run() reports the terminal error automatically.
    * @param error - Error or error message
    */
   reportError(error: Error | string): Promise<void>;

--- a/packages/agents/src/workflows.ts
+++ b/packages/agents/src/workflows.ts
@@ -111,6 +111,12 @@ export class AgentWorkflow<
    */
   private _errorReported = false;
 
+  /**
+   * Guard to prevent automatic completion reporting from duplicating an
+   * explicit reportComplete() call.
+   */
+  private _completionReported = false;
+
   constructor(ctx: ExecutionContext, env: Env) {
     super(ctx, env);
 
@@ -167,7 +173,7 @@ export class AgentWorkflow<
               cleanedEvent
             );
 
-            return await this._runWithErrorReporting(
+            return await this._runWithLifecycleReporting(
               originalRun,
               cleanedEvent,
               wrappedStep
@@ -179,7 +185,7 @@ export class AgentWorkflow<
 
         // If already initialized (e.g., called via super.run()),
         // just call the original with the event as-is.
-        return await this._runWithErrorReporting(
+        return await this._runWithLifecycleReporting(
           originalRun,
           event as WorkflowEvent<Params>,
           step as AgentWorkflowStep
@@ -302,9 +308,9 @@ export class AgentWorkflow<
   }
 
   /**
-   * Call user workflow code and report unhandled errors to the Agent.
+   * Call user workflow code and report its terminal lifecycle to the Agent.
    */
-  private async _runWithErrorReporting(
+  private async _runWithLifecycleReporting(
     originalRun: (
       event: WorkflowEvent<Params>,
       step: AgentWorkflowStep
@@ -313,7 +319,11 @@ export class AgentWorkflow<
     step: AgentWorkflowStep
   ): Promise<unknown> {
     try {
-      return await originalRun.call(this, event, step);
+      const result = await originalRun.call(this, event, step);
+      if (!this._completionReported) {
+        await step.reportComplete(result);
+      }
+      return result;
     } catch (err) {
       await this._autoReportError(err);
       throw err;
@@ -346,6 +356,7 @@ export class AgentWorkflow<
 
     // Add durable Agent methods directly to the step object
     wrappedStep.reportComplete = async <T>(result?: T): Promise<void> => {
+      this._completionReported = true;
       await step.do(`__agent_reportComplete_${stepCounter++}`, async () => {
         await this.notifyAgent({
           workflowName: this._workflowName,


### PR DESCRIPTION
**tl;dr – Automatically report `AgentWorkflow` completion to its originating Agent.**

An Agent that starts a Workflow should receive terminal lifecycle callbacks and tracking updates without application-level decorators or polling `getWorkflowStatus()`.

Successful returns now durably invoke `onWorkflowComplete()` with the returned result. Existing explicit `step.reportComplete()` calls remain compatible and do not produce duplicate callbacks. Unhandled throws continue to invoke `onWorkflowError()` automatically.

---

References: [Agents Workflows documentation](https://developers.cloudflare.com/agents/concepts/workflows/#workflow-tracking), [prior automatic error reporting](https://github.com/cloudflare/agents/pull/1003)