### PR TITLE
fix: #2013 - correctly invoke controller.error during mid-stream closure and update tests accordingly

### DIFF
--- a/.changeset/common-snails-smoke.md
+++ b/.changeset/common-snails-smoke.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fixes #2013 by correctly invoking `controller.error` during a websocket closure before receiving a `done: true` frame. This previously led to the AI SDK's `useChat` interpreting this as a normal completion. Tests have also been updated accordingly.

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -791,7 +791,9 @@ export class WebSocketChatTransport<
 
         const onClose = () =>
           finish(() =>
-            controller.error(new Error("WebSocket closed mid-stream"))
+            requestId === null
+              ? controller.close()
+              : controller.error(new Error("WebSocket closed mid-stream"))
           );
 
         agent.addEventListener("message", onMessage, {

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -433,7 +433,11 @@ export class WebSocketChatTransport<
         };
 
         const onClose = () => {
-          finish(() => controller.close(), false, false);
+          finish(
+            () => controller.error(new Error("WebSocket closed mid-stream")),
+            false,
+            false
+          );
         };
 
         agent.addEventListener("message", onMessage, {
@@ -785,7 +789,10 @@ export class WebSocketChatTransport<
           }
         };
 
-        const onClose = () => finish(() => controller.close());
+        const onClose = () =>
+          finish(() =>
+            controller.error(new Error("WebSocket closed mid-stream"))
+          );
 
         agent.addEventListener("message", onMessage, {
           signal: streamController.signal
@@ -904,7 +911,11 @@ export class WebSocketChatTransport<
         };
 
         const onClose = () => {
-          finish(() => controller.close(), false, false);
+          finish(
+            () => controller.error(new Error("WebSocket closed mid-stream")),
+            false,
+            false
+          );
         };
 
         agent.addEventListener("message", onMessage, {

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -355,7 +355,7 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(result.done).toBe(true);
   });
 
-  it("tool continuation errors and clears resolvers when socket closes before handshake", async () => {
+  it("tool continuation closes and clears resolvers when socket closes before handshake", async () => {
     transport.expectToolContinuation();
 
     const stream = (await transport.reconnectToStream({
@@ -365,9 +365,12 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
     agent.close();
 
-    // A socket close before the resume handshake completes must error the
-    // continuation stream, not close it cleanly (see issue #2013).
-    await expect(reader.read()).rejects.toThrow("WebSocket closed mid-stream");
+    // A socket close before the resume handshake completes closes the
+    // continuation stream cleanly; only mid-chunk closes error (see #2013).
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined
+    });
     expect(transport.handleStreamResuming({ id: "late-tool" })).toBe(false);
     expect(transport.handleStreamResumeNone()).toBe(false);
     expect(transport.abortActiveToolContinuation()).toBe(false);

--- a/packages/ai-chat/src/tests/ws-transport-resume.test.ts
+++ b/packages/ai-chat/src/tests/ws-transport-resume.test.ts
@@ -56,7 +56,7 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
   // ── sendMessages lifecycle ───────────────────────────────────────────
 
-  it("closes the original sendMessages stream when the socket closes before done", async () => {
+  it("errors the original sendMessages stream when the socket closes before done", async () => {
     const stream = await transport.sendMessages({
       chatId: "chat-1",
       messages: [
@@ -75,10 +75,10 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
     agent.close();
 
-    await expect(reader.read()).resolves.toEqual({
-      done: true,
-      value: undefined
-    });
+    // The socket dying mid-stream must surface as a stream error, not a clean
+    // close, so useChat can distinguish a dropped connection from a completed
+    // turn (see issue #2013).
+    await expect(reader.read()).rejects.toThrow("WebSocket closed mid-stream");
     expect(activeRequestIds.size).toBe(0);
   });
 
@@ -355,7 +355,7 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(result.done).toBe(true);
   });
 
-  it("tool continuation closes and clears resolvers when socket closes before handshake", async () => {
+  it("tool continuation errors and clears resolvers when socket closes before handshake", async () => {
     transport.expectToolContinuation();
 
     const stream = (await transport.reconnectToStream({
@@ -365,10 +365,9 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
     agent.close();
 
-    await expect(reader.read()).resolves.toEqual({
-      done: true,
-      value: undefined
-    });
+    // A socket close before the resume handshake completes must error the
+    // continuation stream, not close it cleanly (see issue #2013).
+    await expect(reader.read()).rejects.toThrow("WebSocket closed mid-stream");
     expect(transport.handleStreamResuming({ id: "late-tool" })).toBe(false);
     expect(transport.handleStreamResumeNone()).toBe(false);
     expect(transport.abortActiveToolContinuation()).toBe(false);
@@ -449,7 +448,7 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(activeRequestIds.has("req-keep-id")).toBe(true);
   });
 
-  it("tool continuation closes and removes requestId when socket closes mid-stream", async () => {
+  it("tool continuation errors and removes requestId when socket closes mid-stream", async () => {
     transport.expectToolContinuation();
 
     const stream = (await transport.reconnectToStream({
@@ -474,10 +473,9 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
     agent.close();
 
-    await expect(reader.read()).resolves.toEqual({
-      done: true,
-      value: undefined
-    });
+    // A socket close mid-continuation must error the stream, not close it
+    // cleanly, so useChat can surface the interruption (see issue #2013).
+    await expect(reader.read()).rejects.toThrow("WebSocket closed mid-stream");
     expect(activeRequestIds.has("req-tool-close")).toBe(false);
     expect(transport.abortActiveToolContinuation()).toBe(false);
   });
@@ -770,7 +768,7 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
     expect(activeRequestIds.has("req-cleanup")).toBe(false);
   });
 
-  it("removes requestId from activeRequestIds when resumed stream socket closes", async () => {
+  it("errors and removes requestId from activeRequestIds when resumed stream socket closes", async () => {
     const promise = transport.reconnectToStream({ chatId: "chat-1" });
 
     transport.handleStreamResuming({ id: "req-close-cleanup" });
@@ -793,10 +791,9 @@ describe("WebSocketChatTransport reconnectToStream + handleStreamResuming", () =
 
     agent.close();
 
-    await expect(reader.read()).resolves.toEqual({
-      done: true,
-      value: undefined
-    });
+    // A socket close during chunk replay must error the resumed stream, not
+    // close it cleanly (see issue #2013).
+    await expect(reader.read()).rejects.toThrow("WebSocket closed mid-stream");
     expect(activeRequestIds.has("req-close-cleanup")).toBe(false);
   });
 


### PR DESCRIPTION
This PR aims to fix #2013 by correctly invoking `controller.error` during a websocket closure before receiving a `done: true` frame. This previously led to the AI SDK's `useChat` interpreting this as a normal completion.

Tests have also been updated accordingly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->