### PR TITLE
fix stale initial chat URL on agent switch

### DIFF
--- a/.changeset/quiet-chats-change-address.md
+++ b/.changeset/quiet-chats-change-address.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Prevent initial chat-message loads from using the previous Agent instance URL while a changed Agent address is reconnecting.

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -770,6 +770,20 @@ export function useAgentChat<
     ? `${agentUrl.origin}${agentUrl.pathname}|${agentAddressKey}`
     : null;
   const initialMessagesCacheKey = agentAddressKey;
+  const previousInitialMessagesAddressKeyRef = useRef(agentAddressKey);
+  const isWaitingForAddressedSocket =
+    previousInitialMessagesAddressKeyRef.current !== agentAddressKey &&
+    !agentUrlString;
+  previousInitialMessagesAddressKeyRef.current = agentAddressKey;
+
+  // For ordinary room/sub-agent routing, `.path` is updated from the current
+  // hook options synchronously while the PartySocket replacement happens
+  // after commit. Use that desired leaf identity for the loader so the
+  // request metadata and cache key cannot describe different conversations.
+  // `basePath` sockets have no room and remain server-identity-driven.
+  const socketRoom = (agent as typeof agent & { room?: string }).room;
+  const addressedLeaf =
+    socketRoom && Array.isArray(agent.path) ? agent.path.at(-1) : undefined;
 
   // Stable chat ID for `useChat({ id })`.
   //
@@ -883,7 +897,7 @@ export function useAgentChat<
   }
 
   const shouldFetchInitialMessages =
-    getInitialMessages === null
+    isWaitingForAddressedSocket || getInitialMessages === null
       ? false
       : getInitialMessages
         ? true
@@ -892,8 +906,8 @@ export function useAgentChat<
     ? null
     : doGetInitialMessages(
         {
-          agent: agent.agent,
-          name: agent.name,
+          agent: addressedLeaf?.agent ?? agent.agent,
+          name: addressedLeaf?.name ?? agent.name,
           url: agentUrlString ?? undefined
         },
         initialMessagesCacheKey

--- a/packages/agents/src/react-tests/initial-messages-address-race.test.tsx
+++ b/packages/agents/src/react-tests/initial-messages-address-race.test.tsx
@@ -1,0 +1,71 @@
+import { Suspense, act, useEffect, useState } from "react";
+import { cleanup, render } from "vitest-browser-react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAgentChat } from "../chat/react";
+import { useAgent } from "../react";
+import { getTestWorkerHost } from "./test-config";
+
+describe("useAgentChat initial-message address changes", () => {
+  afterEach(() => cleanup());
+
+  it("never loads a new agent address through the previous socket URL (#1864)", async () => {
+    const { host, protocol } = getTestWorkerHost();
+    const getInitialMessages = vi.fn(
+      async (_options: { agent: string; name: string; url?: string }) => []
+    );
+
+    let changeAddress:
+      | ((address: { name: string; token: string }) => void)
+      | undefined;
+
+    function TestComponent() {
+      const [{ name, token }, setAddress] = useState({
+        name: "address-race-a",
+        token: "token-a"
+      });
+      useEffect(() => {
+        changeAddress = setAddress;
+      }, []);
+      const agent = useAgent({
+        agent: "TestStateAgent",
+        host,
+        name,
+        protocol,
+        query: { token }
+      });
+      useAgentChat({ agent, getInitialMessages, resume: false });
+      return <div data-testid="ready">ready</div>;
+    }
+
+    render(
+      <Suspense fallback="loading">
+        <TestComponent />
+      </Suspense>
+    );
+
+    await vi.waitFor(() => expect(getInitialMessages).toHaveBeenCalled());
+    expect(getInitialMessages.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        name: "address-race-a",
+        url: expect.stringContaining(
+          "/agents/test-state-agent/address-race-a?token=token-a"
+        )
+      })
+    );
+
+    getInitialMessages.mockClear();
+    await act(async () => {
+      changeAddress?.({ name: "address-race-b", token: "token-b" });
+    });
+
+    await vi.waitFor(() => expect(getInitialMessages).toHaveBeenCalled());
+    expect(getInitialMessages.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        name: "address-race-b",
+        url: expect.stringContaining(
+          "/agents/test-state-agent/address-race-b?token=token-b"
+        )
+      })
+    );
+  });
+});

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -1030,6 +1030,15 @@ export function useAgent<State>(options: UseAgentOptions<unknown>): Omit<
   const stub = useMemo(() => createStubProxy(call), [call]);
   agent.stub = stub;
   agent.getHttpUrl = () => {
+    // `usePartySocket` replaces its socket in an effect when the addressed
+    // room changes. During the render that requests that replacement,
+    // `agent` is still the previous room's socket. Never expose that stale URL
+    // to consumers such as `useAgentChat` — it may contain both the previous
+    // room path and credentials. A basePath connection has no client-selected
+    // room, so its server-routed URL is intentionally exempt.
+    if (!options.basePath && agent.room !== (options.name || "default")) {
+      return "";
+    }
     // TODO: upstream to partysocket — expose an HTTP URL property
     // @ts-expect-error accessing protected PartySocket internals
     const wsUrl: string = (agent._url as string | null) || agent._pkurl || "";


### PR DESCRIPTION
## What changed

- suppress `useAgent().getHttpUrl()` while a room change is still rendering against the previous PartySocket
- defer initial-message loading until the socket matches the new logical Agent address
- derive loader identity from the intended leaf address for ordinary room/sub-agent routing
- preserve server-routed `basePath` behavior
- add a browser/Worker regression that changes both the Agent name and auth query

## Why

On an Agent name change, `useAgentChat` could key a new initial-message request under the new conversation while `getHttpUrl()` still returned the previous socket URL. That sent the previous auth token to the new logical request and cached the old conversation under the new key.

Fixes #1864.

## Validation

- regression reproduced before the production fix: the new logical address loaded through the old path/token
- focused regression passes after the fix
- Agents React project: 10 files, 124 tests passed
- affected Agents and React-test TypeScript projects pass
- repository export, formatting, and lint checks pass

The repo-wide check wrapper attempted to reinstall existing `node_modules` and was declined; its individual checks were run directly. The full typecheck wrapper could not resolve `tsgo` from its subprocess PATH, so the affected TypeScript projects were run directly and passed.
