### PR TITLE
Fix tool input reconstruction for approval requests

### DIFF
--- a/.changeset/calm-tools-request.md
+++ b/.changeset/calm-tools-request.md
@@ -1,0 +1,6 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+---
+
+Preserve streamed tool inputs when a tool approval request arrives before the canonical input chunk.

--- a/packages/agents/src/chat/__tests__/message-builder-approval.test.ts
+++ b/packages/agents/src/chat/__tests__/message-builder-approval.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyChunkToParts,
+  isReplayChunk,
+  type MessageParts
+} from "../message-builder";
+
+describe("approval input reconstruction (#1872)", () => {
+  it("accumulates AI SDK inputTextDelta before an approval request", () => {
+    const parts: MessageParts = [];
+    applyChunkToParts(parts, {
+      type: "tool-input-start",
+      toolCallId: "call_1",
+      toolName: "deleteUser"
+    });
+    applyChunkToParts(parts, {
+      type: "tool-input-delta",
+      toolCallId: "call_1",
+      inputTextDelta: '{"userId":"'
+    });
+    applyChunkToParts(parts, {
+      type: "tool-input-delta",
+      toolCallId: "call_1",
+      inputTextDelta: 'u_42"}'
+    });
+    applyChunkToParts(parts, {
+      type: "tool-approval-request",
+      toolCallId: "call_1",
+      approvalId: "approval_1"
+    });
+
+    expect(parts[0]).toEqual(
+      expect.objectContaining({
+        state: "approval-requested",
+        input: { userId: "u_42" },
+        approval: { id: "approval_1" }
+      })
+    );
+  });
+
+  it("fills canonical input without regressing an earlier approval request", () => {
+    const parts: MessageParts = [];
+    applyChunkToParts(parts, {
+      type: "tool-input-start",
+      toolCallId: "call_1",
+      toolName: "deleteUser"
+    });
+    applyChunkToParts(parts, {
+      type: "tool-approval-request",
+      toolCallId: "call_1",
+      approvalId: "approval_1"
+    });
+    const available = {
+      type: "tool-input-available",
+      toolCallId: "call_1",
+      toolName: "deleteUser",
+      input: { userId: "u_42" }
+    } as const;
+
+    // The chunk remains a client-side replay: broadcasting it would regress
+    // the client's approval-requested state. Server reconstruction must still
+    // apply it before suppressing the broadcast.
+    expect(isReplayChunk(parts, available)).toBe(true);
+    applyChunkToParts(parts, available);
+
+    expect(parts[0]).toEqual(
+      expect.objectContaining({
+        state: "approval-requested",
+        input: { userId: "u_42" },
+        approval: { id: "approval_1" }
+      })
+    );
+  });
+
+  it("keeps compatibility with parsed partial-input delta emitters", () => {
+    const parts: MessageParts = [];
+    applyChunkToParts(parts, {
+      type: "tool-input-start",
+      toolCallId: "call_1",
+      toolName: "deleteUser"
+    });
+    applyChunkToParts(parts, {
+      type: "tool-input-delta",
+      toolCallId: "call_1",
+      input: { userId: "u_42" }
+    });
+    applyChunkToParts(parts, {
+      type: "tool-approval-request",
+      toolCallId: "call_1",
+      approvalId: "approval_1"
+    });
+
+    expect(parts[0]).toEqual(
+      expect.objectContaining({ input: { userId: "u_42" } })
+    );
+  });
+});

--- a/packages/agents/src/chat/message-builder.ts
+++ b/packages/agents/src/chat/message-builder.ts
@@ -267,7 +267,21 @@ export function applyChunkToParts(
         toolPart &&
         (toolPart as Record<string, unknown>).state === "input-streaming"
       ) {
-        (toolPart as Record<string, unknown>).input = chunk.input;
+        const p = toolPart as Record<string, unknown>;
+        if (typeof chunk.inputTextDelta === "string") {
+          // AI SDK UI streams carry raw JSON fragments in inputTextDelta.
+          // Retain the raw string until an input-available or approval chunk
+          // gives us a safe boundary at which to parse it.
+          if (typeof p.input === "string") {
+            p.input += chunk.inputTextDelta;
+          } else if (p.input == null) {
+            p.input = chunk.inputTextDelta;
+          }
+        } else if (chunk.input !== undefined) {
+          // Compatibility with older/custom emitters that supplied a parsed
+          // partial input on the delta chunk.
+          p.input = chunk.input;
+        }
       }
       return true;
     }
@@ -284,6 +298,20 @@ export function applyChunkToParts(
         // resolved input/output. See the comment on tool-input-start.
         if (p.state === "input-streaming") {
           p.state = "input-available";
+          p.input = normalizeToolInput(chunk.input).input;
+          if (chunk.providerExecuted != null) {
+            p.providerExecuted = chunk.providerExecuted;
+          }
+          if (chunk.providerMetadata != null) {
+            p.callProviderMetadata = chunk.providerMetadata;
+          }
+          if (chunk.title != null) {
+            p.title = chunk.title;
+          }
+        } else if (p.state === "approval-requested") {
+          // Some stream orderings emit the approval request before the
+          // canonical input-available chunk. Fill the server-side part without
+          // regressing its approval state or discarding the approval object.
           p.input = normalizeToolInput(chunk.input).input;
           if (chunk.providerExecuted != null) {
             p.providerExecuted = chunk.providerExecuted;
@@ -374,6 +402,9 @@ export function applyChunkToParts(
           p.state === "output-denied"
         ) {
           return true;
+        }
+        if (p.state === "input-streaming") {
+          p.input = normalizeToolInput(chunk.input ?? p.input).input;
         }
         p.state = "approval-requested";
         p.approval = {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -6239,6 +6239,13 @@ export class AIChatAgent<
             // already has when the replay matches, so it's
             // semantically a no-op on the client too.
             if (isReplayChunk(message.parts, data as StreamChunkData)) {
+              // Keep the server-side reconstruction convergent even when the
+              // chunk must not reach the client. In particular, an
+              // input-available chunk can follow approval-requested: applying
+              // it fills the persisted input while preserving approval state,
+              // whereas broadcasting it would regress the AI SDK client back
+              // to input-available.
+              applyChunkToParts(message.parts, data);
               continue;
             }
 


### PR DESCRIPTION
Fixes #1872.

## What changed

- Accumulate AI SDK tool input text deltas using the current inputTextDelta field and parse them at a safe boundary.
- Preserve compatibility with custom/older streams that provide parsed input on delta chunks.
- Allow a canonical input-available chunk to complete server-side reconstruction after approval-requested without regressing the approval state or rebroadcasting a stale client transition.
- Add regression coverage for both event orderings and the compatibility path.
- Add patch changesets for agents and @cloudflare/ai-chat.

## Reproduction

Before the fix, the new regression cases reproduced the report: streamed arguments remained undefined both when deltas preceded approval and when approval-requested preceded input-available.

## Validation

- agents chat suite: 26 files, 517 tests passed
- ai-chat Workers suite: 49 files, 655 tests passed
- affected TypeScript configs passed
- repository formatting and lint passed
- package export validation passed
- sherif passed with the two existing missing-package warnings for examples/harness-deck and examples/think-standalone

No documentation update is needed because this restores internal stream reconstruction behavior without changing the public API.