### PR TITLE
Keep hibernation enabled with partial Agent options

### DIFF
--- a/.changeset/tidy-agents-hibernate.md
+++ b/.changeset/tidy-agents-hibernate.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Keep WebSocket hibernation enabled when an Agent subclass overrides unrelated static options.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2333,6 +2333,18 @@ export class Agent<
   }
 
   constructor(ctx: AgentContext, env: Env) {
+    // PartyServer selects its connection manager while `super()` initializes
+    // the base-class fields, before this Agent instance exists. Ensure the raw
+    // subclass option it reads has the same hibernation default as our resolved
+    // options. Replacing (rather than mutating) the object also supports frozen
+    // user-provided option objects.
+    const ctor = new.target as typeof Agent;
+    if (ctor.options?.hibernate === undefined) {
+      ctor.options = {
+        ...ctor.options,
+        hibernate: DEFAULT_AGENT_STATIC_OPTIONS.hibernate
+      };
+    }
     super(ctx, env);
 
     this.mcp = this._withAgentSpan(

--- a/packages/agents/src/tests/static-options.test.ts
+++ b/packages/agents/src/tests/static-options.test.ts
@@ -1,0 +1,33 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { exports } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+
+describe("Agent static options", () => {
+  it("keeps hibernation enabled when a subclass overrides another option", async () => {
+    const room = `partial-static-options-${crypto.randomUUID()}`;
+    const response = await exports.default.fetch(
+      `http://example.com/agents/test-no-identity-agent/${room}`,
+      { headers: { Upgrade: "websocket" } }
+    );
+
+    expect(response.status).toBe(101);
+    const client = response.webSocket;
+    expect(client).toBeDefined();
+    client?.accept();
+
+    const stub = env.TestNoIdentityAgent.getByName(room);
+    const result = await runInDurableObject(stub, (instance, ctx) => ({
+      hibernate: (
+        instance.constructor as typeof instance.constructor & {
+          options: { hibernate?: boolean };
+        }
+      ).options.hibernate,
+      hibernatingConnections: ctx.getWebSockets().length
+    }));
+
+    expect(result.hibernate).toBe(true);
+    expect(result.hibernatingConnections).toBe(1);
+
+    client?.close();
+  });
+});


### PR DESCRIPTION
Fixes #2012.

## What changed

- Resolve the documented hibernation default on the raw subclass static options immediately before PartyServer initializes its connection manager.
- Preserve an explicit hibernate: false override.
- Replace rather than mutate the user-provided options object, which also supports frozen option objects.
- Add a Workers regression test that exercises the existing sendIdentityOnConnect-only subclass and verifies the socket is registered through the Durable Object hibernation API.
- Add an agents patch changeset.

## Reproduction

Before the fix, the regression test observed TestNoIdentityAgent.options.hibernate as undefined after connecting. PartyServer therefore selected its in-memory connection manager even though the Agents resolved options reported hibernation enabled.

## Validation

- focused reproduction failed before the fix and passes after it
- full Agents Workers suite: 91 files, 1,742 tests passed
- affected source and test TypeScript configs passed
- repository formatting and lint passed
- package export validation passed
- sherif passed with the two existing missing-package warnings for examples/harness-deck and examples/think-standalone

No documentation update is needed: the documented default was already correct, and this change makes runtime behavior match it.