### PR TITLE
fix(agents): route facet MCP OAuth callbacks

### DIFF
--- a/.changeset/tidy-facets-callback.md
+++ b/.changeset/tidy-facets-callback.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Route default MCP OAuth callbacks back to the sub-agent facet that started the authorization flow, and let `routeSubAgentRequest()` accept structured descendant paths.

--- a/docs/agents/mcp-client.md
+++ b/docs/agents/mcp-client.md
@@ -256,6 +256,39 @@ https://{host}/{agentsPrefix}/{agent-name}/{instance-name}/callback
 
 For example: `https://my-worker.workers.dev/agents/my-agent/default/callback`
 
+When a sub-agent starts the OAuth flow, the callback URL includes its complete
+root-first path:
+
+```
+https://{host}/{agentsPrefix}/{root-agent}/{root-name}/sub/{child-agent}/{child-name}/callback
+```
+
+For example:
+`https://my-worker.workers.dev/agents/inbox/user-123/sub/chat/chat-abc/callback`.
+Additional nested sub-agents add another `/sub/{agent}/{name}` pair before
+`/callback`. The nested route returns the callback to the sub-agent that stored
+the OAuth state and PKCE verifier.
+
+A custom `callbackPath` bypasses this automatic path construction. Your Worker
+must route a custom callback to the root agent and through the complete
+sub-agent path. Pass the structured descendant path to
+`routeSubAgentRequest()`:
+
+```typescript
+import { getAgentByName, routeSubAgentRequest } from "agents";
+
+const parent = await getAgentByName(env.Inbox, userId);
+return routeSubAgentRequest(request, parent, {
+  fromPath: {
+    path: [{ className: "Chat", name: chatId }],
+    leaf: "/callback"
+  }
+});
+```
+
+This also applies when `sendIdentityOnConnect` is `false`, where an explicit
+`callbackPath` is required to avoid exposing instance names.
+
 OAuth tokens are securely stored in SQLite and persist across agent restarts.
 
 ### Custom Callback Handling

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -13037,6 +13037,14 @@ export async function routeAgentRequest<Env>(
     prefixParts.every((part, index) => pathParts[index] === part) &&
     pathParts.length >= prefixParts.length + 2;
   if (couldMatchAgentRoute && request.headers.has(SUB_AGENT_OUTER_URL_HEADER)) {
+    if (request.bodyUsed) {
+      return new Response(
+        "Cannot route a request whose body was already read",
+        {
+          status: 400
+        }
+      );
+    }
     const headers = new Headers(request.headers);
     headers.delete(SUB_AGENT_OUTER_URL_HEADER);
     routedRequest = new Request(request.clone() as unknown as RequestInfo, {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -19,7 +19,10 @@ export { __DO_NOT_USE_WILL_BREAK__agentContext } from "./internal_context";
  */
 export { withInvocationScope as __DO_NOT_USE_WILL_BREAK__withInvocationScope } from "./observability/tracing/tracer";
 import {
+  SUB_AGENT_OUTER_URL_HEADER,
   SUB_PREFIX,
+  buildSubAgentPath,
+  encodeAgentNameSegment,
   parseSubAgentPath as _parseSubAgentPath
 } from "./sub-routing";
 export {
@@ -28,7 +31,7 @@ export {
   parseSubAgentPath,
   SUB_PREFIX
 } from "./sub-routing";
-export type { SubAgentPathMatch } from "./sub-routing";
+export type { SubAgentPathMatch, SubAgentPathStep } from "./sub-routing";
 import { signAgentHeaders } from "./email";
 import { parseCronExpression } from "cron-schedule";
 import { nanoid } from "nanoid";
@@ -1207,8 +1210,6 @@ const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
  */
 const CF_SUB_AGENT_OUTER_URL_KEY = "_cf_subAgentOuterUrl";
 const CF_SUB_AGENT_TAGS_KEY = "_cf_subAgentTags";
-
-const SUB_AGENT_OUTER_URL_HEADER = "x-cf-agents-subagent-url";
 
 /**
  * The set of all internal keys stored in connection state that must be
@@ -7015,6 +7016,11 @@ export class Agent<
       return super.fetch(request);
     }
 
+    // Capture the public URL before user hooks can replace the Request or its
+    // internal routing header. Nested facets inherit the root-captured value.
+    const outerUrl =
+      request.headers.get(SUB_AGENT_OUTER_URL_HEADER) ?? request.url;
+
     // Hook runs in the parent's isolate before any facet work.
     const decision = await this.onBeforeSubAgent(request, {
       className: match.childClass,
@@ -7031,7 +7037,7 @@ export class Agent<
       return super.fetch(new Request(forwardReq, { headers: acceptHeaders }));
     }
 
-    return this._cf_forwardToFacet(forwardReq, match);
+    return this._cf_forwardToFacet(forwardReq, match, outerUrl);
   }
 
   override broadcast(
@@ -7698,7 +7704,8 @@ export class Agent<
       childClass: string;
       childName: string;
       remainingPath: string;
-    }
+    },
+    outerUrl: string
   ): Promise<Response> {
     let fetcher: { fetch(r: Request): Promise<Response> };
     try {
@@ -7724,13 +7731,11 @@ export class Agent<
     const rewritten = new URL(req.url);
     rewritten.pathname = match.remainingPath;
     const forwardedHeaders = new Headers(req.headers);
+    forwardedHeaders.set(SUB_AGENT_OUTER_URL_HEADER, outerUrl);
     const forwardedInit: RequestInit = {
       method: req.method,
       headers: forwardedHeaders
     };
-    if (req.headers.get("Upgrade")?.toLowerCase() === "websocket") {
-      forwardedHeaders.set(SUB_AGENT_OUTER_URL_HEADER, req.url);
-    }
     if (req.body && req.method !== "GET" && req.method !== "HEAD") {
       forwardedInit.body = await req.arrayBuffer();
     }
@@ -12626,9 +12631,18 @@ export class Agent<
     let callbackUrl: string | undefined;
     if (resolvedCallbackHost) {
       const normalizedHost = resolvedCallbackHost.replace(/\/$/, "");
-      callbackUrl = resolvedCallbackPath
-        ? `${normalizedHost}/${resolvedCallbackPath.replace(/^\//, "")}`
-        : `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
+      if (resolvedCallbackPath) {
+        callbackUrl = `${normalizedHost}/${resolvedCallbackPath.replace(/^\//, "")}`;
+      } else if (this._isFacet) {
+        const [root, ...facets] = this.selfPath;
+        if (!root) {
+          throw new Error("A sub-agent OAuth callback requires a root path");
+        }
+        const rootPath = `/${resolvedAgentsPrefix}/${camelCaseToKebabCase(root.className)}/${encodeAgentNameSegment(root.name)}`;
+        callbackUrl = `${normalizedHost}${rootPath}${buildSubAgentPath(facets, "/callback")}`;
+      } else {
+        callbackUrl = `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
+      }
     }
 
     const id = requestedId ?? existingServer?.id ?? nanoid(8);
@@ -12836,15 +12850,34 @@ export class Agent<
   private async handleMcpOAuthCallback(
     request: Request
   ): Promise<Response | null> {
-    // Check if this is an OAuth callback request
-    const isCallback = this.mcp.isCallbackRequest(request);
+    const outerUrl = this._isFacet
+      ? request.headers.get(SUB_AGENT_OUTER_URL_HEADER)
+      : null;
+    let callbackRequest = request;
+    if (outerUrl) {
+      const callbackUrl = new URL(outerUrl);
+      // The internal header contributes only the public origin/path used for
+      // callback registration matching. OAuth parameters always come from the
+      // actual request URL so a caller cannot substitute code/state via a
+      // forged routing header.
+      callbackUrl.search = new URL(request.url).search;
+      callbackRequest = new Request(callbackUrl, {
+        method: request.method,
+        headers: request.headers
+      });
+    }
+
+    // Check if this is an MCP callback at its public URL. Facet routing strips
+    // `/sub/{class}/{name}` segments before the request reaches the child, so
+    // use the root-recorded outer URL when matching the registered redirect URI.
+    const isCallback = this.mcp.isCallbackRequest(callbackRequest);
     if (!isCallback) {
       return null;
     }
 
     // Handle the OAuth callback (exchanges code for token, clears OAuth credentials from storage)
     // This fires onServerStateChanged event which triggers broadcast
-    const result = await this.mcp.handleCallbackRequest(request);
+    const result = await this.mcp.handleCallbackRequest(callbackRequest);
 
     // If auth was successful, establish the connection in the background
     // (establishConnection handles retries internally using per-server retry config)
@@ -12956,8 +12989,12 @@ export async function routeAgentRequest<Env>(
   env: Env,
   options?: AgentOptions<Env>
 ) {
+  const headers = new Headers(request.headers);
+  headers.delete(SUB_AGENT_OUTER_URL_HEADER);
+  const routedRequest = new Request(request, { headers });
+
   // oxlint-disable-next-line typescript/no-explicit-any
-  return routePartykitRequest(request, env as any, {
+  return routePartykitRequest(routedRequest, env as any, {
     prefix: "agents",
     ...(options as PartyServerOptions<Record<string, unknown>>)
   });

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -12658,17 +12658,23 @@ export class Agent<
 
     // Build the callback URL if we have a host (needed for OAuth, optional for non-OAuth servers)
     let callbackUrl: string | undefined;
+    let callbackUrlError: Error | undefined;
     if (resolvedCallbackHost) {
       const normalizedHost = resolvedCallbackHost.replace(/\/$/, "");
       if (resolvedCallbackPath) {
         callbackUrl = `${normalizedHost}/${resolvedCallbackPath.replace(/^\//, "")}`;
       } else if (this._isFacet) {
-        const [root, ...facets] = this.selfPath;
-        if (!root) {
-          throw new Error("A sub-agent OAuth callback requires a root path");
+        try {
+          const [root, ...facets] = this.selfPath;
+          if (!root) {
+            throw new Error("A sub-agent OAuth callback requires a root path");
+          }
+          const rootPath = `/${resolvedAgentsPrefix}/${camelCaseToKebabCase(root.className)}/${validateRootAgentNameSegment(root.name)}`;
+          callbackUrl = `${normalizedHost}${rootPath}${buildSubAgentPath(facets, "/callback")}`;
+        } catch (error) {
+          callbackUrlError =
+            error instanceof Error ? error : new Error(String(error));
         }
-        const rootPath = `/${resolvedAgentsPrefix}/${camelCaseToKebabCase(root.className)}/${validateRootAgentNameSegment(root.name)}`;
-        callbackUrl = `${normalizedHost}${rootPath}${buildSubAgentPath(facets, "/callback")}`;
       } else {
         callbackUrl = `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
       }
@@ -12726,6 +12732,10 @@ export class Agent<
     const result = await this.mcp.connectToServer(id);
 
     if (result.state === MCPConnectionState.FAILED) {
+      // If callback construction failed, surface that actionable error when
+      // the connection cannot proceed without the omitted OAuth provider.
+      if (callbackUrlError) throw callbackUrlError;
+
       // Server stays in storage so user can retry via connectToServer(id)
       throw new Error(
         `Failed to connect to MCP server at ${normalizedUrl}: ${result.error}`
@@ -12733,6 +12743,7 @@ export class Agent<
     }
 
     if (result.state === MCPConnectionState.AUTHENTICATING) {
+      if (callbackUrlError) throw callbackUrlError;
       if (!callbackUrl) {
         throw new Error(
           "This MCP server requires OAuth authentication. " +

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1211,6 +1211,20 @@ const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
 const CF_SUB_AGENT_OUTER_URL_KEY = "_cf_subAgentOuterUrl";
 const CF_SUB_AGENT_TAGS_KEY = "_cf_subAgentTags";
 
+function validSubAgentOuterUrl(value: string | null, fallback: string): string {
+  if (value) {
+    try {
+      const url = new URL(value);
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        return url.toString();
+      }
+    } catch {
+      // Ignore malformed caller-supplied internal routing headers.
+    }
+  }
+  return fallback;
+}
+
 /**
  * The set of all internal keys stored in connection state that must be
  * hidden from user code and preserved across setState calls.
@@ -7013,13 +7027,24 @@ export class Agent<
     });
 
     if (!match) {
+      // A request tagged by routeSubAgentRequest that still has a `/sub/...`
+      // marker names a child class this parent cannot resolve. Fail explicitly
+      // instead of letting a WebSocket connect to the parent with facet flags.
+      if (
+        request.headers.has(SUB_AGENT_OUTER_URL_HEADER) &&
+        _parseSubAgentPath(request.url)
+      ) {
+        return new Response("Sub-agent class not found", { status: 404 });
+      }
       return super.fetch(request);
     }
 
     // Capture the public URL before user hooks can replace the Request or its
     // internal routing header. Nested facets inherit the root-captured value.
-    const outerUrl =
-      request.headers.get(SUB_AGENT_OUTER_URL_HEADER) ?? request.url;
+    const outerUrl = validSubAgentOuterUrl(
+      request.headers.get(SUB_AGENT_OUTER_URL_HEADER),
+      request.url
+    );
 
     // Hook runs in the parent's isolate before any facet work.
     const decision = await this.onBeforeSubAgent(request, {
@@ -7031,6 +7056,9 @@ export class Agent<
 
     if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
       const acceptHeaders = new Headers(forwardReq.headers);
+      // WebSocket connection bookkeeping needs the locally routed URL so it
+      // can resolve `/sub/...` markers relative to this agent's selfPath. HTTP
+      // forwarding instead carries the original public URL for callback matching.
       const routedUrl = new URL(forwardReq.url);
       routedUrl.pathname = new URL(request.url).pathname;
       acceptHeaders.set(SUB_AGENT_OUTER_URL_HEADER, routedUrl.toString());
@@ -12855,7 +12883,7 @@ export class Agent<
       : null;
     let callbackRequest = request;
     if (outerUrl) {
-      const callbackUrl = new URL(outerUrl);
+      const callbackUrl = new URL(validSubAgentOuterUrl(outerUrl, request.url));
       // The internal header contributes only the public origin/path used for
       // callback registration matching. OAuth parameters always come from the
       // actual request URL so a caller cannot substitute code/state via a
@@ -12989,9 +13017,12 @@ export async function routeAgentRequest<Env>(
   env: Env,
   options?: AgentOptions<Env>
 ) {
-  const headers = new Headers(request.headers);
-  headers.delete(SUB_AGENT_OUTER_URL_HEADER);
-  const routedRequest = new Request(request, { headers });
+  let routedRequest = request;
+  if (request.headers.has(SUB_AGENT_OUTER_URL_HEADER)) {
+    const headers = new Headers(request.headers);
+    headers.delete(SUB_AGENT_OUTER_URL_HEADER);
+    routedRequest = new Request(request, { headers });
+  }
 
   // oxlint-disable-next-line typescript/no-explicit-any
   return routePartykitRequest(routedRequest, env as any, {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -22,8 +22,8 @@ import {
   SUB_AGENT_OUTER_URL_HEADER,
   SUB_PREFIX,
   buildSubAgentPath,
-  encodeAgentNameSegment,
-  parseSubAgentPath as _parseSubAgentPath
+  parseSubAgentPath as _parseSubAgentPath,
+  validateRootAgentNameSegment
 } from "./sub-routing";
 export {
   routeSubAgentRequest,
@@ -7031,6 +7031,7 @@ export class Agent<
       // marker names a child class this parent cannot resolve. Fail explicitly
       // instead of letting a WebSocket connect to the parent with facet flags.
       if (
+        request.headers.get("Upgrade")?.toLowerCase() === "websocket" &&
         request.headers.has(SUB_AGENT_OUTER_URL_HEADER) &&
         _parseSubAgentPath(request.url)
       ) {
@@ -12666,7 +12667,7 @@ export class Agent<
         if (!root) {
           throw new Error("A sub-agent OAuth callback requires a root path");
         }
-        const rootPath = `/${resolvedAgentsPrefix}/${camelCaseToKebabCase(root.className)}/${encodeAgentNameSegment(root.name)}`;
+        const rootPath = `/${resolvedAgentsPrefix}/${camelCaseToKebabCase(root.className)}/${validateRootAgentNameSegment(root.name)}`;
         callbackUrl = `${normalizedHost}${rootPath}${buildSubAgentPath(facets, "/callback")}`;
       } else {
         callbackUrl = `${normalizedHost}/${resolvedAgentsPrefix}/${camelCaseToKebabCase(this._ParentClass.name)}/${this.name}/callback`;
@@ -13018,10 +13019,18 @@ export async function routeAgentRequest<Env>(
   options?: AgentOptions<Env>
 ) {
   let routedRequest = request;
-  if (request.headers.has(SUB_AGENT_OUTER_URL_HEADER)) {
+  const pathParts = new URL(request.url).pathname.split("/").filter(Boolean);
+  const prefixParts = (options?.prefix ?? "agents").split("/").filter(Boolean);
+  const couldMatchAgentRoute =
+    prefixParts.length > 0 &&
+    prefixParts.every((part, index) => pathParts[index] === part) &&
+    pathParts.length >= prefixParts.length + 2;
+  if (couldMatchAgentRoute && request.headers.has(SUB_AGENT_OUTER_URL_HEADER)) {
     const headers = new Headers(request.headers);
     headers.delete(SUB_AGENT_OUTER_URL_HEADER);
-    routedRequest = new Request(request, { headers });
+    routedRequest = new Request(request.clone() as unknown as RequestInfo, {
+      headers
+    });
   }
 
   // oxlint-disable-next-line typescript/no-explicit-any

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -13037,14 +13037,6 @@ export async function routeAgentRequest<Env>(
     prefixParts.every((part, index) => pathParts[index] === part) &&
     pathParts.length >= prefixParts.length + 2;
   if (couldMatchAgentRoute && request.headers.has(SUB_AGENT_OUTER_URL_HEADER)) {
-    if (request.bodyUsed) {
-      return new Response(
-        "Cannot route a request whose body was already read",
-        {
-          status: 400
-        }
-      );
-    }
     const headers = new Headers(request.headers);
     headers.delete(SUB_AGENT_OUTER_URL_HEADER);
     routedRequest = new Request(request.clone() as unknown as RequestInfo, {

--- a/packages/agents/src/sub-routing.ts
+++ b/packages/agents/src/sub-routing.ts
@@ -10,6 +10,7 @@
  *     external HTTP/WS routing goes through `routeSubAgentRequest`.
  *
  * Internal:
+ *   - `buildSubAgentPath(path, leaf?)` — structured path → nested URL tail.
  *   - `parseSubAgentPath(url)` — URL → `{ childClass, childName, remainingPath }`.
  *   - `forwardToFacet(req, parent, match)` — resolves `ctx.facets.get(...)`
  *     on the parent and returns `facetStub.fetch(rewrittenReq)`.
@@ -29,6 +30,16 @@ import type { Agent, SubAgentClass, SubAgentStub } from "./index";
  */
 export const SUB_PREFIX = "sub";
 
+/** @internal Carries the public URL while nested routing rewrites pathname. */
+export const SUB_AGENT_OUTER_URL_HEADER = "x-cf-agents-subagent-url";
+
+export interface SubAgentPathStep {
+  /** CamelCase class name as exported by the Worker. */
+  className: string;
+  /** Logical sub-agent instance name. */
+  name: string;
+}
+
 export interface SubAgentPathMatch {
   /** CamelCase class name of the child, as it appears in `ctx.exports`. */
   childClass: string;
@@ -41,6 +52,56 @@ export interface SubAgentPathMatch {
    * recursively nested sub-agent is being routed.
    */
   remainingPath: string;
+}
+
+/**
+ * Encode a logical agent name as one externally routable URL segment.
+ *
+ * @internal Shared by structured sub-agent routing and root-agent URL construction.
+ */
+export function encodeAgentNameSegment(name: string): string {
+  if (name === "" || name === "." || name === "..") {
+    throw new Error(
+      `Cannot build a sub-agent path for name ${JSON.stringify(name)}. Empty and dot-segment names are not externally routable.`
+    );
+  }
+  return encodeURIComponent(name);
+}
+
+/**
+ * Build a nested pathname for routing through one or more sub-agents.
+ *
+ * @example
+ * ```ts
+ * buildSubAgentPath(
+ *   [
+ *     { className: "Chat", name: "chat-a" },
+ *     { className: "Thread", name: "thread-b" }
+ *   ],
+ *   "/callback"
+ * );
+ * // "/sub/chat/chat-a/sub/thread/thread-b/callback"
+ * ```
+ */
+export function buildSubAgentPath(
+  path: ReadonlyArray<SubAgentPathStep>,
+  remainingPath = ""
+): string {
+  const segments = path.flatMap((step) => {
+    const classSegment = camelCaseToKebabCase(step.className);
+    if (!classSegment || classSegment === SUB_PREFIX) {
+      throw new Error(
+        `Cannot build a sub-agent path for class ${JSON.stringify(step.className)} because its URL segment is reserved or empty.`
+      );
+    }
+    return [SUB_PREFIX, classSegment, encodeAgentNameSegment(step.name)];
+  });
+  const suffix = remainingPath
+    ? remainingPath.startsWith("/")
+      ? remainingPath
+      : `/${remainingPath}`
+    : "";
+  return `${segments.length > 0 ? `/${segments.join("/")}` : ""}${suffix}`;
 }
 
 /**
@@ -167,19 +228,29 @@ export async function routeSubAgentRequest(
   parent: unknown,
   options?: {
     /**
-     * Path to route on. Defaults to `req.url`'s pathname. Useful
-     * when your outer URL is custom (e.g. `/api/v1/...`) and you
-     * want to route the sub-agent tail without rewriting the
-     * Request first.
+     * Path to route on. Pass either an existing `/sub/...` path or a
+     * structured descendant path plus the path the leaf should receive.
+     * Defaults to `req.url`'s pathname.
      */
-    fromPath?: string;
+    fromPath?:
+      | string
+      | {
+          path: ReadonlyArray<SubAgentPathStep>;
+          leaf?: string;
+        };
   }
 ): Promise<Response> {
   // We don't know the parent's ctx.exports from here, so parse with
   // a permissive resolver. If the class doesn't exist, the parent's
   // bridge will 404. This lets us keep the helper self-contained.
-  const pathForParsing = options?.fromPath
-    ? `http://placeholder${options.fromPath.startsWith("/") ? "" : "/"}${options.fromPath}`
+  const fromPath =
+    typeof options?.fromPath === "string"
+      ? options.fromPath
+      : options?.fromPath
+        ? buildSubAgentPath(options.fromPath.path, options.fromPath.leaf)
+        : undefined;
+  const pathForParsing = fromPath
+    ? `http://placeholder${fromPath.startsWith("/") ? "" : "/"}${fromPath}`
     : req.url;
 
   const match = parseSubAgentPath(pathForParsing);
@@ -204,12 +275,12 @@ export async function routeSubAgentRequest(
   // handing off to the child facet. If `fromPath` itself contains a
   // `?query` segment, that overrides the original.
   const forwardUrl =
-    options?.fromPath !== undefined
-      ? rewritePathname(req.url, options.fromPath)
-      : req.url;
+    fromPath !== undefined ? rewritePathname(req.url, fromPath) : req.url;
+  const forwardHeaders = new Headers(req.headers);
+  forwardHeaders.set(SUB_AGENT_OUTER_URL_HEADER, req.url);
   const forwardInit: RequestInit = {
     method: req.method,
-    headers: new Headers(req.headers)
+    headers: forwardHeaders
   };
   if (req.body && req.method !== "GET" && req.method !== "HEAD") {
     forwardInit.body = await req.arrayBuffer();

--- a/packages/agents/src/sub-routing.ts
+++ b/packages/agents/src/sub-routing.ts
@@ -243,15 +243,24 @@ export async function routeSubAgentRequest(
   // We don't know the parent's ctx.exports from here, so parse with
   // a permissive resolver. If the class doesn't exist, the parent's
   // bridge will 404. This lets us keep the helper self-contained.
+  if (
+    typeof options?.fromPath === "object" &&
+    options.fromPath.path.length === 0
+  ) {
+    return new Response("Sub-agent path must contain at least one step", {
+      status: 400
+    });
+  }
   const fromPath =
     typeof options?.fromPath === "string"
       ? options.fromPath
       : options?.fromPath
         ? buildSubAgentPath(options.fromPath.path, options.fromPath.leaf)
         : undefined;
-  const pathForParsing = fromPath
-    ? `http://placeholder${fromPath.startsWith("/") ? "" : "/"}${fromPath}`
-    : req.url;
+  const pathForParsing =
+    fromPath !== undefined
+      ? `http://placeholder${fromPath.startsWith("/") ? "" : "/"}${fromPath}`
+      : req.url;
 
   const match = parseSubAgentPath(pathForParsing);
   if (!match) {

--- a/packages/agents/src/sub-routing.ts
+++ b/packages/agents/src/sub-routing.ts
@@ -40,6 +40,25 @@ export interface SubAgentPathStep {
   name: string;
 }
 
+/** @internal Validate a raw PartyServer room-name URL segment. */
+export function validateRootAgentNameSegment(name: string): string {
+  const path = `/root/${name}/callback`;
+  const url = new URL(path, "https://placeholder.invalid");
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (
+    url.pathname !== path ||
+    segments.length !== 3 ||
+    segments[1] !== name ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      `Cannot build a callback URL for root agent name ${JSON.stringify(name)} because it is not externally routable.`
+    );
+  }
+  return name;
+}
+
 export interface SubAgentPathMatch {
   /** CamelCase class name of the child, as it appears in `ctx.exports`. */
   childClass: string;
@@ -251,12 +270,20 @@ export async function routeSubAgentRequest(
       status: 400
     });
   }
-  const fromPath =
-    typeof options?.fromPath === "string"
-      ? options.fromPath
-      : options?.fromPath
-        ? buildSubAgentPath(options.fromPath.path, options.fromPath.leaf)
-        : undefined;
+  let fromPath: string | undefined;
+  try {
+    fromPath =
+      typeof options?.fromPath === "string"
+        ? options.fromPath || undefined
+        : options?.fromPath
+          ? buildSubAgentPath(options.fromPath.path, options.fromPath.leaf)
+          : undefined;
+  } catch (error) {
+    return new Response(
+      error instanceof Error ? error.message : "Invalid sub-agent path",
+      { status: 400 }
+    );
+  }
   const pathForParsing =
     fromPath !== undefined
       ? `http://placeholder${fromPath.startsWith("/") ? "" : "/"}${fromPath}`

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -60,6 +60,7 @@ export {
   TestSubAgentParent,
   CustomBoundSubAgentParent,
   CounterSubAgent,
+  OAuthCallbackSubAgent,
   OuterSubAgent,
   InnerSubAgent,
   LeafSubAgent,

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -1,9 +1,11 @@
 import { Agent, getCurrentAgent } from "../../index.ts";
 import type {
+  AgentContext,
   FiberInspection,
   FiberRecoveryContext,
   FiberRecoveryResult
 } from "../../index.ts";
+import { MCPConnectionState } from "../../mcp/client-connection.ts";
 import { RpcTarget } from "cloudflare:workers";
 
 // ── SubAgent: Counter ───────────────────────────────────────────────
@@ -552,6 +554,67 @@ export class CounterSubAgent extends Agent {
       agentName: row.agent_name,
       payload: JSON.parse(row.payload) as { callback?: string; id?: string }
     }));
+  }
+}
+
+// ── SubAgent: MCP OAuth callback routing ───────────────────────────
+
+export class OAuthCallbackSubAgent extends Agent {
+  constructor(ctx: AgentContext, env: Cloudflare.Env) {
+    super(ctx, env);
+
+    this.mcp.configureOAuthCallback({
+      customHandler: (result) =>
+        Response.json(
+          { serverId: result.serverId, success: result.authSuccess },
+          { status: result.authSuccess ? 200 : 401 }
+        )
+    });
+
+    this.mcp.connectToServer = async (id: string) => {
+      const provider =
+        this.mcp.mcpConnections[id]?.options.transport.authProvider;
+      if (!provider) {
+        throw new Error("Test OAuth provider was not registered");
+      }
+
+      const redirectUrl = provider.redirectUrl;
+      if (!redirectUrl) {
+        throw new Error("Test OAuth provider has no redirect URL");
+      }
+
+      if (!provider.state) {
+        throw new Error("Test OAuth provider cannot create state");
+      }
+      const authUrl = new URL("https://auth.example.com/authorize");
+      authUrl.searchParams.set("redirect_uri", redirectUrl.toString());
+      authUrl.searchParams.set("state", await provider.state());
+      authUrl.searchParams.set("code_challenge", "test-code-challenge");
+      authUrl.searchParams.set("code_challenge_method", "S256");
+      await provider.redirectToAuthorization(authUrl);
+      this.mcp.mcpConnections[id].connectionState =
+        MCPConnectionState.AUTHENTICATING;
+
+      if (!provider.authUrl) {
+        throw new Error("Test OAuth provider did not record an auth URL");
+      }
+      return {
+        state: MCPConnectionState.AUTHENTICATING,
+        authUrl: provider.authUrl
+      };
+    };
+  }
+
+  async startOAuth(callbackPath?: string): Promise<string> {
+    const result = await this.addMcpServer(
+      "test-oauth-server",
+      "https://mcp.example.com/mcp",
+      { callbackHost: "https://app.example.com", callbackPath }
+    );
+    if (result.state !== "authenticating") {
+      throw new Error(`Expected authenticating state, got ${result.state}`);
+    }
+    return result.authUrl;
   }
 }
 
@@ -1143,6 +1206,14 @@ export class TestSubAgentParent extends Agent {
   async subAgentPing(subAgentName: string): Promise<string> {
     const child = await this.subAgent(CounterSubAgent, subAgentName);
     return child.ping();
+  }
+
+  async startSubAgentOAuth(
+    subAgentName: string,
+    callbackPath?: string
+  ): Promise<string> {
+    const child = await this.subAgent(OAuthCallbackSubAgent, subAgentName);
+    return child.startOAuth(callbackPath);
   }
 
   async seedLegacyCounterSubAgentRegistry(subAgentName: string): Promise<void> {

--- a/packages/agents/src/tests/sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/sub-agent-routing.test.ts
@@ -17,7 +17,10 @@ import { exports, env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import type { Agent } from "../index";
 import { getAgentByName, getSubAgentByName, parseSubAgentPath } from "../index";
-import { buildSubAgentPath } from "../sub-routing";
+import {
+  buildSubAgentPath,
+  validateRootAgentNameSegment
+} from "../sub-routing";
 
 function uniqueName() {
   return `sub-routing-${Math.random().toString(36).slice(2)}`;
@@ -67,6 +70,20 @@ describe("sub-agent routing — routeAgentRequest + /sub/... URLs", () => {
     expect(authUrl.searchParams.get("redirect_uri")).toBe(
       `https://app.example.com/agents/test-sub-agent-parent/${parent}/sub/o-auth-callback-sub-agent/${child}/callback`
     );
+  });
+
+  it("routes an OAuth callback when the root name contains percent escapes", async () => {
+    const parent = `root%2F${uniqueName()}`;
+    const child = uniqueName();
+    const parentStub = await getAgentByName(env.TestSubAgentParent, parent);
+    const authUrl = new URL(await parentStub.startSubAgentOAuth(child));
+    const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri")!);
+    callbackUrl.searchParams.set("error", "access_denied");
+    callbackUrl.searchParams.set("state", authUrl.searchParams.get("state")!);
+
+    const response = await exports.default.fetch(new Request(callbackUrl));
+
+    expect(response.status).toBe(401);
   });
 
   it("routes an OAuth callback to the sub-agent that started the flow", async () => {
@@ -130,6 +147,23 @@ describe("sub-agent routing — routeAgentRequest + /sub/... URLs", () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it("allows ordinary facet HTTP paths containing a sub segment", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const response = await exports.default.fetch(
+      new Request(
+        `https://app.example.com/agents/test-sub-agent-parent/${parent}/sub/outer-sub-agent/${child}/api/sub/items/42`
+      )
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      agentName: child,
+      path: "/api/sub/items/42"
+    });
   });
 
   it("does not take OAuth parameters from the internal outer-URL header", async () => {
@@ -504,26 +538,68 @@ describe("routeSubAgentRequest — query-param preservation", () => {
     expect(response.status).toBe(400);
   });
 
-  it("rejects an empty string path", async () => {
+  it("returns 400 for an invalid structured path step", async () => {
     const { routeSubAgentRequest } = await import("../index");
     const response = await routeSubAgentRequest(
-      new Request("https://app.example.com/sub/chat/child"),
+      new Request("https://app.example.com/callback"),
       { fetch: () => Promise.reject(new Error("should not forward")) },
-      { fromPath: "" }
+      { fromPath: { path: [{ className: "Sub", name: "child" }] } }
     );
 
     expect(response.status).toBe(400);
   });
 
+  it("treats an empty string path as omitted", async () => {
+    const { routeSubAgentRequest } = await import("../index");
+    let forwardedUrl: string | undefined;
+    const response = await routeSubAgentRequest(
+      new Request("https://app.example.com/sub/chat/child?code=test"),
+      {
+        fetch: (request: Request) => {
+          forwardedUrl = request.url;
+          return Promise.resolve(new Response(null, { status: 204 }));
+        }
+      },
+      { fromPath: "" }
+    );
+
+    expect(response.status).toBe(204);
+    expect(forwardedUrl).toBe(
+      "https://app.example.com/sub/chat/child?code=test"
+    );
+  });
+
+  it.each(["%2e", "%2e%2e", "has/slash", "has?query", "has#fragment"])(
+    "rejects the non-routable root name %j",
+    (name) => {
+      expect(() => validateRootAgentNameSegment(name)).toThrow(
+        /not externally routable/
+      );
+    }
+  );
+
   it("does not disturb unmatched request bodies", async () => {
     const { routeAgentRequest } = await import("../index");
     const request = new Request("https://app.example.com/not-an-agent", {
       method: "POST",
+      headers: { "x-cf-agents-subagent-url": "https://forged.example.com" },
       body: "fallback body"
     });
 
     expect(await routeAgentRequest(request, env)).toBeNull();
     await expect(request.text()).resolves.toBe("fallback body");
+  });
+
+  it("does not clone an unmatched request with an already-used body", async () => {
+    const { routeAgentRequest } = await import("../index");
+    const request = new Request("https://app.example.com/not-an-agent", {
+      method: "POST",
+      headers: { "x-cf-agents-subagent-url": "https://forged.example.com" },
+      body: "already read"
+    });
+    await request.text();
+
+    expect(await routeAgentRequest(request, env)).toBeNull();
   });
 
   it("accepts a structured sub-agent path", async () => {

--- a/packages/agents/src/tests/sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/sub-agent-routing.test.ts
@@ -590,6 +590,24 @@ describe("routeSubAgentRequest — query-param preservation", () => {
     await expect(request.text()).resolves.toBe("fallback body");
   });
 
+  it("rejects a matched request with an already-used body before cloning", async () => {
+    const { routeAgentRequest } = await import("../index");
+    const request = new Request(
+      `https://app.example.com/agents/test-sub-agent-parent/${uniqueName()}`,
+      {
+        method: "POST",
+        headers: {
+          "x-cf-agents-subagent-url": "https://forged.example.com"
+        },
+        body: "already read"
+      }
+    );
+    await request.text();
+
+    const response = await routeAgentRequest(request, env);
+    expect(response?.status).toBe(400);
+  });
+
   it("does not clone an unmatched request with an already-used body", async () => {
     const { routeAgentRequest } = await import("../index");
     const request = new Request("https://app.example.com/not-an-agent", {

--- a/packages/agents/src/tests/sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/sub-agent-routing.test.ts
@@ -590,24 +590,6 @@ describe("routeSubAgentRequest — query-param preservation", () => {
     await expect(request.text()).resolves.toBe("fallback body");
   });
 
-  it("rejects a matched request with an already-used body before cloning", async () => {
-    const { routeAgentRequest } = await import("../index");
-    const request = new Request(
-      `https://app.example.com/agents/test-sub-agent-parent/${uniqueName()}`,
-      {
-        method: "POST",
-        headers: {
-          "x-cf-agents-subagent-url": "https://forged.example.com"
-        },
-        body: "already read"
-      }
-    );
-    await request.text();
-
-    const response = await routeAgentRequest(request, env);
-    expect(response?.status).toBe(400);
-  });
-
   it("does not clone an unmatched request with an already-used body", async () => {
     const { routeAgentRequest } = await import("../index");
     const request = new Request("https://app.example.com/not-an-agent", {

--- a/packages/agents/src/tests/sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/sub-agent-routing.test.ts
@@ -17,6 +17,7 @@ import { exports, env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import type { Agent } from "../index";
 import { getAgentByName, getSubAgentByName, parseSubAgentPath } from "../index";
+import { buildSubAgentPath } from "../sub-routing";
 
 function uniqueName() {
   return `sub-routing-${Math.random().toString(36).slice(2)}`;
@@ -51,6 +52,98 @@ describe("sub-agent routing — routeAgentRequest + /sub/... URLs", () => {
 
     const after = await childStub.get("anything");
     expect(after).toBe(1);
+  });
+
+  it("builds a routable OAuth callback URL for a sub-agent", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+    const parentStub = await getAgentByName(env.TestSubAgentParent, parent);
+
+    const authUrl = new URL(await parentStub.startSubAgentOAuth(child));
+
+    expect(authUrl.origin + authUrl.pathname).toBe(
+      "https://auth.example.com/authorize"
+    );
+    expect(authUrl.searchParams.get("redirect_uri")).toBe(
+      `https://app.example.com/agents/test-sub-agent-parent/${parent}/sub/o-auth-callback-sub-agent/${child}/callback`
+    );
+  });
+
+  it("routes an OAuth callback to the sub-agent that started the flow", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+    const parentStub = await getAgentByName(env.TestSubAgentParent, parent);
+    const authUrl = new URL(await parentStub.startSubAgentOAuth(child));
+    const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri")!);
+    callbackUrl.searchParams.set("error", "access_denied");
+    callbackUrl.searchParams.set("state", authUrl.searchParams.get("state")!);
+
+    const response = await exports.default.fetch(
+      new Request(callbackUrl, { redirect: "manual" })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      serverId: authUrl.searchParams.get("state")!.split(".")[1],
+      success: false
+    });
+  });
+
+  it("routes a custom OAuth callback through a structured path", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+    const parentStub = await getAgentByName(env.TestSubAgentParent, parent);
+    const authUrl = new URL(
+      await parentStub.startSubAgentOAuth(child, "/oauth/callback")
+    );
+    const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri")!);
+    callbackUrl.searchParams.set("error", "access_denied");
+    callbackUrl.searchParams.set("state", authUrl.searchParams.get("state")!);
+    const { routeSubAgentRequest } = await import("../index");
+
+    const response = await routeSubAgentRequest(
+      new Request(callbackUrl),
+      parentStub,
+      {
+        fromPath: {
+          path: [{ className: "OAuthCallbackSubAgent", name: child }],
+          leaf: "/callback"
+        }
+      }
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ success: false });
+  });
+
+  it("does not take OAuth parameters from the internal outer-URL header", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+    const parentStub = await getAgentByName(env.TestSubAgentParent, parent);
+    const authUrl = new URL(
+      await parentStub.startSubAgentOAuth(child, "/oauth/callback")
+    );
+    const state = authUrl.searchParams.get("state")!;
+    const internalUrl = new URL(
+      `https://app.example.com/sub/o-auth-callback-sub-agent/${child}/callback`
+    );
+    internalUrl.searchParams.set("error", "access_denied");
+    internalUrl.searchParams.set("state", state);
+
+    const response = await parentStub.fetch(
+      new Request(internalUrl, {
+        headers: {
+          "x-cf-agents-subagent-url":
+            "https://app.example.com/oauth/callback?state=forged.invalid"
+        }
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      serverId: state.split(".")[1],
+      success: false
+    });
   });
 
   it("hasSubAgent reflects spawns driven by the real bridge", async () => {
@@ -253,6 +346,38 @@ describe("onBeforeSubAgent hook — allow / reject / mutate", () => {
   });
 });
 
+describe("buildSubAgentPath", () => {
+  it("builds a nested route and leaf path", () => {
+    expect(
+      buildSubAgentPath(
+        [
+          { className: "Chat", name: "chat/a" },
+          { className: "ThreadAgent", name: "thread one" }
+        ],
+        "/callback"
+      )
+    ).toBe("/sub/chat/chat%2Fa/sub/thread-agent/thread%20one/callback");
+  });
+
+  it("defaults the leaf path to the routed sub-agent root", () => {
+    expect(buildSubAgentPath([{ className: "Chat", name: "chat-a" }])).toBe(
+      "/sub/chat/chat-a"
+    );
+  });
+
+  it.each(["", ".", ".."])("rejects the non-routable name %j", (name) => {
+    expect(() => buildSubAgentPath([{ className: "Chat", name }])).toThrow(
+      /not externally routable/
+    );
+  });
+
+  it("rejects a sub-agent class that collides with the route separator", () => {
+    expect(() =>
+      buildSubAgentPath([{ className: "Sub", name: "child" }])
+    ).toThrow(/reserved/);
+  });
+});
+
 describe("parseSubAgentPath", () => {
   it("matches the default /sub/{class}/{name}", () => {
     const m = parseSubAgentPath("http://x/agents/inbox/alice/sub/chat/abc", {
@@ -352,6 +477,31 @@ describe("parseSubAgentPath", () => {
 });
 
 describe("routeSubAgentRequest — query-param preservation", () => {
+  it("accepts a structured sub-agent path", async () => {
+    const parent = uniqueName();
+    const child = "chat/with space";
+    const parentStub = await getAgentByName(env.HookingSubAgentParent, parent);
+    await parentStub.setHookMode("allow");
+    const { routeSubAgentRequest } = await import("../index");
+
+    await routeSubAgentRequest(
+      new Request("https://app.example.com/oauth/callback?code=test"),
+      parentStub,
+      {
+        fromPath: {
+          path: [{ className: "CounterSubAgent", name: child }],
+          leaf: "/callback"
+        }
+      }
+    );
+
+    const observed = new URL((await parentStub.lastObservedUrl())!);
+    expect(observed.pathname).toBe(
+      "/sub/counter-sub-agent/chat%2Fwith%20space/callback"
+    );
+    expect(observed.search).toBe("?code=test");
+  });
+
   it("preserves original request query params when `fromPath` is used", async () => {
     // Custom-routing worker handler at worker.ts:/custom-sub/...
     // extracts `rest` from the pathname (no query). Without a fix,

--- a/packages/agents/src/tests/sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/sub-agent-routing.test.ts
@@ -116,6 +116,22 @@ describe("sub-agent routing — routeAgentRequest + /sub/... URLs", () => {
     await expect(response.json()).resolves.toMatchObject({ success: false });
   });
 
+  it("ignores a malformed internal outer-URL header", async () => {
+    const parentStub = await getAgentByName(
+      env.TestSubAgentParent,
+      uniqueName()
+    );
+
+    const response = await parentStub.fetch(
+      new Request(
+        `https://app.example.com/sub/counter-sub-agent/${uniqueName()}/request`,
+        { headers: { "x-cf-agents-subagent-url": "not a URL" } }
+      )
+    );
+
+    expect(response.status).toBe(404);
+  });
+
   it("does not take OAuth parameters from the internal outer-URL header", async () => {
     const parent = uniqueName();
     const child = uniqueName();
@@ -477,6 +493,39 @@ describe("parseSubAgentPath", () => {
 });
 
 describe("routeSubAgentRequest — query-param preservation", () => {
+  it("rejects an empty structured path", async () => {
+    const { routeSubAgentRequest } = await import("../index");
+    const response = await routeSubAgentRequest(
+      new Request("https://app.example.com/callback"),
+      { fetch: () => Promise.reject(new Error("should not forward")) },
+      { fromPath: { path: [] } }
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects an empty string path", async () => {
+    const { routeSubAgentRequest } = await import("../index");
+    const response = await routeSubAgentRequest(
+      new Request("https://app.example.com/sub/chat/child"),
+      { fetch: () => Promise.reject(new Error("should not forward")) },
+      { fromPath: "" }
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("does not disturb unmatched request bodies", async () => {
+    const { routeAgentRequest } = await import("../index");
+    const request = new Request("https://app.example.com/not-an-agent", {
+      method: "POST",
+      body: "fallback body"
+    });
+
+    expect(await routeAgentRequest(request, env)).toBeNull();
+    await expect(request.text()).resolves.toBe("fallback body");
+  });
+
   it("accepts a structured sub-agent path", async () => {
     const parent = uniqueName();
     const child = "chat/with space";

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -56,6 +56,7 @@ export {
   TestSubAgentParent,
   CustomBoundSubAgentParent,
   CounterSubAgent,
+  OAuthCallbackSubAgent,
   OuterSubAgent,
   InnerSubAgent,
   LeafSubAgent,

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -201,6 +201,10 @@
         "name": "CounterSubAgent"
       },
       {
+        "class_name": "OAuthCallbackSubAgent",
+        "name": "OAuthCallbackSubAgent"
+      },
+      {
         "class_name": "OuterSubAgent",
         "name": "OuterSubAgent"
       },


### PR DESCRIPTION
This PR routes default MCP OAuth callbacks through the complete root-first sub-agent path so the redirect reaches the facet that initiated authorization. It also gives custom callback handlers a structured `routeSubAgentRequest()` form. Fixes #1856.

## Why

- MCP OAuth state and PKCE data belong to the facet that called `addMcpServer()`. The previous callback URL addressed only the facet class and name as a top-level Durable Object, so the redirect reached a different object with empty storage and returned 404.
- Existing nested `/sub/{class}/{name}` routing can reach the correct facet, but callback URL construction discarded ancestor identity and callback matching lost the public URL as each parent stripped its `/sub/...` prefix.
- We could add `.fetch()` to `getSubAgentByName()`, but that API is a typed RPC proxy and Durable Object stubs cannot be returned across its bridge. Keeping HTTP and WebSocket dispatch in `routeSubAgentRequest()` preserves the existing RPC boundary.
- We could expose a path-string builder, but that would make callers depend on the nested routing wire format and encourage serialize-then-parse call sites. The structured `fromPath` form lets callers describe a destination while the SDK owns encoding.

## Public API Surface

- Adds the exported `SubAgentPathStep` type, containing a sub-agent `className` and instance `name`.
- Additively broadens `routeSubAgentRequest()`'s existing `fromPath` option from `string` to `string | { path: ReadonlyArray<SubAgentPathStep>; leaf?: string }`. Existing string call sites, including an omitted or empty `fromPath`, continue to work.

## Architectural Changes

Default OAuth callbacks now follow the facet ownership chain:

```text
browser
  -> /agents/{root-class}/{root-name}/sub/{child-class}/{child-name}/callback
  -> root Agent
  -> child facet
  -> MCP OAuth state and PKCE storage
```

- Nested HTTP routing carries the original public origin and pathname alongside the rewritten internal request. OAuth query parameters always come from the actual request URL, so internal routing metadata cannot substitute `code`, `state`, or `error` values.
- `routeAgentRequest()` removes caller-supplied routing metadata only for candidate Agent routes, including custom prefixes. It clones the request before sanitation so unmatched fallback handlers retain ownership of the original body.
- WebSocket forwarding intentionally carries the locally routed URL instead. Connection bookkeeping uses its `/sub/...` markers to resolve the targeted facet relative to the current agent.
- Root names retain PartyServer's raw, non-decoding segment semantics. OAuth connections surface a descriptive error when a default facet callback cannot represent the root or child path; non-OAuth MCP connections remain unaffected.

## Code Changes

- `packages/agents/src/index.ts` constructs default facet callback URLs from `selfPath`, preserves root-captured callback identity through recursive HTTP forwarding, validates callback URL metadata, and keeps the existing WebSocket routing model separate.
- `packages/agents/src/sub-routing.ts` centralizes nested path encoding and validation, lets `routeSubAgentRequest()` accept `{ path, leaf }` under the existing `fromPath` option, and returns 400 responses for invalid structured destinations.
- Routing hardening preserves ordinary facet application paths containing `/sub/...`, rejects unresolved internally tagged WebSocket destinations, and avoids disturbing non-Agent fallback requests.
- `docs/agents/mcp-client.md` documents automatic nested callbacks and shows structured dispatch for applications with a fixed custom `callbackPath`.
- `.changeset/tidy-facets-callback.md` records the `agents` patch release.

## Compatibility

- Existing string `fromPath` call sites remain supported. An empty string retains its prior fallback-to-request-URL behavior.
- Non-OAuth MCP servers continue connecting when a facet name cannot round-trip through the default callback route. If the server requires OAuth, the SDK surfaces the deferred routing error; applications can provide an explicit `callbackPath` and route it with `routeSubAgentRequest()`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->



