### PR TITLE
fix(browser): send extraction schemas under json_schema

### DIFF
--- a/.changeset/fix-browser-extract-schema.md
+++ b/.changeset/fix-browser-extract-schema.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Send Browser Run extraction schemas under `response_format.json_schema`, matching the Quick Actions `/json` contract.

--- a/docs/agents/browse-the-web.md
+++ b/docs/agents/browse-the-web.md
@@ -244,7 +244,7 @@ const md = await browserMarkdown(this.env.BROWSER, { url });
 const data = await browserExtract<{ price: number }>(this.env.BROWSER, {
   url,
   prompt: "the product price",
-  response_format: { type: "json_schema", schema: priceSchema }
+  response_format: { type: "json_schema", json_schema: priceSchema }
 });
 ```
 

--- a/examples/browser-quick-actions/src/server.ts
+++ b/examples/browser-quick-actions/src/server.ts
@@ -42,7 +42,7 @@ export class QuickActionsAgent extends Agent<Env> {
       prompt,
       response_format: {
         type: "json_schema",
-        schema: {
+        json_schema: {
           type: "object",
           properties: { items: { type: "array", items: { type: "string" } } },
           required: ["items"]

--- a/packages/agents/src/browser/ai.ts
+++ b/packages/agents/src/browser/ai.ts
@@ -507,7 +507,7 @@ export function createQuickActionTools(
             ...toPage(input, requestOptions),
             prompt: input.prompt,
             response_format: input.schema
-              ? { type: "json_schema", schema: input.schema }
+              ? { type: "json_schema", json_schema: input.schema }
               : undefined
           }),
           maxChars

--- a/packages/agents/src/browser/quick-actions.ts
+++ b/packages/agents/src/browser/quick-actions.ts
@@ -60,7 +60,7 @@ export type QuickActionExtractInput = QuickActionPage & {
   /** Natural-language instruction for what to extract. */
   prompt?: string;
   /** A JSON Schema describing the desired output shape. */
-  response_format?: { type: "json_schema"; schema: unknown };
+  response_format?: { type: "json_schema"; json_schema: unknown };
   /** Bring-your-own model(s), tried in order, for extraction. */
   custom_ai?: { model: string; authorization: string }[];
 };

--- a/packages/agents/src/tests-d/browser-quick-actions.test-d.ts
+++ b/packages/agents/src/tests-d/browser-quick-actions.test-d.ts
@@ -9,7 +9,16 @@ declare const browser: QuickActionBinding;
 runQuickAction(browser, "json", {
   url: "https://example.com",
   prompt: "extract titles",
-  response_format: { type: "json_schema", schema: {} }
+  response_format: { type: "json_schema", json_schema: {} }
+});
+
+runQuickAction(browser, "json", {
+  url: "https://example.com",
+  response_format: {
+    type: "json_schema",
+    // @ts-expect-error Browser Run requires the schema under `json_schema`
+    schema: {}
+  }
 });
 
 // `scrape` accepts `elements`.

--- a/packages/agents/src/tests/browser-quick-actions.test.ts
+++ b/packages/agents/src/tests/browser-quick-actions.test.ts
@@ -72,7 +72,7 @@ describe("quick action helpers", () => {
         prompt: "list products",
         response_format: {
           type: "json_schema",
-          schema: { type: "object" }
+          json_schema: { type: "object" }
         }
       }
     );
@@ -237,7 +237,7 @@ describe("createQuickActionTools", () => {
     );
   });
 
-  it("maps the extract tool's schema onto response_format", async () => {
+  it("maps the extract tool's schema onto response_format.json_schema", async () => {
     const { browser, calls } = fakeBrowser(() => jsonResult({ ok: true }));
     const tools = createQuickActionTools({ browser });
     await runTool(tools.browser_extract, {
@@ -248,7 +248,7 @@ describe("createQuickActionTools", () => {
     expect(calls[0].action).toBe("json");
     expect(calls[0].params.response_format).toEqual({
       type: "json_schema",
-      schema: { type: "object" }
+      json_schema: { type: "object" }
     });
   });
 


### PR DESCRIPTION
This PR fixes Browser Run schema extraction by sending schemas under `response_format.json_schema` and aligning the exported Quick Action type and examples with the service contract. Fixes #2029.

## Why

- `browser_extract` accepts a model-facing `schema`, but forwarded it to Browser Run as `response_format.schema`. Browser Run requires `response_format.json_schema`, so every schema-based extraction failed with HTTP 400.
- The implementation and exported type followed an outdated Browser Run documentation example. The unit test used a fake binding and asserted the same incorrect payload, so it could not detect the contract mismatch.
- This corrects the SDK to use the service-native field rather than supporting two spellings. The old spelling never produced a valid schema-based Browser Run request.

## Public API Surface

- `QuickActionExtractInput.response_format` now uses `json_schema` instead of `schema`.
- The model-facing `browser_extract` input remains unchanged: models still pass the schema through its top-level `schema` field.

## Code Changes

- Map `browser_extract` schemas to `response_format.json_schema`.
- Align the Quick Action extraction type with Browser Run and Workers Types.
- Add type coverage that accepts `json_schema` and rejects the invalid `schema` property.
- Update the package documentation and browser Quick Actions example to show the valid request shape.
- Add an `agents` patch changeset.

## Compatibility

Direct callers of `browserExtract` or `runQuickAction` that construct `response_format` must rename its nested `schema` property to `json_schema`. The previous property matched the published SDK type but was rejected by Browser Run at runtime.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->