### PR TITLE
fix(browser): reject malformed browser tool arguments

### DIFF
--- a/.changeset/strict-browsers-validate.md
+++ b/.changeset/strict-browsers-validate.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Validate BrowserConnector tool arguments before execution and reject JSON-stringified Browser Run extraction schemas with an actionable error.

--- a/packages/agents/src/browser/ai.ts
+++ b/packages/agents/src/browser/ai.ts
@@ -491,7 +491,9 @@ export function createQuickActionTools(
             .optional()
             .describe("What to extract, in natural language"),
           schema: z
-            .unknown()
+            .record(z.string(), z.unknown(), {
+              error: "Schema must be a JSON object"
+            })
             .optional()
             .describe("Optional JSON Schema describing the desired output")
         })

--- a/packages/agents/src/browser/connector.ts
+++ b/packages/agents/src/browser/connector.ts
@@ -1,5 +1,7 @@
+import { Validator, type OutputUnit, type Schema } from "@cfworker/json-schema";
 import {
   CodemodeConnector,
+  type ConnectorTool,
   type ConnectorTools,
   type ExecutionEndStatus,
   type PassEndStatus,
@@ -177,6 +179,26 @@ function isMissingBrowserSession(error: unknown): boolean {
   );
 }
 
+function formatToolValidationError(
+  connector: string,
+  tool: string,
+  errors: OutputUnit[]
+): string {
+  // A failing property emits both a generic parent `properties` error and a
+  // specific child error. Prefer the latter so the model sees what to fix.
+  const specific = errors.filter((error) => error.keyword !== "properties");
+  const relevant = specific.length > 0 ? specific : errors;
+  const details = relevant.map((error) => {
+    const location = error.instanceLocation
+      .replace(/^#\/?/, "")
+      .replaceAll("~1", "/")
+      .replaceAll("~0", "~")
+      .replaceAll("/", ".");
+    return `${location ? ` at ${location}` : ""}: ${error.error}`;
+  });
+  return `Invalid arguments for ${connector}.${tool}${details.join(";")}`;
+}
+
 /**
  * Rewrite the hosted Live View UI's `mode` query param (`tab` | `devtools`).
  * The raw `devtoolsFrontendUrl` is returned unchanged when no mode is asked
@@ -285,6 +307,30 @@ export class BrowserConnector extends CodemodeConnector {
       );
     }
     return lines.join("\n");
+  }
+
+  protected override tool(name: string, tool: ConnectorTool): ConnectorTool {
+    if (!tool.inputSchema) return tool;
+
+    // Both types describe draft-7 schemas, but @cfworker's `Schema` type is
+    // narrower than JSONSchema7 around boolean subschemas.
+    const schema = tool.inputSchema as unknown as Schema;
+    const validator = new Validator(schema, "7", false);
+    return {
+      ...tool,
+      execute: async (args, ctx) => {
+        // Browser's argumentless tools are documented as `cdp.spec()` etc.;
+        // treat an omitted argument as the empty object their schemas expect.
+        const input = args === undefined ? {} : args;
+        const result = validator.validate(input);
+        if (!result.valid) {
+          throw new Error(
+            formatToolValidationError(this.name(), name, result.errors)
+          );
+        }
+        return await tool.execute(input, ctx);
+      }
+    };
   }
 
   protected tools(): ConnectorTools {

--- a/packages/agents/src/tests/browser-connector.test.ts
+++ b/packages/agents/src/tests/browser-connector.test.ts
@@ -285,6 +285,46 @@ describe("BrowserConnector", () => {
     ).rejects.toThrow("execution context");
   });
 
+  it("validates tool arguments before starting browser work", async () => {
+    const { browser, requests } = createFakeBrowser();
+    const store = new MemorySessionStore();
+    const connector = new BrowserConnector(fakeCtx, { browser, store });
+
+    await expect(
+      connector.executeTool(
+        "send",
+        {
+          method: "Runtime.enable",
+          sessionId: { sessionId: "target:target-1" }
+        },
+        { executionId: "exec-invalid" }
+      )
+    ).rejects.toThrow(
+      'Invalid arguments for cdp.send at sessionId: Instance type "object" is invalid. Expected "string".'
+    );
+    await expect(
+      connector.executeTool(
+        "attachToTarget",
+        {},
+        { executionId: "exec-invalid" }
+      )
+    ).rejects.toThrow(
+      'Invalid arguments for cdp.attachToTarget: Instance does not have required property "targetId".'
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  it("accepts omitted arguments for argumentless browser tools", async () => {
+    const { browser } = createFakeBrowser();
+    const store = new MemorySessionStore();
+    const connector = new BrowserConnector(fakeCtx, { browser, store });
+
+    const spec = (await connector.executeTool("spec", undefined)) as {
+      domains: Array<{ name: string }>;
+    };
+    expect(spec.domains.some((domain) => domain.name === "Page")).toBe(true);
+  });
+
   it("creates one session per execution and stores it under cdp:exec:<id>", async () => {
     const { browser, requests } = createFakeBrowser();
     const store = new MemorySessionStore();

--- a/packages/agents/src/tests/browser-quick-actions.test.ts
+++ b/packages/agents/src/tests/browser-quick-actions.test.ts
@@ -1,3 +1,4 @@
+import { asSchema } from "ai";
 import { describe, expect, it } from "vitest";
 import {
   browserContent,
@@ -224,6 +225,33 @@ describe("createQuickActionTools", () => {
       "browser_content",
       "browser_markdown"
     ]);
+  });
+
+  it("rejects stringified extraction schemas", async () => {
+    const { browser } = fakeBrowser(() => jsonResult({ ok: true }));
+    const tool = createQuickActionTools({ browser }).browser_extract;
+    const schema = asSchema(tool.inputSchema);
+    if (!schema.validate)
+      throw new Error("Expected a runtime schema validator");
+
+    expect(schema.jsonSchema).toMatchObject({
+      properties: { schema: { type: "object" } }
+    });
+
+    const invalid = await schema.validate({
+      url: "https://example.com",
+      schema: '{"type":"object"}'
+    });
+    expect(invalid.success).toBe(false);
+    if (invalid.success) throw new Error("Expected validation to fail");
+    expect(invalid.error.message).toContain("Schema must be a JSON object");
+
+    await expect(
+      schema.validate({
+        url: "https://example.com",
+        schema: { type: "object" }
+      })
+    ).resolves.toMatchObject({ success: true });
   });
 
   it("truncates long markdown results to maxChars", async () => {


### PR DESCRIPTION
This PR validates browser tool inputs at their existing schema boundaries so malformed model-generated arguments fail locally with useful errors. Fixes #2030 and #2031.

## Why

- `browser_extract` advertised its extraction schema as `unknown`, so JSON-stringified schemas passed AI SDK validation and failed in Browser Run with an opaque 400 response.
- `BrowserConnector` advertised JSON Schema for its tools but trusted runtime arguments. Passing the full `attachToTarget` result as `send.sessionId` reached `.startsWith()` and crashed with a bare `TypeError`.
- We could coerce both common model mistakes, but that would silently expand the interfaces beyond their advertised shapes. This PR rejects invalid arguments so the model can correct its call.
- Validation stays scoped to browser tools. `packages/agents` already depends on a Workers-compatible JSON Schema validator, so codemode core and its optional peer boundaries remain unchanged.

## Code Changes

- Tighten `browser_extract.schema` to require a JSON object and provide a local validation error.
- Validate every `BrowserConnector` tool invocation against its existing draft 7 input schema before starting browser work.
- Prefer path-specific validation details over redundant parent errors, making failures such as an object-valued `sessionId` actionable.
- Preserve documented argumentless calls such as `cdp.spec()` by treating omitted input as an empty object.
- Add a patch changeset covering both fixes.

## Compatibility

- Valid browser tool calls are unchanged.
- Callers passing values outside the advertised schemas now receive an earlier validation error. Extraction schemas must be objects, and `cdp.send.sessionId` must be the string returned within the `attachToTarget` result.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->