### PR TITLE
feat(agents): add canonical Agent URL builders

### DIFF
--- a/.changeset/calm-facets-route.md
+++ b/.changeset/calm-facets-route.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Add `buildAgentPath()` and `buildAgentUrl()` for constructing canonical root-first Agent and sub-agent addresses for external HTTP requests, WebSocket connections, callbacks, and webhooks. React sub-agent connections now share the same descendant path encoder.

--- a/design/sub-agent-routing.md
+++ b/design/sub-agent-routing.md
@@ -31,6 +31,14 @@ The URL shape is nested under the parent:
 /agents/{parent-class}/{parent-name}/sub/{child-class}/{child-name}
 ```
 
+`buildAgentPath(path, options?)` is the canonical serializer for this wire
+format. It accepts the same root-first `{ className, name }[]` shape exposed by
+`Agent#selfPath`, owns class conversion and name encoding, and can append a
+pathname suffix. When the root Durable Object binding and class names differ,
+`rootBinding` supplies the routing namespace. `buildAgentUrl(origin, path, options?)` adds
+an HTTP(S) or WS(S) origin. The resulting address is transport-neutral: HTTP
+requests and WebSocket upgrades use the same pathname.
+
 The parent DO is always woken first. Its `onBeforeSubAgent(req, { className, name })`
 hook can:
 

--- a/docs/agents/adding-to-existing-project.md
+++ b/docs/agents/adding-to-existing-project.md
@@ -371,7 +371,7 @@ By default, agents are routed at `/agents/{agent-name}/{instance-name}`. You can
 import { routeAgentRequest } from "agents";
 
 const agentResponse = await routeAgentRequest(request, env, {
-  prefix: "/api/agents" // Now routes at /api/agents/{agent-name}/{instance-name}
+  prefix: "api/agents" // Now routes at /api/agents/{agent-name}/{instance-name}
 });
 ```
 

--- a/docs/agents/routing.md
+++ b/docs/agents/routing.md
@@ -96,6 +96,33 @@ export default {
 
 ---
 
+## Building Agent URLs
+
+Use `buildAgentPath()` when a server, external provider, or client needs the canonical pathname for a known root-first Agent identity. It handles the top-level route and every nested `/sub/...` hop:
+
+```typescript
+import { buildAgentPath, buildAgentUrl } from "agents";
+
+const address = [
+  { className: "Inbox", name: userId },
+  { className: "Chat", name: chatId }
+];
+
+buildAgentPath(address, { leafPath: "/callbacks/job" });
+// /agents/inbox/{userId}/sub/chat/{chatId}/callbacks/job
+
+buildAgentUrl("https://app.example.com", address, {
+  leafPath: "/callbacks/job"
+});
+// URL("https://app.example.com/agents/inbox/...")
+```
+
+Inside an Agent, `this.selfPath` has the required root-first shape. If the root Durable Object binding name differs from its class name, pass that binding name as `rootBinding`. The pathname works for both HTTP and WebSocket traffic. For a custom top-level prefix, pass the same `prefix` to `buildAgentPath()` and `routeAgentRequest()`.
+
+See [Sub-agents](./sub-agents.md#direct-http-and-websocket-urls) for callbacks, webhooks, custom routing, and name-encoding details.
+
+---
+
 ## Instance Naming Patterns
 
 The instance name (the last part of the URL) determines which agent instance handles the request. Each unique name gets its own isolated agent with its own state.

--- a/docs/agents/sub-agents.md
+++ b/docs/agents/sub-agents.md
@@ -273,7 +273,52 @@ const chat = useAgent({
 
 Every other `useAgent` feature works as usual: `state` sync, `stub.method()` calls, `@callable` RPCs, `useAgentChat` on top of the returned socket.
 
-### Direct HTTP / custom routing
+### Direct HTTP and WebSocket URLs
+
+Use `buildAgentPath()` to turn a root-first Agent identity into the canonical URL pathname used by both HTTP requests and WebSocket connections:
+
+```typescript
+import { buildAgentPath } from "agents";
+
+const path = buildAgentPath(
+  [
+    { className: "Inbox", name: userId },
+    { className: "Chat", name: chatId }
+  ],
+  { leafPath: "/callbacks/job" }
+);
+
+// /agents/inbox/{userId}/sub/chat/{chatId}/callbacks/job
+```
+
+Inside an Agent, pass `this.selfPath` directly. If the root Durable Object binding name differs from its class name, also pass `rootBinding` in the options. `buildAgentUrl()` adds a public origin, which is useful when registering callbacks, webhooks, approval URLs, or asynchronous job-completion URLs with an external system:
+
+```typescript
+import { buildAgentUrl } from "agents";
+
+export class Chat extends Agent<Env> {
+  callbackUrl() {
+    return buildAgentUrl(this.env.PUBLIC_ORIGIN, this.selfPath, {
+      leafPath: "/callbacks/job"
+    });
+  }
+
+  override async onRequest(request: Request) {
+    if (new URL(request.url).pathname === "/callbacks/job") {
+      return this.handleJobCallback(request);
+    }
+    return new Response("Not found", { status: 404 });
+  }
+}
+```
+
+The Worker must pass the incoming request to `routeAgentRequest()`. Each ancestor's `onBeforeSubAgent` hook runs before the destination receives the request. For a sub-agent destination, the nested `/sub/...` routing segments are removed during forwarding, so its pathname is the `leafPath` suffix.
+
+`buildAgentUrl()` accepts an HTTP(S) or WS(S) origin without a pathname, query, fragment, or credentials. Set callback query parameters through the returned URL's `searchParams`. If you use a custom routing prefix, pass the same value to both `buildAgentPath()` and `routeAgentRequest()`.
+
+Root Agent names follow PartyServer's existing raw pathname-segment behavior and must already be externally routable. The `sub` segment is reserved in routing prefixes, class and binding names, and root Agent names. Descendant names are URL-encoded by the helper, so names containing spaces, Unicode, `/`, or URL-reserved characters round-trip safely.
+
+### Custom routing
 
 For fetch handlers that do their own top-level URL parsing, use `routeSubAgentRequest` to dispatch a request into a sub-agent from an already-resolved parent stub:
 
@@ -293,7 +338,7 @@ export default {
 };
 ```
 
-`fromPath` takes the sub-agent tail (something like `/sub/chat/chat-abc/...`). The helper parses it, runs the parent's `onBeforeSubAgent` hook, and forwards into the facet.
+`fromPath` takes any pathname containing the sub-agent tail (something like `/sub/chat/chat-abc/...`). When the destination is already represented as a root-first Agent path, pass the result of `buildAgentPath()` directly. The helper parses the first child hop, runs the parent's `onBeforeSubAgent` hook, and forwards into the facet.
 
 ### External typed RPC
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -20,15 +20,22 @@ export { __DO_NOT_USE_WILL_BREAK__agentContext } from "./internal_context";
 export { withInvocationScope as __DO_NOT_USE_WILL_BREAK__withInvocationScope } from "./observability/tracing/tracer";
 import {
   SUB_PREFIX,
-  parseSubAgentPath as _parseSubAgentPath
+  parseSubAgentPath as _parseSubAgentPath,
+  type AgentPathStep
 } from "./sub-routing";
 export {
+  buildAgentPath,
+  buildAgentUrl,
   routeSubAgentRequest,
   getSubAgentByName,
   parseSubAgentPath,
   SUB_PREFIX
 } from "./sub-routing";
-export type { SubAgentPathMatch } from "./sub-routing";
+export type {
+  AgentPathStep,
+  BuildAgentPathOptions,
+  SubAgentPathMatch
+} from "./sub-routing";
 import { signAgentHeaders } from "./email";
 import { parseCronExpression } from "cron-schedule";
 import { nanoid } from "nanoid";
@@ -614,8 +621,6 @@ export type Schedule<T = string> = {
       intervalSeconds: number;
     }
 );
-
-type AgentPathStep = { className: string; name: string };
 
 type ScheduleStorageRow = {
   id: string;
@@ -1658,7 +1663,7 @@ export class Agent<
    * via the `parentPath` getter.
    * @internal
    */
-  private _parentPath: ReadonlyArray<{ className: string; name: string }> = [];
+  private _parentPath: ReadonlyArray<AgentPathStep> = [];
 
   /** True while user's onStart() is executing. Used to warn about non-idempotent schedule() calls. */
   private _insideOnStart = false;
@@ -7902,7 +7907,7 @@ export class Agent<
    *
    * @experimental The API surface may change before stabilizing.
    */
-  get parentPath(): ReadonlyArray<{ className: string; name: string }> {
+  get parentPath(): ReadonlyArray<AgentPathStep> {
     return this._parentPath;
   }
 
@@ -7911,7 +7916,7 @@ export class Agent<
    *
    * @experimental The API surface may change before stabilizing.
    */
-  get selfPath(): ReadonlyArray<{ className: string; name: string }> {
+  get selfPath(): ReadonlyArray<AgentPathStep> {
     return [
       ...this._parentPath,
       {

--- a/packages/agents/src/react-tests/useAgent.test.tsx
+++ b/packages/agents/src/react-tests/useAgent.test.tsx
@@ -1085,6 +1085,33 @@ describe("useAgent hook", () => {
   });
 
   describe("sub-agent routing via `sub:` option", () => {
+    it("keeps a disabled placeholder child identity renderable", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let capturedAgent: TestAgent | null = null;
+
+      const { container } = await render(
+        <TestAgentComponent
+          options={{
+            agent: "TestSubAgentParent",
+            name: "placeholder-parent",
+            host,
+            protocol,
+            sub: [{ agent: "CounterSubAgent", name: "" }],
+            enabled: false
+          }}
+          onAgent={(agent) => {
+            capturedAgent = agent;
+          }}
+        />
+      );
+
+      await vi.waitFor(() => expect(capturedAgent).not.toBeNull());
+      expect(
+        container.querySelector('[data-testid="agent-status"]')?.textContent
+      ).toBe("connecting");
+      expect(capturedAgent!.getHttpUrl()).toContain("/sub/counter-sub-agent/");
+    });
+
     // Synchronous URL composition check. The sub-agent WebSocket path
     // is computed at render time, independent of the actual
     // connection handshake, so we can observe it via `getHttpUrl()`

--- a/packages/agents/src/react-tests/useAgent.test.tsx
+++ b/packages/agents/src/react-tests/useAgent.test.tsx
@@ -1128,6 +1128,35 @@ describe("useAgent hook", () => {
       );
     });
 
+    it("preserves URL-normalizable characters in a nested user path", async () => {
+      const { host, protocol } = getTestWorkerHost();
+      let capturedAgent: TestAgent | null = null;
+
+      await render(
+        <TestAgentComponent
+          options={{
+            agent: "TestSubAgentParent",
+            name: "sub-url-parent-unicode",
+            host,
+            protocol,
+            sub: [{ agent: "CounterSubAgent", name: "sub-url-child-unicode" }],
+            path: "rooms/日本語"
+          }}
+          onAgent={(agent) => {
+            capturedAgent = agent;
+          }}
+        />
+      );
+
+      await vi.waitFor(() => expect(capturedAgent).not.toBeNull(), {
+        timeout: 10000
+      });
+
+      expect(capturedAgent!.getHttpUrl()).toContain(
+        "/sub/counter-sub-agent/sub-url-child-unicode/rooms/日本語"
+      );
+    });
+
     it("combines sub-chain alone when no user path is given", async () => {
       const { host, protocol } = getTestWorkerHost();
       let capturedAgent: TestAgent | null = null;

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -19,6 +19,7 @@ import {
   AgentConnectionError as AgentConnectionErrorCtor,
   isTerminalCloseEvent
 } from "./client";
+import { buildSubAgentPath } from "./sub-routing";
 import { camelCaseToKebabCase } from "./utils";
 import { MessageType } from "./types";
 import {
@@ -84,18 +85,10 @@ function buildSubPath(
   subChain: ReadonlyArray<{ agent: string; name: string }>,
   extraPath?: string
 ): string {
-  if (subChain.length === 0) return extraPath ?? "";
-  const parts = subChain.flatMap((step) => [
-    "sub",
-    camelCaseToKebabCase(step.agent),
-    encodeURIComponent(step.name)
-  ]);
-  const combined = parts.join("/");
-  if (extraPath) {
-    const trimmed = extraPath.startsWith("/") ? extraPath.slice(1) : extraPath;
-    return `${combined}/${trimmed}`;
-  }
-  return combined;
+  return buildSubAgentPath(
+    subChain.map((step) => ({ className: step.agent, name: step.name })),
+    extraPath
+  );
 }
 
 function getCacheEntry(key: string): CacheEntry | undefined {

--- a/packages/agents/src/react.tsx
+++ b/packages/agents/src/react.tsx
@@ -19,7 +19,7 @@ import {
   AgentConnectionError as AgentConnectionErrorCtor,
   isTerminalCloseEvent
 } from "./client";
-import { buildSubAgentPath } from "./sub-routing";
+import { buildSubAgentPathUnchecked } from "./sub-routing";
 import { camelCaseToKebabCase } from "./utils";
 import { MessageType } from "./types";
 import {
@@ -85,7 +85,7 @@ function buildSubPath(
   subChain: ReadonlyArray<{ agent: string; name: string }>,
   extraPath?: string
 ): string {
-  return buildSubAgentPath(
+  return buildSubAgentPathUnchecked(
     subChain.map((step) => ({ className: step.agent, name: step.name })),
     extraPath
   );

--- a/packages/agents/src/sub-routing.ts
+++ b/packages/agents/src/sub-routing.ts
@@ -148,22 +148,40 @@ function validateRootAgentName(name: string): string {
   return name;
 }
 
-/** @internal Build the path tail handled recursively by sub-agent routing. */
-export function buildSubAgentPath(
+function serializeSubAgentPath(
   path: ReadonlyArray<AgentPathStep>,
-  leafPath?: string
+  leafPath: string | undefined,
+  validate: boolean
 ): string {
   if (path.length === 0) return leafPath ?? "";
 
   const segments = path.flatMap((child) => [
     SUB_PREFIX,
-    encodeAgentClassName(child.className),
-    encodeChildAgentName(child.name)
+    validate
+      ? encodeAgentClassName(child.className)
+      : camelCaseToKebabCase(child.className),
+    validate ? encodeChildAgentName(child.name) : encodeURIComponent(child.name)
   ]);
   const subPath = segments.join("/");
   if (!leafPath) return subPath;
   const normalizedLeaf = leafPath.startsWith("/") ? leafPath : `/${leafPath}`;
   return `${subPath}${normalizedLeaf}`;
+}
+
+/** @internal Build the strictly validated path tail for sub-agent routing. */
+export function buildSubAgentPath(
+  path: ReadonlyArray<AgentPathStep>,
+  leafPath?: string
+): string {
+  return serializeSubAgentPath(path, leafPath, true);
+}
+
+/** @internal Preserve React's tolerant path composition for disabled placeholders. */
+export function buildSubAgentPathUnchecked(
+  path: ReadonlyArray<AgentPathStep>,
+  leafPath?: string
+): string {
+  return serializeSubAgentPath(path, leafPath, false);
 }
 
 /**

--- a/packages/agents/src/sub-routing.ts
+++ b/packages/agents/src/sub-routing.ts
@@ -29,6 +29,201 @@ import type { Agent, SubAgentClass, SubAgentStub } from "./index";
  */
 export const SUB_PREFIX = "sub";
 
+/** One agent identity in a root-first address chain. */
+export interface AgentPathStep {
+  /** Agent class name as exported by the Worker. */
+  className: string;
+  /** Logical Agent instance name. */
+  name: string;
+}
+
+export interface BuildAgentPathOptions {
+  /** Top-level route prefix. Must match `routeAgentRequest`; defaults to `agents`. */
+  prefix?: string;
+  /** Pathname suffix appended after the destination Agent identity. */
+  leafPath?: string;
+  /** Root Durable Object binding name, when it differs from the root class name. */
+  rootBinding?: string;
+}
+
+function validateLeafPath(leafPath: string): string {
+  const normalized = leafPath.startsWith("/") ? leafPath : `/${leafPath}`;
+  const parsed = new URL(normalized, "https://agents.invalid");
+  if (
+    normalized.includes("//") ||
+    (normalized.length > 1 && normalized.endsWith("/")) ||
+    parsed.pathname !== normalized ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(
+      `Cannot build an Agent path for leaf path ${JSON.stringify(leafPath)} because it is not a stable pathname.`
+    );
+  }
+  return normalized;
+}
+
+function validateRoutingPrefix(prefix: string): string {
+  const prefixParts = prefix.split("/");
+  const rawPath = `/${prefix}/leaf`;
+  const parsed = new URL(rawPath, "https://agents.invalid");
+  if (
+    prefixParts.some(
+      (part) => !part || part === "." || part === ".." || part === SUB_PREFIX
+    ) ||
+    parsed.pathname !== rawPath ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(
+      `Cannot build an Agent path for routing prefix ${JSON.stringify(prefix)} because it is not externally routable.`
+    );
+  }
+  return prefix;
+}
+
+function encodeAgentClassName(className: string): string {
+  const segment = camelCaseToKebabCase(className);
+  if (segment === SUB_PREFIX) {
+    throw new Error(
+      `Cannot build an Agent path for Agent class name ${JSON.stringify(className)} because ${JSON.stringify(SUB_PREFIX)} is reserved.`
+    );
+  }
+
+  const rawPath = `/root/${segment}/leaf`;
+  const parsed = new URL(rawPath, "https://agents.invalid");
+  const parts = parsed.pathname.split("/");
+  if (
+    !segment ||
+    parsed.pathname !== rawPath ||
+    parsed.search ||
+    parsed.hash ||
+    parts.length !== 4 ||
+    parts[2] !== segment
+  ) {
+    throw new Error(
+      `Cannot build an Agent path for Agent class name ${JSON.stringify(className)} because it is not externally routable.`
+    );
+  }
+  return segment;
+}
+
+function encodeChildAgentName(name: string): string {
+  if (!name || name === "." || name === ".." || name.includes("\0")) {
+    throw new Error(
+      `Cannot build an Agent path for child Agent name ${JSON.stringify(name)} because it is not externally routable.`
+    );
+  }
+  try {
+    return encodeURIComponent(name);
+  } catch {
+    throw new Error(
+      `Cannot build an Agent path for child Agent name ${JSON.stringify(name)} because it is not valid Unicode.`
+    );
+  }
+}
+
+function validateRootAgentName(name: string): string {
+  if (name === SUB_PREFIX) {
+    throw new Error(
+      `Cannot build an Agent path for root Agent name ${JSON.stringify(name)} because ${JSON.stringify(SUB_PREFIX)} is reserved.`
+    );
+  }
+
+  const rawPath = `/root/${name}/leaf`;
+  const parsed = new URL(rawPath, "https://agents.invalid");
+  const parts = parsed.pathname.split("/");
+  if (
+    !name ||
+    parsed.pathname !== rawPath ||
+    parsed.search ||
+    parsed.hash ||
+    parts.length !== 4 ||
+    parts[2] !== name
+  ) {
+    throw new Error(
+      `Cannot build an Agent path for root Agent name ${JSON.stringify(name)} because it is not externally routable.`
+    );
+  }
+  return name;
+}
+
+/** @internal Build the path tail handled recursively by sub-agent routing. */
+export function buildSubAgentPath(
+  path: ReadonlyArray<AgentPathStep>,
+  leafPath?: string
+): string {
+  if (path.length === 0) return leafPath ?? "";
+
+  const segments = path.flatMap((child) => [
+    SUB_PREFIX,
+    encodeAgentClassName(child.className),
+    encodeChildAgentName(child.name)
+  ]);
+  const subPath = segments.join("/");
+  if (!leafPath) return subPath;
+  const normalizedLeaf = leafPath.startsWith("/") ? leafPath : `/${leafPath}`;
+  return `${subPath}${normalizedLeaf}`;
+}
+
+/**
+ * Build the canonical pathname for a root Agent or nested sub-agent.
+ *
+ * The address is root-first and accepts `Agent#selfPath`. Pass
+ * `rootBinding` when the root Durable Object binding and class names differ.
+ */
+export function buildAgentPath(
+  path: ReadonlyArray<AgentPathStep>,
+  options: BuildAgentPathOptions = {}
+): string {
+  const [root, ...children] = path;
+  if (!root) {
+    throw new Error("Agent path must contain at least one step.");
+  }
+
+  const rootPath = [
+    validateRoutingPrefix(options.prefix ?? "agents"),
+    encodeAgentClassName(options.rootBinding ?? root.className),
+    validateRootAgentName(root.name)
+  ].join("/");
+  const leafPath = options.leafPath
+    ? validateLeafPath(options.leafPath)
+    : undefined;
+  if (children.length === 0) {
+    return `/${rootPath}${leafPath ?? ""}`;
+  }
+  return `/${rootPath}/${buildSubAgentPath(children, leafPath)}`;
+}
+
+/** Build an absolute URL for a root Agent or nested sub-agent. */
+export function buildAgentUrl(
+  origin: string | URL,
+  path: ReadonlyArray<AgentPathStep>,
+  options: BuildAgentPathOptions = {}
+): URL {
+  let base: URL;
+  try {
+    base = new URL(origin.toString());
+  } catch {
+    throw new Error(`Invalid Agent URL origin ${JSON.stringify(origin)}.`);
+  }
+
+  if (
+    !["http:", "https:", "ws:", "wss:"].includes(base.protocol) ||
+    base.username ||
+    base.password ||
+    base.pathname !== "/" ||
+    base.search ||
+    base.hash
+  ) {
+    throw new Error(
+      `Invalid Agent URL origin ${JSON.stringify(origin.toString())}. Pass an HTTP(S) or WS(S) origin without credentials, a pathname, query, or fragment.`
+    );
+  }
+
+  return new URL(buildAgentPath(path, options), base);
+}
+
 export interface SubAgentPathMatch {
   /** CamelCase class name of the child, as it appears in `ctx.exports`. */
   childClass: string;

--- a/packages/agents/src/tests-d/agent-path.test-d.ts
+++ b/packages/agents/src/tests-d/agent-path.test-d.ts
@@ -1,0 +1,23 @@
+import {
+  Agent,
+  buildAgentPath,
+  buildAgentUrl,
+  type AgentPathStep,
+  type BuildAgentPathOptions
+} from "..";
+
+declare const agent: Agent;
+declare const options: BuildAgentPathOptions;
+
+buildAgentPath(agent.selfPath, options) satisfies string;
+buildAgentUrl("https://example.com", agent.selfPath, options) satisfies URL;
+
+const path = [
+  { className: "Inbox", name: "user-123" },
+  { className: "Chat", name: "chat-abc" }
+] as const satisfies ReadonlyArray<AgentPathStep>;
+
+buildAgentPath(path) satisfies string;
+
+// @ts-expect-error each path step requires a class name
+buildAgentPath([{ name: "user-123" }]);

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -14,7 +14,7 @@
 
 import { exports, env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
-import { getAgentByName, getSubAgentByName } from "../index";
+import { buildAgentPath, getAgentByName, getSubAgentByName } from "../index";
 import { SpikeSubChild } from "./agents/spike-sub-agent-routing";
 
 function uniqueName() {
@@ -88,6 +88,31 @@ function isEchoPong(data: string): boolean {
 }
 
 describe("Spike: sub-agent routing via facet Fetcher", () => {
+  it("uses a canonical Agent path for a nested WebSocket", async () => {
+    const parent = uniqueName();
+    const parentStub = await getAgentByName(env.SpikeSubParent, parent);
+    await parentStub.getCount("on_before");
+
+    const child = "child/with space";
+    const path = buildAgentPath([
+      { className: "SpikeSubParent", name: parent },
+      { className: "SpikeSubChild", name: child }
+    ]);
+
+    const response = await exports.default.fetch(`http://example.com${path}`, {
+      headers: { Upgrade: "websocket" }
+    });
+    expect(response.status).toBe(101);
+    const ws = response.webSocket as WebSocket;
+    expect(ws).toBeDefined();
+    ws.accept();
+
+    ws.send("hello");
+    const [reply] = await collectMessages(ws, 1);
+    expect(reply).toBe(`pong:${child}:hello`);
+    ws.close();
+  });
+
   it("establishes a WebSocket through the parent → facet chain", async () => {
     const parent = uniqueName();
     const child = uniqueName();

--- a/packages/agents/src/tests/sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/sub-agent-routing.test.ts
@@ -16,13 +16,72 @@
 import { exports, env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import type { Agent } from "../index";
-import { getAgentByName, getSubAgentByName, parseSubAgentPath } from "../index";
+import {
+  buildAgentPath,
+  buildAgentUrl,
+  getAgentByName,
+  getSubAgentByName,
+  parseSubAgentPath
+} from "../index";
 
 function uniqueName() {
   return `sub-routing-${Math.random().toString(36).slice(2)}`;
 }
 
 describe("sub-agent routing — routeAgentRequest + /sub/... URLs", () => {
+  it("routes external HTTP through a canonical root-first Agent path", async () => {
+    const parent = uniqueName();
+    const outer = "outer/with space";
+    const inner = "inner%literal";
+    const pathname = buildAgentPath(
+      [
+        { className: "TestSubAgentParent", name: parent },
+        { className: "OuterSubAgent", name: outer },
+        { className: "InnerSubAgent", name: inner }
+      ],
+      { leafPath: "/callbacks/job" }
+    );
+
+    const response = await exports.default.fetch(
+      new Request(`https://app.example.com${pathname}?job=123`, {
+        body: "completed",
+        headers: { "x-parent-agent-test": "yes" },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      agentName: inner,
+      body: "completed",
+      header: "yes",
+      method: "POST",
+      path: "/callbacks/job",
+      search: "?job=123"
+    });
+  });
+
+  it("routes a canonical nested path through a custom prefix", async () => {
+    const child = "custom-prefix-child";
+    const pathname = buildAgentPath(
+      [
+        { className: "TestSubAgentParent", name: uniqueName() },
+        { className: "OuterSubAgent", name: child }
+      ],
+      { prefix: "api/agents", leafPath: "/callbacks/job" }
+    );
+
+    const response = await exports.default.fetch(
+      `https://app.example.com${pathname}`
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      agentName: child,
+      path: "/callbacks/job"
+    });
+  });
+
   it("resolves a child facet when the URL contains /sub/", async () => {
     const parent = uniqueName();
     const child = uniqueName();
@@ -253,6 +312,182 @@ describe("onBeforeSubAgent hook — allow / reject / mutate", () => {
   });
 });
 
+describe("buildAgentPath", () => {
+  it("requires a root Agent identity", () => {
+    expect(() => buildAgentPath([])).toThrow(/at least one step/);
+  });
+
+  it("builds a canonical root-first path to a nested agent", () => {
+    expect(
+      buildAgentPath(
+        [
+          { className: "Inbox", name: "user-123" },
+          { className: "ChatAgent", name: "chat/a" }
+        ],
+        { leafPath: "/callbacks/job" }
+      )
+    ).toBe("/agents/inbox/user-123/sub/chat-agent/chat%2Fa/callbacks/job");
+  });
+
+  it.each([
+    [[{ className: "Inbox", name: "user-123" }], "/agents/inbox/user-123/"],
+    [
+      [
+        { className: "Inbox", name: "user-123" },
+        { className: "Chat", name: "chat-456" }
+      ],
+      "/agents/inbox/user-123/sub/chat/chat-456/"
+    ]
+  ] as const)("preserves a root leaf pathname", (path, expected) => {
+    expect(buildAgentPath(path, { leafPath: "/" })).toBe(expected);
+  });
+
+  it("preserves PartyServer's literal-percent root name semantics", () => {
+    expect(buildAgentPath([{ className: "Inbox", name: "user%2F123" }])).toBe(
+      "/agents/inbox/user%2F123"
+    );
+  });
+
+  it("encodes URL-reserved and Unicode characters in child names", () => {
+    expect(
+      buildAgentPath([
+        { className: "Inbox", name: "user-123" },
+        { className: "Chat", name: "space ü?%#" }
+      ])
+    ).toBe("/agents/inbox/user-123/sub/chat/space%20%C3%BC%3F%25%23");
+  });
+
+  it("builds an absolute URL without inheriting a base pathname", () => {
+    expect(
+      buildAgentUrl(
+        "https://app.example.com/",
+        [{ className: "Inbox", name: "user-123" }],
+        { leafPath: "/webhooks/complete" }
+      ).href
+    ).toBe("https://app.example.com/agents/inbox/user-123/webhooks/complete");
+  });
+
+  it.each([
+    "",
+    ".",
+    "..",
+    "%2e",
+    "%2e%2e",
+    "has/slash",
+    "has?query",
+    "has#fragment",
+    "has space",
+    "ümlaut"
+  ])("rejects the non-routable root Agent name %j", (name) => {
+    expect(() => buildAgentPath([{ className: "Inbox", name }])).toThrow(
+      /root Agent name/
+    );
+  });
+
+  it.each(["", ".", "..", "has\0null", "\ud800"])(
+    "rejects the non-routable child Agent name %j",
+    (name) => {
+      expect(() =>
+        buildAgentPath([
+          { className: "Inbox", name: "user-123" },
+          { className: "Chat", name }
+        ])
+      ).toThrow(/child Agent name/);
+    }
+  );
+
+  it.each(["", ".", "..", "Has/Slash", "Has?Query", "Has#Fragment"])(
+    "rejects the non-routable Agent class name %j",
+    (className) => {
+      expect(() => buildAgentPath([{ className, name: "user-123" }])).toThrow(
+        /Agent class name/
+      );
+    }
+  );
+
+  it.each([
+    [[{ className: "Sub", name: "root" }]],
+    [[{ className: "Inbox", name: "sub" }]],
+    [
+      [
+        { className: "Inbox", name: "user-123" },
+        { className: "Sub", name: "child" }
+      ]
+    ]
+  ] as const)(
+    "rejects an identity that collides with the sub route separator",
+    (path) => {
+      expect(() => buildAgentPath(path)).toThrow(/reserved/);
+    }
+  );
+
+  it("supports a root Durable Object binding that differs from its class", () => {
+    expect(
+      buildAgentPath([{ className: "CounterAgent", name: "user-123" }], {
+        rootBinding: "COUNTER_DO"
+      })
+    ).toBe("/agents/counter-do/user-123");
+  });
+
+  it("supports a multi-segment custom routing prefix", () => {
+    expect(
+      buildAgentPath([{ className: "Inbox", name: "user-123" }], {
+        prefix: "api/agents"
+      })
+    ).toBe("/api/agents/inbox/user-123");
+  });
+
+  it.each([
+    "",
+    "/agents",
+    "agents/",
+    "api//agents",
+    "api/./agents",
+    "api/../agents",
+    "api/sub",
+    "api?version=1"
+  ])("rejects the invalid routing prefix %j", (prefix) => {
+    expect(() =>
+      buildAgentPath([{ className: "Inbox", name: "user-123" }], { prefix })
+    ).toThrow(/routing prefix/);
+  });
+
+  it.each([
+    "/callback?code=test",
+    "/callback#complete",
+    "/api/../callback",
+    "/callbacks//job",
+    "/callbacks/",
+    "/has space"
+  ])("rejects the non-pathname leaf path %j", (leafPath) => {
+    expect(() =>
+      buildAgentPath([{ className: "Inbox", name: "user-123" }], {
+        leafPath
+      })
+    ).toThrow(/leaf path/);
+  });
+
+  it("can build a WebSocket URL from the same transport-neutral path", () => {
+    expect(
+      buildAgentUrl("wss://app.example.com", [
+        { className: "Inbox", name: "user-123" }
+      ]).href
+    ).toBe("wss://app.example.com/agents/inbox/user-123");
+  });
+
+  it.each([
+    "ftp://app.example.com",
+    "https://user:password@app.example.com",
+    "https://app.example.com/deployment",
+    "https://app.example.com/?version=1",
+    "https://app.example.com/#fragment"
+  ])("rejects the invalid URL origin %j", (origin) => {
+    expect(() =>
+      buildAgentUrl(origin, [{ className: "Inbox", name: "user-123" }])
+    ).toThrow(/origin/);
+  });
+});
+
 describe("parseSubAgentPath", () => {
   it("matches the default /sub/{class}/{name}", () => {
     const m = parseSubAgentPath("http://x/agents/inbox/alice/sub/chat/abc", {
@@ -352,6 +587,31 @@ describe("parseSubAgentPath", () => {
 });
 
 describe("routeSubAgentRequest — query-param preservation", () => {
+  it("accepts a canonical root-first Agent path", async () => {
+    const parent = uniqueName();
+    const child = "child/with space";
+    const parentStub = await getAgentByName(env.HookingSubAgentParent, parent);
+    await parentStub.setHookMode("allow");
+    const { routeSubAgentRequest } = await import("../index");
+    const fromPath = buildAgentPath(
+      [
+        { className: "HookingSubAgentParent", name: parent },
+        { className: "CounterSubAgent", name: child }
+      ],
+      { leafPath: "/callbacks/job" }
+    );
+
+    await routeSubAgentRequest(
+      new Request("https://app.example.com/webhooks/complete?job=123"),
+      parentStub,
+      { fromPath }
+    );
+
+    const observed = new URL((await parentStub.lastObservedUrl())!);
+    expect(observed.pathname).toBe(fromPath);
+    expect(observed.search).toBe("?job=123");
+  });
+
   it("preserves original request query params when `fromPath` is used", async () => {
     // Custom-routing worker handler at worker.ts:/custom-sub/...
     // extracts `rest` from the pathname (no query). Without a fix,

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -253,6 +253,13 @@ export default {
       return new Response("Internal Server Error", { status: 500 });
     }
 
+    if (url.pathname.startsWith("/api/agents/")) {
+      return (
+        (await routeAgentRequest(request, env, { prefix: "api/agents" })) ??
+        new Response("Not found", { status: 404 })
+      );
+    }
+
     // Custom routing exercising `routeSubAgentRequest` directly —
     // URL shape: /custom-sub/{parent}/sub/{child-class-kebab}/{child-name}
     // The test worker parses the outer shape itself and delegates

--- a/packages/agents/src/workflow-types.ts
+++ b/packages/agents/src/workflow-types.ts
@@ -13,8 +13,9 @@ import type {
   WorkflowStep,
   WorkflowSleepDuration
 } from "cloudflare:workers";
+import type { AgentPathStep } from "./sub-routing";
 
-export type AgentWorkflowPathStep = { className: string; name: string };
+export type AgentWorkflowPathStep = AgentPathStep;
 
 export type AgentWorkflowOrigin =
   | {


### PR DESCRIPTION
This PR adds canonical path and URL builders for external Agent and nested sub-agent HTTP and WebSocket addresses. It addresses the generic external facet routing gap in #1856 and supersedes the MCP-specific design in #2025.

## Why

- External callbacks, webhooks, and direct clients need the complete root-first identity of a sub-agent. Addressing the child as a top-level Durable Object reaches a different object with different storage.
- The nested `/sub/{class}/{name}` wire format already supports HTTP and WebSocket routing, but callers had to reconstruct it manually and React maintained a private serializer.
- We could add `.fetch()` to `getSubAgentByName()`, but that API is a typed RPC proxy. Keeping external HTTP and WebSocket addressing separate preserves the RPC boundary.
- We could solve only MCP OAuth callback routing, but callbacks, webhooks, approvals, and asynchronous completions all need the same primitive. A transport-neutral address builder keeps routing independent of MCP ownership.
- Root names follow PartyServer's raw segment semantics while descendant names are URL-encoded. Centralizing validation and serialization prevents callers from implementing those rules inconsistently.

## Public API Surface

All additions are additive.

| Symbol | Kind | Notes |
| --- | --- | --- |
| `AgentPathStep` | Type | One `{ className, name }` identity in a root-first path |
| `BuildAgentPathOptions` | Type | Configures the route prefix, leaf suffix, and optional root binding override |
| `buildAgentPath()` | Function | Builds a canonical pathname for a root Agent or nested sub-agent |
| `buildAgentUrl()` | Function | Adds an HTTP(S) or WS(S) origin and returns a `URL` |

## Architectural Changes

Agent identity serialization now has one owner:

```text
Agent#selfPath
    |
    v
buildAgentPath()
    |
    v
/agents/{root-class}/{root-name}/sub/{child-class}/{child-name}
    |
    +-- HTTP request
    +-- WebSocket connection
    +-- routeSubAgentRequest({ fromPath })
```

`buildAgentUrl()` composes the same pathname with a public origin for callbacks and webhooks.

## Code Changes

- `packages/agents/src/sub-routing.ts` owns class conversion, descendant name encoding, prefix and leaf validation, reserved route handling, root binding overrides, and absolute URL construction.
- `useAgent({ sub })` now uses the shared descendant serializer without changing its public options or existing path behavior.
- `Agent#parentPath`, `Agent#selfPath`, and workflow path types reuse the exported `AgentPathStep` vocabulary.
- `routeSubAgentRequest()` continues accepting its existing string `fromPath`; callers can pass a complete `buildAgentPath()` result without a new dispatch abstraction.
- The routing and sub-agent documentation now covers direct HTTP and WebSocket addresses, custom prefixes, callbacks, root binding overrides, and name encoding.
- MCP internals and the `getSubAgentByName()` RPC interface remain unchanged.
- An `agents` patch changeset records the new public API.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->