### PR TITLE
fix(agents): preserve optimistic send dropped on reconnect (#1983)

### DIFF
--- a/.changeset/reconnect-optimistic-send.md
+++ b/.changeset/reconnect-optimistic-send.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix `useAgentChat` dropping an in-flight optimistic send on reconnect. When a message was sent while the socket was down, PartySocket buffers the frame for delivery, but the idle-connect transcript the server replays on reconnect (`cf_agent_chat_messages`) doesn't include it yet — so the whole-array `setMessages` replace erased the just-sent message from the UI until the turn completed and the server rebroadcast. The reconnect replay now preserves a trailing local-only `user` message that was buffered while disconnected, while still letting the server snapshot win for a delivered send it deliberately rolls back (e.g. `messageConcurrency: "drop"`) and for a regenerate's assistant replacement. Also fixes `@cloudflare/ai-chat` and `@cloudflare/think`, which re-export the hook unchanged.

--- a/.changeset/reconnect-optimistic-send.md
+++ b/.changeset/reconnect-optimistic-send.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Fix `useAgentChat` dropping an in-flight optimistic send on reconnect. When a message was sent while the socket was down, PartySocket buffers the frame for delivery, but the idle-connect transcript the server replays on reconnect (`cf_agent_chat_messages`) doesn't include it yet — so the whole-array `setMessages` replace erased the just-sent message from the UI until the turn completed and the server rebroadcast. The reconnect replay now preserves a trailing local-only `user` message that was buffered while disconnected, while still letting the server snapshot win for a delivered send it deliberately rolls back (e.g. `messageConcurrency: "drop"`) and for a regenerate's assistant replacement. Also fixes `@cloudflare/ai-chat` and `@cloudflare/think`, which re-export the hook unchanged.
+Fix `useAgentChat` dropping an in-flight optimistic send on reconnect: a message buffered by PartySocket while the socket was down was omitted from the server's idle-connect transcript replay, so the whole-array `setMessages` erased it from the UI until the turn completed.

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -588,35 +588,26 @@ function prependMissingHydratedMessages<ChatMessage extends UIMessage>(
   return [...missingHydratedMessages, ...currentMessages];
 }
 
-const SOCKET_OPEN = 1; // WebSocket.OPEN
-
-// Re-append trailing local user messages the snapshot omits, stopping at the
-// first already-present or non-user message (never resurrects assistants or
-// reorders history).
-function preserveTrailingLocalUserSends<ChatMessage extends UIMessage>(
+// Re-append the specific buffered sends a snapshot omits, restoring only the
+// tracked ids (in local order) so a message the server deliberately dropped is
+// left alone. Known limitation: a buffered send that is delivered and then
+// rolled back shares its id with the rollback snapshot, so that exact id can
+// still be resurrected under non-`queue` concurrency.
+function restoreBufferedSends<ChatMessage extends UIMessage>(
   snapshot: ChatMessage[],
-  local: readonly ChatMessage[]
+  local: readonly ChatMessage[],
+  bufferedIds: ReadonlySet<string>
 ): ChatMessage[] {
-  if (local.length === 0) {
+  if (bufferedIds.size === 0) {
     return snapshot;
   }
 
   const snapshotIds = new Set(snapshot.map((message) => message.id));
-  const trailing: ChatMessage[] = [];
-  for (let index = local.length - 1; index >= 0; index--) {
-    const message = local[index];
-    if (snapshotIds.has(message.id) || message.role !== "user") {
-      break;
-    }
-    trailing.push(message);
-  }
+  const restored = local.filter(
+    (message) => bufferedIds.has(message.id) && !snapshotIds.has(message.id)
+  );
 
-  if (trailing.length === 0) {
-    return snapshot;
-  }
-
-  trailing.reverse();
-  return [...snapshot, ...trailing];
+  return restored.length === 0 ? snapshot : [...snapshot, ...restored];
 }
 
 /**
@@ -963,6 +954,10 @@ export function useAgentChat<
    * Used by onAgentMessage to skip messages already handled by the transport.
    */
   const localRequestIdsRef = useRef<Set<string>>(new Set());
+  // Ids of sends the transport buffered (socket not OPEN when `send()` ran, so
+  // the server hasn't seen them). Consumed by the next transcript snapshot to
+  // rescue the optimistic messages from the reconnect replay.
+  const pendingBufferedSendIdsRef = useRef<Set<string>>(new Set());
   const pendingReplayResumeRequestIdsRef = useRef<Set<string>>(new Set());
   const replayHydratedAssistantMessageIdsRef = useRef<Set<string>>(new Set());
   /**
@@ -995,6 +990,11 @@ export function useAgentChat<
       agent: agentRef.current,
       activeRequestIds: localRequestIdsRef.current,
       cancelOnClientAbort,
+      onRequestBuffered: (messageId) => {
+        if (messageId) {
+          pendingBufferedSendIdsRef.current.add(messageId);
+        }
+      },
       prepareBody: async ({ messages: msgs, trigger, messageId }) => {
         // Start with the top-level body option (static or dynamic)
         let extraBody: Record<string, unknown> = {};
@@ -1323,12 +1323,6 @@ export function useAgentChat<
     anchorMessageId: string | null;
   } | null>(null);
 
-  // Set when a send is buffered (socket not OPEN); consumed by the next
-  // transcript snapshot to rescue the optimistic message from the reconnect
-  // replay. Known limitation: a non-`queue` concurrency mode that rolls back a
-  // buffered-then-delivered send can still be resurrected by this.
-  const pendingBufferedSendRef = useRef(false);
-
   const preserveProtectedStreamingAssistant = useCallback(
     (messages: readonly ChatMessage[]): ChatMessage[] => {
       const protection = protectedStreamingAssistantRef.current;
@@ -1549,25 +1543,14 @@ export function useAgentChat<
     fallbackAckedResumeRequestIdsRef.current.clear();
     replayHydratedAssistantMessageIdsRef.current.clear();
     protectedStreamingAssistantRef.current = null;
-    pendingBufferedSendRef.current = false;
+    pendingBufferedSendIdsRef.current.clear();
   }, [markInitialMessagesSeeded, setMessages, resetToolContinuation]);
 
   const sendMessageWithStreamingProtection: typeof sendMessage = useCallback(
     async (message, options) => {
-      // Non-OPEN socket => PartySocket buffers this send; flag it for the
-      // reconnect replay. A socket without a numeric readyState (test doubles)
-      // is treated as connected.
-      const socket = agentRef.current;
-      if (
-        socket !== null &&
-        typeof socket === "object" &&
-        "readyState" in socket &&
-        typeof socket.readyState === "number" &&
-        socket.readyState !== SOCKET_OPEN
-      ) {
-        pendingBufferedSendRef.current = true;
-      }
-
+      // Whether this send was buffered is detected at the real send site in the
+      // transport (via `onRequestBuffered`), not here — the socket can drop
+      // during the async request preparation between now and the actual send().
       const request = sendMessage(message, options);
 
       if (
@@ -1969,11 +1952,15 @@ export function useAgentChat<
               next = observed.accumulator.mergeInto(next) as ChatMessage[];
             }
           }
-          // One-shot: rescue a send buffered while the socket was down that the
-          // reconnect replay would otherwise drop.
-          if (pendingBufferedSendRef.current) {
-            pendingBufferedSendRef.current = false;
-            next = preserveTrailingLocalUserSends(next, messagesRef.current);
+          // One-shot: rescue sends the transport buffered while the socket was
+          // down that the reconnect replay would otherwise drop.
+          if (pendingBufferedSendIdsRef.current.size > 0) {
+            next = restoreBufferedSends(
+              next,
+              messagesRef.current,
+              pendingBufferedSendIdsRef.current
+            );
+            pendingBufferedSendIdsRef.current.clear();
           }
           setMessages(next);
           break;

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -588,6 +588,37 @@ function prependMissingHydratedMessages<ChatMessage extends UIMessage>(
   return [...missingHydratedMessages, ...currentMessages];
 }
 
+const SOCKET_OPEN = 1; // WebSocket.OPEN
+
+// Re-append trailing local user messages the snapshot omits, stopping at the
+// first already-present or non-user message (never resurrects assistants or
+// reorders history).
+function preserveTrailingLocalUserSends<ChatMessage extends UIMessage>(
+  snapshot: ChatMessage[],
+  local: readonly ChatMessage[]
+): ChatMessage[] {
+  if (local.length === 0) {
+    return snapshot;
+  }
+
+  const snapshotIds = new Set(snapshot.map((message) => message.id));
+  const trailing: ChatMessage[] = [];
+  for (let index = local.length - 1; index >= 0; index--) {
+    const message = local[index];
+    if (snapshotIds.has(message.id) || message.role !== "user") {
+      break;
+    }
+    trailing.push(message);
+  }
+
+  if (trailing.length === 0) {
+    return snapshot;
+  }
+
+  trailing.reverse();
+  return [...snapshot, ...trailing];
+}
+
 /**
  * React hook for building AI chat interfaces using an Agent
  * @param options Chat options including the agent connection
@@ -1292,6 +1323,12 @@ export function useAgentChat<
     anchorMessageId: string | null;
   } | null>(null);
 
+  // Set when a send is buffered (socket not OPEN); consumed by the next
+  // transcript snapshot to rescue the optimistic message from the reconnect
+  // replay. Known limitation: a non-`queue` concurrency mode that rolls back a
+  // buffered-then-delivered send can still be resurrected by this.
+  const pendingBufferedSendRef = useRef(false);
+
   const preserveProtectedStreamingAssistant = useCallback(
     (messages: readonly ChatMessage[]): ChatMessage[] => {
       const protection = protectedStreamingAssistantRef.current;
@@ -1512,10 +1549,25 @@ export function useAgentChat<
     fallbackAckedResumeRequestIdsRef.current.clear();
     replayHydratedAssistantMessageIdsRef.current.clear();
     protectedStreamingAssistantRef.current = null;
+    pendingBufferedSendRef.current = false;
   }, [markInitialMessagesSeeded, setMessages, resetToolContinuation]);
 
   const sendMessageWithStreamingProtection: typeof sendMessage = useCallback(
     async (message, options) => {
+      // Non-OPEN socket => PartySocket buffers this send; flag it for the
+      // reconnect replay. A socket without a numeric readyState (test doubles)
+      // is treated as connected.
+      const socket = agentRef.current;
+      if (
+        socket !== null &&
+        typeof socket === "object" &&
+        "readyState" in socket &&
+        typeof socket.readyState === "number" &&
+        socket.readyState !== SOCKET_OPEN
+      ) {
+        pendingBufferedSendRef.current = true;
+      }
+
       const request = sendMessage(message, options);
 
       if (
@@ -1916,6 +1968,12 @@ export function useAgentChat<
             if (observed.accumulator.parts.length >= snapshotParts) {
               next = observed.accumulator.mergeInto(next) as ChatMessage[];
             }
+          }
+          // One-shot: rescue a send buffered while the socket was down that the
+          // reconnect replay would otherwise drop.
+          if (pendingBufferedSendRef.current) {
+            pendingBufferedSendRef.current = false;
+            next = preserveTrailingLocalUserSends(next, messagesRef.current);
           }
           setMessages(next);
           break;

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -34,7 +34,9 @@ const RESUME_PENDING_TIMEOUT_MS = 60000;
  * Matches the shape returned by useAgent from agents/react.
  */
 export interface AgentConnection {
-  send: (data: string) => void;
+  // PartySocket returns `false` when the frame was buffered (socket not OPEN)
+  // rather than sent immediately; `void` keeps non-PartySocket providers valid.
+  send: (data: string) => boolean | void;
   addEventListener: (
     type: string,
     listener: (event: MessageEvent) => void,
@@ -73,6 +75,13 @@ export type WebSocketChatTransportOptions<
    * @default false
    */
   cancelOnClientAbort?: boolean;
+  /**
+   * Called when a `submit-message` request frame was buffered rather than sent
+   * immediately (the socket was not OPEN, so PartySocket queued it for the next
+   * reconnect). The hook uses this to preserve the optimistic message across the
+   * reconnect transcript replay. `messageId` is the submitted user message's id.
+   */
+  onRequestBuffered?: (messageId: string | undefined) => void;
 };
 
 /**
@@ -87,6 +96,7 @@ export class WebSocketChatTransport<
   private prepareBody?: WebSocketChatTransportOptions<ChatMessage>["prepareBody"];
   private activeRequestIds?: Set<string>;
   private cancelOnClientAbort: boolean;
+  private onRequestBuffered?: WebSocketChatTransportOptions<ChatMessage>["onRequestBuffered"];
 
   // Pending resume resolver — set by reconnectToStream, called by
   // handleStreamResuming when onAgentMessage sees CF_AGENT_STREAM_RESUMING.
@@ -121,6 +131,7 @@ export class WebSocketChatTransport<
     this.prepareBody = options.prepareBody;
     this.activeRequestIds = options.activeRequestIds;
     this.cancelOnClientAbort = options.cancelOnClientAbort ?? false;
+    this.onRequestBuffered = options.onRequestBuffered;
   }
 
   /**
@@ -458,9 +469,13 @@ export class WebSocketChatTransport<
       return stream;
     }
 
-    // Send the request over WebSocket
+    // Send the request over WebSocket. `send()` returns false when the frame
+    // was buffered (socket not OPEN) rather than sent immediately; a buffered
+    // submit means the server hasn't seen the message yet, so tell the hook to
+    // preserve it across the reconnect transcript replay. Only an explicit
+    // false counts — non-PartySocket doubles return undefined (treated as sent).
     requestSent = true;
-    agent.send(
+    const sent = agent.send(
       JSON.stringify({
         id: requestId,
         init: {
@@ -470,6 +485,12 @@ export class WebSocketChatTransport<
         type: MessageType.CF_AGENT_USE_CHAT_REQUEST
       })
     );
+    if (sent === false && options.trigger === "submit-message") {
+      const lastUserMessage = [...options.messages]
+        .reverse()
+        .find((message) => message.role === "user");
+      this.onRequestBuffered?.(lastUserMessage?.id);
+    }
 
     return stream;
   }

--- a/packages/agents/src/react-tests/reconnect-optimistic-send.test.tsx
+++ b/packages/agents/src/react-tests/reconnect-optimistic-send.test.tsx
@@ -1,0 +1,228 @@
+// Regression: the reconnect transcript replay must not drop a send buffered
+// while the socket was down, but must still honor a rollback of a delivered
+// send. Drives the real hook via a fake EventTarget agent (tracks readyState,
+// which the fix reads to tell buffered from delivered).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render as _render, cleanup } from "vitest-browser-react";
+import type { UIMessage } from "ai";
+import type { useAgent } from "../react";
+import { useAgentChat } from "../chat/react";
+
+// Async WebSocket-driven updates legitimately land outside act() here; disable
+// the act environment after mount (mirrors the other react-tests in this dir).
+const render: typeof _render = async (...args) => {
+  const result = await _render(...args);
+  // @ts-expect-error - globalThis is not typed
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  return result;
+};
+
+const SOCKET_OPEN = 1;
+const SOCKET_CLOSED = 3;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createFakeAgent({ name, url }: { name: string; url: string }) {
+  const target = new EventTarget();
+  const sentMessages: string[] = [];
+  const agent = {
+    _pkurl: url,
+    _pk: name,
+    _url: null as string | null,
+    readyState: SOCKET_OPEN,
+    addEventListener: target.addEventListener.bind(target),
+    agent: "Chat",
+    close: () => {},
+    id: "fake-agent",
+    name,
+    removeEventListener: target.removeEventListener.bind(target),
+    send: (data: string) => sentMessages.push(data),
+    dispatchEvent: target.dispatchEvent.bind(target),
+    path: [{ agent: "Chat", name }],
+    getHttpUrl: () =>
+      url.replace("ws://", "http://").replace("wss://", "https://")
+  };
+  target.addEventListener("open", () => {
+    agent.readyState = SOCKET_OPEN;
+  });
+  target.addEventListener("close", () => {
+    agent.readyState = SOCKET_CLOSED;
+  });
+  return {
+    agent: agent as unknown as ReturnType<typeof useAgent>,
+    target,
+    sentMessages
+  };
+}
+
+function dispatch(target: EventTarget, data: Record<string, unknown>) {
+  target.dispatchEvent(
+    new MessageEvent("message", { data: JSON.stringify(data) })
+  );
+}
+
+function open(target: EventTarget) {
+  target.dispatchEvent(new Event("open"));
+}
+
+function close(target: EventTarget) {
+  target.dispatchEvent(new Event("close"));
+}
+
+const RESUME_NONE = "cf_agent_stream_resume_none";
+const CHAT_MESSAGES = "cf_agent_chat_messages";
+
+const EXISTING_USER = "Existing question";
+const EXISTING_ASSISTANT = "Existing answer";
+const IN_FLIGHT_USER = "In-flight question sent during reconnect";
+const DELIVERED_USER = "Delivered message the server dropped";
+
+function makeInitialMessages(): UIMessage[] {
+  return [
+    {
+      id: "user-existing",
+      role: "user",
+      parts: [{ type: "text", text: EXISTING_USER }]
+    },
+    {
+      id: "assistant-existing",
+      role: "assistant",
+      parts: [{ type: "text", text: EXISTING_ASSISTANT }]
+    }
+  ];
+}
+
+// Persisted transcript without the just-sent message — the shape Think's
+// _buildIdleConnectMessages and AIChatAgent's _rollbackDroppedSubmit both emit.
+function transcriptSnapshot(): Record<string, unknown> {
+  return { type: CHAT_MESSAGES, messages: makeInitialMessages() };
+}
+
+type AgentChatResult = ReturnType<typeof useAgentChat>;
+
+function requireChat(chat: AgentChatResult | null): AgentChatResult {
+  if (!chat) throw new Error("Chat hook was not initialized");
+  return chat;
+}
+
+function mountChat(agent: ReturnType<typeof useAgent>) {
+  let chatInstance: AgentChatResult | null = null;
+
+  function TestComponent() {
+    const chat = useAgentChat({
+      agent,
+      getInitialMessages: null,
+      messages: makeInitialMessages()
+    });
+    chatInstance = chat;
+    return (
+      <div data-testid="transcript">
+        {chat.messages.map((message) => (
+          <div key={message.id} data-testid={`role-${message.role}`}>
+            {message.parts.map((part, index) =>
+              part.type === "text" ? <span key={index}>{part.text}</span> : null
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return { TestComponent, getChat: () => chatInstance };
+}
+
+describe("useAgentChat reconnect transcript replay vs optimistic send", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    cleanup();
+  });
+
+  it("preserves a buffered optimistic send when the reconnect snapshot omits it", async () => {
+    const { agent, target } = createFakeAgent({
+      name: "buffered-send",
+      url: "ws://localhost:3000/agents/chat/buffered-send?_pk=abc"
+    });
+    const { TestComponent, getChat } = mountChat(agent);
+
+    const { container } = await render(<TestComponent />);
+    const transcript = () =>
+      container.querySelector('[data-testid="transcript"]')?.textContent ?? "";
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(EXISTING_USER);
+      expect(transcript()).toContain(EXISTING_ASSISTANT);
+    });
+
+    // Settle the mount-time resume probe so status is "ready".
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await sleep(10);
+
+    // The socket drops (readyState -> CLOSED). The user sends anyway:
+    // PartySocket would buffer the frame; the AI SDK renders it optimistically.
+    close(target);
+    void requireChat(getChat()).sendMessage({ text: IN_FLIGHT_USER });
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(IN_FLIGHT_USER);
+    });
+
+    // Reconnect: the server replays its idle-connect transcript, which does NOT
+    // yet include the buffered send.
+    open(target);
+    dispatch(target, transcriptSnapshot());
+    await sleep(50);
+
+    // The reconnect replay must not drop the in-flight optimistic send.
+    expect(transcript()).toContain(IN_FLIGHT_USER);
+    expect(transcript()).toContain(EXISTING_USER);
+    expect(transcript()).toContain(EXISTING_ASSISTANT);
+  });
+
+  it("does NOT resurrect a delivered send the server rolls back (socket open)", async () => {
+    const { agent, target } = createFakeAgent({
+      name: "delivered-rollback",
+      url: "ws://localhost:3000/agents/chat/delivered-rollback?_pk=abc"
+    });
+    const { TestComponent, getChat } = mountChat(agent);
+
+    const { container } = await render(<TestComponent />);
+    const transcript = () =>
+      container.querySelector('[data-testid="transcript"]')?.textContent ?? "";
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(EXISTING_USER);
+      expect(transcript()).toContain(EXISTING_ASSISTANT);
+    });
+
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await sleep(10);
+
+    // Socket stays OPEN, so the send is delivered to the server (not buffered).
+    expect((agent as unknown as { readyState: number }).readyState).toBe(
+      SOCKET_OPEN
+    );
+    void requireChat(getChat()).sendMessage({ text: DELIVERED_USER });
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(DELIVERED_USER);
+    });
+
+    // The server rejects the overlapping submit and rolls it back by pushing a
+    // transcript snapshot that omits it (messageConcurrency: "drop"). The
+    // rollback must win — the delivered send is removed, not resurrected.
+    dispatch(target, transcriptSnapshot());
+    await sleep(50);
+
+    expect(transcript()).not.toContain(DELIVERED_USER);
+    expect(transcript()).toContain(EXISTING_USER);
+    expect(transcript()).toContain(EXISTING_ASSISTANT);
+  });
+});

--- a/packages/agents/src/react-tests/reconnect-optimistic-send.test.tsx
+++ b/packages/agents/src/react-tests/reconnect-optimistic-send.test.tsx
@@ -1,12 +1,23 @@
 // Regression: the reconnect transcript replay must not drop a send buffered
 // while the socket was down, but must still honor a rollback of a delivered
-// send. Drives the real hook via a fake EventTarget agent (tracks readyState,
-// which the fix reads to tell buffered from delivered).
+// send. Drives the real hook via a fake EventTarget agent whose send() returns
+// false when buffered (like PartySocket) — that return, captured at the real
+// send site in the transport, is what the fix reads to tell the two apart.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render as _render, cleanup } from "vitest-browser-react";
 import type { UIMessage } from "ai";
 import type { useAgent } from "../react";
 import { useAgentChat } from "../chat/react";
+import type {
+  PrepareSendMessagesRequestOptions,
+  PrepareSendMessagesRequestResult
+} from "../chat/react";
+
+type PrepareSendMessagesRequest = (
+  options: PrepareSendMessagesRequestOptions
+) =>
+  | Promise<PrepareSendMessagesRequestResult>
+  | PrepareSendMessagesRequestResult;
 
 // Async WebSocket-driven updates legitimately land outside act() here; disable
 // the act environment after mount (mirrors the other react-tests in this dir).
@@ -38,7 +49,12 @@ function createFakeAgent({ name, url }: { name: string; url: string }) {
     id: "fake-agent",
     name,
     removeEventListener: target.removeEventListener.bind(target),
-    send: (data: string) => sentMessages.push(data),
+    // Mirror PartySocket: `send()` returns false when the frame is buffered
+    // (socket not OPEN) rather than sent immediately.
+    send: (data: string) => {
+      sentMessages.push(data);
+      return agent.readyState === SOCKET_OPEN;
+    },
     dispatchEvent: target.dispatchEvent.bind(target),
     path: [{ agent: "Chat", name }],
     getHttpUrl: () =>
@@ -107,14 +123,18 @@ function requireChat(chat: AgentChatResult | null): AgentChatResult {
   return chat;
 }
 
-function mountChat(agent: ReturnType<typeof useAgent>) {
+function mountChat(
+  agent: ReturnType<typeof useAgent>,
+  prepareSendMessagesRequest?: PrepareSendMessagesRequest
+) {
   let chatInstance: AgentChatResult | null = null;
 
   function TestComponent() {
     const chat = useAgentChat({
       agent,
       getInitialMessages: null,
-      messages: makeInitialMessages()
+      messages: makeInitialMessages(),
+      prepareSendMessagesRequest
     });
     chatInstance = chat;
     return (
@@ -218,6 +238,98 @@ describe("useAgentChat reconnect transcript replay vs optimistic send", () => {
     // The server rejects the overlapping submit and rolls it back by pushing a
     // transcript snapshot that omits it (messageConcurrency: "drop"). The
     // rollback must win — the delivered send is removed, not resurrected.
+    dispatch(target, transcriptSnapshot());
+    await sleep(50);
+
+    expect(transcript()).not.toContain(DELIVERED_USER);
+    expect(transcript()).toContain(EXISTING_USER);
+    expect(transcript()).toContain(EXISTING_ASSISTANT);
+  });
+
+  // Socket OPEN when sendMessage() is called, but CLOSED by the time the
+  // transport actually calls send() (it drops during async request prep). The
+  // frame buffers, so the message must survive the reconnect replay — the case
+  // a readyState-at-call-time check would miss.
+  it("preserves a send that buffers because the socket drops during request prep", async () => {
+    const { agent, target } = createFakeAgent({
+      name: "close-during-prep",
+      url: "ws://localhost:3000/agents/chat/close-during-prep?_pk=abc"
+    });
+    const { TestComponent, getChat } = mountChat(agent, async () => {
+      // Runs mid-send, before the transport's send(): drop the socket.
+      close(target);
+      return {};
+    });
+
+    const { container } = await render(<TestComponent />);
+    const transcript = () =>
+      container.querySelector('[data-testid="transcript"]')?.textContent ?? "";
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(EXISTING_USER);
+      expect(transcript()).toContain(EXISTING_ASSISTANT);
+    });
+
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await sleep(10);
+
+    // Socket is OPEN at call time; the prepare callback closes it before send().
+    expect((agent as unknown as { readyState: number }).readyState).toBe(
+      SOCKET_OPEN
+    );
+    void requireChat(getChat()).sendMessage({ text: IN_FLIGHT_USER });
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(IN_FLIGHT_USER);
+    });
+
+    open(target);
+    dispatch(target, transcriptSnapshot());
+    await sleep(50);
+
+    expect(transcript()).toContain(IN_FLIGHT_USER);
+    expect(transcript()).toContain(EXISTING_USER);
+    expect(transcript()).toContain(EXISTING_ASSISTANT);
+  });
+
+  // Socket CLOSED when sendMessage() is called, but reopened before the
+  // transport's send() runs. The frame is delivered, so a server rollback must
+  // win — the case a readyState-at-call-time check would wrongly preserve.
+  it("does NOT preserve a send delivered after the socket reopens during request prep", async () => {
+    const { agent, target } = createFakeAgent({
+      name: "open-during-prep",
+      url: "ws://localhost:3000/agents/chat/open-during-prep?_pk=abc"
+    });
+    const { TestComponent, getChat } = mountChat(agent, async () => {
+      // Runs mid-send, before the transport's send(): the socket recovers.
+      open(target);
+      return {};
+    });
+
+    const { container } = await render(<TestComponent />);
+    const transcript = () =>
+      container.querySelector('[data-testid="transcript"]')?.textContent ?? "";
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(EXISTING_USER);
+      expect(transcript()).toContain(EXISTING_ASSISTANT);
+    });
+
+    dispatch(target, { type: RESUME_NONE, reason: "idle" });
+    await sleep(10);
+
+    // Socket is CLOSED at call time; the prepare callback reopens it before send().
+    close(target);
+    expect((agent as unknown as { readyState: number }).readyState).toBe(
+      SOCKET_CLOSED
+    );
+    void requireChat(getChat()).sendMessage({ text: DELIVERED_USER });
+
+    await vi.waitFor(() => {
+      expect(transcript()).toContain(DELIVERED_USER);
+    });
+
+    // Delivered on the reopened socket, then rolled back by the server snapshot.
     dispatch(target, transcriptSnapshot());
     await sleep(50);
 


### PR DESCRIPTION
Fixes #1983 `useAgentChat` dropping an in-flight optimistic send on reconnect. When a message was sent while the socket was down, PartySocket buffers the frame for delivery, but the idle-connect transcript the server replays on reconnect (`cf_agent_chat_messages`) doesn't include it yet — so the whole-array `setMessages` replace erased the just-sent message from the UI until the turn completed and the server rebroadcast. The reconnect replay now preserves a trailing local-only `user` message that was buffered while disconnected, while still letting the server snapshot win for a delivered send it deliberately rolls back (e.g. `messageConcurrency: "drop"`) and for a regenerate's assistant replacement. Also fixes `@cloudflare/ai-chat` and `@cloudflare/think`, which re-export the hook unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->