### PR TITLE
fix(chat): reconcile reused tool-call IDs one-to-one

### DIFF
--- a/.changeset/quiet-tools-reconcile.md
+++ b/.changeset/quiet-tools-reconcile.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Reconcile reused tool-call IDs one-to-one so later assistant messages and tool outputs stay attached to the correct turn.

--- a/.changeset/quiet-tools-reconcile.md
+++ b/.changeset/quiet-tools-reconcile.md
@@ -5,3 +5,7 @@
 ---
 
 Reconcile reused tool-call IDs one-to-one so later assistant messages and tool outputs stay attached to the correct turn.
+
+Some providers reuse a `toolCallId` across turns. Assistant reconciliation now claims server rows one-to-one across the whole transcript instead of resolving each message against a conversation-wide `toolCallId` lookup, so a later assistant can no longer adopt an earlier row's ID and overwrite it on upsert. Terminal tool outputs merge from the server row a message actually resolved to; a message that resolved to no row may still merge from an unambiguous `toolCallId` whose tool input is identical, which keeps stale duplicates from persisting in a pre-terminal state.
+
+`resolveToolMergeId` is deprecated. It carries the original conversation-wide behaviour and is no longer used by `@cloudflare/ai-chat` or `@cloudflare/think`; use `reconcileMessages` instead.

--- a/packages/agents/src/chat/__tests__/message-reconciler.test.ts
+++ b/packages/agents/src/chat/__tests__/message-reconciler.test.ts
@@ -323,6 +323,50 @@ describe("reconcileMessages — ID reconciliation", () => {
     );
   });
 
+  it("merges a result stored on a different server row than the one matched", () => {
+    // The incoming message resolves to srv-a1, which carries tc1 but not tc2.
+    // tc2's result was persisted on a separate row, so a per-message-only
+    // lookup would write tc2 back as still pending.
+    const server = [
+      toolAssistantMsg("srv-a1", "tc1", "output-available", {
+        input: { q: "one" },
+        output: "one done"
+      }),
+      toolAssistantMsg("srv-a2", "tc2", "output-available", {
+        input: { q: "two" },
+        output: "two done"
+      })
+    ];
+    const client = [
+      {
+        id: "srv-a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-calc",
+            toolCallId: "tc1",
+            state: "input-available",
+            input: { q: "one" }
+          },
+          {
+            type: "tool-calc",
+            toolCallId: "tc2",
+            state: "input-available",
+            input: { q: "two" }
+          }
+        ]
+      } as unknown as ChatMessage
+    ];
+
+    const result = reconcileMessages(client, server);
+    const parts = result[0].parts as unknown as Record<string, unknown>[];
+
+    expect(parts[0].state).toBe("output-available");
+    expect(parts[0].output).toBe("one done");
+    expect(parts[1].state).toBe("output-available");
+    expect(parts[1].output).toBe("two done");
+  });
+
   it("does not merge a terminal result into a reused-ID call with different input", () => {
     // Same toolCallId but a DIFFERENT input means the provider reused the ID
     // for a genuinely new call, which must not inherit the old result.

--- a/packages/agents/src/chat/__tests__/message-reconciler.test.ts
+++ b/packages/agents/src/chat/__tests__/message-reconciler.test.ts
@@ -294,6 +294,66 @@ describe("reconcileMessages — ID reconciliation", () => {
     ).toBeUndefined();
   });
 
+  it("still merges a terminal result into an unclaimed same-input duplicate", () => {
+    // The server row is claimed by an exact-ID match, so the stale duplicate
+    // can claim nothing. It carries the SAME input, so it is the same call and
+    // must still pick up the server's terminal state — otherwise it persists
+    // as a dangling `input-available` orphan (#1381) and the server's
+    // output-error is lost from that row (#1623).
+    const server = [
+      toolAssistantMsg("srv-a1", "tc1", "output-error", {
+        input: { q: "same" },
+        output: undefined
+      })
+    ];
+    const client = [
+      toolAssistantMsg("srv-a1", "tc1", "output-error", {
+        input: { q: "same" }
+      }),
+      toolAssistantMsg("cli-a9", "tc1", "input-available", {
+        input: { q: "same" }
+      })
+    ];
+
+    const result = reconcileMessages(client, server);
+
+    expect(result).toHaveLength(2);
+    expect((result[1].parts[0] as Record<string, unknown>).state).toBe(
+      "output-error"
+    );
+  });
+
+  it("does not merge a terminal result into a reused-ID call with different input", () => {
+    // Same toolCallId but a DIFFERENT input means the provider reused the ID
+    // for a genuinely new call, which must not inherit the old result.
+    const server = [
+      toolAssistantMsg("srv-a1", "tc1", "output-available", {
+        input: { q: "first" },
+        output: "old result"
+      })
+    ];
+    const client = [
+      toolAssistantMsg("srv-a1", "tc1", "output-available", {
+        input: { q: "first" },
+        output: "old result"
+      }),
+      toolAssistantMsg("cli-a9", "tc1", "input-available", {
+        input: { q: "second" }
+      })
+    ];
+
+    const result = reconcileMessages(client, server);
+
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe("cli-a9");
+    expect((result[1].parts[0] as Record<string, unknown>).state).toBe(
+      "input-available"
+    );
+    expect(
+      (result[1].parts[0] as Record<string, unknown>).output
+    ).toBeUndefined();
+  });
+
   it("passes through when server state is empty", () => {
     const client = [userMsg("u1", "hi"), assistantMsg("cli-a1", "Hello")];
     const result = reconcileMessages(client, []);

--- a/packages/agents/src/chat/__tests__/message-reconciler.test.ts
+++ b/packages/agents/src/chat/__tests__/message-reconciler.test.ts
@@ -253,7 +253,7 @@ describe("reconcileMessages — ID reconciliation", () => {
     expect(result[3].id).toBe("srv-a2");
   });
 
-  it("skips content matching for tool-bearing assistant messages", () => {
+  it("adopts server ID for a toolCallId match", () => {
     const server = [
       toolAssistantMsg("srv-a1", "tc1", "output-available", { output: 1 })
     ];
@@ -261,7 +261,37 @@ describe("reconcileMessages — ID reconciliation", () => {
       toolAssistantMsg("cli-a1", "tc1", "output-available", { output: 1 })
     ];
     const result = reconcileMessages(client, server);
-    expect(result[0].id).toBe("cli-a1");
+    expect(result[0].id).toBe("srv-a1");
+  });
+
+  it("claims reused toolCallIds one-to-one across turns", () => {
+    const server = [
+      userMsg("u1", "first"),
+      toolAssistantMsg("srv-a1", "tc1", "output-available", {
+        output: "old result"
+      })
+    ];
+    const client = [
+      userMsg("u1", "first"),
+      toolAssistantMsg("srv-a1", "tc1", "output-available", {
+        output: "old result"
+      }),
+      userMsg("u2", "second"),
+      toolAssistantMsg("cli-a2", "tc1", "input-available", {
+        input: { turn: 2 }
+      })
+    ];
+
+    const result = reconcileMessages(client, server);
+
+    expect(result[1].id).toBe("srv-a1");
+    expect(result[3].id).toBe("cli-a2");
+    expect((result[3].parts[0] as Record<string, unknown>).state).toBe(
+      "input-available"
+    );
+    expect(
+      (result[3].parts[0] as Record<string, unknown>).output
+    ).toBeUndefined();
   });
 
   it("passes through when server state is empty", () => {
@@ -327,6 +357,7 @@ describe("reconcileMessages — composed stages", () => {
     expect((result[0].parts[0] as Record<string, unknown>).state).toBe(
       "output-available"
     );
+    expect(result[0].id).toBe("srv-a1");
     expect(result[1].id).toBe("srv-a2");
   });
 
@@ -355,7 +386,7 @@ describe("reconcileMessages — composed stages", () => {
       }
     ];
     const result = reconcileMessages([msg], server);
-    expect(result[0].id).toBe("cli-a1");
+    expect(result[0].id).toBe("srv-a1");
   });
 });
 

--- a/packages/agents/src/chat/message-reconciler.ts
+++ b/packages/agents/src/chat/message-reconciler.ts
@@ -151,17 +151,15 @@ function mergeServerToolOutputs(
     string,
     Map<string, Record<string, unknown>>
   >();
-  // Conversation-wide index used ONLY as a fallback for incoming messages that
-  // never matched a server row. `null` marks a toolCallId that resolved on more
-  // than one server row — too ambiguous to merge from.
+  // Conversation-wide index used as a per-part fallback. `null` marks a
+  // toolCallId that resolved on more than one server row — too ambiguous to
+  // merge from.
   const resolvedByToolCallId = new Map<
     string,
     Record<string, unknown> | null
   >();
-  const serverMessageIds = new Set<string>();
 
   for (const msg of serverMessages) {
-    serverMessageIds.add(msg.id);
     if (msg.role !== "assistant") continue;
     const resolvedParts = new Map<string, Record<string, unknown>>();
     for (const part of msg.parts) {
@@ -184,28 +182,26 @@ function mergeServerToolOutputs(
 
   return incoming.map((msg) => {
     if (msg.role !== "assistant") return msg;
-    const serverResolvedParts = serverResolvedPartsByMessage.get(msg.id);
-    // A message that kept its own ID never claimed a server row, so the
-    // per-message index cannot reach it. Fall back to the conversation-wide
-    // index, but only for a tool call carrying an identical input: same
-    // toolCallId AND same input means the same call, whereas a provider
-    // reusing an ID for a NEW call carries different input. Without this a
-    // stale duplicate persists stuck in a pre-terminal state, reintroducing
-    // the dangling orphan of #1381 and losing the server's output-error /
-    // output-denied that #1623 hardened.
-    const useFallback =
-      serverResolvedParts === undefined && !serverMessageIds.has(msg.id);
-    if (!serverResolvedParts && !useFallback) return msg;
+    const ownResolvedParts = serverResolvedPartsByMessage.get(msg.id);
 
     let hasChanges = false;
     const updatedParts = msg.parts.map((part) => {
       const record = part as Record<string, unknown>;
       if (!isPendingToolPart(record)) return part;
 
+      // Prefer the row this message resolved to. If that row does not carry
+      // this call — the message resolved to no row at all, or the result was
+      // persisted on a different row — fall back to the conversation-wide
+      // index, but only for a call carrying an identical input. Same
+      // toolCallId AND same input means the same call, whereas a provider
+      // reusing an ID for a NEW call carries different input. Without the
+      // fallback a pending part persists stuck in a pre-terminal state,
+      // reintroducing the dangling orphan of #1381 and losing the server's
+      // output-error / output-denied that #1623 hardened.
       const toolCallId = record.toolCallId as string;
-      const server = serverResolvedParts
-        ? serverResolvedParts.get(toolCallId)
-        : fallbackResolvedPart(resolvedByToolCallId, record);
+      const server =
+        ownResolvedParts?.get(toolCallId) ??
+        fallbackResolvedPart(resolvedByToolCallId, record);
 
       if (server) {
         hasChanges = true;

--- a/packages/agents/src/chat/message-reconciler.ts
+++ b/packages/agents/src/chat/message-reconciler.ts
@@ -15,7 +15,10 @@ import type { UIMessage } from "ai";
  *
  * 1. Reconciles assistant IDs: exact match → toolCallId match → content-key match
  * 2. Merges server-known tool outputs into incoming messages that still
- *    show stale states (input-available, approval-requested, approval-responded)
+ *    show stale states (input-available, approval-requested, approval-responded).
+ *    Outputs come from the server row the message resolved to; a message that
+ *    resolved to no row may still merge from an unambiguous toolCallId whose
+ *    input is identical.
  *
  * @param incoming - Messages from the client
  * @param serverMessages - Current server-side messages (source of truth)
@@ -40,8 +43,12 @@ export function reconcileMessages(
  * For a single message, resolve its ID by matching toolCallId against server state.
  * Prevents duplicate DB rows when client IDs differ from server IDs.
  *
- * Prefer {@link reconcileMessages} for transcript reconciliation because tool call
- * IDs can repeat across turns and must claim server messages one-to-one.
+ * @deprecated Unsafe when a provider reuses a toolCallId across turns. This
+ * scans the whole conversation and claims nothing, so a later assistant can
+ * adopt an earlier row's ID and overwrite it on upsert (#1992). Use
+ * {@link reconcileMessages}, which claims server rows one-to-one over the
+ * whole transcript. Retained only for backwards compatibility; no longer used
+ * by `@cloudflare/ai-chat` or `@cloudflare/think`.
  */
 export function resolveToolMergeId(
   message: UIMessage,
@@ -144,19 +151,28 @@ function mergeServerToolOutputs(
     string,
     Map<string, Record<string, unknown>>
   >();
+  // Conversation-wide index used ONLY as a fallback for incoming messages that
+  // never matched a server row. `null` marks a toolCallId that resolved on more
+  // than one server row — too ambiguous to merge from.
+  const resolvedByToolCallId = new Map<
+    string,
+    Record<string, unknown> | null
+  >();
+  const serverMessageIds = new Set<string>();
+
   for (const msg of serverMessages) {
+    serverMessageIds.add(msg.id);
     if (msg.role !== "assistant") continue;
     const resolvedParts = new Map<string, Record<string, unknown>>();
     for (const part of msg.parts) {
       const record = part as Record<string, unknown>;
-      if (
-        "toolCallId" in record &&
-        "state" in record &&
-        (record.state === "output-available" ||
-          record.state === "output-error" ||
-          record.state === "output-denied")
-      ) {
-        resolvedParts.set(record.toolCallId as string, record);
+      if (isResolvedToolPart(record)) {
+        const toolCallId = record.toolCallId as string;
+        resolvedParts.set(toolCallId, record);
+        resolvedByToolCallId.set(
+          toolCallId,
+          resolvedByToolCallId.has(toolCallId) ? null : record
+        );
       }
     }
     if (resolvedParts.size > 0) {
@@ -169,21 +185,30 @@ function mergeServerToolOutputs(
   return incoming.map((msg) => {
     if (msg.role !== "assistant") return msg;
     const serverResolvedParts = serverResolvedPartsByMessage.get(msg.id);
-    if (!serverResolvedParts) return msg;
+    // A message that kept its own ID never claimed a server row, so the
+    // per-message index cannot reach it. Fall back to the conversation-wide
+    // index, but only for a tool call carrying an identical input: same
+    // toolCallId AND same input means the same call, whereas a provider
+    // reusing an ID for a NEW call carries different input. Without this a
+    // stale duplicate persists stuck in a pre-terminal state, reintroducing
+    // the dangling orphan of #1381 and losing the server's output-error /
+    // output-denied that #1623 hardened.
+    const useFallback =
+      serverResolvedParts === undefined && !serverMessageIds.has(msg.id);
+    if (!serverResolvedParts && !useFallback) return msg;
 
     let hasChanges = false;
     const updatedParts = msg.parts.map((part) => {
       const record = part as Record<string, unknown>;
-      if (
-        "toolCallId" in record &&
-        "state" in record &&
-        (record.state === "input-available" ||
-          record.state === "approval-requested" ||
-          record.state === "approval-responded") &&
-        serverResolvedParts.has(record.toolCallId as string)
-      ) {
+      if (!isPendingToolPart(record)) return part;
+
+      const toolCallId = record.toolCallId as string;
+      const server = serverResolvedParts
+        ? serverResolvedParts.get(toolCallId)
+        : fallbackResolvedPart(resolvedByToolCallId, record);
+
+      if (server) {
         hasChanges = true;
-        const server = serverResolvedParts.get(record.toolCallId as string)!;
         // Overlay the server's resolved state, keeping the client part's
         // identity/input. Carry ONLY the result field that belongs to the
         // server's terminal state — so a stray `output` left on an
@@ -287,6 +312,53 @@ function reconcileAssistantIds(
 
 function hasToolCallPart(message: UIMessage): boolean {
   return message.parts.some((part) => "toolCallId" in part);
+}
+
+/** A server-side tool part that has reached a terminal state. */
+function isResolvedToolPart(record: Record<string, unknown>): boolean {
+  return (
+    "toolCallId" in record &&
+    "state" in record &&
+    (record.state === "output-available" ||
+      record.state === "output-error" ||
+      record.state === "output-denied")
+  );
+}
+
+/** A client-side tool part still waiting on a result. */
+function isPendingToolPart(record: Record<string, unknown>): boolean {
+  return (
+    "toolCallId" in record &&
+    "state" in record &&
+    (record.state === "input-available" ||
+      record.state === "approval-requested" ||
+      record.state === "approval-responded")
+  );
+}
+
+/**
+ * Resolve a server part for an incoming tool part that never claimed a server
+ * row. Requires an unambiguous toolCallId AND an identical input, so a
+ * provider that reuses a toolCallId for a genuinely new call (different
+ * input) cannot inherit the previous turn's result.
+ */
+function fallbackResolvedPart(
+  resolvedByToolCallId: Map<string, Record<string, unknown> | null>,
+  record: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const server = resolvedByToolCallId.get(record.toolCallId as string);
+  if (!server) return undefined;
+  return sameToolInput(record.input, server.input) ? server : undefined;
+}
+
+/**
+ * Structural comparison of two tool inputs. Both absent counts as equal, which
+ * keeps the pre-existing permissive behaviour for tools that take no input.
+ */
+function sameToolInput(a: unknown, b: unknown): boolean {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
 }
 
 function getToolCallIds(message: UIMessage): Set<string> {

--- a/packages/agents/src/chat/message-reconciler.ts
+++ b/packages/agents/src/chat/message-reconciler.ts
@@ -3,8 +3,8 @@
  * with server state during persistence.
  *
  * Three strategies applied in order:
- * 1. Merge server-known tool outputs into stale client messages
- * 2. Reconcile assistant IDs (exact match → content-key → toolCallId)
+ * 1. Reconcile assistant IDs (exact match → toolCallId → content-key)
+ * 2. Merge server-known tool outputs into the resolved message
  * 3. Per-message toolCallId dedup for persistence
  */
 
@@ -13,9 +13,9 @@ import type { UIMessage } from "ai";
 /**
  * Reconcile incoming client messages against server state.
  *
- * 1. Merges server-known tool outputs into incoming messages that still
+ * 1. Reconciles assistant IDs: exact match → toolCallId match → content-key match
+ * 2. Merges server-known tool outputs into incoming messages that still
  *    show stale states (input-available, approval-requested, approval-responded)
- * 2. Reconciles assistant IDs: exact match → content-key match → toolCallId match
  *
  * @param incoming - Messages from the client
  * @param serverMessages - Current server-side messages (source of truth)
@@ -28,21 +28,20 @@ export function reconcileMessages(
   serverMessages: readonly UIMessage[],
   sanitizeForContentKey?: (message: UIMessage) => UIMessage
 ): UIMessage[] {
-  const withMergedToolOutputs = mergeServerToolOutputs(
+  const withReconciledAssistantIds = reconcileAssistantIds(
     incoming,
-    serverMessages
-  );
-  return reconcileAssistantIds(
-    withMergedToolOutputs,
     serverMessages,
     sanitizeForContentKey
   );
+  return mergeServerToolOutputs(withReconciledAssistantIds, serverMessages);
 }
 
 /**
  * For a single message, resolve its ID by matching toolCallId against server state.
  * Prevents duplicate DB rows when client IDs differ from server IDs.
- * Tool call IDs are unique per conversation, so matching is safe regardless of state.
+ *
+ * Prefer {@link reconcileMessages} for transcript reconciliation because tool call
+ * IDs can repeat across turns and must claim server messages one-to-one.
  */
 export function resolveToolMergeId(
   message: UIMessage,
@@ -138,15 +137,16 @@ function mergeServerToolOutputs(
   incoming: UIMessage[],
   serverMessages: readonly UIMessage[]
 ): UIMessage[] {
-  // Index the server's RESOLVED tool parts so a stale client part (still in a
-  // pre-output state) can't clobber the server's terminal state on persist.
-  // All three terminal states must be protected, not just `output-available`:
-  // otherwise a client that hasn't seen the server's `output-error` /
-  // `output-denied` yet would persist its stale `input-available` over the
-  // resolved result, losing the error/denial.
-  const serverResolvedParts = new Map<string, Record<string, unknown>>();
+  // Index resolved tool parts by message ID first, then toolCallId. Providers
+  // may reuse toolCallIds across turns, so a conversation-wide index can merge
+  // an older result into a newer assistant message.
+  const serverResolvedPartsByMessage = new Map<
+    string,
+    Map<string, Record<string, unknown>>
+  >();
   for (const msg of serverMessages) {
     if (msg.role !== "assistant") continue;
+    const resolvedParts = new Map<string, Record<string, unknown>>();
     for (const part of msg.parts) {
       const record = part as Record<string, unknown>;
       if (
@@ -156,15 +156,20 @@ function mergeServerToolOutputs(
           record.state === "output-error" ||
           record.state === "output-denied")
       ) {
-        serverResolvedParts.set(record.toolCallId as string, record);
+        resolvedParts.set(record.toolCallId as string, record);
       }
+    }
+    if (resolvedParts.size > 0) {
+      serverResolvedPartsByMessage.set(msg.id, resolvedParts);
     }
   }
 
-  if (serverResolvedParts.size === 0) return incoming;
+  if (serverResolvedPartsByMessage.size === 0) return incoming;
 
   return incoming.map((msg) => {
     if (msg.role !== "assistant") return msg;
+    const serverResolvedParts = serverResolvedPartsByMessage.get(msg.id);
+    if (!serverResolvedParts) return msg;
 
     let hasChanges = false;
     const updatedParts = msg.parts.map((part) => {
@@ -228,10 +233,29 @@ function reconcileAssistantIds(
       return incomingMessage;
     }
 
-    if (
-      incomingMessage.role !== "assistant" ||
-      hasToolCallPart(incomingMessage)
-    ) {
+    if (incomingMessage.role !== "assistant") {
+      return incomingMessage;
+    }
+
+    const incomingToolCallIds = getToolCallIds(incomingMessage);
+    if (incomingToolCallIds.size > 0) {
+      for (let i = 0; i < serverMessages.length; i++) {
+        if (claimedServerIndices.has(i)) continue;
+
+        const serverMessage = serverMessages[i];
+        if (
+          serverMessage.role === "assistant" &&
+          serverMessage.parts.some(
+            (part) =>
+              "toolCallId" in part &&
+              typeof part.toolCallId === "string" &&
+              incomingToolCallIds.has(part.toolCallId)
+          )
+        ) {
+          claimedServerIndices.add(i);
+          return { ...incomingMessage, id: serverMessage.id };
+        }
+      }
       return incomingMessage;
     }
 
@@ -263,6 +287,16 @@ function reconcileAssistantIds(
 
 function hasToolCallPart(message: UIMessage): boolean {
   return message.parts.some((part) => "toolCallId" in part);
+}
+
+function getToolCallIds(message: UIMessage): Set<string> {
+  return new Set(
+    message.parts.flatMap((part) =>
+      "toolCallId" in part && typeof part.toolCallId === "string"
+        ? [part.toolCallId]
+        : []
+    )
+  );
 }
 
 function findMessageByToolCallId(

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -28,7 +28,6 @@ import { MessageType, type OutgoingMessage } from "./types";
 import { autoTransformMessages } from "./ai-chat-v5-migration";
 import {
   reconcileMessages,
-  resolveToolMergeId,
   reconcileOrphanPartial,
   repairInterruptedToolParts,
   persistReconstructedOrphan,
@@ -5409,8 +5408,7 @@ export class AIChatAgent<
     // Compares serialized JSON against a cache of last-persisted versions.
     for (const message of mergedMessages) {
       const sanitizedMessage = this._sanitizeMessageForPersistence(message);
-      const resolved = resolveToolMergeId(sanitizedMessage, this.messages);
-      const safe = this._enforceRowSizeLimit(resolved);
+      const safe = this._enforceRowSizeLimit(sanitizedMessage);
       const json = JSON.stringify(safe);
 
       // Skip SQL write if the message is identical to what's already persisted

--- a/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
+++ b/packages/ai-chat/src/tests/client-tool-duplicate-message.test.ts
@@ -81,6 +81,84 @@ describe("Client-side tool duplicate message prevention", () => {
     ws.close(1000);
   });
 
+  it("keeps a later assistant when a toolCallId is reused across turns", async () => {
+    const room = crypto.randomUUID();
+    const res = await exports.default.fetch(
+      `http://example.com/agents/test-chat-agent/${room}`,
+      { headers: { Upgrade: "websocket" } }
+    );
+    expect(res.status).toBe(101);
+    const ws = res.webSocket as WebSocket;
+    ws.accept();
+
+    const agentStub = await getAgentByName(env.TestChatAgent, room);
+    const toolCallId = "call_reused_across_turns";
+    const firstUser: ChatMessage = {
+      id: "user-first",
+      role: "user",
+      parts: [{ type: "text", text: "First turn" }]
+    };
+    const firstAssistant: ChatMessage = {
+      id: "assistant-first",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-testTool",
+          toolCallId,
+          state: "output-available",
+          input: { turn: 1 },
+          output: "first result"
+        }
+      ] as ChatMessage["parts"]
+    };
+
+    await agentStub.persistMessages([firstUser, firstAssistant]);
+
+    const secondUser: ChatMessage = {
+      id: "user-second",
+      role: "user",
+      parts: [{ type: "text", text: "Second turn" }]
+    };
+    const secondAssistant: ChatMessage = {
+      id: "assistant-second",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-testTool",
+          toolCallId,
+          state: "output-available",
+          input: { turn: 2 },
+          output: "second result"
+        }
+      ] as ChatMessage["parts"]
+    };
+
+    await agentStub.persistMessages([
+      firstUser,
+      firstAssistant,
+      secondUser,
+      secondAssistant
+    ]);
+
+    const messages = (await agentStub.getPersistedMessages()) as ChatMessage[];
+    const assistants = messages.filter(
+      (message) => message.role === "assistant"
+    );
+
+    expect(assistants.map((message) => message.id)).toEqual([
+      "assistant-first",
+      "assistant-second"
+    ]);
+    expect((assistants[0].parts[0] as { output?: unknown }).output).toBe(
+      "first result"
+    );
+    expect((assistants[1].parts[0] as { output?: unknown }).output).toBe(
+      "second result"
+    );
+
+    ws.close(1000);
+  });
+
   it("reconciles client-generated ID with server ID for input-available state (#1094)", async () => {
     const room = crypto.randomUUID();
     const res = await exports.default.fetch(

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -788,12 +788,9 @@ export class ThinkTestAgent extends Think {
   async persistIncomingMessageForTest(msg: UIMessage): Promise<void> {
     await (
       this as unknown as {
-        _persistIncomingMessage(
-          m: UIMessage,
-          serverMessages: readonly UIMessage[]
-        ): Promise<void>;
+        _persistIncomingMessage(m: UIMessage): Promise<void>;
       }
-    )._persistIncomingMessage(msg, this.messages);
+    )._persistIncomingMessage(msg);
   }
 
   async runChannelTurnForTest(options: {

--- a/packages/think/src/tests/message-reconciliation.test.ts
+++ b/packages/think/src/tests/message-reconciliation.test.ts
@@ -221,6 +221,41 @@ describe("Think — message reconciliation on incoming submits", () => {
     ws.close(1000);
   });
 
+  it("keeps a later assistant when a toolCallId is reused across turns", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const ws = await connectWS(room);
+
+    await agent.setTextOnlyMode(true);
+
+    const userA = makeUserMessage("user-a", "create a cat");
+    const firstAssistant = makeServerToolAssistant("server-first-assistant");
+    await agent.persistToolCallMessage([userA, firstAssistant]);
+
+    const userB = makeUserMessage("user-b", "create another cat");
+    const secondAssistant = makeServerToolAssistant("client-second-assistant");
+    const userC = makeUserMessage("user-c", "continue");
+
+    const done = waitForDone(ws);
+    sendChatRequest(ws, [userA, firstAssistant, userB, secondAssistant, userC]);
+    await done;
+    await delay(200);
+
+    const messages = (await agent.getMessages()) as UIMessage[];
+    const assistantsWithTool = messages.filter(
+      (message) =>
+        message.role === "assistant" &&
+        assistantToolPart(message)?.toolCallId === TOOL_CALL_ID
+    );
+
+    expect(assistantsWithTool.map((message) => message.id)).toEqual([
+      "server-first-assistant",
+      "client-second-assistant"
+    ]);
+
+    ws.close(1000);
+  });
+
   it("merges server tool outputs into a stale client snapshot when IDs match", async () => {
     const room = crypto.randomUUID();
     const agent = await freshAgent(room);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -201,7 +201,6 @@ import {
   toolPartHasSettledResult,
   persistReconstructedOrphan,
   reconcileMessages,
-  resolveToolMergeId,
   createChatFiberSnapshot,
   unwrapChatFiberSnapshot,
   wrapChatFiberSnapshot,
@@ -11498,7 +11497,7 @@ export class Think<
 
           for (const msg of reconciled) {
             if (this._turnQueue.generation !== epoch) return false;
-            await this._persistIncomingMessage(msg, serverMessages);
+            await this._persistIncomingMessage(msg);
           }
 
           if (this._turnQueue.generation !== epoch) return false;
@@ -12945,21 +12944,12 @@ export class Think<
   }
 
   /**
-   * Persist an incoming message after reconciliation. For assistant
-   * messages, also resolve their ID against any server-side row that
-   * already owns the same `toolCallId` so we update the existing row
-   * instead of inserting an orphan duplicate.
+   * Persist an incoming message after batch reconciliation has resolved
+   * assistant IDs and merged any server-owned tool outputs.
    */
-  private async _persistIncomingMessage(
-    msg: UIMessage,
-    serverMessages: readonly UIMessage[]
-  ): Promise<void> {
+  private async _persistIncomingMessage(msg: UIMessage): Promise<void> {
     const sanitized = this._stripReservedMessageMetadata(msg);
-    const resolved =
-      sanitized.role === "assistant"
-        ? resolveToolMergeId(sanitized, serverMessages)
-        : sanitized;
-    await this._upsertMessageInHistory(resolved);
+    await this._upsertMessageInHistory(sanitized);
   }
 
   /**


### PR DESCRIPTION
Closes #1992.

Some model providers reuse a `toolCallId` across turns. Reconciliation treated
it as unique for the whole conversation, so a later assistant could adopt an
earlier persisted row's ID and the subsequent upsert overwrote that row.
Messages that looked correct while streaming disappeared after a reload.

The core of the fix is **@jcheese1's** patch from
[jcheese1@759bc8d](https://github.com/jcheese1/agents/commit/759bc8dd57b9c22f93400fc9c13f05e878f6048a),
cherry-picked unmodified as the first commit with their authorship intact. They
could not open a PR themselves. The second commit is a follow-up from me that
closes a regression the first one introduced.

## Where the bug actually was

Worth noting for review: `reconcileMessages` never performed `toolCallId`
matching at all, despite its docstring claiming it did. The conversation-wide
lookup lived in a separate exported function, `resolveToolMergeId`, called
per-message at persist time from `ai-chat/src/index.ts` and `think.ts`. It
scanned every server message and claimed nothing. The stale docstring is
probably why this was easy to miss; it's corrected here.

## Commits

| Commit | Author | |
| --- | --- | --- |
| `c056aeaf` | @jcheese1 | One-to-one claiming: exact IDs claim their rows first, unmatched tool-bearing assistants may only claim an *unclaimed* row sharing a `toolCallId`, otherwise they keep their own ID. Tool outputs merge from the resolved row. Drops both `resolveToolMergeId` call sites. |
| `0e854f0f` | @AntoniTok | Restores a merge the above dropped, plus deprecates `resolveToolMergeId`. Detail below. |
| `ce3f0b9f` | @AntoniTok | Makes that fallback per tool call rather than per message, from Devin's review. Detail below. |

## The regression in the second commit

Narrowing the tool-output index from conversation-wide to
`messageId -> toolCallId` closes the overwrite, but it also removes the merge
for any incoming assistant that claimed **no** server row.

That happens when the client submits both the canonical assistant and a stale
duplicate of it under a different ID. The exact-ID match claims the server row
first, so the duplicate can claim nothing and receives no terminal state:

```
plain patch:    srv-a1 => output-error, errorText=boom
                cli-a9 => input-available          <- dangling orphan
main today:     cli-a9 => output-error, errorText=boom   (then collapses into srv-a1)
with 0e854f0f:  cli-a9 => output-error, errorText=boom
```

A dangling `input-available` orphan is the #1381 failure mode (malformed
provider prompt on the next turn), and losing the server's `output-error` /
`output-denied` undoes part of #1623.

Fix: a message that resolved to no server row may still merge from a
conversation-wide index, gated on the `toolCallId` being unambiguous **and**
the tool input being identical. Same `toolCallId` + same input is the same
call; a provider reusing an ID for a genuinely new call carries a different
input and cannot inherit the previous result. The claim logic is untouched, so
this cannot reintroduce #1381's duplicate rows.

Happy to split this into a separate PR if you'd rather review @jcheese1's patch
on its own.

### Follow-up from review (`ce3f0b9f`)

Devin flagged that the fallback above was gated at the *message* level: it only
ran when the incoming message matched no server row at all. So a message that
resolved to a row carrying *some* resolved parts got no fallback for an
individual part whose result had been persisted on a **different** row, and
that part was written back as still pending — losing its recorded
`output-error` / `output-denied`. Reachable whenever an assistant turn's tool
calls end up split across rows.

The lookup is now per part: prefer the row the message resolved to, then fall
back to the conversation-wide index for any call that row doesn't carry. The
guards are unchanged, so a reused ID for a new call still can't inherit the
previous result.

## Verification

The new tests were confirmed to fail before the fix, not just pass after. On
unpatched `main` with the test files applied and **no** source changes:

| Suite | RED | GREEN |
| --- | --- | --- |
| chat unit | 4 failed / 515 | 518 passed |
| ai-chat workers | 1 failed / 40 | 656 passed (full suite) |
| think workers | 1 failed / 9 | 921 passed (full suite) |

The red failures are the real symptom:

```
ai-chat: expected [ 'assistant-first' ] to deeply equal [ 'assistant-first', 'assistant-second' ]
think:   expected [ 'server-first-assistant' ] to deeply equal [ 'server-first-assistant', 'client-second-assistant' ]
```

`pnpm run check` passes (118 projects typecheck). Locally `nx affected -t test`
reports 7 failing tasks, but an identical run on a clean `upstream/main`
checkout fails the same 7 — missing Playwright browsers and an unresolvable
`@babel/plugin-proposal-decorators` in `examples/assistant`. Both are
environmental and should be fine in CI.

## Known gap, not addressed here

Under Think's history compaction, if the older turn is absent from the
submitted transcript, a newer message reusing the same `toolCallId` can still
claim and overwrite the older row:

```
server:   [ u1, srv-a1(tc1, input={turn:1}, output="old result") ]
incoming: [ u2, cli-a2(tc1, input={turn:2}, input-available) ]
result:   [ u2, srv-a1(tc1, input={turn:2}, output="old result") ]
```

Turn 1's row is overwritten and turn 2's input is fused with turn 1's output —
the "stale newer tool part receives the older turn's terminal output" symptom
from the issue. This behaves identically on `main`, so it is not a regression,
but it means the issue's stated expected behaviour is not fully met.

Closing it needs the same input-equality gate on the primary *claim* path, not
just the merge. I left it out because a client's tool input can be partial
mid-stream, so gating the claim risks the duplicate rows #1381 fixed. Happy to
add it if you'd prefer.

## Prior art

#1992 is a recurrence. #1465 reported the same corruption and was closed as
completed on 2026-05-06 with no merged fix and no closing commit. The attempt
against it, #1467, used turn-scoped tool call IDs plus a new
`message-builder.ts` and was closed unmerged.

## API note

`resolveToolMergeId` is now `@deprecated` rather than removed — it is a
published export of `agents/chat`, so removal would be breaking. It keeps its
original behaviour and is no longer used by `@cloudflare/ai-chat` or
`@cloudflare/think`. Callers should use `reconcileMessages`.

Changeset included: patch for `agents`, `@cloudflare/ai-chat`,
`@cloudflare/think`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
