### PR TITLE
Python package support

### DIFF
--- a/.changeset/early-weeks-live.md
+++ b/.changeset/early-weeks-live.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/worker-bundler": patch
+---
+
+Python package support

--- a/packages/worker-bundler/package.json
+++ b/packages/worker-bundler/package.json
@@ -36,6 +36,7 @@
     "@typescript/vfs": "^1.6.4",
     "es-module-lexer": "^2.2.0",
     "esbuild-wasm": "0.28.1",
+    "fflate": "^0.8.2",
     "resolve.exports": "^2.0.3",
     "semver": "^7.8.5",
     "smol-toml": "^1.7.0",

--- a/packages/worker-bundler/src/app.ts
+++ b/packages/worker-bundler/src/app.ts
@@ -101,6 +101,14 @@ export interface CreateAppOptions {
   registry?: string;
 
   /**
+   * When installing Python packages declared in pyproject.toml, prefer the
+   * Pyodide package index over PyPI. Useful when the target runtime uses
+   * Pyodide's wasm32 wheel builds.
+   * @default true
+   */
+  preferPyodideIndex?: boolean;
+
+  /**
    * JSX transform mode passed to esbuild. Applied to both server and client
    * bundles.
    */
@@ -204,6 +212,7 @@ export async function createApp(
     minify = false,
     sourcemap = false,
     registry,
+    preferPyodideIndex,
     jsx,
     jsxImportSource,
     define,
@@ -226,10 +235,10 @@ export async function createApp(
   // Install npm dependencies if needed
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
-    const installResult = await installDependencies(
-      fileSystem,
-      registry ? { registry } : {}
-    );
+    const installResult = await installDependencies(fileSystem, {
+      ...(registry ? { registry } : {}),
+      ...(preferPyodideIndex !== undefined ? { preferPyodideIndex } : {})
+    });
     installWarnings.push(...installResult.warnings);
   }
 

--- a/packages/worker-bundler/src/app.ts
+++ b/packages/worker-bundler/src/app.ts
@@ -101,14 +101,6 @@ export interface CreateAppOptions {
   registry?: string;
 
   /**
-   * When installing Python packages declared in pyproject.toml, prefer the
-   * Pyodide package index over PyPI. Useful when the target runtime uses
-   * Pyodide's wasm32 wheel builds.
-   * @default true
-   */
-  preferPyodideIndex?: boolean;
-
-  /**
    * JSX transform mode passed to esbuild. Applied to both server and client
    * bundles.
    */
@@ -212,7 +204,6 @@ export async function createApp(
     minify = false,
     sourcemap = false,
     registry,
-    preferPyodideIndex,
     jsx,
     jsxImportSource,
     define,
@@ -236,8 +227,7 @@ export async function createApp(
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
     const installResult = await installDependencies(fileSystem, {
-      ...(registry ? { registry } : {}),
-      ...(preferPyodideIndex !== undefined ? { preferPyodideIndex } : {})
+      ...(registry ? { registry } : {})
     });
     installWarnings.push(...installResult.warnings);
   }

--- a/packages/worker-bundler/src/file-system.ts
+++ b/packages/worker-bundler/src/file-system.ts
@@ -11,7 +11,7 @@ export interface FileSystem {
    * @param path The path to the file.
    * @param content The contents of the file.
    */
-  write(path: string, content: string): void;
+  write(path: string, content: FileEntry): void;
 
   /**
    * Deletes a file from the file system.
@@ -294,3 +294,7 @@ export function isFileSystem(
     typeof obj.delete === "function"
   );
 }
+
+// Python packages can contain both text and data entries
+// This type allows filesystem entries to properly support both in the way workerd wants to receive them
+export type FileEntry = string | { data: Uint8Array<ArrayBuffer> };

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -8,7 +8,7 @@ import { bundleWithEsbuild, bundlerOnlyOptionsWarning } from "./bundler";
 import { hasNodejsCompat, parseWranglerConfig } from "./config";
 import { hasDependencies, installDependencies } from "./installer";
 import { transformAndResolve } from "./transformer";
-import type { CreateWorkerOptions, CreateWorkerResult } from "./types";
+import type { CreateWorkerOptions, CreateWorkerResult, Modules } from "./types";
 import {
   DEFAULT_ENTRY_POINTS,
   detectEntryPoint,
@@ -94,6 +94,7 @@ export async function createWorker(
     minify = false,
     sourcemap = false,
     registry,
+    preferPyodideIndex,
     jsx,
     jsxImportSource,
     define,
@@ -117,13 +118,13 @@ export async function createWorker(
   const wranglerConfig = parseWranglerConfig(fileSystem);
   const nodejsCompat = hasNodejsCompat(wranglerConfig);
 
-  // Auto-install dependencies if package.json has dependencies
+  // Auto-install dependencies if package.json or pyproject.toml has dependencies
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
-    const installResult = await installDependencies(
-      fileSystem,
-      registry ? { registry } : {}
-    );
+    const installResult = await installDependencies(fileSystem, {
+      ...(registry ? { registry } : {}),
+      ...(preferPyodideIndex !== undefined ? { preferPyodideIndex } : {})
+    });
     installWarnings.push(...installResult.warnings);
   }
 
@@ -141,6 +142,29 @@ export async function createWorker(
     throw new Error(
       `Entry point "${entryPoint}" was not found in \`files\`. Available files: ${formatFileListForError(fileSystem)}.`
     );
+  }
+
+  if (entryPoint.endsWith(".py")) {
+    const modules: Modules = {};
+    for (const path of fileSystem.list()) {
+      if (path === "pyproject.toml") {
+        continue;
+      }
+      const content = fileSystem.read(path);
+      if (content !== null) {
+        modules[path] = content;
+      }
+    }
+
+    return {
+      mainModule: entryPoint,
+      modules,
+      wranglerConfig: {
+        compatibilityDate: wranglerConfig?.compatibilityDate ?? "2026-07-02",
+        compatibilityFlags: wranglerConfig?.compatibilityFlags ?? []
+      },
+      warnings: installWarnings
+    };
   }
 
   if (bundle) {
@@ -171,7 +195,6 @@ export async function createWorker(
     if (installWarnings.length > 0) {
       result.warnings = [...(result.warnings ?? []), ...installWarnings];
     }
-
     return result;
   } else {
     // No bundling - transform files and resolve dependencies.

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -94,7 +94,6 @@ export async function createWorker(
     minify = false,
     sourcemap = false,
     registry,
-    preferPyodideIndex,
     jsx,
     jsxImportSource,
     define,
@@ -122,8 +121,7 @@ export async function createWorker(
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
     const installResult = await installDependencies(fileSystem, {
-      ...(registry ? { registry } : {}),
-      ...(preferPyodideIndex !== undefined ? { preferPyodideIndex } : {})
+      ...(registry ? { registry } : {})
     });
     installWarnings.push(...installResult.warnings);
   }

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -6,9 +6,14 @@
  */
 
 import * as semver from "semver";
-import type { FileSystem } from "./file-system";
+import { unzipSync } from "fflate";
+import type { FileSystem, FileEntry } from "./file-system";
+import { parse as parseToml } from "smol-toml";
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
+const PYPI_SIMPLE_API = "https://pypi.org/simple";
+// TODO: Update PYODIDE_VERSION once the patch addressing the Python version mismatch for dynamic workers is merged
+const PYODIDE_VERSION = "v0.27.5"; // Used for retrieving a pyodide lockfile, which is done per Pyodide version. If incompatible wheels are being served, this may be why
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
 
 /**
@@ -52,11 +57,71 @@ interface PackageJson {
   };
 }
 
+// Deliberately keeping this minimal
+interface PyprojectToml {
+  project?: {
+    name: string;
+    version: string;
+    dependencies?: string[];
+  };
+}
+
 interface NpmPackageMetadata {
   name: string;
   "dist-tags": Record<string, string>;
   versions: Record<string, PackageJson>;
 }
+
+interface PypiSimpleFile {
+  filename: string;
+  url: string;
+  hashes?: Record<string, string>;
+  "requires-python"?: string;
+  "core-metadata"?: boolean | { hash?: string; url?: string };
+  yanked?: boolean | string;
+}
+
+interface PypiSimpleMetadata {
+  name: string;
+  files: PypiSimpleFile[];
+}
+
+// Describes the packages that are available on the Pyodide CDN for a given Pyodide version
+interface PyodideLockfile {
+  info: {
+    abi_version: string;
+    arch: "wasm32";
+    platform: string;
+    python: string;
+    version: string;
+  };
+  packages: Record<string, PyodideLockfilePackage>;
+}
+
+interface PyodideLockfilePackage {
+  name: string;
+  version: string;
+  file_name: string;
+  sha256: string;
+  package_type:
+    | "package"
+    | "cpython_module"
+    | "shared_library"
+    | "static_library";
+  install_dir: "site" | "dynlib";
+  imports: string[];
+  depends: string[];
+}
+
+interface PyodideWheelInfo {
+  package: PyodideLockfilePackage;
+  url: string;
+  file: PypiSimpleFile;
+}
+
+// Making this global so it will only need to be fetched once per invocation
+// TODO: Consider distributing this with Pyodide itself since it's not likely to change very much between runs
+let pyodideLockfile: PyodideLockfile | null = null;
 
 interface InstallOptions {
   /**
@@ -68,6 +133,11 @@ interface InstallOptions {
    * Registry URL (default: https://registry.npmjs.org)
    */
   registry?: string;
+
+  /**
+   * If installing Python packages, set whether to prefer the Pyodide index (default: true)
+   */
+  preferPyodideIndex?: boolean;
 }
 
 export interface InstallResult {
@@ -97,7 +167,11 @@ export async function installDependencies(
   fileSystem: FileSystem,
   options: InstallOptions = {}
 ): Promise<InstallResult> {
-  const { dev = false, registry = NPM_REGISTRY } = options;
+  const {
+    dev = false,
+    registry = NPM_REGISTRY,
+    preferPyodideIndex = true
+  } = options;
 
   const result: InstallResult = {
     installed: [],
@@ -106,26 +180,101 @@ export async function installDependencies(
 
   // Read package.json
   const packageJsonContent = fileSystem.read("package.json");
-  if (!packageJsonContent) {
-    return result; // No package.json, nothing to install
+  const pyprojectTomlContent = fileSystem.read("pyproject.toml");
+
+  if (packageJsonContent && pyprojectTomlContent) {
+    result.warnings.push("Cannot have package.json and pyproject.toml");
+    return result;
   }
 
-  let packageJson: PackageJson;
+  if (packageJsonContent) {
+    let packageJson: PackageJson;
+    try {
+      packageJson = JSON.parse(packageJsonContent) as PackageJson;
+    } catch {
+      result.warnings.push("Failed to parse package.json");
+      return result;
+    }
+
+    // Collect dependencies to install
+    const depsToInstall: Record<string, string> = {
+      ...packageJson.dependencies,
+      ...(dev ? packageJson.devDependencies : {})
+    };
+
+    if (Object.keys(depsToInstall).length === 0) {
+      return result; // No dependencies to install
+    }
+
+    // Track installed packages to avoid duplicates
+    const installedPackages = new Map<string, string>(); // name -> version
+    // Track in-progress installations to avoid duplicate work
+    const inProgress = new Map<string, Promise<void>>();
+
+    // Install all dependencies in parallel
+    await Promise.all(
+      Object.entries(depsToInstall).map(([name, versionRange]) =>
+        installPackage(
+          name,
+          versionRange,
+          result,
+          fileSystem,
+          installedPackages,
+          inProgress,
+          registry
+        )
+      )
+    );
+  } else if (pyprojectTomlContent) {
+    return await installDependenciesPython(
+      fileSystem,
+      pyprojectTomlContent,
+      preferPyodideIndex
+    );
+  }
+  return result;
+}
+
+/**
+ * Install Python dependencies declared in a pyproject.toml file.
+ */
+async function installDependenciesPython(
+  fileSystem: FileSystem,
+  pyprojectTomlContent: string,
+  preferPyodideIndex: boolean
+): Promise<InstallResult> {
+  const result: InstallResult = {
+    installed: [],
+    warnings: []
+  };
+
+  let pyprojectToml: PyprojectToml;
   try {
-    packageJson = JSON.parse(packageJsonContent) as PackageJson;
+    pyprojectToml = parseToml(pyprojectTomlContent) as PyprojectToml;
   } catch {
-    result.warnings.push("Failed to parse package.json");
+    result.warnings.push("Failed to parse pyproject.toml");
     return result;
   }
 
   // Collect dependencies to install
-  const depsToInstall: Record<string, string> = {
-    ...packageJson.dependencies,
-    ...(dev ? packageJson.devDependencies : {})
-  };
+  const depsToInstall: Record<string, string> = {};
+  depsToInstall["workers-runtime-sdk"] = "*"; // TODO: Should this always take the latest?
+  for (const dep of pyprojectToml.project?.dependencies ?? []) {
+    const { name } = parsePythonVersionString(dep.trim());
+    if (!name) continue;
 
-  if (Object.keys(depsToInstall).length === 0) {
-    return result; // No dependencies to install
+    depsToInstall[dep] = dep;
+  }
+
+  if (!pyodideLockfile) {
+    try {
+      pyodideLockfile = await fetchPyodideLockfile(PYODIDE_VERSION);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.warnings.push(
+        `Could not retrieve Pyodide lockfile, attempts to retrieve packages from the Pyodide CDN may fail. Error: ${message}`
+      );
+    }
   }
 
   // Track installed packages to avoid duplicates
@@ -135,19 +284,18 @@ export async function installDependencies(
 
   // Install all dependencies in parallel
   await Promise.all(
-    Object.entries(depsToInstall).map(([name, versionRange]) =>
-      installPackage(
-        name,
-        versionRange,
+    Object.entries(depsToInstall).map(([depName]) =>
+      installPythonPackage(
+        depName,
         result,
         fileSystem,
         installedPackages,
         inProgress,
-        registry
+        PYPI_SIMPLE_API,
+        preferPyodideIndex
       )
     )
   );
-
   return result;
 }
 
@@ -251,6 +399,206 @@ async function installPackage(
 }
 
 /**
+ * Install a single Python package from PyPI.
+ *
+ * This is an in-progress minimal implementation: it downloads the
+ * latest version of the wheel and adds it to python_modules/. It does not
+ * resolve version ranges.
+ */
+async function installPythonPackage(
+  dependencySpecifier: string, // the full dependency specifier
+  // _versionRange: string, // remove fully if package resolver impl. ends up not going through this path
+  result: InstallResult,
+  fileSystem: FileSystem,
+  installedPackages: Map<string, string>,
+  inProgress: Map<string, Promise<void>>,
+  registry: string,
+  preferPyodideIndex: boolean // TODO: Remove this / remove references to this from other files; we will always prefer the pyodide index
+): Promise<void> {
+  const name = parsePythonVersionString(dependencySpecifier)["name"];
+  // Skip if already installed in this run
+  if (installedPackages.has(name)) {
+    return;
+  }
+
+  if (!shouldInstallDependency(dependencySpecifier)) {
+    return;
+  }
+
+  // We explicitly want to deal in names only here, not full dep strings. Only allowing one version of a package per Python environment is defined behavior
+  // This was previously in installPromise, but was moved up upon observing that races could still lead to redundant fetches
+  installedPackages.set(name, "");
+
+  // TODO: In the JS impl., a check is done here for whether the package already exists in the filesystem
+  // Assess in the future whether this is sensible to repeat
+
+  // If installation is already in progress, wait for it
+  const existing = inProgress.get(name);
+  if (existing) {
+    return existing;
+  }
+
+  const installPromise = (async () => {
+    try {
+      // Setting default values since some of the errors below access these and they may not all be set in all cases
+      let response: Response = {} as Response;
+      let wheel: PypiSimpleFile = {} as PypiSimpleFile;
+      let version: string = "";
+
+      // Putting the logic for retrieving a wheel from PyPI and the Pyodide index into their own functions here
+      // This is so either one can be used as a fallback for the other in a (relatively) tidy way
+      // Try either PyPI or the Pyodide index, then fall back to the other one if that one fails
+      if (preferPyodideIndex) {
+        let registryResult = await retrieveFromPyodide(name);
+        if (registryResult) {
+          [response, wheel, version] = registryResult;
+        } else {
+          registryResult = await retrieveFromPyPI(name, registry);
+          if (registryResult) {
+            [response, wheel, version] = registryResult;
+          } else {
+            throw new Error(
+              `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheel.url})`
+            );
+          }
+        }
+      } else {
+        let registryResult = await retrieveFromPyPI(name, registry);
+        if (registryResult) {
+          [response, wheel, version] = registryResult;
+        } else {
+          registryResult = await retrieveFromPyodide(name);
+          if (registryResult) {
+            [response, wheel, version] = registryResult;
+          } else {
+            throw new Error(
+              `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheel.url})`
+            );
+          }
+        }
+      }
+      const buffer = await response.arrayBuffer();
+
+      const wheelContents = extractWheel(new Uint8Array(buffer));
+      const dependencies = getDependenciesFromWheel(wheelContents);
+      const packageFilesWheel = stripWheelToPackage(wheelContents);
+
+      result.installed.push(`${name}@${version}`);
+
+      // Add files to python_modules
+      for (const [filePath, content] of Object.entries(packageFilesWheel)) {
+        fileSystem.write(`python_modules/${filePath}`, content);
+      }
+
+      await Promise.all(
+        dependencies.map((dep) =>
+          installPythonPackage(
+            dep, // This will change (ie look nicer) after we've completely fleshed out what this should return
+            result,
+            fileSystem,
+            installedPackages,
+            inProgress,
+            PYPI_SIMPLE_API,
+            preferPyodideIndex
+          )
+        )
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.warnings.push(`Failed to install ${name}: ${message}`);
+    }
+  })();
+
+  inProgress.set(name, installPromise);
+
+  try {
+    await installPromise;
+  } finally {
+    inProgress.delete(name);
+  }
+}
+
+async function retrieveFromPyPI(
+  name: string,
+  registry: string
+): Promise<[Response, PypiSimpleFile, string] | null> {
+  const metadata = await fetchPythonPackageMetadata(name, registry);
+  const version = metadata.version;
+  const wheel = metadata.wheel;
+
+  const response = await fetchWithTimeout(
+    wheel.url,
+    {},
+    DEFAULT_TIMEOUT_MS * 2
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return [response, wheel, version];
+}
+
+// TODO: Alter the flow to use the PyPA simple api (index.pyodide.org)
+async function retrieveFromPyodide(
+  name: string
+): Promise<[Response, PypiSimpleFile, string] | null> {
+  const pyodideWheel = getPyodideWheel(name);
+  if (!pyodideWheel) {
+    return null;
+  }
+
+  const response = await fetchWithTimeout(
+    pyodideWheel.url,
+    {},
+    DEFAULT_TIMEOUT_MS * 2
+  );
+  if (!response.ok) {
+    return null;
+  }
+
+  const version = pyodideWheel.package.version;
+  const wheel = pyodideWheel.file;
+  return [response, wheel, version];
+}
+
+function shouldInstallDependency(dependencyString: string): boolean {
+  // TODO: This should actually check whether extras are called for, as well as other environment and compatibility attributes
+  // For the time being, it excludes any dependency that is behind an 'extra'
+  const semicolonPos = dependencyString.indexOf(";");
+  if (
+    semicolonPos > -1 &&
+    (dependencyString.substring(semicolonPos).includes("extra ==") ||
+      dependencyString.substring(semicolonPos).includes("extra=="))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Strip a Python wheel down to just the package contents.
+ *
+ * TODO: Re-review this function once we've cleared issues with file extension limits
+ * in workerd; this function excludes certain metadata files in *.dist-info/ for now but it shouldn't remain this way
+ */
+function stripWheelToPackage(
+  files: Record<string, FileEntry>
+): Record<string, FileEntry> {
+  const result: Record<string, FileEntry> = {};
+  for (const [path, content] of Object.entries(files)) {
+    // Skip wheel metadata and data directories
+    if (path.includes(".dist-info/") || path.includes(".data/")) {
+      continue;
+    }
+    // We'll expect that any remaining directories in the wheel are importable packages
+    result[path] = content;
+  }
+  return result;
+}
+
+/**
  * Fetch package metadata from npm registry.
  */
 async function fetchPackageMetadata(
@@ -284,6 +632,233 @@ async function fetchPackageMetadata(
   }
 
   return (await response.json()) as NpmPackageMetadata;
+}
+
+/**
+ * Fetch the Pyodide lockfile for a given Pyodide version.
+ *
+ * The lockfile lists all pre-built packages available in the Pyodide
+ * distribution, including their wheel URLs, hashes, and dependencies.
+ */
+async function fetchPyodideLockfile(
+  version: string
+): Promise<PyodideLockfile | null> {
+  const url = `https://cdn.jsdelivr.net/pyodide/${version}/full/pyodide-lock.json`;
+  try {
+    const response = await fetchWithTimeout(url);
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as PyodideLockfile;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize a Python package name per PEP 503.
+ *
+ * Lowercases the name and collapses runs of `-`, `_`, and `.` into a single `-`.
+ */
+function normalizePythonName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, "-");
+}
+
+/**
+ * Look up a package in the loaded Pyodide lockfile and return the URL and a
+ * Simple-API-shaped file entry for its wheel.
+ *
+ * Returns `null` if the lockfile is not loaded or the package is not present.
+ */
+function getPyodideWheel(name: string): PyodideWheelInfo | null {
+  if (!pyodideLockfile) return null;
+
+  const normalizedName = normalizePythonName(name);
+  const pkg = pyodideLockfile.packages[normalizedName];
+  if (!pkg) return null;
+
+  const baseUrl = `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full`;
+  const url = pkg.file_name.startsWith("http")
+    ? pkg.file_name
+    : `${baseUrl}/${pkg.file_name}`;
+
+  return {
+    package: pkg,
+    url,
+    file: {
+      filename: pkg.file_name,
+      url,
+      hashes: { sha256: pkg.sha256 }
+    }
+  };
+}
+
+async function fetchPythonPackageMetadata(
+  name: string,
+  registry: string
+): Promise<{ version: string; wheel: PypiSimpleFile }> {
+  const normalizedName = normalizePythonName(name);
+
+  // Fetch package metadata from PyPI Simple API
+  const metadataResponse = await fetchWithTimeout(
+    `${registry}/${normalizedName}/`,
+    {
+      headers: {
+        Accept: "application/vnd.pypi.simple.v1+json"
+      }
+    }
+  );
+
+  if (!metadataResponse.ok) {
+    const hint =
+      metadataResponse.status === 404
+        ? " (package not found — check the name in pyproject.toml)"
+        : "";
+    throw new Error(
+      `PyPI returned ${metadataResponse.status} ${metadataResponse.statusText} for "${name}"${hint}`
+    );
+  }
+  const metadata = (await metadataResponse.json()) as PypiSimpleMetadata;
+
+  const wheel = selectWheel(metadata.files);
+  if (!wheel) {
+    throw new Error(`No compatible wheel found for ${name} on PyPI`);
+  }
+
+  const version = parseWheelVersion(wheel.filename);
+  if (!version) {
+    throw new Error(
+      `Could not parse version from wheel filename: ${wheel.filename}`
+    );
+  }
+
+  return { version, wheel };
+}
+
+/**
+ * Select a compatible wheel from PyPI Simple API files list.
+ * Prefers py3-none-any or py2.py3-none-any wheels for maximum compatibility.
+ * Selects the latest version from compatible wheels.
+ * TODO: implement proper platform/python version matching
+ */
+function selectWheel(files: PypiSimpleFile[]): PypiSimpleFile | null {
+  const wheels = files.filter((f) => f.filename.endsWith(".whl"));
+  if (wheels.length === 0) return null;
+
+  // Filter to universal wheels (py3-none-any or py2.py3-none-any)
+  const universal = wheels.filter(
+    (w) =>
+      w.filename.endsWith("-py3-none-any.whl") ||
+      w.filename.endsWith("-py2.py3-none-any.whl")
+  );
+
+  const candidates = universal.length > 0 ? universal : wheels;
+
+  // Select the wheel with the highest version
+  let latest: PypiSimpleFile | null = null;
+  let latestVersion: string | undefined;
+
+  for (const wheel of candidates) {
+    const version = parseWheelVersion(wheel.filename);
+    if (!version) continue;
+
+    if (
+      !latest ||
+      !latestVersion ||
+      comparePythonVersions(version, latestVersion) > 0
+    ) {
+      latest = wheel;
+      latestVersion = version;
+    }
+  }
+
+  return latest;
+}
+
+/**
+ * Compare two PEP 440 version strings.
+ * Returns >0 if a > b, <0 if a < b, 0 if equal.
+ *
+ * Python versions (PEP 440) are not semver-compatible (e.g. "3.6.2.1" has four
+ * release segments), so semver cannot be used here. This is a minimal
+ * comparison: it compares the dotted numeric release segments, and treats
+ * pre-release/dev versions (a/b/rc/alpha/beta/dev/pre) as lower than the same
+ * release so a stable release is preferred.
+ * TODO: full PEP 440 ordering (post-releases, local versions, epochs) if needed.
+ */
+export function comparePythonVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const releaseMatch = v.match(/^[0-9]+(?:\.[0-9]+)*/);
+    const release = (releaseMatch?.[0] ?? "0").split(".").map(Number);
+    const rest = v.slice(releaseMatch?.[0].length ?? 0);
+    const isPre = /^[.\-_]?(a|b|c|rc|alpha|beta|dev|pre)/i.test(rest);
+    return { release, isPre };
+  };
+
+  const av = parse(a);
+  const bv = parse(b);
+
+  const len = Math.max(av.release.length, bv.release.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (av.release[i] ?? 0) - (bv.release[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  // Same release: a stable version outranks a pre-release/dev version
+  if (av.isPre !== bv.isPre) return av.isPre ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Parse version from a wheel filename.
+ * Wheel format: {distribution}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+ *
+ * With no build tag (5 parts): distribution-version-python-abi-platform.whl
+ * With build tag (6+ parts): distribution-version-build-python-abi-platform.whl
+ *
+ * TODO: handle edge cases with distribution names containing hyphens
+ */
+function parseWheelVersion(filename: string): string | undefined {
+  const parts = filename.replace(/\.whl$/, "").split("-");
+  if (parts.length < 5) return undefined;
+
+  // The last three parts are always: python_tag, abi_tag, platform_tag
+  // For 5 parts: distribution, version, py, abi, platform -> version is parts[1]
+  // For 6+ parts: distribution, version, build?, py, abi, platform -> version is parts[1]
+  return parts[1];
+}
+
+/**
+ * Extract Requires-Dist entries from a wheel's *.dist-info/METADATA file.
+ * Accepts the file record returned by `extractWheel`.
+ * Returns an empty array if METADATA is missing or contains no dependencies.
+ */
+function getDependenciesFromWheel(files: Record<string, FileEntry>): string[] {
+  const metadataPath = Object.keys(files).find((path) =>
+    path.endsWith(".dist-info/METADATA")
+  );
+  if (!metadataPath) return [];
+  const metadata = files[metadataPath];
+  if (!metadata) return [];
+  if (typeof metadata !== "string") return [];
+  return parseRequiresDist(metadata);
+}
+
+/**
+ * Parse Requires-Dist headers from Python package METADATA file (RFC 822 format).
+ */
+function parseRequiresDist(metadata: string): string[] {
+  const requires: string[] = [];
+  const lines = metadata.split(/\r?\n/);
+
+  for (const line of lines) {
+    // Process previous header if it was Requires-Dist
+    if (line !== undefined && line.startsWith("Requires-Dist:")) {
+      requires.push(line.slice("Requires-Dist:".length).trim());
+    }
+  }
+
+  return requires;
 }
 
 /**
@@ -346,6 +921,47 @@ export async function fetchPackageFiles(
 
   // Extract the tarball (npm tarballs are gzipped tar files)
   return extractTarball(new Uint8Array(buffer));
+}
+
+/**
+ * Extract files from a ZIP archive (Python wheel).
+ *
+ * Python wheels are distributed as .whl files (ZIP archives).
+ */
+function extractWheel(data: Uint8Array): Record<string, FileEntry> {
+  const unzipped = unzipSync(data);
+  const files: Record<string, FileEntry> = {};
+  const textDecoder = new TextDecoder();
+
+  for (const [path, content] of Object.entries(unzipped)) {
+    // Keep the wheel's core metadata file so callers can read Requires-Dist from it.
+    // This file has no extension, so it would otherwise be rejected by isTextFile.
+    // TODO: Remove this after we clear the other todo constraining down to just text files
+    if (path.endsWith(".dist-info/METADATA")) {
+      files[path] = textDecoder.decode(content);
+      continue;
+    }
+
+    if (
+      // TODO: This can be removed once it's confirmed that workerd doesn't block these (and other) file extensions
+      path.endsWith(".md") ||
+      path.endsWith(".css") ||
+      path.endsWith(".js") ||
+      path.endsWith(".txt") ||
+      path.endsWith("LICENSE") ||
+      path.endsWith(".rst")
+    ) {
+      continue;
+    }
+
+    if (isTextFile(path)) {
+      files[path] = textDecoder.decode(content);
+    } else {
+      files[path] = { data: new Uint8Array(content) };
+    }
+  }
+
+  return files;
 }
 
 /**
@@ -500,7 +1116,8 @@ function isTextFile(path: string): boolean {
     ".map",
     ".d.ts",
     ".d.mts",
-    ".d.cts"
+    ".d.cts",
+    ".py"
   ];
 
   // Check common config files without extensions
@@ -526,17 +1143,59 @@ function isTextFile(path: string): boolean {
 }
 
 /**
- * Check if files contain a package.json with dependencies that need installing.
+ * Parse a Python version specifier string (PEP 508) and extract the package name.
+ *
+ * Accepts strings as they appear in `pyproject.toml` `[project].dependencies`
+ * or in PyPI JSON API `info.requires_dist` responses. Examples:
+ *   "requests"
+ *   "requests>=2.0"
+ *   "requests[security]>=2.0"
+ *   "requests (>=2.0)"
+ *   "requests; python_version < '3.8'"
+ *   "requests[security] >= 2.0 ; python_version < '3.8'"
+ *
+ * Returns a tuple of `[package_name, null, null]`. The second and third slots
+ * are placeholders reserved for future use (e.g. extras, version specifier).
+ */
+function parsePythonVersionString(spec: string): { name: string } {
+  // Drop the PEP 508 environment marker (everything after `;`)
+  let head = spec.split(";", 1)[0] ?? "";
+
+  // The package name is the leading run of characters allowed in a PEP 508
+  // identifier: letters, digits, `.`, `-`, `_`. Stop at the first character
+  // that isn't one of those (whitespace, `[`, `(`, `<`, `>`, `=`, `!`, `~`, etc.).
+  const match = head.match(/^\s*([A-Za-z0-9][A-Za-z0-9._-]*)/);
+  const name = match ? match[1]! : head.trim();
+
+  return { name: name };
+}
+
+/**
+ * Check if files contain a package.json or pyproject.toml with dependencies that need installing.
  */
 export function hasDependencies(files: FileSystem): boolean {
+  const pyprojectToml = files.read("pyproject.toml");
   const packageJson = files.read("package.json");
-  if (!packageJson) return false;
+  if (!packageJson && !pyprojectToml) return false;
 
-  try {
-    const pkg = JSON.parse(packageJson);
-    const deps = pkg.dependencies ?? {};
-    return Object.keys(deps).length > 0;
-  } catch {
-    return false;
+  if (packageJson) {
+    try {
+      const pkg = JSON.parse(packageJson);
+      const deps = pkg.dependencies ?? {};
+      return Object.keys(deps).length > 0;
+    } catch {
+      return false;
+    }
   }
+
+  if (pyprojectToml) {
+    try {
+      const pkg = parseToml(pyprojectToml) as PyprojectToml;
+      const deps = pkg.project?.dependencies ?? [];
+      return deps.length > 0;
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -133,11 +133,6 @@ interface InstallOptions {
    * Registry URL (default: https://registry.npmjs.org)
    */
   registry?: string;
-
-  /**
-   * If installing Python packages, set whether to prefer the Pyodide index (default: true)
-   */
-  preferPyodideIndex?: boolean;
 }
 
 export interface InstallResult {
@@ -167,11 +162,7 @@ export async function installDependencies(
   fileSystem: FileSystem,
   options: InstallOptions = {}
 ): Promise<InstallResult> {
-  const {
-    dev = false,
-    registry = NPM_REGISTRY,
-    preferPyodideIndex = true
-  } = options;
+  const { dev = false, registry = NPM_REGISTRY } = options;
 
   const result: InstallResult = {
     installed: [],
@@ -226,11 +217,7 @@ export async function installDependencies(
       )
     );
   } else if (pyprojectTomlContent) {
-    return await installDependenciesPython(
-      fileSystem,
-      pyprojectTomlContent,
-      preferPyodideIndex
-    );
+    return await installDependenciesPython(fileSystem, pyprojectTomlContent);
   }
   return result;
 }
@@ -240,8 +227,7 @@ export async function installDependencies(
  */
 async function installDependenciesPython(
   fileSystem: FileSystem,
-  pyprojectTomlContent: string,
-  preferPyodideIndex: boolean
+  pyprojectTomlContent: string
 ): Promise<InstallResult> {
   const result: InstallResult = {
     installed: [],
@@ -291,8 +277,7 @@ async function installDependenciesPython(
         fileSystem,
         installedPackages,
         inProgress,
-        PYPI_SIMPLE_API,
-        preferPyodideIndex
+        PYPI_SIMPLE_API
       )
     )
   );
@@ -412,8 +397,7 @@ async function installPythonPackage(
   fileSystem: FileSystem,
   installedPackages: Map<string, string>,
   inProgress: Map<string, Promise<void>>,
-  registry: string,
-  preferPyodideIndex: boolean // TODO: Remove this / remove references to this from other files; we will always prefer the pyodide index
+  backupRegistry: string
 ): Promise<void> {
   const name = parsePythonVersionString(dependencySpecifier)["name"];
   // Skip if already installed in this run
@@ -445,36 +429,18 @@ async function installPythonPackage(
       let wheel: PypiSimpleFile = {} as PypiSimpleFile;
       let version: string = "";
 
-      // Putting the logic for retrieving a wheel from PyPI and the Pyodide index into their own functions here
-      // This is so either one can be used as a fallback for the other in a (relatively) tidy way
-      // Try either PyPI or the Pyodide index, then fall back to the other one if that one fails
-      if (preferPyodideIndex) {
-        let registryResult = await retrieveFromPyodide(name);
-        if (registryResult) {
-          [response, wheel, version] = registryResult;
-        } else {
-          registryResult = await retrieveFromPyPI(name, registry);
-          if (registryResult) {
-            [response, wheel, version] = registryResult;
-          } else {
-            throw new Error(
-              `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheel.url})`
-            );
-          }
-        }
+      // Try the Pyodide index first, then fall back to PyPI if that fails
+      let registryResult = await retrieveFromPyodide(name);
+      if (registryResult) {
+        [response, wheel, version] = registryResult;
       } else {
-        let registryResult = await retrieveFromPyPI(name, registry);
+        registryResult = await retrieveFromPyPI(name, backupRegistry);
         if (registryResult) {
           [response, wheel, version] = registryResult;
         } else {
-          registryResult = await retrieveFromPyodide(name);
-          if (registryResult) {
-            [response, wheel, version] = registryResult;
-          } else {
-            throw new Error(
-              `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheel.url})`
-            );
-          }
+          throw new Error(
+            `Failed to download ${name}@${version}: ${response.status} ${response.statusText} (${wheel.url})`
+          );
         }
       }
       const buffer = await response.arrayBuffer();
@@ -498,8 +464,7 @@ async function installPythonPackage(
             fileSystem,
             installedPackages,
             inProgress,
-            PYPI_SIMPLE_API,
-            preferPyodideIndex
+            PYPI_SIMPLE_API
           )
         )
       );

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -1047,8 +1047,7 @@ describe("createWorker with pyproject.toml", () => {
           // `attrs` has zero dependencies
           'dependencies = ["typing_extensions==4.16.0", "typing_inspection==0.4.2", "attrs==26.1.0"]'
         ].join("\n")
-      },
-      preferPyodideIndex: false
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1089,8 +1088,7 @@ describe("createWorker with pyproject.toml", () => {
           // typing_inspection depends on typing_extensions
           'dependencies = ["typing_inspection==0.4.2"]'
         ].join("\n")
-      },
-      preferPyodideIndex: false
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1130,8 +1128,7 @@ describe("createWorker with pyproject.toml", () => {
           // typing_inspection depends on typing_extensions
           'dependencies = ["typing_inspection==0.4.2"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1168,8 +1165,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           'dependencies = ["certifi"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1209,8 +1205,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           'dependencies = ["pyyaml"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1259,8 +1254,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           'dependencies = ["pygments", "fastapi", "beautifulsoup4", "flask", "jinja2", "numpy", "libcst"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1307,8 +1301,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           'dependencies = ["numpy"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1359,8 +1352,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           'dependencies = ["fastapi"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1409,8 +1401,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           'dependencies = ["fastapi"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,
@@ -1456,8 +1447,7 @@ describe("createWorker with pyproject.toml", () => {
           'version = "0.0.0"',
           'dependencies = ["libcst"]'
         ].join("\n")
-      },
-      preferPyodideIndex: true
+      }
     });
     const worker = env.LOADER.get(id, () => ({
       mainModule: createWorkerResult.mainModule,

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -8,6 +8,7 @@ import { runInDurableObject } from "cloudflare:test";
 import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
 import type { CreateWorkerOptions } from "../types";
 import { createTypescriptLanguageService } from "../typescript";
+import { comparePythonVersions } from "../installer";
 
 let testId = 0;
 
@@ -982,5 +983,517 @@ describe("hasNodejsCompat", () => {
 
   it("returns false for undefined config", () => {
     expect(hasNodejsCompat(undefined)).toBe(false);
+  });
+});
+
+// Longer timeout duration given since Python workers can take longer to start in the test suite
+describe("createWorker with python main", () => {
+  it("executes a Python script as the main module", async () => {
+    const dynamic_worker = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          '    return Response("hi")'
+        ].join("\n")
+      }
+    });
+    const id = "test-worker-" + testId++;
+
+    // These should both have defaults from createWorker
+    expect(dynamic_worker.wranglerConfig?.compatibilityDate).not.toBeNull();
+    expect(dynamic_worker.wranglerConfig?.compatibilityFlags).not.toBeNull();
+
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: dynamic_worker.mainModule,
+      modules: dynamic_worker.modules,
+      compatibilityDate: dynamic_worker.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: dynamic_worker.wranglerConfig!.compatibilityFlags!
+    }));
+
+    let response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("hi");
+  });
+}, 20000);
+
+describe("createWorker with pyproject.toml", () => {
+  it("works with a pure python package", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import typing_extensions",
+          "import typing_inspection",
+          "import attrs, attr", // `attrs` supplies two importables, attr and attrs. If it's installed properly, both will be available
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "typing_extensions": typing_extensions.__name__,',
+          '      "typing_inspection": typing_inspection.__name__,',
+          '      "attrs": attrs.__name__,',
+          '      "attr": attr.__name__,',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          // typing_extensions has zero dependencies. typing_inspection depends on typing_extensions
+          // `attrs` has zero dependencies
+          'dependencies = ["typing_extensions==4.16.0", "typing_inspection==0.4.2", "attrs==26.1.0"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: false
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.typing_extensions).toBe("typing_extensions");
+    expect(body.typing_inspection).toBe("typing_inspection");
+    expect(body.attrs).toBe("attrs");
+    expect(body.attr).toBe("attr");
+  });
+
+  it("automatically installs a nested dependency", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import typing_inspection",
+          "import typing_extensions",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "typing_extensions": typing_extensions.__name__,',
+          '      "typing_inspection": typing_inspection.__name__,',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          // typing_inspection depends on typing_extensions
+          'dependencies = ["typing_inspection==0.4.2"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: false
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.typing_extensions).toBe("typing_extensions");
+    expect(body.typing_inspection).toBe("typing_inspection");
+  });
+
+  // Checks that the Pyodide index works the same way we expect PyPI to work
+  it("works with the pyodide index", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import typing_inspection",
+          "import typing_extensions", // If nothing has gone wrong with nested deps when using the Pyodide index, this will work fine
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "typing_extensions": typing_extensions.__name__,',
+          '      "typing_inspection": typing_inspection.__name__,',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          // typing_inspection depends on typing_extensions
+          'dependencies = ["typing_inspection==0.4.2"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.typing_extensions).toBe("typing_extensions");
+    expect(body.typing_inspection).toBe("typing_inspection");
+  });
+
+  it("works with packages that include arbitrary binary files", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import certifi",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "certifi": certifi.__name__,',
+          '      "contents": certifi.contents()',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          'dependencies = ["certifi"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.certifi).toBe("certifi");
+    expect(body.contents).toBeTruthy();
+  });
+
+  it("works with packages that have extensions", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import yaml",
+          "from yaml import _yaml",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          '    parsed = yaml.load("hello: world", yaml.CLoader)',
+          "    return Response.json({",
+          '      "yaml": yaml.__name__,',
+          '      "hasCLoader": yaml.CLoader is not None,',
+          '      "parsed": parsed',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          'dependencies = ["pyyaml"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.yaml).toBe("yaml");
+    expect(body.hasCLoader).toBe(true);
+    expect(body.parsed).toEqual({ hello: "world" });
+  });
+
+  it("imports larger packages", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import pygments",
+          "import fastapi",
+          "import bs4", // beautifulsoup4
+          "import flask",
+          "import jinja2",
+          "import numpy",
+          "import libcst",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    return Response.json({",
+          '      "pygments": pygments.__name__,',
+          '      "fastapi": fastapi.__name__,',
+          '      "bs4": bs4.__name__,',
+          '      "flask": flask.__name__,',
+          '      "jinja2": jinja2.__name__,',
+          '      "numpy": numpy.__name__,',
+          '      "libcst": libcst.__name__,',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          'dependencies = ["pygments", "fastapi", "beautifulsoup4", "flask", "jinja2", "numpy", "libcst"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.pygments).toBe("pygments");
+    expect(body.fastapi).toBe("fastapi");
+    expect(body.bs4).toBe("bs4");
+    expect(body.flask).toBe("flask");
+    expect(body.jinja2).toBe("jinja2");
+    expect(body.numpy).toBe("numpy");
+    expect(body.libcst).toBe("libcst");
+  });
+
+  it("doesn't trip on numpy and its extensions", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import numpy as np",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    a = np.array([1, 2, 3], dtype=np.int32)",
+          "    b = np.array([4, 5, 6], dtype=np.int32)",
+          "    dot = int(np.dot(a, b))",
+          "    total = int(np.sum(a))",
+          "    return Response.json({",
+          '      "dot": dot,',
+          '      "sum": total,',
+          '      "dtype": str(a.dtype)',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          'dependencies = ["numpy"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.dot).toBe(32);
+    expect(body.sum).toBe(6);
+    expect(body.dtype).toBe("int32");
+  });
+
+  it("uses fastapi to build routes and generate an openapi schema", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "from fastapi import FastAPI",
+          "from pydantic import BaseModel",
+          "",
+          "app = FastAPI()",
+          "",
+          "class Item(BaseModel):",
+          "  name: str",
+          "  price: float",
+          "",
+          "@app.post('/items')",
+          "async def create_item(item: Item):",
+          "  return item",
+          "",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    schema = app.openapi()",
+          "    return Response.json({",
+          '      "title": schema.get("info", {}).get("title"),',
+          '      "has_paths": "/items" in schema.get("paths", {})',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          'dependencies = ["fastapi"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.title).toBe("FastAPI");
+    expect(body.has_paths).toBe(true);
+  });
+
+  it("uses pydantic native validation required by fastapi", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "from pydantic import BaseModel, ValidationError",
+          "",
+          "class User(BaseModel):",
+          "  name: str",
+          "  age: int",
+          "",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          '    user = User(name="alice", age=30)',
+          "    try:",
+          '      User(name="bob", age="not an int")',
+          "      validation_failed = False",
+          "    except ValidationError:",
+          "      validation_failed = True",
+          "    return Response.json({",
+          '      "name": user.name,',
+          '      "age": user.age,',
+          '      "validation_failed": validation_failed',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          'dependencies = ["fastapi"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.name).toBe("alice");
+    expect(body.age).toBe(30);
+    expect(body.validation_failed).toBe(true);
+  });
+
+  it("uses libcst to parse and inspect python source", async () => {
+    const id = "test-worker-" + testId++;
+    const createWorkerResult = await createWorker({
+      files: {
+        "index.py": [
+          "from workers import Response, WorkerEntrypoint",
+          "import libcst as cst",
+          "",
+          "class Default(WorkerEntrypoint):",
+          "  async def fetch(self, request):",
+          "    source = \"def greet(name):\\n    return f'Hello, {name}!'\\n\"",
+          "    module = cst.parse_module(source)",
+          "    functions = [",
+          "      stmt for stmt in module.body",
+          "      if isinstance(stmt, cst.FunctionDef)",
+          "    ]",
+          "    name = functions[0].name.value if functions else None",
+          "    return Response.json({",
+          '      "function_name": name,',
+          '      "has_code": len(module.code) > 0',
+          "    })"
+        ].join("\n"),
+        "pyproject.toml": [
+          "[project]",
+          'name = "dummy"',
+          'version = "0.0.0"',
+          'dependencies = ["libcst"]'
+        ].join("\n")
+      },
+      preferPyodideIndex: true
+    });
+    const worker = env.LOADER.get(id, () => ({
+      mainModule: createWorkerResult.mainModule,
+      modules: createWorkerResult.modules,
+      compatibilityDate: createWorkerResult.wranglerConfig!.compatibilityDate!,
+      compatibilityFlags: createWorkerResult.wranglerConfig!.compatibilityFlags!
+    }));
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request("http://worker/"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.function_name).toBe("greet");
+    expect(body.has_code).toBe(true);
+  });
+}, 20000);
+
+describe("comparePythonVersions", () => {
+  it("accurately compares versions", () => {
+    expect(comparePythonVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(comparePythonVersions("2.0.0", "1.0.0")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("1.2.3", "1.2.4")).toBeLessThan(0);
+    expect(comparePythonVersions("1.2.4", "1.2.3")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.10.0", "1.2.0")).toBeGreaterThan(0);
+    expect(comparePythonVersions("1.0.1", "1.0")).toBeGreaterThan(0);
+  });
+
+  it("considers non-release versions (a/b/rc/alpha/beta/dev/pre) to be lower versions than numeric ones", () => {
+    expect(comparePythonVersions("2.0.0a1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0", "2.0.0a1")).toBeGreaterThan(0);
+    expect(comparePythonVersions("2.0.0b1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0rc1", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0-alpha", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0beta", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0dev", "2.0.0")).toBeLessThan(0);
+    expect(comparePythonVersions("2.0.0pre", "2.0.0")).toBeLessThan(0);
   });
 });

--- a/packages/worker-bundler/src/types.ts
+++ b/packages/worker-bundler/src/types.ts
@@ -112,6 +112,13 @@ export interface CreateWorkerOptions {
   registry?: string;
 
   /**
+   * When installing Python packages declared in pyproject.toml, prefer the
+   * Pyodide package index over PyPI.
+   * @default true
+   */
+  preferPyodideIndex?: boolean;
+
+  /**
    * JSX transform mode passed to esbuild.
    * `"automatic"` enables the new JSX runtime (no need to import React).
    *

--- a/packages/worker-bundler/src/types.ts
+++ b/packages/worker-bundler/src/types.ts
@@ -112,13 +112,6 @@ export interface CreateWorkerOptions {
   registry?: string;
 
   /**
-   * When installing Python packages declared in pyproject.toml, prefer the
-   * Pyodide package index over PyPI.
-   * @default true
-   */
-  preferPyodideIndex?: boolean;
-
-  /**
    * JSX transform mode passed to esbuild.
    * `"automatic"` enables the new JSX runtime (no need to import React).
    *

--- a/packages/worker-bundler/src/utils.ts
+++ b/packages/worker-bundler/src/utils.ts
@@ -21,6 +21,7 @@ export const DEFAULT_ENTRY_POINTS = [
   "src/index.mjs",
   "index.ts",
   "index.js",
+  "index.py",
   "src/worker.ts",
   "src/worker.js"
 ] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4090,6 +4090,9 @@ importers:
       esbuild-wasm:
         specifier: 0.28.1
         version: 0.28.1
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       resolve.exports:
         specifier: ^2.0.3
         version: 2.0.3
@@ -9164,6 +9167,9 @@ packages:
 
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -16878,6 +16884,8 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   fetchdts@0.1.7: {}
+
+  fflate@0.8.3: {}
 
   figures@3.2.0:
     dependencies:


### PR DESCRIPTION
Adds support for Python packages in worker-bundler, and thus to Python dynamic workers.

The current iteration of this feature leans on the Pyodide package index, with PyPI filling in as a fallback. In this state, it has parity with the way packages work in Pyodide normally, which is to say only one version of a package is made available by the index for a given version of Pyodide. For that reason, it retrieves this version (as long as the package is available) without handling version ranges (as the dependency string spec otherwise allows).

This has been reviewed by the Python Workers team in a series of PR's to a clone (https://github.com/abstractedfox/agents)