### PR TITLE
fix(think): preserve messenger text boundaries

### DIFF
--- a/.changeset/warm-otters-separate.md
+++ b/.changeset/warm-otters-separate.md
@@ -1,7 +1,7 @@
 ---
 "agents": patch
-"@cloudflare/think": patch
+"@cloudflare/think": minor
 "@cloudflare/voice": patch
 ---
 
-Preserve spacing between streamed text segments separated by tool calls. Think messenger delivery and Voice now share the same boundary-aware text joining logic from `agents/chat`.
+Preserve spacing between streamed text segments separated by tool calls. Think messenger delivery and Voice now share the same boundary-aware text joining logic from `agents/chat`. Remove the unsafe `textDeltaFromStreamChunk()` messenger export; consume streams through `TextStreamCallback` so structured boundaries are retained.

--- a/.changeset/warm-otters-separate.md
+++ b/.changeset/warm-otters-separate.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+"@cloudflare/voice": patch
+---
+
+Preserve spacing between streamed text segments separated by tool calls. Think messenger delivery and Voice now share the same boundary-aware text joining logic from `agents/chat`.

--- a/examples/chat-sdk-messenger/src/tests/intelligence.test.ts
+++ b/examples/chat-sdk-messenger/src/tests/intelligence.test.ts
@@ -16,10 +16,7 @@ import {
   shouldRouteToAi,
   toThinkUserMessage
 } from "../intelligence/messages";
-import {
-  TextStreamCallback,
-  textDeltaFromStreamChunk
-} from "@cloudflare/think/messengers";
+import { TextStreamCallback } from "@cloudflare/think/messengers";
 import {
   isExpectedTelegramFinalEditNoop as isExpectedFinalEditNoop,
   isTelegramIgnorableDeliveryError as isIgnorableDeliveryError,
@@ -207,18 +204,6 @@ describe("Telegram intelligence helpers", () => {
 
     expect(chunks.every((chunk) => chunk.length <= 18)).toBe(true);
     expect(chunks.join("")).toBe(text);
-  });
-
-  it("extracts text deltas from Think chat stream chunks", () => {
-    expect(
-      textDeltaFromStreamChunk(
-        JSON.stringify({ type: "text-delta", id: "t1", delta: "hello" })
-      )
-    ).toBe("hello");
-    expect(
-      textDeltaFromStreamChunk(JSON.stringify({ type: "text-start", id: "t1" }))
-    ).toBeNull();
-    expect(textDeltaFromStreamChunk("not json")).toBeNull();
   });
 
   it("tracks streamed text and closes cleanly", async () => {

--- a/packages/agents/src/chat/__tests__/text-segment-joiner.test.ts
+++ b/packages/agents/src/chat/__tests__/text-segment-joiner.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  isTextSegmentBoundary,
+  TextSegmentJoiner
+} from "../text-segment-joiner";
+
+describe("isTextSegmentBoundary", () => {
+  it("treats every structured event other than text deltas as a boundary", () => {
+    expect(isTextSegmentBoundary("tool-call")).toBe(true);
+    expect(isTextSegmentBoundary("tool-result")).toBe(true);
+    expect(isTextSegmentBoundary("text-start")).toBe(true);
+    expect(isTextSegmentBoundary("text-end")).toBe(true);
+    expect(isTextSegmentBoundary("start-step")).toBe(true);
+    expect(isTextSegmentBoundary("finish-step")).toBe(true);
+    expect(isTextSegmentBoundary("start")).toBe(true);
+    expect(isTextSegmentBoundary("finish")).toBe(true);
+    expect(isTextSegmentBoundary("text-delta")).toBe(false);
+    expect(isTextSegmentBoundary(undefined)).toBe(false);
+  });
+});
+
+describe("TextSegmentJoiner", () => {
+  it("separates text segments across a stream boundary", () => {
+    const joiner = new TextSegmentJoiner();
+
+    expect(joiner.pushText("Before.")).toEqual(["Before."]);
+    joiner.markBoundary();
+    expect(joiner.pushText("After.")).toEqual([" ", "After."]);
+  });
+
+  it("does not duplicate whitespace already provided by either segment", () => {
+    const trailingWhitespace = new TextSegmentJoiner();
+    trailingWhitespace.pushText("Before. ");
+    trailingWhitespace.markBoundary();
+    expect(trailingWhitespace.pushText("After.")).toEqual(["After."]);
+
+    const leadingWhitespace = new TextSegmentJoiner();
+    leadingWhitespace.pushText("Before.");
+    leadingWhitespace.markBoundary();
+    expect(leadingWhitespace.pushText("\nAfter.")).toEqual(["\nAfter."]);
+  });
+
+  it("reports only the first repeated boundary", () => {
+    const joiner = new TextSegmentJoiner();
+    expect(joiner.markBoundary()).toBe(false);
+    joiner.pushText("Before.");
+
+    expect(joiner.markBoundary()).toBe(true);
+    expect(joiner.markBoundary()).toBe(false);
+    expect(joiner.pushText("After.")).toEqual([" ", "After."]);
+  });
+
+  it("does not add whitespace without text on both sides", () => {
+    const joiner = new TextSegmentJoiner();
+    joiner.markBoundary();
+    expect(joiner.pushText("First.")).toEqual(["First."]);
+
+    joiner.markBoundary();
+    expect(joiner.pushText("")).toEqual([]);
+    expect(joiner.pushText("Second.")).toEqual([" ", "Second."]);
+  });
+});

--- a/packages/agents/src/chat/__tests__/text-segment-joiner.test.ts
+++ b/packages/agents/src/chat/__tests__/text-segment-joiner.test.ts
@@ -1,62 +1,80 @@
 import { describe, expect, it } from "vitest";
-import {
-  isTextSegmentBoundary,
-  TextSegmentJoiner
-} from "../text-segment-joiner";
+import { TextSegmentJoiner } from "../text-segment-joiner";
 
-describe("isTextSegmentBoundary", () => {
-  it("treats every structured event other than text deltas as a boundary", () => {
-    expect(isTextSegmentBoundary("tool-call")).toBe(true);
-    expect(isTextSegmentBoundary("tool-result")).toBe(true);
-    expect(isTextSegmentBoundary("text-start")).toBe(true);
-    expect(isTextSegmentBoundary("text-end")).toBe(true);
-    expect(isTextSegmentBoundary("start-step")).toBe(true);
-    expect(isTextSegmentBoundary("finish-step")).toBe(true);
-    expect(isTextSegmentBoundary("start")).toBe(true);
-    expect(isTextSegmentBoundary("finish")).toBe(true);
-    expect(isTextSegmentBoundary("text-delta")).toBe(false);
-    expect(isTextSegmentBoundary(undefined)).toBe(false);
-  });
-});
+const text = (value: string) => ({ type: "text", text: value }) as const;
+const boundary = { type: "boundary" } as const;
 
 describe("TextSegmentJoiner", () => {
-  it("separates text segments across a stream boundary", () => {
+  it("classifies structured chunks and separates non-adjacent text", () => {
     const joiner = new TextSegmentJoiner();
 
-    expect(joiner.pushText("Before.")).toEqual(["Before."]);
-    joiner.markBoundary();
-    expect(joiner.pushText("After.")).toEqual([" ", "After."]);
+    expect(joiner.pushChunk({ type: "text-delta", text: "Before." })).toEqual([
+      text("Before.")
+    ]);
+    expect(joiner.pushChunk({ type: "tool-call" })).toEqual([boundary]);
+    expect(joiner.pushChunk({ type: "tool-result" })).toEqual([]);
+    expect(joiner.pushChunk({ type: "text-delta", delta: "After." })).toEqual([
+      text(" "),
+      text("After.")
+    ]);
+  });
+
+  it("treats text and stream lifecycle chunks as boundaries", () => {
+    for (const type of [
+      "text-start",
+      "text-end",
+      "start-step",
+      "finish-step",
+      "start",
+      "finish"
+    ]) {
+      const joiner = new TextSegmentJoiner();
+      joiner.pushChunk({ type: "text-delta", text: "Before." });
+      expect(joiner.pushChunk({ type }), type).toEqual([boundary]);
+    }
   });
 
   it("does not duplicate whitespace already provided by either segment", () => {
     const trailingWhitespace = new TextSegmentJoiner();
-    trailingWhitespace.pushText("Before. ");
-    trailingWhitespace.markBoundary();
-    expect(trailingWhitespace.pushText("After.")).toEqual(["After."]);
+    trailingWhitespace.pushChunk({ type: "text-delta", text: "Before. " });
+    trailingWhitespace.pushChunk({ type: "tool-call" });
+    expect(
+      trailingWhitespace.pushChunk({ type: "text-delta", text: "After." })
+    ).toEqual([text("After.")]);
 
     const leadingWhitespace = new TextSegmentJoiner();
-    leadingWhitespace.pushText("Before.");
-    leadingWhitespace.markBoundary();
-    expect(leadingWhitespace.pushText("\nAfter.")).toEqual(["\nAfter."]);
+    leadingWhitespace.pushChunk({ type: "text-delta", text: "Before." });
+    leadingWhitespace.pushChunk({ type: "tool-call" });
+    expect(
+      leadingWhitespace.pushChunk({ type: "text-delta", text: "\nAfter." })
+    ).toEqual([text("\nAfter.")]);
   });
 
   it("reports only the first repeated boundary", () => {
     const joiner = new TextSegmentJoiner();
-    expect(joiner.markBoundary()).toBe(false);
-    joiner.pushText("Before.");
+    expect(joiner.pushChunk({ type: "tool-call" })).toEqual([]);
+    joiner.pushChunk({ type: "text-delta", text: "Before." });
 
-    expect(joiner.markBoundary()).toBe(true);
-    expect(joiner.markBoundary()).toBe(false);
-    expect(joiner.pushText("After.")).toEqual([" ", "After."]);
+    expect(joiner.pushChunk({ type: "tool-call" })).toEqual([boundary]);
+    expect(joiner.pushChunk({ type: "tool-result" })).toEqual([]);
+    expect(joiner.pushChunk({ type: "text-delta", text: "After." })).toEqual([
+      text(" "),
+      text("After.")
+    ]);
   });
 
   it("does not add whitespace without text on both sides", () => {
     const joiner = new TextSegmentJoiner();
-    joiner.markBoundary();
-    expect(joiner.pushText("First.")).toEqual(["First."]);
+    expect(joiner.pushChunk({ type: "tool-call" })).toEqual([]);
+    expect(joiner.pushChunk({ type: "text-delta", text: "First." })).toEqual([
+      text("First.")
+    ]);
 
-    joiner.markBoundary();
-    expect(joiner.pushText("")).toEqual([]);
-    expect(joiner.pushText("Second.")).toEqual([" ", "Second."]);
+    expect(joiner.pushChunk({ type: "tool-call" })).toEqual([boundary]);
+    expect(joiner.pushChunk({ type: "text-delta", text: "" })).toEqual([]);
+    expect(joiner.pushChunk({ type: "text-delta", text: "Second." })).toEqual([
+      text(" "),
+      text("Second.")
+    ]);
   });
 });

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -24,6 +24,14 @@ export {
 
 export { TurnQueue, type TurnResult, type EnqueueOptions } from "./turn-queue";
 
+/**
+ * @internal Shared text-segment separator for sibling streaming packages.
+ */
+export {
+  isTextSegmentBoundary,
+  TextSegmentJoiner
+} from "./text-segment-joiner";
+
 export {
   SubmitConcurrencyController,
   type NormalizedMessageConcurrency,

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -28,8 +28,9 @@ export { TurnQueue, type TurnResult, type EnqueueOptions } from "./turn-queue";
  * @internal Shared text-segment separator for sibling streaming packages.
  */
 export {
-  isTextSegmentBoundary,
-  TextSegmentJoiner
+  TextSegmentJoiner,
+  type TextSegmentChunk,
+  type TextSegmentEvent
 } from "./text-segment-joiner";
 
 export {

--- a/packages/agents/src/chat/text-segment-joiner.ts
+++ b/packages/agents/src/chat/text-segment-joiner.ts
@@ -1,43 +1,61 @@
-/**
- * @internal Identifies structured stream chunks that can separate text
- * segments. Only text deltas are contiguous text rather than boundaries.
- */
-export function isTextSegmentBoundary(type: unknown): boolean {
-  return typeof type === "string" && type !== "text-delta";
+/** @internal A parsed structured-stream chunk accepted by the joiner. */
+export interface TextSegmentChunk {
+  delta?: unknown;
+  text?: unknown;
+  type?: unknown;
 }
 
+/** @internal A text or semantic boundary emitted by the joiner. */
+export type TextSegmentEvent =
+  | { type: "text"; text: string }
+  | { type: "boundary" };
+
 /**
- * @internal Joins text segments without gluing words across structured stream
- * boundaries. Sibling-package support for `@cloudflare/voice` and
- * `@cloudflare/think`, not a public API.
+ * @internal Converts structured stream chunks into text and boundary events
+ * without gluing words across non-text chunks. Sibling-package support for
+ * `@cloudflare/voice` and `@cloudflare/think`, not a public API.
  */
 export class TextSegmentJoiner {
   #hasText = false;
   #lastTextEndedWithWhitespace = false;
   #needsBoundarySpace = false;
 
-  markBoundary(): boolean {
+  pushChunk(chunk: TextSegmentChunk): TextSegmentEvent[] {
+    if (chunk.type === "text-delta") {
+      const text = textFromChunk(chunk);
+      return text ? this.#pushText(text) : [];
+    }
+
+    if (typeof chunk.type !== "string" || !this.#markBoundary()) return [];
+    return [{ type: "boundary" }];
+  }
+
+  #markBoundary(): boolean {
     if (!this.#hasText || this.#needsBoundarySpace) return false;
     this.#needsBoundarySpace = true;
     return true;
   }
 
-  pushText(text: string): string[] {
-    if (!text) return [];
-
-    const chunks: string[] = [];
+  #pushText(text: string): TextSegmentEvent[] {
+    const events: TextSegmentEvent[] = [];
     if (
       this.#needsBoundarySpace &&
       !this.#lastTextEndedWithWhitespace &&
       !/^\s/.test(text)
     ) {
-      chunks.push(" ");
+      events.push({ type: "text", text: " " });
     }
 
-    chunks.push(text);
+    events.push({ type: "text", text });
     this.#hasText = true;
     this.#lastTextEndedWithWhitespace = /\s$/.test(text);
     this.#needsBoundarySpace = false;
-    return chunks;
+    return events;
   }
+}
+
+function textFromChunk(chunk: TextSegmentChunk): string | null {
+  if (typeof chunk.text === "string") return chunk.text;
+  if (typeof chunk.delta === "string") return chunk.delta;
+  return null;
 }

--- a/packages/agents/src/chat/text-segment-joiner.ts
+++ b/packages/agents/src/chat/text-segment-joiner.ts
@@ -1,0 +1,43 @@
+/**
+ * @internal Identifies structured stream chunks that can separate text
+ * segments. Only text deltas are contiguous text rather than boundaries.
+ */
+export function isTextSegmentBoundary(type: unknown): boolean {
+  return typeof type === "string" && type !== "text-delta";
+}
+
+/**
+ * @internal Joins text segments without gluing words across structured stream
+ * boundaries. Sibling-package support for `@cloudflare/voice` and
+ * `@cloudflare/think`, not a public API.
+ */
+export class TextSegmentJoiner {
+  #hasText = false;
+  #lastTextEndedWithWhitespace = false;
+  #needsBoundarySpace = false;
+
+  markBoundary(): boolean {
+    if (!this.#hasText || this.#needsBoundarySpace) return false;
+    this.#needsBoundarySpace = true;
+    return true;
+  }
+
+  pushText(text: string): string[] {
+    if (!text) return [];
+
+    const chunks: string[] = [];
+    if (
+      this.#needsBoundarySpace &&
+      !this.#lastTextEndedWithWhitespace &&
+      !/^\s/.test(text)
+    ) {
+      chunks.push(" ");
+    }
+
+    chunks.push(text);
+    this.#hasText = true;
+    this.#lastTextEndedWithWhitespace = /\s$/.test(text);
+    this.#needsBoundarySpace = false;
+    return chunks;
+  }
+}

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "@ai-sdk/react": "^3.0.0 || ^4.0.0",
     "@chat-adapter/telegram": "^4.29.0",
-    "agents": ">=0.18.0 <1.0.0",
+    "agents": ">=0.20.2 <1.0.0",
     "ai": "^6.0.0 || ^7.0.0",
     "react": "^19.0.0",
     "vite": ">=6 <9",

--- a/packages/think/src/messengers/delivery.ts
+++ b/packages/think/src/messengers/delivery.ts
@@ -1,5 +1,6 @@
 import { RpcTarget } from "cloudflare:workers";
 import type { FiberContext } from "agents";
+import { isTextSegmentBoundary, TextSegmentJoiner } from "agents/chat";
 import type { UIMessage } from "ai";
 import type { ChatStartEvent, StreamCallback } from "../think";
 import type { MessengerEvent } from "./events";
@@ -23,6 +24,7 @@ export interface TextStreamCallbackOptions {
 
 export class TextStreamCallback extends RpcTarget implements StreamCallback {
   private readonly onVisibleStart?: () => Promise<void> | void;
+  private readonly textSegmentJoiner = new TextSegmentJoiner();
   private readonly visibleChunks: string[] = [];
   private readonly wakeups: Wake[] = [];
   private readonly visibleSoftLimit?: number;
@@ -47,14 +49,24 @@ export class TextStreamCallback extends RpcTarget implements StreamCallback {
   }
 
   onEvent(json: string): void {
-    const text = textDeltaFromStreamChunk(json);
-    if (!text) {
+    const chunk = streamChunkFromJson(json);
+    if (!chunk) return;
+
+    if (chunk.type === "text-delta") {
+      if (typeof chunk.delta === "string") {
+        const textChunks = this.textSegmentJoiner.pushText(chunk.delta);
+        for (const text of textChunks) {
+          this.text += text;
+          this.pushVisibleText(text);
+        }
+        if (textChunks.length > 0) this.wake();
+      }
       return;
     }
 
-    this.text += text;
-    this.pushVisibleText(text);
-    this.wake();
+    if (isTextSegmentBoundary(chunk.type)) {
+      this.textSegmentJoiner.markBoundary();
+    }
   }
 
   onDone(): void {
@@ -188,10 +200,19 @@ export class TextStreamCallback extends RpcTarget implements StreamCallback {
 }
 
 export function textDeltaFromStreamChunk(json: string): string | null {
+  const chunk = streamChunkFromJson(json);
+  return chunk?.type === "text-delta" && typeof chunk.delta === "string"
+    ? chunk.delta
+    : null;
+}
+
+function streamChunkFromJson(
+  json: string
+): { delta?: unknown; type?: unknown } | null {
   try {
-    const chunk = JSON.parse(json) as { delta?: unknown; type?: string };
-    return chunk.type === "text-delta" && typeof chunk.delta === "string"
-      ? chunk.delta
+    const chunk: unknown = JSON.parse(json);
+    return typeof chunk === "object" && chunk !== null
+      ? (chunk as { delta?: unknown; type?: unknown })
       : null;
   } catch {
     return null;

--- a/packages/think/src/messengers/delivery.ts
+++ b/packages/think/src/messengers/delivery.ts
@@ -1,6 +1,6 @@
 import { RpcTarget } from "cloudflare:workers";
 import type { FiberContext } from "agents";
-import { isTextSegmentBoundary, TextSegmentJoiner } from "agents/chat";
+import { TextSegmentJoiner } from "agents/chat";
 import type { UIMessage } from "ai";
 import type { ChatStartEvent, StreamCallback } from "../think";
 import type { MessengerEvent } from "./events";
@@ -52,21 +52,14 @@ export class TextStreamCallback extends RpcTarget implements StreamCallback {
     const chunk = streamChunkFromJson(json);
     if (!chunk) return;
 
-    if (chunk.type === "text-delta") {
-      if (typeof chunk.delta === "string") {
-        const textChunks = this.textSegmentJoiner.pushText(chunk.delta);
-        for (const text of textChunks) {
-          this.text += text;
-          this.pushVisibleText(text);
-        }
-        if (textChunks.length > 0) this.wake();
-      }
-      return;
+    let pushedText = false;
+    for (const event of this.textSegmentJoiner.pushChunk(chunk)) {
+      if (event.type !== "text") continue;
+      this.text += event.text;
+      this.pushVisibleText(event.text);
+      pushedText = true;
     }
-
-    if (isTextSegmentBoundary(chunk.type)) {
-      this.textSegmentJoiner.markBoundary();
-    }
+    if (pushedText) this.wake();
   }
 
   onDone(): void {
@@ -197,13 +190,6 @@ export class TextStreamCallback extends RpcTarget implements StreamCallback {
     this.visibleStarted = true;
     await this.onVisibleStart?.();
   }
-}
-
-export function textDeltaFromStreamChunk(json: string): string | null {
-  const chunk = streamChunkFromJson(json);
-  return chunk?.type === "text-delta" && typeof chunk.delta === "string"
-    ? chunk.delta
-    : null;
 }
 
 function streamChunkFromJson(

--- a/packages/think/src/messengers/index.ts
+++ b/packages/think/src/messengers/index.ts
@@ -38,8 +38,7 @@ export {
   messengerReplyRecoveryMode,
   messengerReplySnapshot,
   parseMessengerReplySnapshot,
-  TextStreamCallback,
-  textDeltaFromStreamChunk
+  TextStreamCallback
 } from "./delivery";
 
 export type {

--- a/packages/think/src/tests/messengers.test.ts
+++ b/packages/think/src/tests/messengers.test.ts
@@ -755,6 +755,27 @@ describe("think messengers core", () => {
     expect(textDeltaFromStreamChunk("{")).toBeNull();
   });
 
+  it("separates text segments across tool-call boundaries (#1841)", async () => {
+    const callback = new TextStreamCallback();
+
+    for (const chunk of [
+      { type: "text-delta", id: "before", delta: "Before." },
+      { type: "tool-call", toolCallId: "tool", toolName: "example" },
+      { type: "tool-result", toolCallId: "tool", toolName: "example" },
+      { type: "text-delta", id: "after", delta: "After." }
+    ]) {
+      callback.onEvent(JSON.stringify(chunk));
+    }
+    callback.close();
+
+    await expect(collectText(callback.stream())).resolves.toEqual([
+      "Before.",
+      " ",
+      "After."
+    ]);
+    expect(callback.textSoFar()).toBe("Before. After.");
+  });
+
   it("streams visible text while retaining overflow", async () => {
     const callback = new TextStreamCallback({ visibleSoftLimit: 5 });
     const chunks = collectText(callback.stream());

--- a/packages/think/src/tests/messengers.test.ts
+++ b/packages/think/src/tests/messengers.test.ts
@@ -25,7 +25,6 @@ import {
   parseMessengerReplySnapshot,
   serializableMessengerEvent,
   TextStreamCallback,
-  textDeltaFromStreamChunk,
   ThinkMessengerRuntime,
   toMessengerAttachment,
   toMessengerUserMessage,
@@ -744,15 +743,6 @@ describe("think messengers core", () => {
     expect(handled).toBe(true);
     expect(posted).toEqual(["interrupted"]);
     expect(resolved).toEqual([{ status: "completed" }]);
-  });
-
-  it("extracts streamed text deltas", () => {
-    expect(
-      textDeltaFromStreamChunk(
-        JSON.stringify({ type: "text-delta", delta: "hello" })
-      )
-    ).toBe("hello");
-    expect(textDeltaFromStreamChunk("{")).toBeNull();
   });
 
   it("separates text segments across tool-call boundaries (#1841)", async () => {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/cloudflare/agents/issues"
   },
   "peerDependencies": {
-    "agents": ">=0.17.1 <1.0.0",
+    "agents": ">=0.20.2 <1.0.0",
     "partysocket": "^1.0.0",
     "react": "^19.0.0"
   },

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -82,5 +82,8 @@
         ]
       }
     }
+  },
+  "devDependencies": {
+    "agents": "workspace:*"
   }
 }

--- a/packages/voice/src/tests/text-stream.test.ts
+++ b/packages/voice/src/tests/text-stream.test.ts
@@ -132,7 +132,7 @@ describe("iterateText", () => {
     expect(chunks).toEqual(["I can help.", " ", "The weather is warm"]);
   });
 
-  it("emits stream boundaries before later stream text deltas", async () => {
+  it("emits stream boundaries between and after text parts", async () => {
     async function* stream() {
       yield { type: "text-start", id: "a" };
       yield { type: "text-delta", id: "a", text: "I can help." };
@@ -148,7 +148,8 @@ describe("iterateText", () => {
       { type: "text", text: "I can help." },
       { type: "boundary" },
       { type: "text", text: " " },
-      { type: "text", text: "The weather is warm" }
+      { type: "text", text: "The weather is warm" },
+      { type: "boundary" }
     ]);
   });
 });

--- a/packages/voice/src/text-stream.ts
+++ b/packages/voice/src/text-stream.ts
@@ -1,4 +1,4 @@
-import { isTextSegmentBoundary, TextSegmentJoiner } from "agents/chat";
+import { TextSegmentJoiner } from "agents/chat";
 
 /**
  * Utilities for normalising various text-producing sources into a uniform
@@ -181,17 +181,6 @@ async function* iterateAsyncTextEvents(
 
     if (!isRecord(chunk)) continue;
 
-    if (chunk.type === "text-delta") {
-      const text = getTextDelta(chunk);
-      if (!text) continue;
-
-      for (const joinedText of textSegmentJoiner.pushText(text)) {
-        yield textEvent(joinedText);
-      }
-      hasYieldedText = true;
-      continue;
-    }
-
     if (chunk.type === "error") {
       if (hasYieldedText) {
         yield { type: "boundary" };
@@ -200,8 +189,9 @@ async function* iterateAsyncTextEvents(
       return;
     }
 
-    if (isTextSegmentBoundary(chunk.type) && textSegmentJoiner.markBoundary()) {
-      yield { type: "boundary" };
+    for (const event of textSegmentJoiner.pushChunk(chunk)) {
+      yield event;
+      if (event.type === "text") hasYieldedText = true;
     }
   }
 }
@@ -218,12 +208,6 @@ function warnDeprecatedTextStream(source?: object): void {
   console.warn(
     "[voice] AI SDK textStream is not recommended because non-adjacent text parts may be joined incorrectly. Return result.stream from onTurn() instead."
   );
-}
-
-function getTextDelta(chunk: Record<string, unknown>): string | null {
-  if (typeof chunk.text === "string") return chunk.text;
-  if (typeof chunk.delta === "string") return chunk.delta;
-  return null;
 }
 
 function toError(error: unknown): Error {

--- a/packages/voice/src/text-stream.ts
+++ b/packages/voice/src/text-stream.ts
@@ -1,3 +1,5 @@
+import { isTextSegmentBoundary, TextSegmentJoiner } from "agents/chat";
+
 /**
  * Utilities for normalising various text-producing sources into a uniform
  * `AsyncGenerator<string>`.  This lets `onTurn()` return any of:
@@ -167,9 +169,8 @@ function hasCustomAsyncIterator(source: Exclude<TextSource, string>): boolean {
 async function* iterateAsyncTextEvents(
   source: AsyncIterable<unknown>
 ): AsyncGenerator<TextStreamEvent> {
-  let needsBoundarySpace = false;
+  const textSegmentJoiner = new TextSegmentJoiner();
   let hasYieldedText = false;
-  let lastTextEndedWithWhitespace = false;
 
   for await (const chunk of source) {
     if (typeof chunk === "string") {
@@ -184,19 +185,10 @@ async function* iterateAsyncTextEvents(
       const text = getTextDelta(chunk);
       if (!text) continue;
 
-      if (
-        needsBoundarySpace &&
-        hasYieldedText &&
-        !lastTextEndedWithWhitespace &&
-        !startsWithWhitespace(text)
-      ) {
-        yield textEvent(" ");
+      for (const joinedText of textSegmentJoiner.pushText(text)) {
+        yield textEvent(joinedText);
       }
-
-      yield textEvent(text);
       hasYieldedText = true;
-      lastTextEndedWithWhitespace = endsWithWhitespace(text);
-      needsBoundarySpace = false;
       continue;
     }
 
@@ -208,9 +200,8 @@ async function* iterateAsyncTextEvents(
       return;
     }
 
-    if (hasYieldedText && isTextBoundary(chunk.type)) {
-      if (!needsBoundarySpace) yield { type: "boundary" };
-      needsBoundarySpace = true;
+    if (isTextSegmentBoundary(chunk.type) && textSegmentJoiner.markBoundary()) {
+      yield { type: "boundary" };
     }
   }
 }
@@ -233,26 +224,6 @@ function getTextDelta(chunk: Record<string, unknown>): string | null {
   if (typeof chunk.text === "string") return chunk.text;
   if (typeof chunk.delta === "string") return chunk.delta;
   return null;
-}
-
-function isTextBoundary(type: unknown): boolean {
-  return (
-    typeof type === "string" &&
-    type !== "text-start" &&
-    type !== "text-end" &&
-    type !== "start" &&
-    type !== "finish" &&
-    type !== "start-step" &&
-    type !== "finish-step"
-  );
-}
-
-function startsWithWhitespace(text: string): boolean {
-  return /^\s/.test(text);
-}
-
-function endsWithWhitespace(text: string): boolean {
-  return /\s$/.test(text);
 }
 
 function toError(error: unknown): Error {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4149,15 +4149,16 @@ importers:
 
   packages/voice:
     dependencies:
-      agents:
-        specifier: '>=0.20.2 <1.0.0'
-        version: link:../agents
       partysocket:
         specifier: ^1.0.0
         version: 1.3.0(react@19.2.7)
       react:
         specifier: ^19.0.0
         version: 19.2.7
+    devDependencies:
+      agents:
+        specifier: workspace:*
+        version: link:../agents
 
   packages/worker-bundler:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4150,7 +4150,7 @@ importers:
   packages/voice:
     dependencies:
       agents:
-        specifier: '>=0.17.1 <1.0.0'
+        specifier: '>=0.20.2 <1.0.0'
         version: link:../agents
       partysocket:
         specifier: ^1.0.0


### PR DESCRIPTION
This PR preserves spacing between messenger text segments separated by structured stream chunks, including tool calls. It shares the boundary-aware joining behavior with Voice. Fixes #1841.

## Why

- Think messenger delivery previously discarded every non-`text-delta` chunk, then concatenated the remaining deltas directly. Text emitted before and after a tool call therefore became `Before.After.`.
- A separator cannot be inserted eagerly when a boundary arrives. The next text segment might never arrive or might already begin with whitespace.
- Voice already tracked this state, but making Think depend on `@cloudflare/voice` would create the wrong package relationship. Duplicating the state machine would also let the two paths diverge.
- The shared joiner lives in `agents/chat`, which both packages already depend on. Voice and Think retain their own parsing and delivery responsibilities.

## Public API Surface

The following sibling-package support symbols are exported from `agents/chat` and marked `@internal`:

| Symbol | Kind | Notes |
| --- | --- | --- |
| `TextSegmentJoiner` | Class | Converts parsed stream chunks into normalized text and boundary events |
| `TextSegmentChunk` | Interface | Accepts `text` and `delta` stream representations |
| `TextSegmentEvent` | Type | Represents normalized text or boundary output |

This PR removes the exported `textDeltaFromStreamChunk()` helper from `@cloudflare/think/messengers`. Stateless delta extraction discards the structured boundaries required for correct joining.

## Architectural Changes

```text
structured stream chunks
          |
          v
 TextSegmentJoiner
    |           |
 text events  boundary events
    |           |
    +-----+-----+
          |
   +------+------+
   |             |
Think delivery  Voice TTS
```

`TextSegmentJoiner.pushChunk()` owns boundary classification, repeated-boundary collapse, delayed separator insertion, and whitespace preservation. Think consumes normalized text events, while Voice also consumes boundary events to flush TTS.

## Code Changes

- `agents/chat` adds the shared joiner and contract coverage for lifecycle events, tool transitions, repeated boundaries, existing whitespace, and missing text on either side.
- `@cloudflare/think` routes messenger stream chunks through the joiner before visible and accumulated text delivery.
- `@cloudflare/voice` replaces its local separator state machine with the shared implementation while retaining source parsing and error handling.
- The obsolete `textDeltaFromStreamChunk()` export and its direct extraction tests are removed so callers use the boundary-aware callback path.
- A coordinated changeset covers Agents, Think, and Voice.

## Compatibility

- New Think and Voice releases require `agents >=0.20.2 <1.0.0`, the first planned Agents release containing the `agents/chat` helper.
- Consumers importing `textDeltaFromStreamChunk()` from `@cloudflare/think/messengers` must migrate to `TextStreamCallback`, which preserves structured boundaries. The Think changeset is minor because this export is removed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->