### PR TITLE
fix(chat): batch replayed chunks on stream resume

### DIFF
--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -11,10 +11,18 @@ loop and threw "Maximum update depth exceeded" — surfacing as a false terminal
 `status: "error"` for a turn the server had completed, with the replayed text
 visibly re-typing beforehand.
 
-Both transport-owned resume paths now buffer `replay: true` chunks and merge
-consecutive deltas of the same part, delivering the compacted batch once at the
-replay boundary (`replayComplete`, `done`, or the first live chunk). Applying a
+Both transport-owned resume paths now collect `replay: true` chunks in a short
+coalescing window and merge consecutive deltas of the same part. The window
+closes at the end of the event-loop turn that opened it, or earlier at a replay
+boundary (`replayComplete`, `done`, or the first live chunk). Applying a
 replayed prefix is now proportional to the number of message parts rather than
-the number of chunks. Cross-part ordering is unchanged, deltas carrying
-`providerMetadata` are kept whole, and an errored resumed turn still delivers
-its replayed content before the terminal error.
+the number of chunks.
+
+The window is bounded to a single turn on purpose: a burst spread over several
+turns cannot trip React's guard, and holding replayed chunks any longer would
+reorder them against the hook's own replay bookkeeping, which repairs a second
+replay of the same turn (#1733) by inspecting already-applied messages.
+
+Cross-part ordering is unchanged, deltas carrying `providerMetadata` are kept
+whole, and an errored resumed turn still delivers its replayed content before
+the terminal error.

--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -18,10 +18,12 @@ boundary (`replayComplete`, `done`, or the first live chunk). Applying a
 replayed prefix is now proportional to the number of message parts rather than
 the number of chunks.
 
-The window is bounded to a single turn on purpose: a burst spread over several
-turns cannot trip React's guard, and holding replayed chunks any longer would
-reorder them against the hook's own replay bookkeeping, which repairs a second
-replay of the same turn (#1733) by inspecting already-applied messages.
+The window is short on purpose: only a burst delivered inside one task can
+outrun React's commit loop, so coalescing anything wider buys nothing and
+delays content. Correctness does not depend on the flush timer: a burst
+boundary flushes synchronously, the transport flushes before it closes or
+detaches a stream, and a second replay of the same turn supersedes the buffered
+pass rather than being appended to it (#1733).
 
 Cross-part ordering is unchanged, deltas carrying `providerMetadata` are kept
 whole, and an errored resumed turn still delivers its replayed content before

--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -1,0 +1,20 @@
+---
+"agents": patch
+---
+
+fix(chat): batch replayed chunks on resume so long turns don't trip React's update depth guard
+
+Resuming a stream replayed every stored chunk as its own frame, and the
+transport forwarded each one into the UI-message stream individually. A long
+turn's replay updated chat state once per chunk, which outpaced React's commit
+loop and threw "Maximum update depth exceeded" — surfacing as a false terminal
+`status: "error"` for a turn the server had completed, with the replayed text
+visibly re-typing beforehand.
+
+Both transport-owned resume paths now buffer `replay: true` chunks and merge
+consecutive deltas of the same part, delivering the compacted batch once at the
+replay boundary (`replayComplete`, `done`, or the first live chunk). Applying a
+replayed prefix is now proportional to the number of message parts rather than
+the number of chunks. Cross-part ordering is unchanged, deltas carrying
+`providerMetadata` are kept whole, and an errored resumed turn still delivers
+its replayed content before the terminal error.

--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -2,28 +2,5 @@
 "agents": patch
 ---
 
-fix(chat): batch replayed chunks on resume so long turns don't trip React's update depth guard
-
-Resuming a stream replayed every stored chunk as its own frame, and the
-transport forwarded each one into the UI-message stream individually. A long
-turn's replay updated chat state once per chunk, which exceeded React's
-nested-update limit and threw "Maximum update depth exceeded" — reported as a
-false terminal `status: "error"` for a turn the server had completed, with the
-replayed text visibly re-typing beforehand.
-
-Both transport-owned resume paths now collect `replay: true` chunks in a short
-coalescing window and merge consecutive deltas of the same part. The window
-closes on a `setTimeout(0)`, or earlier at a replay boundary (`replayComplete`,
-`done`, or the first live chunk). Applying a replayed prefix is now proportional
-to the number of message parts rather than the number of chunks.
-
-The window is short on purpose: only a burst delivered inside one task can
-exceed React's limit, so coalescing anything wider buys nothing and delays
-content. Correctness does not depend on the flush timer: a burst boundary
-flushes synchronously, the transport flushes before it closes or detaches a
-stream, and a second replay of the same turn supersedes the buffered pass rather
-than being appended to it (#1733).
-
-Cross-part ordering is unchanged, deltas carrying `providerMetadata` are kept
-whole, and an errored resumed turn still delivers its replayed content before
-the terminal error.
+Batch replayed chunks during stream resume so long turns do not exceed React's
+update limit and report a false error.

--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -6,24 +6,23 @@ fix(chat): batch replayed chunks on resume so long turns don't trip React's upda
 
 Resuming a stream replayed every stored chunk as its own frame, and the
 transport forwarded each one into the UI-message stream individually. A long
-turn's replay updated chat state once per chunk, which outpaced React's commit
-loop and threw "Maximum update depth exceeded" — surfacing as a false terminal
-`status: "error"` for a turn the server had completed, with the replayed text
-visibly re-typing beforehand.
+turn's replay updated chat state once per chunk, which exceeded React's
+nested-update limit and threw "Maximum update depth exceeded" — reported as a
+false terminal `status: "error"` for a turn the server had completed, with the
+replayed text visibly re-typing beforehand.
 
 Both transport-owned resume paths now collect `replay: true` chunks in a short
 coalescing window and merge consecutive deltas of the same part. The window
-closes at the end of the event-loop turn that opened it, or earlier at a replay
-boundary (`replayComplete`, `done`, or the first live chunk). Applying a
-replayed prefix is now proportional to the number of message parts rather than
-the number of chunks.
+closes on a `setTimeout(0)`, or earlier at a replay boundary (`replayComplete`,
+`done`, or the first live chunk). Applying a replayed prefix is now proportional
+to the number of message parts rather than the number of chunks.
 
 The window is short on purpose: only a burst delivered inside one task can
-outrun React's commit loop, so coalescing anything wider buys nothing and
-delays content. Correctness does not depend on the flush timer: a burst
-boundary flushes synchronously, the transport flushes before it closes or
-detaches a stream, and a second replay of the same turn supersedes the buffered
-pass rather than being appended to it (#1733).
+exceed React's limit, so coalescing anything wider buys nothing and delays
+content. Correctness does not depend on the flush timer: a burst boundary
+flushes synchronously, the transport flushes before it closes or detaches a
+stream, and a second replay of the same turn supersedes the buffered pass rather
+than being appended to it (#1733).
 
 Cross-part ordering is unchanged, deltas carrying `providerMetadata` are kept
 whole, and an errored resumed turn still delivers its replayed content before

--- a/packages/agents/src/chat/__tests__/replay-batch.test.ts
+++ b/packages/agents/src/chat/__tests__/replay-batch.test.ts
@@ -26,7 +26,7 @@ function createRecorder() {
 }
 
 /**
- * A batch whose end-of-turn window is closed manually, so tests decide when
+ * A batch whose coalescing window is closed manually, so tests decide when
  * the turn ends instead of racing a timer.
  */
 function createBatch(
@@ -41,8 +41,8 @@ function createBatch(
   });
   return {
     batch,
-    /** Runs the end-of-turn flush, as the event loop would. */
-    endTurn: () => pending?.(),
+    /** Fires the scheduled flush, as the event loop eventually would. */
+    fireWindow: () => pending?.(),
     windowIsOpen: () => pending !== undefined
   };
 }
@@ -244,31 +244,31 @@ describe("applyChatResponseFrame", () => {
   });
 });
 
-describe("the end-of-turn window", () => {
+describe("the coalescing window", () => {
   it("flushes a burst that never sends a terminator", () => {
     const { controller, enqueued } = createRecorder();
-    const { batch, endTurn } = createBatch(controller);
+    const { batch, fireWindow } = createBatch(controller);
 
     applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
     applyChatResponseFrame(batch, replayFrame(textDelta("t1", "b")));
     expect(enqueued).toEqual([]);
 
-    endTurn();
+    fireWindow();
 
     expect(enqueued).toEqual([textDelta("t1", "ab")]);
   });
 
   it("never holds chunks across turns, so replay passes stay separate", () => {
     const { controller, enqueued } = createRecorder();
-    const { batch, endTurn } = createBatch(controller);
+    const { batch, fireWindow } = createBatch(controller);
 
     // A second announcement of the same stream replays the turn again (#1733).
     // The hook repairs that duplicate by inspecting messages the first pass
     // already applied, so two passes must never merge into one batch.
     applyChatResponseFrame(batch, replayFrame(textDelta("t1", "Hello")));
-    endTurn();
+    fireWindow();
     applyChatResponseFrame(batch, replayFrame(textDelta("t1", "Hello")));
-    endTurn();
+    fireWindow();
 
     expect(enqueued).toEqual([
       textDelta("t1", "Hello"),
@@ -278,7 +278,7 @@ describe("the end-of-turn window", () => {
 
   it("supersedes a buffered pass when the same turn replays again", () => {
     const { controller, enqueued } = createRecorder();
-    const { batch, endTurn } = createBatch(controller);
+    const { batch, fireWindow } = createBatch(controller);
 
     // Two announcements of one stream can replay the turn twice before either
     // pass is delivered (#1733). Every replay rebuilds from its first chunk, so
@@ -290,7 +290,7 @@ describe("the end-of-turn window", () => {
     for (const chunk of replayPass("Hello ", "world")) {
       applyChatResponseFrame(batch, replayFrame(chunk));
     }
-    endTurn();
+    fireWindow();
 
     expect(enqueued).toEqual([
       { messageId: "m1", type: "start" },
@@ -301,7 +301,7 @@ describe("the end-of-turn window", () => {
 
   it("keeps a continuation replay, which appends instead of rebuilding", () => {
     const { controller, enqueued } = createRecorder();
-    const { batch, endTurn } = createBatch(controller);
+    const { batch, fireWindow } = createBatch(controller);
 
     for (const chunk of replayPass("first")) {
       applyChatResponseFrame(batch, {
@@ -315,14 +315,14 @@ describe("the end-of-turn window", () => {
         continuation: true
       });
     }
-    endTurn();
+    fireWindow();
 
     expect(enqueued).toHaveLength(6);
   });
 
   it("closes the window when a terminator arrives first", () => {
     const { controller, enqueued } = createRecorder();
-    const { batch, endTurn, windowIsOpen } = createBatch(controller);
+    const { batch, fireWindow, windowIsOpen } = createBatch(controller);
 
     applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
     expect(windowIsOpen()).toBe(true);
@@ -335,7 +335,7 @@ describe("the end-of-turn window", () => {
     });
     expect(windowIsOpen()).toBe(false);
 
-    endTurn();
+    fireWindow();
     expect(enqueued).toEqual([textDelta("t1", "a")]);
   });
 });

--- a/packages/agents/src/chat/__tests__/replay-batch.test.ts
+++ b/packages/agents/src/chat/__tests__/replay-batch.test.ts
@@ -1,0 +1,272 @@
+import type { UIMessageChunk } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  applyChatResponseFrame,
+  failChatStream,
+  ReplayChunkBatch
+} from "../replay-batch";
+
+/** Minimal stand-in for the stream controller the transport owns. */
+function createRecorder() {
+  const enqueued: UIMessageChunk[] = [];
+  const events: string[] = [];
+  const controller = {
+    close: () => {
+      events.push("close");
+    },
+    enqueue: (chunk: UIMessageChunk) => {
+      enqueued.push(chunk);
+      events.push(`enqueue:${chunk.type}`);
+    },
+    error: (err: unknown) => {
+      events.push(`error:${(err as Error).message}`);
+    }
+  } as unknown as ReadableStreamDefaultController<UIMessageChunk>;
+  return { controller, enqueued, events };
+}
+
+const textDelta = (id: string, delta: string): UIMessageChunk => ({
+  delta,
+  id,
+  type: "text-delta"
+});
+
+const replayFrame = (chunk: UIMessageChunk) => ({
+  body: JSON.stringify(chunk),
+  done: false,
+  replay: true
+});
+
+describe("ReplayChunkBatch", () => {
+  it("merges consecutive deltas of the same part", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    batch.push(textDelta("t1", "Hello"));
+    batch.push(textDelta("t1", " "));
+    batch.push(textDelta("t1", "world"));
+    batch.flush(controller);
+
+    expect(enqueued).toEqual([textDelta("t1", "Hello world")]);
+  });
+
+  it("does not merge across different parts, preserving order", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    batch.push(textDelta("t1", "a"));
+    batch.push({ id: "r1", type: "reasoning-delta", delta: "why" });
+    batch.push(textDelta("t1", "b"));
+    batch.push(textDelta("t2", "c"));
+    batch.flush(controller);
+
+    expect(enqueued).toEqual([
+      textDelta("t1", "a"),
+      { delta: "why", id: "r1", type: "reasoning-delta" },
+      textDelta("t1", "b"),
+      textDelta("t2", "c")
+    ]);
+  });
+
+  it("merges tool input deltas by tool call id", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    batch.push({
+      inputTextDelta: '{"a"',
+      toolCallId: "c1",
+      type: "tool-input-delta"
+    });
+    batch.push({
+      inputTextDelta: ":1}",
+      toolCallId: "c1",
+      type: "tool-input-delta"
+    });
+    batch.push({
+      inputTextDelta: "{}",
+      toolCallId: "c2",
+      type: "tool-input-delta"
+    });
+    batch.flush(controller);
+
+    expect(enqueued).toEqual([
+      { inputTextDelta: '{"a":1}', toolCallId: "c1", type: "tool-input-delta" },
+      { inputTextDelta: "{}", toolCallId: "c2", type: "tool-input-delta" }
+    ]);
+  });
+
+  it("keeps deltas carrying provider metadata whole", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+    const withMetadata: UIMessageChunk = {
+      delta: "b",
+      id: "t1",
+      providerMetadata: { openai: { logprob: 1 } },
+      type: "text-delta"
+    };
+
+    batch.push(textDelta("t1", "a"));
+    batch.push(withMetadata);
+    batch.push(textDelta("t1", "c"));
+    batch.flush(controller);
+
+    expect(enqueued).toEqual([
+      textDelta("t1", "a"),
+      withMetadata,
+      textDelta("t1", "c")
+    ]);
+  });
+
+  it("empties itself on flush", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    batch.push(textDelta("t1", "a"));
+    expect(batch.isEmpty).toBe(false);
+    batch.flush(controller);
+    expect(batch.isEmpty).toBe(true);
+
+    batch.flush(controller);
+    expect(enqueued).toHaveLength(1);
+  });
+});
+
+describe("applyChatResponseFrame", () => {
+  it("buffers mid-burst replay chunks instead of enqueuing them", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "a"))
+    );
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "b"))
+    );
+
+    expect(enqueued).toEqual([]);
+    expect(batch.isEmpty).toBe(false);
+  });
+
+  it("flushes at replayComplete, which carries an empty body", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "a"))
+    );
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "b"))
+    );
+    applyChatResponseFrame(batch, controller, {
+      body: "",
+      done: false,
+      replay: true,
+      replayComplete: true
+    });
+
+    expect(enqueued).toEqual([textDelta("t1", "ab")]);
+  });
+
+  it("flushes at done for streams that never send replayComplete", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "a"))
+    );
+    applyChatResponseFrame(batch, controller, {
+      body: "",
+      done: true,
+      replay: true
+    });
+
+    expect(enqueued).toEqual([textDelta("t1", "a")]);
+  });
+
+  it("flushes the batch before the first live chunk", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "a"))
+    );
+    applyChatResponseFrame(batch, controller, {
+      body: JSON.stringify(textDelta("t1", "live")),
+      done: false
+    });
+
+    expect(enqueued).toEqual([textDelta("t1", "a"), textDelta("t1", "live")]);
+  });
+
+  it("passes live chunks straight through", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    applyChatResponseFrame(batch, controller, {
+      body: JSON.stringify(textDelta("t1", "a")),
+      done: false
+    });
+
+    expect(enqueued).toEqual([textDelta("t1", "a")]);
+    expect(batch.isEmpty).toBe(true);
+  });
+
+  it("skips malformed bodies without stranding the batch", () => {
+    const { controller, enqueued } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "a"))
+    );
+    applyChatResponseFrame(batch, controller, {
+      body: "not json",
+      done: false,
+      replay: true
+    });
+    applyChatResponseFrame(batch, controller, { body: "not json", done: true });
+
+    expect(enqueued).toEqual([textDelta("t1", "a")]);
+  });
+});
+
+describe("failChatStream", () => {
+  it("errors the stream directly when nothing is buffered", () => {
+    const { controller, events } = createRecorder();
+
+    failChatStream(new ReplayChunkBatch(), controller, "boom");
+
+    expect(events).toEqual(["error:boom"]);
+  });
+
+  it("delivers buffered content before the error (#1575)", () => {
+    const { controller, enqueued, events } = createRecorder();
+    const batch = new ReplayChunkBatch();
+
+    applyChatResponseFrame(
+      batch,
+      controller,
+      replayFrame(textDelta("t1", "a"))
+    );
+    failChatStream(batch, controller, "model exploded");
+
+    expect(enqueued).toEqual([
+      textDelta("t1", "a"),
+      { errorText: "model exploded", type: "error" }
+    ]);
+    expect(events).toEqual(["enqueue:text-delta", "enqueue:error", "close"]);
+  });
+});

--- a/packages/agents/src/chat/__tests__/replay-batch.test.ts
+++ b/packages/agents/src/chat/__tests__/replay-batch.test.ts
@@ -53,6 +53,13 @@ const textDelta = (id: string, delta: string): UIMessageChunk => ({
   type: "text-delta"
 });
 
+/** One replay pass of message `m1`: `start`, `text-start`, then deltas. */
+const replayPass = (...deltas: string[]): UIMessageChunk[] => [
+  { messageId: "m1", type: "start" },
+  { id: "t1", type: "text-start" },
+  ...deltas.map((delta) => textDelta("t1", delta))
+];
+
 const replayFrame = (chunk: UIMessageChunk) => ({
   body: JSON.stringify(chunk),
   done: false,
@@ -267,6 +274,50 @@ describe("the end-of-turn window", () => {
       textDelta("t1", "Hello"),
       textDelta("t1", "Hello")
     ]);
+  });
+
+  it("supersedes a buffered pass when the same turn replays again", () => {
+    const { controller, enqueued } = createRecorder();
+    const { batch, endTurn } = createBatch(controller);
+
+    // Two announcements of one stream can replay the turn twice before either
+    // pass is delivered (#1733). Every replay rebuilds from its first chunk, so
+    // delivering both would duplicate the message's parts. This must not
+    // depend on which pass the flush timer happens to land between.
+    for (const chunk of replayPass("Hello ", "world")) {
+      applyChatResponseFrame(batch, replayFrame(chunk));
+    }
+    for (const chunk of replayPass("Hello ", "world")) {
+      applyChatResponseFrame(batch, replayFrame(chunk));
+    }
+    endTurn();
+
+    expect(enqueued).toEqual([
+      { messageId: "m1", type: "start" },
+      { id: "t1", type: "text-start" },
+      textDelta("t1", "Hello world")
+    ]);
+  });
+
+  it("keeps a continuation replay, which appends instead of rebuilding", () => {
+    const { controller, enqueued } = createRecorder();
+    const { batch, endTurn } = createBatch(controller);
+
+    for (const chunk of replayPass("first")) {
+      applyChatResponseFrame(batch, {
+        ...replayFrame(chunk),
+        continuation: true
+      });
+    }
+    for (const chunk of replayPass("second")) {
+      applyChatResponseFrame(batch, {
+        ...replayFrame(chunk),
+        continuation: true
+      });
+    }
+    endTurn();
+
+    expect(enqueued).toHaveLength(6);
   });
 
   it("closes the window when a terminator arrives first", () => {

--- a/packages/agents/src/chat/__tests__/replay-batch.test.ts
+++ b/packages/agents/src/chat/__tests__/replay-batch.test.ts
@@ -25,6 +25,28 @@ function createRecorder() {
   return { controller, enqueued, events };
 }
 
+/**
+ * A batch whose end-of-turn window is closed manually, so tests decide when
+ * the turn ends instead of racing a timer.
+ */
+function createBatch(
+  controller: ReadableStreamDefaultController<UIMessageChunk>
+) {
+  let pending: (() => void) | undefined;
+  const batch = new ReplayChunkBatch(controller, (flush) => {
+    pending = flush;
+    return () => {
+      pending = undefined;
+    };
+  });
+  return {
+    batch,
+    /** Runs the end-of-turn flush, as the event loop would. */
+    endTurn: () => pending?.(),
+    windowIsOpen: () => pending !== undefined
+  };
+}
+
 const textDelta = (id: string, delta: string): UIMessageChunk => ({
   delta,
   id,
@@ -40,25 +62,25 @@ const replayFrame = (chunk: UIMessageChunk) => ({
 describe("ReplayChunkBatch", () => {
   it("merges consecutive deltas of the same part", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
     batch.push(textDelta("t1", "Hello"));
     batch.push(textDelta("t1", " "));
     batch.push(textDelta("t1", "world"));
-    batch.flush(controller);
+    batch.flush();
 
     expect(enqueued).toEqual([textDelta("t1", "Hello world")]);
   });
 
   it("does not merge across different parts, preserving order", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
     batch.push(textDelta("t1", "a"));
     batch.push({ id: "r1", type: "reasoning-delta", delta: "why" });
     batch.push(textDelta("t1", "b"));
     batch.push(textDelta("t2", "c"));
-    batch.flush(controller);
+    batch.flush();
 
     expect(enqueued).toEqual([
       textDelta("t1", "a"),
@@ -70,7 +92,7 @@ describe("ReplayChunkBatch", () => {
 
   it("merges tool input deltas by tool call id", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
     batch.push({
       inputTextDelta: '{"a"',
@@ -87,7 +109,7 @@ describe("ReplayChunkBatch", () => {
       toolCallId: "c2",
       type: "tool-input-delta"
     });
-    batch.flush(controller);
+    batch.flush();
 
     expect(enqueued).toEqual([
       { inputTextDelta: '{"a":1}', toolCallId: "c1", type: "tool-input-delta" },
@@ -97,7 +119,7 @@ describe("ReplayChunkBatch", () => {
 
   it("keeps deltas carrying provider metadata whole", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
     const withMetadata: UIMessageChunk = {
       delta: "b",
       id: "t1",
@@ -108,7 +130,7 @@ describe("ReplayChunkBatch", () => {
     batch.push(textDelta("t1", "a"));
     batch.push(withMetadata);
     batch.push(textDelta("t1", "c"));
-    batch.flush(controller);
+    batch.flush();
 
     expect(enqueued).toEqual([
       textDelta("t1", "a"),
@@ -119,14 +141,14 @@ describe("ReplayChunkBatch", () => {
 
   it("empties itself on flush", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
     batch.push(textDelta("t1", "a"));
     expect(batch.isEmpty).toBe(false);
-    batch.flush(controller);
+    batch.flush();
     expect(batch.isEmpty).toBe(true);
 
-    batch.flush(controller);
+    batch.flush();
     expect(enqueued).toHaveLength(1);
   });
 });
@@ -134,18 +156,10 @@ describe("ReplayChunkBatch", () => {
 describe("applyChatResponseFrame", () => {
   it("buffers mid-burst replay chunks instead of enqueuing them", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "a"))
-    );
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "b"))
-    );
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "b")));
 
     expect(enqueued).toEqual([]);
     expect(batch.isEmpty).toBe(false);
@@ -153,19 +167,11 @@ describe("applyChatResponseFrame", () => {
 
   it("flushes at replayComplete, which carries an empty body", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "a"))
-    );
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "b"))
-    );
-    applyChatResponseFrame(batch, controller, {
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "b")));
+    applyChatResponseFrame(batch, {
       body: "",
       done: false,
       replay: true,
@@ -177,14 +183,10 @@ describe("applyChatResponseFrame", () => {
 
   it("flushes at done for streams that never send replayComplete", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "a"))
-    );
-    applyChatResponseFrame(batch, controller, {
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    applyChatResponseFrame(batch, {
       body: "",
       done: true,
       replay: true
@@ -195,14 +197,10 @@ describe("applyChatResponseFrame", () => {
 
   it("flushes the batch before the first live chunk", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "a"))
-    );
-    applyChatResponseFrame(batch, controller, {
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    applyChatResponseFrame(batch, {
       body: JSON.stringify(textDelta("t1", "live")),
       done: false
     });
@@ -212,9 +210,9 @@ describe("applyChatResponseFrame", () => {
 
   it("passes live chunks straight through", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
-    applyChatResponseFrame(batch, controller, {
+    applyChatResponseFrame(batch, {
       body: JSON.stringify(textDelta("t1", "a")),
       done: false
     });
@@ -225,20 +223,68 @@ describe("applyChatResponseFrame", () => {
 
   it("skips malformed bodies without stranding the batch", () => {
     const { controller, enqueued } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "a"))
-    );
-    applyChatResponseFrame(batch, controller, {
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    applyChatResponseFrame(batch, {
       body: "not json",
       done: false,
       replay: true
     });
-    applyChatResponseFrame(batch, controller, { body: "not json", done: true });
+    applyChatResponseFrame(batch, { body: "not json", done: true });
 
+    expect(enqueued).toEqual([textDelta("t1", "a")]);
+  });
+});
+
+describe("the end-of-turn window", () => {
+  it("flushes a burst that never sends a terminator", () => {
+    const { controller, enqueued } = createRecorder();
+    const { batch, endTurn } = createBatch(controller);
+
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "b")));
+    expect(enqueued).toEqual([]);
+
+    endTurn();
+
+    expect(enqueued).toEqual([textDelta("t1", "ab")]);
+  });
+
+  it("never holds chunks across turns, so replay passes stay separate", () => {
+    const { controller, enqueued } = createRecorder();
+    const { batch, endTurn } = createBatch(controller);
+
+    // A second announcement of the same stream replays the turn again (#1733).
+    // The hook repairs that duplicate by inspecting messages the first pass
+    // already applied, so two passes must never merge into one batch.
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "Hello")));
+    endTurn();
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "Hello")));
+    endTurn();
+
+    expect(enqueued).toEqual([
+      textDelta("t1", "Hello"),
+      textDelta("t1", "Hello")
+    ]);
+  });
+
+  it("closes the window when a terminator arrives first", () => {
+    const { controller, enqueued } = createRecorder();
+    const { batch, endTurn, windowIsOpen } = createBatch(controller);
+
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    expect(windowIsOpen()).toBe(true);
+
+    applyChatResponseFrame(batch, {
+      body: "",
+      done: false,
+      replay: true,
+      replayComplete: true
+    });
+    expect(windowIsOpen()).toBe(false);
+
+    endTurn();
     expect(enqueued).toEqual([textDelta("t1", "a")]);
   });
 });
@@ -247,21 +293,17 @@ describe("failChatStream", () => {
   it("errors the stream directly when nothing is buffered", () => {
     const { controller, events } = createRecorder();
 
-    failChatStream(new ReplayChunkBatch(), controller, "boom");
+    failChatStream(new ReplayChunkBatch(controller), "boom");
 
     expect(events).toEqual(["error:boom"]);
   });
 
   it("delivers buffered content before the error (#1575)", () => {
     const { controller, enqueued, events } = createRecorder();
-    const batch = new ReplayChunkBatch();
+    const { batch } = createBatch(controller);
 
-    applyChatResponseFrame(
-      batch,
-      controller,
-      replayFrame(textDelta("t1", "a"))
-    );
-    failChatStream(batch, controller, "model exploded");
+    applyChatResponseFrame(batch, replayFrame(textDelta("t1", "a")));
+    failChatStream(batch, "model exploded");
 
     expect(enqueued).toEqual([
       textDelta("t1", "a"),

--- a/packages/agents/src/chat/replay-batch.ts
+++ b/packages/agents/src/chat/replay-batch.ts
@@ -1,35 +1,51 @@
 import type { UIMessageChunk } from "ai";
 
 /**
- * Coalescing buffer for the chunk burst a resumed stream replays.
+ * Coalescing window for the chunk burst a resumed stream replays.
  *
  * On reconnect the server re-sends every stored chunk of the active turn
  * back-to-back — one `cf_agent_use_chat_response` frame per chunk, each marked
- * `replay: true` — and closes the burst with `replayComplete` (stream still
- * live) or `done` (stream already finalized). Forwarding each replayed chunk
- * into the UI-message stream individually rebuilds chat state once per chunk,
- * which has two costs:
+ * `replay: true`. Forwarding each replayed chunk into the UI-message stream on
+ * arrival rebuilds chat state once per chunk, which has two costs:
  *
  * 1. Every rebuild deep-clones the whole assistant message, so replaying a long
  *    turn is quadratic in its length.
- * 2. Every rebuild schedules a synchronous React render. A burst long enough
- *    outpaces React's commit loop and trips its nested-update guard —
- *    "Maximum update depth exceeded" (#1913) — which surfaces as a false
- *    terminal `status: "error"` even though the server-side turn is healthy.
+ * 2. Every rebuild schedules a synchronous React render. A burst delivered in a
+ *    single event-loop turn outpaces React's commit loop and trips its
+ *    nested-update guard — "Maximum update depth exceeded" (#1913) — which
+ *    surfaces as a false terminal `status: "error"` even though the server-side
+ *    turn is healthy.
  *
- * Buffering the burst and merging consecutive deltas of the same part reduces
- * the replayed prefix to roughly one chunk per message part, so it applies in
- * one pass and the already-streamed text stops visibly re-typing.
+ * The window collects replayed chunks and merges consecutive deltas of the same
+ * part, so the burst applies as roughly one chunk per message part.
  *
- * Only *adjacent* deltas of the same part are merged, so ordering across parts
- * is preserved exactly, and deltas carrying `providerMetadata` are kept whole
- * so no metadata is summed away.
+ * The window is deliberately short: it closes at the end of the event-loop turn
+ * that opened it, or earlier at a burst boundary. That bound is what makes the
+ * burst safe to coalesce — a burst spread over several turns cannot trip
+ * React's guard in the first place, and holding chunks longer would change the
+ * order in which the hook's own replay bookkeeping in `chat/react.tsx` sees
+ * state. That bookkeeping repairs a second replay of the same turn (#1733) by
+ * inspecting messages already applied, so replayed content must never be held
+ * across the frames that trigger it.
  */
 export class ReplayChunkBatch {
   /** Buffered chunks, in wire order. Owned by the batch — merged in place. */
   private chunks: UIMessageChunk[] = [];
   /** Merge key of the last buffered chunk, or null if it cannot be merged into. */
   private tailMergeKey: string | null = null;
+  /** Cancels the pending end-of-turn flush. Set while the window is open. */
+  private cancelWindow: (() => void) | undefined;
+
+  constructor(
+    private readonly controller: ReadableStreamDefaultController<UIMessageChunk>,
+    /** Schedules the end-of-turn flush. Overridable for deterministic tests. */
+    private readonly closeWindow: (flush: () => void) => () => void = (
+      flush
+    ) => {
+      const timer = setTimeout(flush, 0);
+      return () => clearTimeout(timer);
+    }
+  ) {}
 
   get isEmpty(): boolean {
     return this.chunks.length === 0;
@@ -37,7 +53,8 @@ export class ReplayChunkBatch {
 
   /**
    * Buffers a replayed chunk, merging it into the previous one when both are
-   * deltas of the same part. Takes ownership of the chunk.
+   * deltas of the same part. Takes ownership of the chunk. Opens the window on
+   * the first chunk so the batch cannot outlive the turn that produced it.
    */
   push(chunk: UIMessageChunk): void {
     const key = mergeKeyOf(chunk);
@@ -48,19 +65,51 @@ export class ReplayChunkBatch {
       return;
     }
 
+    if (this.chunks.length === 0) {
+      this.cancelWindow = this.closeWindow(() => {
+        this.cancelWindow = undefined;
+        try {
+          this.flush();
+        } catch {
+          // The stream can close before the window elapses.
+        }
+      });
+    }
+
     this.chunks.push(chunk);
     this.tailMergeKey = key;
   }
 
-  /** Enqueues the buffered batch in wire order and resets the batch. */
-  flush(controller: ReadableStreamDefaultController<UIMessageChunk>): void {
+  /** Enqueues the buffered batch in wire order and closes the window. */
+  flush(): void {
+    this.cancelWindow?.();
+    this.cancelWindow = undefined;
+
     if (this.chunks.length === 0) return;
     const batch = this.chunks;
     this.chunks = [];
     this.tailMergeKey = null;
     for (const chunk of batch) {
-      controller.enqueue(chunk);
+      this.controller.enqueue(chunk);
     }
+  }
+
+  /**
+   * Writes a chunk straight to the stream. Callers flush first — every write
+   * goes through the batch so nothing can overtake replayed content.
+   */
+  enqueueNow(chunk: UIMessageChunk): void {
+    this.controller.enqueue(chunk);
+  }
+
+  /** Closes the stream. */
+  closeNow(): void {
+    this.controller.close();
+  }
+
+  /** Errors the stream, discarding anything still queued in it. */
+  errorNow(error: Error): void {
+    this.controller.error(error);
   }
 }
 
@@ -74,17 +123,15 @@ type ChatResponseFrame = {
 
 /**
  * Routes one non-error `cf_agent_use_chat_response` frame into a chunk stream:
- * mid-burst replay chunks are buffered, anything else flushes the batch first
- * so replayed content always reaches the consumer ahead of live content.
+ * a replayed chunk joins the current window, anything else flushes the window
+ * first so replayed content always reaches the consumer ahead of live content.
  *
- * A burst ends at `replayComplete` (live stream), at `done` (finalized or
- * orphaned stream, which never sends `replayComplete`), or at the first
- * non-replay frame. Both terminators must flush, and `replayComplete` frames
- * carry an empty body — hence the flush on bodyless frames too.
+ * A burst also ends at `replayComplete` (live stream) or at `done` (finalized
+ * or orphaned stream, which never sends `replayComplete`). Both flush, and both
+ * can carry an empty body — hence the flush on bodyless frames too.
  */
 export function applyChatResponseFrame(
   batch: ReplayChunkBatch,
-  controller: ReadableStreamDefaultController<UIMessageChunk>,
   frame: ChatResponseFrame
 ): void {
   const endsReplayBurst =
@@ -94,7 +141,7 @@ export function applyChatResponseFrame(
 
   const body = frame.body?.trim();
   if (!body) {
-    if (endsReplayBurst) batch.flush(controller);
+    if (endsReplayBurst) batch.flush();
     return;
   }
 
@@ -103,13 +150,13 @@ export function applyChatResponseFrame(
     chunk = JSON.parse(body) as UIMessageChunk;
   } catch {
     // Skip malformed chunk bodies, but don't strand a finished batch behind one.
-    if (endsReplayBurst) batch.flush(controller);
+    if (endsReplayBurst) batch.flush();
     return;
   }
 
   if (endsReplayBurst) {
-    batch.flush(controller);
-    controller.enqueue(chunk);
+    batch.flush();
+    batch.enqueueNow(chunk);
     return;
   }
 
@@ -125,19 +172,15 @@ export function applyChatResponseFrame(
  * behind the flushed batch instead — `processUIMessageStream` turns that into
  * the same thrown error, so `useChat` still lands in `status: "error"`.
  */
-export function failChatStream(
-  batch: ReplayChunkBatch,
-  controller: ReadableStreamDefaultController<UIMessageChunk>,
-  message: string
-): void {
+export function failChatStream(batch: ReplayChunkBatch, message: string): void {
   if (batch.isEmpty) {
-    controller.error(new Error(message));
+    batch.errorNow(new Error(message));
     return;
   }
 
-  batch.flush(controller);
-  controller.enqueue({ type: "error", errorText: message });
-  controller.close();
+  batch.flush();
+  batch.enqueueNow({ errorText: message, type: "error" });
+  batch.closeNow();
 }
 
 /**

--- a/packages/agents/src/chat/replay-batch.ts
+++ b/packages/agents/src/chat/replay-batch.ts
@@ -1,0 +1,179 @@
+import type { UIMessageChunk } from "ai";
+
+/**
+ * Coalescing buffer for the chunk burst a resumed stream replays.
+ *
+ * On reconnect the server re-sends every stored chunk of the active turn
+ * back-to-back — one `cf_agent_use_chat_response` frame per chunk, each marked
+ * `replay: true` — and closes the burst with `replayComplete` (stream still
+ * live) or `done` (stream already finalized). Forwarding each replayed chunk
+ * into the UI-message stream individually rebuilds chat state once per chunk,
+ * which has two costs:
+ *
+ * 1. Every rebuild deep-clones the whole assistant message, so replaying a long
+ *    turn is quadratic in its length.
+ * 2. Every rebuild schedules a synchronous React render. A burst long enough
+ *    outpaces React's commit loop and trips its nested-update guard —
+ *    "Maximum update depth exceeded" (#1913) — which surfaces as a false
+ *    terminal `status: "error"` even though the server-side turn is healthy.
+ *
+ * Buffering the burst and merging consecutive deltas of the same part reduces
+ * the replayed prefix to roughly one chunk per message part, so it applies in
+ * one pass and the already-streamed text stops visibly re-typing.
+ *
+ * Only *adjacent* deltas of the same part are merged, so ordering across parts
+ * is preserved exactly, and deltas carrying `providerMetadata` are kept whole
+ * so no metadata is summed away.
+ */
+export class ReplayChunkBatch {
+  /** Buffered chunks, in wire order. Owned by the batch — merged in place. */
+  private chunks: UIMessageChunk[] = [];
+  /** Merge key of the last buffered chunk, or null if it cannot be merged into. */
+  private tailMergeKey: string | null = null;
+
+  get isEmpty(): boolean {
+    return this.chunks.length === 0;
+  }
+
+  /**
+   * Buffers a replayed chunk, merging it into the previous one when both are
+   * deltas of the same part. Takes ownership of the chunk.
+   */
+  push(chunk: UIMessageChunk): void {
+    const key = mergeKeyOf(chunk);
+    const tail = this.chunks[this.chunks.length - 1];
+
+    if (tail !== undefined && key !== null && key === this.tailMergeKey) {
+      appendDeltaText(tail, chunk);
+      return;
+    }
+
+    this.chunks.push(chunk);
+    this.tailMergeKey = key;
+  }
+
+  /** Enqueues the buffered batch in wire order and resets the batch. */
+  flush(controller: ReadableStreamDefaultController<UIMessageChunk>): void {
+    if (this.chunks.length === 0) return;
+    const batch = this.chunks;
+    this.chunks = [];
+    this.tailMergeKey = null;
+    for (const chunk of batch) {
+      controller.enqueue(chunk);
+    }
+  }
+}
+
+/** The subset of `cf_agent_use_chat_response` a chunk stream needs to route a frame. */
+type ChatResponseFrame = {
+  body?: string;
+  done?: boolean;
+  replay?: boolean;
+  replayComplete?: boolean;
+};
+
+/**
+ * Routes one non-error `cf_agent_use_chat_response` frame into a chunk stream:
+ * mid-burst replay chunks are buffered, anything else flushes the batch first
+ * so replayed content always reaches the consumer ahead of live content.
+ *
+ * A burst ends at `replayComplete` (live stream), at `done` (finalized or
+ * orphaned stream, which never sends `replayComplete`), or at the first
+ * non-replay frame. Both terminators must flush, and `replayComplete` frames
+ * carry an empty body — hence the flush on bodyless frames too.
+ */
+export function applyChatResponseFrame(
+  batch: ReplayChunkBatch,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  frame: ChatResponseFrame
+): void {
+  const endsReplayBurst =
+    frame.replay !== true ||
+    frame.done === true ||
+    frame.replayComplete === true;
+
+  const body = frame.body?.trim();
+  if (!body) {
+    if (endsReplayBurst) batch.flush(controller);
+    return;
+  }
+
+  let chunk: UIMessageChunk;
+  try {
+    chunk = JSON.parse(body) as UIMessageChunk;
+  } catch {
+    // Skip malformed chunk bodies, but don't strand a finished batch behind one.
+    if (endsReplayBurst) batch.flush(controller);
+    return;
+  }
+
+  if (endsReplayBurst) {
+    batch.flush(controller);
+    controller.enqueue(chunk);
+    return;
+  }
+
+  batch.push(chunk);
+}
+
+/**
+ * Terminates a chunk stream with an error, without losing buffered content.
+ *
+ * Resuming an errored turn replays its partial content and only then sends the
+ * terminal error frame (#1575). `controller.error()` resets the stream's queue,
+ * so with content still buffered the error is delivered as an `error` chunk
+ * behind the flushed batch instead — `processUIMessageStream` turns that into
+ * the same thrown error, so `useChat` still lands in `status: "error"`.
+ */
+export function failChatStream(
+  batch: ReplayChunkBatch,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  message: string
+): void {
+  if (batch.isEmpty) {
+    controller.error(new Error(message));
+    return;
+  }
+
+  batch.flush(controller);
+  controller.enqueue({ type: "error", errorText: message });
+  controller.close();
+}
+
+/**
+ * Identity of the part a chunk contributes text to, or null when the chunk
+ * must not be merged into (non-delta chunks, and deltas carrying metadata).
+ */
+function mergeKeyOf(chunk: UIMessageChunk): string | null {
+  switch (chunk.type) {
+    case "text-delta":
+    case "reasoning-delta":
+      return chunk.providerMetadata === undefined
+        ? `${chunk.type}\u0000${chunk.id}`
+        : null;
+    case "tool-input-delta":
+      return `tool-input-delta\u0000${chunk.toolCallId}`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Appends `source`'s delta text onto `target`. Only called for chunks with
+ * equal, non-null merge keys, so both are the same kind of delta.
+ */
+function appendDeltaText(target: UIMessageChunk, source: UIMessageChunk): void {
+  if (
+    target.type === "tool-input-delta" &&
+    source.type === "tool-input-delta"
+  ) {
+    target.inputTextDelta += source.inputTextDelta;
+    return;
+  }
+  if (
+    (target.type === "text-delta" || target.type === "reasoning-delta") &&
+    (source.type === "text-delta" || source.type === "reasoning-delta")
+  ) {
+    target.delta += source.delta;
+  }
+}

--- a/packages/agents/src/chat/replay-batch.ts
+++ b/packages/agents/src/chat/replay-batch.ts
@@ -1,51 +1,19 @@
 import type { UIMessageChunk } from "ai";
 
 /**
- * Coalescing window for the chunk burst a resumed stream replays.
+ * Batches chunks replayed during stream resume.
  *
- * On reconnect the server re-sends every stored chunk of the active turn
- * back-to-back — one `cf_agent_use_chat_response` frame per chunk, marked
- * `replay: true`. Rebuilding chat state once per chunk is quadratic in the
- * turn's length, because each rebuild deep-clones the assistant message, and it
- * schedules one synchronous React render per chunk. A burst delivered inside a
- * single task therefore exceeds React's nested-update limit: "Maximum update
- * depth exceeded" (#1913), which reaches the user as a false terminal
- * `status: "error"` while the server-side turn is healthy.
- *
- * The window buffers replayed chunks and merges consecutive deltas of the same
- * part, so a burst applies as roughly one chunk per message part.
- *
- * Coalescing is best-effort. The first buffered chunk opens the window and a
- * `setTimeout(0)` closes it. That timer is a fresh macrotask: it runs no
- * earlier than the end of the current task, but other queued tasks — a socket
- * message, a close — can run before it. A burst split that way is delivered in
- * pieces, which is harmless, since only a burst inside one task can exceed the
- * limit.
- *
- * Correctness never depends on when the timer fires. Three things close the
- * window in a defined order:
- *
- * - A burst boundary flushes synchronously (`applyChatResponseFrame`).
- * - The transport flushes before it closes or detaches a stream, so a
- *   disconnect mid-burst cannot lose received content.
- * - A newer replay of a buffered message supersedes it
- *   (`supersedesBufferedPass`), so two replays of one turn are never
- *   concatenated — what the hook repairs when the passes apply separately
- *   (#1733).
+ * Replaying every chunk separately can exceed React's update limit. Adjacent
+ * deltas for the same message part are merged until the replay pauses or ends.
  */
 export class ReplayChunkBatch {
-  /** Buffered chunks, in wire order. Owned by the batch — merged in place. */
   private chunks: UIMessageChunk[] = [];
-  /** Merge key of the last buffered chunk, or null if it cannot be merged into. */
   private tailMergeKey: string | null = null;
-  /** Cancels the scheduled flush. Set while the window is open. */
   private cancelWindow: (() => void) | undefined;
-  /** `messageId` of the buffered pass, if it began with a `start` chunk. */
   private startMessageId: string | undefined;
 
   constructor(
     private readonly controller: ReadableStreamDefaultController<UIMessageChunk>,
-    /** Schedules the flush, returning a canceller. Injected by tests. */
     private readonly closeWindow: (flush: () => void) => () => void = (
       flush
     ) => {
@@ -62,11 +30,6 @@ export class ReplayChunkBatch {
     return this.chunks.length === 0;
   }
 
-  /**
-   * Buffers a replayed chunk, merging it into the previous one when both are
-   * deltas of the same part. Takes ownership of the chunk, and opens the window
-   * on the first one.
-   */
   push(chunk: UIMessageChunk): void {
     const key = mergeKeyOf(chunk);
     const tail = this.chunks[this.chunks.length - 1];
@@ -90,10 +53,6 @@ export class ReplayChunkBatch {
     this.tailMergeKey = key;
   }
 
-  /**
-   * Drops the buffered pass. Only for a pass that a newer replay of the same
-   * message supersedes — nothing buffered has reached the consumer yet.
-   */
   discard(): void {
     this.cancelWindow?.();
     this.cancelWindow = undefined;
@@ -102,7 +61,6 @@ export class ReplayChunkBatch {
     this.startMessageId = undefined;
   }
 
-  /** Enqueues the buffered batch in wire order and closes the window. */
   flush(): void {
     this.cancelWindow?.();
     this.cancelWindow = undefined;
@@ -117,16 +75,10 @@ export class ReplayChunkBatch {
         this.controller.enqueue(chunk);
       }
     } catch {
-      // Already closed or errored, which discards the stream's queue anyway. A
-      // flush must never throw: callers flush on their way to closing a stream,
-      // and still have to close it.
+      // The stream is already closed; callers still need to finish cleanup.
     }
   }
 
-  /**
-   * Writes a chunk straight to the stream. Callers flush first — every write
-   * goes through the batch so nothing can overtake replayed content.
-   */
   enqueueNow(chunk: UIMessageChunk): void {
     this.controller.enqueue(chunk);
   }
@@ -140,7 +92,6 @@ export class ReplayChunkBatch {
   }
 }
 
-/** The subset of `cf_agent_use_chat_response` a chunk stream needs to route a frame. */
 type ChatResponseFrame = {
   body?: string;
   continuation?: boolean;
@@ -149,15 +100,7 @@ type ChatResponseFrame = {
   replayComplete?: boolean;
 };
 
-/**
- * Routes one non-error `cf_agent_use_chat_response` frame into a chunk stream.
- * A replayed chunk joins the window; anything else flushes it first, so
- * replayed content always reaches the consumer ahead of live content.
- *
- * A burst also ends at `replayComplete` (live stream) or `done` (finalized or
- * orphaned stream, which sends no `replayComplete`). Either can carry an empty
- * body, so bodyless frames flush too.
- */
+/** Buffers replay chunks and flushes them before live or boundary frames. */
 export function applyChatResponseFrame(
   batch: ReplayChunkBatch,
   frame: ChatResponseFrame
@@ -177,7 +120,7 @@ export function applyChatResponseFrame(
   try {
     chunk = JSON.parse(body) as UIMessageChunk;
   } catch {
-    // Skip malformed chunk bodies, but don't strand a finished batch behind one.
+    // Do not leave buffered chunks behind a malformed boundary frame.
     if (endsReplayBurst) batch.flush();
     return;
   }
@@ -195,15 +138,6 @@ export function applyChatResponseFrame(
   batch.push(chunk);
 }
 
-/**
- * True when `chunk` starts a replay pass that makes the buffered one redundant.
- *
- * A stream can announce itself twice, so one turn can replay twice before
- * either pass is delivered (#1733). Every replay rebuilds the message from its
- * first chunk, so the newer pass contains the buffered one, which has reached
- * nobody; delivering both would duplicate the message's parts. Continuation
- * replays append instead of rebuilding, so they never supersede.
- */
 function supersedesBufferedPass(
   batch: ReplayChunkBatch,
   chunk: UIMessageChunk,
@@ -218,13 +152,8 @@ function supersedesBufferedPass(
 }
 
 /**
- * Terminates a chunk stream with an error, without losing buffered content.
- *
- * Resuming an errored turn replays its partial content and only then sends the
- * terminal error frame (#1575). `controller.error()` resets the stream's queue,
- * so with content buffered the error is delivered as an `error` chunk behind
- * the flushed batch instead. `processUIMessageStream` turns that into the same
- * thrown error, so `useChat` still lands in `status: "error"`.
+ * Reports an error after buffered content. `controller.error()` would discard
+ * chunks that have not reached the consumer.
  */
 export function failChatStream(batch: ReplayChunkBatch, message: string): void {
   if (batch.isEmpty) {
@@ -237,10 +166,6 @@ export function failChatStream(batch: ReplayChunkBatch, message: string): void {
   batch.closeNow();
 }
 
-/**
- * Identity of the part a chunk adds text to, or null when the chunk must not be
- * merged into: non-deltas, and deltas carrying metadata.
- */
 function mergeKeyOf(chunk: UIMessageChunk): string | null {
   switch (chunk.type) {
     case "text-delta":
@@ -255,7 +180,6 @@ function mergeKeyOf(chunk: UIMessageChunk): string | null {
   }
 }
 
-/** Appends `source`'s delta text onto `target`. Both have equal merge keys. */
 function appendDeltaText(target: UIMessageChunk, source: UIMessageChunk): void {
   if (
     target.type === "tool-input-delta" &&

--- a/packages/agents/src/chat/replay-batch.ts
+++ b/packages/agents/src/chat/replay-batch.ts
@@ -4,56 +4,48 @@ import type { UIMessageChunk } from "ai";
  * Coalescing window for the chunk burst a resumed stream replays.
  *
  * On reconnect the server re-sends every stored chunk of the active turn
- * back-to-back — one `cf_agent_use_chat_response` frame per chunk, each marked
- * `replay: true`. Forwarding each replayed chunk into the UI-message stream on
- * arrival rebuilds chat state once per chunk, which has two costs:
+ * back-to-back — one `cf_agent_use_chat_response` frame per chunk, marked
+ * `replay: true`. Rebuilding chat state once per chunk is quadratic in the
+ * turn's length, because each rebuild deep-clones the assistant message, and it
+ * schedules one synchronous React render per chunk. A burst delivered inside a
+ * single task therefore exceeds React's nested-update limit: "Maximum update
+ * depth exceeded" (#1913), which reaches the user as a false terminal
+ * `status: "error"` while the server-side turn is healthy.
  *
- * 1. Every rebuild deep-clones the whole assistant message, so replaying a long
- *    turn is quadratic in its length.
- * 2. Every rebuild schedules a synchronous React render. A burst delivered in a
- *    single event-loop turn outpaces React's commit loop and trips its
- *    nested-update guard — "Maximum update depth exceeded" (#1913) — which
- *    surfaces as a false terminal `status: "error"` even though the server-side
- *    turn is healthy.
+ * The window buffers replayed chunks and merges consecutive deltas of the same
+ * part, so a burst applies as roughly one chunk per message part.
  *
- * The window collects replayed chunks and merges consecutive deltas of the same
- * part, so the burst applies as roughly one chunk per message part.
+ * Coalescing is best-effort. The first buffered chunk opens the window and a
+ * `setTimeout(0)` closes it. That timer is a fresh macrotask: it runs no
+ * earlier than the end of the current task, but other queued tasks — a socket
+ * message, a close — can run before it. A burst split that way is delivered in
+ * pieces, which is harmless, since only a burst inside one task can exceed the
+ * limit.
  *
- * The window is deliberately short. It is opened by the first buffered chunk
- * and closed by a `setTimeout(0)`, which runs once the task that delivered the
- * burst finishes. Coalescing is therefore opportunistic: a burst delivered in
- * one task is merged, and a burst spread over several tasks is delivered as it
- * arrives — which is harmless, because only a burst inside a single task can
- * outrun React's commit loop.
- *
- * Correctness does not depend on that timer winning any race, because the
- * timer is not the only thing that closes the window:
+ * Correctness never depends on when the timer fires. Three things close the
+ * window in a defined order:
  *
  * - A burst boundary flushes synchronously (`applyChatResponseFrame`).
  * - The transport flushes before it closes or detaches a stream, so a
  *   disconnect mid-burst cannot lose received content.
- * - A replayed `start` for a message already buffered supersedes the buffered
- *   pass (`supersedesBufferedPass`), so two replays of one turn can never be
- *   concatenated — the case the hook's own bookkeeping repairs when the passes
- *   are applied separately (#1733).
+ * - A newer replay of a buffered message supersedes it
+ *   (`supersedesBufferedPass`), so two replays of one turn are never
+ *   concatenated — what the hook repairs when the passes apply separately
+ *   (#1733).
  */
 export class ReplayChunkBatch {
   /** Buffered chunks, in wire order. Owned by the batch — merged in place. */
   private chunks: UIMessageChunk[] = [];
   /** Merge key of the last buffered chunk, or null if it cannot be merged into. */
   private tailMergeKey: string | null = null;
-  /** Cancels the pending end-of-turn flush. Set while the window is open. */
+  /** Cancels the scheduled flush. Set while the window is open. */
   private cancelWindow: (() => void) | undefined;
-
-  /** `messageId` of the buffered replay pass, if it began with a `start`. */
+  /** `messageId` of the buffered pass, if it began with a `start` chunk. */
   private startMessageId: string | undefined;
 
   constructor(
     private readonly controller: ReadableStreamDefaultController<UIMessageChunk>,
-    /**
-     * Schedules the window's flush and returns a canceller. Runs after the
-     * current task by default; overridable for deterministic tests.
-     */
+    /** Schedules the flush, returning a canceller. Injected by tests. */
     private readonly closeWindow: (flush: () => void) => () => void = (
       flush
     ) => {
@@ -62,7 +54,6 @@ export class ReplayChunkBatch {
     }
   ) {}
 
-  /** `messageId` of the buffered pass, or undefined if none is buffered. */
   get bufferedStartMessageId(): string | undefined {
     return this.startMessageId;
   }
@@ -73,8 +64,8 @@ export class ReplayChunkBatch {
 
   /**
    * Buffers a replayed chunk, merging it into the previous one when both are
-   * deltas of the same part. Takes ownership of the chunk. Opens the window on
-   * the first chunk so the batch cannot outlive the turn that produced it.
+   * deltas of the same part. Takes ownership of the chunk, and opens the window
+   * on the first one.
    */
   push(chunk: UIMessageChunk): void {
     const key = mergeKeyOf(chunk);
@@ -126,9 +117,9 @@ export class ReplayChunkBatch {
         this.controller.enqueue(chunk);
       }
     } catch {
-      // The stream is already closed or errored, which discards its queue
-      // anyway. Never let a flush throw: callers flush on their way to
-      // closing a stream, and must still close it.
+      // Already closed or errored, which discards the stream's queue anyway. A
+      // flush must never throw: callers flush on their way to closing a stream,
+      // and still have to close it.
     }
   }
 
@@ -140,12 +131,10 @@ export class ReplayChunkBatch {
     this.controller.enqueue(chunk);
   }
 
-  /** Closes the stream. */
   closeNow(): void {
     this.controller.close();
   }
 
-  /** Errors the stream, discarding anything still queued in it. */
   errorNow(error: Error): void {
     this.controller.error(error);
   }
@@ -161,13 +150,13 @@ type ChatResponseFrame = {
 };
 
 /**
- * Routes one non-error `cf_agent_use_chat_response` frame into a chunk stream:
- * a replayed chunk joins the current window, anything else flushes the window
- * first so replayed content always reaches the consumer ahead of live content.
+ * Routes one non-error `cf_agent_use_chat_response` frame into a chunk stream.
+ * A replayed chunk joins the window; anything else flushes it first, so
+ * replayed content always reaches the consumer ahead of live content.
  *
- * A burst also ends at `replayComplete` (live stream) or at `done` (finalized
- * or orphaned stream, which never sends `replayComplete`). Both flush, and both
- * can carry an empty body — hence the flush on bodyless frames too.
+ * A burst also ends at `replayComplete` (live stream) or `done` (finalized or
+ * orphaned stream, which sends no `replayComplete`). Either can carry an empty
+ * body, so bodyless frames flush too.
  */
 export function applyChatResponseFrame(
   batch: ReplayChunkBatch,
@@ -209,11 +198,11 @@ export function applyChatResponseFrame(
 /**
  * True when `chunk` starts a replay pass that makes the buffered one redundant.
  *
- * A stream can announce itself twice, so the same turn can replay twice before
+ * A stream can announce itself twice, so one turn can replay twice before
  * either pass is delivered (#1733). Every replay rebuilds the message from its
- * first chunk, so the newer pass is a superset of the buffered one; delivering
- * both would duplicate the message's parts. Continuation replays are excluded:
- * they append to an existing message rather than rebuild it.
+ * first chunk, so the newer pass contains the buffered one, which has reached
+ * nobody; delivering both would duplicate the message's parts. Continuation
+ * replays append instead of rebuilding, so they never supersede.
  */
 function supersedesBufferedPass(
   batch: ReplayChunkBatch,
@@ -233,9 +222,9 @@ function supersedesBufferedPass(
  *
  * Resuming an errored turn replays its partial content and only then sends the
  * terminal error frame (#1575). `controller.error()` resets the stream's queue,
- * so with content still buffered the error is delivered as an `error` chunk
- * behind the flushed batch instead — `processUIMessageStream` turns that into
- * the same thrown error, so `useChat` still lands in `status: "error"`.
+ * so with content buffered the error is delivered as an `error` chunk behind
+ * the flushed batch instead. `processUIMessageStream` turns that into the same
+ * thrown error, so `useChat` still lands in `status: "error"`.
  */
 export function failChatStream(batch: ReplayChunkBatch, message: string): void {
   if (batch.isEmpty) {
@@ -249,8 +238,8 @@ export function failChatStream(batch: ReplayChunkBatch, message: string): void {
 }
 
 /**
- * Identity of the part a chunk contributes text to, or null when the chunk
- * must not be merged into (non-delta chunks, and deltas carrying metadata).
+ * Identity of the part a chunk adds text to, or null when the chunk must not be
+ * merged into: non-deltas, and deltas carrying metadata.
  */
 function mergeKeyOf(chunk: UIMessageChunk): string | null {
   switch (chunk.type) {
@@ -266,10 +255,7 @@ function mergeKeyOf(chunk: UIMessageChunk): string | null {
   }
 }
 
-/**
- * Appends `source`'s delta text onto `target`. Only called for chunks with
- * equal, non-null merge keys, so both are the same kind of delta.
- */
+/** Appends `source`'s delta text onto `target`. Both have equal merge keys. */
 function appendDeltaText(target: UIMessageChunk, source: UIMessageChunk): void {
   if (
     target.type === "tool-input-delta" &&

--- a/packages/agents/src/chat/replay-batch.ts
+++ b/packages/agents/src/chat/replay-batch.ts
@@ -19,14 +19,23 @@ import type { UIMessageChunk } from "ai";
  * The window collects replayed chunks and merges consecutive deltas of the same
  * part, so the burst applies as roughly one chunk per message part.
  *
- * The window is deliberately short: it closes at the end of the event-loop turn
- * that opened it, or earlier at a burst boundary. That bound is what makes the
- * burst safe to coalesce — a burst spread over several turns cannot trip
- * React's guard in the first place, and holding chunks longer would change the
- * order in which the hook's own replay bookkeeping in `chat/react.tsx` sees
- * state. That bookkeeping repairs a second replay of the same turn (#1733) by
- * inspecting messages already applied, so replayed content must never be held
- * across the frames that trigger it.
+ * The window is deliberately short. It is opened by the first buffered chunk
+ * and closed by a `setTimeout(0)`, which runs once the task that delivered the
+ * burst finishes. Coalescing is therefore opportunistic: a burst delivered in
+ * one task is merged, and a burst spread over several tasks is delivered as it
+ * arrives — which is harmless, because only a burst inside a single task can
+ * outrun React's commit loop.
+ *
+ * Correctness does not depend on that timer winning any race, because the
+ * timer is not the only thing that closes the window:
+ *
+ * - A burst boundary flushes synchronously (`applyChatResponseFrame`).
+ * - The transport flushes before it closes or detaches a stream, so a
+ *   disconnect mid-burst cannot lose received content.
+ * - A replayed `start` for a message already buffered supersedes the buffered
+ *   pass (`supersedesBufferedPass`), so two replays of one turn can never be
+ *   concatenated — the case the hook's own bookkeeping repairs when the passes
+ *   are applied separately (#1733).
  */
 export class ReplayChunkBatch {
   /** Buffered chunks, in wire order. Owned by the batch — merged in place. */
@@ -36,9 +45,15 @@ export class ReplayChunkBatch {
   /** Cancels the pending end-of-turn flush. Set while the window is open. */
   private cancelWindow: (() => void) | undefined;
 
+  /** `messageId` of the buffered replay pass, if it began with a `start`. */
+  private startMessageId: string | undefined;
+
   constructor(
     private readonly controller: ReadableStreamDefaultController<UIMessageChunk>,
-    /** Schedules the end-of-turn flush. Overridable for deterministic tests. */
+    /**
+     * Schedules the window's flush and returns a canceller. Runs after the
+     * current task by default; overridable for deterministic tests.
+     */
     private readonly closeWindow: (flush: () => void) => () => void = (
       flush
     ) => {
@@ -46,6 +61,11 @@ export class ReplayChunkBatch {
       return () => clearTimeout(timer);
     }
   ) {}
+
+  /** `messageId` of the buffered pass, or undefined if none is buffered. */
+  get bufferedStartMessageId(): string | undefined {
+    return this.startMessageId;
+  }
 
   get isEmpty(): boolean {
     return this.chunks.length === 0;
@@ -68,16 +88,27 @@ export class ReplayChunkBatch {
     if (this.chunks.length === 0) {
       this.cancelWindow = this.closeWindow(() => {
         this.cancelWindow = undefined;
-        try {
-          this.flush();
-        } catch {
-          // The stream can close before the window elapses.
-        }
+        this.flush();
       });
     }
 
+    if (chunk.type === "start") {
+      this.startMessageId = chunk.messageId;
+    }
     this.chunks.push(chunk);
     this.tailMergeKey = key;
+  }
+
+  /**
+   * Drops the buffered pass. Only for a pass that a newer replay of the same
+   * message supersedes — nothing buffered has reached the consumer yet.
+   */
+  discard(): void {
+    this.cancelWindow?.();
+    this.cancelWindow = undefined;
+    this.chunks = [];
+    this.tailMergeKey = null;
+    this.startMessageId = undefined;
   }
 
   /** Enqueues the buffered batch in wire order and closes the window. */
@@ -89,8 +120,15 @@ export class ReplayChunkBatch {
     const batch = this.chunks;
     this.chunks = [];
     this.tailMergeKey = null;
-    for (const chunk of batch) {
-      this.controller.enqueue(chunk);
+    this.startMessageId = undefined;
+    try {
+      for (const chunk of batch) {
+        this.controller.enqueue(chunk);
+      }
+    } catch {
+      // The stream is already closed or errored, which discards its queue
+      // anyway. Never let a flush throw: callers flush on their way to
+      // closing a stream, and must still close it.
     }
   }
 
@@ -116,6 +154,7 @@ export class ReplayChunkBatch {
 /** The subset of `cf_agent_use_chat_response` a chunk stream needs to route a frame. */
 type ChatResponseFrame = {
   body?: string;
+  continuation?: boolean;
   done?: boolean;
   replay?: boolean;
   replayComplete?: boolean;
@@ -160,7 +199,33 @@ export function applyChatResponseFrame(
     return;
   }
 
+  if (supersedesBufferedPass(batch, chunk, frame)) {
+    batch.discard();
+  }
+
   batch.push(chunk);
+}
+
+/**
+ * True when `chunk` starts a replay pass that makes the buffered one redundant.
+ *
+ * A stream can announce itself twice, so the same turn can replay twice before
+ * either pass is delivered (#1733). Every replay rebuilds the message from its
+ * first chunk, so the newer pass is a superset of the buffered one; delivering
+ * both would duplicate the message's parts. Continuation replays are excluded:
+ * they append to an existing message rather than rebuild it.
+ */
+function supersedesBufferedPass(
+  batch: ReplayChunkBatch,
+  chunk: UIMessageChunk,
+  frame: ChatResponseFrame
+): boolean {
+  return (
+    chunk.type === "start" &&
+    frame.continuation !== true &&
+    chunk.messageId !== undefined &&
+    chunk.messageId === batch.bufferedStartMessageId
+  );
 }
 
 /**

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -695,7 +695,7 @@ export class WebSocketChatTransport<
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
         readerController = controller;
-        const replayBatch = new ReplayChunkBatch();
+        const replayBatch = new ReplayChunkBatch(controller);
         let timeout: ReturnType<typeof setTimeout> | undefined;
 
         const armTimeout = (delay: number) => {
@@ -770,16 +770,12 @@ export class WebSocketChatTransport<
 
             if (data.error) {
               finish(() =>
-                failChatStream(
-                  replayBatch,
-                  controller,
-                  data.body || "Stream error"
-                )
+                failChatStream(replayBatch, data.body || "Stream error")
               );
               return;
             }
 
-            applyChatResponseFrame(replayBatch, controller, data);
+            applyChatResponseFrame(replayBatch, data);
 
             if (data.done) {
               finish(() => controller.close());
@@ -872,7 +868,7 @@ export class WebSocketChatTransport<
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
         streamController = controller;
-        const replayBatch = new ReplayChunkBatch();
+        const replayBatch = new ReplayChunkBatch(controller);
 
         const onMessage = (event: MessageEvent) => {
           try {
@@ -885,16 +881,12 @@ export class WebSocketChatTransport<
 
             if (data.error) {
               finish(() =>
-                failChatStream(
-                  replayBatch,
-                  controller,
-                  data.body || "Stream error"
-                )
+                failChatStream(replayBatch, data.body || "Stream error")
               );
               return;
             }
 
-            applyChatResponseFrame(replayBatch, controller, data);
+            applyChatResponseFrame(replayBatch, data);
 
             if (data.done) {
               finish(() => controller.close());

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -610,6 +610,9 @@ export class WebSocketChatTransport<
     let requestId: string | null = null;
     let readerController: ReadableStreamDefaultController<UIMessageChunk> | null =
       null;
+    // Held outside start() so the close and detach paths can flush replayed
+    // content before they close the stream.
+    let replayBatch: ReplayChunkBatch | null = null;
     const probeId = nanoid(8);
     let onResumeRef: ((data: { id: string }) => void) | null = null;
     let onResumeNoneRef: ((data: { probeId?: string }) => boolean) | null =
@@ -687,7 +690,10 @@ export class WebSocketChatTransport<
     this._abortToolContinuation = abortToolContinuationRef;
     detachResumeStreamRef = () => {
       if (completed) return false;
-      finish(() => readerController?.close());
+      finish(() => {
+        replayBatch?.flush();
+        readerController?.close();
+      });
       return true;
     };
     this._detachResumeStream = detachResumeStreamRef;
@@ -695,7 +701,8 @@ export class WebSocketChatTransport<
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
         readerController = controller;
-        const replayBatch = new ReplayChunkBatch(controller);
+        const batch = new ReplayChunkBatch(controller);
+        replayBatch = batch;
         let timeout: ReturnType<typeof setTimeout> | undefined;
 
         const armTimeout = (delay: number) => {
@@ -769,13 +776,11 @@ export class WebSocketChatTransport<
             }
 
             if (data.error) {
-              finish(() =>
-                failChatStream(replayBatch, data.body || "Stream error")
-              );
+              finish(() => failChatStream(batch, data.body || "Stream error"));
               return;
             }
 
-            applyChatResponseFrame(replayBatch, data);
+            applyChatResponseFrame(batch, data);
 
             if (data.done) {
               finish(() => controller.close());
@@ -785,7 +790,11 @@ export class WebSocketChatTransport<
           }
         };
 
-        const onClose = () => finish(() => controller.close());
+        const onClose = () =>
+          finish(() => {
+            batch.flush();
+            controller.close();
+          });
 
         agent.addEventListener("message", onMessage, {
           signal: streamController.signal
@@ -850,6 +859,9 @@ export class WebSocketChatTransport<
 
     let streamController: ReadableStreamDefaultController<UIMessageChunk> | null =
       null;
+    // Held outside start() so the close and detach paths can flush replayed
+    // content before they close the stream.
+    let replayBatch: ReplayChunkBatch | null = null;
     const cancelActiveRequest = () => {
       if (completed) return false;
       finish(() => streamController?.error(abortError), true);
@@ -860,7 +872,10 @@ export class WebSocketChatTransport<
     const transport = this;
     detachResumeStream = () => {
       if (completed) return false;
-      finish(() => streamController?.close());
+      finish(() => {
+        replayBatch?.flush();
+        streamController?.close();
+      });
       return true;
     };
     this._detachResumeStream = detachResumeStream;
@@ -868,7 +883,8 @@ export class WebSocketChatTransport<
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
         streamController = controller;
-        const replayBatch = new ReplayChunkBatch(controller);
+        const batch = new ReplayChunkBatch(controller);
+        replayBatch = batch;
 
         const onMessage = (event: MessageEvent) => {
           try {
@@ -880,13 +896,11 @@ export class WebSocketChatTransport<
             if (data.id !== requestId) return;
 
             if (data.error) {
-              finish(() =>
-                failChatStream(replayBatch, data.body || "Stream error")
-              );
+              finish(() => failChatStream(batch, data.body || "Stream error"));
               return;
             }
 
-            applyChatResponseFrame(replayBatch, data);
+            applyChatResponseFrame(batch, data);
 
             if (data.done) {
               finish(() => controller.close());
@@ -897,7 +911,14 @@ export class WebSocketChatTransport<
         };
 
         const onClose = () => {
-          finish(() => controller.close(), false, false);
+          finish(
+            () => {
+              batch.flush();
+              controller.close();
+            },
+            false,
+            false
+          );
         };
 
         agent.addEventListener("message", onMessage, {

--- a/packages/agents/src/chat/ws-chat-transport.ts
+++ b/packages/agents/src/chat/ws-chat-transport.ts
@@ -7,6 +7,11 @@
 
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
 import { nanoid } from "nanoid";
+import {
+  applyChatResponseFrame,
+  failChatStream,
+  ReplayChunkBatch
+} from "./replay-batch";
 import { MessageType, type OutgoingMessage } from "./wire-types";
 
 /**
@@ -690,6 +695,7 @@ export class WebSocketChatTransport<
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
         readerController = controller;
+        const replayBatch = new ReplayChunkBatch();
         let timeout: ReturnType<typeof setTimeout> | undefined;
 
         const armTimeout = (delay: number) => {
@@ -764,19 +770,16 @@ export class WebSocketChatTransport<
 
             if (data.error) {
               finish(() =>
-                controller.error(new Error(data.body || "Stream error"))
+                failChatStream(
+                  replayBatch,
+                  controller,
+                  data.body || "Stream error"
+                )
               );
               return;
             }
 
-            if (data.body?.trim()) {
-              try {
-                const chunk = JSON.parse(data.body) as UIMessageChunk;
-                controller.enqueue(chunk);
-              } catch {
-                // Skip malformed chunk bodies
-              }
-            }
+            applyChatResponseFrame(replayBatch, controller, data);
 
             if (data.done) {
               finish(() => controller.close());
@@ -869,6 +872,7 @@ export class WebSocketChatTransport<
     return new ReadableStream<UIMessageChunk>({
       start(controller) {
         streamController = controller;
+        const replayBatch = new ReplayChunkBatch();
 
         const onMessage = (event: MessageEvent) => {
           try {
@@ -881,20 +885,16 @@ export class WebSocketChatTransport<
 
             if (data.error) {
               finish(() =>
-                controller.error(new Error(data.body || "Stream error"))
+                failChatStream(
+                  replayBatch,
+                  controller,
+                  data.body || "Stream error"
+                )
               );
               return;
             }
 
-            // Parse and enqueue the chunk
-            if (data.body?.trim()) {
-              try {
-                const chunk = JSON.parse(data.body) as UIMessageChunk;
-                controller.enqueue(chunk);
-              } catch {
-                // Skip malformed chunk bodies
-              }
-            }
+            applyChatResponseFrame(replayBatch, controller, data);
 
             if (data.done) {
               finish(() => controller.close());

--- a/packages/agents/src/react-tests/resume-replay-burst.test.tsx
+++ b/packages/agents/src/react-tests/resume-replay-burst.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * Regression test for #1913.
+ *
+ * Resuming a long turn replays every stored chunk as its own
+ * `cf_agent_use_chat_response` frame. Before the replay batch landed, the
+ * transport-owned resume path forwarded each frame into the UI-message stream
+ * individually, so chat state — and therefore React — was updated once per
+ * chunk. Past ~50 consecutive updates React's nested-update guard throws
+ * "Maximum update depth exceeded", `useChat` catches it, and the client shows a
+ * terminal `status: "error"` for a turn the server completed fine.
+ *
+ * These cases drive the real hook with the exact wire frames a resume produces
+ * and assert the client stays healthy. They live in the react project because
+ * that is the only layer where the failure is observable: the throw comes from
+ * React's commit loop, not from the transport.
+ */
+import type { UIMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render as _render } from "vitest-browser-react";
+import { useAgentChat } from "../chat/react";
+import type { useAgent } from "../react";
+
+const render: typeof _render = async (...args) => {
+  const result = await _render(...args);
+  // @ts-expect-error - globalThis is not typed
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  return result;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const RESUMING = "cf_agent_stream_resuming";
+const RESUME_REQUEST = "cf_agent_stream_resume_request";
+const CHAT_RESPONSE = "cf_agent_use_chat_response";
+
+function createFakeAgent(name: string) {
+  const target = new EventTarget();
+  const sentMessages: string[] = [];
+  const url = `ws://localhost:3000/agents/chat/${name}?_pk=abc`;
+  const agent = {
+    _pk: name,
+    _pkurl: url,
+    _url: null as string | null,
+    addEventListener: target.addEventListener.bind(target),
+    agent: "Chat",
+    close: () => {},
+    dispatchEvent: target.dispatchEvent.bind(target),
+    getHttpUrl: () => url.replace("ws://", "http://"),
+    id: "fake-agent",
+    name,
+    path: [{ agent: "Chat", name }],
+    removeEventListener: target.removeEventListener.bind(target),
+    send: (data: string) => sentMessages.push(data)
+  };
+  return {
+    agent: agent as unknown as ReturnType<typeof useAgent>,
+    sentMessages,
+    target
+  };
+}
+
+function dispatch(target: EventTarget, data: Record<string, unknown>) {
+  target.dispatchEvent(
+    new MessageEvent("message", { data: JSON.stringify(data) })
+  );
+}
+
+const countType = (sent: string[], type: string) =>
+  sent.filter((m) => {
+    try {
+      return (JSON.parse(m) as { type?: string }).type === type;
+    } catch {
+      return false;
+    }
+  }).length;
+
+/** The frames a server replays for a turn of `deltaCount` text deltas. */
+function replayFrames(requestId: string, deltaCount: number) {
+  const bodies: Record<string, unknown>[] = [
+    { messageId: "asst-1", type: "start" },
+    { type: "start-step" },
+    { id: "t1", type: "text-start" },
+    ...Array.from({ length: deltaCount }, (_, i) => ({
+      delta: `d${i} `,
+      id: "t1",
+      type: "text-delta"
+    }))
+  ];
+  return bodies.map((body) => ({
+    body: JSON.stringify(body),
+    done: false,
+    id: requestId,
+    replay: true,
+    type: CHAT_RESPONSE
+  }));
+}
+
+type Harness = {
+  read: (id: string) => string | null | undefined;
+  sentMessages: string[];
+  target: EventTarget;
+};
+
+async function mount(name: string): Promise<Harness> {
+  const { agent, sentMessages, target } = createFakeAgent(name);
+
+  function TestComponent() {
+    const chat = useAgentChat({
+      agent,
+      getInitialMessages: null,
+      messages: [
+        { id: "u1", parts: [{ text: "hi", type: "text" }], role: "user" }
+      ] as UIMessage[]
+    });
+    const assistantText = chat.messages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => m.parts)
+      .filter((p) => p.type === "text")
+      .map((p) => (p as { text: string }).text)
+      .join("");
+    return (
+      <div>
+        <div data-testid="status">{chat.status}</div>
+        <div data-testid="error">{String(chat.error?.message ?? "")}</div>
+        <div data-testid="chars">{assistantText.length}</div>
+      </div>
+    );
+  }
+
+  const { container } = await render(<TestComponent />);
+  return {
+    read: (id) =>
+      container.querySelector(`[data-testid="${id}"]`)?.textContent ?? null,
+    sentMessages,
+    target
+  };
+}
+
+/** Text length the assistant message should have after `deltaCount` deltas. */
+const expectedChars = (deltaCount: number) =>
+  Array.from({ length: deltaCount }, (_, i) => `d${i} `).join("").length;
+
+describe("#1913 — resume replay burst", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    cleanup();
+  });
+
+  // 400 deltas is ~8x React's nested-update ceiling; 60 is just past it, and
+  // was the smallest burst that failed before the fix.
+  it.each([{ deltas: 60 }, { deltas: 400 }])(
+    "applies a $deltas-delta replay burst without exceeding React's update depth",
+    async ({ deltas }) => {
+      const h = await mount(`replay-${deltas}`);
+      await vi.waitFor(() =>
+        expect(countType(h.sentMessages, RESUME_REQUEST)).toBe(1)
+      );
+
+      dispatch(h.target, { id: "req-1", type: RESUMING });
+      await sleep(10);
+
+      // The whole burst arrives in one task, exactly as replayChunks() sends it.
+      for (const frame of replayFrames("req-1", deltas)) {
+        dispatch(h.target, frame);
+      }
+      dispatch(h.target, {
+        body: "",
+        done: true,
+        id: "req-1",
+        type: CHAT_RESPONSE
+      });
+      await sleep(60);
+
+      expect({
+        chars: h.read("chars"),
+        error: h.read("error"),
+        status: h.read("status")
+      }).toEqual({
+        chars: String(expectedChars(deltas)),
+        error: "",
+        status: "ready"
+      });
+    }
+  );
+
+  it("keeps replayed content when the resumed turn ends in an error", async () => {
+    const h = await mount("replay-error");
+    await vi.waitFor(() =>
+      expect(countType(h.sentMessages, RESUME_REQUEST)).toBe(1)
+    );
+
+    dispatch(h.target, { id: "req-err", type: RESUMING });
+    await sleep(10);
+
+    for (const frame of replayFrames("req-err", 120)) {
+      dispatch(h.target, frame);
+    }
+    // #1575: partial content is replayed, then the terminal error frame.
+    dispatch(h.target, {
+      body: "model exploded",
+      done: true,
+      error: true,
+      id: "req-err",
+      type: CHAT_RESPONSE
+    });
+    await sleep(60);
+
+    expect({
+      chars: h.read("chars"),
+      error: h.read("error"),
+      status: h.read("status")
+    }).toEqual({
+      chars: String(expectedChars(120)),
+      error: "model exploded",
+      status: "error"
+    });
+  });
+
+  it("delivers live chunks after a replayed burst in order", async () => {
+    const h = await mount("replay-then-live");
+    await vi.waitFor(() =>
+      expect(countType(h.sentMessages, RESUME_REQUEST)).toBe(1)
+    );
+
+    dispatch(h.target, { id: "req-live", type: RESUMING });
+    await sleep(10);
+
+    for (const frame of replayFrames("req-live", 80)) {
+      dispatch(h.target, frame);
+    }
+    dispatch(h.target, {
+      body: "",
+      done: false,
+      id: "req-live",
+      replay: true,
+      replayComplete: true,
+      type: CHAT_RESPONSE
+    });
+    await sleep(20);
+
+    // Replayed prefix is applied at the boundary, before any live chunk.
+    expect(h.read("chars")).toBe(String(expectedChars(80)));
+
+    dispatch(h.target, {
+      body: JSON.stringify({ delta: "LIVE", id: "t1", type: "text-delta" }),
+      done: false,
+      id: "req-live",
+      type: CHAT_RESPONSE
+    });
+    dispatch(h.target, {
+      body: "",
+      done: true,
+      id: "req-live",
+      type: CHAT_RESPONSE
+    });
+    await sleep(60);
+
+    expect({
+      chars: h.read("chars"),
+      error: h.read("error"),
+      status: h.read("status")
+    }).toEqual({
+      chars: String(expectedChars(80) + "LIVE".length),
+      error: "",
+      status: "ready"
+    });
+  });
+});

--- a/packages/agents/src/react-tests/resume-replay-burst.test.tsx
+++ b/packages/agents/src/react-tests/resume-replay-burst.test.tsx
@@ -192,6 +192,33 @@ describe("#1913 — resume replay burst", () => {
     }
   );
 
+  it("shows a replayed burst that is not followed by a terminator", async () => {
+    // A burst is coalesced only for the turn of the event loop that delivers
+    // it. Nothing may wait on `replayComplete` or `done` to become visible,
+    // and no content may be held across the frames that drive the hook's own
+    // replay bookkeeping.
+    const h = await mount("replay-no-terminator");
+    await vi.waitFor(() =>
+      expect(countType(h.sentMessages, RESUME_REQUEST)).toBe(1)
+    );
+
+    dispatch(h.target, { id: "req-open", type: RESUMING });
+    await sleep(10);
+
+    for (const frame of replayFrames("req-open", 120)) {
+      dispatch(h.target, frame);
+    }
+    await sleep(60);
+
+    expect({
+      chars: h.read("chars"),
+      error: h.read("error")
+    }).toEqual({
+      chars: String(expectedChars(120)),
+      error: ""
+    });
+  });
+
   it("keeps replayed content when the resumed turn ends in an error", async () => {
     const h = await mount("replay-error");
     await vi.waitFor(() =>

--- a/packages/agents/src/react-tests/resume-replay-burst.test.tsx
+++ b/packages/agents/src/react-tests/resume-replay-burst.test.tsx
@@ -219,6 +219,34 @@ describe("#1913 — resume replay burst", () => {
     });
   });
 
+  it("keeps replayed content when the socket closes during the burst", async () => {
+    // A second disconnect can arrive before the coalescing window closes.
+    // Content already received must not be lost — it was visible before the
+    // batch existed, because each chunk was enqueued on arrival and a closed
+    // stream still yields whatever it has queued.
+    const h = await mount("replay-close");
+    await vi.waitFor(() =>
+      expect(countType(h.sentMessages, RESUME_REQUEST)).toBe(1)
+    );
+
+    dispatch(h.target, { id: "req-close", type: RESUMING });
+    await sleep(10);
+
+    for (const frame of replayFrames("req-close", 120)) {
+      dispatch(h.target, frame);
+    }
+    h.target.dispatchEvent(new Event("close"));
+    await sleep(60);
+
+    expect({
+      chars: h.read("chars"),
+      error: h.read("error")
+    }).toEqual({
+      chars: String(expectedChars(120)),
+      error: ""
+    });
+  });
+
   it("keeps replayed content when the resumed turn ends in an error", async () => {
     const h = await mount("replay-error");
     await vi.waitFor(() =>


### PR DESCRIPTION
Refs #1913. Thanks to @magicismight for the diagnosis and the fork branch that inspired this fix.

## The bug

Your WebSocket drops in the middle of an answer and reconnects a second later. Instead of the answer carrying on, the console fills with `Maximum update depth exceeded` and the chat shows an error - even though the server finished the answer fine and has it stored. Only a reload clears it.

## Why it happens

When a client reconnects mid-turn, the server replays the answer so far: every chunk it has stored, back to back, as fast as the socket will carry them.

The transport handed each chunk straight to the AI SDK. Every chunk rewrites the chat state, and every rewrite is a React render. React allows 50 renders in an unbroken row before it assumes something is looping and throws - and a replayed answer is easily 400 chunks, arriving with nothing in between to break the chain.

The throw lands deep inside the SDK's stream loop, which can't tell a rendering failure from a dead connection, so it marks the turn as failed and stops reading.

```mermaid
flowchart LR
  S["server replays<br/>400 stored chunks"] --> T{transport}
  T -->|"before: one at a time"| B1["400 chat-state writes"] --> B2["renders 1 to 50"] --> B3["render 51 throws<br/>status: error"]
  T -->|"after: collected and merged"| A1["about 5 writes"] --> A2["5 renders"] --> A3["answer restored<br/>status: ready"]
```

## The fix

The transport now catches replayed chunks in a short window instead of forwarding them one by one, and glues together the ones belonging to the same piece of text. A few hundred chunks become a handful of updates - roughly one per part of the message. The replayed text also appears at once, rather than visibly re-typing itself.

Holding chunks is only safe if they can never be stranded. Three rules take care of that:

- The window ends the moment the replay does.
- The transport empties the window before it closes a stream, so a second disconnect can't swallow what already arrived.
- If the same answer replays twice, the newer copy replaces the held one, so it can't be applied twice (#1733).

It's one new module, `chat/replay-batch.ts`, wired into the two resume paths in `ws-chat-transport.ts`. Nothing changes in the server, the wire format, or `chat/react.tsx`.

## Tests

18 unit tests in `chat/__tests__/replay-batch.test.ts` cover the merge rules, the window, the boundaries and an errored turn. Six tests in `react-tests/resume-replay-burst.test.tsx` drive the real hook with real wire frames - all six fail on `main`, and that is the only layer where the React throw is visible at all.

Suites: agents chat 532 · react 133 · workers 1801 · ai-chat 737 + react 82 · think 1000 · `pnpm run check`.

## Next steps

This massively reduces the chance of the bug appearing in the wild, but a few things remain for a follow-up:

| | Problem | Why it remains |
| --- | --- | --- |
| 1 | A replay of more than ~7 tool steps still hits the limit (measured: 6 steps fine, 8 throws) | Merging only joins chunks within a single part, and each tool step costs about 7 updates by itself |
| 2 | A fast enough live stream could do the same in theory | The live path still forwards one chunk at a time. Real models pause between tokens, which lets React reset its counter |
| 3 | Any client-side render error still marks the turn failed until a reload or a reconnect | The SDK's catch can't tell a render failure from a stream failure |

For 1 & 2, setting a default value for `throttle` on `useAgentChat` avoids the crash outright - which is what 25 of our 27 examples already do. Am going to raise a followup PR after this to set a default value for it in `useChatAgent` rather than leaving it unthrottled.
