### PR TITLE
fix(agents): stream forwarded request bodies into sub-agents

### DIFF
--- a/.changeset/facet-forward-stream-body.md
+++ b/.changeset/facet-forward-stream-body.md
@@ -1,0 +1,22 @@
+---
+"agents": patch
+---
+
+Stream forwarded request bodies into sub-agents instead of buffering them in the parent Durable Object.
+
+`Agent._cf_forwardToFacet` and `routeSubAgentRequest` both did `forwardInit.body = await req.arrayBuffer()` before dispatching to a child facet, materialising the entire request body in the parent's isolate. Two consequences:
+
+- The read sat **in front of** application-level validation. `Agent.fetch` returns before `onRequest` whenever the path matches `/sub/{class}/{name}`, so an app that carefully bounded request bodies in `onRequest` still had an unbounded read ahead of it — and no way to bound it itself.
+- The cost was **per hop**. A nested `/sub/.../sub/...` address re-materialised the same bytes at every level.
+
+Both call sites now pass `req.body` through as a stream. Measured on `wrangler dev --local` with a handler that never reads the body, peak RSS across the `workerd` processes for a single POST:
+
+| Request body | facet route, before | facet route, after | canonical route (control) |
+| ------------ | ------------------- | ------------------ | ------------------------- |
+| 16 MB        | +75 MB              | +4 MB              | +2 MB                     |
+| 64 MB        | +268 MB             | +4 MB              | +2 MB                     |
+| 128 MB       | +546 MB             | +4 MB              | +2 MB                     |
+
+This restores the behaviour from before #1443, which switched to an explicit `RequestInit` in order to set a header on WebSocket upgrades and re-attached the body with `arrayBuffer()` as a side effect. The `Upgrade` header handling from that fix is unchanged.
+
+One behavioural note: backpressure now reaches the client. A child that returns without reading the body will cause the remainder of the upload to be cancelled, where previously the parent drained it in full.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -7736,8 +7736,12 @@ export class Agent<
     if (req.headers.get("Upgrade")?.toLowerCase() === "websocket") {
       forwardedHeaders.set(SUB_AGENT_OUTER_URL_HEADER, req.url);
     }
+    // Hand the body through as a stream. Reading it here (e.g.
+    // `await req.arrayBuffer()`) materialises the entire body in the
+    // parent DO's isolate, ahead of any application-level intake limit,
+    // and re-materialises it once per `/sub/` hop — see #2015.
     if (req.body && req.method !== "GET" && req.method !== "HEAD") {
-      forwardedInit.body = await req.arrayBuffer();
+      forwardedInit.body = req.body;
     }
     const forwarded = new Request(rewritten, forwardedInit);
     return fetcher.fetch(forwarded);

--- a/packages/agents/src/sub-routing.ts
+++ b/packages/agents/src/sub-routing.ts
@@ -424,8 +424,12 @@ export async function routeSubAgentRequest(
     method: req.method,
     headers: new Headers(req.headers)
   };
+  // Stream the body through rather than buffering it — see #2015. This
+  // helper runs in the caller's isolate, but the same request then hits
+  // `_cf_forwardToFacet` on the parent, so buffering here would put a
+  // second unbounded copy in front of the child.
   if (req.body && req.method !== "GET" && req.method !== "HEAD") {
-    forwardInit.body = await req.arrayBuffer();
+    forwardInit.body = req.body;
   }
   const forwardReq = new Request(forwardUrl, forwardInit);
 

--- a/packages/agents/src/tests/agents/index.ts
+++ b/packages/agents/src/tests/agents/index.ts
@@ -71,5 +71,7 @@ export {
   Sub_,
   ReservedClassParent,
   TestUnboundParentAgent,
-  TestMinifiedNameParentAgent
+  TestMinifiedNameParentAgent,
+  BodyProbeSubAgent,
+  BodyProbeRootAgent
 } from "./sub-agent";

--- a/packages/agents/src/tests/agents/sub-agent.ts
+++ b/packages/agents/src/tests/agents/sub-agent.ts
@@ -2223,3 +2223,100 @@ class _a extends Agent {
   }
 }
 export { _a as TestMinifiedNameParentAgent };
+
+// ── Request-body forwarding probes (issue #2015) ─────────────────────
+//
+// `_cf_forwardToFacet` and `routeSubAgentRequest` used to materialise
+// the whole forwarded body via `await req.arrayBuffer()` before
+// dispatching. These fixtures let a test observe *when* the child sees
+// the request relative to the client finishing its upload, which is
+// what distinguishes streaming from buffering.
+//
+// The same handler backs a facet child (`BodyProbeSubAgent`) and a
+// root Agent (`BodyProbeRootAgent`). The root is the control: it
+// proves the *test harness* can stream a request body, so a hang on
+// the facet path can be attributed to the forwarder rather than to
+// vitest-pool-workers.
+
+function toHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Probe endpoints:
+ *   - `/probe/ignore`      — reply immediately, never touch the body.
+ *   - `/probe/first-chunk` — read exactly one chunk, then reply.
+ *   - `/probe/drain`       — read to completion, reply with size + digest.
+ */
+async function handleBodyProbe(
+  agentName: string,
+  request: Request
+): Promise<Response> {
+  const { pathname } = new URL(request.url);
+
+  // Matched by suffix, not equality: a facet child sees the tail after
+  // `/sub/{class}/{name}` (the forwarder rewrites the pathname), while a
+  // root Agent sees the full `/agents/{class}/{name}/...` path. The same
+  // handler has to serve both.
+  if (pathname.endsWith("/probe/ignore")) {
+    return Response.json({ agentName, probe: "ignore" });
+  }
+
+  if (pathname.endsWith("/probe/first-chunk")) {
+    if (!request.body) {
+      return Response.json({ agentName, chunk: null, probe: "first-chunk" });
+    }
+    const reader = request.body.getReader();
+    try {
+      const { done, value } = await reader.read();
+      return Response.json({
+        agentName,
+        chunk: value ? new TextDecoder().decode(value) : null,
+        done,
+        probe: "first-chunk"
+      });
+    } finally {
+      // Let go without draining — the point of this probe is that the
+      // child can act on a prefix of a body the client hasn't finished
+      // sending.
+      reader.cancel().catch(() => {});
+    }
+  }
+
+  if (pathname.endsWith("/probe/drain")) {
+    const body = await request.arrayBuffer();
+    return Response.json({
+      agentName,
+      bytes: body.byteLength,
+      contentLength: request.headers.get("content-length"),
+      probe: "drain",
+      sha256: toHex(await crypto.subtle.digest("SHA-256", body))
+    });
+  }
+
+  return Response.json(
+    { agentName, path: pathname, probe: "unknown" },
+    {
+      status: 404
+    }
+  );
+}
+
+/** Facet-only child. Reached via `/sub/body-probe-sub-agent/{name}`. */
+export class BodyProbeSubAgent extends Agent {
+  override async onRequest(request: Request): Promise<Response> {
+    return handleBodyProbe(this.name, request);
+  }
+}
+
+/**
+ * Root Agent running the identical handler — the canonical (non-facet)
+ * control path from the issue's measurement table.
+ */
+export class BodyProbeRootAgent extends Agent {
+  override async onRequest(request: Request): Promise<Response> {
+    return handleBodyProbe(this.name, request);
+  }
+}

--- a/packages/agents/src/tests/sub-agent-body-forwarding.test.ts
+++ b/packages/agents/src/tests/sub-agent-body-forwarding.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Request-body forwarding across a parent↔facet boundary (issue #2015).
+ *
+ * `Agent._cf_forwardToFacet` and `routeSubAgentRequest` both used to
+ * do `forwardInit.body = await req.arrayBuffer()` before dispatching to
+ * the child. That read is unbounded and runs in the *parent* Durable
+ * Object, in front of any application-level intake limit — an app that
+ * carefully bounds bodies in `onRequest` still had an unbounded read
+ * ahead of it. Nesting compounds it: every `/sub/` hop re-materialised
+ * the same bytes.
+ *
+ * The tests below pin the observable consequence rather than the
+ * implementation: whether the child can act on a request before the
+ * client has finished uploading it.
+ *
+ *   - `respondsBeforeUploadCompletes` — the child replies while the
+ *     request body is still open. Buffering makes this deadlock.
+ *   - `first-chunk` — the child reads a prefix of a still-open body.
+ *     This is the decisive one: it distinguishes real incremental
+ *     streaming from "the runtime buffered internally but dispatched
+ *     early".
+ *   - integrity — a multi-megabyte body still arrives byte-exact, over
+ *     one hop and over two nested hops.
+ *
+ * A canonical (non-facet) control runs first. If the test harness
+ * itself can't stream a request body, every facet assertion below
+ * would hang for reasons unrelated to the forwarder, so the control
+ * tells us how to read a failure.
+ */
+
+import { env, exports } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import { getAgentByName } from "../index";
+
+function uniqueName() {
+  return `body-fwd-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * A request body that delivers `firstChunk` immediately and then stays
+ * open until `release()` is called.
+ *
+ * `controller.enqueue` queues the chunk synchronously, so a reader can
+ * consume it while `start` is still pending — that's what lets a probe
+ * observe a prefix of an unfinished upload.
+ */
+function pendingBody(firstChunk: string) {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let released = false;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      controller.enqueue(new TextEncoder().encode(firstChunk));
+      await gate;
+      controller.close();
+    }
+  });
+
+  return {
+    release: () => {
+      released = true;
+      release();
+    },
+    get released() {
+      return released;
+    },
+    stream
+  };
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+type RaceOutcome =
+  | { kind: "settled"; res: Response }
+  | { kind: "error"; err: unknown }
+  | { kind: "pending" };
+
+/**
+ * Resolve as soon as the request settles, or report `pending` after
+ * `ms`. Rejections are captured rather than thrown so a runtime that
+ * refuses stream bodies outright produces a readable message instead of
+ * an anonymous timeout.
+ */
+async function raceSettle(
+  promise: Promise<Response>,
+  ms: number
+): Promise<RaceOutcome> {
+  return Promise.race<RaceOutcome>([
+    promise.then(
+      (res) => ({ kind: "settled" as const, res }),
+      (err) => ({ err, kind: "error" as const })
+    ),
+    sleep(ms).then(() => ({ kind: "pending" as const }))
+  ]);
+}
+
+function describeOutcome(outcome: RaceOutcome): string {
+  if (outcome.kind === "error") {
+    const err = outcome.err;
+    return `request rejected: ${err instanceof Error ? err.message : String(err)}`;
+  }
+  if (outcome.kind === "pending") {
+    return "request never settled while the body was still open (the parent is buffering the whole body before dispatching)";
+  }
+  return `settled with ${outcome.res.status}`;
+}
+
+/**
+ * Send a still-open body at `url` and assert the response comes back
+ * before the upload finishes. Returns the parsed JSON so callers can
+ * make further assertions.
+ */
+async function expectResponseBeforeUploadCompletes(
+  url: string,
+  { chunk = "prefix-payload", timeoutMs = 2500 } = {}
+): Promise<Record<string, unknown>> {
+  const body = pendingBody(chunk);
+  const inFlight = exports.default.fetch(
+    new Request(url, { body: body.stream, method: "POST" })
+  );
+
+  try {
+    const outcome = await raceSettle(inFlight, timeoutMs);
+    expect(outcome.kind, describeOutcome(outcome)).toBe("settled");
+    // Narrowed by the assertion above.
+    const res = (outcome as { res: Response }).res;
+    expect(res.status).toBe(200);
+    // The upload is still open at this point — that's the whole point.
+    expect(body.released).toBe(false);
+    return (await res.json()) as Record<string, unknown>;
+  } finally {
+    // Always unblock, otherwise a failing assertion leaves the stream
+    // (and the worker request) hanging into teardown.
+    body.release();
+    await inFlight.catch(() => {});
+  }
+}
+
+async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Deterministic, non-uniform payload so truncation or reordering shows up. */
+function payload(bytes: number): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(new ArrayBuffer(bytes));
+  for (let i = 0; i < bytes; i++) out[i] = (i * 31 + (i >> 8)) & 0xff;
+  return out;
+}
+
+// ── Control: does the harness stream at all? ─────────────────────────
+
+describe("body forwarding — canonical control path", () => {
+  it("streams a request body to a root Agent (no facet involved)", async () => {
+    // If this fails, the test harness — not the forwarder — is
+    // buffering, and the facet assertions below can't be interpreted.
+    const name = uniqueName();
+    const json = await expectResponseBeforeUploadCompletes(
+      `http://x/agents/body-probe-root-agent/${name}/probe/ignore`
+    );
+    expect(json.probe).toBe("ignore");
+    expect(json.agentName).toBe(name);
+  });
+
+  it("delivers a prefix of an unfinished body to a root Agent", async () => {
+    const name = uniqueName();
+    const json = await expectResponseBeforeUploadCompletes(
+      `http://x/agents/body-probe-root-agent/${name}/probe/first-chunk`,
+      { chunk: "control-prefix" }
+    );
+    expect(json.chunk).toBe("control-prefix");
+    expect(json.done).toBe(false);
+  });
+});
+
+// ── The regression: parent → facet ──────────────────────────────────
+
+describe("body forwarding — parent to facet (_cf_forwardToFacet)", () => {
+  it("dispatches to the child before the upload completes", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const json = await expectResponseBeforeUploadCompletes(
+      `http://x/agents/test-sub-agent-parent/${parent}/sub/body-probe-sub-agent/${child}/probe/ignore`
+    );
+
+    expect(json.probe).toBe("ignore");
+    expect(json.agentName).toBe(child);
+  });
+
+  it("delivers a prefix of an unfinished body to the child", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const json = await expectResponseBeforeUploadCompletes(
+      `http://x/agents/test-sub-agent-parent/${parent}/sub/body-probe-sub-agent/${child}/probe/first-chunk`,
+      { chunk: "facet-prefix" }
+    );
+
+    expect(json.chunk).toBe("facet-prefix");
+    expect(json.done).toBe(false);
+    expect(json.agentName).toBe(child);
+  });
+
+  it("forwards a 2 MB body byte-exact through one hop", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+    const bytes = payload(2 * 1024 * 1024);
+    const expected = await sha256Hex(bytes);
+
+    const res = await exports.default.fetch(
+      `http://x/agents/test-sub-agent-parent/${parent}/sub/body-probe-sub-agent/${child}/probe/drain`,
+      { body: bytes, method: "POST" }
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.bytes).toBe(bytes.byteLength);
+    expect(json.sha256).toBe(expected);
+  });
+
+  it("forwards a 2 MB body byte-exact through two nested hops", async () => {
+    // The amplification the issue measured is per-hop, so the nested
+    // chain is where buffering hurt most.
+    const parent = uniqueName();
+    const outer = uniqueName();
+    const child = uniqueName();
+    const bytes = payload(2 * 1024 * 1024);
+    const expected = await sha256Hex(bytes);
+
+    const res = await exports.default.fetch(
+      `http://x/agents/test-sub-agent-parent/${parent}/sub/outer-sub-agent/${outer}/sub/body-probe-sub-agent/${child}/probe/drain`,
+      { body: bytes, method: "POST" }
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.bytes).toBe(bytes.byteLength);
+    expect(json.sha256).toBe(expected);
+    expect(json.agentName).toBe(child);
+  });
+
+  it("preserves an empty body and GET semantics", async () => {
+    // The forwarder skips body handling for GET/HEAD; make sure the
+    // streaming path didn't disturb that.
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const res = await exports.default.fetch(
+      `http://x/agents/test-sub-agent-parent/${parent}/sub/body-probe-sub-agent/${child}/probe/ignore`
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { agentName: string }).agentName).toBe(child);
+  });
+});
+
+// ── The second call site: routeSubAgentRequest ───────────────────────
+
+describe("body forwarding — routeSubAgentRequest", () => {
+  it("streams through the custom route handler to the child", async () => {
+    // `/custom-sub/...` crosses *two* boundaries: an ordinary DO stub
+    // (routeSubAgentRequest → parent) and then a facet stub (parent →
+    // child). Both call sites buffered, so this covers each in turn.
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const parentStub = await getAgentByName(env.HookingSubAgentParent, parent);
+    await parentStub.setHookMode("allow");
+
+    const json = await expectResponseBeforeUploadCompletes(
+      `http://x/custom-sub/${parent}/sub/body-probe-sub-agent/${child}/probe/first-chunk`,
+      { chunk: "custom-route-prefix" }
+    );
+
+    expect(json.chunk).toBe("custom-route-prefix");
+    expect(json.done).toBe(false);
+    expect(json.agentName).toBe(child);
+  });
+
+  it("forwards a 2 MB body byte-exact through the custom route", async () => {
+    const parent = uniqueName();
+    const child = uniqueName();
+    const bytes = payload(2 * 1024 * 1024);
+    const expected = await sha256Hex(bytes);
+
+    const parentStub = await getAgentByName(env.HookingSubAgentParent, parent);
+    await parentStub.setHookMode("allow");
+
+    const res = await exports.default.fetch(
+      `http://x/custom-sub/${parent}/sub/body-probe-sub-agent/${child}/probe/drain`,
+      { body: bytes, method: "POST" }
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.bytes).toBe(bytes.byteLength);
+    expect(json.sha256).toBe(expected);
+  });
+});

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -70,7 +70,9 @@ export {
   Sub_,
   ReservedClassParent,
   TestUnboundParentAgent,
-  TestMinifiedNameParentAgent
+  TestMinifiedNameParentAgent,
+  BodyProbeSubAgent,
+  BodyProbeRootAgent
 } from "./agents";
 export { ChatSdkStateAgent } from "./agents";
 export { TestRunFiberAgent } from "./agents/run-fiber";
@@ -142,7 +144,8 @@ import type {
   HookingSubAgentParent,
   ReservedClassParent,
   TestUnboundParentAgent,
-  TestMinifiedNameParentAgent
+  TestMinifiedNameParentAgent,
+  BodyProbeRootAgent
 } from "./agents";
 
 export type Env = {
@@ -196,6 +199,7 @@ export type Env = {
   HookingSubAgentParent: DurableObjectNamespace<HookingSubAgentParent>;
   ReservedClassParent: DurableObjectNamespace<ReservedClassParent>;
   TestConnectionUriAgent: DurableObjectNamespace<TestConnectionUriAgent>;
+  BodyProbeRootAgent: DurableObjectNamespace<BodyProbeRootAgent>;
   // SubAgent classes (CounterSubAgent, OuterSubAgent, InnerSubAgent) are
   // accessed via ctx.exports as facet classes — no standalone bindings needed.
   // Workflow bindings for integration testing

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -220,6 +220,17 @@
         "class_name": "BroadcastSubAgent",
         "name": "BroadcastSubAgent"
       },
+      // Request-body forwarding probes (issue #2015). The sub-agent is
+      // facet-only (binding is a harness requirement, no migration); the
+      // root agent is the canonical control path and needs storage.
+      {
+        "class_name": "BodyProbeSubAgent",
+        "name": "BodyProbeSubAgent"
+      },
+      {
+        "class_name": "BodyProbeRootAgent",
+        "name": "BodyProbeRootAgent"
+      },
       {
         "class_name": "TestMigrationAgent",
         "name": "TestMigrationAgent"
@@ -371,7 +382,8 @@
         "HookingSubAgentParent",
         "ReservedClassParent",
         "TestUnboundParentAgent",
-        "TestMinifiedNameParentAgent"
+        "TestMinifiedNameParentAgent",
+        "BodyProbeRootAgent"
       ],
       "tag": "v1"
     }


### PR DESCRIPTION
Closes #2015

## The problem

When a request goes to a sub-agent (a URL with `/sub/...` in it), the parent used to read the *entire* upload into memory before passing it on. No limit. A 128 MB upload made the parent balloon by ~546 MB. And your app couldn't stop it, because this happened before your code ever ran.

## What changed

Two lines. Instead of reading the whole body first, the parent now just hands the body through as a stream — it passes the pipe along instead of filling a bucket and carrying it.

```diff
  if (req.body && req.method !== "GET" && req.method !== "HEAD") {
-   forwardedInit.body = await req.arrayBuffer();
+   forwardedInit.body = req.body;
  }
```

Both call sites had it: `Agent._cf_forwardToFacet` (`src/index.ts`) and `routeSubAgentRequest` (`src/sub-routing.ts`).

## Why it broke in the first place

#1443 fixed a WebSocket bug back in May and needed to set a header on upgrade requests. Doing that meant rebuilding the request from an explicit `RequestInit`, which doesn't inherit a body — so the body got re-attached by hand, the slow way, as a side effect. It streamed fine before that.

I verified this rather than assuming it. Reverting to the pre-#1443 form (`new Request(rewritten, req)`) makes all the new streaming tests pass, which confirms where the buffering came from. So this is a genuine regression, shipped in `agents@0.12.1`. In terms of behaviour this restores the streaming, but #1443's code stays the same. The `RequestInit` and `Upgrade` header handling are untouched and only the body attachment changes.

Worth noting *why* it mattered beyond raw memory: `Agent.fetch` returns before `onRequest` whenever the path matches `/sub/{class}/{name}`, so the unbounded read sat **in front of** application-level validation. An app that carefully bounded request bodies in `onRequest` still had an unbounded read ahead of it and no way to bound it. The cost was also **per hop** — a nested `/sub/.../sub/...` address re-materialised the same bytes at every level.

## Result

Measured with `wrangler dev --local` against the reporter's repro (a handler that never reads the body, so growth is attributable to the forwarder). Two tarballs built from the same commit, differing only in this fix. Fresh worker per row, peak RSS summed across the `workerd` processes for a single POST:

| Request body | facet route, before | facet route, after | canonical route (control) |
| --- | --- | --- | --- |
| 16 MB | +75 MB | +4 MB | +2 MB |
| 64 MB | +268 MB | +4 MB | +2 MB |
| 128 MB | +546 MB | +4 MB | +2 MB |

Flat now, no matter how big the upload. The before column reproduces the reporter's +71/+284/+556 MB; the after column matches the canonical control.

## The one caveat

The upload is now connected end to end. If a sub-agent replies without reading the body, the rest of the upload gets cut off instead of being quietly swallowed. That's the correct behaviour and what you'd want — but it *is* a change, so anyone relying on the old "swallow it all" habit would notice.

## Tests

New file `src/tests/sub-agent-body-forwarding.test.ts` (9 tests), covering both call sites:

- **dispatch before upload completes** — the child replies while the request body is still open. Deadlocks against the old code.
- **prefix of an unfinished body** — the child reads one chunk of a still-open body. This is the decisive one: it distinguishes real incremental streaming from "the runtime buffered internally but dispatched early".
- **integrity** — a 2 MB body arrives byte-exact (SHA-256) over one hop, over two nested hops, and via `routeSubAgentRequest`.
- **GET/HEAD** — unchanged.

The suite includes a canonical (non-facet) control that runs first. If the test harness itself couldn't stream a request body, every facet assertion would hang for unrelated reasons, so the control makes a failure interpretable. Fixtures are `BodyProbeSubAgent` (facet) and `BodyProbeRootAgent` (root control), sharing one handler.

The three streaming assertions fail against `main` with `expected 'pending' to be 'settled'` after 2.5s, and pass in ~25ms with this change.

## Verification

- `pnpm run test:workers` — 91 files / 1810 tests
- full `agents` suite — 131 files / 2552 tests
- `@cloudflare/ai-chat` 50/737, `@cloudflare/voice` 12/225, `nx affected -t test` 27/27
- `pnpm run check` — sherif, export check, oxfmt, oxlint, typecheck (120 projects)

The existing WebSocket sub-agent tests matter here specifically, since this touches the function #1443 changed — they pass.

## Not addressed

If an `onBeforeSubAgent` hook consumes the body and returns `void`, forwarding still throws (the stream is disturbed). That was already true with `arrayBuffer()`, just with a different message — orthogonal to this issue, so I left it alone.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
