### PR TITLE
fix(think): arm declared scheduled tasks on the root agent only

### DIFF
--- a/.changeset/think-scheduled-tasks-root-scope.md
+++ b/.changeset/think-scheduled-tasks-root-scope.md
@@ -1,0 +1,40 @@
+---
+"@cloudflare/think": minor
+---
+
+Arm declared scheduled tasks on the root agent only, so a Think agent that also has sub-agents no longer runs each occurrence once per live sub-agent.
+
+`_reconcileDeclaredScheduledTasks()` ran on every instance of the class with no root/facet guard. It resolves tasks from `getScheduledTasks()` — normally a static code declaration, so it returns the _same_ tasks on every instance — and keyed the arming on `stableHash(this.selfPath)`, which is the instance's own owner. Every live facet therefore armed a full private copy of the schedule, and each slot dispatched once per facet on top of the root:
+
+```sql
+SELECT owner_path, COUNT(*) FROM cf_agents_schedules
+WHERE callback = '_runDeclaredScheduledTask' GROUP BY owner_path;
+-- one full set for the root, plus one per sub-agent
+```
+
+Nothing surfaced this. The write-time duplicate warning only fires for non-idempotent `schedule()` calls in `onStart`, and declared tasks always pass `idempotent: true`; the alarm-time warning needs ten one-shot rows for a single callback, and these are spread across distinct owners. The docs made it worse — the "Scheduled responses" section of the sub-agents guide showed a static `getScheduledTasks()` on an agent with sub-agents, which is exactly the multiplying shape.
+
+Declared tasks now arm on the root only. A new `getScheduledTasksScope()` hook returns `"root"` by default; return `"all"` to restore per-facet arming:
+
+```typescript
+export class PerUserAgent extends Think<Env> {
+  getScheduledTasksScope() {
+    return "all" as const;
+  }
+
+  async getScheduledTasks() {
+    const reminder = await this.getReminderForThisUser();
+    return reminder ? { reminder } : {};
+  }
+}
+```
+
+That opt-in is the right choice only when `getScheduledTasks()` genuinely varies per sub-agent, since each one then owns an independent schedule.
+
+**Migration.** Nothing to do for sub-agents that already armed rows.
+
+Duplicate _executions_ stop immediately. `_runDeclaredScheduledTask` carries the same guard, so a dispatch into a root-scoped sub-agent returns before it runs the action and before the `finally` that arms the next occurrence. Declared tasks are armed as one-shot schedules, so the pending occurrence is consumed and deleted by the alarm loop and the recurrence dies out — no restart required.
+
+The leftover rows are then cleaned up whenever the sub-agent next starts: a root-scoped facet reconciles against an empty task set, so the existing prune pass cancels each underlying Agent schedule and deletes the ledger row. Note this is keyed on the _sub-agent_ starting, not the root — evicting a parent does not evict its facets, and `subAgent()` only replays `onStart` for a facet that is not already running.
+
+A one-time warning naming `getScheduledTasksScope()` is logged whenever a sub-agent declares tasks it will not arm. That covers both populations: agents upgrading with rows to prune, and agents declaring a sub-agent task for the first time under the new default, which would otherwise be inert with nothing in the ledger to notice.

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -845,6 +845,7 @@ path.
 | `getSystemPrompt()`        | `"You are a helpful assistant."` | System prompt (fallback when no context blocks)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `getTools()`               | `{}`                             | AI SDK `ToolSet` for the agentic loop                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `getScheduledTasks()`      | `{}`                             | Code-declared recurring prompts or handlers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `getScheduledTasksScope()` | `"root"`                         | Which instances arm the declared tasks — `"root"` (top-level agent only) or `"all"` (sub-agents too)                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `getDefaultTimezone()`     | `undefined`                      | Default timezone for wall-clock scheduled tasks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `getMessengers()`          | `{}`                             | Messenger ingress and delivery declarations — see [Messengers](./messengers.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `getActions()`             | `{}`                             | Server actions (idempotency, approvals, authorization) compiled into tools — see [Actions](./actions.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
@@ -1192,6 +1193,27 @@ schedule, scheduleKind, timezone, metadata }` and are intended for app-owned
 work such as creating a Workflow run or writing a run ledger. Delivery is
 at-least-once; use `idempotencyKey` or `occurrenceKey` for your own durable
 idempotency.
+
+Declared tasks are armed on the **root agent only**. Because
+`getScheduledTasks()` is normally a static declaration, it returns the same
+tasks on every instance of the class, so arming it on sub-agents as well would
+dispatch each occurrence once per live sub-agent on top of the root. Override
+`getScheduledTasksScope()` to return `"all"` when a class genuinely declares
+different tasks per sub-agent — each sub-agent then owns an independent
+schedule.
+
+```typescript
+export class PerUserAgent extends Think<Env> {
+  getScheduledTasksScope() {
+    return "all" as const;
+  }
+
+  async getScheduledTasks(): Promise<ThinkScheduledTasks> {
+    const reminder = await this.getReminderForThisUser();
+    return reminder ? { reminder } : {};
+  }
+}
+```
 
 Static declarations reconcile on startup. If `getScheduledTasks()` reads
 product-owned data that can change while the Durable Object is live, call

--- a/docs/think/sub-agents.md
+++ b/docs/think/sub-agents.md
@@ -211,7 +211,11 @@ await this.saveMessages((current) => [
 
 ### Scheduled responses
 
-Trigger a recurring prompt turn with `getScheduledTasks()`:
+Declared scheduled tasks are armed on the **root agent only**.
+`getScheduledTasks()` is usually a static declaration, so it returns the same
+tasks on every instance of the class — arming it on sub-agents too would fire
+each occurrence once per live sub-agent on top of the root. Declare the task on
+the root and let it fan out to sub-agents itself:
 
 ```typescript
 export class MyAgent extends Think<Env> {
@@ -224,12 +228,43 @@ export class MyAgent extends Think<Env> {
       dailyReport: {
         schedule: "every day at 09:00",
         timezone: "UTC",
-        prompt: "Generate the daily report."
+        handler: async () => {
+          for (const { name } of this.listSubAgents(ChatAgent)) {
+            const chat = await this.subAgent(ChatAgent, name);
+            await chat.submitMessages([
+              {
+                id: crypto.randomUUID(),
+                role: "user",
+                parts: [{ type: "text", text: "Generate the daily report." }]
+              }
+            ]);
+          }
+        }
       }
     };
   }
 }
 ```
+
+If a class genuinely declares _different_ tasks per sub-agent — for example when
+`getScheduledTasks()` reads per-sub-agent state — opt in with
+`getScheduledTasksScope()` and each sub-agent owns an independent schedule:
+
+```typescript
+export class PerUserAgent extends Think<Env> {
+  getScheduledTasksScope() {
+    return "all" as const;
+  }
+
+  async getScheduledTasks() {
+    const reminder = await this.getReminderForThisUser();
+    return reminder ? { reminder } : {};
+  }
+}
+```
+
+A sub-agent that declares tasks without opting in logs a warning naming this
+hook, so an inert schedule is never silent.
 
 ### Chaining from onChatResponse
 

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -340,6 +340,7 @@ Script execution requires a Worker Loader binding:
 | `getTools()`               | `{}`                               | AI SDK `ToolSet` for the agentic loop                                                                                                                                                                                        |
 | `getMessengers()`          | `{}`                               | Messenger ingress and delivery declarations                                                                                                                                                                                  |
 | `getScheduledTasks()`      | `{}`                               | Code-declared recurring prompts                                                                                                                                                                                              |
+| `getScheduledTasksScope()` | `"root"`                           | Which instances arm declared tasks — `"root"` or `"all"` (sub-agents too)                                                                                                                                                    |
 | `getDefaultTimezone()`     | `undefined`                        | Default timezone for wall-clock schedules                                                                                                                                                                                    |
 | `maxSteps`                 | `10`                               | Max tool-call rounds per turn (property)                                                                                                                                                                                     |
 | `sendReasoning`            | `true`                             | Send reasoning chunks to chat clients                                                                                                                                                                                        |
@@ -516,6 +517,14 @@ schedule, scheduleKind, timezone, metadata }` and are intended for app-owned
 work such as creating a Workflow run or writing a run ledger. Delivery is
 at-least-once; use `idempotencyKey` or `occurrenceKey` for your own durable
 idempotency.
+
+Declared tasks are armed on the **root agent only**. Because
+`getScheduledTasks()` is normally a static declaration, it returns the same
+tasks on every instance of the class, so arming it on sub-agents as well would
+dispatch each occurrence once per live sub-agent on top of the root. Override
+`getScheduledTasksScope()` to return `"all"` when a class genuinely declares
+different tasks per sub-agent — each sub-agent then owns an independent
+schedule.
 
 Static declarations reconcile on startup. If `getScheduledTasks()` reads
 product-owned data that can change while the Durable Object is live, call

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -6108,6 +6108,13 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
     return this.ctx.storage.get<string>("scheduledTasksDefaultTimezone");
   }
 
+  override async getScheduledTasksScope(): Promise<"root" | "all"> {
+    return (
+      (await this.ctx.storage.get<"root" | "all">("scheduledTasksScope")) ??
+      "root"
+    );
+  }
+
   override async getScheduledTasks(): Promise<ThinkScheduledTasks> {
     const config =
       (await this.ctx.storage.get<Record<string, ScheduledTaskConfigForTest>>(
@@ -6180,6 +6187,10 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
       return;
     }
     await this.ctx.storage.put("scheduledTasksDefaultTimezone", timezone);
+  }
+
+  async setScheduledTasksScopeForTest(scope: "root" | "all"): Promise<void> {
+    await this.ctx.storage.put("scheduledTasksScope", scope);
   }
 
   async reconcileScheduledTasksForTest(): Promise<void> {
@@ -6342,6 +6353,45 @@ export class ThinkScheduledTasksTestAgent extends ThinkProgrammaticTestAgent {
   ): Promise<void> {
     const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
     await child.setDefaultTimezoneForTest(timezone);
+  }
+
+  async setChildScheduledTasksScopeForTest(
+    name: string,
+    scope: "root" | "all"
+  ): Promise<void> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    await child.setScheduledTasksScopeForTest(scope);
+  }
+
+  /**
+   * Force the child facet to restart, so the next `subAgent()` call replays
+   * its `onStart` — including the declared-task reconcile step. Storage is
+   * left intact, unlike `deleteSubAgent`.
+   */
+  async restartChildForTest(name: string): Promise<void> {
+    this.abortSubAgent(ThinkScheduledTasksTestAgent, name, "restart-for-test");
+  }
+
+  async runChildDeclaredPayloadForTest(
+    name: string,
+    payload: DeclaredScheduledTaskPayloadForTest
+  ): Promise<void> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    await child.runDeclaredPayloadForTest(payload);
+  }
+
+  async getChildFirstDeclaredPayloadForTest(
+    name: string
+  ): Promise<DeclaredScheduledTaskPayloadForTest> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    return child.getFirstDeclaredPayloadForTest();
+  }
+
+  async listChildScheduledTaskHandlerEventsForTest(
+    name: string
+  ): Promise<ScheduledTaskHandlerEventForTest[]> {
+    const child = await this.subAgent(ThinkScheduledTasksTestAgent, name);
+    return child.listScheduledTaskHandlerEventsForTest();
   }
 
   async reconcileChildScheduledTasksForTest(name: string): Promise<void> {

--- a/packages/think/src/tests/scheduled-tasks.test.ts
+++ b/packages/think/src/tests/scheduled-tasks.test.ts
@@ -44,6 +44,7 @@ type ThinkScheduledTasksTestStub = {
     config: Record<string, ScheduledTaskConfigForTest>
   ): Promise<void>;
   setDefaultTimezoneForTest(timezone?: string): Promise<void>;
+  setScheduledTasksScopeForTest(scope: "root" | "all"): Promise<void>;
   reconcileScheduledTasksForTest(): Promise<void>;
   reconcileScheduledTasksErrorForTest(): Promise<string>;
   validateScheduleForTest(
@@ -87,6 +88,10 @@ type ThinkScheduledTasksTestStub = {
     name: string,
     timezone?: string
   ): Promise<void>;
+  setChildScheduledTasksScopeForTest(
+    name: string,
+    scope: "root" | "all"
+  ): Promise<void>;
   reconcileChildScheduledTasksForTest(name: string): Promise<void>;
   listChildDeclaredScheduledTaskRowsForTest(
     name: string
@@ -94,6 +99,16 @@ type ThinkScheduledTasksTestStub = {
   listChildSchedulesForTest(
     name: string
   ): Promise<Array<{ id: string; payload: unknown }>>;
+  getChildFirstDeclaredPayloadForTest(
+    name: string
+  ): Promise<DeclaredScheduledTaskPayloadForTest>;
+  runChildDeclaredPayloadForTest(
+    name: string,
+    payload: DeclaredScheduledTaskPayloadForTest
+  ): Promise<void>;
+  listChildScheduledTaskHandlerEventsForTest(
+    name: string
+  ): Promise<ScheduledTaskHandlerEventForTest[]>;
   getKeepAliveRefsForTest(): Promise<number>;
   runAlarmForTest(): Promise<{
     keepAliveRefs: number;
@@ -411,6 +426,7 @@ describe("Think scheduled tasks", () => {
 
   it("supports declared scheduled tasks in sub-agents", async () => {
     const parent = await freshAgent();
+    await parent.setChildScheduledTasksScopeForTest("child", "all");
     await parent.setChildDefaultTimezoneForTest("child", "UTC");
     await parent.setChildScheduledTasksForTest("child", {
       childTask: {
@@ -431,6 +447,7 @@ describe("Think scheduled tasks", () => {
 
   it("supports scheduled task handlers in sub-agents", async () => {
     const parent = await freshAgent();
+    await parent.setChildScheduledTasksScopeForTest("child", "all");
     await parent.setChildScheduledTasksForTest("child", {
       childHandler: {
         schedule: "every 1 minute",
@@ -478,6 +495,8 @@ describe("Think scheduled tasks", () => {
         prompt: "Parent task"
       }
     });
+    await parent.setChildScheduledTasksScopeForTest("alpha", "all");
+    await parent.setChildScheduledTasksScopeForTest("beta", "all");
     await parent.setChildScheduledTasksForTest("alpha", {
       shared: {
         schedule: "every 1 minute",
@@ -524,6 +543,106 @@ describe("Think scheduled tasks", () => {
     expect(
       await parent.listChildDeclaredScheduledTaskRowsForTest("beta")
     ).toHaveLength(1);
+  });
+
+  // ── #1877: a static getScheduledTasks() returns the same tasks on every
+  // instance, so without a scope the declared schedule was armed once per live
+  // facet on top of the root and each occurrence fired N+1 times.
+  it("arms a statically declared task on the root only, not on each sub-agent (#1877)", async () => {
+    const parent = await freshAgent();
+    // Same task set on the root and both children — the shape a static
+    // `getScheduledTasks()` override produces in real code.
+    const tasks = {
+      digest: {
+        schedule: "every 1 minute",
+        prompt: "Daily digest"
+      }
+    };
+    await parent.setScheduledTasksForTest(tasks);
+    await parent.setChildScheduledTasksForTest("alpha", tasks);
+    await parent.setChildScheduledTasksForTest("beta", tasks);
+
+    await parent.reconcileScheduledTasksForTest();
+    await parent.reconcileChildScheduledTasksForTest("alpha");
+    await parent.reconcileChildScheduledTasksForTest("beta");
+
+    expect(await parent.listDeclaredScheduledTaskRowsForTest()).toHaveLength(1);
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("alpha")
+    ).toHaveLength(0);
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("beta")
+    ).toHaveLength(0);
+
+    // One armed occurrence in total, not one per facet.
+    expect(
+      declaredTaskScheduleIds(await parent.listSchedulesForTest())
+    ).toHaveLength(1);
+    expect(
+      declaredTaskScheduleIds(await parent.listChildSchedulesForTest("alpha"))
+    ).toHaveLength(0);
+    expect(
+      declaredTaskScheduleIds(await parent.listChildSchedulesForTest("beta"))
+    ).toHaveLength(0);
+  });
+
+  it("prunes and cancels declared tasks a sub-agent armed before the root scope default (#1877)", async () => {
+    const parent = await freshAgent();
+    // Arm under the old behaviour, then upgrade to the root-only default.
+    await parent.setChildScheduledTasksScopeForTest("child", "all");
+    await parent.setChildScheduledTasksForTest("child", {
+      digest: {
+        schedule: "every 1 minute",
+        prompt: "Daily digest"
+      }
+    });
+    await parent.reconcileChildScheduledTasksForTest("child");
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("child")
+    ).toHaveLength(1);
+    expect(
+      declaredTaskScheduleIds(await parent.listChildSchedulesForTest("child"))
+    ).toHaveLength(1);
+
+    await parent.setChildScheduledTasksScopeForTest("child", "root");
+    await parent.reconcileChildScheduledTasksForTest("child");
+
+    // The ledger row is gone AND the underlying Agent schedule was cancelled —
+    // deleting the row alone would leave the alarm firing forever.
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("child")
+    ).toHaveLength(0);
+    expect(
+      declaredTaskScheduleIds(await parent.listChildSchedulesForTest("child"))
+    ).toHaveLength(0);
+  });
+
+  it("ignores a declared task dispatch that reaches a root-scoped sub-agent (#1877)", async () => {
+    const parent = await freshAgent();
+    await parent.setChildScheduledTasksScopeForTest("child", "all");
+    await parent.setChildScheduledTasksForTest("child", {
+      recorded: {
+        schedule: "every 1 minute",
+        handler: "record"
+      }
+    });
+    await parent.reconcileChildScheduledTasksForTest("child");
+    const payload = await parent.getChildFirstDeclaredPayloadForTest("child");
+
+    // Flip to root scope without reconciling, so the ledger row survives and
+    // only the runner guard can stop the dispatch. This is the race where a
+    // root alarm fires into a facet that no longer arms.
+    await parent.setChildScheduledTasksScopeForTest("child", "root");
+    await parent.runChildDeclaredPayloadForTest("child", payload);
+
+    // The handler never ran, and the finally-block re-arm never happened.
+    expect(
+      await parent.listChildScheduledTaskHandlerEventsForTest("child")
+    ).toHaveLength(0);
+    const rows =
+      await parent.listChildDeclaredScheduledTaskRowsForTest("child");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].next_run_at).toBe(payload.scheduledFor);
   });
 
   it("does not arm a keepAlive heartbeat on alarm() when no workflow notifications are pending (#1703)", async () => {

--- a/packages/think/src/tests/think-eviction.test.ts
+++ b/packages/think/src/tests/think-eviction.test.ts
@@ -110,6 +110,47 @@ describe("Think recovery after forced Durable Object eviction", () => {
     ]);
   });
 
+  // #1877: sub-agents that armed declared tasks under the pre-root-scope
+  // default must disarm themselves on their next start, without anyone calling
+  // `internal_reconcileScheduledTasks()`. That is the migration story for
+  // already-deployed agents, and it runs through the reconcile step of
+  // `onStart` — so it has to be exercised across a real restart rather than by
+  // driving the reconcile directly.
+  //
+  // Note the facet is restarted explicitly: evicting the parent does NOT evict
+  // its facets, and `subAgent()` only replays `onStart` on a facet that is not
+  // already running. Cleanup therefore lands whenever the facet itself next
+  // starts (deploy, eviction, abort) — duplicate *executions*, however, stop
+  // at the next occurrence regardless, via the guard in
+  // `_runDeclaredScheduledTask` (covered in scheduled-tasks.test.ts).
+  it("disarms declared tasks a sub-agent armed before root scoping, on its next start", async () => {
+    const name = `evict-think-facet-schedule-${crypto.randomUUID()}`;
+    let parent = await scheduledAgent(name);
+    await parent.setChildScheduledTasksScopeForTest("child", "all");
+    await parent.setChildScheduledTasksForTest("child", {
+      digest: { schedule: "every 1 minute", prompt: "Daily digest" }
+    });
+    await parent.reconcileChildScheduledTasksForTest("child");
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("child")
+    ).toHaveLength(1);
+    expect(await parent.listChildSchedulesForTest("child")).toHaveLength(1);
+
+    // Simulate the upgrade: the class now reports the root-only default, but
+    // nothing has reconciled yet, so the facet's rows are still armed.
+    await parent.setChildScheduledTasksScopeForTest("child", "root");
+
+    parent = await evictAndReacquire(parent, () => scheduledAgent(name));
+    await parent.restartChildForTest("child");
+
+    // Re-resolving the facet fires its `onStart`, whose reconcile step prunes
+    // the rows and cancels the underlying Agent schedules.
+    expect(
+      await parent.listChildDeclaredScheduledTaskRowsForTest("child")
+    ).toHaveLength(0);
+    expect(await parent.listChildSchedulesForTest("child")).toHaveLength(0);
+  });
+
   it("re-runs degraded startup and remains usable on the fresh instance", async () => {
     const name = `evict-think-degraded-${crypto.randomUUID()}`;
     let agent = await hydrationAgent(name);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -3725,6 +3725,7 @@ export class Think<
   private _submissionTableEnsured = false;
   private _workflowNotificationTableEnsured = false;
   private _declaredScheduledTasksTableEnsured = false;
+  private _warnedFacetScheduledTasksDisarmed = false;
   private _actionLedgerTableEnsured = false;
   private _actionPendingTableEnsured = false;
   private _drainingSubmissions = false;
@@ -4408,6 +4409,29 @@ export class Think<
   /** Return code-declared scheduled tasks for this agent. */
   getScheduledTasks(): ThinkScheduledTasks | Promise<ThinkScheduledTasks> {
     return {};
+  }
+
+  /**
+   * Return which instances of this class arm the declared scheduled tasks.
+   *
+   * `"root"` (the default) arms them only on the top-level agent. Because
+   * `getScheduledTasks()` is usually a static code declaration, it returns the
+   * same tasks on every instance — so without this scope an agent that also
+   * has sub-agents would arm one private copy per live facet and dispatch each
+   * occurrence once per facet on top of the root (#1877).
+   *
+   * Return `"all"` to arm on facets as well. That is only correct when
+   * `getScheduledTasks()` genuinely varies per facet (for example when it
+   * reads per-facet state), since each facet then owns an independent
+   * schedule.
+   *
+   * The value must be stable across wakes. Reporting `"root"` on a facet that
+   * previously armed cancels its occurrences, so a scope that flickers with
+   * request-scoped or not-yet-loaded state will repeatedly tear down and
+   * re-create that facet's schedule.
+   */
+  getScheduledTasksScope(): "root" | "all" | Promise<"root" | "all"> {
+    return "root";
   }
 
   /**
@@ -9192,6 +9216,20 @@ export class Think<
     return stableHash(this.selfPath);
   }
 
+  /**
+   * Whether this instance arms the declared scheduled tasks.
+   *
+   * The root always arms. Facets only arm when the class opts in via
+   * `getScheduledTasksScope()`; see that hook for why root-only is the
+   * default (#1877). `parentPath` is hydrated before the reconcile step of
+   * `onStart` — persisted by `_cf_initAsFacet` on a facet's first boot, and
+   * restored from storage by the base agent on every later wake.
+   */
+  private async _declaredScheduledTasksArmedHere(): Promise<boolean> {
+    if (this.parentPath.length === 0) return true;
+    return (await this.getScheduledTasksScope()) === "all";
+  }
+
   private _declaredScheduleValidationError(
     rawSchedule: string,
     taskTimezone?: string,
@@ -9234,11 +9272,19 @@ export class Think<
   }
 
   private async _reconcileDeclaredScheduledTasks(): Promise<void> {
-    const tasks = await this._declaredScheduledTasksForNow();
+    // A facet that does not arm reconciles against an empty task set rather
+    // than skipping outright: the prune pass below then cancels and deletes
+    // any rows an earlier version armed here, so pre-existing duplicates heal
+    // on the next wake instead of firing forever (#1877).
+    const armed = await this._declaredScheduledTasksArmedHere();
+    const tasks = armed
+      ? await this._declaredScheduledTasksForNow()
+      : new Map<string, NormalizedDeclaredTask>();
     this._ensureDeclaredScheduledTasksTable();
     const ownerKey = this._declaredScheduleOwnerKey();
     const now = Date.now();
     const existing = this._listDeclaredScheduledTaskRows();
+    if (!armed) await this._warnFacetScheduledTasksDisarmed(existing.length);
     const seen = new Set<string>();
 
     for (const [taskId, task] of tasks) {
@@ -9351,6 +9397,46 @@ export class Think<
     }
   }
 
+  /**
+   * Warn once when a sub-agent declares tasks it will not arm.
+   *
+   * Two populations need this, and only one of them leaves a trace. A facet
+   * upgrading from the pre-#1877 default has rows to prune, so `armedCount`
+   * is non-zero. A facet declaring tasks for the first time under the root
+   * default never armed anything, so the only way to tell it apart from a
+   * class that declares nothing is to ask — otherwise its schedule is
+   * silently inert, which is the failure mode #1877 was filed about.
+   */
+  private async _warnFacetScheduledTasksDisarmed(
+    armedCount: number
+  ): Promise<void> {
+    if (this._warnedFacetScheduledTasksDisarmed) return;
+    let declaredCount = armedCount;
+    if (declaredCount === 0) {
+      try {
+        declaredCount = Object.keys(await this.getScheduledTasks()).length;
+      } catch {
+        // Only the warning depends on this; a declaration that throws still
+        // surfaces from whichever instance actually arms it.
+        return;
+      }
+    }
+    if (declaredCount === 0) return;
+    this._warnedFacetScheduledTasksDisarmed = true;
+    console.warn(
+      `[Think] Sub-agent "${this.name}" declares ${declaredCount} scheduled ` +
+        `task(s) that are not armed here. Declared tasks run on the root ` +
+        `agent only, so each occurrence fires once rather than once per live ` +
+        `sub-agent (#1877)` +
+        (armedCount > 0
+          ? `; the occurrences this sub-agent had already armed have been ` +
+            `cancelled`
+          : ``) +
+        `. Override getScheduledTasksScope() to return "all" if this class ` +
+        `intentionally declares per-sub-agent tasks.`
+    );
+  }
+
   private async _scheduleDeclaredTaskOccurrence(
     task: NormalizedDeclaredTask,
     now: Date,
@@ -9426,6 +9512,12 @@ export class Think<
     ) {
       throw new Error("Invalid declared scheduled task payload");
     }
+
+    // A dispatch can reach a facet that no longer arms — either racing the
+    // reconcile that prunes its rows, or arriving before this wake got that
+    // far. Returning here keeps the `finally` below from re-arming the very
+    // occurrence the prune is trying to retire (#1877).
+    if (!(await this._declaredScheduledTasksArmedHere())) return;
 
     const row = this._readDeclaredScheduledTaskRow(payload.taskId);
     if (!row || row.schedule_hash !== payload.scheduleHash) return;


### PR DESCRIPTION
Fixes #1877

## The problem

A Think agent's declared scheduled tasks were armed on every instance of the class, including sub-agents — not just the root. `getScheduledTasks()` is normally a static declaration, so it returns the same tasks on every instance. An agent with five live sub-agents armed six copies of one schedule and ran each occurrence six times.

Nothing surfaced it. The existing duplicate-schedule warnings don't apply here: declared tasks are always armed idempotently, and the copies sit under separate owners.

```sql
SELECT owner_path, COUNT(*) FROM cf_agents_schedules
WHERE callback = '_runDeclaredScheduledTask' GROUP BY owner_path;
```

Before: one group per sub-agent, on top of the root. After: only the root.

## Breaking change — affected users must act

Any class that declares scheduled tasks and is also used as a sub-agent will stop running those tasks on its sub-agents.

That is the point of the fix. But for anyone deliberately running per-sub-agent schedules it is a loss of function until they opt back in with one line. Everyone in that position gets a warning in their logs naming the new hook, so it should not be discovered in silence.

## What changed

Declared tasks now arm on the root agent only. The new `getScheduledTasksScope()` hook returns `"root"` by default, and `"all"` restores the previous behavior.

```ts
export class PerUserAgent extends Think<Env> {
  getScheduledTasksScope() {
    return "all" as const;
  }

  async getScheduledTasks() {
    const reminder = await this.getReminderForThisUser();
    return reminder ? { reminder } : {};
  }
}
```

An agent-wide switch rather than a per-task one. Mixing root-owned and per-sub-agent tasks in a single class hasn't come up, and the smaller surface keeps the default obvious. A per-task setting can layer on later using the same precedence rule the timezone hooks already follow.

## What happens to existing deployments

Nothing to do manually. Two pieces of state are involved and they clear at different times.

The booking that actually fires lives in the root's `cf_agents_schedules`, where sub-agents park theirs too. Each sub-agent separately keeps a private note of what it armed.

**The bookings clear on the next occurrence.** Say a root declares a 9am task and has three sub-agents, so today it runs four times. Deploy the fix and at 9am tomorrow the root's alarm still finds four bookings due. The root's own runs the task once and books the next day. The three sub-agent bookings are routed to their sub-agents, which return straight away without doing the work and without booking a replacement. These are one-shot bookings, so the alarm loop then deletes them. Four runs become one after a single cycle, with no restart needed.

**The private notes clear on the sub-agent's next startup.** They are harmless until then, since nothing reads them. Worth knowing that this means the *sub-agent* starting, not the root — evicting a parent does not evict its sub-agents.

## Tests

Four new tests, each confirmed to fail with the guard removed:

- a static declaration on a root with two sub-agents arms exactly one schedule
- a sub-agent that armed under the old default has both its private note and its underlying booking cleared
- a run dispatched into a root-scoped sub-agent neither executes nor re-books
- clearing happens through normal startup, not only when reconciliation is called directly

That last one caught a wrong assumption. I first wrote it evicting the parent and expecting the child to heal; it failed, because the child was still alive and already initialized, so its startup never replayed. It takes the sub-agent itself restarting.

Three existing tests that assert sub-agent scheduling works now opt into `"all"`, exercising the same unchanged machinery.

## Verification

- `@cloudflare/think` — 46 files / 924 tests, plus the smaller suites (55, 10, 10, 5)
- `nx affected -t test --base=upstream/main` — 6 projects, all green
- `pnpm run build` and `pnpm run check` — sherif, export check, oxfmt, oxlint, typecheck across 120 projects
- `examples/assistant` — 21 tests, including the daily-summary reconcile, which confirms the guard does not misfire on a root

## Docs

The scheduled responses section of the sub-agents guide showed a static declaration on an agent with sub-agents — exactly the shape that multiplies. It now leads with the root-only rule and shows the root fanning out to its children, with the opt-in as a separate example.

## Open questions

The hook name and its two values are the part most likely to want changing, and it is cheap to change now and awkward later.

This is marked as a minor release. Given that working schedules stop for some users, a louder release note may be warranted.
