### PR TITLE
fix(think): preserve regeneration branches after restart

### DIFF
--- a/.changeset/fix-think-regeneration-restart-recovery.md
+++ b/.changeset/fix-think-regeneration-restart-recovery.md
@@ -1,0 +1,6 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+---
+
+Preserve Think branch parentage when resumable streams survive hibernation or restart, and replay completed continuations without duplicating hydrated assistant content.

--- a/agent-think/src/workspace-agent.ts
+++ b/agent-think/src/workspace-agent.ts
@@ -16,6 +16,19 @@ export { WorkspaceProxy, WorkspaceServiceProxy };
 const RESET_ABORT_DELAY_MS = 100;
 const SYNC_RETRY_KEY_PREFIX = "workspace:sync-retry:";
 
+type WorkspaceWorkerBackendConstructor = new (options: {
+  id: string;
+  loader: unknown;
+  workspace: { binding: string; id: string };
+  ctx: DurableObjectState;
+}) => WorkspaceBackend;
+
+// SAFETY: this narrows only the constructor surface used at the composition
+// root. WorkerBackend's full loader declaration exceeds TypeScript's generic
+// instantiation depth once the Agents chat API is extended.
+const WorkspaceWorkerBackend =
+  WorkerBackend as unknown as WorkspaceWorkerBackendConstructor;
+
 type WorkspaceSyncRetryIntent = {
   backend: string;
   attempt: number;
@@ -74,7 +87,7 @@ export class WorkspaceAgent extends DurableObject<Env> {
     const backends: WorkspaceBackend[] = [];
     if (env.LOADER) {
       backends.push(
-        new WorkerBackend({
+        new WorkspaceWorkerBackend({
           id: "shell",
           loader: env.LOADER,
           workspace: workspaceRef,

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -90,7 +90,9 @@ function unpackSegmentBody(rowBody: string): string[] {
 function isMissingMetadataColumnError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
-    (message.includes("message_id") || message.includes("is_continuation")) &&
+    (message.includes("message_id") ||
+      message.includes("is_continuation") ||
+      message.includes("parent_message_id")) &&
     (message.toLowerCase().includes("no such column") ||
       message.toLowerCase().includes("has no column named"))
   );
@@ -124,6 +126,11 @@ type StreamMetadata = {
    * legacy rows written before this column existed.
    */
   message_id: string | null;
+  /**
+   * Parent message for a newly reconstructed assistant message. Null for flat
+   * histories, linear appends, and rows written before branch-aware recovery.
+   */
+  parent_message_id: string | null;
   /**
    * Whether this stream is a continuation (appends to the last assistant
    * message rather than starting a new one). Live broadcast frames carry
@@ -190,6 +197,7 @@ export class ResumableStream {
       created_at integer not null,
       completed_at integer,
       message_id text,
+      parent_message_id text,
       is_continuation integer
     )`;
 
@@ -216,6 +224,13 @@ export class ResumableStream {
     if (!hasMessageId) {
       this
         .sql`alter table cf_ai_chat_stream_metadata add column message_id text`;
+    }
+    const hasParentMessageId = columns.some(
+      (column) => column.name === "parent_message_id"
+    );
+    if (!hasParentMessageId) {
+      this
+        .sql`alter table cf_ai_chat_stream_metadata add column parent_message_id text`;
     }
     const hasIsContinuation = columns.some(
       (column) => column.name === "is_continuation"
@@ -258,7 +273,11 @@ export class ResumableStream {
    */
   start(
     requestId: string,
-    options: { messageId?: string; continuation?: boolean } = {}
+    options: {
+      messageId?: string;
+      parentMessageId?: string;
+      continuation?: boolean;
+    } = {}
   ): string {
     // Flush any pending chunks from previous streams to prevent mixing
     this.flushBuffer();
@@ -271,19 +290,30 @@ export class ResumableStream {
     this._activeIsContinuation = options.continuation ?? false;
 
     const messageId = options.messageId ?? null;
+    const parentMessageId = options.parentMessageId ?? null;
+
+    const insertMetadata = () => {
+      if (parentMessageId === null) {
+        // Flat histories and linear Think turns do not need the new column, so
+        // existing databases migrate only when a branch-scoped stream needs it.
+        this.sql`
+          insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
+          values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
+        `;
+        return;
+      }
+      this.sql`
+        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, parent_message_id, is_continuation)
+        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${parentMessageId}, ${this._activeIsContinuation ? 1 : 0})
+      `;
+    };
 
     try {
-      this.sql`
-        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
-        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
-      `;
+      insertMetadata();
     } catch (error) {
       if (!isMissingMetadataColumnError(error)) throw error;
       this._migrateMetadataColumns();
-      this.sql`
-        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
-        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
-      `;
+      insertMetadata();
     }
 
     return streamId;
@@ -308,6 +338,25 @@ export class ResumableStream {
     }
     if (!rows || rows.length === 0) return null;
     return rows[0].message_id ?? null;
+  }
+
+  /**
+   * Parent message captured when the stream started. Orphan persistence uses
+   * this after restart to attach a reconstructed branch response correctly.
+   */
+  getStreamParentMessageId(streamId: string): string | null {
+    let rows: Array<{ parent_message_id: string | null }>;
+    try {
+      rows = this.sql<{ parent_message_id: string | null }>`
+        select parent_message_id from cf_ai_chat_stream_metadata
+        where id = ${streamId}
+      `;
+    } catch (error) {
+      if (!isMissingMetadataColumnError(error)) throw error;
+      return null;
+    }
+    if (!rows || rows.length === 0) return null;
+    return rows[0].parent_message_id ?? null;
   }
 
   /**
@@ -569,10 +618,10 @@ export class ResumableStream {
     const stream = this._latestStreamForRequest(requestId, "completed");
     if (!stream) return false;
 
-    const continuation = stream.is_continuation === 1;
-    if (
-      !this._replayStoredChunks(connection, stream.id, requestId, continuation)
-    ) {
+    // A terminal stream has already been persisted as its own assistant row.
+    // Replay it as that standalone message so a hydrated client resets the row
+    // by id instead of appending the continuation content a second time.
+    if (!this._replayStoredChunks(connection, stream.id, requestId, false)) {
       return false;
     }
 
@@ -583,8 +632,7 @@ export class ResumableStream {
         done: true,
         id: requestId,
         type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
-        replay: true,
-        ...(continuation && { continuation: true })
+        replay: true
       })
     );
   }
@@ -612,12 +660,8 @@ export class ResumableStream {
     const stream = this._latestStreamForRequest(requestId, "error");
     if (!stream) return true;
 
-    return this._replayStoredChunks(
-      connection,
-      stream.id,
-      requestId,
-      stream.is_continuation === 1
-    );
+    // Errored terminal streams also persist their partial as a standalone row.
+    return this._replayStoredChunks(connection, stream.id, requestId, false);
   }
 
   /** Latest stream row for a request with the given terminal status. */

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -90,7 +90,9 @@ function unpackSegmentBody(rowBody: string): string[] {
 function isMissingMetadataColumnError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
-    (message.includes("message_id") || message.includes("is_continuation")) &&
+    (message.includes("message_id") ||
+      message.includes("is_continuation") ||
+      message.includes("parent_message_id")) &&
     (message.toLowerCase().includes("no such column") ||
       message.toLowerCase().includes("has no column named"))
   );
@@ -124,6 +126,11 @@ type StreamMetadata = {
    * legacy rows written before this column existed.
    */
   message_id: string | null;
+  /**
+   * Parent message for a newly reconstructed assistant message. Null for flat
+   * histories, linear appends, and rows written before branch-aware recovery.
+   */
+  parent_message_id: string | null;
   /**
    * Whether this stream is a continuation (appends to the last assistant
    * message rather than starting a new one). Live broadcast frames carry
@@ -190,6 +197,7 @@ export class ResumableStream {
       created_at integer not null,
       completed_at integer,
       message_id text,
+      parent_message_id text,
       is_continuation integer
     )`;
 
@@ -216,6 +224,13 @@ export class ResumableStream {
     if (!hasMessageId) {
       this
         .sql`alter table cf_ai_chat_stream_metadata add column message_id text`;
+    }
+    const hasParentMessageId = columns.some(
+      (column) => column.name === "parent_message_id"
+    );
+    if (!hasParentMessageId) {
+      this
+        .sql`alter table cf_ai_chat_stream_metadata add column parent_message_id text`;
     }
     const hasIsContinuation = columns.some(
       (column) => column.name === "is_continuation"
@@ -258,7 +273,11 @@ export class ResumableStream {
    */
   start(
     requestId: string,
-    options: { messageId?: string; continuation?: boolean } = {}
+    options: {
+      messageId?: string;
+      parentMessageId?: string;
+      continuation?: boolean;
+    } = {}
   ): string {
     // Flush any pending chunks from previous streams to prevent mixing
     this.flushBuffer();
@@ -271,19 +290,30 @@ export class ResumableStream {
     this._activeIsContinuation = options.continuation ?? false;
 
     const messageId = options.messageId ?? null;
+    const parentMessageId = options.parentMessageId ?? null;
+
+    const insertMetadata = () => {
+      if (parentMessageId === null) {
+        // Flat histories and linear Think turns do not need the new column, so
+        // existing databases migrate only when a branch-scoped stream needs it.
+        this.sql`
+          insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
+          values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
+        `;
+        return;
+      }
+      this.sql`
+        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, parent_message_id, is_continuation)
+        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${parentMessageId}, ${this._activeIsContinuation ? 1 : 0})
+      `;
+    };
 
     try {
-      this.sql`
-        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
-        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
-      `;
+      insertMetadata();
     } catch (error) {
       if (!isMissingMetadataColumnError(error)) throw error;
       this._migrateMetadataColumns();
-      this.sql`
-        insert into cf_ai_chat_stream_metadata (id, request_id, status, created_at, message_id, is_continuation)
-        values (${streamId}, ${requestId}, 'streaming', ${Date.now()}, ${messageId}, ${this._activeIsContinuation ? 1 : 0})
-      `;
+      insertMetadata();
     }
 
     return streamId;
@@ -308,6 +338,25 @@ export class ResumableStream {
     }
     if (!rows || rows.length === 0) return null;
     return rows[0].message_id ?? null;
+  }
+
+  /**
+   * Parent message captured when the stream started. Orphan persistence uses
+   * this after restart to attach a reconstructed branch response correctly.
+   */
+  getStreamParentMessageId(streamId: string): string | null {
+    let rows: Array<{ parent_message_id: string | null }>;
+    try {
+      rows = this.sql<{ parent_message_id: string | null }>`
+        select parent_message_id from cf_ai_chat_stream_metadata
+        where id = ${streamId}
+      `;
+    } catch (error) {
+      if (!isMissingMetadataColumnError(error)) throw error;
+      return null;
+    }
+    if (!rows || rows.length === 0) return null;
+    return rows[0].parent_message_id ?? null;
   }
 
   /**

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -196,9 +196,10 @@ export class TestSessionAgent extends Agent {
   // ── ResumableStream legacy migration helpers ────────────────────
 
   /**
-   * Recreate `cf_ai_chat_stream_metadata` with the pre-#1691/#1733 schema
-   * (no `message_id` / `is_continuation`) and seed one in-flight row, so a
-   * fresh `ResumableStream` exercises the legacy lazy-migration path on a
+   * Recreate `cf_ai_chat_stream_metadata` with the pre-branch-parent schema
+   * (no `message_id` / `parent_message_id` / `is_continuation`) and seed one
+   * in-flight row, so a fresh `ResumableStream` exercises the legacy
+   * lazy-migration path on a
    * real workerd SQLite (validates the runtime's actual error strings).
    */
   async setupLegacyStreamTableForTest(): Promise<void> {
@@ -216,10 +217,53 @@ export class TestSessionAgent extends Agent {
       values ('legacy-stream', 'legacy-req', 'streaming', ${Date.now()})`;
   }
 
+  /**
+   * Recreate the metadata table as deployed immediately before branch-parent
+   * persistence: existing stream fields are present, but `parent_message_id`
+   * is not. A normal linear stream should continue using this schema unchanged.
+   */
+  async setupPreBranchParentStreamTableForTest(): Promise<void> {
+    this.sql`drop table if exists cf_ai_chat_stream_metadata`;
+    this.sql`drop table if exists cf_ai_chat_stream_chunks`;
+    this.sql`create table cf_ai_chat_stream_metadata (
+      id text primary key,
+      request_id text not null,
+      status text not null,
+      created_at integer not null,
+      completed_at integer,
+      message_id text,
+      is_continuation integer
+    )`;
+  }
+
   private streamMetadataColumnsForTest(): string[] {
     return this.sql<{ name: string }>`
       select name from pragma_table_info('cf_ai_chat_stream_metadata')
     `.map((c) => c.name);
+  }
+
+  /** A linear start must not migrate a branch-only metadata column. */
+  async resumableLinearStartWithoutParentForTest(): Promise<{
+    startThrew: boolean;
+    columnsAfter: string[];
+  }> {
+    const stream = new ResumableStream(
+      <T = Record<string, unknown>>(
+        strings: TemplateStringsArray,
+        ...values: (string | number | boolean | null)[]
+      ): T[] => this.sql<T>(strings, ...values)
+    );
+
+    let startThrew = false;
+    try {
+      stream.start("linear-request", { messageId: "linear-message" });
+    } catch {
+      startThrew = true;
+    }
+    return {
+      startThrew,
+      columnsAfter: this.streamMetadataColumnsForTest()
+    };
   }
 
   /**
@@ -231,9 +275,11 @@ export class TestSessionAgent extends Agent {
   async resumableLegacyMigrationForTest(): Promise<{
     columnsBefore: string[];
     legacyMessageId: string | null;
+    legacyParentMessageId: string | null;
     startThrew: boolean;
     columnsAfter: string[];
     newStreamMessageId: string | null;
+    newStreamParentMessageId: string | null;
   }> {
     const stream = new ResumableStream(
       <T = Record<string, unknown>>(
@@ -245,6 +291,8 @@ export class TestSessionAgent extends Agent {
     const columnsBefore = this.streamMetadataColumnsForTest();
     // SELECT of the new column on a legacy row: guarded → null, no throw.
     const legacyMessageId = stream.getStreamMessageId("legacy-stream");
+    const legacyParentMessageId =
+      stream.getStreamParentMessageId("legacy-stream");
 
     // INSERT naming the new columns on a legacy table: must migrate + retry.
     let startThrew = false;
@@ -252,6 +300,7 @@ export class TestSessionAgent extends Agent {
     try {
       newStreamId = stream.start("req-x", {
         messageId: "msg-1",
+        parentMessageId: "parent-1",
         continuation: true
       });
     } catch {
@@ -262,13 +311,18 @@ export class TestSessionAgent extends Agent {
     const newStreamMessageId = newStreamId
       ? stream.getStreamMessageId(newStreamId)
       : null;
+    const newStreamParentMessageId = newStreamId
+      ? stream.getStreamParentMessageId(newStreamId)
+      : null;
 
     return {
       columnsBefore,
       legacyMessageId,
+      legacyParentMessageId,
       startThrew,
       columnsAfter,
-      newStreamMessageId
+      newStreamMessageId,
+      newStreamParentMessageId
     };
   }
 }

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -225,9 +225,10 @@ export class TestSessionAgent extends Agent {
   // ── ResumableStream legacy migration helpers ────────────────────
 
   /**
-   * Recreate `cf_ai_chat_stream_metadata` with the pre-#1691/#1733 schema
-   * (no `message_id` / `is_continuation`) and seed one in-flight row, so a
-   * fresh `ResumableStream` exercises the legacy lazy-migration path on a
+   * Recreate `cf_ai_chat_stream_metadata` with the pre-branch-parent schema
+   * (no `message_id` / `parent_message_id` / `is_continuation`) and seed one
+   * in-flight row, so a fresh `ResumableStream` exercises the legacy
+   * lazy-migration path on a
    * real workerd SQLite (validates the runtime's actual error strings).
    */
   async setupLegacyStreamTableForTest(): Promise<void> {
@@ -245,10 +246,53 @@ export class TestSessionAgent extends Agent {
       values ('legacy-stream', 'legacy-req', 'streaming', ${Date.now()})`;
   }
 
+  /**
+   * Recreate the metadata table as deployed immediately before branch-parent
+   * persistence: existing stream fields are present, but `parent_message_id`
+   * is not. A normal linear stream should continue using this schema unchanged.
+   */
+  async setupPreBranchParentStreamTableForTest(): Promise<void> {
+    this.sql`drop table if exists cf_ai_chat_stream_metadata`;
+    this.sql`drop table if exists cf_ai_chat_stream_chunks`;
+    this.sql`create table cf_ai_chat_stream_metadata (
+      id text primary key,
+      request_id text not null,
+      status text not null,
+      created_at integer not null,
+      completed_at integer,
+      message_id text,
+      is_continuation integer
+    )`;
+  }
+
   private streamMetadataColumnsForTest(): string[] {
     return this.sql<{ name: string }>`
       select name from pragma_table_info('cf_ai_chat_stream_metadata')
     `.map((c) => c.name);
+  }
+
+  /** A linear start must not migrate a branch-only metadata column. */
+  async resumableLinearStartWithoutParentForTest(): Promise<{
+    startThrew: boolean;
+    columnsAfter: string[];
+  }> {
+    const stream = new ResumableStream(
+      <T = Record<string, unknown>>(
+        strings: TemplateStringsArray,
+        ...values: (string | number | boolean | null)[]
+      ): T[] => this.sql<T>(strings, ...values)
+    );
+
+    let startThrew = false;
+    try {
+      stream.start("linear-request", { messageId: "linear-message" });
+    } catch {
+      startThrew = true;
+    }
+    return {
+      startThrew,
+      columnsAfter: this.streamMetadataColumnsForTest()
+    };
   }
 
   /**
@@ -260,9 +304,11 @@ export class TestSessionAgent extends Agent {
   async resumableLegacyMigrationForTest(): Promise<{
     columnsBefore: string[];
     legacyMessageId: string | null;
+    legacyParentMessageId: string | null;
     startThrew: boolean;
     columnsAfter: string[];
     newStreamMessageId: string | null;
+    newStreamParentMessageId: string | null;
   }> {
     const stream = new ResumableStream(
       <T = Record<string, unknown>>(
@@ -274,6 +320,8 @@ export class TestSessionAgent extends Agent {
     const columnsBefore = this.streamMetadataColumnsForTest();
     // SELECT of the new column on a legacy row: guarded → null, no throw.
     const legacyMessageId = stream.getStreamMessageId("legacy-stream");
+    const legacyParentMessageId =
+      stream.getStreamParentMessageId("legacy-stream");
 
     // INSERT naming the new columns on a legacy table: must migrate + retry.
     let startThrew = false;
@@ -281,6 +329,7 @@ export class TestSessionAgent extends Agent {
     try {
       newStreamId = stream.start("req-x", {
         messageId: "msg-1",
+        parentMessageId: "parent-1",
         continuation: true
       });
     } catch {
@@ -291,13 +340,18 @@ export class TestSessionAgent extends Agent {
     const newStreamMessageId = newStreamId
       ? stream.getStreamMessageId(newStreamId)
       : null;
+    const newStreamParentMessageId = newStreamId
+      ? stream.getStreamParentMessageId(newStreamId)
+      : null;
 
     return {
       columnsBefore,
       legacyMessageId,
+      legacyParentMessageId,
       startThrew,
       columnsAfter,
-      newStreamMessageId
+      newStreamMessageId,
+      newStreamParentMessageId
     };
   }
 }

--- a/packages/agents/src/tests/resumable-stream-migration.test.ts
+++ b/packages/agents/src/tests/resumable-stream-migration.test.ts
@@ -5,7 +5,8 @@ import { getAgentByName } from "..";
 /**
  * ResumableStream lazy metadata-column migration (#1691, #1733).
  *
- * New tables are created with `message_id` / `is_continuation` up front, so
+ * New tables are created with `message_id` / `parent_message_id` /
+ * `is_continuation` up front, so
  * most wakes never migrate. Tables created by an older release lack those
  * columns and must migrate lazily — on the first stream write that needs
  * them — instead of paying a schema-introspection read on every construction.
@@ -17,12 +18,19 @@ import { getAgentByName } from "..";
 
 interface LegacyMigrationStub {
   setupLegacyStreamTableForTest(): Promise<void>;
+  setupPreBranchParentStreamTableForTest(): Promise<void>;
+  resumableLinearStartWithoutParentForTest(): Promise<{
+    startThrew: boolean;
+    columnsAfter: string[];
+  }>;
   resumableLegacyMigrationForTest(): Promise<{
     columnsBefore: string[];
     legacyMessageId: string | null;
+    legacyParentMessageId: string | null;
     startThrew: boolean;
     columnsAfter: string[];
     newStreamMessageId: string | null;
+    newStreamParentMessageId: string | null;
   }>;
 }
 
@@ -39,7 +47,17 @@ describe("ResumableStream — legacy metadata-column migration", () => {
     name = `rs-migrate-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   });
 
-  it("migrates a legacy table on first stream write instead of throwing", async () => {
+  it("does not migrate the branch parent column for a linear stream", async () => {
+    const agent = await getAgent(name);
+    await agent.setupPreBranchParentStreamTableForTest();
+
+    const result = await agent.resumableLinearStartWithoutParentForTest();
+
+    expect(result.startThrew).toBe(false);
+    expect(result.columnsAfter).not.toContain("parent_message_id");
+  });
+
+  it("migrates a legacy table on first branch stream write instead of throwing", async () => {
     const agent = await getAgent(name);
     await agent.setupLegacyStreamTableForTest();
 
@@ -47,17 +65,21 @@ describe("ResumableStream — legacy metadata-column migration", () => {
 
     // Precondition: the seeded table really is the old schema.
     expect(result.columnsBefore).not.toContain("message_id");
+    expect(result.columnsBefore).not.toContain("parent_message_id");
     expect(result.columnsBefore).not.toContain("is_continuation");
 
-    // Reading the new column off a legacy row is guarded → null, no throw.
+    // Reading the new columns off a legacy row is guarded → null, no throw.
     expect(result.legacyMessageId).toBeNull();
+    expect(result.legacyParentMessageId).toBeNull();
 
     // start() hit the missing columns, migrated, and retried successfully.
     expect(result.startThrew).toBe(false);
     expect(result.columnsAfter).toContain("message_id");
+    expect(result.columnsAfter).toContain("parent_message_id");
     expect(result.columnsAfter).toContain("is_continuation");
 
-    // The migrated row round-trips the value start() wrote.
+    // The migrated row round-trips the values start() wrote.
     expect(result.newStreamMessageId).toBe("msg-1");
+    expect(result.newStreamParentMessageId).toBe("parent-1");
   });
 });

--- a/packages/think/src/react-tests/stream-resume.test.tsx
+++ b/packages/think/src/react-tests/stream-resume.test.tsx
@@ -69,7 +69,9 @@ function countType(sentMessages: string[], type: string): number {
 }
 
 const RESUMING = "cf_agent_stream_resuming";
+const RESUME_REQUEST = "cf_agent_stream_resume_request";
 const RESUME_ACK = "cf_agent_stream_resume_ack";
+const RESUME_NONE = "cf_agent_stream_resume_none";
 const CHAT_RESPONSE = "cf_agent_use_chat_response";
 const CHAT_MESSAGES = "cf_agent_chat_messages";
 
@@ -170,6 +172,224 @@ describe("Think reconnect/resume handshake (client path)", () => {
       );
     });
     expect(screen.getByTestId("assistant-count").textContent).toBe("1");
+    expect(countType(sentMessages, RESUME_ACK)).toBe(1);
+  });
+
+  it("replays a continuation into the existing assistant message", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "continuation-replay",
+      url: "ws://localhost:3000/agents/chat/continuation-replay?_pk=abc"
+    });
+    const initialMessages: UIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Continue" }]
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Before continuation" }]
+      }
+    ];
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: initialMessages
+      });
+      const assistants = chat.messages.filter(
+        (message) => message.role === "assistant"
+      );
+      const assistantText = assistants
+        .flatMap((message) => message.parts)
+        .map((part) => (part.type === "text" ? part.text : ""))
+        .join("");
+      return (
+        <div>
+          <div data-testid="continuation-text">{assistantText}</div>
+          <div data-testid="continuation-count">{assistants.length}</div>
+        </div>
+      );
+    };
+
+    await act(async () => {
+      render(
+        <Suspense fallback="Loading...">
+          <TestComponent />
+        </Suspense>
+      );
+      await sleep(10);
+    });
+
+    // Settle the mount-time transport handshake first so the subsequent
+    // STREAM_RESUMING offer exercises the observer/fallback replay path.
+    await waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBeGreaterThan(0);
+    });
+    // SAFETY: createFakeAgent records only JSON protocol messages emitted by
+    // useAgentChat, and this test reads only the optional handshake fields.
+    const resumeRequest = sentMessages
+      .map(
+        (message) => JSON.parse(message) as { type?: string; probeId?: string }
+      )
+      .find((message) => message.type === RESUME_REQUEST);
+    expect(resumeRequest?.probeId).toBeDefined();
+
+    await act(async () => {
+      dispatch(target, {
+        type: RESUME_NONE,
+        reason: "idle",
+        probeId: resumeRequest?.probeId
+      });
+      await sleep(10);
+      dispatch(target, { type: RESUMING, id: "continuation-request" });
+      await sleep(10);
+      for (const body of [
+        '{"type":"start"}',
+        '{"type":"text-start","id":"continued-text"}',
+        '{"type":"text-delta","id":"continued-text","delta":" after reconnect"}'
+      ]) {
+        dispatch(target, {
+          type: CHAT_RESPONSE,
+          id: "continuation-request",
+          body,
+          done: false,
+          replay: true,
+          continuation: true
+        });
+      }
+      dispatch(target, {
+        type: CHAT_RESPONSE,
+        id: "continuation-request",
+        body: "",
+        done: true,
+        replay: true,
+        continuation: true
+      });
+      await sleep(10);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("continuation-text").textContent).toBe(
+        "Before continuation after reconnect"
+      );
+    });
+    expect(screen.getByTestId("continuation-count").textContent).toBe("1");
+    expect(countType(sentMessages, RESUME_ACK)).toBe(1);
+  });
+
+  it("does not duplicate a completed continuation already present in hydrated history", async () => {
+    const { agent, target, sentMessages } = createFakeAgent({
+      name: "completed-continuation-replay",
+      url: "ws://localhost:3000/agents/chat/completed-continuation-replay?_pk=abc"
+    });
+    const initialMessages: UIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Continue" }]
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Before continuation" }]
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: " after reconnect" }]
+      }
+    ];
+
+    const TestComponent = () => {
+      const chat = useAgentChat({
+        agent,
+        getInitialMessages: null,
+        messages: initialMessages
+      });
+      const assistants = chat.messages.filter(
+        (message) => message.role === "assistant"
+      );
+      const assistantText = assistants
+        .flatMap((message) => message.parts)
+        .map((part) => (part.type === "text" ? part.text : ""))
+        .join("");
+      return (
+        <div>
+          <div data-testid="completed-continuation-text">{assistantText}</div>
+          <div data-testid="completed-continuation-count">
+            {assistants.length}
+          </div>
+        </div>
+      );
+    };
+
+    await act(async () => {
+      render(
+        <Suspense fallback="Loading...">
+          <TestComponent />
+        </Suspense>
+      );
+      await sleep(10);
+    });
+
+    await waitFor(() => {
+      expect(countType(sentMessages, RESUME_REQUEST)).toBeGreaterThan(0);
+    });
+    // SAFETY: createFakeAgent records only JSON protocol messages emitted by
+    // useAgentChat, and this test reads only the optional handshake fields.
+    const resumeRequest = sentMessages
+      .map(
+        (message) => JSON.parse(message) as { type?: string; probeId?: string }
+      )
+      .find((message) => message.type === RESUME_REQUEST);
+    expect(resumeRequest?.probeId).toBeDefined();
+
+    await act(async () => {
+      dispatch(target, {
+        type: RESUME_NONE,
+        reason: "idle",
+        probeId: resumeRequest?.probeId
+      });
+      await sleep(10);
+      dispatch(target, {
+        type: RESUMING,
+        id: "completed-continuation-request"
+      });
+      await sleep(10);
+      for (const body of [
+        '{"type":"start","messageId":"assistant-2"}',
+        '{"type":"text-start","id":"continued-text"}',
+        '{"type":"text-delta","id":"continued-text","delta":" after reconnect"}'
+      ]) {
+        dispatch(target, {
+          type: CHAT_RESPONSE,
+          id: "completed-continuation-request",
+          body,
+          done: false,
+          replay: true
+        });
+      }
+      dispatch(target, {
+        type: CHAT_RESPONSE,
+        id: "completed-continuation-request",
+        body: "",
+        done: true,
+        replay: true
+      });
+      await sleep(10);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("completed-continuation-text").textContent
+      ).toBe("Before continuation after reconnect");
+    });
+    expect(screen.getByTestId("completed-continuation-count").textContent).toBe(
+      "2"
+    );
     expect(countType(sentMessages, RESUME_ACK)).toBe(1);
   });
 

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -5013,6 +5013,14 @@ export class ThinkProgrammaticTestAgent extends Think {
     return this.getMessages();
   }
 
+  async getLastMessageIdentityForTest(): Promise<{
+    id: string;
+    role: UIMessage["role"];
+  } | null> {
+    const message = (await this.getMessages()).at(-1);
+    return message ? { id: message.id, role: message.role } : null;
+  }
+
   override onChatResponse(result: ChatResponseResult): void {
     this._responseLog.push(result);
   }
@@ -8199,6 +8207,57 @@ export class ThinkNonRecoveryTestAgent extends Think {
 
   async getStoredMessages(): Promise<UIMessage[]> {
     return this.getMessages();
+  }
+
+  /**
+   * Seed the durable state reached when a branch-scoped regeneration loses its
+   * live stream reader. Chat recovery is disabled on this agent, so only the
+   * client resume handshake can materialize the buffered partial after restart.
+   */
+  async seedInterruptedRegenerationForResumeTest(): Promise<{
+    requestId: string;
+    userId: string;
+    oldAssistantId: string;
+    partialAssistantId: string;
+  }> {
+    const requestId = "req-resume-regeneration";
+    const userId = "user-resume-regeneration";
+    const oldAssistantId = "assistant-old-resume-regeneration";
+    const partialAssistantId = "assistant-partial-resume-regeneration";
+
+    await this.session.appendMessage({
+      id: userId,
+      role: "user",
+      parts: [{ type: "text", text: "answer this differently" }]
+    });
+    await this.session.appendMessage({
+      id: oldAssistantId,
+      role: "assistant",
+      parts: [{ type: "text", text: "Old answer" }]
+    });
+
+    const streamId = this._startResumableStream(requestId, {
+      parentMessageId: userId
+    });
+    for (const body of [
+      JSON.stringify({ type: "start", messageId: partialAssistantId }),
+      JSON.stringify({ type: "text-start", id: "regenerated-text" }),
+      JSON.stringify({
+        type: "text-delta",
+        id: "regenerated-text",
+        delta: "Partial replacement"
+      })
+    ]) {
+      this._resumableStream.storeChunk(streamId, body);
+    }
+    this._resumableStream.flushBuffer();
+
+    return { requestId, userId, oldAssistantId, partialAssistantId };
+  }
+
+  /** Stored child branches for resume-handshake recovery assertions. */
+  async getBranchesForTest(messageId: string): Promise<UIMessage[]> {
+    return (await this.session.getBranches(messageId)) as UIMessage[];
   }
 
   async getActiveFibers(): Promise<Array<{ id: string; name: string }>> {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -8089,6 +8089,57 @@ export class ThinkNonRecoveryTestAgent extends Think {
     return this.getMessages();
   }
 
+  /**
+   * Seed the durable state reached when a branch-scoped regeneration loses its
+   * live stream reader. Chat recovery is disabled on this agent, so only the
+   * client resume handshake can materialize the buffered partial after restart.
+   */
+  async seedInterruptedRegenerationForResumeTest(): Promise<{
+    requestId: string;
+    userId: string;
+    oldAssistantId: string;
+    partialAssistantId: string;
+  }> {
+    const requestId = "req-resume-regeneration";
+    const userId = "user-resume-regeneration";
+    const oldAssistantId = "assistant-old-resume-regeneration";
+    const partialAssistantId = "assistant-partial-resume-regeneration";
+
+    await this.session.appendMessage({
+      id: userId,
+      role: "user",
+      parts: [{ type: "text", text: "answer this differently" }]
+    });
+    await this.session.appendMessage({
+      id: oldAssistantId,
+      role: "assistant",
+      parts: [{ type: "text", text: "Old answer" }]
+    });
+
+    const streamId = this._startResumableStream(requestId, {
+      parentMessageId: userId
+    });
+    for (const body of [
+      JSON.stringify({ type: "start", messageId: partialAssistantId }),
+      JSON.stringify({ type: "text-start", id: "regenerated-text" }),
+      JSON.stringify({
+        type: "text-delta",
+        id: "regenerated-text",
+        delta: "Partial replacement"
+      })
+    ]) {
+      this._resumableStream.storeChunk(streamId, body);
+    }
+    this._resumableStream.flushBuffer();
+
+    return { requestId, userId, oldAssistantId, partialAssistantId };
+  }
+
+  /** Stored child branches for resume-handshake recovery assertions. */
+  async getBranchesForTest(messageId: string): Promise<UIMessage[]> {
+    return (await this.session.getBranches(messageId)) as UIMessage[];
+  }
+
   async getActiveFibers(): Promise<Array<{ id: string; name: string }>> {
     return this.sql<{ id: string; name: string }>`
       SELECT id, name FROM cf_agents_runs

--- a/packages/think/src/tests/eviction-recovery.test.ts
+++ b/packages/think/src/tests/eviction-recovery.test.ts
@@ -6,15 +6,29 @@
  * does not assert natural idle hibernation or hibernation eligibility.
  */
 import type { UIMessage } from "ai";
-import { env } from "cloudflare:workers";
+import { env, exports } from "cloudflare:workers";
 import { evictDurableObject } from "cloudflare:test";
 import { getServerByName } from "partyserver";
 import { describe, expect, it } from "vitest";
-import type { ThinkRecoveryTestAgent } from "./agents/think-session";
+import type {
+  ThinkNonRecoveryTestAgent,
+  ThinkRecoveryTestAgent
+} from "./agents/think-session";
+
+const MSG_CHAT_RESPONSE = "cf_agent_use_chat_response";
+const MSG_STREAM_RESUME_ACK = "cf_agent_stream_resume_ack";
+const MSG_STREAM_RESUMING = "cf_agent_stream_resuming";
 
 async function recoveryAgent(name: string) {
   return getServerByName(
     env.ThinkRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkRecoveryTestAgent>,
+    name
+  );
+}
+
+async function nonRecoveryAgent(name: string) {
+  return getServerByName(
+    env.ThinkNonRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkNonRecoveryTestAgent>,
     name
   );
 }
@@ -25,6 +39,13 @@ async function getStoredBranches(
 ): Promise<UIMessage[]> {
   // SAFETY: The test agent returns sanitized UIMessage values. PartyServer's
   // RPC serializer cannot infer the AI SDK's open metadata shape.
+  return (await agent.getBranchesForTest(messageId)) as UIMessage[];
+}
+
+async function getNonRecoveryStoredBranches(
+  agent: Awaited<ReturnType<typeof nonRecoveryAgent>>,
+  messageId: string
+): Promise<UIMessage[]> {
   return (await agent.getBranchesForTest(messageId)) as UIMessage[];
 }
 
@@ -39,6 +60,55 @@ async function waitFor(
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
+}
+
+async function connectNonRecoveryAgent(name: string): Promise<WebSocket> {
+  const response = await exports.default.fetch(
+    `http://example.com/agents/think-non-recovery-test-agent/${name}`,
+    { headers: { Upgrade: "websocket" } }
+  );
+  expect(response.status).toBe(101);
+  const webSocket = response.webSocket;
+  expect(webSocket).toBeDefined();
+  webSocket!.accept();
+  return webSocket!;
+}
+
+function waitForWebSocketFrame(
+  webSocket: WebSocket,
+  predicate: (frame: Record<string, unknown>) => boolean,
+  timeoutMs = 3000
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      webSocket.removeEventListener("message", onMessage);
+      reject(new Error(`WebSocket frame not received within ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onMessage = (event: MessageEvent) => {
+      const frame = JSON.parse(event.data as string) as Record<string, unknown>;
+      if (!predicate(frame)) return;
+      clearTimeout(timeout);
+      webSocket.removeEventListener("message", onMessage);
+      resolve(frame);
+    };
+    webSocket.addEventListener("message", onMessage);
+  });
+}
+
+async function closeWebSocket(webSocket: WebSocket): Promise<void> {
+  const closed = new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, 200);
+    webSocket.addEventListener(
+      "close",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+  webSocket.close();
+  await closed;
 }
 
 async function seedInterruptedContinueTurn(
@@ -284,5 +354,57 @@ describe("Think chat recovery after forced Durable Object eviction", () => {
       oldAssistantId,
       partialAssistantId
     ]);
+  });
+});
+
+describe("Think resume handshake after forced Durable Object eviction", () => {
+  it("persists an orphaned regeneration as a sibling without chat recovery", async () => {
+    const name = `evict-resume-regeneration-${crypto.randomUUID()}`;
+    let agent = await nonRecoveryAgent(name);
+    const { requestId, userId, oldAssistantId, partialAssistantId } =
+      await agent.seedInterruptedRegenerationForResumeTest();
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+
+    const webSocket = await connectNonRecoveryAgent(name);
+    try {
+      const resuming = await waitForWebSocketFrame(
+        webSocket,
+        (frame) => frame.type === MSG_STREAM_RESUMING
+      );
+      expect(resuming.id).toBe(requestId);
+
+      const replayDone = waitForWebSocketFrame(
+        webSocket,
+        (frame) =>
+          frame.type === MSG_CHAT_RESPONSE &&
+          frame.id === requestId &&
+          frame.done === true
+      );
+      webSocket.send(
+        JSON.stringify({ type: MSG_STREAM_RESUME_ACK, id: requestId })
+      );
+      await replayDone;
+
+      agent = await nonRecoveryAgent(name);
+      await waitFor(async () => {
+        const userBranches = await getNonRecoveryStoredBranches(agent, userId);
+        const oldAnswerBranches = await getNonRecoveryStoredBranches(
+          agent,
+          oldAssistantId
+        );
+        return [...userBranches, ...oldAnswerBranches].some(
+          (message) => message.id === partialAssistantId
+        );
+      });
+
+      const branches = await getNonRecoveryStoredBranches(agent, userId);
+      expect(branches.map((message) => message.id)).toEqual([
+        oldAssistantId,
+        partialAssistantId
+      ]);
+    } finally {
+      await closeWebSocket(webSocket);
+    }
   });
 });

--- a/packages/think/src/tests/eviction-recovery.test.ts
+++ b/packages/think/src/tests/eviction-recovery.test.ts
@@ -6,15 +6,29 @@
  * does not assert natural idle hibernation or hibernation eligibility.
  */
 import type { UIMessage } from "ai";
-import { env } from "cloudflare:workers";
+import { env, exports } from "cloudflare:workers";
 import { evictDurableObject } from "cloudflare:test";
 import { getServerByName } from "partyserver";
 import { describe, expect, it } from "vitest";
-import type { ThinkRecoveryTestAgent } from "./agents/think-session";
+import type {
+  ThinkNonRecoveryTestAgent,
+  ThinkRecoveryTestAgent
+} from "./agents/think-session";
+
+const MSG_CHAT_RESPONSE = "cf_agent_use_chat_response";
+const MSG_STREAM_RESUME_ACK = "cf_agent_stream_resume_ack";
+const MSG_STREAM_RESUMING = "cf_agent_stream_resuming";
 
 async function recoveryAgent(name: string) {
   return getServerByName(
     env.ThinkRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkRecoveryTestAgent>,
+    name
+  );
+}
+
+async function nonRecoveryAgent(name: string) {
+  return getServerByName(
+    env.ThinkNonRecoveryTestAgent as unknown as DurableObjectNamespace<ThinkNonRecoveryTestAgent>,
     name
   );
 }
@@ -25,6 +39,13 @@ async function getStoredBranches(
 ): Promise<UIMessage[]> {
   // SAFETY: The test agent returns sanitized UIMessage values. PartyServer's
   // RPC serializer cannot infer the AI SDK's open metadata shape.
+  return (await agent.getBranchesForTest(messageId)) as UIMessage[];
+}
+
+async function getNonRecoveryStoredBranches(
+  agent: Awaited<ReturnType<typeof nonRecoveryAgent>>,
+  messageId: string
+): Promise<UIMessage[]> {
   return (await agent.getBranchesForTest(messageId)) as UIMessage[];
 }
 
@@ -39,6 +60,55 @@ async function waitFor(
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
+}
+
+async function connectNonRecoveryAgent(name: string): Promise<WebSocket> {
+  const response = await exports.default.fetch(
+    `http://example.com/agents/think-non-recovery-test-agent/${name}`,
+    { headers: { Upgrade: "websocket" } }
+  );
+  expect(response.status).toBe(101);
+  const webSocket = response.webSocket;
+  expect(webSocket).toBeDefined();
+  webSocket!.accept();
+  return webSocket!;
+}
+
+function waitForWebSocketFrame(
+  webSocket: WebSocket,
+  predicate: (frame: Record<string, unknown>) => boolean,
+  timeoutMs = 3000
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      webSocket.removeEventListener("message", onMessage);
+      reject(new Error(`WebSocket frame not received within ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onMessage = (event: MessageEvent) => {
+      const frame = JSON.parse(event.data as string) as Record<string, unknown>;
+      if (!predicate(frame)) return;
+      clearTimeout(timeout);
+      webSocket.removeEventListener("message", onMessage);
+      resolve(frame);
+    };
+    webSocket.addEventListener("message", onMessage);
+  });
+}
+
+async function closeWebSocket(webSocket: WebSocket): Promise<void> {
+  const closed = new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, 200);
+    webSocket.addEventListener(
+      "close",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+  webSocket.close();
+  await closed;
 }
 
 async function seedInterruptedContinueTurn(
@@ -323,5 +393,57 @@ describe("Think chat recovery after forced Durable Object eviction", () => {
       oldAssistantId,
       partialAssistantId
     ]);
+  });
+});
+
+describe("Think resume handshake after forced Durable Object eviction", () => {
+  it("persists an orphaned regeneration as a sibling without chat recovery", async () => {
+    const name = `evict-resume-regeneration-${crypto.randomUUID()}`;
+    let agent = await nonRecoveryAgent(name);
+    const { requestId, userId, oldAssistantId, partialAssistantId } =
+      await agent.seedInterruptedRegenerationForResumeTest();
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+
+    const webSocket = await connectNonRecoveryAgent(name);
+    try {
+      const resuming = await waitForWebSocketFrame(
+        webSocket,
+        (frame) => frame.type === MSG_STREAM_RESUMING
+      );
+      expect(resuming.id).toBe(requestId);
+
+      const replayDone = waitForWebSocketFrame(
+        webSocket,
+        (frame) =>
+          frame.type === MSG_CHAT_RESPONSE &&
+          frame.id === requestId &&
+          frame.done === true
+      );
+      webSocket.send(
+        JSON.stringify({ type: MSG_STREAM_RESUME_ACK, id: requestId })
+      );
+      await replayDone;
+
+      agent = await nonRecoveryAgent(name);
+      await waitFor(async () => {
+        const userBranches = await getNonRecoveryStoredBranches(agent, userId);
+        const oldAnswerBranches = await getNonRecoveryStoredBranches(
+          agent,
+          oldAssistantId
+        );
+        return [...userBranches, ...oldAnswerBranches].some(
+          (message) => message.id === partialAssistantId
+        );
+      });
+
+      const branches = await getNonRecoveryStoredBranches(agent, userId);
+      expect(branches.map((message) => message.id)).toEqual([
+        oldAssistantId,
+        partialAssistantId
+      ]);
+    } finally {
+      await closeWebSocket(webSocket);
+    }
   });
 });

--- a/packages/think/src/tests/onconnect-broadcast.test.ts
+++ b/packages/think/src/tests/onconnect-broadcast.test.ts
@@ -1,7 +1,10 @@
 import { env, exports } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "agents";
-import type { ThinkTestAgent } from "./agents/think-session";
+import type {
+  ThinkProgrammaticTestAgent,
+  ThinkTestAgent
+} from "./agents/think-session";
 
 // Covers the Think server's `onConnect` broadcast policy. The server must
 // not send `cf_agent_chat_messages` while a resumable stream is in flight,
@@ -21,9 +24,17 @@ async function freshAgent(name?: string) {
   );
 }
 
-async function connectWS(room: string) {
+async function programmaticAgent(name: string) {
+  // SAFETY: The test Wrangler configuration binds this namespace to
+  // ThinkProgrammaticTestAgent; Cloudflare's generated Env type is unavailable.
+  const namespace =
+    env.ThinkProgrammaticTestAgent as unknown as DurableObjectNamespace<ThinkProgrammaticTestAgent>;
+  return getAgentByName(namespace, name);
+}
+
+async function connectWS(room: string, agentName = "think-test-agent") {
   const res = await exports.default.fetch(
-    `http://example.com/agents/think-test-agent/${room}`,
+    `http://example.com/agents/${agentName}/${room}`,
     { headers: { Upgrade: "websocket" } }
   );
   expect(res.status).toBe(101);
@@ -185,6 +196,57 @@ describe("Think — onConnect broadcast policy", () => {
 
     expect(types).toContain(MSG_CHAT_MESSAGES);
     expect(types).not.toContain(MSG_STREAM_RESUMING);
+
+    await closeWS(ws);
+  });
+
+  it("replays completed Think continuations as their persisted assistant message", async () => {
+    const room = `continuation-replay-${crypto.randomUUID()}`;
+    const agent = await programmaticAgent(room);
+
+    await agent.testChat("Start conversation");
+    const continuation = await agent.testContinueLastTurn();
+    expect(continuation.status).toBe("completed");
+    const persistedContinuation = await agent.getLastMessageIdentityForTest();
+    expect(persistedContinuation?.role).toBe("assistant");
+
+    const { ws } = await connectWS(room, "think-programmatic-test-agent");
+    const messagesPromise = collectMessages(ws);
+    ws.send(
+      JSON.stringify({
+        type: MSG_STREAM_RESUME_ACK,
+        id: continuation.requestId
+      })
+    );
+
+    const messages = await messagesPromise;
+    const replayFrames = messages.filter(
+      (message) =>
+        message.type === MSG_CHAT_RESPONSE &&
+        message.id === continuation.requestId &&
+        message.replay === true
+    );
+
+    expect(replayFrames.length).toBeGreaterThan(1);
+    expect(replayFrames.at(-1)).toEqual(
+      expect.objectContaining({ done: true })
+    );
+    expect(replayFrames.every((frame) => frame.continuation !== true)).toBe(
+      true
+    );
+    const startFrame = replayFrames.find((frame) => {
+      if (typeof frame.body !== "string") return false;
+      // SAFETY: replay bodies are serialized AI SDK stream chunks produced by
+      // Think, and this test narrows only the optional discriminator.
+      const body = JSON.parse(frame.body) as { type?: string };
+      return body.type === "start";
+    });
+    if (!startFrame || typeof startFrame.body !== "string") {
+      throw new Error("Expected a serialized start replay frame");
+    }
+    // SAFETY: the matching body was narrowed to Think's serialized start chunk.
+    const start = JSON.parse(startFrame.body) as { messageId?: string };
+    expect(start.messageId).toBe(persistedContinuation?.id);
 
     await closeWS(ws);
   });

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -12586,9 +12586,11 @@ export class Think<
     }
   ): Promise<StreamResultStatus> {
     const clearGen = this._turnQueue.generation;
-    const streamId = this._startResumableStream(requestId);
-    const continuation = options?.continuation ?? false;
     const parentId = options?.parentId;
+    const streamId = this._startResumableStream(requestId, {
+      parentMessageId: parentId
+    });
+    const continuation = options?.continuation ?? false;
 
     if (this._continuation.pending?.requestId === requestId) {
       this._continuation.activatePending();
@@ -15809,7 +15811,10 @@ export class Think<
       pendingResumeConnections: this._pendingResumeConnections,
       pendingChatTerminal: () => this._pendingChatTerminal(),
       persistOrphanedStream: (streamId) =>
-        this._persistOrphanedStream(streamId, this._activeTurnHistory?.leafId),
+        this._persistOrphanedStream(
+          streamId,
+          this._resumableStream.getStreamParentMessageId(streamId) ?? undefined
+        ),
       isConnectionPresent: (connectionId) =>
         this.getConnection(connectionId) !== undefined
     }));
@@ -15841,7 +15846,7 @@ export class Think<
    */
   protected _startResumableStream(
     requestId: string,
-    options?: { messageId?: string }
+    options?: { messageId?: string; parentMessageId?: string }
   ): string {
     const streamId = this._resumableStream.start(requestId, options);
     // Flush connections parked during this turn's pre-stream window (#1784)

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -12016,10 +12016,11 @@ export class Think<
    * otherwise leave the client to generate its own id; the live stream and the
    * persisted message broadcast then can't reconcile by id, and the originating
    * tab briefly renders the turn twice before collapsing. Mirrors the fix in
-   * `@cloudflare/ai-chat`. Continuations are skipped — they reuse the existing
-   * assistant message via the `continuation` frame flag, so the id must not
-   * change mid-message. The orphan-recovery path inherits the id from the
-   * stored chunk, so it needs no separate stamping.
+   * `@cloudflare/ai-chat`. Live and active continuation frames still append via
+   * the top-level `continuation` flag; their stamped id identifies the separate
+   * persisted assistant row if the completed stream is replayed after hydration.
+   * The orphan-recovery path inherits the id from the stored chunk, so it needs
+   * no separate stamping.
    */
   private _alignStreamStartId(
     chunk: StreamChunkData,
@@ -12027,7 +12028,10 @@ export class Think<
     accumulator: StreamAccumulator,
     continuation: boolean
   ): void {
-    if (action?.type === "start" && action.messageId == null && !continuation) {
+    if (
+      action?.type === "start" &&
+      (action.messageId == null || continuation)
+    ) {
       (chunk as { messageId?: string }).messageId = accumulator.messageId;
     }
   }
@@ -12700,9 +12704,19 @@ export class Think<
     }
   ): Promise<StreamResultStatus> {
     const clearGen = this._turnQueue.generation;
-    const streamId = this._startResumableStream(requestId);
-    const continuation = options?.continuation ?? false;
     const parentId = options?.parentId;
+    const continuation = options?.continuation ?? false;
+    const accumulator = new StreamAccumulator({
+      messageId: crypto.randomUUID()
+    });
+    // Persist continuation semantics with the chunk buffer so active reconnect
+    // replay extends the existing assistant message exactly like live frames.
+    // The allocated id targets the standalone persisted row on terminal replay.
+    const streamId = this._startResumableStream(requestId, {
+      messageId: continuation ? accumulator.messageId : undefined,
+      parentMessageId: parentId,
+      continuation
+    });
 
     if (this._continuation.pending?.requestId === requestId) {
       this._continuation.activatePending();
@@ -12711,9 +12725,6 @@ export class Think<
       );
     }
 
-    const accumulator = new StreamAccumulator({
-      messageId: crypto.randomUUID()
-    });
     // Expose the in-flight message so a client tool result arriving before the
     // end-of-stream persist lands on the accumulator instead of being dropped
     // (#1649). Cleared before every return path below.
@@ -15996,7 +16007,7 @@ export class Think<
       persistOrphanedStream: async (streamId) => {
         await this._persistOrphanedStream(
           streamId,
-          this._activeTurnHistory?.leafId
+          this._resumableStream.getStreamParentMessageId(streamId) ?? undefined
         );
       },
       isConnectionPresent: (connectionId) =>
@@ -16030,7 +16041,11 @@ export class Think<
    */
   protected _startResumableStream(
     requestId: string,
-    options?: { messageId?: string }
+    options?: {
+      messageId?: string;
+      parentMessageId?: string;
+      continuation?: boolean;
+    }
   ): string {
     const streamId = this._resumableStream.start(requestId, options);
     // Flush connections parked during this turn's pre-stream window (#1784)


### PR DESCRIPTION
Stacked on #2122.

## What users see

The lower PRs preserve regenerated answers on their selected conversation branch. One restart case remained: if the Durable Object restarted while a regenerated answer was streaming, the recovered text could be saved beneath the original answer instead of beside it.

```mermaid
flowchart TB
  subgraph after["After"]
    AU["User message"] --> AO["Original answer"]
    AU --> AR["Recovered regeneration"]
  end

  subgraph before["Before"]
    BU["User message"] --> BO["Original answer"]
    BO --> BR["Recovered regeneration"]
  end
```

A completed continuation could also be replayed with live-continuation semantics after the client had hydrated its persisted assistant row, appending the same continuation content twice.

## Fix

- persist the selected `parent_message_id` and continuation mode with resumable-stream metadata
- restore interrupted answers beneath that durable parent after hibernation or restart
- lazily migrate legacy stream metadata tables
- stamp continuation starts with the persisted assistant ID
- replay active continuations as appends, but replay completed or errored continuations as their standalone persisted assistant row

Existing rows without parent metadata retain the legacy fallback behavior.

## Testing

- forced Durable Object restart over a real WebSocket with automatic chat recovery disabled
- legacy resumable-stream migration coverage
- server replay assertions for completed continuations
- real `useAgentChat` hydration/replay regression proving continuation text is not duplicated
- final stack: Think Workers 894, Think React 4, `pnpm run build`, and `pnpm run check`

## Typecheck stabilization

The expanded `agents/chat` declaration pushed `WorkerBackend`'s recursive loader type past TypeScript's instantiation limit in `agent-think`. The composition root now narrows that third-party constructor to the four runtime fields it supplies; runtime behavior is unchanged.

## Stack

1. #2120 — Session branch-local compaction
2. #2038 — Think regeneration context
3. #2121 — transcript repair ownership
4. #2122 — branch-aware recovery
5. **This PR — restart durability**

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
