### PR TITLE
feat(chat): throttle chat UI updates by default

### DIFF
--- a/.changeset/silent-paws-shine.md
+++ b/.changeset/silent-paws-shine.md
@@ -1,0 +1,17 @@
+---
+"agents": minor
+---
+
+Throttle chat UI updates by default in `useAgentChat`
+
+Streaming writes chat state once per chunk, and each write re-renders. When
+chunks arrive in a burst — a resumed stream replaying a long turn, for
+example — React reaches its 50-render limit and throws "Maximum update depth
+exceeded", which the AI SDK reports as a failed turn even though the server
+completed it (#1913).
+
+`useAgentChat` now coalesces those updates every 50ms, which removes about 78%
+of renders on a fast stream and matches the value the AI SDK documents. The
+first chunk of a stream is never delayed. Pass `throttle: false` to render
+every chunk as it arrives, or a number to change the interval. The deprecated
+`experimental_throttle` is still honoured.

--- a/.changeset/silent-paws-shine.md
+++ b/.changeset/silent-paws-shine.md
@@ -14,4 +14,6 @@ completed it (#1913).
 of renders on a fast stream and matches the value the AI SDK documents. The
 first chunk of a stream is never delayed. Pass `throttle: false` to render
 every chunk as it arrives, or a number to change the interval. The deprecated
-`experimental_throttle` is still honoured.
+`experimental_throttle` is still honoured. Message snapshots, functional
+updates, and streamed continuations resolve against the current chat store, so
+coalescing renders cannot roll assistant content back to an older snapshot.

--- a/packages/agents/src/chat/__tests__/broadcast-state.test.ts
+++ b/packages/agents/src/chat/__tests__/broadcast-state.test.ts
@@ -243,37 +243,35 @@ describe("broadcast stream state machine", () => {
 
   // ── continuation response ────────────────────────────────────────
 
-  it("creates accumulator with existing parts for continuation", () => {
-    const messages = makeMessages("hi", "first response");
+  it("seeds a continuation from the current messages update", () => {
+    const currentMessages = makeMessages("hi", "current response");
+    const staleRenderedMessages = makeMessages("hi", "stale response");
 
     const result = transition(idle, {
       type: "response",
       streamId: "s1",
       messageId: "fallback-id",
-      chunkData: textChunk(" continued"),
+      chunkData: { type: "text-delta", delta: " continued" },
       continuation: true,
-      currentMessages: messages
+      currentMessages: staleRenderedMessages
     });
 
     expect(result.state.status).toBe("observing");
-    if (result.state.status === "observing") {
-      expect(result.state.accumulator.messageId).toBe("msg-1");
-      expect(result.state.accumulator.parts.length).toBeGreaterThan(0);
-    }
+    expect(result.messagesUpdate).toBeDefined();
+    const messages = result.messagesUpdate!(currentMessages);
+    expect(messages[1].id).toBe("msg-1");
+    expect(messages[1].parts).toMatchObject([
+      { text: "current response continued" }
+    ]);
   });
 
   it("uses fallback messageId when no assistant message exists for continuation", () => {
-    const messages: UIMessage[] = [
-      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] }
-    ] as UIMessage[];
-
     const result = transition(idle, {
       type: "response",
       streamId: "s1",
       messageId: "fallback-id",
       chunkData: textChunk("hello"),
-      continuation: true,
-      currentMessages: messages
+      continuation: true
     });
 
     if (result.state.status === "observing") {
@@ -559,8 +557,7 @@ describe("broadcast stream state machine", () => {
         messageId: "tmp",
         chunkData,
         replay: true,
-        continuation: true,
-        currentMessages: current
+        continuation: true
       });
 
     let state = replay(idle, { type: "start", messageId: "msg-1" }).state;
@@ -571,20 +568,13 @@ describe("broadcast stream state machine", () => {
     }).state;
 
     expect(state.status).toBe("observing");
-    if (state.status === "observing") {
-      // Continuation picked up the trailing assistant's id + parts.
-      expect(state.accumulator.messageId).toBe("msg-1");
-      const texts = state.accumulator.parts.filter((p) => p.type === "text");
-      expect(texts.length).toBeGreaterThan(0);
-    }
 
     const done = transition(state, {
       type: "response",
       streamId: "req-c",
       messageId: "tmp",
       done: true,
-      continuation: true,
-      currentMessages: current
+      continuation: true
     });
     const messages = done.messagesUpdate!(current);
     // Continuation merged into the existing assistant, no extra message.

--- a/packages/agents/src/chat/__tests__/chat-throttle.test.ts
+++ b/packages/agents/src/chat/__tests__/chat-throttle.test.ts
@@ -48,8 +48,7 @@ describe("chatThrottleOptions", () => {
     });
   });
 
-  // Both majors decide with `waitMs != null`, so omitting the option is the
-  // only spelling that reaches the SDK's own unthrottled path.
+  // `false` is represented by omitting both numeric SDK options.
   it("omits both names when throttling is off", () => {
     expect(chatThrottleOptions({ throttle: false })).toEqual({});
   });

--- a/packages/agents/src/chat/__tests__/chat-throttle.test.ts
+++ b/packages/agents/src/chat/__tests__/chat-throttle.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  chatThrottleOptions,
+  DEFAULT_CHAT_THROTTLE_MS,
+  resolveChatThrottleMs
+} from "../chat-throttle";
+
+describe("resolveChatThrottleMs", () => {
+  it("throttles by default, so chat is protected without any configuration", () => {
+    expect(resolveChatThrottleMs({})).toBe(DEFAULT_CHAT_THROTTLE_MS);
+  });
+
+  it("prefers an explicit throttle", () => {
+    expect(resolveChatThrottleMs({ throttle: 25 })).toBe(25);
+  });
+
+  it("accepts the deprecated experimental_throttle, which every example passes", () => {
+    expect(resolveChatThrottleMs({ experimental_throttle: 250 })).toBe(250);
+  });
+
+  it("prefers the current name when both are passed", () => {
+    expect(
+      resolveChatThrottleMs({ experimental_throttle: 250, throttle: 25 })
+    ).toBe(25);
+  });
+
+  it("turns throttling off for false", () => {
+    expect(resolveChatThrottleMs({ throttle: false })).toBeUndefined();
+  });
+
+  it("treats 0 as opting out rather than as unset", () => {
+    expect(resolveChatThrottleMs({ throttle: 0 })).toBe(0);
+    expect(resolveChatThrottleMs({ experimental_throttle: 0 })).toBe(0);
+  });
+});
+
+describe("chatThrottleOptions", () => {
+  // @ai-sdk/react v3 reads `experimental_throttle`; v4 reads `throttle`. Both
+  // majors are in our peer range, so both names have to carry the value.
+  it("spells the throttle under both option names", () => {
+    expect(chatThrottleOptions({})).toEqual({
+      experimental_throttle: DEFAULT_CHAT_THROTTLE_MS,
+      throttle: DEFAULT_CHAT_THROTTLE_MS
+    });
+    expect(chatThrottleOptions({ throttle: 0 })).toEqual({
+      experimental_throttle: 0,
+      throttle: 0
+    });
+  });
+
+  // Both majors decide with `waitMs != null`, so omitting the option is the
+  // only spelling that reaches the SDK's own unthrottled path.
+  it("omits both names when throttling is off", () => {
+    expect(chatThrottleOptions({ throttle: false })).toEqual({});
+  });
+});

--- a/packages/agents/src/chat/__tests__/stream-accumulator.test.ts
+++ b/packages/agents/src/chat/__tests__/stream-accumulator.test.ts
@@ -717,7 +717,7 @@ describe("StreamAccumulator", () => {
       expect((result[1].parts[0] as { text: string }).text).toBe("updated");
     });
 
-    it("continuation falls back to last assistant when messageId not found", () => {
+    it("continuation preserves the last assistant when messageId is not found", () => {
       const a = acc({ messageId: "unknown-id", continuation: true });
       a.applyChunk({ type: "text-start" } as StreamChunkData);
       a.applyChunk({
@@ -727,7 +727,10 @@ describe("StreamAccumulator", () => {
       const result = a.mergeInto([userMsg, assistantMsg]);
       expect(result).toHaveLength(2);
       expect(result[1].id).toBe("asst-1");
-      expect((result[1].parts[0] as { text: string }).text).toBe("continued");
+      expect(result[1].parts).toMatchObject([
+        { text: "hi" },
+        { text: "continued" }
+      ]);
     });
 
     it("continuation appends when no assistant exists", () => {
@@ -814,7 +817,10 @@ describe("StreamAccumulator", () => {
       } as StreamChunkData);
       const result = a.mergeInto([first, target]);
       expect(result[1].id).toBe("target-id");
-      expect((result[1].parts[0] as { text: string }).text).toBe("updated");
+      expect(result[1].parts).toMatchObject([
+        { text: "target" },
+        { text: "updated" }
+      ]);
       expect(result[0]).toBe(first);
     });
 

--- a/packages/agents/src/chat/broadcast-state.ts
+++ b/packages/agents/src/chat/broadcast-state.ts
@@ -40,7 +40,7 @@ export type BroadcastStreamEvent =
       replay?: boolean;
       replayComplete?: boolean;
       continuation?: boolean;
-      /** Required when continuation=true so the accumulator can pick up existing parts. */
+      /** @deprecated Continuations now seed from current messages in `messagesUpdate`. */
       currentMessages?: UIMessage[];
     }
   | {
@@ -103,33 +103,9 @@ export function transition(
         state.streamId !== event.streamId ||
         isReplayedStart
       ) {
-        let messageId = event.messageId;
-        let existingParts: UIMessage["parts"] | undefined;
-        let existingMetadata: Record<string, unknown> | undefined;
-
-        if (event.continuation && event.currentMessages) {
-          for (let i = event.currentMessages.length - 1; i >= 0; i--) {
-            if (event.currentMessages[i].role === "assistant") {
-              messageId = event.currentMessages[i].id;
-              existingParts = [...event.currentMessages[i].parts];
-              if (event.currentMessages[i].metadata != null) {
-                existingMetadata = {
-                  ...(event.currentMessages[i].metadata as Record<
-                    string,
-                    unknown
-                  >)
-                };
-              }
-              break;
-            }
-          }
-        }
-
         accumulator = new StreamAccumulator({
-          messageId,
-          continuation: event.continuation,
-          existingParts,
-          existingMetadata
+          messageId: event.messageId,
+          continuation: event.continuation
         });
       } else {
         accumulator = state.accumulator;

--- a/packages/agents/src/chat/chat-throttle.ts
+++ b/packages/agents/src/chat/chat-throttle.ts
@@ -1,0 +1,85 @@
+/**
+ * How often chat state is allowed to re-render the UI.
+ *
+ * The AI SDK writes chat state once per streamed chunk, and each write is a
+ * React render. Without a throttle a burst of chunks becomes a burst of
+ * renders, and past 50 in an unbroken row React throws "Maximum update depth
+ * exceeded" (#1913). A throttle collapses those renders no matter how many
+ * chunks arrive, which is why it protects cases chunk merging cannot: a replay
+ * of many tool steps, or any other backlog delivered in one go.
+ *
+ * Any value above zero prevents that crash, because the update then arrives
+ * from a timer rather than from the current task. The size of the value is a
+ * cost decision instead, measured over a 200-chunk turn at ~100 chunks/sec:
+ *
+ *   off  404 commits / 138ms   50ms  90 commits / 37ms
+ *   16ms 261 commits /  89ms  100ms  48 commits / 21ms
+ *
+ * 50ms removes 78% of the renders. Going higher saves progressively less and
+ * makes the text lag further behind the stream, so this sits at the knee of
+ * that curve. It is also the value the AI SDK's own documentation uses.
+ *
+ * This does not delay the first chunk. The SDK throttles with `throttleit`,
+ * which runs the first call of an idle window immediately, so only mid-stream
+ * updates are coalesced.
+ *
+ * It is a mitigation rather than a guarantee. `useChat` throttles the store
+ * subscription, but its `getSnapshot` returns a new messages array on every
+ * chunk, and React forces a synchronous re-render whenever that identity moved
+ * during a render — a path the throttle never sees (vercel/ai#6166, fix open in
+ * vercel/ai#17893). Only writing state less often bounds it, which is why the
+ * transport also merges replayed chunks before they reach the SDK.
+ */
+export const DEFAULT_CHAT_THROTTLE_MS = 50;
+
+export type ChatThrottleOptions = {
+  /**
+   * Milliseconds to coalesce chat updates, or `false` to render every chunk.
+   */
+  throttle?: number | false;
+  /** @deprecated Use `throttle`. */
+  experimental_throttle?: number;
+};
+
+/** What gets forwarded to `useChat`. Omitted keys mean "do not throttle". */
+type ForwardedThrottleOptions = {
+  throttle?: number;
+  experimental_throttle?: number;
+};
+
+/**
+ * Picks the throttle from an explicit caller value, the deprecated alias, or
+ * the default — in that order. `false` turns throttling off.
+ */
+export function resolveChatThrottleMs(
+  options: ChatThrottleOptions
+): number | undefined {
+  if (options.throttle === false) return undefined;
+  return (
+    options.throttle ??
+    options.experimental_throttle ??
+    DEFAULT_CHAT_THROTTLE_MS
+  );
+}
+
+/**
+ * The throttle spelled under both option names, or neither name when it is off.
+ *
+ * The two names are not interchangeable across the peer range. `@ai-sdk/react`
+ * v3 only reads `experimental_throttle`; v4 renamed it to `throttle` and reads
+ * `throttle ?? experimental_throttle`. Our peer range allows both majors, so
+ * sending one name would silently do nothing on the other. Unknown option keys
+ * are ignored by both, so sending both names is safe.
+ *
+ * Turning throttling off omits both names rather than sending `0`. Both majors
+ * decide with `waitMs != null`, so an omitted option is the only spelling that
+ * takes the SDK's own unthrottled path; `0` still wraps the callback and only
+ * behaves like "off" as a side effect of how the delay is computed.
+ */
+export function chatThrottleOptions(
+  options: ChatThrottleOptions
+): ForwardedThrottleOptions {
+  const ms = resolveChatThrottleMs(options);
+  if (ms === undefined) return {};
+  return { experimental_throttle: ms, throttle: ms };
+}

--- a/packages/agents/src/chat/chat-throttle.ts
+++ b/packages/agents/src/chat/chat-throttle.ts
@@ -71,10 +71,9 @@ export function resolveChatThrottleMs(
  * sending one name would silently do nothing on the other. Unknown option keys
  * are ignored by both, so sending both names is safe.
  *
- * Turning throttling off omits both names rather than sending `0`. Both majors
- * decide with `waitMs != null`, so an omitted option is the only spelling that
- * takes the SDK's own unthrottled path; `0` still wraps the callback and only
- * behaves like "off" as a side effect of how the delay is computed.
+ * Turning throttling off omits both names rather than inventing a numeric
+ * value. Both majors also treat an explicit `0` as unthrottled, so callers that
+ * pass `0` keep that value under both spellings.
  */
 export function chatThrottleOptions(
   options: ChatThrottleOptions

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -9,6 +9,7 @@ import type {
 } from "ai";
 import { nanoid } from "nanoid";
 import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { chatThrottleOptions } from "./chat-throttle";
 import type { OutgoingMessage } from "./wire-types";
 import { STREAM_RESUME_NONE_REASONS } from "./protocol";
 import { MessageType } from "./wire-types";
@@ -383,7 +384,12 @@ export type UseAgentChatOptions<
   // oxlint-disable-next-line no-unused-vars -- kept for backward compat
   State = unknown,
   ChatMessage extends UIMessage = UIMessage
-> = Omit<UseChatParams<ChatMessage>, "fetch" | "onToolCall"> & {
+> = Omit<
+  UseChatParams<ChatMessage>,
+  // Both throttle names are redeclared below: ours accepts `false`, and
+  // intersecting with the SDK's `throttle?: number` would drop that.
+  "fetch" | "onToolCall" | "throttle" | "experimental_throttle"
+> & {
   /** Agent connection from useAgent (accepts both typed and untyped agents) */
   agent: AgentConnection & {
     agent: string;
@@ -400,6 +406,17 @@ export type UseAgentChatOptions<
   credentials?: RequestCredentials;
   /** Request headers */
   headers?: HeadersInit;
+  /**
+   * Milliseconds to coalesce chat state updates before re-rendering,
+   * defaulting to 50.
+   *
+   * Streaming writes chat state once per chunk, so without a throttle a fast
+   * burst of chunks renders once per chunk. The first chunk is never delayed.
+   * Pass `false` to render every chunk as it arrives.
+   */
+  throttle?: number | false;
+  /** @deprecated Use `throttle`. */
+  experimental_throttle?: number;
   /**
    * Callback for handling client-side tool execution.
    * Called when a tool without server-side `execute` is invoked by the LLM.
@@ -690,6 +707,8 @@ export function useAgentChat<
     syncMessagesToServer = true,
     body: bodyOption,
     prepareSendMessagesRequest,
+    throttle,
+    experimental_throttle,
     ...rest
   } = options;
 
@@ -1017,6 +1036,7 @@ export function useAgentChat<
   // the Chat stable across socket recreations.
   const useChatHelpers = useChat<ChatMessage>({
     ...rest,
+    ...chatThrottleOptions({ experimental_throttle, throttle }),
     onData,
     messages: initialMessages,
     transport: customTransport,

--- a/packages/agents/src/chat/react.tsx
+++ b/packages/agents/src/chat/react.tsx
@@ -1258,9 +1258,6 @@ export function useAgentChat<
     Map<string, unknown>
   >(new Map());
 
-  // Ref to access current messages in callbacks without stale closures
-  const messagesRef = useRef(chatMessages);
-  messagesRef.current = chatMessages;
   const initialMessagesRef = useRef(initialMessages);
   initialMessagesRef.current = initialMessages;
 
@@ -1313,7 +1310,10 @@ export function useAgentChat<
   } | null>(null);
 
   const preserveProtectedStreamingAssistant = useCallback(
-    (messages: readonly ChatMessage[]): ChatMessage[] => {
+    (
+      messages: readonly ChatMessage[],
+      currentMessages: readonly ChatMessage[]
+    ): ChatMessage[] => {
       const protection = protectedStreamingAssistantRef.current;
       if (!protection) {
         return [...messages];
@@ -1342,7 +1342,7 @@ export function useAgentChat<
       }
 
       const protectedAssistant =
-        messagesRef.current.find(
+        currentMessages.find(
           (message) => message.id === protection.assistantId
         ) ?? messages.find((message) => message.id === protection.assistantId);
       if (!protectedAssistant) {
@@ -1362,29 +1362,23 @@ export function useAgentChat<
       return;
     }
 
-    const assistantInfo = findLastAssistantMessage(messagesRef.current);
-    if (!assistantInfo) {
-      return;
-    }
-
-    if (
-      protectedStreamingAssistantRef.current?.assistantId !==
-      assistantInfo.message.id
-    ) {
-      protectedStreamingAssistantRef.current = {
-        assistantId: assistantInfo.message.id,
-        anchorMessageId:
-          messagesRef.current[assistantInfo.index - 1]?.id ?? null
-      };
-    }
-
-    setMessages((prevMessages: ChatMessage[]) => {
-      const protection = protectedStreamingAssistantRef.current;
-      if (!protection) {
-        return prevMessages;
+    setMessages((currentMessages: ChatMessage[]) => {
+      const assistantInfo = findLastAssistantMessage(currentMessages);
+      if (!assistantInfo) {
+        return currentMessages;
       }
 
-      return moveMessageToEnd(prevMessages, protection.assistantId);
+      if (
+        protectedStreamingAssistantRef.current?.assistantId !==
+        assistantInfo.message.id
+      ) {
+        protectedStreamingAssistantRef.current = {
+          assistantId: assistantInfo.message.id,
+          anchorMessageId: currentMessages[assistantInfo.index - 1]?.id ?? null
+        };
+      }
+
+      return moveMessageToEnd(currentMessages, assistantInfo.message.id);
     });
   }, [setMessages]);
 
@@ -1906,38 +1900,43 @@ export function useAgentChat<
           break;
 
         case MessageType.CF_AGENT_CHAT_MESSAGES: {
-          let next = preserveProtectedStreamingAssistant(data.messages);
-          // A cross-tab observer builds the in-flight assistant via the
-          // broadcast accumulator, not the local transport — so
-          // `protectedStreamingAssistantRef` is never armed for it. Without
-          // this, a behind-the-stream snapshot would replace the observed
-          // assistant's streamed parts until the next chunk re-merges them
-          // (the same disappear/reappear the originating tab gets without the
-          // start-chunk re-arm above). Re-apply the accumulator — it adopted
-          // the server id from the `start` chunk, so `mergeInto` replaces the
-          // snapshot's copy in place (or appends a not-yet-persisted turn).
-          const observed = streamStateRef.current;
-          if (
-            observed.status === "observing" &&
-            observed.accumulator.parts.length > 0
-          ) {
-            // Only re-apply the live accumulator when it is at least as
-            // complete as the snapshot's copy of the same message. A fresh
-            // observer rebuilding its accumulator from a chunk-0 replay can
-            // briefly trail a fully-persisted snapshot; merging then would drop
-            // parts until replay catches up. In steady-state live observing the
-            // accumulator is always at or ahead of the snapshot, so this still
-            // fixes the disappear/reappear flicker.
-            const snapshotIdx = next.findIndex(
-              (m) => m.id === observed.accumulator.messageId
+          setMessages((currentMessages: ChatMessage[]) => {
+            let next = preserveProtectedStreamingAssistant(
+              data.messages,
+              currentMessages
             );
-            const snapshotParts =
-              snapshotIdx >= 0 ? next[snapshotIdx].parts.length : 0;
-            if (observed.accumulator.parts.length >= snapshotParts) {
-              next = observed.accumulator.mergeInto(next) as ChatMessage[];
+            // A cross-tab observer builds the in-flight assistant via the
+            // broadcast accumulator, not the local transport — so
+            // `protectedStreamingAssistantRef` is never armed for it. Without
+            // this, a behind-the-stream snapshot would replace the observed
+            // assistant's streamed parts until the next chunk re-merges them
+            // (the same disappear/reappear the originating tab gets without the
+            // start-chunk re-arm above). Re-apply the accumulator — it adopted
+            // the server id from the `start` chunk, so `mergeInto` replaces the
+            // snapshot's copy in place (or appends a not-yet-persisted turn).
+            const observed = streamStateRef.current;
+            if (
+              observed.status === "observing" &&
+              observed.accumulator.parts.length > 0
+            ) {
+              // Only re-apply the live accumulator when it is at least as
+              // complete as the snapshot's copy of the same message. A fresh
+              // observer rebuilding its accumulator from a chunk-0 replay can
+              // briefly trail a fully-persisted snapshot; merging then would drop
+              // parts until replay catches up. In steady-state live observing the
+              // accumulator is always at or ahead of the snapshot, so this still
+              // fixes the disappear/reappear flicker.
+              const snapshotIdx = next.findIndex(
+                (m) => m.id === observed.accumulator.messageId
+              );
+              const snapshotParts =
+                snapshotIdx >= 0 ? next[snapshotIdx].parts.length : 0;
+              if (observed.accumulator.parts.length >= snapshotParts) {
+                next = observed.accumulator.mergeInto(next) as ChatMessage[];
+              }
             }
-          }
-          setMessages(next);
+            return next;
+          });
           break;
         }
 
@@ -2107,7 +2106,8 @@ export function useAgentChat<
                   chunkData.type === "start" &&
                   typeof chunkData.messageId === "string"
                 ) {
-                  localResponseIds.set(data.id, chunkData.messageId);
+                  const messageId = chunkData.messageId;
+                  localResponseIds.set(data.id, messageId);
                   // Re-arm streaming protection to the ACTUAL assistant id for
                   // this turn. `protectStreamingAssistantTail` runs at send
                   // time — before the assistant message is minted — so it can
@@ -2120,19 +2120,22 @@ export function useAgentChat<
                   // are skipped: they extend the existing protected assistant.
                   if (!data.continuation) {
                     const protection = protectedStreamingAssistantRef.current;
-                    if (protection?.assistantId !== chunkData.messageId) {
-                      const msgs = messagesRef.current;
-                      const idx = msgs.findIndex(
-                        (m) => m.id === chunkData.messageId
-                      );
-                      const anchorMessageId =
-                        idx >= 0
-                          ? (msgs[idx - 1]?.id ?? null)
-                          : (msgs[msgs.length - 1]?.id ?? null);
-                      protectedStreamingAssistantRef.current = {
-                        assistantId: chunkData.messageId,
-                        anchorMessageId
-                      };
+                    if (protection?.assistantId !== messageId) {
+                      setMessages((currentMessages: ChatMessage[]) => {
+                        const idx = currentMessages.findIndex(
+                          (message) => message.id === messageId
+                        );
+                        const anchorMessageId =
+                          idx >= 0
+                            ? (currentMessages[idx - 1]?.id ?? null)
+                            : (currentMessages[currentMessages.length - 1]
+                                ?.id ?? null);
+                        protectedStreamingAssistantRef.current = {
+                          assistantId: messageId,
+                          anchorMessageId
+                        };
+                        return currentMessages;
+                      });
                     }
                   }
                   // EVERY replayed `start` rebuilds the message from chunk 0,
@@ -2149,9 +2152,7 @@ export function useAgentChat<
                     observedToolContinuationRequestIdRef.current !== data.id
                   ) {
                     pendingReplayResumeRequestIdsRef.current.delete(data.id);
-                    resetMatchingHydratedAssistantForReplay(
-                      chunkData.messageId
-                    );
+                    resetMatchingHydratedAssistantForReplay(messageId);
                   }
                 }
               } catch {
@@ -2284,8 +2285,7 @@ export function useAgentChat<
             error: data.error,
             replay: data.replay,
             replayComplete: data.replayComplete,
-            continuation: data.continuation,
-            currentMessages: data.continuation ? messagesRef.current : undefined
+            continuation: data.continuation
           });
 
           streamStateRef.current = result.state;
@@ -2506,19 +2506,21 @@ export function useAgentChat<
       // Find the toolCallId from the approval ID
       // The approval ID is stored on the tool part's approval.id field
       let toolCallId: string | undefined;
-      for (const msg of messagesRef.current) {
-        for (const part of msg.parts) {
-          if (
-            "toolCallId" in part &&
-            "approval" in part &&
-            (part.approval as { id?: string })?.id === approvalId
-          ) {
-            toolCallId = part.toolCallId as string;
-            break;
+      setMessages((currentMessages: ChatMessage[]) => {
+        for (const msg of currentMessages) {
+          for (const part of msg.parts) {
+            if (
+              "toolCallId" in part &&
+              "approval" in part &&
+              (part.approval as { id?: string })?.id === approvalId
+            ) {
+              toolCallId = part.toolCallId as string;
+              return currentMessages;
+            }
           }
         }
-        if (toolCallId) break;
-      }
+        return currentMessages;
+      });
 
       if (toolCallId) {
         // Send approval to server first (server updates message in place)
@@ -2717,28 +2719,25 @@ export function useAgentChat<
       );
     },
     setMessages: (messagesOrUpdater: Parameters<typeof setMessages>[0]) => {
-      // Resolve functional updaters to get the actual messages array
-      // before syncing to server. Without this, updater functions would
-      // send an empty array and wipe server-side messages.
-      let resolvedMessages: ChatMessage[];
-      if (typeof messagesOrUpdater === "function") {
-        resolvedMessages = messagesOrUpdater(messagesRef.current);
-      } else {
-        resolvedMessages = messagesOrUpdater;
-      }
+      setMessages((currentMessages: ChatMessage[]) => {
+        const resolvedMessages =
+          typeof messagesOrUpdater === "function"
+            ? messagesOrUpdater(currentMessages)
+            : messagesOrUpdater;
 
-      if (resolvedMessages.length === 0) {
-        markInitialMessagesSeeded();
-      }
-      setMessages(resolvedMessages);
-      if (syncMessagesToServer) {
-        agent.send(
-          JSON.stringify({
-            messages: resolvedMessages,
-            type: MessageType.CF_AGENT_CHAT_MESSAGES
-          })
-        );
-      }
+        if (resolvedMessages.length === 0) {
+          markInitialMessagesSeeded();
+        }
+        if (syncMessagesToServer) {
+          agent.send(
+            JSON.stringify({
+              messages: resolvedMessages,
+              type: MessageType.CF_AGENT_CHAT_MESSAGES
+            })
+          );
+        }
+        return resolvedMessages;
+      });
     }
   };
 }

--- a/packages/agents/src/chat/stream-accumulator.ts
+++ b/packages/agents/src/chat/stream-accumulator.ts
@@ -23,7 +23,9 @@ function asMetadata(value: unknown): Record<string, unknown> | undefined {
 
 export interface StreamAccumulatorOptions {
   messageId: string;
+  /** Whether chunks continue the current assistant message when merged. */
   continuation?: boolean;
+  /** Eager seed; omitted continuations seed from the messages passed to `mergeInto`. */
   existingParts?: UIMessage["parts"];
   existingMetadata?: Record<string, unknown>;
 }
@@ -61,6 +63,8 @@ export class StreamAccumulator {
   readonly parts: UIMessage["parts"];
   metadata?: Record<string, unknown>;
   private _isContinuation: boolean;
+  // Continuation chunks wait here until mergeInto can seed from current state.
+  private _pendingContinuationChunks: StreamChunkData[] | null;
 
   constructor(options: StreamAccumulatorOptions) {
     this.messageId = options.messageId;
@@ -69,9 +73,16 @@ export class StreamAccumulator {
     this.metadata = options.existingMetadata
       ? { ...options.existingMetadata }
       : undefined;
+    this._pendingContinuationChunks =
+      this._isContinuation &&
+      options.existingParts === undefined &&
+      options.existingMetadata === undefined
+        ? []
+        : null;
   }
 
   applyChunk(chunk: StreamChunkData): ChunkResult {
+    this._pendingContinuationChunks?.push(chunk);
     const handled = applyChunkToParts(this.parts, chunk);
 
     // Detect tool-approval-request for early persistence signaling
@@ -198,7 +209,8 @@ export class StreamAccumulator {
   /**
    * Merge this accumulator's message into an existing message array.
    * Handles continuation (walk backward for last assistant), replacement
-   * (update existing by messageId), or append (new message).
+   * (update existing by messageId), or append (new message). An unseeded
+   * continuation adopts current parts here before applying its queued chunks.
    */
   mergeInto(messages: UIMessage[]): UIMessage[] {
     let existingIdx = messages.findIndex((m) => m.id === this.messageId);
@@ -209,6 +221,27 @@ export class StreamAccumulator {
           existingIdx = i;
           break;
         }
+      }
+    }
+
+    if (this._pendingContinuationChunks !== null) {
+      const pendingChunks = this._pendingContinuationChunks;
+      this._pendingContinuationChunks = null;
+      this.parts.splice(
+        0,
+        this.parts.length,
+        ...(existingIdx >= 0 ? messages[existingIdx].parts : [])
+      );
+      const currentMetadata =
+        existingIdx >= 0
+          ? asMetadata(messages[existingIdx].metadata)
+          : undefined;
+      this.metadata = currentMetadata ? { ...currentMetadata } : undefined;
+      if (existingIdx >= 0) {
+        this.messageId = messages[existingIdx].id;
+      }
+      for (const chunk of pendingChunks) {
+        this.applyChunk(chunk);
       }
     }
 

--- a/packages/agents/src/react-tests/default-throttle.test.tsx
+++ b/packages/agents/src/react-tests/default-throttle.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * `useAgentChat` throttles chat updates by default.
+ *
+ * Merging replayed chunks (#1913) removes one update per chunk, but a replayed
+ * turn still costs about one update per part, so a turn with enough tool steps
+ * reaches React's 50-render limit anyway. A throttle is independent of the
+ * number of chunks, so it covers what merging cannot.
+ *
+ * The turn below is the shape that still failed after merging landed: 12 tool
+ * steps, each with reasoning, a streamed tool input, a result, and a paragraph
+ * of text.
+ */
+import type { UIMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render as _render } from "vitest-browser-react";
+import { useAgentChat } from "../chat/react";
+import type { useAgent } from "../react";
+
+const render: typeof _render = async (...args) => {
+  const result = await _render(...args);
+  // @ts-expect-error - globalThis is not typed
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  return result;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const RESUMING = "cf_agent_stream_resuming";
+const RESUME_REQUEST = "cf_agent_stream_resume_request";
+const CHAT_RESPONSE = "cf_agent_use_chat_response";
+
+function createFakeAgent(name: string) {
+  const target = new EventTarget();
+  const sentMessages: string[] = [];
+  const url = `ws://localhost:3000/agents/chat/${name}?_pk=abc`;
+  const agent = {
+    _pk: name,
+    _pkurl: url,
+    _url: null as string | null,
+    addEventListener: target.addEventListener.bind(target),
+    agent: "Chat",
+    close: () => {},
+    dispatchEvent: target.dispatchEvent.bind(target),
+    getHttpUrl: () => url.replace("ws://", "http://"),
+    id: "fake-agent",
+    name,
+    path: [{ agent: "Chat", name }],
+    removeEventListener: target.removeEventListener.bind(target),
+    send: (data: string) => sentMessages.push(data)
+  };
+  return {
+    agent: agent as unknown as ReturnType<typeof useAgent>,
+    sentMessages,
+    target
+  };
+}
+
+function dispatch(target: EventTarget, data: Record<string, unknown>) {
+  target.dispatchEvent(
+    new MessageEvent("message", { data: JSON.stringify(data) })
+  );
+}
+
+const countType = (sent: string[], type: string) =>
+  sent.filter((m) => {
+    try {
+      return (JSON.parse(m) as { type?: string }).type === type;
+    } catch {
+      return false;
+    }
+  }).length;
+
+const TOOL_STEPS = 12;
+const WORDS_PER_STEP = 30;
+
+/** The chunk bodies of an agentic turn: tool call, result, and text per step. */
+function toolTurnBodies() {
+  const bodies: Record<string, unknown>[] = [
+    { messageId: "asst-1", type: "start" }
+  ];
+  for (let step = 0; step < TOOL_STEPS; step++) {
+    bodies.push({ type: "start-step" });
+    bodies.push({ id: `r${step}`, type: "reasoning-start" });
+    for (let i = 0; i < 20; i++) {
+      bodies.push({ delta: "think ", id: `r${step}`, type: "reasoning-delta" });
+    }
+    bodies.push({ id: `r${step}`, type: "reasoning-end" });
+    bodies.push({
+      toolCallId: `call-${step}`,
+      toolName: "search",
+      type: "tool-input-start"
+    });
+    for (let i = 0; i < 10; i++) {
+      bodies.push({
+        inputTextDelta: "x",
+        toolCallId: `call-${step}`,
+        type: "tool-input-delta"
+      });
+    }
+    bodies.push({
+      input: { q: "x" },
+      toolCallId: `call-${step}`,
+      toolName: "search",
+      type: "tool-input-available"
+    });
+    bodies.push({
+      output: { result: "ok" },
+      toolCallId: `call-${step}`,
+      type: "tool-output-available"
+    });
+    bodies.push({ id: `t${step}`, type: "text-start" });
+    for (let i = 0; i < WORDS_PER_STEP; i++) {
+      bodies.push({ delta: "word ", id: `t${step}`, type: "text-delta" });
+    }
+    bodies.push({ id: `t${step}`, type: "text-end" });
+    bodies.push({ type: "finish-step" });
+  }
+  return bodies;
+}
+
+const expectedChars = TOOL_STEPS * WORDS_PER_STEP * "word ".length;
+
+async function mount(name: string, throttle?: number | false) {
+  const { agent, sentMessages, target } = createFakeAgent(name);
+
+  function TestComponent() {
+    const chat = useAgentChat({
+      agent,
+      getInitialMessages: null,
+      messages: [
+        { id: "u1", parts: [{ text: "hi", type: "text" }], role: "user" }
+      ] as UIMessage[],
+      throttle
+    });
+    const assistantText = chat.messages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => m.parts)
+      .filter((p) => p.type === "text")
+      .map((p) => (p as { text: string }).text)
+      .join("");
+    return (
+      <div>
+        <div data-testid="status">{chat.status}</div>
+        <div data-testid="error">{String(chat.error?.message ?? "")}</div>
+        <div data-testid="chars">{assistantText.length}</div>
+      </div>
+    );
+  }
+
+  const { container } = await render(<TestComponent />);
+  return {
+    read: (id: string) =>
+      container.querySelector(`[data-testid="${id}"]`)?.textContent ?? null,
+    sentMessages,
+    target
+  };
+}
+
+/** Replays a whole agentic turn in one task, as a resumed stream does. */
+async function replayTurn(h: Awaited<ReturnType<typeof mount>>) {
+  await vi.waitFor(() =>
+    expect(countType(h.sentMessages, RESUME_REQUEST)).toBe(1)
+  );
+  dispatch(h.target, { id: "req-1", type: RESUMING });
+  await sleep(10);
+
+  for (const body of toolTurnBodies()) {
+    dispatch(h.target, {
+      body: JSON.stringify(body),
+      done: false,
+      id: "req-1",
+      replay: true,
+      type: CHAT_RESPONSE
+    });
+  }
+  dispatch(h.target, {
+    body: "",
+    done: true,
+    id: "req-1",
+    type: CHAT_RESPONSE
+  });
+  await sleep(300);
+}
+
+describe("default chat throttle", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    cleanup();
+  });
+
+  it("replays a tool-heavy turn without exceeding React's update depth", async () => {
+    const h = await mount("throttle-default");
+    await replayTurn(h);
+
+    expect({
+      chars: h.read("chars"),
+      error: h.read("error"),
+      status: h.read("status")
+    }).toEqual({
+      chars: String(expectedChars),
+      error: "",
+      status: "ready"
+    });
+  });
+
+  // Proves the caller's value actually reaches the AI SDK: opting out restores
+  // the unthrottled behaviour, and this turn is large enough to fail without a
+  // throttle even with replayed chunks merged.
+  it("lets a caller opt out with throttle: false", async () => {
+    const h = await mount("throttle-off", false);
+    await replayTurn(h);
+
+    expect(h.read("status")).toBe("error");
+  });
+});

--- a/packages/agents/src/react-tests/default-throttle.test.tsx
+++ b/packages/agents/src/react-tests/default-throttle.test.tsx
@@ -28,6 +28,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const RESUMING = "cf_agent_stream_resuming";
 const RESUME_REQUEST = "cf_agent_stream_resume_request";
 const CHAT_RESPONSE = "cf_agent_use_chat_response";
+const CHAT_MESSAGES = "cf_agent_chat_messages";
 
 function createFakeAgent(name: string) {
   const target = new EventTarget();
@@ -122,6 +123,8 @@ const expectedChars = TOOL_STEPS * WORDS_PER_STEP * "word ".length;
 
 async function mount(name: string, throttle?: number | false) {
   const { agent, sentMessages, target } = createFakeAgent(name);
+  let setChatMessages: ReturnType<typeof useAgentChat>["setMessages"] | null =
+    null;
 
   function TestComponent() {
     const chat = useAgentChat({
@@ -132,6 +135,7 @@ async function mount(name: string, throttle?: number | false) {
       ] as UIMessage[],
       throttle
     });
+    setChatMessages = chat.setMessages;
     const assistantText = chat.messages
       .filter((m) => m.role === "assistant")
       .flatMap((m) => m.parts)
@@ -143,6 +147,9 @@ async function mount(name: string, throttle?: number | false) {
         <div data-testid="status">{chat.status}</div>
         <div data-testid="error">{String(chat.error?.message ?? "")}</div>
         <div data-testid="chars">{assistantText.length}</div>
+        <div data-testid="message-ids">
+          {chat.messages.map((message) => message.id).join(",")}
+        </div>
       </div>
     );
   }
@@ -152,6 +159,12 @@ async function mount(name: string, throttle?: number | false) {
     read: (id: string) =>
       container.querySelector(`[data-testid="${id}"]`)?.textContent ?? null,
     sentMessages,
+    setMessages: (...args: Parameters<NonNullable<typeof setChatMessages>>) => {
+      if (!setChatMessages) {
+        throw new Error("Default throttle test chat is not mounted");
+      }
+      return setChatMessages(...args);
+    },
     target
   };
 }
@@ -212,13 +225,71 @@ describe("default chat throttle", () => {
     });
   });
 
-  // Proves the caller's value actually reaches the AI SDK: opting out restores
-  // the unthrottled behaviour, and this turn is large enough to fail without a
-  // throttle even with replayed chunks merged.
-  it("lets a caller opt out with throttle: false", async () => {
-    const h = await mount("throttle-off", false);
-    await replayTurn(h);
+  it("resolves functional updates against the current Chat store", async () => {
+    const h = await mount("current-store-updater");
 
-    expect(h.read("status")).toBe("error");
+    h.setMessages((messages) => [
+      ...messages,
+      {
+        id: "a1",
+        parts: [{ text: "streamed", type: "text" }],
+        role: "assistant"
+      }
+    ]);
+    h.setMessages((messages) => [
+      ...messages,
+      { id: "u2", parts: [{ text: "next", type: "text" }], role: "user" }
+    ]);
+
+    await vi.waitFor(() => expect(h.read("message-ids")).toBe("u1,a1,u2"));
+    expect(h.sentMessages[h.sentMessages.length - 1]).toContain('"id":"a1"');
+  });
+
+  it("preserves Chat store parts newer than the rendered snapshot", async () => {
+    const h = await mount("current-store-snapshot", 200);
+    await vi.waitFor(() =>
+      expect(countType(h.sentMessages, RESUME_REQUEST)).toBe(1)
+    );
+    dispatch(h.target, { id: "req-snapshot", type: RESUMING });
+    await sleep(10);
+
+    for (const body of [
+      { messageId: "asst-1", type: "start" },
+      { id: "text-1", type: "text-start" },
+      { delta: "first", id: "text-1", type: "text-delta" }
+    ]) {
+      dispatch(h.target, {
+        body: JSON.stringify(body),
+        done: false,
+        id: "req-snapshot",
+        type: CHAT_RESPONSE
+      });
+    }
+    await vi.waitFor(() => expect(h.read("chars")).toBe("5"));
+
+    dispatch(h.target, {
+      body: JSON.stringify({
+        delta: " second",
+        id: "text-1",
+        type: "text-delta"
+      }),
+      done: false,
+      id: "req-snapshot",
+      type: CHAT_RESPONSE
+    });
+    await sleep(10);
+    dispatch(h.target, {
+      messages: [
+        { id: "u1", parts: [{ text: "hi", type: "text" }], role: "user" },
+        {
+          id: "asst-1",
+          parts: [{ text: "first", type: "text" }],
+          role: "assistant"
+        }
+      ],
+      type: CHAT_MESSAGES
+    });
+
+    await vi.waitFor(() => expect(h.read("chars")).toBe("12"));
   });
 });


### PR DESCRIPTION
A proposal, stacked on #2050. Fixes #1913 together with that PR.

## Why a second change

#2050 stops a resumed stream from writing chat state once per replayed chunk. It merges the chunks that belong to the same piece of text, so a few hundred chunks become a handful of writes.

That helps enormously, but it only merges *within* a part. A tool step costs about seven writes on its own, so a replayed turn of more than about seven tool steps still reaches React's 50-render limit and still shows a false error. Measured with the merge in place: six steps fine, eight throws.

A throttle does not care how many chunks arrive, so it covers what merging cannot.

```mermaid
flowchart LR
  C["chunks arrive"] --> M["#2050<br/>merge replayed chunks"] --> T["this PR<br/>throttle renders"] --> R["at most one render<br/>per 50ms"]
```

## The change

`useAgentChat` now coalesces chat updates every 50ms. Pass `throttle: false` to render every chunk as it arrives, or a number to pick your own interval.

Nothing else changes, and the first chunk of a stream is never delayed - the AI SDK throttles with `throttleit`, which runs the first call of an idle window immediately.

## Why 50ms

Any value above zero prevents the crash, because the update then arrives from a timer rather than from the current task. Verified at 1, 4, 16, 50, 100 and 250ms. So the size of the number is a cost decision rather than a safety one. Measured over a 200-chunk turn at ~100 chunks/sec (caveat that this is obvs on a powerful macbook):

| throttle | renders | render time |
| --- | --- | --- |
| off | 404 | 138ms |
| 16ms | 261 | 89ms |
| **50ms** | **90** | **37ms** |
| 100ms | 48 | 21ms |
| 250ms | 22 | 9ms |

50ms removes 78% of the renders. Larger values save progressively less while letting the text lag further behind the stream. It is also the value the AI SDK's own documentation uses, and 25 of our 27 examples already pass 100ms by hand, so throttling is not new behaviour for our own UIs - only the default is.

## Two things worth knowing

`@ai-sdk/react` v3 reads only `experimental_throttle`; v4 renamed it to `throttle`. Both majors are in our peer range, so the value is sent under both names. Turning it off omits both names rather than sending `0`, because both majors decide with `waitMs != null`, and only an omitted option reaches their unthrottled path.

This proposed change provides a mitigation rather than a guarantee. `useChat` throttles its store subscription, but its `getSnapshot` returns a new messages array on every chunk, and React forces a synchronous re-render whenever that identity moved during a render - a path the throttle never sees. That is vercel/ai#6166, with a fix open in vercel/ai#17893. Writing state less often is the only thing that bounds it, which is why #2050 does the heavier lifting.

## Tests

Eight unit tests in `chat/__tests__/chat-throttle.test.ts` cover the precedence rules and both spellings. Two tests in `react-tests/default-throttle.test.tsx` drive the real hook with a 12-step tool turn: it stays healthy on defaults, and `throttle: false` restores the old failure, which proves the caller's value reaches the SDK.

Suites: agents chat 540 · react 135 · ai-chat 737 · think 920 + react 5 · `pnpm run check`.
