### PR TITLE
chore(voice): unprivate voice provider packages

### DIFF
--- a/voice-providers/assemblyai/package.json
+++ b/voice-providers/assemblyai/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@cloudflare/voice-assemblyai",
-  "private": true,
   "version": "0.0.2",
   "description": "AssemblyAI Universal 3.5 Pro Realtime STT provider for Cloudflare Agents voice pipeline",
   "repository": {

--- a/voice-providers/deepgram/package.json
+++ b/voice-providers/deepgram/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@cloudflare/voice-deepgram",
-  "private": true,
   "version": "0.0.1",
   "description": "Deepgram streaming STT provider for Cloudflare Agents voice pipeline",
   "repository": {

--- a/voice-providers/elevenlabs/package.json
+++ b/voice-providers/elevenlabs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@cloudflare/voice-elevenlabs",
-  "private": true,
   "version": "0.0.2",
   "description": "ElevenLabs STT and TTS providers for Cloudflare Agents voice pipeline",
   "repository": {

--- a/voice-providers/plivo/package.json
+++ b/voice-providers/plivo/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@cloudflare/voice-plivo",
-  "private": true,
   "version": "0.0.1",
   "description": "Plivo audio streaming adapter for Cloudflare Agents voice pipeline — connect phone calls to VoiceAgent",
   "repository": {

--- a/voice-providers/twilio/package.json
+++ b/voice-providers/twilio/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@cloudflare/voice-twilio",
-  "private": true,
   "version": "0.0.2",
   "description": "Twilio Media Streams adapter for Cloudflare Agents voice pipeline — connect phone calls to VoiceAgent",
   "repository": {


### PR DESCRIPTION
This PR removes `"private": true` from the five voice provider packages so they can be published to npm. Opened as a draft because publishing still needs npm-side bootstrap first.

## Blocked on

npm trusted publishing cannot create a package's first version. Per npm/cli#8544, "it's not possible to publish the initial version of a package using OIDC, it needs to be published manually or using a token", because the npmjs.com UI requires a package to exist before a trusted publisher can be configured for it. The release workflow publishes over OIDC with `id-token: write` and no `NODE_AUTH_TOKEN`.

| Package | On npm | Needs bootstrap |
| --- | --- | --- |
| `@cloudflare/voice-twilio` | 0.0.0 | No, but needs a trusted publisher configured |
| `@cloudflare/voice-assemblyai` | absent | Yes |
| `@cloudflare/voice-deepgram` | absent | Yes |
| `@cloudflare/voice-elevenlabs` | absent | Yes |
| `@cloudflare/voice-plivo` | absent | Yes |

`changeset publish` throws `ExitError(1)` when any package fails, which fails the whole release job. Merging this before the four missing names exist on the registry would therefore break the release of `agents` itself, which is a worse outcome than the current silent skip.

Someone with publish rights on the `@cloudflare` scope needs to publish a stub for each of the four absent names and configure the trusted publisher for each on npmjs.com. This PR is ready to merge once that is done.