### PR TITLE
fix(think): restore workspace image reads on AI SDK 6

### DIFF
--- a/.changeset/bright-images-see.md
+++ b/.changeset/bright-images-see.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Emit workspace image reads as `image-data` model content so AI SDK v6 routes them as images, while preserving `file-data` output for PDFs.

--- a/packages/think/src/tests/assistant-tools.test.ts
+++ b/packages/think/src/tests/assistant-tools.test.ts
@@ -62,7 +62,7 @@ describe("assistant tools — read", () => {
     expect(result.content).not.toContain("5\tline5");
   });
 
-  it("returns compact image metadata and model image content", async () => {
+  it("returns compact image metadata and image-data model content", async () => {
     const agent = await freshAgent("read-image-mime");
     await agent.seedBytes("/screenshot", PNG_BYTES, "image/png");
 
@@ -96,11 +96,13 @@ describe("assistant tools — read", () => {
     };
     expect(modelOutput.type).toBe("content");
     expect(modelOutput.value).toContainEqual({
-      type: "file-data",
+      type: "image-data",
       data: "iVBORw0KGgo=",
-      mediaType: "image/png",
-      filename: "screenshot"
+      mediaType: "image/png"
     });
+    expect(modelOutput.value).not.toContainEqual(
+      expect.objectContaining({ type: "file-data" })
+    );
   });
 
   it.each([

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -1722,10 +1722,9 @@ describe("Think — model message conversion", () => {
       ?.content?.find((part) => part.output?.type === "content")?.output;
 
     expect(toolResult?.value).toContainEqual({
-      type: "file-data",
+      type: "image-data",
       data: "iVBORw0KGgo=",
-      mediaType: "image/png",
-      filename: "screenshot"
+      mediaType: "image/png"
     });
   });
 });

--- a/packages/think/src/tools/workspace.ts
+++ b/packages/think/src/tools/workspace.ts
@@ -412,6 +412,19 @@ export function createReadTool(options: ReadToolOptions): Tool {
       const data = uint8ArrayToBase64(bytes);
       const note = `Read ${replayOutput.path} (${replayOutput.mediaType}, ${formatSize(bytes.byteLength)}).`;
 
+      // AI SDK v6 routes `image-data` as an image but `file-data` as a
+      // document. v7 accepts and normalizes `image-data`, so preserve this
+      // distinction across both supported majors.
+      if (replayOutput.kind === "image") {
+        return {
+          type: "content",
+          value: [
+            { type: "text", text: note },
+            { type: "image-data", data, mediaType: replayOutput.mediaType }
+          ]
+        };
+      }
+
       return {
         type: "content",
         value: [


### PR DESCRIPTION
This PR restores image-specific model output for Think workspace reads across supported AI SDK peers. Fixes #2080.

## Why

- `@cloudflare/think` supports `ai@6` and `ai@7`, but workspace images currently emit `file-data`, the same content part used for PDFs.
- AI SDK 6 treats `image-data` as image input and `file-data` as document input. Images therefore fail or get dropped before reaching the model.
- AI SDK 7 normalizes either legacy part using its media type, which hid the regression.
- We could detect the installed AI SDK major and emit its preferred shape, but runtime version detection adds complexity without changing behavior. `image-data` preserves image semantics on both supported majors.

## Code Changes

- Restore the image-specific `image-data` branch in the workspace read tool’s model-output conversion.
- Keep PDFs on the existing `file-data` path with their filename.
- Preserve compact workspace results and rehydrate their bytes only when preparing model output.
- Add an `@cloudflare/think` patch changeset.

## Compatibility

- AI SDK 6 now routes workspace image reads as images rather than documents.
- AI SDK 7 accepts and normalizes `image-data`, preserving its existing provider-facing image behavior.
- Consumers do not need to update call sites.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/agents/pull/2082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->