### PR TITLE
fix(voice): exclude current transcript from turn context

### DIFF
--- a/.changeset/calm-voices-remember.md
+++ b/.changeset/calm-voices-remember.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/voice": patch
+---
+
+Define `VoiceTurnContext.messages` as completed history before the current transcript for both text and audio turns, preventing duplicate user messages when following the documented prompt construction.
+
+`onTurn()` implementations that previously passed `context.messages` directly as complete LLM input must now append `transcript` exactly once. The transcript is still persisted before `onTurn()` runs, so direct `getConversationHistory()` calls continue to include it.

--- a/docs/voice/index.md
+++ b/docs/voice/index.md
@@ -177,7 +177,7 @@ Custom transcriber sessions can implement `waitUntilReady(): Promise<void>` when
 
 ### `onTurn(transcript, context)`
 
-**Required.** Called when the user finishes speaking and the transcript is ready.
+**Required.** Called when the user finishes speaking and the transcript is ready. `context.messages` contains completed conversation history before this transcript. Append `transcript` exactly once when constructing an LLM message list.
 
 Return a `string`, `AsyncIterable<string>`, or `ReadableStream` for streaming responses:
 
@@ -217,11 +217,11 @@ async onTurn(transcript: string, context: VoiceTurnContext) {
 
 The `context` object provides:
 
-| Field        | Type                                       | Description                        |
-| ------------ | ------------------------------------------ | ---------------------------------- |
-| `connection` | `Connection`                               | The WebSocket connection           |
-| `messages`   | `Array<{ role: string; content: string }>` | Conversation history from SQLite   |
-| `signal`     | `AbortSignal`                              | Aborted on interrupt or disconnect |
+| Field        | Type                                       | Description                             |
+| ------------ | ------------------------------------------ | --------------------------------------- |
+| `connection` | `Connection`                               | The WebSocket connection                |
+| `messages`   | `Array<{ role: string; content: string }>` | Completed history before the transcript |
+| `signal`     | `AbortSignal`                              | Aborted on interrupt or disconnect      |
 
 ### Lifecycle Hooks
 
@@ -705,10 +705,10 @@ const { metrics } = useVoiceAgent({ agent: "MyAgent" });
 
 ## Conversation History
 
-`withVoice` automatically persists conversation messages to SQLite. Access history in your `onTurn` via `context.messages`, or directly:
+`withVoice` automatically persists conversation messages to SQLite. In `onTurn()`, `context.messages` is a snapshot of the completed history before the current transcript. The pipeline persists the current transcript before invoking the hook, so a direct `getConversationHistory()` call inside `onTurn()` includes it.
 
 ```typescript
-// Get history (most recent N messages)
+// Get stored history, including the current transcript during onTurn()
 const history = this.getConversationHistory(20);
 
 // Manually save a message

--- a/experimental/voice.md
+++ b/experimental/voice.md
@@ -153,7 +153,7 @@ Browser                             VoiceAgent (Durable Object)
 2. When the client detects 500 ms of silence, it sends `end_of_speech`.
 3. The agent runs server-side VAD (`smart-turn-v2`) to confirm the user actually finished speaking.
 4. STT transcribes the audio to text.
-5. `onTurn()` is called with the transcript and conversation history.
+5. `onTurn()` is called with the transcript and completed prior conversation history.
 6. If `onTurn()` returns an `AsyncIterable<string>` (streaming), the pipeline chunks the token stream into sentences and synthesizes TTS concurrently — the user hears the first sentence while the LLM is still generating.
 7. If `onTurn()` returns a plain `string`, the full text is synthesized at once.
 
@@ -163,7 +163,7 @@ If the user speaks while the agent is talking, the client detects it (sustained 
 
 ### Conversation persistence
 
-`VoiceAgent` automatically creates a SQLite table (`cf_voice_messages`) and saves every user and assistant message. Conversation history survives restarts and hibernation. The `context.messages` array passed to `onTurn()` contains the most recent messages (configurable via `voiceOptions.historyLimit`, default 20).
+`VoiceAgent` automatically creates a SQLite table (`cf_voice_messages`) and saves every user and assistant message. Conversation history survives restarts and hibernation. The `context.messages` array passed to `onTurn()` contains the most recent completed messages before the current transcript (configurable via `voiceOptions.historyLimit`, default 20). Append `transcript` exactly once when constructing an LLM message list.
 
 ## VoiceAgent reference
 
@@ -182,7 +182,7 @@ async onTurn(
 
 - `transcript` — The user's transcribed speech.
 - `context.connection` — The WebSocket `Connection` that sent the audio.
-- `context.messages` — Conversation history from SQLite (chronological order).
+- `context.messages` — Completed conversation history before the current transcript (chronological order).
 - `context.signal` — An `AbortSignal` that fires if the user interrupts or disconnects. Pass it to your LLM call.
 
 **Return value:**
@@ -254,7 +254,7 @@ Save a message to the conversation history table. The pipeline calls this automa
 getConversationHistory(limit?: number): Array<{ role: string; content: string }>
 ```
 
-Load the most recent messages from SQLite. Defaults to `voiceOptions.historyLimit` (20).
+Load the most recent messages from SQLite. Defaults to `voiceOptions.historyLimit` (20). The pipeline persists the current transcript before invoking `onTurn()`, so calling this method inside the hook includes the current transcript even though `context.messages` does not.
 
 ### beforeCallStart(connection) — optional
 

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -50,16 +50,21 @@ export class MyAgent extends VoiceAgent<Env> {
 ```typescript
 import { streamText } from "ai";
 
-async onTurn(transcript: string) {
+async onTurn(transcript: string, context: VoiceTurnContext) {
   const result = streamText({
     model: myModel,
     instructions: "You are a helpful voice assistant. Keep replies short.",
-    messages: [{ role: "user", content: transcript }]
+    messages: [
+      ...context.messages,
+      { role: "user", content: transcript }
+    ]
   });
 
   return result.stream;
 }
 ```
+
+`context.messages` contains completed conversation history before the current transcript. Append `transcript` exactly once when constructing the LLM request. The pipeline persists the transcript before `onTurn()` runs, so calling `getConversationHistory()` directly inside the hook returns stored history that includes the current transcript.
 
 ### Provider properties
 

--- a/packages/voice/src/tests/agents/voice.ts
+++ b/packages/voice/src/tests/agents/voice.ts
@@ -648,6 +648,24 @@ export class TestEmptyResponseVoiceAgent extends VoiceBase {
   }
 }
 
+/**
+ * Reports the conversation history supplied to onTurn through its response.
+ * This lets protocol-level tests verify the VoiceTurnContext contract.
+ */
+export class TestContextVoiceAgent extends VoiceBase {
+  static options = { hibernate: false };
+
+  transcriber = new TestTranscriber();
+  tts = new TestTTS();
+
+  async onTurn(
+    _transcript: string,
+    context: VoiceTurnContext
+  ): Promise<string> {
+    return JSON.stringify(context.messages);
+  }
+}
+
 export class TestAiSdkFullStreamVoiceAgent extends VoiceBase {
   static options = { hibernate: false };
 

--- a/packages/voice/src/tests/voice.test.ts
+++ b/packages/voice/src/tests/voice.test.ts
@@ -56,6 +56,10 @@ function uniquePath() {
   return `/agents/test-voice-agent/voice-test-${++instanceCounter}`;
 }
 
+function uniqueContextPath() {
+  return `/agents/test-context-voice-agent/voice-test-${++instanceCounter}`;
+}
+
 function uniqueAISDKStreamPath() {
   return `/agents/test-ai-sdk-full-stream-voice-agent/voice-test-${++instanceCounter}`;
 }
@@ -1074,6 +1078,66 @@ describe("VoiceAgent — continuous STT pipeline", () => {
     );
 
     await waitForStatus(ws, "listening");
+    ws.close();
+  });
+});
+
+describe("VoiceAgent — turn context history", () => {
+  it("gives text turns completed history without the current transcript", async () => {
+    const { ws } = await connectWS(uniqueContextPath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "text_message", text: "first text turn" });
+    const firstResponse = (await waitForType(ws, "transcript_end")) as Record<
+      string,
+      unknown
+    >;
+    expect(firstResponse.text).toBe("[]");
+
+    sendJSON(ws, { type: "text_message", text: "second text turn" });
+    const secondResponse = (await waitForType(ws, "transcript_end")) as Record<
+      string,
+      unknown
+    >;
+    expect(JSON.parse(secondResponse.text as string)).toEqual([
+      { role: "user", content: "first text turn" },
+      { role: "assistant", content: "[]" }
+    ]);
+
+    ws.close();
+  });
+
+  it("gives audio turns completed history without the current transcript", async () => {
+    const { ws } = await connectWS(uniqueContextPath());
+    await waitForStatus(ws, "idle");
+
+    sendJSON(ws, { type: "start_call" });
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const firstResponse = (await waitForType(ws, "transcript_end")) as Record<
+      string,
+      unknown
+    >;
+    expect(firstResponse.text).toBe("[]");
+    await waitForStatus(ws, "listening");
+
+    for (let i = 0; i < 4; i++) {
+      ws.send(new ArrayBuffer(5000));
+    }
+
+    const secondResponse = (await waitForType(ws, "transcript_end")) as Record<
+      string,
+      unknown
+    >;
+    expect(JSON.parse(secondResponse.text as string)).toEqual([
+      { role: "user", content: "utterance 1 (20000 bytes)" },
+      { role: "assistant", content: "[]" }
+    ]);
+
     ws.close();
   });
 });

--- a/packages/voice/src/tests/worker.ts
+++ b/packages/voice/src/tests/worker.ts
@@ -3,6 +3,7 @@ import { routeAgentRequest } from "agents";
 export {
   TestVoiceAgent,
   TestEmptyResponseVoiceAgent,
+  TestContextVoiceAgent,
   TestAiSdkFullStreamVoiceAgent,
   TestAiSdkTextStreamVoiceAgent,
   TestPcm24kVoiceAgent
@@ -16,6 +17,7 @@ export {
 export type Env = {
   TestVoiceAgent: DurableObjectNamespace;
   TestEmptyResponseVoiceAgent: DurableObjectNamespace;
+  TestContextVoiceAgent: DurableObjectNamespace;
   TestAiSdkFullStreamVoiceAgent: DurableObjectNamespace;
   TestAiSdkTextStreamVoiceAgent: DurableObjectNamespace;
   TestPcm24kVoiceAgent: DurableObjectNamespace;

--- a/packages/voice/src/tests/wrangler.jsonc
+++ b/packages/voice/src/tests/wrangler.jsonc
@@ -20,6 +20,10 @@
         "name": "TestEmptyResponseVoiceAgent"
       },
       {
+        "class_name": "TestContextVoiceAgent",
+        "name": "TestContextVoiceAgent"
+      },
+      {
         "class_name": "TestAiSdkFullStreamVoiceAgent",
         "name": "TestAiSdkFullStreamVoiceAgent"
       },
@@ -47,6 +51,7 @@
       "new_sqlite_classes": [
         "TestVoiceAgent",
         "TestEmptyResponseVoiceAgent",
+        "TestContextVoiceAgent",
         "TestAiSdkFullStreamVoiceAgent",
         "TestAiSdkTextStreamVoiceAgent",
         "TestPcm24kVoiceAgent",

--- a/packages/voice/src/voice.ts
+++ b/packages/voice/src/voice.ts
@@ -111,6 +111,7 @@ export type {
 /** Context passed to the `onTurn()` hook. */
 export interface VoiceTurnContext {
   connection: Connection;
+  /** Completed conversation history before the current transcript. */
   messages: Array<{ role: VoiceRole; content: string }>;
   signal: AbortSignal;
 }
@@ -728,6 +729,7 @@ export function withVoice<TBase extends AgentLike>(
 
       this.#sendJSON(connection, { type: "status", status: "thinking" });
 
+      const priorMessages = this.getConversationHistory();
       this.saveMessage("user", userText);
       this.#sendJSON(connection, {
         type: "transcript",
@@ -738,7 +740,7 @@ export function withVoice<TBase extends AgentLike>(
       try {
         const context: VoiceTurnContext = {
           connection,
-          messages: this.getConversationHistory(),
+          messages: priorMessages,
           signal
         };
 
@@ -840,6 +842,7 @@ export function withVoice<TBase extends AgentLike>(
           return;
         }
 
+        const priorMessages = this.getConversationHistory();
         this.saveMessage("user", userText);
         this.#sendJSON(connection, {
           type: "transcript",
@@ -851,7 +854,7 @@ export function withVoice<TBase extends AgentLike>(
 
         const context: VoiceTurnContext = {
           connection,
-          messages: this.getConversationHistory(),
+          messages: priorMessages,
           signal
         };
 


### PR DESCRIPTION
This PR defines `VoiceTurnContext.messages` as completed conversation history before the current transcript for both text and audio turns. Fixes #2078.

## Why

- The voice pipeline persisted each current user transcript before loading `context.messages`, so the context already ended with that transcript.
- The documented prompt construction spreads `context.messages` and then appends `transcript`. That produced two adjacent copies of every current user turn.
- The implementation and examples had contradicted each other since the API was introduced, while the previous documentation did not explicitly define whether history included the current turn.
- We could change the examples to stop appending `transcript`, but that would require applications following the documented pattern to update and would make the separate `transcript` parameter redundant for prompt construction.
- Snapshotting prior history resolves the contract in favor of the existing examples. The pipeline still persists the transcript before invoking `onTurn()`, preserving its durability timing.

## Public API Surface

`VoiceTurnContext.messages` keeps the same type, but its documented behavior changes: it contains completed conversation history before the current transcript. The current user input remains available through the `transcript` parameter.

## Code Changes

- Snapshot conversation history before saving the current user message in both the text-message and audio/STT turn paths.
- Pass that prior-history snapshot to `onTurn()` while retaining the existing persistence order relative to the hook.
- Clarify the contract and canonical prompt construction in the package README, voice documentation, experimental guide, and exported type comment.
- Add an `@cloudflare/voice` patch changeset with migration guidance.

## Compatibility

Consumers following the documented pattern can continue appending `transcript` once and will no longer send a duplicate current turn.

Consumers that currently pass `context.messages` directly as a complete LLM input must append `transcript` once. Calling `getConversationHistory()` directly inside `onTurn()` continues to include the current transcript because it is still persisted before the hook runs.
