### PR TITLE
fix(skills): run compiled scripts loaded from R2

### DIFF
--- a/.changeset/swift-skills-bundle.md
+++ b/.changeset/swift-skills-bundle.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fix precompiled JavaScript and TypeScript skill scripts loaded from R2 or other dynamic sources. Output from `compileSkillScript` can now run without separately preserving the `precompiled` resource descriptor.

--- a/.changeset/swift-skills-bundle.md
+++ b/.changeset/swift-skills-bundle.md
@@ -2,4 +2,4 @@
 "agents": patch
 ---
 
-Fix precompiled JavaScript and TypeScript skill scripts loaded from R2 or other dynamic sources. Output from `compileSkillScript` can now run without separately preserving the `precompiled` resource descriptor.
+Fix precompiled JavaScript and TypeScript skill scripts loaded from R2 or other dynamic sources. Header-marked output from `compileSkillScript` can now run without separately preserving the `precompiled` resource descriptor.

--- a/design/skills.md
+++ b/design/skills.md
@@ -255,9 +255,10 @@ returned by `run_skill_script` without mutating the workspace. The Agents Vite
 plugin compiles bundled JavaScript and TypeScript with esbuild before deployment.
 R2 and other dynamic sources use `compileSkillScript` in Node-based publish
 tooling and store its self-contained ESM output unchanged. The compiler prepends
-an Agents skill-script format header, and the runner requires that header plus
-esbuild's `export { binding as default }` bundle form. Dynamic sources therefore
-do not need to preserve the optional `precompiled` resource descriptor.
+an Agents skill-script format header that selects the compiled runner path; the
+runner then normalizes esbuild's expected `export { binding as default }` bundle
+form into its function wrapper. Dynamic sources therefore do not need to
+preserve the optional `precompiled` resource descriptor.
 
 Python (`.py`) and Bash (`.sh`/`.bash`) keep the path-based contract, matching
 CLI-oriented Agent Skills. The runner mounts:

--- a/design/skills.md
+++ b/design/skills.md
@@ -254,9 +254,10 @@ tools; and `ctx.output.writeFile(name, content)` records scratch artifacts
 returned by `run_skill_script` without mutating the workspace. The Agents Vite
 plugin compiles bundled JavaScript and TypeScript with esbuild before deployment.
 R2 and other dynamic sources use `compileSkillScript` in Node-based publish
-tooling and store its self-contained ESM output. The runner recognizes esbuild's
-`export { binding as default }` bundle form, so dynamic sources do not need to
-preserve the optional `precompiled` resource descriptor.
+tooling and store its self-contained ESM output unchanged. The compiler prepends
+an Agents skill-script format header, and the runner requires that header plus
+esbuild's `export { binding as default }` bundle form. Dynamic sources therefore
+do not need to preserve the optional `precompiled` resource descriptor.
 
 Python (`.py`) and Bash (`.sh`/`.bash`) keep the path-based contract, matching
 CLI-oriented Agent Skills. The runner mounts:

--- a/design/skills.md
+++ b/design/skills.md
@@ -251,8 +251,12 @@ removed); `ctx.workspace` exposes async `readFile`/`listFiles`/`glob`/`stat`/
 `writeFile` gated by the workspace permission; `ctx.tools` exposes
 `tools.call(name, input)` and `tools.<name>(input)` for explicitly granted
 tools; and `ctx.output.writeFile(name, content)` records scratch artifacts
-returned by `run_skill_script` without mutating the workspace. TypeScript and
-multi-file scripts are compiled/bundled with `@cloudflare/worker-bundler`.
+returned by `run_skill_script` without mutating the workspace. The Agents Vite
+plugin compiles bundled JavaScript and TypeScript with esbuild before deployment.
+R2 and other dynamic sources use `compileSkillScript` in Node-based publish
+tooling and store its self-contained ESM output. The runner recognizes esbuild's
+`export { binding as default }` bundle form, so dynamic sources do not need to
+preserve the optional `precompiled` resource descriptor.
 
 Python (`.py`) and Bash (`.sh`/`.bash`) keep the path-based contract, matching
 CLI-oriented Agent Skills. The runner mounts:

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -956,9 +956,25 @@ Script execution is opt-in and requires a Worker Loader binding:
 ```
 
 `skills.runner()` is experimental and runs JavaScript, TypeScript, Python, and
-Bash scripts under `scripts/`. TypeScript is compiled with
-`@cloudflare/worker-bundler`; Python runs as Python Dynamic Workers; Bash runs
-through `just-bash`.
+Bash scripts under `scripts/`. The Agents Vite plugin compiles bundled JavaScript
+and TypeScript with esbuild before deployment. The runtime executes
+self-contained JavaScript and does not bundle raw TypeScript or multi-file
+scripts.
+
+For skills served from R2 or another dynamic source, compile the entry point in
+Node-based publish tooling and upload the returned content unchanged:
+
+```typescript
+import { compileSkillScript } from "agents/skills/compile";
+
+const compiled = await compileSkillScript(
+  "./skills/release-notes/scripts/format-release-notes.ts"
+);
+await skillsBucket.put(
+  "skills/release-notes/scripts/format-release-notes.ts",
+  compiled.content
+);
+```
 
 JavaScript and TypeScript scripts are function-style:
 
@@ -1320,8 +1336,10 @@ Bundled with `@cloudflare/think`:
 | `aywson`               | Wrangler JSON/JSONC parsing for the framework plugin  |
 
 The Agent Skills engine and its script runner live in
-[`agents/skills`](https://github.com/cloudflare/agents/blob/main/packages/agents/AGENTS.md) (so skill scripts pull
-`@cloudflare/worker-bundler` and `just-bash` through `agents`, not Think).
+[`agents/skills`](https://github.com/cloudflare/agents/blob/main/packages/agents/AGENTS.md).
+JavaScript skill scripts execute through `@cloudflare/codemode`, Bash scripts
+execute through `just-bash`, and build-time JavaScript and TypeScript compilation
+uses esbuild through `agents/skills/compile`.
 
 ## Docs
 

--- a/docs/think/index.md
+++ b/docs/think/index.md
@@ -962,7 +962,8 @@ self-contained JavaScript and does not bundle raw TypeScript or multi-file
 scripts.
 
 For skills served from R2 or another dynamic source, compile the entry point in
-Node-based publish tooling and upload the returned content unchanged:
+Node-based publish tooling and upload the returned content unchanged. The
+compiler prepends the format header used to recognize the generated bundle:
 
 ```typescript
 import { compileSkillScript } from "agents/skills/compile";

--- a/examples/agent-skills/README.md
+++ b/examples/agent-skills/README.md
@@ -57,20 +57,21 @@ export class SkillsAgent extends Think<Env> {
 ```
 
 The `agents/vite` plugin turns the local `src/skills/*/SKILL.md` directories
-into a `SkillSource` that Think can register at startup. The optional,
-experimental script runner executes the TypeScript file under `scripts/` in a
-sandboxed Worker, using `@cloudflare/worker-bundler` to compile TypeScript and
-bundle sibling script imports. JS/TS scripts are function-style
-(`export default async function run(input, ctx)`) and read bundled text files
-from `ctx.files`, call explicit `ctx.tools`, access `ctx.workspace`, and write
-scratch artifacts with `ctx.output.writeFile(name, content)`. The same runner
-also supports Python and Bash scripts via the path-based `/input.json` /
-`/skill` / `/output` contract — this example keeps it to TypeScript. Script
-execution requires the `worker_loaders` binding shown in `wrangler.jsonc`.
-Passing `workspaceInstance` gives scripts read-only workspace access by default;
-opt in to `workspace: "read-write"`, tools, or network only when a skill needs
-them. The default 30 second timeout leaves room for TypeScript compilation and
-Dynamic Worker cold starts in local development.
+into a `SkillSource` that Think can register at startup. It compiles JavaScript
+and TypeScript scripts with esbuild during the Vite build, bundling sibling
+imports before deployment. The optional, experimental script runner executes
+the resulting self-contained JavaScript in a sandboxed Worker. JS/TS scripts
+are function-style (`export default async function run(input, ctx)`) and read
+bundled text files from `ctx.files`, call explicit `ctx.tools`, access
+`ctx.workspace`, and write scratch artifacts with
+`ctx.output.writeFile(name, content)`. The same runner also supports Python and
+Bash scripts via the path-based `/input.json` / `/skill` / `/output` contract —
+this example keeps it to TypeScript. Script execution requires the
+`worker_loaders` binding shown in `wrangler.jsonc`. Passing `workspaceInstance`
+gives scripts read-only workspace access by default; opt in to
+`workspace: "read-write"`, tools, or network only when a skill needs them. The
+default 30 second timeout leaves room for script execution and Dynamic Worker
+cold starts in local development.
 
 ## Related
 

--- a/packages/agents/src/cli-tests/vite-skills.test.ts
+++ b/packages/agents/src/cli-tests/vite-skills.test.ts
@@ -234,6 +234,18 @@ describe("compileSkillScript", () => {
     );
   });
 
+  it("removes a shebang that cannot run inside the skill wrapper", async () => {
+    const entry = join(compileDir, "run.ts");
+    await writeFile(
+      entry,
+      '#!/usr/bin/env node\nexport default function run() { return "ok"; }\n'
+    );
+
+    const result = await compileSkillScript(entry);
+
+    expect(result.content).not.toContain("#!/usr/bin/env node");
+  });
+
   it("throws when the entry file does not exist", async () => {
     await expect(
       compileSkillScript(join(compileDir, "missing.ts"))

--- a/packages/agents/src/cli-tests/vite-skills.test.ts
+++ b/packages/agents/src/cli-tests/vite-skills.test.ts
@@ -226,7 +226,9 @@ describe("compileSkillScript", () => {
     expect(result.content).not.toContain('from "./helper"');
     expect(result.content).not.toContain("type Input");
     expect(result.content).toContain("toUpperCase()");
-    expect(result.content).toMatch(/as default/);
+    expect(result.content).toMatch(
+      /export\s*\{[\s\S]*\brun\s+as\s+default\b[\s\S]*\}/
+    );
   });
 
   it("throws when the entry file does not exist", async () => {

--- a/packages/agents/src/cli-tests/vite-skills.test.ts
+++ b/packages/agents/src/cli-tests/vite-skills.test.ts
@@ -223,6 +223,9 @@ describe("compileSkillScript", () => {
     const result = await compileSkillScript(entry);
 
     expect(result.precompiled).toBe(true);
+    expect(result.content).toMatch(
+      /^\/\/ @cloudflare\/agents compiled skill script v1\n/
+    );
     expect(result.content).not.toContain('from "./helper"');
     expect(result.content).not.toContain("type Input");
     expect(result.content).toContain("toUpperCase()");

--- a/packages/agents/src/cli-tests/vite-skills.test.ts
+++ b/packages/agents/src/cli-tests/vite-skills.test.ts
@@ -224,7 +224,7 @@ describe("compileSkillScript", () => {
 
     expect(result.precompiled).toBe(true);
     expect(result.content).toMatch(
-      /^\/\/ @cloudflare\/agents compiled skill script v1\n/
+      /^\/\/ cloudflare-agents:compiled-skill-script:v1\n/
     );
     expect(result.content).not.toContain('from "./helper"');
     expect(result.content).not.toContain("type Input");

--- a/packages/agents/src/skills/compile.ts
+++ b/packages/agents/src/skills/compile.ts
@@ -1,4 +1,5 @@
 import { build } from "esbuild";
+import { COMPILED_SKILL_SCRIPT_HEADER } from "./compiled-script-format";
 
 /**
  * Build-time skill-script compiler.
@@ -19,7 +20,10 @@ import { build } from "esbuild";
 const COMPILABLE_SCRIPT_EXTENSIONS = new Set([".js", ".mjs", ".ts", ".tsx"]);
 
 export interface CompiledSkillScript {
-  /** Self-contained ESM source, ready to embed and run without a bundler. */
+  /**
+   * Self-contained ESM source with a generated format header. Upload this
+   * content unchanged so dynamic skill sources remain recognizable.
+   */
   content: string;
   /** Always `true`; mirrors the `precompiled` flag on skill resources. */
   precompiled: true;
@@ -78,5 +82,8 @@ export async function compileSkillScript(
     );
   }
 
-  return { content: output.text, precompiled: true };
+  return {
+    content: `${COMPILED_SKILL_SCRIPT_HEADER}\n${output.text}`,
+    precompiled: true
+  };
 }

--- a/packages/agents/src/skills/compile.ts
+++ b/packages/agents/src/skills/compile.ts
@@ -1,5 +1,5 @@
 import { build } from "esbuild";
-import { COMPILED_SKILL_SCRIPT_HEADER } from "./compiled-script-format";
+import { COMPILED_SKILL_SCRIPT_FORMAT_V1 } from "./compiled-script-format";
 
 /**
  * Build-time skill-script compiler.
@@ -83,7 +83,7 @@ export async function compileSkillScript(
   }
 
   return {
-    content: `${COMPILED_SKILL_SCRIPT_HEADER}\n${output.text}`,
+    content: `${COMPILED_SKILL_SCRIPT_FORMAT_V1}\n${output.text}`,
     precompiled: true
   };
 }

--- a/packages/agents/src/skills/compile.ts
+++ b/packages/agents/src/skills/compile.ts
@@ -43,6 +43,11 @@ function extensionOf(path: string): string {
   return index === -1 ? "" : file.slice(index).toLowerCase();
 }
 
+/** Remove a CLI hashbang that cannot run inside the skill function wrapper. */
+function stripLeadingHashbang(source: string): string {
+  return source.replace(/^#![^\r\n]*(?:\r?\n|$)/, "");
+}
+
 /**
  * Whether a resource path is a skill script that should be compiled ahead of
  * time (i.e. has a `.js`, `.mjs`, `.ts`, or `.tsx` extension).
@@ -58,7 +63,8 @@ export function isCompilableSkillScript(path: string): boolean {
  * TypeScript types, and emits ESM so the script can run in the Worker sandbox
  * without an in-Worker bundler.
  *
- * @param entryPath Absolute path to the skill script file on disk.
+ * @param entryPath Path to the skill script file on disk. Relative paths are
+ * resolved from the current working directory.
  */
 export async function compileSkillScript(
   entryPath: string,
@@ -83,7 +89,7 @@ export async function compileSkillScript(
   }
 
   return {
-    content: `${COMPILED_SKILL_SCRIPT_FORMAT_V1}\n${output.text}`,
+    content: `${COMPILED_SKILL_SCRIPT_FORMAT_V1}\n${stripLeadingHashbang(output.text)}`,
     precompiled: true
   };
 }

--- a/packages/agents/src/skills/compiled-script-format.ts
+++ b/packages/agents/src/skills/compiled-script-format.ts
@@ -5,3 +5,18 @@
  */
 export const COMPILED_SKILL_SCRIPT_FORMAT_V1 =
   "// cloudflare-agents:compiled-skill-script:v1";
+
+/**
+ * Whether source starts with the V1 compiled skill-script marker. A UTF-8 BOM
+ * and CRLF line ending are accepted because publish tooling may normalize them.
+ */
+export function hasCompiledSkillScriptFormatV1(source: string): boolean {
+  const markerStart = source.charCodeAt(0) === 0xfeff ? 1 : 0;
+  const lineEndingStart = markerStart + COMPILED_SKILL_SCRIPT_FORMAT_V1.length;
+
+  return (
+    source.startsWith(COMPILED_SKILL_SCRIPT_FORMAT_V1, markerStart) &&
+    (source.startsWith("\n", lineEndingStart) ||
+      source.startsWith("\r\n", lineEndingStart))
+  );
+}

--- a/packages/agents/src/skills/compiled-script-format.ts
+++ b/packages/agents/src/skills/compiled-script-format.ts
@@ -1,0 +1,7 @@
+/**
+ * First line added to generated skill bundles so dynamic sources can identify
+ * the build-time compiled script format without relying on JavaScript syntax
+ * alone.
+ */
+export const COMPILED_SKILL_SCRIPT_HEADER =
+  "// @cloudflare/agents compiled skill script v1";

--- a/packages/agents/src/skills/compiled-script-format.ts
+++ b/packages/agents/src/skills/compiled-script-format.ts
@@ -3,5 +3,5 @@
  * the build-time compiled script format without relying on JavaScript syntax
  * alone.
  */
-export const COMPILED_SKILL_SCRIPT_HEADER =
-  "// @cloudflare/agents compiled skill script v1";
+export const COMPILED_SKILL_SCRIPT_FORMAT_V1 =
+  "// cloudflare-agents:compiled-skill-script:v1";

--- a/packages/agents/src/skills/runner.ts
+++ b/packages/agents/src/skills/runner.ts
@@ -3,7 +3,7 @@ import { DynamicWorkerExecutor, resolveProvider } from "@cloudflare/codemode";
 import type { ToolProvider } from "@cloudflare/codemode";
 import { Bash, defineCommand } from "just-bash";
 import type { ToolSet } from "ai";
-import { COMPILED_SKILL_SCRIPT_FORMAT_V1 } from "./compiled-script-format";
+import { hasCompiledSkillScriptFormatV1 } from "./compiled-script-format";
 import type {
   SkillScriptRequest,
   SkillScriptRunner,
@@ -250,7 +250,7 @@ function bashFiles(
  * object from the host bridge proxy (`__host`), and invoke it.
  */
 function scriptModule(source: string, request: SkillScriptRequest): string {
-  const runnableSource = stripStrayExports(
+  const runnableSource = stripFinalExportBlock(
     source.replace(/^\s*export\s+default\s+/m, "const __skillRun = ")
   );
   const skillMeta = skillScriptContext(request).skill;
@@ -291,12 +291,32 @@ function scriptModule(source: string, request: SkillScriptRequest): string {
   ].join("\n");
 }
 
+type FinalExportBlock = {
+  readonly exports: string;
+  readonly start: number;
+  readonly end: number;
+};
+
+/** Find the final ESM export-list statement emitted by esbuild. */
+function findFinalExportBlock(source: string): FinalExportBlock | null {
+  const match = source.match(
+    /(?:^|\r?\n)[\t ]*export[\t ]*\{([^}]*)\}[\t ]*;?[\t ]*(?:\r?\n)?$/
+  );
+  if (match?.index === undefined || match[1] === undefined) return null;
+
+  return {
+    exports: match[1],
+    start: match.index,
+    end: match.index + match[0].length
+  };
+}
+
 /** Return the local binding exported as default by an esbuild ESM bundle. */
 function findBundledDefaultExportBinding(source: string): string | null {
+  const exportBlock = findFinalExportBlock(source);
   return (
-    source.match(
-      /\bexport\s*\{[^}]*\b([A-Za-z_$][\w$]*)\s+as\s+default\b[^}]*\}/m
-    )?.[1] ?? null
+    exportBlock?.exports.match(/\b([A-Za-z_$][\w$]*)\s+as\s+default\b/)?.[1] ??
+    null
   );
 }
 
@@ -312,22 +332,20 @@ function hasDefaultExport(source: string): boolean {
   );
 }
 
-/**
- * Remove `export { ... }` blocks, which are illegal inside the function wrapper
- * the runner builds around skill scripts.
- */
-function stripStrayExports(source: string): string {
-  return source.replace(/\n?export\s*\{[\s\S]*?\};?/g, "");
+/** Remove the final ESM export list, which is illegal inside the wrapper. */
+function stripFinalExportBlock(source: string): string {
+  const exportBlock = findFinalExportBlock(source);
+  if (!exportBlock) return source;
+  return source.slice(0, exportBlock.start) + source.slice(exportBlock.end);
 }
 
 function rewriteBundledSource(source: string): string {
-  // esbuild emits the default export as a binding inside an `export { ... }`
-  // block, e.g. `export { run as default }` or, when the module also has named
-  // exports, `export { helper, run as default }`. Extract the binding aliased
-  // to `default` from anywhere in those blocks, then strip the (illegal-inside-
-  // a-function) export statements and bind the captured name to `__skillRun`.
+  // esbuild emits the default binding in a final `export { ... }` block, e.g.
+  // `export { run as default }` or `export { helper, run as default }`. Extract
+  // that binding, remove the statement that is illegal inside the function
+  // wrapper, and bind the captured name to `__skillRun`.
   const defaultBinding = findBundledDefaultExportBinding(source);
-  const stripped = stripStrayExports(source);
+  const stripped = stripFinalExportBlock(source);
   if (defaultBinding) {
     return `${stripped}\nconst __skillRun = ${defaultBinding};`;
   }
@@ -351,7 +369,7 @@ async function prepareJavaScriptSource(
       resource.path === request.path && resource.precompiled === true
   );
   const hasCompiledSkillScriptFormat =
-    request.source.startsWith(`${COMPILED_SKILL_SCRIPT_FORMAT_V1}\n`) &&
+    hasCompiledSkillScriptFormatV1(request.source) &&
     findBundledDefaultExportBinding(request.source) !== null;
   if (entryPrecompiled || hasCompiledSkillScriptFormat) {
     return rewriteBundledSource(request.source);

--- a/packages/agents/src/skills/runner.ts
+++ b/packages/agents/src/skills/runner.ts
@@ -3,7 +3,7 @@ import { DynamicWorkerExecutor, resolveProvider } from "@cloudflare/codemode";
 import type { ToolProvider } from "@cloudflare/codemode";
 import { Bash, defineCommand } from "just-bash";
 import type { ToolSet } from "ai";
-import { COMPILED_SKILL_SCRIPT_HEADER } from "./compiled-script-format";
+import { COMPILED_SKILL_SCRIPT_FORMAT_V1 } from "./compiled-script-format";
 import type {
   SkillScriptRequest,
   SkillScriptRunner,
@@ -351,7 +351,7 @@ async function prepareJavaScriptSource(
       resource.path === request.path && resource.precompiled === true
   );
   const hasCompiledSkillScriptFormat =
-    request.source.startsWith(`${COMPILED_SKILL_SCRIPT_HEADER}\n`) &&
+    request.source.startsWith(`${COMPILED_SKILL_SCRIPT_FORMAT_V1}\n`) &&
     findBundledDefaultExportBinding(request.source) !== null;
   if (entryPrecompiled || hasCompiledSkillScriptFormat) {
     return rewriteBundledSource(request.source);

--- a/packages/agents/src/skills/runner.ts
+++ b/packages/agents/src/skills/runner.ts
@@ -290,6 +290,15 @@ function scriptModule(source: string, request: SkillScriptRequest): string {
   ].join("\n");
 }
 
+/** Return the local binding exported as default by an esbuild ESM bundle. */
+function findBundledDefaultExportBinding(source: string): string | null {
+  return (
+    source.match(
+      /\bexport\s*\{[^}]*\b([A-Za-z_$][\w$]*)\s+as\s+default\b[^}]*\}/m
+    )?.[1] ?? null
+  );
+}
+
 /**
  * Whether a script declares a default export, in either the raw author form
  * (`export default ...`) or the bundled form esbuild emits
@@ -298,7 +307,7 @@ function scriptModule(source: string, request: SkillScriptRequest): string {
 function hasDefaultExport(source: string): boolean {
   return (
     /^\s*export\s+default\s+/m.test(source) ||
-    /export\s*\{[^}]*\bas\s+default\b[^}]*\}/m.test(source)
+    findBundledDefaultExportBinding(source) !== null
   );
 }
 
@@ -316,12 +325,10 @@ function rewriteBundledSource(source: string): string {
   // exports, `export { helper, run as default }`. Extract the binding aliased
   // to `default` from anywhere in those blocks, then strip the (illegal-inside-
   // a-function) export statements and bind the captured name to `__skillRun`.
-  const defaultBinding = source.match(
-    /\bexport\s*\{[^}]*\b([A-Za-z_$][\w$]*)\s+as\s+default\b[^}]*\}/m
-  );
+  const defaultBinding = findBundledDefaultExportBinding(source);
   const stripped = stripStrayExports(source);
   if (defaultBinding) {
-    return `${stripped}\nconst __skillRun = ${defaultBinding[1]};`;
+    return `${stripped}\nconst __skillRun = ${defaultBinding};`;
   }
   return stripped;
 }
@@ -332,14 +339,20 @@ async function prepareJavaScriptSource(
 ): Promise<string> {
   // Skill scripts run directly in the sandbox; the runtime ships no in-Worker
   // bundler. Build-time compiled scripts (Agents Vite plugin / `compileSkillScript`
-  // from "agents/skills/compile") arrive as self-contained ESM. Normalize
-  // esbuild's `export { run as default }` (or a raw `export default`) into the
-  // `__skillRun` binding the wrapper expects.
+  // from "agents/skills/compile") arrive as self-contained ESM. Vite marks its
+  // resources as precompiled; dynamic sources can be recognized by the bundled
+  // default-export form emitted by compileSkillScript. Normalize either before
+  // extension and sibling-file checks because compiled output may retain a
+  // TypeScript path and its original sibling resources.
   const entryPrecompiled = (request.resources ?? []).some(
     (resource) =>
       resource.path === request.path && resource.precompiled === true
   );
-  if (entryPrecompiled) return rewriteBundledSource(request.source);
+  const hasBundledDefaultExport =
+    findBundledDefaultExportBinding(request.source) !== null;
+  if (entryPrecompiled || hasBundledDefaultExport) {
+    return rewriteBundledSource(request.source);
+  }
 
   // Count sibling script files to detect skills that span multiple modules.
   let scriptFileCount = 1;

--- a/packages/agents/src/skills/runner.ts
+++ b/packages/agents/src/skills/runner.ts
@@ -250,9 +250,14 @@ function bashFiles(
  * object from the host bridge proxy (`__host`), and invoke it.
  */
 function scriptModule(source: string, request: SkillScriptRequest): string {
-  const runnableSource = stripFinalExportBlock(
-    source.replace(/^\s*export\s+default\s+/m, "const __skillRun = ")
+  const defaultExportRewritten = source.replace(
+    /^\s*export\s+default\s+/m,
+    "const __skillRun = "
   );
+  const runnableSource =
+    defaultExportRewritten === source
+      ? stripFinalExportBlock(source)
+      : stripAuthoredExportLists(defaultExportRewritten);
   const skillMeta = skillScriptContext(request).skill;
 
   return [
@@ -300,7 +305,7 @@ type FinalExportBlock = {
 /** Find the final ESM export-list statement emitted by esbuild. */
 function findFinalExportBlock(source: string): FinalExportBlock | null {
   const match = source.match(
-    /(?:^|\r?\n)[\t ]*export[\t ]*\{([^}]*)\}[\t ]*;?[\t ]*(?:\r?\n)?$/
+    /(?:^|\r?\n)[\t ]*export[\t ]*\{([^}]*)\}[\t ]*;?[\t ]*(?=\s*$)/
   );
   if (match?.index === undefined || match[1] === undefined) return null;
 
@@ -320,6 +325,11 @@ function findBundledDefaultExportBinding(source: string): string | null {
   );
 }
 
+/** Whether source contains an authored `export default` declaration. */
+function hasAuthoredDefaultExport(source: string): boolean {
+  return /^\s*export\s+default\s+/m.test(source);
+}
+
 /**
  * Whether a script declares a default export, in either the raw author form
  * (`export default ...`) or the bundled form esbuild emits
@@ -327,8 +337,22 @@ function findBundledDefaultExportBinding(source: string): string | null {
  */
 function hasDefaultExport(source: string): boolean {
   return (
-    /^\s*export\s+default\s+/m.test(source) ||
+    hasAuthoredDefaultExport(source) ||
     findBundledDefaultExportBinding(source) !== null
+  );
+}
+
+function missingSkillDefaultExportError(): Error {
+  return new Error(
+    "JS/TS skill scripts must `export default` an async run(input, ctx) function."
+  );
+}
+
+/** Remove authored ESM export lists that are illegal inside the wrapper. */
+function stripAuthoredExportLists(source: string): string {
+  return source.replace(
+    /(?:^|\r?\n)[\t ]*export[\t ]*\{[\s\S]*?\}[\t ]*;?/g,
+    ""
   );
 }
 
@@ -339,17 +363,19 @@ function stripFinalExportBlock(source: string): string {
   return source.slice(0, exportBlock.start) + source.slice(exportBlock.end);
 }
 
-function rewriteBundledSource(source: string): string {
+function rewriteBundledSource(source: string): string | null {
   // esbuild emits the default binding in a final `export { ... }` block, e.g.
   // `export { run as default }` or `export { helper, run as default }`. Extract
   // that binding, remove the statement that is illegal inside the function
   // wrapper, and bind the captured name to `__skillRun`.
   const defaultBinding = findBundledDefaultExportBinding(source);
-  const stripped = stripFinalExportBlock(source);
   if (defaultBinding) {
-    return `${stripped}\nconst __skillRun = ${defaultBinding};`;
+    return `${stripFinalExportBlock(source)}\nconst __skillRun = ${defaultBinding};`;
   }
-  return stripped;
+
+  // Descriptor-marked precompiled resources historically also accepted the
+  // authored default-export form. `scriptModule` normalizes it later.
+  return hasAuthoredDefaultExport(source) ? source : null;
 }
 
 async function prepareJavaScriptSource(
@@ -360,19 +386,26 @@ async function prepareJavaScriptSource(
   // bundler. Build-time compiled scripts (Agents Vite plugin / `compileSkillScript`
   // from "agents/skills/compile") arrive as self-contained ESM. Vite marks its
   // resources as precompiled; compileSkillScript marks output from dynamic
-  // sources with a generated header. Require both that header and esbuild's
-  // bundled default-export form before trusting source without a descriptor.
-  // Normalize recognized output before extension and sibling-file checks because
-  // compiled output may retain a TypeScript path and its original resources.
+  // sources with a generated header. Either marker selects the compiled path.
+  // Normalization still locates the default binding because the function-style
+  // wrapper must call it; that is an execution requirement, not a second format
+  // recognition signal. Normalize before extension and sibling-file checks
+  // because compiled output may retain a TypeScript path and its resources.
   const entryPrecompiled = (request.resources ?? []).some(
     (resource) =>
       resource.path === request.path && resource.precompiled === true
   );
-  const hasCompiledSkillScriptFormat =
-    hasCompiledSkillScriptFormatV1(request.source) &&
-    findBundledDefaultExportBinding(request.source) !== null;
+  const hasCompiledSkillScriptFormat = hasCompiledSkillScriptFormatV1(
+    request.source
+  );
   if (entryPrecompiled || hasCompiledSkillScriptFormat) {
-    return rewriteBundledSource(request.source);
+    const rewritten = rewriteBundledSource(request.source);
+    if (rewritten !== null) return rewritten;
+    throw missingSkillDefaultExportError();
+  }
+
+  if (!hasDefaultExport(request.source)) {
+    throw missingSkillDefaultExportError();
   }
 
   // Count sibling script files to detect skills that span multiple modules.
@@ -1048,12 +1081,6 @@ async function runJavaScriptScript(
   bridge: SkillScriptHostBridge,
   runtime: "javascript" | "typescript"
 ): Promise<unknown> {
-  if (!hasDefaultExport(request.source)) {
-    throw new Error(
-      "JS/TS skill scripts must `export default` an async run(input, ctx) function."
-    );
-  }
-
   const source = await prepareJavaScriptSource(request, runtime);
   const executor = new DynamicWorkerExecutor({
     loader: options.loader,

--- a/packages/agents/src/skills/runner.ts
+++ b/packages/agents/src/skills/runner.ts
@@ -3,6 +3,7 @@ import { DynamicWorkerExecutor, resolveProvider } from "@cloudflare/codemode";
 import type { ToolProvider } from "@cloudflare/codemode";
 import { Bash, defineCommand } from "just-bash";
 import type { ToolSet } from "ai";
+import { COMPILED_SKILL_SCRIPT_HEADER } from "./compiled-script-format";
 import type {
   SkillScriptRequest,
   SkillScriptRunner,
@@ -340,17 +341,19 @@ async function prepareJavaScriptSource(
   // Skill scripts run directly in the sandbox; the runtime ships no in-Worker
   // bundler. Build-time compiled scripts (Agents Vite plugin / `compileSkillScript`
   // from "agents/skills/compile") arrive as self-contained ESM. Vite marks its
-  // resources as precompiled; dynamic sources can be recognized by the bundled
-  // default-export form emitted by compileSkillScript. Normalize either before
-  // extension and sibling-file checks because compiled output may retain a
-  // TypeScript path and its original sibling resources.
+  // resources as precompiled; compileSkillScript marks output from dynamic
+  // sources with a generated header. Require both that header and esbuild's
+  // bundled default-export form before trusting source without a descriptor.
+  // Normalize recognized output before extension and sibling-file checks because
+  // compiled output may retain a TypeScript path and its original resources.
   const entryPrecompiled = (request.resources ?? []).some(
     (resource) =>
       resource.path === request.path && resource.precompiled === true
   );
-  const hasBundledDefaultExport =
+  const hasCompiledSkillScriptFormat =
+    request.source.startsWith(`${COMPILED_SKILL_SCRIPT_HEADER}\n`) &&
     findBundledDefaultExportBinding(request.source) !== null;
-  if (entryPrecompiled || hasBundledDefaultExport) {
+  if (entryPrecompiled || hasCompiledSkillScriptFormat) {
     return rewriteBundledSource(request.source);
   }
 

--- a/packages/agents/src/skills/types.ts
+++ b/packages/agents/src/skills/types.ts
@@ -24,8 +24,8 @@ export interface SkillResourceDescriptor {
   /**
    * Set when a source preserves that a script was compiled to self-contained
    * JavaScript ahead of time. The Agents Vite plugin sets this for bundled
-   * skills; dynamic sources may omit it because the runner also recognizes the
-   * ESM bundle form emitted by `compileSkillScript`.
+   * skills; dynamic sources may omit it when they preserve the generated header
+   * and ESM bundle form emitted by `compileSkillScript`.
    */
   precompiled?: boolean;
 }

--- a/packages/agents/src/skills/types.ts
+++ b/packages/agents/src/skills/types.ts
@@ -22,11 +22,10 @@ export interface SkillResourceDescriptor {
   encoding?: "text" | "base64";
   mimeType?: string;
   /**
-   * Set when a script resource was compiled to a self-contained JavaScript
-   * module ahead of time — by the Agents Vite plugin for bundled skills, or via
-   * `compileSkillScript` from `agents/skills/compile` for R2/dynamic skills. The
-   * runtime runs precompiled scripts directly; the runtime ships no in-Worker
-   * bundler, so non-precompiled TypeScript or multi-file scripts cannot run.
+   * Set when a source preserves that a script was compiled to self-contained
+   * JavaScript ahead of time. The Agents Vite plugin sets this for bundled
+   * skills; dynamic sources may omit it because the runner also recognizes the
+   * ESM bundle form emitted by `compileSkillScript`.
    */
   precompiled?: boolean;
 }

--- a/packages/agents/src/tests/r2-skills.test.ts
+++ b/packages/agents/src/tests/r2-skills.test.ts
@@ -194,7 +194,8 @@ describe("R2 Think skills", () => {
   ])(
     "runs compileSkillScript output loaded from R2 at $scriptPath",
     async ({ scriptPath, siblingScripts }) => {
-      const compiledSource = `function run(input) {
+      const compiledSource = `// @cloudflare/agents compiled skill script v1
+function run(input) {
   return input.text.toUpperCase();
 }
 export {

--- a/packages/agents/src/tests/r2-skills.test.ts
+++ b/packages/agents/src/tests/r2-skills.test.ts
@@ -183,6 +183,7 @@ describe("R2 Think skills", () => {
       scriptPath: "scripts/run.js",
       byteOrderMark: "",
       lineEnding: "\n",
+      trailingSuffix: "",
       siblingScripts: []
     },
     {
@@ -190,6 +191,7 @@ describe("R2 Think skills", () => {
       scriptPath: "scripts/run.ts",
       byteOrderMark: "",
       lineEnding: "\n",
+      trailingSuffix: "",
       siblingScripts: [
         {
           key: "skills/demo/scripts/helper.ts",
@@ -202,6 +204,7 @@ describe("R2 Think skills", () => {
       scriptPath: "scripts/run.ts",
       byteOrderMark: "\uFEFF",
       lineEnding: "\n",
+      trailingSuffix: "",
       siblingScripts: []
     },
     {
@@ -209,20 +212,36 @@ describe("R2 Think skills", () => {
       scriptPath: "scripts/run.ts",
       byteOrderMark: "",
       lineEnding: "\r\n",
+      trailingSuffix: "",
+      siblingScripts: []
+    },
+    {
+      formatVariant: "with trailing blank lines",
+      scriptPath: "scripts/run.ts",
+      byteOrderMark: "",
+      lineEnding: "\n",
+      trailingSuffix: "\n\n",
       siblingScripts: []
     }
   ])(
     "runs compileSkillScript output loaded from R2 at $scriptPath ($formatVariant)",
-    async ({ scriptPath, byteOrderMark, lineEnding, siblingScripts }) => {
-      const compiledSource = [
-        `${byteOrderMark}// cloudflare-agents:compiled-skill-script:v1`,
-        "function run(input) {",
-        "  return input.text.toUpperCase();",
-        "}",
-        "export {",
-        "  run as default",
-        "};"
-      ].join(lineEnding);
+    async ({
+      scriptPath,
+      byteOrderMark,
+      lineEnding,
+      trailingSuffix,
+      siblingScripts
+    }) => {
+      const compiledSource =
+        [
+          `${byteOrderMark}// cloudflare-agents:compiled-skill-script:v1`,
+          "function run(input) {",
+          "  return input.text.toUpperCase();",
+          "}",
+          "export {",
+          "  run as default",
+          "};"
+        ].join(lineEnding) + trailingSuffix;
       const source = skills.r2(
         fakeBucket([
           {

--- a/packages/agents/src/tests/r2-skills.test.ts
+++ b/packages/agents/src/tests/r2-skills.test.ts
@@ -194,7 +194,7 @@ describe("R2 Think skills", () => {
   ])(
     "runs compileSkillScript output loaded from R2 at $scriptPath",
     async ({ scriptPath, siblingScripts }) => {
-      const compiledSource = `// @cloudflare/agents compiled skill script v1
+      const compiledSource = `// cloudflare-agents:compiled-skill-script:v1
 function run(input) {
   return input.text.toUpperCase();
 }

--- a/packages/agents/src/tests/r2-skills.test.ts
+++ b/packages/agents/src/tests/r2-skills.test.ts
@@ -179,28 +179,50 @@ describe("R2 Think skills", () => {
 
   it.each([
     {
+      formatVariant: "unchanged",
       scriptPath: "scripts/run.js",
+      byteOrderMark: "",
+      lineEnding: "\n",
       siblingScripts: []
     },
     {
+      formatVariant: "unchanged with sibling source",
       scriptPath: "scripts/run.ts",
+      byteOrderMark: "",
+      lineEnding: "\n",
       siblingScripts: [
         {
           key: "skills/demo/scripts/helper.ts",
           content: "export function helper(value: string) { return value; }"
         }
       ]
+    },
+    {
+      formatVariant: "with a UTF-8 BOM",
+      scriptPath: "scripts/run.ts",
+      byteOrderMark: "\uFEFF",
+      lineEnding: "\n",
+      siblingScripts: []
+    },
+    {
+      formatVariant: "with CRLF line endings",
+      scriptPath: "scripts/run.ts",
+      byteOrderMark: "",
+      lineEnding: "\r\n",
+      siblingScripts: []
     }
   ])(
-    "runs compileSkillScript output loaded from R2 at $scriptPath",
-    async ({ scriptPath, siblingScripts }) => {
-      const compiledSource = `// cloudflare-agents:compiled-skill-script:v1
-function run(input) {
-  return input.text.toUpperCase();
-}
-export {
-  run as default
-};`;
+    "runs compileSkillScript output loaded from R2 at $scriptPath ($formatVariant)",
+    async ({ scriptPath, byteOrderMark, lineEnding, siblingScripts }) => {
+      const compiledSource = [
+        `${byteOrderMark}// cloudflare-agents:compiled-skill-script:v1`,
+        "function run(input) {",
+        "  return input.text.toUpperCase();",
+        "}",
+        "export {",
+        "  run as default",
+        "};"
+      ].join(lineEnding);
       const source = skills.r2(
         fakeBucket([
           {

--- a/packages/agents/src/tests/r2-skills.test.ts
+++ b/packages/agents/src/tests/r2-skills.test.ts
@@ -1,3 +1,4 @@
+import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import * as skills from "../skills";
 
@@ -12,6 +13,16 @@ type FakeBucket = R2Bucket & {
   getCalls: string[];
   setObjects(objects: FakeObject[]): void;
 };
+
+type ExecutableTool = {
+  execute(input: Record<string, unknown>): Promise<unknown> | unknown;
+};
+
+function executableTool(tool: unknown): ExecutableTool {
+  // SAFETY: SkillRegistry only registers run_skill_script with an execute
+  // function. The AI SDK ToolSet union does not expose that shared property.
+  return tool as ExecutableTool;
+}
 
 function fakeBucket(initialObjects: FakeObject[]): FakeBucket {
   let objects = initialObjects;
@@ -165,6 +176,62 @@ describe("R2 Think skills", () => {
       ]
     });
   });
+
+  it.each([
+    {
+      scriptPath: "scripts/run.js",
+      siblingScripts: []
+    },
+    {
+      scriptPath: "scripts/run.ts",
+      siblingScripts: [
+        {
+          key: "skills/demo/scripts/helper.ts",
+          content: "export function helper(value: string) { return value; }"
+        }
+      ]
+    }
+  ])(
+    "runs compileSkillScript output loaded from R2 at $scriptPath",
+    async ({ scriptPath, siblingScripts }) => {
+      const compiledSource = `function run(input) {
+  return input.text.toUpperCase();
+}
+export {
+  run as default
+};`;
+      const source = skills.r2(
+        fakeBucket([
+          {
+            key: "skills/demo/SKILL.md",
+            content:
+              "---\nname: demo\ndescription: Run a compiled script.\n---\nRun the script.\n"
+          },
+          {
+            key: `skills/demo/${scriptPath}`,
+            content: compiledSource
+          },
+          ...siblingScripts
+        ]),
+        { prefix: "skills/" }
+      );
+      const registry = new skills.SkillRegistry(
+        [source],
+        skills.runner({ loader: env.LOADER })
+      );
+      await registry.load();
+
+      const result = await executableTool(
+        registry.tools().run_skill_script
+      ).execute({
+        name: "demo",
+        path: scriptPath,
+        input: { text: "hello" }
+      });
+
+      expect(result).toBe("HELLO");
+    }
+  );
 
   it("reads resources by skill name and relative path", async () => {
     const source = skills.r2(bucket, { prefix: "skills/" });

--- a/packages/agents/src/tests/skill-runner.test.ts
+++ b/packages/agents/src/tests/skill-runner.test.ts
@@ -69,6 +69,29 @@ describe("skill script runner", () => {
     });
   });
 
+  it("runs plain JavaScript with a named export list before the default export", async () => {
+    const runner = skills.runner({ loader: env.LOADER });
+
+    await expect(
+      runner.run({
+        skill: {
+          name: "named-export",
+          description: "Run a script with a named export.",
+          body: "Run the script."
+        },
+        path: "scripts/run.js",
+        input: { text: "hello" },
+        source: `function format(text) {
+  return text.toUpperCase();
+}
+export { format };
+export default function run(input) {
+  return format(input.text);
+}`
+      })
+    ).resolves.toBe("HELLO");
+  });
+
   it("surfaces script failures with console output", async () => {
     const runner = skills.runner({
       loader: env.LOADER

--- a/packages/agents/src/tests/skill-runner.test.ts
+++ b/packages/agents/src/tests/skill-runner.test.ts
@@ -190,6 +190,44 @@ export default function run(input: { text: string }) {
     }
   );
 
+  it.each([
+    {
+      matchLocation: "a comment",
+      sourcePrefix: "// export { fake as default }",
+      returnExpression: "input.text.toUpperCase()",
+      expected: "HELLO"
+    },
+    {
+      matchLocation: "a string",
+      sourcePrefix: 'const example = "export { fake as default }";',
+      returnExpression: "example",
+      expected: "export { fake as default }"
+    }
+  ])(
+    "preserves export-shaped text in $matchLocation inside a compiled bundle",
+    async ({ sourcePrefix, returnExpression, expected }) => {
+      const runner = skills.runner({ loader: env.LOADER });
+
+      await expect(
+        runner.run({
+          skill: {
+            name: "compiled-script-text",
+            description: "Compiled script containing export-shaped text.",
+            body: "Run the script."
+          },
+          path: "scripts/run.ts",
+          input: { text: "hello" },
+          source: `// cloudflare-agents:compiled-skill-script:v1
+${sourcePrefix}
+function run(input) {
+  return ${returnExpression};
+}
+export { run as default };`
+        })
+      ).resolves.toBe(expected);
+    }
+  );
+
   it("runs a precompiled bundled script (esbuild `export { run as default }` form)", async () => {
     const runner = skills.runner({
       loader: env.LOADER

--- a/packages/agents/src/tests/skill-runner.test.ts
+++ b/packages/agents/src/tests/skill-runner.test.ts
@@ -146,6 +146,50 @@ export default function run(input: { text: string }) {
     ).rejects.toThrow("must be compiled to a self-contained JavaScript module");
   });
 
+  it.each([
+    {
+      matchLocation: "an export statement",
+      source: `function run(input) {
+  return input.text.toUpperCase();
+}
+export { run as default };`
+    },
+    {
+      matchLocation: "a comment",
+      source: `// export { run as default }
+export default function run(input: { text: string }) {
+  return input.text.toUpperCase();
+}`
+    },
+    {
+      matchLocation: "a string",
+      source: `const example = "export { run as default }";
+export default function run(input: { text: string }) {
+  return input.text.toUpperCase() + example.length;
+}`
+    }
+  ])(
+    "requires the compiled script header when the export shape appears in $matchLocation",
+    async ({ source }) => {
+      const runner = skills.runner({ loader: env.LOADER });
+
+      await expect(
+        runner.run({
+          skill: {
+            name: "unmarked-script",
+            description: "Script without the generated header.",
+            body: "Run the script."
+          },
+          path: "scripts/run.ts",
+          input: { text: "hello" },
+          source
+        })
+      ).rejects.toThrow(
+        "must be compiled to a self-contained JavaScript module"
+      );
+    }
+  );
+
   it("runs a precompiled bundled script (esbuild `export { run as default }` form)", async () => {
     const runner = skills.runner({
       loader: env.LOADER

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -295,7 +295,7 @@ The Agents Vite plugin compiles bundled JavaScript and TypeScript scripts with
 esbuild before deployment. The runtime executes self-contained JavaScript and
 does not bundle raw TypeScript or multi-file scripts. Compile scripts from R2 or
 other dynamic sources in Node-based publish tooling, then upload the returned
-content unchanged:
+content unchanged, including its generated format header:
 
 ```ts
 import { compileSkillScript } from "agents/skills/compile";

--- a/packages/think/README.md
+++ b/packages/think/README.md
@@ -291,6 +291,24 @@ export default async function run(input: unknown, ctx: SkillRunContext) {
 }
 ```
 
+The Agents Vite plugin compiles bundled JavaScript and TypeScript scripts with
+esbuild before deployment. The runtime executes self-contained JavaScript and
+does not bundle raw TypeScript or multi-file scripts. Compile scripts from R2 or
+other dynamic sources in Node-based publish tooling, then upload the returned
+content unchanged:
+
+```ts
+import { compileSkillScript } from "agents/skills/compile";
+
+const compiled = await compileSkillScript(
+  "./skills/release-notes/scripts/format-release-notes.ts"
+);
+await skillsBucket.put(
+  "skills/release-notes/scripts/format-release-notes.ts",
+  compiled.content
+);
+```
+
 `ctx` is `{ skill, files, workspace, tools, output }`: `ctx.files` holds bundled
 text resources by relative path, `ctx.workspace` is gated by the workspace
 permission, `ctx.tools` exposes only the tools the runner was given, and
@@ -301,9 +319,9 @@ for artifacts (Python supports both `def run(input, ctx)` and CLI-style scripts)
 
 If `workspaceInstance` is provided, scripts get read-only workspace access by
 default. Workspace writes, tools, and network access are opt-in. Scripts default
-to a 30 second timeout, which can be overridden with `timeout`. TypeScript
-scripts are compiled with `@cloudflare/worker-bundler`; Python scripts run as
-Python Dynamic Workers; Bash scripts run through `just-bash`.
+to a 30 second timeout, which can be overridden with `timeout`. JavaScript and
+compiled TypeScript run as sandboxed Dynamic Workers, Python runs as a Python
+Dynamic Worker, and Bash runs through `just-bash`.
 
 Script execution requires a Worker Loader binding:
 
@@ -999,16 +1017,15 @@ getTools() {
 
 ## Runtime dependencies
 
-| Package                      | Notes                                                     |
-| ---------------------------- | --------------------------------------------------------- |
-| `agents`                     | Cloudflare Agents SDK peer dependency                     |
-| `ai`                         | Vercel AI SDK v6 peer dependency                          |
-| `zod`                        | Schema validation peer dependency                         |
-| `@cloudflare/shell`          | Workspace filesystem                                      |
-| `@cloudflare/codemode`       | Code execution, `createExecuteTool`, and JS skill scripts |
-| `@cloudflare/worker-bundler` | TypeScript skill script compilation                       |
-| `just-bash`                  | Bash skill script execution                               |
-| `@chat-adapter/telegram`     | Required for Telegram messengers                          |
+| Package                  | Notes                                                     |
+| ------------------------ | --------------------------------------------------------- |
+| `agents`                 | Cloudflare Agents SDK peer dependency                     |
+| `ai`                     | Vercel AI SDK v6 peer dependency                          |
+| `zod`                    | Schema validation peer dependency                         |
+| `@cloudflare/shell`      | Workspace filesystem                                      |
+| `@cloudflare/codemode`   | Code execution, `createExecuteTool`, and JS skill scripts |
+| `just-bash`              | Bash skill script execution                               |
+| `@chat-adapter/telegram` | Required for Telegram messengers                          |
 
 ## Acknowledgments
 


### PR DESCRIPTION
Fixes #2068.

## What is the bug

A skill loaded through `skills.r2()` cannot run the output of `compileSkillScript()`, even though compiling before upload is the documented path for TypeScript and multi-file scripts.

Raw TypeScript tells the user to compile first. The compiled JavaScript then fails because the runner reports that its default export is not a function.

## Why it happens

`compileSkillScript()` emits esbuild's ESM export-list form:

```js
function run(input) {
  return input.text.toUpperCase();
}

export { run as default };
```

The runner already knows how to turn that export back into its internal `__skillRun` binding, but only when the resource descriptor says `precompiled: true`. The Vite plugin preserves that flag; R2 (and other dynamic sources) might only preserve the actual compiled content.

Without the flag, a `.js` bundle takes the raw JavaScript path, where its export list is removed without rebinding `run`. A bundle stored under a `.ts` path, or next to sibling script resources, is rejected as if it still needed compilation.

## The fix

`compileSkillScript()` now stamps its output with a versioned first-line header:

```js
// cloudflare-agents:compiled-skill-script:v1
```

When a dynamic source does not have a `precompiled` descriptor, the runner requires both that header and esbuild's final bundled default-export block before normalizing the script. Recognition happens before the file-extension and sibling-script checks, so header-marked output can keep its original `.ts` path and resource list. The marker check tolerates a UTF-8 BOM or CRLF line endings added by publish tooling.

The compiler removes an entry-point shebang from the generated bundle because skill code is embedded inside a function wrapper rather than launched as a CLI. The existing `precompiled` path remains in place for Vite manifests and sources that can preserve the descriptor. This also keeps the runtime compiler-free: raw TypeScript and unbundled multi-file scripts are still rejected. Dynamic publishers compile in Node and upload `compiled.content` unchanged.

## Why use a header

Recognizing `export { binding as default }` alone was too guessy. That text could appear anywhere, including inside a comment or string, and should not be enough to opt a file into the compiled path.

The header makes this an explicit contract between `compileSkillScript()` and the runner. Unrelated JavaScript syntax can no longer accidentally look precompiled. Keeping the export-shape check as well makes sure the marked file still has the structure the runner knows how to normalise.

## Documentation

The Think docs, Agent Skills example, and skills design notes now describe build-time esbuild compilation instead of the removed runtime `@cloudflare/worker-bundler` behavior. Dynamic-source examples preserve the generated content, including its header.

## Tests

Regression coverage drives the public path from a fake R2 bucket through `skills.r2()`, `SkillRegistry`, `skills.runner()`, and a live Worker Loader. It covers header-marked content stored as `.js`, content stored as `.ts`, a compiled entry with a sibling TypeScript resource, and BOM/CRLF-normalized uploads.

The compiler tests pin the generated header and esbuild default-export shape and verify that retained shebangs are removed. Runner tests verify that unmarked export-shaped source does not bypass the compile-required path, while export-shaped text inside a marked bundle's comments or strings is preserved.

Suites: skills runner/R2 49 · compiler/Vite 14 · full agents 2554 · `pnpm run check`.
