### PR TITLE
feat(agents): support flexible schemas in agent tools

### DIFF
--- a/.changeset/kind-tools-share.md
+++ b/.changeset/kind-tools-share.md
@@ -1,0 +1,6 @@
+---
+"agents": minor
+"@cloudflare/ai-chat": patch
+---
+
+Accept AI SDK flexible schemas in `agentTool`, including Valibot adapters, while preserving schema-driven input inference and structured output validation. Zod is no longer a peer requirement of `@cloudflare/ai-chat`.

--- a/docs/agents/agent-tools.md
+++ b/docs/agents/agent-tools.md
@@ -48,6 +48,35 @@ export class Assistant extends Think<Env> {
 }
 ```
 
+### Use Valibot or another schema library
+
+`agentTool()` accepts the AI SDK's flexible schema format. For Valibot, wrap the
+schema with `valibotSchema()` so the AI SDK receives both runtime validation and
+the JSON Schema required by the model. Use `@ai-sdk/valibot` v2 with AI SDK 6
+and v3 with AI SDK 7:
+
+```ts
+import { valibotSchema } from "@ai-sdk/valibot";
+import { agentTool } from "agents/agent-tools";
+import * as v from "valibot";
+
+const researchInput = valibotSchema(
+  v.object({
+    query: v.pipe(v.string(), v.minLength(3))
+  })
+);
+
+const research = agentTool(Researcher, {
+  description: "Research one topic in depth.",
+  inputSchema: researchInput
+});
+```
+
+You can also provide a Zod schema, a Standard JSON Schema-compatible schema, or
+a raw JSON Schema wrapped with `jsonSchema()` from `ai`. A validation-only
+Standard Schema is not sufficient for a tool input because it does not provide
+the JSON Schema sent to the model.
+
 The child can also be an `AIChatAgent`:
 
 ```ts

--- a/docs/agents/mcp-servers.md
+++ b/docs/agents/mcp-servers.md
@@ -14,6 +14,12 @@ This guide covers the different ways to create MCP servers with the Agents SDK a
 - **`McpAgent`** is a retained, feature-frozen SDK v1 path for existing stateful deployments. New servers should use `createMcpHandler()`.
 - **Raw transport** gives you low-level control if the standard handler lifecycle is not suitable.
 
+`McpAgent` and the other retained SDK v1 registration APIs use the upstream
+Zod-based schema contract. Define their tool input and output schemas as Zod
+shapes; AI SDK flexible-schema adapters are not accepted. For a new MCP server
+that needs Standard Schema support, use `@modelcontextprotocol/server` v2 with
+`createMcpHandler()`.
+
 ## Stateless MCP Server with `createMcpHandler()`
 
 The simplest way to create an MCP server. Install the exact SDK v2 server peer, then use the isolated server entry point so legacy Agents transports and MCP clients stay out of your Worker bundle:

--- a/examples/x402-mcp/README.md
+++ b/examples/x402-mcp/README.md
@@ -37,6 +37,10 @@ Try the free **echo** tool and the paid **square** tool ($0.01) — the payment 
 
 ### Server: creating paid tools
 
+`paidTool()` requires raw Zod shapes for its input and output schemas. Define
+fields directly, as in `{ number: z.number() }` below; AI SDK flexible-schema
+adapters are not accepted by this API.
+
 ```typescript
 import { withX402, type X402Config } from "agents/x402";
 

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -262,6 +262,29 @@ export class Assistant extends Think<Env> {
 }
 ```
 
+`inputSchema` accepts schemas supported by the AI SDK, including Zod, Standard
+JSON Schema-compatible schemas, raw JSON Schema through `jsonSchema()`, and
+schemas exposed through AI SDK adapters. For example, use `@ai-sdk/valibot` v2
+with AI SDK 6 or v3 with AI SDK 7:
+
+```typescript
+import { valibotSchema } from "@ai-sdk/valibot";
+import * as v from "valibot";
+
+const researchInput = valibotSchema(
+  v.object({ query: v.pipe(v.string(), v.minLength(3)) })
+);
+
+agentTool(Researcher, {
+  description: "Research one topic in depth.",
+  inputSchema: researchInput
+});
+```
+
+Tool inputs need model-facing JSON Schema in addition to runtime validation. A
+validation-only Standard Schema is therefore insufficient; use its Standard
+JSON Schema extension or an AI SDK adapter.
+
 For deterministic fan-out, call `this.runAgentTool(Researcher, { input })`
 directly. Parent recovery reconciles stale child rows after restarts and marks
 unrecoverable runs `interrupted` instead of hanging. In React, use

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@ai-sdk/react": "^4.0.0",
+    "@ai-sdk/valibot": "3.0.6",
     "@cloudflare/codemode": "workspace:*",
     "@modelcontextprotocol/client": "2.0.0",
     "@modelcontextprotocol/conformance-v2": "npm:@modelcontextprotocol/conformance@0.2.0-alpha.10",
@@ -46,6 +47,7 @@
     "@tanstack/ai": "0.38.0",
     "@types/react": "^19.2.17",
     "@types/yargs": "^17.0.35",
+    "@valibot/to-json-schema": "1.3.0",
     "@vitest/browser-playwright": "^4.1.9",
     "@x402/core": "^2.17.0",
     "@x402/evm": "^2.17.0",
@@ -54,6 +56,7 @@
     "glob": "^13.0.6",
     "just-bash": "^3.0.2",
     "react": "^19.2.7",
+    "valibot": "1.4.1",
     "vitest-browser-react": "^2.2.0",
     "zod": "^4.4.3"
   },

--- a/packages/agents/src/agent-tools.ts
+++ b/packages/agents/src/agent-tools.ts
@@ -1,4 +1,10 @@
-import { tool, type Tool } from "ai";
+import {
+  asSchema,
+  tool,
+  type FlexibleSchema,
+  type InferSchema,
+  type Tool
+} from "ai";
 import { __DO_NOT_USE_WILL_BREAK__agentContext as agentContext } from "./internal_context";
 import type {
   ChatCapableAgentClass,
@@ -8,17 +14,31 @@ import type {
   AgentToolFailure
 } from "./agent-tool-types";
 
-type SchemaLike<T = unknown> = {
-  parse(value: unknown): T;
+type ParseSchema<Output = unknown> = {
+  parse(value: unknown): Output;
 };
 
-type AgentToolFactoryOptions<Output = unknown> = {
+type AgentToolOutputSchema<Output> =
+  | FlexibleSchema<Output>
+  | ParseSchema<Output>;
+
+type AgentToolFactoryOptions<Output = unknown, Input = unknown> = {
   description: string;
-  inputSchema: unknown;
-  outputSchema?: SchemaLike<Output>;
+  inputSchema: FlexibleSchema<Input>;
+  outputSchema?: AgentToolOutputSchema<Output>;
   displayName?: string;
   icon?: string;
   display?: AgentToolDisplayMetadata;
+};
+
+// Capture the concrete schema type so the overload below can derive its input
+// with InferSchema. AgentToolFactoryOptions remains available for callers that
+// explicitly supply agentTool<Input, Output>() type arguments.
+type InferredAgentToolFactoryOptions<
+  InputSchema extends FlexibleSchema,
+  Output
+> = Omit<AgentToolFactoryOptions<Output>, "inputSchema"> & {
+  inputSchema: InputSchema;
 };
 
 type ToolExecutionOptions = {
@@ -32,6 +52,33 @@ type AgentToolRunner = {
     options: RunAgentToolOptions<Input>
   ): Promise<RunAgentToolResult<Output>>;
 };
+
+/**
+ * Preserve the existing Zod-style `.parse()` output-schema contract while
+ * extending validation to the other formats supported by AI SDK FlexibleSchema.
+ */
+async function validateOutput<Output>(
+  schema: AgentToolOutputSchema<Output>,
+  value: unknown
+): Promise<Output> {
+  if (
+    typeof schema === "object" &&
+    schema !== null &&
+    "parse" in schema &&
+    typeof schema.parse === "function"
+  ) {
+    return schema.parse(value);
+  }
+
+  const validate = asSchema(schema as FlexibleSchema<Output>).validate;
+  if (!validate) {
+    throw new Error("agentTool outputSchema must provide runtime validation");
+  }
+
+  const result = await validate(value);
+  if (!result.success) throw result.error;
+  return result.value;
+}
 
 function currentAgentToolRunner(): AgentToolRunner {
   const agent = agentContext.getStore()?.agent;
@@ -69,9 +116,18 @@ function failure(
  * Create an AI SDK tool that dispatches a chat-capable sub-agent through
  * `Agent.runAgentTool`.
  */
+export function agentTool<InputSchema extends FlexibleSchema, Output = unknown>(
+  cls: ChatCapableAgentClass,
+  options: InferredAgentToolFactoryOptions<InputSchema, Output>
+): Tool<InferSchema<InputSchema>, string | Output | AgentToolFailure>;
+// Preserve existing callers that explicitly provide agentTool<Input, Output>().
 export function agentTool<Input = unknown, Output = unknown>(
   cls: ChatCapableAgentClass,
-  options: AgentToolFactoryOptions<Output>
+  options: AgentToolFactoryOptions<Output, Input>
+): Tool<Input, string | Output | AgentToolFailure>;
+export function agentTool<Input = unknown, Output = unknown>(
+  cls: ChatCapableAgentClass,
+  options: AgentToolFactoryOptions<Output, Input>
 ): Tool<Input, string | Output | AgentToolFailure> {
   const createTool = tool as unknown as <I, O>(config: {
     description: string;
@@ -125,7 +181,7 @@ export function agentTool<Input = unknown, Output = unknown>(
               false
             );
           }
-          return options.outputSchema.parse(result.output);
+          return validateOutput(options.outputSchema, result.output);
         }
         return result.summary ?? "";
       }

--- a/packages/agents/src/tests-d/agent-tool-schema.test-d.ts
+++ b/packages/agents/src/tests-d/agent-tool-schema.test-d.ts
@@ -1,0 +1,95 @@
+import { valibotSchema } from "@ai-sdk/valibot";
+import { jsonSchema, type FlexibleSchema, type InferToolInput } from "ai";
+import * as v from "valibot";
+import { z } from "zod";
+import { agentTool } from "../agent-tools";
+import type { ChatCapableAgentClass } from "../agent-tool-types";
+
+const inputSchema = jsonSchema<{ query: string }>({
+  type: "object",
+  properties: { query: { type: "string" } },
+  required: ["query"]
+});
+
+const delegated = agentTool(class {} as unknown as ChatCapableAgentClass, {
+  description: "Research a topic",
+  inputSchema
+});
+
+declare const input: InferToolInput<typeof delegated>;
+input.query satisfies string;
+
+// @ts-expect-error input is inferred from the supplied flexible schema
+input.missing;
+
+const zodDelegated = agentTool(class {} as unknown as ChatCapableAgentClass, {
+  description: "Research a topic",
+  inputSchema: z.object({ query: z.string() })
+});
+
+declare const zodInput: InferToolInput<typeof zodDelegated>;
+zodInput.query satisfies string;
+
+// @ts-expect-error existing Zod input inference remains intact
+zodInput.missing;
+
+const valibotInputSchema = valibotSchema(
+  v.object({ query: v.pipe(v.string(), v.minLength(3)) })
+);
+const valibotDelegated = agentTool(
+  class {} as unknown as ChatCapableAgentClass,
+  {
+    description: "Research a topic",
+    inputSchema: valibotInputSchema
+  }
+);
+
+declare const valibotInput: InferToolInput<typeof valibotDelegated>;
+valibotInput.query satisfies string;
+
+// @ts-expect-error Valibot input inference rejects unknown fields
+valibotInput.missing;
+
+const standardInputSchema: FlexibleSchema<{ topic: string }> = {
+  "~standard": {
+    version: 1 as const,
+    vendor: "test",
+    types: undefined as unknown as {
+      input: { topic: string };
+      output: { topic: string };
+    },
+    validate: (value: unknown) =>
+      typeof value === "object" &&
+      value !== null &&
+      "topic" in value &&
+      typeof value.topic === "string"
+        ? { value: { topic: value.topic } }
+        : { issues: [{ message: "topic is required" }] },
+    jsonSchema: {
+      input: (_options: { target: string }) => ({
+        type: "object",
+        properties: { topic: { type: "string" } },
+        required: ["topic"]
+      }),
+      output: (_options: { target: string }) => ({
+        type: "object",
+        properties: { topic: { type: "string" } },
+        required: ["topic"]
+      })
+    }
+  }
+};
+
+const standardDelegated = agentTool(
+  class {} as unknown as ChatCapableAgentClass,
+  {
+    description: "Research a topic",
+    inputSchema: standardInputSchema
+  }
+);
+
+declare const standardInput: InferToolInput<typeof standardDelegated>;
+standardInput.topic satisfies string;
+
+// @ts-expect-error Standard Schema inference must not make input optional
+const _missingStandardInput: typeof standardInput = undefined;

--- a/packages/agents/src/tests/agent-tools-failure.test.ts
+++ b/packages/agents/src/tests/agent-tools-failure.test.ts
@@ -1,4 +1,6 @@
+import { valibotSchema } from "@ai-sdk/valibot";
 import { describe, expect, it } from "vitest";
+import * as v from "valibot";
 import { z } from "zod";
 import { agentTool } from "../agent-tools";
 import { __DO_NOT_USE_WILL_BREAK__agentContext as agentContext } from "../internal_context";
@@ -8,6 +10,8 @@ import type {
   RunAgentToolOptions,
   RunAgentToolResult
 } from "../agent-tool-types";
+
+const answerSchema = valibotSchema(v.object({ answer: v.number() }));
 
 /**
  * Drive `agentTool().execute` against a stubbed `runAgentTool` so we can assert
@@ -107,6 +111,71 @@ describe("agentTool failure envelope", () => {
     });
 
     expect(out).toBe("all done");
+  });
+
+  it("validates structured output with a Valibot adapter", async () => {
+    const stubAgent = {
+      async runAgentTool(): Promise<RunAgentToolResult> {
+        return {
+          runId: "r5",
+          agentType: "Child",
+          status: "completed",
+          output: { answer: 42 }
+        };
+      }
+    };
+    const subAgent = agentTool(class {} as unknown as ChatCapableAgentClass, {
+      description: "Run a sub-agent",
+      inputSchema: z.object({ task: z.string() }),
+      outputSchema: answerSchema
+    });
+    const execute = subAgent.execute as (input: {
+      task: string;
+    }) => Promise<unknown>;
+
+    const output = await agentContext.run(
+      {
+        agent: stubAgent,
+        connection: undefined,
+        request: undefined,
+        email: undefined
+      },
+      () => execute({ task: "calculate" })
+    );
+
+    expect(output).toEqual({ answer: 42 });
+  });
+
+  it("rejects structured output that fails flexible schema validation", async () => {
+    const subAgent = agentTool(class {} as unknown as ChatCapableAgentClass, {
+      description: "Run a sub-agent",
+      inputSchema: z.object({ task: z.string() }),
+      outputSchema: answerSchema
+    });
+    const execute = subAgent.execute as (input: {
+      task: string;
+    }) => Promise<unknown>;
+
+    await expect(
+      agentContext.run(
+        {
+          agent: {
+            async runAgentTool(): Promise<RunAgentToolResult> {
+              return {
+                runId: "r6",
+                agentType: "Child",
+                status: "completed",
+                output: { answer: "not a number" }
+              };
+            }
+          },
+          connection: undefined,
+          request: undefined,
+          email: undefined
+        },
+        () => execute({ task: "calculate" })
+      )
+    ).rejects.toThrow('Expected number but received "not a number"');
   });
 
   it("derives a stable runId from the tool call id so recovery re-attaches instead of re-running (#1630)", async () => {

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -33,8 +33,7 @@
     "@ai-sdk/react": "^3.0.0 || ^4.0.0",
     "agents": ">=0.17.1 <1.0.0",
     "ai": "^6.0.0 || ^7.0.0",
-    "react": "^19.0.0",
-    "zod": "^4.0.0"
+    "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/react": {

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -289,7 +289,7 @@ function isValidMessageStructure(msg: unknown): msg is UIMessage {
  * These tools are executed on the client, not the server.
  *
  * **For most apps**, define tools on the server with `tool()` from `"ai"` —
- * you get full Zod type safety, server-side execution, and simpler code.
+ * you get schema-derived type safety, server-side execution, and simpler code.
  * Use `onToolCall` in `useAgentChat` for tools that need client-side execution.
  *
  * **For SDKs and platforms** where the tool surface is determined dynamically
@@ -297,7 +297,8 @@ function isValidMessageStructure(msg: unknown): msg is UIMessage {
  * client register tools the server does not know about at deploy time.
  *
  * Note: Uses `parameters` (JSONSchema7) rather than AI SDK's `inputSchema`
- * because this is the wire format. Zod schemas cannot be serialized.
+ * because this is the wire format. Runtime validation schemas cannot be
+ * serialized.
  */
 export type { ClientToolSchema } from "agents/chat";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3976,6 +3976,9 @@ importers:
       '@ai-sdk/react':
         specifier: ^4.0.0
         version: 4.0.19(react@19.2.7)(zod@4.4.3)
+      '@ai-sdk/valibot':
+        specifier: 3.0.6
+        version: 3.0.6(@valibot/to-json-schema@1.3.0(valibot@1.4.1(typescript@6.0.3)))(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)
       '@cloudflare/codemode':
         specifier: workspace:*
         version: link:../codemode
@@ -4000,6 +4003,9 @@ importers:
       '@types/yargs':
         specifier: ^17.0.35
         version: 17.0.35
+      '@valibot/to-json-schema':
+        specifier: 1.3.0
+        version: 1.3.0(valibot@1.4.1(typescript@6.0.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.9
         version: 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
@@ -4024,6 +4030,9 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      valibot:
+        specifier: 1.4.1
+        version: 1.4.1(typescript@6.0.3)
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(patch_hash=1c11a562f8f4bcb95c9e73d63f769ffaf898ea427aecfd147d6d58acd07f9316)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -5027,6 +5036,13 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@ai-sdk/valibot@3.0.6':
+    resolution: {integrity: sha512-xQKw1r66OCfqNddOZO0hMUcUY1nzN3NniAJRb083rqEmhE666Fi2gPINrLtUyMaGU77DnnTujypHVEunECTelw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@valibot/to-json-schema': ^1.3.0
+      valibot: ^1.1.0
 
   '@ai-sdk/vue@4.0.0':
     resolution: {integrity: sha512-Hg0iUppvfDXidfwC4LMjdyMMp0Nf6fL2uGCGAqU4X2vcCcF/gSm572qgtI7v49MQlUF5vMgbgMIBKOMrNzW3uw==}
@@ -8267,6 +8283,11 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       react: '>=16.8'
+
+  '@valibot/to-json-schema@1.3.0':
+    resolution: {integrity: sha512-82Vv6x7sOYhv5YmTRgSppSqj1nn2pMCk5BqCMGWYp0V/fq+qirrbGncqZAtZ09/lrO40ne/7z8ejwE728aVreg==}
+    peerDependencies:
+      valibot: ^1.1.0
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -12678,6 +12699,14 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@ai-sdk/valibot@3.0.6(@valibot/to-json-schema@1.3.0(valibot@1.4.1(typescript@6.0.3)))(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
+      '@valibot/to-json-schema': 1.3.0(valibot@1.4.1(typescript@6.0.3))
+      valibot: 1.4.1(typescript@6.0.3)
+    transitivePeerDependencies:
+      - zod
+
   '@ai-sdk/vue@4.0.0(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
@@ -16045,6 +16074,10 @@ snapshots:
   '@use-it/interval@1.0.0(react@19.2.7)':
     dependencies:
       react: 19.2.7
+
+  '@valibot/to-json-schema@1.3.0(valibot@1.4.1(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.1(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
 


### PR DESCRIPTION
This PR closes the remaining schema-library compatibility gap in `agentTool()`. Most tool surfaces were already validation-library-agnostic: for example, `Think.getTools()` returns a standard AI SDK `ToolSet`, so ordinary tools could already use Zod, AI SDK `jsonSchema()`, Standard JSON Schema-compatible schemas, or adapters such as `@ai-sdk/valibot`.

`agentTool()` is the specialized helper that exposes a child Agent as an AI SDK tool. This change aligns that helper with the same AI SDK `FlexibleSchema` contract.

Fixes #2081.

## Why

Although `agentTool()` passed its input schema through at runtime, it typed the schema as `unknown`. That left this helper behind the rest of the tool surface: non-Zod schemas did not receive reliable schema-derived input inference, and structured output validation assumed a Zod-style `.parse()` method.

This change closes that bounded gap while preserving existing callers:

- types `agentTool()` input schemas as `FlexibleSchema` and captures the concrete schema type with `InferSchema`
- preserves explicit `agentTool<Input, Output>()` type arguments through a compatibility overload
- validates flexible output schemas through `asSchema(...).validate` while retaining the existing `.parse()` output contract
- covers Zod, AI SDK JSON Schema, Valibot, and Standard JSON Schema-compatible input inference, plus Valibot output success and failure paths
- removes the unused Zod peer requirement from `@cloudflare/ai-chat`
- documents the supported `agentTool()` schema formats and keeps the retained MCP v1 and x402 Zod-specific contracts explicit beside those APIs

No new package exports are introduced. The public `agentTool()` signature is broadened to the AI SDK flexible-schema contract without removing the existing explicit-generic call shape. The included changeset releases `agents` as a minor and `@cloudflare/ai-chat` as a patch.
