### PR TITLE
docs: note flexible schema support in chat and HITL guides

### DIFF
--- a/docs/agents/chat-agents.md
+++ b/docs/agents/chat-agents.md
@@ -956,6 +956,8 @@ async onChatMessage() {
 }
 ```
 
+The `inputSchema` accepts the AI SDK's flexible schema format, so you are not limited to Zod. You can also use Valibot, a Standard JSON Schema-compatible schema, or a raw JSON Schema wrapped with `jsonSchema()` from `ai`. See [Use Valibot or another schema library](./agent-tools.md#use-valibot-or-another-schema-library) for details.
+
 ### Client-Side Tools
 
 Define a tool on the server without `execute`, then handle it on the client with `onToolCall`. Use this for tools that need browser APIs:

--- a/docs/agents/human-in-the-loop.md
+++ b/docs/agents/human-in-the-loop.md
@@ -246,6 +246,8 @@ export class MyAgent extends AIChatAgent {
 }
 ```
 
+The `inputSchema` accepts the AI SDK's flexible schema format, so you are not limited to Zod. You can also use Valibot, a Standard JSON Schema-compatible schema, or a raw JSON Schema wrapped with `jsonSchema()` from `ai`. See [Use Valibot or another schema library](./agent-tools.md#use-valibot-or-another-schema-library) for details.
+
 ### Client
 
 Handle approval requests with `addToolApprovalResponse`:


### PR DESCRIPTION
This PR adds short flexible-schema notes to the chat and human-in-the-loop guides after #2091, so those pages do not read as Zod-only.

## Why

- #2091 made `agentTool()` accept AI SDK flexible schemas, and the detailed guidance already lives in `docs/agents/agent-tools.md`.
- The main chat and HITL guides still show only Zod `inputSchema` examples, so readers can miss that Valibot, Standard JSON Schema-compatible schemas, and `jsonSchema()` wrappers are valid there too.
- Fabian proposed the same two call sites in https://github.com/cloudflare/agents/issues/2081#issuecomment-5258313913. This keeps the wording schema-library agnostic, matching the agent-tools section instead of framing the feature as Valibot-only.

## Code Changes

- `docs/agents/chat-agents.md`: after the server-side tools example, note that `inputSchema` accepts the AI SDK flexible schema format and link to the agent-tools section.
- `docs/agents/human-in-the-loop.md`: same note after the `needsApproval` server example.