### PR TITLE
fix(agents): route nested facet WebSockets without recursing

### DIFF
--- a/.changeset/nested-facet-ws-routing.md
+++ b/.changeset/nested-facet-ws-routing.md
@@ -1,0 +1,7 @@
+---
+"agents": patch
+---
+
+Fix nested sub-agent WebSocket routes recursing until the facet depth limit is exceeded. A route two or more hops deep (`/sub/{class}/{name}/sub/{class}/{name}`) upgraded with HTTP 101 and then closed with code `1011`, because the root's private route header was copied into every descendant's forwarded request — so a leaf read its own ancestor as one of its children and created facets recursively.
+
+Descendants now route from their already-stripped connection URI. Deliveries back to the client are also awaited at each hop, so a reply or `broadcast()` from a leaf reaches the root-owned socket instead of being cut off with "RPC stub used after being disposed".

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1680,10 +1680,16 @@ export class Agent<
   private _protocolBroadcastExcludeIds = new Set<string>();
   private _cf_currentSubAgentBridge?: SubAgentConnectionBridgeLike;
   /**
-   * Facet deliveries started from a sync API (`broadcast`) that have not
-   * settled. Drained before an inbound sub-agent RPC returns (#2026).
+   * Collects facet deliveries started from a sync API (`broadcast`)
+   * while a single inbound sub-agent frame is being handled, so that
+   * frame can await them before returning (#2026).
+   *
+   * Scoped to the frame on purpose. An agent-wide set would also catch
+   * background and concurrent-frame broadcasts — a streaming agent could
+   * then hold one frame's RPC open for the length of an unrelated
+   * stream, and one connection could stall another.
    */
-  private _cf_pendingSubAgentDeliveries = new Set<Promise<unknown>>();
+  private _cf_currentDeliverySink?: Set<Promise<unknown>>;
   private _cf_virtualSubAgentConnections = new Map<
     string,
     StoredSubAgentConnection
@@ -7389,37 +7395,71 @@ export class Agent<
     );
   }
 
-  /** Track a delivery that has no synchronous caller to await it. */
+  /**
+   * Track a delivery that has no synchronous caller to await it.
+   *
+   * Only while a frame is in progress. A broadcast started outside one —
+   * from an alarm, a background task, or a stream that outlives the
+   * frame that began it — travels via `_rootAlarmOwner()` on a stub this
+   * agent owns, so it is not exposed to the borrowed-bridge disposal
+   * race and nothing needs to wait for it.
+   */
   private _cf_trackSubAgentDelivery(promise: Promise<unknown>): void {
-    this._cf_pendingSubAgentDeliveries.add(promise);
+    const sink = this._cf_currentDeliverySink;
+    if (!sink) {
+      void promise.catch(() => {});
+      return;
+    }
+    sink.add(promise);
     void promise
       .catch(() => {})
       .finally(() => {
-        this._cf_pendingSubAgentDeliveries.delete(promise);
+        sink.delete(promise);
       });
   }
 
   /**
-   * Wait for deliveries this agent started while handling a frame.
+   * Run `fn` as one sub-agent frame, then wait for the deliveries it
+   * started before letting the inbound RPC return.
+   *
+   * That wait is what keeps a borrowed bridge stub alive until the next
+   * hop has the message (#2026). The set is snapshotted once rather than
+   * polled: `send` and `broadcast` register synchronously, so everything
+   * the frame started is already present by the time it returns, and a
+   * completing delivery never queues another. Draining therefore cannot
+   * be extended by unrelated traffic.
+   */
+  private async _cf_runSubAgentFrame<T>(
+    id: string,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    const sink = new Set<Promise<unknown>>();
+    const previous = this._cf_currentDeliverySink;
+    this._cf_currentDeliverySink = sink;
+    try {
+      return await fn();
+    } finally {
+      this._cf_currentDeliverySink = previous;
+      await this._cf_drainSubAgentConnection(id, sink);
+    }
+  }
+
+  /**
+   * Wait for in-flight deliveries on a virtual connection.
    *
    * A no-op for a root-owned physical socket, which sends natively and
-   * has nothing in flight. On an intermediate facet it is what keeps the
-   * bridge stub alive while the next hop completes (#2026). Loops
-   * because a delivery can itself queue another one.
+   * has nothing in flight.
    */
-  private async _cf_drainSubAgentConnection(id: string): Promise<void> {
-    const awaited = new Set<Promise<unknown>>();
-    // Terminates because each pass only awaits promises it has not seen,
-    // and a frame can only queue finitely many.
-    while (true) {
-      const inFlight = [
-        ...(this._cf_virtualSubAgentConnections.get(id)?.pending ?? []),
-        ...this._cf_pendingSubAgentDeliveries
-      ].filter((promise) => !awaited.has(promise));
-      if (inFlight.length === 0) return;
-      for (const promise of inFlight) awaited.add(promise);
-      await Promise.allSettled(inFlight);
-    }
+  private async _cf_drainSubAgentConnection(
+    id: string,
+    sink?: ReadonlySet<Promise<unknown>>
+  ): Promise<void> {
+    const inFlight = [
+      ...(this._cf_virtualSubAgentConnections.get(id)?.pending ?? []),
+      ...(sink ?? [])
+    ];
+    if (inFlight.length === 0) return;
+    await Promise.allSettled(inFlight);
   }
 
   private async _cf_forwardSubAgentWebSocketMessage(
@@ -7557,11 +7597,9 @@ export class Agent<
     bridge: SubAgentConnectionBridge,
     meta: SubAgentConnectionMeta
   ): Promise<void> {
-    try {
-      await this._cf_handleSubAgentWebSocketConnectInner(bridge, meta);
-    } finally {
-      await this._cf_drainSubAgentConnection(meta.id);
-    }
+    await this._cf_runSubAgentFrame(meta.id, () =>
+      this._cf_handleSubAgentWebSocketConnectInner(bridge, meta)
+    );
   }
 
   private async _cf_handleSubAgentWebSocketConnectInner(
@@ -7606,13 +7644,11 @@ export class Agent<
   ): Promise<void> {
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
     this._cf_storeVirtualSubAgentConnection(bridge, connection);
-    try {
-      await this._cf_runWithSubAgentBridge(bridge, () =>
+    await this._cf_runSubAgentFrame(meta.id, () =>
+      this._cf_runWithSubAgentBridge(bridge, () =>
         this.onMessage(connection, message)
-      );
-    } finally {
-      await this._cf_drainSubAgentConnection(meta.id);
-    }
+      )
+    );
   }
 
   async _cf_handleSubAgentWebSocketClose(
@@ -7625,11 +7661,12 @@ export class Agent<
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
     this._cf_storeVirtualSubAgentConnection(bridge, connection);
     try {
-      await this._cf_runWithSubAgentBridge(bridge, () =>
-        this.onClose(connection, code, reason, wasClean)
+      await this._cf_runSubAgentFrame(meta.id, () =>
+        this._cf_runWithSubAgentBridge(bridge, () =>
+          this.onClose(connection, code, reason, wasClean)
+        )
       );
     } finally {
-      await this._cf_drainSubAgentConnection(meta.id);
       this._cf_virtualSubAgentConnections.delete(meta.id);
     }
   }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -383,21 +383,34 @@ type SubAgentConnectionMeta = {
   requestHeaders?: [string, string][];
 };
 
+/**
+ * Delivery methods return a promise so each hop can be awaited before
+ * the RPC that carried the bridge returns. A bridge is an `RpcTarget`
+ * whose stub is disposed the moment its inbound call completes, so a
+ * fire-and-forget hop deeper in the chain would be cut off with
+ * "RPC stub used after being disposed" (#2026).
+ */
 type SubAgentConnectionBridgeLike = {
-  send(message: string | ArrayBuffer | ArrayBufferView): void;
-  close(code?: number, reason?: string): void;
+  send(message: string | ArrayBuffer | ArrayBufferView): void | Promise<void>;
+  close(code?: number, reason?: string): void | Promise<void>;
   setState(state: unknown): unknown;
   broadcast(
     ownerPath: ReadonlyArray<{ className: string; name: string }>,
     message: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
-  ): void;
+  ): void | Promise<void>;
 };
 
 type StoredSubAgentConnection = {
   bridge: SubAgentConnectionBridgeLike;
   meta: SubAgentConnectionMeta;
   connection?: Connection;
+  /**
+   * Deliveries started by this agent's virtual connection that have not
+   * settled yet. Drained before the inbound RPC returns so the bridge
+   * stub outlives the hop it feeds.
+   */
+  pending?: Set<Promise<unknown>>;
 };
 
 type SubAgentWebSocketEndpoint = {
@@ -428,7 +441,13 @@ class SubAgentConnectionBridge
     ownerPath: ReadonlyArray<{ className: string; name: string }>,
     message: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
-  ) => void;
+  ) => void | Promise<void>;
+  /**
+   * Awaits any delivery this hop started on its own virtual connection.
+   * Without it, a nested chain returns while the next hop is still in
+   * flight and the caller disposes the stub underneath it (#2026).
+   */
+  #flush?: () => Promise<void>;
 
   constructor(
     connection: Connection,
@@ -436,31 +455,38 @@ class SubAgentConnectionBridge
       ownerPath: ReadonlyArray<{ className: string; name: string }>,
       message: string | ArrayBuffer | ArrayBufferView,
       without?: string[]
-    ) => void
+    ) => void | Promise<void>,
+    flush?: () => Promise<void>
   ) {
     super();
     this.#connection = connection;
     this.#broadcast = broadcast;
+    this.#flush = flush;
   }
 
-  send(message: string | ArrayBuffer | ArrayBufferView): void {
+  async send(message: string | ArrayBuffer | ArrayBufferView): Promise<void> {
     this.#connection.send(message);
+    await this.#flush?.();
   }
 
-  close(code?: number, reason?: string): void {
+  async close(code?: number, reason?: string): Promise<void> {
     this.#connection.close(code, reason);
+    await this.#flush?.();
   }
 
-  setState(state: unknown): unknown {
-    return this.#connection.setState(state);
+  async setState(state: unknown): Promise<unknown> {
+    const next = this.#connection.setState(state);
+    await this.#flush?.();
+    return next;
   }
 
-  broadcast(
+  async broadcast(
     ownerPath: ReadonlyArray<{ className: string; name: string }>,
     message: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
-  ): void {
-    this.#broadcast?.(ownerPath, message, without);
+  ): Promise<void> {
+    await this.#broadcast?.(ownerPath, message, without);
+    await this.#flush?.();
   }
 }
 
@@ -473,12 +499,12 @@ class RootSubAgentConnectionBridge implements SubAgentConnectionBridgeLike {
     this.#connectionId = connectionId;
   }
 
-  send(message: string | ArrayBuffer | ArrayBufferView): void {
-    void this.#root._cf_sendToSubAgentConnection(this.#connectionId, message);
+  async send(message: string | ArrayBuffer | ArrayBufferView): Promise<void> {
+    await this.#root._cf_sendToSubAgentConnection(this.#connectionId, message);
   }
 
-  close(code?: number, reason?: string): void {
-    void this.#root._cf_closeSubAgentConnection(
+  async close(code?: number, reason?: string): Promise<void> {
+    await this.#root._cf_closeSubAgentConnection(
       this.#connectionId,
       code,
       reason
@@ -490,12 +516,12 @@ class RootSubAgentConnectionBridge implements SubAgentConnectionBridgeLike {
     return state;
   }
 
-  broadcast(
+  async broadcast(
     ownerPath: ReadonlyArray<{ className: string; name: string }>,
     message: string | ArrayBuffer | ArrayBufferView,
     without?: string[]
-  ): void {
-    void this.#root._cf_broadcastToSubAgent(ownerPath, message, without);
+  ): Promise<void> {
+    await this.#root._cf_broadcastToSubAgent(ownerPath, message, without);
   }
 }
 
@@ -1209,6 +1235,15 @@ const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
  * Hibernated events then wake the parent, which forwards frames to
  * the child over serializable RPC while keeping native WebSocket I/O
  * parent-owned.
+ *
+ * INVARIANT: only the agent that owns the physical socket — the root —
+ * may hold this. The route it describes is written from the root's
+ * point of view, so a descendant that holds it reads its own ancestors
+ * as its children. See issue #2026: descendants must route from their
+ * already-stripped `meta.uri` instead. Enforced at both ends —
+ * `_cf_getForwardedSubAgentState` and `_cf_resolveSubAgentConnection`
+ * strip it from forwarded state and headers, and
+ * `_cf_resolveSubAgentConnection` ignores it outright on a facet.
  */
 const CF_SUB_AGENT_OUTER_URL_KEY = "_cf_subAgentOuterUrl";
 const CF_SUB_AGENT_TAGS_KEY = "_cf_subAgentTags";
@@ -1644,6 +1679,11 @@ export class Agent<
 
   private _protocolBroadcastExcludeIds = new Set<string>();
   private _cf_currentSubAgentBridge?: SubAgentConnectionBridgeLike;
+  /**
+   * Facet deliveries started from a sync API (`broadcast`) that have not
+   * settled. Drained before an inbound sub-agent RPC returns (#2026).
+   */
+  private _cf_pendingSubAgentDeliveries = new Set<Promise<unknown>>();
   private _cf_virtualSubAgentConnections = new Map<
     string,
     StoredSubAgentConnection
@@ -7044,7 +7084,13 @@ export class Agent<
     without?: string[]
   ): void {
     if (this._isFacet) {
-      void this._cf_broadcastToParentSubAgent(msg, without);
+      // `broadcast` is sync by contract, so the delivery is tracked
+      // rather than awaited. The frame that triggered it drains the set
+      // before its RPC returns, so the bridge stub carrying the message
+      // upstream is not disposed mid-flight (#2026).
+      this._cf_trackSubAgentDelivery(
+        this._cf_broadcastToParentSubAgent(msg, without)
+      );
       return;
     }
 
@@ -7112,7 +7158,11 @@ export class Agent<
     without?: string[]
   ): Promise<void> {
     if (this._cf_currentSubAgentBridge) {
-      this._cf_currentSubAgentBridge.broadcast(this.selfPath, message, without);
+      await this._cf_currentSubAgentBridge.broadcast(
+        this.selfPath,
+        message,
+        without
+      );
       return;
     }
     const root = await this._rootAlarmOwner();
@@ -7125,7 +7175,11 @@ export class Agent<
     without?: string[]
   ): Promise<void> {
     if (this._isFacet && this._cf_currentSubAgentBridge) {
-      this._cf_currentSubAgentBridge.broadcast(ownerPath, message, without);
+      await this._cf_currentSubAgentBridge.broadcast(
+        ownerPath,
+        message,
+        without
+      );
       return;
     }
 
@@ -7329,10 +7383,43 @@ export class Agent<
   ): SubAgentConnectionBridge {
     return new SubAgentConnectionBridge(
       connection,
-      (ownerPath, message, without) => {
-        void this._cf_broadcastToSubAgent(ownerPath, message, without);
-      }
+      (ownerPath, message, without) =>
+        this._cf_broadcastToSubAgent(ownerPath, message, without),
+      () => this._cf_drainSubAgentConnection(connection.id)
     );
+  }
+
+  /** Track a delivery that has no synchronous caller to await it. */
+  private _cf_trackSubAgentDelivery(promise: Promise<unknown>): void {
+    this._cf_pendingSubAgentDeliveries.add(promise);
+    void promise
+      .catch(() => {})
+      .finally(() => {
+        this._cf_pendingSubAgentDeliveries.delete(promise);
+      });
+  }
+
+  /**
+   * Wait for deliveries this agent started while handling a frame.
+   *
+   * A no-op for a root-owned physical socket, which sends natively and
+   * has nothing in flight. On an intermediate facet it is what keeps the
+   * bridge stub alive while the next hop completes (#2026). Loops
+   * because a delivery can itself queue another one.
+   */
+  private async _cf_drainSubAgentConnection(id: string): Promise<void> {
+    const awaited = new Set<Promise<unknown>>();
+    // Terminates because each pass only awaits promises it has not seen,
+    // and a frame can only queue finitely many.
+    while (true) {
+      const inFlight = [
+        ...(this._cf_virtualSubAgentConnections.get(id)?.pending ?? []),
+        ...this._cf_pendingSubAgentDeliveries
+      ].filter((promise) => !awaited.has(promise));
+      if (inFlight.length === 0) return;
+      for (const promise of inFlight) awaited.add(promise);
+      await Promise.allSettled(inFlight);
+    }
   }
 
   private async _cf_forwardSubAgentWebSocketMessage(
@@ -7378,10 +7465,14 @@ export class Agent<
     meta: SubAgentConnectionMeta;
   } | null> {
     this._ensureConnectionWrapped(connection);
-    const outerUri = this._unsafe_getConnectionFlag(
-      connection,
-      CF_SUB_AGENT_OUTER_URL_KEY
-    );
+    // Only the root may hold the outer URL — see
+    // CF_SUB_AGENT_OUTER_URL_KEY. A facet's connection is virtual and
+    // its `uri` is already stripped one hop per level, so routing from
+    // it is both correct and immune to a stale ancestor route leaking
+    // back in (#2026).
+    const outerUri = this._isFacet
+      ? undefined
+      : this._unsafe_getConnectionFlag(connection, CF_SUB_AGENT_OUTER_URL_KEY);
     const uri = typeof outerUri === "string" ? outerUri : connection.uri;
     if (!uri) return null;
 
@@ -7438,12 +7529,42 @@ export class Agent<
         uri: childUri.toString(),
         tags,
         state: this._cf_getForwardedSubAgentState(connection),
-        requestHeaders: forwardReq ? [...forwardReq.headers] : undefined
+        requestHeaders: forwardReq
+          ? this._cf_getForwardedSubAgentHeaders(forwardReq)
+          : undefined
       }
     };
   }
 
+  /**
+   * Headers forwarded to a descendant, minus the private route note.
+   *
+   * The child rebuilds a Request from these and hands it to its own
+   * `onConnect`, which copies SUB_AGENT_OUTER_URL_HEADER onto the
+   * connection. Propagating it would give the child its *ancestor's*
+   * route, which it would then read as a route to one of its own
+   * children (#2026). Mirrors `_cf_getForwardedSubAgentState`.
+   */
+  private _cf_getForwardedSubAgentHeaders(
+    request: Request
+  ): [string, string][] {
+    return [...request.headers].filter(
+      ([name]) => name.toLowerCase() !== SUB_AGENT_OUTER_URL_HEADER
+    );
+  }
+
   async _cf_handleSubAgentWebSocketConnect(
+    bridge: SubAgentConnectionBridge,
+    meta: SubAgentConnectionMeta
+  ): Promise<void> {
+    try {
+      await this._cf_handleSubAgentWebSocketConnectInner(bridge, meta);
+    } finally {
+      await this._cf_drainSubAgentConnection(meta.id);
+    }
+  }
+
+  private async _cf_handleSubAgentWebSocketConnectInner(
     bridge: SubAgentConnectionBridge,
     meta: SubAgentConnectionMeta
   ): Promise<void> {
@@ -7485,9 +7606,13 @@ export class Agent<
   ): Promise<void> {
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
     this._cf_storeVirtualSubAgentConnection(bridge, connection);
-    await this._cf_runWithSubAgentBridge(bridge, () =>
-      this.onMessage(connection, message)
-    );
+    try {
+      await this._cf_runWithSubAgentBridge(bridge, () =>
+        this.onMessage(connection, message)
+      );
+    } finally {
+      await this._cf_drainSubAgentConnection(meta.id);
+    }
   }
 
   async _cf_handleSubAgentWebSocketClose(
@@ -7499,10 +7624,14 @@ export class Agent<
   ): Promise<void> {
     const connection = this._cf_createSubAgentBridgeConnection(bridge, meta);
     this._cf_storeVirtualSubAgentConnection(bridge, connection);
-    await this._cf_runWithSubAgentBridge(bridge, () =>
-      this.onClose(connection, code, reason, wasClean)
-    );
-    this._cf_virtualSubAgentConnections.delete(meta.id);
+    try {
+      await this._cf_runWithSubAgentBridge(bridge, () =>
+        this.onClose(connection, code, reason, wasClean)
+      );
+    } finally {
+      await this._cf_drainSubAgentConnection(meta.id);
+      this._cf_virtualSubAgentConnections.delete(meta.id);
+    }
   }
 
   private async _cf_runWithSubAgentBridge<T>(
@@ -7554,6 +7683,23 @@ export class Agent<
         current.meta = { ...current.meta, state: nextState };
       }
     };
+    // Record an in-flight delivery so the frame that triggered it can
+    // wait for it. `Connection.send` is sync by contract, so the promise
+    // has nowhere else to go (#2026).
+    const trackPending = (result: unknown) => {
+      if (!result || typeof (result as Promise<unknown>).then !== "function") {
+        return;
+      }
+      const promise = result as Promise<unknown>;
+      const current = getStored();
+      const pending = (current.pending ??= new Set());
+      pending.add(promise);
+      void promise
+        .catch(() => {})
+        .finally(() => {
+          pending.delete(promise);
+        });
+    };
 
     const connection = {
       id: meta.id,
@@ -7567,14 +7713,14 @@ export class Agent<
         const currentState = getStored().meta.state;
         const state = typeof next === "function" ? next(currentState) : next;
         updateStoredState(state);
-        void getStored().bridge.setState(state);
+        trackPending(getStored().bridge.setState(state));
         return state;
       },
       send(message: string | ArrayBuffer | ArrayBufferView) {
-        void getStored().bridge.send(message);
+        trackPending(getStored().bridge.send(message));
       },
       close(code?: number, reason?: string) {
-        void getStored().bridge.close(code, reason);
+        trackPending(getStored().bridge.close(code, reason));
       },
       addEventListener() {},
       removeEventListener() {}
@@ -7601,7 +7747,10 @@ export class Agent<
         tags: [...connection.tags],
         state: this._cf_getRawConnectionState(connection)
       },
-      connection: stored?.connection ?? connection
+      connection: stored?.connection ?? connection,
+      // Carry in-flight deliveries across the re-store, otherwise the
+      // frame that started them loses track and returns early (#2026).
+      pending: stored?.pending
     });
   }
 

--- a/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
+++ b/packages/agents/src/tests/agents/spike-sub-agent-routing.ts
@@ -134,6 +134,22 @@ export class SpikeSubChild extends Agent {
     return true;
   }
 
+  /**
+   * Register a delivery that never settles, from outside any frame —
+   * standing in for a background broadcast or a stream that outlives
+   * the frame that started it.
+   *
+   * A frame must not wait on this. When deliveries were tracked in an
+   * agent-wide set, every later frame drained it and hung forever.
+   */
+  stallBackgroundDeliveryForTest(): void {
+    (
+      this as unknown as {
+        _cf_trackSubAgentDelivery(promise: Promise<unknown>): void;
+      }
+    )._cf_trackSubAgentDelivery(new Promise<never>(() => {}));
+  }
+
   async onConnect(_connection: Connection): Promise<void> {
     this.bump("connect");
   }

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { exports, env } from "cloudflare:workers";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildAgentPath, getAgentByName, getSubAgentByName } from "../index";
 import { SpikeSubChild } from "./agents/spike-sub-agent-routing";
 
@@ -185,6 +185,41 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
     expect(ws.readyState).toBe(WebSocket.OPEN);
 
     ws.close();
+  });
+
+  it("completes a frame without waiting on a background delivery", async () => {
+    // The #2026 fix makes a frame wait for its own deliveries so the
+    // borrowed bridge stub outlives them. That wait has to stay scoped
+    // to the frame. Tracking deliveries in one agent-wide set instead
+    // would mean every frame also waited on background work and on
+    // other connections' frames — a streaming agent could hold a frame
+    // open for the length of an unrelated stream, and one client could
+    // stall another.
+    //
+    // Observed via close, because the message content is delivered
+    // before the drain and so arrives either way. It is frame
+    // *completion* that stalls: `_cf_handleSubAgentWebSocketClose` only
+    // drops the connection once its frame finishes, so an unscoped
+    // drain leaves the facet holding a closed connection forever.
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(parent, "spike-sub-child", child);
+    ws.send("warmup");
+    expect(await collectMessages(ws, 1)).toEqual([`pong:${child}:warmup`]);
+
+    const parentStub = await getAgentByName(env.SpikeSubParent, parent);
+    const childStub = await getSubAgentByName(parentStub, SpikeSubChild, child);
+    await childStub.stallBackgroundDeliveryForTest();
+
+    ws.close();
+
+    await vi.waitFor(
+      async () => {
+        expect((await childStub.connectionSnapshot()).all).toHaveLength(0);
+      },
+      { timeout: 3000, interval: 50 }
+    );
   });
 
   it("this.broadcast(...) inside a facet reaches the facet's own WS clients", async () => {

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -126,6 +126,67 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
     ws.close();
   });
 
+  it("establishes a WebSocket through two nested facet hops", async () => {
+    // Regression for #2026. The root owns the physical socket and
+    // remembers the whole route in a private header. That header used
+    // to be copied into every descendant's forwarded request, so the
+    // leaf stored its *ancestor's* route as its own and re-read the
+    // first hop as one of its own children — creating facets
+    // recursively until workerd rejected the chain with "Facet nesting
+    // depth limit exceeded". The upgrade returned 101 and the socket
+    // then died with 1011 during session setup.
+    //
+    // One hop passed only by accident: the single-hop self-strip in
+    // `_cf_resolveSubAgentConnection` happened to consume the leaf's
+    // own segment, leaving nothing to route.
+    const parent = uniqueName();
+    const middle = uniqueName();
+    const leaf = uniqueName();
+
+    const ws = await openWS(
+      parent,
+      "spike-sub-child",
+      middle,
+      `/sub/spike-sub-child/${leaf}`
+    );
+
+    ws.send("hello");
+    const [reply] = await collectMessages(ws, 1);
+
+    expect(reply).toBe(`pong:${leaf}:hello`);
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+
+    ws.close();
+  });
+
+  it("delivers a leaf broadcast to the root-owned socket across two hops", async () => {
+    // The reply travels leaf → middle → root, and each hop is a fresh
+    // RpcTarget stub disposed as soon as its inbound call returns. Every
+    // hop used to be fire-and-forget, so with two hops the inner send
+    // was still in flight when its stub went away ("RPC stub used after
+    // being disposed") and the client got nothing. One hop was short
+    // enough to win the race. Covers `broadcast()`, which is sync by
+    // contract and so cannot be awaited by its caller.
+    const parent = uniqueName();
+    const middle = uniqueName();
+    const leaf = uniqueName();
+
+    const ws = await openWS(
+      parent,
+      "spike-sub-child",
+      middle,
+      `/sub/spike-sub-child/${leaf}`
+    );
+
+    ws.send("broadcast:hello");
+    const [reply] = await collectMessages(ws, 1);
+
+    expect(reply).toBe(`pong:${leaf}:broadcast:hello`);
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+
+    ws.close();
+  });
+
   it("this.broadcast(...) inside a facet reaches the facet's own WS clients", async () => {
     // Regression: an earlier guard in Agent.broadcast() no-op'd when
     // `_isFacet` was set, assuming facets had no direct client


### PR DESCRIPTION
Closes #2026

## The problem

A WebSocket two or more hops deep (`/sub/{class}/{name}/sub/{class}/{name}`) upgraded with HTTP 101 and then immediately died with code `1011`. One hop was fine.

Only the root agent owns the real socket. It remembers the whole route in a private header, `x-cf-agents-subagent-url`, and strips one `/sub/{class}/{name}` hop each time it passes the connection down. But it also copied **every** header down — including that private one.

So the leaf ended up holding a route written from the *root's* point of view. It read the first hop in it, saw `middle`, and concluded `middle` must be one of its own children. `middle` is its grandparent. It created a new facet, which read the same note, and so on until workerd stopped it:

```
Facet nesting depth limit exceeded. The maximum depth including the root Durable Object is 4.
```

One hop only passed by accident: the single-hop self-strip in `_cf_resolveSubAgentConnection` happened to consume the leaf's own segment, leaving nothing to route.

## What changed

Descendants no longer receive the header, and no longer read it even if they somehow get one:

```diff
-        requestHeaders: forwardReq ? [...forwardReq.headers] : undefined
+        requestHeaders: forwardReq
+          ? this._cf_getForwardedSubAgentHeaders(forwardReq)
+          : undefined
```

```diff
-    const outerUri = this._unsafe_getConnectionFlag(
-      connection,
-      CF_SUB_AGENT_OUTER_URL_KEY
-    );
+    const outerUri = this._isFacet
+      ? undefined
+      : this._unsafe_getConnectionFlag(connection, CF_SUB_AGENT_OUTER_URL_KEY);
```

A facet's connection URI is already stripped one hop per level, so routing from it is correct at any depth. The invariant — only the root may hold this route — is now written down at the declaration. `_cf_getForwardedSubAgentState` already stripped the same key from forwarded *state*; the header channel was the remaining hole.

## The second defect

Fixing the routing exposed a bug underneath it. The nested socket now reached the leaf, but the reply never came back:

```
Error: RPC stub used after being disposed.
```

Each hop hands the next one a `SubAgentConnectionBridge`, an `RpcTarget` whose stub is disposed the moment its inbound call returns. Every delivery was fire-and-forget:

```ts
send(message) { void getStored().bridge.send(message); }
```

The bridge is effectively on loan for the duration of the call. Returning without waiting means hanging up while your reply is still travelling:

```
Browser sends "hello":

1. ROOT gets "hello" from the browser
2. ROOT calls MIDDLE, lending it bridge-A   (to reply to Root)
3. MIDDLE calls LEAF, lending it bridge-B   (to reply to Middle)
4. LEAF runs user code: connection.send("pong")
      -> starts sending "pong" over bridge-B
5. LEAF does not wait for it to arrive. LEAF returns.
6. MIDDLE sees LEAF is done, so bridge-B is disposed
7. "pong" was still in flight on bridge-B
      -> severed -> "RPC stub used after being disposed"
```

Step 7 is only the *first* place this is visible, not the only place it is wrong. Every link had the same flaw: if the reply had survived step 7, Middle would then have sent it over bridge-A and returned without waiting, and Root would have disposed bridge-A out from under it. The message dies at whichever link loses the race first.

That is also why one hop passed. With no middle there is a single link and a single short trip, so the send usually landed before the bridge was reclaimed. Two hops means winning two races instead of one, and it lost consistently. Depth 1 was never correct, only lucky.

Deliveries are now awaited at each hop, so no agent finishes while it is still holding someone else's message:

```diff
-  send(message: string | ArrayBuffer | ArrayBufferView): void {
+  async send(message: string | ArrayBuffer | ArrayBufferView): Promise<void> {
     this.#connection.send(message);
+    await this.#flush?.();
   }
```

`Connection.send` and `broadcast` are synchronous by contract, so their promises have nowhere to be returned. Those are recorded instead, and drained before the frame's RPC returns. Deliveries flow strictly rootward, so the drain cannot cycle; on the root it is a no-op, since a real socket sends natively.

I kept these together because #2026's expected behaviour — the client receiving `pong:{leaf}:hello` — is unreachable with only the routing fix, and the delivery bug is unobservable without it.

## Tests

Two additions to `src/tests/spike-sub-agent-routing.test.ts`, using the existing `SpikeSubParent`/`SpikeSubChild` fixtures:

- **two nested facet hops** — the repro from the issue. Fails on `main` with the depth-limit error.
- **leaf broadcast across two hops** — covers `broadcast()`, the sync-contract path that cannot await itself. Also fails on `main`.

Verified red→green rather than assumed: with only the header fix applied, the first test still fails with `RPC stub used after being disposed`. That is the evidence the delivery fix is load-bearing rather than speculative.

## Verification

- `pnpm run test:workers` — 90 files / 1803 tests
- `pnpm run check` — sherif, export check, oxfmt, oxlint, 121 projects typecheck
- `@cloudflare/ai-chat` 50/737, `@cloudflare/voice` 12/227, `@cloudflare/think` 2/5
- `nx affected -t test` — 16 projects

`AIChatAgent` and `Think` both wrap `onConnect`/`onMessage` and branch on `_cf_connectionTargetsSubAgent`, which reads `connection.uri`. That semantics is unchanged, and their suites pass.

## Not addressed

- `_cf_broadcastToSubAgent` still falls through to `super.getConnections()` when a facet has no ambient bridge, which is the #1677 cross-DO hazard. Reachable, but a separate fix.
- `_cf_currentSubAgentBridge` is an instance field with LIFO save/restore and is not concurrency-safe. That is #1991's territory and #2027 is already in that code.
- The follow-up checklist item to unskip the nested test in `sub-agent-rpc-bridge.test.ts` is not actionable here — that file only exists on #2027's branch, and the test was removed there in `9a66232c`. It should be restored on that branch now this has landed.
