### PR TITLE
fix+chore (worker-bundler): Select Pyodide lockfile version by compatibility date + update relevant dependencies

### DIFF
--- a/.changeset/some-rats-behave.md
+++ b/.changeset/some-rats-behave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/worker-bundler": minor
+---
+
+Undoes a bandaid fix for what amounted to a bug where the same Pyodide version would be served to the dynamic worker regardless of compatibility date

--- a/agent-think/package.json
+++ b/agent-think/package.json
@@ -32,7 +32,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.19.0",
+    "@cloudflare/vitest-pool-workers": "^0.21.2",
     "@types/diff": "^8.0.0",
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@changesets/cli": "^2.31.0",
     "@cloudflare/kumo": "^2.6.0",
     "@cloudflare/vite-plugin": "^1.48.0",
-    "@cloudflare/vitest-pool-workers": "^0.19.0",
+    "@cloudflare/vitest-pool-workers": "^0.21.2",
     "@cloudflare/workers-types": "^5.20260729.1",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@openai/agents": "^0.12.0",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -15,7 +15,7 @@
     "isomorphic-git": "^1.38.5"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.19.0",
+    "@cloudflare/vitest-pool-workers": "^0.21.2",
     "vitest": "4.1.9"
   },
   "types": "dist/index.d.ts",

--- a/packages/worker-bundler/src/index.ts
+++ b/packages/worker-bundler/src/index.ts
@@ -113,12 +113,14 @@ export async function createWorker(
   // Parse wrangler config for compatibility settings
   const wranglerConfig = parseWranglerConfig(fileSystem);
   const nodejsCompat = hasNodejsCompat(wranglerConfig);
+  const compatibilityDate = wranglerConfig?.compatibilityDate ?? "2026-07-02";
 
   // Auto-install dependencies if package.json or pyproject.toml has dependencies
   const installWarnings: string[] = [];
   if (hasDependencies(fileSystem)) {
     const installResult = await installDependencies(fileSystem, {
-      ...(registry ? { registry } : {})
+      ...(registry ? { registry } : {}),
+      compatibilityDate: compatibilityDate
     });
     installWarnings.push(...installResult.warnings);
   }
@@ -155,7 +157,7 @@ export async function createWorker(
       mainModule: entryPoint,
       modules,
       wranglerConfig: {
-        compatibilityDate: wranglerConfig?.compatibilityDate ?? "2026-07-02",
+        compatibilityDate: compatibilityDate,
         compatibilityFlags: wranglerConfig?.compatibilityFlags ?? []
       },
       warnings: installWarnings

--- a/packages/worker-bundler/src/installer-python.ts
+++ b/packages/worker-bundler/src/installer-python.ts
@@ -104,9 +104,22 @@ interface PyodideWheelInfo {
   file: PyPASimpleFile;
 }
 
-// Making this global so it will only need to be fetched once per invocation
-// TODO: Consider caching this somewhere since it's not likely to change between runs
-let pyodideLockfile: PyodideLockfile | null = null;
+// Cache Pyodide lockfiles per version so that workers using different
+// compatibility dates can resolve packages against the correct Pyodide index.
+const pyodideLockfileCache = new Map<string, Promise<PyodideLockfile | null>>();
+
+function getCachedPyodideLockfile(
+  version: string
+): Promise<PyodideLockfile | null> {
+  const cached = pyodideLockfileCache.get(version);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = fetchPyodideLockfile(version);
+  pyodideLockfileCache.set(version, promise);
+  return promise;
+}
 
 /**
  * Install Python dependencies declared in a pyproject.toml file.
@@ -137,15 +150,14 @@ export async function installDependenciesPython(
     options["compatibilityDate"]!
   );
 
-  if (!pyodideLockfile) {
-    try {
-      pyodideLockfile = await fetchPyodideLockfile(pyodideVersion);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      result.warnings.push(
-        `Could not retrieve Pyodide lockfile, attempts to retrieve packages from the Pyodide CDN may fail. Error: ${message}`
-      );
-    }
+  let pyodideLockfile: PyodideLockfile | null = null;
+  try {
+    pyodideLockfile = await getCachedPyodideLockfile(pyodideVersion);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result.warnings.push(
+      `Could not retrieve Pyodide lockfile, attempts to retrieve packages from the Pyodide CDN may fail. Error: ${message}`
+    );
   }
 
   // Track installed packages to avoid duplicates
@@ -163,7 +175,8 @@ export async function installDependenciesPython(
         installedPackages,
         inProgress,
         PYPI_SIMPLE_API,
-        pyodideVersion
+        pyodideVersion,
+        pyodideLockfile
       )
     )
   );
@@ -197,7 +210,8 @@ export async function installPythonPackage(
   installedPackages: Set<string>,
   inProgress: Map<string, Promise<void>>,
   backupRegistry: string,
-  pyodideVersion: string
+  pyodideVersion: string,
+  pyodideLockfile: PyodideLockfile | null
 ): Promise<void> {
   const name = parsePythonDependencySpecifier(dependencySpecifier)["name"];
   // Skip if already installed in this run
@@ -229,7 +243,11 @@ export async function installPythonPackage(
       let version: string = "";
 
       // Try the Pyodide index first, then fall back to PyPI if that fails
-      let registryResult = await retrieveFromPyodide(name, pyodideVersion);
+      let registryResult = await retrieveFromPyodide(
+        name,
+        pyodideVersion,
+        pyodideLockfile
+      );
       if (registryResult) {
         [response, wheel, version] = registryResult;
       } else {
@@ -265,7 +283,8 @@ export async function installPythonPackage(
             installedPackages,
             inProgress,
             PYPI_SIMPLE_API,
-            pyodideVersion
+            pyodideVersion,
+            pyodideLockfile
           )
         )
       );
@@ -309,9 +328,10 @@ async function retrieveFromPyPI(
 // TODO: Alter the flow to use the PyPA simple api (index.pyodide.org)
 async function retrieveFromPyodide(
   name: string,
-  pyodideVersion: string
+  pyodideVersion: string,
+  pyodideLockfile: PyodideLockfile | null
 ): Promise<[Response, PyPASimpleFile, string] | null> {
-  const pyodideWheel = getPyodideWheel(name, pyodideVersion);
+  const pyodideWheel = getPyodideWheel(name, pyodideVersion, pyodideLockfile);
   if (!pyodideWheel) {
     return null;
   }
@@ -405,7 +425,8 @@ function normalizePythonName(name: string): string {
  */
 function getPyodideWheel(
   name: string,
-  pyodideVersion: string
+  pyodideVersion: string,
+  pyodideLockfile: PyodideLockfile | null
 ): PyodideWheelInfo | null {
   if (!pyodideLockfile) return null;
 

--- a/packages/worker-bundler/src/installer-python.ts
+++ b/packages/worker-bundler/src/installer-python.ts
@@ -373,7 +373,7 @@ function stripWheelToPackage(
  * The lockfile lists all pre-built packages available in the Pyodide
  * distribution, including their wheel URLs, hashes, and dependencies.
  */
-async function fetchPyodideLockfile(
+export async function fetchPyodideLockfile(
   version: string
 ): Promise<PyodideLockfile | null> {
   const url = `https://cdn.jsdelivr.net/pyodide/${version}/full/pyodide-lock.json`;

--- a/packages/worker-bundler/src/installer-python.ts
+++ b/packages/worker-bundler/src/installer-python.ts
@@ -29,7 +29,7 @@ const PYODIDE_VERSIONS_BY_COMPATIBILITY_DATE: Array<{
  * earliest mapped version.
  */
 export function getPyodideVersionForCompatibilityDate(
-  compatibilityDate: string | undefined
+  compatibilityDate: string
 ): string {
   const earliestVersion = PYODIDE_VERSIONS_BY_COMPATIBILITY_DATE[0]?.version;
 
@@ -134,7 +134,7 @@ export async function installDependenciesPython(
   depsToInstall.push("workers-runtime-sdk");
 
   const pyodideVersion = getPyodideVersionForCompatibilityDate(
-    options["compatibilityDate"]
+    options["compatibilityDate"]!
   );
 
   if (!pyodideLockfile) {

--- a/packages/worker-bundler/src/installer-python.ts
+++ b/packages/worker-bundler/src/installer-python.ts
@@ -5,12 +5,48 @@
 import { isTextFile, fetchWithTimeout, DEFAULT_TIMEOUT_MS } from "./common.ts";
 import type { InstallResult } from "./common.ts";
 import type { FileSystem, FileEntry } from "./file-system";
+import type { InstallOptions } from "./installer";
 import { unzipSync } from "fflate";
 import { parse as parseToml } from "smol-toml";
 
-// TODO: Update PYODIDE_VERSION once the patch addressing the Python version mismatch for dynamic workers is merged
-const PYODIDE_VERSION = "v0.27.5"; // Used for retrieving a pyodide lockfile, which is done per Pyodide version. If incompatible wheels are being served, this may be why
 const PYPI_SIMPLE_API = "https://pypi.org/simple";
+
+// Derived from workerd's src/workerd/io/compatibility-date.capnp (the dates
+// when each pythonWorkers* flag is implied by pythonWorkers) and
+// build/python_metadata.bzl (the Pyodide version associated with each flag).
+const PYODIDE_VERSIONS_BY_COMPATIBILITY_DATE: Array<{
+  date: string;
+  version: string;
+}> = [
+  { date: "2024-03-01", version: "v0.27.5" },
+  { date: "2025-09-29", version: "v0.28.2" },
+  { date: "2026-08-25", version: "v314.0.4" }
+];
+
+/**
+ * Return the Pyodide version relevant for a given Cloudflare Workers
+ * compatibility date. Dates earlier than the first mapped entry return the
+ * earliest mapped version.
+ */
+export function getPyodideVersionForCompatibilityDate(
+  compatibilityDate: string | undefined
+): string {
+  const earliestVersion = PYODIDE_VERSIONS_BY_COMPATIBILITY_DATE[0]?.version;
+
+  if (!compatibilityDate) {
+    return earliestVersion ?? "v0.27.5";
+  }
+
+  for (let i = PYODIDE_VERSIONS_BY_COMPATIBILITY_DATE.length - 1; i >= 0; i--) {
+    const entry = PYODIDE_VERSIONS_BY_COMPATIBILITY_DATE[i];
+    // note: this works since dates are formatted YYYY-MM-DD
+    if (entry && compatibilityDate >= entry.date) {
+      return entry.version;
+    }
+  }
+
+  return earliestVersion ?? "v0.27.5";
+}
 
 // Deliberately keeping this minimal
 export interface PyprojectToml {
@@ -77,7 +113,8 @@ let pyodideLockfile: PyodideLockfile | null = null;
  */
 export async function installDependenciesPython(
   fileSystem: FileSystem,
-  pyprojectTomlContent: string
+  pyprojectTomlContent: string,
+  options: InstallOptions = {}
 ): Promise<InstallResult> {
   const result: InstallResult = {
     installed: [],
@@ -96,9 +133,13 @@ export async function installDependenciesPython(
   const depsToInstall: string[] = pyprojectToml.project?.dependencies ?? [];
   depsToInstall.push("workers-runtime-sdk");
 
+  const pyodideVersion = getPyodideVersionForCompatibilityDate(
+    options["compatibilityDate"]
+  );
+
   if (!pyodideLockfile) {
     try {
-      pyodideLockfile = await fetchPyodideLockfile(PYODIDE_VERSION);
+      pyodideLockfile = await fetchPyodideLockfile(pyodideVersion);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       result.warnings.push(
@@ -121,7 +162,8 @@ export async function installDependenciesPython(
         fileSystem,
         installedPackages,
         inProgress,
-        PYPI_SIMPLE_API
+        PYPI_SIMPLE_API,
+        pyodideVersion
       )
     )
   );
@@ -154,7 +196,8 @@ export async function installPythonPackage(
   fileSystem: FileSystem,
   installedPackages: Set<string>,
   inProgress: Map<string, Promise<void>>,
-  backupRegistry: string
+  backupRegistry: string,
+  pyodideVersion: string
 ): Promise<void> {
   const name = parsePythonDependencySpecifier(dependencySpecifier)["name"];
   // Skip if already installed in this run
@@ -186,10 +229,11 @@ export async function installPythonPackage(
       let version: string = "";
 
       // Try the Pyodide index first, then fall back to PyPI if that fails
-      let registryResult = await retrieveFromPyodide(name);
+      let registryResult = await retrieveFromPyodide(name, pyodideVersion);
       if (registryResult) {
         [response, wheel, version] = registryResult;
       } else {
+        result.warnings.push(`Falling back to PyPI for ${name}`);
         registryResult = await retrieveFromPyPI(name, backupRegistry);
         if (registryResult) {
           [response, wheel, version] = registryResult;
@@ -220,7 +264,8 @@ export async function installPythonPackage(
             fileSystem,
             installedPackages,
             inProgress,
-            PYPI_SIMPLE_API
+            PYPI_SIMPLE_API,
+            pyodideVersion
           )
         )
       );
@@ -263,9 +308,10 @@ async function retrieveFromPyPI(
 
 // TODO: Alter the flow to use the PyPA simple api (index.pyodide.org)
 async function retrieveFromPyodide(
-  name: string
+  name: string,
+  pyodideVersion: string
 ): Promise<[Response, PyPASimpleFile, string] | null> {
-  const pyodideWheel = getPyodideWheel(name);
+  const pyodideWheel = getPyodideWheel(name, pyodideVersion);
   if (!pyodideWheel) {
     return null;
   }
@@ -357,14 +403,17 @@ function normalizePythonName(name: string): string {
  *
  * Returns `null` if the lockfile is not loaded or the package is not present.
  */
-function getPyodideWheel(name: string): PyodideWheelInfo | null {
+function getPyodideWheel(
+  name: string,
+  pyodideVersion: string
+): PyodideWheelInfo | null {
   if (!pyodideLockfile) return null;
 
   const normalizedName = normalizePythonName(name);
   const pkg = pyodideLockfile.packages[normalizedName];
   if (!pkg) return null;
 
-  const baseUrl = `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full`;
+  const baseUrl = `https://cdn.jsdelivr.net/pyodide/${pyodideVersion}/full`;
   const url = pkg.file_name.startsWith("http")
     ? pkg.file_name
     : `${baseUrl}/${pkg.file_name}`;

--- a/packages/worker-bundler/src/installer.ts
+++ b/packages/worker-bundler/src/installer.ts
@@ -38,7 +38,7 @@ interface NpmPackageMetadata {
   versions: Record<string, PackageJson>;
 }
 
-interface InstallOptions {
+export interface InstallOptions {
   /**
    * Include devDependencies (default: false)
    */
@@ -48,6 +48,11 @@ interface InstallOptions {
    * Registry URL (default: https://registry.npmjs.org)
    */
   registry?: string;
+
+  /**
+   * Workers compatibility date
+   */
+  compatibilityDate?: string;
 }
 
 /**
@@ -119,7 +124,11 @@ export async function installDependencies(
       )
     );
   } else if (pyprojectTomlContent) {
-    return await installDependenciesPython(fileSystem, pyprojectTomlContent);
+    return await installDependenciesPython(
+      fileSystem,
+      pyprojectTomlContent,
+      options
+    );
   }
   return result;
 }

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -8,7 +8,11 @@ import { runInDurableObject } from "cloudflare:test";
 import { InMemoryFileSystem, DurableObjectKVFileSystem } from "../file-system";
 import type { CreateWorkerOptions } from "../types";
 import { createTypescriptLanguageService } from "../typescript";
-import { comparePythonVersions } from "../installer-python";
+import {
+  comparePythonVersions,
+  getPyodideVersionForCompatibilityDate,
+  fetchPyodideLockfile
+} from "../installer-python";
 
 let testId = 0;
 
@@ -1485,5 +1489,33 @@ describe("comparePythonVersions", () => {
     expect(comparePythonVersions("2.0.0beta", "2.0.0")).toBeLessThan(0);
     expect(comparePythonVersions("2.0.0dev", "2.0.0")).toBeLessThan(0);
     expect(comparePythonVersions("2.0.0pre", "2.0.0")).toBeLessThan(0);
+  });
+});
+
+describe("getPyodideVersionForCompatibilityDate", () => {
+  it("accurately returns an appropriate Pyodide version for different compatibility dates", async () => {
+    expect(getPyodideVersionForCompatibilityDate("2024-03-01")).toBe("v0.27.5");
+    expect(getPyodideVersionForCompatibilityDate("2024-04-01")).toBe("v0.27.5");
+    expect(getPyodideVersionForCompatibilityDate("2025-09-29")).toBe("v0.28.2");
+    expect(getPyodideVersionForCompatibilityDate("2025-09-30")).toBe("v0.28.2");
+    expect(getPyodideVersionForCompatibilityDate("2026-08-25")).toBe(
+      "v314.0.4"
+    );
+    expect(getPyodideVersionForCompatibilityDate("2026-08-26")).toBe(
+      "v314.0.4"
+    );
+
+    const pyodideLockfileA = await fetchPyodideLockfile(
+      getPyodideVersionForCompatibilityDate("2024-04-01")
+    );
+    expect(pyodideLockfileA!["info"]["python"]).toBe("3.12.7");
+    const pyodideLockfileB = await fetchPyodideLockfile(
+      getPyodideVersionForCompatibilityDate("2025-09-30")
+    );
+    expect(pyodideLockfileB!["info"]["python"]).toBe("3.13.2");
+    const pyodideLockfileC = await fetchPyodideLockfile(
+      getPyodideVersionForCompatibilityDate("2026-08-25")
+    );
+    expect(pyodideLockfileC!["info"]["python"]).toBe("3.14.0");
   });
 });

--- a/packages/worker-bundler/src/tests/e2e.test.ts
+++ b/packages/worker-bundler/src/tests/e2e.test.ts
@@ -10,8 +10,7 @@ import type { CreateWorkerOptions } from "../types";
 import { createTypescriptLanguageService } from "../typescript";
 import {
   comparePythonVersions,
-  getPyodideVersionForCompatibilityDate,
-  fetchPyodideLockfile
+  getPyodideVersionForCompatibilityDate
 } from "../installer-python";
 
 let testId = 0;
@@ -1504,18 +1503,5 @@ describe("getPyodideVersionForCompatibilityDate", () => {
     expect(getPyodideVersionForCompatibilityDate("2026-08-26")).toBe(
       "v314.0.4"
     );
-
-    const pyodideLockfileA = await fetchPyodideLockfile(
-      getPyodideVersionForCompatibilityDate("2024-04-01")
-    );
-    expect(pyodideLockfileA!["info"]["python"]).toBe("3.12.7");
-    const pyodideLockfileB = await fetchPyodideLockfile(
-      getPyodideVersionForCompatibilityDate("2025-09-30")
-    );
-    expect(pyodideLockfileB!["info"]["python"]).toBe("3.13.2");
-    const pyodideLockfileC = await fetchPyodideLockfile(
-      getPyodideVersionForCompatibilityDate("2026-08-25")
-    );
-    expect(pyodideLockfileC!["info"]["python"]).toBe("3.14.0");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,10 +35,10 @@ importers:
         version: 2.6.0(@date-fns/tz@1.5.0)(@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       '@cloudflare/vite-plugin':
         specifier: ^1.48.0
-        version: 1.48.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.115.0(@cloudflare/workers-types@5.20260729.1))
+        version: 1.48.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.122.0(@cloudflare/workers-types@5.20260729.1))
       '@cloudflare/vitest-pool-workers':
-        specifier: ^0.19.0
-        version: 0.19.0(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
+        specifier: ^0.21.2
+        version: 0.21.2(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
       '@cloudflare/workers-types':
         specifier: ^5.20260729.1
         version: 5.20260729.1
@@ -146,7 +146,7 @@ importers:
         version: 4.0.0(@ai-sdk/anthropic@4.0.10(zod@4.4.3))(@ai-sdk/google@4.0.10(zod@4.4.3))(@ai-sdk/openai@4.0.9(zod@4.4.3))(@ai-sdk/provider@4.0.2)(ai@7.0.18(zod@4.4.3))
       wrangler:
         specifier: ^4.115.0
-        version: 4.115.0(@cloudflare/workers-types@5.20260729.1)
+        version: 4.122.0(@cloudflare/workers-types@5.20260729.1)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -197,8 +197,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@cloudflare/vitest-pool-workers':
-        specifier: ^0.19.0
-        version: 0.19.0(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
+        specifier: ^0.21.2
+        version: 0.21.2(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
       '@types/diff':
         specifier: ^8.0.0
         version: 8.0.0
@@ -3780,7 +3780,7 @@ importers:
     dependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.48.0
-        version: 1.48.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.115.0(@cloudflare/workers-types@5.20260729.1))
+        version: 1.48.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.122.0(@cloudflare/workers-types@5.20260729.1))
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
         version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -4017,8 +4017,8 @@ importers:
         version: 1.38.5
     devDependencies:
       '@cloudflare/vitest-pool-workers':
-        specifier: ^0.19.0
-        version: 0.19.0(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
+        specifier: ^0.21.2
+        version: 0.21.2(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -5137,8 +5137,8 @@ packages:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.115.0
 
-  '@cloudflare/vitest-pool-workers@0.19.0':
-    resolution: {integrity: sha512-6t6zs1YBoAo9jJVpA8pTxPWYEY3c/ai07MWZYJ4vkUc5cyW9PHfMB6tFhDsRg7eLS+i26NMuB3aUOlBKdRiwhw==}
+  '@cloudflare/vitest-pool-workers@0.21.2':
+    resolution: {integrity: sha512-728q7/ydJQtyAsQqw/ptxpp1hYaqQbK0i6kgFHV5HwWcaVFDh0/LWgbRcJBQ3b4ABz77O3MrdHppPu/CPMqimw==}
     peerDependencies:
       '@vitest/runner': ^4.1.0
       '@vitest/snapshot': ^4.1.0
@@ -5150,8 +5150,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260722.1':
     resolution: {integrity: sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -5162,14 +5174,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260722.1':
     resolution: {integrity: sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260722.1':
     resolution: {integrity: sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -9612,6 +9642,10 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@5.20260811.0-alpha:
+    resolution: {integrity: sha512-sypXsD5fjY88fZNedPqnwrwR1dwfnfbfW7MfvMyIfPJdtRiCCOpUnjWGeFVYYZ+0fQVICye6Juu+vZgzTEx8XA==}
+    engines: {node: '>=22.0.0'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -11044,6 +11078,10 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -11415,6 +11453,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260811.1:
+    resolution: {integrity: sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   workers-ai-provider@4.0.0:
     resolution: {integrity: sha512-FkhwMP1EP/MKXR8Jv1o7wLVKfTqu0h/PUaEmhZ7gyDiioib5Wsh3oPAKhG+7+SWfU3roTDHaEWlJpkJjpXu+fQ==}
     peerDependencies:
@@ -11437,6 +11480,16 @@ packages:
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^5.20260722.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.122.0:
+    resolution: {integrity: sha512-qkskzgQ76Y1qvVe5JARgvc3RISq6BC2rPoxQhFoKH1dKIwQc3GDFttQ/7m2OfeQ+tmQRzynv2dy/DXnxFCj2Lw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260811.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -12659,6 +12712,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260722.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260811.1
+
   '@cloudflare/vite-plugin@1.48.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.115.0(@cloudflare/workers-types@5.20260729.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
@@ -12672,16 +12731,29 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.19.0(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)':
+  '@cloudflare/vite-plugin@1.48.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.122.0(@cloudflare/workers-types@5.20260729.1))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
+      miniflare: 4.20260722.1
+      unenv: 2.0.0-rc.24
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      workerd: 1.20260722.1
+      wrangler: 4.122.0(@cloudflare/workers-types@5.20260729.1)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@cloudflare/vitest-pool-workers@0.21.2(@cloudflare/workers-types@5.20260729.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
-      miniflare: 4.20260722.1
+      miniflare: 5.20260811.0-alpha
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      wrangler: 4.115.0(@cloudflare/workers-types@5.20260729.1)
-      zod: 3.25.76
+      wrangler: 4.122.0(@cloudflare/workers-types@5.20260729.1)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - bufferutil
@@ -12690,16 +12762,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260722.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260722.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260722.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260722.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260722.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
     optional: true
 
   '@cloudflare/workers-oauth-provider@0.8.1': {}
@@ -16670,7 +16757,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -17283,6 +17370,18 @@ snapshots:
       sharp: 0.35.2
       undici: 7.28.0
       workerd: 1.20260722.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  miniflare@5.20260811.0-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260811.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -18987,6 +19086,8 @@ snapshots:
 
   undici@7.28.0: {}
 
+  undici@7.29.0: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -19336,6 +19437,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260722.1
       '@cloudflare/workerd-windows-64': 1.20260722.1
 
+  workerd@1.20260811.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260811.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260811.1
+      '@cloudflare/workerd-linux-64': 1.20260811.1
+      '@cloudflare/workerd-linux-arm64': 1.20260811.1
+      '@cloudflare/workerd-windows-64': 1.20260811.1
+
   workers-ai-provider@4.0.0(@ai-sdk/anthropic@4.0.10(zod@4.4.3))(@ai-sdk/google@4.0.10(zod@4.4.3))(@ai-sdk/openai@4.0.9(zod@4.4.3))(@ai-sdk/provider@4.0.2)(ai@7.0.18(zod@4.4.3)):
     dependencies:
       '@ai-sdk/provider': 4.0.2
@@ -19355,6 +19464,23 @@ snapshots:
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260722.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260729.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.122.0(@cloudflare/workers-types@5.20260729.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260811.0-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260811.1
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260729.1
       fsevents: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,9 +36,9 @@ minimumReleaseAgeExclude:
   - "@cloudflare/*"
   - "@typescript/*"
   - workerd@1.20260722.1
-  - miniflare@4.20260722.1
+  - miniflare@4.20260722.1 || 5.20260811.0-alpha
   - partyserver@0.5.9
-  - wrangler@4.115.0
+  - wrangler@4.115.0 || 4.122.0
   - workers-ai-provider@3.2.1 || 3.3.0 || 4.0.0
   - "@shikijs/core@4.3.0"
   - "@shikijs/engine-javascript@4.3.0"


### PR DESCRIPTION
At an earlier stage in development, a hard Pyodide version was set for retrieving Pyodide lockfiles (which affects whether compatible wheels are served) in response to what amounted to an issue with workerd. This has since been fixed, which means that bandaid fix is now (correctly) breaking. This change maps the version of Pyodide used when retrieving wheels to the compatibility date of the dynamic worker.

This also makes necessary dependency updates to the repo itself so it won't fail tests; because the older version of workerd used by the test suite predated the bug fix, the fix fails on it. (Let me know if this was done improperly, I'm less accustomed to making these kinds of changes on TS repos)