### PR TITLE
Allow AgentThink to test scuffi/flue

### DIFF
--- a/agent-think/src/run-context.ts
+++ b/agent-think/src/run-context.ts
@@ -1,5 +1,5 @@
 const GITHUB_LOGIN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
-const CLOUDFLARE_REPO = /^cloudflare\/[A-Za-z0-9_.-]+$/;
+const ALLOWED_REPO = /^(?:cloudflare\/[A-Za-z0-9_.-]+|scuffi\/flue)$/;
 
 export interface RequestedBy {
   login: string;
@@ -23,7 +23,7 @@ export function repoDirectory(repo: string | undefined): string {
 
 export function validateRunTarget(target: RunTarget): RunTarget {
   if (
-    !CLOUDFLARE_REPO.test(target.repo) ||
+    !ALLOWED_REPO.test(target.repo) ||
     target.repo.endsWith("/.") ||
     target.repo.endsWith("/..")
   ) {

--- a/agent-think/test/run-context.test.ts
+++ b/agent-think/test/run-context.test.ts
@@ -34,10 +34,18 @@ describe("agent-think run context", () => {
     expect(repoDirectory("owner/my repo")).toBe("/workspace/my-repo");
   });
 
-  it("rejects substituted targets and unsafe requester mentions", () => {
-    expect(() => validateRunTarget({ ...target, repo: "other/repo" })).toThrow(
-      "Invalid Cloudflare repository"
+  it("allows the scoped Repo Manager repository", () => {
+    expect(validateRunTarget({ ...target, repo: "scuffi/flue" }).repo).toBe(
+      "scuffi/flue"
     );
+  });
+
+  it("rejects substituted targets and unsafe requester mentions", () => {
+    for (const repo of ["scuffi/other", "Scuffi/flue", "other/repo"]) {
+      expect(() => validateRunTarget({ ...target, repo })).toThrow(
+        "Invalid Cloudflare repository"
+      );
+    }
     expect(() =>
       validateRunTarget({
         ...target,


### PR DESCRIPTION
Temporarily allow `scuffi/flue` as an AgentThink run target while I test the Repo Manager integration.

Existing `cloudflare/*` behavior is unchanged, and other `scuffi/*` repositories remain blocked. This can be removed once testing is complete.