### PR TITLE
fix(agents): keep session compactions branch-local

### DIFF
--- a/.changeset/fix-session-branch-compaction.md
+++ b/.changeset/fix-session-branch-compaction.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Keep Session compaction overlays scoped to their selected conversation branch and preserve deterministic ordering for overlays created in the same second.

--- a/packages/agents/src/experimental/memory/session/providers/agent.ts
+++ b/packages/agents/src/experimental/memory/session/providers/agent.ts
@@ -354,8 +354,11 @@ export class AgentSessionProvider implements SessionProvider {
       to_message_id: string;
       created_at: string;
     };
+    // SQLite CURRENT_TIMESTAMP has one-second resolution. Iterative overlays
+    // created in the same second must still retain insertion order so the last
+    // matching overlay is the newest one.
     return this.agent.sql<Row>`
-      SELECT * FROM assistant_compactions WHERE session_id = ${this.sessionId} ORDER BY created_at ASC
+      SELECT * FROM assistant_compactions WHERE session_id = ${this.sessionId} ORDER BY created_at ASC, rowid ASC
     `.map((r) => ({
       id: r.id,
       summary: r.summary,
@@ -530,16 +533,24 @@ export class AgentSessionProvider implements SessionProvider {
     compactions: StoredCompaction[]
   ): SessionMessage[] {
     const ids = messages.map((m) => m.id);
+    const messageIndexById = new Map(
+      ids.map((messageId, index) => [messageId, index])
+    );
     const result: SessionMessage[] = [];
     let i = 0;
     while (i < messages.length) {
-      // Find all compactions starting at this message, pick the latest
-      // (widest range) so newer compactions supersede older ones
-      const matching = compactions.filter((c) => c.fromMessageId === ids[i]);
+      // Sibling branches can have compactions with the same starting message.
+      // Consider only ranges ending on this branch, then let the latest valid
+      // compaction supersede earlier ranges on the same branch.
+      const matching = compactions.filter(
+        (compaction) =>
+          compaction.fromMessageId === ids[i] &&
+          (messageIndexById.get(compaction.toMessageId) ?? -1) >= i
+      );
       const comp =
         matching.length > 1 ? matching[matching.length - 1] : matching[0];
       if (comp) {
-        const endIdx = ids.indexOf(comp.toMessageId);
+        const endIdx = messageIndexById.get(comp.toMessageId) ?? -1;
         if (endIdx >= i) {
           result.push({
             id: `${COMPACTION_PREFIX}${comp.id}`,

--- a/packages/agents/src/experimental/memory/session/providers/postgres.ts
+++ b/packages/agents/src/experimental/memory/session/providers/postgres.ts
@@ -266,14 +266,24 @@ export class PostgresSessionProvider implements SessionProvider {
     compactions: StoredCompaction[]
   ): SessionMessage[] {
     const ids = messages.map((m) => m.id);
+    const messageIndexById = new Map(
+      ids.map((messageId, index) => [messageId, index])
+    );
     const result: SessionMessage[] = [];
     let i = 0;
     while (i < messages.length) {
-      const matching = compactions.filter((c) => c.fromMessageId === ids[i]);
+      // Sibling branches can have compactions with the same starting message.
+      // Consider only ranges ending on this branch, then let the latest valid
+      // compaction supersede earlier ranges on the same branch.
+      const matching = compactions.filter(
+        (compaction) =>
+          compaction.fromMessageId === ids[i] &&
+          (messageIndexById.get(compaction.toMessageId) ?? -1) >= i
+      );
       const comp =
         matching.length > 1 ? matching[matching.length - 1] : matching[0];
       if (comp) {
-        const endIdx = ids.indexOf(comp.toMessageId);
+        const endIdx = messageIndexById.get(comp.toMessageId) ?? -1;
         if (endIdx >= i) {
           result.push({
             id: `compaction_${comp.id}`,

--- a/packages/agents/src/experimental/memory/session/session.ts
+++ b/packages/agents/src/experimental/memory/session/session.ts
@@ -25,7 +25,10 @@ import {
 } from "./context";
 import { AgentSessionProvider, type SqlProvider } from "./providers/agent";
 import { AgentContextProvider } from "./providers/agent-context";
-import type { CompactResult } from "../utils/compaction-helpers";
+import {
+  COMPACTION_PREFIX,
+  type CompactResult
+} from "../utils/compaction-helpers";
 import { estimateMessageTokens, estimateStringTokens } from "../utils/tokens";
 import { MessageType } from "../../../types";
 
@@ -732,9 +735,10 @@ export class Session {
 
   /**
    * Run the registered compaction function and store the result as an overlay.
-   * Requires `onCompaction()` to be called first.
+   * When `leafId` is provided, compact that root-to-leaf branch instead of the
+   * active branch. Requires `onCompaction()` to be called first.
    */
-  async compact(): Promise<CompactResult | null> {
+  async compact(leafId?: string | null): Promise<CompactResult | null> {
     await this._ensureRestored();
     if (!this._compactionFn) {
       throw new Error(
@@ -743,6 +747,7 @@ export class Session {
     }
 
     const tokensBefore = await this._emitStatus("compacting");
+    const history = await this.getHistory(leafId);
 
     let result: CompactResult | null;
     try {
@@ -750,7 +755,7 @@ export class Session {
       // function's boundary logic can use the same accounting as the
       // fire/no-fire decision (see CompactContext). The function still wins if
       // it was given its own explicit counter.
-      result = await this._compactionFn(await this.getHistory(), {
+      result = await this._compactionFn(history, {
         tokenCounter: this._tokenCounter
       });
     } catch (err) {
@@ -763,15 +768,21 @@ export class Session {
       return null;
     }
 
-    // Validate toMessageId exists in the history
-    const historyIds = new Set((await this.getHistory()).map((m) => m.id));
+    // Validate toMessageId exists in the selected history.
+    const historyIds = new Set(history.map((message) => message.id));
     if (!historyIds.has(result.toMessageId)) {
       await this._emitStatus("idle");
       return null;
     }
 
-    // Iterative compaction — extend from earliest existing compaction's start
-    const existing = await this.getCompactions();
+    // Iterative compaction extends only an overlay visible on this branch.
+    // Other sibling branches may have unrelated overlays in the same session.
+    const existing = (await this.getCompactions()).filter(
+      (compaction) =>
+        historyIds.has(`${COMPACTION_PREFIX}${compaction.id}`) ||
+        (historyIds.has(compaction.fromMessageId) &&
+          historyIds.has(compaction.toMessageId))
+    );
     const fromId =
       existing.length > 0 ? existing[0].fromMessageId : result.fromMessageId;
 

--- a/packages/agents/src/tests/agents/session.ts
+++ b/packages/agents/src/tests/agents/session.ts
@@ -108,6 +108,27 @@ export class TestSessionAgent extends Agent {
     return this.session.getCompactions();
   }
 
+  /** Seed same-timestamp compactions in an index order opposite insertion. */
+  async seedSameTimestampCompactionsForTest(): Promise<void> {
+    const createdAt = "2026-08-15 12:00:00";
+    this.sql`
+      INSERT INTO assistant_compactions
+        (id, session_id, summary, from_message_id, to_message_id, created_at)
+      VALUES
+        (${"compaction-a-old"}, ${""}, ${"Old summary"}, ${"m0"}, ${"m1"}, ${createdAt})
+    `;
+    this.sql`
+      INSERT INTO assistant_compactions
+        (id, session_id, summary, from_message_id, to_message_id, created_at)
+      VALUES
+        (${"compaction-z-new"}, ${""}, ${"New summary"}, ${"m0"}, ${"m2"}, ${createdAt})
+    `;
+    this.sql`
+      CREATE INDEX assistant_compactions_tie_order_test
+      ON assistant_compactions(session_id, created_at ASC, id DESC)
+    `;
+  }
+
   // ── Search ──────────────────────────────────────────────────────
 
   async search(

--- a/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/postgres-providers.test.ts
@@ -468,6 +468,45 @@ describe("PostgresSessionProvider", () => {
     expect(all[0].summary).toBe("summary");
   });
 
+  it("keeps sibling branch compaction overlays isolated", async () => {
+    await provider.appendMessage(makeMessage("m0", "user", "root"));
+    await provider.appendMessage(makeMessage("m1", "assistant", "shared"));
+    await provider.appendMessage(makeMessage("a2", "user", "branch A"), "m1");
+    await provider.appendMessage(
+      makeMessage("a3", "assistant", "branch A reply"),
+      "a2"
+    );
+    await provider.appendMessage(
+      makeMessage("a4", "user", "branch A tail"),
+      "a3"
+    );
+    await provider.appendMessage(makeMessage("b2", "user", "branch B"), "m1");
+    await provider.appendMessage(
+      makeMessage("b3", "assistant", "branch B tail"),
+      "b2"
+    );
+
+    await provider.addCompaction("Branch A summary 1", "m0", "a2");
+    await provider.addCompaction("Branch B summary", "m0", "b2");
+    await provider.addCompaction("Branch A summary 2", "m0", "a3");
+
+    const historyA = await provider.getHistory("a4");
+    expect(historyA).toHaveLength(2);
+    expect(historyA[0].parts[0]).toEqual({
+      type: "text",
+      text: "Branch A summary 2"
+    });
+    expect(historyA[1].id).toBe("a4");
+
+    const historyB = await provider.getHistory("b3");
+    expect(historyB).toHaveLength(2);
+    expect(historyB[0].parts[0]).toEqual({
+      type: "text",
+      text: "Branch B summary"
+    });
+    expect(historyB[1].id).toBe("b3");
+  });
+
   it("normalizes compaction timestamps returned as Date objects", async () => {
     const createdAt = new Date("2026-05-18T15:42:29.000Z");
     const dateConn: PostgresConnection = {

--- a/packages/agents/src/tests/experimental/memory/session/provider.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/provider.test.ts
@@ -22,6 +22,7 @@ interface SessionAgentStub {
     toId: string
   ): Promise<unknown>;
   getCompactions(): Promise<unknown[]>;
+  seedSameTimestampCompactionsForTest(): Promise<void>;
   search(
     query: string
   ): Promise<Array<{ id: string; role: string; content: string }>>;
@@ -350,6 +351,102 @@ describe("AgentSessionProvider — tree-structured messages", () => {
     // Both compactions stored, but only the latest applies
     const compactions = await agent.getCompactions();
     expect(compactions).toHaveLength(2);
+  });
+
+  it("uses insertion order when compaction timestamps tie", async () => {
+    const agent = await getAgent(name);
+    for (let i = 0; i < 4; i++) {
+      await agent.appendMessage({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `msg ${i}` }]
+      });
+    }
+
+    await agent.seedSameTimestampCompactionsForTest();
+
+    const history = await agent.getHistory("m3");
+    expect(history).toHaveLength(2);
+    expect(history[0].parts[0]).toEqual({
+      type: "text",
+      text: "New summary"
+    });
+    expect(history[1].id).toBe("m3");
+  });
+
+  it("keeps sibling branch compaction overlays isolated", async () => {
+    const agent = await getAgent(name);
+
+    await agent.appendMessage({
+      id: "m0",
+      role: "user",
+      parts: [{ type: "text", text: "root" }]
+    });
+    await agent.appendMessage({
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: "text", text: "shared" }]
+    });
+    await agent.appendMessage(
+      {
+        id: "a2",
+        role: "user",
+        parts: [{ type: "text", text: "branch A" }]
+      },
+      "m1"
+    );
+    await agent.appendMessage(
+      {
+        id: "a3",
+        role: "assistant",
+        parts: [{ type: "text", text: "branch A reply" }]
+      },
+      "a2"
+    );
+    await agent.appendMessage(
+      {
+        id: "a4",
+        role: "user",
+        parts: [{ type: "text", text: "branch A tail" }]
+      },
+      "a3"
+    );
+    await agent.appendMessage(
+      {
+        id: "b2",
+        role: "user",
+        parts: [{ type: "text", text: "branch B" }]
+      },
+      "m1"
+    );
+    await agent.appendMessage(
+      {
+        id: "b3",
+        role: "assistant",
+        parts: [{ type: "text", text: "branch B tail" }]
+      },
+      "b2"
+    );
+
+    await agent.addCompaction("Branch A summary 1", "m0", "a2");
+    await agent.addCompaction("Branch B summary", "m0", "b2");
+    await agent.addCompaction("Branch A summary 2", "m0", "a3");
+
+    const historyA = await agent.getHistory("a4");
+    expect(historyA).toHaveLength(2);
+    expect(historyA[0].parts[0]).toEqual({
+      type: "text",
+      text: "Branch A summary 2"
+    });
+    expect(historyA[1].id).toBe("a4");
+
+    const historyB = await agent.getHistory("b3");
+    expect(historyB).toHaveLength(2);
+    expect(historyB[0].parts[0]).toEqual({
+      type: "text",
+      text: "Branch B summary"
+    });
+    expect(historyB[1].id).toBe("b3");
   });
 
   it("FTS search", async () => {

--- a/packages/agents/src/tests/experimental/memory/session/session.test.ts
+++ b/packages/agents/src/tests/experimental/memory/session/session.test.ts
@@ -638,14 +638,19 @@ describe("ContextBlocks — edge cases", () => {
 // ── Compaction tests ─────────────────────────────────────────────
 
 function createCompactableSession(
-  compactFn: (msgs: SessionMessage[]) => Promise<CompactResult | null>
+  compactFn: (msgs: SessionMessage[]) => Promise<CompactResult | null>,
+  selectHistory?: (
+    messages: SessionMessage[],
+    leafId?: string | null
+  ) => SessionMessage[]
 ) {
   const messages: SessionMessage[] = [];
   const compactions: StoredCompaction[] = [];
 
   const storage: SessionProvider = {
     getMessage: (id) => messages.find((m) => m.id === id) ?? null,
-    getHistory: () => messages,
+    getHistory: (leafId) =>
+      selectHistory ? selectHistory(messages, leafId) : messages,
     getLatestLeaf: () => messages[messages.length - 1] ?? null,
     getBranches: () => [],
     getPathLength: () => messages.length,
@@ -734,6 +739,59 @@ describe("Session.compact()", () => {
     expect(compactions[0].summary).toBe("Summary of m1-m3");
     expect(compactions[0].fromMessageId).toBe("m1");
     expect(compactions[0].toMessageId).toBe("m3");
+  });
+
+  it("compacts an explicit branch without extending a sibling overlay", async () => {
+    const compactedMessageIds: string[][] = [];
+    const { session, messages, compactions } = createCompactableSession(
+      async (history): Promise<CompactResult> => {
+        compactedMessageIds.push(history.map((message) => message.id));
+        return {
+          fromMessageId: "m1",
+          toMessageId: "m1",
+          summary: "Selected branch summary"
+        };
+      },
+      (allMessages, leafId) =>
+        leafId === "m2" ? allMessages.slice(0, 3) : allMessages
+    );
+
+    messages.push(
+      { id: "m0", role: "user", parts: [{ type: "text", text: "start" }] },
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [{ type: "text", text: "first answer" }]
+      },
+      {
+        id: "m2",
+        role: "user",
+        parts: [{ type: "text", text: "follow-up" }]
+      },
+      {
+        id: "old-assistant",
+        role: "assistant",
+        parts: [{ type: "text", text: "superseded answer" }]
+      }
+    );
+
+    compactions.push({
+      id: "sibling-compaction",
+      fromMessageId: "m0",
+      toMessageId: "old-assistant",
+      summary: "Sibling branch summary",
+      createdAt: new Date().toISOString()
+    });
+
+    await session.compact("m2");
+
+    expect(compactedMessageIds).toEqual([["m0", "m1", "m2"]]);
+    expect(compactions).toHaveLength(2);
+    expect(compactions[1]).toMatchObject({
+      fromMessageId: "m1",
+      toMessageId: "m1",
+      summary: "Selected branch summary"
+    });
   });
 
   it("returns null when compaction function returns null", async () => {


### PR DESCRIPTION
## Problem

Session compaction overlays* were selected globally before the provider checked whether their endpoint belonged to the requested conversation branch. A newer sibling-branch compaction could therefore hide a valid compaction for the branch being read.

SQLite compactions were also ordered only by `CURRENT_TIMESTAMP`, whose one-second resolution made the winning overlay nondeterministic when multiple compactions were created together.

* called an overlay because it's a summary of a single thread of messages through the tree. Those messages are still stored - the compaction is just an 'overlay' over the top of them.

## Fix

- validate each compaction endpoint against the requested root-to-leaf path before selecting it
- select the latest valid branch-local overlay in both Agent and Postgres session providers
- order SQLite compactions by `created_at, rowid` for deterministic ties
- preserve iterative compaction on the same branch without allowing sibling branches to interfere

## Testing

- 170 Session/provider tests
- includes sibling-branch and same-timestamp regressions for both providers

## Stack

**This PR was getting too big so I've stacked a bunch of related fixes into separate PRs:**

1. **This PR — Session branch-local compaction**
2. #2038 — Think regeneration context
3. #2121 — transcript repair ownership
4. #2122 — branch-aware recovery
5. #2057 — restart durability
