### PR TITLE
fix(think): preserve active transcript during repair

### DIFF
--- a/.changeset/fix-think-transcript-repair.md
+++ b/.changeset/fix-think-transcript-repair.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Keep provider transcript repair from replacing the client-visible active branch with selected model history.

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -711,8 +711,10 @@ export class ThinkClientToolsAgent extends Think {
   private _responseLog: ChatResponseResult[] = [];
   private _lastTurnToolNames: string[] = [];
   private _textOnlyPromptRoles: string[][] = [];
+  private _liveMessageIdsAtTurnStart: string[][] = [];
   private _textOnlyOverflowAttemptsRemaining = 0;
   private _compactionHistoryMessageIds: string[][] = [];
+  private _failNextTurnBeforeStream = false;
 
   override classifyChatError = defaultContextOverflowClassifier;
 
@@ -733,6 +735,13 @@ export class ThinkClientToolsAgent extends Think {
 
   override beforeTurn(ctx: { tools: ToolSet }): void {
     this._lastTurnToolNames = Object.keys(ctx.tools);
+    this._liveMessageIdsAtTurnStart.push(
+      this.messages.map((message) => message.id)
+    );
+    if (this._failNextTurnBeforeStream) {
+      this._failNextTurnBeforeStream = false;
+      throw new Error("Test failure before stream creation");
+    }
   }
 
   async getLastTurnToolNames(): Promise<string[]> {
@@ -820,6 +829,15 @@ export class ThinkClientToolsAgent extends Think {
   /** Set the maximum stored content hydrated for each model-facing history. */
   async setHydrationByteBudgetForTest(bytes: number): Promise<void> {
     this.hydrationByteBudget = bytes;
+  }
+
+  /** Active transcript IDs observed when each inference turn starts. */
+  async getLiveMessageIdsAtTurnStart(): Promise<string[][]> {
+    return this._liveMessageIdsAtTurnStart;
+  }
+
+  async failNextTurnBeforeStream(): Promise<void> {
+    this._failNextTurnBeforeStream = true;
   }
 
   /** Make the next text-only attempt overflow and enable compact-and-retry. */

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -8,6 +8,7 @@ import type { ChatResponseResult } from "../think";
 const MSG_CHAT_REQUEST = "cf_agent_use_chat_request";
 const MSG_CHAT_RESPONSE = "cf_agent_use_chat_response";
 const MSG_CHAT_CLEAR = "cf_agent_chat_clear";
+const MSG_CHAT_MESSAGES = "cf_agent_chat_messages";
 const MSG_TOOL_RESULT = "cf_agent_tool_result";
 const MSG_TOOL_APPROVAL = "cf_agent_tool_approval";
 const MSG_MESSAGE_UPDATED = "cf_agent_message_updated";
@@ -3043,6 +3044,83 @@ describe("Think — regeneration", () => {
     expect(promptRoles).toEqual([
       ["system", "user"],
       ["system", "user"]
+    ]);
+
+    await closeWS(ws);
+  });
+
+  it("repairs selected model history without replacing the active transcript", async () => {
+    const room = crypto.randomUUID();
+    const agent = await freshAgent(room);
+    const { ws } = await connectWS(room);
+    await collectMessages(ws, 3);
+
+    await agent.setTextOnlyMode(true);
+
+    const firstUser = makeUserMessage("look this up");
+    const interruptedAssistant = makeToolMessage(
+      "tc-interrupted-branch",
+      "server_lookup",
+      "input-available"
+    );
+    const selectedUser = makeUserMessage("give me a different answer");
+    const previousAssistant: UIMessage = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      parts: [{ type: "text", text: "Previous answer" }]
+    };
+    await agent.persistToolCallMessage([
+      firstUser,
+      interruptedAssistant,
+      selectedUser,
+      previousAssistant
+    ]);
+
+    await agent.failNextTurnBeforeStream();
+    const donePromise = waitForDone(ws);
+    sendChatRequest(ws, [firstUser, interruptedAssistant, selectedUser], {
+      trigger: "regenerate-message"
+    });
+    const responseFrames = await donePromise;
+    await delay(200);
+
+    // Provider repair runs against the selected branch (which excludes the old
+    // answer), but the live cache remains the active path until the new sibling
+    // is persisted. Replacing it with model history would drop this id here.
+    const liveIdsAtTurnStart = await agent.getLiveMessageIdsAtTurnStart();
+    expect(liveIdsAtTurnStart.at(-1)).toEqual([
+      firstUser.id,
+      interruptedAssistant.id,
+      selectedUser.id,
+      previousAssistant.id
+    ]);
+
+    // The inference failed before a new sibling could be persisted. The active
+    // transcript and its client-facing view therefore still include the old
+    // answer, while the interrupted common-ancestor tool call was repaired.
+    const activeMessages = (await agent.getMessages()) as UIMessage[];
+    expect(activeMessages.map((message) => message.id)).toEqual([
+      firstUser.id,
+      interruptedAssistant.id,
+      selectedUser.id,
+      previousAssistant.id
+    ]);
+    expect((activeMessages[1].parts[0] as { state?: string }).state).toBe(
+      "output-error"
+    );
+    const repairedBroadcast = responseFrames.find(
+      (frame) => frame.type === MSG_CHAT_MESSAGES
+    );
+    if (!repairedBroadcast || !Array.isArray(repairedBroadcast.messages)) {
+      throw new Error("Expected repaired transcript broadcast");
+    }
+    expect(
+      (repairedBroadcast.messages as UIMessage[]).map((message) => message.id)
+    ).toEqual(activeMessages.map((message) => message.id));
+
+    const branches = (await agent.getBranches(selectedUser.id)) as UIMessage[];
+    expect(branches.map((message) => message.id)).toEqual([
+      previousAssistant.id
     ]);
 
     await closeWS(ws);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -3294,17 +3294,28 @@ export class Think<
 
     // Repair preserves every message (orphans are flipped to errored in place,
     // never deleted), so there are no removed rows to delete — only updates.
+    // `messages` may be a selected historical branch used only for inference;
+    // persist those repairs without replacing the independently-owned active
+    // transcript cache with that branch.
+    const originalById = new Map(
+      messages.map((message) => [message.id, message] as const)
+    );
+    const activeMessageIds = new Set(
+      this._cachedMessages.map((message) => message.id)
+    );
+    let activeTranscriptChanged = false;
     for (const message of repair.messages) {
-      const original = messages.find(
-        (candidate) => candidate.id === message.id
-      );
+      const original = originalById.get(message.id);
       if (original && original.parts !== message.parts) {
+        activeTranscriptChanged ||= activeMessageIds.has(message.id);
         await this.session.updateMessage(sanitizeMessage(message));
       }
     }
 
-    this._replaceCachedMessages(repair.messages);
-    this._broadcastMessages();
+    // Session update events patch matching cached rows. Broadcast only when a
+    // repaired row belongs to the live view; branch-only model history must not
+    // change what connected clients see.
+    if (activeTranscriptChanged) this._broadcastMessages();
     this._emit("chat:transcript:repaired", {
       removedToolCalls: repair.removedToolCalls,
       normalizedInputs: repair.normalizedInputs,


### PR DESCRIPTION
Stacked on #2038.

## Problem

Think can repair provider-normalized messages for a selected model branch. That repair path also replaced `_cachedMessages` with the selected branch, even when it was not the active client-visible transcript. Regenerating from an older branch could therefore make connected clients lose or switch away from their live branch.

## Fix

- persist provider-normalized rows for the selected model history
- patch matching rows in the active Session cache
- never install arbitrary branch history as the client-visible transcript
- keep WebSocket broadcasts scoped to the active transcript

## Testing

- 88 client-tools tests
- regression forces provider repair during sibling regeneration and verifies the repaired row, active transcript, WebSocket broadcast, and previous sibling

## Stack

1. #2120 — Session branch-local compaction
2. #2038 — Think regeneration context
3. **This PR — transcript repair ownership**
4. #2122 — branch-aware recovery
5. #2057 — restart durability
