### PR TITLE
fix(think): preserve branches during recovery

### DIFF
--- a/.changeset/fix-think-branch-recovery.md
+++ b/.changeset/fix-think-branch-recovery.md
@@ -1,0 +1,6 @@
+---
+"agents": patch
+"@cloudflare/think": patch
+---
+
+Preserve selected Think conversation branches through chat recovery, including retries with no materialized assistant and continuations from persisted partial answers.

--- a/packages/agents/src/chat/__tests__/recovery-engine.test.ts
+++ b/packages/agents/src/chat/__tests__/recovery-engine.test.ts
@@ -1697,6 +1697,7 @@ describe("ChatRecoveryEngine.handleChatFiberRecovery (fake adapter + wake hooks)
     detail?: TestDetail;
     onChatRecovery?: ChatRecoveryOptions | void;
     basePersist?: boolean;
+    persistedOrphanMessageId?: string | null;
     dispatchThrows?: boolean;
     seedExhausted?: boolean;
     /**
@@ -1811,7 +1812,11 @@ describe("ChatRecoveryEngine.handleChatFiberRecovery (fake adapter + wake hooks)
       persistOrphanedStream: (streamId) => {
         calls.push("persist");
         persisted.push(streamId);
-        return Promise.resolve();
+        return Promise.resolve(
+          options.persistedOrphanMessageId === undefined
+            ? "assistant-persisted"
+            : options.persistedOrphanMessageId
+        );
       },
       completeRecoveredStream: (streamId) => {
         calls.push("complete");
@@ -1922,6 +1927,9 @@ describe("ChatRecoveryEngine.handleChatFiberRecovery (fake adapter + wake hooks)
     expect(h.dispatched[0].detail).toBe(detail);
     expect(h.dispatched[0].recoveryKind).toBe("retry");
     expect(h.dispatched[0].requestId).toBe("req-1");
+    expect(h.dispatched[0].persistedOrphanMessageId).toBe(
+      "assistant-persisted"
+    );
   });
 
   it("persists with the default clause (persist undefined) when the base gate is open", async () => {
@@ -1942,6 +1950,17 @@ describe("ChatRecoveryEngine.handleChatFiberRecovery (fake adapter + wake hooks)
     });
     await h.engine.handleChatFiberRecovery(h.ctx, h.wake);
     expect(h.persisted).toEqual([]);
+    expect(h.dispatched[0].persistedOrphanMessageId).toBeNull();
+  });
+
+  it("forwards a null outcome when persistence produces no assistant message", async () => {
+    const h = makeHarness({
+      basePersist: true,
+      persistedOrphanMessageId: null
+    });
+    await h.engine.handleChatFiberRecovery(h.ctx, h.wake);
+    expect(h.persisted).toEqual(["s1"]);
+    expect(h.dispatched[0].persistedOrphanMessageId).toBeNull();
   });
 
   it("ALWAYS persists settled tool results even when the hook returns persist:false (#1631)", async () => {

--- a/packages/agents/src/chat/orphan-persist.ts
+++ b/packages/agents/src/chat/orphan-persist.ts
@@ -39,6 +39,8 @@ export interface PersistReconstructedOrphanOptions<
    * present.
    */
   fallbackId: string;
+  /** Parent for a newly reconstructed message in tree-structured stores. */
+  parentId?: string | null;
   /**
    * Finalize the reconstructed message before upsert — e.g. strip internal
    * parts or resolve the persist-target id. Return `null` to skip persistence
@@ -84,7 +86,7 @@ export async function persistReconstructedOrphan<
   if (existing) {
     await options.store.updateMessage(options.merge(existing, prepared));
   } else {
-    await options.store.appendMessage(prepared);
+    await options.store.appendMessage(prepared, options.parentId);
   }
   return true;
 }

--- a/packages/agents/src/chat/recovery-engine.ts
+++ b/packages/agents/src/chat/recovery-engine.ts
@@ -296,6 +296,12 @@ export interface DispatchRecoveredTurnInput<TClassify> {
   recoveryRootRequestId: string;
   streamId: string;
   streamStatus?: ChatStreamStatus;
+  /**
+   * The exact assistant message materialized from the orphaned stream, or
+   * `null` when persistence was skipped or produced no message. Hosts that do
+   * not expose persistence outcomes also yield `null`.
+   */
+  persistedOrphanMessageId: string | null;
   /** The package-specific classification detail produced by `classifyRecoveredTurn`. */
   detail: TClassify;
 }
@@ -351,8 +357,15 @@ export interface ChatFiberWakeHooks<TClassify> {
   shouldPersistOrphanedPartial(
     input: PersistOrphanedPartialInput
   ): boolean | Promise<boolean>;
-  /** Materialize the orphaned stream's partial into a persisted assistant message. */
-  persistOrphanedStream(streamId: string): Promise<void>;
+  /**
+   * Materialize the orphaned stream's partial into a persisted assistant
+   * message. Return its exact id when the host exposes the persistence outcome;
+   * legacy or flat-history hosts may return `void`.
+   */
+  persistOrphanedStream(
+    streamId: string,
+    snapshot: ChatFiberSnapshot | null
+  ): Promise<string | null | void>;
   /** Mark the (still-active) recovered stream complete and schedule cleanup. */
   completeRecoveredStream(streamId: string): void | Promise<void>;
   /**
@@ -469,7 +482,7 @@ export class ChatRecoveryEngine {
           partial
         })
       ) {
-        await wake.persistOrphanedStream(streamId);
+        await wake.persistOrphanedStream(streamId, snapshot);
       }
       await adapter.exhaustChatRecovery(
         incident,
@@ -498,6 +511,7 @@ export class ChatRecoveryEngine {
           createdAt: ctx.createdAt
         })) ?? {};
 
+      let persistedOrphanMessageId: string | null = null;
       if (
         await this._shouldPersistOrphanedPartial(wake, {
           streamId,
@@ -508,7 +522,13 @@ export class ChatRecoveryEngine {
           partial
         })
       ) {
-        await wake.persistOrphanedStream(streamId);
+        const persistenceResult = await wake.persistOrphanedStream(
+          streamId,
+          snapshot
+        );
+        if (typeof persistenceResult === "string") {
+          persistedOrphanMessageId = persistenceResult;
+        }
       }
 
       if (streamStillActive) {
@@ -525,6 +545,7 @@ export class ChatRecoveryEngine {
         recoveryRootRequestId,
         streamId,
         streamStatus,
+        persistedOrphanMessageId,
         detail
       });
 

--- a/packages/agents/src/chat/recovery.ts
+++ b/packages/agents/src/chat/recovery.ts
@@ -23,6 +23,10 @@ export type ChatFiberSnapshot<Kind extends string = string> = {
   latestMessageId?: string;
   latestMessageRole?: string;
   latestUserMessageId?: string;
+  /** Explicit history endpoint for a branch-scoped turn such as regeneration. */
+  historyLeafId?: string;
+  /** Physical active leaf observed when a branch-scoped turn was accepted. */
+  activeLeafIdAtStart?: string;
   startedAt: number;
   lastBody?: Record<string, unknown>;
   lastClientTools?: ClientToolSchema[];
@@ -34,6 +38,8 @@ export function createChatFiberSnapshot<Kind extends string>({
   recoveryRootRequestId,
   continuation,
   messages,
+  historyLeafId,
+  activeLeafIdAtStart,
   lastBody,
   lastClientTools
 }: {
@@ -42,6 +48,8 @@ export function createChatFiberSnapshot<Kind extends string>({
   recoveryRootRequestId?: string;
   continuation: boolean;
   messages: ReadonlyArray<SnapshotMessage>;
+  historyLeafId?: string;
+  activeLeafIdAtStart?: string;
   lastBody?: Record<string, unknown>;
   lastClientTools?: ClientToolSchema[];
 }): ChatFiberSnapshot<Kind> {
@@ -65,6 +73,8 @@ export function createChatFiberSnapshot<Kind extends string>({
     latestMessageId: latestMessage?.id,
     latestMessageRole: latestMessage?.role,
     latestUserMessageId: latestUser?.id,
+    historyLeafId,
+    activeLeafIdAtStart,
     startedAt: Date.now(),
     lastBody,
     lastClientTools

--- a/packages/think/src/tests/agents/client-tools.ts
+++ b/packages/think/src/tests/agents/client-tools.ts
@@ -715,10 +715,22 @@ export class ThinkClientToolsAgent extends Think {
   private _textOnlyOverflowAttemptsRemaining = 0;
   private _compactionHistoryMessageIds: string[][] = [];
   private _failNextTurnBeforeStream = false;
+  private _selectedHistoryReadCount = 0;
 
   override classifyChatError = defaultContextOverflowClassifier;
 
   override configureSession(session: Session): Session {
+    const getRecentHistory = session.getRecentHistory.bind(session);
+    session.getRecentHistory = async (
+      maxContentBytes,
+      minRecentMessages,
+      leafId
+    ) => {
+      if (leafId !== undefined && leafId !== null) {
+        this._selectedHistoryReadCount++;
+      }
+      return getRecentHistory(maxContentBytes, minRecentMessages, leafId);
+    };
     return session.onCompaction(async (messages) => {
       this._compactionHistoryMessageIds.push(
         messages.map((message) => message.id)
@@ -829,6 +841,16 @@ export class ThinkClientToolsAgent extends Think {
   /** Set the maximum stored content hydrated for each model-facing history. */
   async setHydrationByteBudgetForTest(bytes: number): Promise<void> {
     this.hydrationByteBudget = bytes;
+  }
+
+  /** Reset selected-branch history reads before a branch-scoped turn. */
+  async resetSelectedHistoryReadCount(): Promise<void> {
+    this._selectedHistoryReadCount = 0;
+  }
+
+  /** Selected-branch history reads performed since the last counter reset. */
+  async getSelectedHistoryReadCount(): Promise<number> {
+    return this._selectedHistoryReadCount;
   }
 
   /** Active transcript IDs observed when each inference turn starts. */

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -109,6 +109,7 @@ type CapturedModelCallSettings = {
 
 type MockModelOptions = {
   onCall?: (settings: CapturedModelCallSettings) => void;
+  onPromptRoles?: (roles: string[]) => void;
 };
 
 function captureModelCallSettings(options: unknown): CapturedModelCallSettings {
@@ -130,6 +131,28 @@ function captureModelCallSettings(options: unknown): CapturedModelCallSettings {
   };
 }
 
+function captureModelPromptRoles(options: unknown): string[] {
+  if (
+    options === null ||
+    typeof options !== "object" ||
+    !("prompt" in options)
+  ) {
+    return [];
+  }
+  const prompt = Array.isArray(options.prompt) ? options.prompt : [];
+  return prompt.flatMap((message) => {
+    if (
+      typeof message !== "object" ||
+      message === null ||
+      !("role" in message) ||
+      typeof message.role !== "string"
+    ) {
+      return [];
+    }
+    return [message.role];
+  });
+}
+
 function createMockModel(
   response: string,
   options: MockModelOptions = {}
@@ -144,6 +167,7 @@ function createMockModel(
     },
     doStream(callOptions: unknown) {
       options.onCall?.(captureModelCallSettings(callOptions));
+      options.onPromptRoles?.(captureModelPromptRoles(callOptions));
       _mockCallCount++;
       const callId = _mockCallCount;
       const stream = new ReadableStream({
@@ -4854,6 +4878,7 @@ export class ThinkToolsTestAgent extends Think {
       this as unknown as {
         _chatRecoveryContinue(d: {
           targetAssistantId?: string;
+          historyLeafId?: string;
           lastBody?: Record<string, unknown> | null;
           lastClientTools?: ClientToolSchema[] | null;
         }): Promise<void>;
@@ -4861,6 +4886,7 @@ export class ThinkToolsTestAgent extends Think {
     )._chatRecoveryContinue(
       JSON.parse(rows[0].payload) as {
         targetAssistantId?: string;
+        historyLeafId?: string;
         lastBody?: Record<string, unknown> | null;
         lastClientTools?: ClientToolSchema[] | null;
       }
@@ -6501,6 +6527,7 @@ export class ThinkRecoveryTestAgent extends Think {
   private _stashResult: { success: boolean; error?: string } | null = null;
   private _rejectPrefill = false;
   private _lastPromptRole: string | undefined;
+  private _promptRoles: string[][] = [];
   private _throwBeforeTurnMessage: string | null = null;
   // recovery × channels: capture the channel context + assembled system prompt
   // that each turn (including recovered ones) actually ran with, so a test can
@@ -6543,7 +6570,9 @@ export class ThinkRecoveryTestAgent extends Think {
         }
       });
     }
-    return createMockModel("Continued response.");
+    return createMockModel("Continued response.", {
+      onPromptRoles: (roles) => this._promptRoles.push(roles)
+    });
   }
 
   override beforeTurn(ctx: TurnContext): void {
@@ -6617,6 +6646,28 @@ export class ThinkRecoveryTestAgent extends Think {
 
   async getTurnCallCount(): Promise<number> {
     return this._turnCallCount;
+  }
+
+  /** Stored child branches for recovery integration assertions. */
+  async getBranchesForTest(messageId: string): Promise<UIMessage[]> {
+    // SAFETY: Think's Session stores sanitized UIMessage values; the provider's
+    // narrower SessionMessage type intentionally avoids depending on the AI SDK.
+    return (await this.session.getBranches(messageId)) as UIMessage[];
+  }
+
+  /** Model prompt roles recorded after a recovered turn starts. */
+  async getPromptRolesForTest(): Promise<string[][]> {
+    return this._promptRoles;
+  }
+
+  /** Re-deliver a branch-scoped retry callback to verify recovery idempotency. */
+  async retryBranchForTest(input: {
+    targetUserId: string;
+    historyLeafId: string;
+    activeLeafIdAtStart: string;
+    originalRequestId: string;
+  }): Promise<void> {
+    await this._chatRecoveryRetry(input);
   }
 
   /** The active channel id captured at each turn's `beforeTurn` (""=none). */
@@ -7623,6 +7674,7 @@ export class ThinkRecoveryTestAgent extends Think {
     await this._chatRecoveryContinue(
       JSON.parse(rows[0].payload) as {
         targetAssistantId?: string;
+        historyLeafId?: string;
         lastBody?: Record<string, unknown> | null;
         lastClientTools?: ClientToolSchema[] | null;
       }
@@ -7812,6 +7864,65 @@ export class ThinkRecoveryTestAgent extends Think {
     await (
       this as unknown as { _checkRunFibers(): Promise<void> }
     )._checkRunFibers();
+  }
+
+  /** Capture a real branch snapshot after clearing only the live transcript. */
+  async captureBranchRecoverySnapshotWithEmptyCacheForTest(
+    historyLeafId: string
+  ): Promise<{ requestId: string; snapshot: unknown }> {
+    const internals = this as unknown as {
+      _replaceCachedMessages(messages: UIMessage[]): UIMessage[];
+      _runChatRecoveryFiber<T>(
+        requestId: string,
+        continuation: boolean,
+        fn: () => Promise<T>,
+        history: { leafId: string }
+      ): Promise<T>;
+    };
+    internals._replaceCachedMessages([]);
+
+    const requestId = `empty-cache-${crypto.randomUUID()}`;
+    const name = `${(this.constructor as typeof Think).CHAT_FIBER_NAME}:${requestId}`;
+    const snapshot = await internals._runChatRecoveryFiber(
+      requestId,
+      false,
+      async () => {
+        const rows = this.sql<{ snapshot: string | null }>`
+          SELECT snapshot FROM cf_agents_runs WHERE name = ${name} LIMIT 1
+        `;
+        return rows[0]?.snapshot ? JSON.parse(rows[0].snapshot) : null;
+      },
+      { leafId: historyLeafId }
+    );
+    return { requestId, snapshot };
+  }
+
+  /** Recover a fiber, then execute its claimed retry callback twice. */
+  async recoverFiberWithRetryRedeliveryForTest(): Promise<void> {
+    await this.triggerFiberRecovery();
+    const rows = this.sql<{ id: string; payload: string }>`
+      SELECT id, payload FROM cf_agents_schedules
+      WHERE callback = '_chatRecoveryRetry'
+      ORDER BY time ASC
+      LIMIT 1
+    `;
+    const row = rows[0];
+    if (!row) throw new Error("No scheduled chat recovery retry to redeliver");
+    this.sql`DELETE FROM cf_agents_schedules WHERE id = ${row.id}`;
+
+    const parsed: unknown = JSON.parse(row.payload);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error("Scheduled chat recovery retry payload is not an object");
+    }
+    // SAFETY: The object shape was checked above; the recovery callback owns
+    // validation of its optional wire fields, matching real schedule delivery.
+    const data = parsed as Record<string, unknown>;
+    await this.runChatRecoveryRetryForTestWith(data);
+    await this.runChatRecoveryRetryForTestWith(data);
   }
 
   async persistTestMessage(msg: UIMessage): Promise<void> {

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -3020,6 +3020,7 @@ describe("Think — regeneration", () => {
     expect(firstAssistant.role).toBe("assistant");
 
     // Regenerate: send truncated list (just the user message) with trigger
+    await agent.resetSelectedHistoryReadCount();
     const donePromise2 = waitForDone(ws);
     sendChatRequest(ws, [userMsg], { trigger: "regenerate-message" });
     await donePromise2;
@@ -3045,6 +3046,9 @@ describe("Think — regeneration", () => {
       ["system", "user"],
       ["system", "user"]
     ]);
+    // The recovery snapshot and inference preparation share one durable read
+    // of the selected branch.
+    expect(await agent.getSelectedHistoryReadCount()).toBe(1);
 
     await closeWS(ws);
   });

--- a/packages/think/src/tests/client-tools.test.ts
+++ b/packages/think/src/tests/client-tools.test.ts
@@ -3313,6 +3313,10 @@ describe("Think — regeneration", () => {
     expect(await agent.getCompactionHistoryMessageIds()).toEqual([
       [user1.id, assistant1.id, user2.id]
     ]);
+    expect((await agent.getTextOnlyPromptRoles()).slice(-2)).toEqual([
+      ["system", "user", "assistant", "user"],
+      ["system", "assistant", "assistant", "user"]
+    ]);
     expect(await agent.getBranches(user2.id)).toHaveLength(2);
 
     await closeWS(ws);

--- a/packages/think/src/tests/eviction-recovery.test.ts
+++ b/packages/think/src/tests/eviction-recovery.test.ts
@@ -19,6 +19,15 @@ async function recoveryAgent(name: string) {
   );
 }
 
+async function getStoredBranches(
+  agent: Awaited<ReturnType<typeof recoveryAgent>>,
+  messageId: string
+): Promise<UIMessage[]> {
+  // SAFETY: The test agent returns sanitized UIMessage values. PartyServer's
+  // RPC serializer cannot infer the AI SDK's open metadata shape.
+  return (await agent.getBranchesForTest(messageId)) as UIMessage[];
+}
+
 async function waitFor(
   condition: () => Promise<boolean>,
   timeoutMs = 3000
@@ -75,6 +84,117 @@ async function seedInterruptedContinueTurn(
   });
 }
 
+async function seedInterruptedRegeneration(
+  agent: Awaited<ReturnType<typeof recoveryAgent>>,
+  streamStatus: "streaming" | "completed" | "error" = "streaming",
+  includePartialChunks = true
+): Promise<{
+  userId: string;
+  oldAssistantId: string;
+  partialAssistantId: string;
+}> {
+  const requestId = "req-regeneration-eviction";
+  const userId = "user-regeneration-eviction";
+  const oldAssistantId = "assistant-old-regeneration-eviction";
+  const partialAssistantId = "assistant-partial-regeneration-eviction";
+
+  await agent.persistTestMessage({
+    id: userId,
+    role: "user",
+    parts: [{ type: "text", text: "answer this differently" }]
+  });
+  await agent.persistTestMessage({
+    id: oldAssistantId,
+    role: "assistant",
+    parts: [{ type: "text", text: "Old answer" }]
+  });
+  const partialChunks = includePartialChunks
+    ? [
+        {
+          body: JSON.stringify({
+            type: "start",
+            messageId: partialAssistantId
+          }),
+          index: 0
+        },
+        {
+          body: JSON.stringify({
+            type: "text-start",
+            id: "regenerated-text"
+          }),
+          index: 1
+        },
+        {
+          body: JSON.stringify({
+            type: "text-delta",
+            id: "regenerated-text",
+            delta: "Partial replacement"
+          }),
+          index: 2
+        }
+      ]
+    : [];
+  await agent.insertInterruptedStream(
+    `stream-${requestId}`,
+    requestId,
+    partialChunks,
+    streamStatus
+  );
+  await agent.insertInterruptedFiber(`__cf_internal_chat_turn:${requestId}`, {
+    __cfThinkChatFiberSnapshot: {
+      kind: "think-chat-turn",
+      version: 1,
+      requestId,
+      continuation: false,
+      latestMessageId: userId,
+      latestMessageRole: "user",
+      latestUserMessageId: userId,
+      historyLeafId: userId,
+      activeLeafIdAtStart: oldAssistantId,
+      startedAt: Date.now()
+    },
+    user: null
+  });
+
+  return { userId, oldAssistantId, partialAssistantId };
+}
+
+async function seedPreStreamRegeneration(
+  agent: Awaited<ReturnType<typeof recoveryAgent>>
+): Promise<{ requestId: string; userId: string; oldAssistantId: string }> {
+  const requestId = "req-pre-stream-regeneration-eviction";
+  const userId = "user-pre-stream-regeneration-eviction";
+  const oldAssistantId = "assistant-old-pre-stream-regeneration-eviction";
+
+  await agent.persistTestMessage({
+    id: userId,
+    role: "user",
+    parts: [{ type: "text", text: "try another answer" }]
+  });
+  await agent.persistTestMessage({
+    id: oldAssistantId,
+    role: "assistant",
+    parts: [{ type: "text", text: "Old answer" }]
+  });
+  await agent.insertInterruptedFiber(`__cf_internal_chat_turn:${requestId}`, {
+    __cfThinkChatFiberSnapshot: {
+      kind: "think-chat-turn",
+      version: 1,
+      requestId,
+      continuation: false,
+      latestMessageId: userId,
+      latestMessageRole: "user",
+      latestUserMessageId: userId,
+      historyLeafId: userId,
+      activeLeafIdAtStart: oldAssistantId,
+      startedAt: Date.now()
+    },
+    user: null
+  });
+
+  return { requestId, userId, oldAssistantId };
+}
+
 describe("Think chat recovery after forced Durable Object eviction", () => {
   it("startup schedules and executes one continuation from durable state", async () => {
     const name = `evict-recovery-${crypto.randomUUID()}`;
@@ -106,5 +226,102 @@ describe("Think chat recovery after forced Durable Object eviction", () => {
     expect(JSON.stringify(messages.at(-1)?.parts)).toContain(
       "Continued response."
     );
+  });
+
+  it("retries pre-stream regeneration from the selected branch point", async () => {
+    const name = `evict-pre-stream-regeneration-${crypto.randomUUID()}`;
+    let agent = await recoveryAgent(name);
+    const { requestId, userId, oldAssistantId } =
+      await seedPreStreamRegeneration(agent);
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+    agent = await recoveryAgent(name);
+
+    await waitFor(async () => (await agent.getTurnCallCount()) === 1);
+    await waitFor(async () => (await agent.getActiveFibers()).length === 0);
+
+    const branches = await getStoredBranches(agent, userId);
+    expect(branches).toHaveLength(2);
+    expect(branches.map((message) => message.id)).toContain(oldAssistantId);
+    expect(await agent.getPromptRolesForTest()).toEqual([["system", "user"]]);
+
+    await agent.retryBranchForTest({
+      targetUserId: userId,
+      historyLeafId: userId,
+      activeLeafIdAtStart: oldAssistantId,
+      originalRequestId: requestId
+    });
+    expect(await getStoredBranches(agent, userId)).toHaveLength(2);
+    expect(await agent.getTurnCallCount()).toBe(1);
+  });
+
+  it("retries the selected regeneration branch when the stream has no chunks", async () => {
+    const name = `evict-empty-stream-regeneration-${crypto.randomUUID()}`;
+    let agent = await recoveryAgent(name);
+    const { userId, oldAssistantId } = await seedInterruptedRegeneration(
+      agent,
+      "streaming",
+      false
+    );
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+    agent = await recoveryAgent(name);
+
+    await waitFor(async () => (await agent.getTurnCallCount()) === 1);
+    await waitFor(async () => (await agent.getActiveFibers()).length === 0);
+
+    const branches = await getStoredBranches(agent, userId);
+    expect(branches).toHaveLength(2);
+    expect(branches.map((message) => message.id)).toContain(oldAssistantId);
+    expect(await agent.getPromptRolesForTest()).toEqual([["system", "user"]]);
+  });
+
+  it("recovers regeneration on the selected sibling branch", async () => {
+    const name = `evict-regeneration-${crypto.randomUUID()}`;
+    let agent = await recoveryAgent(name);
+    const { userId, oldAssistantId, partialAssistantId } =
+      await seedInterruptedRegeneration(agent);
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+    agent = await recoveryAgent(name);
+
+    await waitFor(async () => (await agent.getTurnCallCount()) === 1);
+    await waitFor(async () => (await agent.getActiveFibers()).length === 0);
+
+    const branches = await getStoredBranches(agent, userId);
+    expect(branches.map((message) => message.id)).toEqual([
+      oldAssistantId,
+      partialAssistantId
+    ]);
+    const continuationBranches = await getStoredBranches(
+      agent,
+      partialAssistantId
+    );
+    expect(continuationBranches).toHaveLength(1);
+    expect(JSON.stringify(continuationBranches[0].parts)).toContain(
+      "Continued response."
+    );
+    expect(await agent.getPromptRolesForTest()).toEqual([
+      ["system", "user", "assistant", "user"]
+    ]);
+  });
+
+  it("persists terminal regeneration on the selected sibling branch", async () => {
+    const name = `evict-terminal-regeneration-${crypto.randomUUID()}`;
+    let agent = await recoveryAgent(name);
+    const { userId, oldAssistantId, partialAssistantId } =
+      await seedInterruptedRegeneration(agent, "completed");
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+    agent = await recoveryAgent(name);
+
+    await waitFor(async () => (await agent.getActiveFibers()).length === 0);
+
+    expect(await agent.getTurnCallCount()).toBe(0);
+    const branches = await getStoredBranches(agent, userId);
+    expect(branches.map((message) => message.id)).toEqual([
+      oldAssistantId,
+      partialAssistantId
+    ]);
   });
 });

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3423,6 +3423,69 @@ describe("Think — onChatRecovery", () => {
     expect(await agent.getTurnBodies()).toEqual([{ mode: "snapshot" }]);
   });
 
+  it("deduplicates branch retry redelivery when snapshot creation starts with an empty cache", async () => {
+    const agent = await freshRecoveryAgent(
+      `empty-cache-retry-redelivery-${crypto.randomUUID()}`
+    );
+    const userId = "user-empty-cache-retry";
+    const oldAssistantId = "assistant-before-empty-cache-retry";
+
+    await agent.persistTestMessage({
+      id: userId,
+      role: "user",
+      parts: [{ type: "text", text: "retry this branch" }]
+    });
+    await agent.persistTestMessage({
+      id: oldAssistantId,
+      role: "assistant",
+      parts: [{ type: "text", text: "previous answer" }]
+    });
+
+    const { requestId, snapshot } =
+      await agent.captureBranchRecoverySnapshotWithEmptyCacheForTest(userId);
+    await agent.insertInterruptedFiber(
+      `__cf_internal_chat_turn:${requestId}`,
+      snapshot
+    );
+    await agent.recoverFiberWithRetryRedeliveryForTest();
+
+    expect(await agent.getBranchesForTest(userId)).toHaveLength(2);
+    expect(await agent.getTurnCallCount()).toBe(1);
+  });
+
+  it("deduplicates retry redelivery from a legacy fiber snapshot", async () => {
+    const agent = await freshRecoveryAgent(
+      `legacy-retry-redelivery-${crypto.randomUUID()}`
+    );
+    const requestId = "req-legacy-pre-stream-retry";
+    const userId = "user-legacy-pre-stream-retry";
+
+    await agent.persistTestMessage({
+      id: userId,
+      role: "user",
+      parts: [{ type: "text", text: "retry after upgrading" }]
+    });
+    await agent.insertInterruptedFiber(`__cf_internal_chat_turn:${requestId}`, {
+      __cfThinkChatFiberSnapshot: {
+        kind: "think-chat-turn",
+        version: 1,
+        requestId,
+        continuation: false,
+        latestMessageId: userId,
+        latestMessageRole: "user",
+        latestUserMessageId: userId,
+        startedAt: Date.now()
+      },
+      user: null
+    });
+
+    await agent.recoverFiberWithRetryRedeliveryForTest();
+
+    const branches = (await agent.getBranchesForTest(userId)) as UIMessage[];
+    expect(branches).toHaveLength(1);
+    expect(await agent.getTurnCallCount()).toBe(1);
+  });
+
   it("continues a partial stream with request context from the recovered snapshot", async () => {
     const agent = await freshRecoveryAgent(
       `partial-continue-context-${crypto.randomUUID()}`
@@ -4405,6 +4468,71 @@ describe("Think — onChatRecovery", () => {
         .map((part) => part.text)
         .join("")
     ).toBe("Already persisted");
+  });
+
+  it("{ persist: false, continue: true } retries the selected user branch", async () => {
+    const agent = await freshRecoveryAgent(
+      `skip-partial-retry-selected-branch-${crypto.randomUUID()}`
+    );
+    const requestId = "req-skip-partial-retry";
+    const userId = "user-skip-partial-retry";
+    const oldAssistantId = "assistant-old-skip-partial-retry";
+
+    await agent.setRecoveryOverride({ persist: false, continue: true });
+    await agent.persistTestMessage({
+      id: userId,
+      role: "user",
+      parts: [{ type: "text", text: "answer differently" }]
+    });
+    await agent.persistTestMessage({
+      id: oldAssistantId,
+      role: "assistant",
+      parts: [{ type: "text", text: "Old answer" }]
+    });
+    await agent.insertInterruptedStream(`stream-${requestId}`, requestId, [
+      {
+        body: JSON.stringify({
+          type: "start",
+          messageId: "assistant-dropped-partial"
+        }),
+        index: 0
+      },
+      { body: JSON.stringify({ type: "text-start" }), index: 1 },
+      {
+        body: JSON.stringify({ type: "text-delta", delta: "Dropped partial" }),
+        index: 2
+      }
+    ]);
+    await agent.insertInterruptedFiber(`__cf_internal_chat_turn:${requestId}`, {
+      __cfThinkChatFiberSnapshot: {
+        kind: "think-chat-turn",
+        version: 1,
+        requestId,
+        continuation: false,
+        latestMessageId: userId,
+        latestMessageRole: "user",
+        latestUserMessageId: userId,
+        historyLeafId: userId,
+        activeLeafIdAtStart: oldAssistantId,
+        startedAt: Date.now()
+      },
+      user: null
+    });
+
+    await agent.triggerFiberRecovery();
+
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
+    ).toBe(1);
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
+    ).toBe(0);
+    expect(await agent.getTurnCallCount()).toBe(1);
+
+    const branches = (await agent.getBranchesForTest(userId)) as UIMessage[];
+    expect(branches).toHaveLength(2);
+    expect(branches.map((message) => message.id)).toContain(oldAssistantId);
+    expect(await agent.getPromptRolesForTest()).toEqual([["system", "user"]]);
   });
 
   it("{ persist: false, continue: false } skips both", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -1017,6 +1017,8 @@ type ProgrammaticMessagesResult = SaveMessagesResult & {
 
 type ChatRecoveryRetryData = {
   targetUserId?: string;
+  historyLeafId?: string;
+  activeLeafIdAtStart?: string;
   originalRequestId?: string;
   incidentId?: string;
   lastBody?: Record<string, unknown> | null;
@@ -1026,6 +1028,7 @@ type ChatRecoveryRetryData = {
 
 type ChatRecoveryContinueData = {
   targetAssistantId?: string;
+  historyLeafId?: string;
   originalRequestId?: string;
   incidentId?: string;
   lastBody?: Record<string, unknown> | null;
@@ -1040,6 +1043,10 @@ type ChatRecoveryContinueData = {
  * `streamStatus` rather than carrying it here.
  */
 type ThinkRecoveryClassification = { retryTargetUserId: string | null };
+
+type ThinkRecoveredTurnTarget =
+  | { recoveryKind: "retry"; messageId: string }
+  | { recoveryKind: "continue"; messageId?: string };
 
 // `ChatRecoveryIncident` / `ChatRecoveryKind` / `CHAT_RECOVERY_INCIDENT_KEY_PREFIX`
 // are the canonical shared symbols from `agents/chat` (imported above); the
@@ -2061,6 +2068,11 @@ import type {
 /** Branch endpoint whose root-to-message path supplies model context. */
 type InferenceHistorySelection = {
   readonly leafId: string;
+};
+
+/** Branch selection resolved once after turn admission. */
+type ResolvedInferenceHistorySelection = InferenceHistorySelection & {
+  readonly resolvedMessages: UIMessage[];
 };
 
 /**
@@ -4349,11 +4361,6 @@ export class Think<
       : undefined;
   }
 
-  /** Re-resolve the channel for a continuation from the latest user message. */
-  private _channelFromLatestUserMessage(): string | undefined {
-    return this._channelFromMessages(this.messages);
-  }
-
   /**
    * Deliver a no-turn, channel-routed message — a deterministic status, fallback,
    * or notice — straight to the channel's delivery surface WITHOUT invoking the
@@ -4502,21 +4509,33 @@ export class Think<
   private async _runChatRecoveryFiber<T>(
     requestId: string,
     continuation: boolean,
-    fn: () => Promise<T>
+    fn: (history?: ResolvedInferenceHistorySelection) => Promise<T>,
+    history?: InferenceHistorySelection
   ): Promise<T> {
+    const resolvedHistory = history
+      ? {
+          leafId: history.leafId,
+          resolvedMessages: await this._readRecentInferenceMessages(history)
+        }
+      : undefined;
+    const activeLeafIdAtStart = resolvedHistory
+      ? (await this.session.getLatestLeaf())?.id
+      : undefined;
     const snapshot = createChatFiberSnapshot({
       kind: "think-chat-turn",
       requestId,
       recoveryRootRequestId: this._activeChatRecoveryRootRequestId ?? requestId,
       continuation,
-      messages: this.messages,
+      messages: resolvedHistory?.resolvedMessages ?? this.messages,
+      historyLeafId: resolvedHistory?.leafId,
+      activeLeafIdAtStart,
       lastBody: this._lastBody,
       lastClientTools: this._lastClientTools
     });
 
     return this._runFiberWithStashWrapper(
       `${(this.constructor as typeof Think).CHAT_FIBER_NAME}:${requestId}`,
-      async () => fn(),
+      async () => fn(resolvedHistory),
       {
         initialSnapshot: wrapChatFiberSnapshot(
           "__cfThinkChatFiberSnapshot",
@@ -5639,7 +5658,7 @@ export class Think<
    */
   private async _runInferenceLoop(
     input: TurnInput,
-    history?: InferenceHistorySelection
+    history?: InferenceHistorySelection | ResolvedInferenceHistorySelection
   ): Promise<StreamableResult> {
     const turn = admittedTurnContext.getStore();
     const invoke = await withAgentSpan(
@@ -5666,7 +5685,9 @@ export class Think<
 
   private async _prepareInferenceInvocation(
     input: TurnInput,
-    historySelection?: InferenceHistorySelection
+    historySelection?:
+      | InferenceHistorySelection
+      | ResolvedInferenceHistorySelection
   ): Promise<() => StreamableResult> {
     // Keep one exposure policy for this inference attempt even if subclass
     // code changes the instance property while asynchronous setup is running.
@@ -5675,10 +5696,17 @@ export class Think<
     // turn that doesn't override falls back to the instance-level value.
     this._activeStallTimeoutMs = undefined;
     this._activeTurnAuthorization = { allowed: true };
-    this._activeTurnHistory = historySelection;
-    const inferenceHistory = historySelection
-      ? await this._readRecentInferenceMessages(historySelection)
-      : this.messages;
+    // Keep only the durable selector beyond preparation. Retaining resolved
+    // messages here would pin a full branch in memory after the turn settles.
+    this._activeTurnHistory = historySelection
+      ? { leafId: historySelection.leafId }
+      : undefined;
+    const inferenceHistory =
+      historySelection && "resolvedMessages" in historySelection
+        ? historySelection.resolvedMessages
+        : historySelection
+          ? await this._readRecentInferenceMessages(historySelection)
+          : this.messages;
     this._activeTurnApprovedActionInputs =
       this._approvedActionInputsFromTranscript(inferenceHistory);
     // Reset the proactive-compaction cap for this streamText run.
@@ -11035,11 +11063,20 @@ export class Think<
    */
   protected async continueLastTurn(
     body?: Record<string, unknown>,
-    options?: SaveMessagesOptions & { trigger?: TurnTrigger; channel?: string }
+    options?: SaveMessagesOptions & {
+      trigger?: TurnTrigger;
+      channel?: string;
+      history?: InferenceHistorySelection;
+    }
   ): Promise<SaveMessagesResult> {
     const trigger = options?.trigger ?? "programmatic";
     this._assertNotInsideAdmittedTurn(trigger);
-    const lastLeaf = await this.session.getLatestLeaf();
+    const continuationHistory = options?.history
+      ? await this._readRecentInferenceMessages(options.history)
+      : this.messages;
+    const lastLeaf = options?.history
+      ? await this.session.getMessage(options.history.leafId)
+      : await this.session.getLatestLeaf();
     if (!lastLeaf || lastLeaf.role !== "assistant") {
       return { requestId: "", status: "skipped" };
     }
@@ -11054,7 +11091,8 @@ export class Think<
     const epoch = this._turnQueue.generation;
     // Re-resolve the channel from durable history so a continued/recovered turn
     // re-applies per-channel policy.
-    const channel = options?.channel ?? this._channelFromLatestUserMessage();
+    const channel =
+      options?.channel ?? this._channelFromMessages(continuationHistory);
     let status: SaveMessagesResult["status"] = "completed";
     let error: string | undefined;
     let wasAborted = false;
@@ -11078,7 +11116,9 @@ export class Think<
           options?.signal
         );
         try {
-          const continueTurnBody = async () => {
+          const continueTurnBody = async (
+            inferenceHistory = options?.history
+          ) => {
             const result = await agentContext.run(
               {
                 agent: this,
@@ -11087,12 +11127,15 @@ export class Think<
                 email: undefined
               },
               () =>
-                this._runInferenceLoop({
-                  signal: abortSignal,
-                  clientTools,
-                  body: resolvedBody,
-                  continuation: true
-                })
+                this._runInferenceLoop(
+                  {
+                    signal: abortSignal,
+                    clientTools,
+                    body: resolvedBody,
+                    continuation: true
+                  },
+                  inferenceHistory
+                )
             );
 
             if (result) {
@@ -11101,7 +11144,8 @@ export class Think<
                 result,
                 abortSignal,
                 {
-                  continuation: true
+                  continuation: true,
+                  parentId: inferenceHistory?.leafId
                 }
               );
               status = streamResult.status;
@@ -11110,9 +11154,14 @@ export class Think<
           };
 
           if (this.chatRecovery) {
-            await this._runChatRecoveryFiber(requestId, true, continueTurnBody);
+            await this._runChatRecoveryFiber(
+              requestId,
+              true,
+              continueTurnBody,
+              options?.history
+            );
           } else {
-            await continueTurnBody();
+            await continueTurnBody(options?.history);
           }
         } finally {
           if (abortSignal?.aborted) wasAborted = true;
@@ -11137,11 +11186,20 @@ export class Think<
   private async _retryLastUserTurn(
     clientTools?: ClientToolSchema[],
     body?: Record<string, unknown>,
-    options?: SaveMessagesOptions & { trigger?: TurnTrigger; channel?: string }
+    options?: SaveMessagesOptions & {
+      trigger?: TurnTrigger;
+      channel?: string;
+      history?: InferenceHistorySelection;
+    }
   ): Promise<SaveMessagesResult> {
     const trigger = options?.trigger ?? "recovery-retry";
     this._assertNotInsideAdmittedTurn(trigger);
-    const lastLeaf = await this.session.getLatestLeaf();
+    const retryHistory = options?.history
+      ? await this._readRecentInferenceMessages(options.history)
+      : this.messages;
+    const lastLeaf = options?.history
+      ? await this.session.getMessage(options.history.leafId)
+      : await this.session.getLatestLeaf();
     if (!lastLeaf || lastLeaf.role !== "user") {
       return { requestId: "", status: "skipped" };
     }
@@ -11156,7 +11214,7 @@ export class Think<
     // retry re-applies per-channel policy, exactly like `continueLastTurn`. The
     // `metadata.channel` stamp survives the interruption; without this the
     // retried turn would silently fall back to the default policy.
-    const channel = options?.channel ?? this._channelFromLatestUserMessage();
+    const channel = options?.channel ?? this._channelFromMessages(retryHistory);
     let status: SaveMessagesResult["status"] = "completed";
     let error: string | undefined;
     let wasAborted = false;
@@ -11180,7 +11238,7 @@ export class Think<
           options?.signal
         );
         try {
-          const retryTurnBody = async () => {
+          const retryTurnBody = async (inferenceHistory = options?.history) => {
             const result = await agentContext.run(
               {
                 agent: this,
@@ -11189,19 +11247,23 @@ export class Think<
                 email: undefined
               },
               () =>
-                this._runInferenceLoop({
-                  signal: abortSignal,
-                  clientTools,
-                  body,
-                  continuation: false
-                })
+                this._runInferenceLoop(
+                  {
+                    signal: abortSignal,
+                    clientTools,
+                    body,
+                    continuation: false
+                  },
+                  inferenceHistory
+                )
             );
 
             if (result) {
               const streamResult = await this._streamResult(
                 requestId,
                 result,
-                abortSignal
+                abortSignal,
+                { parentId: inferenceHistory?.leafId }
               );
               status = streamResult.status;
               error = streamResult.error;
@@ -11209,9 +11271,14 @@ export class Think<
           };
 
           if (this.chatRecovery) {
-            await this._runChatRecoveryFiber(requestId, false, retryTurnBody);
+            await this._runChatRecoveryFiber(
+              requestId,
+              false,
+              retryTurnBody,
+              options?.history
+            );
           } else {
-            await retryTurnBody();
+            await retryTurnBody(options?.history);
           }
         } finally {
           if (abortSignal?.aborted) wasAborted = true;
@@ -11659,7 +11726,9 @@ export class Think<
               }
             }
 
-            const chatTurnBody = async () => {
+            const chatTurnBody = async (
+              inferenceHistory = regenerationHistory
+            ) => {
               // Bounded compact-and-retry loop (opt-in via
               // `contextOverflow.reactive`). A turn that overflows the
               // context window mid-flight is compacted and re-run from the
@@ -11682,7 +11751,7 @@ export class Think<
                         body: bodyForTurn,
                         continuation: false
                       },
-                      regenerationHistory
+                      inferenceHistory
                     )
                 );
 
@@ -11777,9 +11846,14 @@ export class Think<
             };
 
             if (this.chatRecovery) {
-              await this._runChatRecoveryFiber(requestId, false, chatTurnBody);
+              await this._runChatRecoveryFiber(
+                requestId,
+                false,
+                chatTurnBody,
+                regenerationHistory
+              );
             } else {
-              await chatTurnBody();
+              await chatTurnBody(regenerationHistory);
             }
           }
         });
@@ -14331,8 +14405,8 @@ export class Think<
             input.streamStatus === "error",
           snapshot: input.snapshot
         }),
-      persistOrphanedStream: (streamId) =>
-        this._persistOrphanedStream(streamId),
+      persistOrphanedStream: (streamId, snapshot) =>
+        this._persistOrphanedStream(streamId, snapshot?.historyLeafId),
       completeRecoveredStream: (streamId) =>
         this._completeResumableStream(streamId),
       dispatchRecoveredTurn: (input) => this._dispatchRecoveredThinkTurn(input)
@@ -14423,21 +14497,12 @@ export class Think<
       recoveryRootRequestId,
       streamStatus
     } = input;
-    const { retryTargetUserId } = input.detail;
     const streamIsTerminal =
       streamStatus === "completed" || streamStatus === "error";
-
-    const shouldRetry =
-      retryTargetUserId !== null &&
-      options.continue !== false &&
-      !streamIsTerminal;
-    const lastLeaf = shouldRetry ? null : await this.session.getLatestLeaf();
-    const targetId =
-      lastLeaf?.role === "assistant" && !streamIsTerminal
-        ? lastLeaf.id
-        : undefined;
-    const canContinue =
-      !shouldRetry && options.continue !== false && !streamIsTerminal;
+    const target =
+      options.continue !== false && !streamIsTerminal
+        ? await this._resolveThinkRecoveredTurnTarget(input)
+        : null;
     // The durable submission is keyed by the recovery ROOT request id (stable
     // across the whole continuation chain), not this turn's per-continuation
     // requestId. Keying off `requestId` loses the link on every chained
@@ -14459,17 +14524,21 @@ export class Think<
     }
 
     const recoveredRequestId =
-      (canContinue || shouldRetry) && hasRunningSubmission
-        ? recoveryRootRequestId
-        : undefined;
+      target && hasRunningSubmission ? recoveryRootRequestId : undefined;
 
-    if (shouldRetry) {
+    if (target?.recoveryKind === "retry") {
+      const activeLeafIdAtStart = this._recoveryActiveLeafIdAtStart(snapshot);
       await this._chatRecoveryEngine().scheduleRecovery({
         incident,
-        recoveryKind: input.recoveryKind,
+        // A recovered stream may classify as `continue` before persistence but
+        // produce no assistant anchor (zero chunks or `persist: false`). In
+        // that case the selected user leaf must be retried instead.
+        recoveryKind: "retry",
         callback: "_chatRecoveryRetry",
         data: {
-          targetUserId: retryTargetUserId,
+          targetUserId: target.messageId,
+          historyLeafId: target.messageId,
+          ...(activeLeafIdAtStart !== undefined ? { activeLeafIdAtStart } : {}),
           originalRequestId: recoveryRootRequestId,
           incidentId: incident.incidentId,
           lastBody: snapshot?.lastBody ?? null,
@@ -14477,13 +14546,18 @@ export class Think<
           ...(recoveredRequestId ? { recoveredRequestId } : {})
         }
       });
-    } else if (canContinue) {
+    } else if (target?.recoveryKind === "continue") {
       await this._chatRecoveryEngine().scheduleRecovery({
         incident,
-        recoveryKind: input.recoveryKind,
+        recoveryKind: "continue",
         callback: "_chatRecoveryContinue",
         data: {
-          ...(targetId ? { targetAssistantId: targetId } : {}),
+          ...(target.messageId
+            ? {
+                targetAssistantId: target.messageId,
+                historyLeafId: target.messageId
+              }
+            : {}),
           originalRequestId: recoveryRootRequestId,
           incidentId: incident.incidentId,
           ...(snapshot
@@ -14534,6 +14608,57 @@ export class Think<
     }
   }
 
+  /**
+   * Resolve the exact durable leaf a recovered turn should run from. A newly
+   * materialized orphan assistant takes precedence. Without one, an explicit
+   * branch snapshot retries a user leaf or continues an assistant leaf. Only
+   * legacy snapshots without branch context fall back to the global latest
+   * leaf.
+   */
+  private async _resolveThinkRecoveredTurnTarget(
+    input: DispatchRecoveredTurnInput<ThinkRecoveryClassification>
+  ): Promise<ThinkRecoveredTurnTarget | null> {
+    if (input.persistedOrphanMessageId) {
+      const persistedAssistant = await this.session.getMessage(
+        input.persistedOrphanMessageId
+      );
+      if (persistedAssistant?.role === "assistant") {
+        return {
+          recoveryKind: "continue",
+          messageId: persistedAssistant.id
+        };
+      }
+    }
+
+    if (input.snapshot?.historyLeafId) {
+      const selectedLeaf = await this.session.getMessage(
+        input.snapshot.historyLeafId
+      );
+      if (selectedLeaf?.role === "user") {
+        return { recoveryKind: "retry", messageId: selectedLeaf.id };
+      }
+      if (selectedLeaf?.role === "assistant") {
+        return { recoveryKind: "continue", messageId: selectedLeaf.id };
+      }
+      return null;
+    }
+
+    if (input.detail.retryTargetUserId) {
+      return {
+        recoveryKind: "retry",
+        messageId: input.detail.retryTargetUserId
+      };
+    }
+
+    const legacyLatestLeaf = await this.session.getLatestLeaf();
+    return {
+      recoveryKind: "continue",
+      ...(legacyLatestLeaf?.role === "assistant"
+        ? { messageId: legacyLatestLeaf.id }
+        : {})
+    };
+  }
+
   private async _recoverablePreStreamUserId(
     snapshot: ChatFiberSnapshot | null,
     streamId: string,
@@ -14550,6 +14675,16 @@ export class Think<
       return null;
     }
 
+    if (snapshot.historyLeafId) {
+      const selectedLeaf = await this.session.getMessage(
+        snapshot.historyLeafId
+      );
+      return selectedLeaf?.role === "user" &&
+        selectedLeaf.id === snapshot.latestUserMessageId
+        ? selectedLeaf.id
+        : null;
+    }
+
     const lastLeaf = await this.session.getLatestLeaf();
     return lastLeaf?.role === "user" &&
       lastLeaf.id === snapshot.latestUserMessageId
@@ -14557,13 +14692,33 @@ export class Think<
       : null;
   }
 
+  /**
+   * Resolve the active endpoint captured by a recovery snapshot.
+   *
+   * Modern branch snapshots carry `activeLeafIdAtStart` explicitly. Legacy
+   * linear snapshots predate both branch fields, so their `latestMessageId`
+   * was the active endpoint. Never apply that fallback to a partial modern
+   * branch snapshot: there `latestMessageId` can be a selected historical user.
+   */
+  private _recoveryActiveLeafIdAtStart(
+    snapshot: ChatFiberSnapshot | null
+  ): string | undefined {
+    if (!snapshot) return undefined;
+    if (snapshot.activeLeafIdAtStart !== undefined) {
+      return snapshot.activeLeafIdAtStart;
+    }
+    return snapshot.historyLeafId === undefined
+      ? snapshot.latestMessageId
+      : undefined;
+  }
+
   private async _hasPersistedRecoveredAssistant(
     snapshot: ChatFiberSnapshot | null
   ): Promise<boolean> {
     const lastLeaf = await this.session.getLatestLeaf();
+    const activeLeafIdAtStart = this._recoveryActiveLeafIdAtStart(snapshot);
     return (
-      lastLeaf?.role === "assistant" &&
-      lastLeaf.id !== snapshot?.latestMessageId
+      lastLeaf?.role === "assistant" && lastLeaf.id !== activeLeafIdAtStart
     );
   }
 
@@ -14967,11 +15122,14 @@ export class Think<
         return;
       }
 
-      const lastLeaf = await this.session.getLatestLeaf();
-      if (!lastLeaf || lastLeaf.role !== "user") {
-        // The user turn is no longer the leaf — it was already answered (an
-        // assistant message now follows) or the conversation moved on. This is
-        // a benign skip, not an error: a completing turn marks the submission
+      const activeLeaf = await this.session.getLatestLeaf();
+      const retryLeaf = data?.historyLeafId
+        ? await this.session.getMessage(data.historyLeafId)
+        : activeLeaf;
+      if (!retryLeaf || retryLeaf.role !== "user") {
+        // The default active endpoint is no longer an unanswered user, or a
+        // branch-scoped retry target disappeared. This is a benign skip, not
+        // an error: a completing turn marks the submission
         // `completed`; otherwise it is terminally `skipped`, never `error`.
         await this._updateChatRecoveryIncident(
           data?.incidentId,
@@ -14989,9 +15147,16 @@ export class Think<
         return;
       }
 
-      if (data?.targetUserId && lastLeaf.id !== data.targetUserId) {
-        // Superseded by a genuinely newer user turn — terminal `skipped`, not an
-        // error (recovery being superseded is benign).
+      const branchMovedSinceStart =
+        data?.historyLeafId !== undefined &&
+        data.activeLeafIdAtStart !== undefined &&
+        activeLeaf?.id !== data.activeLeafIdAtStart;
+      if (
+        (data?.targetUserId && retryLeaf.id !== data.targetUserId) ||
+        branchMovedSinceStart
+      ) {
+        // Superseded by a newer turn or already completed by an earlier delivery
+        // of this branch-scoped retry — terminal `skipped`, not an error.
         await this._updateChatRecoveryIncident(
           data?.incidentId,
           "skipped",
@@ -15009,12 +15174,19 @@ export class Think<
       }
 
       this._applyRecoveredRequestContext(data);
+      const history = data?.historyLeafId
+        ? { leafId: data.historyLeafId }
+        : undefined;
       const result = await this._retryLastUserTurn(
         this._lastClientTools,
         this._lastBody,
         controller
-          ? { signal: controller.signal, trigger: "recovery-retry" }
-          : { trigger: "recovery-retry" }
+          ? {
+              signal: controller.signal,
+              trigger: "recovery-retry",
+              history
+            }
+          : { trigger: "recovery-retry", history }
       );
       await this._updateChatRecoveryIncident(
         data?.incidentId,
@@ -15249,12 +15421,14 @@ export class Think<
       }
 
       this._applyRecoveredRequestContext(data);
-      const result = await this.continueLastTurn(
-        undefined,
-        controller
-          ? { signal: controller.signal, trigger: "recovery-continue" }
-          : { trigger: "recovery-continue" }
-      );
+      const history = data?.historyLeafId
+        ? { leafId: data.historyLeafId }
+        : undefined;
+      const result = await this.continueLastTurn(undefined, {
+        signal: controller?.signal,
+        trigger: "recovery-continue",
+        history
+      });
       await this._updateChatRecoveryIncident(
         data?.incidentId,
         result.status === "completed"
@@ -15819,8 +15993,12 @@ export class Think<
       preStream: this._preStream,
       pendingResumeConnections: this._pendingResumeConnections,
       pendingChatTerminal: () => this._pendingChatTerminal(),
-      persistOrphanedStream: (streamId) =>
-        this._persistOrphanedStream(streamId),
+      persistOrphanedStream: async (streamId) => {
+        await this._persistOrphanedStream(
+          streamId,
+          this._activeTurnHistory?.leafId
+        );
+      },
       isConnectionPresent: (connectionId) =>
         this.getConnection(connectionId) !== undefined
     }));
@@ -15914,10 +16092,13 @@ export class Think<
     );
   }
 
-  private async _persistOrphanedStream(streamId: string): Promise<void> {
+  private async _persistOrphanedStream(
+    streamId: string,
+    parentId?: string
+  ): Promise<string | null> {
     this._resumableStream.flushBuffer();
     const chunks = this._resumableStream.getStreamChunks(streamId);
-    if (chunks.length === 0) return;
+    if (chunks.length === 0) return null;
 
     // The accumulate loop and the `getMessage → update(merge) XOR append` upsert
     // are the shared `persistReconstructedOrphan` core. Think supplies the two
@@ -15929,13 +16110,21 @@ export class Think<
     // NOTE: progress is bumped at production/flush time in `_storeChunkDurably`
     // (#1637), NOT here — persisting on recovery or a client reconnect must not
     // be miscounted as new forward progress.
+    let persistedMessageId: string | null = null;
     const wrote = await persistReconstructedOrphan(chunks, {
       store: this._orphanStore(),
       fallbackId: crypto.randomUUID(),
-      prepare: (message) => this._strippedForPersist(message),
+      parentId,
+      prepare: (message) => {
+        const prepared = this._strippedForPersist(message);
+        persistedMessageId = prepared?.id ?? null;
+        return prepared;
+      },
       merge: (_existing, incoming) => incoming
     });
-    if (wrote) this._broadcastMessages();
+    if (!wrote) return null;
+    this._broadcastMessages();
+    return persistedMessageId;
   }
 
   private _broadcastChat(message: Record<string, unknown>, exclude?: string[]) {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -11824,7 +11824,10 @@ export class Think<
                     );
                     // Compaction shortened history → retry. A no-op compaction
                     // can't fix the overflow, so fall through to terminal.
-                    if (shortened) continue;
+                    if (shortened) {
+                      inferenceHistory = regenerationHistory;
+                      continue;
+                    }
                   }
                   // Budget spent, aborted, or compaction no-op: deliver
                   // terminally (through onChatError, classified) so the turn


### PR DESCRIPTION
Stacked on #2121.

## Problem

Branch-aware regeneration could lose its selected branch during chat recovery:

- a resumable stream may exist before any assistant message is materialized
- `{ persist: false, continue: true }` deliberately leaves no assistant to continue from
- recovery previously re-derived the target from mutable global state
- recovery snapshot creation and inference independently loaded the same unbounded branch history

Those cases could continue from the wrong leaf, skip a required retry, or perform duplicate full-history reads.

## Fix

- return the exact persisted orphan assistant ID through `ChatRecoveryEngine`
- continue from that exact assistant when one was materialized
- retry the selected user leaf when no assistant was materialized
- carry explicit branch history through retry and continuation entry points
- resolve selected history once after turn admission and share it between the recovery snapshot and inference
- preserve legacy linear recovery when no branch context exists

## Testing

- 66 Agents recovery-engine tests
- 295 focused Think recovery/session/client tests
- forced-eviction coverage before the first chunk, `persist: false`, persisted partial continuation, sibling placement, and selected-history read count

## Stack

1. #2120 — Session branch-local compaction
2. #2038 — Think regeneration context
3. #2121 — transcript repair ownership
4. **This PR — branch-aware recovery**
5. #2057 — restart durability

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->