### PR TITLE
docs: add migration guidance for next release

### DIFF
--- a/.changeset/bright-images-see.md
+++ b/.changeset/bright-images-see.md
@@ -3,3 +3,5 @@
 ---
 
 Emit workspace image reads as `image-data` model content so AI SDK v6 routes them as images, while preserving `file-data` output for PDFs.
+
+Existing consumers that inspect raw workspace tool content must handle `image-data` for images; PDFs continue to use `file-data`. Normal tool callers require no change.

--- a/.changeset/calm-voices-remember.md
+++ b/.changeset/calm-voices-remember.md
@@ -4,4 +4,8 @@
 
 Define `VoiceTurnContext.messages` as completed history before the current transcript for both text and audio turns, preventing duplicate user messages when following the documented prompt construction.
 
-`onTurn()` implementations that previously passed `context.messages` directly as complete LLM input must now append `transcript` exactly once. The transcript is still persisted before `onTurn()` runs, so direct `getConversationHistory()` calls continue to include it.
+Existing `onTurn()` implementations:
+
+- If you pass `context.messages` directly as the complete LLM input, append `transcript` exactly once.
+- If you already append `transcript` to `context.messages`, no change is required.
+- Direct `getConversationHistory()` calls inside `onTurn()` continue to include the current transcript.

--- a/.changeset/early-weeks-live.md
+++ b/.changeset/early-weeks-live.md
@@ -2,4 +2,10 @@
 "@cloudflare/worker-bundler": patch
 ---
 
-Python package support
+Add Python package support.
+
+Existing worker-bundler users should note:
+
+- Automatic dependency installation accepts either `package.json` or `pyproject.toml`, not both. Projects that provide both must remove one manifest from the bundler input or install dependencies separately.
+- `index.py` is now considered before `src/worker.ts` and `src/worker.js` during default entry-point detection. Set `entryPoint`, `server`, or `wrangler.main` in projects where that is ambiguous.
+- Custom `FileSystem.write()` implementations used with Python packages must accept both strings and `{ data: Uint8Array }` binary entries.

--- a/.changeset/facet-forward-stream-body.md
+++ b/.changeset/facet-forward-stream-body.md
@@ -19,4 +19,4 @@ Both call sites now pass `req.body` through as a stream. Measured on `wrangler d
 
 This restores the behaviour from before #1443, which switched to an explicit `RequestInit` in order to set a header on WebSocket upgrades and re-attached the body with `arrayBuffer()` as a side effect. The `Upgrade` header handling from that fix is unchanged.
 
-One behavioural note: backpressure now reaches the client. A child that returns without reading the body will cause the remainder of the upload to be cancelled, where previously the parent drained it in full.
+One behavioural note: backpressure now reaches the client. A child that returns without reading the body will cause the remainder of the upload to be cancelled, where previously the parent drained it in full. Existing handlers that require the complete upload must consume or stream `request.body` before returning.

--- a/.changeset/fix-browser-extract-schema.md
+++ b/.changeset/fix-browser-extract-schema.md
@@ -3,3 +3,5 @@
 ---
 
 Send Browser Run extraction schemas under `response_format.json_schema`, matching the Quick Actions `/json` contract.
+
+Direct `browserExtract()` and `runQuickAction()` callers must rename `response_format.schema` to `response_format.json_schema`. The model-facing `browser_extract` tool still accepts its schema in the top-level `schema` field.

--- a/.changeset/fix-observer-error-frames.md
+++ b/.changeset/fix-observer-error-frames.md
@@ -7,3 +7,5 @@
 Treat `useAgentChat` observer error frames as terminal responses.
 
 Plain-text error bodies are no longer parsed as stream chunks or merged into an empty assistant message. Error frames now clear observer streaming, replay, recovery, and tool-continuation state even when they omit `done`, matching the transport-owned stream behavior.
+
+Existing observer UIs that displayed error bodies as assistant messages must move those diagnostics to a dedicated error surface.

--- a/.changeset/fuzzy-cats-chat.md
+++ b/.changeset/fuzzy-cats-chat.md
@@ -4,3 +4,5 @@
 ---
 
 Expose `WebSocketChatTransport` and its connection types from the framework-neutral `agents/chat/transport` entry point. React peers are now optional for framework-neutral clients and servers.
+
+Existing users of `agents/chat/react` or `@cloudflare/ai-chat/react` must continue to declare compatible `react` and `@ai-sdk/react` dependencies explicitly.

--- a/.changeset/kind-tools-share.md
+++ b/.changeset/kind-tools-share.md
@@ -4,3 +4,5 @@
 ---
 
 Accept AI SDK flexible schemas in `agentTool`, including Valibot adapters, while preserving schema-driven input inference and structured output validation. Zod is no longer a peer requirement of `@cloudflare/ai-chat`.
+
+Existing custom schemas that no longer type-check as AI SDK `FlexibleSchema` must use the schema library's AI SDK adapter or wrap raw JSON Schema with `jsonSchema()`. Validation-only Standard Schema implementations are insufficient because tool inputs must expose JSON Schema to the model.

--- a/.changeset/neat-spans-nest.md
+++ b/.changeset/neat-spans-nest.md
@@ -3,3 +3,22 @@
 ---
 
 Use `wrapAISDK()` as the single AI SDK v6 and v7 tracing integration, removing the separate `createAISDKTelemetry()` callback adapter that could not preserve the `invoke_agent` parent hierarchy. Mark asynchronously decided AI SDK v7 top-level approval spans when they outlive their invocation.
+
+Existing `createAISDKTelemetry()` users must:
+
+- Remove it from `registerTelemetry()` and per-call telemetry integrations.
+- Wrap the AI SDK namespace and call the wrapped functions instead:
+
+  ```ts
+  import * as ai from "ai";
+  import { wrapAISDK } from "agents/observability/ai";
+
+  const tracedAI = wrapAISDK(ai, {
+    storeMessages: true,
+    storeTools: true
+  });
+
+  await tracedAI.generateText(/* ... */);
+  ```
+
+- Update telemetry queries that use the removed callback-only `cloudflare.agents.call.id` or `cloudflare.agents.tool_context.*` attributes.

--- a/.changeset/plain-points-play.md
+++ b/.changeset/plain-points-play.md
@@ -3,3 +3,8 @@
 ---
 
 Add connection-scoped Kitesurf support to Browser Tools through the `browser: "kitesurf"` session option. Unsupported durable session, Live View, recording, pause/resume, and Kitesurf-backed Quick Action surfaces remain unavailable.
+
+Existing Browser Tools users should note:
+
+- Large base64 values returned outside the canonical `{ type: "browser_screenshot", mediaType, data }` shape are now redacted. Return screenshots in that shape or store binary output elsewhere.
+- TanStack browser tools have one output channel, so screenshot output is reduced to the compact model-facing summary rather than returning raw base64 data.

--- a/.changeset/remove-think-framework.md
+++ b/.changeset/remove-think-framework.md
@@ -3,3 +3,20 @@
 ---
 
 Remove the convention-driven Think framework, including the Vite plugin, generated Worker entry and virtual modules, CLI, Studio, framework helpers, and server-entry helpers. Remove the separate `create-think` scaffolder and its starter templates. Think remains available as an explicit runtime for hand-written Worker entries.
+
+**Migration for existing framework users**
+
+If you only use the `Think` runtime, React integration, messengers, workflows, extensions, or tools, no migration is required.
+
+| Existing use                                      | Required change                                                                                                                                                             |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@cloudflare/think/vite`                          | Use `agents/vite` for decorators and `agents:skills`, alongside `@cloudflare/vite-plugin`.                                                                                  |
+| `virtual:think/entry`                             | Add a real Worker entry, such as `src/server.ts`, that explicitly exports each Think class.                                                                                 |
+| Generated bindings, migrations, and routing       | Declare top-level Durable Object bindings and migrations in `wrangler.jsonc`; route with `routeAgentRequest()` and, for custom sub-agent routing, `routeSubAgentRequest()`. |
+| `@cloudflare/think/framework`                     | Move generated configuration and class exports into application code.                                                                                                       |
+| `@cloudflare/think/server-entry`                  | Use Agents SDK routing helpers and application-owned request handlers.                                                                                                      |
+| `think types`                                     | Use `wrangler types`.                                                                                                                                                       |
+| `think init` or `create-think`                    | Use `npx create-cloudflare@latest --template cloudflare/agents-starter`, or manually configure a Think Worker.                                                              |
+| `think studio`, `think state`, or `think inspect` | No direct replacement.                                                                                                                                                      |
+
+Existing deployments must preserve generated `ThinkAgent_*` and `ThinkSubAgent_*` constructor names and existing migration history. Sub-agent registries use `Class.name`, so export aliases alone do not preserve compatibility. If renaming classes, use a data-preserving Durable Object rename migration.

--- a/.changeset/strict-browsers-validate.md
+++ b/.changeset/strict-browsers-validate.md
@@ -3,3 +3,8 @@
 ---
 
 Validate BrowserConnector tool arguments before execution and reject JSON-stringified Browser Run extraction schemas with an actionable error.
+
+Existing callers that pass values outside the documented schemas must correct them before execution:
+
+- Pass extraction schemas as JSON objects, not JSON strings.
+- Pass the string returned in `attachToTarget().sessionId` to `cdp.send`, not the complete attachment result.

--- a/.changeset/tidy-pandas-connect.md
+++ b/.changeset/tidy-pandas-connect.md
@@ -3,3 +3,5 @@
 ---
 
 Preserve HTTP rejection responses returned by `onBeforeConnect` instead of continuing through downstream Hono handlers.
+
+Existing applications that relied on rejected Agent WebSocket requests falling through to another Hono handler must mount `agentsMiddleware` on a narrower path or configure a distinct Agent route prefix. `hono-agents@3.0.12` also requires `agents >=0.17.1`.

--- a/.changeset/warm-otters-separate.md
+++ b/.changeset/warm-otters-separate.md
@@ -4,4 +4,10 @@
 "@cloudflare/voice": patch
 ---
 
-Preserve spacing between streamed text segments separated by tool calls. Think messenger delivery and Voice now share the same boundary-aware text joining logic from `agents/chat`. Remove the unsafe `textDeltaFromStreamChunk()` messenger export; consume streams through `TextStreamCallback` so structured boundaries are retained.
+Preserve spacing between streamed text segments separated by tool calls. Think messenger delivery and Voice now share the same boundary-aware text joining logic from `agents/chat`.
+
+Existing users must:
+
+- Replace imports of `textDeltaFromStreamChunk()` from `@cloudflare/think/messengers` with `TextStreamCallback`, passing it the complete structured stream events.
+- Upgrade to `agents@0.21.0` when installing `@cloudflare/think@0.16.0` or `@cloudflare/voice@0.3.6`; both now require `agents >=0.20.2`.
+- Update exact-text expectations if they relied on segments around tool calls being concatenated without a space.


### PR DESCRIPTION
## Summary

- add concise migration guidance to the changesets feeding #1995
- map removed Think framework surfaces to their replacements, with Durable Object data-preservation guidance
- document required changes for removed APIs, peer-version floors, and conditional behavior changes
- keep each note scoped to existing users of the affected surface

Updating the source changesets lets the Changesets release PR regenerate the package changelogs after this merges.

## Verification

- `pnpm run build`
- `pnpm run check`
