### PR TITLE
feat(agent-think): expose submission status over RPC

### DIFF
--- a/agent-think/AGENTS.md
+++ b/agent-think/AGENTS.md
@@ -37,8 +37,9 @@ gh-app  (GitLab: cloudflare/ai-agents/team-apps, apps/gh-app — PRIVATE)
    │  RPC: env.AGENT_THINK.dispatch({repo, issueNumber, instruction, installationToken})
    ▼
 agent-think  (this dir — PUBLIC-safe, holds no App creds)
-   ├─ AgentThink WorkerEntrypoint.dispatch  (src/index.ts)
-   │     getAgentByName(env.ThinkAgent, session) → setContext → start()
+   ├─ AgentThink WorkerEntrypoint  (src/index.ts)
+   │     dispatch: getAgentByName(env.ThinkAgent, session) → setContext → start()
+   │     getSubmissionStatus: read one durable submission's state over private RPC
    │     start() ONLY submits the durable turn — returns in ~1s
    │     failed-run continuation refreshes GitHub auth through gh-app's private
    │     AgentThinkTokenBroker binding before submitting into the same session

--- a/agent-think/src/agent.ts
+++ b/agent-think/src/agent.ts
@@ -21,6 +21,7 @@ import type {
   ChatRecoveryOptions,
   ChatResponseResult,
   Session,
+  ThinkSubmissionStatus,
   ToolCallResultContext,
   TurnContext,
   WorkspaceLike as ThinkWorkspaceLike
@@ -55,6 +56,19 @@ const RESET_ABORT_DELAY_MS = 100;
 export interface RunContext extends RunTarget {
   /** Short-lived GitHub App installation token. */
   installationToken: string;
+}
+
+/** Durable state for one Think submission, safe to return across RPC. */
+export interface AgentThinkSubmissionStatus {
+  /**
+   * Persisted submission state, not a liveness signal. `running` may remain
+   * while durable recovery is pending; callers must wait for a terminal state.
+   */
+  status: ThinkSubmissionStatus;
+  error?: string;
+  createdAt: number;
+  startedAt?: number;
+  completedAt?: number;
 }
 
 /**
@@ -224,6 +238,29 @@ export class ThinkAgent extends ThinkBase {
   /** Test/diagnostic proof of the stable Think-session → Workspace mapping. */
   async debugWorkspaceIdentity(): Promise<{ id: string }> {
     return this.#workspaceAgent.debugIdentity();
+  }
+
+  /**
+   * Returns null when no durable record exists. This includes unknown ids and
+   * submissions removed by a session reset; null never means pending.
+   */
+  async getSubmissionStatus(
+    submissionId: string
+  ): Promise<AgentThinkSubmissionStatus | null> {
+    const submission = await this.inspectSubmission(submissionId);
+    if (!submission) return null;
+
+    return {
+      status: submission.status,
+      createdAt: submission.createdAt,
+      ...(submission.error === undefined ? {} : { error: submission.error }),
+      ...(submission.startedAt === undefined
+        ? {}
+        : { startedAt: submission.startedAt }),
+      ...(submission.completedAt === undefined
+        ? {}
+        : { completedAt: submission.completedAt })
+    };
   }
 
   async refreshInstallationToken(installationToken: string): Promise<void> {

--- a/agent-think/src/index.ts
+++ b/agent-think/src/index.ts
@@ -24,7 +24,11 @@
  */
 
 import { getAgentByName, routeAgentRequest } from "agents";
-import { type AgentThinkEnv, ThinkAgent } from "./agent";
+import {
+  type AgentThinkEnv,
+  type AgentThinkSubmissionStatus,
+  ThinkAgent
+} from "./agent";
 import {
   WorkspaceAgent,
   WorkspaceProxy,
@@ -91,6 +95,13 @@ export interface DispatchResult {
   submissionId: string;
 }
 
+export interface SubmissionStatusInput {
+  session: string;
+  submissionId: string;
+}
+
+export type { AgentThinkSubmissionStatus } from "./agent";
+
 import { WorkerEntrypoint } from "cloudflare:workers";
 
 export class AgentThink extends WorkerEntrypoint<AgentThinkEnv> {
@@ -102,6 +113,20 @@ export class AgentThink extends WorkerEntrypoint<AgentThinkEnv> {
    */
   async dispatch(input: DispatchInput): Promise<DispatchResult> {
     return runDispatch(this.env, input);
+  }
+
+  /**
+   * Read the durable state of one submission. A continuation creates a new
+   * submission id and does not change the original submission's result.
+   */
+  async getSubmissionStatus(
+    input: SubmissionStatusInput
+  ): Promise<AgentThinkSubmissionStatus | null> {
+    const agent = await getAgentByName<AgentThinkEnv, ThinkAgent>(
+      this.env.ThinkAgent,
+      input.session
+    );
+    return agent.getSubmissionStatus(input.submissionId);
   }
 
   /**

--- a/agent-think/test/submission-status.test.ts
+++ b/agent-think/test/submission-status.test.ts
@@ -1,0 +1,153 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import type { ThinkSubmissionStatus } from "@cloudflare/think";
+import { getAgentByName } from "agents";
+import { describe, expect, it } from "vitest";
+import { AgentThink, type ThinkAgent } from "../src/index";
+
+async function createSubmission(
+  agent: Awaited<ReturnType<typeof getAgentByName<Env, ThinkAgent>>>,
+  input: {
+    submissionId: string;
+    status: ThinkSubmissionStatus;
+    error?: string;
+    createdAt: number;
+    startedAt?: number;
+    completedAt?: number;
+  }
+): Promise<void> {
+  await runInDurableObject(agent, async (instance, state) => {
+    await instance.listSubmissions();
+    state.storage.sql.exec(
+      `INSERT INTO cf_think_submissions
+        (submission_id, idempotency_key, request_id, stream_id, status,
+         messages_json, metadata_json, error_message, created_at, started_at, completed_at)
+       VALUES (?, ?, ?, ?, ?, '[]', ?, ?, ?, ?, ?)`,
+      input.submissionId,
+      `key-${input.submissionId}`,
+      `request-${input.submissionId}`,
+      `stream-${input.submissionId}`,
+      input.status,
+      JSON.stringify({ instruction: "private workflow instruction" }),
+      input.error ?? null,
+      input.createdAt,
+      input.startedAt ?? null,
+      input.completedAt ?? null
+    );
+  });
+}
+
+describe("AgentThink submission status", () => {
+  it("returns the durable submission status without its internal metadata", async () => {
+    const agent = await getAgentByName<Env, ThinkAgent>(
+      env.ThinkAgent,
+      `run-status-${crypto.randomUUID()}`
+    );
+    const submissionId = crypto.randomUUID();
+
+    await createSubmission(agent, {
+      submissionId,
+      status: "completed",
+      createdAt: 100,
+      startedAt: 200,
+      completedAt: 300
+    });
+
+    await expect(
+      agent.getSubmissionStatus(submissionId)
+    ).resolves.toStrictEqual({
+      status: "completed",
+      createdAt: 100,
+      startedAt: 200,
+      completedAt: 300
+    });
+  });
+
+  it("returns non-terminal state without terminal fields", async () => {
+    const agent = await getAgentByName<Env, ThinkAgent>(
+      env.ThinkAgent,
+      `submission-pending-${crypto.randomUUID()}`
+    );
+    const submissionId = crypto.randomUUID();
+
+    await createSubmission(agent, {
+      submissionId,
+      status: "pending",
+      createdAt: 100
+    });
+
+    await expect(
+      agent.getSubmissionStatus(submissionId)
+    ).resolves.toStrictEqual({
+      status: "pending",
+      createdAt: 100
+    });
+  });
+
+  it("returns the durable error details", async () => {
+    const agent = await getAgentByName<Env, ThinkAgent>(
+      env.ThinkAgent,
+      `run-status-error-${crypto.randomUUID()}`
+    );
+    const submissionId = crypto.randomUUID();
+
+    await createSubmission(agent, {
+      submissionId,
+      status: "error",
+      error: "The model request failed.",
+      createdAt: 100,
+      startedAt: 200,
+      completedAt: 300
+    });
+
+    await expect(
+      agent.getSubmissionStatus(submissionId)
+    ).resolves.toStrictEqual({
+      status: "error",
+      error: "The model request failed.",
+      createdAt: 100,
+      startedAt: 200,
+      completedAt: 300
+    });
+  });
+
+  it("resolves the session through the WorkerEntrypoint", async () => {
+    const session = `submission-entrypoint-${crypto.randomUUID()}`;
+    const agent = await getAgentByName<Env, ThinkAgent>(
+      env.ThinkAgent,
+      session
+    );
+    const submissionId = crypto.randomUUID();
+    await createSubmission(agent, {
+      submissionId,
+      status: "running",
+      createdAt: 100,
+      startedAt: 200
+    });
+    const context = {
+      passThroughOnException() {},
+      waitUntil() {},
+      props: {}
+    } as unknown as ExecutionContext;
+    const entrypoint = new AgentThink(context, env);
+
+    await expect(
+      entrypoint.getSubmissionStatus({ session, submissionId })
+    ).resolves.toStrictEqual({
+      status: "running",
+      createdAt: 100,
+      startedAt: 200
+    });
+  });
+
+  it("returns null for an unknown submission", async () => {
+    const agent = await getAgentByName<Env, ThinkAgent>(
+      env.ThinkAgent,
+      `submission-missing-${crypto.randomUUID()}`
+    );
+
+    await expect(
+      agent.getSubmissionStatus(crypto.randomUUID())
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- expose authoritative Think submission status through the private `AgentThink` RPC entrypoint
- return only status, error, and lifecycle timestamps
- document status semantics and cover pending, running, completed, error, missing, and entrypoint resolution

## Why

The command center is a best-effort observer. Callers that track AgentThink work need to read the durable submission record instead.
