### PR TITLE
feat(think): integrate channel host

### DIFF
--- a/.changeset/durable-think-channels.md
+++ b/.changeset/durable-think-channels.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": minor
+---
+
+Let Think supply its Durable Object storage and retry scheduler to a Channel Host, mount Channel ingress internally, persistently switch the approval route, and resolve responses arriving through any Channel against the existing durable Actions HITL ledger.

--- a/docs/think/actions.md
+++ b/docs/think/actions.md
@@ -185,6 +185,38 @@ Both approval-gated and durable-pause parts carry a stable
 permissions, risk, kind }`) so your UI has everything it needs to render the
 prompt.
 
+Configure a Channel Host to project a structured summary of the approval onto
+an out-of-band surface after the durable-pause Action and its paused assistant
+output are persisted:
+
+```typescript
+import { telegram } from "@cloudflare/channels";
+
+override configureChannelHost() {
+  return {
+    channels: {
+      telegram: telegram({
+        botToken: this.env.TELEGRAM_BOT_TOKEN,
+        chatId: this.env.TELEGRAM_CHAT_ID,
+        webhook: { secretToken: this.env.TELEGRAM_WEBHOOK_SECRET_TOKEN }
+      })
+    },
+    approvalRequests: "telegram"
+  };
+}
+```
+
+Think initializes `channelHost` with its Durable Object storage and retry
+scheduler, mounts HTTP ingress internally, and resolves normalized Channel
+responses through the same `approveExecution()` / `rejectExecution()` path used
+by browser approval controls. Delivery intent, provider-reference correlation,
+and replay receipts survive isolate recreation. Call
+`await setApprovalRequestsChannel(channelId)` to persistently switch the route
+at runtime. Passing `undefined` clears the durable override; after the next
+restart, Think uses the declarative default again.
+Override `onActionApprovalRequest()` only for additional observation or custom
+side effects; hook failure leaves the authoritative pending approval intact.
+
 ## Authorization
 
 Declare the permissions an action requires with `permissions`, then grant them
@@ -279,16 +311,20 @@ into a channel notice.
 
 ### Hooks and methods on the agent
 
-| Member                                  | Description                                                                        |
-| --------------------------------------- | ---------------------------------------------------------------------------------- |
-| `getActions()`                          | Return the action descriptors to compile into tools.                               |
-| `authorizeTurn(ctx)`                    | Decide granted permissions once per turn. Defaults to full grant.                  |
-| `authorizeAction(ctx)`                  | Decide authorization per action call. Defaults to checking `authorizeTurn` grants. |
-| `pendingApprovals(executionId?)`        | List parked actions and paused Codemode executions awaiting approval.              |
-| `approveExecution(executionId)`         | Approve a parked execution; runs `execute` and auto-continues the turn.            |
-| `rejectExecution(executionId, reason?)` | Reject a parked execution without running it.                                      |
-| `replyAttachments(requestId?)`          | Read the advisory attachments recorded during a turn.                              |
-| `actionLedgerPendingRetryLeaseMs`       | Stale-pending reclaim window (default `300000`; `false` to disable).               |
+| Member                                   | Description                                                                         |
+| ---------------------------------------- | ----------------------------------------------------------------------------------- |
+| `getActions()`                           | Return the action descriptors to compile into tools.                                |
+| `authorizeTurn(ctx)`                     | Decide granted permissions once per turn. Defaults to full grant.                   |
+| `authorizeAction(ctx)`                   | Decide authorization per action call. Defaults to checking `authorizeTurn` grants.  |
+| `configureChannelHost()`                 | Register hosted Channels, ingress, durable routes, and Host approval-link settings. |
+| `setApprovalRequestsChannel(channelId?)` | Persistently select a Channel, or clear the current route and persisted override.   |
+| `onChannelMessage(event)`                | Observe an ordinary normalized message accepted through Host ingress.               |
+| `onActionApprovalRequest(approval)`      | Observe a durable-pause Action after its Host notification is attempted.            |
+| `pendingApprovals(executionId?)`         | List parked actions and paused Codemode executions awaiting approval.               |
+| `approveExecution(executionId)`          | Approve a parked execution; runs `execute` and auto-continues the turn.             |
+| `rejectExecution(executionId, reason?)`  | Reject a parked execution without running it.                                       |
+| `replyAttachments(requestId?)`           | Read the advisory attachments recorded during a turn.                               |
+| `actionLedgerPendingRetryLeaseMs`        | Stale-pending reclaim window (default `300000`; `false` to disable).                |
 
 ## Related
 

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.0",
     "@ai-sdk/openai": "^4.0.0",
+    "@cloudflare/channels": "workspace:*",
     "@cloudflare/codemode": ">=0.5.0",
     "@cloudflare/shell": ">=0.4.0",
     "chat": "^4.31.0",
@@ -48,7 +49,7 @@
   "peerDependencies": {
     "@ai-sdk/react": "^3.0.0 || ^4.0.0",
     "@chat-adapter/telegram": "^4.29.0",
-    "agents": ">=0.20.2 <1.0.0",
+    "agents": ">=0.21.0 <1.0.0",
     "ai": "^6.0.0 || ^7.0.0",
     "react": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/think/src/tests/actions-durable-pause.test.ts
+++ b/packages/think/src/tests/actions-durable-pause.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
+import { evictDurableObject } from "cloudflare:test";
 import { getAgentByName } from "agents";
 import type { UIMessage } from "ai";
 import { z } from "zod";
@@ -65,6 +66,205 @@ describe("durable-pause actions", () => {
     expect(descriptor.risk).toBe("high");
     expect(descriptor.permissions).toEqual(["pause:run"]);
     expect(descriptor.input).toEqual({ message: "hi" });
+  });
+
+  it("notifies after the approval is durably visible", async () => {
+    const agent = await freshPauseAgent(`dp-hook-${crypto.randomUUID()}`);
+    await agent.useDurablePauseActionForTest();
+    await agent.configureActionApprovalRequestHookForTest("capture");
+
+    await agent.testChat("call pauseAction");
+    const pending = await agent.listActionPendingForTest();
+    const log = JSON.parse(
+      await agent.actionApprovalRequestLogForTest()
+    ) as Array<{
+      approval: {
+        executionId: string;
+        source: string;
+        descriptor: Record<string, unknown>;
+      };
+      visibleWhenCalled: boolean;
+    }>;
+
+    expect(log).toHaveLength(1);
+    expect(log[0].visibleWhenCalled).toBe(true);
+    expect(log[0].approval.executionId).toBe(pending[0].execution_id);
+    expect(log[0].approval.source).toBe("action");
+    expect(log[0].approval.descriptor).toMatchObject({
+      action: "pauseAction",
+      input: { message: "hello" },
+      kind: "durable-pause"
+    });
+  });
+
+  it("routes the persisted approval through its ChannelHost", async () => {
+    const agent = await freshPauseAgent(`dp-channel-${crypto.randomUUID()}`);
+    await agent.useDurablePauseActionForTest();
+    await agent.setApprovalRequestsChannelForTest("approvalTest");
+
+    await agent.testChat("call pauseAction");
+
+    const requests = JSON.parse(
+      await agent.channelApprovalRequestLogForTest()
+    ) as Array<{
+      channelId: string;
+      interactionId: string;
+      request: { title?: string; summary: string; input: unknown };
+    }>;
+    const pending = await agent.listActionPendingForTest();
+    expect(requests).toEqual([
+      {
+        channelId: "approvalTest",
+        interactionId: pending[0].execution_id,
+        request: {
+          title: "Approval required",
+          summary: "Approve pause action",
+          input: { message: "hello" }
+        }
+      }
+    ]);
+  });
+
+  it("uses the latest dynamically selected approval Channel", async () => {
+    const agent = await freshPauseAgent(
+      `dp-channel-switch-${crypto.randomUUID()}`
+    );
+    await agent.useDurablePauseActionForTest();
+    await agent.setApprovalRequestsChannelForTest("approvalTest");
+    await agent.setApprovalRequestsChannelForTest("approvalTestSecondary");
+
+    await agent.testChat("call pauseAction");
+
+    const requests = JSON.parse(
+      await agent.channelApprovalRequestLogForTest()
+    ) as Array<{ channelId: string }>;
+    expect(requests).toHaveLength(1);
+    expect(requests[0].channelId).toBe("approvalTestSecondary");
+  });
+
+  it("restores a dynamically selected approval Channel after isolate recreation", async () => {
+    const name = `dp-channel-route-recreate-${crypto.randomUUID()}`;
+    let agent = await freshPauseAgent(name);
+    await agent.setApprovalRequestsChannelForTest("approvalTestSecondary");
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+    agent = await freshPauseAgent(name);
+
+    await expect(
+      agent.requestChannelApprovalForTest("after-recreation")
+    ).resolves.toBe(true);
+    const requests = JSON.parse(
+      await agent.channelApprovalRequestLogForTest()
+    ) as Array<{ channelId: string; interactionId: string }>;
+    expect(requests).toEqual([
+      {
+        channelId: "approvalTestSecondary",
+        interactionId: "after-recreation",
+        request: { summary: "Test approval", input: {} }
+      }
+    ]);
+  });
+
+  it("resolves Channel ingress through the existing approval ledger", async () => {
+    const agent = await freshPauseAgent(
+      `dp-channel-response-${crypto.randomUUID()}`
+    );
+    await agent.useDurablePauseActionForTest();
+    await agent.setApprovalRequestsChannelForTest("approvalTest");
+
+    await agent.testChat("call pauseAction");
+    const pending = await agent.listActionPendingForTest();
+    const executionId = pending[0].execution_id;
+
+    await expect(
+      agent.respondToChannelApprovalForTest(executionId, "approve")
+    ).resolves.toBe(200);
+    expect(await agent.listActionPendingForTest()).toHaveLength(0);
+    expect(await agent.getDurablePauseExecCount()).toBe(1);
+  });
+
+  it("composes Telegram rendering and ingress with the Think approval ledger", async () => {
+    const agent = await freshPauseAgent(
+      `dp-channel-telegram-${crypto.randomUUID()}`
+    );
+    await agent.useDurablePauseActionForTest();
+    await agent.setApprovalRequestsChannelForTest("telegramIntegration");
+
+    await agent.testChat("call pauseAction");
+
+    await expect(
+      agent.respondToTelegramApprovalForTest("approve")
+    ).resolves.toBe(200);
+    expect(await agent.listActionPendingForTest()).toHaveLength(0);
+    expect(await agent.getDurablePauseExecCount()).toBe(1);
+  });
+
+  it("resolves provider-recovered Channel ingress after isolate recreation", async () => {
+    const name = `dp-channel-recreate-${crypto.randomUUID()}`;
+    let agent = await freshPauseAgent(name);
+    await agent.useDurablePauseActionForTest();
+    await agent.setApprovalRequestsChannelForTest("approvalTest");
+
+    await agent.testChat("call pauseAction");
+    const pending = await agent.listActionPendingForTest();
+    const executionId = pending[0].execution_id;
+
+    await evictDurableObject(agent as unknown as DurableObjectStub);
+    agent = await freshPauseAgent(name);
+
+    await expect(
+      agent.respondToChannelApprovalForTest(executionId, "reject")
+    ).resolves.toBe(200);
+    expect(await agent.listActionPendingForTest()).toHaveLength(0);
+    expect(await agent.getDurablePauseExecCount()).toBe(0);
+  });
+
+  it("keeps the approval pending when notification fails", async () => {
+    const agent = await freshPauseAgent(`dp-hook-fail-${crypto.randomUUID()}`);
+    await agent.useDurablePauseActionForTest();
+    await agent.configureActionApprovalRequestHookForTest("throw");
+
+    await agent.testChat("call pauseAction");
+
+    expect(await agent.listActionPendingForTest()).toHaveLength(1);
+  });
+
+  it("can resolve immediately without leaving a stale paused transcript part", async () => {
+    const agent = await freshPauseAgent(
+      `dp-hook-reject-${crypto.randomUUID()}`
+    );
+    await agent.useDurablePauseActionForTest();
+    await agent.configureActionApprovalRequestHookForTest("reject");
+
+    await agent.testChat("call pauseAction");
+
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    const pausePart = messages
+      .flatMap((message) => message.parts)
+      .find(
+        (part) =>
+          "toolCallId" in part &&
+          (part as Record<string, unknown>).toolCallId === "dp1"
+      ) as Record<string, unknown> | undefined;
+    expect(pausePart?.output).toMatchObject({
+      status: "rejected",
+      reason: "Rejected immediately by approval hook"
+    });
+    expect(await agent.listActionPendingForTest()).toHaveLength(0);
+  });
+
+  it("does not notify when a durable-pause predicate runs inline", async () => {
+    const agent = await freshPauseAgent(
+      `dp-hook-inline-${crypto.randomUUID()}`
+    );
+    await agent.useDurablePauseActionForTest({ approval: "predicate-hello" });
+    await agent.configureActionApprovalRequestHookForTest("capture");
+
+    await agent.parkDurablePauseForTest("other");
+
+    expect(JSON.parse(await agent.actionApprovalRequestLogForTest())).toEqual(
+      []
+    );
   });
 
   it("runs the action exactly once on approve and clears the pending row", async () => {

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -41,6 +41,7 @@ import type {
   Action,
   ActionAuthorizationContext,
   ActionAuthorizationDecision,
+  PendingApproval,
   StepContext,
   ChunkContext
 } from "../../think";
@@ -51,6 +52,11 @@ import {
 } from "agents/chat";
 import type { ClientToolSchema } from "agents/chat";
 import type { Schedule } from "agents";
+import {
+  telegram,
+  type Channel,
+  type ChannelApprovalRequestOptions
+} from "@cloudflare/channels";
 import { Session } from "agents/experimental/memory/session";
 import { z } from "zod";
 
@@ -3801,9 +3807,117 @@ export class ThinkToolsTestAgent extends Think {
     previousToolResultCount: number;
   }> = [];
   private _responseLog: ChatResponseResult[] = [];
+  private _channelApprovalRequests: Array<
+    ChannelApprovalRequestOptions & { channelId: string }
+  > = [];
+  private _telegramApprovalTexts: string[] = [];
+  private _captureActionApprovalRequests = false;
+  private _actionApprovalRequestThrows = false;
+  private _actionApprovalRequestRejects = false;
+  private _actionApprovalRequestLog: Array<{
+    approval: PendingApproval;
+    visibleWhenCalled: boolean;
+  }> = [];
+
+  override configureChannelHost() {
+    const channel = (channelId: string): Channel => ({
+      deliver: async () => ({
+        status: "failed",
+        retryable: false,
+        error: { code: "NOT_USED", message: "Not used by this test Channel" }
+      }),
+      requestApproval: async ({
+        delivery: _delivery,
+        getApprovalLinks: _links,
+        ...request
+      }) => {
+        this._channelApprovalRequests.push({ channelId, ...request });
+        return {
+          status: "delivered",
+          reference: `test-${request.interactionId}`
+        };
+      }
+    });
+    const approvalTest: Channel = {
+      ...channel("approvalTest"),
+      ingress: {
+        path: "/webhooks/test-approval",
+        receive: async (request) => {
+          const payload = (await request.json()) as {
+            interactionId?: unknown;
+            decision?: unknown;
+            reference?: unknown;
+          };
+          if (
+            typeof payload.interactionId !== "string" ||
+            (payload.decision !== "approve" && payload.decision !== "reject") ||
+            typeof payload.reference !== "string"
+          ) {
+            return {
+              events: [],
+              response: new Response(null, { status: 400 })
+            };
+          }
+          return {
+            events: [
+              {
+                type: "approval-response" as const,
+                interactionId: payload.interactionId,
+                decision: payload.decision,
+                reference: payload.reference
+              }
+            ],
+            response: new Response(null, { status: 200 })
+          };
+        }
+      }
+    };
+    const telegramIntegration = telegram({
+      botToken: "test-token",
+      chatId: "123456",
+      webhook: {
+        secretToken: "test-webhook-secret",
+        path: "/webhooks/test-telegram"
+      },
+      fetch: async (_input, init) => {
+        const payload = JSON.parse(String(init?.body)) as { text?: unknown };
+        if (typeof payload.text === "string") {
+          this._telegramApprovalTexts.push(payload.text);
+        }
+        return Response.json({ ok: true, result: { message_id: 42 } });
+      }
+    });
+    return {
+      channels: {
+        approvalTest,
+        approvalTestSecondary: channel("approvalTestSecondary"),
+        telegramIntegration
+      }
+    };
+  }
 
   override onChatResponse(result: ChatResponseResult): void {
     this._responseLog.push(result);
+  }
+
+  override async onActionApprovalRequest(
+    approval: PendingApproval
+  ): Promise<void> {
+    if (!this._captureActionApprovalRequests) return;
+    const visible = await this.pendingApprovals(approval.executionId);
+    this._actionApprovalRequestLog.push({
+      approval,
+      visibleWhenCalled: visible.length === 1
+    });
+    if (this._actionApprovalRequestRejects) {
+      await this.rejectExecution(
+        approval.executionId,
+        "Rejected immediately by approval hook"
+      );
+    }
+    if (this._actionApprovalRequestThrows) {
+      throw new Error("approval notification failed");
+    }
   }
 
   override beforeStep(ctx: PrepareStepContext): StepConfig | void {
@@ -4402,6 +4516,80 @@ export class ThinkToolsTestAgent extends Think {
   }
 
   // ── Durable-pause action test helpers ───────────────────────────
+
+  async setApprovalRequestsChannelForTest(channelId?: string): Promise<void> {
+    await this.setApprovalRequestsChannel(channelId);
+  }
+
+  async channelApprovalRequestLogForTest(): Promise<string> {
+    return JSON.stringify(this._channelApprovalRequests);
+  }
+
+  async requestChannelApprovalForTest(interactionId: string): Promise<boolean> {
+    const delivery = await this.channelHost.requestApproval({
+      interactionId,
+      request: { summary: "Test approval", input: {} }
+    });
+    return delivery !== undefined;
+  }
+
+  async respondToChannelApprovalForTest(
+    interactionId: string,
+    decision: "approve" | "reject"
+  ): Promise<number> {
+    const response = await this.onRequest(
+      new Request("https://example.com/webhooks/test-approval", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          interactionId,
+          decision,
+          reference: crypto.randomUUID()
+        })
+      })
+    );
+    return response.status;
+  }
+
+  async respondToTelegramApprovalForTest(
+    decision: "approve" | "reject"
+  ): Promise<number> {
+    const replyText = this._telegramApprovalTexts.at(-1);
+    if (!replyText) throw new Error("No Telegram approval was delivered");
+    const response = await this.onRequest(
+      new Request("https://example.com/webhooks/test-telegram", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "test-webhook-secret"
+        },
+        body: JSON.stringify({
+          update_id: 1,
+          message: {
+            message_id: 43,
+            text: decision === "approve" ? "YES" : "NO",
+            chat: { id: 123456 },
+            from: { id: 123456 },
+            reply_to_message: { message_id: 42, text: replyText }
+          }
+        })
+      })
+    );
+    return response.status;
+  }
+
+  async configureActionApprovalRequestHookForTest(
+    mode: "capture" | "throw" | "reject" | "off"
+  ): Promise<void> {
+    this._captureActionApprovalRequests = mode !== "off";
+    this._actionApprovalRequestThrows = mode === "throw";
+    this._actionApprovalRequestRejects = mode === "reject";
+    this._actionApprovalRequestLog.length = 0;
+  }
+
+  async actionApprovalRequestLogForTest(): Promise<string> {
+    return JSON.stringify(this._actionApprovalRequestLog);
+  }
 
   async useDurablePauseActionForTest(options?: {
     approval?: boolean | "predicate-hello";

--- a/packages/think/src/tests/channel-tool-integration.test.ts
+++ b/packages/think/src/tests/channel-tool-integration.test.ts
@@ -1,0 +1,38 @@
+import type { Channel, DeliveryResult } from "@cloudflare/channels";
+import { createChannelTool } from "@cloudflare/channels/ai-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { Think } from "../think";
+
+const deliver = vi.fn(
+  async (): Promise<DeliveryResult> => ({
+    status: "delivered",
+    reference: "delivery-1"
+  })
+);
+const escalationChannel: Channel = { deliver };
+
+class ChannelEnabledThink extends Think {
+  override getTools() {
+    return {
+      escalate: createChannelTool(escalationChannel, {
+        description: "Escalate the current situation to a human"
+      })
+    };
+  }
+}
+
+describe("experimental channel tools", () => {
+  it("can be returned directly from a Think agent's getTools()", async () => {
+    const tools = ChannelEnabledThink.prototype.getTools();
+    const execute = tools.escalate.execute as unknown as (input: {
+      markdown: string;
+      title?: string;
+    }) => Promise<DeliveryResult>;
+
+    await expect(execute({ markdown: "Please investigate" })).resolves.toEqual({
+      status: "delivered",
+      reference: "delivery-1"
+    });
+    expect(deliver).toHaveBeenCalledWith({ markdown: "Please investigate" });
+  });
+});

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -244,6 +244,13 @@ import type {
   ChatFiberSnapshot,
   OrphanPersistStore
 } from "agents/chat";
+import {
+  ChannelApprovalConflictError,
+  ChannelHost,
+  type Channel,
+  type ChannelInboundMessage
+} from "@cloudflare/channels";
+import type { AgentEmail } from "agents/email";
 import { Session } from "agents/experimental/memory/session";
 import type { SessionMessage } from "agents/experimental/memory/session";
 import { truncateOlderMessages } from "agents/experimental/memory/utils";
@@ -1399,6 +1406,20 @@ export interface PendingApproval {
   descriptor: ActionApprovalDescriptor;
 }
 
+/** Channels and initial routing used to construct this Think Agent's Host. */
+export type ThinkChannelMessageEvent = {
+  channelId: string;
+  message: ChannelInboundMessage;
+};
+
+export type ThinkChannelHostConfig = {
+  channels: Record<string, Channel>;
+  approvalRequests?: string;
+  delivery?: string;
+  publicBaseUrl?: string;
+  approvalLinkPath?: string;
+};
+
 export interface ActionConfig<
   InputSchema extends FlexibleSchema = FlexibleSchema,
   Output = unknown
@@ -1936,6 +1957,18 @@ const THINK_FINAL_ANSWER_TOOL_NAME = "think_final_answer";
  * structured-output final-answer tool. Used to strip the internal tool's parts
  * from persisted assistant messages regardless of which per-turn name was used.
  */
+function approvalWasAlreadyResolved(result: unknown): boolean {
+  return (
+    result !== null &&
+    typeof result === "object" &&
+    "status" in result &&
+    result.status === "error" &&
+    "error" in result &&
+    typeof result.error === "string" &&
+    result.error.includes("no longer pending")
+  );
+}
+
 function isThinkFinalAnswerToolName(name: string): boolean {
   return (
     name === THINK_FINAL_ANSWER_TOOL_NAME ||
@@ -2838,6 +2871,9 @@ export class Think<
 
   private _messengerRuntime?: ThinkMessengerRuntime;
 
+  /** Central runtime for typed Channel delivery and ingress. */
+  channelHost!: ChannelHost;
+
   /** Resolved channel registry (implicit web + configureChannels + messengers). */
   private _channels?: Map<string, NormalizedChannelDefinition>;
 
@@ -3024,6 +3060,7 @@ export class Think<
           this._resumableStream = new ResumableStream(this.sql.bind(this));
           this._restoreClientTools();
           this._restoreBody();
+          await this._initializeChannelHost();
           this._setupProtocolHandlers();
           await this._initializeChannels();
         }
@@ -4108,6 +4145,37 @@ export class Think<
     return {};
   }
 
+  /**
+   * Return the Channels owned by this Agent's Host and their initial approval
+   * route. Think initializes the Host before {@link onStart} and mounts all
+   * Channel ingress internally.
+   */
+  configureChannelHost():
+    | ThinkChannelHostConfig
+    | Promise<ThinkChannelHostConfig> {
+    return { channels: {} };
+  }
+
+  /**
+   * Persistently select the Channel used for subsequent approval requests.
+   * Passing `undefined` clears the current route and removes the persisted
+   * override, so the declarative default is used after the next restart.
+   */
+  async setApprovalRequestsChannel(channelId?: string): Promise<void> {
+    if (!this.channelHost) {
+      throw new Error("ChannelHost is not initialized yet");
+    }
+    await this.channelHost.setApprovalRequestsChannel(channelId);
+  }
+
+  /** Observe an ordinary normalized message received through Channel ingress. */
+  onChannelMessage(_event: ThinkChannelMessageEvent): void | Promise<void> {}
+
+  /** Route a Workers Email event through configured Channel Email ingress. */
+  async onEmail(email: AgentEmail): Promise<void> {
+    await this.channelHost.handleEmail(email);
+  }
+
   getMessengerContext(): MessengerContext | undefined {
     if (this._activeMessengerContext) {
       return this._activeMessengerContext;
@@ -4392,6 +4460,83 @@ export class Think<
       parts: [{ type: "text", text }],
       metadata: { deliveryKind: kind }
     };
+  }
+
+  private async _initializeChannelHost(): Promise<void> {
+    const configured = await this.configureChannelHost();
+    this.channelHost = new ChannelHost({
+      channels: configured.channels,
+      storage: this.ctx.storage,
+      approvalRequests: configured.approvalRequests,
+      delivery: configured.delivery,
+      publicBaseUrl: configured.publicBaseUrl,
+      approvalLinkPath: configured.approvalLinkPath,
+      scheduler: {
+        schedule: async (deliveryId, at) => {
+          await this.schedule(
+            new Date(at),
+            "_handleChannelAlarm",
+            { deliveryId, at },
+            { idempotent: true }
+          );
+        }
+      },
+      onMessage: (event) => this.onChannelMessage(event),
+      onApprovalResponse: async ({ interactionId, decision, channelId }) => {
+        const result =
+          decision === "approve"
+            ? await this.approveExecution(interactionId)
+            : await this.rejectExecution(
+                interactionId,
+                `Rejected through ${channelId}`
+              );
+        if (approvalWasAlreadyResolved(result)) {
+          throw new ChannelApprovalConflictError(
+            `Interaction "${interactionId}" is already settled`
+          );
+        }
+      }
+    });
+    await this.channelHost.init();
+    await this._reconcileChannelApprovalRequests();
+  }
+
+  private async _reconcileChannelApprovalRequests(): Promise<void> {
+    const persisted = new Set<string>();
+    for (const message of this.messages) {
+      for (const part of message.parts) {
+        if (!("output" in part)) continue;
+        const output = part.output;
+        if (output === null || typeof output !== "object") continue;
+        const executionId = (output as { executionId?: unknown }).executionId;
+        if (typeof executionId === "string") persisted.add(executionId);
+      }
+    }
+
+    for (const row of this._listActionPendingRows()) {
+      if (!persisted.has(row.execution_id) || !row.descriptor_json) continue;
+      let descriptor: ActionApprovalDescriptor;
+      try {
+        descriptor = JSON.parse(
+          row.descriptor_json
+        ) as ActionApprovalDescriptor;
+      } catch {
+        continue;
+      }
+      await this._requestChannelApproval({
+        executionId: row.execution_id,
+        source: "action",
+        descriptor
+      });
+    }
+  }
+
+  /** @internal Durable callback for ChannelHost retry schedules. */
+  async _handleChannelAlarm(_payload: {
+    deliveryId: string;
+    at: number;
+  }): Promise<void> {
+    await this.channelHost.handleAlarm();
   }
 
   private async _initializeChannels(): Promise<void> {
@@ -4699,6 +4844,10 @@ export class Think<
     ActionApprovalDescriptor
   >();
   private _activeTurnApprovedActionInputs = new Map<string, unknown>();
+  private _pendingActionApprovalNotifications = new Map<
+    string,
+    PendingApproval
+  >();
   private _activeActionLedgerExecutions = new Map<string, Promise<unknown>>();
   /**
    * Advisory reply attachments recorded by actions during the current admitted
@@ -4932,6 +5081,14 @@ export class Think<
   ): Partial<ActionApprovalDescriptor> | undefined {
     return undefined;
   }
+
+  /**
+   * Called after a durable-pause Action and its paused assistant output are
+   * persisted for human approval. Override this to notify an out-of-band
+   * approval surface. Notification
+   * failures are logged and leave the authoritative pending approval intact.
+   */
+  onActionApprovalRequest(_approval: PendingApproval): void | Promise<void> {}
 
   /**
    * Called before each AI SDK step in the agentic loop. Backed by
@@ -6592,6 +6749,11 @@ export class Think<
       type: "action:pause:created",
       payload: { action: toolName, executionId, toolCallId: ctx.toolCallId }
     });
+    this._pendingActionApprovalNotifications.set(executionId, {
+      executionId,
+      source: "action",
+      descriptor
+    });
     return {
       status: "paused",
       executionId,
@@ -6600,6 +6762,67 @@ export class Think<
         "This action is awaiting human approval. Stop and wait for the " +
         "approval result before proceeding."
     };
+  }
+
+  private async _requestChannelApproval(
+    approval: PendingApproval
+  ): Promise<void> {
+    try {
+      const delivery = await this.channelHost.requestApproval({
+        interactionId: approval.executionId,
+        request: {
+          title: "Approval required",
+          summary: approval.descriptor.summary,
+          input: approval.descriptor.input
+        }
+      });
+      if (delivery && delivery.result.status !== "delivered") {
+        console.error(
+          `[Think] Channel approval request was not delivered for "${approval.executionId}" through "${delivery.channelId}" (${delivery.result.status}):`,
+          delivery.result.error.message
+        );
+      }
+    } catch (error) {
+      console.error(
+        `[Think] Channel approval request failed for "${approval.executionId}":`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Notify only after the paused tool output is present in the persisted
+   * assistant message. This prevents a fast inbound decision from resolving
+   * the pending row before `_applyExecutionOutcome` can find its transcript
+   * part.
+   */
+  private async _notifyActionApprovalRequests(
+    message: UIMessage
+  ): Promise<void> {
+    const persisted = new Set<string>();
+    for (const part of message.parts) {
+      if (!("output" in part)) continue;
+      const output = part.output;
+      if (output === null || typeof output !== "object") continue;
+      const executionId = (output as { executionId?: unknown }).executionId;
+      if (typeof executionId === "string") persisted.add(executionId);
+    }
+
+    for (const executionId of persisted) {
+      const approval =
+        this._pendingActionApprovalNotifications.get(executionId);
+      if (!approval) continue;
+      this._pendingActionApprovalNotifications.delete(executionId);
+      await this._requestChannelApproval(approval);
+      try {
+        await this.onActionApprovalRequest(approval);
+      } catch (error) {
+        console.error(
+          `[Think] onActionApprovalRequest failed for "${executionId}":`,
+          error
+        );
+      }
+    }
   }
 
   /** Default hook timeout in milliseconds. */
@@ -11245,6 +11468,10 @@ export class Think<
       ) {
         return Response.json(this.messages);
       }
+      const channelResponse = await this.channelHost.handleRequest(request);
+      if (channelResponse) {
+        return channelResponse;
+      }
       const messengerResponse =
         await this._messengerRuntime?.handleRequest(request);
       if (messengerResponse) {
@@ -12928,6 +13155,7 @@ export class Think<
     const toPersist = this._strippedForPersist(msg);
     if (toPersist === null) return;
     await this._upsertMessageInHistory(toPersist, parentId);
+    await this._notifyActionApprovalRequests(toPersist);
   }
 
   /**
@@ -13270,6 +13498,12 @@ export class Think<
       };
     }
 
+    await this.channelHost.settleApproval(
+      executionId,
+      "approve",
+      "application"
+    );
+
     const action = await this._findRegisteredAction(row.action_name);
     if (!action) {
       const output = {
@@ -13455,6 +13689,7 @@ export class Think<
         error: `Execution "${executionId}" is no longer pending — it was approved or rejected elsewhere.`
       };
     }
+    await this.channelHost.settleApproval(executionId, "reject", "application");
     const output = {
       status: "rejected",
       executionId,
@@ -13484,6 +13719,7 @@ export class Think<
     executionId: string,
     output: unknown
   ): Promise<boolean> {
+    this._pendingActionApprovalNotifications.delete(executionId);
     const toolCallId = this._findPausedExecutionToolCall(executionId);
     if (!toolCallId) {
       // Already resolved in place (e.g. approved from another tab)? Then the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4136,6 +4136,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^4.0.0
         version: 4.0.9(zod@4.4.3)
+      '@cloudflare/channels':
+        specifier: workspace:*
+        version: link:../channels
       '@cloudflare/codemode':
         specifier: '>=0.5.0'
         version: link:../codemode


### PR DESCRIPTION
This draft PR integrates `ChannelHost` with Think’s durable Action approval ledger. It is stacked on the standalone Channels package branch and must remain unmerged until `@cloudflare/channels` has been published.

## Why

- Think Actions already persist pending approval state, but notifying and receiving decisions through external transports currently requires application-specific wiring.
- Channel delivery should not become a second source of truth for approval state. Think’s Action ledger remains authoritative, while `ChannelHost` owns transport delivery, ingress correlation, and settlement notifications.
- Think should own the Host lifecycle because it owns the Durable Object storage, request entrypoint, scheduler, and Action execution lifecycle.
- This integration is deliberately staged separately from the Channels package so the package can be reviewed and published before Think takes a runtime dependency on it.

## Public API Surface

| Symbol | Kind | Purpose |
| --- | --- | --- |
| `ThinkChannelHostConfig` | Type | Configures Channels, initial routes, public URL, and approval-link path |
| `ThinkChannelMessageEvent` | Type | Describes an ordinary normalized inbound Channel message |
| `channelHost` | `Think` property | Exposes the initialized Host owned by the Think Agent |
| `configureChannelHost()` | `Think` hook | Supplies Channels and initial routing before `onStart()` |
| `setApprovalRequestsChannel()` | `Think` method | Persistently switches or clears the approval-request route |
| `onChannelMessage()` | `Think` hook | Receives ordinary normalized inbound messages |
| `onEmail()` | `Think` method | Routes Workers Email events through configured Channel ingress |
| `onActionApprovalRequest()` | `Think` hook | Observes approval notification after paused Action output is persisted |

## Architectural Changes

```text
Think Action pauses
        |
        | durable approval request
        v
   ChannelHost
        |
        v
 configured Channel
        |
        | correlated response
        v
   ChannelHost
        |
        v
Think approveExecution() / rejectExecution()
        |
        v
authoritative Action ledger
```

- Think initializes the Host before `onStart()` and mounts its HTTP and Email ingress internally.
- Approval notifications are sent only after the paused assistant output has been persisted, preventing fast responses from racing transcript persistence.
- Startup reconciliation recreates missing approval notifications from durable pending Action rows.
- Decisions received through Channels call Think’s existing approval methods. Application-side decisions settle the corresponding Host interaction.
- Think adapts its existing scheduler to the Host rather than claiming the Durable Object alarm separately.
- First terminal settlement remains authoritative, and conflicting responses surface as approval conflicts.

## Code Changes

- Adds `@cloudflare/channels` as a Think runtime dependency.
- Initializes `ChannelHost` with Think’s Durable Object storage and scheduler.
- Routes HTTP and Workers Email ingress through the Host.
- Sends durable Action approval requests through the configured approval Channel.
- Reconciles pending Action approvals after recreation.
- Settles Host interactions when approvals or rejections happen through application APIs.
- Adds documentation for configuring Channels and switching approval routes.

## Compatibility

- The new Think hooks and methods are additive.
- `@cloudflare/think` now requires `agents >=0.21.0`.
- This PR must not merge until `@cloudflare/channels` has been published and the workspace dependency can resolve to the released package.
