### PR TITLE
fix(tracing): tracing capability check

### DIFF
--- a/.changeset/quiet-tracers-fallback.md
+++ b/.changeset/quiet-tracers-fallback.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Fall back to no-op tracing when an older Workers runtime exposes tracing without `startActiveSpan`, preventing Agent initialization from failing.

--- a/packages/agents/src/observability/tracing/cloudflare.ts
+++ b/packages/agents/src/observability/tracing/cloudflare.ts
@@ -14,10 +14,25 @@ const noopRuntime: SpanRuntime = {
   }
 };
 
-// Accessed via the namespace so runtimes that predate the `tracing` export
-// degrade to a no-op tracer instead of failing at module-link time — this
-// module loads with the main `agents` entry, not just for tracing users.
-const runtime: SpanRuntime =
-  (cloudflareWorkers as { tracing?: SpanRuntime }).tracing ?? noopRuntime;
+// Accessed via the namespace because this loads with the main `agents` entry.
+// Runtimes can omit `tracing` or expose it without `startActiveSpan`; both
+// degrade to no-op tracing instead of breaking Agent behavior.
+const runtime = resolveCloudflareSpanRuntime(
+  (cloudflareWorkers as { tracing?: unknown }).tracing
+);
+
+/** Selects native Cloudflare tracing or a no-op for unsupported runtimes. */
+export function resolveCloudflareSpanRuntime(runtime: unknown): SpanRuntime {
+  return isSpanRuntime(runtime) ? runtime : noopRuntime;
+}
+
+function isSpanRuntime(runtime: unknown): runtime is SpanRuntime {
+  return (
+    typeof runtime === "object" &&
+    runtime !== null &&
+    "startActiveSpan" in runtime &&
+    typeof runtime.startActiveSpan === "function"
+  );
+}
 
 export const tracer: AgentTracer = createTracer(runtime);

--- a/packages/agents/src/observability/tracing/cloudflare.ts
+++ b/packages/agents/src/observability/tracing/cloudflare.ts
@@ -23,16 +23,10 @@ const runtime = resolveCloudflareSpanRuntime(
 
 /** Selects native Cloudflare tracing or a no-op for unsupported runtimes. */
 export function resolveCloudflareSpanRuntime(runtime: unknown): SpanRuntime {
-  return isSpanRuntime(runtime) ? runtime : noopRuntime;
-}
-
-function isSpanRuntime(runtime: unknown): runtime is SpanRuntime {
-  return (
-    typeof runtime === "object" &&
-    runtime !== null &&
-    "startActiveSpan" in runtime &&
-    typeof runtime.startActiveSpan === "function"
-  );
+  const candidate = runtime as Partial<SpanRuntime> | null | undefined;
+  return typeof candidate?.startActiveSpan === "function"
+    ? (candidate as SpanRuntime)
+    : noopRuntime;
 }
 
 export const tracer: AgentTracer = createTracer(runtime);

--- a/packages/agents/src/tests/observability/cloudflare-tracer.test.ts
+++ b/packages/agents/src/tests/observability/cloudflare-tracer.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveCloudflareSpanRuntime } from "../../observability/tracing/cloudflare";
+import { createTracer } from "../../observability/tracing/tracer";
+import type { SpanRuntime } from "../../observability/tracing/tracer";
+
+describe("resolveCloudflareSpanRuntime", () => {
+  it("uses native tracing only when startActiveSpan is available", () => {
+    let nativeTracingUsed = false;
+    const nativeRuntime: SpanRuntime = {
+      startActiveSpan(_name, run) {
+        nativeTracingUsed = true;
+        return run({
+          isTraced: false,
+          setAttribute() {},
+          end() {}
+        });
+      }
+    };
+
+    createTracer(resolveCloudflareSpanRuntime(nativeRuntime)).withSpan(
+      "operation",
+      {},
+      () => undefined
+    );
+
+    expect(nativeTracingUsed).toBe(true);
+
+    const tracer = createTracer(
+      resolveCloudflareSpanRuntime({
+        enterSpan() {
+          throw new Error("enterSpan should not be adapted");
+        }
+      })
+    );
+
+    expect(tracer.withSpan("operation", {}, () => "application result")).toBe(
+      "application result"
+    );
+  });
+});

--- a/packages/agents/src/tests/observability/cloudflare-tracer.test.ts
+++ b/packages/agents/src/tests/observability/cloudflare-tracer.test.ts
@@ -1,29 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { resolveCloudflareSpanRuntime } from "../../observability/tracing/cloudflare";
 import { createTracer } from "../../observability/tracing/tracer";
-import type { SpanRuntime } from "../../observability/tracing/tracer";
 
 describe("resolveCloudflareSpanRuntime", () => {
   it("uses native tracing only when startActiveSpan is available", () => {
-    let nativeTracingUsed = false;
-    const nativeRuntime: SpanRuntime = {
-      startActiveSpan(_name, run) {
-        nativeTracingUsed = true;
-        return run({
-          isTraced: false,
-          setAttribute() {},
-          end() {}
-        });
-      }
-    };
-
-    createTracer(resolveCloudflareSpanRuntime(nativeRuntime)).withSpan(
-      "operation",
-      {},
-      () => undefined
-    );
-
-    expect(nativeTracingUsed).toBe(true);
+    const nativeRuntime = { startActiveSpan() {} };
+    expect(resolveCloudflareSpanRuntime(nativeRuntime)).toBe(nativeRuntime);
 
     const tracer = createTracer(
       resolveCloudflareSpanRuntime({


### PR DESCRIPTION
Fixes #2087 for agents on older `workerd` versions that had `tracing` defined but did not have a `startActiveSpan` function.

```text
   Old workerd                    → silently use a no-op tracer
     tracing is undefined

   Intermediate workerd           x throws an error
     tracing.enterSpan exists
     tracing.startActiveSpan does not exist

   Modern workerd                 → use native Cloudflare tracing already
     tracing.enterSpan exists
     tracing.startActiveSpan exists
 ```

This fix also handles the intermediate case where a partial tracing runtime exists.
