### PR TITLE
refactor(agents): extract internal WebSocket channel and propose lifecycle-composed channels

### DIFF
--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -99,8 +99,8 @@ Keep it concise. A few paragraphs is fine. These are records, not essays.
 | `rfc-coding-agent.md`                   | RFC        | `CodingAgent` — new `@cloudflare/coding-agent` package (extends AIChatAgent), CLI coding agents in Sandbox, pluggable engine (Cli/Harness), two-lifecycle durability (proposed) |
 | `test-coverage-matrix.md`               | design doc | Feature × test-layer coverage rollup, CI→layer mapping, skipped-test debt, nightly hygiene                                                                                      |
 | `mcp.md`                                | design doc | Stateless, Legacy compatibility, Legacy sessionful, client, package boundary, and conformance architecture                                                                      |
-| `agent-channels.md`                     | design doc | Internal browser WebSocket channel and the boundary between lifecycle, protocols, and future Agent channels                                                                     |
-| `rfc-agent-channels.md`                 | RFC        | Proposed Agent-owned channel registry, normalized message entry point, Worker gateways, and WebSocket ownership                                                                 |
+| `agent-channels.md`                     | design doc | Internal Agent browser WebSocket channel and the boundary between lifecycle, protocols, and future durable channels                                                             |
+| `rfc-agent-channels.md`                 | RFC        | Proposed Lifecycle-composed channel runtime, normalized message entry point, Worker routing, and WebSocket ownership                                                            |
 | `rfc-durable-object-lifecycle.md`       | RFC        | Constructor-composed Durable Object lifecycle with reusable components and always-hibernating WebSockets                                                                        |
 
 ## Relationship to `/docs`

--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -99,6 +99,8 @@ Keep it concise. A few paragraphs is fine. These are records, not essays.
 | `rfc-coding-agent.md`                   | RFC        | `CodingAgent` — new `@cloudflare/coding-agent` package (extends AIChatAgent), CLI coding agents in Sandbox, pluggable engine (Cli/Harness), two-lifecycle durability (proposed) |
 | `test-coverage-matrix.md`               | design doc | Feature × test-layer coverage rollup, CI→layer mapping, skipped-test debt, nightly hygiene                                                                                      |
 | `mcp.md`                                | design doc | Stateless, Legacy compatibility, Legacy sessionful, client, package boundary, and conformance architecture                                                                      |
+| `agent-channels.md`                     | design doc | Internal browser WebSocket channel and the boundary between lifecycle, protocols, and future Agent channels                                                                     |
+| `rfc-agent-channels.md`                 | RFC        | Proposed Agent-owned channel registry, normalized message entry point, Worker gateways, and WebSocket ownership                                                                 |
 | `rfc-durable-object-lifecycle.md`       | RFC        | Constructor-composed Durable Object lifecycle with reusable components and always-hibernating WebSockets                                                                        |
 
 ## Relationship to `/docs`

--- a/design/README.md
+++ b/design/README.md
@@ -18,6 +18,6 @@ The goal is to give contributors (and future-us) a quick way to understand _why_
 | [rfc-sub-agents.md](./rfc-sub-agents.md)                                         | RFC: Sub-agents — child DOs via facets, typed stubs, mixin API                |
 | [rfc-helper-sub-agent-orchestration.md](./rfc-helper-sub-agent-orchestration.md) | RFC: Agent tool orchestration — `runAgentTool`, `agentTool`, event forwarding |
 | [loopback.md](./loopback.md)                                                     | Loopback pattern — cross-boundary RPC for sub-agents and dynamic isolates     |
-| [agent-channels.md](./agent-channels.md)                                         | Internal browser channel and future Agent channel boundary                    |
-| [rfc-agent-channels.md](./rfc-agent-channels.md)                                 | RFC: Agent-owned channels and one normalized message entry point              |
+| [agent-channels.md](./agent-channels.md)                                         | Internal Agent browser channel and future durable channel boundary            |
+| [rfc-agent-channels.md](./rfc-agent-channels.md)                                 | RFC: Lifecycle-composed channels and one normalized message entry point       |
 | [test-coverage-matrix.md](./test-coverage-matrix.md)                             | Feature × test-layer coverage rollup, CI mapping, skipped-test debt, hygiene  |

--- a/design/README.md
+++ b/design/README.md
@@ -18,4 +18,6 @@ The goal is to give contributors (and future-us) a quick way to understand _why_
 | [rfc-sub-agents.md](./rfc-sub-agents.md)                                         | RFC: Sub-agents — child DOs via facets, typed stubs, mixin API                |
 | [rfc-helper-sub-agent-orchestration.md](./rfc-helper-sub-agent-orchestration.md) | RFC: Agent tool orchestration — `runAgentTool`, `agentTool`, event forwarding |
 | [loopback.md](./loopback.md)                                                     | Loopback pattern — cross-boundary RPC for sub-agents and dynamic isolates     |
+| [agent-channels.md](./agent-channels.md)                                         | Internal browser channel and future Agent channel boundary                    |
+| [rfc-agent-channels.md](./rfc-agent-channels.md)                                 | RFC: Agent-owned channels and one normalized message entry point              |
 | [test-coverage-matrix.md](./test-coverage-matrix.md)                             | Feature × test-layer coverage rollup, CI mapping, skipped-test debt, hygiene  |

--- a/design/agent-channels.md
+++ b/design/agent-channels.md
@@ -1,8 +1,8 @@
 # Agent channels
 
-Agent channels are the boundary between communication protocols and Agent
-application behavior. The public channel API is still proposed. The base Agents
-SDK now has one internal channel: the browser WebSocket channel.
+Channels are the boundary between communication protocols and durable
+application behavior. The public API is still proposed. The base Agents SDK now
+has one internal channel: the Agent browser WebSocket channel.
 
 ## Current implementation
 
@@ -77,8 +77,10 @@ owners.
 ## Proposed user model
 
 The proposed API is recorded in
-[`rfc-agent-channels.md`](./rfc-agent-channels.md). The intended direction is an
-Agent-owned registry and one transport-neutral application entry point:
+[`rfc-agent-channels.md`](./rfc-agent-channels.md). The intended foundation is a
+Lifecycle-composed runtime usable by any Durable Object. Agent provides a
+preconfigured browser protocol and one transport-neutral application entry
+point:
 
 ```ts
 export class SupportAgent extends Agent<Env> {
@@ -110,8 +112,8 @@ not a committed signature.
 
 ## Key decisions
 
-- The Agent owns its channel registry. Provider implementations may be separate
-  modules, but there is no second application host beside Agent.
+- The durable application owns its channel runtime as a Lifecycle capability.
+  Agent provides convenience over the same runtime rather than a separate host.
 - Raw connection callbacks belong to the WebSocket channel. They are retained on
   Agent only as compatibility hooks.
 - The lifecycle owns physical hibernating WebSockets. A channel never accepts a
@@ -120,7 +122,9 @@ not a committed signature.
   socket compose inside its protocol dispatcher.
 - `onRequest` remains a raw HTTP fallback. Lifecycle capabilities such as MCP
   may claim feature callback URLs before it, and request channels may normalize
-  selected requests into Agent messages.
+  selected requests into channel messages.
+- A configured set handles multiple shared provider webhooks. Each provider's
+  `route` callback returns the complete Durable Object target.
 
 ## Tradeoffs
 

--- a/design/agent-channels.md
+++ b/design/agent-channels.md
@@ -1,0 +1,142 @@
+# Agent channels
+
+Agent channels are the boundary between communication protocols and Agent
+application behavior. The public channel API is still proposed. The base Agents
+SDK now has one internal channel: the browser WebSocket channel.
+
+## Current implementation
+
+A browser connection still enters through the Durable Object lifecycle:
+
+```text
+routeAgentRequest
+-> Agent.fetch
+-> Lifecycle.fetch
+-> hibernating WebSocket acceptance
+-> Agent browser WebSocket channel
+```
+
+The internal browser channel owns the Agents WebSocket protocol:
+
+- connection setup and protocol suppression;
+- Agent identity delivery;
+- initial state delivery and later state broadcasts;
+- client state updates and readonly rejection;
+- callable RPC, including streaming responses;
+- MCP server announcements;
+- agent-tool replay on connect;
+- sub-agent WebSocket forwarding;
+- connect and disconnect observability;
+- forwarding unrecognized frames to the compatibility hook.
+
+The implementation lives in
+`packages/agents/src/internal/agent-websocket-channel.ts`. RPC parsing and
+streaming response mechanics live in `packages/agents/src/internal/rpc.ts`.
+Neither file is a package entry point. The extraction adds no channel API or
+import path.
+
+## Compatibility hooks
+
+`Agent.onConnect`, `Agent.onMessage(connection, frame)`, and `Agent.onClose`
+remain public for compatibility. The Agent constructor captures the subclass
+implementations, creates the internal browser channel, then installs channel
+methods as the lifecycle callbacks. Once the channel has handled its own
+protocol work, it invokes the captured callback.
+
+This preserves the existing wrapper order used by `AIChatAgent` and Think:
+
+```text
+Lifecycle WebSocket callback
+-> AIChatAgent or Think protocol wrapper
+-> base Agent browser channel
+-> user compatibility callback
+```
+
+A later public channel API can move these callbacks into
+`webSocketChannel({ onConnect, onMessage, onClose })`. That migration must not
+happen until the higher chat layers register their protocol behavior without
+rewriting Agent methods in their constructors.
+
+## Lifecycle ownership
+
+The current lifecycle has one WebSocket host. It accepts every upgrade and
+calls the host's `onConnect`, `onMessage`, `onClose`, and `onError` methods. The
+internal extraction works within that constraint because every Agent socket
+still belongs to the built-in browser channel.
+
+Multiple WebSocket channels need a stronger lifecycle contract. The lifecycle
+must let a named handler claim an upgrade, persist the handler key in its private
+WebSocket attachment, and route hibernation wakes back to that handler. It must
+not broadcast frames to all capabilities.
+
+Until that exists, the internal browser channel is the only physical WebSocket
+owner. State synchronization, RPC, identity, MCP announcements, and chat are
+protocol extensions carried by that channel rather than competing channel
+owners.
+
+## Proposed user model
+
+The proposed API is recorded in
+[`rfc-agent-channels.md`](./rfc-agent-channels.md). The intended direction is an
+Agent-owned registry and one transport-neutral application entry point:
+
+```ts
+export class SupportAgent extends Agent<Env> {
+  readonly channels = this.defineChannels({
+    web: webSocketChannel({
+      onConnect({ connection }) {
+        console.log("connected", connection.id);
+      }
+    }),
+    api: requestChannel({ path: "/messages" }),
+    slack: slackChannel({
+      webhookPath: "/slack",
+      signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
+      botToken: ({ env }) => env.SLACK_BOT_TOKEN
+    })
+  });
+
+  async onMessage(
+    message: AgentMessage,
+    context: AgentMessageContext
+  ): Promise<void> {
+    await context.reply({ markdown: await this.answer(message.text) });
+  }
+}
+```
+
+These symbols are not exported today. The code records ownership and call flow,
+not a committed signature.
+
+## Key decisions
+
+- The Agent owns its channel registry. Provider implementations may be separate
+  modules, but there is no second application host beside Agent.
+- Raw connection callbacks belong to the WebSocket channel. They are retained on
+  Agent only as compatibility hooks.
+- The lifecycle owns physical hibernating WebSockets. A channel never accepts a
+  socket behind the lifecycle's back.
+- One physical socket has one channel owner. Features multiplexed over that
+  socket compose inside its protocol dispatcher.
+- `onRequest` remains a raw HTTP fallback. Lifecycle capabilities such as MCP
+  may claim feature callback URLs before it, and request channels may normalize
+  selected requests into Agent messages.
+
+## Tradeoffs
+
+The internal channel currently receives a narrow callback object backed by
+Agent operations. This is more wiring than letting it reach into Agent directly,
+but it keeps the protocol module independent from Agent's large implementation
+and makes its dependencies visible.
+
+Compatibility means the raw WebSocket methods cannot disappear yet. Think and
+AIChatAgent both decorate them at runtime, and applications override them. The
+private extraction improves ownership without pretending the migration is
+complete.
+
+## History
+
+- [rfc-durable-object-lifecycle.md](./rfc-durable-object-lifecycle.md) introduced
+  the composed lifecycle and removed the PartyServer base class.
+- [rfc-agent-channels.md](./rfc-agent-channels.md) proposes the public Agent
+  channel and normalized message model.

--- a/design/rfc-agent-channels.md
+++ b/design/rfc-agent-channels.md
@@ -1,0 +1,455 @@
+Status: proposed
+
+# Agent channels
+
+## The problem
+
+`Agent` still presents WebSocket callbacks as its application interface:
+
+```ts
+class MyAgent extends Agent {
+  onConnect(connection) {}
+  onMessage(connection, frame) {}
+  onClose(connection) {}
+}
+```
+
+That boundary came from PartyServer. It no longer matches the runtime or the
+product we want to build.
+
+The Durable Object lifecycle owns physical requests, alarms, and hibernating
+WebSockets. The base Agent then mixes several concerns into its WebSocket
+callbacks:
+
+- connection setup and sub-agent forwarding;
+- Agent identity and state synchronization;
+- callable RPC;
+- MCP server announcements;
+- application frames.
+
+Slack, Telegram, Discord, email, and HTTP messages have separate entry points.
+An application cannot implement its behavior once and reuse it across those
+providers.
+
+HTTP is overloaded too. `onRequest` can mean an application endpoint, but
+features such as the MCP client also need HTTP callback URLs. The MCP callback
+is not an application message. It should be claimed by an MCP lifecycle
+capability before the user's raw request fallback.
+
+## Terms
+
+This RFC uses these terms:
+
+- **Lifecycle**: coordinates Durable Object startup, requests, alarms, and
+  hibernating WebSockets.
+- **Capability**: a reusable lifecycle extension. A capability may claim a
+  request such as an MCP OAuth callback.
+- **Channel**: an Agent-owned inbound and outbound communication adapter. The
+  browser WebSocket protocol, Slack, and a selected JSON message endpoint are
+  channels.
+- **Transport**: the mechanism carrying a channel, usually HTTP or WebSocket.
+  HTTP itself is not a channel.
+- **Gateway**: Worker-side channel ingress used when a shared provider webhook
+  must resolve the target Agent before calling it.
+- **Agent message**: the normalized application input produced by a channel.
+- **Protocol extension**: behavior multiplexed over a channel, such as state
+  synchronization or RPC over the browser WebSocket.
+
+## Decision
+
+Channels belong to the Agent. Provider implementations may live in separate
+modules, but there is no second application host beside `Agent`.
+
+A channel authenticates and decodes input, then calls one framework-owned Agent
+receive path. That path handles admission, durable acceptance where required,
+tracing, and invocation context before calling one application hook.
+
+Raw WebSocket connection hooks belong to the WebSocket channel. We retain the
+current Agent methods temporarily as compatibility callbacks.
+
+`onRequest` remains a raw HTTP fallback. Lifecycle capabilities and request
+channels may claim selected requests before it.
+
+## Proposed user experience
+
+The exact names are provisional. This PR does not export any of them.
+
+```ts
+import {
+  Agent,
+  routeAgentRequest,
+  type AgentMessage,
+  type AgentMessageContext
+} from "agents";
+import {
+  requestChannel,
+  slackChannel,
+  webSocketChannel
+} from "agents/channels";
+
+export class SupportAgent extends Agent<Env> {
+  readonly channels = this.defineChannels({
+    web: webSocketChannel({
+      onConnect({ connection }) {
+        console.log("browser connected", connection.id);
+      },
+      decode({ frame }) {
+        if (typeof frame !== "string") return null;
+        return {
+          id: crypto.randomUUID(),
+          text: frame
+        };
+      },
+      onClose({ connection }) {
+        console.log("browser disconnected", connection.id);
+      }
+    }),
+
+    api: requestChannel({
+      path: "/messages",
+      async decode(request) {
+        const input = await request.json<{
+          id: string;
+          text: string;
+        }>();
+        return input;
+      }
+    }),
+
+    slack: slackChannel({
+      webhookPath: "/slack",
+      signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
+      botToken: ({ env }) => env.SLACK_BOT_TOKEN
+    })
+  });
+
+  async onMessage(
+    message: AgentMessage,
+    context: AgentMessageContext
+  ): Promise<void> {
+    const answer = await this.answer(message.text);
+    await context.reply({ markdown: answer });
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return (
+      (await routeAgentRequest(request, env)) ??
+      new Response("Not found", { status: 404 })
+    );
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+The ownership is the important part:
+
+- the registry is declared on the Agent;
+- WebSocket callbacks are configured on `webSocketChannel`;
+- provider details stay in provider adapters;
+- application messages reach one Agent callback;
+- unknown HTTP requests reach `onRequest`, then 404.
+
+The initial normalized contract should stay small:
+
+```ts
+type AgentMessage = {
+  /** Stable within the source channel. */
+  id: string;
+  text: string;
+  attachments?: readonly AgentMessageAttachment[];
+};
+
+type AgentMessageContext = {
+  /** Stable key from the Agent's channel registry. */
+  channel: string;
+  actor?: AgentMessageActor;
+  conversation?: {
+    id: string;
+    threadId?: string;
+  };
+  reply(message: AgentReply): Promise<AgentDeliveryResult>;
+};
+```
+
+Provider payloads do not enter the application hook. An adapter may expose a
+provider-specific routing callback in its own configuration, where the raw
+payload type is known.
+
+A reply target must be serializable so the Agent can persist it with accepted
+work. Channel keys therefore become durable identifiers. Renaming one requires
+a migration for stored reply targets.
+
+## One application hook
+
+The Agent should not grow `onSlackMessage`, `onTelegramMessage`, or
+`onDiscordMessage`. That would preserve provider coupling and add a base-class
+hook for every integration.
+
+The target hook is `onMessage(message, context)`. It conflicts with the current
+raw WebSocket signature. An additive release may use `onAgentMessage`
+temporarily, but the API should converge on `onMessage` after raw frame handling
+has moved into `webSocketChannel`.
+
+Channels call an internal receive operation rather than invoking the override
+directly:
+
+```text
+channel ingress
+-> Agent receive operation
+   -> parse normalized envelope
+   -> deduplicate when the source can redeliver
+   -> persist work and reply target when required
+   -> establish tracing and channel context
+   -> Agent.onMessage(message, context)
+```
+
+For webhook channels, provider acknowledgement means the target Agent has
+accepted the event durably. It does not mean the model has finished. Long
+processing must not hold a provider webhook open.
+
+## The browser WebSocket channel
+
+The first channel is the existing Agents browser protocol. It owns one physical
+WebSocket and multiplexes its protocol extensions in a fixed order:
+
+```text
+Lifecycle
+-> browser WebSocket channel
+   -> sub-agent forwarding
+   -> identity protocol
+   -> state protocol
+   -> RPC protocol
+   -> MCP publication protocol
+   -> higher chat protocol
+   -> application frame decoder
+```
+
+State synchronization, RPC, identity, and MCP announcements are not separate
+channels. They share one connection and compose inside its protocol dispatcher.
+A binary voice socket could later be a different WebSocket channel with none of
+those browser frames.
+
+This PR performs only a private extraction:
+
+- `packages/agents/src/internal/agent-websocket-channel.ts` owns connection
+  setup, state sync, RPC dispatch, identity, MCP announcements, sub-agent
+  forwarding, agent-tool replay, and unrecognized-frame forwarding;
+- `packages/agents/src/internal/rpc.ts` owns callable RPC parsing and streaming
+  response mechanics;
+- neither module has a package export;
+- existing `Agent.onConnect`, raw `Agent.onMessage`, and `Agent.onClose` remain
+  compatibility callbacks;
+- `AIChatAgent` and Think retain their current wrapper order.
+
+The current connection form of `Agent.onError` still belongs to the lifecycle
+compatibility path. It should move with the other connection hooks when the
+public WebSocket channel API lands.
+
+## Requests and capabilities
+
+A request is not automatically a message. Request ownership remains explicit:
+
+```text
+Lifecycle startup
+-> lifecycle capability request hooks
+-> Agent request-channel adapters
+-> Agent.onRequest
+-> 404
+```
+
+Examples:
+
+- an MCP OAuth callback is claimed by the MCP capability;
+- a Slack webhook routed to an Agent is claimed by the Slack channel;
+- `POST /messages` is normalized by a request channel;
+- a health endpoint can remain in `onRequest` or its own capability;
+- an unknown request returns 404.
+
+The first returned `Response` wins. Every capability and channel must decline
+requests outside its scope. Configuration should reject detectable path
+conflicts during startup.
+
+## Shared provider gateways
+
+The simple provider URL contains the Agent class and name:
+
+```text
+/agents/support-agent/customer-123/slack
+```
+
+`routeAgentRequest` resolves the Durable Object first, then the Agent's Slack
+channel verifies and handles the request.
+
+Some providers instead call one webhook shared by many Agent instances. In
+that case, a Worker-side gateway must authenticate and normalize the event
+before the target Agent is known:
+
+```text
+provider webhook
+-> channel gateway
+-> resolve Agent name
+-> Agent receive operation
+-> durable acceptance
+-> provider acknowledgement
+```
+
+The same adapter definition should support both roles:
+
+```ts
+const slack = slackChannel<Env>({
+  webhookPath: "/slack",
+  signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
+  botToken: ({ env }) => env.SLACK_BOT_TOKEN
+});
+
+export class SupportAgent extends Agent<Env> {
+  readonly channels = this.defineChannels({ slack });
+
+  async onMessage(message: AgentMessage, context: AgentMessageContext) {
+    await context.reply({ markdown: await this.answer(message.text) });
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return (
+      (await routeAgentChannelRequest({
+        request,
+        env,
+        namespace: env.SupportAgent,
+        channel: slack,
+        resolveAgent: (event) => event.workspaceId
+      })) ??
+      (await routeAgentRequest(request, env)) ??
+      new Response("Not found", { status: 404 })
+    );
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+The gateway is an inbound adapter, not a `ChannelHost`. It does not own
+application callbacks, conversation state, an outbox, retries, or delivery
+preferences. Its job ends at durable Agent acceptance.
+
+## Lifecycle prerequisite for multiple WebSocket channels
+
+The current lifecycle has one WebSocket host. It accepts every upgrade and
+calls host methods on the Durable Object. The private browser-channel
+extraction works because every Agent socket still has the same owner.
+
+Before exposing a second WebSocket channel, the lifecycle needs named ownership:
+
+```ts
+interface DurableObjectCapability {
+  webSocket?: {
+    /** Stable key persisted with accepted sockets. */
+    key: string;
+    onUpgrade(
+      context: WebSocketUpgradeContext
+    ):
+      | { type: "accept"; tags?: readonly string[] }
+      | { type: "respond"; response: Response }
+      | undefined
+      | Promise<
+          | { type: "accept"; tags?: readonly string[] }
+          | { type: "respond"; response: Response }
+          | undefined
+        >;
+    onConnect?(context: WebSocketConnectContext): MaybePromise<void>;
+    onMessage?(context: WebSocketMessageContext): MaybePromise<void>;
+    onClose?(context: WebSocketCloseContext): MaybePromise<void>;
+    onError?(context: WebSocketErrorContext): MaybePromise<void>;
+  };
+}
+```
+
+The exact type is open. The required behavior is:
+
+1. handlers claim upgrades in registration order;
+2. the first accept or explicit response wins;
+3. the lifecycle accepts the socket through the Hibernation API;
+4. it stores the handler key in lifecycle-owned attachment metadata;
+5. wakes dispatch only to that handler;
+6. a missing handler is an ownership error, never fallthrough;
+7. old sockets without a key use the current host fallback;
+8. duplicate or renamed keys fail loudly.
+
+The owner key must not live in `connection.state`, which belongs to channel and
+application code.
+
+The in-progress request-only MCP capability does not depend on this change. If
+MCP publishes state over the browser socket, that publication should later
+register as a browser protocol extension rather than become a second socket
+owner.
+
+## Compatibility and migration
+
+1. Extract the browser protocol into an internal channel and retain current
+   hooks as callbacks. This PR does that.
+2. Add named WebSocket ownership to the lifecycle without changing Agent users.
+3. Add the Agent channel registry and normalized receive path.
+4. Move `AIChatAgent` and Think away from constructor-time method wrapping and
+   into browser protocol registration.
+5. Introduce the semantic message hook and deprecate raw Agent connection hooks.
+6. Remove or rename raw hooks only at an allowed breaking boundary.
+
+Compatibility must cover the browser client, React hooks, state sync, readonly
+connections, protocol suppression, RPC, chat recovery, connection ordering, and
+sub-agent routing.
+
+## Relationship to existing channel work
+
+Think already exports `ChannelDefinition`. It combines messenger configuration,
+turn policy, tool narrowing, and delivery. This RFC defines a lower boundary:
+transport normalization and reply delivery in base Agent, with turn policy and
+recovery remaining in Think.
+
+We should avoid publishing another unrelated type named simply `Channel`.
+Explicit base names such as `AgentChannel`, `AgentMessage`, and
+`AgentMessageContext` are safer until the layers converge.
+
+PR #2129 contains useful pieces, especially normalized provider events,
+serializable reply destinations, stable source IDs, and honest delivery
+outcomes. Its `ChannelHost` creates a second application callback and routing
+system beside Agent, and the PR also takes on identities, approvals, fallback,
+fanout, AI tools, and several providers at once.
+
+This proposal starts smaller:
+
+1. private browser-channel extraction;
+2. lifecycle ownership for multiple WebSocket channels;
+3. one Agent message and reply boundary;
+4. request channel and one external provider;
+5. only then revisit identities, approvals, and composite delivery.
+
+## Alternatives
+
+- **Provider-specific Agent hooks.** Rejected because application logic stays
+  tied to providers.
+- **Standalone `ChannelHost` as the application owner.** Rejected because Agent
+  would still need a second routing, callback, and durability model.
+- **Every capability observes every frame.** Rejected because consumption,
+  ordering, errors, and hibernation ownership become ambiguous.
+- **State and RPC as channels.** Rejected because they are extensions of one
+  browser connection.
+- **Every HTTP request becomes a message.** Rejected because callbacks, health
+  checks, assets, and arbitrary APIs have different semantics.
+- **Every provider URL includes the Agent name.** Preferred where possible, but
+  insufficient for a shared webhook serving many Agent instances.
+
+## Open questions
+
+- What temporary name should carry normalized messages while raw `onMessage`
+  remains supported?
+- How should one adapter definition bind Worker gateway configuration and Agent
+  instance delivery without duplication?
+- Which actor and conversation fields belong in base Agent rather than Think?
+- What durable inbox should webhook channels use?
+- How should protocol extensions register with the browser channel?
+- Should the first external proof use Slack or Telegram?
+
+## Decision status
+
+Proposed. This PR makes the first private move by extracting the existing
+browser protocol without exporting a channel API.

--- a/design/rfc-agent-channels.md
+++ b/design/rfc-agent-channels.md
@@ -1,6 +1,6 @@
 Status: proposed
 
-# Agent channels
+# Lifecycle-composed channels
 
 ## The problem
 
@@ -14,86 +14,255 @@ class MyAgent extends Agent {
 }
 ```
 
-That boundary came from PartyServer. It no longer matches the runtime or the
-product we want to build.
+That shape came from PartyServer. It mixes several responsibilities:
 
-The Durable Object lifecycle owns physical requests, alarms, and hibernating
-WebSockets. The base Agent then mixes several concerns into its WebSocket
-callbacks:
+- the Durable Object lifecycle accepts and hibernates the socket;
+- the Agents browser protocol sends identity and synchronizes state;
+- callable RPC shares the same wire;
+- MCP and chat add more protocol frames;
+- unrecognized frames reach application code.
 
-- connection setup and sub-agent forwarding;
-- Agent identity and state synchronization;
-- callable RPC;
-- MCP server announcements;
-- application frames.
+Slack, Telegram, Discord, email, and HTTP messages enter through different
+APIs. An application cannot implement its behavior once and reuse it across
+those providers.
 
-Slack, Telegram, Discord, email, and HTTP messages have separate entry points.
-An application cannot implement its behavior once and reuse it across those
-providers.
-
-HTTP is overloaded too. `onRequest` can mean an application endpoint, but
-features such as the MCP client also need HTTP callback URLs. The MCP callback
-is not an application message. It should be claimed by an MCP lifecycle
-capability before the user's raw request fallback.
+HTTP is overloaded too. An MCP OAuth callback and an application JSON message
+both arrive as requests, but they are not the same kind of input. The MCP
+capability should claim its callback before channels and before the
+application's raw request fallback.
 
 ## Terms
 
-This RFC uses these terms:
-
-- **Lifecycle**: coordinates Durable Object startup, requests, alarms, and
+- **Lifecycle** coordinates Durable Object startup, requests, alarms, and
   hibernating WebSockets.
-- **Capability**: a reusable lifecycle extension. A capability may claim a
-  request such as an MCP OAuth callback.
-- **Channel**: an Agent-owned inbound and outbound communication adapter. The
-  browser WebSocket protocol, Slack, and a selected JSON message endpoint are
-  channels.
-- **Transport**: the mechanism carrying a channel, usually HTTP or WebSocket.
-  HTTP itself is not a channel.
-- **Gateway**: Worker-side channel ingress used when a shared provider webhook
-  must resolve the target Agent before calling it.
-- **Agent message**: the normalized application input produced by a channel.
-- **Protocol extension**: behavior multiplexed over a channel, such as state
-  synchronization or RPC over the browser WebSocket.
+- **Capability** is a reusable extension installed into a Lifecycle.
+- **Channel definition** describes one communication adapter without binding it
+  to a Durable Object instance. For shared ingress it also owns the application
+  routing callback that chooses the complete durable target. A Worker router and
+  a Durable Object runtime can share the same definition.
+- **Channel runtime** binds definitions to a Durable Object, storage, scheduling,
+  and an application message callback. It is a Lifecycle capability.
+- **Channel router** is Worker-side ingress over a set of channel definitions.
+  It is used when a shared provider webhook must resolve the target Durable
+  Object before calling it.
+- **Channel message** is the normalized application input produced by a channel.
+- **Reply target** is serializable data identifying the exact channel
+  destination derived from an inbound message.
+- **WebSocket owner** is the one named Lifecycle handler responsible for a
+  physical hibernating socket.
+- **Protocol extension** is behavior multiplexed inside one WebSocket channel,
+  such as state sync or RPC.
 
-## Decision
+# Ideal end state
 
-Channels belong to the Agent. Provider implementations may live in separate
-modules, but there is no second application host beside `Agent`.
+## Architecture
 
-A channel authenticates and decodes input, then calls one framework-owned Agent
-receive path. That path handles admission, durable acceptance where required,
-tracing, and invocation context before calling one application hook.
+Channels belong to the durable application, not specifically to `Agent`.
+`Agent` provides defaults and a shorter configuration API over the same runtime.
 
-Raw WebSocket connection hooks belong to the WebSocket channel. We retain the
-current Agent methods temporarily as compatibility callbacks.
+```text
+Worker
+├─ shared channel router, only when the target is not in the URL
+└─ ordinary Durable Object routing
 
-`onRequest` remains a raw HTTP fallback. Lifecycle capabilities and request
-channels may claim selected requests before it.
+DurableObject
+├─ Lifecycle
+│  ├─ MCP capability
+│  ├─ Channels capability
+│  ├─ schedules capability
+│  └─ raw host fallback
+├─ durable application state
+└─ one normalized channel-message handler
 
-## Proposed user experience
+Agent extends DurableObject
+├─ installs the same Lifecycle and Channels capability
+├─ preconfigures the Agents browser channel
+├─ supplies state, RPC, observability, and sub-agent protocol extensions
+└─ exposes defineChannels() and onMessage() as convenience
+```
 
-The exact names are provisional. This PR does not export any of them.
+The core dependency direction is:
+
+```text
+Lifecycle knows WebSocket owners and capability phases
+    ↑
+Channel runtime knows channel definitions and normalized messages
+    ↑
+Agent adds Agent-specific protocols and convenience
+    ↑
+Think adds turns, model policy, streaming recovery, and notices
+```
+
+`Lifecycle` does not know what a message, actor, Slack workspace, or model turn
+is. A provider adapter does not own application state. `Agent` is not required
+for channels to work.
+
+## End-state contracts
+
+The exact names remain open, but the final concepts should resemble this:
+
+```ts
+type ChannelMessage = {
+  /** Stable within the configured source channel. */
+  id: string;
+  text: string;
+  attachments?: readonly ChannelAttachment[];
+};
+
+type ChannelMessageContext = {
+  /** Stable configured key. This may be persisted with application data. */
+  channel: string;
+  actor?: ChannelActor;
+  conversation?: {
+    id: string;
+    threadId?: string;
+  };
+  replyTarget: ChannelReplyTarget;
+  reply(message: ChannelReply): Promise<ChannelDeliveryResult>;
+};
+
+type ChannelDeliveryResult =
+  | { status: "delivered"; reference?: string }
+  | { status: "failed"; retryable: boolean; error: ChannelError }
+  | { status: "uncertain"; error: ChannelError };
+```
+
+Provider payloads do not enter the application handler. Adapters may expose
+provider-specific routing callbacks in their configuration, where the raw type
+is known.
+
+One outbound `reply()` call performs one provider attempt. The runtime does not
+silently retry an uncertain delivery because that can duplicate a real message.
+
+Definitions are reusable and grouped into one configured set. The set handles
+more than one provider request path and retains each stable channel key:
+
+```ts
+const externalChannels = defineChannelSet<Env>({
+  slack: slackChannel({
+    webhookPath: "/webhooks/slack",
+    signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
+    botToken: ({ env }) => env.SLACK_BOT_TOKEN,
+    route({ event, env }) {
+      return env.SupportAgent.getByName(event.workspaceId);
+    }
+  }),
+
+  telegram: telegramChannel({
+    webhookPath: "/webhooks/telegram",
+    secretToken: ({ env }) => env.TELEGRAM_WEBHOOK_SECRET,
+    botToken: ({ env }) => env.TELEGRAM_BOT_TOKEN,
+    route({ event, env }) {
+      return env.SupportAgent.getByName(`telegram:${event.chatId}`);
+    }
+  })
+});
+```
+
+`externalChannels.routeRequest(request, env)` offers the request to each
+HTTP-ingress definition. A channel returns `undefined` when the path does not
+belong to it. Once a channel claims and authenticates the request, its `route`
+callback chooses the complete Durable Object target.
+
+Returning the target keeps one routing decision together:
+
+```ts
+route({ event, env }) {
+  return env.SupportAgent.getByName(event.workspaceId);
+}
+```
+
+The alternative splits that decision across `namespace`, `resolveName`, and the
+router's own call to `getByName`. That makes the framework own application
+naming and prevents a channel from selecting another Durable Object class,
+jurisdiction, location hint, or existing stub. The router needs only a target
+with `fetch(request): Promise<Response>`.
+
+A route may return `null` to deliberately ignore an authenticated event. It must
+not return `undefined`, which is reserved for a channel declining an HTTP
+request before authentication and normalization.
+
+A runtime binds the same definitions to a durable host:
+
+```ts
+const channels = createChannelRuntime({
+  storage,
+  scheduler,
+  env,
+  channels: externalChannels.definitions,
+  onMessage
+});
+```
+
+The configured keys `slack` and `telegram` are durable data. Renaming one
+requires a migration for persisted inbox records and reply targets.
+
+## End state in an Agent
+
+`Agent` is the simple path. It already owns storage, Lifecycle, invocation
+context, observability, and the browser protocol.
 
 ```ts
 import {
   Agent,
+  callable,
   routeAgentRequest,
-  type AgentMessage,
-  type AgentMessageContext
+  type StreamingResponse
 } from "agents";
 import {
+  agentBrowserChannel,
+  defineChannelSet,
   requestChannel,
   slackChannel,
-  webSocketChannel
+  telegramChannel,
+  type ChannelMessage,
+  type ChannelMessageContext
 } from "agents/channels";
 
-export class SupportAgent extends Agent<Env> {
+interface Env {
+  SupportAgent: DurableObjectNamespace<SupportAgent>;
+  SLACK_BOT_TOKEN: string;
+  SLACK_SIGNING_SECRET: string;
+  TELEGRAM_BOT_TOKEN: string;
+  TELEGRAM_WEBHOOK_SECRET: string;
+}
+
+type SupportState = {
+  handled: number;
+  lastChannel?: string;
+};
+
+const externalChannels = defineChannelSet<Env>({
+  slack: slackChannel({
+    webhookPath: "/webhooks/slack",
+    signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
+    botToken: ({ env }) => env.SLACK_BOT_TOKEN,
+    route({ event, env }) {
+      return env.SupportAgent.getByName(event.workspaceId);
+    }
+  }),
+
+  telegram: telegramChannel({
+    webhookPath: "/webhooks/telegram",
+    secretToken: ({ env }) => env.TELEGRAM_WEBHOOK_SECRET,
+    botToken: ({ env }) => env.TELEGRAM_BOT_TOKEN,
+    route({ event, env }) {
+      return env.SupportAgent.getByName(`telegram:${event.chatId}`);
+    }
+  })
+});
+
+export class SupportAgent extends Agent<Env, SupportState> {
+  initialState: SupportState = { handled: 0 };
+
   readonly channels = this.defineChannels({
-    web: webSocketChannel({
+    // This channel includes the Agent identity, state, RPC, MCP publication,
+    // sub-agent, and chat protocol extensions.
+    web: agentBrowserChannel({
       onConnect({ connection }) {
         console.log("browser connected", connection.id);
       },
-      decode({ frame }) {
+      decodeApplicationFrame({ frame }) {
         if (typeof frame !== "string") return null;
         return {
           id: crypto.randomUUID(),
@@ -105,36 +274,57 @@ export class SupportAgent extends Agent<Env> {
       }
     }),
 
+    // Only this path is translated into a message. Other requests continue.
     api: requestChannel({
       path: "/messages",
       async decode(request) {
-        const input = await request.json<{
-          id: string;
-          text: string;
-        }>();
-        return input;
+        return request.json<{ id: string; text: string }>();
       }
     }),
 
-    slack: slackChannel({
-      webhookPath: "/slack",
-      signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
-      botToken: ({ env }) => env.SLACK_BOT_TOKEN
-    })
+    ...externalChannels.definitions
   });
 
   async onMessage(
-    message: AgentMessage,
-    context: AgentMessageContext
+    message: ChannelMessage,
+    context: ChannelMessageContext
   ): Promise<void> {
-    const answer = await this.answer(message.text);
+    this.setState({
+      handled: this.state.handled + 1,
+      lastChannel: context.channel
+    });
+
+    const answer = await this.answer({
+      text: message.text,
+      channel: context.channel,
+      conversationId: context.conversation?.id
+    });
+
     await context.reply({ markdown: answer });
+  }
+
+  // RPC remains a protocol extension of the Agent browser channel.
+  @callable({ streaming: true })
+  async streamStatus(stream: StreamingResponse): Promise<void> {
+    stream.send({ phase: "working" });
+    stream.end({ phase: "ready", handled: this.state.handled });
+  }
+
+  // This runs only when no capability or channel claimed the request.
+  onRequest(request: Request): Response {
+    if (new URL(request.url).pathname.endsWith("/health")) {
+      return Response.json({ ok: true, handled: this.state.handled });
+    }
+    return new Response("Not found", { status: 404 });
   }
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    // One router handles every gateway-capable definition. Each channel owns
+    // its provider-specific route to the complete Durable Object target.
     return (
+      (await externalChannels.routeRequest(request, env)) ??
       (await routeAgentRequest(request, env)) ??
       new Response("Not found", { status: 404 })
     );
@@ -142,314 +332,852 @@ export default {
 } satisfies ExportedHandler<Env>;
 ```
 
-The ownership is the important part:
+`defineChannels()` is convenience over the generic runtime. It installs the
+runtime into the Agent's Lifecycle and binds the normalized callback to
+`Agent.onMessage()`.
 
-- the registry is declared on the Agent;
-- WebSocket callbacks are configured on `webSocketChannel`;
-- provider details stay in provider adapters;
-- application messages reach one Agent callback;
-- unknown HTTP requests reach `onRequest`, then 404.
+The flow is:
 
-The initial normalized contract should stay small:
+```text
+browser / API / Slack
+-> channel adapter
+-> durable channel admission
+-> Agent.onMessage(message, context)
+-> context.reply(...)
+-> originating reply target
+```
+
+## End state in a plain Durable Object
+
+The reusable foundation uses the same definitions without extending `Agent`.
+The application supplies an explicit callback, so `Lifecycle` remains free of
+messaging concepts.
 
 ```ts
-type AgentMessage = {
-  /** Stable within the source channel. */
-  id: string;
-  text: string;
-  attachments?: readonly AgentMessageAttachment[];
-};
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle, routeDurableObjectRequest } from "agents/lifecycle";
+import {
+  createChannelRuntime,
+  defineChannelSet,
+  requestChannel,
+  slackChannel,
+  telegramChannel,
+  webSocketChannel,
+  type ChannelMessage,
+  type ChannelMessageContext
+} from "agents/channels";
 
-type AgentMessageContext = {
-  /** Stable key from the Agent's channel registry. */
-  channel: string;
-  actor?: AgentMessageActor;
-  conversation?: {
-    id: string;
-    threadId?: string;
-  };
-  reply(message: AgentReply): Promise<AgentDeliveryResult>;
-};
+interface Env {
+  SupportConversation: DurableObjectNamespace<SupportConversation>;
+  SLACK_BOT_TOKEN: string;
+  SLACK_SIGNING_SECRET: string;
+  TELEGRAM_BOT_TOKEN: string;
+  TELEGRAM_WEBHOOK_SECRET: string;
+}
+
+const externalChannels = defineChannelSet<Env>({
+  slack: slackChannel({
+    webhookPath: "/webhooks/slack",
+    signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
+    botToken: ({ env }) => env.SLACK_BOT_TOKEN,
+    route({ event, env }) {
+      return env.SupportConversation.getByName(event.workspaceId);
+    }
+  }),
+
+  telegram: telegramChannel({
+    webhookPath: "/webhooks/telegram",
+    secretToken: ({ env }) => env.TELEGRAM_WEBHOOK_SECRET,
+    botToken: ({ env }) => env.TELEGRAM_BOT_TOKEN,
+    route({ event, env }) {
+      return env.SupportConversation.getByName(`telegram:${event.chatId}`);
+    }
+  })
+});
+
+export class SupportConversation extends DurableObject<Env> {
+  private readonly channels = createChannelRuntime({
+    storage: this.ctx.storage,
+    env: this.env,
+
+    channels: {
+      web: webSocketChannel({
+        path: "/socket",
+        decode({ frame }) {
+          if (typeof frame !== "string") return null;
+          return {
+            id: crypto.randomUUID(),
+            text: frame
+          };
+        }
+      }),
+
+      api: requestChannel({
+        path: "/messages",
+        async decode(request) {
+          return request.json<{ id: string; text: string }>();
+        }
+      }),
+
+      ...externalChannels.definitions
+    },
+
+    onMessage: (message, context) => this.handleMessage(message, context)
+  });
+
+  readonly lifecycle = Lifecycle.install(this).use(this.channels);
+
+  onStart(): void {
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS messages (
+        channel TEXT NOT NULL,
+        message_id TEXT NOT NULL,
+        text TEXT NOT NULL,
+        received_at INTEGER NOT NULL,
+        PRIMARY KEY (channel, message_id)
+      )
+    `);
+  }
+
+  private async handleMessage(
+    message: ChannelMessage,
+    context: ChannelMessageContext
+  ): Promise<void> {
+    this.ctx.storage.sql.exec(
+      `INSERT OR IGNORE INTO messages
+       (channel, message_id, text, received_at)
+       VALUES (?, ?, ?, ?)`,
+      context.channel,
+      message.id,
+      message.text,
+      Date.now()
+    );
+
+    const rows = [
+      ...this.ctx.storage.sql.exec<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM messages"
+      )
+    ];
+
+    await context.reply({
+      markdown: `Stored message ${rows[0]?.count ?? 0}: ${message.text}`
+    });
+  }
+
+  // Raw fallback after lifecycle capabilities decline.
+  onRequest(request: Request): Response {
+    if (new URL(request.url).pathname.endsWith("/health")) {
+      return new Response("ok");
+    }
+    return new Response("Not found", { status: 404 });
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return (
+      (await externalChannels.routeRequest(request, env)) ??
+      (await routeDurableObjectRequest(request, env, {
+        prefix: "conversations"
+      })) ??
+      new Response("Not found", { status: 404 })
+    );
+  }
+} satisfies ExportedHandler<Env>;
 ```
 
-Provider payloads do not enter the application hook. An adapter may expose a
-provider-specific routing callback in its own configuration, where the raw
-payload type is known.
-
-A reply target must be serializable so the Agent can persist it with accepted
-work. Channel keys therefore become durable identifiers. Renaming one requires
-a migration for stored reply targets.
-
-## One application hook
-
-The Agent should not grow `onSlackMessage`, `onTelegramMessage`, or
-`onDiscordMessage`. That would preserve provider coupling and add a base-class
-hook for every integration.
-
-The target hook is `onMessage(message, context)`. It conflicts with the current
-raw WebSocket signature. An additive release may use `onAgentMessage`
-temporarily, but the API should converge on `onMessage` after raw frame handling
-has moved into `webSocketChannel`.
-
-Channels call an internal receive operation rather than invoking the override
-directly:
+The call path is:
 
 ```text
-channel ingress
--> Agent receive operation
-   -> parse normalized envelope
-   -> deduplicate when the source can redeliver
-   -> persist work and reply target when required
-   -> establish tracing and channel context
-   -> Agent.onMessage(message, context)
+routeDurableObjectRequest or provider gateway
+-> Durable Object stub.fetch(...)
+-> Lifecycle startup
+-> earlier request capabilities, such as MCP OAuth
+-> Channels capability
+-> handleMessage(message, context)
+-> raw Durable Object onRequest when unclaimed
 ```
 
-For webhook channels, provider acknowledgement means the target Agent has
-accepted the event durably. It does not mean the model has finished. Long
-processing must not hold a provider webhook open.
+## Request ownership in the end state
 
-## The browser WebSocket channel
-
-The first channel is the existing Agents browser protocol. It owns one physical
-WebSocket and multiplexes its protocol extensions in a fixed order:
-
-```text
-Lifecycle
--> browser WebSocket channel
-   -> sub-agent forwarding
-   -> identity protocol
-   -> state protocol
-   -> RPC protocol
-   -> MCP publication protocol
-   -> higher chat protocol
-   -> application frame decoder
-```
-
-State synchronization, RPC, identity, and MCP announcements are not separate
-channels. They share one connection and compose inside its protocol dispatcher.
-A binary voice socket could later be a different WebSocket channel with none of
-those browser frames.
-
-This PR performs only a private extraction:
-
-- `packages/agents/src/internal/agent-websocket-channel.ts` owns connection
-  setup, state sync, RPC dispatch, identity, MCP announcements, sub-agent
-  forwarding, agent-tool replay, and unrecognized-frame forwarding;
-- `packages/agents/src/internal/rpc.ts` owns callable RPC parsing and streaming
-  response mechanics;
-- neither module has a package export;
-- existing `Agent.onConnect`, raw `Agent.onMessage`, and `Agent.onClose` remain
-  compatibility callbacks;
-- `AIChatAgent` and Think retain their current wrapper order.
-
-The current connection form of `Agent.onError` still belongs to the lifecycle
-compatibility path. It should move with the other connection hooks when the
-public WebSocket channel API lands.
-
-## Requests and capabilities
-
-A request is not automatically a message. Request ownership remains explicit:
+A request is not automatically a message:
 
 ```text
 Lifecycle startup
--> lifecycle capability request hooks
--> Agent request-channel adapters
--> Agent.onRequest
--> 404
+-> capability onRequest hooks in registration order
+   -> MCP OAuth callback may return Response
+   -> Channels may return Response
+-> host onRequest
+-> 404 chosen by host
 ```
 
 Examples:
 
-- an MCP OAuth callback is claimed by the MCP capability;
-- a Slack webhook routed to an Agent is claimed by the Slack channel;
-- `POST /messages` is normalized by a request channel;
-- a health endpoint can remain in `onRequest` or its own capability;
-- an unknown request returns 404.
+- MCP OAuth callback: MCP capability.
+- Slack webhook routed directly to an instance: Slack channel.
+- `POST /messages`: request channel.
+- Health endpoint: host `onRequest` or a health capability.
+- Unknown request: 404.
 
-The first returned `Response` wins. Every capability and channel must decline
-requests outside its scope. Configuration should reject detectable path
-conflicts during startup.
+The first returned `Response` wins. Capabilities and channels decline requests
+outside their scope. Startup should reject path conflicts it can detect.
 
-## Shared provider gateways
+## WebSocket ownership in the end state
 
-The simple provider URL contains the Agent class and name:
-
-```text
-/agents/support-agent/customer-123/slack
-```
-
-`routeAgentRequest` resolves the Durable Object first, then the Agent's Slack
-channel verifies and handles the request.
-
-Some providers instead call one webhook shared by many Agent instances. In
-that case, a Worker-side gateway must authenticate and normalize the event
-before the target Agent is known:
+A physical socket has exactly one durable owner. Lifecycle owns acceptance and
+hibernation. The channel owns protocol semantics.
 
 ```text
-provider webhook
--> channel gateway
--> resolve Agent name
--> Agent receive operation
--> durable acceptance
--> provider acknowledgement
+Lifecycle WebSocket owner "channels:web"
+└─ browser channel
+   ├─ sub-agent forwarding protocol
+   ├─ identity protocol
+   ├─ state protocol
+   ├─ RPC protocol
+   ├─ MCP publication protocol
+   ├─ Think or AIChat protocol
+   └─ application frame decoder
 ```
 
-The same adapter definition should support both roles:
+A voice channel can claim another path and receive none of the browser
+protocols. Lifecycle never broadcasts one frame to every capability.
+
+The owner key belongs in Lifecycle attachment metadata, not
+`connection.state`. User and channel code must not be able to change ownership.
+
+## Durable ingress and acknowledgement
+
+A shared provider webhook must not wait for model completion, but it must not be
+acknowledged before the target Durable Object accepts it durably.
+
+The channel runtime owns a narrow normalized inbox for this handoff:
+
+```text
+Channel router receives provider event
+-> adapter authenticates and normalizes
+-> adapter computes stable dispatchId and serializable replyTarget
+-> router forwards an internal channel envelope to target.fetch(...)
+-> target ChannelRuntime transactionally inserts inbox row
+-> target schedules inbox drain
+-> target returns accepted
+-> router acknowledges provider
+-> target invokes application handler separately
+```
+
+This inbox is not the application's conversation store, delivery preference
+store, or outbound retry system. It records only accepted normalized ingress
+that must survive eviction and provider redelivery.
+
+Pseudocode:
 
 ```ts
-const slack = slackChannel<Env>({
-  webhookPath: "/slack",
-  signingSecret: ({ env }) => env.SLACK_SIGNING_SECRET,
-  botToken: ({ env }) => env.SLACK_BOT_TOKEN
+type ChannelEnvelope = {
+  channel: string;
+  dispatchId: string;
+  message: ChannelMessage;
+  context: {
+    actor?: ChannelActor;
+    conversation?: ChannelConversation;
+    replyTarget: ChannelReplyTarget;
+  };
+};
+
+async function accept(envelope: ChannelEnvelope): Promise<AcceptResult> {
+  return storage.transactionSync(() => {
+    const existing = inbox.get(envelope.channel, envelope.dispatchId);
+    if (existing) return { status: "duplicate" };
+
+    inbox.insert({
+      ...envelope,
+      state: "pending",
+      acceptedAt: Date.now()
+    });
+
+    scheduler.requestRun("channels:drain");
+    return { status: "accepted" };
+  });
+}
+```
+
+WebSocket and explicit request-response channels may use inline handling when
+their acknowledgement is the application response. Provider webhook channels
+use durable admission by default.
+
+# How we get there
+
+## Phase 0: extract the current browser protocol
+
+Status: included privately in this PR.
+
+Today `Agent` wraps its own methods in the constructor. The first step moves
+that behavior behind one internal object while preserving every public hook:
+
+```ts
+const userHooks = {
+  onConnect: this.onConnect.bind(this),
+  onMessage: this.onMessage.bind(this),
+  onClose: this.onClose.bind(this)
+};
+
+this.#webSocketChannel = new AgentWebSocketChannel(
+  agentProtocolPorts(this),
+  userHooks
+);
+
+this.onConnect = this.#webSocketChannel.onConnect.bind(this.#webSocketChannel);
+this.onMessage = this.#webSocketChannel.onMessage.bind(this.#webSocketChannel);
+this.onClose = this.#webSocketChannel.onClose.bind(this.#webSocketChannel);
+```
+
+The internal channel owns state and RPC frame classification. Unknown frames
+still reach the captured `Agent.onMessage(connection, frame)` callback.
+`AIChatAgent` and Think continue wrapping the same methods outside this layer.
+
+Exit criteria:
+
+- no new package export;
+- generated declarations contain no channel internals;
+- browser identity, state, RPC, readonly, protocol suppression, ordering, and
+  sub-agent tests remain unchanged;
+- AIChat and Think suites remain unchanged.
+
+## Phase 1: add named WebSocket ownership to Lifecycle
+
+The current Lifecycle assumes one host callback. Add an internal owner
+registry, then expose it only after the behavior is proven.
+
+Proposed shape:
+
+```ts
+type LifecycleWebSocketOwner = {
+  /** Stable key persisted in the socket attachment. */
+  key: string;
+  onUpgrade(
+    context: WebSocketUpgradeContext
+  ):
+    | { type: "accept"; tags?: readonly string[] }
+    | { type: "respond"; response: Response }
+    | undefined
+    | Promise<
+        | { type: "accept"; tags?: readonly string[] }
+        | { type: "respond"; response: Response }
+        | undefined
+      >;
+  onConnect?(context: WebSocketConnectContext): MaybePromise<void>;
+  onMessage?(context: WebSocketMessageContext): MaybePromise<void>;
+  onClose?(context: WebSocketCloseContext): MaybePromise<void>;
+  onError?(context: WebSocketErrorContext): MaybePromise<void>;
+};
+
+interface DurableObjectCapability {
+  webSockets?: readonly LifecycleWebSocketOwner[];
+}
+```
+
+Upgrade dispatch:
+
+```ts
+async function fetch(request: Request): Promise<Response> {
+  await start();
+
+  if (!isWebSocketUpgrade(request)) {
+    return dispatchRequest(request);
+  }
+
+  for (const owner of webSocketOwners) {
+    const decision = await owner.onUpgrade({ request });
+    if (decision === undefined) continue;
+    if (decision.type === "respond") return decision.response;
+
+    const connection = acceptHibernatingWebSocket({
+      request,
+      tags: decision.tags,
+      owner: owner.key
+    });
+    await owner.onConnect?.({ connection, request });
+    return switchingProtocols(connection);
+  }
+
+  return hostWebSocketFallback(request);
+}
+```
+
+Attachment metadata changes from:
+
+```ts
+{
+  (id, tags, uri);
+}
+```
+
+to:
+
+```ts
+{ id, tags, uri, owner: "channels:web" }
+```
+
+Wake dispatch:
+
+```ts
+async function webSocketMessage(socket, frame) {
+  const metadata = readLifecycleAttachment(socket);
+
+  if (metadata.owner === undefined) {
+    return host.onMessage?.(connection(socket), frame);
+  }
+
+  const owner = ownersByKey.get(metadata.owner);
+  if (!owner) {
+    socket.close(1011, "WebSocket owner is no longer configured");
+    reportMissingOwner(metadata.owner);
+    return;
+  }
+
+  await owner.onMessage?.({ connection: connection(socket), frame });
+}
+```
+
+Rules:
+
+1. first claim wins;
+2. duplicate owner keys fail during setup;
+3. a missing owner never falls through to another owner;
+4. owner keys are durable identifiers;
+5. old sockets without an owner retain current behavior;
+6. Lifecycle remains the only code calling `acceptWebSocket`.
+
+## Phase 2: replace method wrapping with browser protocol composition
+
+Define a protocol contract inside the WebSocket channel. Protocols consume a
+frame in order or pass it onward.
+
+```ts
+type WebSocketProtocol = {
+  onConnect?(context: ProtocolConnectContext): MaybePromise<void>;
+  onFrame?(context: ProtocolFrameContext): MaybePromise<"handled" | "next">;
+  onClose?(context: ProtocolCloseContext): MaybePromise<void>;
+  onError?(context: ProtocolErrorContext): MaybePromise<void>;
+};
+
+function webSocketChannel(options: {
+  path: string;
+  protocols?: readonly WebSocketProtocol[];
+  decode?: ApplicationFrameDecoder;
+  onConnect?: ConnectionHook;
+  onClose?: CloseHook;
+}): ChannelDefinition;
+```
+
+Agent composes its browser channel:
+
+```ts
+function createAgentBrowserChannel(agent: Agent) {
+  return webSocketChannel({
+    path: "/",
+    protocols: [
+      subAgentProtocol(agent),
+      identityProtocol(agent),
+      stateProtocol(agent),
+      rpcProtocol(agent),
+      mcpPublicationProtocol(agent.mcp),
+      ...agent.chatProtocols()
+    ],
+    decode: agent.applicationFrameDecoder
+  });
+}
+```
+
+Frame dispatch:
+
+```ts
+for (const protocol of protocols) {
+  if ((await protocol.onFrame?.(context)) === "handled") return;
+}
+
+const message = await decode?.(context);
+if (message) await channelRuntime.receive(message, context.replyTarget);
+```
+
+At this point `AIChatAgent` and Think register protocols instead of assigning to
+`this.onConnect` and `this.onMessage` in their constructors.
+
+The MCP request capability and MCP browser publication remain separate roles:
+
+```text
+MCP capability onRequest -> OAuth callback ownership
+MCP browser protocol     -> server-list publication on Agent browser sockets
+```
+
+## Phase 3: introduce internal channel definitions and runtime
+
+Start package-private. Prove the generic Durable Object composition before
+adding `agents/channels` to package exports.
+
+```ts
+type ChannelTarget = {
+  fetch(request: Request): Promise<Response>;
+};
+
+interface ChannelDefinition<Env, RoutingEvent = unknown, Raw = unknown> {
+  gateway?: {
+    receive(
+      request: Request,
+      context: { env: Env }
+    ): Promise<ChannelGatewayResult<RoutingEvent, Raw> | undefined>;
+    route(context: {
+      event: RoutingEvent;
+      raw: Raw;
+      env: Env;
+    }): MaybePromise<ChannelTarget | null>;
+  };
+  request?: ChannelRequestIngress<Env>;
+  email?: ChannelEmailIngress<Env>;
+  webSockets?: readonly ChannelWebSocketIngress<Env>[];
+  deliver(
+    target: ChannelReplyTarget,
+    message: ChannelReply
+  ): Promise<ChannelDeliveryResult>;
+}
+
+class ChannelRuntime<Env> implements DurableObjectCapability {
+  constructor(options: {
+    storage: DurableObjectStorage;
+    scheduler: DurableScheduler;
+    env: Env;
+    channels: Record<string, ChannelDefinition<Env>>;
+    onMessage: ChannelMessageHandler;
+  });
+
+  onStart(): void;
+  onRequest(context: CapabilityRequestContext): Promise<Response | undefined>;
+  onAlarm(): Promise<void>;
+  readonly webSockets: readonly LifecycleWebSocketOwner[];
+  accept(envelope: ChannelEnvelope): Promise<AcceptResult>;
+}
+```
+
+The configured set stamps channel keys onto normalized reply targets and gateway
+envelopes. A definition never needs to know the key under which an application
+installed it.
+
+Request dispatch pseudocode:
+
+```ts
+async onRequest({ request }): Promise<Response | undefined> {
+  if (isInternalGatewayEnvelope(request)) {
+    const envelope = await parseAndVerifyInternalEnvelope(request);
+    return Response.json(await this.accept(envelope), { status: 202 });
+  }
+
+  for (const [key, channel] of configuredChannels) {
+    const result = await channel.request?.receive(request);
+    if (result === undefined) continue;
+
+    const envelope = stampChannelKey(key, result.envelope);
+    if (result.mode === "durable") {
+      await this.accept(envelope);
+    } else {
+      await this.dispatchInline(envelope);
+    }
+    return result.response;
+  }
+}
+```
+
+## Phase 4: add durable inbox draining
+
+The runtime stores only normalized ingress needed for durable acknowledgement.
+The application owns conversation state and outbound policy.
+
+```ts
+type InboxRow = {
+  channel: string;
+  dispatchId: string;
+  envelopeJson: string;
+  state: "pending" | "running" | "completed";
+  acceptedAt: number;
+  leaseUntil: number | null;
+};
+```
+
+Drain pseudocode:
+
+```ts
+async function drainInbox(): Promise<void> {
+  for (const row of inbox.claimPending({ leaseMs: 60_000 })) {
+    const envelope = parseEnvelope(row.envelopeJson);
+
+    try {
+      await onMessage(envelope.message, makeContext(envelope));
+      inbox.complete(row.channel, row.dispatchId);
+    } catch (error) {
+      inbox.releaseOrFail(row, classifyChannelHandlerError(error));
+    }
+  }
+
+  if (inbox.hasPending()) {
+    scheduler.requestRun("channels:drain");
+  }
+}
+```
+
+The runtime deduplicates stable `(channel, dispatchId)` pairs. It does not claim
+exactly-once application side effects. Application handlers that perform
+external mutations still need their own idempotency key.
+
+## Phase 5: add request channels and one provider
+
+First prove two transports entering the same handler:
+
+```ts
+channels: {
+  web: webSocketChannel(...),
+  api: requestChannel(...)
+}
+```
+
+Then add one real provider, Slack or Telegram:
+
+```ts
+channels: {
+  web: webSocketChannel(...),
+  api: requestChannel(...),
+  slack: slackChannel(...)
+}
+```
+
+Do not add identity linking, approvals, fallback, fanout, AI tools, or automatic
+outbound retries in this phase. Those features should be evaluated against the
+working Agent and plain Durable Object consumers.
+
+## Phase 6: add the Worker channel router
+
+One configured set handles any number of gateway-capable channels:
+
+```ts
+const externalChannels = defineChannelSet({
+  slack: slackChannel(...),
+  telegram: telegramChannel(...),
+  discord: discordChannel(...)
 });
 
-export class SupportAgent extends Agent<Env> {
-  readonly channels = this.defineChannels({ slack });
-
-  async onMessage(message: AgentMessage, context: AgentMessageContext) {
-    await context.reply({ markdown: await this.answer(message.text) });
-  }
-}
-
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    return (
-      (await routeAgentChannelRequest({
-        request,
-        env,
-        namespace: env.SupportAgent,
-        channel: slack,
-        resolveAgent: (event) => event.workspaceId
-      })) ??
-      (await routeAgentRequest(request, env)) ??
-      new Response("Not found", { status: 404 })
-    );
-  }
-} satisfies ExportedHandler<Env>;
+const response = await externalChannels.routeRequest(request, env);
 ```
 
-The gateway is an inbound adapter, not a `ChannelHost`. It does not own
-application callbacks, conversation state, an outbox, retries, or delivery
-preferences. Its job ends at durable Agent acceptance.
-
-## Lifecycle prerequisite for multiple WebSocket channels
-
-The current lifecycle has one WebSocket host. It accepts every upgrade and
-calls host methods on the Durable Object. The private browser-channel
-extraction works because every Agent socket still has the same owner.
-
-Before exposing a second WebSocket channel, the lifecycle needs named ownership:
+The set checks channels in declaration order. A channel first decides whether it
+owns the HTTP request. Once it claims the request, no later channel sees it. The
+claiming channel either returns its provider-specific authentication error or
+normalizes provider events. Its own `route` callback then chooses the complete
+durable target for each event.
 
 ```ts
-interface DurableObjectCapability {
-  webSocket?: {
-    /** Stable key persisted with accepted sockets. */
-    key: string;
-    onUpgrade(
-      context: WebSocketUpgradeContext
-    ):
-      | { type: "accept"; tags?: readonly string[] }
-      | { type: "respond"; response: Response }
-      | undefined
-      | Promise<
-          | { type: "accept"; tags?: readonly string[] }
-          | { type: "respond"; response: Response }
-          | undefined
-        >;
-    onConnect?(context: WebSocketConnectContext): MaybePromise<void>;
-    onMessage?(context: WebSocketMessageContext): MaybePromise<void>;
-    onClose?(context: WebSocketCloseContext): MaybePromise<void>;
-    onError?(context: WebSocketErrorContext): MaybePromise<void>;
-  };
+async function routeRequest(request, env) {
+  for (const [channelKey, channel] of configuredChannels) {
+    const received = await channel.receiveGateway(request, { env });
+    if (received === undefined) continue;
+
+    for (const item of received.events) {
+      const target = await channel.route({
+        event: item.routing,
+        raw: item.raw,
+        env
+      });
+
+      if (target === null) continue;
+
+      const response = await target.fetch(
+        makeInternalChannelRequest({
+          channelKey,
+          envelope: item.envelope
+        })
+      );
+
+      if (!response.ok) return received.retryResponse();
+    }
+
+    return received.acknowledge();
+  }
+
+  return undefined;
 }
 ```
 
-The exact type is open. The required behavior is:
+`route` returns a stub rather than a name:
 
-1. handlers claim upgrades in registration order;
-2. the first accept or explicit response wins;
-3. the lifecycle accepts the socket through the Hibernation API;
-4. it stores the handler key in lifecycle-owned attachment metadata;
-5. wakes dispatch only to that handler;
-6. a missing handler is an ownership error, never fallthrough;
-7. old sockets without a key use the current host fallback;
-8. duplicate or renamed keys fail loudly.
+```ts
+route({ event, env }) {
+  return env.SupportAgent.getByName(event.workspaceId);
+}
+```
 
-The owner key must not live in `connection.state`, which belongs to channel and
-application code.
+This lets application policy choose the Durable Object class and any namespace
+options in one place. The router neither knows nor reconstructs application
+identity. The structural requirement is only:
 
-The in-progress request-only MCP capability does not depend on this change. If
-MCP publishes state over the browser socket, that publication should later
-register as a browser protocol extension rather than become a second socket
-owner.
+```ts
+type ChannelTarget = {
+  fetch(request: Request): Promise<Response>;
+};
+```
 
-## Compatibility and migration
+A provider request may contain several events. Each event may route to a
+different target. The router acknowledges the provider only after every
+non-ignored event has been durably accepted.
 
-1. Extract the browser protocol into an internal channel and retain current
-   hooks as callbacks. This PR does that.
-2. Add named WebSocket ownership to the lifecycle without changing Agent users.
-3. Add the Agent channel registry and normalized receive path.
-4. Move `AIChatAgent` and Think away from constructor-time method wrapping and
-   into browser protocol registration.
-5. Introduce the semantic message hook and deprecate raw Agent connection hooks.
-6. Remove or rename raw hooks only at an allowed breaking boundary.
+Use `target.fetch`, not arbitrary RPC, so Lifecycle startup and capability
+ordering remain automatic. The internal envelope must be authenticated or
+impossible to forge from the public internet.
 
-Compatibility must cover the browser client, React hooks, state sync, readonly
-connections, protocol suppression, RPC, chat recovery, connection ordering, and
-sub-agent routing.
+## Phase 7: add Agent convenience and migrate the hook
 
-## Relationship to existing channel work
+`Agent.defineChannels()` constructs and installs the generic runtime:
 
-Think already exports `ChannelDefinition`. It combines messenger configuration,
-turn policy, tool narrowing, and delivery. This RFC defines a lower boundary:
-transport normalization and reply delivery in base Agent, with turn policy and
-recovery remaining in Think.
+```ts
+protected defineChannels(definitions) {
+  const runtime = createChannelRuntime({
+    storage: this.ctx.storage,
+    scheduler: this.schedules,
+    env: this.env,
+    channels: {
+      web: createAgentBrowserChannel(this),
+      ...definitions
+    },
+    onMessage: (message, context) =>
+      this.onAgentMessage(message, context)
+  });
 
-We should avoid publishing another unrelated type named simply `Channel`.
-Explicit base names such as `AgentChannel`, `AgentMessage`, and
-`AgentMessageContext` are safer until the layers converge.
+  this.lifecycle.use(runtime);
+  return runtime;
+}
+```
 
-PR #2129 contains useful pieces, especially normalized provider events,
-serializable reply destinations, stable source IDs, and honest delivery
-outcomes. Its `ChannelHost` creates a second application callback and routing
-system beside Agent, and the PR also takes on identities, approvals, fallback,
-fanout, AI tools, and several providers at once.
+Use a temporary semantic hook while raw `onMessage(connection, frame)` exists:
 
-This proposal starts smaller:
+```ts
+async onAgentMessage(
+  message: ChannelMessage,
+  context: ChannelMessageContext
+): Promise<void> {}
+```
 
-1. private browser-channel extraction;
-2. lifecycle ownership for multiple WebSocket channels;
-3. one Agent message and reply boundary;
-4. request channel and one external provider;
-5. only then revisit identities, approvals, and composite delivery.
+Migration:
 
-## Alternatives
+```text
+release N
+  add onAgentMessage(message, context)
+  keep raw onMessage(connection, frame)
+  move docs to channel configuration
 
-- **Provider-specific Agent hooks.** Rejected because application logic stays
+breaking release
+  rename raw hook to onWebSocketFrame or remove it
+  rename onAgentMessage to onMessage
+  keep raw hooks only inside webSocketChannel options
+```
+
+The ideal final Agent has one semantic `onMessage(message, context)` method.
+Connection events live only in the configured WebSocket channel.
+
+## Phase 8: converge Think channels
+
+Think currently owns channel policy above a special-cased transport layer. It
+should consume base Channel messages rather than define another unrelated
+transport system.
+
+```text
+base ChannelRuntime receives message
+-> Think resolves channel policy
+-> Think admits durable turn
+-> Think runs model and recovery
+-> Think calls base context.reply
+```
+
+Think continues owning:
+
+- model instructions and tool narrowing;
+- turn admission and concurrency;
+- streaming and recovery;
+- notices and reply attachments.
+
+Base channels continue owning:
+
+- provider authentication and normalization;
+- durable ingress acceptance;
+- reply targets and delivery attempts;
+- WebSocket connection ownership.
+
+## Phase 9: publish only after the seams hold
+
+Add `agents/channels` only after:
+
+- one Agent and one plain Durable Object use the same runtime;
+- browser, request, and one external provider reach the same handler;
+- hibernation restores the correct WebSocket owner;
+- the shared channel router acknowledges only after durable acceptance;
+- existing Agent, AIChat, Think, React, RPC, state, readonly, and sub-agent tests
+  remain green;
+- generated declarations expose no implementation host interfaces.
+
+# Relationship to current work
+
+## This PR
+
+This PR implements Phase 0 only. It also records the proposed end state and
+migration. It exports no channel API.
+
+## MCP capability work
+
+The request-only MCP capability can proceed independently using the existing
+ordered `onRequest` phase. Later, MCP publication becomes a protocol extension
+inside the Agent browser channel. MCP does not become a WebSocket owner.
+
+## PR #2129
+
+PR #2129 contains useful ideas:
+
+- normalized provider events;
+- serializable reply destinations;
+- stable source IDs;
+- delivery results that admit uncertainty.
+
+This RFC does not adopt a standalone `ChannelHost` as the application owner.
+The durable application owns a `ChannelRuntime` capability beside its other
+capabilities. Identity linking, approvals, fallback, fanout, AI tools, and
+multiple providers are deferred until this smaller boundary works.
+
+# Alternatives
+
+- **Provider-specific Agent hooks.** Rejected because application logic remains
   tied to providers.
-- **Standalone `ChannelHost` as the application owner.** Rejected because Agent
-  would still need a second routing, callback, and durability model.
-- **Every capability observes every frame.** Rejected because consumption,
-  ordering, errors, and hibernation ownership become ambiguous.
-- **State and RPC as channels.** Rejected because they are extensions of one
-  browser connection.
-- **Every HTTP request becomes a message.** Rejected because callbacks, health
-  checks, assets, and arbitrary APIs have different semantics.
-- **Every provider URL includes the Agent name.** Preferred where possible, but
-  insufficient for a shared webhook serving many Agent instances.
+- **A standalone application `ChannelHost`.** Rejected because Agent and plain
+  Durable Objects would gain a second routing, callback, and durability model.
+- **Every capability observes every WebSocket frame.** Rejected because
+  consumption, ordering, error ownership, and hibernation routing become
+  ambiguous.
+- **State and RPC are channels.** Rejected because they are protocols carried by
+  one browser connection.
+- **Every HTTP request is a message.** Rejected because callbacks, health checks,
+  assets, and arbitrary APIs have different semantics.
+- **Every provider URL contains the Durable Object name.** Preferred where
+  possible, but insufficient for shared webhooks.
+- **Durability inside every adapter.** Rejected because providers would expose
+  inconsistent guarantees and duplicate runtime storage logic.
 
-## Open questions
+# Open questions
 
-- What temporary name should carry normalized messages while raw `onMessage`
-  remains supported?
-- How should one adapter definition bind Worker gateway configuration and Agent
-  instance delivery without duplication?
-- Which actor and conversation fields belong in base Agent rather than Think?
-- What durable inbox should webhook channels use?
-- How should protocol extensions register with the browser channel?
-- Should the first external proof use Slack or Telegram?
+- Should the temporary semantic hook be `onAgentMessage`, `onChannelMessage`, or
+  another name?
+- What scheduler port should the runtime use before schedules are fully
+  extracted from Agent?
+- Which actor and conversation fields belong in the base normalized contract?
+- Which ingress types may opt into inline rather than durable handling?
+- How should internal router envelopes be authenticated?
+- Should the first provider proof use Slack or Telegram?
+- When should the existing Think `ChannelDefinition` converge with this base
+  contract?
 
-## Decision status
+# Decision status
 
-Proposed. This PR makes the first private move by extracting the existing
-browser protocol without exporting a channel API.
+Proposed. The ideal architecture is a Lifecycle-composed `ChannelRuntime` usable
+from any Durable Object, with `Agent` providing the preconfigured browser
+protocol and a simpler API. This PR makes the first private move by extracting
+the current Agent browser protocol without exporting channel symbols.

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -49,6 +49,10 @@ src/
   utils.ts              # Helpers (camelCaseToKebabCase, etc.)
   internal_context.ts   # AsyncLocalStorage context for getCurrentAgent()
 
+  internal/             # Package-private protocol implementation (not exported)
+    agent-websocket-channel.ts # Built-in browser WS protocol owner
+    rpc.ts              # Callable RPC parsing, dispatch types, streaming response
+
   lifecycle/            # Public Durable Object lifecycle composition
     index.ts            # Intentionally small public lifecycle surface
     durable-object-lifecycle.ts # Runtime handlers, routing, capabilities

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -53,6 +53,15 @@ import {
   type WSMessage,
   routeDurableObjectRequest
 } from "./lifecycle/durable-object-lifecycle";
+import { AgentWebSocketChannel } from "./internal/agent-websocket-channel";
+import { callableMetadata, type CallableMetadata } from "./internal/rpc";
+export { callable, StreamingResponse, unstable_callable } from "./internal/rpc";
+export type {
+  CallableMetadata,
+  RPCRequest,
+  RPCResponse,
+  StateUpdateMessage
+} from "./internal/rpc";
 import { getAgentByName } from "./agent-routing";
 export { getAgentByName, type AgentGetOptions } from "./agent-routing";
 import { camelCaseToKebabCase, isInternalJsStubProp } from "./utils";
@@ -215,47 +224,6 @@ export type SendEmailOptions = {
 };
 
 /**
- * RPC request message from client
- */
-export type RPCRequest = {
-  type: "rpc";
-  id: string;
-  method: string;
-  args: unknown[];
-};
-
-/**
- * State update message from client
- */
-export type StateUpdateMessage = {
-  type: MessageType.CF_AGENT_STATE;
-  state: unknown;
-};
-
-/**
- * RPC response message to client
- */
-export type RPCResponse = {
-  type: MessageType.RPC;
-  id: string;
-} & (
-  | {
-      success: true;
-      result: unknown;
-      done?: false;
-    }
-  | {
-      success: true;
-      result: unknown;
-      done: true;
-    }
-  | {
-      success: false;
-      error: string;
-    }
-);
-
-/**
  * Enters an agent invocation: the context every handler reads, plus the span
  * scope that stops invocation-bounded spans from outliving it. Scopes do not
  * nest, so the outermost live entry point owns the boundary — pass
@@ -268,69 +236,6 @@ function runInInvocation<T>(
 ): T {
   return agentContext.run(store, () => withInvocationScope(body, options));
 }
-
-function isClosedWebSocketSendError(error: unknown): boolean {
-  return (
-    error instanceof TypeError &&
-    error.message.includes("WebSocket send() after close")
-  );
-}
-
-function sendRpcResponseIfOpen(
-  connection: Connection,
-  response: RPCResponse
-): boolean {
-  try {
-    connection.send(JSON.stringify(response));
-    return true;
-  } catch (error) {
-    if (isClosedWebSocketSendError(error)) return false;
-    throw error;
-  }
-}
-
-/**
- * Type guard for RPC request messages
- */
-function isRPCRequest(msg: unknown): msg is RPCRequest {
-  return (
-    typeof msg === "object" &&
-    msg !== null &&
-    "type" in msg &&
-    msg.type === MessageType.RPC &&
-    "id" in msg &&
-    typeof msg.id === "string" &&
-    "method" in msg &&
-    typeof msg.method === "string" &&
-    "args" in msg &&
-    Array.isArray((msg as RPCRequest).args)
-  );
-}
-
-/**
- * Type guard for state update messages
- */
-function isStateUpdateMessage(msg: unknown): msg is StateUpdateMessage {
-  return (
-    typeof msg === "object" &&
-    msg !== null &&
-    "type" in msg &&
-    msg.type === MessageType.CF_AGENT_STATE &&
-    "state" in msg
-  );
-}
-
-/**
- * Metadata for a callable method
- */
-export type CallableMetadata = {
-  /** Optional description of what the method does */
-  description?: string;
-  /** Whether the method supports streaming responses */
-  streaming?: boolean;
-};
-
-const callableMetadata = new WeakMap<Function, CallableMetadata>();
 
 /**
  * Error class for SQL execution failures, containing the query that failed
@@ -538,40 +443,6 @@ export type SubAgentStub<T extends Agent> = {
       : never]: T[K] extends (...args: infer A) => infer R
     ? (...args: A) => Promisify<R>
     : never;
-};
-
-/**
- * Decorator that marks a method as callable by clients
- * @param metadata Optional metadata about the callable method
- */
-export function callable(metadata: CallableMetadata = {}) {
-  return function callableDecorator<This, Args extends unknown[], Return>(
-    target: (this: This, ...args: Args) => Return,
-    _context: ClassMethodDecoratorContext
-  ) {
-    if (!callableMetadata.has(target)) {
-      callableMetadata.set(target, metadata);
-    }
-
-    return target;
-  };
-}
-
-let didWarnAboutUnstableCallable = false;
-
-/**
- * Decorator that marks a method as callable by clients
- * @deprecated this has been renamed to callable, and unstable_callable will be removed in the next major version
- * @param metadata Optional metadata about the callable method
- */
-export const unstable_callable = (metadata: CallableMetadata = {}) => {
-  if (!didWarnAboutUnstableCallable) {
-    didWarnAboutUnstableCallable = true;
-    console.warn(
-      "unstable_callable is deprecated, use callable instead. unstable_callable will be removed in the next major version."
-    );
-  }
-  return callable(metadata);
 };
 
 export type QueueItem<T = string> = {
@@ -1301,12 +1172,6 @@ function sanitizeErrorString(error: string | null): string | null {
 const _onStateUpdateWarnedClasses = new WeakSet<Function>();
 
 /**
- * Tracks which agent constructors have already emitted the
- * sendIdentityOnConnect deprecation warning, so it fires at most once per class.
- */
-const _sendIdentityWarnedClasses = new WeakSet<Function>();
-
-/**
  * Default options for Agent configuration.
  * Child classes can override specific options without spreading.
  */
@@ -1687,7 +1552,7 @@ export class Agent<
   /** True when this agent runs as a facet (sub-agent) inside a parent. */
   private _isFacet = false;
 
-  private _protocolBroadcastExcludeIds = new Set<string>();
+  #webSocketChannel: AgentWebSocketChannel<State>;
   private _cf_currentSubAgentBridge?: SubAgentConnectionBridgeLike;
   private _cf_virtualSubAgentConnections = new Map<
     string,
@@ -2497,277 +2362,107 @@ export class Agent<
       );
     };
 
-    const _onMessage = this.onMessage.bind(this);
-    this.onMessage = async (connection: Connection, message: WSMessage) => {
-      if (await this._cf_forwardSubAgentWebSocketMessage(connection, message)) {
-        return;
-      }
-      this._ensureConnectionWrapped(connection);
-      return runInInvocation(
-        { agent: this, connection, request: undefined, email: undefined },
-        async () => {
-          if (typeof message !== "string") {
-            return this._tryCatch(() => _onMessage(connection, message));
-          }
+    const legacyOnMessage = this.onMessage.bind(this);
+    const legacyOnConnect = this.onConnect.bind(this);
+    const legacyOnClose = this.onClose.bind(this);
 
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(message);
-          } catch (_e) {
-            // silently fail and let the onMessage handler handle it
-            return this._tryCatch(() => _onMessage(connection, message));
-          }
-
-          if (isStateUpdateMessage(parsed)) {
-            // Check if connection is readonly
-            if (this.isConnectionReadonly(connection)) {
-              // Send error response back to the connection
-              connection.send(
-                JSON.stringify({
-                  type: MessageType.CF_AGENT_STATE_ERROR,
-                  error: "Connection is readonly"
-                })
-              );
-              return;
-            }
-            try {
-              this._setStateInternal(parsed.state as State, connection);
-            } catch (e) {
-              // validateStateChange (or another sync error) rejected the update.
-              // Log the full error server-side, send a generic message to the client.
-              console.error("[Agent] State update rejected:", e);
-              connection.send(
-                JSON.stringify({
-                  type: MessageType.CF_AGENT_STATE_ERROR,
-                  error: "State update rejected"
-                })
-              );
-            }
-            return;
-          }
-
-          if (isRPCRequest(parsed)) {
-            try {
-              const { id, method, args } = parsed;
-
-              // Check if method exists and is callable
-              const methodFn = this[method as keyof this];
-              if (typeof methodFn !== "function") {
-                throw new Error(`Method ${method} does not exist`);
-              }
-
-              if (!this._isCallable(method)) {
-                throw new Error(`Method ${method} is not callable`);
-              }
-
-              const metadata = callableMetadata.get(methodFn as Function);
-
-              // For streaming methods, pass a StreamingResponse object
-              if (metadata?.streaming) {
-                const stream = new StreamingResponse(connection, id);
-
-                this._emit("rpc", { method, streaming: true });
-
-                try {
-                  await methodFn.apply(this, [stream, ...args]);
-                } catch (err) {
-                  console.error(`Error in streaming method "${method}":`, err);
-                  this._emit("rpc:error", {
-                    method,
-                    error: err instanceof Error ? err.message : String(err)
-                  });
-                  // Auto-close stream with error if method throws before closing
-                  if (!stream.isClosed) {
-                    stream.error(
-                      err instanceof Error ? err.message : String(err)
-                    );
-                  }
-                }
-                return;
-              }
-
-              // For regular methods, execute and send response
-              const result = await methodFn.apply(this, args);
-
-              this._emit("rpc", { method, streaming: metadata?.streaming });
-
-              const response: RPCResponse = {
-                done: true,
-                id,
-                result,
-                success: true,
-                type: MessageType.RPC
-              };
-              sendRpcResponseIfOpen(connection, response);
-            } catch (e) {
-              // Send error response
-              const response: RPCResponse = {
-                error:
-                  e instanceof Error ? e.message : "Unknown error occurred",
-                id: parsed.id,
-                success: false,
-                type: MessageType.RPC
-              };
-              sendRpcResponseIfOpen(connection, response);
-              console.error("RPC error:", e);
-              this._emit("rpc:error", {
-                method: parsed.method,
-                error: e instanceof Error ? e.message : String(e)
-              });
-            }
-            return;
-          }
-
-          return this._tryCatch(() => _onMessage(connection, message));
-        }
-      );
-    };
-
-    const _onConnect = this.onConnect.bind(this);
-    this.onConnect = async (connection: Connection, ctx: ConnectionContext) => {
-      this._ensureConnectionWrapped(connection);
-      const subAgentOuterUrl = ctx.request.headers.get(
-        SUB_AGENT_OUTER_URL_HEADER
-      );
-      if (subAgentOuterUrl) {
-        this._unsafe_setConnectionFlag(
-          connection,
-          CF_SUB_AGENT_OUTER_URL_KEY,
-          subAgentOuterUrl
-        );
-      }
-      if (
-        await this._cf_forwardSubAgentWebSocketConnect(
-          connection,
-          ctx.request,
-          {
+    this.#webSocketChannel = new AgentWebSocketChannel<State>(
+      {
+        ensureConnectionWrapped: (connection) =>
+          this._ensureConnectionWrapped(connection),
+        setConnectionFlag: (connection, key, value) =>
+          this._unsafe_setConnectionFlag(connection, key, value),
+        forwardSubAgentConnect: (connection, request) =>
+          this._cf_forwardSubAgentWebSocketConnect(connection, request, {
             gate: false
-          }
-        )
-      ) {
-        return;
-      }
-      // TODO: This is a hack to ensure the state is sent after the connection is established
-      // must fix this
-      return runInInvocation(
-        { agent: this, connection, request: ctx.request, email: undefined },
-        async () => {
-          // Check if connection should be readonly before sending any messages
-          // so that the flag is set before the client can respond
-          if (this.shouldConnectionBeReadonly(connection, ctx)) {
-            this.setConnectionReadonly(connection, true);
-          }
-
-          // Check if protocol messages should be suppressed for this
-          // connection. When disabled, no identity/state/MCP text frames
-          // are sent — useful for binary-only clients (e.g. MQTT devices).
-          if (this.shouldSendProtocolMessages(connection, ctx)) {
-            // Send agent identity first so client knows which instance it's connected to
-            // Can be disabled via static options for security-sensitive instance names
-            if (this._resolvedOptions.sendIdentityOnConnect) {
-              const ctor = this.constructor as typeof Agent;
-              if (
-                ctor.options?.sendIdentityOnConnect === undefined &&
-                !_sendIdentityWarnedClasses.has(ctor) &&
-                // Facets are always addressed via `/sub/{class}/{name}`
-                // in the OUTER client URL, even though the request the
-                // facet itself receives has that segment stripped by
-                // `_cf_forwardToFacet`. The sendIdentityOnConnect
-                // concern (name only reachable via identity push) does
-                // not apply — skip the warning entirely for facets.
-                !this._isFacet
-              ) {
-                // Only warn when using custom routing — with default routing
-                // the name is already visible in the URL path (/agents/{class}/{name})
-                // so sendIdentityOnConnect leaks no additional information.
-                const urlPath = new URL(ctx.request.url).pathname;
-                if (!urlPath.includes(this.name)) {
-                  _sendIdentityWarnedClasses.add(ctor);
-                  console.warn(
-                    `[Agent] ${ctor.name}: sending instance name "${this.name}" to clients ` +
-                      `via sendIdentityOnConnect (the name is not visible in the URL with ` +
-                      `custom routing). If this name is sensitive, add ` +
-                      `\`static options = { sendIdentityOnConnect: false }\` to opt out. ` +
-                      `Set it to true to silence this message.`
-                  );
-                }
-              }
-              connection.send(
-                JSON.stringify({
-                  name: this.name,
-                  agent: camelCaseToKebabCase(this._ParentClass.name),
-                  type: MessageType.CF_AGENT_IDENTITY
-                })
-              );
-            }
-
-            const wasExcludedFromStateInitBroadcast =
-              this._protocolBroadcastExcludeIds.has(connection.id);
-            let currentState: State | undefined;
-            this._protocolBroadcastExcludeIds.add(connection.id);
-            try {
-              currentState = this.state;
-            } finally {
-              if (!wasExcludedFromStateInitBroadcast) {
-                this._protocolBroadcastExcludeIds.delete(connection.id);
-              }
-            }
-
-            if (currentState !== undefined) {
-              connection.send(
-                JSON.stringify({
-                  state: currentState,
-                  type: MessageType.CF_AGENT_STATE
-                })
-              );
-            }
-
-            connection.send(
-              JSON.stringify({
-                mcp: this.getMcpServers(),
-                type: MessageType.CF_AGENT_MCP_SERVERS
-              })
-            );
-          } else {
-            this._setConnectionNoProtocol(connection);
-          }
-
-          this._emit("connect", { connectionId: connection.id });
-          await this._replayAgentToolRuns(connection);
-          return this._tryCatch(() => _onConnect(connection, ctx));
-        }
-      );
-    };
-
-    const _onClose = this.onClose.bind(this);
-    this.onClose = async (
-      connection: Connection,
-      code: number,
-      reason: string,
-      wasClean: boolean
-    ) => {
-      if (
-        await this._cf_forwardSubAgentWebSocketClose(
-          connection,
-          code,
-          reason,
-          wasClean
-        )
-      ) {
-        return;
-      }
-      return runInInvocation(
-        { agent: this, connection, request: undefined, email: undefined },
-        () => {
-          this._emit("disconnect", {
-            connectionId: connection.id,
+          }),
+        forwardSubAgentMessage: (connection, message) =>
+          this._cf_forwardSubAgentWebSocketMessage(connection, message),
+        forwardSubAgentClose: (connection, code, reason, wasClean) =>
+          this._cf_forwardSubAgentWebSocketClose(
+            connection,
             code,
-            reason
-          });
-          return _onClose(connection, code, reason, wasClean);
-        }
-      );
-    };
+            reason,
+            wasClean
+          ),
+        runInConnectionContext: <T>(
+          connection: Connection,
+          request: Request | undefined,
+          operation: () => T
+        ): T =>
+          runInInvocation(
+            { agent: this, connection, request, email: undefined },
+            operation
+          ),
+        withErrorBoundary: (operation) => this._tryCatch(operation),
+        shouldConnectionBeReadonly: (connection, context) =>
+          this.shouldConnectionBeReadonly(connection, context),
+        setConnectionReadonly: (connection, readonly) =>
+          this.setConnectionReadonly(connection, readonly),
+        isConnectionReadonly: (connection) =>
+          this.isConnectionReadonly(connection),
+        shouldSendProtocolMessages: (connection, context) =>
+          this.shouldSendProtocolMessages(connection, context),
+        disableProtocolMessages: (connection) =>
+          this._setConnectionNoProtocol(connection),
+        isConnectionProtocolEnabled: (connection) =>
+          this.isConnectionProtocolEnabled(connection),
+        getConnections: () => this.getConnections(),
+        broadcast: (message, without) => this.broadcast(message, without),
+        getIdentity: () => {
+          const ctor = this.constructor as typeof Agent;
+          return {
+            agent: camelCaseToKebabCase(this._ParentClass.name),
+            agentClass: ctor,
+            explicitSetting: ctor.options?.sendIdentityOnConnect !== undefined,
+            isFacet: this._isFacet,
+            name: this.name,
+            sendOnConnect: this._resolvedOptions.sendIdentityOnConnect
+          };
+        },
+        getState: () => this.state,
+        setStateFromClient: (state, connection) =>
+          this._setStateInternal(state, connection),
+        getMcpServers: () => this.getMcpServers(),
+        resolveCallable: (method) => {
+          const methodFn = this[method as keyof this];
+          if (typeof methodFn !== "function") {
+            throw new Error(`Method ${method} does not exist`);
+          }
+          if (!this._isCallable(method)) {
+            throw new Error(`Method ${method} is not callable`);
+          }
+          const metadata = callableMetadata.get(methodFn as Function);
+          if (!metadata) {
+            throw new Error(`Method ${method} is not callable`);
+          }
+          return {
+            metadata,
+            invoke: (args: unknown[]) => methodFn.apply(this, args)
+          };
+        },
+        emit: (type, payload) => this._emit(type, payload),
+        replayAgentToolRuns: (connection) =>
+          this._replayAgentToolRuns(connection)
+      },
+      {
+        onConnect: legacyOnConnect,
+        onMessage: legacyOnMessage,
+        onClose: legacyOnClose
+      },
+      {
+        outerUrlHeader: SUB_AGENT_OUTER_URL_HEADER,
+        outerUrlKey: CF_SUB_AGENT_OUTER_URL_KEY
+      }
+    );
+
+    this.onConnect = this.#webSocketChannel.onConnect.bind(
+      this.#webSocketChannel
+    );
+    this.onMessage = this.#webSocketChannel.onMessage.bind(
+      this.#webSocketChannel
+    );
+    this.onClose = this.#webSocketChannel.onClose.bind(this.#webSocketChannel);
 
     const _onStart = this.onStart.bind(this);
     const startAgent = async (
@@ -2970,13 +2665,7 @@ export class Agent<
    * @param excludeIds Additional connection IDs to exclude (e.g. the source)
    */
   private _broadcastProtocol(msg: string, excludeIds: string[] = []) {
-    const exclude = [...excludeIds, ...this._protocolBroadcastExcludeIds];
-    for (const conn of this.getConnections()) {
-      if (!this.isConnectionProtocolEnabled(conn)) {
-        exclude.push(conn.id);
-      }
-    }
-    this.broadcast(msg, exclude);
+    this.#webSocketChannel.broadcastProtocol(msg, excludeIds);
   }
 
   private _setStateInternal(
@@ -2994,14 +2683,8 @@ export class Agent<
       VALUES (${STATE_ROW_ID}, ${JSON.stringify(nextState)})
     `;
 
-    // Broadcast state to protocol-enabled connections, excluding the source
-    this._broadcastProtocol(
-      JSON.stringify({
-        state: nextState,
-        type: MessageType.CF_AGENT_STATE
-      }),
-      source !== "server" ? [source.id] : []
-    );
+    // The browser channel owns state protocol delivery.
+    this.#webSocketChannel.broadcastState(nextState, source);
 
     // Notification hook (non-gating). Run after broadcast and do not block.
     // Use waitUntil for reliability after the handler returns.
@@ -13123,86 +12806,4 @@ export async function routeAgentEmail<
     _secureRouted: routingInfo._secureRouted,
     _bridge: bridge
   });
-}
-
-/**
- * A wrapper for streaming responses in callable methods
- */
-export class StreamingResponse {
-  private _connection: Connection;
-  private _id: string;
-  private _closed = false;
-
-  constructor(connection: Connection, id: string) {
-    this._connection = connection;
-    this._id = id;
-  }
-
-  /**
-   * Whether the stream has been closed (via end() or error())
-   */
-  get isClosed(): boolean {
-    return this._closed;
-  }
-
-  /**
-   * Send a chunk of data to the client
-   * @param chunk The data to send
-   * @returns false if stream is already closed (no-op), true if sent
-   */
-  send(chunk: unknown): boolean {
-    if (this._closed) {
-      console.warn(
-        "StreamingResponse.send() called after stream was closed - data not sent"
-      );
-      return false;
-    }
-    const response: RPCResponse = {
-      done: false,
-      id: this._id,
-      result: chunk,
-      success: true,
-      type: MessageType.RPC
-    };
-    return sendRpcResponseIfOpen(this._connection, response);
-  }
-
-  /**
-   * End the stream and send the final chunk (if any)
-   * @param finalChunk Optional final chunk of data to send
-   * @returns false if stream is already closed (no-op), true if sent
-   */
-  end(finalChunk?: unknown): boolean {
-    if (this._closed) {
-      return false;
-    }
-    this._closed = true;
-    const response: RPCResponse = {
-      done: true,
-      id: this._id,
-      result: finalChunk,
-      success: true,
-      type: MessageType.RPC
-    };
-    return sendRpcResponseIfOpen(this._connection, response);
-  }
-
-  /**
-   * Send an error to the client and close the stream
-   * @param message Error message to send
-   * @returns false if stream is already closed (no-op), true if sent
-   */
-  error(message: string): boolean {
-    if (this._closed) {
-      return false;
-    }
-    this._closed = true;
-    const response: RPCResponse = {
-      error: message,
-      id: this._id,
-      success: false,
-      type: MessageType.RPC
-    };
-    return sendRpcResponseIfOpen(this._connection, response);
-  }
 }

--- a/packages/agents/src/internal/agent-websocket-channel.ts
+++ b/packages/agents/src/internal/agent-websocket-channel.ts
@@ -1,0 +1,430 @@
+import type {
+  Connection,
+  ConnectionContext,
+  WSMessage
+} from "../lifecycle/durable-object-lifecycle";
+import {
+  isRPCRequest,
+  isStateUpdateMessage,
+  sendRpcResponseIfOpen,
+  StreamingResponse,
+  type CallableMetadata,
+  type RPCResponse
+} from "./rpc";
+import { MessageType } from "../types";
+
+const identityWarningClasses = new WeakSet<Function>();
+
+/** @internal A callable Agent method resolved for the browser protocol. */
+export type ResolvedAgentCallable = {
+  metadata: CallableMetadata;
+  invoke(args: unknown[]): unknown | Promise<unknown>;
+};
+
+/** @internal Identity sent when an Agent browser connection opens. */
+export type AgentWebSocketIdentity = {
+  agent: string;
+  agentClass: Function;
+  explicitSetting: boolean;
+  isFacet: boolean;
+  name: string;
+  sendOnConnect: boolean;
+};
+
+/** @internal Operations the built-in Agent WebSocket channel needs from Agent. */
+export interface AgentWebSocketChannelHost<State> {
+  ensureConnectionWrapped(connection: Connection): void;
+  setConnectionFlag(connection: Connection, key: string, value: unknown): void;
+  forwardSubAgentConnect(
+    connection: Connection,
+    request: Request
+  ): Promise<boolean>;
+  forwardSubAgentMessage(
+    connection: Connection,
+    message: WSMessage
+  ): Promise<boolean>;
+  forwardSubAgentClose(
+    connection: Connection,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): Promise<boolean>;
+  runInConnectionContext<T>(
+    connection: Connection,
+    request: Request | undefined,
+    operation: () => T
+  ): T;
+  withErrorBoundary<T>(operation: () => T | Promise<T>): Promise<T>;
+  shouldConnectionBeReadonly(
+    connection: Connection,
+    context: ConnectionContext
+  ): boolean;
+  setConnectionReadonly(connection: Connection, readonly?: boolean): void;
+  isConnectionReadonly(connection: Connection): boolean;
+  shouldSendProtocolMessages(
+    connection: Connection,
+    context: ConnectionContext
+  ): boolean;
+  disableProtocolMessages(connection: Connection): void;
+  isConnectionProtocolEnabled(connection: Connection): boolean;
+  getConnections(): Iterable<Connection>;
+  broadcast(message: string, without?: string[]): void;
+  getIdentity(): AgentWebSocketIdentity;
+  getState(): State;
+  setStateFromClient(state: State, connection: Connection): void;
+  getMcpServers(): unknown;
+  resolveCallable(method: string): ResolvedAgentCallable;
+  emit(
+    type: "connect" | "disconnect" | "rpc" | "rpc:error",
+    payload: Record<string, unknown>
+  ): void;
+  replayAgentToolRuns(connection: Connection): Promise<void>;
+}
+
+/** @internal Legacy connection callbacks retained while channels remain private. */
+export type AgentWebSocketChannelHooks = {
+  onConnect(
+    connection: Connection,
+    context: ConnectionContext
+  ): void | Promise<void>;
+  onMessage(connection: Connection, message: WSMessage): void | Promise<void>;
+  onClose(
+    connection: Connection,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): void | Promise<void>;
+};
+
+/**
+ * Internal built-in channel for the Agents browser WebSocket protocol.
+ *
+ * This module deliberately has no package export. It separates protocol
+ * ownership from the Agent class while preserving the existing connection
+ * hooks as compatibility callbacks until the public channel API is designed.
+ *
+ * @internal
+ */
+export class AgentWebSocketChannel<State> {
+  readonly #host: AgentWebSocketChannelHost<State>;
+  readonly #hooks: AgentWebSocketChannelHooks;
+  readonly #protocolBroadcastExcludeIds = new Set<string>();
+  readonly #subAgentOuterUrlHeader: string;
+  readonly #subAgentOuterUrlKey: string;
+
+  /**
+   * Create the built-in Agent browser channel.
+   *
+   * @param host - Agent operations needed by the protocol.
+   * @param hooks - Existing user connection hooks used as compatibility exits.
+   * @param subAgentRouting - Internal sub-agent routing metadata.
+   */
+  constructor(
+    host: AgentWebSocketChannelHost<State>,
+    hooks: AgentWebSocketChannelHooks,
+    subAgentRouting: { outerUrlHeader: string; outerUrlKey: string }
+  ) {
+    this.#host = host;
+    this.#hooks = hooks;
+    this.#subAgentOuterUrlHeader = subAgentRouting.outerUrlHeader;
+    this.#subAgentOuterUrlKey = subAgentRouting.outerUrlKey;
+  }
+
+  /** Handle a newly accepted lifecycle WebSocket. */
+  async onConnect(
+    connection: Connection,
+    context: ConnectionContext
+  ): Promise<void> {
+    this.#host.ensureConnectionWrapped(connection);
+
+    const subAgentOuterUrl = context.request.headers.get(
+      this.#subAgentOuterUrlHeader
+    );
+    if (subAgentOuterUrl) {
+      this.#host.setConnectionFlag(
+        connection,
+        this.#subAgentOuterUrlKey,
+        subAgentOuterUrl
+      );
+    }
+
+    if (await this.#host.forwardSubAgentConnect(connection, context.request)) {
+      return;
+    }
+
+    return this.#host.runInConnectionContext(
+      connection,
+      context.request,
+      async () => {
+        if (this.#host.shouldConnectionBeReadonly(connection, context)) {
+          this.#host.setConnectionReadonly(connection, true);
+        }
+
+        if (this.#host.shouldSendProtocolMessages(connection, context)) {
+          this.#sendInitialProtocolState(connection, context.request);
+        } else {
+          this.#host.disableProtocolMessages(connection);
+        }
+
+        this.#host.emit("connect", { connectionId: connection.id });
+        await this.#host.replayAgentToolRuns(connection);
+        await this.#host.withErrorBoundary(() =>
+          this.#hooks.onConnect(connection, context)
+        );
+      }
+    );
+  }
+
+  /** Handle one raw frame from a lifecycle WebSocket. */
+  async onMessage(connection: Connection, message: WSMessage): Promise<void> {
+    if (await this.#host.forwardSubAgentMessage(connection, message)) {
+      return;
+    }
+
+    this.#host.ensureConnectionWrapped(connection);
+    return this.#host.runInConnectionContext(
+      connection,
+      undefined,
+      async () => {
+        if (typeof message !== "string") {
+          await this.#forwardUnhandledMessage(connection, message);
+          return;
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(message);
+        } catch {
+          await this.#forwardUnhandledMessage(connection, message);
+          return;
+        }
+
+        if (isStateUpdateMessage(parsed)) {
+          // SAFETY: State is the Agent owner's declared wire-state type. The
+          // channel preserves the existing protocol boundary and the Agent's
+          // validateStateChange hook rejects invalid values before persistence.
+          this.#handleStateUpdate(connection, parsed.state as State);
+          return;
+        }
+
+        if (isRPCRequest(parsed)) {
+          await this.#handleRpc(connection, parsed);
+          return;
+        }
+
+        await this.#forwardUnhandledMessage(connection, message);
+      }
+    );
+  }
+
+  /** Handle a lifecycle WebSocket closing. */
+  async onClose(
+    connection: Connection,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): Promise<void> {
+    if (
+      await this.#host.forwardSubAgentClose(connection, code, reason, wasClean)
+    ) {
+      return;
+    }
+
+    return this.#host.runInConnectionContext(
+      connection,
+      undefined,
+      async () => {
+        this.#host.emit("disconnect", {
+          connectionId: connection.id,
+          code,
+          reason
+        });
+        await this.#hooks.onClose(connection, code, reason, wasClean);
+      }
+    );
+  }
+
+  /** Broadcast an Agents protocol frame to protocol-enabled connections. */
+  broadcastProtocol(message: string, excludeIds: string[] = []): void {
+    const exclude = [...excludeIds, ...this.#protocolBroadcastExcludeIds];
+    for (const connection of this.#host.getConnections()) {
+      if (!this.#host.isConnectionProtocolEnabled(connection)) {
+        exclude.push(connection.id);
+      }
+    }
+    this.#host.broadcast(message, exclude);
+  }
+
+  /** Broadcast a state change, excluding the client that originated it. */
+  broadcastState(state: State, source: Connection | "server"): void {
+    this.broadcastProtocol(
+      JSON.stringify({
+        state,
+        type: MessageType.CF_AGENT_STATE
+      }),
+      source === "server" ? [] : [source.id]
+    );
+  }
+
+  #sendInitialProtocolState(connection: Connection, request: Request): void {
+    const identity = this.#host.getIdentity();
+    if (identity.sendOnConnect) {
+      this.#warnIfCustomRouteRevealsIdentity(identity, request);
+      connection.send(
+        JSON.stringify({
+          name: identity.name,
+          agent: identity.agent,
+          type: MessageType.CF_AGENT_IDENTITY
+        })
+      );
+    }
+
+    const wasExcluded = this.#protocolBroadcastExcludeIds.has(connection.id);
+    this.#protocolBroadcastExcludeIds.add(connection.id);
+    let currentState: State;
+    try {
+      currentState = this.#host.getState();
+    } finally {
+      if (!wasExcluded) {
+        this.#protocolBroadcastExcludeIds.delete(connection.id);
+      }
+    }
+
+    if (currentState !== undefined) {
+      connection.send(
+        JSON.stringify({
+          state: currentState,
+          type: MessageType.CF_AGENT_STATE
+        })
+      );
+    }
+
+    connection.send(
+      JSON.stringify({
+        mcp: this.#host.getMcpServers(),
+        type: MessageType.CF_AGENT_MCP_SERVERS
+      })
+    );
+  }
+
+  #warnIfCustomRouteRevealsIdentity(
+    identity: AgentWebSocketIdentity,
+    request: Request
+  ): void {
+    if (
+      identity.explicitSetting ||
+      identity.isFacet ||
+      identityWarningClasses.has(identity.agentClass) ||
+      new URL(request.url).pathname.includes(identity.name)
+    ) {
+      return;
+    }
+
+    identityWarningClasses.add(identity.agentClass);
+    console.warn(
+      `[Agent] ${identity.agentClass.name}: sending instance name "${identity.name}" to clients ` +
+        `via sendIdentityOnConnect (the name is not visible in the URL with ` +
+        `custom routing). If this name is sensitive, add ` +
+        `\`static options = { sendIdentityOnConnect: false }\` to opt out. ` +
+        `Set it to true to silence this message.`
+    );
+  }
+
+  #handleStateUpdate(connection: Connection, state: State): void {
+    if (this.#host.isConnectionReadonly(connection)) {
+      connection.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_STATE_ERROR,
+          error: "Connection is readonly"
+        })
+      );
+      return;
+    }
+
+    try {
+      this.#host.setStateFromClient(state, connection);
+    } catch (error) {
+      console.error("[Agent] State update rejected:", error);
+      connection.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_STATE_ERROR,
+          error: "State update rejected"
+        })
+      );
+    }
+  }
+
+  async #handleRpc(
+    connection: Connection,
+    request: { id: string; method: string; args: unknown[] }
+  ): Promise<void> {
+    try {
+      const callable = this.#host.resolveCallable(request.method);
+
+      if (callable.metadata.streaming) {
+        const stream = new StreamingResponse(connection, request.id);
+        this.#host.emit("rpc", {
+          method: request.method,
+          streaming: true
+        });
+
+        try {
+          await callable.invoke([stream, ...request.args]);
+        } catch (error) {
+          console.error(
+            `Error in streaming method "${request.method}":`,
+            error
+          );
+          this.#host.emit("rpc:error", {
+            method: request.method,
+            error: error instanceof Error ? error.message : String(error)
+          });
+          if (!stream.isClosed) {
+            stream.error(
+              error instanceof Error ? error.message : String(error)
+            );
+          }
+        }
+        return;
+      }
+
+      const result = await callable.invoke(request.args);
+      this.#host.emit("rpc", {
+        method: request.method,
+        streaming: callable.metadata.streaming
+      });
+
+      const response: RPCResponse = {
+        done: true,
+        id: request.id,
+        result,
+        success: true,
+        type: MessageType.RPC
+      };
+      sendRpcResponseIfOpen(connection, response);
+    } catch (error) {
+      const response: RPCResponse = {
+        error:
+          error instanceof Error ? error.message : "Unknown error occurred",
+        id: request.id,
+        success: false,
+        type: MessageType.RPC
+      };
+      sendRpcResponseIfOpen(connection, response);
+      console.error("RPC error:", error);
+      this.#host.emit("rpc:error", {
+        method: request.method,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  async #forwardUnhandledMessage(
+    connection: Connection,
+    message: WSMessage
+  ): Promise<void> {
+    await this.#host.withErrorBoundary(() =>
+      this.#hooks.onMessage(connection, message)
+    );
+  }
+}

--- a/packages/agents/src/internal/rpc.ts
+++ b/packages/agents/src/internal/rpc.ts
@@ -1,0 +1,224 @@
+import type { Connection } from "../lifecycle/types";
+import { MessageType } from "../types";
+
+/** RPC request message sent by an Agent client. */
+export type RPCRequest = {
+  type: "rpc";
+  id: string;
+  method: string;
+  args: unknown[];
+};
+
+/** State update message sent by an Agent client. */
+export type StateUpdateMessage = {
+  type: MessageType.CF_AGENT_STATE;
+  state: unknown;
+};
+
+/** RPC response message sent to an Agent client. */
+export type RPCResponse = {
+  type: MessageType.RPC;
+  id: string;
+} & (
+  | {
+      success: true;
+      result: unknown;
+      done?: false;
+    }
+  | {
+      success: true;
+      result: unknown;
+      done: true;
+    }
+  | {
+      success: false;
+      error: string;
+    }
+);
+
+/** Metadata attached to a method exposed through Agent RPC. */
+export type CallableMetadata = {
+  /** Optional description of what the callable method does. */
+  description?: string;
+  /** Whether the callable method supports streaming responses. */
+  streaming?: boolean;
+};
+
+/** @internal Metadata registered by the callable decorator. */
+export const callableMetadata = new WeakMap<Function, CallableMetadata>();
+
+/**
+ * Decorate an Agent method so clients may invoke it through RPC.
+ *
+ * @param metadata - Description and streaming behavior for the method.
+ * @returns A stage-three method decorator.
+ */
+export function callable(metadata: CallableMetadata = {}) {
+  return function callableDecorator<This, Args extends unknown[], Return>(
+    target: (this: This, ...args: Args) => Return,
+    _context: ClassMethodDecoratorContext
+  ) {
+    if (!callableMetadata.has(target)) {
+      callableMetadata.set(target, metadata);
+    }
+
+    return target;
+  };
+}
+
+let didWarnAboutUnstableCallable = false;
+
+/**
+ * Decorate an Agent method so clients may invoke it through RPC.
+ *
+ * @deprecated Use {@link callable}. This alias will be removed in the next
+ * major version.
+ * @param metadata - Description and streaming behavior for the method.
+ * @returns A stage-three method decorator.
+ */
+export const unstable_callable = (metadata: CallableMetadata = {}) => {
+  if (!didWarnAboutUnstableCallable) {
+    didWarnAboutUnstableCallable = true;
+    console.warn(
+      "unstable_callable is deprecated, use callable instead. unstable_callable will be removed in the next major version."
+    );
+  }
+  return callable(metadata);
+};
+
+/** @internal Whether an unknown WebSocket payload is an Agent RPC request. */
+export function isRPCRequest(message: unknown): message is RPCRequest {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    message.type === MessageType.RPC &&
+    "id" in message &&
+    typeof message.id === "string" &&
+    "method" in message &&
+    typeof message.method === "string" &&
+    "args" in message &&
+    Array.isArray(message.args)
+  );
+}
+
+/** @internal Whether an unknown WebSocket payload is an Agent state update. */
+export function isStateUpdateMessage(
+  message: unknown
+): message is StateUpdateMessage {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    message.type === MessageType.CF_AGENT_STATE &&
+    "state" in message
+  );
+}
+
+function isClosedWebSocketSendError(error: unknown): boolean {
+  return (
+    error instanceof TypeError &&
+    error.message.includes("WebSocket send() after close")
+  );
+}
+
+/** @internal Send an RPC response unless the WebSocket has already closed. */
+export function sendRpcResponseIfOpen(
+  connection: Connection,
+  response: RPCResponse
+): boolean {
+  try {
+    connection.send(JSON.stringify(response));
+    return true;
+  } catch (error) {
+    if (isClosedWebSocketSendError(error)) return false;
+    throw error;
+  }
+}
+
+/** A server-side stream injected into an Agent method marked as streaming. */
+export class StreamingResponse {
+  private _connection: Connection;
+  private _id: string;
+  private _closed = false;
+
+  /**
+   * Create a response stream for one RPC request.
+   *
+   * @param connection - Client connection receiving stream frames.
+   * @param id - RPC request identifier.
+   */
+  constructor(connection: Connection, id: string) {
+    this._connection = connection;
+    this._id = id;
+  }
+
+  /** Whether the stream has ended or failed. */
+  get isClosed(): boolean {
+    return this._closed;
+  }
+
+  /**
+   * Send a non-terminal chunk.
+   *
+   * @param chunk - Serializable stream value.
+   * @returns `false` when the stream or connection is already closed.
+   */
+  send(chunk: unknown): boolean {
+    if (this._closed) {
+      console.warn(
+        "StreamingResponse.send() called after stream was closed - data not sent"
+      );
+      return false;
+    }
+    const response: RPCResponse = {
+      done: false,
+      id: this._id,
+      result: chunk,
+      success: true,
+      type: MessageType.RPC
+    };
+    return sendRpcResponseIfOpen(this._connection, response);
+  }
+
+  /**
+   * End the stream, optionally with a final value.
+   *
+   * @param finalChunk - Optional terminal stream value.
+   * @returns `false` when the stream or connection is already closed.
+   */
+  end(finalChunk?: unknown): boolean {
+    if (this._closed) {
+      return false;
+    }
+    this._closed = true;
+    const response: RPCResponse = {
+      done: true,
+      id: this._id,
+      result: finalChunk,
+      success: true,
+      type: MessageType.RPC
+    };
+    return sendRpcResponseIfOpen(this._connection, response);
+  }
+
+  /**
+   * Fail the stream and send the error to the client.
+   *
+   * @param message - Error text sent in the terminal RPC frame.
+   * @returns `false` when the stream or connection is already closed.
+   */
+  error(message: string): boolean {
+    if (this._closed) {
+      return false;
+    }
+    this._closed = true;
+    const response: RPCResponse = {
+      error: message,
+      id: this._id,
+      success: false,
+      type: MessageType.RPC
+    };
+    return sendRpcResponseIfOpen(this._connection, response);
+  }
+}


### PR DESCRIPTION
## Summary

- extract the existing Agents browser WebSocket protocol into a package-private channel
- propose a Lifecycle-composed channel runtime usable by both `Agent` and plain Durable Objects
- keep current Agent hooks and public RPC exports compatible

This PR exports no channel API. It implements only the first private refactor and records the intended architecture.

## What ships

`packages/agents/src/internal/agent-websocket-channel.ts` now owns:

- connection setup and protocol suppression
- identity and state synchronization
- callable and streaming RPC
- MCP server announcements
- agent-tool replay and sub-agent forwarding
- forwarding unrecognized frames to current compatibility hooks

`Agent.onConnect`, raw `Agent.onMessage`, and `Agent.onClose` remain available and retain the wrapper order used by AIChatAgent and Think.

## Proposed end state

The full proposal is in [`design/rfc-agent-channels.md`](https://github.com/mattzcarey/agents/blob/design/agent-channels/design/rfc-agent-channels.md).

It covers:

- the ideal public API for `Agent` and plain `DurableObject`
- multiple channels in one configured set
- channel-owned routing that returns the complete Durable Object target
- lifecycle-owned WebSocket hibernation and durable owner keys
- browser protocol composition instead of method wrapping
- durable webhook admission and provider acknowledgement
- shared Worker-side channel routing
- the staged migration from today's API to one semantic `onMessage(message, context)` hook

The key layering is:

```text
DurableObject
├─ Lifecycle
├─ ChannelRuntime capability
├─ other capabilities such as MCP and schedules
└─ normalized message handler

Agent = the same runtime plus browser, state, RPC, observability, and convenience
```

## Scope

This PR implements Phase 0 from the RFC only. Lifecycle WebSocket ownership, channel definitions, gateways, inbox durability, provider adapters, and public exports remain follow-up work.

No changeset is included because there is no public API or behavior change.

## Verification

- `pnpm run check`, including all 114 TypeScript projects
- Agents Workers: 1,841 tests
- AI Chat Workers: 655 tests
- Think Workers: 886 tests
- package build and focused protocol suites
