### PR TITLE
fix(ci): cap broken AI SDK v6 patches

### DIFF
--- a/scripts/use-ai-sdk-major.mjs
+++ b/scripts/use-ai-sdk-major.mjs
@@ -18,10 +18,16 @@ if (major !== "6" && major !== "7") {
 
 // AI SDK v7 pairs with @ai-sdk/* and workers-ai-provider v4; v6 pairs with
 // @ai-sdk/* and workers-ai-provider v3.
+//
+// ai@6.0.260 through 6.0.263 regress tool-result handling in the Workers
+// runtime. Cap compatibility coverage at the last known-good v6 release until
+// an upstream patch restores the affected client-tool and HITL behavior.
+const AI_V6_RANGE = ">=6.0.0 <6.0.260";
+
 const ranges =
   major === "6"
     ? {
-        ai: "^6.0.0",
+        ai: AI_V6_RANGE,
         "@ai-sdk/react": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/anthropic": "^3.0.0",


### PR DESCRIPTION
## Summary

Temporarily cap the AI SDK v6 compatibility lane at the last known-good patch:

```text
>=6.0.0 <6.0.260
```

This changes only the throwaway dependency range written by `scripts/use-ai-sdk-major.mjs`. Published peer ranges and the repository lockfile are unchanged.

## Why

The compatibility workflow uses `pnpm install --no-frozen-lockfile`, so `ai@^6.0.0` began resolving newly published patches during existing PR runs.

Observed behavior:

- `ai@6.0.259`: Think Workers **886/886**
- `ai@6.0.260`: 16 deterministic failures in client-tool and HITL tests
- `ai@6.0.261`: same 16 failures
- `ai@6.0.263`: same 16 failures

The failure reproduces on current `main`, so it is not caused by the PR that first exposed it. The affected tool results remain at `input-available`, and RPC client-tool executors are not invoked.

The cap keeps testing the supported v6 line without silently dropping AI v6 coverage. It should be removed or advanced when an upstream patch restores the affected behavior.

## Verification

- compatibility script rewrites every targeted `ai` dependency to `>=6.0.0 <6.0.260`
- pnpm resolves that range to `ai@6.0.259`
- exact Think Workers compatibility lane: **44 files, 886 tests passed**
- script syntax, Oxfmt, Oxlint, and `git diff --check` pass
