### PR TITLE
test(channels): add live delivery smoke tests

### DIFF
--- a/packages/channels/live-tests/README.md
+++ b/packages/channels/live-tests/README.md
@@ -1,0 +1,45 @@
+# Live delivery tests
+
+This local-only test calls the real `telegram()`, `slack()`, and `email()`
+adapters, then reads each destination through an independent provider API. It
+is not part of normal package tests, Nx affected tests, or CI.
+
+The configured destinations must be disposable. The test deletes their messages
+before and after delivery. Telegram's immutable chat/channel creation service
+record is ignored, but every text message is deleted. Do not use personal or
+shared destinations.
+
+## Configuration
+
+Set these variables in an uncommitted environment file or the shell:
+
+- Telegram: `CHANNELS_LIVE_TELEGRAM_BOT_TOKEN`,
+  `CHANNELS_LIVE_TELEGRAM_CHAT_ID`, `CHANNELS_LIVE_TELEGRAM_API_ID`,
+  `CHANNELS_LIVE_TELEGRAM_API_HASH`, `CHANNELS_LIVE_TELEGRAM_SESSION`
+- Slack: `CHANNELS_LIVE_SLACK_BOT_TOKEN`,
+  `CHANNELS_LIVE_SLACK_CHANNEL_ID`
+- Email: `CHANNELS_LIVE_EMAIL_FROM`, `CHANNELS_LIVE_EMAIL_TO`,
+  `CHANNELS_LIVE_FASTMAIL_API_TOKEN`,
+  `CHANNELS_LIVE_CLOUDFLARE_ACCOUNT_ID`,
+  `CHANNELS_LIVE_CLOUDFLARE_API_TOKEN`
+
+Telegram observation uses a non-bot Teleproto `StringSession`. Slack needs
+`chat:write`, `channels:history`, and membership in the configured channel. The
+email sender needs Cloudflare Email Service access; Fastmail supplies independent
+JMAP observation and deletion.
+
+## Run
+
+```sh
+pnpm --filter @cloudflare/channels test:live
+```
+
+Run one provider with Vitest's name filter:
+
+```sh
+pnpm --filter @cloudflare/channels test:live -t telegram
+```
+
+Each test sends `Cloudflare Channels live delivery smoke test.`, polls once per
+second for up to two minutes, waits five more seconds for duplicates, and
+snapshots the exact observed `[{ text }]` array.

--- a/packages/channels/live-tests/binding.ts
+++ b/packages/channels/live-tests/binding.ts
@@ -1,0 +1,17 @@
+export type ObservedMessage = { text: string };
+
+export type LiveDeliveryBinding = {
+  name: "telegram" | "slack" | "email";
+  destination: string;
+  open?(): Promise<void>;
+  clear(): Promise<void>;
+  deliver(text: string): Promise<unknown>;
+  read(): Promise<ObservedMessage[]>;
+  close?(): Promise<void>;
+};
+
+export function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing live delivery configuration: ${name}`);
+  return value;
+}

--- a/packages/channels/live-tests/bindings/email.ts
+++ b/packages/channels/live-tests/bindings/email.ts
@@ -1,0 +1,161 @@
+import {
+  email,
+  type ChannelEmailMessage,
+  type EmailSendBinding
+} from "../../src/adapters/email/email";
+import type { ChannelMessageSurface } from "../../src/surface";
+import {
+  requiredEnv,
+  type LiveDeliveryBinding,
+  type ObservedMessage
+} from "../binding";
+
+const CORE = "urn:ietf:params:jmap:core";
+const MAIL = "urn:ietf:params:jmap:mail";
+
+type FastmailSession = { apiUrl: string; accountId: string };
+type FastmailEmail = {
+  id: string;
+  textBody: { partId: string }[];
+  bodyValues: Record<string, { value: string }>;
+};
+
+async function openFastmail(token: string): Promise<FastmailSession> {
+  const response = await fetch("https://api.fastmail.com/jmap/session", {
+    headers: { authorization: `Bearer ${token}` }
+  });
+  if (!response.ok) throw new Error(`Fastmail session: ${response.status}`);
+  const session = (await response.json()) as {
+    apiUrl: string;
+    primaryAccounts: Record<string, string>;
+  };
+  return {
+    apiUrl: session.apiUrl,
+    accountId: session.primaryAccounts[MAIL]
+  };
+}
+
+async function jmap<T>(
+  token: string,
+  session: FastmailSession,
+  method: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  const response = await fetch(session.apiUrl, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      using: [CORE, MAIL],
+      methodCalls: [[method, args, "live"]]
+    })
+  });
+  if (!response.ok) throw new Error(`Fastmail ${method}: ${response.status}`);
+  const payload = (await response.json()) as {
+    methodResponses: [string, unknown, string][];
+  };
+  const [returnedMethod, result] = payload.methodResponses[0];
+  if (returnedMethod !== method) {
+    throw new Error(`Fastmail ${method}: ${returnedMethod}`);
+  }
+  return result as T;
+}
+
+function cloudflareBinding(accountId: string, token: string): EmailSendBinding {
+  return {
+    async send(message: ChannelEmailMessage) {
+      const response = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/email/sending/send`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            "content-type": "application/json"
+          },
+          body: JSON.stringify(message)
+        }
+      );
+      const payload = (await response.json()) as { success?: boolean };
+      if (!response.ok || payload.success !== true) {
+        throw new Error(`Cloudflare Email Service: ${response.status}`);
+      }
+      return { messageId: "channels-live-test" };
+    }
+  };
+}
+
+export function emailBinding(): LiveDeliveryBinding {
+  const from = requiredEnv("CHANNELS_LIVE_EMAIL_FROM");
+  const to = requiredEnv("CHANNELS_LIVE_EMAIL_TO");
+  const fastmailToken = requiredEnv("CHANNELS_LIVE_FASTMAIL_API_TOKEN");
+  const channel = email({
+    from,
+    binding: cloudflareBinding(
+      requiredEnv("CHANNELS_LIVE_CLOUDFLARE_ACCOUNT_ID"),
+      requiredEnv("CHANNELS_LIVE_CLOUDFLARE_API_TOKEN")
+    )
+  });
+  const surface: ChannelMessageSurface = {
+    channelKey: "email",
+    version: 1,
+    address: { from, to },
+    label: `Email · ${to}`
+  };
+  let session: FastmailSession;
+
+  async function ids(): Promise<string[]> {
+    return (
+      await jmap<{ ids: string[] }>(fastmailToken, session, "Email/query", {
+        accountId: session.accountId,
+        filter: { to },
+        limit: 100
+      })
+    ).ids;
+  }
+
+  async function messages(): Promise<FastmailEmail[]> {
+    const emailIds = await ids();
+    if (emailIds.length === 0) return [];
+    return (
+      await jmap<{ list: FastmailEmail[] }>(
+        fastmailToken,
+        session,
+        "Email/get",
+        {
+          accountId: session.accountId,
+          ids: emailIds,
+          properties: ["id", "textBody", "bodyValues"],
+          fetchTextBodyValues: true
+        }
+      )
+    ).list;
+  }
+
+  return {
+    name: "email",
+    destination: `email inbox ${to}`,
+    async open() {
+      session = await openFastmail(fastmailToken);
+    },
+    async clear() {
+      const emailIds = await ids();
+      if (emailIds.length > 0) {
+        await jmap(fastmailToken, session, "Email/set", {
+          accountId: session.accountId,
+          destroy: emailIds
+        });
+      }
+    },
+    async deliver(text) {
+      return await channel.deliver!(surface, { markdown: text });
+    },
+    async read(): Promise<ObservedMessage[]> {
+      return (await messages()).map((message) => {
+        const partId = message.textBody[0].partId;
+        return { text: message.bodyValues[partId].value };
+      });
+    }
+  };
+}

--- a/packages/channels/live-tests/bindings/slack.ts
+++ b/packages/channels/live-tests/bindings/slack.ts
@@ -1,0 +1,71 @@
+import { slack } from "../../src/adapters/slack";
+import type { ChannelMessageSurface } from "../../src/surface";
+import {
+  requiredEnv,
+  type LiveDeliveryBinding,
+  type ObservedMessage
+} from "../binding";
+
+type SlackMessage = { ts: string; text: string };
+type SlackResponse = {
+  ok: boolean;
+  error?: string;
+  messages?: SlackMessage[];
+};
+
+async function slackApi(
+  token: string,
+  method: string,
+  values: Record<string, string>
+): Promise<SlackResponse> {
+  const response = await fetch(`https://slack.com/api/${method}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/x-www-form-urlencoded"
+    },
+    body: new URLSearchParams(values)
+  });
+  const payload = (await response.json()) as SlackResponse;
+  if (!payload.ok) throw new Error(`Slack ${method}: ${payload.error}`);
+  return payload;
+}
+
+export function slackBinding(): LiveDeliveryBinding {
+  const token = requiredEnv("CHANNELS_LIVE_SLACK_BOT_TOKEN");
+  const channelId = requiredEnv("CHANNELS_LIVE_SLACK_CHANNEL_ID");
+  const channel = slack({ botToken: token });
+  const surface: ChannelMessageSurface = {
+    channelKey: "slack",
+    version: 1,
+    address: { channelId },
+    label: `Slack · ${channelId}`
+  };
+
+  async function messages(): Promise<SlackMessage[]> {
+    const result = await slackApi(token, "conversations.history", {
+      channel: channelId,
+      limit: "100"
+    });
+    return result.messages ?? [];
+  }
+
+  return {
+    name: "slack",
+    destination: `Slack channel ${channelId}`,
+    async clear() {
+      for (const message of await messages()) {
+        await slackApi(token, "chat.delete", {
+          channel: channelId,
+          ts: message.ts
+        });
+      }
+    },
+    async deliver(text) {
+      return await channel.deliver!(surface, { markdown: text });
+    },
+    async read(): Promise<ObservedMessage[]> {
+      return (await messages()).map(({ text }) => ({ text }));
+    }
+  };
+}

--- a/packages/channels/live-tests/bindings/telegram.ts
+++ b/packages/channels/live-tests/bindings/telegram.ts
@@ -1,0 +1,75 @@
+import { TelegramClient } from "teleproto";
+import { StringSession } from "teleproto/sessions";
+import { telegram } from "../../src/adapters/telegram";
+import type { ChannelMessageSurface } from "../../src/surface";
+import {
+  requiredEnv,
+  type LiveDeliveryBinding,
+  type ObservedMessage
+} from "../binding";
+
+const creationActions = new Set([
+  "MessageActionChannelCreate",
+  "MessageActionChatCreate"
+]);
+
+export function telegramBinding(): LiveDeliveryBinding {
+  const chatId = requiredEnv("CHANNELS_LIVE_TELEGRAM_CHAT_ID");
+  const numericChatId = Number(chatId);
+  const client = new TelegramClient(
+    new StringSession(requiredEnv("CHANNELS_LIVE_TELEGRAM_SESSION")),
+    Number(requiredEnv("CHANNELS_LIVE_TELEGRAM_API_ID")),
+    requiredEnv("CHANNELS_LIVE_TELEGRAM_API_HASH"),
+    { connectionRetries: 3 }
+  );
+  const channel = telegram({
+    botToken: requiredEnv("CHANNELS_LIVE_TELEGRAM_BOT_TOKEN")
+  });
+  const surface: ChannelMessageSurface = {
+    channelKey: "telegram",
+    version: 1,
+    address: { chatId },
+    label: `Telegram · ${chatId}`
+  };
+
+  async function messages() {
+    return Array.from(
+      await client.getMessages(numericChatId, { limit: undefined })
+    );
+  }
+
+  function isCreationMessage(
+    message: Awaited<ReturnType<typeof messages>>[number]
+  ) {
+    return creationActions.has(message.action?.className ?? "");
+  }
+
+  return {
+    name: "telegram",
+    destination: `Telegram chat ${chatId}`,
+    async open() {
+      await client.connect();
+      await client.getDialogs({ folder: 0 });
+      await client.getEntity(numericChatId);
+    },
+    async clear() {
+      const deletable = (await messages()).filter(
+        (message) => !isCreationMessage(message)
+      );
+      if (deletable.length > 0) {
+        await client.deleteMessages(numericChatId, deletable, { revoke: true });
+      }
+    },
+    async deliver(text) {
+      return await channel.deliver!(surface, { markdown: text });
+    },
+    async read(): Promise<ObservedMessage[]> {
+      return (await messages()).flatMap((message) =>
+        typeof message.message === "string" ? [{ text: message.message }] : []
+      );
+    },
+    async close() {
+      await client.disconnect();
+    }
+  };
+}

--- a/packages/channels/live-tests/delivery.test.ts
+++ b/packages/channels/live-tests/delivery.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { emailBinding } from "./bindings/email";
+import { slackBinding } from "./bindings/slack";
+import { telegramBinding } from "./bindings/telegram";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const providers = [
+  ["telegram", telegramBinding],
+  ["slack", slackBinding],
+  ["email", emailBinding]
+] as const;
+
+describe("live channel delivery", () => {
+  test.each(providers)("delivers through %s", async (_name, create) => {
+    const channel = create();
+    console.info(`[${channel.name}] clearing ${channel.destination}`);
+    await channel.open?.();
+
+    try {
+      await channel.clear();
+      expect(await channel.read()).toEqual([]);
+
+      const result = await channel.deliver(
+        "Cloudflare Channels live delivery smoke test."
+      );
+      console.info(`[${channel.name}] ${JSON.stringify(result)}`);
+
+      let messages = [];
+      const deadline = Date.now() + 120_000;
+      while (messages.length === 0 && Date.now() < deadline) {
+        await sleep(1_000);
+        messages = await channel.read();
+      }
+      expect(messages.length).toBeGreaterThan(0);
+
+      await sleep(5_000);
+      messages = await channel.read();
+      console.info(`[${channel.name}] observed ${JSON.stringify(messages)}`);
+      await expect(
+        `${JSON.stringify(messages, null, 2)}\n`
+      ).toMatchFileSnapshot(`./snapshots/${channel.name}.json`);
+    } finally {
+      try {
+        await channel.clear();
+        expect(await channel.read()).toEqual([]);
+      } finally {
+        await channel.close?.();
+      }
+    }
+  });
+});

--- a/packages/channels/live-tests/snapshots/email.json
+++ b/packages/channels/live-tests/snapshots/email.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Cloudflare Channels live delivery smoke test.\n\n"
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack.json
+++ b/packages/channels/live-tests/snapshots/slack.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Cloudflare Channels live delivery smoke test."
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram.json
+++ b/packages/channels/live-tests/snapshots/telegram.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Cloudflare Channels live delivery smoke test."
+  }
+]

--- a/packages/channels/live-tests/tsconfig.json
+++ b/packages/channels/live-tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": []
+}

--- a/packages/channels/package.json
+++ b/packages/channels/package.json
@@ -54,7 +54,8 @@
   ],
   "scripts": {
     "build": "tsx ./scripts/build.ts",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "test:live": "vitest --run -c vitest.live.config.ts"
   },
   "dependencies": {
     "@cloudflare/voice": "workspace:*",
@@ -75,6 +76,7 @@
   "devDependencies": {
     "@tanstack/ai": "0.38.0",
     "ai": "^7.0.0",
+    "teleproto": "^1.228.5",
     "vitest": "4.1.10"
   },
   "publishConfig": {

--- a/packages/channels/tsconfig.json
+++ b/packages/channels/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "agents/tsconfig",
-  "exclude": ["src/__tests__"]
+  "exclude": ["src/__tests__", "live-tests"]
 }

--- a/packages/channels/vitest.live.config.ts
+++ b/packages/channels/vitest.live.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["live-tests/delivery.test.ts"],
+    testTimeout: 180_000
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4116,7 +4116,7 @@ importers:
         version: 13.0.6
       just-bash:
         specifier: ^3.0.2
-        version: 3.0.2
+        version: 3.0.2(supports-color@7.2.0)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -4170,6 +4170,9 @@ importers:
       ai:
         specifier: ^7.0.0
         version: 7.0.18(zod@4.4.3)
+      teleproto:
+        specifier: ^1.228.5
+        version: 1.228.5
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.1.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -4243,7 +4246,7 @@ importers:
         version: 4.31.0(ai@7.0.18(zod@4.4.3))(zod@4.4.3)
       just-bash:
         specifier: ^3.0.2
-        version: 3.0.2
+        version: 3.0.2(supports-color@7.2.0)
       workers-ai-provider:
         specifier: ^4.0.0
         version: 4.0.0(@ai-sdk/anthropic@4.0.10(zod@4.4.3))(@ai-sdk/google@4.0.10(zod@4.4.3))(@ai-sdk/openai@4.0.9(zod@4.4.3))(@ai-sdk/provider@4.0.2)(ai@7.0.18(zod@4.4.3))
@@ -8026,6 +8029,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -9258,6 +9265,10 @@ packages:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -10075,6 +10086,10 @@ packages:
     resolution: {integrity: sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==}
     engines: {node: '>=16.0.0'}
     hasBin: true
+
+  node-localstorage@2.2.1:
+    resolution: {integrity: sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==}
+    engines: {node: '>=0.12'}
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -11019,6 +11034,13 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
+  slide@1.1.6:
+    resolution: {integrity: sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -11026,6 +11048,10 @@ packages:
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -11065,6 +11091,9 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  store2@2.14.4:
+    resolution: {integrity: sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==}
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
@@ -11190,6 +11219,10 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  teleproto@1.228.5:
+    resolution: {integrity: sha512-NMBFB4oB+0mjJIPVqdLd3wAaU7kf5dw7frrYdnnXM38DSdbnN36Dao6Ae1xNZR9NICiefbfJqM8yDijOPqE8MA==}
+    engines: {node: '>=18'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -11846,6 +11879,9 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@1.3.4:
+    resolution: {integrity: sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==}
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
@@ -13321,7 +13357,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260730.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.1.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler: 4.116.0(@cloudflare/workers-types@5.20260812.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13383,7 +13419,7 @@ snapshots:
   '@cloudflare/workspace@https://pkg.pr.new/cloudflare/workspace/@cloudflare/workspace@98b74eb(@platformatic/vfs@0.4.0)(diff@9.0.0)(isomorphic-git@1.38.5)':
     dependencies:
       capnweb: 0.8.0
-      just-bash: 3.0.2
+      just-bash: 3.0.2(supports-color@7.2.0)
     optionalDependencies:
       '@platformatic/vfs': 0.4.0
       diff: 9.0.0
@@ -15165,7 +15201,7 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@7.2.0)':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       token-types: 6.1.2
@@ -16051,6 +16087,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  big-integer@1.6.52: {}
 
   bignumber.js@9.3.1: {}
 
@@ -16971,9 +17009,9 @@ snapshots:
       token-types: 6.1.2
       uint8array-extras: 1.5.0
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@7.2.0):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@7.2.0)
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -17427,6 +17465,8 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
+  imurmurhash@0.1.4: {}
+
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
@@ -17618,11 +17658,11 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  just-bash@3.0.2:
+  just-bash@3.0.2(supports-color@7.2.0):
     dependencies:
       diff: 8.0.4
       fast-xml-parser: 5.9.3
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@7.2.0)
       ini: 6.0.0
       minimatch: 10.2.5
       modern-tar: 0.7.6
@@ -18430,6 +18470,10 @@ snapshots:
       node-addon-api: 8.8.0
       node-gyp-build: 4.8.4
     optional: true
+
+  node-localstorage@2.2.1:
+    dependencies:
+      write-file-atomic: 1.3.4
 
   node-mock-http@1.0.4: {}
 
@@ -19690,9 +19734,18 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
+  slide@1.1.6: {}
+
+  smart-buffer@4.2.0: {}
+
   smol-toml@1.6.1: {}
 
   smol-toml@1.7.0: {}
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
     dependencies:
@@ -19726,6 +19779,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
+
+  store2@2.14.4: {}
 
   stream-shift@1.0.3: {}
 
@@ -19907,6 +19962,14 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  teleproto@1.228.5:
+    dependencies:
+      big-integer: 1.6.52
+      mime: 3.0.0
+      node-localstorage: 2.2.1
+      socks: 2.8.9
+      store2: 2.14.4
 
   term-size@2.2.1: {}
 
@@ -20588,6 +20651,12 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@1.3.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      imurmurhash: 0.1.4
+      slide: 1.1.6
 
   ws@8.20.1: {}
 


### PR DESCRIPTION
This PR adds an opt-in, local-only live delivery suite for the `@cloudflare/channels` Telegram, Slack, and Email adapters.

## Why

- Mocked adapter tests cannot prove that provider credentials, destination addressing, and recipient-visible delivery work together.
- Live tests require credentials and destructively clear their destinations, so they must remain outside normal package tests, Nx affected tests, and CI.
- Provider responses alone do not prove delivery. Each test therefore observes the destination through an independent read path.

## Code Changes

- Adds an explicit `test:live` script and separate Vitest configuration that normal test and CI commands do not select.
- Calls each concrete adapter’s `deliver()` method, polls the independent destination once per second for up to two minutes, waits five seconds for duplicates, and compares the exact observed `{ text }` array with a file snapshot.
- Clears suite-owned destinations before and after each run. Telegram ignores only its immutable chat and channel creation service records.
- Observes Telegram through an authenticated Teleproto user session and Slack through conversation history.
- Sends Email through Cloudflare Email Service and observes and deletes it independently through Fastmail JMAP.
- Documents the required disposable destinations, credentials, and focused-run commands.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->