### PR TITLE
feat(agents): move WebSockets out of Lifecycle into an opt-in capability

### DIFF
--- a/.changeset/websockets-capability.md
+++ b/.changeset/websockets-capability.md
@@ -1,0 +1,47 @@
+---
+"agents": minor
+---
+
+Move WebSockets out of Lifecycle into the opt-in `WebSockets`
+capability, with callables served from an `RpcTarget`.
+
+Lifecycle no longer models WebSockets — many hosts never use sockets.
+Hosts that want connections install the capability, which owns the
+subsystem end to end:
+
+```ts
+new WebSockets({
+  handlers: { onConnect, onMessage, onClose },
+  callables: new RoomCallables()
+});
+```
+
+The capability claims WebSocket upgrades, accepts hibernating sockets,
+dispatches handlers inside the host invocation boundary, reciprocates
+close handshakes, closes owned connections on host destruction, and
+answers `getConnections()`/`getConnection()`. Without it installed,
+upgrades are declined.
+
+`callables` exposes an `RpcTarget`'s prototype methods to remote
+callers over a Cap'n Web session (`?__agents_rpc=capnweb`), with native
+`ReadableStream` streaming. `Agent` adds no new surface for this: its
+`@callable()`-decorated methods are its interface, served on every wire
+— natively over the legacy JSON RPC protocol and, through the
+decorator-derived target, over the Cap'n Web endpoint. There is no
+separate browser client either: `useAgent().stub`/`call` reach the
+same interface, and a plain host's endpoint is one
+`newWebSocketRpcSession(new WebSocket(callablesRpcUrl(url)))` away.
+
+`Agent` installs the capability itself, so its `onConnect`/`onMessage`/
+`onClose`/`onError`/`getConnectionTags` overrides and connection APIs
+behave exactly as before (same wire, same hibernation attachment
+format). The Lifecycle host contract drops the WebSocket hooks and
+Lifecycle's `getConnections`/`getConnection`/`broadcast` are removed.
+
+Lifecycle keeps only generic platform pass-throughs —
+`onWebSocketUpgrade` plus `onWebSocketMessage`/`Close`/`Error` for
+capability-owned hibernation wakes — and `LifecycleServices` gains a
+narrow `sockets` surface (accept/get) and a connection/request scope on
+`runInHostContext`. The capability interaction contract (three
+channels: hooks, services, composition-root apertures) is now
+documented on `DurableObjectCapability`.

--- a/docs/agents/lifecycle.md
+++ b/docs/agents/lifecycle.md
@@ -65,9 +65,10 @@ export default {
 The default URL shape is `/agents/:binding/:name`. Direct
 `env.MY_OBJECT.getByName(name).fetch(request)` calls work as well.
 
-`Agent` already constructs this lifecycle. Existing Agent classes continue to
-override `onStart`, `onRequest`, `onConnect`, `onMessage`, `onClose`, and
-`onError` normally.
+`Agent` already constructs this lifecycle (and installs the `WebSockets`
+capability for its connections). Existing Agent classes continue to override
+`onStart`, `onRequest`, `onConnect`, `onMessage`, `onClose`, and `onError`
+normally.
 
 ## Request call path
 
@@ -267,33 +268,54 @@ Host context values follow the invocation:
 
 - `onStart` and `onAlarm`: object;
 - `onRequest`: object and request;
-- `onConnect`: object, connection, and upgrade request;
-- `onMessage`, `onClose`, and `onError`: object and connection.
+- `WebSockets` capability handlers `onConnect`: object, connection, and
+  upgrade request;
+- `WebSockets` capability handlers `onMessage`, `onClose`, and `onError`:
+  object and connection.
 
 `getConnectionTags(connection, { request })` remains argument-driven because it
 already receives both values explicitly. The root `agents` package continues
 to export `getCurrentAgent()` for the `Agent` class as a compatibility alias.
 
-## WebSockets always hibernate
+## WebSockets are an opt-in capability
 
-The lifecycle always uses Cloudflare's WebSocket Hibernation API. Idle clients
-remain connected while the Durable Object can leave memory. When a message
-wakes the object, its constructor and lifecycle startup run again before
-`onMessage`.
-
-State needed after a wake must be stored durably or through connection state:
+Lifecycle itself does not model WebSockets. Hosts that want connections
+install the `WebSockets` capability, which owns the subsystem end to end —
+it claims upgrades, accepts hibernating sockets, dispatches handlers inside
+the host invocation boundary, and answers `getConnections()`:
 
 ```ts
-onConnect(connection: Connection): void {
-  connection.setState({ authenticated: true });
-}
+import { WebSockets } from "agents/websockets";
 
-onMessage(connection: Connection<{ authenticated: boolean }>): void {
-  console.log(connection.state?.authenticated);
+export class MyObject extends DurableObject<Env> {
+  readonly webSockets = new WebSockets({
+    handlers: {
+      onConnect: (connection) => {
+        connection.setState({ authenticated: true });
+      },
+      onMessage: (connection, message) => {
+        connection.send(`echo:${message}`);
+      }
+    }
+  });
+  readonly lifecycle = Lifecycle.install(this).use(this.webSockets);
 }
 ```
 
-There is no non-hibernating mode.
+Without the capability installed, WebSocket upgrades are declined.
+
+The capability can also serve remote methods: pass an `RpcTarget` as
+`callables` and its prototype methods become the complete remote interface,
+served over a Cap'n Web session (`?__agents_rpc=capnweb`). An `Agent` adds
+no new surface for this — its `@callable()`-decorated methods are its
+interface, served on every wire: natively over the legacy JSON RPC protocol
+and, through the decorator-derived target, over the Cap'n Web endpoint.
+
+Connections use Cloudflare's WebSocket Hibernation API. Idle clients remain
+connected while the Durable Object can leave memory; when a message wakes the
+object, its constructor and lifecycle startup run again before `onMessage`.
+State needed after a wake must be stored durably or through
+`connection.setState()`. There is no non-hibernating mode.
 
 ## Native RPC
 

--- a/examples/next/lifecycle/README.md
+++ b/examples/next/lifecycle/README.md
@@ -8,7 +8,18 @@ base class.
 export class DoAgent extends DurableObject<Env> {
   private readonly activity = new ActivityCapability(this.ctx.storage);
   private wake: { id: string; startedAt: string } | undefined;
-  readonly lifecycle = Lifecycle.install(this).use(this.activity);
+
+  // WebSockets are opt-in: connections live in the WebSockets capability.
+  private readonly webSockets = new WebSockets({
+    handlers: {
+      onConnect: (connection) => connection.send("connected"),
+      onMessage: (connection, message) => connection.send(`echo:${message}`)
+    }
+  });
+
+  readonly lifecycle = Lifecycle.install(this)
+    .use(this.activity)
+    .use(this.webSockets);
 
   onStart() {
     // Runs once whenever this Durable Object enters memory, including after a
@@ -55,10 +66,12 @@ curl http://localhost:8787/agents/do-agent/demo
 curl http://localhost:8787/agents/do-agent/demo/stats
 ```
 
-Connect a WebSocket to `ws://localhost:8787/agents/do-agent/demo`. The object
-sends a connection snapshot and echoes each message. The socket uses Cloudflare's
-WebSocket Hibernation API, so it remains connected while the Durable Object can
-leave memory.
+Connect a WebSocket to `ws://localhost:8787/agents/do-agent/demo`. The
+`WebSockets` capability claims the upgrade, sends a connection snapshot, and
+echoes each message. The socket uses Cloudflare's WebSocket Hibernation API, so
+it remains connected while the Durable Object can leave memory. Lifecycle itself
+does not model WebSockets — without the capability installed, upgrades are
+declined.
 
 Each normal HTTP request schedules an alarm five seconds later. The capability
 records the alarm before the object's `onAlarm` callback runs.

--- a/examples/next/lifecycle/src/index.ts
+++ b/examples/next/lifecycle/src/index.ts
@@ -1,12 +1,11 @@
-import { DurableObject } from "cloudflare:workers";
+import { DurableObject, RpcTarget } from "cloudflare:workers";
 import { routeAgentRequest } from "agents";
 import {
   Lifecycle,
   type CapabilityRequestContext,
-  type Connection,
-  type DurableObjectCapability,
-  type WSMessage
+  type DurableObjectCapability
 } from "agents/lifecycle";
+import { WebSockets } from "agents/websockets";
 
 type Activity = {
   requests: number;
@@ -58,11 +57,51 @@ class ActivityCapability implements DurableObjectCapability {
   }
 }
 
+/**
+ * Remote methods served over the Cap'n Web callables endpoint
+ * (`?__agents_rpc=capnweb`). The target's prototype methods are the
+ * complete remote interface.
+ */
+class ActivityCallables extends RpcTarget {
+  constructor(private readonly host: DoAgent) {
+    super();
+  }
+
+  activity(): Promise<Activity> {
+    return this.host.getActivity();
+  }
+}
+
 /** A plain Durable Object composed with the Agents lifecycle. */
 export class DoAgent extends DurableObject<Env> {
   private readonly activity = new ActivityCapability(this.ctx.storage);
   private wake: Wake | undefined;
-  readonly lifecycle = Lifecycle.install(this).use(this.activity);
+
+  // WebSockets are opt-in: Lifecycle itself does not model connections.
+  // The capability owns upgrades, hibernating sockets, handler
+  // dispatch, and the Cap'n Web callables endpoint.
+  private readonly webSockets = new WebSockets({
+    callables: new ActivityCallables(this),
+    handlers: {
+      onConnect: (connection) => {
+        connection.send(
+          JSON.stringify({
+            type: "connected",
+            name: this.lifecycle.name,
+            wake: this.wake,
+            activity: this.activity.getActivity()
+          })
+        );
+      },
+      onMessage: (connection, message) => {
+        connection.send(`echo:${String(message)}`);
+      }
+    }
+  });
+
+  readonly lifecycle = Lifecycle.install(this)
+    .use(this.activity)
+    .use(this.webSockets);
 
   onStart(): void {
     this.wake = {
@@ -84,21 +123,6 @@ export class DoAgent extends DurableObject<Env> {
 
   onAlarm(): void {
     console.log("alarm", this.lifecycle.name, this.activity.getActivity());
-  }
-
-  onConnect(connection: Connection): void {
-    connection.send(
-      JSON.stringify({
-        type: "connected",
-        name: this.lifecycle.name,
-        wake: this.wake,
-        activity: this.activity.getActivity()
-      })
-    );
-  }
-
-  onMessage(connection: Connection, message: WSMessage): void {
-    connection.send(`echo:${String(message)}`);
   }
 
   async getActivity(): Promise<Activity> {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -24,6 +24,7 @@
     "@babel/plugin-proposal-decorators": "^8.0.2",
     "@cfworker/json-schema": "^4.1.1",
     "@rolldown/plugin-babel": "^0.2.3",
+    "capnweb": "^0.12.0",
     "cron-schedule": "^6.0.0",
     "esbuild": "^0.28.1",
     "mimetext": "^3.0.28",
@@ -166,6 +167,11 @@
       "types": "./dist/react.d.ts",
       "import": "./dist/react.js",
       "require": "./dist/react.js"
+    },
+    "./websockets": {
+      "types": "./dist/websockets/index.d.ts",
+      "import": "./dist/websockets/index.js",
+      "require": "./dist/websockets/index.js"
     },
     "./schedule": {
       "types": "./dist/schedule.d.ts",

--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -23,6 +23,7 @@ const entries = [
   "src/observability/ai/index.ts",
   "src/schedules/index.ts",
   "src/schedules/parser.ts",
+  "src/websockets/index.ts",
   "src/codemode/ai.ts",
   "src/experimental/memory/session/index.ts",
   "src/experimental/memory/utils/index.ts",

--- a/packages/agents/src/callable-decorator.ts
+++ b/packages/agents/src/callable-decorator.ts
@@ -1,0 +1,103 @@
+/**
+ * The `@callable()` method decorator and its metadata registry.
+ *
+ * Consumed by Agent's legacy JSON RPC protocol and, as a fallback
+ * interface source, by the WebSockets capability's Cap'n Web callables
+ * endpoint. Kept dependency-free so both can import it without cycles.
+ */
+
+/**
+ * Metadata for a callable method
+ */
+export type CallableMetadata = {
+  /** Optional description of what the method does */
+  description?: string;
+  /** Whether the method supports streaming responses */
+  streaming?: boolean;
+};
+
+const callableMetadata = new WeakMap<Function, CallableMetadata>();
+
+/**
+ * Decorator that marks a method as callable by clients
+ * @param metadata Optional metadata about the callable method
+ */
+export function callable(metadata: CallableMetadata = {}) {
+  return function callableDecorator<This, Args extends unknown[], Return>(
+    target: (this: This, ...args: Args) => Return,
+    _context: ClassMethodDecoratorContext
+  ) {
+    if (!callableMetadata.has(target)) {
+      callableMetadata.set(target, metadata);
+    }
+
+    return target;
+  };
+}
+
+let didWarnAboutUnstableCallable = false;
+
+/**
+ * Decorator that marks a method as callable by clients
+ * @deprecated this has been renamed to callable, and unstable_callable will be removed in the next major version
+ * @param metadata Optional metadata about the callable method
+ */
+export const unstable_callable = (metadata: CallableMetadata = {}) => {
+  if (!didWarnAboutUnstableCallable) {
+    didWarnAboutUnstableCallable = true;
+    console.warn(
+      "unstable_callable is deprecated, use callable instead. unstable_callable will be removed in the next major version."
+    );
+  }
+  return callable(metadata);
+};
+
+/** @internal Read the metadata registered for a decorated method. */
+export function getCallableMetadata(
+  method: Function
+): CallableMetadata | undefined {
+  return callableMetadata.get(method);
+}
+
+/** @internal Whether a method was registered with `@callable()`. */
+export function isCallableMethod(method: Function): boolean {
+  return callableMetadata.has(method);
+}
+
+/**
+ * @internal Preserve registration when a framework wraps a decorated
+ * method (e.g. Agent's context auto-wrapping).
+ */
+export function copyCallableMetadata(source: Function, target: Function): void {
+  const metadata = callableMetadata.get(source);
+  if (metadata) callableMetadata.set(target, metadata);
+}
+
+/**
+ * Every `@callable()`-registered method reachable on a host's prototype
+ * chain, with its metadata. The nearest declaration wins when a
+ * subclass overrides a decorated parent method.
+ *
+ * The canonical decorator scan — Agent introspection and the WebSockets
+ * capability's decorator-fallback target both consume it.
+ *
+ * @param host - The object whose prototype chain is scanned.
+ * @returns Method names mapped to their registered metadata.
+ */
+export function decoratedMethods(
+  host: object
+): ReadonlyMap<string, CallableMetadata> {
+  const result = new Map<string, CallableMetadata>();
+  let prototype: object | null = Object.getPrototypeOf(host);
+  while (prototype && prototype !== Object.prototype) {
+    for (const name of Object.getOwnPropertyNames(prototype)) {
+      if (name === "constructor" || result.has(name)) continue;
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+      if (!descriptor || typeof descriptor.value !== "function") continue;
+      const metadata = getCallableMetadata(descriptor.value);
+      if (metadata) result.set(name, metadata);
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return result;
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -63,6 +63,7 @@ import {
   type CurrentAgentContext
 } from "./lifecycle/current-agent";
 import { getAgentByName, type AgentOptions } from "./agent-routing";
+import { callablesFromDecorated, WebSockets } from "./websockets";
 export {
   getAgentByName,
   routeAgentRequest,
@@ -383,17 +384,18 @@ function isStateUpdateMessage(msg: unknown): msg is StateUpdateMessage {
   );
 }
 
-/**
- * Metadata for a callable method
- */
-export type CallableMetadata = {
-  /** Optional description of what the method does */
-  description?: string;
-  /** Whether the method supports streaming responses */
-  streaming?: boolean;
-};
-
-const callableMetadata = new WeakMap<Function, CallableMetadata>();
+export {
+  callable,
+  unstable_callable,
+  type CallableMetadata
+} from "./callable-decorator";
+import {
+  copyCallableMetadata,
+  decoratedMethods,
+  getCallableMetadata,
+  isCallableMethod,
+  type CallableMetadata
+} from "./callable-decorator";
 
 export { SqlError } from "./sql-error";
 
@@ -594,40 +596,6 @@ export type SubAgentStub<T extends Agent> = {
       : never]: T[K] extends (...args: infer A) => infer R
     ? (...args: A) => Promisify<R>
     : never;
-};
-
-/**
- * Decorator that marks a method as callable by clients
- * @param metadata Optional metadata about the callable method
- */
-export function callable(metadata: CallableMetadata = {}) {
-  return function callableDecorator<This, Args extends unknown[], Return>(
-    target: (this: This, ...args: Args) => Return,
-    _context: ClassMethodDecoratorContext
-  ) {
-    if (!callableMetadata.has(target)) {
-      callableMetadata.set(target, metadata);
-    }
-
-    return target;
-  };
-}
-
-let didWarnAboutUnstableCallable = false;
-
-/**
- * Decorator that marks a method as callable by clients
- * @deprecated this has been renamed to callable, and unstable_callable will be removed in the next major version
- * @param metadata Optional metadata about the callable method
- */
-export const unstable_callable = (metadata: CallableMetadata = {}) => {
-  if (!didWarnAboutUnstableCallable) {
-    didWarnAboutUnstableCallable = true;
-    console.warn(
-      "unstable_callable is deprecated, use callable instead. unstable_callable will be removed in the next major version."
-    );
-  }
-  return callable(metadata);
 };
 
 export type QueueItem<T = string> = {
@@ -1569,6 +1537,34 @@ export class Agent<
    */
   readonly lifecycle = Lifecycle.install<Env, Props>(this);
 
+  /**
+   * WebSocket connection subsystem. Constructed as a field initializer
+   * so it exists before the constructor installs it; the handler arrows
+   * defer to `this.*`, so they always hit the framework-wrapped hooks.
+   * Those wrappers still open their own invocation scope even though
+   * the capability's dispatch already entered one via the host invoker
+   * — the inner wrap is kept because the wrapped hooks are also invoked
+   * from paths that do not pass through the capability (facet bridging,
+   * direct calls).
+   */
+  private readonly _webSockets = new WebSockets({
+    handlers: {
+      onConnect: (connection, ctx) => this.onConnect(connection, ctx),
+      onMessage: (connection, message) => this.onMessage(connection, message),
+      onClose: (connection, code, reason, wasClean) =>
+        this.onClose(connection, code, reason, wasClean),
+      onError: (connection, error) => this.onError(connection, error)
+    },
+    // Agent's callable interface comes from its existing public
+    // surface — @callable()-decorated methods — served here over the
+    // Cap'n Web endpoint and, natively, over the legacy JSON RPC
+    // protocol: one interface on every wire, no new Agent members.
+    // Capability hosts pass an RpcTarget directly instead.
+    callables: callablesFromDecorated(this),
+    getConnectionTags: (connection, ctx) =>
+      this.getConnectionTags(connection, ctx)
+  });
+
   /** Run user initialization after lifecycle components have started. */
   onStart(_props?: Props): void | Promise<void> {}
 
@@ -2268,12 +2264,14 @@ export class Agent<
     // capability callbacks tomorrow) enter through Agent's invocation
     // boundary so they get the same tracing span scope as every other Agent
     // entry point.
-    setLifecycleHostInvoker(this.lifecycle, (run) =>
+    // Connection-scoped callbacks (e.g. from a WebSockets capability)
+    // carry their live connection/request in the scope.
+    setLifecycleHostInvoker(this.lifecycle, (run, scope) =>
       runInInvocation(
         {
           agent: this,
-          connection: undefined,
-          request: undefined,
+          connection: scope?.connection,
+          request: scope?.request,
           email: undefined
         },
         run
@@ -2348,7 +2346,10 @@ export class Agent<
       }
     );
 
-    this.lifecycle.use(this.scheduler).use(this.mcp);
+    // Agent's WebSocket connections ride the WebSockets capability —
+    // Lifecycle itself no longer models connections. The handlers call
+    // through `this.*` so they always hit the framework-wrapped hooks.
+    this.lifecycle.use(this.scheduler).use(this.mcp).use(this._webSockets);
 
     // MCP starts before Agent restores facet routing state. Defer its initial
     // publication until broadcasts can be routed to the correct owner.
@@ -2498,7 +2499,7 @@ export class Agent<
                 throw new Error(`Method ${method} is not callable`);
               }
 
-              const metadata = callableMetadata.get(methodFn as Function);
+              const metadata = getCallableMetadata(methodFn as Function);
 
               // For streaming methods, pass a StreamingResponse object
               if (metadata?.streaming) {
@@ -3532,9 +3533,9 @@ export class Agent<
 
         // if the method is callable, copy the metadata from the original method
         if (this._isCallable(methodName)) {
-          callableMetadata.set(
-            wrappedFunction,
-            callableMetadata.get(this[methodName as keyof this] as Function)!
+          copyCallableMetadata(
+            this[methodName as keyof this] as Function,
+            wrappedFunction
           );
         }
 
@@ -5946,7 +5947,7 @@ export class Agent<
       return;
     }
 
-    for (const connection of this.lifecycle.getConnections()) {
+    for (const connection of this._webSockets.getConnections()) {
       if (without?.includes(connection.id)) continue;
       if (this._cf_connectionHasSubAgentTarget(connection)) continue;
       connection.send(msg);
@@ -5967,7 +5968,7 @@ export class Agent<
       return undefined;
     }
 
-    const connection = this.lifecycle.getConnection<TState>(id);
+    const connection = this._webSockets.getConnection<TState>(id);
     if (!connection || this._cf_connectionHasSubAgentTarget(connection)) {
       return undefined;
     }
@@ -5980,7 +5981,7 @@ export class Agent<
     if (this._isFacet) {
       // A facet's client connections are all virtual — they are real
       // WebSockets owned by the ROOT DO and bridged in. We must NOT fall
-      // through to `this.lifecycle.getConnections()` here: on a facet that resolves to
+      // through to `this._webSockets.getConnections()` here: on a facet that resolves to
       // the host/root DO's hibernatable sockets, and reading their attachments
       // from the facet's I/O context throws
       // "Cannot perform I/O on behalf of a different Durable Object (Native)".
@@ -5995,7 +5996,7 @@ export class Agent<
       return;
     }
 
-    for (const connection of this.lifecycle.getConnections<TState>(tag)) {
+    for (const connection of this._webSockets.getConnections<TState>(tag)) {
       if (this._cf_connectionHasSubAgentTarget(connection)) continue;
       yield connection;
     }
@@ -6142,7 +6143,7 @@ export class Agent<
       return;
     }
 
-    for (const connection of this.lifecycle.getConnections()) {
+    for (const connection of this._webSockets.getConnections()) {
       if (without?.includes(connection.id)) continue;
       const targetPath = this._cf_subAgentTargetPath(connection);
       if (!targetPath) continue;
@@ -6155,7 +6156,7 @@ export class Agent<
     ownerPath: ReadonlyArray<AgentPathStep>
   ): Promise<SubAgentConnectionMeta[]> {
     const metas: SubAgentConnectionMeta[] = [];
-    for (const connection of this.lifecycle.getConnections()) {
+    for (const connection of this._webSockets.getConnections()) {
       const meta = this._cf_subAgentConnectionMetaForPath(
         connection,
         ownerPath
@@ -6169,7 +6170,7 @@ export class Agent<
     connectionId: string,
     message: string | ArrayBuffer | ArrayBufferView
   ): Promise<void> {
-    const connection = this.lifecycle.getConnection(connectionId);
+    const connection = this._webSockets.getConnection(connectionId);
     if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
       return;
     }
@@ -6181,7 +6182,7 @@ export class Agent<
     code?: number,
     reason?: string
   ): Promise<void> {
-    const connection = this.lifecycle.getConnection(connectionId);
+    const connection = this._webSockets.getConnection(connectionId);
     if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
       return;
     }
@@ -6192,7 +6193,7 @@ export class Agent<
     connectionId: string,
     state: unknown
   ): Promise<unknown> {
-    const connection = this.lifecycle.getConnection(connectionId);
+    const connection = this._webSockets.getConnection(connectionId);
     if (!connection || !this._cf_connectionHasSubAgentTarget(connection)) {
       return null;
     }
@@ -10174,7 +10175,7 @@ export class Agent<
    * @returns True if the method is marked as callable
    */
   private _isCallable(method: string): boolean {
-    return callableMetadata.has(this[method as keyof this] as Function);
+    return isCallableMethod(this[method as keyof this] as Function);
   }
 
   /**
@@ -10182,34 +10183,7 @@ export class Agent<
    * @returns A map of method names to their metadata
    */
   getCallableMethods(): Map<string, CallableMetadata> {
-    const result = new Map<string, CallableMetadata>();
-
-    // Walk the entire prototype chain to find callable methods from parent classes
-    let prototype = Object.getPrototypeOf(this);
-    while (prototype && prototype !== Object.prototype) {
-      for (const name of Object.getOwnPropertyNames(prototype)) {
-        if (name === "constructor") continue;
-        // Don't override child class methods (first one wins)
-        if (result.has(name)) continue;
-
-        try {
-          const fn = prototype[name];
-          if (typeof fn === "function") {
-            const meta = callableMetadata.get(fn as Function);
-            if (meta) {
-              result.set(name, meta);
-            }
-          }
-        } catch (e) {
-          if (!(e instanceof TypeError)) {
-            throw e;
-          }
-        }
-      }
-      prototype = Object.getPrototypeOf(prototype);
-    }
-
-    return result;
+    return new Map(decoratedMethods(this));
   }
 
   // ==========================================

--- a/packages/agents/src/lifecycle/capability-runner.ts
+++ b/packages/agents/src/lifecycle/capability-runner.ts
@@ -1,5 +1,6 @@
 import { lifecycleCapabilityId } from "./capability";
 import type { LifecycleRouteContext } from "./capability";
+import type { WSMessage } from "./types";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -41,13 +42,40 @@ export type CapabilityRequestContext = {
   readonly request: Request;
 };
 
+/** Context supplied when a capability inspects a WebSocket upgrade. */
+export type CapabilityWebSocketUpgradeContext = {
+  /** The WebSocket upgrade request entering the Durable Object. */
+  readonly request: Request;
+};
+
 /**
  * A capability installed into a Durable Object lifecycle.
  *
  * Capabilities extending `LifecycleCapability` receive the standard storage,
  * readiness, alarm, event, and routing surface. Host-specific bindings and
  * protocol adapters remain explicit constructor dependencies. Hook parameters
- * carry only phase data; hooks do not run in ambient host context.
+ * carry only phase data; hooks do not run in ambient host context — a
+ * capability-held user callback re-enters host context exactly once,
+ * through `LifecycleServices.runInHostContext(fn, scope)`.
+ *
+ * A capability interacts with Lifecycle through exactly three channels:
+ * these declared hooks, the `LifecycleServices` surface, and
+ * composition-root `set*()` apertures. Any other direct reach in either
+ * direction is a design smell.
+ *
+ * Dispatch contract, hook by hook:
+ * - `onRequest` and `onWebSocketUpgrade` are offered in declaration
+ *   order; the first capability to return a `Response` claims the
+ *   request, and a claimed upgrade's socket belongs to that capability
+ *   for its whole lifetime.
+ * - `onWebSocketMessage`/`onWebSocketClose`/`onWebSocketError` are
+ *   platform wakes, offered in declaration order; return `true` to
+ *   consume one. Socket ownership is the capability's to determine —
+ *   keep a private hibernation-attachment namespace and recognize your
+ *   own sockets by it.
+ * - `onRoute` is addressed to one capability by its id; `getNextAlarm`
+ *   contributions are merged, with Lifecycle owning the one physical
+ *   alarm.
  *
  * @experimental The API surface may change before stabilizing.
  */
@@ -63,6 +91,43 @@ export interface DurableObjectCapability<Props extends object = object> {
   onRequest?(
     context: CapabilityRequestContext
   ): MaybePromise<Response | undefined | void>;
+
+  /**
+   * Claim a WebSocket upgrade before the host's legacy connection path.
+   *
+   * A capability that returns a response owns that socket and its lifetime,
+   * including any hibernation attachment it needs to recognize the socket
+   * later. Return `undefined` to decline.
+   */
+  onWebSocketUpgrade?(
+    context: CapabilityWebSocketUpgradeContext
+  ): MaybePromise<Response | undefined | void>;
+
+  /**
+   * Handle a platform `webSocketMessage` wake for a socket this capability
+   * owns. Return `true` to consume the event; anything else offers it to
+   * the next capability and finally the host's legacy path. Ownership is
+   * the capability's to determine — typically via its own hibernation
+   * attachment namespace.
+   */
+  onWebSocketMessage?(
+    ws: WebSocket,
+    message: WSMessage
+  ): MaybePromise<boolean | void>;
+
+  /** Handle a platform `webSocketClose` wake for an owned socket. */
+  onWebSocketClose?(
+    ws: WebSocket,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): MaybePromise<boolean | void>;
+
+  /** Handle a platform `webSocketError` wake for an owned socket. */
+  onWebSocketError?(
+    ws: WebSocket,
+    error: unknown
+  ): MaybePromise<boolean | void>;
 
   /** Run work assigned to the capability when the host's alarm fires. */
   onAlarm?(): MaybePromise<void>;
@@ -147,6 +212,69 @@ export class CapabilityRunner<Props extends object = object> {
       if (response !== undefined) return response;
     }
     return undefined;
+  }
+
+  /**
+   * Offer a WebSocket upgrade to each capability in declaration order.
+   *
+   * @param context - The upgrade request entering the Durable Object.
+   * @returns The first capability response, or `undefined` when unclaimed.
+   */
+  async webSocketUpgrade(
+    context: CapabilityWebSocketUpgradeContext
+  ): Promise<Response | undefined> {
+    await this.#ensureReady("handle a WebSocket upgrade");
+    for (const capability of this.#getCapabilities()) {
+      const response = await capability.onWebSocketUpgrade?.(context);
+      if (response !== undefined) return response;
+    }
+    return undefined;
+  }
+
+  /**
+   * Offer a platform `webSocketMessage` wake to each capability in
+   * declaration order.
+   *
+   * @returns Whether a capability consumed the event.
+   */
+  async webSocketMessage(ws: WebSocket, message: WSMessage): Promise<boolean> {
+    await this.#ensureReady("handle a WebSocket message");
+    for (const capability of this.#getCapabilities()) {
+      if ((await capability.onWebSocketMessage?.(ws, message)) === true) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Offer a platform `webSocketClose` wake to each capability. */
+  async webSocketClose(
+    ws: WebSocket,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): Promise<boolean> {
+    await this.#ensureReady("handle a WebSocket close");
+    for (const capability of this.#getCapabilities()) {
+      if (
+        (await capability.onWebSocketClose?.(ws, code, reason, wasClean)) ===
+        true
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Offer a platform `webSocketError` wake to each capability. */
+  async webSocketError(ws: WebSocket, error: unknown): Promise<boolean> {
+    await this.#ensureReady("handle a WebSocket error");
+    for (const capability of this.#getCapabilities()) {
+      if ((await capability.onWebSocketError?.(ws, error)) === true) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Return alarm requests from every installed capability. */

--- a/packages/agents/src/lifecycle/capability.ts
+++ b/packages/agents/src/lifecycle/capability.ts
@@ -2,6 +2,7 @@ import type {
   CapabilityStartContext,
   DurableObjectCapability
 } from "./capability-runner";
+import type { Connection } from "./types";
 
 /** Opaque address understood by a Lifecycle routing transport. */
 export type LifecycleRouteAddress = {
@@ -50,12 +51,37 @@ export type LifecycleRoutes = {
 };
 
 /**
+ * Ambient scope a capability supplies when entering host context on
+ * behalf of a live connection or request.
+ */
+export type LifecycleHostContextScope = {
+  /** The connection the callback runs on behalf of, when there is one. */
+  readonly connection?: Connection;
+  /** The request the callback runs on behalf of, when there is one. */
+  readonly request?: Request;
+};
+
+/**
+ * The platform's hibernatable-socket surface, exposed narrowly so a
+ * capability that owns connections (e.g. WebSockets) can accept and
+ * enumerate them without holding the whole `DurableObjectState`.
+ * These are workerd API names, not Lifecycle modeling sockets.
+ */
+export type LifecycleSockets = {
+  /** Accept a socket into hibernation under the given tags. */
+  readonly accept: (ws: WebSocket, tags: string[]) => void;
+  /** Every hibernated socket on the object, optionally by tag. */
+  readonly get: (tag?: string) => WebSocket[];
+};
+
+/**
  * Standard services granted to every installed Lifecycle capability.
  *
  * @experimental The API surface may change before stabilizing.
  */
 export type LifecycleServices = {
   readonly storage: DurableObjectStorage;
+  readonly sockets: LifecycleSockets;
   readonly ready: () => Promise<void>;
   /** True while capability and host startup hooks are still running. */
   readonly starting: () => boolean;
@@ -64,9 +90,13 @@ export type LifecycleServices = {
    * Run a capability-held user callback inside the host invocation context.
    * Capability hooks run outside host context; this is the one boundary for
    * entering it, and a host composition root may substitute its own wrapper
-   * (Agent adds tracing span scope).
+   * (Agent adds tracing span scope). Pass `scope` to make a live
+   * connection or request ambient for the callback.
    */
-  readonly runInHostContext: (fn: () => unknown) => Promise<unknown>;
+  readonly runInHostContext: (
+    fn: () => unknown,
+    scope?: LifecycleHostContextScope
+  ) => Promise<unknown>;
   readonly events: LifecycleEvents;
   readonly routes: LifecycleRoutes;
 };

--- a/packages/agents/src/lifecycle/current-agent.ts
+++ b/packages/agents/src/lifecycle/current-agent.ts
@@ -2,8 +2,8 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { DurableObject } from "cloudflare:workers";
 
 import type { AlarmContribution } from "./capability-runner";
-import type { Lifecycle, WSMessage } from "./durable-object-lifecycle";
-import type { Connection, ConnectionContext } from "./types";
+import type { Lifecycle } from "./durable-object-lifecycle";
+import type { Connection } from "./types";
 
 /**
  * A Durable Object that has installed the Agents SDK Lifecycle.
@@ -22,22 +22,6 @@ export interface LifecycleObject<
   onRequest?(request: Request): Response | Promise<Response>;
   onAlarm?(): void | Promise<void>;
   getNextAlarm?(): AlarmContribution | Promise<AlarmContribution>;
-  onConnect?(
-    connection: Connection,
-    context: ConnectionContext
-  ): void | Promise<void>;
-  onMessage?(connection: Connection, message: WSMessage): void | Promise<void>;
-  onClose?(
-    connection: Connection,
-    code: number,
-    reason: string,
-    wasClean: boolean
-  ): void | Promise<void>;
-  onError?(connection: Connection, error: unknown): void | Promise<void>;
-  getConnectionTags?(
-    connection: Connection,
-    context: ConnectionContext
-  ): string[] | Promise<string[]>;
 }
 
 /** Values associated with the currently executing Lifecycle host. */

--- a/packages/agents/src/lifecycle/durable-object-lifecycle.ts
+++ b/packages/agents/src/lifecycle/durable-object-lifecycle.ts
@@ -1,5 +1,4 @@
 import { DurableObject } from "cloudflare:workers";
-import { nanoid } from "nanoid";
 
 import { publishDiagnosticsEvent } from "../observability/diagnostics";
 import {
@@ -13,98 +12,29 @@ import {
   bindLifecycleCapability,
   lifecycleCapabilityId,
   LifecycleCapability,
+  type LifecycleHostContextScope,
   type LifecycleRouteAddress,
   type LifecycleServices
 } from "./capability";
-import {
-  createConnection,
-  ConnectionManager,
-  isManagedWebSocket
-} from "./connection";
-
 import {
   runInLifecycleHostContext,
   runWithoutCurrentAgent,
   type LifecycleObject
 } from "./current-agent";
 import { isBenignTeardownError } from "./transport-errors";
-
-import type {
-  Connection,
-  ConnectionSetStateFn,
-  ConnectionState
-} from "./types";
+import type { WSMessage } from "./types";
 
 export {
   type AlarmContribution,
   type CapabilityRequestContext,
+  type CapabilityWebSocketUpgradeContext,
   type LifecycleEvent,
   type CapabilityStartContext,
   type DurableObjectCapability
 } from "./capability-runner";
 export * from "./types";
 
-/** Payload delivered to a lifecycle-managed WebSocket callback. */
-export type WSMessage = ArrayBuffer | ArrayBufferView | string;
-
 const LEGACY_NAME_STORAGE_KEY = "__ps_name";
-
-/**
- * Reserved WebSocket close codes the runtime synthesizes when there
- * was no real Close frame from the peer:
- *  - 1005 (NoStatusReceived) — peer's frame had no status code.
- *  - 1006 (AbnormalClosure)  — peer dropped the underlying transport
- *                              without sending a Close frame at all.
- *  - 1015 (TLSHandshake)     — TLS failure during connection setup.
- *
- * These cannot legally appear in an outgoing Close frame, and — more
- * importantly for our reciprocation path — there is no peer left to
- * receive a reciprocating Close frame. Trying to send one anyway can
- * succeed synchronously but fail asynchronously inside the runtime
- * with "WebSocket peer disconnected" / "Network connection lost",
- * which escapes a synchronous try/catch and surfaces as an unhandled
- * promise rejection.
- */
-function isReservedCloseCode(code: number): boolean {
-  return code === 1005 || code === 1006 || code === 1015;
-}
-
-/**
- * Reciprocate a peer-initiated Close frame to complete the handshake.
- *
- * Best-effort: swallows synchronous errors from invalid codes,
- * oversize reasons, or sockets that have already been closed by user
- * code. Skips the reciprocation entirely when the peer didn't
- * actually send a Close frame (reserved codes 1005/1006/1015) — in
- * those cases the underlying transport is already gone and writing
- * to it would fail asynchronously, which we can't catch here.
- *
- * Used by the hibernating close handler to complete real close handshakes.
- */
-function closeQuietly(ws: WebSocket, code: number, reason: string): void {
-  // No real Close frame from the peer → nothing to reciprocate.
-  // Calling `ws.close(...)` here would synchronously succeed but
-  // schedule an outbound write on a dead transport, which the runtime
-  // would later reject with "Network connection lost". That rejection
-  // can't be observed from here (it's not thrown synchronously and
-  // ws.close() doesn't return a Promise to attach a `.catch` to), so
-  // it would surface as an unhandled rejection.
-  if (isReservedCloseCode(code)) return;
-  try {
-    ws.close(code, reason);
-  } catch {
-    // Reasons we end up here:
-    //   - the socket was already closed (user called `connection.close()`
-    //     in `onClose`, or the runtime auto-replied on compat dates
-    //     >= 2026-04-07 for the standard `accept()` API)
-    //   - `reason` exceeds the 123-byte UTF-8 limit (compat date
-    //     >= 2026-03-03)
-    //   - some other invariant violation we don't want to crash the
-    //     handler over
-    // None of these are recoverable here; the handshake is either already
-    // done or the runtime is out of our control.
-  }
-}
 
 function mutableRequest(request: Request): Request {
   return new Request(request);
@@ -181,9 +111,13 @@ type LifecycleHost<
  * Boundary wrapping user callbacks that capabilities run through
  * `LifecycleServices.runInHostContext`. The default boundary is
  * {@link runInLifecycleHostContext}; a host composition root may substitute
- * its own invocation wrapper (Agent adds tracing span scope).
+ * its own invocation wrapper (Agent adds tracing span scope). The optional
+ * scope carries the live connection/request the callback runs on behalf of.
  */
-export type LifecycleHostInvoker = <T>(run: () => T) => T;
+export type LifecycleHostInvoker = <T>(
+  run: () => T,
+  scope?: LifecycleHostContextScope
+) => T;
 
 const lifecycleEventSinks = new WeakMap<object, LifecycleEventSink>();
 const lifecycleRouteTransports = new WeakMap<object, LifecycleRouteTransport>();
@@ -233,7 +167,6 @@ export class Lifecycle<
   readonly #capabilityRunner = new CapabilityRunner<Props>(
     () => this.#capabilities
   );
-  readonly #connectionManager: ConnectionManager;
 
   #status: "zero" | "starting" | "started" = "zero";
   #alarmRearmQueue: Promise<void> = Promise.resolve();
@@ -270,7 +203,6 @@ export class Lifecycle<
     this.#host = host as unknown as LifecycleHost<Env, Props>;
     this.#ctx = this.#host.ctx;
     this.#parentClassName = this.#host.constructor.name;
-    this.#connectionManager = new ConnectionManager(this.#ctx);
   }
 
   /**
@@ -344,14 +276,21 @@ export class Lifecycle<
     });
     return Object.freeze({
       storage: this.#ctx.storage,
+      sockets: Object.freeze({
+        accept: (ws: WebSocket, tags: string[]) =>
+          this.#ctx.acceptWebSocket(ws, tags),
+        get: (tag?: string) => this.#ctx.getWebSockets(tag)
+      }),
       ready: () => this.#readyForCapabilityOperation(),
       starting: () => this.#status === "starting",
       alarms: Object.freeze({
         rearm: () => this.rearmAlarm(),
         disabled: () => this.#alarmsDisabled
       }),
-      runInHostContext: async (fn: () => unknown) =>
-        this.#runInHostBoundary(fn),
+      runInHostContext: async (
+        fn: () => unknown,
+        scope?: LifecycleHostContextScope
+      ) => this.#runInHostBoundary(fn, scope),
       events: Object.freeze({
         emit: (type: string, payload: unknown) =>
           this.#emitCapabilityEvent({ source: capabilityId, type, payload })
@@ -384,12 +323,22 @@ export class Lifecycle<
    * context by default, or the composition root's substitute (Agent installs
    * its tracing invocation scope).
    */
-  #runInHostBoundary(fn: () => unknown): Promise<unknown> {
+  #runInHostBoundary(
+    fn: () => unknown,
+    scope?: LifecycleHostContextScope
+  ): Promise<unknown> {
     const boundary = lifecycleHostInvokers.get(this);
     return Promise.resolve(
       boundary
-        ? boundary(fn)
-        : runInLifecycleHostContext({ host: this.#host }, fn)
+        ? boundary(fn, scope)
+        : runInLifecycleHostContext(
+            {
+              host: this.#host,
+              connection: scope?.connection,
+              request: scope?.request
+            },
+            fn
+          )
     );
   }
 
@@ -507,8 +456,6 @@ export class Lifecycle<
 
       await this.#ensureInitialized();
 
-      const url = new URL(request.url);
-
       if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
         const capabilityResponse = await runWithoutCurrentAgent(() =>
           this.#capabilityRunner.request({ request })
@@ -522,49 +469,18 @@ export class Lifecycle<
         }
         return new Response("Not implemented", { status: 404 });
       } else {
-        // Create the websocket pair for the client
-        const { 0: clientWebSocket, 1: serverWebSocket } = new WebSocketPair();
-        let connectionId = url.searchParams.get("_pk");
-        if (!connectionId) {
-          connectionId = nanoid();
-        }
-
-        let connection: Connection = Object.assign(serverWebSocket, {
-          id: connectionId,
-          uri: request.url,
-          tags: [] as string[],
-          state: null as unknown as ConnectionState<unknown>,
-          setState<T = unknown>(setState: T | ConnectionSetStateFn<T>) {
-            let state: T;
-            if (setState instanceof Function) {
-              state = setState(this.state as ConnectionState<T>);
-            } else {
-              state = setState;
-            }
-
-            // TODO: deepFreeze object?
-            this.state = state as ConnectionState<T>;
-            return this.state;
-          }
-        });
-
-        const ctx = { request };
-
-        // getConnectionTags already receives both connection and request
-        // explicitly. TODO: run it in host context if shared callback code
-        // develops a concrete need for getCurrentAgent() in this hook.
-        const tags = this.#host.getConnectionTags
-          ? await this.#host.getConnectionTags(connection, ctx)
-          : [];
-
-        // Hibernating WebSockets remain connected while the object is evicted.
-        connection = this.#connectionManager.accept(connection, { tags });
-        await runInLifecycleHostContext(
-          { host: this.#host, connection, request },
-          () => this.#host.onConnect?.(connection, ctx)
+        // Lifecycle does not model WebSockets. A capability that owns
+        // connection behavior (e.g. the WebSockets capability) claims the
+        // upgrade here; without one, upgrades are not supported.
+        const upgradeResponse = await runWithoutCurrentAgent(() =>
+          this.#capabilityRunner.webSocketUpgrade({ request })
         );
+        if (upgradeResponse !== undefined) return upgradeResponse;
 
-        return new Response(null, { status: 101, webSocket: clientWebSocket });
+        return new Response(
+          "WebSocket upgrades are not enabled on this Durable Object. Install a capability that claims them (e.g. WebSockets).",
+          { status: 404 }
+        );
       }
     } catch (err) {
       console.error(
@@ -589,19 +505,15 @@ export class Lifecycle<
 
   /** @internal Dispatch a hibernating WebSocket message. */
   async webSocketMessage(ws: WebSocket, message: WSMessage): Promise<void> {
-    // Ignore WebSockets accepted outside this lifecycle (e.g. via
-    // `state.acceptWebSocket()` in user code). These sockets do not have the
-    // managed attachment required to rehydrate a Connection.
-    if (!isManagedWebSocket(ws)) {
-      return;
-    }
-
     try {
-      const connection = createConnection(ws);
-
       await this.#ensureInitialized();
-      return runInLifecycleHostContext({ host: this.#host, connection }, () =>
-        this.#host.onMessage?.(connection, message)
+
+      // Sockets are owned by whichever capability claimed their upgrade
+      // (recognized via its own hibernation attachment). Wakes for sockets
+      // no capability owns — e.g. `state.acceptWebSocket()` in user code —
+      // are ignored.
+      await runWithoutCurrentAgent(() =>
+        this.#capabilityRunner.webSocketMessage(ws, message)
       );
     } catch (e) {
       console.error(
@@ -611,64 +523,42 @@ export class Lifecycle<
     }
   }
 
-  /** @internal Dispatch and reciprocate a hibernating WebSocket close. */
+  /** @internal Dispatch a hibernating WebSocket close. */
   async webSocketClose(
     ws: WebSocket,
     code: number,
     reason: string,
     wasClean: boolean
   ): Promise<void> {
-    if (!isManagedWebSocket(ws)) {
-      return;
-    }
-
     try {
-      const connection = createConnection(ws);
-
       await this.#ensureInitialized();
-      await runInLifecycleHostContext({ host: this.#host, connection }, () =>
-        this.#host.onClose?.(connection, code, reason, wasClean)
+      // The owning capability also reciprocates the close handshake, as
+      // the Hibernation API contract requires.
+      await runWithoutCurrentAgent(() =>
+        this.#capabilityRunner.webSocketClose(ws, code, reason, wasClean)
       );
     } catch (e) {
       console.error(
         `Error in ${this.#parentClassName}:${this.#ctx.id.name ?? "<unnamed>"} webSocketClose:`,
         e
       );
-    } finally {
-      // Reciprocate the peer's Close frame to complete the handshake.
-      // The Hibernation API requires applications to do this — without it,
-      // clients stay in CLOSING and end up reporting 1006 abnormal closure.
-      // The standard `accept()` API gets this for free on compat dates
-      // >= 2026-04-07 via the `web_socket_auto_reply_to_close` flag, but the
-      // Hibernation API contract is unchanged: see
-      // https://developers.cloudflare.com/durable-objects/api/base/#websocketclose
-      // Calling close() on an already-closed socket is a silent no-op, so
-      // this is safe regardless of compat date or whether user code in
-      // `onClose` already called `connection.close()`.
-      closeQuietly(ws, code, reason);
     }
   }
 
   /** @internal Dispatch a hibernating WebSocket error. */
   async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
-    if (!isManagedWebSocket(ws)) {
-      return;
-    }
-
     // Suppress retryable transport-teardown errors on an already closing/closed
     // socket — the connection going away during/after the close handshake, not
     // an application error. Genuine mid-connection (OPEN) errors still reach
-    // onError below.
+    // the owning handler below.
     if (isBenignTeardownError(ws, error)) {
       return;
     }
 
     try {
-      const connection = createConnection(ws);
-
       await this.#ensureInitialized();
-      return runInLifecycleHostContext({ host: this.#host, connection }, () =>
-        this.#host.onError?.(connection, error)
+      await runWithoutCurrentAgent(() =>
+        this.#capabilityRunner.webSocketError(ws, error)
       );
     } catch (e) {
       console.error(
@@ -753,37 +643,6 @@ export class Lifecycle<
         "expose ctx.id.name. Alarms created before 2026-03-15 must be " +
         "rescheduled from a named fetch or RPC handler."
     );
-  }
-
-  #sendMessageToConnection(connection: Connection, message: WSMessage): void {
-    try {
-      connection.send(message);
-    } catch (_e) {
-      // close connection
-      connection.close(1011, "Unexpected error");
-    }
-  }
-
-  /** Send a message to all connected clients, except connection ids listed in `without` */
-  broadcast(
-    msg: string | ArrayBuffer | ArrayBufferView,
-    without?: string[] | undefined
-  ): void {
-    for (const connection of this.#connectionManager.getConnections()) {
-      if (!without || !without.includes(connection.id)) {
-        this.#sendMessageToConnection(connection, msg);
-      }
-    }
-  }
-
-  /** Get a connection by connection id */
-  getConnection<TState = unknown>(id: string): Connection<TState> | undefined {
-    return this.#connectionManager.getConnection<TState>(id);
-  }
-
-  /** Get all managed connections, optionally filtered by tag. */
-  getConnections<TState = unknown>(tag?: string): Iterable<Connection<TState>> {
-    return this.#connectionManager.getConnections<TState>(tag);
   }
 
   #props?: Props;

--- a/packages/agents/src/lifecycle/index.ts
+++ b/packages/agents/src/lifecycle/index.ts
@@ -9,8 +9,10 @@ export {
   type LifecycleEvents,
   type LifecycleRouteAddress,
   type LifecycleRouteContext,
+  type LifecycleHostContextScope,
   type LifecycleRoutes,
-  type LifecycleServices
+  type LifecycleServices,
+  type LifecycleSockets
 } from "./capability";
 export {
   getCurrentAgent,
@@ -27,6 +29,7 @@ export {
   type DurableObjectCapability,
   type CapabilityRequestContext,
   type CapabilityStartContext,
+  type CapabilityWebSocketUpgradeContext,
   type LifecycleEvent,
   type WSMessage
 } from "./durable-object-lifecycle";

--- a/packages/agents/src/lifecycle/types.ts
+++ b/packages/agents/src/lifecycle/types.ts
@@ -14,6 +14,14 @@ type ImmutableMap<K, V> = ReadonlyMap<Immutable<K>, Immutable<V>>;
 type ImmutableSet<T> = ReadonlySet<Immutable<T>>;
 type ImmutableObject<T> = { readonly [K in keyof T]: Immutable<T[K]> };
 
+/** A payload delivered on a WebSocket connection. */
+export type WSMessage = ArrayBuffer | ArrayBufferView | string;
+
+// Connection vocabulary is shared language: the WebSockets capability
+// implements it, and Lifecycle's host-context scope references it. The
+// connection MACHINERY lives entirely in the capability
+// (`src/websockets/`); only the types are defined here.
+
 /** Immutable state persisted in a hibernating WebSocket attachment. */
 export type ConnectionState<T> = ImmutableObject<T> | null;
 

--- a/packages/agents/src/tests-d/lifecycle-export.test-d.ts
+++ b/packages/agents/src/tests-d/lifecycle-export.test-d.ts
@@ -20,6 +20,7 @@ import {
   type DurableObjectCapability,
   type WSMessage
 } from "../lifecycle";
+import type { WebSocketHandlers, WebSocketMessage } from "../websockets";
 
 expectTypeOf<AgentConnection>().toEqualTypeOf<Connection>();
 expectTypeOf<AgentConnectionContext>().toEqualTypeOf<ConnectionContext>();
@@ -51,18 +52,20 @@ expectTypeOf<ProbeLifecycleObject["onAlarm"]>().toEqualTypeOf<
 expectTypeOf<ProbeLifecycleObject["getNextAlarm"]>().toEqualTypeOf<
   (() => AlarmContribution | Promise<AlarmContribution>) | undefined
 >();
-expectTypeOf<ProbeLifecycleObject["onConnect"]>().toEqualTypeOf<
+// WebSocket hooks are no longer part of the Lifecycle host contract —
+// connection handlers live in the opt-in WebSockets capability.
+expectTypeOf<WebSocketHandlers["onConnect"]>().toEqualTypeOf<
+  | ((connection: Connection, ctx: ConnectionContext) => void | Promise<void>)
+  | undefined
+>();
+expectTypeOf<WebSocketHandlers["onMessage"]>().toEqualTypeOf<
   | ((
       connection: Connection,
-      context: ConnectionContext
+      message: WebSocketMessage
     ) => void | Promise<void>)
   | undefined
 >();
-expectTypeOf<ProbeLifecycleObject["onMessage"]>().toEqualTypeOf<
-  | ((connection: Connection, message: WSMessage) => void | Promise<void>)
-  | undefined
->();
-expectTypeOf<ProbeLifecycleObject["onClose"]>().toEqualTypeOf<
+expectTypeOf<WebSocketHandlers["onClose"]>().toEqualTypeOf<
   | ((
       connection: Connection,
       code: number,
@@ -71,15 +74,8 @@ expectTypeOf<ProbeLifecycleObject["onClose"]>().toEqualTypeOf<
     ) => void | Promise<void>)
   | undefined
 >();
-expectTypeOf<ProbeLifecycleObject["onError"]>().toEqualTypeOf<
+expectTypeOf<WebSocketHandlers["onError"]>().toEqualTypeOf<
   ((connection: Connection, error: unknown) => void | Promise<void>) | undefined
->();
-expectTypeOf<ProbeLifecycleObject["getConnectionTags"]>().toEqualTypeOf<
-  | ((
-      connection: Connection,
-      context: ConnectionContext
-    ) => string[] | Promise<string[]>)
-  | undefined
 >();
 expectTypeOf(getCurrentAgent().agent).toEqualTypeOf<
   LifecycleObject | undefined

--- a/packages/agents/src/tests/agents/callable.ts
+++ b/packages/agents/src/tests/agents/callable.ts
@@ -8,6 +8,22 @@ export class TestCallableAgent extends Agent<
 > {
   initialState = { value: 0 };
 
+  // Served over BOTH wires: natively on the legacy JSON RPC protocol
+  // and, via the decorator-fallback target, on the WebSockets
+  // capability's Cap'n Web endpoint.
+  @callable()
+  multiply(a: number, b: number): number {
+    return a * b;
+  }
+
+  // For client call-timeout tests over the Cap'n Web endpoint.
+  @callable()
+  slowConfig(): Promise<string> {
+    return new Promise<string>((resolve) =>
+      setTimeout(() => resolve("done"), 60_000)
+    );
+  }
+
   // Basic sync method
   @callable()
   add(a: number, b: number): number {

--- a/packages/agents/src/tests/capabilities/lifecycle.ts
+++ b/packages/agents/src/tests/capabilities/lifecycle.ts
@@ -1,4 +1,4 @@
-import { DurableObject } from "cloudflare:workers";
+import { DurableObject, RpcTarget } from "cloudflare:workers";
 import {
   getCurrentAgent as getCurrentRootAgent,
   __DO_NOT_USE_WILL_BREAK__agentContext as agentContext
@@ -7,10 +7,9 @@ import {
   getCurrentAgent,
   Lifecycle,
   LifecycleCapability,
-  type Connection,
-  type DurableObjectCapability,
-  type WSMessage
+  type DurableObjectCapability
 } from "../../lifecycle";
+import { WebSockets } from "../../websockets";
 
 type StartupProps = { label: string };
 
@@ -158,6 +157,41 @@ function currentWebSocketContext(
 }
 
 /**
+ * Callables target served by the WebSockets capability. The private
+ * field proves methods run with the real instance as `this`.
+ */
+class PlainHostCallables extends RpcTarget {
+  readonly #greeting = "host";
+
+  add(a: number, b: number): number {
+    return a + b;
+  }
+
+  fail(message: string): never {
+    throw new Error(message);
+  }
+
+  hostContext(): boolean {
+    return getCurrentAgent().agent !== undefined;
+  }
+
+  greeting(): string {
+    return this.#greeting;
+  }
+
+  streamNumbers(): ReadableStream<number> {
+    return new ReadableStream<number>({
+      start(controller) {
+        controller.enqueue(1);
+        controller.enqueue(2);
+        controller.enqueue(3);
+        controller.close();
+      }
+    });
+  }
+}
+
+/**
  * A plain Durable Object composed with Lifecycle and an assortment of probe
  * capabilities. The Lifecycle test suites drive it to prove phase ordering,
  * shared alarm arbitration, context boundaries, routing, identity, and
@@ -170,6 +204,22 @@ export class PlainLifecycleObject extends DurableObject<Cloudflare.Env> {
   readonly #startupEvent = new StartupEventProbe();
   readonly #routedCapability = new RoutedCapabilityProbe();
   readonly #hostBoundary = new HostBoundaryProbe();
+  readonly #webSockets = new WebSockets({
+    handlers: {
+      onConnect: (connection) => {
+        this.#webSocketContexts.push(currentWebSocketContext("connect"));
+        connection.send(`connected:${this.lifecycle.name}`);
+      },
+      onMessage: (connection, message) => {
+        this.#webSocketContexts.push(currentWebSocketContext("message"));
+        connection.send(`echo:${String(message)}`);
+      },
+      onClose: () => {
+        this.#webSocketContexts.push(currentWebSocketContext("close"));
+      }
+    },
+    callables: new PlainHostCallables()
+  });
   readonly #hostContexts: HostContextEvent[] = [];
   readonly #webSocketContexts: WebSocketContextEvent[] = [];
   #firstAlarm: number | null = null;
@@ -185,6 +235,7 @@ export class PlainLifecycleObject extends DurableObject<Cloudflare.Env> {
     .use(this.#startupEvent)
     .use(this.#routedCapability)
     .use(this.#hostBoundary)
+    .use(this.#webSockets)
     .use({
       onStart: ({ props }) => {
         this.#events.push(`capability:start:${props?.label ?? "none"}`);
@@ -252,20 +303,6 @@ export class PlainLifecycleObject extends DurableObject<Cloudflare.Env> {
       getCurrentAgent<PlainLifecycleObject>().agent === this
     );
     return this.#hostAlarm;
-  }
-
-  onConnect(connection: Connection): void {
-    this.#webSocketContexts.push(currentWebSocketContext("connect"));
-    connection.send(`connected:${this.lifecycle.name}`);
-  }
-
-  onMessage(connection: Connection, message: WSMessage): void {
-    this.#webSocketContexts.push(currentWebSocketContext("message"));
-    connection.send(`echo:${String(message)}`);
-  }
-
-  onClose(): void {
-    this.#webSocketContexts.push(currentWebSocketContext("close"));
   }
 
   installHandlersAgainForTest(): string {

--- a/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
+++ b/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
@@ -1,0 +1,225 @@
+import { env } from "cloudflare:workers";
+import {
+  subscribe as subscribeDiagnostic,
+  unsubscribe as unsubscribeDiagnostic
+} from "node:diagnostics_channel";
+import { newWebSocketRpcSession } from "capnweb";
+import { describe, expect, it } from "vitest";
+import { routeAgentRequest } from "../..";
+import { CALLABLES_RPC_QUERY, CALLABLES_RPC_VALUE } from "../../websockets";
+
+/**
+ * The WebSockets capability's callables endpoint: an `RpcTarget`'s
+ * methods served over a Cap'n Web session claimed from
+ * `?__agents_rpc=capnweb` upgrades.
+ *
+ * The capability's connection-handler surface is covered by the
+ * Lifecycle WebSocket suites — PlainLifecycleObject's handlers live in
+ * its WebSockets capability.
+ */
+
+type PlainHostCallables = {
+  add(a: number, b: number): Promise<number>;
+  fail(message: string): Promise<never>;
+  hostContext(): Promise<boolean>;
+  greeting(): Promise<string>;
+  streamNumbers(): Promise<ReadableStream<number>>;
+};
+
+type AgentCallables = {
+  multiply(a: number, b: number): Promise<number>;
+  add(a: number, b: number): Promise<number>;
+};
+
+async function connectCallables<Api>(path: string) {
+  const url = new URL(path, "https://example.com");
+  url.searchParams.set(CALLABLES_RPC_QUERY, CALLABLES_RPC_VALUE);
+  const response = await routeAgentRequest(
+    new Request(url, { headers: { Upgrade: "websocket" } }),
+    env
+  );
+  expect(response).not.toBeNull();
+  expect(response!.status).toBe(101);
+  const socket = response!.webSocket as WebSocket;
+  expect(socket).toBeDefined();
+  socket.accept();
+  const rpc = newWebSocketRpcSession<Api>(socket);
+  return {
+    rpc,
+    close() {
+      try {
+        (rpc as Partial<Disposable>)[Symbol.dispose]?.();
+      } catch {
+        socket.close();
+      }
+    }
+  };
+}
+
+describe("WebSockets capability callables", () => {
+  it("serves the target's methods on a plain lifecycle host", async () => {
+    const session = await connectCallables<PlainHostCallables>(
+      `/agents/plain-lifecycle-object/${crypto.randomUUID()}`
+    );
+    try {
+      await expect(session.rpc.add(2, 3)).resolves.toBe(5);
+    } finally {
+      session.close();
+    }
+  });
+
+  it("invokes methods on the real target — private fields work", async () => {
+    const session = await connectCallables<PlainHostCallables>(
+      `/agents/plain-lifecycle-object/${crypto.randomUUID()}`
+    );
+    try {
+      await expect(session.rpc.greeting()).resolves.toBe("host");
+    } finally {
+      session.close();
+    }
+  });
+
+  it("runs methods inside the host invocation boundary", async () => {
+    const session = await connectCallables<PlainHostCallables>(
+      `/agents/plain-lifecycle-object/${crypto.randomUUID()}`
+    );
+    try {
+      await expect(session.rpc.hostContext()).resolves.toBe(true);
+    } finally {
+      session.close();
+    }
+  });
+
+  it("propagates thrown errors and emits rpc events", async () => {
+    const name = crypto.randomUUID();
+    const observed: Array<Record<string, unknown>> = [];
+    const handler = (event: unknown) => {
+      if (event === null || typeof event !== "object") return;
+      const record = event as Record<string, unknown>;
+      if (record.name !== name || record.source !== "websockets") return;
+      observed.push(record);
+    };
+    // `rpc`/`rpc:error` events route to the dedicated rpc diagnostics
+    // channel, same as the Agent's legacy RPC protocol events.
+    subscribeDiagnostic("agents:rpc", handler);
+    const session = await connectCallables<PlainHostCallables>(
+      `/agents/plain-lifecycle-object/${name}`
+    );
+    try {
+      await expect(session.rpc.add(1, 1)).resolves.toBe(2);
+      await expect(session.rpc.fail("kaboom")).rejects.toThrow("kaboom");
+      expect(observed).toEqual([
+        expect.objectContaining({
+          type: "rpc",
+          payload: { method: "add", streaming: false }
+        }),
+        expect.objectContaining({
+          type: "rpc:error",
+          payload: { method: "fail", error: "kaboom" }
+        })
+      ]);
+    } finally {
+      unsubscribeDiagnostic("agents:rpc", handler);
+      session.close();
+    }
+  });
+
+  it("rejects names outside the target's interface", async () => {
+    const session = await connectCallables<
+      PlainHostCallables & { unregistered(): Promise<unknown> }
+    >(`/agents/plain-lifecycle-object/${crypto.randomUUID()}`);
+    try {
+      await expect(session.rpc.unregistered()).rejects.toThrow();
+    } finally {
+      session.close();
+    }
+  });
+
+  it("streams ReadableStream results to the caller", async () => {
+    const session = await connectCallables<PlainHostCallables>(
+      `/agents/plain-lifecycle-object/${crypto.randomUUID()}`
+    );
+    try {
+      const stream = await session.rpc.streamNumbers();
+      const reader = stream.getReader();
+      const chunks: number[] = [];
+      while (true) {
+        const next = await reader.read();
+        if (next.done) break;
+        chunks.push(next.value);
+      }
+      expect(chunks).toEqual([1, 2, 3]);
+    } finally {
+      session.close();
+    }
+  });
+
+  it("serves an Agent's decorated methods over capnweb — one interface, every wire", async () => {
+    const session = await connectCallables<
+      AgentCallables & { notCallableMethod(): Promise<unknown> }
+    >(`/agents/test-callable-agent/${crypto.randomUUID()}`);
+    try {
+      await expect(session.rpc.multiply(6, 7)).resolves.toBe(42);
+      await expect(session.rpc.add(2, 3)).resolves.toBe(5);
+      // Undecorated methods stay unreachable.
+      await expect(session.rpc.notCallableMethod()).rejects.toThrow();
+    } finally {
+      session.close();
+    }
+  });
+
+  it("serves decorated methods over capnweb without an explicit target", async () => {
+    const session = await connectCallables<{
+      childMethod(): Promise<string>;
+      parentMethod(): Promise<string>;
+      nonCallableMethod(): Promise<unknown>;
+    }>(`/agents/test-child-agent/${crypto.randomUUID()}`);
+    try {
+      await expect(session.rpc.childMethod()).resolves.toBeDefined();
+      await expect(session.rpc.parentMethod()).resolves.toBeDefined();
+      await expect(session.rpc.nonCallableMethod()).rejects.toThrow();
+    } finally {
+      session.close();
+    }
+  });
+
+  it("serves the same interface over the legacy JSON RPC wire", async () => {
+    const name = crypto.randomUUID();
+    const response = await routeAgentRequest(
+      new Request(`https://example.com/agents/test-callable-agent/${name}`, {
+        headers: { Upgrade: "websocket" }
+      }),
+      env
+    );
+    expect(response!.status).toBe(101);
+    const socket = response!.webSocket as WebSocket;
+    socket.accept();
+
+    const reply = new Promise<Record<string, unknown>>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Timed out waiting for RPC reply")),
+        5000
+      );
+      socket.addEventListener("message", (event) => {
+        if (typeof event.data !== "string") return;
+        const frame = JSON.parse(event.data) as Record<string, unknown>;
+        if (frame.type === "rpc" && frame.id === "legacy-1") {
+          clearTimeout(timer);
+          resolve(frame);
+        }
+      });
+    });
+    socket.send(
+      JSON.stringify({
+        type: "rpc",
+        id: "legacy-1",
+        method: "multiply",
+        args: [6, 7]
+      })
+    );
+    const frame = await reply;
+    expect(frame.success).toBe(true);
+    expect(frame.result).toBe(42);
+    socket.close();
+  });
+});

--- a/packages/agents/src/websockets/callables-target.ts
+++ b/packages/agents/src/websockets/callables-target.ts
@@ -1,0 +1,119 @@
+import { RpcTarget } from "cloudflare:workers";
+import { decoratedMethods } from "../callable-decorator";
+
+/** A named remote method ready to be exposed on a callables root. */
+export type CallableInvoker = (...args: unknown[]) => unknown;
+
+/**
+ * The single exposure policy for callable names. `Object.prototype` and
+ * `RpcTarget.prototype` members are unreachable over Cap'n Web anyway
+ * and are silently excluded; `then` is rejected loudly because exposing
+ * it would make the remote stub thenable.
+ */
+function assertExposable(name: string): boolean {
+  if (name === "then") {
+    throw new Error(
+      'A callables target cannot expose a method named "then" — it would make the remote stub thenable'
+    );
+  }
+  return !(
+    name === "constructor" ||
+    name in Object.prototype ||
+    name in RpcTarget.prototype
+  );
+}
+
+/**
+ * The exposable prototype methods of a callables target, each bound to
+ * invoke on the real instance (so private fields and `this` behave).
+ *
+ * Cap'n Web resolves methods on the prototype chain and rejects own
+ * instance properties, so only prototype methods participate. The
+ * nearest declaration wins for overridden names.
+ *
+ * @param target - The callables target to enumerate.
+ * @returns Method names mapped to invokers on the target.
+ */
+export function exposableMethods(
+  target: RpcTarget
+): ReadonlyMap<string, CallableInvoker> {
+  const methods = new Map<string, CallableInvoker>();
+  const seen = new Set<string>();
+  let prototype: object | null = Object.getPrototypeOf(target);
+  while (
+    prototype &&
+    prototype !== RpcTarget.prototype &&
+    prototype !== Object.prototype
+  ) {
+    for (const name of Object.getOwnPropertyNames(prototype)) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      if (!assertExposable(name)) continue;
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+      if (!descriptor || typeof descriptor.value !== "function") continue;
+      // SAFETY: `typeof descriptor.value === "function"` was checked
+      // above; TypeScript cannot narrow a descriptor's `value` field.
+      const method = descriptor.value as CallableInvoker;
+      methods.set(name, (...args) => Reflect.apply(method, target, args));
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return methods;
+}
+
+/**
+ * Build a Cap'n Web session root exposing exactly the given methods.
+ *
+ * Cap'n Web resolves methods on the prototype chain, rejects own
+ * instance properties, and breaks on Proxy-wrapped roots — so the root
+ * is a private `RpcTarget` subclass whose prototype carries the
+ * methods and nothing else.
+ *
+ * @param methods - Method names mapped to their invokers.
+ * @returns A root suitable as a Cap'n Web session's local main.
+ */
+export function buildCallablesRoot(
+  methods: ReadonlyMap<string, CallableInvoker>
+): RpcTarget {
+  class CallablesRoot extends RpcTarget {}
+  for (const [name, invoke] of methods) {
+    Object.defineProperty(CallablesRoot.prototype, name, {
+      value: invoke,
+      writable: true,
+      configurable: true,
+      enumerable: false
+    });
+  }
+  return new CallablesRoot();
+}
+
+/**
+ * Build a callables target from a host's `@callable()`-decorated
+ * methods — the fallback interface source when no `RpcTarget` is
+ * configured (an explicit target is preferred and wins).
+ *
+ * Methods are resolved on the host at call time, so framework wrapping
+ * applied after construction (e.g. Agent's context auto-wrapping) is
+ * honored. Methods registered with `streaming: true` expect the legacy
+ * Agent RPC protocol's injected `StreamingResponse` and are not exposed
+ * here — return a `ReadableStream` from an `RpcTarget` method instead.
+ *
+ * @param host - The object whose decorated methods form the interface.
+ * @returns A target exposing the decorated methods, or `undefined`
+ * when the host has none.
+ */
+export function callablesFromDecorated(host: object): RpcTarget | undefined {
+  const methods = new Map<string, CallableInvoker>();
+  for (const [name, metadata] of decoratedMethods(host)) {
+    if (metadata.streaming || !assertExposable(name)) continue;
+    methods.set(name, (...args) => {
+      const method = Reflect.get(host, name) as unknown;
+      if (typeof method !== "function") {
+        throw new Error(`Method ${name} is not callable`);
+      }
+      return Reflect.apply(method, host, args);
+    });
+  }
+  if (methods.size === 0) return undefined;
+  return buildCallablesRoot(methods);
+}

--- a/packages/agents/src/websockets/connection.ts
+++ b/packages/agents/src/websockets/connection.ts
@@ -5,8 +5,9 @@
 import type {
   Connection,
   ConnectionSetStateFn,
-  ConnectionState
-} from "./types";
+  ConnectionState,
+  LifecycleSockets
+} from "../lifecycle";
 
 if (!("OPEN" in WebSocket)) {
   const WebSocketStatus = {
@@ -182,9 +183,9 @@ export const createConnection = (ws: WebSocket | Connection): Connection => {
 
 class ConnectionIterator<T> implements IterableIterator<Connection<T>> {
   private index = 0;
-  private sockets: WebSocket[] | undefined;
+  #sockets: WebSocket[] | undefined;
   constructor(
-    private state: DurableObjectState,
+    private sockets: LifecycleSockets,
     private tag?: string
   ) {}
 
@@ -194,7 +195,7 @@ class ConnectionIterator<T> implements IterableIterator<Connection<T>> {
 
   next(): IteratorResult<Connection<T>, number | undefined> {
     const sockets =
-      this.sockets ?? (this.sockets = this.state.getWebSockets(this.tag));
+      this.#sockets ?? (this.#sockets = this.sockets.get(this.tag));
 
     let socket: WebSocket;
     while ((socket = sockets[this.index++])) {
@@ -247,11 +248,11 @@ function prepareTags(connectionId: string, userTags: string[]): string[] {
 
 /** The platform-backed manager for hibernating WebSockets. */
 export class ConnectionManager<TState = unknown> {
-  constructor(private controller: DurableObjectState) {}
+  constructor(private controller: LifecycleSockets) {}
 
   getConnection<T = TState>(id: string) {
     // TODO: Should we cache the connections?
-    const sockets = this.controller.getWebSockets(id);
+    const sockets = this.controller.get(id);
     const matching = sockets.filter((ws) => {
       return tryGetManagedWebSocketMeta(ws)?.id === id;
     });
@@ -272,7 +273,7 @@ export class ConnectionManager<TState = unknown> {
   accept(connection: Connection, options: { tags: string[] }) {
     const tags = prepareTags(connection.id, options.tags);
 
-    this.controller.acceptWebSocket(connection, tags);
+    this.controller.accept(connection, tags);
     attachments.set(connection, {
       __pk: {
         id: connection.id,

--- a/packages/agents/src/websockets/index.ts
+++ b/packages/agents/src/websockets/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Opt-in WebSocket support for Lifecycle Objects: connection handlers
+ * and Cap'n Web callables, owned entirely by the capability.
+ *
+ * @experimental The WebSockets surface may change before stabilizing.
+ */
+export { WebSockets } from "./websockets";
+export { callablesFromDecorated } from "./callables-target";
+export type {
+  WebSocketHandlers,
+  WebSocketMessage,
+  WebSocketsOptions
+} from "./options";
+export {
+  CALLABLES_RPC_QUERY,
+  CALLABLES_RPC_VALUE,
+  callablesRpcUrl,
+  isCallablesRpcUpgrade
+} from "./protocol";

--- a/packages/agents/src/websockets/options.ts
+++ b/packages/agents/src/websockets/options.ts
@@ -1,0 +1,66 @@
+import type { RpcTarget } from "cloudflare:workers";
+import type { Connection, ConnectionContext, WSMessage } from "../lifecycle";
+
+/** A frame delivered on a capability-owned WebSocket connection. */
+export type WebSocketMessage = WSMessage;
+
+/**
+ * Connection handlers for the WebSockets capability. Handlers run inside
+ * the host invocation boundary with the live connection in ambient
+ * context (`getCurrentAgent().connection`).
+ *
+ * @experimental The API surface may change before stabilizing.
+ */
+export type WebSocketHandlers = {
+  /** Handle a newly accepted hibernating WebSocket connection. */
+  onConnect?(
+    connection: Connection,
+    ctx: ConnectionContext
+  ): void | Promise<void>;
+  /** Handle a message from a hibernating WebSocket connection. */
+  onMessage?(
+    connection: Connection,
+    message: WebSocketMessage
+  ): void | Promise<void>;
+  /** Handle a closing hibernating WebSocket connection. */
+  onClose?(
+    connection: Connection,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): void | Promise<void>;
+  /** Handle a mid-connection WebSocket error. */
+  onError?(connection: Connection, error: unknown): void | Promise<void>;
+};
+
+/**
+ * Configuration for the WebSockets capability.
+ *
+ * @experimental The API surface may change before stabilizing.
+ */
+export interface WebSocketsOptions {
+  /**
+   * Connection handlers for WebSocket clients. When present, the
+   * capability claims WebSocket upgrades and owns those connections end
+   * to end. When absent, upgrades are declined.
+   */
+  readonly handlers?: WebSocketHandlers;
+
+  /**
+   * An `RpcTarget` whose methods are exposed to remote callers over a
+   * Cap'n Web session (`?__agents_rpc=capnweb`). The target's prototype
+   * methods are the complete remote interface. Methods run through the
+   * host invocation boundary and may return a `ReadableStream` to
+   * stream results.
+   */
+  readonly callables?: RpcTarget;
+
+  /**
+   * Tags attached to each accepted connection, queryable through
+   * `getConnections(tag)`. The connection id is always the first tag.
+   */
+  readonly getConnectionTags?: (
+    connection: Connection,
+    ctx: ConnectionContext
+  ) => string[] | Promise<string[]>;
+}

--- a/packages/agents/src/websockets/protocol.ts
+++ b/packages/agents/src/websockets/protocol.ts
@@ -1,0 +1,31 @@
+/**
+ * Isomorphic pieces of the callables RPC wire contract.
+ *
+ * Imported from browser bundles (via the client) and from the Worker
+ * runtime, so it must not import `cloudflare:workers`.
+ */
+
+/** Query parameter selecting the callables Cap'n Web RPC endpoint. */
+export const CALLABLES_RPC_QUERY = "__agents_rpc";
+export const CALLABLES_RPC_VALUE = "capnweb";
+
+/** Whether a request is a WebSocket upgrade addressed to callables RPC. */
+export function isCallablesRpcUpgrade(request: Request): boolean {
+  return (
+    request.headers.get("Upgrade")?.toLowerCase() === "websocket" &&
+    new URL(request.url).searchParams.get(CALLABLES_RPC_QUERY) ===
+      CALLABLES_RPC_VALUE
+  );
+}
+
+/**
+ * Derive the callables RPC socket URL from a host route. Accepts http(s)
+ * or ws(s) URLs and returns a ws(s) URL with the RPC query parameter set.
+ */
+export function callablesRpcUrl(url: string | URL): string {
+  const resolved = new URL(url);
+  if (resolved.protocol === "http:") resolved.protocol = "ws:";
+  if (resolved.protocol === "https:") resolved.protocol = "wss:";
+  resolved.searchParams.set(CALLABLES_RPC_QUERY, CALLABLES_RPC_VALUE);
+  return resolved.toString();
+}

--- a/packages/agents/src/websockets/websockets.ts
+++ b/packages/agents/src/websockets/websockets.ts
@@ -1,0 +1,283 @@
+import { RpcTarget } from "cloudflare:workers";
+import { newWorkersWebSocketRpcResponse } from "capnweb";
+import { nanoid } from "nanoid";
+import {
+  LifecycleCapability,
+  type CapabilityWebSocketUpgradeContext,
+  type Connection,
+  type ConnectionSetStateFn,
+  type ConnectionState
+} from "../lifecycle";
+import {
+  ConnectionManager,
+  createConnection,
+  isManagedWebSocket
+} from "./connection";
+import {
+  buildCallablesRoot,
+  exposableMethods,
+  type CallableInvoker
+} from "./callables-target";
+import type {
+  WebSocketHandlers,
+  WebSocketMessage,
+  WebSocketsOptions
+} from "./options";
+import { isCallablesRpcUpgrade } from "./protocol";
+
+/**
+ * Reserved close codes the runtime synthesizes when there was no real
+ * Close frame from the peer (1005 NoStatusReceived, 1006 AbnormalClosure,
+ * 1015 TLSHandshake). They cannot appear in an outgoing Close frame, and
+ * there is no peer left to receive a reciprocation.
+ */
+function isReservedCloseCode(code: number): boolean {
+  return code === 1005 || code === 1006 || code === 1015;
+}
+
+/**
+ * Reciprocate a peer-initiated Close frame to complete the handshake, as
+ * the Hibernation API contract requires. Best-effort: swallows errors
+ * from already-closed sockets or invalid codes/reasons, and skips
+ * reciprocation entirely for reserved codes (dead transport).
+ */
+function reciprocateClose(ws: WebSocket, code: number, reason: string): void {
+  if (isReservedCloseCode(code)) return;
+  try {
+    ws.close(code, reason);
+  } catch {
+    // Already closed, oversize reason, or another unrecoverable
+    // invariant — the handshake is either done or out of our control.
+  }
+}
+
+/**
+ * Opt-in WebSocket support for Lifecycle Objects.
+ *
+ * Lifecycle itself does not model WebSockets — hosts that want them
+ * install this capability, which owns the connection subsystem end to
+ * end: it claims upgrades, accepts hibernating sockets, dispatches
+ * `onConnect`/`onMessage`/`onClose` inside the host invocation
+ * boundary, reciprocates close handshakes, and answers
+ * `getConnections()`/`getConnection()`.
+ *
+ * ```ts
+ * class Room extends DurableObject<Env> {
+ *   readonly webSockets = new WebSockets({
+ *     handlers: {
+ *       onConnect: (connection) => connection.send("welcome"),
+ *       onMessage: (connection, message) => { ... },
+ *       onClose: (connection, code) => { ... }
+ *     },
+ *     callables: new RoomCallables()
+ *   });
+ *   readonly lifecycle = Lifecycle.install(this).use(this.webSockets);
+ * }
+ * ```
+ *
+ * `callables` exposes an `RpcTarget`'s prototype methods to remote
+ * callers over a Cap'n Web session claimed from `?__agents_rpc=capnweb`
+ * upgrades. Methods run through the host invocation boundary, may
+ * return a `ReadableStream` to stream results, and emit
+ * `rpc`/`rpc:error` capability events. Callable sessions are
+ * non-hibernating: while a client holds one open, the Durable Object
+ * stays pinned in memory.
+ *
+ * There is no separate browser client: against an `Agent`, the
+ * `useAgent` hook's `stub`/`call` reach the same interface over the
+ * protocol socket. A plain host's endpoint is reached with capnweb
+ * directly — `newWebSocketRpcSession(new WebSocket(callablesRpcUrl(url)))`.
+ *
+ * @experimental The API surface may change before stabilizing.
+ */
+export class WebSockets extends LifecycleCapability {
+  readonly #handlers: WebSocketHandlers | undefined;
+  readonly #getConnectionTags: WebSocketsOptions["getConnectionTags"];
+  readonly #callablesTarget: RpcTarget | undefined;
+  #manager: ConnectionManager | undefined;
+
+  constructor(options: WebSocketsOptions = {}) {
+    super("websockets");
+    this.#handlers = options.handlers;
+    this.#getConnectionTags = options.getConnectionTags;
+    this.#callablesTarget = options.callables
+      ? this.#buildCallablesTarget(options.callables)
+      : undefined;
+  }
+
+  // ── Lifecycle capability hooks ─────────────────────────────────────────
+
+  /** Claim callables RPC upgrades and, with handlers, plain upgrades. */
+  onWebSocketUpgrade({
+    request
+  }: CapabilityWebSocketUpgradeContext):
+    | Promise<Response>
+    | Response
+    | undefined {
+    if (isCallablesRpcUpgrade(request)) {
+      if (!this.#callablesTarget) return undefined;
+      return newWorkersWebSocketRpcResponse(request, this.#callablesTarget);
+    }
+    if (!this.#handlers) return undefined;
+    return this.#acceptConnection(request);
+  }
+
+  /** Dispatch a platform message wake for a capability-owned socket. */
+  async onWebSocketMessage(
+    ws: WebSocket,
+    message: WebSocketMessage
+  ): Promise<boolean> {
+    if (!isManagedWebSocket(ws)) return false;
+    const connection = createConnection(ws);
+    await this.lifecycle.runInHostContext(
+      () => this.#handlers?.onMessage?.(connection, message),
+      { connection }
+    );
+    return true;
+  }
+
+  /** Dispatch and reciprocate a close wake for an owned socket. */
+  async onWebSocketClose(
+    ws: WebSocket,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): Promise<boolean> {
+    if (!isManagedWebSocket(ws)) return false;
+    const connection = createConnection(ws);
+    try {
+      await this.lifecycle.runInHostContext(
+        () => this.#handlers?.onClose?.(connection, code, reason, wasClean),
+        { connection }
+      );
+    } finally {
+      reciprocateClose(ws, code, reason);
+    }
+    return true;
+  }
+
+  /** Dispatch an error wake for an owned socket. */
+  async onWebSocketError(ws: WebSocket, error: unknown): Promise<boolean> {
+    if (!isManagedWebSocket(ws)) return false;
+    const connection = createConnection(ws);
+    await this.lifecycle.runInHostContext(
+      () => this.#handlers?.onError?.(connection, error),
+      { connection }
+    );
+    return true;
+  }
+
+  /**
+   * Close every owned connection during explicit host destruction. The
+   * capability owns its sockets' lifetimes, so it also owns tearing
+   * them down.
+   */
+  dispose(): void {
+    for (const connection of this.getConnections()) {
+      try {
+        connection.close(1001, "Durable Object destroyed");
+      } catch {
+        // Already closed or mid-handshake — nothing left to tear down.
+      }
+    }
+  }
+
+  // ── Connections ────────────────────────────────────────────────────────
+
+  /** Open connections accepted by this capability, optionally by tag. */
+  getConnections<TState = unknown>(
+    tag?: string
+  ): IterableIterator<Connection<TState>> {
+    return this.#connectionManager.getConnections<TState>(tag);
+  }
+
+  /** One connection accepted by this capability, by id. */
+  getConnection<TState = unknown>(id: string): Connection<TState> | undefined {
+    return this.#connectionManager.getConnection<TState>(id);
+  }
+
+  get #connectionManager(): ConnectionManager {
+    this.#manager ??= new ConnectionManager(this.lifecycle.sockets);
+    return this.#manager;
+  }
+
+  async #acceptConnection(request: Request): Promise<Response> {
+    const { 0: clientWebSocket, 1: serverWebSocket } = new WebSocketPair();
+    const url = new URL(request.url);
+    // `||`, not `??`: an empty `?_pk=` value must fall back to a
+    // generated id — an empty connection id would later throw in tag
+    // validation and reject the upgrade.
+    const connectionId = url.searchParams.get("_pk") || nanoid();
+
+    let connection: Connection = Object.assign(serverWebSocket, {
+      id: connectionId,
+      uri: request.url,
+      tags: [] as string[],
+      state: null as unknown as ConnectionState<unknown>,
+      setState<T = unknown>(setState: T | ConnectionSetStateFn<T>) {
+        // Pre-accept shim: hold state on the socket until accept()
+        // persists it into the hibernation attachment.
+        const state =
+          setState instanceof Function
+            ? setState(this.state as ConnectionState<T>)
+            : setState;
+        this.state = state as ConnectionState<T>;
+        return this.state as ConnectionState<T>;
+      }
+    });
+
+    const ctx = { request };
+    const tags = this.#getConnectionTags
+      ? await this.#getConnectionTags(connection, ctx)
+      : [];
+
+    // Hibernating WebSockets remain connected while the object is evicted.
+    connection = this.#connectionManager.accept(connection, { tags });
+    await this.lifecycle.runInHostContext(
+      () => this.#handlers?.onConnect?.(connection, ctx),
+      { connection, request }
+    );
+
+    return new Response(null, { status: 101, webSocket: clientWebSocket });
+  }
+
+  // ── Callables ──────────────────────────────────────────────────────────
+
+  /**
+   * Wrap a callables target for serving: every exposable method
+   * dispatches through the host invocation boundary and emits
+   * `rpc`/`rpc:error` events.
+   */
+  #buildCallablesTarget(target: RpcTarget): RpcTarget {
+    const dispatching = new Map<string, CallableInvoker>();
+    for (const [name, invoke] of exposableMethods(target)) {
+      dispatching.set(name, (...args) =>
+        this.#dispatchCallable(name, () => invoke(...args))
+      );
+    }
+    return buildCallablesRoot(dispatching);
+  }
+
+  async #dispatchCallable(
+    name: string,
+    invoke: () => unknown
+  ): Promise<unknown> {
+    // Throws with installation guidance when the capability was never
+    // installed with Lifecycle.use().
+    const services = this.lifecycle;
+    try {
+      const result = await services.runInHostContext(invoke);
+      services.events.emit("rpc", {
+        method: name,
+        streaming: result instanceof ReadableStream
+      });
+      return result;
+    } catch (error) {
+      services.events.emit("rpc:error", {
+        method: name,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      throw error;
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4047,6 +4047,9 @@ importers:
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      capnweb:
+        specifier: ^0.12.0
+        version: 0.12.0
       cron-schedule:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5770,21 +5773,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-arm64@0.35.2':
-    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.35.2':
-    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
@@ -5798,29 +5789,13 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
-    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-x64@1.2.4':
     resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.1':
-    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
-    cpu: [x64]
-    os: [darwin]
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm64@1.3.1':
-    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -5831,20 +5806,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.1':
-    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
-    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -5855,20 +5818,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
-    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.3.1':
-    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -5879,32 +5830,14 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.1':
-    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
-    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
-    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5916,23 +5849,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm64@0.35.2':
-    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.35.2':
-    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
-    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -5944,23 +5863,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.2':
-    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.35.2':
-    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
-    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -5972,23 +5877,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.2':
-    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.35.2':
-    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -6000,23 +5891,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
-    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.35.2':
-    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -6025,10 +5902,6 @@ packages:
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
-
-  '@img/sharp-wasm32@0.35.2':
-    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
-    engines: {node: '>=20.9.0'}
 
   '@img/sharp-webcontainers-wasm32@0.35.2':
     resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
@@ -6041,33 +5914,15 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-arm64@0.35.2':
-    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [win32]
-
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.2':
-    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
-    engines: {node: ^20.9.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.35.2':
-    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -8257,6 +8112,9 @@ packages:
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  capnweb@0.12.0:
+    resolution: {integrity: sha512-jgZ/LMtMVTi+RVlooIslH78Gg23XbDTdvcLghWx3oz17D6u5GuJARt+uhZk/wcTo+f81eeabfnow4d3zLBj+JQ==}
 
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
@@ -13914,84 +13772,42 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
-    optional: true
-
   '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.1
-    optional: true
-
   '@img/sharp-freebsd-wasm32@0.35.2':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -13999,19 +13815,9 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.1
-    optional: true
-
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.1
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -14019,19 +13825,9 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
-    optional: true
-
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -14039,19 +13835,9 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.1
-    optional: true
-
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.1
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -14059,19 +13845,9 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -14079,32 +13855,16 @@ snapshots:
       '@emnapi/runtime': 1.11.1
     optional: true
 
-  '@img/sharp-wasm32@0.35.2':
-    dependencies:
-      '@emnapi/runtime': 1.11.1
-    optional: true
-
   '@img/sharp-webcontainers-wasm32@0.35.2':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.2':
-    optional: true
-
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.2':
-    optional: true
-
   '@img/sharp-win32-x64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.2':
     optional: true
 
   '@inquirer/ansi@2.0.7': {}
@@ -16426,6 +16186,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001809: {}
+
+  capnweb@0.12.0: {}
 
   capnweb@0.8.0: {}
 
@@ -19854,31 +19616,8 @@ snapshots:
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.2
-      '@img/sharp-darwin-x64': 0.35.2
       '@img/sharp-freebsd-wasm32': 0.35.2
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
-      '@img/sharp-libvips-darwin-x64': 1.3.1
-      '@img/sharp-libvips-linux-arm': 1.3.1
-      '@img/sharp-libvips-linux-arm64': 1.3.1
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
-      '@img/sharp-libvips-linux-s390x': 1.3.1
-      '@img/sharp-libvips-linux-x64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
-      '@img/sharp-linux-arm': 0.35.2
-      '@img/sharp-linux-arm64': 0.35.2
-      '@img/sharp-linux-ppc64': 0.35.2
-      '@img/sharp-linux-riscv64': 0.35.2
-      '@img/sharp-linux-s390x': 0.35.2
-      '@img/sharp-linux-x64': 0.35.2
-      '@img/sharp-linuxmusl-arm64': 0.35.2
-      '@img/sharp-linuxmusl-x64': 0.35.2
       '@img/sharp-webcontainers-wasm32': 0.35.2
-      '@img/sharp-win32-arm64': 0.35.2
-      '@img/sharp-win32-ia32': 0.35.2
-      '@img/sharp-win32-x64': 0.35.2
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## What

WebSockets move **out of Lifecycle** into an opt-in capability, and callables come with them. Lifecycle no longer models connections at all.

```ts
class Room extends DurableObject<Env> {
  readonly webSockets = new WebSockets({
    handlers: {
      onConnect: (connection) => connection.send("welcome"),
      onMessage: (connection, message) => { ... },
      onClose: (connection, code) => { ... }
    },
    callables: new RoomCallables()   // an RpcTarget
  });
  readonly lifecycle = Lifecycle.install(this).use(this.webSockets);
}
```

The capability owns the subsystem end to end: it claims upgrades, accepts hibernating sockets (connection layer moved wholesale from `lifecycle/connection.ts` — **attachment format unchanged**, live connections survive), dispatches handlers inside the host invocation boundary, reciprocates close handshakes, closes owned connections on host destruction, and answers `getConnections()`/`getConnection()`. Without it, upgrades are declined.

## Callables: RpcTarget preferred, decorators as fallback — served on every wire

- Pass an `RpcTarget` as `callables`; its prototype methods are the remote interface, served over a Cap'n Web session (`?__agents_rpc=capnweb`) with native `ReadableStream` streaming, host-boundary dispatch, and `rpc`/`rpc:error` events. **No separate browser client**: `useAgent().stub`/`call` reach the same interface; a plain host's endpoint is one `newWebSocketRpcSession(new WebSocket(callablesRpcUrl(url)))` away.
- **The `@callable()` decorator stays, and Agent adds no new members.** An Agent's decorated methods ARE its interface, exposed over the Cap'n Web endpoint through a decorator-derived target; the explicit `RpcTarget` config is the capability-host API.
- **One interface, both wires**: an Agent's decorated methods are served over the legacy PartySocket JSON RPC protocol *and* the Cap'n Web endpoint. The decorator machinery moved to `callable-decorator.ts` so both consumers share one registry.

## Lifecycle ↔ capability interactions, standardized

Following the interaction audit:

- **No raw `DurableObjectState`**: `LifecycleServices` exposes a narrow `sockets` surface (`accept`/`get`) instead of `ctx`, so alarm arbitration can't be bypassed.
- **The interaction contract is documented on `DurableObjectCapability`**: exactly three channels (declared hooks, `LifecycleServices`, composition-root `set*()` apertures), with the dispatch rules spelled out — Response-to-claim for requests/upgrades, `true`-to-consume for platform wakes, ownership via a private attachment namespace, declaration-order dispatch.
- **Host context re-entry happens exactly once** via `runInHostContext(fn, scope)`; Agent's remaining inner wrap is documented as serving non-capability call paths.
- **`WebSockets.dispose()`** closes owned connections on explicit host destruction.
- Type vocabulary tidied: connection types stay in `lifecycle/types` as shared language (with a note saying the machinery lives in the capability); `WebSocketMessage` aliases `WSMessage` (single source).

## Agent migrated, legacy path deleted

`Agent` installs the capability itself; public API and wire protocol unchanged — the full Agent suite passes as-is. Lifecycle's legacy connection path, host WebSocket hooks, and `getConnections`/`getConnection`/`broadcast` are deleted. think packages need no changes. `examples/next/lifecycle` and `docs/agents/lifecycle.md` show the capability (handlers + callables).

## Testing

Pre-existing Lifecycle WebSocket/host-context/hibernation suites prove handler parity (PlainLifecycleObject runs on the capability). New suites cover callables on both wires: receiver binding, host boundary, `rpc` events, streaming, merged-interface precedence, decorator-only Agents over capnweb, and legacy-wire dispatch of target methods. Full workers suite (1917) and react suite (140) pass.

## Stack

First of two: #2156 adds the **Cap'n Web connection transport** on this capability.

