### PR TITLE
docs(lifecycle): frame request dispatch as capability middleware

### DIFF
--- a/docs/agents/lifecycle.md
+++ b/docs/agents/lifecycle.md
@@ -71,18 +71,27 @@ override `onStart`, `onRequest`, `onConnect`, `onMessage`, `onClose`, and
 
 ## Request call path
 
+The lifecycle-installed `fetch` is the request handler. It offloads each
+request to the installed capabilities, which act as middleware: the first
+capability registered that matches the request handles it by returning a
+`Response`. A capability that returns `undefined` passes the request on to
+the next capability, and a request no capability claims falls through to the
+host's `onRequest`.
+
 ```text
 routeAgentRequest(request)
 └─ named Durable Object stub.fetch(request)
    └─ lifecycle-installed fetch
       ├─ lifecycle startup capabilities
       ├─ host onStart
-      ├─ lifecycle request capabilities
-      │  └─ first Response wins
+      ├─ capability middleware, in registration order
+      │  └─ first Response handles the request
       └─ host onRequest
 ```
 
-A warm object skips startup but still offers every request to its capabilities.
+A warm object skips startup but still offers every request to its middleware.
+There is no `next()` today: a capability either handles a request or declines
+it, and cannot wrap or observe a downstream response.
 
 ## Reusable capabilities
 
@@ -128,7 +137,8 @@ export class MyObject extends DurableObject<Env> {
 ```
 
 Capabilities run in registration order. Startup and alarms run every hook
-sequentially. Request handling stops at the first returned `Response`. A phase
+sequentially. Request handling is middleware dispatch: it stops at the first
+returned `Response`, and returning `undefined` passes the request on. A phase
 failure propagates, and failed startup can be retried.
 
 Capabilities extending `LifecycleCapability` receive one standard service

--- a/packages/agents/src/lifecycle/capability-runner.ts
+++ b/packages/agents/src/lifecycle/capability-runner.ts
@@ -56,9 +56,10 @@ export interface DurableObjectCapability<Props extends object = object> {
   onStart?(context: CapabilityStartContext<Props>): MaybePromise<void>;
 
   /**
-   * Inspect an HTTP request before the host's request handler.
+   * Act as middleware over HTTP requests, ahead of the host's request handler.
    *
-   * Return a response to handle the request, or `undefined` to continue.
+   * Return a response to handle the request, or `undefined` to pass it to the
+   * next capability and finally the host.
    */
   onRequest?(
     context: CapabilityRequestContext
@@ -81,8 +82,9 @@ export interface DurableObjectCapability<Props extends object = object> {
  * Runs ordered lifecycle phases for capabilities installed in a Durable Object.
  *
  * Capabilities are resolved lazily on the first phase and retained for the
- * lifetime of this runner. Startup and alarms run in declaration order, and
- * requests stop at the first response.
+ * lifetime of this runner. Startup and alarms run in declaration order.
+ * Requests dispatch as a middleware chain: the first capability to return a
+ * response handles the request.
  */
 export class CapabilityRunner<Props extends object = object> {
   readonly #resolveCapabilities: () => Iterable<DurableObjectCapability<Props>>;
@@ -133,10 +135,11 @@ export class CapabilityRunner<Props extends object = object> {
   }
 
   /**
-   * Offer a request to each capability in declaration order.
+   * Offer a request to each capability middleware in registration order.
    *
    * @param context - The request entering the Durable Object.
-   * @returns The first capability response, or `undefined` when unhandled.
+   * @returns The first capability response, or `undefined` when no
+   * capability claimed the request.
    */
   async request(
     context: CapabilityRequestContext

--- a/packages/agents/src/lifecycle/durable-object-lifecycle.ts
+++ b/packages/agents/src/lifecycle/durable-object-lifecycle.ts
@@ -495,6 +495,9 @@ export class Lifecycle<
 
   /**
    * Handle an incoming request for the owning Durable Object.
+   *
+   * Non-upgrade requests run through the capability middleware chain first,
+   * then fall through to the host's `onRequest`.
    */
   async fetch(request: Request): Promise<Response> {
     try {


### PR DESCRIPTION
## What

Reframes the lifecycle request docs around a request-handler-plus-middleware model: the lifecycle-installed `fetch` is the request handler, and installed capabilities are the middleware it offloads requests to. The first capability registered that matches the request handles it by returning a `Response`; returning `undefined` passes the request on, and unclaimed requests fall through to the host's `onRequest`.

Also states explicitly that there is no `next()` today. A capability either handles a request or declines it, and cannot wrap or observe a downstream response. That keeps the door open for pass-through/wrapping as a future expansion without implying it exists.

## Changes

- `docs/agents/lifecycle.md`: request call path + dispatch paragraphs rewritten in middleware terms
- `capability-runner.ts` / `durable-object-lifecycle.ts`: doc comments only

No behavior change.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->