### PR TITLE
fix(conformance): stop failing on acceptable sse-retry timing warning

### DIFF
--- a/packages/agents/conformance/run-suite.mjs
+++ b/packages/agents/conformance/run-suite.mjs
@@ -206,8 +206,19 @@ async function runScenario(name) {
   }
   const result = await runNode(args, { timeoutMs: scenarioTimeoutMs });
   // Alpha.10's server command reports WARNING checks but exits zero. Warnings
-  // remain non-conformant unless the scenario is explicitly baselined.
-  const warned = /"status"\s*:\s*"WARNING"/.test(result.stdout);
+  // remain non-conformant unless the scenario is explicitly baselined — with
+  // one exception: the sse-retry "reconnected slightly late" timing warning
+  // (client-sse-retry-timing), which the referee itself calls acceptable.
+  // Loaded CI runners add 200-400ms of scheduling jitter, so failing on it is
+  // pure flake; the too-early and very-late bands still emit FAILURE.
+  const warningCount = (result.stdout.match(/"status"\s*:\s*"WARNING"/g) ?? [])
+    .length;
+  const acceptableWarningCount = (
+    result.stdout.match(
+      /"errorMessage"\s*:\s*"Client reconnected slightly late/g
+    ) ?? []
+  ).length;
+  const warned = warningCount > acceptableWarningCount;
   const failed = result.code !== 0 || result.timedOut || warned;
   return { name, expected: expected.has(name), failed, ...result };
 }


### PR DESCRIPTION
Our MCP Conformance CI job on main fails now and then, and every failure turns out to be the same thing: the `sse-retry` scenario. The client does everything right — it reconnects and sends the right headers — but on a busy CI machine it reconnects a few hundred milliseconds later than the ideal 500ms. The conformance referee looks at that and says "a bit slow, but that's fine" because it's a warning, not a failure.

The problem is our test harness treated every warning as a failure. So a delay the referee itself calls acceptable was turning builds red, and we kept retrying them by hand.

This change makes the harness ignore that one specific warning and nothing else. If the client reconnects way too late, too early, or drops other requirements, the tests still fail like they should.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->