### PR TITLE
feat(channels): stream outbound messages

### DIFF
--- a/.changeset/pink-poems-brake.md
+++ b/.changeset/pink-poems-brake.md
@@ -1,0 +1,30 @@
+---
+"@cloudflare/channels": minor
+---
+
+Stream outbound messages.
+
+`host.stream(surface, chunks, options?)` takes a
+`ReadableStream<ChannelChunk>` and resolves one `DeliveryResult`. Channels that
+can stream consume the stream themselves; Channels that cannot never learn it
+was a stream, because the Host collects the answer and calls `deliver` once.
+
+- New `ChannelChunk` union covering `text`, `reasoning`, `tool`, and `source`,
+  plus an optional `stream` method on `Channel` and `OutboundResolver`.
+- New `consumeChunks` helper for Channel authors, which reads a stream to
+  completion and then finalizes exactly once, whether it closed or errored.
+- Slack streams through `chat.startStream` / `appendStream` / `stopStream`,
+  collecting into an ordinary message for top-level channels where Slack does
+  not support native streaming. Telegram previews with `sendMessageDraft`
+  before persisting the answer with `sendMessage`.
+- `fanout` tees the stream per destination; `fallback` buffers consumed chunks
+  and replays them to the next destination after a failure.
+- `toChannelChunks` maps an AI SDK `fullStream` onto `ChannelChunk`.
+- `DeliveryResult`'s `uncertain` arm gains an optional `reference`, and the
+  three statuses are now defined by what the reader received rather than by
+  what the transport accepted. A stream that ends before its answer is complete
+  is `uncertain`.
+
+Slack reply surfaces derived from ingress now carry `recipientUserId` and
+`recipientTeamId` for non-direct messages, which Slack requires to stream into
+a channel.

--- a/.changeset/pink-poems-brake.md
+++ b/.changeset/pink-poems-brake.md
@@ -18,8 +18,10 @@ was a stream, because the Host collects the answer and calls `deliver` once.
   collecting into an ordinary message for top-level channels where Slack does
   not support native streaming. Telegram previews with `sendMessageDraft`
   before persisting the answer with `sendMessage`.
-- `fanout` tees the stream per destination; `fallback` buffers consumed chunks
-  and replays them to the next destination after a failure.
+- `fanout` tees the stream per destination and cancels branches whose
+  destinations return without consuming them. `fallback` advances after a
+  failure only before that destination starts reading, avoiding an unbounded
+  replay buffer.
 - `toChannelChunks` maps an AI SDK `fullStream` onto `ChannelChunk`.
 - `DeliveryResult`'s `uncertain` arm gains an optional `reference`, and the
   three statuses are now defined by what the reader received rather than by

--- a/.changeset/pink-poems-brake.md
+++ b/.changeset/pink-poems-brake.md
@@ -9,8 +9,9 @@ Stream outbound messages.
 can stream consume the stream themselves; Channels that cannot never learn it
 was a stream, because the Host collects the answer and calls `deliver` once.
 
-- New `ChannelChunk` union covering `text`, `reasoning`, `tool`, and `source`,
-  plus an optional `stream` method on `Channel` and `OutboundResolver`.
+- New `ChannelChunk` union covering `text`, `reasoning`, `tool`, and `source`;
+  tool chunks can carry a stable invocation ID. `Channel` and
+  `OutboundResolver` gain an optional `stream` method.
 - New `consumeChunks` helper for Channel authors, which reads a stream to
   completion and then finalizes exactly once, whether it closed or errored.
 - Slack streams through `chat.startStream` / `appendStream` / `stopStream`,
@@ -25,6 +26,7 @@ was a stream, because the Host collects the answer and calls `deliver` once.
   what the transport accepted. A stream that ends before its answer is complete
   is `uncertain`.
 
-Slack reply surfaces derived from ingress now carry `recipientUserId` and
-`recipientTeamId` for non-direct messages, which Slack requires to stream into
-a channel.
+Slack reply surfaces derived from ingress carry `recipientUserId` and
+`recipientTeamId`, which distinguishes native-streaming direct messages from
+buffered top-level channel delivery and identifies the reader for channel
+streams.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "experimentalSortPackageJson": false,
   "ignorePatterns": [
     "packages/agents/CHANGELOG.md",
+    "packages/channels/live-tests/snapshots",
     "site/agents/.astro",
     "**/routeTree.gen.ts",
     "**/think.d.ts"

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -297,7 +297,7 @@ Durability is a property of how your application uses it.
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | A `dispatchId` stable across redelivery and unaffected by routing       | Deduplicate on it before starting any side effect                           |
 | The Host awaits your callback before the provider is acknowledged       | Hand off durably before returning — a DO RPC, queue send, or workflow start |
-| One provider attempt per `deliver()`, reported honestly                 | Decide whether to retry; `uncertain` may duplicate a real delivery          |
+| One outbound attempt per `deliver()` or `stream()`, reported honestly   | Decide whether to retry; `uncertain` may duplicate a real delivery          |
 | Surfaces are plain JSON you can persist                                 | Keep configured channel keys stable                                         |
 | Decisions arrive as normalized events carrying your own `interactionId` | Own settlement; an interaction id is not an authorization credential        |
 
@@ -305,8 +305,10 @@ Durability is a property of how your application uses it.
 
 - [ ] Approval-link ingress: signing, verification, and a confirmation page, so
       link approvals return through the same normalized path as Slack buttons
-- [ ] Streaming output delivery — see
-      [`design/rfc-channel-streaming.md`](../../design/rfc-channel-streaming.md)
+- [ ] Reader-initiated stream cancellation: Slack's `message_stream_stopped`
+      and Telegram's `stopped_message_generation` should reach the running
+      generation as ordinary ingress, so aborting it errors the stream and
+      each Channel finalizes on the path it already has
 - [ ] More built-in channels
 - [ ] Rendering templates (pretty emails)
 - [ ] Automatic webhook registration

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -291,7 +291,9 @@ Returning `null` declines the request so another Channel can claim it.
 ## Durability contract
 
 Channels holds no state: no outbox, no retries, no deduplication, no scheduler.
-Durability is a property of how your application uses it.
+Durability is a property of how your application uses it. A caller-supplied
+`deliveryId` is correlation metadata, not an idempotency guarantee; an adapter
+may map it to a provider primitive when one exists.
 
 | Channels guarantees                                                     | Your application must                                                       |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------- |

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -90,8 +90,11 @@ await host.deliver(fanout([slackSurface, emailSurface]), message);
 ```
 
 `fallback()` tries destinations in order, advancing only after a _confirmed_
-failure, so it can never duplicate a delivery. `fanout()` sends to all of them;
-a partial or uncertain result is reported as `uncertain` for the same reason.
+failure, so it can never duplicate a delivery. For a stream, it advances only
+when that failure happens before the destination starts reading; replaying an
+arbitrarily large consumed prefix would require an unbounded buffer. `fanout()`
+sends to all destinations; a partial or uncertain result is reported as
+`uncertain` for the same reason.
 The Host installs both policies as ordinary Channels under reserved keys. You
 can register another composite policy as an ordinary Channel under your own key
 and pair it with a surface constructor that writes that key; inject only the

--- a/packages/channels/live-tests/README.md
+++ b/packages/channels/live-tests/README.md
@@ -1,8 +1,9 @@
 # Live delivery tests
 
-This local-only test calls the real `telegram()`, `slack()`, and `email()`
-adapters, then reads each destination through an independent provider API. It
-is not part of normal package tests, Nx affected tests, or CI.
+These local-only tests call the real `telegram()`, `slack()`, and `email()`
+adapters through `ChannelHost`, then read each destination through an independent
+provider API. They are not part of normal package tests, Nx affected tests, or
+CI.
 
 The configured destinations must be disposable. The test deletes their messages
 before and after delivery. Telegram's immutable chat/channel creation service
@@ -28,6 +29,16 @@ Telegram observation uses a non-bot Teleproto `StringSession`. Slack needs
 email sender needs Cloudflare Email Service access; Fastmail supplies independent
 JMAP observation and deletion.
 
+Slack live streaming posts a disposable anchor and streams its thread reply. It
+also needs the reader's user and team ids; the binding derives them from
+`auth.test` and the one channel member that is not this bot, so no extra
+configuration or scope is needed.
+
+Telegram only shows drafts in private chats. Point
+`CHANNELS_LIVE_TELEGRAM_CHAT_ID` at a private chat with the bot to exercise the
+draft path. A group still receives the terminal message, but cannot prove that
+streaming previews reached a reader.
+
 ## Run
 
 ```sh
@@ -39,7 +50,3 @@ Run one provider with Vitest's name filter:
 ```sh
 pnpm --filter @cloudflare/channels test:live -t telegram
 ```
-
-Each test sends `Cloudflare Channels live delivery smoke test.`, polls once per
-second for up to two minutes, waits five more seconds for duplicates, and
-snapshots the exact observed `[{ text }]` array.

--- a/packages/channels/live-tests/binding.ts
+++ b/packages/channels/live-tests/binding.ts
@@ -1,11 +1,26 @@
+import type { ChannelChunk, DeliveryResult } from "../src/channel";
+import type { ChannelHost } from "../src/host";
+import type { ChannelMessageSurface } from "../src/surface";
+
 export type ObservedMessage = { text: string };
 
+export type LiveStreamSession = {
+  push(chunk: ChannelChunk): Promise<void>;
+  finish(): Promise<DeliveryResult>;
+  /** End the stream the way a failed generation does. */
+  fail(reason: string): Promise<DeliveryResult>;
+};
+
 export type LiveDeliveryBinding = {
-  name: "telegram" | "slack" | "email";
+  name: "telegram" | "slack" | "slack-thread" | "email";
   destination: string;
-  open?(): Promise<void>;
+  host: ChannelHost;
+  surface: ChannelMessageSurface;
+  /** Initialize the observer and start from an empty destination. */
+  open(): Promise<void>;
   clear(): Promise<void>;
-  deliver(text: string): Promise<unknown>;
+  /** Provider-side evidence that an ephemeral preview reached the reader. */
+  previews?(): number;
   read(): Promise<ObservedMessage[]>;
   close?(): Promise<void>;
 };

--- a/packages/channels/live-tests/bindings/email.ts
+++ b/packages/channels/live-tests/bindings/email.ts
@@ -1,9 +1,11 @@
+import { execFileSync } from "node:child_process";
 import {
   email,
   type ChannelEmailMessage,
   type EmailSendBinding
 } from "../../src/adapters/email/email";
 import type { ChannelMessageSurface } from "../../src/surface";
+import { ChannelHost } from "../../src/host";
 import {
   requiredEnv,
   type LiveDeliveryBinding,
@@ -12,6 +14,26 @@ import {
 
 const CORE = "urn:ietf:params:jmap:core";
 const MAIL = "urn:ietf:params:jmap:mail";
+
+function wranglerAuthToken(): string {
+  try {
+    const output = execFileSync("pnpm", ["exec", "wrangler", "auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    const token = output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .at(-1);
+    if (!token) throw new Error("Wrangler returned an empty token");
+    return token;
+  } catch {
+    throw new Error(
+      "Could not obtain a Cloudflare API token from Wrangler. Run `pnpm exec wrangler login` before the email live tests."
+    );
+  }
+}
 
 type FastmailSession = { apiUrl: string; accountId: string };
 type FastmailEmail = {
@@ -94,9 +116,10 @@ export function emailBinding(): LiveDeliveryBinding {
     from,
     binding: cloudflareBinding(
       requiredEnv("CHANNELS_LIVE_CLOUDFLARE_ACCOUNT_ID"),
-      requiredEnv("CHANNELS_LIVE_CLOUDFLARE_API_TOKEN")
+      wranglerAuthToken()
     )
   });
+  const host = new ChannelHost({ channels: { email: channel } });
   const surface: ChannelMessageSurface = {
     channelKey: "email",
     version: 1,
@@ -113,6 +136,16 @@ export function emailBinding(): LiveDeliveryBinding {
         limit: 100
       })
     ).ids;
+  }
+
+  async function clear(): Promise<void> {
+    const emailIds = await ids();
+    if (emailIds.length > 0) {
+      await jmap(fastmailToken, session, "Email/set", {
+        accountId: session.accountId,
+        destroy: emailIds
+      });
+    }
   }
 
   async function messages(): Promise<FastmailEmail[]> {
@@ -135,22 +168,15 @@ export function emailBinding(): LiveDeliveryBinding {
 
   return {
     name: "email",
+    host,
+    surface,
     destination: `email inbox ${to}`,
     async open() {
       session = await openFastmail(fastmailToken);
+      await clear();
     },
-    async clear() {
-      const emailIds = await ids();
-      if (emailIds.length > 0) {
-        await jmap(fastmailToken, session, "Email/set", {
-          accountId: session.accountId,
-          destroy: emailIds
-        });
-      }
-    },
-    async deliver(text) {
-      return await channel.deliver!(surface, { markdown: text });
-    },
+    clear,
+
     async read(): Promise<ObservedMessage[]> {
       return (await messages()).map((message) => {
         const partId = message.textBody[0].partId;

--- a/packages/channels/live-tests/bindings/slack.ts
+++ b/packages/channels/live-tests/bindings/slack.ts
@@ -1,4 +1,5 @@
 import { slack } from "../../src/adapters/slack";
+import { ChannelHost } from "../../src/host";
 import type { ChannelMessageSurface } from "../../src/surface";
 import {
   requiredEnv,
@@ -6,10 +7,19 @@ import {
   type ObservedMessage
 } from "../binding";
 
-type SlackMessage = { ts: string; text: string };
+type SlackMessage = {
+  ts: string;
+  text: string;
+  reply_count?: number;
+  subtype?: string;
+};
 type SlackResponse = {
   ok: boolean;
   error?: string;
+  ts?: string;
+  team_id?: string;
+  user_id?: string;
+  members?: string[];
   messages?: SlackMessage[];
 };
 
@@ -31,11 +41,13 @@ async function slackApi(
   return payload;
 }
 
-export function slackBinding(): LiveDeliveryBinding {
+function createSlackBinding(threaded: boolean): LiveDeliveryBinding {
   const token = requiredEnv("CHANNELS_LIVE_SLACK_BOT_TOKEN");
   const channelId = requiredEnv("CHANNELS_LIVE_SLACK_CHANNEL_ID");
   const channel = slack({ botToken: token });
-  const surface: ChannelMessageSurface = {
+  const host = new ChannelHost({ channels: { slack: channel } });
+  let anchorTs: string | undefined;
+  let surface: ChannelMessageSurface = {
     channelKey: "slack",
     version: 1,
     address: { channelId },
@@ -47,25 +59,102 @@ export function slackBinding(): LiveDeliveryBinding {
       channel: channelId,
       limit: "100"
     });
-    return result.messages ?? [];
+    const history = result.messages ?? [];
+    const observed: SlackMessage[] = [];
+    for (const message of history) {
+      observed.push(message);
+      if (!message.reply_count) continue;
+      const thread = await slackApi(token, "conversations.replies", {
+        channel: channelId,
+        ts: message.ts,
+        limit: "100"
+      });
+      observed.push(
+        ...(thread.messages ?? []).filter((reply) => reply.ts !== message.ts)
+      );
+    }
+    return observed;
   }
 
-  return {
-    name: "slack",
-    destination: `Slack channel ${channelId}`,
-    async clear() {
-      for (const message of await messages()) {
+  async function clear(): Promise<void> {
+    // Replies must be deleted before their parent. Slack may retain thread
+    // tombstones after deletion; those are not messages the bot can delete.
+    for (const message of (await messages()).reverse()) {
+      if (message.subtype === "message_deleted") continue;
+      try {
         await slackApi(token, "chat.delete", {
           channel: channelId,
           ts: message.ts
         });
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("message_not_found")
+        ) {
+          continue;
+        }
+        throw error;
       }
+    }
+  }
+
+  return {
+    name: threaded ? "slack-thread" : "slack",
+    host,
+    get surface() {
+      return surface;
     },
-    async deliver(text) {
-      return await channel.deliver!(surface, { markdown: text });
+    destination: threaded
+      ? `Slack thread in channel ${channelId}`
+      : `Slack channel ${channelId}`,
+    async open() {
+      await clear();
+      if (!threaded) return;
+
+      // Native channel streaming needs a thread and the intended reader.
+      const identity = await slackApi(token, "auth.test", {});
+      const members = await slackApi(token, "conversations.members", {
+        channel: channelId,
+        limit: "100"
+      });
+      const recipientUserId = (members.members ?? []).find(
+        (member) => member !== identity.user_id
+      );
+      if (!recipientUserId) {
+        throw new Error(
+          `Slack channel ${channelId} has no member besides this bot to stream to`
+        );
+      }
+      const anchor = await slackApi(token, "chat.postMessage", {
+        channel: channelId,
+        text: "Cloudflare Channels live streaming thread."
+      });
+      anchorTs = anchor.ts;
+      surface = {
+        ...surface,
+        address: {
+          channelId,
+          threadTs: anchorTs!,
+          recipientUserId,
+          recipientTeamId: identity.team_id!
+        }
+      };
     },
+    clear,
     async read(): Promise<ObservedMessage[]> {
-      return (await messages()).map(({ text }) => ({ text }));
+      return (await messages())
+        .filter((message) => message.ts !== anchorTs)
+        .map(({ text }) => ({ text }));
     }
   };
+}
+
+/** A top-level Slack channel destination. Streams collect and deliver once. */
+export function slackBinding(): LiveDeliveryBinding {
+  return createSlackBinding(false);
+}
+
+/** A Slack thread destination that exercises Slack's native streaming API. */
+export function slackThreadBinding(): LiveDeliveryBinding {
+  return createSlackBinding(true);
 }

--- a/packages/channels/live-tests/bindings/telegram.ts
+++ b/packages/channels/live-tests/bindings/telegram.ts
@@ -2,6 +2,7 @@ import { TelegramClient } from "teleproto";
 import { StringSession } from "teleproto/sessions";
 import { telegram } from "../../src/adapters/telegram";
 import type { ChannelMessageSurface } from "../../src/surface";
+import { ChannelHost } from "../../src/host";
 import {
   requiredEnv,
   type LiveDeliveryBinding,
@@ -13,18 +14,55 @@ const creationActions = new Set([
   "MessageActionChatCreate"
 ]);
 
+/** The raw MTProto update that carries a bot's draft to the reader's client. */
+type TypingUpdate = {
+  className?: string;
+  userId?: unknown;
+  action?: { className?: string };
+};
+
+/** Recover the bot's own user id from its BotFather token prefix. */
+function botUserId(botToken: string): number {
+  const id = Number(botToken.match(/^(\d+):/)?.[1]);
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new Error("Could not read a bot user id from the Telegram bot token");
+  }
+  return id;
+}
+
 export function telegramBinding(): LiveDeliveryBinding {
   const chatId = requiredEnv("CHANNELS_LIVE_TELEGRAM_CHAT_ID");
   const numericChatId = Number(chatId);
+  if (!Number.isSafeInteger(numericChatId) || numericChatId <= 0) {
+    throw new Error(
+      "Telegram streaming live tests require a private-chat user ID; groups and channels discard sendMessageDraft previews"
+    );
+  }
+  const botToken = requiredEnv("CHANNELS_LIVE_TELEGRAM_BOT_TOKEN");
+  /**
+   * The two sides of a direct message address it by different ids: the bot
+   * sends to the user's id, while the observing user session reads the chat
+   * named by the bot's id. They coincide only for groups and channels.
+   *
+   * Getting this wrong is destructive rather than merely wrong, because the
+   * user's own id names Saved Messages, and `clear()` revokes everything it
+   * finds. `open()` refuses to proceed unless the target is the intended one.
+   */
+  const observedChatId = botUserId(botToken);
   const client = new TelegramClient(
     new StringSession(requiredEnv("CHANNELS_LIVE_TELEGRAM_SESSION")),
     Number(requiredEnv("CHANNELS_LIVE_TELEGRAM_API_ID")),
     requiredEnv("CHANNELS_LIVE_TELEGRAM_API_HASH"),
     { connectionRetries: 3 }
   );
-  const channel = telegram({
-    botToken: requiredEnv("CHANNELS_LIVE_TELEGRAM_BOT_TOKEN")
-  });
+  const channel = telegram({ botToken });
+  const botId = botUserId(botToken);
+  // Telegram surfaces a bot's draft to the recipient's client as a typing
+  // update with its own action, distinct from an ordinary typing indicator.
+  // Counting those is the only positive evidence available that a preview
+  // reached the reader, since the Bot API cannot read back its own draft.
+  let previews = 0;
+  const host = new ChannelHost({ channels: { telegram: channel } });
   const surface: ChannelMessageSurface = {
     channelKey: "telegram",
     version: 1,
@@ -34,7 +72,7 @@ export function telegramBinding(): LiveDeliveryBinding {
 
   async function messages() {
     return Array.from(
-      await client.getMessages(numericChatId, { limit: undefined })
+      await client.getMessages(observedChatId, { limit: undefined })
     );
   }
 
@@ -44,25 +82,51 @@ export function telegramBinding(): LiveDeliveryBinding {
     return creationActions.has(message.action?.className ?? "");
   }
 
+  async function clear(): Promise<void> {
+    const deletable = (await messages()).filter(
+      (message) => !isCreationMessage(message)
+    );
+    if (deletable.length > 0) {
+      await client.deleteMessages(observedChatId, deletable, {
+        revoke: true
+      });
+    }
+  }
+
   return {
     name: "telegram",
+    host,
+    surface,
     destination: `Telegram chat ${chatId}`,
     async open() {
       await client.connect();
+      client.addEventHandler((update: TypingUpdate) => {
+        if (
+          update?.className === "UpdateUserTyping" &&
+          update.action?.className === "SendMessageTextDraftAction" &&
+          Number(update.userId) === botId
+        ) {
+          previews += 1;
+        }
+      });
       await client.getDialogs({ folder: 0 });
-      await client.getEntity(numericChatId);
-    },
-    async clear() {
-      const deletable = (await messages()).filter(
-        (message) => !isCreationMessage(message)
-      );
-      if (deletable.length > 0) {
-        await client.deleteMessages(numericChatId, deletable, { revoke: true });
+      const sessionUserId = Number((await client.getMe()).id);
+      if (observedChatId === sessionUserId) {
+        throw new Error(
+          "Refusing to run: the observed chat is this account's Saved Messages, whose contents clear() would revoke"
+        );
       }
+      if (numericChatId !== sessionUserId) {
+        throw new Error(
+          `Refusing to run: the bot would send to user ${numericChatId}, but the observing session is user ${sessionUserId}, so the test would read a different conversation`
+        );
+      }
+      await client.getEntity(observedChatId);
+      await clear();
+      previews = 0;
     },
-    async deliver(text) {
-      return await channel.deliver!(surface, { markdown: text });
-    },
+    clear,
+    previews: () => previews,
     async read(): Promise<ObservedMessage[]> {
       return (await messages()).flatMap((message) =>
         typeof message.message === "string" ? [{ text: message.message }] : []

--- a/packages/channels/live-tests/delivery.test.ts
+++ b/packages/channels/live-tests/delivery.test.ts
@@ -1,52 +1,35 @@
-import { describe, expect, test } from "vitest";
-import { emailBinding } from "./bindings/email";
-import { slackBinding } from "./bindings/slack";
-import { telegramBinding } from "./bindings/telegram";
+import { expect, test } from "vitest";
+import { readUntil, uniqueText, withDestination } from "./helpers";
+import { providers } from "./providers";
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const providers = [
-  ["telegram", telegramBinding],
-  ["slack", slackBinding],
-  ["email", emailBinding]
-] as const;
-
-describe("live channel delivery", () => {
-  test.each(providers)("delivers through %s", async (_name, create) => {
-    const channel = create();
-    console.info(`[${channel.name}] clearing ${channel.destination}`);
-    await channel.open?.();
-
-    try {
-      await channel.clear();
-      expect(await channel.read()).toEqual([]);
-
-      const result = await channel.deliver(
-        "Cloudflare Channels live delivery smoke test."
-      );
-      console.info(`[${channel.name}] ${JSON.stringify(result)}`);
-
-      let messages = [];
-      const deadline = Date.now() + 120_000;
-      while (messages.length === 0 && Date.now() < deadline) {
-        await sleep(1_000);
-        messages = await channel.read();
-      }
-      expect(messages.length).toBeGreaterThan(0);
-
-      await sleep(5_000);
-      messages = await channel.read();
-      console.info(`[${channel.name}] observed ${JSON.stringify(messages)}`);
-      await expect(
-        `${JSON.stringify(messages, null, 2)}\n`
-      ).toMatchFileSnapshot(`./snapshots/${channel.name}.json`);
-    } finally {
-      try {
-        await channel.clear();
-        expect(await channel.read()).toEqual([]);
-      } finally {
-        await channel.close?.();
-      }
-    }
+test.each(providers)("delivers through %s", async (_name, create) => {
+  await withDestination(create, async (channel) => {
+    const text = "Cloudflare Channels live delivery smoke test.";
+    const result = await channel.host.deliver(channel.surface, {
+      markdown: uniqueText(text)
+    });
+    console.info(`[${channel.name}] ${JSON.stringify(result)}`);
+    expect(result.status).toBe("delivered");
+    await expect(
+      `${JSON.stringify(await readUntil(channel, text), null, 2)}\n`
+    ).toMatchFileSnapshot(`./snapshots/${channel.name}.json`);
   });
 });
+
+test.each(providers)(
+  "delivers rich content through %s",
+  async (_name, create) => {
+    await withDestination(create, async (channel) => {
+      const result = await channel.host.deliver(channel.surface, {
+        title: "Live rich delivery",
+        markdown: uniqueText(
+          "Rich delivery with **bold text**, [a link](https://example.com), and `code`."
+        )
+      });
+      expect(result.status).toBe("delivered");
+      await expect(
+        `${JSON.stringify(await readUntil(channel, "Rich delivery"), null, 2)}\n`
+      ).toMatchFileSnapshot(`./snapshots/${channel.name}-rich.json`);
+    });
+  }
+);

--- a/packages/channels/live-tests/helpers.ts
+++ b/packages/channels/live-tests/helpers.ts
@@ -1,0 +1,110 @@
+import { expect } from "vitest";
+import type { ChannelChunk, DeliveryResult } from "../src/channel";
+import type {
+  LiveDeliveryBinding,
+  LiveStreamSession,
+  ObservedMessage
+} from "./binding";
+
+const SETTLE_MS = 3_000;
+const OBSERVATION_TIMEOUT_MS = 240_000;
+const RUN_MARKER = `[channels-live:${crypto.randomUUID()}] `;
+
+/** Keep repeated live runs distinct to providers that deduplicate traffic. */
+export function uniqueText(text: string): string {
+  return `${RUN_MARKER}${text}`;
+}
+
+export async function readObserved(
+  channel: LiveDeliveryBinding
+): Promise<ObservedMessage[]> {
+  return (await channel.read()).map((message) => ({
+    text: message.text.replaceAll(RUN_MARKER, "")
+  }));
+}
+
+/** Run one scenario against an empty destination and leave it empty. */
+export async function withDestination(
+  create: () => LiveDeliveryBinding,
+  run: (channel: LiveDeliveryBinding) => Promise<void>
+): Promise<void> {
+  const channel = create();
+  await channel.open();
+  try {
+    expect(await readObserved(channel)).toEqual([]);
+    await run(channel);
+  } finally {
+    try {
+      await channel.clear();
+      expect(await readObserved(channel)).toEqual([]);
+    } finally {
+      await channel.close?.();
+    }
+  }
+}
+
+/** Poll the destination until the expected text lands, or give up loudly. */
+export async function readUntil(
+  channel: LiveDeliveryBinding,
+  expected: string
+): Promise<ObservedMessage[]> {
+  const deadline = Date.now() + OBSERVATION_TIMEOUT_MS;
+  let messages: ObservedMessage[] = [];
+  while (Date.now() < deadline) {
+    messages = await readObserved(channel);
+    if (messages.some((message) => message.text.includes(expected))) break;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  expect(
+    messages.some((message) => message.text.includes(expected)),
+    `${channel.name} never showed ${JSON.stringify(expected)}`
+  ).toBe(true);
+  // Settle, so a duplicate or a late edit shows up in the snapshot. Return
+  // only this scenario's messages: Email Service may finish an earlier send
+  // after that scenario's cleanup has already run.
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  return (await readObserved(channel)).filter((message) =>
+    message.text.includes(expected)
+  );
+}
+
+export async function snapshot(
+  channel: LiveDeliveryBinding,
+  scenario: string,
+  observed: unknown
+): Promise<void> {
+  console.info(`[${channel.name}] ${scenario} ${JSON.stringify(observed)}`);
+  await expect(`${JSON.stringify(observed, null, 2)}\n`).toMatchFileSnapshot(
+    `./snapshots/${channel.name}-${scenario}.json`
+  );
+}
+
+/** Drive one outbound stream by hand so tests can inspect intermediate state. */
+export function chunkPump(
+  run: (chunks: ReadableStream<ChannelChunk>) => Promise<DeliveryResult>
+): LiveStreamSession {
+  let controller!: ReadableStreamDefaultController<ChannelChunk>;
+  const chunks = new ReadableStream<ChannelChunk>({
+    start(streamController) {
+      controller = streamController;
+    }
+  });
+  const delivery = run(chunks);
+  // Keep an early rejection from surfacing before the test calls finish/fail.
+  delivery.catch(() => {});
+
+  return {
+    async push(chunk) {
+      controller.enqueue(chunk);
+      await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+    },
+    finish() {
+      controller.close();
+      return delivery;
+    },
+    fail(reason) {
+      controller.error(new Error(reason));
+      return delivery;
+    }
+  };
+}

--- a/packages/channels/live-tests/providers.ts
+++ b/packages/channels/live-tests/providers.ts
@@ -1,0 +1,12 @@
+import type { LiveDeliveryBinding } from "./binding";
+import { emailBinding } from "./bindings/email";
+import { slackBinding, slackThreadBinding } from "./bindings/slack";
+import { telegramBinding } from "./bindings/telegram";
+
+/** Every destination shape must support both finished and streamed delivery. */
+export const providers = [
+  ["telegram", telegramBinding],
+  ["slack", slackBinding],
+  ["slack-thread", slackThreadBinding],
+  ["email", emailBinding]
+] as const satisfies readonly [string, () => LiveDeliveryBinding][];

--- a/packages/channels/live-tests/snapshots/email-rich.json
+++ b/packages/channels/live-tests/snapshots/email-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Rich delivery with **bold text**, [a link](https://example.com), and `code`.\n\n"
+  }
+]

--- a/packages/channels/live-tests/snapshots/email-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/email-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then \n\n"
+  }
+]

--- a/packages/channels/live-tests/snapshots/email-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/email-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Rich streaming smoke test.\n\n"
+  }
+]

--- a/packages/channels/live-tests/snapshots/email-stream.json
+++ b/packages/channels/live-tests/snapshots/email-stream.json
@@ -1,0 +1,12 @@
+{
+  "duringStream": [
+    [],
+    [],
+    []
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test.\n\n"
+    }
+  ]
+}

--- a/packages/channels/live-tests/snapshots/slack-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich delivery\n\nRich delivery with **bold text**, [a link](<https://example.com>), and `code`."
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/slack-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then "
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich stream\n\nRich streaming smoke test."
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-stream.json
+++ b/packages/channels/live-tests/snapshots/slack-stream.json
@@ -1,0 +1,12 @@
+{
+  "duringStream": [
+    [],
+    [],
+    []
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test."
+    }
+  ]
+}

--- a/packages/channels/live-tests/snapshots/slack-thread-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich delivery\n\nRich delivery with **bold text**, [a link](<https://example.com>), and `code`."
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-thread-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then"
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-thread-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich stream\n\n Rich streaming smoke test. <https://example.com|Example>, with interactive elements"
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-thread-stream.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-stream.json
@@ -1,0 +1,24 @@
+{
+  "duringStream": [
+    [
+      {
+        "text": "Cloudflare Channels"
+      }
+    ],
+    [
+      {
+        "text": "Cloudflare Channels live streaming"
+      }
+    ],
+    [
+      {
+        "text": "Cloudflare Channels live streaming smoke test."
+      }
+    ]
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test."
+    }
+  ]
+}

--- a/packages/channels/live-tests/snapshots/slack-thread.json
+++ b/packages/channels/live-tests/snapshots/slack-thread.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Cloudflare Channels live delivery smoke test."
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-rich.json
+++ b/packages/channels/live-tests/snapshots/telegram-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich delivery\n\nRich delivery with **bold text**, [a link](https://example.com), and `code`."
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/telegram-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then"
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/telegram-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich stream\n\nRich streaming smoke test."
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-stream.json
+++ b/packages/channels/live-tests/snapshots/telegram-stream.json
@@ -1,0 +1,13 @@
+{
+  "duringStream": [
+    [],
+    [],
+    []
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test."
+    }
+  ],
+  "previews": 3
+}

--- a/packages/channels/live-tests/streaming.test.ts
+++ b/packages/channels/live-tests/streaming.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import type { ChannelChunk } from "../src/channel";
+import type { ObservedMessage } from "./binding";
+import {
+  chunkPump,
+  readObserved,
+  readUntil,
+  snapshot,
+  uniqueText,
+  withDestination
+} from "./helpers";
+import { providers } from "./providers";
+
+const STREAM_CHUNKS: readonly ChannelChunk[] = [
+  { type: "text", text: uniqueText("Cloudflare Channels ") },
+  { type: "text", text: "live streaming " },
+  { type: "text", text: "smoke test." }
+];
+
+/**
+ * Every chunk variant and the title, none of which the text-only smoke test
+ * can produce. This is a request-shape test: Slack rejected an earlier title
+ * with `streaming_mode_mismatch`, which no mock could catch.
+ */
+const RICH_CHUNKS: readonly ChannelChunk[] = [
+  {
+    type: "tool",
+    name: "search",
+    status: "started",
+    title: "Searching docs",
+    detail: "query: streaming"
+  },
+  { type: "text", text: uniqueText("Rich streaming ") },
+  { type: "reasoning", text: "every Channel may ignore this" },
+  {
+    type: "tool",
+    name: "search",
+    status: "completed",
+    title: "Searching docs"
+  },
+  { type: "text", text: "smoke test." },
+  { type: "source", url: "https://example.com", title: "Example" }
+];
+
+describe("live channel streaming", () => {
+  test.each(providers)("streams through %s", async (_name, create) => {
+    await withDestination(create, async (channel) => {
+      const session = chunkPump((chunks) =>
+        channel.host.stream(channel.surface, chunks)
+      );
+      const duringStream: ObservedMessage[][] = [];
+      for (const chunk of STREAM_CHUNKS) {
+        await session.push(chunk);
+        duringStream.push(await readObserved(channel));
+      }
+      const result = await session.finish();
+      expect(result.status).toBe("delivered");
+
+      const complete = "Cloudflare Channels live streaming smoke test.";
+      await snapshot(channel, "stream", {
+        duringStream,
+        afterStream: await readUntil(channel, complete),
+        ...(channel.previews && { previews: channel.previews() })
+      });
+    });
+  });
+
+  test.each(providers)(
+    "streams every chunk variant through %s",
+    async (_name, create) => {
+      await withDestination(create, async (channel) => {
+        const session = chunkPump((chunks) =>
+          channel.host.stream(channel.surface, chunks, {
+            title: "Live rich stream"
+          })
+        );
+        for (const chunk of RICH_CHUNKS) await session.push(chunk);
+        expect((await session.finish()).status).toBe("delivered");
+
+        await snapshot(
+          channel,
+          "stream-rich",
+          await readUntil(channel, "Rich streaming smoke test.")
+        );
+      });
+    }
+  );
+
+  /**
+   * A Channel must finalize after an abnormal ending too. Telegram is the
+   * sharp case: its draft is not the message, so omitting the terminal
+   * `sendMessage` leaves the chat empty when the draft expires.
+   */
+  test.each(providers)(
+    "persists a partial answer when the generation fails through %s",
+    async (_name, create) => {
+      await withDestination(create, async (channel) => {
+        const session = chunkPump((chunks) =>
+          channel.host.stream(channel.surface, chunks)
+        );
+        await session.push({
+          type: "text",
+          text: uniqueText("The model started ")
+        });
+        await session.push({ type: "text", text: "answering and then " });
+        const result = await session.fail("model failed mid-generation");
+
+        expect(result.status).toBe("uncertain");
+        expect(result).toHaveProperty("reference");
+        await snapshot(
+          channel,
+          "stream-interrupted",
+          await readUntil(channel, "The model started answering and then")
+        );
+      });
+    }
+  );
+});

--- a/packages/channels/package.json
+++ b/packages/channels/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@cloudflare/voice": "workspace:*",
+    "agents": "workspace:*",
     "postal-mime": "^2.7.5"
   },
   "peerDependencies": {

--- a/packages/channels/src/__tests__/ai-sdk.test.ts
+++ b/packages/channels/src/__tests__/ai-sdk.test.ts
@@ -6,7 +6,7 @@ import {
   type ChannelMessage,
   type DeliveryResult
 } from "..";
-import { createSendMessageTool } from "../ai-sdk";
+import { createSendMessageTool, toChannelChunks } from "../ai-sdk";
 
 function executable(tool: ReturnType<typeof createSendMessageTool>) {
   return tool.execute as unknown as (
@@ -86,5 +86,75 @@ describe("AI SDK message adapter", () => {
       success: true,
       value: { markdown: "Ready" }
     });
+  });
+});
+
+describe("AI SDK stream adapter", () => {
+  async function collect(parts: unknown[]) {
+    const chunks: unknown[] = [];
+    const stream = toChannelChunks(
+      (async function* () {
+        for (const part of parts) yield part as never;
+      })()
+    );
+    for await (const chunk of stream) chunks.push(chunk);
+    return chunks;
+  }
+
+  it("keeps the parts a Channel can express and drops the rest", async () => {
+    await expect(
+      collect([
+        { type: "start" },
+        { type: "text-start", id: "1" },
+        { type: "text-delta", id: "1", text: "Hello" },
+        { type: "reasoning-delta", id: "2", text: "thinking" },
+        { type: "tool-call", toolCallId: "t1", toolName: "search", input: {} },
+        {
+          type: "tool-result",
+          toolCallId: "t1",
+          toolName: "search",
+          input: {},
+          output: "ok"
+        },
+        { type: "tool-error", toolCallId: "t2", toolName: "fetch", error: "x" },
+        {
+          type: "source",
+          sourceType: "url",
+          id: "s1",
+          url: "https://example.com",
+          title: "Example"
+        },
+        {
+          type: "source",
+          sourceType: "document",
+          id: "s2",
+          mediaType: "application/pdf",
+          title: "Report"
+        },
+        { type: "finish", finishReason: "stop" }
+      ])
+    ).resolves.toEqual([
+      { type: "text", text: "Hello" },
+      { type: "reasoning", text: "thinking" },
+      { type: "tool", name: "search", status: "started" },
+      { type: "tool", name: "search", status: "completed" },
+      { type: "tool", name: "fetch", status: "failed" },
+      { type: "source", url: "https://example.com", title: "Example" }
+    ]);
+  });
+
+  it("errors the stream when the generation fails, so Channels finalize", async () => {
+    await expect(
+      collect([
+        { type: "text-delta", id: "1", text: "Half an " },
+        { type: "error", error: new Error("model failed") }
+      ])
+    ).rejects.toThrow("model failed");
+  });
+
+  it("errors the stream when the generation is aborted", async () => {
+    await expect(
+      collect([{ type: "abort", reason: "stopped by the reader" }])
+    ).rejects.toThrow("stopped by the reader");
   });
 });

--- a/packages/channels/src/__tests__/ai-sdk.test.ts
+++ b/packages/channels/src/__tests__/ai-sdk.test.ts
@@ -136,9 +136,9 @@ describe("AI SDK stream adapter", () => {
     ).resolves.toEqual([
       { type: "text", text: "Hello" },
       { type: "reasoning", text: "thinking" },
-      { type: "tool", name: "search", status: "started" },
-      { type: "tool", name: "search", status: "completed" },
-      { type: "tool", name: "fetch", status: "failed" },
+      { type: "tool", id: "t1", name: "search", status: "started" },
+      { type: "tool", id: "t1", name: "search", status: "completed" },
+      { type: "tool", id: "t2", name: "fetch", status: "failed" },
       { type: "source", url: "https://example.com", title: "Example" }
     ]);
   });
@@ -157,4 +157,32 @@ describe("AI SDK stream adapter", () => {
       collect([{ type: "abort", reason: "stopped by the reader" }])
     ).rejects.toThrow("stopped by the reader");
   });
+
+  it.each([
+    {
+      part: { type: "error", error: new Error("model failed") },
+      message: "model failed"
+    },
+    {
+      part: { type: "abort", reason: "reader stopped" },
+      message: "reader stopped"
+    }
+  ])(
+    "closes the source iterator after a $part.type part",
+    async ({ part, message }) => {
+      let finalized = false;
+      const source = (async function* () {
+        try {
+          yield part as never;
+          yield { type: "text-delta", id: "1", text: "never" } as never;
+        } finally {
+          finalized = true;
+        }
+      })();
+
+      const reader = toChannelChunks(source).getReader();
+      await expect(reader.read()).rejects.toThrow(message);
+      expect(finalized).toBe(true);
+    }
+  );
 });

--- a/packages/channels/src/__tests__/fallback.test.ts
+++ b/packages/channels/src/__tests__/fallback.test.ts
@@ -4,9 +4,64 @@ import {
   fallback,
   fallbackChannel,
   type Channel,
+  type ChannelChunk,
   type DeliveryResult,
   type OutboundResolver
 } from "..";
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function text(...parts: string[]): ChannelChunk[] {
+  return parts.map((part) => ({ type: "text", text: part }));
+}
+
+/** A Channel that records what it read, then reports a fixed outcome. */
+function streamingChannel(
+  result: DeliveryResult,
+  options: { readAtMost?: number; available?: boolean } = {}
+): Channel & { seen: ChannelChunk[]; calls: number } {
+  const channel = {
+    seen: [] as ChannelChunk[],
+    calls: 0,
+    ...(options.available === undefined
+      ? {}
+      : { isAvailable: () => options.available! }),
+    async stream(_surface: unknown, chunks: ReadableStream<ChannelChunk>) {
+      channel.calls += 1;
+      const reader = chunks.getReader();
+      let read = 0;
+      for (;;) {
+        if (read === options.readAtMost) break;
+        const next = await reader.read();
+        if (next.done) break;
+        channel.seen.push(next.value);
+        read += 1;
+      }
+      reader.releaseLock();
+      return result;
+    }
+  };
+  return channel as Channel & { seen: ChannelChunk[]; calls: number };
+}
+
+const rejected: DeliveryResult = {
+  status: "failed",
+  retryable: false,
+  error: { code: "DELIVERY_FAILED", message: "Not delivered" }
+};
 
 function surface(channelKey: string) {
   return {
@@ -104,14 +159,14 @@ describe("fallback surfaces", () => {
     const first = channel({ status: "delivered" });
     const channelHost = host({ first });
     const message = { markdown: "Hello" };
-    const context = { deliveryId: "notice-1" };
+    const options = { delivery: { deliveryId: "notice-1" } };
 
-    await channelHost.deliver(fallback([surface("first")]), message, context);
+    await channelHost.deliver(fallback([surface("first")]), message, options);
 
     expect(first.deliver).toHaveBeenCalledWith(
       surface("first"),
       message,
-      context
+      options
     );
   });
 
@@ -181,5 +236,143 @@ describe("fallback surfaces", () => {
       address: { surfaces: [surface("Slack"), surface("email")] },
       label: "Slack, then email"
     });
+  });
+});
+
+describe("fallback streaming", () => {
+  it("replays what a failed destination consumed to the next one", async () => {
+    const first = streamingChannel(rejected);
+    const second = streamingChannel({ status: "delivered", reference: "s-1" });
+    const channelHost = host({ first, second });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello ", "world"))
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "s-1" });
+    expect(second.seen).toEqual([
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world" }
+    ]);
+    expect(second.seen).toEqual(first.seen);
+  });
+
+  it("replays the consumed prefix and streams the untouched remainder", async () => {
+    const first = streamingChannel(rejected, { readAtMost: 1 });
+    const second = streamingChannel({ status: "delivered" });
+    const channelHost = host({ first, second });
+
+    await channelHost.stream(
+      fallback([surface("first"), surface("second")]),
+      streamOf(text("one", "two", "three"))
+    );
+
+    expect(first.seen).toEqual([{ type: "text", text: "one" }]);
+    expect(second.seen).toEqual([
+      { type: "text", text: "one" },
+      { type: "text", text: "two" },
+      { type: "text", text: "three" }
+    ]);
+  });
+
+  it("skips an unavailable destination without consuming the stream", async () => {
+    const skipped = streamingChannel(
+      { status: "delivered" },
+      {
+        available: false
+      }
+    );
+    const final = streamingChannel({ status: "delivered", reference: "f-1" });
+    const channelHost = host({ skipped, final });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("skipped"), surface("final")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "f-1" });
+    expect(skipped.calls).toBe(0);
+    expect(final.seen).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("stops after an uncertain streaming outcome", async () => {
+    const first = streamingChannel({
+      status: "uncertain",
+      reference: "half-written",
+      error: { code: "STREAM_ERROR", message: "Partly sent" }
+    });
+    const second = streamingChannel({ status: "delivered" });
+    const channelHost = host({ first, second });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "half-written",
+      error: { code: "STREAM_ERROR", message: "Partly sent" }
+    });
+    expect(second.calls).toBe(0);
+  });
+
+  it("attempts the final destination even after every earlier one failed", async () => {
+    const first = streamingChannel(rejected);
+    const second = streamingChannel(rejected);
+    const channelHost = host({ first, second });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toEqual(rejected);
+    expect(second.seen).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("replays into a destination that cannot stream", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+    const first = streamingChannel(rejected);
+    const channelHost = host({ first, second: { deliver } });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello ", "world")),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({ status: "delivered" });
+    expect(deliver).toHaveBeenCalledWith(
+      surface("second"),
+      { title: "Update", markdown: "Hello world" },
+      undefined
+    );
+  });
+
+  it("passes an interrupted generation on to the destination", async () => {
+    const seen: ChannelChunk[] = [];
+    let interrupted = false;
+    const channelHost = host({
+      only: {
+        async stream(_surface, chunks) {
+          try {
+            for await (const chunk of chunks) seen.push(chunk);
+          } catch {
+            interrupted = true;
+          }
+          return { status: "uncertain", error: { code: "X", message: "y" } };
+        }
+      }
+    });
+
+    await channelHost.stream(
+      fallback([surface("only")]),
+      streamOf(text("Half an "), new Error("model failed"))
+    );
+
+    expect(seen).toEqual([{ type: "text", text: "Half an " }]);
+    expect(interrupted).toBe(true);
   });
 });

--- a/packages/channels/src/__tests__/fallback.test.ts
+++ b/packages/channels/src/__tests__/fallback.test.ts
@@ -240,8 +240,13 @@ describe("fallback surfaces", () => {
 });
 
 describe("fallback streaming", () => {
-  it("replays what a failed destination consumed to the next one", async () => {
-    const first = streamingChannel(rejected);
+  it("advances when a destination fails before reading", async () => {
+    const first: Channel = {
+      async stream(_surface, chunks) {
+        await chunks.cancel();
+        return rejected;
+      }
+    };
     const second = streamingChannel({ status: "delivered", reference: "s-1" });
     const channelHost = host({ first, second });
 
@@ -255,25 +260,73 @@ describe("fallback streaming", () => {
       { type: "text", text: "Hello " },
       { type: "text", text: "world" }
     ]);
-    expect(second.seen).toEqual(first.seen);
   });
 
-  it("replays the consumed prefix and streams the untouched remainder", async () => {
+  it("stops fallback once a destination starts reading", async () => {
     const first = streamingChannel(rejected, { readAtMost: 1 });
+    const second = streamingChannel({ status: "delivered" });
+    const cancel = vi.fn();
+    let produced = 0;
+    const source = new ReadableStream<ChannelChunk>({
+      pull(controller) {
+        produced += 1;
+        if (produced <= 3) {
+          controller.enqueue({ type: "text", text: String(produced) });
+        } else {
+          controller.close();
+        }
+      },
+      cancel
+    });
+    const channelHost = host({ first, second });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        source
+      )
+    ).resolves.toEqual(rejected);
+
+    expect(first.seen).toEqual([{ type: "text", text: "1" }]);
+    expect(second.calls).toBe(0);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not advance while an earlier attempt has a pending pull", async () => {
+    let releaseSource: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      releaseSource = resolve;
+    });
+    let sent = false;
+    const source = new ReadableStream<ChannelChunk>({
+      async pull(controller) {
+        if (sent) {
+          controller.close();
+          return;
+        }
+        await blocked;
+        sent = true;
+        controller.enqueue({ type: "text", text: "late" });
+      }
+    });
+    const first: Channel = {
+      async stream(_surface, chunks) {
+        const reader = chunks.getReader();
+        void reader.read().finally(() => reader.releaseLock());
+        return rejected;
+      }
+    };
     const second = streamingChannel({ status: "delivered" });
     const channelHost = host({ first, second });
 
-    await channelHost.stream(
+    const delivery = channelHost.stream(
       fallback([surface("first"), surface("second")]),
-      streamOf(text("one", "two", "three"))
+      source
     );
+    setTimeout(() => releaseSource?.(), 0);
 
-    expect(first.seen).toEqual([{ type: "text", text: "one" }]);
-    expect(second.seen).toEqual([
-      { type: "text", text: "one" },
-      { type: "text", text: "two" },
-      { type: "text", text: "three" }
-    ]);
+    await expect(delivery).resolves.toEqual(rejected);
+    expect(second.calls).toBe(0);
   });
 
   it("skips an unavailable destination without consuming the stream", async () => {
@@ -318,8 +371,8 @@ describe("fallback streaming", () => {
     expect(second.calls).toBe(0);
   });
 
-  it("attempts the final destination even after every earlier one failed", async () => {
-    const first = streamingChannel(rejected);
+  it("attempts the final destination after earlier failures before reading", async () => {
+    const first: Channel = { stream: async () => rejected };
     const second = streamingChannel(rejected);
     const channelHost = host({ first, second });
 
@@ -332,9 +385,9 @@ describe("fallback streaming", () => {
     expect(second.seen).toEqual([{ type: "text", text: "Hello" }]);
   });
 
-  it("replays into a destination that cannot stream", async () => {
+  it("falls back to a non-streaming destination before the first read", async () => {
     const deliver = vi.fn(async () => ({ status: "delivered" as const }));
-    const first = streamingChannel(rejected);
+    const first: Channel = { stream: async () => rejected };
     const channelHost = host({ first, second: { deliver } });
 
     await expect(

--- a/packages/channels/src/__tests__/fanout.test.ts
+++ b/packages/channels/src/__tests__/fanout.test.ts
@@ -5,9 +5,28 @@ import {
   fanout,
   fanoutChannel,
   type Channel,
+  type ChannelChunk,
   type DeliveryResult,
   type OutboundResolver
 } from "..";
+
+function streamOf<T>(values: readonly T[]): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+      } else {
+        controller.close();
+      }
+    }
+  });
+}
+
+function text(...parts: string[]): ChannelChunk[] {
+  return parts.map((part) => ({ type: "text", text: part }));
+}
 
 function surface(channelKey: string) {
   return {
@@ -55,19 +74,19 @@ describe("fanout surfaces", () => {
     const second = channel({ status: "delivered", reference: "email-1" });
     const channelHost = host({ first, second });
     const message = { title: "Update", markdown: "Hello" };
-    const context = { deliveryId: "notice-1" };
+    const options = { delivery: { deliveryId: "notice-1" } };
 
     const delivery = channelHost.deliver(
       fanout([surface("first"), surface("second")]),
       message,
-      context
+      options
     );
     await vi.waitFor(() => {
       expect(started).toEqual(["first"]);
       expect(second.deliver).toHaveBeenCalledWith(
         surface("second"),
         message,
-        context
+        options
       );
     });
     release?.();
@@ -202,5 +221,113 @@ describe("fanout surfaces", () => {
     ).resolves.toEqual({ status: "delivered", reference: "final" });
     expect(first.deliver).not.toHaveBeenCalled();
     expect(unavailable.deliver).not.toHaveBeenCalled();
+  });
+});
+
+describe("fanout streaming", () => {
+  it("gives every destination its own branch of the stream", async () => {
+    const seen: Record<string, ChannelChunk[]> = { first: [], second: [] };
+    const streaming = (key: string): Channel => ({
+      async stream(_surface, chunks) {
+        for await (const chunk of chunks) seen[key]!.push(chunk);
+        return { status: "delivered" };
+      }
+    });
+    const channelHost = host({
+      first: streaming("first"),
+      second: streaming("second")
+    });
+
+    await expect(
+      channelHost.stream(
+        fanout([surface("first"), surface("second")]),
+        streamOf(text("Hello ", "world"))
+      )
+    ).resolves.toEqual({ status: "delivered" });
+    expect(seen.first).toEqual(seen.second);
+    expect(seen.first).toEqual([
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world" }
+    ]);
+  });
+
+  it("lets a fast destination finish while a slow one is still reading", async () => {
+    let release: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const order: string[] = [];
+    const channelHost = host({
+      slow: {
+        async stream(_surface, chunks) {
+          await blocked;
+          for await (const _chunk of chunks) order.push("slow");
+          return { status: "delivered" };
+        }
+      },
+      fast: {
+        async stream(_surface, chunks) {
+          for await (const _chunk of chunks) order.push("fast");
+          return { status: "delivered" };
+        }
+      }
+    });
+
+    const delivery = channelHost.stream(
+      fanout([surface("slow"), surface("fast")]),
+      streamOf(text("one", "two"))
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual(["fast", "fast"]);
+
+    release?.();
+    await expect(delivery).resolves.toEqual({ status: "delivered" });
+    expect(order).toEqual(["fast", "fast", "slow", "slow"]);
+  });
+
+  it("reports a partial streaming outcome as uncertain", async () => {
+    const channelHost = host({
+      first: { stream: async () => ({ status: "delivered" as const }) },
+      second: {
+        stream: async () => ({
+          status: "failed" as const,
+          retryable: false,
+          error: { code: "NOPE", message: "Rejected" }
+        })
+      }
+    });
+
+    await expect(
+      channelHost.stream(
+        fanout([surface("first"), surface("second")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toMatchObject({
+      status: "uncertain",
+      error: { code: "FANOUT_DELIVERY_UNCERTAIN" }
+    });
+  });
+
+  it("collects for a destination that cannot stream and streams to one that can", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+    const channelHost = host({
+      plain: { deliver },
+      streaming: {
+        stream: async () => ({ status: "delivered" as const })
+      }
+    });
+
+    await expect(
+      channelHost.stream(
+        fanout([surface("plain"), surface("streaming")]),
+        streamOf(text("Hello ", "world")),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({ status: "delivered" });
+    expect(deliver).toHaveBeenCalledWith(
+      surface("plain"),
+      { title: "Update", markdown: "Hello world" },
+      undefined
+    );
   });
 });

--- a/packages/channels/src/__tests__/fanout.test.ts
+++ b/packages/channels/src/__tests__/fanout.test.ts
@@ -251,6 +251,39 @@ describe("fanout streaming", () => {
     ]);
   });
 
+  it("cancels a branch when its destination returns without reading", async () => {
+    const source = streamOf(text("one", "two", "three"));
+    const [unreadBranch, drainingBranch] = source.tee();
+    const cancel = vi.spyOn(unreadBranch, "cancel");
+    const branchedSource = {
+      tee: () => [unreadBranch, drainingBranch]
+    } as ReadableStream<ChannelChunk>;
+    const seen: ChannelChunk[] = [];
+    const channelHost = host({
+      unread: {
+        stream: async () => ({
+          status: "failed",
+          retryable: false,
+          error: { code: "NOPE", message: "Rejected" }
+        })
+      },
+      draining: {
+        async stream(_surface, chunks) {
+          for await (const chunk of chunks) seen.push(chunk);
+          return { status: "delivered" };
+        }
+      }
+    });
+
+    await channelHost.stream(
+      fanout([surface("unread"), surface("draining")]),
+      branchedSource
+    );
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(seen).toEqual(text("one", "two", "three"));
+  });
+
   it("lets a fast destination finish while a slow one is still reading", async () => {
     let release: (() => void) | undefined;
     const blocked = new Promise<void>((resolve) => {

--- a/packages/channels/src/__tests__/host.test.ts
+++ b/packages/channels/src/__tests__/host.test.ts
@@ -653,6 +653,50 @@ describe("stateless ChannelHost", () => {
     expect(requestApproval).toHaveBeenCalledWith(destination, approval);
   });
 
+  it("rejects malformed outbound surfaces before a custom Channel sees them", async () => {
+    const deliver = vi.fn(delivered);
+    const stream = vi.fn(delivered);
+    const requestApproval = vi.fn(delivered);
+    const isAvailable = vi.fn(async () => true);
+    const channelHost = host({
+      outbound: { deliver, stream, requestApproval, isAvailable }
+    });
+    const malformed = {
+      ...surface,
+      channelKey: "outbound",
+      label: " "
+    };
+    const cancel = vi.fn();
+    const chunks = new ReadableStream({ cancel });
+
+    await expect(
+      channelHost.deliver(malformed, { markdown: "Hello" })
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "CHANNEL_SURFACE_INVALID" }
+    });
+    await expect(
+      channelHost.requestApproval(malformed, {
+        interactionId: "approval-1",
+        request: { summary: "Proceed?", input: {} }
+      })
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "CHANNEL_SURFACE_INVALID" }
+    });
+    await expect(channelHost.isAvailable(malformed)).resolves.toBe(false);
+    await expect(channelHost.stream(malformed, chunks)).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "CHANNEL_SURFACE_INVALID" }
+    });
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(stream).not.toHaveBeenCalled();
+    expect(requestApproval).not.toHaveBeenCalled();
+    expect(isAvailable).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("resolves a contact surface directly through the identity Channel key", () => {
     const first = vi.fn(() => {
       throw new Error("must not inspect a different configured Channel");

--- a/packages/channels/src/__tests__/slack-stream.test.ts
+++ b/packages/channels/src/__tests__/slack-stream.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChannelChunk } from "..";
+import { slack } from "../adapters/slack";
+
+const BOT_TOKEN = "xoxb-secret-token";
+const CHANNEL_SURFACE = {
+  channelKey: "slack",
+  version: 1,
+  address: {
+    channelId: "CDEST",
+    threadTs: "1711000000.000100",
+    recipientUserId: "UHUMAN",
+    recipientTeamId: "TWORK"
+  },
+  label: "Slack · CDEST"
+} as const;
+
+type Call = { method: string; body: Record<string, unknown> };
+
+/** Record every Slack call, answering each stream method with ok. */
+function recorder(overrides: Record<string, () => Response> = {}): {
+  fetch: typeof globalThis.fetch;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+    const method = String(input).split("/").pop()!;
+    calls.push({ method, body: JSON.parse(String(init?.body)) });
+    return (
+      overrides[method]?.() ??
+      Response.json({ ok: true, channel: "CDEST", ts: "1711000000.9" })
+    );
+  });
+  return { fetch, calls };
+}
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function chunks(...parts: string[]): ReadableStream<ChannelChunk> {
+  return streamOf(parts.map((text) => ({ type: "text", text }) as const));
+}
+
+describe("Slack streaming", () => {
+  it("collects a top-level channel stream and posts it once", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch });
+
+    await expect(
+      channel.stream!(
+        {
+          ...CHANNEL_SURFACE,
+          address: { channelId: "CDEST" }
+        },
+        chunks("Hello", " world"),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({
+      status: "delivered",
+      reference: "slack:channel:CDEST:message:1711000000.9"
+    });
+    expect(calls).toEqual([
+      {
+        method: "chat.postMessage",
+        body: {
+          channel: "CDEST",
+          text: "Update\n\nHello world",
+          mrkdwn: true
+        }
+      }
+    ]);
+  });
+
+  it("starts, appends, and stops one streaming message", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, chunks("Hello ", "world"), {})
+    ).resolves.toEqual({
+      status: "delivered",
+      reference: "slack:channel:CDEST:message:1711000000.9"
+    });
+    expect(calls.map((call) => call.method)).toEqual([
+      "chat.startStream",
+      "chat.appendStream",
+      "chat.appendStream",
+      "chat.stopStream"
+    ]);
+    expect(calls[0]?.body).toEqual({
+      channel: "CDEST",
+      thread_ts: "1711000000.000100",
+      recipient_user_id: "UHUMAN",
+      recipient_team_id: "TWORK"
+    });
+    expect(calls[1]?.body).toEqual({
+      channel: "CDEST",
+      ts: "1711000000.9",
+      chunks: [{ type: "markdown_text", text: "Hello " }]
+    });
+    expect(calls[3]?.body).toEqual({
+      channel: "CDEST",
+      ts: "1711000000.9"
+    });
+  });
+
+  it("opens the stream with the title, which is known before the first token", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(CHANNEL_SURFACE, chunks("Body"), {
+      title: "Deploy status"
+    });
+
+    // The title must travel as a chunk, not as `markdown_text`. Slack locks a
+    // stream into the mode it was opened in and rejects every later append
+    // with `streaming_mode_mismatch`, which loses the entire answer.
+    expect(calls[0]?.body).toMatchObject({
+      chunks: [{ type: "markdown_text", text: "Deploy status\n\n" }]
+    });
+    expect(calls[0]?.body.markdown_text).toBeUndefined();
+    expect(calls.every((call) => call.body.markdown_text === undefined)).toBe(
+      true
+    );
+  });
+
+  it("appends every chunk produced inside one interval together", async () => {
+    vi.useFakeTimers();
+    const { fetch, calls } = recorder();
+    const channel = slack({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 1000
+    });
+
+    await channel.stream!(CHANNEL_SURFACE, chunks("a", "b", "c"), {});
+
+    expect(
+      calls
+        .filter((call) => call.method === "chat.appendStream")
+        .map((call) => call.body.chunks)
+    ).toEqual([[{ type: "markdown_text", text: "a" }]]);
+    // Whatever the interval withheld rides on the terminal call rather than
+    // costing another round trip, so nothing is dropped.
+    expect(calls.at(-1)).toEqual({
+      method: "chat.stopStream",
+      body: {
+        channel: "CDEST",
+        ts: "1711000000.9",
+        chunks: [
+          { type: "markdown_text", text: "b" },
+          { type: "markdown_text", text: "c" }
+        ]
+      }
+    });
+    vi.useRealTimers();
+  });
+
+  it("renders tool progress as task updates and sources beneath the answer", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const parts: ChannelChunk[] = [
+      { type: "reasoning", text: "dropped" },
+      {
+        type: "tool",
+        name: "search",
+        status: "started",
+        title: "Searching",
+        detail: "query"
+      },
+      { type: "tool", name: "search", status: "completed" },
+      { type: "source", url: "https://example.com", title: "Example" },
+      { type: "text", text: "Answer" }
+    ];
+
+    await channel.stream!(CHANNEL_SURFACE, streamOf(parts), {});
+
+    const appended = calls
+      .filter((call) => call.method === "chat.appendStream")
+      .flatMap((call) => call.body.chunks as unknown[]);
+    expect(appended).toEqual([
+      {
+        type: "task_update",
+        id: "search",
+        title: "Searching",
+        status: "in_progress",
+        details: "query"
+      },
+      {
+        type: "task_update",
+        id: "search",
+        title: "search",
+        status: "complete"
+      },
+      { type: "markdown_text", text: "Answer" }
+    ]);
+    expect(calls.at(-1)?.body.blocks).toEqual([
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "<https://example.com|Example>"
+          }
+        ]
+      }
+    ]);
+  });
+
+  it("splits text past Slack's append limit", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(CHANNEL_SURFACE, chunks("x".repeat(12_001)), {});
+
+    const appended = calls.filter(
+      (call) => call.method === "chat.appendStream"
+    );
+    expect(
+      (appended[0]!.body.chunks as { text: string }[]).map(
+        (chunk) => chunk.text.length
+      )
+    ).toEqual([12_000, 1]);
+  });
+
+  it("stops the stream and reports uncertain when the generation fails", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const interrupted = streamOf(
+      [{ type: "text", text: "Half an " } as const],
+      new Error("model failed")
+    );
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, interrupted, {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "slack:channel:CDEST:message:1711000000.9",
+      error: {
+        code: "SLACK_STREAM_INTERRUPTED",
+        message: "The answer ended early, so the Slack message is incomplete"
+      }
+    });
+    expect(calls.at(-1)?.method).toBe("chat.stopStream");
+  });
+
+  it("stops the stream even after an append is rejected", async () => {
+    const { fetch, calls } = recorder({
+      "chat.appendStream": () => Response.json({ ok: false, error: "no_text" })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, chunks("a", "b"), {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "slack:channel:CDEST:message:1711000000.9",
+      error: {
+        code: "SLACK_API_ERROR_NO_TEXT",
+        message: "Slack rejected the message: no_text"
+      }
+    });
+    expect(calls.map((call) => call.method)).toEqual([
+      "chat.startStream",
+      "chat.appendStream",
+      "chat.stopStream"
+    ]);
+  });
+
+  it("reports a rejected stop as uncertain, since the message exists", async () => {
+    const { fetch } = recorder({
+      "chat.stopStream": () =>
+        Response.json({ ok: false, error: "internal_error" }, { status: 500 })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, chunks("a"), {})
+    ).resolves.toMatchObject({
+      status: "uncertain",
+      reference: "slack:channel:CDEST:message:1711000000.9",
+      error: { code: "SLACK_API_ERROR_INTERNAL_ERROR" }
+    });
+  });
+
+  it("never reads the stream when Slack refuses to start one", async () => {
+    const { fetch, calls } = recorder({
+      "chat.startStream": () =>
+        Response.json({ ok: false, error: "not_in_channel" })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const source = chunks("a");
+
+    await expect(channel.stream!(CHANNEL_SURFACE, source, {})).resolves.toEqual(
+      {
+        status: "failed",
+        retryable: false,
+        error: {
+          code: "SLACK_API_ERROR_NOT_IN_CHANNEL",
+          message: "Slack rejected the message: not_in_channel"
+        }
+      }
+    );
+    expect(calls).toHaveLength(1);
+    expect(source.locked).toBe(false);
+  });
+
+  it("rejects a malformed surface without calling Slack", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch });
+
+    await expect(
+      channel.stream!(
+        { channelKey: "slack", version: 1, address: null, label: "bad" },
+        chunks("a"),
+        {}
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "SLACK_SURFACE_INVALID" }
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("opens a direct message and streams to the resolved conversation", async () => {
+    const { fetch, calls } = recorder({
+      "conversations.open": () =>
+        Response.json({ ok: true, channel: { id: "DADA" } })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(
+      {
+        channelKey: "slack",
+        version: 1,
+        address: { teamId: "TWORK", userId: "UADA" },
+        label: "Slack · user UADA"
+      },
+      chunks("Hi"),
+      {}
+    );
+
+    expect(calls[1]).toEqual({
+      method: "chat.startStream",
+      body: {
+        channel: "DADA",
+        recipient_user_id: "UADA",
+        recipient_team_id: "TWORK"
+      }
+    });
+  });
+
+  it("falls back to delivery when a top-level surface has an incomplete recipient pair", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(
+      {
+        channelKey: "slack",
+        version: 1,
+        address: { channelId: "CDEST", recipientUserId: "UHUMAN" },
+        label: "Slack · CDEST"
+      },
+      chunks("Hi"),
+      {}
+    );
+
+    expect(calls[0]).toEqual({
+      method: "chat.postMessage",
+      body: { channel: "CDEST", text: "Hi", mrkdwn: true }
+    });
+  });
+
+  it("rejects a nonsensical stream interval when the Channel is created", () => {
+    expect(() => slack({ botToken: BOT_TOKEN, streamIntervalMs: -1 })).toThrow(
+      "streamIntervalMs must be a non-negative integer"
+    );
+  });
+});

--- a/packages/channels/src/__tests__/slack-stream.test.ts
+++ b/packages/channels/src/__tests__/slack-stream.test.ts
@@ -175,12 +175,13 @@ describe("Slack streaming", () => {
       { type: "reasoning", text: "dropped" },
       {
         type: "tool",
+        id: "call-1",
         name: "search",
         status: "started",
         title: "Searching",
         detail: "query"
       },
-      { type: "tool", name: "search", status: "completed" },
+      { type: "tool", id: "call-1", name: "search", status: "completed" },
       { type: "source", url: "https://example.com", title: "Example" },
       { type: "text", text: "Answer" }
     ];
@@ -193,14 +194,14 @@ describe("Slack streaming", () => {
     expect(appended).toEqual([
       {
         type: "task_update",
-        id: "search",
+        id: "call-1",
         title: "Searching",
         status: "in_progress",
         details: "query"
       },
       {
         type: "task_update",
-        id: "search",
+        id: "call-1",
         title: "search",
         status: "complete"
       },
@@ -219,6 +220,25 @@ describe("Slack streaming", () => {
     ]);
   });
 
+  it("keeps repeated tool calls distinct by invocation id", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const parts: ChannelChunk[] = [
+      { type: "tool", id: "call-1", name: "search", status: "started" },
+      { type: "tool", id: "call-2", name: "search", status: "started" },
+      { type: "tool", id: "call-2", name: "search", status: "completed" },
+      { type: "tool", id: "call-1", name: "search", status: "completed" }
+    ];
+
+    await channel.stream!(CHANNEL_SURFACE, streamOf(parts), {});
+
+    const taskIds = calls
+      .filter((call) => call.method === "chat.appendStream")
+      .flatMap((call) => call.body.chunks as { id: string }[])
+      .map((chunk) => chunk.id);
+    expect(taskIds).toEqual(["call-1", "call-2", "call-2", "call-1"]);
+  });
+
   it("splits text past Slack's append limit", async () => {
     const { fetch, calls } = recorder();
     const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
@@ -233,6 +253,50 @@ describe("Slack streaming", () => {
         (chunk) => chunk.text.length
       )
     ).toEqual([12_000, 1]);
+  });
+
+  it("splits a long title into valid opening chunks without breaking emoji", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const title = `${"x".repeat(11_999)}😀tail`;
+
+    await channel.stream!(CHANNEL_SURFACE, chunks("Body"), { title });
+
+    const opening = calls[0]?.body.chunks as { text: string }[];
+    expect(opening.every((chunk) => [...chunk.text].length <= 12_000)).toBe(
+      true
+    );
+    expect(opening.map((chunk) => chunk.text).join("")).toBe(`${title}\n\n`);
+  });
+
+  it("escapes source link delimiters", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(
+      CHANNEL_SURFACE,
+      streamOf<ChannelChunk>([
+        {
+          type: "source",
+          url: "https://example.com/a|b?x=1&y=<two>",
+          title: "A | B <unsafe> & more"
+        },
+        { type: "text", text: "Answer" }
+      ]),
+      {}
+    );
+
+    expect(calls.at(-1)?.body.blocks).toEqual([
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "<https://example.com/a%7Cb?x=1&amp;y=&lt;two&gt;|A &#124; B &lt;unsafe&gt; &amp; more>"
+          }
+        ]
+      }
+    ]);
   });
 
   it("stops the stream and reports uncertain when the generation fails", async () => {
@@ -357,6 +421,36 @@ describe("Slack streaming", () => {
       body: {
         channel: "DADA",
         recipient_user_id: "UADA",
+        recipient_team_id: "TWORK"
+      }
+    });
+  });
+
+  it("streams an inbound-style unthreaded direct-message surface", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(
+      {
+        channelKey: "slack",
+        version: 1,
+        address: {
+          teamId: "TWORK",
+          channelId: "D123",
+          recipientUserId: "UHUMAN",
+          recipientTeamId: "TWORK"
+        },
+        label: "Slack · D123"
+      },
+      chunks("Hi"),
+      {}
+    );
+
+    expect(calls[0]).toEqual({
+      method: "chat.startStream",
+      body: {
+        channel: "D123",
+        recipient_user_id: "UHUMAN",
         recipient_team_id: "TWORK"
       }
     });

--- a/packages/channels/src/__tests__/slack.test.ts
+++ b/packages/channels/src/__tests__/slack.test.ts
@@ -152,7 +152,9 @@ describe("Slack signed ingress", () => {
         address: {
           teamId: "TWORK",
           channelId: "CGENERAL",
-          threadTs: "1710000000.000100"
+          threadTs: "1710000000.000100",
+          recipientUserId: "UHUMAN",
+          recipientTeamId: "TWORK"
         },
         label: "Slack · CGENERAL · thread 1710000000.000100"
       },
@@ -711,7 +713,7 @@ describe("Slack interactions and delivery outcomes", () => {
     const result = await channel.deliver(
       threadSurface,
       { title: "Build blocked", markdown: "Please **help**" },
-      { deliveryId: "caller-delivery-1" }
+      { delivery: { deliveryId: "caller-delivery-1" } }
     );
 
     expect(result).toEqual({

--- a/packages/channels/src/__tests__/slack.test.ts
+++ b/packages/channels/src/__tests__/slack.test.ts
@@ -220,6 +220,14 @@ describe("Slack signed ingress", () => {
       id: "slack:TWORK:channel:D123",
       isDirectMessage: true
     });
+    expect(unthreaded.events[0]?.event.replySurface).toMatchObject({
+      address: {
+        teamId: "TWORK",
+        channelId: "D123",
+        recipientUserId: "UHUMAN",
+        recipientTeamId: "TWORK"
+      }
+    });
     expect(threaded.events[0]?.event.thread).toEqual({
       id: "slack:TWORK:channel:D123:thread:1710000100.000100",
       isDirectMessage: true

--- a/packages/channels/src/__tests__/stream.test.ts
+++ b/packages/channels/src/__tests__/stream.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ChannelHost,
+  consumeChunks,
+  type Channel,
+  type ChannelChunk,
+  type DeliveryResult
+} from "..";
+import { collectText, createPacer } from "../stream";
+
+const surface = {
+  channelKey: "test",
+  version: 1,
+  address: null,
+  label: "Test destination"
+} as const;
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function text(...parts: string[]): ChannelChunk[] {
+  return parts.map((part) => ({ type: "text", text: part }));
+}
+
+async function drain<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of stream) values.push(value);
+  return values;
+}
+
+function host(channels: Record<string, Channel>) {
+  return new ChannelHost({ channels, onMessage() {} });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("collectText", () => {
+  it("joins every text chunk and ignores the other variants", async () => {
+    const chunks: ChannelChunk[] = [
+      { type: "reasoning", text: "thinking" },
+      { type: "text", text: "Hello " },
+      { type: "tool", name: "search", status: "started" },
+      { type: "text", text: "world" },
+      { type: "source", url: "https://example.com" }
+    ];
+
+    await expect(collectText(streamOf(chunks))).resolves.toEqual({
+      text: "Hello world",
+      interrupted: false
+    });
+  });
+
+  it("separates text segments divided by a semantic chunk", async () => {
+    const chunks: ChannelChunk[] = [
+      { type: "text", text: "Hello" },
+      { type: "tool", name: "search", status: "completed" },
+      { type: "text", text: "world" }
+    ];
+
+    await expect(collectText(streamOf(chunks))).resolves.toEqual({
+      text: "Hello world",
+      interrupted: false
+    });
+  });
+
+  it("does not separate adjacent text deltas", async () => {
+    await expect(
+      collectText(streamOf(text("Half an", "swer")))
+    ).resolves.toEqual({
+      text: "Half answer",
+      interrupted: false
+    });
+  });
+
+  it("reports interruption instead of losing the partial answer", async () => {
+    const chunks = streamOf(text("Half an "), new Error("model failed"));
+
+    await expect(collectText(chunks)).resolves.toEqual({
+      text: "Half an ",
+      interrupted: true
+    });
+  });
+});
+
+describe("consumeChunks", () => {
+  it("finalizes once when the stream closes normally", async () => {
+    const onFinish = vi.fn(() => "done");
+
+    await expect(
+      consumeChunks(streamOf(text("a", "b")), { onChunk() {}, onFinish })
+    ).resolves.toBe("done");
+    expect(onFinish).toHaveBeenCalledExactlyOnceWith({ interrupted: false });
+  });
+
+  it("finalizes with the cause when the generation fails", async () => {
+    const error = new Error("model failed");
+    const seen: ChannelChunk[] = [];
+
+    const outcome = await consumeChunks(streamOf(text("a"), error), {
+      onChunk: (chunk) => void seen.push(chunk),
+      onFinish: (result) => result
+    });
+
+    expect(seen).toEqual(text("a"));
+    expect(outcome).toEqual({ interrupted: true, error });
+  });
+
+  it("finalizes and stops the producer when the handler throws", async () => {
+    const cancel = vi.fn();
+    const chunks = new ReadableStream<ChannelChunk>({
+      pull: (controller) => controller.enqueue({ type: "text", text: "a" }),
+      cancel
+    });
+    const error = new Error("provider rejected the append");
+
+    const outcome = await consumeChunks(chunks, {
+      onChunk() {
+        throw error;
+      },
+      onFinish: (result) => result
+    });
+
+    expect(outcome).toEqual({ interrupted: true, error });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createPacer", () => {
+  it("allows the first flush immediately", () => {
+    expect(createPacer(1000)()).toBe(true);
+  });
+
+  it("withholds a flush until the interval has passed", () => {
+    vi.useFakeTimers();
+    const shouldFlush = createPacer(1000);
+
+    expect([shouldFlush(), shouldFlush(), shouldFlush()]).toEqual([
+      true,
+      false,
+      false
+    ]);
+
+    vi.setSystemTime(Date.now() + 1000);
+    expect(shouldFlush()).toBe(true);
+  });
+
+  it("never withholds when the interval is zero", () => {
+    vi.useFakeTimers();
+    const shouldFlush = createPacer(0);
+
+    expect([shouldFlush(), shouldFlush()]).toEqual([true, true]);
+  });
+});
+
+describe("ChannelHost.stream", () => {
+  it("hands a streaming Channel the normalized stream", async () => {
+    const seen: ChannelChunk[] = [];
+    const stream = vi.fn(
+      async (
+        _surface,
+        chunks: ReadableStream<ChannelChunk>
+      ): Promise<DeliveryResult> => {
+        seen.push(...(await drain(chunks)));
+        return { status: "delivered", reference: "message-1" };
+      }
+    );
+
+    await expect(
+      host({ test: { stream } }).stream(
+        surface,
+        streamOf(text("Hello ", "world")),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "message-1" });
+    expect(seen).toEqual(text("Hello ", "world"));
+    expect(stream.mock.calls[0]?.[2]).toEqual({ title: "Update" });
+  });
+
+  it("accepts a plain string stream so textStream needs no adaptation", async () => {
+    const received: ChannelChunk[] = [];
+    const channelHost = host({
+      test: {
+        async stream(_surface, chunks) {
+          received.push(...(await drain(chunks)));
+          return { status: "delivered" };
+        }
+      }
+    });
+
+    await channelHost.stream(surface, streamOf(text("Hello ", "world")));
+
+    expect(received).toEqual(text("Hello ", "world"));
+  });
+
+  it("accepts an async iterable", async () => {
+    async function* generate() {
+      yield* text("Hello ", "world");
+    }
+    const received: ChannelChunk[] = [];
+    const channelHost = host({
+      test: {
+        async stream(_surface, chunks) {
+          received.push(...(await drain(chunks)));
+          return { status: "delivered" };
+        }
+      }
+    });
+
+    await channelHost.stream(surface, generate());
+
+    expect(received).toEqual(text("Hello ", "world"));
+  });
+
+  it("collects the answer for a Channel that cannot stream", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+
+    await expect(
+      host({ test: { deliver } }).stream(surface, streamOf(text("a", "b")), {
+        title: "Update",
+        delivery: { deliveryId: "notice-1" }
+      })
+    ).resolves.toEqual({ status: "delivered" });
+    expect(deliver).toHaveBeenCalledWith(
+      surface,
+      { title: "Update", markdown: "ab" },
+      { delivery: { deliveryId: "notice-1" } }
+    );
+  });
+
+  it("delivers a partial answer as uncertain when the generation fails", async () => {
+    const deliver = vi.fn(async () => ({
+      status: "delivered" as const,
+      reference: "message-1"
+    }));
+
+    await expect(
+      host({ test: { deliver } }).stream(
+        surface,
+        streamOf(text("Half an "), new Error("model failed"))
+      )
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "message-1",
+      error: {
+        code: "CHANNEL_STREAM_INTERRUPTED",
+        message:
+          "An incomplete answer was delivered because the stream ended early"
+      }
+    });
+    expect(deliver).toHaveBeenCalledWith(
+      surface,
+      { markdown: "Half an " },
+      undefined
+    );
+  });
+
+  it("does not call a Channel when a failed generation produced nothing", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+
+    await expect(
+      host({ test: { deliver } }).stream(
+        surface,
+        streamOf<ChannelChunk>([], new Error("model failed"))
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "CHANNEL_STREAM_INTERRUPTED" }
+    });
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("releases the stream when the Channel cannot deliver at all", async () => {
+    const chunks = streamOf(text("a"));
+
+    await expect(
+      host({ test: {} }).stream(surface, chunks)
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "CHANNEL_DELIVERY_UNSUPPORTED" }
+    });
+    expect(chunks.locked).toBe(false);
+    await expect(drain(chunks)).resolves.toEqual([]);
+  });
+});

--- a/packages/channels/src/__tests__/stream.test.ts
+++ b/packages/channels/src/__tests__/stream.test.ts
@@ -137,6 +137,32 @@ describe("consumeChunks", () => {
     expect(outcome).toEqual({ interrupted: true, error });
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it("finalizes without waiting for a sibling tee branch to close", async () => {
+    const source = new ReadableStream<ChannelChunk>({
+      start(controller) {
+        controller.enqueue({ type: "text", text: "a" });
+      }
+    });
+    const [failedBranch, openSibling] = source.tee();
+    const consumption = consumeChunks(failedBranch, {
+      onChunk() {
+        throw new Error("provider rejected the append");
+      },
+      onFinish: () => "finished"
+    });
+
+    const settledFirst = await Promise.race([
+      consumption,
+      new Promise<"blocked">((resolve) =>
+        setTimeout(() => resolve("blocked"), 0)
+      )
+    ]);
+    await openSibling.cancel();
+    await consumption;
+
+    expect(settledFirst).toBe("finished");
+  });
 });
 
 describe("createPacer", () => {

--- a/packages/channels/src/__tests__/stream.test.ts
+++ b/packages/channels/src/__tests__/stream.test.ts
@@ -138,30 +138,43 @@ describe("consumeChunks", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
-  it("finalizes without waiting for a sibling tee branch to close", async () => {
+  it("finalizes before awaiting sibling-dependent producer cleanup", async () => {
     const source = new ReadableStream<ChannelChunk>({
       start(controller) {
         controller.enqueue({ type: "text", text: "a" });
       }
     });
     const [failedBranch, openSibling] = source.tee();
+    let markFinalized: (() => void) | undefined;
+    const finalized = new Promise<void>((resolve) => {
+      markFinalized = resolve;
+    });
     const consumption = consumeChunks(failedBranch, {
       onChunk() {
         throw new Error("provider rejected the append");
       },
-      onFinish: () => "finished"
+      onFinish() {
+        markFinalized?.();
+        return "finished";
+      }
     });
 
-    const settledFirst = await Promise.race([
+    const finalizedFirst = await Promise.race([
+      finalized.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 0))
+    ]);
+    const settledBeforeSibling = await Promise.race([
       consumption,
       new Promise<"blocked">((resolve) =>
         setTimeout(() => resolve("blocked"), 0)
       )
     ]);
-    await openSibling.cancel();
-    await consumption;
 
-    expect(settledFirst).toBe("finished");
+    expect(finalizedFirst).toBe(true);
+    expect(settledBeforeSibling).toBe("blocked");
+
+    await openSibling.cancel();
+    await expect(consumption).resolves.toBe("finished");
   });
 });
 

--- a/packages/channels/src/__tests__/telegram-stream.test.ts
+++ b/packages/channels/src/__tests__/telegram-stream.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChannelChunk } from "..";
+import { telegram } from "../adapters/telegram";
+
+const BOT_TOKEN = "4242:bot-secret";
+const PRIVATE_SURFACE = {
+  channelKey: "telegram",
+  version: 1,
+  address: { chatId: "99" },
+  label: "Telegram · 99"
+} as const;
+
+type Call = { method: string; body: Record<string, unknown> };
+
+function recorder(overrides: Record<string, () => Response> = {}): {
+  fetch: typeof globalThis.fetch;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  let messageId = 500;
+  const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+    const method = String(input).split("/").pop()!;
+    calls.push({ method, body: JSON.parse(String(init?.body)) });
+    if (overrides[method]) return overrides[method]!();
+    if (method !== "sendMessage")
+      return Response.json({ ok: true, result: true });
+    messageId += 1;
+    return Response.json({ ok: true, result: { message_id: messageId } });
+  });
+  return { fetch, calls };
+}
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function chunks(...parts: string[]): ReadableStream<ChannelChunk> {
+  return streamOf(parts.map((text) => ({ type: "text", text }) as const));
+}
+
+function of(calls: Call[], method: string): Call[] {
+  return calls.filter((call) => call.method === method);
+}
+
+describe("Telegram streaming", () => {
+  it("previews cumulative drafts, then persists the whole answer", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("Hello ", "world"), {})
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+
+    const drafts = of(calls, "sendMessageDraft");
+    expect(drafts.map((call) => call.body.text)).toEqual([
+      "Hello ",
+      "Hello world"
+    ]);
+    // One draft id, so Telegram animates between the snapshots.
+    expect(new Set(drafts.map((call) => call.body.draft_id)).size).toBe(1);
+    expect(drafts[0]?.body.chat_id).toBe(99);
+    expect(calls.at(-1)).toEqual({
+      method: "sendMessage",
+      body: { chat_id: "99", text: "Hello world" }
+    });
+  });
+
+  it("previews at most once per interval, then persists everything", async () => {
+    vi.useFakeTimers();
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 1000
+    });
+
+    await channel.stream!(PRIVATE_SURFACE, chunks("a", "b", "c"), {});
+
+    // No trailing preview: the message that replaces it lands immediately
+    // after, so drafting the tail would only flicker.
+    expect(of(calls, "sendMessageDraft").map((call) => call.body.text)).toEqual(
+      ["a"]
+    );
+    expect(calls.at(-1)?.body.text).toBe("abc");
+    vi.useRealTimers();
+  });
+
+  it("prefixes the title on both the preview and the message", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await channel.stream!(PRIVATE_SURFACE, chunks("Body"), {
+      title: "Deploy status"
+    });
+
+    expect(of(calls, "sendMessageDraft")[0]?.body.text).toBe(
+      "Deploy status\n\nBody"
+    );
+    expect(calls.at(-1)?.body.text).toBe("Deploy status\n\nBody");
+  });
+
+  it("never applies a parse mode to a draft, whose markup is unbalanced", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      parseMode: "MarkdownV2",
+      streamIntervalMs: 0
+    });
+
+    await channel.stream!(PRIVATE_SURFACE, chunks("*bold", "*"), {});
+
+    expect(of(calls, "sendMessageDraft")[0]?.body.parse_mode).toBeUndefined();
+    expect(calls.at(-1)?.body.parse_mode).toBe("MarkdownV2");
+  });
+
+  it("sends the real message even when the generation failed part-way", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+    const interrupted = streamOf(
+      [{ type: "text", text: "Half an " } as const],
+      new Error("model failed")
+    );
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, interrupted, {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "501",
+      error: {
+        code: "TELEGRAM_STREAM_INTERRUPTED",
+        message: "An incomplete answer was sent because the stream ended early"
+      }
+    });
+    expect(calls.at(-1)).toEqual({
+      method: "sendMessage",
+      body: { chat_id: "99", text: "Half an " }
+    });
+  });
+
+  it("sends the real message even when every draft was rejected", async () => {
+    const { fetch, calls } = recorder({
+      sendMessageDraft: () =>
+        Response.json({ ok: false, error_code: 400, description: "nope" })
+    });
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("a", "b"), {})
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+    // Drafting stops after the first refusal rather than retrying per chunk.
+    expect(of(calls, "sendMessageDraft")).toHaveLength(1);
+    expect(of(calls, "sendMessage")).toHaveLength(1);
+  });
+
+  it("skips drafts in a group, where Telegram does not support them", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(
+        {
+          channelKey: "telegram",
+          version: 1,
+          address: { chatId: "-100200" },
+          label: "Telegram · group"
+        },
+        chunks("Hello"),
+        {}
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+    expect(of(calls, "sendMessageDraft")).toEqual([]);
+    expect(calls.at(-1)?.body).toEqual({ chat_id: "-100200", text: "Hello" });
+  });
+
+  it("splits an answer that outgrows one Telegram message", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      maxLength: 10,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("0123456789abc"), {})
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+    expect(of(calls, "sendMessage").map((call) => call.body.text)).toEqual([
+      "0123456789",
+      "abc"
+    ]);
+    // The preview cannot outgrow the limit either.
+    expect(of(calls, "sendMessageDraft")[0]?.body.text).toBe("0123456789");
+  });
+
+  it("reports a partly accepted split answer as uncertain", async () => {
+    let sends = 0;
+    const { fetch } = recorder({
+      sendMessage: () => {
+        sends += 1;
+        return sends === 1
+          ? Response.json({ ok: true, result: { message_id: 501 } })
+          : Response.json({ ok: false, error_code: 400, description: "no" });
+      }
+    });
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      maxLength: 10,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("0123456789abc"), {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "501",
+      error: {
+        code: "TELEGRAM_STREAM_PARTIAL",
+        message: "Telegram accepted only part of a split answer"
+      }
+    });
+  });
+
+  it("refuses a stream that carried no text", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(
+        PRIVATE_SURFACE,
+        streamOf([{ type: "reasoning", text: "quiet" } as const]),
+        {}
+      )
+    ).resolves.toEqual({
+      status: "failed",
+      retryable: false,
+      error: {
+        code: "TELEGRAM_STREAM_EMPTY",
+        message: "The stream carried no text to send"
+      }
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("distinguishes an empty stream from one that died before its first token", async () => {
+    const { fetch } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(
+        PRIVATE_SURFACE,
+        streamOf<ChannelChunk>([], new Error("model failed")),
+        {}
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "TELEGRAM_STREAM_INTERRUPTED" }
+    });
+  });
+
+  it("rejects a malformed surface without calling Telegram", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({ botToken: BOT_TOKEN, fetch });
+
+    await expect(
+      channel.stream!(
+        { channelKey: "telegram", version: 1, address: null, label: "bad" },
+        chunks("a"),
+        {}
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "TELEGRAM_SURFACE_INVALID" }
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects a nonsensical stream interval when the Channel is created", () => {
+    expect(() =>
+      telegram({ botToken: BOT_TOKEN, streamIntervalMs: 1.5 })
+    ).toThrow("streamIntervalMs must be a non-negative integer");
+  });
+});

--- a/packages/channels/src/__tests__/telegram-stream.test.ts
+++ b/packages/channels/src/__tests__/telegram-stream.test.ts
@@ -224,6 +224,45 @@ describe("Telegram streaming", () => {
     expect(of(calls, "sendMessageDraft")[0]?.body.text).toBe("0123456789");
   });
 
+  it("does not split an emoji across messages", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      maxLength: 1,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("😀a"), {})
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+    expect(of(calls, "sendMessage").map((call) => call.body.text)).toEqual([
+      "😀",
+      "a"
+    ]);
+    expect(of(calls, "sendMessageDraft")[0]?.body.text).toBe("😀");
+  });
+
+  it("sends split formatted answers as literal text rather than invalid markup", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      maxLength: 6,
+      parseMode: "HTML",
+      streamIntervalMs: 0
+    });
+
+    await channel.stream!(PRIVATE_SURFACE, chunks("<b>hello</b>"), {});
+
+    const sends = of(calls, "sendMessage");
+    expect(sends).toHaveLength(2);
+    expect(sends.map((call) => call.body.text).join("")).toBe("<b>hello</b>");
+    expect(sends.every((call) => call.body.parse_mode === undefined)).toBe(
+      true
+    );
+  });
+
   it("reports a partly accepted split answer as uncertain", async () => {
     let sends = 0;
     const { fetch } = recorder({

--- a/packages/channels/src/adapters/slack.ts
+++ b/packages/channels/src/adapters/slack.ts
@@ -1,10 +1,13 @@
 import type {
   Channel,
   ChannelApprovalRequest,
+  ChannelChunk,
   ChannelMessage,
   ChannelRoute,
+  ChannelStreamOptions,
   DeliveryResult
 } from "../channel";
+import { collectText, consumeChunks, createPacer } from "../stream";
 import type { ChannelIdentity } from "../identity";
 import {
   isChannelMessageSurface,
@@ -116,7 +119,14 @@ export type SlackWebhookOptions = {
 
 export type SlackMessageSurface = ChannelMessageSurface<
   string,
-  { channelId: string; threadTs?: string } | { teamId: string; userId: string }
+  | {
+      channelId: string;
+      threadTs?: string;
+      /** The reader a channel stream is rendered for. Slack requires it. */
+      recipientUserId?: string;
+      recipientTeamId?: string;
+    }
+  | { teamId: string; userId: string }
 >;
 
 /** Configuration for a Slack Channel. */
@@ -127,6 +137,11 @@ export type SlackChannelOptions = {
   apiBaseUrl?: string;
   /** Project canonical Channel Markdown into Slack mrkdwn text. */
   toText?: (message: ChannelMessage) => string;
+  /**
+   * Smallest gap between `chat.appendStream` calls. Chunks produced inside
+   * one interval are appended together. @default 500
+   */
+  streamIntervalMs?: number;
   /** Add signed Slack HTTP ingress to the returned Channel. */
   webhook?: SlackWebhookOptions;
   /** Select an application route from the event, exact payload, and Host context. */
@@ -158,6 +173,10 @@ const DEFAULT_SLACK_WEBHOOK_PATH = "/webhooks/slack";
 const DEFAULT_MAX_SKEW_SECONDS = 5 * 60;
 const APPROVE_ACTION_ID = "cloudflare_channels_approve_v1";
 const REJECT_ACTION_ID = "cloudflare_channels_reject_v1";
+const DEFAULT_STREAM_INTERVAL_MS = 500;
+const SLACK_APPEND_LIMIT = 12_000;
+const SLACK_TASK_FIELD_LIMIT = 256;
+const SLACK_CONTEXT_LIMIT = 3000;
 const AMBIGUOUS_SLACK_ERRORS = new Set([
   "fatal_error",
   "internal_error",
@@ -305,6 +324,12 @@ function normalizedEvent(
         channelId,
         ...((threadTimestamp || !isDirectMessage) && {
           threadTs: threadTimestamp ?? timestamp
+        }),
+        // Slack renders a channel stream for one reader, and requires both
+        // ids to do it. A direct message already has a single reader.
+        ...(!isDirectMessage && {
+          recipientUserId: actorId,
+          recipientTeamId: teamId
         })
       },
       label: replySurfaceLabel(
@@ -431,7 +456,11 @@ async function normalizedInteractions(
         address: {
           teamId,
           channelId,
-          threadTs: threadTimestamp ?? timestamp
+          threadTs: threadTimestamp ?? timestamp,
+          ...(!isDirectMessage && {
+            recipientUserId: actorId,
+            recipientTeamId: teamId
+          })
         },
         label: replySurfaceLabel(channelId, threadTimestamp ?? timestamp)
       },
@@ -602,7 +631,7 @@ function failed(
   code: string,
   message: string,
   retryable: boolean
-): DeliveryResult {
+): Extract<DeliveryResult, { status: "failed" }> {
   return {
     status: "failed",
     retryable,
@@ -614,23 +643,10 @@ function slackErrorCode(error: string): string {
   return `SLACK_API_ERROR_${error.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}`;
 }
 
-function classifyApiResponse(
+function classifyApiFailure(
   response: Response,
   payload: SlackApiResponse
-): DeliveryResult {
-  if (payload.ok === true) {
-    if (typeof payload.channel === "string" && typeof payload.ts === "string") {
-      return {
-        status: "delivered",
-        reference: outboundReference(payload.channel, payload.ts)
-      };
-    }
-    return uncertain(
-      "SLACK_DELIVERY_ERROR",
-      "Slack returned an invalid delivery response"
-    );
-  }
-
+): Exclude<DeliveryResult, { status: "delivered" }> {
   if (payload.ok === false) {
     const error =
       typeof payload.error === "string" ? payload.error : "unknown_error";
@@ -681,9 +697,19 @@ function approvalValue(
   } satisfies ApprovalValue);
 }
 
-type SlackTarget =
-  | { teamId?: string; channelId: string; threadTs?: string }
-  | { teamId: string; userId: string };
+/** A resolved conversation, with the reader a stream should be rendered for. */
+type SlackDestination = {
+  channelId: string;
+  threadTs?: string;
+  recipientUserId?: string;
+  recipientTeamId?: string;
+};
+
+type SlackTarget = SlackDestination | { teamId: string; userId: string };
+
+function optionalId(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
 
 function slackTarget(surface: ChannelMessageSurface): SlackTarget | undefined {
   if (
@@ -712,11 +738,94 @@ function slackTarget(surface: ChannelMessageSurface): SlackTarget | undefined {
   ) {
     return undefined;
   }
+  const recipientUserId = optionalId(address.recipientUserId);
+  const recipientTeamId = optionalId(address.recipientTeamId);
   return {
     channelId: address.channelId,
     ...(typeof address.threadTs === "string" && {
       threadTs: address.threadTs
-    })
+    }),
+    // Slack rejects one without the other, so only carry a complete pair.
+    ...(recipientUserId &&
+      recipientTeamId && { recipientUserId, recipientTeamId })
+  };
+}
+
+type SlackStreamChunk =
+  | { type: "markdown_text"; text: string }
+  | {
+      type: "task_update";
+      id: string;
+      title: string;
+      status: "in_progress" | "complete" | "error";
+      details?: string;
+    };
+
+const SLACK_TASK_STATUS = {
+  started: "in_progress",
+  completed: "complete",
+  failed: "error"
+} as const;
+
+function clamp(value: string, limit: number): string {
+  return value.length <= limit ? value : `${value.slice(0, limit - 1)}\u2026`;
+}
+
+function splitText(text: string, limit: number): string[] {
+  if (text.length <= limit) return text.length > 0 ? [text] : [];
+  const pieces: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    pieces.push(text.slice(index, index + limit));
+  }
+  return pieces;
+}
+
+/**
+ * Render a neutral chunk as Slack stream content.
+ *
+ * `reasoning` has no Slack rendering and is dropped. A `source` is collected
+ * rather than appended, so it can be rendered once beneath the finished
+ * message instead of interrupting the text.
+ */
+function toStreamChunks(
+  chunk: ChannelChunk,
+  sources: { url: string; title?: string }[]
+): SlackStreamChunk[] {
+  switch (chunk.type) {
+    case "text":
+      return splitText(chunk.text, SLACK_APPEND_LIMIT).map((text) => ({
+        type: "markdown_text",
+        text
+      }));
+    case "tool":
+      return [
+        {
+          type: "task_update",
+          id: chunk.name,
+          title: clamp(chunk.title ?? chunk.name, SLACK_TASK_FIELD_LIMIT),
+          status: SLACK_TASK_STATUS[chunk.status],
+          ...(chunk.detail !== undefined && {
+            details: clamp(chunk.detail, SLACK_TASK_FIELD_LIMIT)
+          })
+        }
+      ];
+    case "source":
+      sources.push(chunk);
+      return [];
+    case "reasoning":
+      return [];
+  }
+}
+
+function sourcesBlock(
+  sources: readonly { url: string; title?: string }[]
+): Record<string, unknown> {
+  const text = sources
+    .map((source) => `<${source.url}|${source.title ?? source.url}>`)
+    .join(" \u00b7 ");
+  return {
+    type: "context",
+    elements: [{ type: "mrkdwn", text: clamp(text, SLACK_CONTEXT_LIMIT) }]
   };
 }
 
@@ -733,11 +842,16 @@ export function slack(
     ""
   );
   const toText = options.toText ?? defaultText;
+  const streamIntervalMs =
+    options.streamIntervalMs ?? DEFAULT_STREAM_INTERVAL_MS;
+  if (!Number.isInteger(streamIntervalMs) || streamIntervalMs < 0) {
+    throw new Error("streamIntervalMs must be a non-negative integer");
+  }
   const ingress = options.webhook ? slackWebhook(options.webhook) : undefined;
 
   async function resolveTarget(
     target: SlackTarget
-  ): Promise<{ channelId: string; threadTs?: string } | DeliveryResult> {
+  ): Promise<SlackDestination | DeliveryResult> {
     if (!("userId" in target)) return target;
 
     let response: Response;
@@ -772,7 +886,11 @@ export function slack(
       ? (payload as SlackOpenConversationResponse)
       : undefined;
     if (result?.ok === true && typeof result.channel?.id === "string") {
-      return { channelId: result.channel.id };
+      return {
+        channelId: result.channel.id,
+        recipientUserId: target.userId,
+        recipientTeamId: target.teamId
+      };
     }
     const error = typeof result?.error === "string" ? result.error : "unknown";
     return failed(
@@ -801,21 +919,44 @@ export function slack(
     const target = await resolveTarget(unresolvedTarget);
     if ("status" in target) return target;
 
+    const sent = await callSlack("chat.postMessage", {
+      channel: target.channelId,
+      text,
+      mrkdwn: true,
+      ...(target.threadTs && { thread_ts: target.threadTs }),
+      ...(blocks && { blocks })
+    });
+    return "status" in sent
+      ? sent
+      : {
+          status: "delivered",
+          reference: outboundReference(sent.channelId, sent.ts)
+        };
+  }
+
+  /**
+   * One transport path for every Slack method this Channel calls.
+   *
+   * Each of them answers with the conversation and timestamp on success, and
+   * every failure mode is classified the same way, so posting and streaming
+   * cannot drift apart.
+   */
+  async function callSlack(
+    method: string,
+    body: Record<string, unknown>
+  ): Promise<
+    | { channelId: string; ts: string }
+    | Exclude<DeliveryResult, { status: "delivered" }>
+  > {
     let response: Response;
     try {
-      response = await fetch(`${apiBaseUrl}/chat.postMessage`, {
+      response = await fetch(`${apiBaseUrl}/${method}`, {
         method: "POST",
         headers: {
           authorization: `Bearer ${options.botToken}`,
           "content-type": "application/json; charset=utf-8"
         },
-        body: JSON.stringify({
-          channel: target.channelId,
-          text,
-          mrkdwn: true,
-          ...(target.threadTs && { thread_ts: target.threadTs }),
-          ...(blocks && { blocks })
-        })
+        body: JSON.stringify(body)
       });
     } catch {
       return uncertain(
@@ -828,33 +969,152 @@ export function slack(
     try {
       payload = await response.json();
     } catch {
-      if (response.status === 429) {
-        return failed(
-          "SLACK_HTTP_ERROR_429",
-          "Slack rate limited the message",
-          true
-        );
-      }
-      if (response.status >= 400 && response.status < 500) {
-        return failed(
-          `SLACK_HTTP_ERROR_${response.status}`,
-          `Slack rejected the message with HTTP ${response.status}`,
-          false
-        );
-      }
-      return uncertain(
-        "SLACK_DELIVERY_ERROR",
-        "Slack returned an invalid delivery response"
+      payload = undefined;
+    }
+    const apiResponse = asApiResponse(payload);
+    if (
+      apiResponse?.ok === true &&
+      typeof apiResponse.channel === "string" &&
+      typeof apiResponse.ts === "string"
+    ) {
+      return { channelId: apiResponse.channel, ts: apiResponse.ts };
+    }
+    return apiResponse?.ok === true
+      ? uncertain(
+          "SLACK_DELIVERY_ERROR",
+          "Slack returned an invalid delivery response"
+        )
+      : classifyApiFailure(response, apiResponse ?? {});
+  }
+
+  async function streamMessage(
+    destination: ChannelMessageSurface,
+    chunks: ReadableStream<ChannelChunk>,
+    streamOptions: ChannelStreamOptions
+  ): Promise<DeliveryResult> {
+    const unresolvedTarget = slackTarget(destination);
+    if (!unresolvedTarget) {
+      await chunks.cancel().catch(() => {});
+      return failed(
+        "SLACK_SURFACE_INVALID",
+        `Slack cannot parse the address for Channel "${destination.channelKey}"`,
+        false
       );
     }
 
-    const apiResponse = asApiResponse(payload);
-    return apiResponse
-      ? classifyApiResponse(response, apiResponse)
-      : uncertain(
-          "SLACK_DELIVERY_ERROR",
-          "Slack returned an invalid delivery response"
+    // Slack only permits native channel streaming in a thread. Preserve the
+    // simpler top-level application API by collecting and posting one ordinary
+    // message; direct-message targets still use native streaming.
+    if (!("userId" in unresolvedTarget) && !unresolvedTarget.threadTs) {
+      const collected = await collectText(chunks);
+      if (collected.interrupted && collected.text.length === 0) {
+        return failed(
+          "SLACK_STREAM_INTERRUPTED",
+          "The stream ended before producing any content to deliver",
+          false
         );
+      }
+      const delivered = await postMessage(
+        destination,
+        toText({
+          ...(streamOptions.title && { title: streamOptions.title }),
+          markdown: collected.text
+        })
+      );
+      if (!collected.interrupted || delivered.status !== "delivered") {
+        return delivered;
+      }
+      return uncertain(
+        "SLACK_STREAM_INTERRUPTED",
+        "An incomplete answer was delivered because the stream ended early",
+        delivered.reference
+      );
+    }
+
+    const target = await resolveTarget(unresolvedTarget);
+    if ("status" in target) {
+      await chunks.cancel().catch(() => {});
+      return target;
+    }
+
+    const started = await callSlack("chat.startStream", {
+      channel: target.channelId,
+      ...(target.threadTs && { thread_ts: target.threadTs }),
+      ...(target.recipientUserId && {
+        recipient_user_id: target.recipientUserId,
+        recipient_team_id: target.recipientTeamId
+      }),
+      // Every call in a stream must use the mode the stream was opened in,
+      // so the title goes in a chunk rather than `markdown_text`. Opening
+      // with `markdown_text` makes Slack reject each later append with
+      // `streaming_mode_mismatch`, losing the whole answer.
+      ...(streamOptions.title && {
+        chunks: [{ type: "markdown_text", text: `${streamOptions.title}\n\n` }]
+      })
+    });
+    if ("status" in started) {
+      await chunks.cancel().catch(() => {});
+      return started;
+    }
+
+    const reference = outboundReference(started.channelId, started.ts);
+    const sources: { url: string; title?: string }[] = [];
+    const shouldFlush = createPacer(streamIntervalMs);
+    let pending: SlackStreamChunk[] = [];
+    let appendFailure:
+      | Exclude<DeliveryResult, { status: "delivered" }>
+      | undefined;
+
+    return consumeChunks(chunks, {
+      async onChunk(chunk) {
+        pending.push(...toStreamChunks(chunk, sources));
+        if (pending.length === 0 || !shouldFlush()) return;
+        const appended = await callSlack("chat.appendStream", {
+          channel: started.channelId,
+          ts: started.ts,
+          chunks: pending
+        });
+        pending = [];
+        if ("status" in appended) {
+          appendFailure = appended;
+          // Stop reading, but still stop the stream: Slack leaves a message
+          // stuck in its streaming state otherwise.
+          throw new Error(appended.error.message);
+        }
+      },
+      async onFinish(outcome) {
+        // Whatever the pacer withheld rides along on the terminal call, so an
+        // interrupted answer keeps its tail without an extra round trip.
+        const stopped = await callSlack("chat.stopStream", {
+          channel: started.channelId,
+          ts: started.ts,
+          ...(pending.length > 0 && !appendFailure && { chunks: pending }),
+          ...(sources.length > 0 && { blocks: [sourcesBlock(sources)] })
+        });
+        if ("status" in stopped) {
+          return uncertain(
+            stopped.error.code,
+            `Slack could not stop the stream: ${stopped.error.message}`,
+            reference
+          );
+        }
+        if (appendFailure) {
+          return uncertain(
+            appendFailure.error.code,
+            appendFailure.error.message,
+            reference
+          );
+        }
+        if (outcome.interrupted) {
+          return uncertain(
+            "SLACK_STREAM_INTERRUPTED",
+            "The answer ended early, so the Slack message is incomplete",
+            reference
+          );
+        }
+        return { status: "delivered", reference };
+      }
+    });
   }
 
   return {
@@ -870,6 +1130,9 @@ export function slack(
     },
     deliver(destination, message) {
       return postMessage(destination, toText(message));
+    },
+    stream(destination, chunks, streamOptions) {
+      return streamMessage(destination, chunks, streamOptions);
     },
     requestApproval(destination, { interactionId, request }) {
       if (interactionId.length === 0) {

--- a/packages/channels/src/adapters/slack.ts
+++ b/packages/channels/src/adapters/slack.ts
@@ -325,12 +325,10 @@ function normalizedEvent(
         ...((threadTimestamp || !isDirectMessage) && {
           threadTs: threadTimestamp ?? timestamp
         }),
-        // Slack renders a channel stream for one reader, and requires both
-        // ids to do it. A direct message already has a single reader.
-        ...(!isDirectMessage && {
-          recipientUserId: actorId,
-          recipientTeamId: teamId
-        })
+        // Preserve the reader even for a known DM conversation so outbound
+        // routing can distinguish it from a top-level public channel.
+        recipientUserId: actorId,
+        recipientTeamId: teamId
       },
       label: replySurfaceLabel(
         channelId,
@@ -767,17 +765,43 @@ const SLACK_TASK_STATUS = {
   failed: "error"
 } as const;
 
-function clamp(value: string, limit: number): string {
-  return value.length <= limit ? value : `${value.slice(0, limit - 1)}\u2026`;
+function splitText(text: string, limit: number): string[] {
+  const pieces: string[] = [];
+  let piece = "";
+  let length = 0;
+  for (const character of text) {
+    if (length === limit) {
+      pieces.push(piece);
+      piece = "";
+      length = 0;
+    }
+    piece += character;
+    length += 1;
+  }
+  if (piece.length > 0) pieces.push(piece);
+  return pieces;
 }
 
-function splitText(text: string, limit: number): string[] {
-  if (text.length <= limit) return text.length > 0 ? [text] : [];
-  const pieces: string[] = [];
-  for (let index = 0; index < text.length; index += limit) {
-    pieces.push(text.slice(index, index + limit));
-  }
-  return pieces;
+function clamp(value: string, limit: number): string {
+  const characters = [...value];
+  return characters.length <= limit
+    ? value
+    : `${characters.slice(0, limit - 1).join("")}\u2026`;
+}
+
+function escapeMrkdwn(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeLinkUrl(value: string): string {
+  return escapeMrkdwn(value.replaceAll("|", "%7C"));
+}
+
+function escapeLinkLabel(value: string): string {
+  return escapeMrkdwn(value).replaceAll("|", "&#124;");
 }
 
 /**
@@ -801,7 +825,7 @@ function toStreamChunks(
       return [
         {
           type: "task_update",
-          id: chunk.name,
+          id: clamp(chunk.id ?? chunk.name, SLACK_TASK_FIELD_LIMIT),
           title: clamp(chunk.title ?? chunk.name, SLACK_TASK_FIELD_LIMIT),
           status: SLACK_TASK_STATUS[chunk.status],
           ...(chunk.detail !== undefined && {
@@ -821,7 +845,10 @@ function sourcesBlock(
   sources: readonly { url: string; title?: string }[]
 ): Record<string, unknown> {
   const text = sources
-    .map((source) => `<${source.url}|${source.title ?? source.url}>`)
+    .map(
+      (source) =>
+        `<${escapeLinkUrl(source.url)}|${escapeLinkLabel(source.title ?? source.url)}>`
+    )
     .join(" \u00b7 ");
   return {
     type: "context",
@@ -1005,7 +1032,11 @@ export function slack(
     // Slack only permits native channel streaming in a thread. Preserve the
     // simpler top-level application API by collecting and posting one ordinary
     // message; direct-message targets still use native streaming.
-    if (!("userId" in unresolvedTarget) && !unresolvedTarget.threadTs) {
+    if (
+      !("userId" in unresolvedTarget) &&
+      !unresolvedTarget.threadTs &&
+      !unresolvedTarget.recipientUserId
+    ) {
       const collected = await collectText(chunks);
       if (collected.interrupted && collected.text.length === 0) {
         return failed(
@@ -1049,7 +1080,9 @@ export function slack(
       // with `markdown_text` makes Slack reject each later append with
       // `streaming_mode_mismatch`, losing the whole answer.
       ...(streamOptions.title && {
-        chunks: [{ type: "markdown_text", text: `${streamOptions.title}\n\n` }]
+        chunks: splitText(`${streamOptions.title}\n\n`, SLACK_APPEND_LIMIT).map(
+          (text) => ({ type: "markdown_text", text })
+        )
       })
     });
     if ("status" in started) {

--- a/packages/channels/src/adapters/telegram.ts
+++ b/packages/channels/src/adapters/telegram.ts
@@ -1,10 +1,13 @@
 import type {
   Channel,
   ChannelApprovalRequest,
+  ChannelChunk,
   ChannelMessage,
   ChannelRoute,
+  ChannelStreamOptions,
   DeliveryResult
 } from "../channel";
+import { consumeChunks, createPacer } from "../stream";
 import type { ChannelIdentity } from "../identity";
 import {
   isChannelMessageSurface,
@@ -89,6 +92,11 @@ export type TelegramChannelOptions = {
   toText?: (message: ChannelMessage) => string;
   /** Parse mode for caller-formatted delivery text. */
   parseMode?: "HTML" | "MarkdownV2";
+  /**
+   * Smallest gap between `sendMessageDraft` previews. Snapshots produced
+   * inside one interval are replaced rather than sent. @default 500
+   */
+  streamIntervalMs?: number;
   /** Select an application route from the event, raw update, and Host context. */
   route?: ChannelRoute<TelegramUpdate>;
   /** Add secret-verified Telegram webhook ingress to the returned Channel. */
@@ -109,6 +117,7 @@ type TelegramApiResponse = {
 };
 
 const TELEGRAM_MESSAGE_LIMIT = 4096;
+const DEFAULT_STREAM_INTERVAL_MS = 500;
 const DEFAULT_TELEGRAM_WEBHOOK_PATH = "/webhooks/telegram";
 const APPROVAL_INSTRUCTIONS = "Reply YES to approve or NO to reject.";
 const INTERACTION_FOOTER =
@@ -498,6 +507,31 @@ function telegramSurface(
   return surface as TelegramMessageSurface;
 }
 
+/**
+ * Whether a chat can show an animated draft.
+ *
+ * `sendMessageDraft` is private chats only, and Telegram gives private chats
+ * positive ids. Anywhere else the answer is simply sent once at the end.
+ */
+function supportsDraft(chatId: string): boolean {
+  const numeric = Number(chatId);
+  return Number.isSafeInteger(numeric) && numeric > 0;
+}
+
+/** A non-zero draft identifier; reusing one animates between snapshots. */
+function newDraftId(): number {
+  const [random] = crypto.getRandomValues(new Uint32Array(1));
+  return ((random ?? 1) % 2_147_483_647) + 1;
+}
+
+function splitText(text: string, limit: number): string[] {
+  const pieces: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    pieces.push(text.slice(index, index + limit));
+  }
+  return pieces;
+}
+
 /** Create a configured Telegram Bot API Channel. */
 export function telegram(
   options: TelegramChannelOptions
@@ -521,6 +555,11 @@ export function telegram(
     );
   }
   const toText = options.toText ?? defaultText;
+  const streamIntervalMs =
+    options.streamIntervalMs ?? DEFAULT_STREAM_INTERVAL_MS;
+  if (!Number.isInteger(streamIntervalMs) || streamIntervalMs < 0) {
+    throw new Error("streamIntervalMs must be a non-negative integer");
+  }
   const botUserId = telegramBotUserId(options.botToken);
   const ingress = options.webhook
     ? telegramWebhook({ ...options.webhook, botUserId })
@@ -606,6 +645,138 @@ export function telegram(
         );
   }
 
+  /**
+   * Show one ephemeral preview. Failures are swallowed on purpose: a draft is
+   * a 30-second animation, and losing one must never cost the real message.
+   *
+   * The configured parse mode is deliberately not applied. A partial answer
+   * routinely holds unbalanced markup, which Telegram rejects outright.
+   */
+  async function sendDraft(
+    destination: TelegramMessageSurface,
+    draftId: number,
+    text: string
+  ): Promise<boolean> {
+    try {
+      const response = await fetch(
+        `${apiBaseUrl}/bot${options.botToken}/sendMessageDraft`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            chat_id: Number(destination.address.chatId),
+            draft_id: draftId,
+            text,
+            ...(destination.address.messageThreadId !== undefined && {
+              message_thread_id: destination.address.messageThreadId
+            })
+          })
+        }
+      );
+      return asApiResponse(await response.json())?.ok === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Persist the answer, splitting it when it outgrows one Telegram message. */
+  async function sendComplete(
+    destination: ChannelMessageSurface,
+    text: string
+  ): Promise<DeliveryResult> {
+    const [head, ...tail] = splitText(text, maxLength);
+    const first = await send(destination, head!, options.parseMode);
+    if (first.status !== "delivered") return first;
+
+    for (const piece of tail) {
+      const result = await send(destination, piece, options.parseMode);
+      // A later piece failing still leaves earlier ones in the chat.
+      if (result.status !== "delivered") {
+        return uncertain(
+          "TELEGRAM_STREAM_PARTIAL",
+          "Telegram accepted only part of a split answer",
+          first.reference
+        );
+      }
+    }
+    return first;
+  }
+
+  async function streamMessage(
+    destinationValue: ChannelMessageSurface,
+    chunks: ReadableStream<ChannelChunk>,
+    streamOptions: ChannelStreamOptions
+  ): Promise<DeliveryResult> {
+    const destination = telegramSurface(destinationValue);
+    if (
+      !destination ||
+      (botUserId !== undefined &&
+        destination.address.botUserId !== undefined &&
+        destination.address.botUserId !== botUserId)
+    ) {
+      await chunks.cancel().catch(() => {});
+      return {
+        status: "failed",
+        retryable: false,
+        error: {
+          code: "TELEGRAM_SURFACE_INVALID",
+          message: `Telegram cannot parse the address for Channel "${destinationValue.channelKey}"`
+        }
+      };
+    }
+
+    const draftId = supportsDraft(destination.address.chatId)
+      ? newDraftId()
+      : undefined;
+    const prefix = streamOptions.title ? `${streamOptions.title}\n\n` : "";
+    const shouldPreview = createPacer(streamIntervalMs);
+    let answer = "";
+    let draftsStopped = draftId === undefined;
+
+    return consumeChunks(chunks, {
+      async onChunk(chunk) {
+        if (chunk.type !== "text" || chunk.text.length === 0) return;
+        answer += chunk.text;
+        if (draftsStopped || !shouldPreview()) return;
+        const shown = await sendDraft(
+          destination,
+          draftId!,
+          `${prefix}${answer}`.slice(0, maxLength)
+        );
+        if (!shown) draftsStopped = true;
+      },
+      async onFinish(outcome) {
+        // The draft is not the message. Without this send the reader's screen
+        // goes blank in thirty seconds and nothing is kept.
+        if (answer.length === 0) {
+          return {
+            status: "failed",
+            retryable: false,
+            error: outcome.interrupted
+              ? {
+                  code: "TELEGRAM_STREAM_INTERRUPTED",
+                  message: "The answer ended before producing any text to send"
+                }
+              : {
+                  code: "TELEGRAM_STREAM_EMPTY",
+                  message: "The stream carried no text to send"
+                }
+          };
+        }
+
+        const result = await sendComplete(destination, `${prefix}${answer}`);
+        if (!outcome.interrupted || result.status !== "delivered") {
+          return result;
+        }
+        return uncertain(
+          "TELEGRAM_STREAM_INTERRUPTED",
+          "An incomplete answer was sent because the stream ended early",
+          result.reference
+        );
+      }
+    });
+  }
+
   return {
     ...(options.route && { route: options.route }),
     ...(ingress && { ingress }),
@@ -624,6 +795,9 @@ export function telegram(
     },
     deliver(destination, message) {
       return send(destination, toText(message), options.parseMode);
+    },
+    stream(destination, chunks, streamOptions) {
+      return streamMessage(destination, chunks, streamOptions);
     },
     requestApproval(destination, { interactionId, request }) {
       if (interactionId.length === 0) {

--- a/packages/channels/src/adapters/telegram.ts
+++ b/packages/channels/src/adapters/telegram.ts
@@ -526,10 +526,23 @@ function newDraftId(): number {
 
 function splitText(text: string, limit: number): string[] {
   const pieces: string[] = [];
-  for (let index = 0; index < text.length; index += limit) {
-    pieces.push(text.slice(index, index + limit));
+  let piece = "";
+  let length = 0;
+  for (const character of text) {
+    if (length === limit) {
+      pieces.push(piece);
+      piece = "";
+      length = 0;
+    }
+    piece += character;
+    length += 1;
   }
+  if (piece.length > 0) pieces.push(piece);
   return pieces;
+}
+
+function textLength(text: string): number {
+  return [...text].length;
 }
 
 /** Create a configured Telegram Bot API Channel. */
@@ -586,7 +599,7 @@ export function telegram(
         }
       };
     }
-    if (text.length > maxLength) {
+    if (textLength(text) > maxLength) {
       return {
         status: "failed",
         retryable: false,
@@ -685,11 +698,14 @@ export function telegram(
     text: string
   ): Promise<DeliveryResult> {
     const [head, ...tail] = splitText(text, maxLength);
-    const first = await send(destination, head!, options.parseMode);
+    // Raw HTML and Markdown cannot be partitioned safely without parsing it.
+    // Preserve all content literally rather than send malformed fragments.
+    const parseMode = tail.length === 0 ? options.parseMode : undefined;
+    const first = await send(destination, head!, parseMode);
     if (first.status !== "delivered") return first;
 
     for (const piece of tail) {
-      const result = await send(destination, piece, options.parseMode);
+      const result = await send(destination, piece, parseMode);
       // A later piece failing still leaves earlier ones in the chat.
       if (result.status !== "delivered") {
         return uncertain(
@@ -738,11 +754,8 @@ export function telegram(
         if (chunk.type !== "text" || chunk.text.length === 0) return;
         answer += chunk.text;
         if (draftsStopped || !shouldPreview()) return;
-        const shown = await sendDraft(
-          destination,
-          draftId!,
-          `${prefix}${answer}`.slice(0, maxLength)
-        );
+        const preview = splitText(`${prefix}${answer}`, maxLength)[0] ?? "";
+        const shown = await sendDraft(destination, draftId!, preview);
         if (!shown) draftsStopped = true;
       },
       async onFinish(outcome) {

--- a/packages/channels/src/ai-sdk.ts
+++ b/packages/channels/src/ai-sdk.ts
@@ -1,5 +1,11 @@
-import { jsonSchema, tool, type Tool } from "ai";
-import type { ChannelMessage, DeliveryResult } from "./channel";
+import {
+  jsonSchema,
+  tool,
+  type TextStreamPart,
+  type Tool,
+  type ToolSet
+} from "ai";
+import type { ChannelChunk, ChannelMessage, DeliveryResult } from "./channel";
 import type { ChannelHost } from "./host";
 import type { ChannelMessageSurface } from "./surface";
 import { channelMessageJsonSchema, parseChannelMessage } from "./tool-schema";
@@ -48,5 +54,78 @@ export function createSendMessageTool(
     ...options,
     inputSchema: channelMessageSchema,
     execute: (message) => host.deliver(surface, message)
+  });
+}
+
+function toChannelChunk(
+  part: TextStreamPart<ToolSet>
+): ChannelChunk | undefined {
+  switch (part.type) {
+    case "text-delta":
+      return { type: "text", text: part.text };
+    case "reasoning-delta":
+      return { type: "reasoning", text: part.text };
+    case "source":
+      return part.sourceType === "url"
+        ? {
+            type: "source",
+            url: part.url,
+            ...(part.title !== undefined && { title: part.title })
+          }
+        : undefined;
+    case "tool-call":
+      return { type: "tool", name: part.toolName, status: "started" };
+    case "tool-result":
+      return { type: "tool", name: part.toolName, status: "completed" };
+    case "tool-error":
+      return { type: "tool", name: part.toolName, status: "failed" };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Project an AI SDK `fullStream` onto neutral Channel chunks.
+ *
+ * Parts a Channel cannot express are dropped, which keeps provider part
+ * shapes out of `ChannelChunk`. An `error` or `abort` part errors the returned
+ * stream, so a generation that fails part-way reaches a Channel as the
+ * abnormal ending it is rather than as a complete answer.
+ */
+export function toChannelChunks(
+  fullStream: AsyncIterable<TextStreamPart<ToolSet>>
+): ReadableStream<ChannelChunk> {
+  const parts = fullStream[Symbol.asyncIterator]();
+  return new ReadableStream<ChannelChunk>({
+    async pull(controller) {
+      while (true) {
+        const { done, value } = await parts.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        if (value.type === "error") {
+          controller.error(
+            value.error instanceof Error
+              ? value.error
+              : new Error(String(value.error))
+          );
+          return;
+        }
+        if (value.type === "abort") {
+          controller.error(
+            new Error(value.reason ?? "The generation was aborted")
+          );
+          return;
+        }
+        const chunk = toChannelChunk(value);
+        if (!chunk) continue;
+        controller.enqueue(chunk);
+        return;
+      }
+    },
+    async cancel(reason) {
+      await parts.return?.(reason);
+    }
   });
 }

--- a/packages/channels/src/ai-sdk.ts
+++ b/packages/channels/src/ai-sdk.ts
@@ -74,11 +74,26 @@ function toChannelChunk(
           }
         : undefined;
     case "tool-call":
-      return { type: "tool", name: part.toolName, status: "started" };
+      return {
+        type: "tool",
+        id: part.toolCallId,
+        name: part.toolName,
+        status: "started"
+      };
     case "tool-result":
-      return { type: "tool", name: part.toolName, status: "completed" };
+      return {
+        type: "tool",
+        id: part.toolCallId,
+        name: part.toolName,
+        status: "completed"
+      };
     case "tool-error":
-      return { type: "tool", name: part.toolName, status: "failed" };
+      return {
+        type: "tool",
+        id: part.toolCallId,
+        name: part.toolName,
+        status: "failed"
+      };
     default:
       return undefined;
   }
@@ -96,36 +111,51 @@ export function toChannelChunks(
   fullStream: AsyncIterable<TextStreamPart<ToolSet>>
 ): ReadableStream<ChannelChunk> {
   const parts = fullStream[Symbol.asyncIterator]();
+  let sourceClosed = false;
+
+  async function closeSource(reason?: unknown): Promise<void> {
+    if (sourceClosed) return;
+    sourceClosed = true;
+    await parts.return?.(reason);
+  }
+
   return new ReadableStream<ChannelChunk>({
     async pull(controller) {
-      while (true) {
-        const { done, value } = await parts.next();
-        if (done) {
-          controller.close();
+      try {
+        while (true) {
+          const { done, value } = await parts.next();
+          if (done) {
+            sourceClosed = true;
+            controller.close();
+            return;
+          }
+          if (value.type === "error") {
+            const error =
+              value.error instanceof Error
+                ? value.error
+                : new Error(String(value.error));
+            await closeSource().catch(() => {});
+            controller.error(error);
+            return;
+          }
+          if (value.type === "abort") {
+            const error = new Error(
+              value.reason ?? "The generation was aborted"
+            );
+            await closeSource().catch(() => {});
+            controller.error(error);
+            return;
+          }
+          const chunk = toChannelChunk(value);
+          if (!chunk) continue;
+          controller.enqueue(chunk);
           return;
         }
-        if (value.type === "error") {
-          controller.error(
-            value.error instanceof Error
-              ? value.error
-              : new Error(String(value.error))
-          );
-          return;
-        }
-        if (value.type === "abort") {
-          controller.error(
-            new Error(value.reason ?? "The generation was aborted")
-          );
-          return;
-        }
-        const chunk = toChannelChunk(value);
-        if (!chunk) continue;
-        controller.enqueue(chunk);
-        return;
+      } catch (error) {
+        await closeSource().catch(() => {});
+        controller.error(error);
       }
     },
-    async cancel(reason) {
-      await parts.return?.(reason);
-    }
+    cancel: closeSource
   });
 }

--- a/packages/channels/src/channel.ts
+++ b/packages/channels/src/channel.ts
@@ -26,12 +26,15 @@ export type DeliveryFailure = {
 };
 
 /**
- * The result of a direct delivery attempt.
+ * The result of a direct delivery attempt, defined by what reached the reader.
  *
- * `delivered` means the transport accepted the message, not that a person read
- * it. `failed` means the transport confirmed that no delivery occurred; its
- * `retryable` field says whether the same route can be attempted again.
- * `uncertain` means another attempt or route could produce a duplicate.
+ * `delivered` means the whole message reached the reader, not that a person
+ * read it. `failed` means none of it did; its `retryable` field says whether
+ * the same route can be attempted again. `uncertain` means an unknown amount
+ * of the message reached the reader, so another attempt or route could
+ * duplicate content. A stream that ends before its answer is complete is
+ * `uncertain`, and carries a `reference` when the Channel created something
+ * the caller can point at.
  */
 export type DeliveryResult =
   | {
@@ -45,8 +48,50 @@ export type DeliveryResult =
     }
   | {
       status: "uncertain";
+      reference?: string;
       error: DeliveryFailure;
     };
+
+/**
+ * One element of a progressively generated answer.
+ *
+ * The variants describe what an Agent produces, not what a provider renders.
+ * Any Channel may ignore any variant, so `text` alone must always be a
+ * complete answer; a variant carrying meaning `text` does not is a bug in the
+ * variant.
+ */
+export type ChannelChunk =
+  | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | {
+      type: "tool";
+      name: string;
+      status: "started" | "completed" | "failed";
+      title?: string;
+      detail?: string;
+    }
+  | { type: "source"; url: string; title?: string };
+
+/** The normalized stream shape accepted by `ChannelHost.stream`. */
+export type ChannelChunkSource = ReadableStream<ChannelChunk>;
+
+/** Caller options for one finished delivery. */
+export type ChannelDeliveryOptions = {
+  /** Caller-owned identity for provider idempotency and observability. */
+  delivery?: ChannelDeliveryContext;
+};
+
+/** Caller options for one streamed answer. */
+export type ChannelStreamOptions = {
+  /**
+   * Optional topic. It is an option rather than a chunk because it is known
+   * before the first token, and a Channel usually needs it in its opening
+   * provider call.
+   */
+  title?: string;
+  /** Caller-owned identity for provider idempotency and observability. */
+  delivery?: ChannelDeliveryContext;
+};
 
 /** A caller-owned identity supplied to one provider delivery attempt. */
 export type ChannelDeliveryContext = {
@@ -91,7 +136,12 @@ export type OutboundResolver = {
   deliver(
     surface: ChannelMessageSurface,
     message: ChannelMessage,
-    context?: ChannelDeliveryContext
+    options?: ChannelDeliveryOptions
+  ): Promise<DeliveryResult>;
+  stream(
+    surface: ChannelMessageSurface,
+    chunks: ChannelChunkSource,
+    options?: ChannelStreamOptions
   ): Promise<DeliveryResult>;
   requestApproval(
     surface: ChannelMessageSurface,
@@ -121,7 +171,20 @@ export interface Channel<TRaw = unknown> {
   deliver?(
     surface: ChannelMessageSurface,
     message: ChannelMessage,
-    context?: ChannelDeliveryContext
+    options?: ChannelDeliveryOptions
+  ): Promise<DeliveryResult>;
+  /**
+   * Deliver one progressively generated answer. Absent for Channels that
+   * cannot stream, which the Host serves by collecting and calling `deliver`.
+   *
+   * The Channel owns the consumption loop. It must finalize whether the
+   * stream closed or errored, because a model can fail mid-generation, and it
+   * must not abandon a terminal provider call on error.
+   */
+  stream?(
+    surface: ChannelMessageSurface,
+    chunks: ReadableStream<ChannelChunk>,
+    options: ChannelStreamOptions
   ): Promise<DeliveryResult>;
   requestApproval?(
     surface: ChannelMessageSurface,

--- a/packages/channels/src/channel.ts
+++ b/packages/channels/src/channel.ts
@@ -65,6 +65,8 @@ export type ChannelChunk =
   | { type: "reasoning"; text: string }
   | {
       type: "tool";
+      /** Stable identity for one invocation when the producer provides it. */
+      id?: string;
       name: string;
       status: "started" | "completed" | "failed";
       title?: string;
@@ -77,7 +79,7 @@ export type ChannelChunkSource = ReadableStream<ChannelChunk>;
 
 /** Caller options for one finished delivery. */
 export type ChannelDeliveryOptions = {
-  /** Caller-owned identity for provider idempotency and observability. */
+  /** Caller-owned correlation an Adapter may use where the provider supports it. */
   delivery?: ChannelDeliveryContext;
 };
 
@@ -89,11 +91,16 @@ export type ChannelStreamOptions = {
    * provider call.
    */
   title?: string;
-  /** Caller-owned identity for provider idempotency and observability. */
+  /** Caller-owned correlation an Adapter may use where the provider supports it. */
   delivery?: ChannelDeliveryContext;
 };
 
-/** A caller-owned identity supplied to one provider delivery attempt. */
+/**
+ * Caller-owned correlation supplied to one provider delivery attempt.
+ *
+ * This is not an idempotency guarantee. An Adapter may map it to a provider
+ * idempotency primitive when one exists, or otherwise use it for observability.
+ */
 export type ChannelDeliveryContext = {
   deliveryId: string;
 };
@@ -114,7 +121,7 @@ export type ChannelApprovalRequest = {
 export type ChannelApprovalRequestOptions = {
   interactionId: string;
   request: ChannelApprovalRequest;
-  /** Caller-owned identity for provider idempotency and observability. */
+  /** Caller-owned correlation an Adapter may use where the provider supports it. */
   delivery?: ChannelDeliveryContext;
   /** Lazily obtains approval links supplied and settled by the caller. */
   getApprovalLinks?: () => Promise<ChannelApprovalLinks>;

--- a/packages/channels/src/fallback.ts
+++ b/packages/channels/src/fallback.ts
@@ -1,8 +1,10 @@
 import type {
   Channel,
   ChannelApprovalRequestOptions,
-  ChannelDeliveryContext,
+  ChannelChunk,
+  ChannelDeliveryOptions,
   ChannelMessage,
+  ChannelStreamOptions,
   DeliveryResult,
   OutboundResolver
 } from "./channel";
@@ -39,6 +41,68 @@ export function fallback(surfaces: FallbackSurfaceOptions): FallbackSurface {
   };
 }
 
+/**
+ * Advance past a failed destination, replaying what the failed one consumed.
+ *
+ * Buffering the answer keeps `failed` meaning that nothing reached the reader,
+ * so streaming failover behaves exactly like one-shot failover. No Channel has
+ * to obey an invisible rule about calling its provider before its first read.
+ */
+async function streamWithReplay(
+  resolve: OutboundResolver,
+  destinations: readonly ChannelMessageSurface[],
+  chunks: ReadableStream<ChannelChunk>,
+  options: ChannelStreamOptions
+): Promise<DeliveryResult> {
+  const reader = chunks.getReader();
+  const buffered: ChannelChunk[] = [];
+  let drained = false;
+
+  function attempt(): ReadableStream<ChannelChunk> {
+    let index = 0;
+    return new ReadableStream<ChannelChunk>({
+      async pull(controller) {
+        if (index < buffered.length) {
+          controller.enqueue(buffered[index]!);
+          index += 1;
+          return;
+        }
+        if (drained) {
+          controller.close();
+          return;
+        }
+        const result = await reader.read();
+        if (result.done) {
+          drained = true;
+          controller.close();
+          return;
+        }
+        buffered.push(result.value);
+        index = buffered.length;
+        controller.enqueue(result.value);
+      }
+      // A cancelling destination must not cancel the shared source, which the
+      // next destination may still need.
+    });
+  }
+
+  try {
+    for (let index = 0; index < destinations.length - 1; index += 1) {
+      const destination = destinations[index]!;
+      if (!(await resolve.isAvailable(destination))) continue;
+
+      const result = await resolve.stream(destination, attempt(), options);
+      if (result.status !== "failed") return result;
+    }
+    // `return await` so the shared reader is released only after the final
+    // destination has finished consuming it.
+    return await resolve.stream(destinations.at(-1)!, attempt(), options);
+  } finally {
+    if (!drained) await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
 /** Build the ordinary Channel installed under the reserved fallback key. */
 export function fallbackChannel(resolve: OutboundResolver): Channel {
   async function run(
@@ -68,11 +132,27 @@ export function fallbackChannel(resolve: OutboundResolver): Channel {
     deliver(
       surface: ChannelMessageSurface,
       message: ChannelMessage,
-      context?: ChannelDeliveryContext
+      options?: ChannelDeliveryOptions
     ) {
       return run(surface, (destination) =>
-        resolve.deliver(destination, message, context)
+        resolve.deliver(destination, message, options)
       );
+    },
+
+    async stream(
+      surface: ChannelMessageSurface,
+      chunks: ReadableStream<ChannelChunk>,
+      options: ChannelStreamOptions
+    ) {
+      const destinations = compositeDestinations(surface);
+      if (!destinations) {
+        await chunks.cancel().catch(() => {});
+        return unsupported(
+          "FALLBACK_SURFACE_INVALID",
+          "Fallback surface must contain at least one valid destination"
+        );
+      }
+      return streamWithReplay(resolve, destinations, chunks, options);
     },
 
     requestApproval(

--- a/packages/channels/src/fallback.ts
+++ b/packages/channels/src/fallback.ts
@@ -42,48 +42,49 @@ export function fallback(surfaces: FallbackSurfaceOptions): FallbackSurface {
 }
 
 /**
- * Advance past a failed destination, replaying what the failed one consumed.
+ * Advance only when a failed destination has not started reading the answer.
  *
- * Buffering the answer keeps `failed` meaning that nothing reached the reader,
- * so streaming failover behaves exactly like one-shot failover. No Channel has
- * to obey an invisible rule about calling its provider before its first read.
+ * Replaying an arbitrarily large consumed prefix requires an arbitrarily large
+ * buffer. Instead, each attempt gets a cancellation-shielded view of the same
+ * source. Once an attempt asks for its first chunk, its result is terminal and
+ * the source is never handed to another destination.
  */
-async function streamWithReplay(
+async function streamWithFallbackBeforeRead(
   resolve: OutboundResolver,
   destinations: readonly ChannelMessageSurface[],
   chunks: ReadableStream<ChannelChunk>,
   options: ChannelStreamOptions
 ): Promise<DeliveryResult> {
   const reader = chunks.getReader();
-  const buffered: ChannelChunk[] = [];
   let drained = false;
 
-  function attempt(): ReadableStream<ChannelChunk> {
-    let index = 0;
-    return new ReadableStream<ChannelChunk>({
-      async pull(controller) {
-        if (index < buffered.length) {
-          controller.enqueue(buffered[index]!);
-          index += 1;
-          return;
-        }
-        if (drained) {
-          controller.close();
-          return;
-        }
-        const result = await reader.read();
-        if (result.done) {
-          drained = true;
-          controller.close();
-          return;
-        }
-        buffered.push(result.value);
-        index = buffered.length;
-        controller.enqueue(result.value);
-      }
-      // A cancelling destination must not cancel the shared source, which the
-      // next destination may still need.
-    });
+  function attempt(): {
+    chunks: ReadableStream<ChannelChunk>;
+    startedReading: () => boolean;
+  } {
+    let startedReading = false;
+    return {
+      chunks: new ReadableStream<ChannelChunk>(
+        {
+          async pull(controller) {
+            startedReading = true;
+            const result = await reader.read();
+            if (result.done) {
+              drained = true;
+              controller.close();
+              return;
+            }
+            controller.enqueue(result.value);
+          },
+          // A destination may cancel after an opening failure. Shield the
+          // untouched source so the next destination can still try it.
+          cancel() {}
+        },
+        // Do not prefetch: creating an attempt must not consume the source.
+        { highWaterMark: 0 }
+      ),
+      startedReading: () => startedReading
+    };
   }
 
   try {
@@ -91,12 +92,14 @@ async function streamWithReplay(
       const destination = destinations[index]!;
       if (!(await resolve.isAvailable(destination))) continue;
 
-      const result = await resolve.stream(destination, attempt(), options);
-      if (result.status !== "failed") return result;
+      const current = attempt();
+      const result = await resolve.stream(destination, current.chunks, options);
+      if (result.status !== "failed" || current.startedReading()) return result;
     }
+    const final = attempt();
     // `return await` so the shared reader is released only after the final
     // destination has finished consuming it.
-    return await resolve.stream(destinations.at(-1)!, attempt(), options);
+    return await resolve.stream(destinations.at(-1)!, final.chunks, options);
   } finally {
     if (!drained) await reader.cancel().catch(() => {});
     reader.releaseLock();
@@ -152,7 +155,12 @@ export function fallbackChannel(resolve: OutboundResolver): Channel {
           "Fallback surface must contain at least one valid destination"
         );
       }
-      return streamWithReplay(resolve, destinations, chunks, options);
+      return streamWithFallbackBeforeRead(
+        resolve,
+        destinations,
+        chunks,
+        options
+      );
     },
 
     requestApproval(

--- a/packages/channels/src/fanout.ts
+++ b/packages/channels/src/fanout.ts
@@ -1,8 +1,10 @@
 import type {
   Channel,
   ChannelApprovalRequestOptions,
-  ChannelDeliveryContext,
+  ChannelChunk,
+  ChannelDeliveryOptions,
   ChannelMessage,
+  ChannelStreamOptions,
   DeliveryResult,
   OutboundResolver
 } from "./channel";
@@ -23,6 +25,21 @@ export type FanoutSurfaceOptions = readonly [
 type FanoutOperation = (
   surface: ChannelMessageSurface
 ) => Promise<DeliveryResult>;
+
+function teeAll<T>(
+  source: ReadableStream<T>,
+  count: number
+): ReadableStream<T>[] {
+  const branches: ReadableStream<T>[] = [];
+  let rest = source;
+  for (let index = 0; index < count - 1; index += 1) {
+    const [branch, remainder] = rest.tee();
+    branches.push(branch);
+    rest = remainder;
+  }
+  branches.push(rest);
+  return branches;
+}
 
 /** Build an inert fanout destination for a `ChannelHost` to resolve. */
 export function fanout(surfaces: FanoutSurfaceOptions): FanoutSurface {
@@ -48,7 +65,10 @@ export function fanoutChannel(resolve: OutboundResolver): Channel {
       );
     }
 
-    const results = await Promise.all(destinations.map(operation));
+    return combine(await Promise.all(destinations.map(operation)));
+  }
+
+  function combine(results: readonly DeliveryResult[]): DeliveryResult {
     if (results.every((result) => result.status === "delivered")) {
       return { status: "delivered" };
     }
@@ -78,10 +98,33 @@ export function fanoutChannel(resolve: OutboundResolver): Channel {
     deliver(
       surface: ChannelMessageSurface,
       message: ChannelMessage,
-      context?: ChannelDeliveryContext
+      options?: ChannelDeliveryOptions
     ) {
       return run(surface, (destination) =>
-        resolve.deliver(destination, message, context)
+        resolve.deliver(destination, message, options)
+      );
+    },
+    async stream(
+      surface: ChannelMessageSurface,
+      chunks: ReadableStream<ChannelChunk>,
+      options: ChannelStreamOptions
+    ) {
+      const destinations = compositeDestinations(surface);
+      if (!destinations) {
+        await chunks.cancel().catch(() => {});
+        return unsupported(
+          "FANOUT_SURFACE_INVALID",
+          "Fanout surface must contain at least one valid destination"
+        );
+      }
+      // One branch per destination, so a slow reader cannot pace a fast one.
+      const branches = teeAll(chunks, destinations.length);
+      return combine(
+        await Promise.all(
+          destinations.map((destination, index) =>
+            resolve.stream(destination, branches[index]!, options)
+          )
+        )
       );
     },
     requestApproval(

--- a/packages/channels/src/fanout.ts
+++ b/packages/channels/src/fanout.ts
@@ -121,9 +121,18 @@ export function fanoutChannel(resolve: OutboundResolver): Channel {
       const branches = teeAll(chunks, destinations.length);
       return combine(
         await Promise.all(
-          destinations.map((destination, index) =>
-            resolve.stream(destination, branches[index]!, options)
-          )
+          destinations.map(async (destination, index) => {
+            const branch = branches[index]!;
+            try {
+              return await resolve.stream(destination, branch, options);
+            } finally {
+              // A destination may return after an opening failure without
+              // reading. Cancel immediately so tee does not retain every chunk
+              // consumed by the remaining destinations. Do not await: one tee
+              // branch's cancellation settles only after its siblings finish.
+              void branch.cancel().catch(() => {});
+            }
+          })
         )
       );
     },

--- a/packages/channels/src/host/index.ts
+++ b/packages/channels/src/host/index.ts
@@ -1,10 +1,13 @@
 import type {
   Channel,
   ChannelApprovalRequestOptions,
-  ChannelDeliveryContext,
+  ChannelChunk,
+  ChannelChunkSource,
+  ChannelDeliveryOptions,
   ChannelMessage,
   ChannelRoute,
   ChannelRouteContext,
+  ChannelStreamOptions,
   DeliveryResult
 } from "../channel";
 import { fallbackChannel } from "../fallback";
@@ -15,6 +18,7 @@ import type {
   UserIdentity
 } from "../identity";
 import { unsupported } from "../internal";
+import { collectText } from "../stream";
 import type {
   ChannelApprovalResponse,
   ChannelEmailInput,
@@ -23,10 +27,9 @@ import type {
   ChannelIngressEvent,
   ChannelIngressEventInput
 } from "../ingress";
-import {
-  isChannelMessageSurface,
-  type ChannelMessageSurface,
-  type ChannelMessageSurfaceInput
+import type {
+  ChannelMessageSurface,
+  ChannelMessageSurfaceInput
 } from "../surface";
 
 export type ChannelMessageEvent = {
@@ -143,7 +146,7 @@ export class ChannelHost {
   deliver(
     surface: ChannelMessageSurface,
     message: ChannelMessage,
-    context?: ChannelDeliveryContext
+    options?: ChannelDeliveryOptions
   ): Promise<DeliveryResult> {
     return this.#outbound(surface, (channel, destination) => {
       if (!channel.deliver) {
@@ -154,8 +157,34 @@ export class ChannelHost {
           )
         );
       }
-      return channel.deliver(destination, message, context);
+      return channel.deliver(destination, message, options);
     });
+  }
+
+  /**
+   * Deliver a progressively generated answer to the Channel or composite
+   * named by the surface.
+   *
+   * A Channel that can stream consumes the stream itself. A Channel that
+   * cannot never learns it was a stream, because the Host collects the answer
+   * and calls `deliver` once.
+   */
+  async stream(
+    surface: ChannelMessageSurface,
+    chunks: ChannelChunkSource,
+    options: ChannelStreamOptions = {}
+  ): Promise<DeliveryResult> {
+    const channel = this.#configuredChannel(surface.channelKey);
+    if (!channel.stream && !channel.deliver) {
+      await chunks.cancel().catch(() => {});
+      return unsupported(
+        "CHANNEL_DELIVERY_UNSUPPORTED",
+        `Channel "${surface.channelKey}" does not support delivery`
+      );
+    }
+
+    if (channel.stream) return channel.stream(surface, chunks, options);
+    return collectAndDeliver(channel, surface, chunks, options);
   }
 
   /** Request approval through the Channel or composite named by the surface. */
@@ -190,7 +219,6 @@ export class ChannelHost {
 
   /** Resolve whether a surface can currently be selected without delivery. */
   async isAvailable(surface: ChannelMessageSurface): Promise<boolean> {
-    if (!isChannelMessageSurface(surface)) return true;
     const channel = this.#configuredChannel(surface.channelKey);
     return channel.isAvailable?.(surface) ?? true;
   }
@@ -199,12 +227,6 @@ export class ChannelHost {
     surface: ChannelMessageSurface,
     operation: OutboundOperation
   ): Promise<DeliveryResult> {
-    if (!isChannelMessageSurface(surface)) {
-      return unsupported(
-        "CHANNEL_SURFACE_INVALID",
-        "Cannot resolve an invalid Channel message surface"
-      );
-    }
     const channel = this.#configuredChannel(surface.channelKey);
     return operation(channel, surface);
   }
@@ -300,6 +322,51 @@ export class ChannelHost {
       }
     };
   }
+}
+
+/**
+ * Serve a Channel that cannot stream by collecting the answer first.
+ *
+ * A generation that failed part-way still delivers what it produced, because
+ * losing the partial answer helps nobody, but the result is downgraded to
+ * `uncertain` since the reader received an incomplete answer.
+ */
+async function collectAndDeliver(
+  channel: Channel,
+  surface: ChannelMessageSurface,
+  stream: ReadableStream<ChannelChunk>,
+  options: ChannelStreamOptions
+): Promise<DeliveryResult> {
+  const collected = await collectText(stream);
+  if (collected.interrupted && collected.text.length === 0) {
+    return {
+      status: "failed",
+      retryable: false,
+      error: {
+        code: "CHANNEL_STREAM_INTERRUPTED",
+        message: "The stream ended before producing any content to deliver"
+      }
+    };
+  }
+
+  const result = await channel.deliver!(
+    surface,
+    {
+      ...(options.title !== undefined && { title: options.title }),
+      markdown: collected.text
+    },
+    options.delivery ? { delivery: options.delivery } : undefined
+  );
+  if (!collected.interrupted || result.status !== "delivered") return result;
+  return {
+    status: "uncertain",
+    ...(result.reference !== undefined && { reference: result.reference }),
+    error: {
+      code: "CHANNEL_STREAM_INTERRUPTED",
+      message:
+        "An incomplete answer was delivered because the stream ended early"
+    }
+  };
 }
 
 function stampSurface<TAddress extends ChannelMessageSurfaceInput["address"]>(

--- a/packages/channels/src/host/index.ts
+++ b/packages/channels/src/host/index.ts
@@ -27,9 +27,10 @@ import type {
   ChannelIngressEvent,
   ChannelIngressEventInput
 } from "../ingress";
-import type {
-  ChannelMessageSurface,
-  ChannelMessageSurfaceInput
+import {
+  isChannelMessageSurface,
+  type ChannelMessageSurface,
+  type ChannelMessageSurfaceInput
 } from "../surface";
 
 export type ChannelMessageEvent = {
@@ -174,6 +175,11 @@ export class ChannelHost {
     chunks: ChannelChunkSource,
     options: ChannelStreamOptions = {}
   ): Promise<DeliveryResult> {
+    if (!isChannelMessageSurface(surface)) {
+      await chunks.cancel().catch(() => {});
+      return invalidSurface();
+    }
+
     const channel = this.#configuredChannel(surface.channelKey);
     if (!channel.stream && !channel.deliver) {
       await chunks.cancel().catch(() => {});
@@ -219,6 +225,7 @@ export class ChannelHost {
 
   /** Resolve whether a surface can currently be selected without delivery. */
   async isAvailable(surface: ChannelMessageSurface): Promise<boolean> {
+    if (!isChannelMessageSurface(surface)) return false;
     const channel = this.#configuredChannel(surface.channelKey);
     return channel.isAvailable?.(surface) ?? true;
   }
@@ -227,6 +234,7 @@ export class ChannelHost {
     surface: ChannelMessageSurface,
     operation: OutboundOperation
   ): Promise<DeliveryResult> {
+    if (!isChannelMessageSurface(surface)) return invalidSurface();
     const channel = this.#configuredChannel(surface.channelKey);
     return operation(channel, surface);
   }
@@ -331,6 +339,13 @@ export class ChannelHost {
  * losing the partial answer helps nobody, but the result is downgraded to
  * `uncertain` since the reader received an incomplete answer.
  */
+function invalidSurface(): DeliveryResult {
+  return unsupported(
+    "CHANNEL_SURFACE_INVALID",
+    "Cannot resolve an invalid Channel message surface"
+  );
+}
+
 async function collectAndDeliver(
   channel: Channel,
   surface: ChannelMessageSurface,

--- a/packages/channels/src/index.ts
+++ b/packages/channels/src/index.ts
@@ -7,4 +7,11 @@ export * from "./host";
 export * from "./identity";
 export * from "./ingress";
 export * from "./routes";
+// Only the finalization contract is public. Pacing and collection stay
+// internal until a Channel outside this package needs them.
+export {
+  consumeChunks,
+  type ChunkConsumer,
+  type StreamOutcome
+} from "./stream";
 export * from "./surface";

--- a/packages/channels/src/internal.ts
+++ b/packages/channels/src/internal.ts
@@ -31,9 +31,14 @@ export function renderInput(input: unknown): string {
   }
 }
 
-export function uncertain(code: string, message: string): DeliveryResult {
+export function uncertain(
+  code: string,
+  message: string,
+  reference?: string
+): Extract<DeliveryResult, { status: "uncertain" }> {
   return {
     status: "uncertain",
+    ...(reference !== undefined && { reference }),
     error: { code, message }
   };
 }

--- a/packages/channels/src/stream.ts
+++ b/packages/channels/src/stream.ts
@@ -1,0 +1,91 @@
+import { TextSegmentJoiner } from "agents/chat";
+import type { Awaitable, ChannelChunk } from "./channel";
+
+/** Why a consumption loop stopped reading. */
+export type StreamOutcome =
+  | { interrupted: false }
+  | { interrupted: true; error: unknown };
+
+export type ChunkConsumer<TChunk, TResult> = {
+  onChunk(chunk: TChunk): Awaitable<void>;
+  /** Runs exactly once, whether the stream closed or ended abnormally. */
+  onFinish(outcome: StreamOutcome): Awaitable<TResult>;
+};
+
+/** The complete text of a stream, and whether it ended before its answer did. */
+export type CollectedText = {
+  text: string;
+  interrupted: boolean;
+};
+
+/**
+ * Read a stream to completion, then finalize exactly once.
+ *
+ * `onFinish` runs whether the stream closed normally, errored because the
+ * generation failed, or stopped because `onChunk` threw. A Channel that
+ * finalizes here cannot lose a terminal provider call to an early ending.
+ */
+export async function consumeChunks<TChunk, TResult>(
+  chunks: ReadableStream<TChunk>,
+  consumer: ChunkConsumer<TChunk, TResult>
+): Promise<TResult> {
+  const reader = chunks.getReader();
+  let outcome: StreamOutcome = { interrupted: false };
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await consumer.onChunk(value);
+    }
+  } catch (error) {
+    outcome = { interrupted: true, error };
+    // Stop the producer, which is still generating when `onChunk` threw.
+    await reader.cancel().catch(() => {});
+  } finally {
+    reader.releaseLock();
+  }
+  return consumer.onFinish(outcome);
+}
+
+/**
+ * Collect every `text` chunk into one Markdown answer.
+ *
+ * The result reports interruption instead of throwing, because a Channel that
+ * has partial text still has to decide what to deliver.
+ */
+export function collectText(
+  chunks: ReadableStream<ChannelChunk>
+): Promise<CollectedText> {
+  let text = "";
+  const joiner = new TextSegmentJoiner();
+  return consumeChunks(chunks, {
+    onChunk(chunk) {
+      for (const event of joiner.pushChunk(
+        chunk.type === "text"
+          ? { type: "text-delta", text: chunk.text }
+          : { type: chunk.type }
+      )) {
+        if (event.type === "text") text += event.text;
+      }
+    },
+    onFinish: (outcome) => ({ text, interrupted: outcome.interrupted })
+  });
+}
+
+/**
+ * Pace repeated provider calls without dropping anything.
+ *
+ * A Channel accumulates into its own buffer and asks whether enough time has
+ * passed to flush. Keeping the buffer in the Channel means an interrupted
+ * stream leaves its tail in hand, ready for the terminal provider call, rather
+ * than stranded inside a transform.
+ */
+export function createPacer(intervalMs: number): () => boolean {
+  let lastFlushAt = Number.NEGATIVE_INFINITY;
+  return () => {
+    const now = Date.now();
+    if (now - lastFlushAt < intervalMs) return false;
+    lastFlushAt = now;
+    return true;
+  };
+}

--- a/packages/channels/src/stream.ts
+++ b/packages/channels/src/stream.ts
@@ -39,8 +39,10 @@ export async function consumeChunks<TChunk, TResult>(
     }
   } catch (error) {
     outcome = { interrupted: true, error };
-    // Stop the producer, which is still generating when `onChunk` threw.
-    await reader.cancel().catch(() => {});
+    // Initiate cancellation without waiting for sibling tee branches. Their
+    // cancellation promises settle together, but this consumer still has to
+    // finalize its provider message immediately.
+    void reader.cancel().catch(() => {});
   } finally {
     reader.releaseLock();
   }

--- a/packages/channels/src/stream.ts
+++ b/packages/channels/src/stream.ts
@@ -31,6 +31,7 @@ export async function consumeChunks<TChunk, TResult>(
 ): Promise<TResult> {
   const reader = chunks.getReader();
   let outcome: StreamOutcome = { interrupted: false };
+  let cancellation: Promise<void> | undefined;
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -39,14 +40,17 @@ export async function consumeChunks<TChunk, TResult>(
     }
   } catch (error) {
     outcome = { interrupted: true, error };
-    // Initiate cancellation without waiting for sibling tee branches. Their
-    // cancellation promises settle together, but this consumer still has to
-    // finalize its provider message immediately.
-    void reader.cancel().catch(() => {});
+    // Start cancellation before finalizing, but do not block the terminal
+    // provider call on sibling tee branches. Await cleanup only afterward.
+    cancellation = reader.cancel().catch(() => {});
   } finally {
     reader.releaseLock();
   }
-  return consumer.onFinish(outcome);
+  try {
+    return await consumer.onFinish(outcome);
+  } finally {
+    await cancellation;
+  }
 }
 
 /**

--- a/packages/channels/vitest.live.config.ts
+++ b/packages/channels/vitest.live.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["live-tests/delivery.test.ts"],
-    testTimeout: 180_000
+    include: ["live-tests/*.test.ts"],
+    // Every scenario clears the same provider-owned destinations.
+    fileParallelism: false,
+    testTimeout: 300_000
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4116,7 +4116,7 @@ importers:
         version: 13.0.6
       just-bash:
         specifier: ^3.0.2
-        version: 3.0.2(supports-color@7.2.0)
+        version: 3.0.2
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -4160,6 +4160,9 @@ importers:
       '@cloudflare/voice':
         specifier: workspace:*
         version: link:../voice
+      agents:
+        specifier: workspace:*
+        version: link:../agents
       postal-mime:
         specifier: ^2.7.5
         version: 2.7.5
@@ -4246,7 +4249,7 @@ importers:
         version: 4.31.0(ai@7.0.18(zod@4.4.3))(zod@4.4.3)
       just-bash:
         specifier: ^3.0.2
-        version: 3.0.2(supports-color@7.2.0)
+        version: 3.0.2
       workers-ai-provider:
         specifier: ^4.0.0
         version: 4.0.0(@ai-sdk/anthropic@4.0.10(zod@4.4.3))(@ai-sdk/google@4.0.10(zod@4.4.3))(@ai-sdk/openai@4.0.9(zod@4.4.3))(@ai-sdk/provider@4.0.2)(ai@7.0.18(zod@4.4.3))
@@ -5770,9 +5773,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
@@ -5786,13 +5801,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-x64@1.2.4':
     resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -5803,8 +5834,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -5815,8 +5858,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -5827,14 +5882,32 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5846,9 +5919,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -5860,9 +5947,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -5874,9 +5975,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -5888,9 +6003,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5899,6 +6028,10 @@ packages:
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
+
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
 
   '@img/sharp-webcontainers-wasm32@0.35.2':
     resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
@@ -5911,15 +6044,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -13357,7 +13508,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260730.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.1.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler: 4.116.0(@cloudflare/workers-types@5.20260812.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13419,7 +13570,7 @@ snapshots:
   '@cloudflare/workspace@https://pkg.pr.new/cloudflare/workspace/@cloudflare/workspace@98b74eb(@platformatic/vfs@0.4.0)(diff@9.0.0)(isomorphic-git@1.38.5)':
     dependencies:
       capnweb: 0.8.0
-      just-bash: 3.0.2(supports-color@7.2.0)
+      just-bash: 3.0.2
     optionalDependencies:
       '@platformatic/vfs': 0.4.0
       diff: 9.0.0
@@ -13766,42 +13917,84 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
   '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -13809,9 +14002,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -13819,9 +14022,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -13829,9 +14042,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+    optional: true
+
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -13839,9 +14062,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -13849,16 +14082,32 @@ snapshots:
       '@emnapi/runtime': 1.11.1
     optional: true
 
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
   '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
+  '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
   '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
     optional: true
 
   '@inquirer/ansi@2.0.7': {}
@@ -15201,7 +15450,7 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@tokenizer/inflate@0.4.1(supports-color@7.2.0)':
+  '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       token-types: 6.1.2
@@ -17009,9 +17258,9 @@ snapshots:
       token-types: 6.1.2
       uint8array-extras: 1.5.0
 
-  file-type@21.3.4(supports-color@7.2.0):
+  file-type@21.3.4:
     dependencies:
-      '@tokenizer/inflate': 0.4.1(supports-color@7.2.0)
+      '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -17658,11 +17907,11 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  just-bash@3.0.2(supports-color@7.2.0):
+  just-bash@3.0.2:
     dependencies:
       diff: 8.0.4
       fast-xml-parser: 5.9.3
-      file-type: 21.3.4(supports-color@7.2.0)
+      file-type: 21.3.4
       ini: 6.0.0
       minimatch: 10.2.5
       modern-tar: 0.7.6
@@ -19608,8 +19857,31 @@ snapshots:
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
       '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
       '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
This PR adds outbound message streaming to `@cloudflare/channels`, including native Slack and Telegram streaming, composite routing, and an AI SDK adapter.

## Why

- Channels currently wait for a complete model response before delivering anything, even when the destination supports progressive rendering.
- Streaming needs transport-neutral chunks because provider-specific payloads do not compose across Slack, Telegram, fallback routes, and fanout routes.
- A Channel owns stream consumption and terminal provider calls. This ensures an interrupted generation still finalizes its provider message instead of leaving a draft or streaming message unfinished.
- Channels that cannot stream collect the text and use ordinary delivery, so callers use one Host API regardless of transport capability.
- Slack cannot stream at the top level of an ordinary channel. The adapter collects and posts one ordinary message there, while threads and direct messages use Slack's native streaming methods.

## Public API Surface

| Symbol | Kind | Notes |
| --- | --- | --- |
| `ChannelChunk` | Type | Neutral `text`, `reasoning`, `tool`, and `source` stream chunks |
| `ChannelChunkSource` | Type | Normalized `ReadableStream<ChannelChunk>` input |
| `ChannelDeliveryOptions` | Type | Wraps caller-owned delivery context |
| `ChannelStreamOptions` | Type | Supplies an optional title and delivery context |
| `Channel.stream` | Optional method | Lets a Channel consume and finalize a streamed answer |
| `OutboundResolver.stream` | Method | Recursively streams through composite Channels |
| `ChannelHost.stream` | Method | Resolves a destination and streams or collects before delivery |
| `consumeChunks` | Function | Finalizes exactly once after normal or interrupted consumption |
| `ChunkConsumer` | Type | Defines chunk and finalization callbacks |
| `StreamOutcome` | Type | Reports normal or interrupted stream completion |
| `toChannelChunks` | Function | Maps an AI SDK `fullStream` to Channel chunks |

`DeliveryResult` now permits a `reference` on its `uncertain` arm.

`deliver` now takes `ChannelDeliveryOptions` as its third argument instead of a bare `ChannelDeliveryContext`.

## Architectural Changes

```text
ReadableStream<ChannelChunk>
             |
        ChannelHost
             |
       +-----+------+
       |            |
 Channel.stream   collect text
       |            |
 native provider  Channel.deliver
```

Composite Channels preserve the same contract:

- `fanout` tees the source so each destination receives its own stream.
- `fallback` retains consumed chunks and replays them after a confirmed failure.
- `uncertain` stops fallback to avoid potentially duplicating partial delivery.

## Code Changes

- Slack uses `chat.startStream`, `chat.appendStream`, and `chat.stopStream` for threads and direct messages. Top-level channel streams collect into `chat.postMessage`.
- Telegram uses `sendMessageDraft` for private-chat previews and always finishes with `sendMessage`, including after an interrupted generation.
- The Host collects text for Channels without native streaming support and uses `TextSegmentJoiner` to preserve semantic spacing around tool and metadata boundaries.
- The AI SDK adapter maps `fullStream` parts into neutral chunks and turns abort or error parts into abnormal stream completion.
- Live fixtures independently observe Telegram, Slack top-level, Slack threads, and email through one shared provider matrix.

## Compatibility

The third argument to `deliver` changed from:

```ts
ChannelDeliveryContext
```

to:

```ts
ChannelDeliveryOptions
```

Callers passing a delivery ID must wrap it:

```ts
host.deliver(surface, message, {
  delivery: { deliveryId }
});
```

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->